### PR TITLE
fix(app): support storage-authoritative CV1 capture

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -38,6 +38,8 @@ outputs:
     value: ${{ steps.changed.outputs.has_app_compile_smoke }}
   has_app_dart:
     value: ${{ steps.changed.outputs.has_app_dart }}
+  has_app_ios_native:
+    value: ${{ steps.changed.outputs.has_app_ios_native }}
   has_desktop_auth_session_ratchet:
     value: ${{ steps.changed.outputs.has_desktop_auth_session_ratchet }}
   has_format:
@@ -73,6 +75,7 @@ runs:
         has_dart=$(echo "$FILES" | grep -q '\.dart$' && echo true || echo false)
         has_python=$(echo "$FILES" | grep -q 'backend/.*\.py$' && echo true || echo false)
         has_arb=$(echo "$FILES" | grep -q '\.arb$' && echo true || echo false)
+        has_app_ios_native=$(echo "$FILES" | grep -qE '^app/ios/' && echo true || echo false)
         has_firmware=$(echo "$FILES" | grep -qE '^(omi|omiGlass)/.*\.(c|cpp|cc|cxx|h|hpp)$' && echo true || echo false)
         has_frontend=$(echo "$FILES" | grep -qE '^web/frontend/|^\.github/workflows/web-checks\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
         has_web_app=$(echo "$FILES" | grep -qE '^web/app/|^\.github/workflows/web-checks\.yml$|^\.github/actions/detect-changes/' && echo true || echo false)
@@ -97,6 +100,7 @@ runs:
           echo "has_dart=$has_dart"
           echo "has_python=$has_python"
           echo "has_arb=$has_arb"
+          echo "has_app_ios_native=$has_app_ios_native"
           echo "has_firmware=$has_firmware"
           echo "has_frontend=$has_frontend"
           echo "has_web_app=$has_web_app"

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -265,6 +265,12 @@ checks:
     triggers: ["app/scripts/verify_ios_physical_test_auth_config.sh", "app/scripts/test_verify_ios_physical_test_auth_config.sh", "app/AGENTS.md", "app/e2e/IOS_DEVICE_TESTING.md", "app/e2e/SKILL.md", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "authenticated isolated iOS hardware runs must reject the hermetic API target, the wrong Firebase project, and non-iOS Firebase app registrations before a build can create false BLE evidence"
+  - id: ios-dogfood-artifact-mode
+    command: ["python3", "app/e2e/scripts/test_verify_ios_dogfood_artifact.py"]
+    triggers: ["app/e2e/scripts/build_signed_ios_physical_dev.sh", "app/e2e/scripts/install_ios_dogfood_profile.sh", "app/e2e/scripts/verify_ios_dogfood_artifact.py", "app/e2e/scripts/test_verify_ios_dogfood_artifact.py", "app/e2e/BLE_RELIABILITY_ACCEPTANCE.md", "app/e2e/IOS_DEVICE_TESTING.md", "app/e2e/SKILL.md", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["linux", "macos"]
+    reason: "the 2026-08-05 detached-debug incident proved that an authenticated physical pass can still leave a JIT app that crashes during unattended dogfooding; this artifact-boundary guard is narrower than runtime Flutter policy and must fail before device mutation"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -255,6 +255,11 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "SCA-273: the real watch presentation contract must stop its ripple after five seconds, preserve elapsed time, and localize accessibility labels for every native locale"
+  - id: android-physical-test-auth-config
+    command: ["bash", "app/scripts/test_verify_android_physical_test_auth_config.sh"]
+    triggers: ["app/scripts/verify_android_physical_test_auth_config.sh", "app/scripts/test_verify_android_physical_test_auth_config.sh", "app/AGENTS.md", "app/e2e/BLE_RELIABILITY_ACCEPTANCE.md", "app/e2e/SKILL.md", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "authenticated Android hardware runs must reject the hermetic empty-URL and placeholder-Firebase inputs before an APK can create false BLE evidence"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -260,6 +260,11 @@ checks:
     triggers: ["app/scripts/verify_android_physical_test_auth_config.sh", "app/scripts/test_verify_android_physical_test_auth_config.sh", "app/AGENTS.md", "app/e2e/BLE_RELIABILITY_ACCEPTANCE.md", "app/e2e/SKILL.md", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "authenticated Android hardware runs must reject the hermetic empty-URL and placeholder-Firebase inputs before an APK can create false BLE evidence"
+  - id: ios-physical-test-auth-config
+    command: ["bash", "app/scripts/test_verify_ios_physical_test_auth_config.sh"]
+    triggers: ["app/scripts/verify_ios_physical_test_auth_config.sh", "app/scripts/test_verify_ios_physical_test_auth_config.sh", "app/AGENTS.md", "app/e2e/IOS_DEVICE_TESTING.md", "app/e2e/SKILL.md", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "authenticated isolated iOS hardware runs must reject the hermetic API target, the wrong Firebase project, and non-iOS Firebase app registrations before a build can create false BLE evidence"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/.github/workflows/mobile-app-checks.yml
+++ b/.github/workflows/mobile-app-checks.yml
@@ -18,6 +18,7 @@ jobs:
       has_app_codegen: ${{ steps.changes.outputs.has_app_codegen }}
       has_app_compile_smoke: ${{ steps.changes.outputs.has_app_compile_smoke }}
       has_app_dart: ${{ steps.changes.outputs.has_app_dart }}
+      has_app_ios_native: ${{ steps.changes.outputs.has_app_ios_native }}
       has_app_l10n: ${{ steps.changes.outputs.has_app_l10n }}
       has_flutter_generated: ${{ steps.changes.outputs.has_flutter_generated }}
     steps:
@@ -282,6 +283,10 @@ jobs:
       - name: Setup Gradle for Flutter compile smoke
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Run Android native unit tests
+        working-directory: app
+        run: ./android/gradlew -p android testDevDebugUnitTest
+
       - name: Build Flutter Android dev debug APK
         working-directory: app
         env:
@@ -294,3 +299,15 @@ jobs:
         # Single ABI: a compile smoke doesn't need arm + arm64 + x86_64 native
         # libs, and the extra ABIs double disk usage during stripDebugSymbols.
         run: flutter build apk --debug --flavor dev --target-platform android-arm64
+
+  ios-native-unit-tests:
+    name: iOS Native Unit Tests
+    runs-on: macos-15
+    needs: changes
+    if: needs.changes.outputs.has_app_ios_native == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run hermetic iOS BLE ownership tests
+        run: bash app/ios/test/run_ble_legacy_audio_ownership_tests.sh

--- a/.github/workflows/mobile-app-checks.yml
+++ b/.github/workflows/mobile-app-checks.yml
@@ -288,6 +288,10 @@ jobs:
           # android/gradle/wrapper/gradle-wrapper.properties instead.
           gradle-version: '8.14.2'
 
+      - name: Configure Flutter SDK for Gradle
+        working-directory: app
+        run: printf 'flutter.sdk=%s\n' "$FLUTTER_ROOT" > android/local.properties
+
       - name: Run Android native unit tests
         working-directory: app
         run: gradle -p android testDevDebugUnitTest

--- a/.github/workflows/mobile-app-checks.yml
+++ b/.github/workflows/mobile-app-checks.yml
@@ -282,10 +282,15 @@ jobs:
 
       - name: Setup Gradle for Flutter compile smoke
         uses: gradle/actions/setup-gradle@v6
+        with:
+          # The repository intentionally does not track Flutter's generated
+          # gradlew scripts or wrapper jar. Pin the distribution declared by
+          # android/gradle/wrapper/gradle-wrapper.properties instead.
+          gradle-version: '8.14.2'
 
       - name: Run Android native unit tests
         working-directory: app
-        run: ./android/gradlew -p android testDevDebugUnitTest
+        run: gradle -p android testDevDebugUnitTest
 
       - name: Build Flutter Android dev debug APK
         working-directory: app

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -42,6 +42,15 @@ compatibility projections are derived views: their updates are committed to
 the outbox with canonical state and retried from authoritative memory, never
 treated as memory authority themselves.
 
+## Proposed capture continuity
+
+The end-to-end capture contract is
+[`INV-CAPTURE-1`](docs/product/invariants/capture-continuity.md). It defines one
+durable conversation timeline across pendant storage, Android, iOS, desktop,
+live transcription, retry, and backend projection. Storage slices and transport
+sessions are never conversation boundaries; live capture has priority over
+user-authorized historical recovery.
+
 ## Before you build
 
 - Large or ambiguous features start as a GitHub issue

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -35,8 +35,10 @@ Never run `flutterfire configure` — it overwrites prod credentials. Config fil
 authenticated Android hardware build, follow `e2e/BLE_RELIABILITY_ACCEPTANCE.md`
 → “Authenticated Android physical-device builds” plus its verified maintainer
 toolchain, and require
-`scripts/verify_android_physical_test_auth_config.sh` to pass. Physical iPhone
-testing uses the prod inputs in `e2e/IOS_DEVICE_TESTING.md`.
+`scripts/verify_android_physical_test_auth_config.sh` to pass. For an
+authenticated physical iPhone build, follow `e2e/IOS_DEVICE_TESTING.md`, use an
+isolated dev app with the maintainer's production-backed test inputs, and
+require `scripts/verify_ios_physical_test_auth_config.sh` to pass.
 
 ## Native Bridge
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -33,7 +33,8 @@ Never run `flutterfire configure` — it overwrites prod credentials. Config fil
 
 `test.sh` writes unit-test-only placeholder auth inputs. Before installing an
 authenticated Android hardware build, follow `e2e/BLE_RELIABILITY_ACCEPTANCE.md`
-→ “Authenticated Android physical-device builds” and require
+→ “Authenticated Android physical-device builds” plus its verified maintainer
+toolchain, and require
 `scripts/verify_android_physical_test_auth_config.sh` to pass. Physical iPhone
 testing uses the prod inputs in `e2e/IOS_DEVICE_TESTING.md`.
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -29,6 +29,14 @@ Never run `flutterfire configure` — it overwrites prod credentials. Config fil
 - Dev: `ios/Config/Dev/`, `android/app/src/dev/`, `lib/firebase_options_dev.dart`
 - Prod: `ios/Config/Prod/`, `android/app/src/prod/`, `lib/firebase_options_prod.dart`
 
+#### Authenticated physical-device exception
+
+`test.sh` writes unit-test-only placeholder auth inputs. Before installing an
+authenticated Android hardware build, follow `e2e/BLE_RELIABILITY_ACCEPTANCE.md`
+→ “Authenticated Android physical-device builds” and require
+`scripts/verify_android_physical_test_auth_config.sh` to pass. Physical iPhone
+testing uses the prod inputs in `e2e/IOS_DEVICE_TESTING.md`.
+
 ## Native Bridge
 
 ### Pigeon Interface (bidirectional, iOS ↔ Dart)

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -109,8 +109,9 @@ android {
 
     signingConfigs {
         release {
-            if (System.getenv()["CI"]) { // CI=true is exported by Codemagic
-                storeFile file(System.getenv()["CM_KEYSTORE_PATH"])
+            def codemagicKeystorePath = System.getenv()["CM_KEYSTORE_PATH"]
+            if (codemagicKeystorePath) {
+                storeFile file(codemagicKeystorePath)
                 storePassword System.getenv()["CM_KEYSTORE_PASSWORD"]
                 keyAlias System.getenv()["CM_KEY_ALIAS"]
                 keyPassword System.getenv()["CM_KEY_PASSWORD"]

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleHostApiImpl.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleHostApiImpl.kt
@@ -133,11 +133,11 @@ class BleHostApiImpl(private val getActivity: () -> Activity?) : BleHostApi {
     // ── Diagnostics ──
 
     override fun startRssiStreaming(uuid: String) {
-        bleManager.isRssiStreamingEnabled = true
+        bleManager.startRssiStreaming(uuid)
     }
 
     override fun stopRssiStreaming(uuid: String) {
-        bleManager.isRssiStreamingEnabled = false
+        bleManager.stopRssiStreaming(uuid)
     }
 
     override fun getBatteryHistory(uuid: String, callback: (Result<List<BleBatteryPoint>>) -> Unit) {

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleReconnectBackoff.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleReconnectBackoff.kt
@@ -1,0 +1,59 @@
+package com.friend.ios.ble
+
+import kotlin.math.roundToLong
+
+internal object BleReconnectBackoff {
+    private const val INITIAL_DELAY_MS = 500L
+    private const val MAX_DELAY_MS = 30_000L
+    private const val JITTER_FRACTION = 0.20
+
+    /**
+     * Exponential reconnect delay with bounded jitter.
+     *
+     * [jitterUnit] is injected so production can spread radio work while tests
+     * remain deterministic: 0 maps to -20%, 0.5 to no jitter, and 1 to +20%.
+     */
+    fun delayMillis(attempt: Int, jitterUnit: Double): Long {
+        val boundedAttempt = attempt.coerceIn(0, 30)
+        val multiplier = 1L shl boundedAttempt
+        val base = (INITIAL_DELAY_MS * multiplier).coerceAtMost(MAX_DELAY_MS)
+        val boundedJitter = jitterUnit.coerceIn(0.0, 1.0)
+        val factor = 1.0 - JITTER_FRACTION + (2.0 * JITTER_FRACTION * boundedJitter)
+        return (base * factor).roundToLong().coerceAtMost(MAX_DELAY_MS)
+    }
+}
+
+internal data class BleReconnectAttempt(
+    val number: Int,
+    val delayMillis: Long,
+)
+
+/**
+ * Reconnect lifecycle ownership. Reaching L2CAP is not success: discovery,
+ * MTU, and subscriptions may still fail. Only a stable session (or an
+ * explicit user/OS reconnect signal) resets the failure history.
+ */
+internal class BleReconnectState {
+    private var failedAttempts = 0
+
+    fun recordFailure(jitterUnit: Double): BleReconnectAttempt {
+        val attempt = failedAttempts
+        failedAttempts = (attempt + 1).coerceAtMost(30)
+        return BleReconnectAttempt(
+            number = attempt + 1,
+            delayMillis = BleReconnectBackoff.delayMillis(attempt, jitterUnit),
+        )
+    }
+
+    fun markTransportConnected() {
+        // Intentionally retained: setup may still fail after physical connect.
+    }
+
+    fun markStable() {
+        failedAttempts = 0
+    }
+
+    fun resetForExplicitRequest() {
+        failedAttempts = 0
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/GattCompletionRegistry.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/GattCompletionRegistry.kt
@@ -1,0 +1,97 @@
+package com.friend.ios.ble
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Identity of a callback-bearing characteristic operation.
+ *
+ * UUIDs are not sufficient: Android can deliver a callback from a retired
+ * BluetoothGatt after a replacement session has started an operation against
+ * the same characteristic. Session and characteristic instance IDs keep those
+ * operations distinct; exact object identity is verified when taking an entry.
+ */
+internal data class GattCompletionKey(
+    val address: String,
+    val sessionId: Long,
+    val serviceUuid: String,
+    val characteristicUuid: String,
+    val characteristicInstanceId: Int,
+) {
+    fun normalized(): GattCompletionKey =
+        copy(
+            address = address.uppercase(),
+            serviceUuid = serviceUuid.lowercase(),
+            characteristicUuid = characteristicUuid.lowercase(),
+        )
+}
+
+/**
+ * Thread-safe retained completion owner used directly by OmiBleManager.
+ *
+ * Completion callbacks are always invoked after releasing the registry lock.
+ */
+internal class GattCompletionRegistry<T> {
+    private data class Entry<T>(
+        val sessionToken: Any,
+        val characteristicToken: Any,
+        val completion: (Result<T>) -> Unit,
+    )
+
+    private val entries = mutableMapOf<GattCompletionKey, Entry<T>>()
+
+    fun register(
+        key: GattCompletionKey,
+        sessionToken: Any,
+        characteristicToken: Any,
+        completion: (Result<T>) -> Unit,
+    ): ((Result<T>) -> Unit)? =
+        synchronized(entries) {
+            entries.put(
+                key.normalized(),
+                Entry(sessionToken, characteristicToken, completion),
+            )?.completion
+        }
+
+    fun takeMatching(
+        key: GattCompletionKey,
+        sessionToken: Any,
+        characteristicToken: Any,
+    ): ((Result<T>) -> Unit)? =
+        synchronized(entries) {
+            val normalized = key.normalized()
+            val entry = entries[normalized] ?: return@synchronized null
+            if (entry.sessionToken !== sessionToken || entry.characteristicToken !== characteristicToken) {
+                return@synchronized null
+            }
+            entries.remove(normalized)?.completion
+        }
+
+    fun failSession(
+        sessionId: Long,
+        failure: () -> Throwable,
+    ): Int {
+        val completions =
+            synchronized(entries) {
+                val matching =
+                    entries
+                        .filterKeys { it.sessionId == sessionId }
+                        .map { it.key to it.value.completion }
+                matching.forEach { entries.remove(it.first) }
+                matching.map { it.second }
+            }
+
+        completions.forEach { it(Result.failure(failure())) }
+        return completions.size
+    }
+
+    internal fun pendingCount(): Int = synchronized(entries) { entries.size }
+}
+
+internal fun <T> onceGattCompletion(completion: (Result<T>) -> Unit): (Result<T>) -> Unit {
+    val completed = AtomicBoolean(false)
+    return { result ->
+        if (completed.compareAndSet(false, true)) {
+            completion(result)
+        }
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/GattOperationQueue.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/GattOperationQueue.kt
@@ -1,0 +1,235 @@
+package com.friend.ios.ble
+
+import java.util.ArrayDeque
+
+/**
+ * Identity of one asynchronous Android GATT operation.
+ *
+ * Android permits only one outstanding GATT operation per client. Matching the
+ * callback to this identity prevents a late callback from releasing an
+ * unrelated command.
+ */
+internal data class GattOperationKey(
+    val address: String,
+    val kind: GattOperationKind,
+    val target: String = "",
+) {
+    fun normalized(): GattOperationKey = copy(
+        address = address.uppercase(),
+        target = target.lowercase(),
+    )
+}
+
+internal enum class GattOperationKind {
+    DISCOVER_SERVICES,
+    REQUEST_MTU,
+    READ_CHARACTERISTIC,
+    WRITE_CHARACTERISTIC,
+    WRITE_WITHOUT_RESPONSE,
+    WRITE_DESCRIPTOR,
+    READ_RSSI,
+}
+
+internal enum class GattOperationFailure {
+    REJECTED,
+    TIMED_OUT,
+    CANCELLED,
+    EXCEPTION,
+}
+
+internal enum class GattWriteMode {
+    WITH_RESPONSE,
+    WITHOUT_RESPONSE,
+}
+
+internal fun preferredGattWriteMode(
+    supportsWrite: Boolean,
+    supportsWriteWithoutResponse: Boolean,
+): GattWriteMode? =
+    when {
+        supportsWrite -> GattWriteMode.WITH_RESPONSE
+        supportsWriteWithoutResponse -> GattWriteMode.WITHOUT_RESPONSE
+        else -> null
+    }
+
+/**
+ * Small, platform-independent state machine for Android's one-operation GATT
+ * contract. Production supplies Handler-backed dispatch/scheduling; JVM tests
+ * use deterministic fakes.
+ */
+internal class GattOperationQueue(
+    private val dispatch: (() -> Unit) -> Unit,
+    private val schedule: (delayMillis: Long, task: () -> Unit) -> (() -> Unit),
+    private val timeoutMillis: Long,
+) {
+    private data class Entry(
+        val key: GattOperationKey,
+        val start: () -> Boolean,
+        val onFailure: (GattOperationFailure) -> Unit,
+        var cancelTimeout: (() -> Unit)? = null,
+    )
+
+    private val queued = ArrayDeque<Entry>()
+    private var current: Entry? = null
+    private var callbackDepth = 0
+
+    fun enqueue(
+        key: GattOperationKey,
+        start: () -> Boolean,
+        onFailure: (GattOperationFailure) -> Unit = {},
+    ) {
+        synchronized(this) {
+            queued.addLast(Entry(key.normalized(), start, onFailure))
+        }
+        processNext()
+    }
+
+    fun contains(key: GattOperationKey): Boolean {
+        val normalized = key.normalized()
+        return synchronized(this) {
+            current?.key == normalized || queued.any { it.key == normalized }
+        }
+    }
+
+    fun isActive(key: GattOperationKey): Boolean {
+        val normalized = key.normalized()
+        return synchronized(this) {
+            current?.key == normalized
+        }
+    }
+
+    /**
+     * Completes only the currently active matching operation. [onSuccess] runs
+     * before the next command can start, so per-operation callback state can be
+     * safely removed without a same-characteristic successor overwriting it.
+     */
+    fun complete(key: GattOperationKey, onSuccess: () -> Unit = {}): Boolean {
+        val normalized = key.normalized()
+        val entry = synchronized(this) {
+            current?.takeIf { it.key == normalized }?.also {
+                current = null
+                callbackDepth++
+            }
+        } ?: return false
+
+        entry.cancelTimeout?.invoke()
+        try {
+            onSuccess()
+        } finally {
+            synchronized(this) {
+                callbackDepth--
+            }
+            processNext()
+        }
+        return true
+    }
+
+    fun cancelAddress(address: String) {
+        val normalizedAddress = address.uppercase()
+        val cancelled = mutableListOf<Entry>()
+
+        synchronized(this) {
+            current?.takeIf { it.key.address == normalizedAddress }?.let {
+                current = null
+                cancelled.add(it)
+            }
+
+            val iterator = queued.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                if (entry.key.address == normalizedAddress) {
+                    iterator.remove()
+                    cancelled.add(entry)
+                }
+            }
+            if (cancelled.isNotEmpty()) callbackDepth++
+        }
+
+        try {
+            for (entry in cancelled) {
+                entry.cancelTimeout?.invoke()
+                try {
+                    entry.onFailure(GattOperationFailure.CANCELLED)
+                } catch (_: Exception) {
+                    // One caller must not prevent the remaining operations
+                    // from learning that their peripheral disconnected.
+                }
+            }
+        } finally {
+            if (cancelled.isNotEmpty()) {
+                synchronized(this) {
+                    callbackDepth--
+                }
+            }
+            processNext()
+        }
+    }
+
+    internal fun pendingCount(): Int = synchronized(this) {
+        queued.size + if (current == null) 0 else 1
+    }
+
+    private fun processNext() {
+        val entry = synchronized(this) {
+            if (current != null || callbackDepth > 0 || queued.isEmpty()) return
+            queued.removeFirst().also { current = it }
+        }
+
+        dispatch {
+            if (!isCurrent(entry)) return@dispatch
+
+            val cancelTimeout = schedule(timeoutMillis) {
+                fail(entry, GattOperationFailure.TIMED_OUT)
+            }
+            val accepted = synchronized(this) {
+                if (current === entry) {
+                    entry.cancelTimeout = cancelTimeout
+                    true
+                } else {
+                    false
+                }
+            }
+            if (!accepted) {
+                cancelTimeout()
+                return@dispatch
+            }
+
+            val started = try {
+                entry.start()
+            } catch (_: Exception) {
+                fail(entry, GattOperationFailure.EXCEPTION)
+                return@dispatch
+            }
+            if (!started) {
+                fail(entry, GattOperationFailure.REJECTED)
+            }
+        }
+    }
+
+    private fun isCurrent(entry: Entry): Boolean = synchronized(this) {
+        current === entry
+    }
+
+    private fun fail(entry: Entry, reason: GattOperationFailure) {
+        val removed = synchronized(this) {
+            if (current !== entry) {
+                false
+            } else {
+                current = null
+                callbackDepth++
+                true
+            }
+        }
+        if (!removed) return
+
+        entry.cancelTimeout?.invoke()
+        try {
+            entry.onFailure(reason)
+        } finally {
+            synchronized(this) {
+                callbackDepth--
+            }
+            processNext()
+        }
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/GattOperationQueue.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/GattOperationQueue.kt
@@ -13,6 +13,7 @@ internal data class GattOperationKey(
     val address: String,
     val kind: GattOperationKind,
     val target: String = "",
+    val sessionId: Long = 0L,
 ) {
     fun normalized(): GattOperationKey = copy(
         address = address.uppercase(),
@@ -126,10 +127,24 @@ internal class GattOperationQueue(
 
     fun cancelAddress(address: String) {
         val normalizedAddress = address.uppercase()
+        cancelMatching { it.key.address == normalizedAddress }
+    }
+
+    fun cancelSession(
+        address: String,
+        sessionId: Long,
+    ) {
+        val normalizedAddress = address.uppercase()
+        cancelMatching {
+            it.key.address == normalizedAddress && it.key.sessionId == sessionId
+        }
+    }
+
+    private fun cancelMatching(matches: (Entry) -> Boolean) {
         val cancelled = mutableListOf<Entry>()
 
         synchronized(this) {
-            current?.takeIf { it.key.address == normalizedAddress }?.let {
+            current?.takeIf(matches)?.let {
                 current = null
                 cancelled.add(it)
             }
@@ -137,7 +152,7 @@ internal class GattOperationQueue(
             val iterator = queued.iterator()
             while (iterator.hasNext()) {
                 val entry = iterator.next()
-                if (entry.key.address == normalizedAddress) {
+                if (matches(entry)) {
                     iterator.remove()
                     cancelled.add(entry)
                 }

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/GattReadySessionGuard.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/GattReadySessionGuard.kt
@@ -1,0 +1,22 @@
+package com.friend.ios.ble
+
+/**
+ * Prevents delayed post-discovery work from crossing a GATT replacement.
+ *
+ * The foreground service checks this guard both when its delayed MTU request
+ * starts and when that request completes. A retired session can therefore
+ * neither operate on nor publish services for its replacement.
+ */
+internal class GattReadySessionGuard(
+    private val activeSessionId: (String) -> Long?,
+) {
+    fun runIfCurrent(
+        address: String,
+        expectedSessionId: Long,
+        action: () -> Unit,
+    ): Boolean {
+        if (activeSessionId(address) != expectedSessionId) return false
+        action()
+        return true
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/NativeAudioSubscriptionOwnership.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/NativeAudioSubscriptionOwnership.kt
@@ -1,0 +1,59 @@
+package com.friend.ios.ble
+
+internal data class NativeAudioSubscriptionTarget(
+    val serviceUuid: String,
+    val characteristicUuid: String,
+)
+
+internal data class NativeAudioSubscriptionTransition(
+    val unsubscribe: NativeAudioSubscriptionTarget? = null,
+    val subscribe: NativeAudioSubscriptionTarget? = null,
+)
+
+/**
+ * Tracks only the audio CCCD enabled by the native background owner.
+ *
+ * Ownership is scoped to a concrete GATT object. A replacement GATT starts with
+ * no CCCD state, so it must never inherit an "already subscribed" decision from
+ * the retired session.
+ */
+internal class NativeAudioSubscriptionOwnership {
+    private data class OwnedTarget(
+        val sessionToken: Int,
+        val target: NativeAudioSubscriptionTarget,
+    )
+
+    private val ownedTargets = mutableMapOf<String, OwnedTarget>()
+
+    @Synchronized
+    fun reconcile(
+        address: String,
+        sessionToken: Int,
+        desired: NativeAudioSubscriptionTarget?,
+    ): NativeAudioSubscriptionTransition {
+        val key = address.uppercase()
+        val owned = ownedTargets[key]
+
+        if (owned?.sessionToken != sessionToken) {
+            if (desired == null) {
+                ownedTargets.remove(key)
+                return NativeAudioSubscriptionTransition()
+            }
+            ownedTargets[key] = OwnedTarget(sessionToken, desired)
+            return NativeAudioSubscriptionTransition(subscribe = desired)
+        }
+
+        if (owned.target == desired) return NativeAudioSubscriptionTransition()
+
+        if (desired == null) {
+            ownedTargets.remove(key)
+            return NativeAudioSubscriptionTransition(unsubscribe = owned.target)
+        }
+
+        ownedTargets[key] = OwnedTarget(sessionToken, desired)
+        return NativeAudioSubscriptionTransition(
+            unsubscribe = owned.target,
+            subscribe = desired,
+        )
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/NotificationTransitionState.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/NotificationTransitionState.kt
@@ -1,0 +1,44 @@
+package com.friend.ios.ble
+
+/**
+ * Coalesces notification requests for one CCCD.
+ *
+ * Android callbacks do not expose a request ID or the value written. Keeping
+ * only one transition in flight and remembering the latest desired state
+ * avoids redundant same-state writes when native/background and Flutter
+ * subscribers attach to the same characteristic.
+ */
+internal class NotificationTransitionState {
+    private var confirmed: Boolean? = null
+    private var desired: Boolean? = null
+    private var inFlight: Boolean? = null
+
+    @Synchronized
+    fun request(enabled: Boolean): Boolean? {
+        desired = enabled
+        if (inFlight != null || confirmed == enabled) return null
+        inFlight = enabled
+        return enabled
+    }
+
+    @Synchronized
+    fun currentInFlight(): Boolean? = inFlight
+
+    /**
+     * Returns the next coalesced transition, already marked in-flight.
+     * Failures are left to session recovery rather than retried on a GATT that
+     * may no longer be usable.
+     */
+    @Synchronized
+    fun complete(attempted: Boolean, success: Boolean): Boolean? {
+        if (inFlight != attempted) return null
+        inFlight = null
+        if (!success) return null
+        confirmed = attempted
+
+        val next = desired
+        if (next == null || next == confirmed) return null
+        inFlight = next
+        return next
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -167,6 +167,9 @@ class OmiBleForegroundService : Service() {
     private var isBluetoothEnabled = true
     private val syncLock = Any()
     private val bleManager get() = OmiBleManager.instance
+    private val readySessionGuard by lazy {
+        GattReadySessionGuard(bleManager::activeGattSessionId)
+    }
     private val backgroundAudioStreamer by lazy { OmiBackgroundAudioStreamer(applicationContext) }
     private val batchAudioWriter by lazy { OmiBatchAudioWriter(applicationContext) }
     private val limitlessBatchWriter by lazy { LimitlessBatchAudioWriter(applicationContext) }
@@ -204,7 +207,11 @@ class OmiBleForegroundService : Service() {
             handleDisconnection(addr, gattHash, status)
         }
 
-        override fun onGattServicesDiscovered(address: String, services: List<BleService>) {
+        override fun onGattServicesDiscovered(
+            address: String,
+            services: List<BleService>,
+            sessionId: Long,
+        ) {
             val addr = address.uppercase()
             val managed = managedDevices[addr] ?: return
 
@@ -219,10 +226,10 @@ class OmiBleForegroundService : Service() {
                     val bonded = result.getOrDefault(false)
                     Log.i(TAG, "Bond result for $addr: $bonded")
                     if (bonded) managed.requiresBond = false
-                    requestMtuThenNotifyReady(addr, services)
+                    requestMtuThenNotifyReady(addr, services, sessionId)
                 }
             } else {
-                requestMtuThenNotifyReady(addr, services)
+                requestMtuThenNotifyReady(addr, services, sessionId)
             }
         }
 
@@ -230,14 +237,27 @@ class OmiBleForegroundService : Service() {
 
     // ── Post-discovery pipeline ──
 
-    private fun requestMtuThenNotifyReady(address: String, services: List<BleService>) {
+    private fun requestMtuThenNotifyReady(
+        address: String,
+        services: List<BleService>,
+        expectedSessionId: Long,
+    ) {
         val addr = address.uppercase()
-        if (!bleManager.connectedGatts.containsKey(addr)) return
 
         handler.postDelayed({
-            bleManager.requestMtu(addr, MTU_SIZE) { mtu, status ->
-                Log.i(TAG, "MTU done for $addr (mtu=$mtu, status=$status)")
-                fireDeviceReady(addr, services)
+            val started = readySessionGuard.runIfCurrent(addr, expectedSessionId) {
+                bleManager.requestMtu(addr, MTU_SIZE, expectedSessionId) { mtu, status ->
+                    val published = readySessionGuard.runIfCurrent(addr, expectedSessionId) {
+                        Log.i(TAG, "MTU done for $addr (mtu=$mtu, status=$status, session=$expectedSessionId)")
+                        fireDeviceReady(addr, services)
+                    }
+                    if (!published) {
+                        Log.i(TAG, "Ignoring MTU completion from retired GATT session $expectedSessionId for $addr")
+                    }
+                }
+            }
+            if (!started) {
+                Log.i(TAG, "Skipping delayed MTU from retired GATT session $expectedSessionId for $addr")
             }
         }, MTU_REQUEST_DELAY_MS)
     }

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -44,7 +44,6 @@ class OmiBleForegroundService : Service() {
         private const val MTU_REQUEST_DELAY_MS = 100L
         private const val MTU_SIZE = 512
         private const val STABILITY_TIMER_MS = 60_000L
-        private const val RECONNECT_DELAY_MS = 3_000L
         private const val COMPANION_RATE_LIMIT_MS = 15_000L
         private const val PREFS_NAME = "ble_config"
         private const val PREFS_KEY = "managed_device"
@@ -143,10 +142,10 @@ class OmiBleForegroundService : Service() {
 
     // ── Per-device state ──
 
-    data class ManagedDevice(
+    private data class ManagedDevice(
         val address: String,
         var requiresBond: Boolean,
-        var retryCount: Int = 0,
+        val reconnectState: BleReconnectState = BleReconnectState(),
         var connectionStartTime: Long? = null,
         var currentGattHash: Int? = null,
         var hasEverConnected: Boolean = false,
@@ -186,8 +185,8 @@ class OmiBleForegroundService : Service() {
                 incrementReconnectionCount(addr)
                 backfillTimeToReconnect(addr, managed)
             }
-            managed.retryCount = 0
             managed.hasEverConnected = true
+            managed.reconnectState.markTransportConnected()
             managed.currentAttemptEstablished = true
             managed.pendingReconnect?.let { handler.removeCallbacks(it) }
             managed.pendingReconnect = null
@@ -195,7 +194,7 @@ class OmiBleForegroundService : Service() {
             managed.currentGattHash = gatt.hashCode()
 
             startStabilityTimer(addr)
-            bleManager.startRssiKeepAlive(addr)
+            bleManager.resumeRssiDiagnostics(addr)
             updateNotification("Connected to Omi")
         }
 
@@ -219,10 +218,7 @@ class OmiBleForegroundService : Service() {
                 bleManager.requestBond(addr) { result ->
                     val bonded = result.getOrDefault(false)
                     Log.i(TAG, "Bond result for $addr: $bonded")
-                    if (bonded) {
-                        managed.retryCount = 0
-                        managed.requiresBond = false
-                    }
+                    if (bonded) managed.requiresBond = false
                     requestMtuThenNotifyReady(addr, services)
                 }
             } else {
@@ -230,41 +226,18 @@ class OmiBleForegroundService : Service() {
             }
         }
 
-        override fun onMtuChanged(address: String, mtu: Int, status: Int) {
-            // Handled inline via the MTU flow in requestMtuThenNotifyReady
-        }
     }
 
     // ── Post-discovery pipeline ──
 
     private fun requestMtuThenNotifyReady(address: String, services: List<BleService>) {
         val addr = address.uppercase()
-        val gatt = bleManager.connectedGatts[addr] ?: return
-
-        val originalListener = bleManager.connectionListener
-        bleManager.connectionListener = object : OmiBleManager.BleConnectionListener by connectionListener {
-            override fun onMtuChanged(address: String, mtu: Int, status: Int) {
-                bleManager.connectionListener = originalListener
-                Log.i(TAG, "MTU done for $addr (mtu=$mtu, status=$status)")
-                fireDeviceReady(addr, services)
-            }
-        }
+        if (!bleManager.connectedGatts.containsKey(addr)) return
 
         handler.postDelayed({
-            bleManager.enqueueCommand {
-                try {
-                    if (!gatt.requestMtu(MTU_SIZE)) {
-                        Log.e(TAG, "requestMtu failed for $addr")
-                        bleManager.completeCommand()
-                        bleManager.connectionListener = originalListener
-                        fireDeviceReady(addr, services)
-                    }
-                } catch (e: Exception) {
-                    Log.e(TAG, "requestMtu exception for $addr: ${e.message}")
-                    bleManager.completeCommand()
-                    bleManager.connectionListener = originalListener
-                    fireDeviceReady(addr, services)
-                }
+            bleManager.requestMtu(addr, MTU_SIZE) { mtu, status ->
+                Log.i(TAG, "MTU done for $addr (mtu=$mtu, status=$status)")
+                fireDeviceReady(addr, services)
             }
         }, MTU_REQUEST_DELAY_MS)
     }
@@ -317,12 +290,7 @@ class OmiBleForegroundService : Service() {
         }
 
         Log.i(TAG, "notifyReadyForConnectedGatt: rediscovering services for already-connected $addr")
-        bleManager.enqueueCommand {
-            if (!gatt.discoverServices()) {
-                Log.e(TAG, "notifyReadyForConnectedGatt: discoverServices returned false for $addr")
-                bleManager.completeCommand()
-            }
-        }
+        bleManager.discoverServices(addr)
         return true
     }
 
@@ -346,7 +314,7 @@ class OmiBleForegroundService : Service() {
         val existing = managedDevices[addr]
         if (existing != null && bleManager.isPeripheralConnected(addr)) {
             if (requiresBond && !existing.requiresBond) existing.requiresBond = true
-            existing.retryCount = 0
+            existing.reconnectState.resetForExplicitRequest()
             existing.currentGattHash = bleManager.connectedGatts[addr]?.hashCode()
             existing.hasEverConnected = true
             existing.currentAttemptEstablished = true
@@ -434,7 +402,7 @@ class OmiBleForegroundService : Service() {
 
         managed.pendingReconnect?.let { handler.removeCallbacks(it) }
         managed.pendingReconnect = null
-        managed.retryCount = 0
+        managed.reconnectState.resetForExplicitRequest()
         connectToDevice(addr, source)
     }
 
@@ -458,7 +426,7 @@ class OmiBleForegroundService : Service() {
                 // Cancel any pending retry so it doesn't race with the fresh attempt
                 managed.pendingReconnect?.let { handler.removeCallbacks(it) }
                 managed.pendingReconnect = null
-                managed.retryCount = 0
+                managed.reconnectState.resetForExplicitRequest()
                 // Close the stuck GATT so connectToDevice opens a fresh one
                 if (bleManager.connectedGatts.containsKey(addr)) {
                     bleManager.closeGatt(addr)
@@ -489,7 +457,7 @@ class OmiBleForegroundService : Service() {
 
             val duration = managed.connectionStartTime?.let { System.currentTimeMillis() - it } ?: 0
             if (duration >= STABILITY_TIMER_MS) {
-                managed.retryCount = 0
+                managed.reconnectState.markStable()
             }
 
             bleManager.disconnectGatt(addr)
@@ -541,15 +509,15 @@ class OmiBleForegroundService : Service() {
 
         if (isDestroying || status == -1 || status == 137 || !isBluetoothEnabled) return
 
-        managed.retryCount++
-        Log.i(TAG, "Retry #${managed.retryCount} for $addr in ${RECONNECT_DELAY_MS}ms (status=$status)")
+        val retry = managed.reconnectState.recordFailure(Math.random())
+        Log.i(TAG, "Retry #${retry.number} for $addr in ${retry.delayMillis}ms (status=$status)")
 
         val runnable = Runnable {
             managed.pendingReconnect = null
-            connectToDevice(addr, "retry_${managed.retryCount}")
+            connectToDevice(addr, "retry_${retry.number}")
         }
         managed.pendingReconnect = runnable
-        handler.postDelayed(runnable, RECONNECT_DELAY_MS)
+        handler.postDelayed(runnable, retry.delayMillis)
     }
 
     // ── Stability timer ──
@@ -560,7 +528,7 @@ class OmiBleForegroundService : Service() {
 
         managed.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
         val runnable = Runnable {
-            managed.retryCount = 0
+            managed.reconnectState.markStable()
         }
         managed.stabilityTimerRunnable = runnable
         handler.postDelayed(runnable, STABILITY_TIMER_MS)
@@ -580,7 +548,6 @@ class OmiBleForegroundService : Service() {
             when (bondState) {
                 BluetoothDevice.BOND_BONDED -> {
                     Log.i(TAG, "Bond completed for $address")
-                    managed.retryCount = 0
                 }
                 BluetoothDevice.BOND_NONE -> {
                     Log.w(TAG, "Bond removed/failed for $address")
@@ -605,7 +572,7 @@ class OmiBleForegroundService : Service() {
                         managed.pendingReconnect = null
                         managed.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
                         managed.stabilityTimerRunnable = null
-                        bleManager.stopRssiKeepAlive()
+                        bleManager.pauseRssiDiagnostics(addr)
                         bleManager.closeGatt(addr)
                         managed.currentGattHash = null
                         bleManager.mainHandler.post {
@@ -768,6 +735,7 @@ class OmiBleForegroundService : Service() {
         34 -> "link_key_mismatch"
         62 -> "connection_failed_instant_passed"
         -1 -> "app_closed"
+        -2 -> "gatt_operation_timeout"
         else -> "gatt_error_$status"
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -170,6 +170,7 @@ class OmiBleForegroundService : Service() {
     private val readySessionGuard by lazy {
         GattReadySessionGuard(bleManager::activeGattSessionId)
     }
+    private val nativeAudioSubscriptionOwnership = NativeAudioSubscriptionOwnership()
     private val backgroundAudioStreamer by lazy { OmiBackgroundAudioStreamer(applicationContext) }
     private val batchAudioWriter by lazy { OmiBatchAudioWriter(applicationContext) }
     private val limitlessBatchWriter by lazy { LimitlessBatchAudioWriter(applicationContext) }
@@ -274,20 +275,39 @@ class OmiBleForegroundService : Service() {
     }
 
     private fun ensureBackgroundAudioSubscription(address: String, services: List<BleService>) {
-        if (OmiBleManager.isFlutterAlive) return
-        // Subscribe for background streaming OR batch capture (whichever is configured)
-        // so native keeps receiving audio after the Flutter engine is gone.
-        val target = backgroundAudioStreamer.configuredAudioTargetFor(address)
-            ?: batchAudioWriter.configuredAudioTargetFor(address)
-            ?: return
-        val hasTarget = services.any { service ->
-            service.uuid.equals(target.first, ignoreCase = true) &&
-                service.characteristicUuids.any { it.equals(target.second, ignoreCase = true) }
-        }
-        if (!hasTarget) return
+        val addr = address.uppercase()
+        val sessionToken = managedDevices[addr]?.currentGattHash ?: return
+        // Native may own legacy audio only while Flutter is dead and a complete
+        // config names a characteristic exposed by this GATT session. In
+        // particular, a storage-authoritative app omits that config because its
+        // ring tail owns the audio path.
+        val configuredTarget =
+            if (OmiBleManager.isFlutterAlive) {
+                null
+            } else {
+                backgroundAudioStreamer.configuredAudioTargetFor(addr)
+                    ?: batchAudioWriter.configuredAudioTargetFor(addr)
+            }
+        val desiredTarget = configuredTarget?.takeIf { target ->
+            services.any { service ->
+                service.uuid.equals(target.first, ignoreCase = true) &&
+                    service.characteristicUuids.any { it.equals(target.second, ignoreCase = true) }
+            }
+        }?.let { NativeAudioSubscriptionTarget(it.first, it.second) }
 
-        Log.i(TAG, "Ensuring BLE audio subscription for background transcription on $address")
-        bleManager.subscribeCharacteristic(address, target.first, target.second)
+        val transition = nativeAudioSubscriptionOwnership.reconcile(
+            address = addr,
+            sessionToken = sessionToken,
+            desired = desiredTarget,
+        )
+        transition.unsubscribe?.let { target ->
+            Log.i(TAG, "Releasing native-owned BLE audio subscription for $addr")
+            bleManager.unsubscribeCharacteristic(addr, target.serviceUuid, target.characteristicUuid)
+        }
+        transition.subscribe?.let { target ->
+            Log.i(TAG, "Claiming BLE audio subscription for native background capture on $addr")
+            bleManager.subscribeCharacteristic(addr, target.serviceUuid, target.characteristicUuid)
+        }
     }
 
     private fun mapGattServices(services: List<BluetoothGattService>): List<BleService> =

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
@@ -21,8 +21,10 @@ import android.os.Looper
 import android.os.ParcelUuid
 import android.util.Log
 import androidx.core.content.ContextCompat
+import java.util.IdentityHashMap
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Pure GATT wrapper — scanning, characteristic ops, and command queue.
@@ -83,7 +85,7 @@ class OmiBleManager private constructor(private val application: Application) {
     interface BleConnectionListener {
         fun onGattConnected(address: String, gatt: BluetoothGatt)
         fun onGattDisconnected(address: String, gattHash: Int, status: Int)
-        fun onGattServicesDiscovered(address: String, services: List<BleService>)
+        fun onGattServicesDiscovered(address: String, services: List<BleService>, sessionId: Long)
     }
 
     @Volatile
@@ -104,14 +106,22 @@ class OmiBleManager private constructor(private val application: Application) {
     val mainHandler = Handler(Looper.getMainLooper())
 
     val connectedGatts = ConcurrentHashMap<String, BluetoothGatt>()
-    private val readCompletions = ConcurrentHashMap<String, (Result<ByteArray>) -> Unit>()
-    private val writeCompletions = ConcurrentHashMap<String, (Result<Unit>) -> Unit>()
-    private val mtuCompletions = ConcurrentHashMap<String, (Int, Int) -> Unit>()
+    private val readCompletions = GattCompletionRegistry<ByteArray>()
+    private val writeCompletions = GattCompletionRegistry<Unit>()
+    private data class MtuCompletionKey(
+        val address: String,
+        val sessionId: Long,
+    )
+
+    private val mtuCompletions = ConcurrentHashMap<MtuCompletionKey, (Int, Int) -> Unit>()
+    private val nextGattSessionId = AtomicLong(1L)
+    private val gattSessionIds = IdentityHashMap<BluetoothGatt, Long>()
 
     private val servicesDiscoveredFor = ConcurrentHashMap.newKeySet<String>()
 
     private data class NotificationStateKey(
         val address: String,
+        val sessionId: Long,
         val gattIdentity: Int,
         val serviceUuid: String,
         val characteristicUuid: String,
@@ -289,7 +299,20 @@ class OmiBleManager private constructor(private val application: Application) {
         val callback = createGattCallback()
         val gatt = device.connectGatt(application, autoConnect, callback, BluetoothDevice.TRANSPORT_LE)
         if (gatt != null) {
-            connectedGatts[addr] = gatt
+            synchronized(gattSessionIds) {
+                gattSessionIds[gatt] = nextGattSessionId.getAndIncrement()
+            }
+            connectedGatts.put(addr, gatt)?.let { retiredGatt ->
+                retireGattSession(addr, retiredGatt, "replaced by a new GATT session")
+                try {
+                    retiredGatt.disconnect()
+                } catch (_: Exception) {
+                }
+                try {
+                    retiredGatt.close()
+                } catch (_: Exception) {
+                }
+            }
         } else {
             Log.e(TAG, "connectGatt returned null for $addr")
         }
@@ -303,7 +326,9 @@ class OmiBleManager private constructor(private val application: Application) {
     fun closeGatt(address: String) {
         val addr = address.uppercase()
         val gatt = connectedGatts.remove(addr)
-        cleanupPeripheral(addr)
+        if (gatt != null) {
+            cleanupPeripheral(addr, gatt, "GATT session closed")
+        }
         gatt?.close()
     }
 
@@ -365,21 +390,24 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
-        val key = "$addr:$serviceUuid:$characteristicUuid".lowercase()
-        val operationKey = characteristicOperationKey(
-            addr,
-            GattOperationKind.READ_CHARACTERISTIC,
-            serviceUuid,
-            characteristicUuid,
-        )
+        val operationKey =
+            characteristicOperationKey(gatt, GattOperationKind.READ_CHARACTERISTIC, characteristic)
+        val completionKey = characteristicCompletionKey(gatt, characteristic)
+        if (operationKey == null || completionKey == null) {
+            completion(Result.failure(Exception("GATT session is no longer active")))
+            return
+        }
+        val finish = onceGattCompletion(completion)
         enqueueGattOperation(
             key = operationKey,
             start = {
-                readCompletions[key] = completion
+                readCompletions
+                    .register(completionKey, gatt, characteristic, finish)
+                    ?.invoke(Result.failure(Exception("GATT read completion was superseded")))
                 gatt.readCharacteristic(characteristic)
             },
             onFailure = { reason ->
-                (readCompletions.remove(key) ?: completion).invoke(
+                (readCompletions.takeMatching(completionKey, gatt, characteristic) ?: finish).invoke(
                     Result.failure(Exception("GATT read failed before callback: $reason")),
                 )
             }
@@ -407,29 +435,35 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
-        val key = "$addr:$serviceUuid:$characteristicUuid".lowercase()
         val operationKey = characteristicOperationKey(
-            addr,
+            gatt,
             if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
                 GattOperationKind.WRITE_CHARACTERISTIC
             } else {
                 GattOperationKind.WRITE_WITHOUT_RESPONSE
             },
-            serviceUuid,
-            characteristicUuid,
+            characteristic,
         )
+        val completionKey = characteristicCompletionKey(gatt, characteristic)
+        if (operationKey == null || completionKey == null) {
+            completion(Result.failure(Exception("GATT session is no longer active")))
+            return
+        }
+        val finish = onceGattCompletion(completion)
         enqueueGattOperation(
             key = operationKey,
             start = {
                 if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
-                    writeCompletions[key] = completion
+                    writeCompletions
+                        .register(completionKey, gatt, characteristic, finish)
+                        ?.invoke(Result.failure(Exception("GATT write completion was superseded")))
                 }
 
                 @Suppress("deprecation")
                 val success = if (Build.VERSION.SDK_INT >= 33) {
                     val result = gatt.writeCharacteristic(characteristic, data, writeType)
                     if (result != BluetoothStatusCodes.SUCCESS) {
-                        Log.e(TAG, "writeCharacteristic returned $result for $key")
+                        Log.e(TAG, "writeCharacteristic returned $result for $completionKey")
                     }
                     result == BluetoothStatusCodes.SUCCESS
                 } else {
@@ -440,14 +474,19 @@ class OmiBleManager private constructor(private val application: Application) {
 
                 if (success && writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
                     gattOperations.complete(operationKey) {
-                        completion(Result.success(Unit))
+                        finish(Result.success(Unit))
                     }
                 }
                 success
             },
             onFailure = { reason ->
-                writeCompletions.remove(key)
-                completion(Result.failure(Exception("GATT write failed before callback: $reason")))
+                val retained =
+                    if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
+                        writeCompletions.takeMatching(completionKey, gatt, characteristic)
+                    } else {
+                        null
+                    }
+                (retained ?: finish).invoke(Result.failure(Exception("GATT write failed before callback: $reason")))
             },
         )
     }
@@ -504,7 +543,11 @@ class OmiBleManager private constructor(private val application: Application) {
             override fun run() {
                 val gatt = connectedGatts[addr]
                 if (gatt != null && rssiDiagnosticsPolicy.shouldPoll(addr, isConnected = true)) {
-                    val operationKey = GattOperationKey(addr, GattOperationKind.READ_RSSI)
+                    val operationKey = gattOperationKey(gatt, GattOperationKind.READ_RSSI)
+                    if (operationKey == null) {
+                        mainHandler.postDelayed(this, rssiDiagnosticsInterval)
+                        return
+                    }
                     if (!gattOperations.contains(operationKey)) {
                         enqueueGattOperation(
                             key = operationKey,
@@ -562,28 +605,72 @@ class OmiBleManager private constructor(private val application: Application) {
         )
     }
 
-    private fun characteristicOperationKey(
-        address: String,
+    private fun gattSessionId(gatt: BluetoothGatt): Long? =
+        synchronized(gattSessionIds) {
+            gattSessionIds[gatt]
+        }
+
+    internal fun activeGattSessionId(address: String): Long? {
+        val gatt = connectedGatts[address.uppercase()] ?: return null
+        return gattSessionId(gatt)
+    }
+
+    private fun gattOperationKey(
+        gatt: BluetoothGatt,
         kind: GattOperationKind,
-        serviceUuid: String,
-        characteristicUuid: String,
-    ) = GattOperationKey(
-        address = address,
-        kind = kind,
-        target = "${serviceUuid.lowercase()}:${characteristicUuid.lowercase()}",
-    )
+    ): GattOperationKey? {
+        val sessionId = gattSessionId(gatt) ?: return null
+        return GattOperationKey(
+            address = gatt.device.address,
+            kind = kind,
+            sessionId = sessionId,
+        )
+    }
+
+    private fun characteristicOperationKey(
+        gatt: BluetoothGatt,
+        kind: GattOperationKind,
+        characteristic: BluetoothGattCharacteristic,
+    ): GattOperationKey? {
+        val sessionId = gattSessionId(gatt) ?: return null
+        return GattOperationKey(
+            address = gatt.device.address,
+            kind = kind,
+            target =
+                "${characteristic.service.uuid}:${characteristic.uuid}:${characteristic.instanceId}".lowercase(),
+            sessionId = sessionId,
+        )
+    }
+
+    private fun characteristicCompletionKey(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+    ): GattCompletionKey? {
+        val sessionId = gattSessionId(gatt) ?: return null
+        return GattCompletionKey(
+            address = gatt.device.address,
+            sessionId = sessionId,
+            serviceUuid = characteristic.service.uuid.toString(),
+            characteristicUuid = characteristic.uuid.toString(),
+            characteristicInstanceId = characteristic.instanceId,
+        )
+    }
 
     private fun notificationStateKey(
         gatt: BluetoothGatt,
         characteristic: BluetoothGattCharacteristic,
         descriptor: BluetoothGattDescriptor?,
-    ) = NotificationStateKey(
-        address = gatt.device.address.uppercase(),
-        gattIdentity = System.identityHashCode(gatt),
-        serviceUuid = characteristic.service.uuid.toString().lowercase(),
-        characteristicUuid = characteristic.uuid.toString().lowercase(),
-        descriptorUuid = descriptor?.uuid?.toString()?.lowercase().orEmpty(),
-    )
+    ): NotificationStateKey? {
+        val sessionId = gattSessionId(gatt) ?: return null
+        return NotificationStateKey(
+            address = gatt.device.address.uppercase(),
+            sessionId = sessionId,
+            gattIdentity = System.identityHashCode(gatt),
+            serviceUuid = characteristic.service.uuid.toString().lowercase(),
+            characteristicUuid = characteristic.uuid.toString().lowercase(),
+            descriptorUuid = descriptor?.uuid?.toString()?.lowercase().orEmpty(),
+        )
+    }
 
     private fun notificationOperationKey(key: NotificationStateKey, enabled: Boolean) =
         GattOperationKey(
@@ -591,6 +678,7 @@ class OmiBleManager private constructor(private val application: Application) {
             kind = GattOperationKind.WRITE_DESCRIPTOR,
             target =
                 "${key.gattIdentity}:${key.serviceUuid}:${key.characteristicUuid}:${key.descriptorUuid}:${if (enabled) "enable" else "disable"}",
+            sessionId = key.sessionId,
         )
 
     private fun enqueueNotificationChange(
@@ -600,7 +688,7 @@ class OmiBleManager private constructor(private val application: Application) {
         descriptor: BluetoothGattDescriptor?,
         enabled: Boolean,
     ) {
-        val stateKey = notificationStateKey(gatt, characteristic, descriptor)
+        val stateKey = notificationStateKey(gatt, characteristic, descriptor) ?: return
         val state = notificationTransitions.computeIfAbsent(stateKey) { NotificationTransitionState() }
         val transition = state.request(enabled) ?: return
         startNotificationTransition(address, gatt, characteristic, descriptor, stateKey, transition)
@@ -726,7 +814,7 @@ class OmiBleManager private constructor(private val application: Application) {
     fun discoverServices(address: String) {
         val addr = address.uppercase()
         val gatt = connectedGatts[addr] ?: return
-        val operationKey = GattOperationKey(addr, GattOperationKind.DISCOVER_SERVICES)
+        val operationKey = gattOperationKey(gatt, GattOperationKind.DISCOVER_SERVICES) ?: return
         enqueueGattOperation(
             key = operationKey,
             start = { gatt.discoverServices() },
@@ -747,22 +835,35 @@ class OmiBleManager private constructor(private val application: Application) {
      * Immediate rejection falls back to the default ATT MTU; a missing callback
      * is treated as an unresponsive GATT and recovered by reconnecting.
      */
-    fun requestMtu(address: String, mtu: Int, completion: (mtu: Int, status: Int) -> Unit) {
+    fun requestMtu(
+        address: String,
+        mtu: Int,
+        expectedSessionId: Long,
+        completion: (mtu: Int, status: Int) -> Unit,
+    ) {
         val addr = address.uppercase()
         val gatt = connectedGatts[addr]
         if (gatt == null) {
             completion(23, BluetoothGatt.GATT_FAILURE)
             return
         }
-        val operationKey = GattOperationKey(addr, GattOperationKind.REQUEST_MTU)
+        val operationKey = gattOperationKey(gatt, GattOperationKind.REQUEST_MTU)
+        if (operationKey == null || operationKey.sessionId != expectedSessionId) {
+            completion(23, BluetoothGatt.GATT_FAILURE)
+            return
+        }
+        val completionKey = MtuCompletionKey(addr, expectedSessionId)
         enqueueGattOperation(
             key = operationKey,
             start = {
-                mtuCompletions[addr] = completion
+                if (!isActiveGatt(gatt) || gattSessionId(gatt) != expectedSessionId) {
+                    return@enqueueGattOperation false
+                }
+                mtuCompletions[completionKey] = completion
                 gatt.requestMtu(mtu)
             },
             onFailure = { reason ->
-                mtuCompletions.remove(addr)
+                mtuCompletions.remove(completionKey)
                 if (reason == GattOperationFailure.REJECTED || reason == GattOperationFailure.EXCEPTION) {
                     completion(23, BluetoothGatt.GATT_FAILURE)
                 }
@@ -770,8 +871,19 @@ class OmiBleManager private constructor(private val application: Application) {
         )
     }
 
-    fun cleanupPeripheral(address: String) {
+    private fun cleanupPeripheral(
+        address: String,
+        gatt: BluetoothGatt,
+        reason: String,
+    ) {
         val addr = address.uppercase()
+        if (gattSessionId(gatt) == null) return
+        if (connectedGatts[addr]?.let { it !== gatt } == true) {
+            // This session lost a race with a replacement after its callback
+            // passed isActiveGatt(). Retire only its session-owned work.
+            retireGattSession(addr, gatt, reason)
+            return
+        }
         servicesDiscoveredFor.remove(addr)
         pauseRssiDiagnostics(addr)
         bondingAddress = null
@@ -780,30 +892,57 @@ class OmiBleManager private constructor(private val application: Application) {
         bondCompletionCallback?.invoke(false)
         bondCompletionCallback = null
 
-        gattOperations.cancelAddress(addr)
+        retireGattSession(addr, gatt, reason)
+    }
+
+    private fun retireGattSession(
+        address: String,
+        gatt: BluetoothGatt,
+        reason: String,
+    ) {
+        val addr = address.uppercase()
+        val sessionId = gattSessionId(gatt) ?: return
+        gattOperations.cancelSession(addr, sessionId)
+        readCompletions.failSession(sessionId) {
+            Exception("GATT read failed because the session was retired: $reason")
+        }
+        writeCompletions.failSession(sessionId) {
+            Exception("GATT write failed because the session was retired: $reason")
+        }
+        mtuCompletions.remove(MtuCompletionKey(addr, sessionId))
         notificationTransitions.keys
-            .filter { it.address == addr }
+            .filter { it.address == addr && it.sessionId == sessionId }
             .forEach { notificationTransitions.remove(it) }
-        mtuCompletions.remove(addr)
+        synchronized(gattSessionIds) {
+            gattSessionIds.remove(gatt)
+        }
     }
 
     private fun recoverRejectedGatt(key: GattOperationKey, reason: GattOperationFailure) {
         // Rejection of discovery/CCCD setup leaves a connected-but-unusable
         // session. Reconnect instead of advertising a false ready state.
         Log.e(TAG, "Recovering unusable GATT after ${key.kind} $reason for ${key.address}")
-        recoverGatt(key.address, BluetoothGatt.GATT_FAILURE)
+        recoverGatt(key.address, key.sessionId, BluetoothGatt.GATT_FAILURE)
     }
 
     private fun recoverTimedOutGatt(key: GattOperationKey) {
         Log.e(TAG, "GATT operation timed out: ${key.kind} for ${key.address}")
-        recoverGatt(key.address, GATT_OPERATION_TIMEOUT_STATUS)
+        recoverGatt(key.address, key.sessionId, GATT_OPERATION_TIMEOUT_STATUS)
     }
 
-    private fun recoverGatt(address: String, status: Int) {
+    private fun recoverGatt(
+        address: String,
+        expectedSessionId: Long,
+        status: Int,
+    ) {
         val addr = address.uppercase()
-        val gatt = connectedGatts.remove(addr) ?: return
+        val gatt = connectedGatts[addr] ?: return
+        if (gattSessionId(gatt) != expectedSessionId || !connectedGatts.remove(addr, gatt)) {
+            Log.w(TAG, "Ignoring recovery from retired GATT session $expectedSessionId for $addr")
+            return
+        }
         val gattHash = gatt.hashCode()
-        cleanupPeripheral(addr)
+        cleanupPeripheral(addr, gatt, "GATT recovery status $status")
         try {
             gatt.disconnect()
         } catch (_: Exception) {
@@ -816,7 +955,7 @@ class OmiBleManager private constructor(private val application: Application) {
     }
 
     private fun isActiveGatt(gatt: BluetoothGatt): Boolean =
-        connectedGatts[gatt.device.address.uppercase()] === gatt
+        connectedGatts[gatt.device.address.uppercase()] === gatt && gattSessionId(gatt) != null
 
     // ── Battery history ──
 
@@ -896,7 +1035,7 @@ class OmiBleManager private constructor(private val application: Application) {
                 BluetoothProfile.STATE_DISCONNECTED -> {
                     Log.i(TAG, "Disconnected from $address (status=$status, gattHash=${gatt.hashCode()})")
                     connectedGatts.remove(address, gatt)
-                    cleanupPeripheral(address)
+                    cleanupPeripheral(address, gatt, "GATT disconnected with status $status")
                     try {
                         gatt.close()
                     } catch (_: Exception) {
@@ -916,9 +1055,10 @@ class OmiBleManager private constructor(private val application: Application) {
             } else {
                 Log.i(TAG, "MTU changed to $mtu for $address")
             }
-            val operationKey = GattOperationKey(address, GattOperationKind.REQUEST_MTU)
+            val operationKey = gattOperationKey(gatt, GattOperationKind.REQUEST_MTU) ?: return
+            val completionKey = MtuCompletionKey(address, operationKey.sessionId)
             if (!gattOperations.complete(operationKey) {
-                    mtuCompletions.remove(address)?.invoke(mtu, status)
+                    mtuCompletions.remove(completionKey)?.invoke(mtu, status)
                 }
             ) {
                 Log.w(TAG, "Ignoring MTU callback with no matching request for $address")
@@ -928,7 +1068,7 @@ class OmiBleManager private constructor(private val application: Application) {
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             val address = gatt.device.address.uppercase()
             if (!isActiveGatt(gatt)) return
-            val operationKey = GattOperationKey(address, GattOperationKind.DISCOVER_SERVICES)
+            val operationKey = gattOperationKey(gatt, GattOperationKind.DISCOVER_SERVICES) ?: return
 
             // CoreBluetooth stacks can emit duplicate callbacks, but an
             // explicit rediscovery for an already-connected GATT is valid
@@ -978,7 +1118,7 @@ class OmiBleManager private constructor(private val application: Application) {
                 return
             }
 
-            connectionListener?.onGattServicesDiscovered(address, bleServices)
+            connectionListener?.onGattServicesDiscovered(address, bleServices, operationKey.sessionId)
         }
 
         override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray) {
@@ -1006,20 +1146,13 @@ class OmiBleManager private constructor(private val application: Application) {
         }
 
         override fun onCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray, status: Int) {
-            val address = gatt.device.address.uppercase()
             if (!isActiveGatt(gatt)) return
-            val serviceUuid = characteristic.service.uuid.toString().lowercase()
-            val charUuid = characteristic.uuid.toString().lowercase()
-            val key = "$address:$serviceUuid:$charUuid".lowercase()
-            val operationKey = characteristicOperationKey(
-                address,
-                GattOperationKind.READ_CHARACTERISTIC,
-                serviceUuid,
-                charUuid,
-            )
+            val completionKey = characteristicCompletionKey(gatt, characteristic) ?: return
+            val operationKey =
+                characteristicOperationKey(gatt, GattOperationKind.READ_CHARACTERISTIC, characteristic) ?: return
 
             if (!gattOperations.complete(operationKey) {
-                    val completion = readCompletions.remove(key)
+                    val completion = readCompletions.takeMatching(completionKey, gatt, characteristic)
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         completion?.invoke(Result.success(value))
                     } else {
@@ -1027,7 +1160,7 @@ class OmiBleManager private constructor(private val application: Application) {
                     }
                 }
             ) {
-                Log.w(TAG, "Ignoring characteristic read callback with no matching operation: $key")
+                Log.w(TAG, "Ignoring characteristic read callback with no matching operation: $completionKey")
             }
         }
 
@@ -1038,27 +1171,20 @@ class OmiBleManager private constructor(private val application: Application) {
         }
 
         override fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
-            val address = gatt.device.address.uppercase()
             if (!isActiveGatt(gatt)) return
-            val serviceUuid = characteristic.service.uuid.toString().lowercase()
-            val charUuid = characteristic.uuid.toString().lowercase()
-            val key = "$address:$serviceUuid:$charUuid".lowercase()
+            val completionKey = characteristicCompletionKey(gatt, characteristic) ?: return
             if (preferredWriteType(characteristic) == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
                 // Some Android stacks emit this optional callback after the
                 // accepted WNR operation was completed synchronously. Never
                 // let it release a later operation for the same target.
-                Log.d(TAG, "Ignoring optional write-without-response callback: $key")
+                Log.d(TAG, "Ignoring optional write-without-response callback: $completionKey")
                 return
             }
-            val operationKey = characteristicOperationKey(
-                address,
-                GattOperationKind.WRITE_CHARACTERISTIC,
-                serviceUuid,
-                charUuid,
-            )
+            val operationKey =
+                characteristicOperationKey(gatt, GattOperationKind.WRITE_CHARACTERISTIC, characteristic) ?: return
 
             if (!gattOperations.complete(operationKey) {
-                    val completion = writeCompletions.remove(key)
+                    val completion = writeCompletions.takeMatching(completionKey, gatt, characteristic)
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         completion?.invoke(Result.success(Unit))
                     } else {
@@ -1066,7 +1192,7 @@ class OmiBleManager private constructor(private val application: Application) {
                     }
                 }
             ) {
-                Log.d(TAG, "Ignoring characteristic write callback with no matching operation: $key")
+                Log.d(TAG, "Ignoring characteristic write callback with no matching operation: $completionKey")
             }
         }
 
@@ -1075,7 +1201,7 @@ class OmiBleManager private constructor(private val application: Application) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Descriptor write failed (status=$status) for ${descriptor.characteristic.uuid}")
             }
-            val stateKey = notificationStateKey(gatt, descriptor.characteristic, descriptor)
+            val stateKey = notificationStateKey(gatt, descriptor.characteristic, descriptor) ?: return
             val enabled = notificationTransitions[stateKey]?.currentInFlight()
             if (enabled == null) {
                 Log.w(TAG, "Ignoring descriptor callback with no notification transition for ${descriptor.uuid}")
@@ -1119,7 +1245,7 @@ class OmiBleManager private constructor(private val application: Application) {
         override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
             if (!isActiveGatt(gatt)) return
             val address = gatt.device.address.uppercase()
-            val operationKey = GattOperationKey(address, GattOperationKind.READ_RSSI)
+            val operationKey = gattOperationKey(gatt, GattOperationKind.READ_RSSI) ?: return
             if (!gattOperations.complete(operationKey)) {
                 Log.d(TAG, "Ignoring RSSI callback with no matching operation for $address")
                 return

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
@@ -23,7 +23,6 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * Pure GATT wrapper — scanning, characteristic ops, and command queue.
@@ -38,6 +37,8 @@ class OmiBleManager private constructor(private val application: Application) {
         private const val TAG = "OmiBle"
         private const val RSSI_HISTORY_LIMIT = 10
         private const val BOND_TIMEOUT_MS = 15000L // 15s — bond request timeout
+        private const val GATT_OPERATION_TIMEOUT_MS = 30_000L
+        private const val GATT_OPERATION_TIMEOUT_STATUS = -2
         private const val PREFS_BATTERY = "battery_history"
         private const val MAX_BATTERY_HISTORY = 2000
         private const val BATTERY_RETENTION_MS = 7L * 24 * 3600 * 1000
@@ -83,7 +84,6 @@ class OmiBleManager private constructor(private val application: Application) {
         fun onGattConnected(address: String, gatt: BluetoothGatt)
         fun onGattDisconnected(address: String, gattHash: Int, status: Int)
         fun onGattServicesDiscovered(address: String, services: List<BleService>)
-        fun onMtuChanged(address: String, mtu: Int, status: Int)
     }
 
     @Volatile
@@ -106,21 +106,38 @@ class OmiBleManager private constructor(private val application: Application) {
     val connectedGatts = ConcurrentHashMap<String, BluetoothGatt>()
     private val readCompletions = ConcurrentHashMap<String, (Result<ByteArray>) -> Unit>()
     private val writeCompletions = ConcurrentHashMap<String, (Result<Unit>) -> Unit>()
+    private val mtuCompletions = ConcurrentHashMap<String, (Int, Int) -> Unit>()
 
     private val servicesDiscoveredFor = ConcurrentHashMap.newKeySet<String>()
+
+    private data class NotificationStateKey(
+        val address: String,
+        val gattIdentity: Int,
+        val serviceUuid: String,
+        val characteristicUuid: String,
+        val descriptorUuid: String,
+    )
+
+    private val notificationTransitions = ConcurrentHashMap<NotificationStateKey, NotificationTransitionState>()
 
     private var isScanning = false
     private var scanCallback: ScanCallback? = null
     private var scanTimeoutRunnable: Runnable? = null
 
-    private val gattQueue: ConcurrentLinkedQueue<Runnable> = ConcurrentLinkedQueue()
-    @Volatile
-    private var isProcessingCommand = false
+    private val gattOperations = GattOperationQueue(
+        dispatch = { command -> mainHandler.post(command) },
+        schedule = { delayMillis, task ->
+            val runnable = Runnable(task)
+            mainHandler.postDelayed(runnable, delayMillis)
+            val cancel: () -> Unit = { mainHandler.removeCallbacks(runnable) }
+            cancel
+        },
+        timeoutMillis = GATT_OPERATION_TIMEOUT_MS,
+    )
 
-    private var rssiKeepAliveRunnable: Runnable? = null
-    private val rssiKeepAliveInterval = 3000L // ms
-    @Volatile
-    var isRssiStreamingEnabled = false
+    private val rssiDiagnosticsPolicy = RssiDiagnosticsPolicy()
+    private var rssiDiagnosticsRunnable: Runnable? = null
+    private val rssiDiagnosticsInterval = 3000L // ms
 
     /// Most recent RSSI per device (uppercase MAC). Used by the foreground service
     /// to annotate disconnect events so we can tell range-driven drops from healthy-signal drops.
@@ -285,9 +302,9 @@ class OmiBleManager private constructor(private val application: Application) {
 
     fun closeGatt(address: String) {
         val addr = address.uppercase()
+        val gatt = connectedGatts.remove(addr)
         cleanupPeripheral(addr)
-        connectedGatts[addr]?.close()
-        connectedGatts.remove(addr)
+        gatt?.close()
     }
 
     fun isPeripheralConnected(address: String): Boolean {
@@ -349,15 +366,24 @@ class OmiBleManager private constructor(private val application: Application) {
         }
 
         val key = "$addr:$serviceUuid:$characteristicUuid".lowercase()
-        readCompletions[key] = completion
-
-        enqueueCommand {
-            if (!gatt.readCharacteristic(characteristic)) {
-                Log.e(TAG, "readCharacteristic returned false for $key")
-                readCompletions.remove(key)?.invoke(Result.failure(Exception("Read request rejected")))
-                completeCommand()
+        val operationKey = characteristicOperationKey(
+            addr,
+            GattOperationKind.READ_CHARACTERISTIC,
+            serviceUuid,
+            characteristicUuid,
+        )
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                readCompletions[key] = completion
+                gatt.readCharacteristic(characteristic)
+            },
+            onFailure = { reason ->
+                (readCompletions.remove(key) ?: completion).invoke(
+                    Result.failure(Exception("GATT read failed before callback: $reason")),
+                )
             }
-        }
+        )
     }
 
     fun writeCharacteristic(
@@ -375,42 +401,55 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
-        val writeType = if (characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0) {
-            BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-        } else {
-            BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+        val writeType = preferredWriteType(characteristic)
+        if (writeType == null) {
+            completion(Result.failure(Exception("Characteristic is not writable")))
+            return
         }
 
         val key = "$addr:$serviceUuid:$characteristicUuid".lowercase()
-        if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
-            writeCompletions[key] = completion
-        }
-
-        enqueueCommand {
-            @Suppress("deprecation")
-            val success = if (Build.VERSION.SDK_INT >= 33) {
-                val result = gatt.writeCharacteristic(characteristic, data, writeType)
-                if (result != BluetoothStatusCodes.SUCCESS) {
-                    Log.e(TAG, "writeCharacteristic returned $result for $key")
-                }
-                result == BluetoothStatusCodes.SUCCESS
+        val operationKey = characteristicOperationKey(
+            addr,
+            if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
+                GattOperationKind.WRITE_CHARACTERISTIC
             } else {
-                characteristic.value = data
-                characteristic.writeType = writeType
-                gatt.writeCharacteristic(characteristic)
-            }
-            if (!success) {
-                Log.e(TAG, "writeCharacteristic failed for $key")
-                writeCompletions.remove(key)?.invoke(Result.failure(Exception("Write request rejected")))
-                completeCommand()
-            } else if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-                completeCommand()
-            }
-        }
+                GattOperationKind.WRITE_WITHOUT_RESPONSE
+            },
+            serviceUuid,
+            characteristicUuid,
+        )
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
+                    writeCompletions[key] = completion
+                }
 
-        if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-            completion(Result.success(Unit))
-        }
+                @Suppress("deprecation")
+                val success = if (Build.VERSION.SDK_INT >= 33) {
+                    val result = gatt.writeCharacteristic(characteristic, data, writeType)
+                    if (result != BluetoothStatusCodes.SUCCESS) {
+                        Log.e(TAG, "writeCharacteristic returned $result for $key")
+                    }
+                    result == BluetoothStatusCodes.SUCCESS
+                } else {
+                    characteristic.value = data
+                    characteristic.writeType = writeType
+                    gatt.writeCharacteristic(characteristic)
+                }
+
+                if (success && writeType == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
+                    gattOperations.complete(operationKey) {
+                        completion(Result.success(Unit))
+                    }
+                }
+                success
+            },
+            onFailure = { reason ->
+                writeCompletions.remove(key)
+                completion(Result.failure(Exception("GATT write failed before callback: $reason")))
+            },
+        )
     }
 
     fun subscribeCharacteristic(address: String, serviceUuid: String, characteristicUuid: String) {
@@ -419,14 +458,13 @@ class OmiBleManager private constructor(private val application: Application) {
         val characteristic = findCharacteristic(gatt, serviceUuid, characteristicUuid) ?: return
 
         val descriptor = characteristic.getDescriptor(CCCD_UUID)
-        enqueueCommand {
-            gatt.setCharacteristicNotification(characteristic, true)
-            if (descriptor != null) {
-                writeDescriptorCompat(gatt, descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
-            } else {
-                completeCommand()
-            }
-        }
+        enqueueNotificationChange(
+            addr,
+            gatt,
+            characteristic,
+            descriptor,
+            enabled = true,
+        )
     }
 
     fun unsubscribeCharacteristic(address: String, serviceUuid: String, characteristicUuid: String) {
@@ -435,33 +473,61 @@ class OmiBleManager private constructor(private val application: Application) {
         val characteristic = findCharacteristic(gatt, serviceUuid, characteristicUuid) ?: return
 
         val descriptor = characteristic.getDescriptor(CCCD_UUID)
-        enqueueCommand {
-            gatt.setCharacteristicNotification(characteristic, false)
-            if (descriptor != null) {
-                writeDescriptorCompat(gatt, descriptor, BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
-            } else {
-                completeCommand()
-            }
+        enqueueNotificationChange(
+            addr,
+            gatt,
+            characteristic,
+            descriptor,
+            enabled = false,
+        )
+    }
+
+    // ── RSSI diagnostics ──
+
+    fun startRssiStreaming(address: String) {
+        val addr = address.uppercase()
+        rssiDiagnosticsPolicy.subscribe(addr)
+        resumeRssiDiagnostics(addr)
+    }
+
+    fun stopRssiStreaming(address: String) {
+        if (rssiDiagnosticsPolicy.unsubscribe(address)) {
+            pauseRssiDiagnostics()
         }
     }
 
-    // ── RSSI keep-alive ──
-
-    fun startRssiKeepAlive(address: String) {
-        stopRssiKeepAlive()
+    fun resumeRssiDiagnostics(address: String) {
+        val addr = address.uppercase()
+        if (!rssiDiagnosticsPolicy.shouldPoll(addr, connectedGatts.containsKey(addr))) return
+        pauseRssiDiagnostics()
         val runnable = object : Runnable {
             override fun run() {
-                connectedGatts[address]?.readRemoteRssi()
-                mainHandler.postDelayed(this, rssiKeepAliveInterval)
+                val gatt = connectedGatts[addr]
+                if (gatt != null && rssiDiagnosticsPolicy.shouldPoll(addr, isConnected = true)) {
+                    val operationKey = GattOperationKey(addr, GattOperationKind.READ_RSSI)
+                    if (!gattOperations.contains(operationKey)) {
+                        enqueueGattOperation(
+                            key = operationKey,
+                            start = { gatt.readRemoteRssi() },
+                            onFailure = { reason ->
+                                Log.w(TAG, "RSSI read was not completed for $addr: $reason")
+                            },
+                        )
+                    }
+                }
+                if (rssiDiagnosticsPolicy.shouldPoll(addr, connectedGatts.containsKey(addr))) {
+                    mainHandler.postDelayed(this, rssiDiagnosticsInterval)
+                }
             }
         }
-        rssiKeepAliveRunnable = runnable
-        mainHandler.postDelayed(runnable, rssiKeepAliveInterval)
+        rssiDiagnosticsRunnable = runnable
+        mainHandler.postDelayed(runnable, rssiDiagnosticsInterval)
     }
 
-    fun stopRssiKeepAlive() {
-        rssiKeepAliveRunnable?.let { mainHandler.removeCallbacks(it) }
-        rssiKeepAliveRunnable = null
+    fun pauseRssiDiagnostics(address: String? = null) {
+        if (address != null && !rssiDiagnosticsPolicy.isSubscribed(address)) return
+        rssiDiagnosticsRunnable?.let { mainHandler.removeCallbacks(it) }
+        rssiDiagnosticsRunnable = null
     }
 
     // ── State & utility ──
@@ -477,32 +543,144 @@ class OmiBleManager private constructor(private val application: Application) {
         }
     }
 
-    // ── Command queue ──
+    // ── Serialized GATT operations ──
 
-    @Synchronized
-    fun enqueueCommand(command: Runnable) {
-        gattQueue.add(command)
-        processNextCommand()
+    private fun enqueueGattOperation(
+        key: GattOperationKey,
+        start: () -> Boolean,
+        onFailure: (GattOperationFailure) -> Unit = {},
+    ) {
+        gattOperations.enqueue(
+            key = key,
+            start = start,
+            onFailure = { reason ->
+                onFailure(reason)
+                if (reason == GattOperationFailure.TIMED_OUT && shouldRecoverAfterGattTimeout(key.kind)) {
+                    recoverTimedOutGatt(key)
+                }
+            },
+        )
     }
 
-    @Synchronized
-    private fun processNextCommand() {
-        if (isProcessingCommand) return
-        val cmd = gattQueue.peek() ?: return
-        isProcessingCommand = true
-        try {
-            mainHandler.post(cmd)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error posting command: ${e.message}")
-            completeCommand()
-        }
+    private fun characteristicOperationKey(
+        address: String,
+        kind: GattOperationKind,
+        serviceUuid: String,
+        characteristicUuid: String,
+    ) = GattOperationKey(
+        address = address,
+        kind = kind,
+        target = "${serviceUuid.lowercase()}:${characteristicUuid.lowercase()}",
+    )
+
+    private fun notificationStateKey(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+    ) = NotificationStateKey(
+        address = gatt.device.address.uppercase(),
+        gattIdentity = System.identityHashCode(gatt),
+        serviceUuid = characteristic.service.uuid.toString().lowercase(),
+        characteristicUuid = characteristic.uuid.toString().lowercase(),
+        descriptorUuid = descriptor?.uuid?.toString()?.lowercase().orEmpty(),
+    )
+
+    private fun notificationOperationKey(key: NotificationStateKey, enabled: Boolean) =
+        GattOperationKey(
+            address = key.address,
+            kind = GattOperationKind.WRITE_DESCRIPTOR,
+            target =
+                "${key.gattIdentity}:${key.serviceUuid}:${key.characteristicUuid}:${key.descriptorUuid}:${if (enabled) "enable" else "disable"}",
+        )
+
+    private fun enqueueNotificationChange(
+        address: String,
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+        enabled: Boolean,
+    ) {
+        val stateKey = notificationStateKey(gatt, characteristic, descriptor)
+        val state = notificationTransitions.computeIfAbsent(stateKey) { NotificationTransitionState() }
+        val transition = state.request(enabled) ?: return
+        startNotificationTransition(address, gatt, characteristic, descriptor, stateKey, transition)
     }
 
-    @Synchronized
-    fun completeCommand() {
-        gattQueue.poll()
-        isProcessingCommand = false
-        processNextCommand()
+    private fun startNotificationTransition(
+        address: String,
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+        stateKey: NotificationStateKey,
+        enabled: Boolean,
+    ) {
+        val operationKey = notificationOperationKey(stateKey, enabled)
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                if (!gatt.setCharacteristicNotification(characteristic, enabled)) {
+                    return@enqueueGattOperation false
+                }
+                if (descriptor == null) {
+                    gattOperations.complete(operationKey) {
+                        finishNotificationTransition(
+                            address,
+                            gatt,
+                            characteristic,
+                            descriptor,
+                            stateKey,
+                            enabled,
+                            success = true,
+                        )
+                    }
+                    true
+                } else {
+                    writeDescriptorCompat(
+                        gatt,
+                        descriptor,
+                        if (enabled) {
+                            BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                        } else {
+                            BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+                        },
+                    )
+                }
+            },
+            onFailure = { reason ->
+                finishNotificationTransition(
+                    address,
+                    gatt,
+                    characteristic,
+                    descriptor,
+                    stateKey,
+                    enabled,
+                    success = false,
+                )
+                Log.e(
+                    TAG,
+                    "Notification ${if (enabled) "enable" else "disable"} failed for ${characteristic.uuid}: $reason",
+                )
+                if (
+                    reason == GattOperationFailure.REJECTED ||
+                    reason == GattOperationFailure.EXCEPTION
+                ) {
+                    recoverRejectedGatt(operationKey, reason)
+                }
+            },
+        )
+    }
+
+    private fun finishNotificationTransition(
+        address: String,
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        descriptor: BluetoothGattDescriptor?,
+        stateKey: NotificationStateKey,
+        attempted: Boolean,
+        success: Boolean,
+    ) {
+        val next = notificationTransitions[stateKey]?.complete(attempted, success) ?: return
+        startNotificationTransition(address, gatt, characteristic, descriptor, stateKey, next)
     }
 
     private fun findCharacteristic(gatt: BluetoothGatt?, serviceUuid: String, characteristicUuid: String): BluetoothGattCharacteristic? {
@@ -510,40 +688,135 @@ class OmiBleManager private constructor(private val application: Application) {
         return service.getCharacteristic(UUID.fromString(characteristicUuid))
     }
 
+    /**
+     * A write-with-response property wins when a characteristic advertises
+     * both modes. Its callback gives the queue an actual delivery boundary;
+     * write-without-response is reserved for characteristics with no safer
+     * option.
+     */
+    private fun preferredWriteType(characteristic: BluetoothGattCharacteristic): Int? =
+        when (
+            preferredGattWriteMode(
+                supportsWrite =
+                    characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE != 0,
+                supportsWriteWithoutResponse =
+                    characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0,
+            )
+        ) {
+            GattWriteMode.WITH_RESPONSE ->
+                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+            GattWriteMode.WITHOUT_RESPONSE ->
+                BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+            null -> null
+        }
+
     @Suppress("deprecation")
-    private fun writeDescriptorCompat(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, value: ByteArray) {
-        val success = if (Build.VERSION.SDK_INT >= 33) {
+    private fun writeDescriptorCompat(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        value: ByteArray,
+    ): Boolean =
+        if (Build.VERSION.SDK_INT >= 33) {
             gatt.writeDescriptor(descriptor, value) == BluetoothStatusCodes.SUCCESS
         } else {
             descriptor.value = value
             gatt.writeDescriptor(descriptor)
         }
-        if (!success) {
-            Log.e(TAG, "writeDescriptor failed for ${descriptor.uuid}")
-            completeCommand()
+
+    fun discoverServices(address: String) {
+        val addr = address.uppercase()
+        val gatt = connectedGatts[addr] ?: return
+        val operationKey = GattOperationKey(addr, GattOperationKind.DISCOVER_SERVICES)
+        enqueueGattOperation(
+            key = operationKey,
+            start = { gatt.discoverServices() },
+            onFailure = { reason ->
+                Log.e(TAG, "Service discovery did not start/finish for $addr: $reason")
+                if (
+                    reason == GattOperationFailure.REJECTED ||
+                    reason == GattOperationFailure.EXCEPTION
+                ) {
+                    recoverRejectedGatt(operationKey, reason)
+                }
+            },
+        )
+    }
+
+    /**
+     * Requests MTU without replacing the process-wide connection listener.
+     * Immediate rejection falls back to the default ATT MTU; a missing callback
+     * is treated as an unresponsive GATT and recovered by reconnecting.
+     */
+    fun requestMtu(address: String, mtu: Int, completion: (mtu: Int, status: Int) -> Unit) {
+        val addr = address.uppercase()
+        val gatt = connectedGatts[addr]
+        if (gatt == null) {
+            completion(23, BluetoothGatt.GATT_FAILURE)
+            return
         }
+        val operationKey = GattOperationKey(addr, GattOperationKind.REQUEST_MTU)
+        enqueueGattOperation(
+            key = operationKey,
+            start = {
+                mtuCompletions[addr] = completion
+                gatt.requestMtu(mtu)
+            },
+            onFailure = { reason ->
+                mtuCompletions.remove(addr)
+                if (reason == GattOperationFailure.REJECTED || reason == GattOperationFailure.EXCEPTION) {
+                    completion(23, BluetoothGatt.GATT_FAILURE)
+                }
+            },
+        )
     }
 
     fun cleanupPeripheral(address: String) {
         val addr = address.uppercase()
         servicesDiscoveredFor.remove(addr)
-        stopRssiKeepAlive()
+        pauseRssiDiagnostics(addr)
         bondingAddress = null
         bondTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
         bondTimeoutRunnable = null
         bondCompletionCallback?.invoke(false)
         bondCompletionCallback = null
 
-        for (key in readCompletions.keys().toList().filter { it.startsWith(addr.lowercase()) }) {
-            readCompletions.remove(key)?.invoke(Result.failure(Exception("Peripheral disconnected")))
-        }
-        for (key in writeCompletions.keys().toList().filter { it.startsWith(addr.lowercase()) }) {
-            writeCompletions.remove(key)?.invoke(Result.failure(Exception("Peripheral disconnected")))
-        }
-
-        gattQueue.clear()
-        isProcessingCommand = false
+        gattOperations.cancelAddress(addr)
+        notificationTransitions.keys
+            .filter { it.address == addr }
+            .forEach { notificationTransitions.remove(it) }
+        mtuCompletions.remove(addr)
     }
+
+    private fun recoverRejectedGatt(key: GattOperationKey, reason: GattOperationFailure) {
+        // Rejection of discovery/CCCD setup leaves a connected-but-unusable
+        // session. Reconnect instead of advertising a false ready state.
+        Log.e(TAG, "Recovering unusable GATT after ${key.kind} $reason for ${key.address}")
+        recoverGatt(key.address, BluetoothGatt.GATT_FAILURE)
+    }
+
+    private fun recoverTimedOutGatt(key: GattOperationKey) {
+        Log.e(TAG, "GATT operation timed out: ${key.kind} for ${key.address}")
+        recoverGatt(key.address, GATT_OPERATION_TIMEOUT_STATUS)
+    }
+
+    private fun recoverGatt(address: String, status: Int) {
+        val addr = address.uppercase()
+        val gatt = connectedGatts.remove(addr) ?: return
+        val gattHash = gatt.hashCode()
+        cleanupPeripheral(addr)
+        try {
+            gatt.disconnect()
+        } catch (_: Exception) {
+        }
+        try {
+            gatt.close()
+        } catch (_: Exception) {
+        }
+        connectionListener?.onGattDisconnected(addr, gattHash, status)
+    }
+
+    private fun isActiveGatt(gatt: BluetoothGatt): Boolean =
+        connectedGatts[gatt.device.address.uppercase()] === gatt
 
     // ── Battery history ──
 
@@ -601,25 +874,33 @@ class OmiBleManager private constructor(private val application: Application) {
             val address = gatt.device.address.uppercase()
             Log.i(TAG, "onConnectionStateChange: address=$address, status=$status, newState=$newState")
 
+            if (!isActiveGatt(gatt)) {
+                Log.w(TAG, "Ignoring callback from retired GATT for $address (${gatt.hashCode()})")
+                if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    try {
+                        gatt.close()
+                    } catch (_: Exception) {
+                    }
+                }
+                return
+            }
+
             when (newState) {
                 BluetoothProfile.STATE_CONNECTED -> {
                     Log.i(TAG, "Connected to $address, discovering services")
-                    connectedGatts[address] = gatt
-
-                    // Discover services
-                    enqueueCommand {
-                        if (!gatt.discoverServices()) {
-                            Log.e(TAG, "discoverServices returned false for $address")
-                            completeCommand()
-                        }
-                    }
+                    discoverServices(address)
 
                     // Notify the connection owner
                     connectionListener?.onGattConnected(address, gatt)
                 }
                 BluetoothProfile.STATE_DISCONNECTED -> {
                     Log.i(TAG, "Disconnected from $address (status=$status, gattHash=${gatt.hashCode()})")
+                    connectedGatts.remove(address, gatt)
                     cleanupPeripheral(address)
+                    try {
+                        gatt.close()
+                    } catch (_: Exception) {
+                    }
 
                     // Notify the connection owner with GATT hash for stale callback rejection
                     connectionListener?.onGattDisconnected(address, gatt.hashCode(), status)
@@ -629,23 +910,31 @@ class OmiBleManager private constructor(private val application: Application) {
 
         override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "MTU request failed for $address (status=$status)")
             } else {
                 Log.i(TAG, "MTU changed to $mtu for $address")
             }
-            completeCommand()
-
-            // Notify connection owner so it can fire onDeviceReady
-            connectionListener?.onMtuChanged(address, mtu, status)
+            val operationKey = GattOperationKey(address, GattOperationKind.REQUEST_MTU)
+            if (!gattOperations.complete(operationKey) {
+                    mtuCompletions.remove(address)?.invoke(mtu, status)
+                }
+            ) {
+                Log.w(TAG, "Ignoring MTU callback with no matching request for $address")
+            }
         }
 
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
+            val operationKey = GattOperationKey(address, GattOperationKind.DISCOVER_SERVICES)
 
-            if (servicesDiscoveredFor.contains(address)) {
+            // CoreBluetooth stacks can emit duplicate callbacks, but an
+            // explicit rediscovery for an already-connected GATT is valid
+            // (the foreground service uses it when Flutter reattaches).
+            if (servicesDiscoveredFor.contains(address) && !gattOperations.isActive(operationKey)) {
                 Log.i(TAG, "Ignoring duplicate onServicesDiscovered for $address")
-                completeCommand()
                 return
             }
 
@@ -653,12 +942,22 @@ class OmiBleManager private constructor(private val application: Application) {
 
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Service discovery failed for $address (status=$status)")
-                completeCommand()
+                if (!gattOperations.complete(operationKey) {
+                        recoverRejectedGatt(operationKey, GattOperationFailure.REJECTED)
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring failed service callback with no matching discovery for $address")
+                }
                 return
             }
 
             val services = gatt.services ?: run {
-                completeCommand()
+                if (!gattOperations.complete(operationKey) {
+                        recoverRejectedGatt(operationKey, GattOperationFailure.REJECTED)
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring empty service callback with no matching discovery for $address")
+                }
                 return
             }
             val bleServices = services.map { svc ->
@@ -668,18 +967,22 @@ class OmiBleManager private constructor(private val application: Application) {
                 )
             }
 
-            servicesDiscoveredFor.add(address)
-
-            if (!gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)) {
-                Log.w(TAG, "Failed to request high connection priority")
+            if (!gattOperations.complete(operationKey) {
+                    servicesDiscoveredFor.add(address)
+                    if (!gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)) {
+                        Log.w(TAG, "Failed to request high connection priority")
+                    }
+                }
+            ) {
+                Log.w(TAG, "Ignoring service callback with no matching discovery for $address")
+                return
             }
-
-            completeCommand()
 
             connectionListener?.onGattServicesDiscovered(address, bleServices)
         }
 
         override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray) {
+            if (!isActiveGatt(gatt)) return
             val address = gatt.device.address.uppercase()
             val serviceUuid = characteristic.service.uuid.toString().lowercase()
             val charUuid = characteristic.uuid.toString().lowercase()
@@ -704,18 +1007,28 @@ class OmiBleManager private constructor(private val application: Application) {
 
         override fun onCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
             val serviceUuid = characteristic.service.uuid.toString().lowercase()
             val charUuid = characteristic.uuid.toString().lowercase()
             val key = "$address:$serviceUuid:$charUuid".lowercase()
+            val operationKey = characteristicOperationKey(
+                address,
+                GattOperationKind.READ_CHARACTERISTIC,
+                serviceUuid,
+                charUuid,
+            )
 
-            val completion = readCompletions.remove(key)
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                completion?.invoke(Result.success(value))
-            } else {
-                completion?.invoke(Result.failure(Exception("Read failed with status $status")))
+            if (!gattOperations.complete(operationKey) {
+                    val completion = readCompletions.remove(key)
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        completion?.invoke(Result.success(value))
+                    } else {
+                        completion?.invoke(Result.failure(Exception("Read failed with status $status")))
+                    }
+                }
+            ) {
+                Log.w(TAG, "Ignoring characteristic read callback with no matching operation: $key")
             }
-
-            completeCommand()
         }
 
         // Deprecated overload called on Android < 13 (API < 33)
@@ -726,40 +1039,102 @@ class OmiBleManager private constructor(private val application: Application) {
 
         override fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
             val address = gatt.device.address.uppercase()
+            if (!isActiveGatt(gatt)) return
             val serviceUuid = characteristic.service.uuid.toString().lowercase()
             val charUuid = characteristic.uuid.toString().lowercase()
             val key = "$address:$serviceUuid:$charUuid".lowercase()
-
-            val completion = writeCompletions.remove(key)
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                completion?.invoke(Result.success(Unit))
-            } else {
-                completion?.invoke(Result.failure(Exception("Write failed with status $status")))
+            if (preferredWriteType(characteristic) == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
+                // Some Android stacks emit this optional callback after the
+                // accepted WNR operation was completed synchronously. Never
+                // let it release a later operation for the same target.
+                Log.d(TAG, "Ignoring optional write-without-response callback: $key")
+                return
             }
+            val operationKey = characteristicOperationKey(
+                address,
+                GattOperationKind.WRITE_CHARACTERISTIC,
+                serviceUuid,
+                charUuid,
+            )
 
-            completeCommand()
+            if (!gattOperations.complete(operationKey) {
+                    val completion = writeCompletions.remove(key)
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        completion?.invoke(Result.success(Unit))
+                    } else {
+                        completion?.invoke(Result.failure(Exception("Write failed with status $status")))
+                    }
+                }
+            ) {
+                Log.d(TAG, "Ignoring characteristic write callback with no matching operation: $key")
+            }
         }
 
         override fun onDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+            if (!isActiveGatt(gatt)) return
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Descriptor write failed (status=$status) for ${descriptor.characteristic.uuid}")
             }
-            completeCommand()
+            val stateKey = notificationStateKey(gatt, descriptor.characteristic, descriptor)
+            val enabled = notificationTransitions[stateKey]?.currentInFlight()
+            if (enabled == null) {
+                Log.w(TAG, "Ignoring descriptor callback with no notification transition for ${descriptor.uuid}")
+                return
+            }
+            val operationKey = notificationOperationKey(stateKey, enabled)
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                if (!gattOperations.complete(operationKey) {
+                        finishNotificationTransition(
+                            gatt.device.address,
+                            gatt,
+                            descriptor.characteristic,
+                            descriptor,
+                            stateKey,
+                            enabled,
+                            success = true,
+                        )
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring descriptor callback with no matching operation for ${descriptor.uuid}")
+                }
+            } else {
+                if (!gattOperations.complete(operationKey) {
+                        finishNotificationTransition(
+                            gatt.device.address,
+                            gatt,
+                            descriptor.characteristic,
+                            descriptor,
+                            stateKey,
+                            enabled,
+                            success = false,
+                        )
+                        recoverRejectedGatt(operationKey, GattOperationFailure.REJECTED)
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring failed descriptor callback with no matching operation for ${descriptor.uuid}")
+                }
+            }
         }
 
         override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
+            if (!isActiveGatt(gatt)) return
+            val address = gatt.device.address.uppercase()
+            val operationKey = GattOperationKey(address, GattOperationKind.READ_RSSI)
+            if (!gattOperations.complete(operationKey)) {
+                Log.d(TAG, "Ignoring RSSI callback with no matching operation for $address")
+                return
+            }
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.w(TAG, "RSSI read failed: status=$status for ${gatt.device.address}")
                 return
             }
-            val address = gatt.device.address.uppercase()
             lastRssi[address] = rssi
             val deque = rssiHistory.getOrPut(address) { java.util.ArrayDeque() }
             synchronized(deque) {
                 deque.addLast(Pair(System.currentTimeMillis(), rssi))
                 while (deque.size > RSSI_HISTORY_LIMIT) deque.removeFirst()
             }
-            if (isRssiStreamingEnabled) {
+            if (rssiDiagnosticsPolicy.isSubscribed(address)) {
                 mainHandler.post {
                     flutterApi?.onRssiUpdate(address, rssi.toLong()) {}
                 }

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicy.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicy.kt
@@ -1,0 +1,32 @@
+package com.friend.ios.ble
+
+/**
+ * Keeps RSSI polling scoped to the one diagnostics view that requested it.
+ *
+ * A disconnect pauses polling without losing the subscription, so a reconnect
+ * can resume diagnostics without turning RSSI reads into connection keep-alives.
+ */
+internal class RssiDiagnosticsPolicy {
+    @Volatile
+    private var subscribedAddress: String? = null
+
+    fun subscribe(address: String) {
+        subscribedAddress = address.uppercase()
+    }
+
+    fun unsubscribe(address: String): Boolean {
+        val normalized = address.uppercase()
+        if (subscribedAddress != normalized) return false
+        subscribedAddress = null
+        return true
+    }
+
+    fun shouldPoll(address: String, isConnected: Boolean): Boolean =
+        isConnected && subscribedAddress == address.uppercase()
+
+    fun isSubscribed(address: String): Boolean =
+        subscribedAddress == address.uppercase()
+}
+
+internal fun shouldRecoverAfterGattTimeout(kind: GattOperationKind): Boolean =
+    kind != GattOperationKind.READ_RSSI

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedger.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedger.kt
@@ -1,0 +1,66 @@
+package com.friend.ios.limitless
+
+/**
+ * Orders a Limitless flash drain and exposes only its contiguous, appended
+ * prefix as ACK-eligible.
+ *
+ * The pendant's ACK is cumulative: ACKing page N deletes every page through N.
+ * A later page must therefore never move the watermark across a missing page.
+ */
+internal class ContiguousFlashPageLedger(
+    oldestPageIndex: Int,
+    val newestPageIndex: Int,
+    private val appendPage: (LimitlessProtocol.FlashPage) -> Boolean,
+) {
+    enum class OfferResult {
+        NO_PROGRESS,
+        PROGRESSED,
+        APPEND_FAILED,
+        BUFFER_LIMIT_REACHED,
+    }
+
+    companion object {
+        private const val MAX_PENDING_PAGES = 64
+    }
+
+    private val pendingPages = mutableMapOf<Int, LimitlessProtocol.FlashPage>()
+    private var nextPageIndex = oldestPageIndex
+
+    var lastAppendedPageIndex: Int = oldestPageIndex - 1
+        private set
+
+    var pagesSinceAck: Int = 0
+        private set
+
+    val isComplete: Boolean
+        get() = nextPageIndex > newestPageIndex
+
+    internal val pendingPageCount: Int
+        get() = pendingPages.size
+
+    fun offer(page: LimitlessProtocol.FlashPage): OfferResult {
+        val index = page.index ?: return OfferResult.NO_PROGRESS
+        if (index < nextPageIndex || index > newestPageIndex) return OfferResult.NO_PROGRESS
+
+        pendingPages.putIfAbsent(index, page)
+        if (pendingPages.size > MAX_PENDING_PAGES) return OfferResult.BUFFER_LIMIT_REACHED
+
+        var progressed = false
+        while (true) {
+            val nextPage = pendingPages[nextPageIndex] ?: break
+            if (!appendPage(nextPage)) return OfferResult.APPEND_FAILED
+
+            pendingPages.remove(nextPageIndex)
+            lastAppendedPageIndex = nextPageIndex
+            nextPageIndex++
+            pagesSinceAck++
+            progressed = true
+        }
+
+        return if (progressed) OfferResult.PROGRESSED else OfferResult.NO_PROGRESS
+    }
+
+    fun markAcked() {
+        pagesSinceAck = 0
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessFlashDrainEngine.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/limitless/LimitlessFlashDrainEngine.kt
@@ -57,10 +57,9 @@ class LimitlessFlashDrainEngine(
     private var requestId = 0L
     private val fragmentBuffer = mutableMapOf<Int, MutableMap<Int, ByteArray>>()
     private var endPage = 0
-    private var maxSeenPageIndex = -1
-    private var lastAppendedPageIndex = -1
+    private var pageLedger: ContiguousFlashPageLedger? = null
     private var lastAckedPageIndex = -1
-    private var pagesSinceAck = 0
+    private var ackBarrierFailed = false
     private var lastPageAtMs = 0L
     private var cycleTask: ScheduledFuture<*>? = null
     private var statusTimeoutTask: ScheduledFuture<*>? = null
@@ -175,10 +174,11 @@ class LimitlessFlashDrainEngine(
         val address = deviceAddress ?: run { phase = Phase.IDLE; return }
         fragmentBuffer.clear()
         endPage = state.newestFlashPage
-        maxSeenPageIndex = -1
-        lastAppendedPageIndex = -1
-        lastAckedPageIndex = -1
-        pagesSinceAck = 0
+        pageLedger = ContiguousFlashPageLedger(state.oldestFlashPage, state.newestFlashPage) { page ->
+            page.opusFrames.isEmpty() || writer.append(page.opusFrames, page.timestampMs)
+        }
+        lastAckedPageIndex = state.oldestFlashPage - 1
+        ackBarrierFailed = false
         lastPageAtMs = System.currentTimeMillis()
         phase = Phase.DRAINING
         setBoolPref("pendantDraining", true)
@@ -195,45 +195,50 @@ class LimitlessFlashDrainEngine(
 
     private fun processFlashPage(page: LimitlessProtocol.FlashPage) {
         lastPageAtMs = System.currentTimeMillis()
-        val index = page.index ?: return
+        val ledger = pageLedger ?: return
 
-        if (page.opusFrames.isNotEmpty()) {
-            if (!writer.append(page.opusFrames, page.timestampMs)) {
+        when (ledger.offer(page)) {
+            ContiguousFlashPageLedger.OfferResult.APPEND_FAILED -> {
                 Log.w(TAG, "append failed (storage guard?) — pausing drain without ACKing unwritten pages")
                 finishDrain("append_failed")
                 return
             }
+            ContiguousFlashPageLedger.OfferResult.BUFFER_LIMIT_REACHED -> {
+                Log.w(TAG, "too many pages buffered behind a gap — pausing drain for a clean retry")
+                finishDrain("page_gap")
+                return
+            }
+            ContiguousFlashPageLedger.OfferResult.NO_PROGRESS,
+            ContiguousFlashPageLedger.OfferResult.PROGRESSED -> Unit
         }
-        lastAppendedPageIndex = maxOf(lastAppendedPageIndex, index)
-        maxSeenPageIndex = maxOf(maxSeenPageIndex, index)
-        pagesSinceAck++
 
-        if (pagesSinceAck >= ACK_EVERY_PAGES) {
+        if (ledger.pagesSinceAck >= ACK_EVERY_PAGES) {
             if (!ackWritten()) {
                 finishDrain("fsync_failed")
                 return
             }
         }
-        if (maxSeenPageIndex >= endPage) {
+        if (ledger.isComplete) {
             finishDrain("caught_up")
         }
     }
 
-    /** fsync barrier, then ACK everything appended so far. Never ACKs unwritten pages.
-     *  On a failed barrier the watermark rolls back to the last ACK — a later ACK is
-     *  up-to-index and would otherwise cover the unconfirmed pages — and the caller
-     *  must end the drain so those pages redeliver next cycle. */
+    /** fsync barrier, then ACK the contiguous prefix appended so far.
+     *  A failed barrier blocks every later ACK in this drain cycle. */
     private fun ackWritten(): Boolean {
         val address = deviceAddress ?: return true
+        if (ackBarrierFailed) return false
+        val ledger = pageLedger ?: return true
+        val lastAppendedPageIndex = ledger.lastAppendedPageIndex
         if (lastAppendedPageIndex <= lastAckedPageIndex) return true
         if (!writer.sync()) {
-            Log.w(TAG, "fsync failed — dropping ACK watermark, pages redrain next cycle")
-            lastAppendedPageIndex = lastAckedPageIndex
+            Log.w(TAG, "fsync failed — blocking ACKs so pages redrain next cycle")
+            ackBarrierFailed = true
             return false
         }
         write(address, LimitlessProtocol.encodeAcknowledgeProcessedData(messageIndex++, ++requestId, lastAppendedPageIndex))
         lastAckedPageIndex = lastAppendedPageIndex
-        pagesSinceAck = 0
+        ledger.markAcked()
         return true
     }
 
@@ -251,7 +256,12 @@ class LimitlessFlashDrainEngine(
         }
         phase = Phase.IDLE
         setBoolPref("pendantDraining", false)
-        Log.i(TAG, "drain finished ($reason): appended<=$lastAppendedPageIndex acked<=$lastAckedPageIndex end=$endPage")
+        Log.i(
+            TAG,
+            "drain finished ($reason): appended<=${pageLedger?.lastAppendedPageIndex ?: -1} " +
+                "acked<=$lastAckedPageIndex end=$endPage",
+        )
+        pageLedger = null
     }
 
     private fun resetDrainState(reason: String) {
@@ -260,6 +270,8 @@ class LimitlessFlashDrainEngine(
         statusTimeoutTask = null
         stallCheckTask = null
         fragmentBuffer.clear()
+        pageLedger = null
+        ackBarrierFailed = false
         if (phase == Phase.DRAINING) {
             Log.i(TAG, "drain aborted ($reason): acked<=$lastAckedPageIndex")
             setBoolPref("pendantDraining", false)

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/BleReconnectBackoffTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/BleReconnectBackoffTest.kt
@@ -1,0 +1,40 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BleReconnectBackoffTest {
+    @Test
+    fun repeatedFailuresBackOffAndCap() {
+        assertEquals(500L, BleReconnectBackoff.delayMillis(attempt = 0, jitterUnit = 0.5))
+        assertEquals(1_000L, BleReconnectBackoff.delayMillis(attempt = 1, jitterUnit = 0.5))
+        assertEquals(8_000L, BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 0.5))
+        assertEquals(30_000L, BleReconnectBackoff.delayMillis(attempt = 6, jitterUnit = 0.5))
+        assertEquals(30_000L, BleReconnectBackoff.delayMillis(attempt = 100, jitterUnit = 0.5))
+    }
+
+    @Test
+    fun jitterStaysBoundedAndSeparatesReconnectStorms() {
+        val low = BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 0.0)
+        val middle = BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 0.5)
+        val high = BleReconnectBackoff.delayMillis(attempt = 4, jitterUnit = 1.0)
+
+        assertEquals(6_400L, low)
+        assertEquals(8_000L, middle)
+        assertEquals(9_600L, high)
+        assertTrue(low < middle && middle < high)
+    }
+
+    @Test
+    fun physicalConnectDoesNotResetBackoffBeforeTheSessionIsStable() {
+        val state = BleReconnectState()
+
+        assertEquals(BleReconnectAttempt(number = 1, delayMillis = 500), state.recordFailure(jitterUnit = 0.5))
+        state.markTransportConnected()
+        assertEquals(BleReconnectAttempt(number = 2, delayMillis = 1_000), state.recordFailure(jitterUnit = 0.5))
+
+        state.markStable()
+        assertEquals(BleReconnectAttempt(number = 1, delayMillis = 500), state.recordFailure(jitterUnit = 0.5))
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/GattCompletionRegistryTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/GattCompletionRegistryTest.kt
@@ -1,0 +1,125 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GattCompletionRegistryTest {
+    private fun key(
+        sessionId: Long,
+        instanceId: Int = 7,
+    ) = GattCompletionKey(
+        address = "aa:bb:cc:dd:ee:ff",
+        sessionId = sessionId,
+        serviceUuid = "0000180f-0000-1000-8000-00805f9b34fb",
+        characteristicUuid = "00002a19-0000-1000-8000-00805f9b34fb",
+        characteristicInstanceId = instanceId,
+    )
+
+    @Test
+    fun staleOldSessionReadCallbackCannotCompleteOrRemoveReplacementRead() {
+        val registry = GattCompletionRegistry<ByteArray>()
+        val oldGatt = Any()
+        val newGatt = Any()
+        val oldCharacteristic = Any()
+        val newCharacteristic = Any()
+        val oldResults = mutableListOf<Result<ByteArray>>()
+        val newResults = mutableListOf<Result<ByteArray>>()
+
+        registry.register(key(sessionId = 1), oldGatt, oldCharacteristic, oldResults::add)
+        assertEquals(1, registry.failSession(1) { Exception("reconnected") })
+        registry.register(key(sessionId = 2), newGatt, newCharacteristic, newResults::add)
+
+        assertNull(registry.takeMatching(key(sessionId = 1), oldGatt, oldCharacteristic))
+        assertEquals(1, registry.pendingCount())
+        assertEquals(1, oldResults.size)
+        assertTrue(oldResults.single().isFailure)
+        assertTrue(newResults.isEmpty())
+
+        val replacement = registry.takeMatching(key(sessionId = 2), newGatt, newCharacteristic)
+        assertNotNull(replacement)
+        replacement?.invoke(Result.success(byteArrayOf(0x2A)))
+        assertEquals(0, registry.pendingCount())
+        assertArrayEquals(byteArrayOf(0x2A), newResults.single().getOrThrow())
+    }
+
+    @Test
+    fun staleOldSessionWriteCallbackAndCleanupCannotAffectReplacementWrite() {
+        val registry = GattCompletionRegistry<Unit>()
+        val oldGatt = Any()
+        val newGatt = Any()
+        val oldCharacteristic = Any()
+        val newCharacteristic = Any()
+        val oldResults = mutableListOf<Result<Unit>>()
+        val newResults = mutableListOf<Result<Unit>>()
+
+        registry.register(key(sessionId = 10), oldGatt, oldCharacteristic, oldResults::add)
+        registry.register(key(sessionId = 11), newGatt, newCharacteristic, newResults::add)
+
+        assertEquals(1, registry.failSession(10) { Exception("old session disconnected") })
+        assertEquals(1, registry.pendingCount())
+        assertTrue(oldResults.single().isFailure)
+        assertTrue(newResults.isEmpty())
+        assertNull(registry.takeMatching(key(sessionId = 10), oldGatt, oldCharacteristic))
+
+        val replacement = registry.takeMatching(key(sessionId = 11), newGatt, newCharacteristic)
+        assertNotNull(replacement)
+        replacement?.invoke(Result.success(Unit))
+        assertTrue(newResults.single().isSuccess)
+        assertEquals(0, registry.pendingCount())
+    }
+
+    @Test
+    fun callbackRequiresExactGattAndCharacteristicObjects() {
+        val registry = GattCompletionRegistry<ByteArray>()
+        val gatt = Any()
+        val characteristic = Any()
+        val callbackResults = mutableListOf<Result<ByteArray>>()
+        val completionKey = key(sessionId = 22, instanceId = 3)
+
+        registry.register(completionKey, gatt, characteristic, callbackResults::add)
+
+        assertNull(registry.takeMatching(completionKey, Any(), characteristic))
+        assertNull(registry.takeMatching(completionKey, gatt, Any()))
+        assertEquals(1, registry.pendingCount())
+
+        registry.takeMatching(completionKey, gatt, characteristic)?.invoke(Result.success(byteArrayOf(1)))
+        assertEquals(0, registry.pendingCount())
+        assertFalse(callbackResults.isEmpty())
+    }
+
+    @Test
+    fun sessionCleanupFailsAndClearsEveryRetainedCompletionExactlyOnce() {
+        val registry = GattCompletionRegistry<Unit>()
+        val gatt = Any()
+        val firstCharacteristic = Any()
+        val secondCharacteristic = Any()
+        var firstCallbackCount = 0
+        var secondCallbackCount = 0
+
+        registry.register(
+            key(sessionId = 30, instanceId = 1),
+            gatt,
+            firstCharacteristic,
+            onceGattCompletion<Unit> { firstCallbackCount++ },
+        )
+        registry.register(
+            key(sessionId = 30, instanceId = 2),
+            gatt,
+            secondCharacteristic,
+            onceGattCompletion<Unit> { secondCallbackCount++ },
+        )
+
+        assertEquals(2, registry.failSession(30) { Exception("disconnected") })
+        assertEquals(0, registry.pendingCount())
+        assertEquals(1, firstCallbackCount)
+        assertEquals(1, secondCallbackCount)
+        assertEquals(0, registry.failSession(30) { Exception("duplicate cleanup") })
+        assertEquals(1, firstCallbackCount)
+        assertEquals(1, secondCallbackCount)
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/GattOperationQueueTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/GattOperationQueueTest.kt
@@ -29,7 +29,8 @@ class GattOperationQueueTest {
         kind: GattOperationKind,
         target: String = "",
         address: String = "aa:bb:cc:dd:ee:ff",
-    ) = GattOperationKey(address, kind, target)
+        sessionId: Long = 0L,
+    ) = GattOperationKey(address, kind, target, sessionId)
 
     @Test
     fun writeWithResponseWinsWhenCharacteristicAdvertisesBothModes() {
@@ -225,6 +226,51 @@ class GattOperationQueueTest {
             failures,
         )
         assertTrue(queue.complete(other))
+    }
+
+    @Test
+    fun retiredSessionCleanupCannotCancelOrReleaseReplacementSessionOperation() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<String>()
+        val starts = mutableListOf<String>()
+        val oldRead =
+            key(
+                GattOperationKind.READ_CHARACTERISTIC,
+                target = "battery:7",
+                sessionId = 41,
+            )
+        val replacementRead =
+            key(
+                GattOperationKind.READ_CHARACTERISTIC,
+                target = "battery:7",
+                sessionId = 42,
+            )
+        val queue =
+            GattOperationQueue(
+                dispatch = { it() },
+                schedule = scheduler::schedule,
+                timeoutMillis = 30_000,
+            )
+
+        queue.enqueue(
+            oldRead,
+            start = { starts.add("old"); true },
+            onFailure = { failures.add("old:$it") },
+        )
+        queue.enqueue(
+            replacementRead,
+            start = { starts.add("replacement"); true },
+            onFailure = { failures.add("replacement:$it") },
+        )
+
+        queue.cancelSession(oldRead.address, oldRead.sessionId)
+
+        assertEquals(listOf("old", "replacement"), starts)
+        assertEquals(listOf("old:${GattOperationFailure.CANCELLED}"), failures)
+        assertFalse(queue.complete(oldRead))
+        assertEquals(1, queue.pendingCount())
+        assertTrue(queue.complete(replacementRead))
+        assertEquals(0, queue.pendingCount())
     }
 
     @Test

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/GattOperationQueueTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/GattOperationQueueTest.kt
@@ -1,0 +1,341 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GattOperationQueueTest {
+    private class FakeScheduler {
+        private data class Scheduled(val task: () -> Unit, var cancelled: Boolean = false)
+
+        private val scheduled = mutableListOf<Scheduled>()
+
+        fun schedule(@Suppress("UNUSED_PARAMETER") delayMillis: Long, task: () -> Unit): () -> Unit {
+            val item = Scheduled(task)
+            scheduled.add(item)
+            return { item.cancelled = true }
+        }
+
+        fun runNext() {
+            scheduled.firstOrNull { !it.cancelled }?.also {
+                it.cancelled = true
+                it.task()
+            }
+        }
+    }
+
+    private fun key(
+        kind: GattOperationKind,
+        target: String = "",
+        address: String = "aa:bb:cc:dd:ee:ff",
+    ) = GattOperationKey(address, kind, target)
+
+    @Test
+    fun writeWithResponseWinsWhenCharacteristicAdvertisesBothModes() {
+        assertEquals(
+            GattWriteMode.WITH_RESPONSE,
+            preferredGattWriteMode(
+                supportsWrite = true,
+                supportsWriteWithoutResponse = true,
+            ),
+        )
+        assertEquals(
+            GattWriteMode.WITHOUT_RESPONSE,
+            preferredGattWriteMode(
+                supportsWrite = false,
+                supportsWriteWithoutResponse = true,
+            ),
+        )
+        assertEquals(
+            null,
+            preferredGattWriteMode(
+                supportsWrite = false,
+                supportsWriteWithoutResponse = false,
+            ),
+        )
+    }
+
+    @Test
+    fun serializesCommandsUntilMatchingCallbackArrives() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val first = key(GattOperationKind.READ_CHARACTERISTIC, "battery")
+        val second = key(GattOperationKind.WRITE_CHARACTERISTIC, "control")
+
+        queue.enqueue(first, start = { starts.add("first"); true })
+        queue.enqueue(second, start = { starts.add("second"); true })
+
+        assertEquals(listOf("first"), starts)
+        assertTrue(queue.complete(first))
+        assertEquals(listOf("first", "second"), starts)
+        assertTrue(queue.complete(second))
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun activeOperationIsDistinguishedFromQueuedDuplicate() {
+        val scheduler = FakeScheduler()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val discovery = key(GattOperationKind.DISCOVER_SERVICES)
+        val read = key(GattOperationKind.READ_CHARACTERISTIC, "battery")
+
+        queue.enqueue(read, start = { true })
+        queue.enqueue(discovery, start = { true })
+
+        assertTrue(queue.contains(discovery))
+        assertFalse(queue.isActive(discovery))
+        assertTrue(queue.complete(read))
+        assertTrue(queue.isActive(discovery))
+        assertTrue(queue.complete(discovery))
+    }
+
+    @Test
+    fun completionCleanupRunsBeforeSameTargetSuccessorStarts() {
+        val scheduler = FakeScheduler()
+        val events = mutableListOf<String>()
+        val operation = key(GattOperationKind.READ_CHARACTERISTIC, "battery")
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(operation, start = { events.add("first-start"); true })
+        queue.enqueue(operation, start = { events.add("second-start"); true })
+
+        assertTrue(queue.complete(operation) { events.add("first-cleanup") })
+        assertEquals(listOf("first-start", "first-cleanup", "second-start"), events)
+        assertTrue(queue.complete(operation))
+    }
+
+    @Test
+    fun operationEnqueuedByCompletionWaitsUntilCompletionReturns() {
+        val scheduler = FakeScheduler()
+        val events = mutableListOf<String>()
+        val first = key(GattOperationKind.REQUEST_MTU)
+        val followUp = key(GattOperationKind.WRITE_DESCRIPTOR)
+        lateinit var queue: GattOperationQueue
+        queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(first, start = { events.add("first-start"); true })
+        assertTrue(
+            queue.complete(first) {
+                events.add("callback-start")
+                queue.enqueue(followUp, start = { events.add("follow-up-start"); true })
+                events.add("callback-end")
+            },
+        )
+
+        assertEquals(
+            listOf("first-start", "callback-start", "callback-end", "follow-up-start"),
+            events,
+        )
+        assertTrue(queue.complete(followUp))
+    }
+
+    @Test
+    fun staleCallbackCannotCompleteNewerOperation() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val first = key(GattOperationKind.REQUEST_MTU)
+        val newer = key(GattOperationKind.READ_RSSI)
+
+        queue.enqueue(first, start = { starts.add("mtu"); true })
+        queue.enqueue(newer, start = { starts.add("rssi"); true })
+
+        assertTrue(queue.complete(first))
+        assertEquals(listOf("mtu", "rssi"), starts)
+        assertFalse(queue.complete(first))
+        assertEquals(1, queue.pendingCount())
+        assertTrue(queue.complete(newer))
+    }
+
+    @Test
+    fun timeoutFailsCurrentAndUnblocksQueue() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<GattOperationFailure>()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(
+            key(GattOperationKind.DISCOVER_SERVICES),
+            start = { starts.add("discovery"); true },
+            onFailure = failures::add,
+        )
+        queue.enqueue(key(GattOperationKind.READ_RSSI), start = { starts.add("rssi"); true })
+
+        scheduler.runNext()
+
+        assertEquals(listOf(GattOperationFailure.TIMED_OUT), failures)
+        assertEquals(listOf("discovery", "rssi"), starts)
+    }
+
+    @Test
+    fun disconnectDrainsAndFailsPendingOperationsForOnlyThatPeripheral() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<GattOperationFailure>()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(
+            key(GattOperationKind.READ_CHARACTERISTIC, address = "AA:AA:AA:AA:AA:AA"),
+            start = { starts.add("a1"); true },
+            onFailure = failures::add,
+        )
+        queue.enqueue(
+            key(GattOperationKind.WRITE_CHARACTERISTIC, address = "AA:AA:AA:AA:AA:AA"),
+            start = { starts.add("a2"); true },
+            onFailure = failures::add,
+        )
+        val other = key(GattOperationKind.READ_RSSI, address = "BB:BB:BB:BB:BB:BB")
+        queue.enqueue(other, start = { starts.add("b"); true })
+
+        queue.cancelAddress("aa:aa:aa:aa:aa:aa")
+
+        assertEquals(listOf("a1", "b"), starts)
+        assertEquals(
+            listOf(GattOperationFailure.CANCELLED, GattOperationFailure.CANCELLED),
+            failures,
+        )
+        assertTrue(queue.complete(other))
+    }
+
+    @Test
+    fun disconnectStillFailsRemainingOperationsWhenOneCallbackThrows() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val address = "AA:AA:AA:AA:AA:AA"
+
+        queue.enqueue(
+            key(GattOperationKind.READ_CHARACTERISTIC, address = address),
+            start = { true },
+            onFailure = { throw IllegalStateException("caller failed") },
+        )
+        queue.enqueue(
+            key(GattOperationKind.WRITE_CHARACTERISTIC, address = address),
+            start = { true },
+            onFailure = { failures.add("second") },
+        )
+
+        queue.cancelAddress(address)
+
+        assertEquals(listOf("second"), failures)
+        assertEquals(0, queue.pendingCount())
+    }
+
+    @Test
+    fun rejectedStartFailsAndAdvancesImmediately() {
+        val scheduler = FakeScheduler()
+        val failures = mutableListOf<GattOperationFailure>()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+
+        queue.enqueue(
+            key(GattOperationKind.WRITE_DESCRIPTOR),
+            start = { starts.add("descriptor"); false },
+            onFailure = failures::add,
+        )
+        val next = key(GattOperationKind.READ_RSSI)
+        queue.enqueue(next, start = { starts.add("rssi"); true })
+
+        assertEquals(listOf(GattOperationFailure.REJECTED), failures)
+        assertEquals(listOf("descriptor", "rssi"), starts)
+        assertTrue(queue.complete(next))
+    }
+
+    @Test
+    fun periodicRssiIsDeduplicatedAndCannotJumpAheadOfBulkCommands() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        val queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val bulk1 = key(GattOperationKind.WRITE_CHARACTERISTIC, "bulk-1")
+        val bulk2 = key(GattOperationKind.WRITE_CHARACTERISTIC, "bulk-2")
+        val rssi = key(GattOperationKind.READ_RSSI)
+
+        queue.enqueue(bulk1, start = { starts.add("bulk-1"); true })
+        queue.enqueue(bulk2, start = { starts.add("bulk-2"); true })
+        repeat(100) {
+            if (!queue.contains(rssi)) {
+                queue.enqueue(rssi, start = { starts.add("rssi"); true })
+            }
+        }
+
+        assertEquals(3, queue.pendingCount())
+        assertTrue(queue.complete(bulk1))
+        assertEquals(listOf("bulk-1", "bulk-2"), starts)
+        assertTrue(queue.complete(bulk2))
+        assertEquals(listOf("bulk-1", "bulk-2", "rssi"), starts)
+        assertTrue(queue.complete(rssi))
+    }
+
+    @Test
+    fun lateWriteWithoutResponseCallbackCannotReleaseLaterWrite() {
+        val scheduler = FakeScheduler()
+        val starts = mutableListOf<String>()
+        lateinit var queue: GattOperationQueue
+        queue = GattOperationQueue(
+            dispatch = { it() },
+            schedule = scheduler::schedule,
+            timeoutMillis = 30_000,
+        )
+        val target = "control"
+        val writeWithoutResponse = key(GattOperationKind.WRITE_WITHOUT_RESPONSE, target)
+        val laterWriteWithoutResponse = key(GattOperationKind.WRITE_WITHOUT_RESPONSE, target)
+        val optionalCallback = key(GattOperationKind.WRITE_CHARACTERISTIC, target)
+
+        queue.enqueue(
+            writeWithoutResponse,
+            start = {
+                starts.add("wnr")
+                queue.complete(writeWithoutResponse)
+                true
+            },
+        )
+        queue.enqueue(laterWriteWithoutResponse, start = { starts.add("later-wnr"); true })
+
+        assertEquals(listOf("wnr", "later-wnr"), starts)
+        assertFalse(queue.complete(optionalCallback))
+        assertEquals(1, queue.pendingCount())
+        assertTrue(queue.complete(laterWriteWithoutResponse))
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/GattReadySessionGuardTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/GattReadySessionGuardTest.kt
@@ -1,0 +1,55 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GattReadySessionGuardTest {
+    @Test
+    fun retiredDelayedPipelineCannotStartOrPublishForReplacementSession() {
+        var activeSessionId: Long? = 41L
+        val events = mutableListOf<String>()
+        val guard = GattReadySessionGuard { activeSessionId }
+
+        assertTrue(
+            guard.runIfCurrent("aa:bb:cc:dd:ee:ff", 41L) {
+                events.add("old MTU started")
+            },
+        )
+
+        activeSessionId = 42L
+
+        assertFalse(
+            guard.runIfCurrent("aa:bb:cc:dd:ee:ff", 41L) {
+                events.add("old services published")
+            },
+        )
+        assertTrue(
+            guard.runIfCurrent("aa:bb:cc:dd:ee:ff", 42L) {
+                events.add("replacement services published")
+            },
+        )
+
+        assertEquals(
+            listOf("old MTU started", "replacement services published"),
+            events,
+        )
+    }
+
+    @Test
+    fun retiredSessionCannotStartAfterDelay() {
+        var activeSessionId: Long? = 7L
+        var starts = 0
+        val guard = GattReadySessionGuard { activeSessionId }
+
+        activeSessionId = 8L
+
+        assertFalse(
+            guard.runIfCurrent("AA:BB:CC:DD:EE:FF", 7L) {
+                starts++
+            },
+        )
+        assertEquals(0, starts)
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/NativeAudioSubscriptionOwnershipTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/NativeAudioSubscriptionOwnershipTest.kt
@@ -1,0 +1,46 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NativeAudioSubscriptionOwnershipTest {
+    private val legacyAudio = NativeAudioSubscriptionTarget(
+        serviceUuid = "service",
+        characteristicUuid = "legacy-audio",
+    )
+
+    @Test
+    fun omittedConfigReleasesLegacySubscriptionOwnedByNativeOnSameGatt() {
+        val ownership = NativeAudioSubscriptionOwnership()
+
+        assertEquals(
+            legacyAudio,
+            ownership.reconcile("aa:bb", sessionToken = 7, desired = legacyAudio).subscribe,
+        )
+
+        val handoff = ownership.reconcile("AA:BB", sessionToken = 7, desired = null)
+
+        assertEquals(legacyAudio, handoff.unsubscribe)
+        assertNull(handoff.subscribe)
+        assertEquals(
+            NativeAudioSubscriptionTransition(),
+            ownership.reconcile("aa:bb", sessionToken = 7, desired = null),
+        )
+    }
+
+    @Test
+    fun replacementGattDoesNotInheritOrDisableRetiredSessionState() {
+        val ownership = NativeAudioSubscriptionOwnership()
+        ownership.reconcile("AA:BB", sessionToken = 7, desired = legacyAudio)
+
+        val replacement = ownership.reconcile(
+            "AA:BB",
+            sessionToken = 8,
+            desired = legacyAudio,
+        )
+
+        assertNull(replacement.unsubscribe)
+        assertEquals(legacyAudio, replacement.subscribe)
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/NotificationTransitionStateTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/NotificationTransitionStateTest.kt
@@ -1,0 +1,48 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NotificationTransitionStateTest {
+    @Test
+    fun redundantSameStateRequestsCoalesceIntoOneCccdWrite() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.request(true))
+        assertNull(state.complete(attempted = true, success = true))
+        assertNull(state.request(true))
+    }
+
+    @Test
+    fun latestDesiredStateRunsAfterTheActiveTransition() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.request(false))
+        assertEquals(false, state.complete(attempted = true, success = true))
+        assertEquals(false, state.currentInFlight())
+        assertNull(state.complete(attempted = false, success = true))
+    }
+
+    @Test
+    fun enableDisableEnableBurstAvoidsAnUnnecessaryToggle() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.request(false))
+        assertNull(state.request(true))
+        assertNull(state.complete(attempted = true, success = true))
+        assertNull(state.request(true))
+    }
+
+    @Test
+    fun failedTransitionWaitsForGattSessionRecovery() {
+        val state = NotificationTransitionState()
+
+        assertEquals(true, state.request(true))
+        assertNull(state.complete(attempted = true, success = false))
+        assertNull(state.currentInFlight())
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicyTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/RssiDiagnosticsPolicyTest.kt
@@ -1,0 +1,46 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RssiDiagnosticsPolicyTest {
+    @Test
+    fun pollingRequiresAnExplicitMatchingDiagnosticsSubscription() {
+        val policy = RssiDiagnosticsPolicy()
+
+        assertFalse(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+
+        policy.subscribe("aa:bb:cc:dd:ee:ff")
+
+        assertTrue(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+        assertFalse(policy.shouldPoll("11:22:33:44:55:66", isConnected = true))
+    }
+
+    @Test
+    fun disconnectPausesPollingAndReconnectResumesWithoutResubscribing() {
+        val policy = RssiDiagnosticsPolicy()
+        policy.subscribe("AA:BB:CC:DD:EE:FF")
+
+        assertFalse(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = false))
+        assertTrue(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+    }
+
+    @Test
+    fun onlyTheMatchingDiagnosticsViewCanStopPolling() {
+        val policy = RssiDiagnosticsPolicy()
+        policy.subscribe("AA:BB:CC:DD:EE:FF")
+
+        assertFalse(policy.unsubscribe("11:22:33:44:55:66"))
+        assertTrue(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+        assertTrue(policy.unsubscribe("AA:BB:CC:DD:EE:FF"))
+        assertFalse(policy.shouldPoll("AA:BB:CC:DD:EE:FF", isConnected = true))
+    }
+
+    @Test
+    fun missingDiagnosticsRssiCallbackDoesNotForceAReconnect() {
+        assertFalse(shouldRecoverAfterGattTimeout(GattOperationKind.READ_RSSI))
+        assertTrue(shouldRecoverAfterGattTimeout(GattOperationKind.DISCOVER_SERVICES))
+        assertTrue(shouldRecoverAfterGattTimeout(GattOperationKind.WRITE_DESCRIPTOR))
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedgerTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/limitless/ContiguousFlashPageLedgerTest.kt
@@ -1,0 +1,76 @@
+package com.friend.ios.limitless
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContiguousFlashPageLedgerTest {
+
+    private fun page(index: Int) =
+        LimitlessProtocol.FlashPage(
+            index = index,
+            session = 1,
+            timestampMs = index.toLong(),
+            opusFrames = listOf(byteArrayOf(index.toByte())),
+        )
+
+    @Test
+    fun laterPageCannotAdvanceAckWatermarkAcrossHole() {
+        val appended = mutableListOf<Int>()
+        val ledger = ContiguousFlashPageLedger(100, 102) {
+            appended += it.index!!
+            true
+        }
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.PROGRESSED, ledger.offer(page(100)))
+        assertEquals(ContiguousFlashPageLedger.OfferResult.NO_PROGRESS, ledger.offer(page(102)))
+        assertEquals(listOf(100), appended)
+        assertEquals(100, ledger.lastAppendedPageIndex)
+        assertFalse(ledger.isComplete)
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.PROGRESSED, ledger.offer(page(101)))
+        assertEquals(listOf(100, 101, 102), appended)
+        assertEquals(102, ledger.lastAppendedPageIndex)
+        assertEquals(3, ledger.pagesSinceAck)
+        assertTrue(ledger.isComplete)
+    }
+
+    @Test
+    fun failedAppendDoesNotMakePageAckEligible() {
+        val ledger = ContiguousFlashPageLedger(7, 8) { it.index != 8 }
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.PROGRESSED, ledger.offer(page(7)))
+        assertEquals(ContiguousFlashPageLedger.OfferResult.APPEND_FAILED, ledger.offer(page(8)))
+        assertEquals(7, ledger.lastAppendedPageIndex)
+        assertFalse(ledger.isComplete)
+    }
+
+    @Test
+    fun duplicatePageIsNotAppendedTwice() {
+        val appended = mutableListOf<Int>()
+        val ledger = ContiguousFlashPageLedger(4, 5) {
+            appended += it.index!!
+            true
+        }
+
+        ledger.offer(page(4))
+        ledger.offer(page(4))
+
+        assertEquals(listOf(4), appended)
+        assertEquals(4, ledger.lastAppendedPageIndex)
+    }
+
+    @Test
+    fun gapBufferIsBounded() {
+        val ledger = ContiguousFlashPageLedger(100, 200) { true }
+
+        for (index in 101..164) {
+            assertEquals(ContiguousFlashPageLedger.OfferResult.NO_PROGRESS, ledger.offer(page(index)))
+        }
+
+        assertEquals(ContiguousFlashPageLedger.OfferResult.BUFFER_LIMIT_REACHED, ledger.offer(page(165)))
+        assertEquals(65, ledger.pendingPageCount)
+        assertEquals(99, ledger.lastAppendedPageIndex)
+    }
+}

--- a/app/e2e/ANDROID_CV1_RELIABILITY_RUN_2026-07-25.md
+++ b/app/e2e/ANDROID_CV1_RELIABILITY_RUN_2026-07-25.md
@@ -1,0 +1,176 @@
+# Android CV1 BLE Reliability Run — 2026-07-25
+
+This is the physical-device evidence record for the Android half of
+[`BLE_RELIABILITY_ACCEPTANCE.md`](./BLE_RELIABILITY_ACCEPTANCE.md). It records
+both passes and failures; it is not a claim that the full acceptance matrix
+passes.
+
+## Fixture
+
+| Item | Value |
+|---|---|
+| Phone | Samsung SM-S936U, Android 16 (API 36) |
+| App | Omi Dev `com.friend.ios.dev`, `1.0.543` (`992`) |
+| Installed source revision at evidence capture | Exactly `9981ef2ccec1c8769f696d5611082604f06b5f36` |
+| Pendant | Omi CV1; address masked as `**:**:**:**:0B:95` |
+| Firmware before OTA | `3.0.28.1` |
+| Firmware after OTA | `3.0.28.2`, confirmed and active |
+| DFU artifact SHA-256 | `79ade33e69f3112e2dddee8a0876db68dfef11870f11111c94628d4d5efd2e90` |
+
+The current uncommitted reliability changes—including DFU ownership/reclaim,
+Android session-bound GATT/ready handling, reconnect stream lifecycle, and
+per-GATT-ready time sync—were developed after this run. They were not installed
+on the phone and none of the physical results below are evidence for them.
+
+Do not publish full Bluetooth addresses, Firebase identities, email addresses,
+bearer tokens, WebSocket URLs, or raw transcript content with this evidence.
+All results below were extracted from redacted Flutter/Android logs.
+
+## Safety and preflight
+
+- Verified the exact paired pendant before any GATT management or DFU action.
+- Captured the durable ring read/write cursors and dropped-record count before
+  every destructive transfer.
+- Used only the dev app. The production app was not stopped or replaced.
+- Did not erase ring storage. `ADVANCE` was allowed only after `DONE`.
+- Performed one OTA reboot. No later management reboot was run.
+- Stopped intentional Bluetooth disruptions when live transcription became the
+  user's priority. The last backlog was preserved for the post-fix run.
+
+The firmware artifact's manifest advertised `3.0.28.2`. After activation, an
+independent MCUboot image-list query returned slot 0 as active, confirmed,
+bootable `3.0.28.2`.
+
+## Historical pre-registry automated evidence
+
+Before the current uncommitted session-bound completion-registry work began,
+the Android BLE unit lane was run locally with the Homebrew JDK:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@21 \
+  ./gradlew :app:testDevDebugUnitTest --tests 'com.friend.ios.ble.*'
+```
+
+That pre-registry run reported `BUILD SUCCESSFUL` across 757 tasks. It is
+hermetic native test evidence for the earlier source state only; it does not
+cover the current uncommitted Kotlin registry work, change the installed-source
+provenance, or repair the failed physical cases above.
+
+## Final integrated local automated evidence
+
+After the session-bound Android completion registry, exact-session delayed
+MTU/ready guard, bounded exact-device DFU reclaim, reconnect stream lifecycle,
+and per-ready-generation time sync were integrated, the current worktree
+passed:
+
+```bash
+JAVA_HOME=/opt/homebrew/opt/openjdk@21 \
+  ./gradlew :app:testDevDebugUnitTest --tests 'com.friend.ios.ble.*'
+
+flutter test \
+  test/unit/device_transport_exclusive_release_test.dart \
+  test/unit/firmware_dfu_connection_handoff_test.dart \
+  test/unit/native_ble_transport_exclusive_release_test.dart \
+  test/unit/omi_mcu_dfu_policy_test.dart \
+  test/unit/omi_ready_generation_time_sync_test.dart \
+  test/providers/device_provider_test.dart
+
+bash test.sh
+scripts/analyze_ratchet.sh
+git diff --check
+```
+
+The Gradle lane reported `BUILD SUCCESSFUL` across 757 actionable tasks
+(14 executed, 743 up-to-date). The focused Flutter reliability set passed 35
+tests, the full Flutter suite passed 1,008 tests, and the analyzer ratchet and
+diff check passed.
+
+This is hermetic source-level evidence only. These integrated changes were not
+installed on either phone or exercised against the pendant, so none of these
+results change the physical verdicts or installed-source revision recorded
+above.
+
+## Seams exercised
+
+- Android native BLE connection ownership and automatic reconnect
+- Flutter connection readiness after a new native connection generation
+- CV1 ring protocol: `RingInfo`, `READ_BEGIN`, `DONE`, and `ADVANCE`
+- Interrupted range transfer and retry from the durable cursor
+- Screen-off/doze transfer behavior
+- App process relaunch with persisted authentication and pairing
+- MCUboot DFU handoff, activation, and post-reboot reclaim
+- Firmware RTC timestamps across ordinary reconnect and OTA reboot
+
+## Results
+
+| Case | Result | Evidence |
+|---|---|---|
+| Large pre-OTA backlog | Pass | 46,800 records advanced from cursor 880,869 to 927,669 at 88.77 kB/s, followed by 2,383 records to cursor 930,052. Firmware reported `dropped=0`. |
+| OTA and activation | Pass | `3.0.28.2` uploaded, activated, confirmed, and independently observed active after reboot. |
+| Cursor integrity across OTA | Pass | Pre-OTA durable cursor was 930,052. First post-OTA `RingInfo` read cursor was exactly 930,052; 714 newly captured records were pending and `dropped=0`. |
+| Small post-OTA drain | Pass | 714 records, 317,016 raw bytes, 3.946 s, 80.34 kB/s. `DONE` preceded successful `ADVANCE`; postcondition `read == write == 930,766`, `dropped=0`. |
+| Passive recovery after OTA reboot | **Fail** | App remained Offline for more than 60 s. A Bluetooth off/on cycle did not reclaim it within 15 s. Force-stop/relaunch was required; authentication was retained and connection then completed in 1.087 s, ring-ready in about 2.5 s. |
+| Ordinary reconnect after app restart | Pass with latency | Four measured connects were 3.13, 3.76, 3.62, and 2.67 s; ring-ready was 5.36, 5.71, 5.62, and 4.73 s respectively. No spontaneous radio disconnect occurred during these cycles. |
+| Mid-range interruption safety | Pass | Transfer began at cursor 930,766 for 1,800 records. Bluetooth was disabled 2.17 s after `READ_BEGIN`, after 306 records plus 406 pending bytes. The app logged incomplete transfer and skipped `ADVANCE`. After reconnect, firmware still reported read cursor 930,766 and `dropped=0`. |
+| Interrupted range retry | Pass | Retry drained 930,766–932,566, then 932,566–933,461. Both ranges reached `DONE` before `ADVANCE`; final `read == write == 933,461`, `dropped=0`. |
+| Retry throughput | **Regression** | 1,196,580 raw bytes in 16.148 s = 74.10 kB/s (72.36 KiB/s), about 16.5% slower than the 88.77 kB/s large-backlog baseline. |
+| Timestamp order on ordinary outage/retry | Pass | Controlled outage segments were monotonic and their starts were within about one second of the corresponding disruption start. |
+| Timestamp order across OTA reboot | **Fail** | Post-OTA segments moved from epoch 1,785,022,655 back to 1,785,018,726 (about 65 minutes), then forward again. Sequence cursors remained contiguous, but cursor order alone cannot reconstruct conversation chronology after this RTC migration. |
+| Screen-off transfer | Partial | A 268-record range (933,461–933,729) completed with `DONE` then `ADVANCE` while the phone initially reported Dozing. The phone woke within about 10 s, so sustained screen-off transfer remains unproven. |
+| Process relaunch | Pass | Before relaunch `read == write == 933,729`, `dropped=0`. Force-stop/relaunch retained auth and pairing; exact-device connection completed in about 1.1 s and ring status followed. |
+| Sustained doze reconnect | Partial | After roughly 100 s of screen-off capture, automatic reconnect completed in about 2.3 s and ring status followed about 1.8 s later. The reported 2,159-record backlog also included an earlier management-client disconnect, so it is not a pure doze capture-volume measurement. |
+| Final 2,159-record drain | Held | The user resumed live Listening/transcription. No further disconnect, reboot, foreground navigation, or drain was performed. Preserve this backlog for the post-fix acceptance run. |
+
+## Findings
+
+1. The durable cursor contract is working: incomplete BLE reads did not advance
+   firmware state, and reconnect retried the exact range without a gap.
+2. DFU activation and cursor preservation worked, but automatic ownership
+   recovery after the firmware reboot did not. Requiring an app process restart
+   is an acceptance failure.
+3. Ordinary reconnect timestamps were accurate, while the OTA reboot produced
+   a large timestamp rewind. RTC/time-sync ordering around DFU reboot is a
+   separate correctness defect from BLE transport reliability.
+4. Transfer speed varies materially. The interrupted-retry path was slower than
+   the large-backlog baseline and should be measured separately from initial
+   bulk drain.
+5. An independent MCU management client can cause the app to forget/unmanage
+   the pendant. Future test tooling must treat management ownership as
+   exclusive and verify the persisted exact-device identity afterward.
+6. A UI duration label can remain stale or represent the phone-side WAL rather
+   than the current pendant backlog. Protocol cursors are the acceptance source
+   of truth.
+
+## Required post-fix rerun
+
+Resume with the preserved 2,159-record backlog while live capture is active.
+The run passes only if the app drains it without an early `ADVANCE`, keeps
+subsequent live audio connected, reports `dropped=0`, and reconstructs monotonic
+conversation time. Show the Offline-test and Connection-restored notices
+required by the acceptance playbook around every intentional disruption. Then
+repeat:
+
+1. DFU activation followed by passive exact-device reclaim, with no app restart.
+2. A sustained locked-screen/background drain long enough to prove the phone
+   remains asleep.
+3. At least three large clean throughput ranges where the backlog permits,
+   measured separately from interrupted retries against the 88.77 kB/s clean
+   baseline.
+4. The same artifact and cases on a physical iPhone.
+5. Five reconnect cycles on each platform only after notifying the tester that
+   live capture will be intentionally interrupted.
+
+## Local evidence index
+
+The raw evidence remains local because it contains device and account data.
+Redact it before attaching excerpts to a PR.
+
+- `/tmp/omi-android-plus2-dfu-live.log`
+- `/tmp/omi-active-imagelist-excerpt.log`
+- `/tmp/omi-android-714-drain-excerpt.log`
+- `/tmp/omi-android-midrange-cut-excerpt.log`
+- `/tmp/omi-android-midrange-resume-reconnect.log`
+- `/tmp/omi-android-resume-drain-excerpt.log`
+- `/tmp/omi-android-bg-sync-excerpt.log`
+- `/tmp/omi-android-relaunch-excerpt.log`
+- `/tmp/omi-android-sustained-doze-reconnect.log`

--- a/app/e2e/ANDROID_CV1_RELIABILITY_RUN_2026-07-25.md
+++ b/app/e2e/ANDROID_CV1_RELIABILITY_RUN_2026-07-25.md
@@ -28,6 +28,10 @@ All results below were extracted from redacted Flutter/Android logs.
 
 ## Safety and preflight
 
+- Before installing an authenticated dev APK, the ignored build inputs must
+  pass `bash scripts/verify_android_physical_test_auth_config.sh`. A build made
+  after `test.sh` without reseeding prod-backed dev auth configuration is
+  invalid for physical BLE acceptance.
 - Verified the exact paired pendant before any GATT management or DFU action.
 - Captured the durable ring read/write cursors and dropped-record count before
   every destructive transfer.

--- a/app/e2e/ANDROID_CV1_STORAGE_FIRST_RUN_2026-07-28.md
+++ b/app/e2e/ANDROID_CV1_STORAGE_FIRST_RUN_2026-07-28.md
@@ -108,3 +108,26 @@ phone copy.
 - `/tmp/omi-acceptance-postfix-wals-final.json`
 - `/tmp/omi-cv1-marker-online.aiff`
 - `/tmp/omi-cv1-marker-offline.aiff`
+
+## 2026-07-30 live-authority rerun
+
+The authenticated Android dev build was rebuilt and installed in place after
+removing charging from the deep-backlog authority path. Authentication,
+preferences, the exact pendant pairing, and local recovery state were retained.
+Automatic offline sync remained off.
+
+The development transcription endpoint repeatedly closed with WebSocket code
+1006 before reporting service readiness. The app therefore left the
+storage-authoritative tail on the pendant: the run contained no ring
+`READ_BEGIN`, `READ`, or `ADVANCE` command while transcription was unavailable.
+This is the intended containment result and prevents an unavailable live
+service from turning durable pendant history into an unbounded phone-side
+queue. It is not live-preview evidence.
+
+Android Bluetooth was then disabled and re-enabled. The exact pendant began
+reconnecting about 5.2 seconds after radio shutdown, completed the physical
+GATT connection about 2.2 seconds later, republished app readiness in another
+0.3 seconds, and completed time sync in another 0.25 seconds. No ring read or
+advance occurred during the service outage. This proves transport recovery and
+live/deep authority containment; the live transcript still requires a healthy
+development transcription endpoint.

--- a/app/e2e/ANDROID_CV1_STORAGE_FIRST_RUN_2026-07-28.md
+++ b/app/e2e/ANDROID_CV1_STORAGE_FIRST_RUN_2026-07-28.md
@@ -1,0 +1,110 @@
+# Android CV1 Storage-First Acceptance — 2026-07-28
+
+This is the physical-device evidence record for the storage-authoritative CV1
+path in [`BLE_RELIABILITY_ACCEPTANCE.md`](./BLE_RELIABILITY_ACCEPTANCE.md).
+Failures and external-service interruptions are recorded alongside passes. This
+run did not authorize a full historical-backlog drain and is not evidence for
+the unrun iOS matrix.
+
+## Fixture
+
+| Item | Value |
+|---|---|
+| Phone | Samsung SM-S936U, Android 16 |
+| App | Omi Dev `com.friend.ios.dev`, `1.0.543` (`992`) |
+| Candidate source | `bd664d8fb2` (physically installed); rebased equivalent `64866c89ad` |
+| APK SHA-256 | `42ba81588cee5572f8828e558243b83ac935c3a7631fb08b0bbb537a88242b1d` |
+| Pendant | Omi CV1, identifying address redacted |
+| Firmware | Storage-authoritative `3.0.29` candidate |
+| App policy | automatic offline sync off; Remote VAD on; Android background mode off |
+| Initial pendant state | battery 85%; read cursor 1,341,641; dropped records 0 |
+
+The APK passed
+`scripts/verify_android_physical_test_auth_config.sh` immediately before it
+was installed. Installation used `adb install -r`, retaining the authenticated
+dev account, exact pendant pairing, preferences, and local WAL manifest. The
+production app was not stopped or replaced.
+
+Do not publish the raw log or manifest. They contain device and account
+identifiers even though this record does not.
+
+## Automated evidence
+
+The candidate passed:
+
+```bash
+flutter test test/unit/local_wal_sync_test.dart
+flutter analyze \
+  lib/services/wals/local_wal_sync.dart \
+  test/unit/local_wal_sync_test.dart
+
+cd android
+./gradlew app:assembleDevDebug \
+  -x app:uploadCrashlyticsMappingFileDevDebug \
+  -Ptarget-platform=android-arm64 \
+  -Ptarget=lib/main.dart
+```
+
+The WAL test file passed all 70 tests, the focused analyzer reported no issues,
+and the authenticated Android build completed successfully.
+
+New regression coverage proves:
+
+- all transitive ring ranges separated by less than the configured 120-second
+  conversation boundary are claimed before canonical publication;
+- a range at exactly the boundary remains a separate conversation;
+- a missing local archive is quarantined once instead of failing every
+  compaction timer;
+- truthful pendant recovery replaces an unavailable exact range and retires a
+  stale covered alias.
+
+## Physical results
+
+| Case | Result | Evidence |
+|---|---|---|
+| Locked-screen cold start | Pass | The in-place dev build connected to the exact paired pendant, performed one time sync for the ready generation, started the storage-authoritative tail, and retained authentication. |
+| Historical missing-file failure | Pass | The previously retryable missing archive moved to one `corrupted` manifest entry. No `historical archive group remains retryable` event recurred after the new build. The old pendant read cursor remained unchanged, so device recovery remains available. |
+| Automatic deep backlog policy | Pass | The app logged that automatic sync was disabled. The historical read cursor remained 1,341,641; the run did not silently authorize or advance the old backlog. |
+| Bluetooth off/on while locked | Pass | Bluetooth was disabled at 14:08:51, a deterministic offline marker played twice, and Bluetooth was enabled at 14:09:03. The exact pendant reported connected at 14:09:06.485 and time sync at 14:09:06.901. No force-stop, relaunch, or user reconnect was needed. |
+| Offline range recovery | Pass | Recovery began at sequence 1,389,400 and durably completed two ranges: 96 records / 39,479 encoded bytes in 1.065 s, then 88 records / 36,077 encoded bytes in 0.775 s. The final write cursor was 1,389,584 and `dropped` remained 0. |
+| Preview identity across outage | Pass after backend recovery | Reconnect explicitly preserved 48 visible preview segments. The transcription endpoint returned HTTP 503 during the outage, then became ready at 14:09:53.892. Pending durable ranges replayed idempotently, and the same preview advanced from 48 to 53 visible segments beginning 6.005 s after backend readiness. |
+| Conversation assembly after the configured boundary | Pass | At 14:12:18 the app stamped 456 physical WALs from the continuous run. The manifest published one conversation-bound canonical replacement spanning 871 wall-clock seconds and 43,511 frames instead of exposing hundreds of short files. |
+| Short-run battery observation | No regression observed | Pendant battery reported 85% throughout the measured reconnect/replay interval. This is not a substitute for the planned overnight battery comparison. |
+
+The two recovery reads correspond to small interrupted-live ranges, not a clean
+large-backlog benchmark. Their encoded throughputs were approximately 37.1 and
+46.6 kB/s. They must not be compared to or folded into the existing 88.77 kB/s
+large-range clean baseline.
+
+## External-service interruption
+
+The first reconnect attempts reached the pendant normally but the transcription
+WebSocket received HTTP 503. Local durability therefore passed before live
+transcription could pass. Once the service became ready, the app replayed the
+already durable pending ranges, did not create duplicate WAL identities, and
+continued the existing preview. This is the intended failure separation: a
+backend outage can delay transcription, but it cannot erase the pendant or
+phone copy.
+
+## Remaining acceptance work
+
+- Unlock the phone and authorize one immutable manual backlog snapshot. Interrupt
+  BLE after `READ_BEGIN`, resume without another Sync tap, and prove completion
+  through the original target without starving live audio.
+- Measure at least three large clean ranges and keep interrupted retries out of
+  the clean p50.
+- Reconcile the uploaded canonical job to a terminal server result and inspect
+  the final transcript chronology without publishing transcript content.
+- Run the same marker, locked-screen reconnect, conversation-boundary, manual
+  backlog, and DFU cases on the physical iPhone.
+- Run a longer unplugged quiet/speech cycle to quantify the battery cost of the
+  live tail and optional historical lane.
+
+## Local evidence
+
+- `/tmp/omi-acceptance-20260728.log`
+- `/tmp/omi-acceptance-postfix-20260728.log`
+- `/tmp/omi-acceptance-postfix-wals-initial.json`
+- `/tmp/omi-acceptance-postfix-wals-final.json`
+- `/tmp/omi-cv1-marker-online.aiff`
+- `/tmp/omi-cv1-marker-offline.aiff`

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -1,0 +1,127 @@
+# Pendant BLE Reliability Acceptance
+
+Use this playbook for changes to Omi pendant connection ownership, native
+auto-reconnect, firmware update handoff, time sync, or offline-backlog recovery.
+It complements hermetic Flutter/Kotlin tests; it is not a CI test because it
+requires one physical pendant and phone.
+
+Do not run two app clients against the pendant at once. Stop only the dev build
+you launched. Never stop or replace a production desktop Omi app.
+
+## Automated preflight
+
+From `app/`, run the focused behavioral contracts before touching hardware:
+
+```bash
+flutter test \
+  test/unit/device_transport_exclusive_release_test.dart \
+  test/unit/firmware_dfu_connection_handoff_test.dart \
+  test/unit/native_ble_transport_exclusive_release_test.dart \
+  test/unit/omi_mcu_dfu_policy_test.dart \
+  test/unit/omi_ready_generation_time_sync_test.dart \
+  test/providers/device_provider_test.dart
+
+scripts/analyze_ratchet.sh
+```
+
+If native Android BLE code changed, also run its focused Gradle test target
+named in `app/AGENTS.md`. These tests must pass without a phone, network, sleep,
+or plugin callbacks.
+
+## Fixture and evidence
+
+Record:
+
+- app commit, flavor, phone model/OS, pendant ID suffix, and firmware version;
+- whether Android background mode is enabled;
+- wall-clock time from each disruption to `connected`, audio resumption, and
+  backlog resumption;
+- the app log spanning the disruption, including
+  `OmiDeviceConnection: Time synced to device`;
+- the backlog packet/byte count before and after the run.
+
+Use `flutter run ... > /tmp/omi-flutter.log 2>&1` so the same log drives
+`agent-flutter` and preserves evidence. On iOS, follow
+[`IOS_DEVICE_TESTING.md`](./IOS_DEVICE_TESTING.md). On Android, use the setup in
+[`SKILL.md`](./SKILL.md) and keep `adb logcat` as supplemental native evidence.
+
+## Acceptance matrix
+
+Run the matrix once on Android and once on iOS. Start each row with live audio
+visible in the app and speak a unique marker phrase before and after the
+disruption.
+
+Before every intentional Bluetooth outage, show the tester a user-facing
+`Offline test active — capture will reconnect and backfill` notice. As soon as
+live audio and backlog processing are restored, show
+`Connection restored — live capture and backfill resumed`. Do not begin the
+next disruption until the tester has seen the restoration notice.
+
+| Case | Action | Required result |
+|---|---|---|
+| Initial owner | Cold-launch the dev app with the paired pendant available | The exact paired pendant reaches ready, time sync is attempted once, and live audio starts without a second connect action |
+| Bluetooth cycle | Turn phone Bluetooth off, speak a marker, turn it on, repeat five times | Every cycle reconnects without force-stop/relaunch; one time-sync attempt occurs per new ready generation; live audio resumes |
+| Pendant absence | Take the pendant out of range or power-cycle it, speak while disconnected, then return it | Native reconnect restores live audio; stored audio drains afterward with its original chronology |
+| Foreground/background | Background and foreground the app with the screen both unlocked and locked; on Android test background mode off and on | Reconnect does not create duplicate subscriptions or duplicate time-sync writes; capture/backfill resumes according to the platform mode |
+| MCU DFU success | Complete one normal firmware update | The DFU updater releases BLE, one serialized bounded reclaim loop targets only the exact pre-DFU pendant (up to three attempts), normal audio/backlog sync resumes without app restart, and pendant application settings remain unchanged |
+| DFU failure | Abort or use a controlled failing test image before activation | The app clears firmware-update state and runs one bounded reclaim loop for the same pendant; a plugin error plus thrown future must not start a second loop |
+| Page disposal | Leave the firmware page while terminal cleanup is in flight | Disposal and the later terminal callback share one cleanup/reclaim future; neither strands nor duplicates the BLE owner |
+| Backlog | Begin with a known non-empty pendant backlog, disrupt BLE during transfer, then restore it | Durable records are not acknowledged early; transfer resumes, finishes, and preserves timestamp order without duplicates |
+
+## Repeatable backlog throughput
+
+Use the same exact phone, pendant, app source, firmware artifact, distance, and
+power conditions for candidate-versus-baseline comparisons. Where the backlog
+permits, measure at least three large, clean ranges.
+
+For every range, record:
+
+- start/end durable cursors, record count, raw audio payload bytes, and
+  `dropped` before and after;
+- elapsed time from `READ_BEGIN` acceptance through `DONE`; exclude discovery,
+  connection, service setup, and UI time;
+- raw payload kB/s using decimal kB, plus the clean-run minimum and p50;
+- negotiated MTU, PHY, and connection interval for that connection;
+- whether the range was clean or an interrupted retry.
+
+Interrupted retries are a separate population and must never be folded into the
+clean p50. For this exact fixture, compare the clean p50 against the measured
+88.77 kB/s clean baseline. A lower clean p50 is a regression until a
+parameter-matched rerun explains it; this comparison gate is not an absolute
+speed promise for every phone or radio environment. Keep the measured
+74.10 kB/s retry result classified as an interrupted-retry regression
+(approximately 16.5% below that clean baseline) until it is remeasured on the
+same path.
+
+## Timestamp-specific checks
+
+Firmware reboot can reset its clock. For every initial connection and native
+auto-reconnect:
+
+1. Confirm exactly one `Time synced to device` log for that ready generation.
+2. Confirm a failed GATT write is logged but does not suppress the next
+   generation's attempt.
+3. During rapid reconnects, confirm writes are serialized. A stale generation
+   must never finish after a newer write.
+4. Compare the marker phrases and stored-segment timestamps. Post-reconnect
+   audio must not rewind into an earlier conversation.
+
+## Known DFU telemetry limitation
+
+DFU suspension currently traverses the normal disconnect path before the
+exclusive transport-release seam. Native diagnostics can therefore record this
+ownership handoff as a user-requested manual disconnect even though the user
+did not choose “Disconnect.” Treat that event as DFU lifecycle noise when it
+coincides with firmware update start. A dedicated native suspend reason would
+remove the ambiguity, but is outside this narrowly scoped reliability fix.
+
+## Pass and escalation
+
+Pass only when all rows complete without force-stop/relaunch, manual reconnect,
+wrong-device attachment, duplicate terminal cleanup, or chronological rewind.
+Record measured reconnect and drain times rather than hiding slow runs behind a
+large timeout.
+
+If a row fails, retain the full Flutter/native log and the exact disruption
+sequence. Re-run only once to classify reproducibility; repeated blind retries
+erase the failure state that the reliability work needs.

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -44,17 +44,42 @@ history. A historical drain requires either one explicit Sync action or the
 existing Auto Sync opt-in. Charging changes scheduling capacity, not user
 authority, and therefore never starts a deep drain.
 
-Once the user authorizes a drain, the live lane remains scheduler authority.
-Historical work runs only in bounded slices, and audio that arrives during one
-of those slices must be fetched before another historical slice begins. Being
-plugged in may supply the power budget for requested work; it does not permit
-backlog transfer to delay, replace, or disable live transcription.
+Automatic historical work remains subordinate to the live lane and runs only
+in bounded slices. Explicit **Fast Sync** is a different, user-visible mode: it
+latches one immutable ring write-sequence target, pauses preview delivery, and
+uses larger sequential reads to move that fixed snapshot to durable phone
+storage. Audio recorded after the target remains on the pendant and must not
+expand the active snapshot. Completion, cancellation, or a recoverable transfer
+failure must release BLE to live capture immediately. Being plugged in may
+supply the power budget for requested work; it does not authorize Fast Sync or
+an automatic deep drain.
+
+The Sync page exposes determinate progress against that immutable target while
+Fast Sync owns BLE. The used/free byte count is a cached device-status sample,
+not a transfer counter: the app must not fabricate a decreasing value because
+newer audio continues entering the ring after the target. A later status read
+may refresh those bytes independently of the target-progress indicator.
 
 This contract is shared Dart policy. Android and iOS provide transport
 ownership but do not choose different backlog behavior. If the transcription
 service is unavailable, storage-authoritative firmware keeps recording on the
 pendant; the app must not move an unbounded queue of tiny ranges onto the
 phone while no live transcript can accept them.
+
+### Internal 3.0.30 black-box harness
+
+Production routing remains exact to the 3.0.29 storage-authoritative test
+line. A physical run against diagnostic firmware 3.0.30 build 110 is valid
+only when the app was compiled and launched with
+`--dart-define OMI_BLACKBOX_HARNESS=true`. Before collecting evidence, the
+runtime log must show both `usesStorageAuthoritativeAudio=true` and an active
+ring-audio owner. The define alone is not evidence: a build missing the
+dev-only policy gate silently falls back to the legacy live characteristic and
+invalidates Fast Sync and preview results.
+
+Never widen production firmware routing to admit a diagnostic build. Keep the
+harness artifact in the permanent CV1 evidence directory with its SHA-256,
+bundle identifier, source commit, firmware build, and exact launch command.
 
 ### Authenticated Android physical-device builds
 
@@ -189,7 +214,8 @@ next disruption until the tester has seen the restoration notice.
 | MCU DFU success | Complete one normal firmware update | The DFU updater releases BLE, one serialized bounded reclaim loop targets only the exact pre-DFU pendant (up to three attempts), normal audio/backlog sync resumes without app restart, and pendant application settings remain unchanged |
 | DFU failure | Abort or use a controlled failing test image before activation | The app clears firmware-update state and runs one bounded reclaim loop for the same pendant; a plugin error plus thrown future must not start a second loop |
 | Page disposal | Leave the firmware page while terminal cleanup is in flight | Disposal and the later terminal callback share one cleanup/reclaim future; neither strands nor duplicates the BLE owner |
-| Backlog | Begin with a known non-empty pendant backlog, disrupt BLE during transfer, then restore it | Durable records are not acknowledged early; transfer resumes, finishes, and preserves timestamp order without duplicates |
+| Fast Sync | Begin with a known non-empty pendant backlog, start Fast Sync, disrupt BLE during transfer, then restore it | The fixed snapshot resumes without a second tap; durable records are not acknowledged early; newer capture does not expand the target; transfer finishes in timestamp order without duplicates; live preview resumes immediately |
+| Fast Sync cancel | Start Fast Sync, wait for one bounded range to begin, then cancel | At most the in-flight bounded range finishes and is durably acknowledged; no further historical range begins; live preview resumes without reconnect or app restart |
 
 ## Cross-host ownership handoff
 
@@ -257,21 +283,27 @@ consume historical backlog.
 3. Confirm adjacent physical archives render as one pending row whose duration
    spans their wall-clock capture interval. A five-minute storage boundary is
    never, by itself, a conversation boundary.
-4. Tap Sync once while continuing to produce audio. Capture the
+4. Tap Fast Sync once while continuing to produce audio. Capture the
    `manual backlog snapshot latched` log and its immutable
-   `target_write_seq=T`. Historical ranges authorized by this tap must end at
-   or before `T`; newer records may stream live but must not expand the
-   historical target.
+   `target_write_seq=T`. Preview is intentionally paused while the fixed
+   snapshot drains. Historical ranges authorized by this tap must end at or
+   before `T`; newer records stay in the ring and must not expand the target.
+   Require the Sync page to show determinate progress toward `T`; do not treat
+   its separately cached storage byte count as live transfer progress.
 5. Disable Bluetooth after `NOTIFY_READ_BEGIN` and before `NOTIFY_DONE`, play a
-   unique offline marker, then re-enable Bluetooth. Do not tap Sync again. The
-   same pendant must reconnect, retry from durable coverage, resume the
-   existing live preview, and emit `manual backlog snapshot completed` for the
-   original `T`.
+   unique offline marker, then re-enable Bluetooth. Do not tap Fast Sync again.
+   The same pendant must reconnect, retry from durable coverage, and emit
+   `manual backlog snapshot completed` for the original `T`. The existing live
+   preview then resumes and includes capture produced after `T`.
 6. After the configured conversation boundary closes, require one logical row
    and one upload job for the continuous run. Every physical member must share
    the terminal job result; sequence coverage through `T` must have no holes or
    duplicate source identities. The offline marker must occur once in
    timestamp order.
+7. Repeat with a second fixed snapshot and cancel during one bounded range.
+   Preserve the cancellation time and the first post-cancel live frame time.
+   Already durable coverage may advance, but no subsequent historical READ may
+   begin and the user must not need to reconnect or reopen the capture screen.
 
 A `429` or server `5xx` is not an end-to-end pass. Confirm bounded retry with
 local data retained, then verify the final transcript when the backend is
@@ -338,6 +370,12 @@ auto-reconnect:
    must never finish after a newer write.
 4. Compare the marker phrases and stored-segment timestamps. Post-reconnect
    audio must not rewind into an earlier conversation.
+5. Inject adjacent, contiguous source ranges whose embedded RTC timestamps jump
+   forward beyond the configured conversation boundary. They must never be
+   assembled into one silence-padded canonical file or reported as one long
+   conversation. Preserve both source sequence and embedded timestamp in the
+   diagnostic evidence; sequence establishes identity, while wall clock owns
+   the conversation boundary.
 
 ## Known DFU telemetry limitation
 

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -35,6 +35,12 @@ history. A historical drain requires either one explicit Sync action or the
 existing Auto Sync opt-in. Charging changes scheduling capacity, not user
 authority, and therefore never starts a deep drain.
 
+Once the user authorizes a drain, the live lane remains scheduler authority.
+Historical work runs only in bounded slices, and audio that arrives during one
+of those slices must be fetched before another historical slice begins. Being
+plugged in may supply the power budget for requested work; it does not permit
+backlog transfer to delay, replace, or disable live transcription.
+
 This contract is shared Dart policy. Android and iOS provide transport
 ownership but do not choose different backlog behavior. If the transcription
 service is unavailable, storage-authoritative firmware keeps recording on the

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -24,6 +24,44 @@ flutter test \
 scripts/analyze_ratchet.sh
 ```
 
+### Authenticated Android physical-device builds
+
+The hermetic `test.sh` bootstrap intentionally writes an empty `.dev.env` and
+placeholder development Firebase files. Those inputs are valid for unit tests
+only. Building an APK from them produces a sign-in screen whose OAuth URL is
+relative and whose Firebase identity cannot authenticate the real test
+account.
+
+Before every authenticated Android CV1 run, seed these ignored files from the
+primary maintainer checkout that already has the working prod-backed dev
+configuration:
+
+```bash
+M=/absolute/path/to/maintainer-checkout/app
+W=/absolute/path/to/test-worktree/app
+
+cp "$M/.dev.env" "$W/.dev.env"
+cp "$M/lib/firebase_options_dev.dart" "$W/lib/firebase_options_dev.dart"
+cp "$M/android/app/src/dev/google-services.json" \
+  "$W/android/app/src/dev/google-services.json"
+
+cd "$W"
+dart run build_runner clean
+dart run build_runner build --delete-conflicting-outputs
+bash scripts/verify_android_physical_test_auth_config.sh
+flutter build apk --debug --flavor dev --target-platform android-arm64
+```
+
+The clean is required because build_runner's cached asset graph may not notice
+an ignored `.dev.env` change and can report "wrote 0 outputs" while retaining
+the empty test URL. The preflight decrypts the generated
+`lib/env/dev_env.g.dart`; it must report generated prod API + prod Firebase with
+the dev package before the APK is installed. Re-run it after every `test.sh`,
+`flutter pub get`, setup script, branch switch, or rebase that may regenerate
+ignored configuration.
+An auth failure from an APK that did not pass this preflight is a build-fixture
+failure, not BLE evidence.
+
 If native Android BLE code changed, also run its focused Gradle test target
 named in `app/AGENTS.md`. These tests must pass without a phone, network, sleep,
 or plugin callbacks.

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -81,6 +81,23 @@ Never widen production firmware routing to admit a diagnostic build. Keep the
 harness artifact in the permanent CV1 evidence directory with its SHA-256,
 bundle identifier, source commit, firmware build, and exact launch command.
 
+### Standalone iOS dogfood builds
+
+A debug/JIT app is valid only while Flutter tooling is actively attached. It
+may keep running after detach, but a later process death can leave SpringBoard
+relaunch crashing in generated plugin registration before Dart starts. Before
+an unattended drain or dogfood handoff, run
+`app/e2e/scripts/build_signed_ios_physical_dev.sh` in its default profile mode,
+install that signed AOT app over the same isolated bundle identifier, and prove
+one terminate/relaunch cycle. Never uninstall to change modes: the in-place
+update preserves auth, pairing, recordings, and the durable sync manifest.
+The final handoff command is
+`app/e2e/scripts/install_ios_dogfood_profile.sh /absolute/path/to/profile.app`.
+It refuses any bundle containing Flutter's JIT `kernel_blob.bin`, verifies the
+exact Firebase, signing, and bundle identities, installs in place, and performs
+the required cold launch. A generic `flutter run` or a successful debug test
+session is never the final dogfood handoff.
+
 ### Authenticated Android physical-device builds
 
 The hermetic `test.sh` bootstrap intentionally writes an empty `.dev.env` and

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -21,10 +21,12 @@ flutter test \
   test/services/capture/device_audio_streaming_policy_test.dart \
   test/services/capture/live_transcript_preview_test.dart \
   test/services/wals/ring_storage_sync_test.dart \
+  test/unit/audio_player_utils_test.dart \
   test/unit/conversation_audio_assembler_test.dart \
   test/unit/device_transport_exclusive_release_test.dart \
   test/unit/firmware_dfu_connection_handoff_test.dart \
   test/unit/local_wal_sync_test.dart \
+  test/unit/wal_upload_resilience_test.dart \
   test/unit/native_ble_transport_exclusive_release_test.dart \
   test/unit/omi_mcu_dfu_policy_test.dart \
   test/unit/omi_ready_generation_time_sync_test.dart \
@@ -233,6 +235,8 @@ next disruption until the tester has seen the restoration notice.
 | Page disposal | Leave the firmware page while terminal cleanup is in flight | Disposal and the later terminal callback share one cleanup/reclaim future; neither strands nor duplicates the BLE owner |
 | Fast Sync | Begin with a known non-empty pendant backlog, start Fast Sync, disrupt BLE during transfer, then restore it | The fixed snapshot resumes without a second tap; durable records are not acknowledged early; newer capture does not expand the target; transfer finishes in timestamp order without duplicates; live preview resumes immediately |
 | Fast Sync cancel | Start Fast Sync, wait for one bounded range to begin, then cancel | At most the in-flight bounded range finishes and is durably acknowledged; no further historical range begins; live preview resumes without reconnect or app restart |
+| Recovered playback | Play a known recovered recording, let another app own audio, return, then play it again | Both attempts are audible; route activation precedes player start; completion/stop releases the owned session; a route failure is visible and cannot leave an advancing silent player |
+| Oversized cloud transaction | Inject or select one immutable batch that receives HTTP 413 with healthy recordings queued behind it | Every rejected source file remains local; the deterministic batch stops automatic retrying; later healthy recordings upload in the same drain; a manual retry remains available and surfaces the boundary failure |
 
 ## Cross-host ownership handoff
 
@@ -286,6 +290,16 @@ rows or change the local-files upload boundary. It is valid to retain multiple
 bounded ring/archive artifacts internally, but adjacent artifacts inside the
 configured conversation-silence boundary must appear as one logical recording
 and upload as one ordered multipart job.
+
+If that complete multipart transaction receives HTTP 413, the app must retain
+every immutable source and quarantine only that transaction from automatic
+retry. It must continue uploading later healthy recordings; a deterministic
+size rejection is not evidence that the network or whole lane is offline.
+Do not split one logical conversation into independent asynchronous jobs as an
+app-only workaround: without a durable shared owner, those jobs can race into
+duplicate or fragmented conversations. A recording that exceeds the request
+boundary needs a resumable/direct-upload server contract or a durable
+sequential chunk protocol.
 
 Run this case with `autoSyncOfflineRecordings=false`. Charging never authorizes
 a deep drain; only a Sync tap or explicit automatic offline-sync opt-in may

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -14,15 +14,24 @@ From `app/`, run the focused behavioral contracts before touching hardware:
 
 ```bash
 flutter test \
+  test/providers/capture_provider_test.dart \
+  test/providers/device_provider_test.dart \
+  test/providers/sync_provider_sync_wal_wake_test.dart \
+  test/services/capture/conversation_session_window_test.dart \
   test/services/capture/device_audio_streaming_policy_test.dart \
+  test/services/capture/live_transcript_preview_test.dart \
   test/services/wals/ring_storage_sync_test.dart \
+  test/unit/conversation_audio_assembler_test.dart \
   test/unit/device_transport_exclusive_release_test.dart \
   test/unit/firmware_dfu_connection_handoff_test.dart \
+  test/unit/local_wal_sync_test.dart \
   test/unit/native_ble_transport_exclusive_release_test.dart \
   test/unit/omi_mcu_dfu_policy_test.dart \
   test/unit/omi_ready_generation_time_sync_test.dart \
-  test/providers/device_provider_test.dart
+  test/widgets/transcription_paused_warning_test.dart
 
+bash scripts/test_verify_android_physical_test_auth_config.sh
+bash scripts/test_verify_ios_physical_test_auth_config.sh
 scripts/analyze_ratchet.sh
 ```
 
@@ -57,7 +66,8 @@ account.
 
 Before every authenticated Android CV1 run, seed these ignored files from the
 primary maintainer checkout that already has the working prod-backed dev
-configuration:
+configuration. Do not install the APK unless the mandatory preflight below
+passes after generation:
 
 ```bash
 M=/absolute/path/to/maintainer-checkout/app
@@ -67,6 +77,15 @@ cp "$M/.dev.env" "$W/.dev.env"
 cp "$M/lib/firebase_options_dev.dart" "$W/lib/firebase_options_dev.dart"
 cp "$M/android/app/src/dev/google-services.json" \
   "$W/android/app/src/dev/google-services.json"
+# main.dart imports both flavor option libraries at compile time. A dev build
+# still needs the checked-in setup fixture at the unused prod import path.
+cp "$W/setup/prebuilt/firebase_options.dart" \
+  "$W/lib/firebase_options_prod.dart"
+cp "$W/setup/prebuilt/key.properties" "$W/android/key.properties"
+
+# The maintainer checkout may target the development API. Hardware acceptance
+# must exercise the canonical customer data plane with the production Firebase
+# project; set API_BASE_URL=https://api.omi.me/ in the copied .dev.env.
 
 cd "$W"
 dart run build_runner clean
@@ -78,8 +97,13 @@ flutter build apk --debug --flavor dev --target-platform android-arm64
 The clean is required because build_runner's cached asset graph may not notice
 an ignored `.dev.env` change and can report "wrote 0 outputs" while retaining
 the empty test URL. The preflight decrypts the generated
-`lib/env/dev_env.g.dart`; it must report generated prod API + prod Firebase with
-the dev package before the APK is installed. Re-run it after every `test.sh`,
+`lib/env/dev_env.g.dart`; it must report the canonical production API + prod
+Firebase with the dev package before the APK is installed. `api.omiapi.com` is
+a development backend and is invalid acceptance evidence even when Firebase
+authentication succeeds. Android and iOS preflights source the same executable
+authority in `scripts/physical_test_customer_plane.sh`; do not duplicate or
+override its endpoint in a platform-specific test workflow. Re-run the
+preflight after every `test.sh`,
 `flutter pub get`, setup script, branch switch, or rebase that may regenerate
 ignored configuration.
 An auth failure from an APK that did not pass this preflight is a build-fixture
@@ -105,7 +129,10 @@ that upload task. Gradle still compiles and packages the complete dev APK:
 
 ```bash
 cd android
-./gradlew app:assembleDevDebug \
+"$JAVA_HOME/bin/java" \
+  -classpath gradle/wrapper/gradle-wrapper.jar \
+  org.gradle.wrapper.GradleWrapperMain \
+  app:assembleDevDebug \
   -x app:uploadCrashlyticsMappingFileDevDebug \
   -Ptarget-platform=android-arm64 \
   -Ptarget=lib/main.dart

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -62,6 +62,41 @@ ignored configuration.
 An auth failure from an APK that did not pass this preflight is a build-fixture
 failure, not BLE evidence.
 
+#### Verified maintainer workstation toolchain
+
+On the maintainer Mac used for CV1 acceptance, establish the toolchain before
+regenerating or building. Do not replace `PATH` with a reduced list: Node lives
+under `$HOME/.local/bin` on this machine and repository gates require it.
+
+```bash
+export JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home
+export PATH="/opt/homebrew/bin:$HOME/.local/bin:$PATH"
+
+java -version
+flutter --version  # verified with Flutter 3.44.8
+node --version     # verified with Node 22.23.1
+```
+
+If the local network blocks the debug Crashlytics mapping upload, exclude only
+that upload task. Gradle still compiles and packages the complete dev APK:
+
+```bash
+cd android
+./gradlew app:assembleDevDebug \
+  -x app:uploadCrashlyticsMappingFileDevDebug \
+  -Ptarget-platform=android-arm64 \
+  -Ptarget=lib/main.dart
+cd ..
+
+shasum -a 256 build/app/outputs/flutter-apk/app-dev-debug.apk
+```
+
+Git hooks export the Omi worktree's `GIT_DIR`. Raw Flutter commands inside a
+hook can then inspect Omi instead of the Flutter SDK and report
+`0.0.0-unknown`. Hook-owned Flutter commands must use the checked-in
+`scripts/flutter-with-clean-git-env` wrapper. Its behavioral regression is part
+of the existing `setup-pre-push-prerequisites` gate.
+
 If native Android BLE code changed, also run its focused Gradle test target
 named in `app/AGENTS.md`. These tests must pass without a phone, network, sleep,
 or plugin callbacks.

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -131,6 +131,51 @@ speed promise for every phone or radio environment. Keep the measured
 (approximately 16.5% below that clean baseline) until it is remeasured on the
 same path.
 
+## Storage-authoritative logical backlog
+
+Remote VAD and backlog grouping are independent contracts. Remote VAD adds a
+voice gate to the live transcription socket; it does not merge Sync-screen
+rows or change the local-files upload boundary. It is valid to retain multiple
+bounded ring/archive artifacts internally, but adjacent artifacts inside the
+configured conversation-silence boundary must appear as one logical recording
+and upload as one ordered multipart job.
+
+Run this case with the pendant off its charger and
+`autoSyncOfflineRecordings=false`; charging or enabling automatic offline sync
+independently authorizes a deep drain.
+
+1. Record the configured conversation-silence duration, Remote VAD state,
+   initial battery, and initial ring `read`, `write`, and `dropped` counters.
+   Preserve the WAL manifest and a SHA-256 inventory of audio artifacts.
+2. Cold-launch the authenticated dev app and establish live transcription.
+   Wait 60–90 seconds without tapping Sync. Recent live/recovery reads are
+   allowed, but old backlog must neither drain nor upload automatically.
+3. Confirm adjacent physical archives render as one pending row whose duration
+   spans their wall-clock capture interval. A five-minute storage boundary is
+   never, by itself, a conversation boundary.
+4. Tap Sync once while continuing to produce audio. Capture the
+   `manual backlog snapshot latched` log and its immutable
+   `target_write_seq=T`. Historical ranges authorized by this tap must end at
+   or before `T`; newer records may stream live but must not expand the
+   historical target.
+5. Disable Bluetooth after `NOTIFY_READ_BEGIN` and before `NOTIFY_DONE`, play a
+   unique offline marker, then re-enable Bluetooth. Do not tap Sync again. The
+   same pendant must reconnect, retry from durable coverage, resume the
+   existing live preview, and emit `manual backlog snapshot completed` for the
+   original `T`.
+6. After the configured conversation boundary closes, require one logical row
+   and one upload job for the continuous run. Every physical member must share
+   the terminal job result; sequence coverage through `T` must have no holes or
+   duplicate source identities. The offline marker must occur once in
+   timestamp order.
+
+A `429` or server `5xx` is not an end-to-end pass. Confirm bounded retry with
+local data retained, then verify the final transcript when the backend is
+available. Report record throughput (`count * 444 / elapsed`) and encoded-audio
+throughput (`count * 440 / elapsed`) separately, and keep interrupted retries
+out of the clean p50. Do not publish raw manifests, preferences, account IDs,
+or full Bluetooth addresses.
+
 ## Deterministic voice-gate fixture
 
 Use recorded or synthesized speech instead of tester speech when comparing

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -131,6 +131,52 @@ speed promise for every phone or radio environment. Keep the measured
 (approximately 16.5% below that clean baseline) until it is remeasured on the
 same path.
 
+## Deterministic voice-gate fixture
+
+Use recorded or synthesized speech instead of tester speech when comparing
+firmware voice-gate candidates. Keep the pendant position, phone position,
+speaker, macOS output level, and pendant microphone gain unchanged for the
+entire comparison.
+
+Create one reusable marker:
+
+```bash
+say -v Samantha -r 165 \
+  -o /tmp/omi-cv1-marker.aiff \
+  "Omi marker seven. The blue train reaches the station at nine forty."
+```
+
+For each firmware artifact:
+
+1. Record the artifact SHA-256 and the initial ring `read`, `write`, and
+   `dropped` counters.
+2. Leave the fixture silent for 60 seconds. After the configured audio
+   hangover, `write` must remain stable; hardware-AAD wakeups alone are not
+   stored speech.
+3. Play the marker five times at the fixed normal level, separated by
+   one-second pauses:
+
+   ```bash
+   for run in 1 2 3 4 5; do
+     afplay -v 0.50 /tmp/omi-cv1-marker.aiff
+     sleep 1
+   done
+   ```
+
+4. Repeat once at the fixed quiet level with `afplay -v 0.25`.
+5. Leave the fixture silent again. The ring must stop growing within the
+   encoded-audio hangover even if the low-power conversation window remains
+   armed.
+6. Cycle phone Bluetooth off, play one marker while disconnected, then turn
+   Bluetooth on. The app must resume live audio first and durably recover the
+   missing marker with its capture timestamp.
+
+Pass only when all normal-level markers and the quiet marker are durably
+present, the two silence windows do not create audio records, `dropped` does
+not increase, and the reconnect produces neither a duplicate marker nor a
+chronological rewind. Preserve the generated audio file, artifact hash, ring
+snapshots, and Flutter/native log with the run evidence.
+
 ## Timestamp-specific checks
 
 Firmware reboot can reset its clock. For every initial connection and native

--- a/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
+++ b/app/e2e/BLE_RELIABILITY_ACCEPTANCE.md
@@ -14,6 +14,8 @@ From `app/`, run the focused behavioral contracts before touching hardware:
 
 ```bash
 flutter test \
+  test/services/capture/device_audio_streaming_policy_test.dart \
+  test/services/wals/ring_storage_sync_test.dart \
   test/unit/device_transport_exclusive_release_test.dart \
   test/unit/firmware_dfu_connection_handoff_test.dart \
   test/unit/native_ble_transport_exclusive_release_test.dart \
@@ -23,6 +25,21 @@ flutter test \
 
 scripts/analyze_ratchet.sh
 ```
+
+## Storage-authoritative operating contract
+
+The default connected mode is live capture. It may repair missing audio from
+the still-open conversation, using the configured conversation-silence
+boundary and durable sequence coverage, but it must not consume older pendant
+history. A historical drain requires either one explicit Sync action or the
+existing Auto Sync opt-in. Charging changes scheduling capacity, not user
+authority, and therefore never starts a deep drain.
+
+This contract is shared Dart policy. Android and iOS provide transport
+ownership but do not choose different backlog behavior. If the transcription
+service is unavailable, storage-authoritative firmware keeps recording on the
+pendant; the app must not move an unbounded queue of tiny ranges onto the
+phone while no live transcript can accept them.
 
 ### Authenticated Android physical-device builds
 
@@ -134,12 +151,31 @@ next disruption until the tester has seen the restoration notice.
 |---|---|---|
 | Initial owner | Cold-launch the dev app with the paired pendant available | The exact paired pendant reaches ready, time sync is attempted once, and live audio starts without a second connect action |
 | Bluetooth cycle | Turn phone Bluetooth off, speak a marker, turn it on, repeat five times | Every cycle reconnects without force-stop/relaunch; one time-sync attempt occurs per new ready generation; live audio resumes |
-| Pendant absence | Take the pendant out of range or power-cycle it, speak while disconnected, then return it | Native reconnect restores live audio; stored audio drains afterward with its original chronology |
+| Pendant absence | Take the pendant out of range or power-cycle it, speak while disconnected, then return it | Native reconnect restores live audio; the still-open conversation gap is repaired in its original chronology without authorizing older history |
 | Foreground/background | Background and foreground the app with the screen both unlocked and locked; on Android test background mode off and on | Reconnect does not create duplicate subscriptions or duplicate time-sync writes; capture/backfill resumes according to the platform mode |
 | MCU DFU success | Complete one normal firmware update | The DFU updater releases BLE, one serialized bounded reclaim loop targets only the exact pre-DFU pendant (up to three attempts), normal audio/backlog sync resumes without app restart, and pendant application settings remain unchanged |
 | DFU failure | Abort or use a controlled failing test image before activation | The app clears firmware-update state and runs one bounded reclaim loop for the same pendant; a plugin error plus thrown future must not start a second loop |
 | Page disposal | Leave the firmware page while terminal cleanup is in flight | Disposal and the later terminal callback share one cleanup/reclaim future; neither strands nor duplicates the BLE owner |
 | Backlog | Begin with a known non-empty pendant backlog, disrupt BLE during transfer, then restore it | Durable records are not acknowledged early; transfer resumes, finishes, and preserves timestamp order without duplicates |
+
+## Cross-host ownership handoff
+
+CV1 firmware exposes one BLE connection. An installed iOS app may be relaunched
+by CoreBluetooth restoration even when it is not the companion the user is
+actively using. With iOS Background Mode disabled:
+
+1. Connect iOS, terminate the dev app, and confirm iOS performs a restoration
+   launch.
+2. Leave that restored iOS process running and enable Bluetooth on the paired
+   Android phone.
+3. Android must acquire the pendant without terminating iOS again. The
+   background-launched Flutter engine must not reclaim the link.
+4. Disable Android Bluetooth and foreground iOS. iOS must then reconnect and
+   republish GATT readiness.
+
+Repeat with iOS Background Mode enabled. In that opt-in mode, restoration owns
+the background capture link until the user explicitly releases or switches the
+device; this is expected rather than a handoff failure.
 
 ## Repeatable backlog throughput
 
@@ -175,9 +211,9 @@ bounded ring/archive artifacts internally, but adjacent artifacts inside the
 configured conversation-silence boundary must appear as one logical recording
 and upload as one ordered multipart job.
 
-Run this case with the pendant off its charger and
-`autoSyncOfflineRecordings=false`; charging or enabling automatic offline sync
-independently authorizes a deep drain.
+Run this case with `autoSyncOfflineRecordings=false`. Charging never authorizes
+a deep drain; only a Sync tap or explicit automatic offline-sync opt-in may
+consume historical backlog.
 
 1. Record the configured conversation-silence duration, Remote VAD state,
    initial battery, and initial ring `read`, `write`, and `dropped` counters.

--- a/app/e2e/IOS_CV1_BUILD110_RUN_2026-08-04.md
+++ b/app/e2e/IOS_CV1_BUILD110_RUN_2026-08-04.md
@@ -1,0 +1,76 @@
+# iOS CV1 build-110 physical run — 2026-08-04
+
+Status: bounded physical pass on a composite qualification build. This is not
+evidence that this PR head by itself contains every native iOS commit in the
+composite; the serialized/session-bound GATT layer remains separately reviewed
+in #10573.
+
+## Configuration
+
+- firmware: CV1 `3.0.30+110`
+- firmware ZIP SHA-256:
+  `8ad0dad061fe637b922d5ed6667a4ac0713ebbe9539fa03ab0744b45e0dcabec`
+- composite IPA SHA-256:
+  `2ddaf0e3c63a6cf49f0630d9fa5858ca1306056aaa0a58d255f9f5f14b94db8f`
+- isolated iOS bundle: `com.omi.reliability.alexsmacbookpro`
+- authenticated customer plane: production Firebase plus
+  `https://api.omi.me/`
+- historical sync authority: explicit Sync tap
+
+The production App Store Omi app was removed from this dedicated test phone
+after the user authorized it. The postflight inventory used
+`devicectl ... apps --include-all-apps` and proved Omi Dev was the only Omi
+bundle. The `--include-all-apps` flag is required: the default inventory lists
+developer apps and previously hid the App Store BLE owner.
+
+## Cold reconnect and no-touch preview
+
+1. The previous app process was stopped.
+2. The user power-cycled the pendant.
+3. The exact composite IPA was cold-launched.
+4. Home was left untouched; Listening was never opened.
+5. TTS marker `Uniform` ended at `2026-08-04T19:50:00Z`.
+6. The home preview contained marker text at the +5-second screenshot and
+   remained populated at +15 seconds.
+
+Result: pass. A card tap is not required to publish preview text after the
+tested cold app plus pendant reconnect.
+
+The five-second observation is **not** launch-to-first-text latency. It is the
+time from the end of a controlled marker to the first scheduled screenshot.
+Ambient speech may have warmed the session. Future latency work must timestamp
+app launch, BLE connect, GATT ready, ring-tail ready, durable audio, socket
+ready, first transcript, and preview paint separately.
+
+## Explicit historical drain while live
+
+The Sync page showed 560 recordings and 196 MB used (42%). Sync was started by
+an explicit tap. While upload remained active, the tester returned Home and
+spoke TTS marker `Victor`.
+
+- preview contained Victor marker text at the +5-second checkpoint;
+- the app remained responsive;
+- no BLE disconnect or preview interruption was observed;
+- pendant storage decreased to 195 MB / 41% during the controlled window;
+- the recording count became 561 because new live capture continued;
+- the user later observed 188 MB used, corroborating continued drain.
+
+Result: pass for live-preview priority during one user-authorized historical
+drain. The complete backlog and post-drain semantic state have not yet been
+audited.
+
+## Open items
+
+- compare canonical source coverage with historical archive manifests after
+  drain to exclude duplicate binding;
+- verify process-death audio is bound into the original conversation rather
+  than merely retained as durable unbound WALs;
+- investigate any repeatable whole-app freeze with a timeline/main-thread
+  sample;
+- measure cold first-preview phase latency and battery/thermal impact;
+- repeat Android parity on the same final artifact.
+
+The independent Kimi follow-up classified the process-death owner defect and
+the final-pass nits as app-side. It recommended proceeding with this bounded
+gate and stopping if a freeze interrupted sync or preview. No freeze occurred
+in this run.

--- a/app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md
+++ b/app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md
@@ -107,3 +107,31 @@ contract is implemented and tested end to end.
   resumes without starving live continuity.
 - Run an unplugged quiet/speech cycle long enough to compare 3.0.29 battery use
   with the prior firmware.
+
+## 2026-07-30 cross-host restoration audit
+
+CV1 exposes one BLE connection, so an iOS restoration launch can prevent an
+otherwise healthy Android companion from acquiring the pendant. Two initial
+release-policy variants failed the physical handoff and are not counted as
+passes. A fresh iPhone system-log archive showed why: `bluetoothd` retained the
+restorable CoreBluetooth session, SpringBoard relaunched the isolated dev app
+in the background, and the restored session associated the already-connected
+pendant before the Flutter foreground policy ran.
+
+This distinguishes two responsibilities:
+
+- a process-level gate prevents new background `connectPeripheral` requests;
+- the app must also cancel the exact OS-restored physical peripheral when
+  Background Mode is disabled.
+
+The candidate now uses the exact paired UUID supplied by Flutter to retrieve
+and release that restored peripheral, even when CoreBluetooth's restoration
+dictionary is empty. The foreground callback consumes the gate and reconnects
+the deferred UUID. With Background Mode enabled, restoration remains the
+explicitly authorized owner.
+
+The signed isolated build containing the exact-UUID release policy is installed
+without replacing the production app. A final physical four-leg proof remains:
+iOS connect, OS background restoration, Android acquisition while restored iOS
+stays alive, then iOS foreground reacquisition after Android releases the
+pendant. No pass is claimed until all four legs complete.

--- a/app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md
+++ b/app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md
@@ -1,0 +1,78 @@
+# iOS CV1 Storage-First Acceptance — 2026-07-29
+
+This is the physical-device evidence record for the storage-authoritative CV1
+path in [`BLE_RELIABILITY_ACCEPTANCE.md`](./BLE_RELIABILITY_ACCEPTANCE.md).
+It records the passing durability result and the timeline defect exposed by
+the final server result. It does not claim the unrun iOS Bluetooth-radio or
+manual historical-backlog cases.
+
+## Fixture
+
+| Item | Value |
+|---|---|
+| Phone | iPhone 13 Pro Max, iOS 26.5.2 |
+| App | isolated Omi Dev build; production API and Firebase project |
+| Candidate source | `3bf17faf7a` |
+| Pendant | Omi CV1, identifier ending `1240` |
+| Firmware | storage-authoritative `3.0.29` candidate |
+| App policy | automatic offline sync off |
+| Initial/final reported battery | 56% / 54% |
+
+The build passed
+`scripts/verify_ios_physical_test_auth_config.sh` before installation. The
+production iOS app was not replaced. Do not publish the raw logs, WAL manifest,
+or recording filename: they contain account and complete device identifiers.
+
+## Physical results
+
+| Case | Result | Evidence |
+|---|---|---|
+| Authenticated isolated build | Pass | The dev app retained the signed-in account, loaded Conversations, and connected to the exact paired CV1 on firmware 3.0.29. |
+| Automatic deep backlog policy | Pass | Device Settings showed Auto-Sync off. Current-conversation recovery proceeded without authorizing the historical queue. |
+| No-client storage interval | Pass | Every Omi app process was terminated for a 25-second marker interval. The same installed build then relaunched, reclaimed the exact pendant, and resumed live capture without a manual reconnect. |
+| Canonical conversation assembly | Pass | The phone published and reconciled one `synced` canonical WAL containing 14,077 Opus frames, 281.54 seconds of decoded audio, and the full before/offline/after interval. The encoded artifact SHA-256 was `2cc31ec80d554b5fff7c76df03ea837499517cf9f2a9d880314ef0805c8e5ad3`. |
+| Offline speech recovery | Pass | Independent local Whisper transcription of the canonical audio recovered the complete offline marker, including `Cobalt River 913`, followed later by the post-reconnect marker `Silver Pine 826`. |
+| Final content chronology | Pass | The server-generated conversation included the offline and post-reconnect markers in the same result. |
+| Final duration/timeline | **Fail** | The resulting card reported 11 seconds although the canonical source was 281.54 seconds. Content survived, but its transcript origin was still the post-reconnect live session. |
+| iOS Bluetooth Settings off/on | Not run | WebDriverAgent compiled and signed, but XCTest timed out while enabling automation mode before a session existed. An app-process outage is not a substitute for a radio-toggle result. |
+| Battery | Observation only | The displayed drop from 56% to 54% includes build, reconnect, automation, TTS, upload, and processing time; it is not a controlled battery benchmark. |
+
+## Timeline-defect diagnosis
+
+The app requests a canonical transcript replacement by adding
+`transcript_mode=replace` to `POST /v2/sync-local-files`. The current backend
+route does not declare or consume that parameter. It instead merges recovered
+segments into the existing live conversation while keeping the live
+conversation's later `started_at`. Earlier recovered segments therefore receive
+negative relative offsets, and the app's duration calculation reports only the
+latest positive transcript end.
+
+This is not an audio-loss failure: the canonical artifact and final summary
+both contain the offline material. It is an app/backend contract gap, and the
+candidate must not claim correct final timeline reconstruction until that
+contract is implemented and tested end to end.
+
+## Local evidence
+
+- `/tmp/omi-ios-storage-first-recovery-20260729-live.log`
+- `/tmp/omi-ios-storage-first-runner-syslog.log`
+- `/tmp/omi-ios-storage-first-wals-latest.0iAw1m/wals.json`
+- `/tmp/omi-ios-storage-final-wals.XXXXXX.json`
+- `/tmp/omi-ios-canonical-recovered.wav`
+- `/tmp/omi-ios-offline-window.txt`
+- `/tmp/omi-ios-post-window.txt`
+- `/tmp/omi-ios-reconnect-conversation.png`
+
+## Remaining acceptance work
+
+- Implement the canonical replacement contract with atomic transcript/timeline
+  ownership, then rerun this exact marker case and require an approximately
+  282-second final conversation with no duplicate text.
+- Reprocess one completed canonical conversation once per batch, not once per
+  VAD segment.
+- Run the physical iOS Bluetooth Settings off/on case after XCTest automation
+  is available, including foreground, background, and locked-screen reconnect.
+- Authorize one bounded manual historical-backlog snapshot and prove it
+  resumes without starving live continuity.
+- Run an unplugged quiet/speech cycle long enough to compare 3.0.29 battery use
+  with the prior firmware.

--- a/app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md
+++ b/app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md
@@ -37,6 +37,34 @@ or recording filename: they contain account and complete device identifiers.
 | iOS Bluetooth Settings off/on | Not run | WebDriverAgent compiled and signed, but XCTest timed out while enabling automation mode before a session existed. An app-process outage is not a substitute for a radio-toggle result. |
 | Battery | Observation only | The displayed drop from 56% to 54% includes build, reconnect, automation, TTS, upload, and processing time; it is not a controlled battery benchmark. |
 
+## Rebased process-relaunch rerun
+
+A second isolated build from the rebased PR reproduced an iOS-only readiness
+gap before the fix. CoreBluetooth retained the physical pendant link across
+process termination, so the relaunched app observed the peripheral as
+`connected`. `connectPeripheral` returned without rediscovering services, no
+notification transitions followed, and Dart never received a fresh
+`onDeviceReady`. This is the concrete "connected but no live preview" failure;
+it is not a difference in the phone-side canonical assembler.
+
+The fixed build treats an already-connected peripheral as a GATT recovery
+request. It reassigns the delegate and rediscovers services, which republishes
+readiness after Flutter has installed its callback. On the physical rerun:
+
+- app launch began at `16:38:34`;
+- native revalidation began at `16:38:35.779`;
+- required notification transitions completed between `16:38:36.414` and
+  `16:38:37.645`;
+- no manual device selection or reconnect was required.
+
+The redwood / offline cedar / post-reconnect sequoia marker interval produced
+20 immutable ring WALs containing 2,253 Opus frames. Their pendant sequence
+ranges formed one exact contiguous interval, `[1490992, 1491492)`, including
+the audio captured while the app process was absent. This rerun proves
+transport recovery and durable source coverage. It does not replace the
+earlier canonical/server chronology test: production still lacks the backend
+replacement contract described below.
+
 ## Timeline-defect diagnosis
 
 The app requests a canonical transcript replacement by adding
@@ -62,6 +90,9 @@ contract is implemented and tested end to end.
 - `/tmp/omi-ios-offline-window.txt`
 - `/tmp/omi-ios-post-window.txt`
 - `/tmp/omi-ios-reconnect-conversation.png`
+- `/tmp/omi-ios-storage-first-rebased-reconnect-live-20260729.log`
+- `/tmp/omi-ios-storage-first-recoveryfix-reconnect-live-20260729.log`
+- `/tmp/omi-ios-wals-after-reconnectfix-20260729.json`
 
 ## Remaining acceptance work
 

--- a/app/e2e/IOS_DEVICE_TESTING.md
+++ b/app/e2e/IOS_DEVICE_TESTING.md
@@ -69,6 +69,34 @@ First build in a worktree ≈ 10 min (pods + Xcode). Incremental relaunches are 
 
 **Auth:** if the app boots to onboarding, an agent can drive consent/permission screens, but Sign in with Apple/Google needs the human once (Face ID / device biometrics). Ask, then take over — everything after sign-in is agent-drivable.
 
+### Final unattended handoff is profile/AOT, never debug/JIT
+
+`flutter run` is an attached test session, not the build to leave on the phone
+for a drain or day-long dogfood run. A detached debug/JIT build can die later
+and its next SpringBoard launch can crash in generated native plugin
+registration before Dart starts. That exact failure was observed after about
+23 minutes on 2026-08-05.
+
+Before giving the phone back, build and install the signed profile/AOT app over
+the same isolated bundle identifier:
+
+```bash
+cd app
+PROFILE_APP="$(e2e/scripts/build_signed_ios_physical_dev.sh | tail -1)"
+e2e/scripts/install_ios_dogfood_profile.sh "$PROFILE_APP"
+```
+
+The local-only signing and device identities live in
+`~/.config/omi-mobile-test/ios-physical-test.env`; the scripts fail closed when
+that ignored config is absent. Never put a personal team ID, signing identity,
+provisioning-profile path, or physical device UUID in the repository.
+
+The final installer rejects any Flutter artifact containing the JIT
+`kernel_blob.bin`, verifies the physical-test identity, updates in place so
+auth/pairing/recordings/sync state survive, and proves a terminate/relaunch
+cycle. Do not uninstall to change modes. A successful debug run or detach does
+not satisfy the handoff gate.
+
 ## 4. Connect and drive
 
 ```bash
@@ -113,13 +141,20 @@ Verified order of attack; stop at the first rung that works:
 
 ## 7. Session hygiene & gotchas
 
-- **Keep the phone unlocked.** iOS terminates the debug link after prolonged backgrounding: `"The OS has terminated the Flutter debug connection for being inactive"` — the app keeps running but you must relaunch `flutter run` to reattach. This is a session-ender if you're mid-flow; check the phone before long code-reading pauses.
+- **Keep the phone unlocked during an attached debug session.** iOS terminates
+  the debug link after prolonged backgrounding: `"The OS has terminated the
+  Flutter debug connection for being inactive"`. The process may continue
+  temporarily, but it is not a standalone handoff and may later die or fail to
+  relaunch. Reattach for more debug testing, or install profile/AOT before
+  unattended use.
 - **Test data**: create-then-delete your own artifacts (e.g. a memory literally named "smoke-test — safe to delete"); never exercise destructive flows on the user's real data. If a leftover survives (session died first), tell the user exactly what to remove.
 - **Build side effects**: `flutter run` can dirty `app/ios/Podfile.lock`,
   `app/ios/Flutter/AppFrameworkInfo.plist`, and `app/pubspec.lock`. Restore only
   the mechanical build changes you inspected; do not discard unrelated user
   edits.
-- **After the session**: the phone carries your branch build. Tell the user; App Store reinstall restores the release binary (data survives).
+- **After the session**: the phone must carry the guarded profile/AOT branch
+  build, not the debug/JIT runner. Tell the user which artifact is installed.
+  App Store reinstall restores the release binary (data survives).
 
 ## 8. Known limitations
 

--- a/app/e2e/IOS_DEVICE_TESTING.md
+++ b/app/e2e/IOS_DEVICE_TESTING.md
@@ -23,23 +23,43 @@ Device prerequisites (human, once): iPhone in Developer Mode, cable to the Mac, 
 
 ## 2. Per-worktree app setup
 
-The app builds fine from any git worktree, but `app/test.sh`'s bootstrap seeds **dev-placeholder** Firebase/env files that point at the wrong project for prod flavor. Before a `--flavor prod` build in a fresh worktree, copy the real config from the primary checkout:
+Use an isolated dev app backed by the production API and the production
+Firebase project. This preserves the App Store app while still exercising the
+real auth and transcription path. A staging Firebase registration with the
+production API fails custom-token exchange with
+`firebase_auth/custom-token-mismatch`; an Android Firebase app ID placed in the
+iOS options crashes Firebase initialization.
+
+Seed these ignored files from the maintainer's known-good iOS physical-test
+fixture (never commit their credentials):
 
 ```bash
-M=<primary-checkout>/app; W=<worktree>/app
-cp $M/.env $W/.env
-cp $M/lib/firebase_options_prod.dart $W/lib/firebase_options_prod.dart
-cp $M/ios/Config/Prod/GoogleService-Info.plist $W/ios/Config/Prod/GoogleService-Info.plist
-cp $M/lib/env/prod_env.g.dart $W/lib/env/prod_env.g.dart   # or rerun build_runner after copying .env
+M=<maintainer-config-source>/app; W=<worktree>/app
+cp "$M/.dev.env" "$W/.dev.env"
+cp "$M/lib/firebase_options_dev.dart" "$W/lib/firebase_options_dev.dart"
+cp "$M/ios/Config/Dev/GoogleService-Info.plist" "$W/ios/Config/Dev/GoogleService-Info.plist"
+cp "$M/lib/env/dev_env.g.dart" "$W/lib/env/dev_env.g.dart"
 ```
 
-**Which flavor:** prefer `prod` on a physical device. The dev flavor's bundle id may have no usable provisioning profile in a fresh worktree — it fails with `Provisioning profile "iOS Team Provisioning Profile: *" doesn't support the App Groups capability`. Prod uses the routinely-provisioned profile. Note: a prod build **replaces the App Store app** on the phone (same bundle id; data/keychain survive, but reinstall from the App Store afterwards if the user wants the signed release back).
+Then run the mandatory preflight:
+
+```bash
+cd "$W"
+scripts/verify_ios_physical_test_auth_config.sh
+```
+
+It checks only project/platform metadata and the generated API target; it does
+not print credentials. A passing check means the dev flavor has a production
+API, a `based-hardware` Firebase project, and an iOS (not Android) Firebase app
+registration. Signing and the isolated bundle ID remain local maintainer
+concerns.
 
 ## 3. Launch
 
 ```bash
 flutter devices                                # get the device id (cable connected, phone unlocked)
-cd app && flutter run -d <device-id> --flavor prod \
+cd app && scripts/verify_ios_physical_test_auth_config.sh
+flutter run -d <device-id> --flavor dev \
   > /tmp/omi-flutter.log 2>&1 &                # ALWAYS capture stdout — it is the auth token for agent-flutter AND your verification log
 # wait for: "A Dart VM Service on <device> is available at: http://127.0.0.1:<port>/<token>/"
 ```
@@ -94,11 +114,18 @@ Verified order of attack; stop at the first rung that works:
 
 - **Keep the phone unlocked.** iOS terminates the debug link after prolonged backgrounding: `"The OS has terminated the Flutter debug connection for being inactive"` — the app keeps running but you must relaunch `flutter run` to reattach. This is a session-ender if you're mid-flow; check the phone before long code-reading pauses.
 - **Test data**: create-then-delete your own artifacts (e.g. a memory literally named "smoke-test — safe to delete"); never exercise destructive flows on the user's real data. If a leftover survives (session died first), tell the user exactly what to remove.
-- **Build side effects**: `flutter run` dirties `app/ios/Flutter/AppFrameworkInfo.plist` and sometimes `app/pubspec.lock` — `git checkout --` them before committing anything.
+- **Build side effects**: `flutter run` can dirty `app/ios/Podfile.lock`,
+  `app/ios/Flutter/AppFrameworkInfo.plist`, and `app/pubspec.lock`. Restore only
+  the mechanical build changes you inspected; do not discard unrelated user
+  edits.
 - **After the session**: the phone carries your branch build. Tell the user; App Store reinstall restores the release binary (data survives).
 
 ## 8. Known limitations
 
 - No biometric/OS-dialog control: Sign in with Apple, system permission prompts mid-flow, and Safari OAuth sheets need the human (agent-flutter sees only the Flutter tree).
+- XCTest/Appium can fail before a session with `Timed out while enabling
+  automation mode` even while the phone is unlocked. Record radio-toggle cases
+  as unrun; an app-process outage proves storage recovery but is not evidence
+  for the iOS Bluetooth Settings toggle itself.
 - Semantic `text` dump is partial — some visual text (image-heavy cards, custom painters) never appears; corroborate with widget-tree types/bounds.
 - One session at a time per device; `flutter run` owns the VM Service.

--- a/app/e2e/IOS_DEVICE_TESTING.md
+++ b/app/e2e/IOS_DEVICE_TESTING.md
@@ -49,9 +49,10 @@ scripts/verify_ios_physical_test_auth_config.sh
 ```
 
 It checks only project/platform metadata and the generated API target; it does
-not print credentials. A passing check means the dev flavor has a production
-API, a `based-hardware` Firebase project, and an iOS (not Android) Firebase app
-registration. Signing and the isolated bundle ID remain local maintainer
+not print credentials. A passing check means the dev flavor has the canonical
+`https://api.omi.me/` customer API, a `based-hardware` Firebase project, and an
+iOS (not Android) Firebase app registration. It explicitly rejects
+`api.omiapi.com`. Signing and the isolated bundle ID remain local maintainer
 concerns.
 
 ## 3. Launch

--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -42,6 +42,8 @@ agent-flutter snapshot -i --json    # see what's on screen
 ### Setup (iOS physical device)
 
 Full iOS physical-device playbook (setup, driving, verification, troubleshooting): [`IOS_DEVICE_TESTING.md`](./IOS_DEVICE_TESTING.md).
+For pendant reconnect, DFU handoff, timestamp, and backlog acceptance on Android and iOS, also run
+[`BLE_RELIABILITY_ACCEPTANCE.md`](./BLE_RELIABILITY_ACCEPTANCE.md).
 
 Verified 2026-07-11 on an iPhone XR (iOS 18.7.9), app 1.0.543, prod-flavor debug build, agent-flutter CLI + marionette MCP. iOS Simulator has no BLE — use a physical device for anything beyond onboarding/UI checks (see also iOS Simulator Known Limitations below).
 

--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -52,24 +52,32 @@ Full iOS physical-device playbook (setup, driving, verification, troubleshooting
 For pendant reconnect, DFU handoff, timestamp, and backlog acceptance on Android and iOS, also run
 [`BLE_RELIABILITY_ACCEPTANCE.md`](./BLE_RELIABILITY_ACCEPTANCE.md).
 
-Verified 2026-07-11 on an iPhone XR (iOS 18.7.9), app 1.0.543, prod-flavor debug build, agent-flutter CLI + marionette MCP. iOS Simulator has no BLE — use a physical device for anything beyond onboarding/UI checks (see also iOS Simulator Known Limitations below).
+Verified 2026-07-29 on an iPhone 13 Pro Max (iOS 26.5.2), isolated
+production-backed dev build, agent-flutter CLI, and a CV1 on firmware 3.0.29.
+iOS Simulator has no BLE — use a physical device for anything beyond
+onboarding/UI checks (see also iOS Simulator Known Limitations below).
 
 ```bash
 # 1. Get the physical device id
 flutter devices
 
-# 2. Run in debug mode with stdout captured — prod flavor (dev flavor can fail codesigning on a
-#    fresh worktree: "provisioning profile doesn't support the App Groups capability")
-cd app && flutter run -d <device-id> --flavor prod > /tmp/omi-flutter.log 2>&1 &
+# 2. Verify the ignored production-backed dev inputs before building
+cd app && scripts/verify_ios_physical_test_auth_config.sh
+
+# 3. Run the isolated dev app in debug mode with stdout captured
+flutter run -d <device-id> --flavor dev > /tmp/omi-flutter.log 2>&1 &
 # Wait for "A Dart VM Service ... is available" in the log
 
-# 3. Connect agent-flutter — auto-detects the ws URI from the log
+# 4. Connect agent-flutter — auto-detects the ws URI from the log
 AGENT_FLUTTER_LOG=/tmp/omi-flutter.log agent-flutter connect
 agent-flutter snapshot -i --json
 ```
 
 **Gotchas:**
-- **Fresh git worktrees need real prod config seeded from the primary checkout** before building the `prod` flavor: copy `app/.env`, `app/lib/firebase_options_prod.dart`, `app/ios/Config/Prod/GoogleService-Info.plist`, `app/lib/env/prod_env.g.dart`. The `test.sh` bootstrap seeds dev-placeholder versions that point at the wrong Firebase project.
+- **Fresh worktrees need the maintainer's production-backed dev fixture** before
+  building. The exact ignored files and safe metadata preflight are documented
+  in `IOS_DEVICE_TESTING.md`. Staging Firebase plus the production API fails
+  custom-token auth; an Android Firebase app ID crashes iOS initialization.
 - **adb-backed commands do NOT work on iOS**: `back`, `press x y`, `dismiss`, `text --press`, `text --fill`. Use in-app back buttons (find the top-left `IconButton` ref) and marionette ref presses only.
 - **`fill @ref` can silently no-op on keyless `TextField`s on iOS** — it reports success but the controller stays empty. Verify via the marionette MCP `get_interactive_elements` (shows the `TextEditingController` contents). Durable fix: add a `ValueKey` to the field, hot reload (sheet state survives), then enter text by key.
 - **`snapshot` labels are empty with `marionette_flutter` 0.3.0** on iOS. Primary orientation/assertion tool is `agent-flutter text` (semantic text dump) — assert outcomes by text presence (e.g. the copy snackbar text). Target elements by type + bounds from `snapshot -i`.

--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -39,6 +39,13 @@ agent-flutter snapshot -i --json    # see what's on screen
 - **App must be authenticated and connected to the correct backend** (local, dev, or prod — depends on the task)
 - Marionette already integrated: `marionette_flutter: ^0.3.0` in pubspec.yaml
 
+For an authenticated physical Android run, do not build immediately after
+`test.sh`: its ignored local configuration is intentionally hermetic. Follow
+[`BLE_RELIABILITY_ACCEPTANCE.md`](./BLE_RELIABILITY_ACCEPTANCE.md) →
+"Authenticated Android physical-device builds" and require
+`scripts/verify_android_physical_test_auth_config.sh` to pass before installing
+the dev APK.
+
 ### Setup (iOS physical device)
 
 Full iOS physical-device playbook (setup, driving, verification, troubleshooting): [`IOS_DEVICE_TESTING.md`](./IOS_DEVICE_TESTING.md).

--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -84,6 +84,11 @@ agent-flutter snapshot -i --json
 - `agent-flutter screenshot` output path must be under `/tmp`.
 - Check behavior via the run log: `grep -iE 'exception|error' /tmp/omi-flutter.log` after each flow. A `PlatformException` 4001 (Intercom push token, notifications not granted) is benign.
 - iOS terminates the debug connection if the app is backgrounded/locked too long ("The OS has terminated the Flutter debug connection for being inactive") — keep the device unlocked; reconnecting requires relaunching `flutter run`.
+- **Never hand the phone back with that debug/JIT build.** Before an
+  unattended drain or dogfood run, use the signed profile/AOT build and guarded
+  in-place installer in `BLE_RELIABILITY_ACCEPTANCE.md` → "Standalone iOS
+  dogfood builds". The installer rejects `kernel_blob.bin` and cold-launches
+  the exact isolated bundle while preserving its data container.
 - General key guidance (same as Android): prefer `find key "name"`; when a control can't be targeted, add a `ValueKey` in source + hot reload rather than fighting coordinates.
 
 ### Commands

--- a/app/e2e/scripts/bootstrap_physical_dev_config.sh
+++ b/app/e2e/scripts/bootstrap_physical_dev_config.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG_DIR="${1:-${HOME}/.config/omi-mobile-test}"
+
+fail() {
+  echo "physical-dev bootstrap: $*" >&2
+  exit 1
+}
+
+required=(
+  dev.env
+  firebase_options_dev.dart
+  google-services.json
+  GoogleService-Info.plist
+  dev_env.g.dart
+  prod_env.g.dart
+)
+
+for name in "${required[@]}"; do
+  [[ -f "${CONFIG_DIR}/${name}" ]] || fail "missing ${CONFIG_DIR}/${name}"
+done
+
+android_project="$(jq -r '.project_info.project_id // empty' "${CONFIG_DIR}/google-services.json")"
+ios_project="$(plutil -extract PROJECT_ID raw "${CONFIG_DIR}/GoogleService-Info.plist" 2>/dev/null || true)"
+dart_android_project="$(
+  sed -n '/static const FirebaseOptions android =/,/);/p' "${CONFIG_DIR}/firebase_options_dev.dart" |
+    sed -n "s/.*projectId: '\([^']*\)'.*/\1/p"
+)"
+dart_ios_project="$(
+  sed -n '/static const FirebaseOptions ios =/,/);/p' "${CONFIG_DIR}/firebase_options_dev.dart" |
+    sed -n "s/.*projectId: '\([^']*\)'.*/\1/p"
+)"
+
+for project in "$android_project" "$ios_project" "$dart_android_project" "$dart_ios_project"; do
+  [[ "$project" == "based-hardware" ]] ||
+    fail "refusing non-canonical Firebase project '${project:-missing}' (expected based-hardware)"
+done
+
+mkdir -p \
+  "${APP_DIR}/android/app/src/dev" \
+  "${APP_DIR}/ios/Config/Dev" \
+  "${APP_DIR}/ios/Runner" \
+  "${APP_DIR}/lib/env"
+
+cp "${CONFIG_DIR}/dev.env" "${APP_DIR}/.dev.env"
+cp "${CONFIG_DIR}/firebase_options_dev.dart" "${APP_DIR}/lib/firebase_options_dev.dart"
+android_config_tmp="$(mktemp /private/tmp/omi-google-services.XXXXXX)"
+jq '
+  ([.client[] | select(.client_info.android_client_info.package_name == "com.friend.ios.dev")][0]) as $source
+  | if $source == null then error("canonical com.friend.ios.dev Firebase client is missing")
+    else .client += [($source | .client_info.android_client_info.package_name = "com.friend.ios.dev.blackbox")]
+    end
+' "${CONFIG_DIR}/google-services.json" > "$android_config_tmp"
+mv "$android_config_tmp" "${APP_DIR}/android/app/src/dev/google-services.json"
+cp "${CONFIG_DIR}/GoogleService-Info.plist" "${APP_DIR}/ios/Config/Dev/GoogleService-Info.plist"
+cp "${CONFIG_DIR}/GoogleService-Info.plist" "${APP_DIR}/ios/Runner/GoogleService-Info.plist"
+cp "${CONFIG_DIR}/dev_env.g.dart" "${APP_DIR}/lib/env/dev_env.g.dart"
+cp "${CONFIG_DIR}/prod_env.g.dart" "${APP_DIR}/lib/env/prod_env.g.dart"
+cp "${APP_DIR}/setup/prebuilt/key.properties" "${APP_DIR}/android/key.properties"
+
+# main.dart imports both option files even in a dev build. This is a compile-only
+# stub; physical commands below must always use --flavor dev.
+if [[ ! -f "${APP_DIR}/lib/firebase_options_prod.dart" ]]; then
+  cp "${APP_DIR}/setup/prebuilt/firebase_options.dart" "${APP_DIR}/lib/firebase_options_prod.dart"
+fi
+
+"${APP_DIR}/scripts/verify_android_physical_test_auth_config.sh"
+"${APP_DIR}/scripts/verify_ios_physical_test_auth_config.sh"
+
+echo "physical-dev bootstrap: canonical based-hardware config installed for Android and iOS dev flavors"

--- a/app/e2e/scripts/build_signed_ios_physical_dev.sh
+++ b/app/e2e/scripts/build_signed_ios_physical_dev.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PHYSICAL_CONFIG="${OMI_IOS_PHYSICAL_CONFIG:-${HOME}/.config/omi-mobile-test/ios-physical-test.env}"
+BUILD_MODE="${OMI_IOS_BUILD_MODE:-profile}"
+
+fail() {
+  echo "signed-ios-dev build: $*" >&2
+  exit 1
+}
+
+[[ -f "$PHYSICAL_CONFIG" ]] || fail "missing local physical-device config: $PHYSICAL_CONFIG"
+# The ignored maintainer config owns machine/device/signing identities. They
+# must never be committed to a public branch.
+# shellcheck disable=SC1090
+source "$PHYSICAL_CONFIG"
+
+DEVICE_BUNDLE_ID="${OMI_IOS_DOGFOOD_BUNDLE_ID:-}"
+TEAM_ID="${OMI_IOS_TEAM_ID:-}"
+SIGNING_IDENTITY="${OMI_IOS_SIGNING_IDENTITY:-}"
+PROFILE_SOURCE="${OMI_IOS_PROFILE_SOURCE:-}"
+
+[[ -n "$DEVICE_BUNDLE_ID" ]] || fail "OMI_IOS_DOGFOOD_BUNDLE_ID is missing from $PHYSICAL_CONFIG"
+[[ -n "$TEAM_ID" ]] || fail "OMI_IOS_TEAM_ID is missing from $PHYSICAL_CONFIG"
+[[ -n "$SIGNING_IDENTITY" ]] || fail "OMI_IOS_SIGNING_IDENTITY is missing from $PHYSICAL_CONFIG"
+[[ -n "$PROFILE_SOURCE" ]] || fail "OMI_IOS_PROFILE_SOURCE is missing from $PHYSICAL_CONFIG"
+[[ -f "$PROFILE_SOURCE" ]] || fail "missing provisioning profile source: $PROFILE_SOURCE"
+security find-identity -v -p codesigning | grep -Fq "$SIGNING_IDENTITY" || fail "missing signing identity: $SIGNING_IDENTITY"
+[[ "$BUILD_MODE" == "debug" || "$BUILD_MODE" == "profile" ]] ||
+  fail "OMI_IOS_BUILD_MODE must be debug or profile, got: $BUILD_MODE"
+
+"${APP_DIR}/e2e/scripts/bootstrap_physical_dev_config.sh" "$(dirname "$PHYSICAL_CONFIG")"
+
+# CocoaPods writes its local tool version into the tracked lockfile even when
+# dependency resolution is unchanged. A physical test build must be
+# repeatable and must not manufacture source changes, so restore the exact
+# pre-build lockfile on every exit path.
+POD_LOCK="${APP_DIR}/ios/Podfile.lock"
+POD_LOCK_BACKUP="$(mktemp /private/tmp/omi-podfile-lock.XXXXXX)"
+ENTITLEMENTS="$(mktemp /private/tmp/omi-ios-entitlements.XXXXXX)"
+cp "$POD_LOCK" "$POD_LOCK_BACKUP"
+restore_pod_lock() {
+  mv "$POD_LOCK_BACKUP" "$POD_LOCK"
+  rm -f "$ENTITLEMENTS"
+}
+trap restore_pod_lock EXIT
+
+python3 - "$ENTITLEMENTS" "$TEAM_ID" "$DEVICE_BUNDLE_ID" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+path, team_id, bundle_id = sys.argv[1:]
+application_id = f"{team_id}.{bundle_id}"
+with Path(path).open("wb") as stream:
+    plistlib.dump(
+        {
+            "application-identifier": application_id,
+            "com.apple.developer.team-identifier": team_id,
+            "get-task-allow": True,
+            "keychain-access-groups": [application_id],
+        },
+        stream,
+    )
+PY
+
+cd "$APP_DIR"
+flutter build ios "--${BUILD_MODE}" --no-codesign --flavor dev -t lib/main.dart --dart-define OMI_BLACKBOX_HARNESS=true
+
+UNSIGNED_APP="${APP_DIR}/build/ios/iphoneos/Runner.app"
+[[ -d "$UNSIGNED_APP" ]] || fail "Flutter did not produce $UNSIGNED_APP"
+
+ARTIFACT_ROOT="$(mktemp -d /private/tmp/omi-ios-blackbox.XXXXXX)"
+SIGNED_APP="${ARTIFACT_ROOT}/OmiBlackbox.app"
+mkdir "$SIGNED_APP"
+rsync -a --exclude _CodeSignature --exclude embedded.mobileprovision --exclude PlugIns --exclude Watch \
+  "${UNSIGNED_APP}/" "${SIGNED_APP}/"
+
+plutil -replace CFBundleIdentifier -string "$DEVICE_BUNDLE_ID" "${SIGNED_APP}/Info.plist"
+cp "$PROFILE_SOURCE" "${SIGNED_APP}/embedded.mobileprovision"
+
+[[ "$(plutil -extract PROJECT_ID raw "${SIGNED_APP}/GoogleService-Info.plist" 2>/dev/null || true)" == "based-hardware" ]] ||
+  fail "built app does not contain canonical based-hardware Firebase configuration"
+
+while IFS= read -r framework; do
+  codesign --force --sign "$SIGNING_IDENTITY" --timestamp=none "$framework"
+done < <(find "${SIGNED_APP}/Frameworks" -maxdepth 2 -type d -name '*.framework' | sort)
+
+while IFS= read -r dylib; do
+  codesign --force --sign "$SIGNING_IDENTITY" --timestamp=none "$dylib"
+done < <(find "${SIGNED_APP}/Frameworks" -type f -name '*.dylib' | sort)
+
+codesign --force \
+  --sign "$SIGNING_IDENTITY" \
+  --timestamp=none \
+  --entitlements "$ENTITLEMENTS" \
+  "$SIGNED_APP"
+
+codesign --verify --deep --strict --verbose=2 "$SIGNED_APP"
+
+actual_bundle="$(plutil -extract CFBundleIdentifier raw "${SIGNED_APP}/Info.plist")"
+[[ "$actual_bundle" == "$DEVICE_BUNDLE_ID" ]] || fail "unexpected bundle id: $actual_bundle"
+codesign -d --entitlements :- "$SIGNED_APP" 2>/dev/null | grep -Fq "${TEAM_ID}.${DEVICE_BUNDLE_ID}" ||
+  fail "signed app has the wrong application identifier"
+[[ ! -e "${SIGNED_APP}/PlugIns" && ! -e "${SIGNED_APP}/Watch" ]] || fail "companion payload was not stripped"
+if [[ "$BUILD_MODE" == "profile" ]]; then
+  [[ ! -e "${SIGNED_APP}/Frameworks/App.framework/flutter_assets/kernel_blob.bin" ]] ||
+    fail "profile handoff artifact still contains Flutter JIT kernel_blob.bin"
+fi
+
+echo "$SIGNED_APP"

--- a/app/e2e/scripts/install_ios_dogfood_profile.sh
+++ b/app/e2e/scripts/install_ios_dogfood_profile.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PHYSICAL_CONFIG="${OMI_IOS_PHYSICAL_CONFIG:-${HOME}/.config/omi-mobile-test/ios-physical-test.env}"
+APP_PATH="${1:-}"
+
+fail() {
+  echo "ios-dogfood install: $*" >&2
+  exit 1
+}
+
+[[ -f "$PHYSICAL_CONFIG" ]] || fail "missing local physical-device config: $PHYSICAL_CONFIG"
+# shellcheck disable=SC1090
+source "$PHYSICAL_CONFIG"
+
+DEVICE_ID="${OMI_IOS_DEVICE_ID:-}"
+BUNDLE_ID="${OMI_IOS_DOGFOOD_BUNDLE_ID:-}"
+TEAM_ID="${OMI_IOS_TEAM_ID:-}"
+[[ -n "$DEVICE_ID" ]] || fail "OMI_IOS_DEVICE_ID is missing from $PHYSICAL_CONFIG"
+[[ -n "$BUNDLE_ID" ]] || fail "OMI_IOS_DOGFOOD_BUNDLE_ID is missing from $PHYSICAL_CONFIG"
+[[ -n "$TEAM_ID" ]] || fail "OMI_IOS_TEAM_ID is missing from $PHYSICAL_CONFIG"
+APPLICATION_ID="${TEAM_ID}.${BUNDLE_ID}"
+
+[[ -n "$APP_PATH" ]] || fail "usage: $0 /absolute/path/to/profile.app"
+python3 "$(dirname "$0")/verify_ios_dogfood_artifact.py" \
+  --app "$APP_PATH" \
+  --bundle-id "$BUNDLE_ID" \
+  --application-id "$APPLICATION_ID" || fail "artifact verification failed"
+
+# Updating the exact bundle in place preserves auth, pairing, local recordings,
+# and the durable sync manifest. Never uninstall to change build modes.
+xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH"
+xcrun devicectl device process launch --terminate-existing --device "$DEVICE_ID" "$BUNDLE_ID"
+
+echo "ios-dogfood install: standalone AOT app installed in place and cold-launched"

--- a/app/e2e/scripts/test_verify_ios_dogfood_artifact.py
+++ b/app/e2e/scripts/test_verify_ios_dogfood_artifact.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import plistlib
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify_ios_dogfood_artifact.py")
+BUNDLE_ID = "com.example.omi-dogfood"
+APPLICATION_ID = f"TESTTEAM.{BUNDLE_ID}"
+
+
+class IosDogfoodArtifactVerifierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.app = self.root / "Omi.app"
+        (self.app / "Frameworks/App.framework/flutter_assets").mkdir(parents=True)
+        self._write_plist(
+            self.app / "Info.plist", {"CFBundleIdentifier": BUNDLE_ID}
+        )
+        self._write_plist(
+            self.app / "GoogleService-Info.plist", {"PROJECT_ID": "based-hardware"}
+        )
+        self.codesign = self.root / "codesign"
+        self.codesign.write_text(
+            "#!/bin/sh\n"
+            "if [ \"$1\" = \"-d\" ]; then\n"
+            f"  echo '<string>{APPLICATION_ID}</string>' >&2\n"
+            "fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        self.codesign.chmod(self.codesign.stat().st_mode | stat.S_IXUSR)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @staticmethod
+    def _write_plist(path: Path, value: dict[str, str]) -> None:
+        with path.open("wb") as stream:
+            plistlib.dump(value, stream)
+
+    def _verify(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--app",
+                str(self.app),
+                "--bundle-id",
+                BUNDLE_ID,
+                "--application-id",
+                APPLICATION_ID,
+                "--codesign",
+                str(self.codesign),
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+
+    def test_accepts_signed_profile_aot_artifact(self) -> None:
+        result = self._verify()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("signed standalone AOT app", result.stdout)
+
+    def test_rejects_flutter_debug_jit_artifact_before_handoff(self) -> None:
+        marker = self.app / "Frameworks/App.framework/flutter_assets/kernel_blob.bin"
+        marker.touch()
+
+        result = self._verify()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing Flutter debug/JIT artifact", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/e2e/scripts/verify_ios_dogfood_artifact.py
+++ b/app/e2e/scripts/verify_ios_dogfood_artifact.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fail closed unless an iOS dogfood app is a signed standalone AOT artifact."""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"iOS dogfood artifact verification FAILED: {message}")
+
+
+def load_plist(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        fail(f"missing {path}")
+    try:
+        with path.open("rb") as stream:
+            value = plistlib.load(stream)
+    except (OSError, plistlib.InvalidFileException) as error:
+        fail(f"invalid plist {path}: {error}")
+    if not isinstance(value, dict):
+        fail(f"plist root is not a dictionary: {path}")
+    return value
+
+
+def verify(
+    app: Path,
+    bundle_id: str,
+    application_id: str,
+    codesign: str,
+) -> None:
+    if not app.is_dir():
+        fail(f"app does not exist: {app}")
+
+    info = load_plist(app / "Info.plist")
+    if info.get("CFBundleIdentifier") != bundle_id:
+        fail(f"unexpected bundle identifier {info.get('CFBundleIdentifier')!r}")
+
+    firebase = load_plist(app / "GoogleService-Info.plist")
+    if firebase.get("PROJECT_ID") != "based-hardware":
+        fail("artifact is not configured for the canonical Firebase project")
+
+    jit_kernel = app / "Frameworks/App.framework/flutter_assets/kernel_blob.bin"
+    if jit_kernel.exists():
+        fail("refusing Flutter debug/JIT artifact; unattended dogfood requires profile/AOT")
+
+    try:
+        subprocess.run(
+            [codesign, "--verify", "--deep", "--strict", str(app)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        entitlement_result = subprocess.run(
+            [codesign, "-d", "--entitlements", ":-", str(app)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        fail(f"artifact signature is invalid: {error}")
+
+    entitlements = entitlement_result.stdout + entitlement_result.stderr
+    if application_id not in entitlements:
+        fail("artifact has the wrong application identifier")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", type=Path, required=True)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--application-id", required=True)
+    parser.add_argument("--codesign", default="codesign")
+    args = parser.parse_args()
+    verify(args.app, args.bundle_id, args.application_id, args.codesign)
+    print("iOS dogfood artifact verification: PASS (signed standalone AOT app)")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		42A7BA4C2E788F0100138969 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42A7BA4B2E788F0100138969 /* WatchConnectivity.framework */; };
 		42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
 		42B17C642F69B9E100BFDA9D /* BleHostApiImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */; };
+		42B17C662F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */; };
 		42B17C7C2F69BC6600BFDA9D /* PigeonCommunicator.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */; };
 		42BABFB82F2A81B100E78A3C /* OmiRecordingAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */; };
 		42BABFB92F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */; };
@@ -74,6 +75,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
+		99ADCEC6933A6FA3EE3AAE5D /* BleLegacyAudioOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */; };
 		9A25BD940EC94B21766CB950 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E5BBFB39079A4743502BBEE /* Pods_Runner.framework */; };
 		9A26EFBA2ABCE6C441ADBE8E /* OmiCallCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFC62F2A81B100E78A3C /* OmiCallCoordinatorProtocol.swift */; };
 		9A519AEFA12F139B0082101F /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CF2F518C2EC08EA60025B331 /* Base.xcconfig */; };
@@ -205,6 +207,7 @@
 		42A7BA4B2E788F0100138969 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiBleManager.swift; sourceTree = "<group>"; };
 		42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleHostApiImpl.swift; sourceTree = "<group>"; };
+		42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleLegacyAudioOwnership.swift; sourceTree = "<group>"; };
 		42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PigeonCommunicator.g.swift; sourceTree = "<group>"; };
 		42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiRecordingAudioDevice.swift; sourceTree = "<group>"; };
 		42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiPhoneCallsPlugin.swift; sourceTree = "<group>"; };
@@ -491,6 +494,7 @@
 			children = (
 				42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */,
 				42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */,
+				42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */,
 			);
 			path = Ble;
 			sourceTree = "<group>";
@@ -924,6 +928,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */,
+				42B17C662F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D2 /* BatchAudioWriter.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D4 /* BaseBatchAudioWriter.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D6 /* LimitlessBatchAudioWriter.swift in Sources */,
@@ -968,6 +973,7 @@
 			files = (
 				873C99F3D85C142369688A1D /* AppDelegate.swift in Sources */,
 				99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */,
+				99ADCEC6933A6FA3EE3AAE5D /* BleLegacyAudioOwnership.swift in Sources */,
 				0658C1BEFC86B56785C10A69 /* BatchAudioWriter.swift in Sources */,
 				BB125CDB70C0DB5AAFB15E9C /* BaseBatchAudioWriter.swift in Sources */,
 				CD15410D0ED1D611F4A1B596 /* LimitlessBatchAudioWriter.swift in Sources */,

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
 		42B17C642F69B9E100BFDA9D /* BleHostApiImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */; };
 		42B17C662F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */; };
+		42B17C682F69BA0100BFDA9D /* BleKnownPeripheralConnectionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C672F69BA0100BFDA9D /* BleKnownPeripheralConnectionPolicy.swift */; };
 		42B17C7C2F69BC6600BFDA9D /* PigeonCommunicator.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */; };
 		42BABFB82F2A81B100E78A3C /* OmiRecordingAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */; };
 		42BABFB92F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */; };
@@ -76,6 +77,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */; };
 		99ADCEC6933A6FA3EE3AAE5D /* BleLegacyAudioOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */; };
+		99ADCEC7933A6FA3EE3AAE5D /* BleKnownPeripheralConnectionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C672F69BA0100BFDA9D /* BleKnownPeripheralConnectionPolicy.swift */; };
 		9A25BD940EC94B21766CB950 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E5BBFB39079A4743502BBEE /* Pods_Runner.framework */; };
 		9A26EFBA2ABCE6C441ADBE8E /* OmiCallCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFC62F2A81B100E78A3C /* OmiCallCoordinatorProtocol.swift */; };
 		9A519AEFA12F139B0082101F /* Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CF2F518C2EC08EA60025B331 /* Base.xcconfig */; };
@@ -208,6 +210,7 @@
 		42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiBleManager.swift; sourceTree = "<group>"; };
 		42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleHostApiImpl.swift; sourceTree = "<group>"; };
 		42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleLegacyAudioOwnership.swift; sourceTree = "<group>"; };
+		42B17C672F69BA0100BFDA9D /* BleKnownPeripheralConnectionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleKnownPeripheralConnectionPolicy.swift; sourceTree = "<group>"; };
 		42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PigeonCommunicator.g.swift; sourceTree = "<group>"; };
 		42BABFB62F2A81B100E78A3C /* OmiRecordingAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiRecordingAudioDevice.swift; sourceTree = "<group>"; };
 		42BABFB72F2A81B100E78A3C /* OmiPhoneCallsPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmiPhoneCallsPlugin.swift; sourceTree = "<group>"; };
@@ -495,6 +498,7 @@
 				42B17C612F69B9CF00BFDA9D /* OmiBleManager.swift */,
 				42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */,
 				42B17C652F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift */,
+				42B17C672F69BA0100BFDA9D /* BleKnownPeripheralConnectionPolicy.swift */,
 			);
 			path = Ble;
 			sourceTree = "<group>";
@@ -929,6 +933,7 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				42B17C622F69B9CF00BFDA9D /* OmiBleManager.swift in Sources */,
 				42B17C662F69B9F100BFDA9D /* BleLegacyAudioOwnership.swift in Sources */,
+				42B17C682F69BA0100BFDA9D /* BleKnownPeripheralConnectionPolicy.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D2 /* BatchAudioWriter.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D4 /* BaseBatchAudioWriter.swift in Sources */,
 				BAADF00DF00DF00DF00DF0D6 /* LimitlessBatchAudioWriter.swift in Sources */,
@@ -974,6 +979,7 @@
 				873C99F3D85C142369688A1D /* AppDelegate.swift in Sources */,
 				99ADCEC5933A6FA3EE3AAE5D /* OmiBleManager.swift in Sources */,
 				99ADCEC6933A6FA3EE3AAE5D /* BleLegacyAudioOwnership.swift in Sources */,
+				99ADCEC7933A6FA3EE3AAE5D /* BleKnownPeripheralConnectionPolicy.swift in Sources */,
 				0658C1BEFC86B56785C10A69 /* BatchAudioWriter.swift in Sources */,
 				BB125CDB70C0DB5AAFB15E9C /* BaseBatchAudioWriter.swift in Sources */,
 				CD15410D0ED1D611F4A1B596 /* LimitlessBatchAudioWriter.swift in Sources */,

--- a/app/ios/Runner/Ble/BleKnownPeripheralConnectionPolicy.swift
+++ b/app/ios/Runner/Ble/BleKnownPeripheralConnectionPolicy.swift
@@ -1,0 +1,16 @@
+enum BleKnownPeripheralConnectionAction: Equatable {
+  case rediscoverServices
+  case connect
+}
+
+/// Chooses how a Dart connection request repairs a CoreBluetooth peripheral.
+///
+/// CoreBluetooth can preserve a physical connection across process relaunch
+/// without replaying `didConnect`. Treating that state as "nothing to do"
+/// strands Dart before `onDeviceReady`; rediscovering services republishes the
+/// GATT boundary and lets the storage-first stream resume.
+enum BleKnownPeripheralConnectionPolicy {
+  static func action(isConnected: Bool) -> BleKnownPeripheralConnectionAction {
+    isConnected ? .rediscoverServices : .connect
+  }
+}

--- a/app/ios/Runner/Ble/BleKnownPeripheralConnectionPolicy.swift
+++ b/app/ios/Runner/Ble/BleKnownPeripheralConnectionPolicy.swift
@@ -14,3 +14,31 @@ enum BleKnownPeripheralConnectionPolicy {
     isConnected ? .rediscoverServices : .connect
   }
 }
+
+enum BleRestoredPeripheralAction: Equatable {
+  case restoreConnection
+  case releaseConnection
+}
+
+/// Prevents an OS-restored iOS process from silently taking the pendant away
+/// from another companion host.
+///
+/// A foreground Flutter session always calls `manageDevice` and can reconnect.
+/// Process-level CoreBluetooth restoration is only justified when the user
+/// explicitly enabled Background Mode.
+enum BleRestoredPeripheralPolicy {
+  static func action(backgroundModeEnabled: Bool) -> BleRestoredPeripheralAction {
+    backgroundModeEnabled ? .restoreConnection : .releaseConnection
+  }
+
+  static func shouldDeferConnect(requiresForegroundActivation: Bool) -> Bool {
+    requiresForegroundActivation
+  }
+
+  static func shouldResumeDeferredConnect(
+    requiresForegroundActivation: Bool,
+    applicationIsActive: Bool
+  ) -> Bool {
+    requiresForegroundActivation && applicationIsActive
+  }
+}

--- a/app/ios/Runner/Ble/BleLegacyAudioOwnership.swift
+++ b/app/ios/Runner/Ble/BleLegacyAudioOwnership.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Native fail-closed policy for the legacy CV1 audio notification.
+///
+/// CoreBluetooth may restore a CCCD subscription before Dart rebuilds its
+/// foreground transport. A storage-authoritative session deliberately omits
+/// `nativeBleStreamConfig`, so a restored legacy notification must not consume
+/// BLE bandwidth or cross the Flutter bridge while the ring protocol owns GATT.
+struct BleLegacyAudioOwner: Equatable {
+  let peripheralUuid: String
+  let serviceUuid: String
+  let characteristicUuid: String
+}
+
+enum BleLegacyAudioOwnershipDecision: Equatable {
+  case notLegacyAudio
+  case configuredOwner
+  case orphanedLegacyAudio
+}
+
+enum BleLegacyAudioOwnershipPolicy {
+  static let serviceUuid = "19b10000-e8f2-537e-4f6c-d104768a1214"
+  static let characteristicUuid = "19b10001-e8f2-537e-4f6c-d104768a1214"
+
+  static func owner(from rawConfig: String?) -> BleLegacyAudioOwner? {
+    guard let rawConfig, !rawConfig.isEmpty,
+      let data = rawConfig.data(using: .utf8),
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let deviceId = json["deviceId"] as? String, !deviceId.isEmpty,
+      let serviceUuid = json["serviceUuid"] as? String, !serviceUuid.isEmpty,
+      let characteristicUuid = json["characteristicUuid"] as? String,
+      !characteristicUuid.isEmpty
+    else {
+      return nil
+    }
+
+    return BleLegacyAudioOwner(
+      peripheralUuid: deviceId.lowercased(),
+      serviceUuid: serviceUuid.lowercased(),
+      characteristicUuid: characteristicUuid.lowercased()
+    )
+  }
+
+  static func decision(
+    peripheralUuid: String,
+    serviceUuid: String,
+    characteristicUuid: String,
+    configuredOwner: BleLegacyAudioOwner?
+  ) -> BleLegacyAudioOwnershipDecision {
+    let service = serviceUuid.lowercased()
+    let characteristic = characteristicUuid.lowercased()
+    guard service == Self.serviceUuid, characteristic == Self.characteristicUuid else {
+      return .notLegacyAudio
+    }
+
+    guard
+      configuredOwner
+        == BleLegacyAudioOwner(
+          peripheralUuid: peripheralUuid.lowercased(),
+          serviceUuid: service,
+          characteristicUuid: characteristic
+        )
+    else {
+      return .orphanedLegacyAudio
+    }
+    return .configuredOwner
+  }
+}

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -135,11 +135,7 @@ final class OmiBleManager: NSObject {
         manuallyDisconnected.remove(uuid)
 
         if let peripheral = peripherals[uuid] {
-            if peripheral.state == .connected {
-                NSLog("[OmiBle] connectPeripheral: \(uuid) already connected, skipping")
-                return
-            }
-            centralManager.connect(peripheral, options: nil)
+            connectOrRevalidate(peripheral, uuid: uuid)
             return
         }
 
@@ -149,6 +145,23 @@ final class OmiBleManager: NSObject {
         if let peripheral = retrieved.first {
             peripheral.delegate = self
             peripherals[uuid] = peripheral
+            connectOrRevalidate(peripheral, uuid: uuid)
+        }
+    }
+
+    private func connectOrRevalidate(_ peripheral: CBPeripheral, uuid: String) {
+        switch BleKnownPeripheralConnectionPolicy.action(
+            isConnected: peripheral.state == .connected
+        ) {
+        case .rediscoverServices:
+            // CoreBluetooth may keep the link alive across process relaunch
+            // without replaying didConnect. Rediscovery republishes onDeviceReady
+            // after Flutter installs its callback, restoring the canonical ring
+            // stream instead of leaving a connected-but-inert session.
+            NSLog("[OmiBle] connectPeripheral: \(uuid) already connected; rediscovering services")
+            peripheral.delegate = self
+            peripheral.discoverServices(nil)
+        case .connect:
             centralManager.connect(peripheral, options: nil)
         }
     }

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -63,6 +63,16 @@ final class OmiBleManager: NSObject {
     /// Queued scan request if Bluetooth wasn't ready when startScan was called.
     private var pendingScan: (timeout: Int, serviceUuids: [String])?
 
+    /// CCCD disables already requested for restored legacy audio subscriptions
+    /// that have no current Dart/native owner.
+    private var orphanedLegacyAudioDisableRequests: Set<String> = []
+
+    /// Parsed native stream ownership. The raw preference is compared on each
+    /// legacy audio callback, while JSON parsing only repeats when Dart changes it.
+    private var nativeBleConfigCacheInitialized = false
+    private var cachedNativeBleConfigRaw: String?
+    private var cachedLegacyAudioOwner: BleLegacyAudioOwner?
+
     // MARK: - Initialization
 
     private override init() {
@@ -283,6 +293,58 @@ final class OmiBleManager: NSObject {
 
     private func peripheralUuidString(_ peripheral: CBPeripheral) -> String {
         return peripheral.identifier.uuidString
+    }
+
+    private func characteristicKey(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String
+    ) -> String {
+        return "\(peripheralUuid):\(serviceUuid):\(characteristicUuid)".lowercased()
+    }
+
+    private func configuredLegacyAudioOwner() -> BleLegacyAudioOwner? {
+        let raw = UserDefaults.standard.string(forKey: "flutter.nativeBleStreamConfig")
+        if !nativeBleConfigCacheInitialized || raw != cachedNativeBleConfigRaw {
+            nativeBleConfigCacheInitialized = true
+            cachedNativeBleConfigRaw = raw
+            cachedLegacyAudioOwner = BleLegacyAudioOwnershipPolicy.owner(from: raw)
+        }
+        return cachedLegacyAudioOwner
+    }
+
+    /// Returns true when the notification is orphaned and must not be forwarded.
+    ///
+    /// iOS restores notification subscriptions independently of Flutter. When
+    /// Dart intentionally omits its native stream config (the 3.0.29 ring owner),
+    /// release a restored legacy audio CCCD and drop packets until CoreBluetooth
+    /// confirms the transition.
+    private func rejectOrphanedLegacyAudioNotification(
+        peripheral: CBPeripheral,
+        characteristic: CBCharacteristic
+    ) -> Bool {
+        guard let service = characteristic.service else { return false }
+        let uuid = peripheralUuidString(peripheral)
+        let serviceUuid = fullUuidString(service.uuid)
+        let characteristicUuid = fullUuidString(characteristic.uuid)
+        let decision = BleLegacyAudioOwnershipPolicy.decision(
+            peripheralUuid: uuid,
+            serviceUuid: serviceUuid,
+            characteristicUuid: characteristicUuid,
+            configuredOwner: configuredLegacyAudioOwner()
+        )
+        guard decision == .orphanedLegacyAudio else { return false }
+
+        let key = characteristicKey(
+            peripheralUuid: uuid,
+            serviceUuid: serviceUuid,
+            characteristicUuid: characteristicUuid
+        )
+        if characteristic.isNotifying, orphanedLegacyAudioDisableRequests.insert(key).inserted {
+            NSLog("[OmiBle] Releasing orphaned legacy audio notification for \(uuid)")
+            peripheral.setNotifyValue(false, for: characteristic)
+        }
+        return true
     }
 
     /// Normalize a CBUUID to its full 128-bit string representation.
@@ -521,6 +583,9 @@ final class OmiBleManager: NSObject {
     private func cleanupPeripheral(_ peripheralUuid: String) {
         stopRssiKeepAlive()
         discoveredServices.removeValue(forKey: peripheralUuid)
+        orphanedLegacyAudioDisableRequests = orphanedLegacyAudioDisableRequests.filter {
+            !$0.hasPrefix(peripheralUuid.lowercased())
+        }
 
         // Clean up pending completions
         let completionKeys = readCompletions.keys.filter { $0.hasPrefix(peripheralUuid.lowercased()) }
@@ -703,6 +768,18 @@ extension OmiBleManager: CBPeripheralDelegate {
         let allDiscovered = services.allSatisfy { $0.characteristics != nil }
 
         if allDiscovered {
+            // State restoration can bring back a legacy audio CCCD before Dart
+            // selects the storage-authoritative ring owner. Release it before
+            // publishing device readiness so only the selected audio lane runs.
+            for discoveredService in services {
+                for characteristic in discoveredService.characteristics ?? [] {
+                    _ = rejectOrphanedLegacyAudioNotification(
+                        peripheral: peripheral,
+                        characteristic: characteristic
+                    )
+                }
+            }
+
             let bleServices = services.map { svc in
                 BleService(
                     uuid: self.fullUuidString(svc.uuid),
@@ -762,6 +839,13 @@ extension OmiBleManager: CBPeripheralDelegate {
         // Handle notification
         guard let data = characteristic.value, !data.isEmpty else { return }
 
+        if rejectOrphanedLegacyAudioNotification(
+            peripheral: peripheral,
+            characteristic: characteristic
+        ) {
+            return
+        }
+
         if characteristic.uuid == OmiBleManager.batteryLevelCharUuid, let firstByte = data.first {
             persistBatteryReading(uuid: uuid, level: Int(firstByte))
         }
@@ -817,6 +901,15 @@ extension OmiBleManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
         let uuid = peripheralUuidString(peripheral)
         let charUuid = fullUuidString(characteristic.uuid)
+        if let service = characteristic.service {
+            orphanedLegacyAudioDisableRequests.remove(
+                characteristicKey(
+                    peripheralUuid: uuid,
+                    serviceUuid: fullUuidString(service.uuid),
+                    characteristicUuid: charUuid
+                )
+            )
+        }
         if let error = error {
             NSLog("[OmiBle] Failed to update notification state for \(charUuid): \(error.localizedDescription)")
         } else {

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -31,6 +31,13 @@ final class OmiBleManager: NSObject {
     /// Whether the user explicitly disconnected (suppress auto-reconnect).
     private var manuallyDisconnected: Set<String> = []
 
+    /// A CoreBluetooth restoration launch with Background Mode disabled must
+    /// not be allowed to reconnect any cached paired UUID. The restoration
+    /// dictionary can be empty even though Flutter still knows the device.
+    /// Only a real foreground transition consumes this process-wide gate.
+    private var backgroundRestoreRequiresForegroundActivation = false
+    private var deferredForegroundConnectUuids: Set<String> = []
+
     /// RSSI keep-alive timer — periodic reads prevent connection supervision timeout.
     private var rssiTimer: Timer?
 
@@ -132,6 +139,17 @@ final class OmiBleManager: NSObject {
     // MARK: - Connection
 
     func connectPeripheral(uuid: String) {
+        if BleRestoredPeripheralPolicy.shouldDeferConnect(
+            requiresForegroundActivation: backgroundRestoreRequiresForegroundActivation
+        ) {
+            deferredForegroundConnectUuids.insert(uuid)
+            releaseDeferredRestoredPeripheral(uuid: uuid)
+            NSLog(
+                "[OmiBle] Deferred connect for restored peripheral \(uuid); "
+                    + "waiting for foreground activation"
+            )
+            return
+        }
         manuallyDisconnected.remove(uuid)
 
         if let peripheral = peripherals[uuid] {
@@ -146,6 +164,24 @@ final class OmiBleManager: NSObject {
             peripheral.delegate = self
             peripherals[uuid] = peripheral
             connectOrRevalidate(peripheral, uuid: uuid)
+        }
+    }
+
+    private func releaseDeferredRestoredPeripheral(uuid: String) {
+        guard let identifier = UUID(uuidString: uuid) else { return }
+        let peripheral = peripherals[uuid]
+            ?? centralManager.retrievePeripherals(withIdentifiers: [identifier]).first
+        guard let peripheral else { return }
+
+        peripheral.delegate = self
+        peripherals[uuid] = peripheral
+        manuallyDisconnected.insert(uuid)
+        if peripheral.state == .connected || peripheral.state == .connecting {
+            centralManager.cancelPeripheralConnection(peripheral)
+            NSLog(
+                "[OmiBle] Released deferred restored peripheral \(uuid); "
+                    + "waiting for foreground activation"
+            )
         }
     }
 
@@ -193,6 +229,15 @@ final class OmiBleManager: NSObject {
     /// cost nothing while iOS waits at the chipset level.
     func reconnectStalePeripherals() {
         guard centralManager.state == .poweredOn else { return }
+        if backgroundRestoreRequiresForegroundActivation {
+            backgroundRestoreRequiresForegroundActivation = false
+            let deferredUuids = deferredForegroundConnectUuids
+            deferredForegroundConnectUuids.removeAll()
+            for uuid in deferredUuids {
+                NSLog("[OmiBle] Foreground activation reconnecting deferred peripheral \(uuid)")
+                connectPeripheral(uuid: uuid)
+            }
+        }
         for (uuid, peripheral) in peripherals {
             guard everConnected.contains(uuid) else { continue }
             if manuallyDisconnected.contains(uuid) { continue }
@@ -628,23 +673,50 @@ extension OmiBleManager: CBCentralManagerDelegate {
             NSLog("[OmiBle] Executing queued scan (timeout=\(pending.timeout))")
             startScan(timeout: pending.timeout, serviceUuids: pending.serviceUuids)
         }
+        if central.state == .poweredOn,
+           BleRestoredPeripheralPolicy.shouldResumeDeferredConnect(
+               requiresForegroundActivation: backgroundRestoreRequiresForegroundActivation,
+               applicationIsActive: UIApplication.shared.applicationState == .active
+           ) {
+            reconnectStalePeripherals()
+        }
     }
 
     func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
-        // Restore previously connected peripherals after app relaunch
+        let restoredAction = BleRestoredPeripheralPolicy.action(
+            backgroundModeEnabled: UserDefaults.standard.bool(
+                forKey: "flutter.backgroundModeEnabled"
+            )
+        )
+        if restoredAction == .releaseConnection {
+            backgroundRestoreRequiresForegroundActivation = true
+        }
+
+        // Restore previously connected peripherals after app relaunch only
+        // when the user explicitly opted into Background Mode. Otherwise an
+        // OS-restored iOS process can monopolize a one-connection pendant while
+        // the user is deliberately trying to use Android or another host.
         if let restoredPeripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
             var uuids: [String] = []
             for peripheral in restoredPeripherals {
                 let uuid = peripheralUuidString(peripheral)
                 peripheral.delegate = self
                 peripherals[uuid] = peripheral
-                uuids.append(uuid)
-
-                // Re-establish connection if not already connected
-                if peripheral.state != .connected {
-                    central.connect(peripheral, options: nil)
-                } else {
-                    peripheral.discoverServices(nil)
+                switch restoredAction {
+                case .restoreConnection:
+                    uuids.append(uuid)
+                    if peripheral.state != .connected {
+                        central.connect(peripheral, options: nil)
+                    } else {
+                        peripheral.discoverServices(nil)
+                    }
+                case .releaseConnection:
+                    manuallyDisconnected.insert(uuid)
+                    central.cancelPeripheralConnection(peripheral)
+                    NSLog(
+                        "[OmiBle] Released restored peripheral \(uuid); "
+                            + "Background Mode is disabled"
+                    )
                 }
             }
             flutterApi?.onStateRestored(peripheralUuids: uuids) { _ in }

--- a/app/ios/test/BleKnownPeripheralConnectionPolicyTests.swift
+++ b/app/ios/test/BleKnownPeripheralConnectionPolicyTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+private enum TestFailure: Error {
+  case failed(String)
+}
+
+private func expectEqual<T: Equatable>(_ actual: T, _ expected: T, _ message: String) throws {
+  guard actual == expected else {
+    throw TestFailure.failed("\(message): expected \(expected), got \(actual)")
+  }
+}
+
+@main
+private struct BleKnownPeripheralConnectionPolicyTests {
+  static func main() throws {
+    try expectEqual(
+      BleKnownPeripheralConnectionPolicy.action(isConnected: true),
+      .rediscoverServices,
+      "an OS-restored physical link must republish GATT readiness"
+    )
+    try expectEqual(
+      BleKnownPeripheralConnectionPolicy.action(isConnected: false),
+      .connect,
+      "a disconnected known peripheral must start a physical connection"
+    )
+
+    print("BleKnownPeripheralConnectionPolicyTests: PASS")
+  }
+}

--- a/app/ios/test/BleKnownPeripheralConnectionPolicyTests.swift
+++ b/app/ios/test/BleKnownPeripheralConnectionPolicyTests.swift
@@ -23,6 +23,46 @@ private struct BleKnownPeripheralConnectionPolicyTests {
       .connect,
       "a disconnected known peripheral must start a physical connection"
     )
+    try expectEqual(
+      BleRestoredPeripheralPolicy.action(backgroundModeEnabled: false),
+      .releaseConnection,
+      "an unapproved background restore must release the one-connection pendant"
+    )
+    try expectEqual(
+      BleRestoredPeripheralPolicy.action(backgroundModeEnabled: true),
+      .restoreConnection,
+      "Background Mode opt-in must preserve CoreBluetooth restoration"
+    )
+    try expectEqual(
+      BleRestoredPeripheralPolicy.shouldDeferConnect(
+        requiresForegroundActivation: true
+      ),
+      true,
+      "Flutter cannot reclaim a released pendant before the foreground callback"
+    )
+    try expectEqual(
+      BleRestoredPeripheralPolicy.shouldDeferConnect(
+        requiresForegroundActivation: false
+      ),
+      false,
+      "the foreground callback or Background Mode opt-in clears the gate"
+    )
+    try expectEqual(
+      BleRestoredPeripheralPolicy.shouldResumeDeferredConnect(
+        requiresForegroundActivation: true,
+        applicationIsActive: false
+      ),
+      false,
+      "an inactive restoration launch must not consume foreground authority"
+    )
+    try expectEqual(
+      BleRestoredPeripheralPolicy.shouldResumeDeferredConnect(
+        requiresForegroundActivation: true,
+        applicationIsActive: true
+      ),
+      true,
+      "Bluetooth becoming ready in an active app may resume deferred ownership"
+    )
 
     print("BleKnownPeripheralConnectionPolicyTests: PASS")
   }

--- a/app/ios/test/BleLegacyAudioOwnershipTests.swift
+++ b/app/ios/test/BleLegacyAudioOwnershipTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+private enum TestFailure: Error {
+  case failed(String)
+}
+
+private func expectEqual<T: Equatable>(_ actual: T, _ expected: T, _ message: String) throws {
+  guard actual == expected else {
+    throw TestFailure.failed("\(message): expected \(expected), got \(actual)")
+  }
+}
+
+@main
+private struct BleLegacyAudioOwnershipTests {
+  static func main() throws {
+    let device = "47D3572B-2464-40C0-BBBE-3BFCD9EF1BE5"
+    let service = BleLegacyAudioOwnershipPolicy.serviceUuid
+    let characteristic = BleLegacyAudioOwnershipPolicy.characteristicUuid
+
+    try expectEqual(
+      BleLegacyAudioOwnershipPolicy.decision(
+        peripheralUuid: device,
+        serviceUuid: service,
+        characteristicUuid: characteristic,
+        configuredOwner: BleLegacyAudioOwnershipPolicy.owner(from: nil)
+      ),
+      .orphanedLegacyAudio,
+      "omitted config must release a restored legacy audio notification"
+    )
+
+    try expectEqual(
+      BleLegacyAudioOwnershipPolicy.owner(from: "{not-json"),
+      nil,
+      "malformed config must fail closed"
+    )
+
+    let matchingConfig = """
+      {
+        "deviceId":"\(device.lowercased())",
+        "serviceUuid":"\(service.uppercased())",
+        "characteristicUuid":"\(characteristic.uppercased())"
+      }
+      """
+    try expectEqual(
+      BleLegacyAudioOwnershipPolicy.decision(
+        peripheralUuid: device,
+        serviceUuid: service,
+        characteristicUuid: characteristic,
+        configuredOwner: BleLegacyAudioOwnershipPolicy.owner(from: matchingConfig)
+      ),
+      .configuredOwner,
+      "matching configured legacy owner must retain its notification"
+    )
+
+    let otherDeviceConfig = matchingConfig.replacingOccurrences(
+      of: device.lowercased(),
+      with: "00000000-0000-0000-0000-000000000000"
+    )
+    try expectEqual(
+      BleLegacyAudioOwnershipPolicy.decision(
+        peripheralUuid: device,
+        serviceUuid: service,
+        characteristicUuid: characteristic,
+        configuredOwner: BleLegacyAudioOwnershipPolicy.owner(from: otherDeviceConfig)
+      ),
+      .orphanedLegacyAudio,
+      "a stale config for another pendant must not own this notification"
+    )
+
+    try expectEqual(
+      BleLegacyAudioOwnershipPolicy.decision(
+        peripheralUuid: device,
+        serviceUuid: service,
+        characteristicUuid: "19b10002-e8f2-537e-4f6c-d104768a1214",
+        configuredOwner: nil
+      ),
+      .notLegacyAudio,
+      "the guard must not interfere with storage or control characteristics"
+    )
+
+    print("BleLegacyAudioOwnershipTests: PASS")
+  }
+}

--- a/app/ios/test/run_ble_legacy_audio_ownership_tests.sh
+++ b/app/ios/test/run_ble_legacy_audio_ownership_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+test_binary="$(mktemp "${TMPDIR:-/tmp}/ble-legacy-audio-ownership.XXXXXX")"
+trap 'rm -f "$test_binary"' EXIT
+
+xcrun swiftc \
+  "$repo_root/app/ios/Runner/Ble/BleLegacyAudioOwnership.swift" \
+  "$repo_root/app/ios/test/BleLegacyAudioOwnershipTests.swift" \
+  -o "$test_binary"
+
+"$test_binary"

--- a/app/ios/test/run_ble_legacy_audio_ownership_tests.sh
+++ b/app/ios/test/run_ble_legacy_audio_ownership_tests.sh
@@ -2,12 +2,20 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-test_binary="$(mktemp "${TMPDIR:-/tmp}/ble-legacy-audio-ownership.XXXXXX")"
-trap 'rm -f "$test_binary"' EXIT
+ownership_test_binary="$(mktemp "${TMPDIR:-/tmp}/ble-legacy-audio-ownership.XXXXXX")"
+connection_test_binary="$(mktemp "${TMPDIR:-/tmp}/ble-known-peripheral-connection.XXXXXX")"
+trap 'rm -f "$ownership_test_binary" "$connection_test_binary"' EXIT
 
 xcrun swiftc \
   "$repo_root/app/ios/Runner/Ble/BleLegacyAudioOwnership.swift" \
   "$repo_root/app/ios/test/BleLegacyAudioOwnershipTests.swift" \
-  -o "$test_binary"
+  -o "$ownership_test_binary"
 
-"$test_binary"
+"$ownership_test_binary"
+
+xcrun swiftc \
+  "$repo_root/app/ios/Runner/Ble/BleKnownPeripheralConnectionPolicy.swift" \
+  "$repo_root/app/ios/test/BleKnownPeripheralConnectionPolicyTests.swift" \
+  -o "$connection_test_binary"
+
+"$connection_test_binary"

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -510,6 +510,19 @@ class SyncRecoveryWindowExceededException implements Exception {
   String toString() => 'SyncRecoveryWindowExceededException()';
 }
 
+/// Thrown when the upload boundary rejects the complete multipart request as
+/// too large (HTTP 413).
+///
+/// This is deterministic for the same immutable WAL batch. Callers must keep
+/// the source audio, stop automatic retries for that batch, and let unrelated
+/// recordings continue instead of treating it like an offline lane.
+class SyncUploadTooLargeException implements Exception {
+  const SyncUploadTooLargeException();
+
+  @override
+  String toString() => 'SyncUploadTooLargeException()';
+}
+
 /// Classifies a sync 422 as the backend's terminal lookback rejection.
 ///
 /// Keyed on the bounded `code` the sync routes emit, never on human-readable
@@ -620,7 +633,7 @@ Future<UploadFilesResult> uploadLocalFilesV2(
   if (response.statusCode == 400) {
     throw Exception('Audio file could not be processed by server');
   } else if (response.statusCode == 413) {
-    throw Exception('Audio file is too large to upload');
+    throw const SyncUploadTooLargeException();
   } else if (response.statusCode == 429 ||
       (response.statusCode == 503 &&
           response.headers['x-omi-rate-limit-reason']?.trim().toLowerCase() == 'backfill_capacity')) {

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -451,6 +451,13 @@ class UploadFilesResult {
 /// 429 is backend capacity unless the response carries Omi's explicit reason.
 enum SyncRateLimitKind { fairUse, backendCapacity }
 
+/// Client-side upload scheduling priority.
+///
+/// This does not create a separate persisted rate-limit domain: current
+/// servers apply one upload admission boundary. It only keeps newly captured
+/// continuity work ahead of historical recovery in the local scheduler.
+enum SyncUploadLane { fresh, backfill }
+
 @visibleForTesting
 bool shouldRequestSyncCaptureManifest(String? conversationId, bool claimLiveCapture) =>
     conversationId != null && claimLiveCapture;

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -568,7 +568,12 @@ Future<UploadFilesResult> uploadLocalFilesV2(
   UploadProgressCallback? onUploadProgress,
   String? conversationId,
   bool claimLiveCapture = false,
+  SyncUploadLane syncLane = SyncUploadLane.fresh,
+  bool replaceTranscript = false,
 }) async {
+  if (replaceTranscript && conversationId == null) {
+    throw ArgumentError('Canonical transcript replacement requires a conversation id');
+  }
   String? captureManifest;
   if (shouldRequestSyncCaptureManifest(conversationId, claimLiveCapture)) {
     captureManifest = await _createSyncCaptureManifest(files, conversationId!);
@@ -576,6 +581,9 @@ Future<UploadFilesResult> uploadLocalFilesV2(
   var url = '${Env.apiBaseUrl}v2/sync-local-files';
   if (conversationId != null) {
     url += '?conversation_id=${Uri.encodeQueryComponent(conversationId)}';
+  }
+  if (replaceTranscript) {
+    url += '${conversationId == null ? '?' : '&'}transcript_mode=replace';
   }
   var response = await makeMultipartApiCall(
     url: url,

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -192,9 +192,11 @@ class SharedPreferencesUtil {
 
   bool get useCustomStt => customSttConfig.isEnabled;
 
-  // Whether offline recordings auto-sync to Omi when the device connects.
-  // Defaults to true (auto-sync on) — the feature is opt-out from introduction.
-  bool get autoSyncOfflineRecordings => getBool('autoSyncOfflineRecordings', defaultValue: true);
+  // Whether historical offline recordings auto-sync to Omi when the device
+  // connects. Current-conversation gap repair is independent of this setting.
+  // Defaults off to protect pendant and phone battery; charging can still
+  // enable the bounded background drain.
+  bool get autoSyncOfflineRecordings => getBool('autoSyncOfflineRecordings');
 
   set autoSyncOfflineRecordings(bool value) => saveBool('autoSyncOfflineRecordings', value);
 

--- a/app/lib/backend/schema/message_event.dart
+++ b/app/lib/backend/schema/message_event.dart
@@ -12,6 +12,8 @@ abstract class MessageEvent {
         return MessageServiceStatusEvent.fromJson(json);
       case 'memory_processing_started':
         return ConversationProcessingStartedEvent.fromJson(json);
+      case 'conversation_session':
+        return ConversationSessionEvent.fromJson(json);
       case 'memory_created':
         return ConversationEvent.fromJson(json);
       case 'last_memory':
@@ -43,6 +45,37 @@ abstract class MessageEvent {
 
 class UnknownEvent extends MessageEvent {
   UnknownEvent({required super.eventType});
+}
+
+class ConversationSessionEvent extends MessageEvent {
+  ConversationSessionEvent({
+    required this.conversationId,
+    required this.status,
+    this.recordingSessionId,
+    this.lifecycleVersion,
+    this.lifecyclePhase,
+    this.lifecycleSequence,
+  }) : super(eventType: 'conversation_session');
+
+  final String conversationId;
+  final String status;
+  final String? recordingSessionId;
+  final int? lifecycleVersion;
+  final String? lifecyclePhase;
+  final int? lifecycleSequence;
+
+  bool get isInProgress => status == 'in_progress' && (lifecyclePhase == null || lifecyclePhase == 'in_progress');
+
+  factory ConversationSessionEvent.fromJson(Map<String, dynamic> json) {
+    return ConversationSessionEvent(
+      conversationId: json['conversation_id'] as String,
+      status: json['status'] as String? ?? 'in_progress',
+      recordingSessionId: json['recording_session_id'] as String?,
+      lifecycleVersion: (json['lifecycle_version'] as num?)?.toInt(),
+      lifecyclePhase: json['lifecycle_phase'] as String?,
+      lifecycleSequence: (json['lifecycle_sequence'] as num?)?.toInt(),
+    );
+  }
 }
 
 class MessageServiceStatusEvent extends MessageEvent {

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -104,7 +104,12 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
                     if (DeviceStorageProtocolPolicy.isRingBufferFirmware(deviceProvider.currentFirmwareVersion) &&
                         deviceProvider.ringStatus != null) ...[
                       const SizedBox(height: 32),
-                      DeviceStorageCard(status: deviceProvider.ringStatus!),
+                      DeviceStorageCard(
+                        status: deviceProvider.ringStatus!,
+                        drainProgress: syncState.isSyncing && syncState.phase == SyncPhase.downloadingFromDevice
+                            ? syncState.progress
+                            : null,
+                      ),
                     ],
                     const SizedBox(height: 32),
                     _buildStorageSettings(userProvider),
@@ -157,7 +162,11 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
           title = l.syncCardDownloadingTitle;
           final cur = s.currentFile ?? 0;
           final tot = s.totalFiles ?? 0;
-          if (tot > 0) progressText = l.syncCardProgressOf(cur, tot);
+          if (tot > 0) {
+            progressText = l.syncCardProgressOf(cur, tot);
+          } else {
+            progressText = '${(s.progress.clamp(0.0, 1.0) * 100).round()}%';
+          }
           break;
         case SyncPhase.waitingForInternet:
           title = l.syncCardWaitingInternet;
@@ -210,12 +219,13 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           if (showSpinner) ...[
-            const SizedBox(
+            SizedBox(
               width: 16,
               height: 16,
               child: CircularProgressIndicator(
+                value: s.phase == SyncPhase.downloadingFromDevice ? s.progress.clamp(0.0, 1.0) : null,
                 strokeWidth: 2,
-                valueColor: AlwaysStoppedAnimation(Colors.deepPurpleAccent),
+                valueColor: const AlwaysStoppedAnimation(Colors.deepPurpleAccent),
               ),
             ),
             const SizedBox(width: 12),

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -56,7 +56,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
     return Consumer3<SyncProvider, UserProvider, DeviceProvider>(
       builder: (context, syncProvider, userProvider, deviceProvider, _) {
         final syncState = syncProvider.syncState;
-        final hasAnyRecording = syncProvider.allWals.isNotEmpty;
+        final hasAnyRecording = syncProvider.userVisibleWals.isNotEmpty;
         // Compute the filtered list once per build and pass it down — the
         // SliverList.builder uses it via index, so calling it again inside
         // itemBuilder would re-sort+re-filter on every visible row.
@@ -141,7 +141,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
               w.syncDisplayState == WalSyncDisplayState.waiting || w.syncDisplayState == WalSyncDisplayState.retrying,
         )
         .length;
-    final hasAnyRecording = p.allWals.isNotEmpty;
+    final hasAnyRecording = p.userVisibleWals.isNotEmpty;
 
     final isActive = s.isSyncing || s.isFetchingConversations;
     final bool showSpinner = (isActive || uploaded > 0) && !p.isRateLimited;

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -540,7 +540,9 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             // Index suffix because `wal.id` (device_timerStart) is not unique
             // across SD-card + on-phone copies of the same recording.
             key: ValueKey('${wal.id}#$i'),
-            direction: state == WalSyncDisplayState.syncing ? DismissDirection.none : DismissDirection.endToStart,
+            direction: state == WalSyncDisplayState.syncing || !syncProvider.canDeleteWal(wal)
+                ? DismissDirection.none
+                : DismissDirection.endToStart,
             confirmDismiss: (direction) {
               final uploading = wal.syncDisplayState == WalSyncDisplayState.uploaded;
               return OmiConfirmDialog.show(
@@ -591,6 +593,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
       behavior: HitTestBehavior.opaque,
       onTap: () {
         final syncProvider = context.read<SyncProvider>();
+        if (syncProvider.isLogicalRingArchiveDisplayWal(wal)) return;
         if (syncProvider.isSyncing && wal.storage == WalStorage.sdcard) {
           ScaffoldMessenger.of(
             context,

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -591,16 +591,25 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: () {
+      onTap: () async {
         final syncProvider = context.read<SyncProvider>();
-        if (syncProvider.isLogicalRingArchiveDisplayWal(wal)) return;
         if (syncProvider.isSyncing && wal.storage == WalStorage.sdcard) {
           ScaffoldMessenger.of(
             context,
           ).showSnackBar(SnackBar(content: Text(context.l10n.syncInProgress), duration: const Duration(seconds: 2)));
           return;
         }
-        Navigator.of(context).push(MaterialPageRoute(builder: (_) => WalItemDetailPage(wal: wal)));
+        final detailWal = await syncProvider.resolveWalForDetail(wal);
+        if (!mounted) return;
+        if (detailWal == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(context.l10n.audioPlaybackUnavailable)),
+          );
+          return;
+        }
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => WalItemDetailPage(wal: detailWal)),
+        );
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -101,7 +101,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
                       _buildConversationsCard(syncProvider),
                     ],
                     if (syncState.hasError) ...[const SizedBox(height: 16), _buildErrorCard(syncState, syncProvider)],
-                    if (WalSyncs.isRingBufferFirmware(deviceProvider.currentFirmwareVersion) &&
+                    if (DeviceStorageProtocolPolicy.isRingBufferFirmware(deviceProvider.currentFirmwareVersion) &&
                         deviceProvider.ringStatus != null) ...[
                       const SizedBox(height: 32),
                       DeviceStorageCard(status: deviceProvider.ringStatus!),

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -905,7 +905,7 @@ class _SyncPageState extends State<SyncPage> {
                 // Recordings list
                 Consumer<SyncProvider>(
                   builder: (context, syncProvider, child) {
-                    if (syncProvider.isLoadingWals && syncProvider.allWals.isEmpty) {
+                    if (syncProvider.isLoadingWals && syncProvider.userVisibleWals.isEmpty) {
                       return const SliverToBoxAdapter(
                         child: Center(
                           child: Padding(
@@ -916,7 +916,7 @@ class _SyncPageState extends State<SyncPage> {
                       );
                     }
 
-                    if (syncProvider.allWals.isEmpty) {
+                    if (syncProvider.userVisibleWals.isEmpty) {
                       return SliverToBoxAdapter(child: _buildEmptyState(context));
                     }
 

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -154,9 +154,18 @@ class WalListItem extends StatelessWidget {
             },
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
-              onTap: () {
-                if (syncProvider.isLogicalRingArchiveDisplayWal(wal)) return;
-                Navigator.of(context).push(MaterialPageRoute(builder: (context) => WalItemDetailPage(wal: wal)));
+              onTap: () async {
+                final detailWal = await syncProvider.resolveWalForDetail(wal);
+                if (!context.mounted) return;
+                if (detailWal == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(context.l10n.audioPlaybackUnavailable)),
+                  );
+                  return;
+                }
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (context) => WalItemDetailPage(wal: detailWal)),
+                );
               },
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -11,7 +11,6 @@ import 'package:omi/pages/conversations/sync_cooldown_copy.dart';
 import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/providers/user_provider.dart';
-import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/widgets/omi_confirm_dialog.dart';
 import 'package:omi/utils/other/temp.dart';
@@ -131,8 +130,9 @@ class WalListItem extends StatelessWidget {
           decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(16)),
           child: Dismissible(
             key: Key(wal.id),
-            direction:
-                displayState == WalSyncDisplayState.syncing ? DismissDirection.none : DismissDirection.endToStart,
+            direction: displayState == WalSyncDisplayState.syncing || !syncProvider.canDeleteWal(wal)
+                ? DismissDirection.none
+                : DismissDirection.endToStart,
             confirmDismiss: (direction) {
               final uploading = wal.syncDisplayState == WalSyncDisplayState.uploaded;
               return OmiConfirmDialog.show(
@@ -150,11 +150,12 @@ class WalListItem extends StatelessWidget {
               child: const Icon(Icons.delete, color: Colors.white),
             ),
             onDismissed: (direction) {
-              ServiceManager.instance().wal.getSyncs().deleteWal(wal);
+              syncProvider.deleteWal(wal);
             },
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () {
+                if (syncProvider.isLogicalRingArchiveDisplayWal(wal)) return;
                 Navigator.of(context).push(MaterialPageRoute(builder: (context) => WalItemDetailPage(wal: wal)));
               },
               child: Padding(

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -498,8 +498,8 @@ class _SyncPageState extends State<SyncPage> {
     }
 
     final isActive = syncProvider.isSyncing;
-    final uploaded = syncProvider.uploadedWals.length;
-    final readyToSync = syncProvider.missingWals.length;
+    final uploaded = syncProvider.processingRecordingCount;
+    final readyToSync = syncProvider.readyToSyncRecordingCount;
     final bool showSpinner = (isActive || uploaded > 0) && !syncProvider.isRateLimited;
 
     String title;

--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -65,7 +65,7 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
     });
 
     final syncProvider = context.read<SyncProvider>();
-    final waveformData = await syncProvider.getWaveformForWal(widget.wal.id);
+    final waveformData = await syncProvider.getWaveformForWal(widget.wal);
 
     if (mounted) {
       setState(() {

--- a/app/lib/pages/conversations/widgets/device_storage_card.dart
+++ b/app/lib/pages/conversations/widgets/device_storage_card.dart
@@ -10,8 +10,13 @@ import 'package:omi/utils/responsive/responsive_helper.dart';
 /// bar (amber ≥80%, red ≥95%), and a "used of total · free" summary line.
 class DeviceStorageCard extends StatelessWidget {
   final RingStatus status;
+  final double? drainProgress;
 
-  const DeviceStorageCard({super.key, required this.status});
+  const DeviceStorageCard({
+    super.key,
+    required this.status,
+    this.drainProgress,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +27,7 @@ class DeviceStorageCard extends StatelessWidget {
     final fraction = total == 0 ? 0.0 : (used / total).clamp(0.0, 1.0);
     final percent = (fraction * 100).round();
     final nearlyFull = fraction >= 0.95;
+    final boundedDrainProgress = drainProgress?.clamp(0.0, 1.0);
 
     // Neutral white for normal usage (brand INV-UI-1: white/neutral accents);
     // amber/red are reserved for the near-full warning/critical bands.
@@ -64,6 +70,34 @@ class DeviceStorageCard extends StatelessWidget {
             '${l.deviceStorageUsedOfTotal(WavBytesUtil.formatBytes(used, decimals: 0), WavBytesUtil.formatBytes(total, decimals: 0))}  ·  ${l.deviceStorageFree(WavBytesUtil.formatBytes(free, decimals: 0))}',
             style: TextStyle(color: Colors.grey.shade500, fontSize: 13, fontWeight: FontWeight.w400),
           ),
+          if (boundedDrainProgress != null) ...[
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    l.syncCardDownloadingTitle,
+                    style: TextStyle(color: Colors.grey.shade400, fontSize: 13, fontWeight: FontWeight.w400),
+                  ),
+                ),
+                Text(
+                  '${(boundedDrainProgress * 100).round()}%',
+                  style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                key: const ValueKey('device-storage-drain-progress'),
+                value: boundedDrainProgress,
+                minHeight: 4,
+                backgroundColor: Colors.grey.shade800,
+                valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+            ),
+          ],
           if (nearlyFull) ...[
             const SizedBox(height: 8),
             Text(

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -280,11 +280,14 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     } else if (!isHavingRecordingDevice && !isUsingPhoneMic) {
       stateText = "";
     } else if (isUsingPhoneMic || isHavingRecordingDevice) {
-      if (captureProvider.terminalTranscriptionFailure != null) {
-        // Audio remains in the WAL while reconnecting, but the server has
-        // explicitly said live STT is unavailable. Do not claim "Listening".
-        stateText = context.l10n.transcriptionUnavailable;
-        statusIndicator = const PausedStatusIndicator();
+      final transcriptionFailure = captureProvider.terminalTranscriptionFailure;
+      if (transcriptionFailure != null) {
+        // Audio remains in the WAL while reconnecting. Distinguish a retryable
+        // upstream interruption from a terminal outage so a short recovery
+        // does not flash the stronger "unavailable" state.
+        final isRetrying = transcriptionFailure.retryable == true;
+        stateText = isRetrying ? context.l10n.transcriptionReconnecting : context.l10n.transcriptionUnavailable;
+        statusIndicator = isRetrying ? const RecordingStatusIndicator() : const PausedStatusIndicator();
       } else {
         // Show "Listening" for all active recording states — WAL ensures audio is
         // saved locally regardless of transcription connection status.
@@ -362,7 +365,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     } else if (isPhoneRecording) {
       isPaused = _isPhoneMicPaused || provider.isPaused || isCallInterrupted;
     }
-    final hasTerminalTranscriptionFailure = provider.terminalTranscriptionFailure != null;
+    final transcriptionFailure = provider.terminalTranscriptionFailure;
 
     // Determine if this is an OmiGlass-type device (captures photos)
     bool hasPhotos = provider.photos.isNotEmpty;
@@ -372,8 +375,10 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
         ? context.l10n.paused
         : isPaused
             ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
-            : hasTerminalTranscriptionFailure
-                ? context.l10n.transcriptionUnavailable
+            : transcriptionFailure != null
+                ? transcriptionFailure.retryable == true
+                    ? context.l10n.transcriptionReconnecting
+                    : context.l10n.transcriptionUnavailable
                 : hasPhotos
                     ? 'Capturing'
                     : context.l10n.listening;

--- a/app/lib/pages/home/firmware_mixin.dart
+++ b/app/lib/pages/home/firmware_mixin.dart
@@ -20,6 +20,27 @@ import 'package:omi/utils/device.dart';
 import 'package:omi/utils/firmware_update_build_policy.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/manifest/manifest.dart';
+import 'package:omi/utils/omi_mcu_dfu_policy.dart';
+
+class FirmwareDfuConnectionHandoff {
+  FirmwareDfuConnectionHandoff({required this.releaseUpdater, required this.resumeDeviceConnection});
+
+  final Future<void> Function() releaseUpdater;
+  final Future<void> Function() resumeDeviceConnection;
+  Future<void>? _finishFuture;
+
+  bool get hasStarted => _finishFuture != null;
+
+  Future<void> finish() => _finishFuture ??= _finish();
+
+  Future<void> _finish() async {
+    try {
+      await releaseUpdater();
+    } finally {
+      await resumeDeviceConnection();
+    }
+  }
+}
 
 mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
   FirmwareUpdateBuildPolicy get firmwareUpdatePolicy => FirmwareUpdateBuildPolicy.current;
@@ -36,6 +57,7 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
   late final mcumgr.FirmwareUpdateManagerFactory? managerFactory =
       firmwareUpdatePolicy.allowsOmiFirmwareUpdate ? mcumgr.FirmwareUpdateManagerFactory() : null;
   mcumgr.FirmwareUpdateManager? _mcuUpdateManager;
+  FirmwareDfuConnectionHandoff? _activeDfuHandoff;
 
   /// Process ZIP file and return firmware image list
   Future<List<mcumgr.Image>> processZipFile(Uint8List zipFileData) async {
@@ -103,69 +125,135 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
     }
   }
 
+  Future<void> _releaseLegacyDfu() async {
+    // nordic_dfu 6.2.0 sends abort synchronously but does not complete the
+    // MethodChannel result on Android or iOS. Do not let that plugin bug strand
+    // connection reclaim during page disposal.
+    unawaited(NordicDfu().abortDfu());
+  }
+
+  /// Ends whichever DFU implementation currently owns BLE and reclaims the
+  /// exact device connection. Safe to call from a terminal callback and page
+  /// disposal concurrently.
+  Future<void> finishDfuSession() async {
+    final handoff = _activeDfuHandoff;
+    if (handoff == null) {
+      await killMcuUpdateManager();
+      return;
+    }
+    await _finishDfuHandoff(handoff);
+  }
+
+  Future<void> _finishDfuHandoff(FirmwareDfuConnectionHandoff handoff) async {
+    try {
+      await handoff.finish();
+    } finally {
+      if (identical(_activeDfuHandoff, handoff)) {
+        _activeDfuHandoff = null;
+      }
+    }
+  }
+
+  Future<void> _completeDfu(
+    FirmwareDfuConnectionHandoff handoff, {
+    required bool successful,
+    Object? error,
+  }) async {
+    final isFirstTerminalEvent = !handoff.hasStarted;
+    final finishFuture = _finishDfuHandoff(handoff);
+
+    if (isFirstTerminalEvent && mounted) {
+      setState(() {
+        isInstalling = false;
+        isInstalled = successful;
+      });
+    }
+    if (error != null) {
+      Logger.debug('Firmware update failed: $error');
+    }
+
+    try {
+      await finishFuture;
+    } catch (e) {
+      Logger.error(
+        'Firmware update reached a terminal state, but exact-device BLE reclaim '
+        'failed after bounded retries: $e',
+      );
+    }
+  }
+
   Future<void> startMCUDfu(BtDevice btDevice, {bool fileInAssets = false, String? zipFilePath}) async {
     if (!firmwareUpdatePolicy.allowsOmiFirmwareUpdate) {
       Logger.debug('MCU firmware updates are unavailable in the Ray-Ban DAT build');
       return;
     }
-    setState(() {
-      isInstalling = true;
-    });
-    await Provider.of<DeviceProvider>(context, listen: false).prepareDFU();
-    await Future.delayed(const Duration(seconds: 2));
-
     String firmwareFile = zipFilePath ?? '${(await getApplicationDocumentsDirectory()).path}/firmware.zip';
     final file = File(firmwareFile);
     if (!await file.exists()) {
       Logger.debug('Firmware file not found: $firmwareFile');
-      if (mounted) {
-        setState(() {
-          isInstalling = false;
-        });
-      }
       return;
     }
     final bytes = await file.readAsBytes();
-    const configuration = mcumgr.FirmwareUpgradeConfiguration(
-      estimatedSwapTime: Duration(seconds: 0),
-      eraseAppSettings: true,
-      pipelineDepth: 1,
-    );
-
-    await killMcuUpdateManager();
-    final updateManager = await managerFactory!.getUpdateManager(btDevice.id);
-    _mcuUpdateManager = updateManager;
     final images = await processZipFile(bytes);
+    final configuration = OmiMcuDfuPolicy.createConfiguration();
 
-    final updateStream = updateManager.setup();
+    if (!mounted) return;
+    setState(() {
+      isInstalling = true;
+    });
+    final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: killMcuUpdateManager,
+      resumeDeviceConnection: deviceProvider.resumeConnectionAfterDFU,
+    );
+    _activeDfuHandoff = handoff;
 
-    updateStream.listen((state) {
-      if (state == mcumgr.FirmwareUpgradeState.success) {
-        Logger.debug('update success');
-        killMcuUpdateManager();
+    try {
+      await deviceProvider.prepareDFU();
+      await Future.delayed(const Duration(seconds: 2));
+
+      await killMcuUpdateManager();
+      final updateManager = await managerFactory!.getUpdateManager(btDevice.id);
+      _mcuUpdateManager = updateManager;
+
+      final updateStream = updateManager.setup();
+
+      updateStream.listen(
+        (state) {
+          if (state == mcumgr.FirmwareUpgradeState.success) {
+            Logger.debug('update success');
+            unawaited(_completeDfu(handoff, successful: true));
+          } else {
+            Logger.debug('update state: $state');
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          unawaited(_completeDfu(handoff, successful: false, error: error));
+        },
+        onDone: () {
+          unawaited(_completeDfu(handoff, successful: false));
+        },
+      );
+
+      updateManager.progressStream.listen((progress) {
+        Logger.debug('progress: $progress');
+        if (!mounted) return;
         setState(() {
-          isInstalling = false;
-          isInstalled = true;
+          installProgress = (progress.bytesSent / progress.imageSize * 100).round();
         });
-      } else {
-        Logger.debug('update state: $state');
-      }
-    });
-
-    updateManager.progressStream.listen((progress) {
-      Logger.debug('progress: $progress');
-      setState(() {
-        installProgress = (progress.bytesSent / progress.imageSize * 100).round();
       });
-    });
 
-    updateManager.logger.logMessageStream
-        .where((log) => log.level.rawValue > 1) // Filter debug messages
-        .listen((log) {
-      Logger.debug('dfu log: ${log.message}');
-    });
+      updateManager.logger.logMessageStream
+          .where((log) => log.level.rawValue > 1) // Filter debug messages
+          .listen((log) {
+        Logger.debug('dfu log: ${log.message}');
+      });
 
-    await updateManager.update(images, configuration: configuration);
+      await updateManager.update(images, configuration: configuration);
+    } catch (e) {
+      await _completeDfu(handoff, successful: false, error: e);
+      rethrow;
+    }
   }
 
   Future<void> startLegacyDfu(BtDevice btDevice, {bool fileInAssets = false, String? zipFilePath}) async {
@@ -173,54 +261,71 @@ mixin FirmwareMixin<T extends StatefulWidget> on State<T> {
       Logger.debug('Legacy firmware updates are unavailable in the Ray-Ban DAT build');
       return;
     }
+    final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
+    final firmwareFile = zipFilePath ?? '${(await getApplicationDocumentsDirectory()).path}/firmware.zip';
+    if (!fileInAssets && !await File(firmwareFile).exists()) {
+      Logger.debug('Firmware file not found: $firmwareFile');
+      return;
+    }
+
     setState(() {
       isInstalling = true;
     });
-    await Provider.of<DeviceProvider>(context, listen: false).prepareDFU();
-    await Future.delayed(const Duration(seconds: 2));
-    String firmwareFile = zipFilePath ?? '${(await getApplicationDocumentsDirectory()).path}/firmware.zip';
-    NordicDfu dfu = NordicDfu();
-    await dfu.startDfu(
-      btDevice.id,
-      firmwareFile,
-      fileInAsset: fileInAssets,
-      numberOfPackets: 8,
-      enableUnsafeExperimentalButtonlessServiceInSecureDfu: true,
-      iosSpecialParameter: const IosSpecialParameter(
-        packetReceiptNotificationParameter: 8,
-        forceScanningForNewAddressInLegacyDfu: true,
-        connectionTimeout: 60,
-      ),
-      androidSpecialParameter: const AndroidSpecialParameter(packetReceiptNotificationsEnabled: true, rebootTime: 1000),
-      onProgressChanged: (deviceAddress, percent, speed, avgSpeed, currentPart, partsTotal) {
-        Logger.debug('deviceAddress: $deviceAddress, percent: $percent');
-        setState(() {
-          installProgress = percent.toInt();
-        });
-      },
-      onError: (deviceAddress, error, errorType, message) {
-        Logger.debug('deviceAddress: $deviceAddress, error: $error, errorType: $errorType, message: $message');
-        setState(() {
-          isInstalling = false;
-        });
-        // Reset firmware update state on error
-        final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
-        deviceProvider.resetFirmwareUpdateState();
-      },
-      onDeviceConnecting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnecting'),
-      onDeviceConnected: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnected'),
-      onDfuProcessStarting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarting'),
-      onDfuProcessStarted: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarted'),
-      onEnablingDfuMode: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onEnablingDfuMode'),
-      onFirmwareValidating: (deviceAddress) => Logger.debug('address: $deviceAddress, onFirmwareValidating'),
-      onDfuCompleted: (deviceAddress) {
-        Logger.debug('deviceAddress: $deviceAddress, onDfuCompleted');
-        setState(() {
-          isInstalling = false;
-          isInstalled = true;
-        });
-      },
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: _releaseLegacyDfu,
+      resumeDeviceConnection: deviceProvider.resumeConnectionAfterDFU,
     );
+    _activeDfuHandoff = handoff;
+
+    try {
+      await deviceProvider.prepareDFU();
+      await Future.delayed(const Duration(seconds: 2));
+      final dfu = NordicDfu();
+      await dfu.startDfu(
+        btDevice.id,
+        firmwareFile,
+        fileInAsset: fileInAssets,
+        numberOfPackets: 8,
+        enableUnsafeExperimentalButtonlessServiceInSecureDfu: true,
+        iosSpecialParameter: const IosSpecialParameter(
+          packetReceiptNotificationParameter: 8,
+          forceScanningForNewAddressInLegacyDfu: true,
+          connectionTimeout: 60,
+        ),
+        androidSpecialParameter: const AndroidSpecialParameter(
+          packetReceiptNotificationsEnabled: true,
+          rebootTime: 1000,
+        ),
+        onProgressChanged: (deviceAddress, percent, speed, avgSpeed, currentPart, partsTotal) {
+          Logger.debug('deviceAddress: $deviceAddress, percent: $percent');
+          if (!mounted) return;
+          setState(() {
+            installProgress = percent.toInt();
+          });
+        },
+        onError: (deviceAddress, error, errorType, message) {
+          Logger.debug('deviceAddress: $deviceAddress, error: $error, errorType: $errorType, message: $message');
+          unawaited(_completeDfu(handoff, successful: false, error: message));
+        },
+        onDfuAborted: (deviceAddress) {
+          Logger.debug('deviceAddress: $deviceAddress, onDfuAborted');
+          unawaited(_completeDfu(handoff, successful: false));
+        },
+        onDeviceConnecting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnecting'),
+        onDeviceConnected: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDeviceConnected'),
+        onDfuProcessStarting: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarting'),
+        onDfuProcessStarted: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onDfuProcessStarted'),
+        onEnablingDfuMode: (deviceAddress) => Logger.debug('deviceAddress: $deviceAddress, onEnablingDfuMode'),
+        onFirmwareValidating: (deviceAddress) => Logger.debug('address: $deviceAddress, onFirmwareValidating'),
+        onDfuCompleted: (deviceAddress) {
+          Logger.debug('deviceAddress: $deviceAddress, onDfuCompleted');
+          unawaited(_completeDfu(handoff, successful: true));
+        },
+      );
+    } catch (e) {
+      await _completeDfu(handoff, successful: false, error: e);
+      rethrow;
+    }
   }
 
   Future getLatestVersion({

--- a/app/lib/pages/home/firmware_update.dart
+++ b/app/lib/pages/home/firmware_update.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -79,12 +81,11 @@ class _FirmwareUpdateState extends State<FirmwareUpdate> with FirmwareMixin {
 
   @override
   void dispose() {
-    killMcuUpdateManager();
+    unawaited(finishDfuSession());
     final provider = _deviceProvider;
     if (provider != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         provider.setOnFirmwareUpdatePage(false);
-        provider.resetFirmwareUpdateState();
       });
     }
     super.dispose();

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:omi/utils/platform/platform_manager.dart';
@@ -1790,7 +1791,7 @@ class _ManualFirmwareFlashPageState extends State<_ManualFirmwareFlashPage> with
 
   @override
   void dispose() {
-    killMcuUpdateManager();
+    unawaited(finishDfuSession());
     super.dispose();
   }
 

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -353,7 +353,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (connection is! OmiDeviceConnection) return;
 
     final currentStatus = await connection.readChargingStatus();
-    ServiceManager.instance().wal.getSyncs().setDeviceCharging(currentStatus);
     if (isCharging != currentStatus) {
       isCharging = currentStatus;
       notifyListeners();
@@ -361,7 +360,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
     _bleChargingStatusListener = await connection.getChargingStatusListener(
       onChargingStatusChange: (bool charging) {
-        ServiceManager.instance().wal.getSyncs().setDeviceCharging(charging);
         if (isCharging != charging) {
           isCharging = charging;
           if (!charging) {

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -21,7 +21,7 @@ import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/battery_widget_service.dart';
-import 'package:omi/services/wals/wal_syncs.dart';
+import 'package:omi/services/wals/device_storage_routing.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/firmware_update_build_policy.dart';
@@ -498,8 +498,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     });
 
     // Wals
-    ServiceManager.instance().wal.getSyncs().sdcard.setDevice(null);
-    ServiceManager.instance().wal.getSyncs().flashPage.setDevice(null);
+    ServiceManager.instance().wal.getSyncs().setDevice(null);
 
     PlatformManager.instance.crashReporter.logInfo('Omi Device Disconnected');
 
@@ -587,10 +586,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // connect object whose firmwareRevision is often still 'Unknown'.
     final syncs = ServiceManager.instance().wal.getSyncs();
     syncs.setDevice(device, firmwareVersion: currentFirmwareVersion);
-    syncs.sdcard.setDevice(device);
-    syncs.flashPage.setDevice(device);
-    syncs.storage.setDevice(device);
-    syncs.ring.setDevice(device);
 
     // Device connection and inventory are a recovery wake, even when the
     // home page is not mounted. The coordinator serializes it with every
@@ -616,25 +611,12 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   /// Check firmware version to determine multi-file sync support.
-  /// Firmware >= 3.0.17 supports the new LittleFS multi-file protocol.
-  static bool _isFirmwareVersionSupported(String? version) {
-    if (version == null || version.isEmpty || version == 'Unknown') return false;
-    final parts = version.split('.').map((p) => int.tryParse(p) ?? 0).toList();
-    if (parts.length < 3) return false;
-    // Compare against 3.0.17
-    if (parts[0] > 3) return true;
-    if (parts[0] < 3) return false;
-    if (parts[1] > 0) return true;
-    if (parts[1] < 0) return false;
-    return parts[2] >= 17;
-  }
-
   Future<void> _checkAndStartAutoSync(BtDevice device) async {
     try {
       // Use firmware version as the reliable signal for multi-file support
       // Read from pairedDevice which has firmwareRevision populated by getDeviceInfo()
       final fwVersion = pairedDevice?.firmwareRevision ?? device.firmwareRevision;
-      supportsMultiFileSync = _isFirmwareVersionSupported(fwVersion);
+      supportsMultiFileSync = DeviceStorageProtocolPolicy.supportsModernStorage(fwVersion);
       SharedPreferencesUtil().deviceSupportsMultiFileSync = supportsMultiFileSync;
       notifyListeners();
 
@@ -646,7 +628,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       // fw >= 3.0.20 speaks the ring-buffer protocol; auto-detect via the 16-byte
       // ring status read instead of the multi-file file-list endpoint (which the
       // ring firmware no longer serves).
-      if (WalSyncs.isRingBufferFirmware(fwVersion)) {
+      if (DeviceStorageProtocolPolicy.isRingBufferFirmware(fwVersion)) {
         final ringStatus = await connection.getRingStatus();
         if (ringStatus != null) {
           _ringStatus = ringStatus;
@@ -676,7 +658,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   Future<void> refreshRingStorageStatus() async {
     try {
       final fwVersion = pairedDevice?.firmwareRevision ?? connectedDevice?.firmwareRevision;
-      if (!WalSyncs.isRingBufferFirmware(fwVersion)) return;
+      if (!DeviceStorageProtocolPolicy.isRingBufferFirmware(fwVersion)) return;
       final deviceId = pairedDevice?.id ?? connectedDevice?.id;
       if (deviceId == null) return;
       final connection = await ServiceManager.instance().device.ensureConnection(deviceId);

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -88,8 +88,12 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   Map<String, dynamic> get latestOmiGlassFirmwareDetails => _latestOmiGlassFirmwareDetails;
 
   Timer? _discoveryTimer;
-  final Debouncer _disconnectDebouncer = Debouncer(delay: const Duration(milliseconds: 500));
-  final Debouncer _connectDebouncer = Debouncer(delay: const Duration(milliseconds: 100));
+  final Debouncer _disconnectDebouncer = Debouncer(
+    delay: const Duration(milliseconds: 500),
+  );
+  final Debouncer _connectDebouncer = Debouncer(
+    delay: const Duration(milliseconds: 100),
+  );
   final DeviceService _deviceService;
 
   void Function(BtDevice device)? onDeviceConnected;
@@ -123,10 +127,32 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     ).whenComplete(() => _pairingLostDialogShowing = false);
   }
 
-  void setProviders(CaptureProvider provider, LocalRecordingsProvider recordingsProvider) {
+  void setProviders(
+    CaptureProvider provider,
+    LocalRecordingsProvider recordingsProvider,
+  ) {
+    if (!identical(captureProvider, provider)) {
+      captureProvider?.removeListener(_onCaptureReadinessChanged);
+      provider.addListener(_onCaptureReadinessChanged);
+    }
     captureProvider = provider;
     localRecordingsProvider = recordingsProvider;
     notifyListeners();
+  }
+
+  void _onCaptureReadinessChanged() {
+    final capture = captureProvider;
+    if (capture == null || connectedDevice == null || capture.isPaused) return;
+    if (!DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio(currentFirmwareVersion)) return;
+
+    final audioReady = capture.hasActiveDeviceAudioStream;
+    if (isConnected == audioReady) return;
+    setIsConnected(audioReady);
+    if (!audioReady) {
+      Logger.warning(
+        'DeviceProvider: storage-authoritative BLE session is connected without a healthy audio path',
+      );
+    }
   }
 
   Future<void> setConnectedDevice(BtDevice? device) async {
@@ -209,7 +235,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         SharedPreferencesUtil().btDevice = pairedDevice!;
         return;
       }
-      var connection = await ServiceManager.instance().device.ensureConnection(connectedDevice!.id);
+      var connection = await ServiceManager.instance().device.ensureConnection(
+            connectedDevice!.id,
+          );
       pairedDevice = await connectedDevice?.getDeviceInfo(connection);
       SharedPreferencesUtil().btDevice = pairedDevice!;
     } else {
@@ -223,7 +251,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   Future<int> _retrieveBatteryLevel(String deviceId) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return -1;
     }
@@ -235,16 +265,22 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     void Function(int)? onBatteryLevelChange,
   }) async {
     {
-      var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      var connection = await ServiceManager.instance().device.ensureConnection(
+            deviceId,
+          );
       if (connection == null) {
         return Future.value(null);
       }
-      return connection.getBleBatteryLevelListener(onBatteryLevelChange: onBatteryLevelChange);
+      return connection.getBleBatteryLevelListener(
+        onBatteryLevelChange: onBatteryLevelChange,
+      );
     }
   }
 
   Future<List<int>> _getStorageList(String deviceId) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return [];
     }
@@ -310,7 +346,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (connectedDevice == null) return;
     _bleChargingStatusListener?.cancel();
 
-    var connection = await ServiceManager.instance().device.ensureConnection(connectedDevice!.id);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          connectedDevice!.id,
+        );
     if (connection == null) return;
     if (connection is! OmiDeviceConnection) return;
 
@@ -373,7 +411,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   /// Kicks off a single connection attempt. Native handles auto-reconnect after this.
-  Future<void> initiateConnection(String caller, {bool boundDeviceOnly = false}) async {
+  Future<void> initiateConnection(
+    String caller, {
+    bool boundDeviceOnly = false,
+  }) async {
     final pairedDeviceId = SharedPreferencesUtil().btDevice.id;
 
     // Already connected — nothing to do
@@ -391,7 +432,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // then connects natively. If native is already connected, it just re-notifies Dart.
     // force: true ensures we retry even if a previous attempt left a stale connection.
     try {
-      await ServiceManager.instance().device.ensureConnection(pairedDeviceId, force: true);
+      await ServiceManager.instance().device.ensureConnection(
+            pairedDeviceId,
+            force: true,
+          );
     } catch (e) {
       // Timeout or transport failure — native keeps trying in the background.
       // NativeBleTransport's BleBridge registration persists, so auto-reconnect still works.
@@ -402,7 +446,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void _startDiscoveryScanning() {
     _discoveryTimer?.cancel();
     _runDiscoveryScan();
-    _discoveryTimer = Timer.periodic(const Duration(seconds: 10), (_) => _runDiscoveryScan());
+    _discoveryTimer = Timer.periodic(
+      const Duration(seconds: 10),
+      (_) => _runDiscoveryScan(),
+    );
   }
 
   Future<void> _runDiscoveryScan() async {
@@ -434,7 +481,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     }
 
     try {
-      var connection = await ServiceManager.instance().device.ensureConnection(pairedDeviceId, force: true);
+      var connection = await ServiceManager.instance().device.ensureConnection(
+            pairedDeviceId,
+            force: true,
+          );
       if (connection != null) {
         await setConnectedDevice(connection.device);
         setisDeviceStorageSupport();
@@ -468,6 +518,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (BleBridge.instance.pairingLostCallback == _showPairingLostDialog) {
       BleBridge.instance.pairingLostCallback = null;
     }
+    captureProvider?.removeListener(_onCaptureReadinessChanged);
     _bleBatteryLevelListener?.cancel();
     _bleChargingStatusListener?.cancel();
     _discoveryTimer?.cancel();
@@ -555,7 +606,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     }
 
     setisDeviceStorageSupport();
-    setIsConnected(true);
 
     // Read initial battery level
     int currentLevel = await _retrieveBatteryLevel(device.id);
@@ -575,22 +625,31 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (batteryLevel != -1 && batteryLevel < 20) {
       _hasLowBatteryAlerted = false;
     }
-    updateConnectingStatus(false);
-    await captureProvider?.streamDeviceRecording(device: device);
-
-    await getDeviceInfo();
     SharedPreferencesUtil().deviceName = device.name;
 
-    // Wals — pass the firmware resolved by getDeviceInfo() above so background
-    // discovery routes ring-buffer devices correctly; `device` here is the raw
-    // connect object whose firmwareRevision is often still 'Unknown'.
+    // Bind the enriched firmware route before capture starts. Storage-
+    // authoritative firmware gets its audio from the ring owner, so starting
+    // capture against the raw "Unknown" connect object would subscribe to a
+    // deliberately silent legacy audio characteristic.
     final syncs = ServiceManager.instance().wal.getSyncs();
-    syncs.setDevice(device, firmwareVersion: currentFirmwareVersion);
+    syncs.setDevice(pairedDevice ?? device, firmwareVersion: currentFirmwareVersion);
+    await captureProvider?.streamDeviceRecording(device: device);
+
+    final audioReady = captureProvider == null || captureProvider!.hasActiveDeviceAudioStream;
+    setIsConnected(audioReady);
+    updateConnectingStatus(false);
+    if (!audioReady) {
+      Logger.warning(
+        'DeviceProvider: BLE connected but the audio path failed readiness',
+      );
+    }
 
     // Device connection and inventory are a recovery wake, even when the
     // home page is not mounted. The coordinator serializes it with every
     // other foreground trigger and applies the auto-sync preference itself.
-    unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.deviceConnected));
+    unawaited(
+      RecordingTransferCoordinator.instance.wake(WakeTrigger.deviceConnected),
+    );
 
     // Auto-sync: check if device has offline files
     _checkAndStartAutoSync(device);
@@ -616,13 +675,17 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       // Use firmware version as the reliable signal for multi-file support
       // Read from pairedDevice which has firmwareRevision populated by getDeviceInfo()
       final fwVersion = pairedDevice?.firmwareRevision ?? device.firmwareRevision;
-      supportsMultiFileSync = DeviceStorageProtocolPolicy.supportsModernStorage(fwVersion);
+      supportsMultiFileSync = DeviceStorageProtocolPolicy.supportsModernStorage(
+        fwVersion,
+      );
       SharedPreferencesUtil().deviceSupportsMultiFileSync = supportsMultiFileSync;
       notifyListeners();
 
       if (!supportsMultiFileSync) return;
 
-      var connection = await ServiceManager.instance().device.ensureConnection(device.id);
+      var connection = await ServiceManager.instance().device.ensureConnection(
+            device.id,
+          );
       if (connection == null) return;
 
       // fw >= 3.0.20 speaks the ring-buffer protocol; auto-detect via the 16-byte
@@ -638,15 +701,25 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         Logger.debug(
           'DeviceProvider: Ring auto-sync detected ${ringStatus.unreadPackets} unread packets (${ringStatus.usedBytes} bytes)',
         );
-        onOfflineDataDetected?.call(device, ringStatus.unreadPackets, ringStatus.usedBytes);
+        onOfflineDataDetected?.call(
+          device,
+          ringStatus.unreadPackets,
+          ringStatus.usedBytes,
+        );
         return;
       }
 
       final status = await connection.getStorageFileStats();
       if (status == null || status.fileCount == 0) return;
 
-      Logger.debug('DeviceProvider: Auto-sync detected ${status.fileCount} files (${status.totalUsedBytes} bytes)');
-      onOfflineDataDetected?.call(device, status.fileCount, status.totalUsedBytes);
+      Logger.debug(
+        'DeviceProvider: Auto-sync detected ${status.fileCount} files (${status.totalUsedBytes} bytes)',
+      );
+      onOfflineDataDetected?.call(
+        device,
+        status.fileCount,
+        status.totalUsedBytes,
+      );
     } catch (e) {
       Logger.debug('DeviceProvider: Auto-sync check failed: $e');
     }
@@ -688,7 +761,10 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
-              child: Text(context.l10n.improveConnectionAction, style: const TextStyle(color: Colors.white)),
+              child: Text(
+                context.l10n.improveConnectionAction,
+                style: const TextStyle(color: Colors.white),
+              ),
             ),
           ],
         ),
@@ -699,7 +775,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   void _handleDeviceConnected(String deviceId) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return;
     }
@@ -848,7 +926,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           return false;
         }
         retryCount++;
-        Logger.debug('Error checking firmware update (attempt $retryCount): $e');
+        Logger.debug(
+          'Error checking firmware update (attempt $retryCount): $e',
+        );
 
         if (retryCount == maxRetries) {
           Logger.debug('Max retries reached, giving up');
@@ -948,8 +1028,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   @override
-  void onDeviceConnectionStateChanged(String deviceId, DeviceConnectionState state) async {
-    Logger.debug("provider > device connection state changed...$deviceId...$state...${connectedDevice?.id}");
+  void onDeviceConnectionStateChanged(
+    String deviceId,
+    DeviceConnectionState state,
+  ) async {
+    Logger.debug(
+      "provider > device connection state changed...$deviceId...$state...${connectedDevice?.id}",
+    );
     switch (state) {
       case DeviceConnectionState.connected:
         _disconnectDebouncer.cancel();
@@ -990,7 +1075,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       try {
         await _deviceService.resumeConnectionAfterDfu();
       } catch (rollbackError) {
-        Logger.debug('Failed to roll back device connection after DFU suspend error: $rollbackError');
+        Logger.debug(
+          'Failed to roll back device connection after DFU suspend error: $rollbackError',
+        );
       } finally {
         resetFirmwareUpdateState();
       }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -353,6 +353,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (connection is! OmiDeviceConnection) return;
 
     final currentStatus = await connection.readChargingStatus();
+    ServiceManager.instance().wal.getSyncs().setDeviceCharging(currentStatus);
     if (isCharging != currentStatus) {
       isCharging = currentStatus;
       notifyListeners();
@@ -360,6 +361,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
     _bleChargingStatusListener = await connection.getChargingStatusListener(
       onChargingStatusChange: (bool charging) {
+        ServiceManager.instance().wal.getSyncs().setDeviceCharging(charging);
         if (isCharging != charging) {
           isCharging = charging;
           if (!charging) {

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -90,13 +90,17 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   Timer? _discoveryTimer;
   final Debouncer _disconnectDebouncer = Debouncer(delay: const Duration(milliseconds: 500));
   final Debouncer _connectDebouncer = Debouncer(delay: const Duration(milliseconds: 100));
+  final DeviceService _deviceService;
 
   void Function(BtDevice device)? onDeviceConnected;
   void Function(BtDevice device, int fileCount, int totalBytes)? onOfflineDataDetected;
 
-  DeviceProvider({BleDiagnosticsLoader? bleDiagnosticsLoader})
-      : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
-    ServiceManager.instance().device.subscribe(this, this);
+  DeviceProvider({
+    BleDiagnosticsLoader? bleDiagnosticsLoader,
+    DeviceService? deviceService,
+  })  : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics,
+        _deviceService = deviceService ?? ServiceManager.instance().device {
+    _deviceService.subscribe(this, this);
     BleBridge.instance.pairingLostCallback = _showPairingLostDialog;
   }
 
@@ -216,10 +220,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       }
     }
     notifyListeners();
-  }
-
-  Future _bleDisconnectDevice(BtDevice btDevice) async {
-    await ServiceManager.instance().device.disconnectDevice();
   }
 
   Future<int> _retrieveBatteryLevel(String deviceId) async {
@@ -473,7 +473,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     _discoveryTimer?.cancel();
     _disconnectDebouncer.cancel();
     _connectDebouncer.cancel();
-    ServiceManager.instance().device.unsubscribe(this);
+    _deviceService.unsubscribe(this);
     super.dispose();
   }
 
@@ -992,12 +992,36 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   @override
   void onStatusChanged(DeviceServiceStatus status) {}
 
-  prepareDFU() {
+  Future<void> prepareDFU() async {
     if (!FirmwareUpdateBuildPolicy.current.allowsOmiFirmwareUpdate || connectedDevice == null) {
       return;
     }
+    final deviceId = connectedDevice!.id;
     setFirmwareUpdateInProgress(true);
-    _bleDisconnectDevice(connectedDevice!);
+    try {
+      await _deviceService.suspendConnectionForDfu(deviceId);
+    } catch (error, stackTrace) {
+      // Suspend is transactional. If disconnect succeeded but releasing the
+      // retired transport failed, DeviceService retains the exact-device lease
+      // so this rollback can restore normal ownership before surfacing the
+      // original suspend error.
+      try {
+        await _deviceService.resumeConnectionAfterDfu();
+      } catch (rollbackError) {
+        Logger.debug('Failed to roll back device connection after DFU suspend error: $rollbackError');
+      } finally {
+        resetFirmwareUpdateState();
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  Future<void> resumeConnectionAfterDFU() async {
+    try {
+      await _deviceService.resumeConnectionAfterDfu();
+    } finally {
+      resetFirmwareUpdateState();
+    }
   }
 
   // Reset firmware update state when update completes or fails

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -635,7 +635,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // deliberately silent legacy audio characteristic.
     final syncs = ServiceManager.instance().wal.getSyncs();
     syncs.setDevice(pairedDevice ?? device, firmwareVersion: currentFirmwareVersion);
-    await captureProvider?.streamDeviceRecording(device: device);
+    await _startOrResumeCapture(device);
 
     final audioReady = captureProvider == null || captureProvider!.hasActiveDeviceAudioStream;
     setIsConnected(audioReady);
@@ -670,6 +670,19 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Notify interactive device onboarding of reconnect
     captureProvider?.deviceOnboardingProvider?.onDeviceReconnected();
   }
+
+  Future<void> _startOrResumeCapture(BtDevice device) async {
+    final capture = captureProvider;
+    if (capture == null) return;
+    if (capture.shouldResumeDeviceRecordingAfterReconnect) {
+      await capture.resumeDeviceRecordingAfterReconnect(device: device);
+      return;
+    }
+    await capture.streamDeviceRecording(device: device);
+  }
+
+  @visibleForTesting
+  Future<void> startOrResumeCaptureForTesting(BtDevice device) => _startOrResumeCapture(device);
 
   /// Check firmware version to determine multi-file sync support.
   Future<void> _checkAndStartAutoSync(BtDevice device) async {

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -280,6 +280,15 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   List<Wal> get uploadedWals => _allWals.where((w) => w.status == WalStatus.uploaded).toList();
 
+  /// Logical recordings ready for a user-initiated upload.
+  ///
+  /// Raw pendant ranges and physical archive boundaries are intentionally
+  /// excluded so status cards describe the same recordings as the Sync list.
+  int get readyToSyncRecordingCount => userVisibleWals.where((w) => w.status == WalStatus.miss).length;
+
+  /// Logical recordings accepted by the server and awaiting reconciliation.
+  int get processingRecordingCount => userVisibleWals.where((w) => w.status == WalStatus.uploaded).length;
+
   List<Wal> get pendingDeletableWals =>
       userVisibleWals.where((w) => !w.isSyncing && w.status == WalStatus.miss).toList();
 

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -390,6 +390,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         drain: _drainEligibleWals,
         autoUploadEnabled: () =>
             !SharedPreferencesUtil().useCustomStt && SharedPreferencesUtil().autoSyncOfflineRecordings,
+        backgroundDeviceRecoveryEnabled: () =>
+            defaultTargetPlatform == TargetPlatform.android && SharedPreferencesUtil().backgroundModeEnabled,
         connectivityChanges: ConnectivityService().onConnectionChange,
         initiallyConnected: ConnectivityService().isConnected,
       );

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 
@@ -8,6 +9,7 @@ import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
+import 'package:omi/services/wals/conversation_audio_assembler.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/mutex.dart';
@@ -20,6 +22,11 @@ import 'package:omi/utils/waveform_utils.dart';
 enum WalStatusFilter { pending, synced, corrupted }
 
 enum WalDisplayFilter { all, pending, synced }
+
+typedef LogicalArchivePlaybackMaterializer = Future<Wal?> Function(
+  Wal logicalWal,
+  List<Wal> members,
+);
 
 bool _isPhysicalRingArchive(Wal wal) =>
     wal.originalStorage == WalStorage.sdcard &&
@@ -96,6 +103,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   final Future<void> Function(LocalWalSyncImpl phone) _waitForWalReady;
   final Future<void> Function() _startRecovery;
   final Future<void> Function(WakeTrigger trigger) _wakeTransfer;
+  final LogicalArchivePlaybackMaterializer? _logicalArchivePlaybackMaterializer;
   final Mutex _syncOperationMutex = Mutex();
 
   /// Completes after WAL loading and startup fair-use reconciliation finish.
@@ -108,6 +116,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   RingBacklogDrainReceipt? _manualRingBacklogReceipt;
   List<Wal>? _userVisibleWalsCache;
   int _userVisibleWalsCacheStamp = 0;
+  final Map<String, Future<Wal?>> _logicalPlaybackWals = {};
 
   int get _effectiveConversationBoundarySeconds => effectiveConversationBoundarySeconds(
         SharedPreferencesUtil().conversationSilenceDuration,
@@ -489,12 +498,14 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
     @visibleForTesting Future<void> Function()? startRecovery,
     @visibleForTesting Future<void> Function(WakeTrigger trigger)? wakeTransfer,
+    @visibleForTesting LogicalArchivePlaybackMaterializer? logicalArchivePlaybackMaterializer,
   })  : _walServiceOverride = walService,
         _uploadGate = uploadGate ?? SyncUploadGate.instance,
         _startBackgroundSync = startBackgroundSync,
         _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
         _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
-        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
+        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)),
+        _logicalArchivePlaybackMaterializer = logicalArchivePlaybackMaterializer {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _rateLimitWasActive = SyncRateLimiter.instance.isLimited;
@@ -997,6 +1008,77 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   bool isWalPlaying(String walId) => _audioPlayerUtils.isPlaying(walId);
   bool canPlayOrShareWal(Wal wal) => _audioPlayerUtils.canPlayOrShare(wal);
 
+  /// Resolves a user-visible logical ring row to one playable, ordered file.
+  /// Physical storage archives remain hidden; the detail page receives the
+  /// same conversation-shaped audio boundary used by cloud upload.
+  Future<Wal?> resolveWalForDetail(Wal wal) async {
+    final members = _logicalMembersFor(wal);
+    if (members.isEmpty) return wal;
+
+    final cached = _logicalPlaybackWals[wal.id];
+    if (cached != null) return cached;
+
+    final materialization = _logicalArchivePlaybackMaterializer != null
+        ? _logicalArchivePlaybackMaterializer!(wal, members)
+        : _materializeLogicalArchiveForPlayback(wal, members);
+    _logicalPlaybackWals[wal.id] = materialization;
+    final resolved = await materialization;
+    if (resolved == null) _logicalPlaybackWals.remove(wal.id);
+    return resolved;
+  }
+
+  Future<Wal?> _materializeLogicalArchiveForPlayback(
+    Wal logicalWal,
+    List<Wal> members,
+  ) async {
+    try {
+      final parts = <ConversationAudioPart>[];
+      for (final member in members) {
+        final path = await Wal.getFilePath(member.filePath);
+        if (path == null || !await File(path).exists()) return null;
+        parts.add(ConversationAudioPart(wal: member, file: File(path)));
+      }
+
+      final firstFile = parts.first.file;
+      final safeSource = logicalWal.sourceId!.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '');
+      final destination = File('${firstFile.parent.path}/playback_$safeSource.bin');
+      final assembly = await assembleConversationAudio(
+        parts: parts,
+        destination: destination,
+        silenceFrameFactory: encodeOpusSilenceFrame,
+        conversationBoundarySeconds: _effectiveConversationBoundarySeconds,
+      );
+      final framesPerSecond = logicalWal.codec.getFramesPerSecond();
+      final playable = Wal(
+        timerStart: assembly.timerStart,
+        codec: logicalWal.codec,
+        seconds: framesPerSecond > 0 ? (assembly.totalFrames + framesPerSecond - 1) ~/ framesPerSecond : 0,
+        captureEndSeconds: assembly.captureEndSeconds,
+        sampleRate: logicalWal.sampleRate,
+        channel: logicalWal.channel,
+        status: logicalWal.status,
+        storage: WalStorage.disk,
+        filePath: destination.path.split('/').last,
+        device: logicalWal.device,
+        deviceModel: logicalWal.deviceModel,
+        totalFrames: assembly.totalFrames,
+        originalStorage: WalStorage.sdcard,
+        sourceId: logicalWal.sourceId,
+        uploadIntent: logicalWal.uploadIntent,
+        retryCount: logicalWal.retryCount,
+      );
+      playable.isSyncing = logicalWal.isSyncing;
+      return playable;
+    } catch (error, stackTrace) {
+      Logger.handle(
+        error,
+        stackTrace,
+        message: 'Unable to assemble logical recording for playback',
+      );
+      return null;
+    }
+  }
+
   Future<void> toggleWalPlayback(Wal wal) async {
     await _audioPlayerUtils.togglePlayback(wal);
   }
@@ -1017,15 +1099,13 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     await _audioPlayerUtils.skipBackward(duration: duration);
   }
 
-  Future<List<double>?> getWaveformForWal(String walId) async {
-    final wal = _allWals.firstWhere((w) => w.id == walId, orElse: () => throw Exception('WAL not found'));
-
-    String? wavFilePath = _audioPlayerUtils.getCachedAudioPath(walId);
+  Future<List<double>?> getWaveformForWal(Wal wal) async {
+    String? wavFilePath = _audioPlayerUtils.getCachedAudioPath(wal.id);
     if (wavFilePath == null && canPlayOrShareWal(wal)) {
       wavFilePath = await _audioPlayerUtils.ensureAudioFileExists(wal);
     }
 
-    return await compute(_generateWaveformInBackground, {'walId': walId, 'wavFilePath': wavFilePath});
+    return await compute(_generateWaveformInBackground, {'walId': wal.id, 'wavFilePath': wavFilePath});
   }
 
   static Future<List<double>?> _generateWaveformInBackground(Map<String, dynamic> params) async {

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -151,6 +151,10 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       ..sort((left, right) {
         final deviceCompare = left.device.compareTo(right.device);
         if (deviceCompare != 0) return deviceCompare;
+        final leftRange = RingProtocol.parseRecoverySourceRange(left.sourceId);
+        final rightRange = RingProtocol.parseRecoverySourceRange(right.sourceId);
+        final sequenceCompare = (leftRange?.start ?? 0).compareTo(rightRange?.start ?? 0);
+        if (sequenceCompare != 0) return sequenceCompare;
         final timeCompare = left.timerStart.compareTo(right.timerStart);
         if (timeCompare != 0) return timeCompare;
         return left.id.compareTo(right.id);

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/connectivity_service.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/debug_log_manager.dart';
@@ -48,6 +49,28 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   // WAL management
   List<Wal> _allWals = [];
   List<Wal> get allWals => _allWals;
+  List<Wal>? _userVisibleWalsCache;
+  int _userVisibleWalsCacheStamp = 0;
+
+  /// User-facing recordings exclude the pendant's immutable transfer ranges.
+  ///
+  /// Those ranges are internal assembly inputs, not independently meaningful
+  /// recordings. They become visible only after LocalWalSync has compacted
+  /// them into one historical archive or canonical conversation artifact.
+  List<Wal> get userVisibleWals {
+    final stamp = identityHashCode(_allWals) ^ _allWals.length;
+    final cached = _userVisibleWalsCache;
+    if (cached != null && _userVisibleWalsCacheStamp == stamp) return cached;
+    final visible = _allWals
+        .where(
+          (wal) => wal.originalStorage != WalStorage.sdcard || RingProtocol.parseSourceRange(wal.sourceId) == null,
+        )
+        .toList(growable: false);
+    _userVisibleWalsCache = visible;
+    _userVisibleWalsCacheStamp = stamp;
+    return visible;
+  }
+
   bool _isLoadingWals = false;
   bool get isLoadingWals => _isLoadingWals;
 
@@ -105,7 +128,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     final pending = <Wal>[];
     final synced = <Wal>[];
     final corrupted = <Wal>[];
-    for (final w in _allWals) {
+    for (final w in userVisibleWals) {
       if (w.status == WalStatus.synced) {
         synced.add(w);
       } else if (w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow) {
@@ -139,7 +162,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   List<Wal> get uploadedWals => _allWals.where((w) => w.status == WalStatus.uploaded).toList();
 
-  List<Wal> get pendingDeletableWals => _allWals.where((w) => !w.isSyncing && w.status == WalStatus.miss).toList();
+  List<Wal> get pendingDeletableWals =>
+      userVisibleWals.where((w) => !w.isSyncing && w.status == WalStatus.miss).toList();
 
   // Count-only accessors for status-chip badges. Read length from the
   // shared cached partitions so the chips don't trigger an extra iteration
@@ -197,14 +221,15 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     final stamp = identityHashCode(_allWals) ^ _allWals.length;
     final cached = _sortedCache;
     if (cached != null && _sortedCacheStamp == stamp) return cached;
-    final list = List<Wal>.from(_allWals);
+    final list = List<Wal>.from(userVisibleWals);
     list.sort((a, b) => b.timerStart.compareTo(a.timerStart));
     _sortedCache = list;
     _sortedCacheStamp = stamp;
     return list;
   }
 
-  int _countWhere(bool Function(WalSyncDisplayState) test) => _allWals.where((w) => test(w.syncDisplayState)).length;
+  int _countWhere(bool Function(WalSyncDisplayState) test) =>
+      userVisibleWals.where((w) => test(w.syncDisplayState)).length;
 
   int get syncingWalsCount => _countWhere((s) => s == WalSyncDisplayState.syncing);
   int get syncedWalsCount => _countWhere((s) => s == WalSyncDisplayState.synced);
@@ -241,26 +266,26 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   List<Wal> get filteredWals {
     if (_storageFilter == null) {
-      return _allWals;
+      return userVisibleWals;
     }
 
     // SD Card filter: show WALs on SD card OR transferred from SD card
     if (_storageFilter == WalStorage.sdcard) {
-      return _allWals
+      return userVisibleWals
           .where((wal) => wal.storage == WalStorage.sdcard || wal.originalStorage == WalStorage.sdcard)
           .toList();
     }
 
     // Flash Page filter: show WALs on flash page OR transferred from flash page
     if (_storageFilter == WalStorage.flashPage) {
-      return _allWals
+      return userVisibleWals
           .where((wal) => wal.storage == WalStorage.flashPage || wal.originalStorage == WalStorage.flashPage)
           .toList();
     }
 
     // Phone filter: show WALs on phone that are NOT originally from SD card or flash page
     if (_storageFilter == WalStorage.disk || _storageFilter == WalStorage.mem) {
-      return _allWals
+      return userVisibleWals
           .where(
             (wal) =>
                 (wal.storage == WalStorage.disk || wal.storage == WalStorage.mem) &&
@@ -271,7 +296,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     }
 
     // Other filters
-    return _allWals.where((wal) => wal.storage == _storageFilter).toList();
+    return userVisibleWals.where((wal) => wal.storage == _storageFilter).toList();
   }
 
   // Sync state

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -606,7 +606,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     // receipt, every upload/reconcile retry reuses that immutable boundary.
     // This prevents a slow backend from repeatedly latching newer writeSeq.
     final requestedRingDrain = activeRingTail && trigger == WakeTrigger.userRetry && receipt == null
-        ? syncs.requestActiveRingBacklogDrain()
+        ? syncs.requestActiveRingBacklogDrain(progress: this)
         : null;
     final hadEligibleWals = missingWals.isNotEmpty || requestedRingDrain != null || receipt != null;
     if (!hadEligibleWals) return const RecordingTransferDrainResult.skipped();

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -10,6 +10,7 @@ import 'package:omi/services/services.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/mutex.dart';
 import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/utils/audio_player_utils.dart';
@@ -19,6 +20,60 @@ import 'package:omi/utils/waveform_utils.dart';
 enum WalStatusFilter { pending, synced, corrupted }
 
 enum WalDisplayFilter { all, pending, synced }
+
+bool _isPhysicalRingArchive(Wal wal) =>
+    wal.originalStorage == WalStorage.sdcard &&
+    (wal.sourceId?.startsWith('archive_ring_') == true || wal.sourceId?.startsWith('archive2_ring_') == true) &&
+    RingProtocol.parseRecoverySourceRange(wal.sourceId) != null;
+
+WalStatus _logicalArchiveStatus(List<Wal> members) {
+  if (members.any((wal) => wal.status == WalStatus.corrupted)) return WalStatus.corrupted;
+  if (members.any((wal) => wal.status == WalStatus.miss)) return WalStatus.miss;
+  if (members.any((wal) => wal.status == WalStatus.inProgress)) return WalStatus.inProgress;
+  if (members.any((wal) => wal.status == WalStatus.uploaded)) return WalStatus.uploaded;
+  return WalStatus.synced;
+}
+
+class _LogicalRingArchiveWal extends Wal {
+  _LogicalRingArchiveWal(this.members)
+      : assert(members.isNotEmpty),
+        super(
+          timerStart: members.first.timerStart,
+          codec: members.first.codec,
+          seconds: _wallSpanSeconds(members),
+          captureEndSeconds: _captureEndSeconds(members),
+          sampleRate: members.first.sampleRate,
+          channel: members.first.channel,
+          status: _logicalArchiveStatus(members),
+          storage: WalStorage.disk,
+          device: members.first.device,
+          deviceModel: members.first.deviceModel,
+          totalFrames: members.fold(0, (total, wal) => total + wal.totalFrames),
+          originalStorage: WalStorage.sdcard,
+          sourceId: _sourceId(members),
+          uploadIntent: WalUploadIntent.historicalBackfill,
+          retryCount: members.map((wal) => wal.retryCount).reduce((left, right) => left > right ? left : right),
+        ) {
+    isSyncing = members.any((wal) => wal.isSyncing);
+    syncStartedAt = members
+        .map((wal) => wal.syncStartedAt)
+        .whereType<DateTime>()
+        .fold<DateTime?>(null, (earliest, value) => earliest == null || value.isBefore(earliest) ? value : earliest);
+  }
+
+  final List<Wal> members;
+
+  static double _captureEndSeconds(List<Wal> members) =>
+      members.map((wal) => wal.wallClockEndSeconds).reduce((left, right) => left > right ? left : right);
+
+  static int _wallSpanSeconds(List<Wal> members) => (_captureEndSeconds(members) - members.first.timerStart).ceil();
+
+  static String _sourceId(List<Wal> members) {
+    final first = RingProtocol.parseRecoverySourceRange(members.first.sourceId)!;
+    final last = RingProtocol.parseRecoverySourceRange(members.last.sourceId)!;
+    return 'logical_ring_archives_${first.start}_${last.end}_${members.first.timerStart}';
+  }
+}
 
 List<SyncedConversationPointer> sortSyncedConversationPointers(
   Iterable<SyncedConversationPointer> pointers,
@@ -41,6 +96,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   final Future<void> Function(LocalWalSyncImpl phone) _waitForWalReady;
   final Future<void> Function() _startRecovery;
   final Future<void> Function(WakeTrigger trigger) _wakeTransfer;
+  final Mutex _syncOperationMutex = Mutex();
 
   /// Completes after WAL loading and startup fair-use reconciliation finish.
   @visibleForTesting
@@ -49,8 +105,23 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   // WAL management
   List<Wal> _allWals = [];
   List<Wal> get allWals => _allWals;
+  RingBacklogDrainReceipt? _manualRingBacklogReceipt;
   List<Wal>? _userVisibleWalsCache;
   int _userVisibleWalsCacheStamp = 0;
+
+  int get _effectiveConversationBoundarySeconds => effectiveConversationBoundarySeconds(
+        SharedPreferencesUtil().conversationSilenceDuration,
+      );
+
+  /// Shared invalidation key for every cache derived from [userVisibleWals].
+  ///
+  /// Conversation timeout changes can regroup the same underlying WAL list,
+  /// so list identity and length alone are insufficient.
+  int get _displayCacheStamp => Object.hash(
+        identityHashCode(_allWals),
+        _allWals.length,
+        _effectiveConversationBoundarySeconds,
+      );
 
   /// User-facing recordings exclude the pendant's immutable transfer ranges.
   ///
@@ -58,18 +129,64 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// recordings. They become visible only after LocalWalSync has compacted
   /// them into one historical archive or canonical conversation artifact.
   List<Wal> get userVisibleWals {
-    final stamp = identityHashCode(_allWals) ^ _allWals.length;
+    final effectiveBoundarySeconds = _effectiveConversationBoundarySeconds;
+    final stamp = _displayCacheStamp;
     final cached = _userVisibleWalsCache;
     if (cached != null && _userVisibleWalsCacheStamp == stamp) return cached;
-    final visible = _allWals
+    final nonRaw = _allWals
         .where(
           (wal) => wal.originalStorage != WalStorage.sdcard || RingProtocol.parseSourceRange(wal.sourceId) == null,
         )
-        .toList(growable: false);
+        .toList();
+    final physicalArchives = nonRaw.where(_isPhysicalRingArchive).toList()
+      ..sort((left, right) {
+        final deviceCompare = left.device.compareTo(right.device);
+        if (deviceCompare != 0) return deviceCompare;
+        final timeCompare = left.timerStart.compareTo(right.timerStart);
+        if (timeCompare != 0) return timeCompare;
+        return left.id.compareTo(right.id);
+      });
+    final groups = <List<Wal>>[];
+    for (final archive in physicalArchives) {
+      if (groups.isEmpty) {
+        groups.add([archive]);
+        continue;
+      }
+      final current = groups.last;
+      final previous = current.last;
+      final sameEncoding = previous.device == archive.device &&
+          previous.codec == archive.codec &&
+          previous.sampleRate == archive.sampleRate &&
+          previous.channel == archive.channel &&
+          previous.frameSize == archive.frameSize;
+      final wallGap = archive.timerStart - previous.wallClockEndSeconds;
+      if (sameEncoding && wallGap < effectiveBoundarySeconds) {
+        current.add(archive);
+      } else {
+        groups.add([archive]);
+      }
+    }
+    final logicalArchives = groups.map((members) {
+      final immutableMembers = List<Wal>.unmodifiable(members);
+      return _LogicalRingArchiveWal(immutableMembers);
+    });
+    final visible = [
+      ...nonRaw.where((wal) => !_isPhysicalRingArchive(wal)),
+      ...logicalArchives,
+    ];
     _userVisibleWalsCache = visible;
     _userVisibleWalsCacheStamp = stamp;
     return visible;
   }
+
+  bool isLogicalRingArchiveDisplayWal(Wal wal) => wal is _LogicalRingArchiveWal;
+
+  bool canDeleteWal(Wal wal) => !isLogicalRingArchiveDisplayWal(wal);
+
+  List<Wal> _logicalMembersFor(Wal wal) => wal is _LogicalRingArchiveWal ? wal.members : const [];
+
+  @visibleForTesting
+  List<Wal> logicalRingArchiveMembersForTest(Wal wal) => List<Wal>.unmodifiable(_logicalMembersFor(wal));
 
   bool _isLoadingWals = false;
   bool get isLoadingWals => _isLoadingWals;
@@ -105,8 +222,9 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   // cache off the input list's identity, so without stable refs here the
   // widget-level cache misses every rebuild and recomputes the sort.
   //
-  // Invalidation: stamp = identityHashCode(_allWals) ^ _allWals.length.
-  // This works because every wal-status mutation path in the codebase
+  // Invalidation includes the shared display cache stamp so a conversation
+  // timeout preference change also rebuilds these logical-WAL partitions.
+  // List identity works because every wal-status mutation path in the codebase
   // (sdcard, flash, storage, local) flips state in place, then notifies
   // the provider, which calls refreshWals() to reassign _allWals from
   // the wal service (see refreshWals at the bottom of this class). The
@@ -123,7 +241,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   int _filteredWalsCacheStamp = 0;
 
   void _ensureFilteredCaches() {
-    final stamp = identityHashCode(_allWals) ^ _allWals.length;
+    final stamp = _displayCacheStamp;
     if (_pendingWalsCache != null && _filteredWalsCacheStamp == stamp) return;
     final pending = <Wal>[];
     final synced = <Wal>[];
@@ -218,7 +336,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// thousands of wals and frequent `notifyListeners()` during active sync
   /// this avoids 5–15ms of redundant sort work per rebuild.
   List<Wal> get displaySortedWals {
-    final stamp = identityHashCode(_allWals) ^ _allWals.length;
+    final stamp = _displayCacheStamp;
     final cached = _sortedCache;
     if (cached != null && _sortedCacheStamp == stamp) return cached;
     final list = List<Wal>.from(userVisibleWals);
@@ -452,13 +570,25 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     await _walService.getSyncs().refreshWalsFromDevice();
   }
 
-  Future<RecordingTransferDrainResult> _drainEligibleWals() async {
+  Future<RecordingTransferDrainResult> _drainEligibleWals(WakeTrigger trigger) async {
     if (_isDisposed || _syncState.isProcessing) return const RecordingTransferDrainResult.contended();
-    if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) {
+    final syncs = _walService.getSyncs();
+    final activeRingTail = syncs.isRingAudioTailActive == true;
+    if ((syncs.isStorageSyncing && !activeRingTail) || syncs.isSdCardSyncing) {
       return const RecordingTransferDrainResult.contended();
     }
 
-    final hadEligibleWals = missingWals.isNotEmpty;
+    final isManualPass = trigger == WakeTrigger.userRetry || trigger == WakeTrigger.userRetryLocalUpload;
+    RingBacklogDrainReceipt? receipt =
+        isManualPass ? _manualRingBacklogReceipt : syncs.pendingAutomaticRingBacklogReceipt as RingBacklogDrainReceipt?;
+
+    // Only a brand-new user tap may arm a device snapshot. Once it yields a
+    // receipt, every upload/reconcile retry reuses that immutable boundary.
+    // This prevents a slow backend from repeatedly latching newer writeSeq.
+    final requestedRingDrain = activeRingTail && trigger == WakeTrigger.userRetry && receipt == null
+        ? syncs.requestActiveRingBacklogDrain()
+        : null;
+    final hadEligibleWals = missingWals.isNotEmpty || requestedRingDrain != null || receipt != null;
     if (!hadEligibleWals) return const RecordingTransferDrainResult.skipped();
 
     // Reconciles a persisted fair-use cooldown the server may already have
@@ -471,18 +601,88 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     _updateSyncState(_syncState.toIdle());
     _totalWalsToProcess = missingWals.length;
     _walsProcessedCount = 0;
-    final result = await _performSync(
-      operation: () => _walService.getSyncs().syncAll(progress: this),
-      context: 'coordinated recording transfer',
-      rethrowOnError: true,
-    );
-    await refreshWals();
+    AuthorizedRecoverySyncResult? authorizedResult;
+    var manualReceiptWasUsed = isManualPass && receipt != null;
+    var automaticReceiptWasUsed = !isManualPass && receipt != null;
+    var requestCancelled = false;
+    SyncLocalFilesResponse? result;
+    try {
+      result = await _performSync(
+        operation: () async {
+          if (requestedRingDrain != null) {
+            final completed = await requestedRingDrain;
+            if (completed == null) {
+              requestCancelled = true;
+              return null;
+            }
+            receipt = completed;
+            _manualRingBacklogReceipt = completed;
+            manualReceiptWasUsed = true;
+          }
+
+          final authorizedReceipt = receipt;
+          if (authorizedReceipt != null) {
+            authorizedResult = await syncs.syncAuthorizedRingRecovery(
+              receipt: authorizedReceipt,
+              progress: this,
+            ) as AuthorizedRecoverySyncResult;
+            return authorizedResult!.response;
+          }
+
+          // Ordinary wakes while the live tail owns BLE may upload only the
+          // fresh phone lane. A row retry and an exhausted receipt likewise
+          // stay phone-only; neither can start a second device reader.
+          final phoneOnly = syncs.isRingAudioTailActive == true ||
+              trigger == WakeTrigger.userRetryLocalUpload ||
+              trigger == WakeTrigger.ringBacklogSnapshotCompleted;
+          if (phoneOnly) {
+            return syncs.syncPhoneWals(
+              progress: this,
+              includeBackfill: false,
+            );
+          }
+          return syncs.syncAll(progress: this);
+        },
+        context: 'coordinated recording transfer',
+        rethrowOnError: true,
+      );
+      await refreshWals();
+    } catch (_) {
+      return RecordingTransferDrainResult(
+        attempted: true,
+        failed: true,
+        needsReconciliation: uploadedWals.isNotEmpty,
+        hasDeviceSnapshotReceipt: manualReceiptWasUsed,
+      );
+    }
+
+    if (requestCancelled) {
+      return const RecordingTransferDrainResult.skipped();
+    }
+    final failed = (result?.localUploadFailures ?? 0) > 0;
+    final deferred = authorizedResult?.hasDeferredRecovery ?? false;
+    if (authorizedResult != null && !failed && !deferred) {
+      final completedReceipt = receipt!;
+      if (manualReceiptWasUsed && identical(_manualRingBacklogReceipt, completedReceipt)) {
+        _manualRingBacklogReceipt = null;
+      }
+      if (automaticReceiptWasUsed) {
+        syncs.completeAutomaticRingBacklogReceipt(completedReceipt);
+      }
+    }
     return RecordingTransferDrainResult(
       attempted: true,
-      failed: (result?.localUploadFailures ?? 0) > 0,
+      failed: failed,
       needsReconciliation: uploadedWals.isNotEmpty,
+      deferred: deferred,
+      hasDeviceSnapshotReceipt: manualReceiptWasUsed,
     );
   }
+
+  /// Production drain seam exposed only so coordinator regressions can execute
+  /// the real provider orchestration with deterministic transports.
+  @visibleForTesting
+  Future<RecordingTransferDrainResult> drainEligibleWalsForTest(WakeTrigger trigger) => _drainEligibleWals(trigger);
 
   void _onAudioPlayerStateChanged() {
     notifyListeners();
@@ -522,6 +722,10 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> deleteWal(Wal wal) async {
+    if (!canDeleteWal(wal)) {
+      Logger.debug('SyncProvider: logical ring archive deletion is disabled to preserve complete recovery coverage');
+      return;
+    }
     await _walService.getSyncs().deleteWal(wal);
     await refreshWals();
   }
@@ -567,17 +771,28 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> syncWal(Wal wal) async {
-    // UI Sync/Auto Sync still call syncWal for a single row, but must not
-    // race a coordinator drain (or device download) on the same WAL stack.
-    if (_startBackgroundSync && _isTransferSeamBusy()) {
-      await _wakeTransfer(WakeTrigger.userRetry);
+    final logicalMembers = _logicalMembersFor(wal);
+    final selectedWal = logicalMembers.isEmpty
+        ? wal
+        : logicalMembers.firstWhere(
+            (member) => member.status == WalStatus.miss,
+            orElse: () => logicalMembers.first,
+          );
+    final isPhoneWal = selectedWal.storage == WalStorage.disk || selectedWal.storage == WalStorage.mem;
+    if (_startBackgroundSync && !isPhoneWal && _isTransferSeamBusy()) {
+      // A selected device row is not authority to drain the whole pendant.
+      // Keep the row retryable while the one BLE reader is occupied instead
+      // of translating its identity into a global coordinator wake.
+      const message = 'Device recording transfer is already in progress. Try this recording again when it finishes';
+      Logger.debug('SyncProvider: deferring selected device WAL ${selectedWal.id}: $message');
+      _updateSyncState(_syncState.toError(message: message, failedWal: wal));
       return;
     }
     await _uploadGate.prepareToUpload();
     if (_isDisposed) return;
     _updateSyncState(_syncState.toIdle());
     final result = await _performSync(
-      operation: () => _walService.getSyncs().syncWal(wal: wal, progress: this),
+      operation: () => _walService.getSyncs().syncWal(wal: selectedWal, progress: this),
       context: 'sync WAL ${wal.id}',
       failedWal: wal,
     );
@@ -591,10 +806,29 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   bool _isTransferSeamBusy() {
     if (_syncState.isProcessing) return true;
     final syncs = _walService.getSyncs();
-    return syncs.isStorageSyncing == true || syncs.isSdCardSyncing == true;
+    return syncs.isRingAudioTailActive == true || syncs.isStorageSyncing == true || syncs.isSdCardSyncing == true;
   }
 
   Future<SyncLocalFilesResponse?> _performSync({
+    required Future<SyncLocalFilesResponse?> Function() operation,
+    required String context,
+    Wal? failedWal,
+    bool rethrowOnError = false,
+  }) async {
+    await _syncOperationMutex.acquire();
+    try {
+      return await _performSyncOwned(
+        operation: operation,
+        context: context,
+        failedWal: failedWal,
+        rethrowOnError: rethrowOnError,
+      );
+    } finally {
+      _syncOperationMutex.release();
+    }
+  }
+
+  Future<SyncLocalFilesResponse?> _performSyncOwned({
     required Future<SyncLocalFilesResponse?> Function() operation,
     required String context,
     Wal? failedWal,
@@ -685,16 +919,16 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   Future<void> retrySync() async {
+    final failedWal = _syncState.failedWal;
+    if (failedWal != null) {
+      await syncWal(failedWal);
+      return;
+    }
     if (_startBackgroundSync) {
       await _wakeTransfer(WakeTrigger.userRetry);
       return;
     }
-    final failedWal = _syncState.failedWal;
-    if (failedWal != null) {
-      await syncWal(failedWal);
-    } else {
-      await _syncWalsDirect();
-    }
+    await _syncWalsDirect();
   }
 
   void clearSyncResult() {

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -32,6 +32,7 @@ import 'package:omi/services/capture/conversation_capture_window.dart';
 import 'package:omi/services/capture/conversation_session_window.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
+import 'package:omi/services/capture/device_audio_streaming_policy.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
 import 'package:omi/services/capture/live_audio_frame_pacer.dart';
 import 'package:omi/services/capture/live_transcript_preview.dart';
@@ -753,15 +754,22 @@ class CaptureController extends ChangeNotifier
     // outage so it can re-enable streaming if needed (e.g. Limitless pendant).
     // Guard on deviceRecord: skip if the user has paused — no point waking the
     // device when _bleBytesStream is cancelled and audio would just be dropped.
-    if (_socketReconnectPending && _recordingDevice != null && recordingState == RecordingState.deviceRecord) {
+    final recordingDevice = _recordingDevice;
+    final reconnectWasPending =
+        _socketReconnectPending && recordingDevice != null && recordingState == RecordingState.deviceRecord;
+    if (reconnectWasPending) {
       _socketReconnectPending = false;
       final conn = await ServiceManager.instance().device.ensureConnection(
-            _recordingDevice!.id,
+            recordingDevice.id,
           );
       await conn?.onNetworkSocketReconnected();
-      if (!deferDeviceAudioResume) {
-        await _initiateDeviceAudioStreaming(resumeLiveContinuity: true);
-      }
+    }
+    final storageTailNeedsResume = _wal.getSyncs().usesStorageAuthoritativeAudio == true &&
+        recordingDevice != null &&
+        recordingState == RecordingState.deviceRecord &&
+        _ringAudioTailSession == null;
+    if (!deferDeviceAudioResume && (reconnectWasPending || storageTailNeedsResume)) {
+      await _initiateDeviceAudioStreaming(resumeLiveContinuity: true);
     }
 
     await _loadInProgressConversation();
@@ -1081,6 +1089,13 @@ class CaptureController extends ChangeNotifier
 
   void _scheduleStorageAudioTailRestart(String deviceId) {
     if (_recordingDevice?.id != deviceId || _isPaused || _ringAudioTailSession != null) return;
+    if (!DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+      usesStorageAuthoritativeAudio: true,
+      transcribeLaterEnabled: SharedPreferencesUtil().batchModeEnabled,
+      transcriptionServiceReady: _socket?.serverReady == true,
+    )) {
+      return;
+    }
     if (_storageAudioTailRestartTimer?.isActive == true || _storageAudioTailRestartInFlight) return;
 
     _storageAudioTailRestartAttempt += 1;
@@ -1099,7 +1114,12 @@ class CaptureController extends ChangeNotifier
     if (_storageAudioTailRestartInFlight ||
         _recordingDevice?.id != deviceId ||
         _isPaused ||
-        _ringAudioTailSession != null) {
+        _ringAudioTailSession != null ||
+        !DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+          usesStorageAuthoritativeAudio: true,
+          transcribeLaterEnabled: SharedPreferencesUtil().batchModeEnabled,
+          transcriptionServiceReady: _socket?.serverReady == true,
+        )) {
       return;
     }
     _storageAudioTailRestartInFlight = true;
@@ -1253,6 +1273,20 @@ class CaptureController extends ChangeNotifier
     _wal.getSyncs().phone.setDeviceInfo(deviceId, deviceModel);
 
     await streamButton(deviceId);
+    final usesStorageAuthoritativeAudio = _wal.getSyncs().usesStorageAuthoritativeAudio == true;
+    if (!DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+      usesStorageAuthoritativeAudio: usesStorageAuthoritativeAudio,
+      transcribeLaterEnabled: SharedPreferencesUtil().batchModeEnabled,
+      transcriptionServiceReady: _socket?.serverReady == true,
+    )) {
+      await _suspendStorageAuthoritativeTailForTranscriptionOutage();
+      updateRecordingState(RecordingState.deviceRecord);
+      Logger.warning(
+        'Storage-authoritative audio remains on the pendant until the '
+        'transcription service is ready',
+      );
+      return;
+    }
     final foregroundAudioReady = await streamAudioToWs(
       deviceId,
       codec,
@@ -1272,6 +1306,23 @@ class CaptureController extends ChangeNotifier
       if (SharedPreferencesUtil().batchMuted) SharedPreferencesUtil().batchMuted = false;
     }
     updateRecordingState(RecordingState.deviceRecord);
+    notifyListeners();
+  }
+
+  Future<void> _suspendStorageAuthoritativeTailForTranscriptionOutage() async {
+    if (_wal.getSyncs().usesStorageAuthoritativeAudio != true || SharedPreferencesUtil().batchModeEnabled) {
+      return;
+    }
+    _storageAudioTailRestartTimer?.cancel();
+    _storageAudioTailRestartTimer = null;
+    final session = _ringAudioTailSession;
+    _ringAudioTailSession = null;
+    _liveAudioFramePacer?.rejectPending();
+    await session?.cancel();
+    await SharedPreferencesUtil().saveBool(
+      'nativeBleForegroundReady',
+      false,
+    );
     notifyListeners();
   }
 
@@ -1916,6 +1967,9 @@ class CaptureController extends ChangeNotifier
     // enable-data-stream command after its BLE audio times out).
     if (recordingState == RecordingState.deviceRecord) {
       _socketReconnectPending = true;
+      unawaited(
+        _suspendStorageAuthoritativeTailForTranscriptionOutage(),
+      );
     }
 
     notifyListeners();
@@ -1970,6 +2024,12 @@ class CaptureController extends ChangeNotifier
   void onError(Object err) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
+    if (recordingState == RecordingState.deviceRecord) {
+      _socketReconnectPending = true;
+      unawaited(
+        _suspendStorageAuthoritativeTailForTranscriptionOutage(),
+      );
+    }
 
     notifyListeners();
     _startKeepAliveServices();

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -729,14 +729,25 @@ class CaptureController extends ChangeNotifier
         );
     _socket = connectedSocket;
     if (connectedSocket == null) {
+      _markRetryableTranscriptionInterruption(
+        reason: 'socket_connect_failed',
+        outcome: 'transport_unavailable',
+      );
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
+      notifyListeners();
       return;
     }
     connectedSocket.subscribe(this, this);
     _transcriptServiceReady = await connectedSocket.waitUntilServerReady();
     if (!identical(_socket, connectedSocket)) return;
     if (!_transcriptServiceReady) {
+      _markRetryableTranscriptionInterruption(
+        reason: connectedSocket.state == SocketServiceState.disconnected
+            ? 'socket_closed_before_ready'
+            : 'service_readiness_timeout',
+        outcome: 'not_ready',
+      );
       Logger.warning(
         'Transcription transport connected without a ready STT session; '
         'holding durable audio for reconnect',
@@ -1941,6 +1952,13 @@ class CaptureController extends ChangeNotifier
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
 
+    if (recordingDeviceServiceReady && _socket?.serverReady != true) {
+      _markRetryableTranscriptionInterruption(
+        reason: 'socket_closed',
+        outcome: 'transport_unavailable',
+      );
+    }
+
     if (closeCode == 4002) {
       externalActions.markAsOutOfCreditsAndRefresh();
     }
@@ -2024,6 +2042,12 @@ class CaptureController extends ChangeNotifier
   void onError(Object err) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
+    if (recordingDeviceServiceReady && _socket?.serverReady != true) {
+      _markRetryableTranscriptionInterruption(
+        reason: 'socket_error',
+        outcome: 'transport_unavailable',
+      );
+    }
     if (recordingState == RecordingState.deviceRecord) {
       _socketReconnectPending = true;
       unawaited(
@@ -2033,6 +2057,23 @@ class CaptureController extends ChangeNotifier
 
     notifyListeners();
     _startKeepAliveServices();
+  }
+
+  void _markRetryableTranscriptionInterruption({
+    required String reason,
+    required String outcome,
+  }) {
+    // Preserve a provider-authored failure: it carries more useful diagnosis
+    // than the transport close that normally follows it.
+    if (_terminalTranscriptionFailure != null) return;
+    _terminalTranscriptionFailure = MessageServiceStatusEvent(
+      status: 'stt_failed',
+      statusText: 'Live transcription is reconnecting',
+      outcome: outcome,
+      provider: 'transport',
+      retryable: true,
+      reason: reason,
+    );
   }
 
   @override

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -27,9 +27,14 @@ import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/providers/device_onboarding_provider.dart';
 import 'package:omi/services/capture/capture_external_actions.dart';
 import 'package:omi/services/capture/capture_metrics_tracker.dart';
+import 'package:omi/services/capture/capture_start_gate.dart';
+import 'package:omi/services/capture/conversation_capture_window.dart';
+import 'package:omi/services/capture/conversation_session_window.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
+import 'package:omi/services/capture/live_audio_frame_pacer.dart';
+import 'package:omi/services/capture/live_transcript_preview.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/voice_playback/omi_voice_playback_service.dart';
@@ -54,6 +59,7 @@ import 'package:omi/backend/schema/message_event.dart'
     show
         MessageEvent,
         MessageServiceStatusEvent,
+        ConversationSessionEvent,
         ConversationProcessingStartedEvent,
         ConversationEvent,
         LastConversationEvent,
@@ -76,6 +82,9 @@ class CaptureController extends ChangeNotifier
   );
 
   final ConversationLocationCapture _conversationLocationCapture = ConversationLocationCapture();
+  final CaptureStartGate _captureStartGate = CaptureStartGate();
+  final CaptureStartGate _deviceCaptureStartGate = CaptureStartGate();
+  final ConversationSessionWindow _conversationSessionWindow = ConversationSessionWindow();
 
   CaptureExternalActions externalActions;
   DeviceOnboardingProvider? deviceOnboardingProvider;
@@ -280,6 +289,7 @@ class CaptureController extends ChangeNotifier
 
   ServerConversation? _conversation;
   List<TranscriptSegment> segments = [];
+  String? _activeConversationId;
   List<ConversationPhoto> photos = [];
 
   /// Unix timestamp (seconds) when the current capture session started.
@@ -392,6 +402,7 @@ class CaptureController extends ChangeNotifier
 
   StreamSubscription? _bleBytesStream;
   RingAudioTailSession? _ringAudioTailSession;
+  LiveAudioFramePacer? _liveAudioFramePacer;
   Timer? _storageAudioTailRestartTimer;
   int _storageAudioTailRestartAttempt = 0;
   bool _storageAudioTailRestartInFlight = false;
@@ -456,6 +467,12 @@ class CaptureController extends ChangeNotifier
 
   BtDevice? get recordingDevice => _recordingDevice;
 
+  /// A transient BLE loss must resume the existing capture owner instead of
+  /// starting a second websocket/conversation and clearing its live preview.
+  bool get shouldResumeDeviceRecordingAfterReconnect =>
+      recordingState == RecordingState.deviceRecord &&
+      (_socket != null || _sessionStartSeconds > 0 || segments.isNotEmpty);
+
   void setHasTranscripts(bool value) {
     hasTranscripts = value;
     notifyListeners();
@@ -487,6 +504,7 @@ class CaptureController extends ChangeNotifier
     hasTranscripts = false;
     suggestionsBySegmentId = {};
     _conversation = null;
+    _activeConversationId = null;
     taggingSegmentIds = [];
     _sessionStartSeconds = 0;
     _endOfflineSession();
@@ -659,6 +677,7 @@ class CaptureController extends ChangeNotifier
     bool? isPcm,
     bool force = false,
     String? source,
+    bool deferDeviceAudioResume = false,
   }) async {
     Logger.debug('initiateWebsocket in capture_provider');
 
@@ -698,23 +717,36 @@ class CaptureController extends ChangeNotifier
     }
 
     // Connect to the transcript socket
-    _socket = await ServiceManager.instance().socket.conversation(
+    final connectedSocket = await ServiceManager.instance().socket.conversation(
           codec: codec,
           sampleRate: sampleRate,
           language: language,
           force: force,
           source: source,
+          clientConversationId: _activeConversationId,
           customSttConfig: effectiveConfig,
         );
-    if (_socket == null) {
+    _socket = connectedSocket;
+    if (connectedSocket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
       return;
     }
-    _socket?.subscribe(this, this);
-    _transcriptServiceReady = true;
+    connectedSocket.subscribe(this, this);
+    _transcriptServiceReady = await connectedSocket.waitUntilServerReady();
+    if (!identical(_socket, connectedSocket)) return;
+    if (!_transcriptServiceReady) {
+      Logger.warning(
+        'Transcription transport connected without a ready STT session; '
+        'holding durable audio for reconnect',
+      );
+      await connectedSocket.stop(reason: 'transcription service readiness timeout');
+      _startKeepAliveServices();
+      notifyListeners();
+      return;
+    }
     if (_sessionStartSeconds == 0) {
-      _sessionStartSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      _sessionStartSeconds = _conversationSessionWindow.ensureStarted(_nowSeconds);
     }
 
     // Notify the device connection that the socket reconnected after a network
@@ -727,6 +759,9 @@ class CaptureController extends ChangeNotifier
             _recordingDevice!.id,
           );
       await conn?.onNetworkSocketReconnected();
+      if (!deferDeviceAudioResume) {
+        await _initiateDeviceAudioStreaming(resumeLiveContinuity: true);
+      }
     }
 
     await _loadInProgressConversation();
@@ -915,30 +950,44 @@ class CaptureController extends ChangeNotifier
     );
   }
 
-  Future<bool> streamAudioToWs(String deviceId, BleAudioCodec codec) async {
+  Future<bool> streamAudioToWs(
+    String deviceId,
+    BleAudioCodec codec, {
+    bool resumeLiveContinuity = false,
+  }) async {
     Logger.debug('streamAudioToWs in capture_provider');
     _storageAudioTailRestartTimer?.cancel();
     await _bleBytesStream?.cancel();
     await _ringAudioTailSession?.cancel();
+    if (!resumeLiveContinuity) {
+      _liveAudioFramePacer?.rejectPending();
+    }
     _bleBytesStream = null;
     _ringAudioTailSession = null;
     _startMetricsTracking();
     final syncs = _wal.getSyncs();
     if (syncs.usesStorageAuthoritativeAudio == true) {
-      final session = await syncs.startStorageAuthoritativeAudioTail(
-        onLiveFrames: (List<List<int>> frames) {
-          _storageAudioTailRestartAttempt = 0;
-          if (_socket?.state != SocketServiceState.connected) return false;
-          for (final frame in frames) {
+      if (!resumeLiveContinuity || _liveAudioFramePacer == null) {
+        _liveAudioFramePacer?.dispose();
+        _liveAudioFramePacer = LiveAudioFramePacer(
+          framesPerSecond: codec.getFramesPerSecond(),
+          canSend: () => _socket?.serverReady == true,
+          send: (frame) {
             if (_voiceCommandSession != null) {
               _commandBytes.add(List<int>.from(frame));
             }
             _socket?.send(frame);
             _metrics.addBleBytes(frame.length);
             _metrics.addSocketBytes(frame.length);
-          }
-          return true;
+          },
+        );
+      }
+      final session = await syncs.startStorageAuthoritativeAudioTail(
+        onLiveFrames: (List<List<int>> frames) {
+          _storageAudioTailRestartAttempt = 0;
+          return _liveAudioFramePacer?.enqueue(frames) ?? LiveAudioFrameDelivery.rejected();
         },
+        resumeLiveContinuity: resumeLiveContinuity,
       );
       _ringAudioTailSession = session;
       if (session != null) {
@@ -985,7 +1034,7 @@ class CaptureController extends ChangeNotifier
         }
 
         // Send WS
-        if (_socket?.state == SocketServiceState.connected) {
+        if (_socket?.serverReady == true) {
           final socketPayload = _activeSource?.getSocketPayload(snapshot) ?? snapshot;
           _socket?.send(socketPayload);
 
@@ -1038,7 +1087,7 @@ class CaptureController extends ChangeNotifier
     final exponent = (_storageAudioTailRestartAttempt - 1).clamp(0, 4);
     final delay = Duration(seconds: 1 << exponent);
     Logger.warning(
-      'Storage-authoritative audio tail retry ${_storageAudioTailRestartAttempt} in ${delay.inSeconds}s',
+      'Storage-authoritative audio tail retry $_storageAudioTailRestartAttempt in ${delay.inSeconds}s',
     );
     _storageAudioTailRestartTimer = Timer(delay, () {
       _storageAudioTailRestartTimer = null;
@@ -1070,7 +1119,9 @@ class CaptureController extends ChangeNotifier
     }
   }
 
-  Future<void> _resetState() async {
+  Future<void> _resetState() => _captureStartGate.run(_resetStateOnce);
+
+  Future<void> _resetStateOnce() async {
     Logger.debug('resetState');
     await _cleanupCurrentState();
 
@@ -1165,11 +1216,14 @@ class CaptureController extends ChangeNotifier
         audioCodec: codec,
         force: true,
         source: _getConversationSourceFromDevice(),
+        deferDeviceAudioResume: true,
       );
     }
   }
 
-  Future<void> _initiateDeviceAudioStreaming() async {
+  Future<void> _initiateDeviceAudioStreaming({
+    bool resumeLiveContinuity = false,
+  }) async {
     final device = _recordingDevice;
     if (device == null) {
       return;
@@ -1199,7 +1253,11 @@ class CaptureController extends ChangeNotifier
     _wal.getSyncs().phone.setDeviceInfo(deviceId, deviceModel);
 
     await streamButton(deviceId);
-    final foregroundAudioReady = await streamAudioToWs(deviceId, codec);
+    final foregroundAudioReady = await streamAudioToWs(
+      deviceId,
+      codec,
+      resumeLiveContinuity: resumeLiveContinuity,
+    );
     if (foregroundAudioReady) {
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
     }
@@ -1500,6 +1558,7 @@ class CaptureController extends ChangeNotifier
     _storageAudioTailRestartTimer?.cancel();
     await _bleBytesStream?.cancel();
     await _ringAudioTailSession?.cancel();
+    _liveAudioFramePacer?.reset();
     _bleBytesStream = null;
     _ringAudioTailSession = null;
     await _blePhotoStream?.cancel();
@@ -1530,6 +1589,7 @@ class CaptureController extends ChangeNotifier
     _storageAudioTailRestartTimer?.cancel();
     _bleBytesStream?.cancel();
     _ringAudioTailSession?.cancel();
+    _liveAudioFramePacer?.dispose();
     _blePhotoStream?.cancel();
     _bleButtonStream?.cancel();
     _socket?.unsubscribe(this);
@@ -1748,7 +1808,22 @@ class CaptureController extends ChangeNotifier
     }
   }
 
-  Future streamDeviceRecording({BtDevice? device}) async {
+  Future<void> streamDeviceRecording({BtDevice? device}) => _deviceCaptureStartGate.run(() async {
+        if (canReuseActiveDeviceCapture(
+          activeDeviceId: _recordingDevice?.id,
+          requestedDeviceId: device?.id ?? _recordingDevice?.id,
+          recordingActive: recordingState == RecordingState.deviceRecord,
+          audioPathActive: hasActiveDeviceAudioStream,
+        )) {
+          Logger.debug(
+            'streamDeviceRecording reused active exact-device capture ${_recordingDevice?.id}',
+          );
+          return;
+        }
+        await _startDeviceRecording(device: device);
+      });
+
+  Future<void> _startDeviceRecording({BtDevice? device}) async {
     Logger.debug("streamDeviceRecording $device");
     if (deviceOnboardingProvider == null && SharedPreferencesUtil().batchModeSuspendedForOnboarding) {
       await restoreBatchModeAfterOnboarding();
@@ -1769,8 +1844,40 @@ class CaptureController extends ChangeNotifier
     }
   }
 
+  /// Rebinds BLE audio after a transport reconnect without replacing the
+  /// conversation socket, transcript segments, or session boundary.
+  Future<void> resumeDeviceRecordingAfterReconnect({
+    required BtDevice device,
+  }) =>
+      _deviceCaptureStartGate.run(
+        () => _resumeDeviceRecordingAfterReconnect(device),
+      );
+
+  Future<void> _resumeDeviceRecordingAfterReconnect(BtDevice device) async {
+    final preservedSegmentCount = segments.length;
+    Logger.debug(
+      'resumeDeviceRecordingAfterReconnect ${device.id} '
+      '(preserving $preservedSegmentCount preview segments)',
+    );
+    _updateRecordingDevice(device);
+
+    final wasPaused = _isPaused;
+    await _ensureDeviceSocketConnection();
+    await _initiateDeviceAudioStreaming(resumeLiveContinuity: true);
+
+    if (wasPaused) {
+      await pauseDeviceRecording();
+    }
+    Logger.debug(
+      'resumeDeviceRecordingAfterReconnect complete '
+      '(preserved ${segments.length} preview segments)',
+    );
+  }
+
   Future stopStreamDeviceRecording({bool cleanDevice = false}) async {
     await _cleanupCurrentState(disableNativeBackground: true);
+    _conversationSessionWindow.reset();
+    _sessionStartSeconds = 0;
     if (cleanDevice) {
       _updateRecordingDevice(null);
     }
@@ -1827,7 +1934,7 @@ class CaptureController extends ChangeNotifier
       }
 
       _keepAliveLastExecutedAt = DateTime.now();
-      if (!recordingDeviceServiceReady || _socket?.state == SocketServiceState.connected) {
+      if (!recordingDeviceServiceReady || _socket?.serverReady == true) {
         t.cancel();
         return;
       }
@@ -1870,7 +1977,7 @@ class CaptureController extends ChangeNotifier
 
   @override
   void onConnected() {
-    _transcriptServiceReady = true;
+    Logger.debug('transcription websocket transport connected');
     // Restart mic on reconnect if interrupted (skip during active call).
     if (recordingState == RecordingState.interrupted && !_micInterrupted) {
       if (_activeSource is PhoneMicSource) {
@@ -1993,7 +2100,11 @@ class CaptureController extends ChangeNotifier
     );
     _conversation = convos.isNotEmpty ? convos.first : null;
     if (_conversation != null) {
-      segments = _conversation!.transcriptSegments;
+      _activeConversationId ??= _conversation!.id;
+      segments = LiveTranscriptPreview.reconcile(
+        current: segments,
+        serverSnapshot: _conversation!.transcriptSegments,
+      );
       // Merge server photos with locally-captured temp photos to avoid losing
       // photos that haven't been processed server-side yet.
       final serverPhotos = _conversation!.photos;
@@ -2007,7 +2118,7 @@ class CaptureController extends ChangeNotifier
         }
       }
       photos = mergedPhotos;
-    } else {
+    } else if (!_canRefreshInProgressConversation) {
       segments = [];
       photos = [];
     }
@@ -2018,19 +2129,41 @@ class CaptureController extends ChangeNotifier
 
   @override
   void onMessageEventReceived(MessageEvent event) {
+    if (event is ConversationSessionEvent) {
+      Logger.debug(
+        'transcription conversation session status=${event.status} '
+        'phase=${event.lifecyclePhase ?? 'legacy'}',
+      );
+      if (event.isInProgress) {
+        _activeConversationId = event.conversationId;
+        _sessionStartSeconds = _conversationSessionWindow.observe(
+          conversationId: event.conversationId,
+          nowSeconds: _nowSeconds,
+        );
+      }
+      return;
+    }
+
     if (event is ConversationProcessingStartedEvent) {
+      if (_activeConversationId == event.memory.id) {
+        _activeConversationId = null;
+      }
       externalActions.addProcessingConversation(event.memory);
-      _pendingAutoSyncSessionStart = _sessionStartSeconds;
+      _pendingAutoSyncSessionStart = _conversationSessionWindow.complete(
+        conversationId: event.memory.id,
+        fallbackStartSeconds: _sessionStartSeconds,
+      );
       _pendingAutoSyncConversationId = event.memory.id;
 
       // Force-drain tail buffer, stamp WALs with conversation ID, then clear state.
       // Store the future so the coordinated transfer wake waits for the stamp.
       _pendingFinalizeAndStamp = _finalizeAndStampSession(
-        _sessionStartSeconds,
-        event.memory.id,
+        _pendingAutoSyncSessionStart,
+        event.memory,
       );
 
       _resetStateVariables();
+      _sessionStartSeconds = _conversationSessionWindow.nextStartSeconds ?? 0;
 
       // Start 30s fallback timer in case ConversationEvent never arrives (WS disconnect)
       _autoSyncFallbackTimer?.cancel();
@@ -2085,6 +2218,11 @@ class CaptureController extends ChangeNotifier
     }
 
     if (event is MessageServiceStatusEvent) {
+      Logger.debug(
+        'transcription service status=${event.status} '
+        'provider=${event.provider ?? 'unspecified'} '
+        'retryable=${event.retryable ?? false}',
+      );
       // Handle freemium threshold event via status field
       if (event.status == 'freemium_threshold_reached') {
         // Parse as FreemiumThresholdReachedEvent for consistent handling
@@ -2100,8 +2238,10 @@ class CaptureController extends ChangeNotifier
       // list so the user can see the outage while the reconnect loop runs.
       if (event.status == 'stt_failed') {
         _terminalTranscriptionFailure = event;
+        _transcriptServiceReady = false;
       } else if (event.status == 'ready') {
         _terminalTranscriptionFailure = null;
+        _transcriptServiceReady = true;
       }
 
       _transcriptionServiceStatuses.add(event);
@@ -2168,12 +2308,31 @@ class CaptureController extends ChangeNotifier
       _processConversationCreated(result.conversation, result.messages);
 
       // Stamp WALs with conversation ID and auto-sync
-      if (sessionStart > 0 && result.conversation != null) {
-        await phoneSync.stampConversationId(
-          sessionStart,
-          result.conversation!.id,
+      final completedSessionStart = _conversationSessionWindow.complete(
+        conversationId: result.conversation!.id,
+        fallbackStartSeconds: sessionStart,
+      );
+      if (completedSessionStart > 0) {
+        final hasServerSpeechProof = ConversationCaptureWindow.hasServerSpeechProof(
+          result.conversation!.transcriptSegments,
         );
-        _autoSyncSessionWals();
+        final captureWindow = ConversationCaptureWindow.fromTranscript(
+          sessionOriginSeconds: result.conversation!.startedAt == null
+              ? completedSessionStart
+              : result.conversation!.startedAt!.millisecondsSinceEpoch ~/ 1000,
+          fallbackStartSeconds: completedSessionStart,
+          fallbackEndSeconds: _nowSeconds,
+          segments: result.conversation!.transcriptSegments,
+        );
+        await phoneSync.stampConversationId(
+          captureWindow.startSeconds,
+          result.conversation!.id,
+          hasServerSpeechProof: hasServerSpeechProof,
+          sessionEndSeconds: captureWindow.endSeconds,
+        );
+        if (hasServerSpeechProof) {
+          _autoSyncSessionWals();
+        }
       }
     });
 
@@ -2184,15 +2343,28 @@ class CaptureController extends ChangeNotifier
   /// Called from synchronous onMessageEventReceived — fire-and-forget async.
   Future<void> _finalizeAndStampSession(
     int sessionStartSeconds,
-    String conversationId,
+    ServerConversation conversation,
   ) async {
     try {
       final phoneSync = _wal.getSyncs().phone;
       await phoneSync.finalizeCurrentSession();
       if (sessionStartSeconds > 0) {
+        final hasServerSpeechProof = ConversationCaptureWindow.hasServerSpeechProof(
+          conversation.transcriptSegments,
+        );
+        final captureWindow = ConversationCaptureWindow.fromTranscript(
+          sessionOriginSeconds: conversation.startedAt == null
+              ? sessionStartSeconds
+              : conversation.startedAt!.millisecondsSinceEpoch ~/ 1000,
+          fallbackStartSeconds: sessionStartSeconds,
+          fallbackEndSeconds: _nowSeconds,
+          segments: conversation.transcriptSegments,
+        );
         await phoneSync.stampConversationId(
-          sessionStartSeconds,
-          conversationId,
+          captureWindow.startSeconds,
+          conversation.id,
+          hasServerSpeechProof: hasServerSpeechProof,
+          sessionEndSeconds: captureWindow.endSeconds,
         );
       }
     } catch (e) {
@@ -2427,6 +2599,10 @@ class CaptureController extends ChangeNotifier
       newSegments,
     );
     segments.addAll(remainSegments);
+    Logger.debug(
+      'live transcript preview received=${newSegments.length} '
+      'added=${remainSegments.length} visible=${segments.length}',
+    );
 
     // Refresh people cache if we see unknown personIds (backend-created persons)
     // Check all newSegments, not just remainSegments, to catch updates to existing segments
@@ -2492,6 +2668,7 @@ class CaptureController extends ChangeNotifier
     // Pause the BLE stream but keep the device connection
     await _bleBytesStream?.cancel();
     await _ringAudioTailSession?.cancel();
+    _liveAudioFramePacer?.reset();
     _bleBytesStream = null;
     _ringAudioTailSession = null;
     await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -40,6 +40,7 @@ import 'package:omi/services/devices/connectors/limitless_connection.dart';
 import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/audio_sources/phone_mic_source.dart';
 import 'package:omi/services/wals.dart';
+import 'package:omi/services/wals/ring_storage_sync.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/batch_recording.dart';
 import 'package:omi/utils/enums.dart';
@@ -66,9 +67,13 @@ import 'package:omi/backend/schema/message_event.dart'
 class CaptureController extends ChangeNotifier
     with MessageNotifierMixin
     implements ITransctiptSegmentSocketServiceListener {
-  static const MethodChannel _nativeBleTranscriptChannel = MethodChannel('com.friend.ios/native_ble_transcript');
+  static const MethodChannel _nativeBleTranscriptChannel = MethodChannel(
+    'com.friend.ios/native_ble_transcript',
+  );
   static const int _maxInProgressConversationRefreshAttempts = 30;
-  static const Duration _inProgressConversationRefreshInterval = Duration(seconds: 2);
+  static const Duration _inProgressConversationRefreshInterval = Duration(
+    seconds: 2,
+  );
 
   final ConversationLocationCapture _conversationLocationCapture = ConversationLocationCapture();
 
@@ -130,7 +135,9 @@ class CaptureController extends ChangeNotifier
 
   bool _isLoadingInProgressConversation = false;
 
-  late final CaptureMetricsTracker _metrics = CaptureMetricsTracker(onNotify: notifyListeners);
+  late final CaptureMetricsTracker _metrics = CaptureMetricsTracker(
+    onNotify: notifyListeners,
+  );
 
   double get bleReceiveRateKbps => _metrics.bleReceiveRateKbps;
   double get wsSendRateKbps => _metrics.wsSendRateKbps;
@@ -159,10 +166,14 @@ class CaptureController extends ChangeNotifier
     // the device reconnects, streamDeviceRecording() reads _isPaused as
     // `wasPaused` and re-applies the mute instead of silently resuming.
     _isPaused = SharedPreferencesUtil().deviceMuted;
-    _connectionStateListener = ConnectivityService().onConnectionChange.listen((bool isConnected) {
+    _connectionStateListener = ConnectivityService().onConnectionChange.listen((
+      bool isConnected,
+    ) {
       onConnectionStateChanged(isConnected);
     });
-    BleBridge.instance.addBatchRecordingFinalizedListener(_onOfflineRecordingFinalized);
+    BleBridge.instance.addBatchRecordingFinalizedListener(
+      _onOfflineRecordingFinalized,
+    );
   }
 
   // True while the audio session is interrupted (phone call, Siri, alarm).
@@ -203,7 +214,9 @@ class CaptureController extends ChangeNotifier
       // Use _resumeMicRecording (not streamRecording) to preserve existing socket/segments.
       await _resumeMicRecording();
     } catch (e, st) {
-      Logger.error('[CaptureProvider] _restartPhoneMicRecording failed: $e\n$st');
+      Logger.error(
+        '[CaptureProvider] _restartPhoneMicRecording failed: $e\n$st',
+      );
     } finally {
       _phoneMicRestartInFlight = false;
     }
@@ -378,9 +391,14 @@ class CaptureController extends ChangeNotifier
   bool hasTranscripts = false;
 
   StreamSubscription? _bleBytesStream;
+  RingAudioTailSession? _ringAudioTailSession;
+  Timer? _storageAudioTailRestartTimer;
+  int _storageAudioTailRestartAttempt = 0;
+  bool _storageAudioTailRestartInFlight = false;
   StreamSubscription? _blePhotoStream;
 
   get bleBytesStream => _bleBytesStream;
+  bool get hasActiveDeviceAudioStream => _bleBytesStream != null || (_ringAudioTailSession?.isActive ?? false);
 
   StreamSubscription? _bleButtonStream;
   DateTime? _voiceCommandSession;
@@ -450,7 +468,9 @@ class CaptureController extends ChangeNotifier
   }
 
   void _updateRecordingDevice(BtDevice? device) {
-    Logger.debug('connected device changed from ${_recordingDevice?.id} to ${device?.id}');
+    Logger.debug(
+      'connected device changed from ${_recordingDevice?.id} to ${device?.id}',
+    );
     _recordingDevice = device;
     if (device == null) _endOfflineSession();
     notifyListeners();
@@ -502,7 +522,9 @@ class CaptureController extends ChangeNotifier
     // With batch on the realtime socket is suppressed for every device type, so a
     // device without a batch capture path would record nothing at all.
     if (enabled && _recordingDevice != null && !deviceSupportsTranscribeLater) {
-      Logger.debug('[setBatchMode] refused: ${_recordingDevice?.type} has no Transcribe Later support');
+      Logger.debug(
+        '[setBatchMode] refused: ${_recordingDevice?.type} has no Transcribe Later support',
+      );
       return false;
     }
     SharedPreferencesUtil().batchModeEnabled = enabled;
@@ -513,7 +535,10 @@ class CaptureController extends ChangeNotifier
     // native BLE route is connected, and background mode is opted in.
     final enableNativeStreaming =
         !enabled && hasNativeBackgroundStreamRoute && SharedPreferencesUtil().backgroundModeEnabled;
-    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', enableNativeStreaming);
+    await SharedPreferencesUtil().saveBool(
+      'nativeBleStreamingEnabled',
+      enableNativeStreaming,
+    );
     await _applyLimitlessRealtimeSuppression(enabled);
     notifyListeners();
     // A phone-mic session's mode is fixed at start, so a mid-session toggle
@@ -526,7 +551,9 @@ class CaptureController extends ChangeNotifier
         await stopStreamRecording();
         await streamRecording();
       } catch (e, st) {
-        Logger.error('[CaptureProvider] mode-switch session roll failed: $e\n$st');
+        Logger.error(
+          '[CaptureProvider] mode-switch session roll failed: $e\n$st',
+        );
       }
       return true;
     }
@@ -579,13 +606,19 @@ class CaptureController extends ChangeNotifier
   /// Called when transcription settings are changed (e.g., custom STT provider)
   /// This resets the socket connection to use the new configuration
   Future<void> onTranscriptionSettingsChanged() async {
-    Logger.debug("Transcription settings changed, refreshing socket connection...");
+    Logger.debug(
+      "Transcription settings changed, refreshing socket connection...",
+    );
 
     // Handle device recording
     if (_recordingDevice != null) {
       await _socket?.stop(reason: 'transcription settings changed');
       BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-      await _initiateWebsocket(audioCodec: codec, force: true, source: _getConversationSourceFromDevice());
+      await _initiateWebsocket(
+        audioCodec: codec,
+        force: true,
+        source: _getConversationSourceFromDevice(),
+      );
       return;
     }
 
@@ -642,19 +675,25 @@ class CaptureController extends ChangeNotifier
     channels ??= (codec == BleAudioCodec.pcm16 || codec == BleAudioCodec.pcm8) ? 1 : 2;
 
     Logger.debug('is ws null: ${_socket == null}');
-    Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
+    Logger.debug(
+      'Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm',
+    );
 
     // Get language and custom STT config
     String language =
         SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
-    Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
+    Logger.debug(
+      'Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}',
+    );
 
     // Check codec compatibility for custom STT - fallback to default if incompatible
     CustomSttConfig? effectiveConfig = customSttConfig.isEnabled ? customSttConfig : null;
     if (effectiveConfig != null && !TranscriptSocketServiceFactory.isCodecSupportedForCustomStt(codec)) {
-      Logger.debug('[CustomSTT] Codec $codec not supported, falling back to Omi');
+      Logger.debug(
+        '[CustomSTT] Codec $codec not supported, falling back to Omi',
+      );
       effectiveConfig = null;
     }
 
@@ -684,7 +723,9 @@ class CaptureController extends ChangeNotifier
     // device when _bleBytesStream is cancelled and audio would just be dropped.
     if (_socketReconnectPending && _recordingDevice != null && recordingState == RecordingState.deviceRecord) {
       _socketReconnectPending = false;
-      final conn = await ServiceManager.instance().device.ensureConnection(_recordingDevice!.id);
+      final conn = await ServiceManager.instance().device.ensureConnection(
+            _recordingDevice!.id,
+          );
       await conn?.onNetworkSocketReconnected();
     }
 
@@ -782,7 +823,9 @@ class CaptureController extends ChangeNotifier
             Logger.debug("Double tap: toggling pause/mute");
             _isProcessingButtonEvent = true;
             if (_isPaused) {
-              PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
+              PlatformManager.instance.analytics.omiDoubleTap(
+                feature: 'unmute',
+              );
               resumeDeviceRecording().then((_) {
                 _isProcessingButtonEvent = false;
               }).catchError((e) {
@@ -803,19 +846,25 @@ class CaptureController extends ChangeNotifier
             Logger.debug("Double tap: marking conversation for starring");
             if (!_starOngoingConversation) {
               markConversationForStarring();
-              PlatformManager.instance.analytics.omiDoubleTap(feature: 'star_conversation');
+              PlatformManager.instance.analytics.omiDoubleTap(
+                feature: 'star_conversation',
+              );
               // Haptic feedback to confirm
               HapticFeedback.mediumImpact();
             } else {
               // Toggle off if already marked
               unmarkConversationForStarring();
-              PlatformManager.instance.analytics.omiDoubleTap(feature: 'unstar_conversation');
+              PlatformManager.instance.analytics.omiDoubleTap(
+                feature: 'unstar_conversation',
+              );
               HapticFeedback.lightImpact();
             }
           } else {
             // End conversation and process (default)
             Logger.debug("Double tap: processing conversation");
-            PlatformManager.instance.analytics.omiDoubleTap(feature: 'process_conversation');
+            PlatformManager.instance.analytics.omiDoubleTap(
+              feature: 'process_conversation',
+            );
             forceProcessingCurrentConversation();
           }
           return;
@@ -868,8 +917,37 @@ class CaptureController extends ChangeNotifier
 
   Future<bool> streamAudioToWs(String deviceId, BleAudioCodec codec) async {
     Logger.debug('streamAudioToWs in capture_provider');
-    _bleBytesStream?.cancel();
+    _storageAudioTailRestartTimer?.cancel();
+    await _bleBytesStream?.cancel();
+    await _ringAudioTailSession?.cancel();
+    _bleBytesStream = null;
+    _ringAudioTailSession = null;
     _startMetricsTracking();
+    final syncs = _wal.getSyncs();
+    if (syncs.usesStorageAuthoritativeAudio == true) {
+      final session = await syncs.startStorageAuthoritativeAudioTail(
+        onLiveFrames: (List<List<int>> frames) {
+          _storageAudioTailRestartAttempt = 0;
+          if (_socket?.state != SocketServiceState.connected) return false;
+          for (final frame in frames) {
+            if (_voiceCommandSession != null) {
+              _commandBytes.add(List<int>.from(frame));
+            }
+            _socket?.send(frame);
+            _metrics.addBleBytes(frame.length);
+            _metrics.addSocketBytes(frame.length);
+          }
+          return true;
+        },
+      );
+      _ringAudioTailSession = session;
+      if (session != null) {
+        _watchStorageAudioTail(session, deviceId);
+      }
+      notifyListeners();
+      return session != null;
+    }
+
     final subscription = await _getBleAudioBytesListener(
       deviceId,
       onAudioBytesReceived: (List<int> value) {
@@ -928,6 +1006,70 @@ class CaptureController extends ChangeNotifier
     return subscription != null;
   }
 
+  void _watchStorageAudioTail(RingAudioTailSession session, String deviceId) {
+    unawaited(
+      session.done.then<void>(
+        (_) {
+          if (!identical(_ringAudioTailSession, session)) return;
+          _ringAudioTailSession = null;
+          notifyListeners();
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!identical(_ringAudioTailSession, session)) return;
+          _ringAudioTailSession = null;
+          unawaited(SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false));
+          Logger.handle(
+            error,
+            stackTrace,
+            message: 'Storage-authoritative audio tail stopped; scheduling recovery',
+          );
+          notifyListeners();
+          _scheduleStorageAudioTailRestart(deviceId);
+        },
+      ),
+    );
+  }
+
+  void _scheduleStorageAudioTailRestart(String deviceId) {
+    if (_recordingDevice?.id != deviceId || _isPaused || _ringAudioTailSession != null) return;
+    if (_storageAudioTailRestartTimer?.isActive == true || _storageAudioTailRestartInFlight) return;
+
+    _storageAudioTailRestartAttempt += 1;
+    final exponent = (_storageAudioTailRestartAttempt - 1).clamp(0, 4);
+    final delay = Duration(seconds: 1 << exponent);
+    Logger.warning(
+      'Storage-authoritative audio tail retry ${_storageAudioTailRestartAttempt} in ${delay.inSeconds}s',
+    );
+    _storageAudioTailRestartTimer = Timer(delay, () {
+      _storageAudioTailRestartTimer = null;
+      unawaited(_restartStorageAudioTail(deviceId));
+    });
+  }
+
+  Future<void> _restartStorageAudioTail(String deviceId) async {
+    if (_storageAudioTailRestartInFlight ||
+        _recordingDevice?.id != deviceId ||
+        _isPaused ||
+        _ringAudioTailSession != null) {
+      return;
+    }
+    _storageAudioTailRestartInFlight = true;
+    try {
+      await _initiateDeviceAudioStreaming();
+    } catch (error, stackTrace) {
+      Logger.handle(
+        error,
+        stackTrace,
+        message: 'Storage-authoritative audio tail recovery failed',
+      );
+    } finally {
+      _storageAudioTailRestartInFlight = false;
+    }
+    if (_recordingDevice?.id == deviceId && !_isPaused && _ringAudioTailSession == null) {
+      _scheduleStorageAudioTailRestart(deviceId);
+    }
+  }
+
   Future<void> _resetState() async {
     Logger.debug('resetState');
     await _cleanupCurrentState();
@@ -938,7 +1080,9 @@ class CaptureController extends ChangeNotifier
 
     // Additionally, stream photos if the device supports it
     if (_recordingDevice != null) {
-      var connection = await ServiceManager.instance().device.ensureConnection(_recordingDevice!.id);
+      var connection = await ServiceManager.instance().device.ensureConnection(
+            _recordingDevice!.id,
+          );
       if (connection != null && await connection.hasPhotoStreamingCharacteristic()) {
         await _initiateDevicePhotoStreaming();
       }
@@ -956,7 +1100,9 @@ class CaptureController extends ChangeNotifier
   }
 
   Future<BleAudioCodec> _getAudioCodec(String deviceId) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return BleAudioCodec.pcm8;
     }
@@ -964,7 +1110,9 @@ class CaptureController extends ChangeNotifier
   }
 
   Future<bool> _playSpeakerHaptic(String deviceId, int level) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return false;
     }
@@ -975,18 +1123,24 @@ class CaptureController extends ChangeNotifier
     String deviceId, {
     required void Function(List<int>) onAudioBytesReceived,
   }) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return Future.value(null);
     }
-    return connection.getBleAudioBytesListener(onAudioBytesReceived: onAudioBytesReceived);
+    return connection.getBleAudioBytesListener(
+      onAudioBytesReceived: onAudioBytesReceived,
+    );
   }
 
   Future<StreamSubscription?> _getBleButtonListener(
     String deviceId, {
     required void Function(List<int>) onButtonReceived,
   }) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) {
       return Future.value(null);
     }
@@ -1007,7 +1161,11 @@ class CaptureController extends ChangeNotifier
         codec != _socket?.codec ||
         _socket?.state != SocketServiceState.connected ||
         _socket?.sttConfigId != sttConfigId) {
-      await _initiateWebsocket(audioCodec: codec, force: true, source: _getConversationSourceFromDevice());
+      await _initiateWebsocket(
+        audioCodec: codec,
+        force: true,
+        source: _getConversationSourceFromDevice(),
+      );
     }
   }
 
@@ -1020,7 +1178,9 @@ class CaptureController extends ChangeNotifier
     if (deviceId.isEmpty) {
       return;
     }
-    final connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    final connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) return;
     final codec = await _getAudioCodec(deviceId);
     await _wal.getSyncs().phone.onAudioCodecChanged(codec);
@@ -1030,7 +1190,11 @@ class CaptureController extends ChangeNotifier
     final pd = await device.getDeviceInfo(connection);
     final deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Omi";
     if (device.type == DeviceType.omi || device.type == DeviceType.openglass) {
-      _activeSource = BleDeviceSource(codec: codec, deviceId: deviceId, deviceModel: deviceModel);
+      _activeSource = BleDeviceSource(
+        codec: codec,
+        deviceId: deviceId,
+        deviceModel: deviceModel,
+      );
     }
     _wal.getSyncs().phone.setDeviceInfo(deviceId, deviceModel);
 
@@ -1053,7 +1217,25 @@ class CaptureController extends ChangeNotifier
     notifyListeners();
   }
 
-  Future<void> _saveNativeBleStreamConfig(BtDevice device, BleAudioCodec codec) async {
+  Future<void> _saveNativeBleStreamConfig(
+    BtDevice device,
+    BleAudioCodec codec,
+  ) async {
+    if (_wal.getSyncs().usesStorageAuthoritativeAudio == true) {
+      // The current native background service only understands the legacy
+      // live characteristic. Pointing it at 3.0.29 would report a healthy
+      // connection while consuming no audio and competing with the ring owner.
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+      await SharedPreferencesUtil().saveBool(
+        'nativeBleStreamingEnabled',
+        false,
+      );
+      await SharedPreferencesUtil().remove('nativeBleStreamConfig');
+      Logger.debug(
+        '[saveNativeBleStreamConfig] storage-authoritative ring owns audio; native legacy route disabled',
+      );
+      return;
+    }
     final audioTarget = _nativeBleAudioTarget(device);
     if (audioTarget == null) {
       // No native route — clear all background/streaming state and stale config.
@@ -1061,7 +1243,10 @@ class CaptureController extends ChangeNotifier
         '[saveNativeBleStreamConfig] no native BLE route for device ${device.id} type=${device.type} — clearing state',
       );
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
-      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool(
+        'nativeBleStreamingEnabled',
+        false,
+      );
       SharedPreferencesUtil().backgroundModeEnabled = false;
       await SharedPreferencesUtil().remove('nativeBleStreamConfig');
       return;
@@ -1102,9 +1287,15 @@ class CaptureController extends ChangeNotifier
     switch (device.type) {
       case DeviceType.omi:
       case DeviceType.openglass:
-        return const MapEntry(omiServiceUuid, audioDataStreamCharacteristicUuid);
+        return const MapEntry(
+          omiServiceUuid,
+          audioDataStreamCharacteristicUuid,
+        );
       case DeviceType.friendPendant:
-        return const MapEntry(friendPendantServiceUuid, friendPendantAudioCharacteristicUuid);
+        return const MapEntry(
+          friendPendantServiceUuid,
+          friendPendantAudioCharacteristicUuid,
+        );
       case DeviceType.limitless:
         return const MapEntry(limitlessServiceUuid, limitlessRxCharUuid);
       case DeviceType.appleWatch:
@@ -1128,6 +1319,7 @@ class CaptureController extends ChangeNotifier
     final device = _recordingDevice;
     if (device == null) return false;
     if (device.id.isEmpty) return false;
+    if (_wal.getSyncs().usesStorageAuthoritativeAudio == true) return false;
     return _nativeBleAudioTarget(device) != null;
   }
 
@@ -1160,12 +1352,17 @@ class CaptureController extends ChangeNotifier
       // currently live. Reconnect/setup paths will refresh it when needed.
       final keepBatchConfig = SharedPreferencesUtil().batchModeEnabled;
       SharedPreferencesUtil().backgroundModeEnabled = false;
-      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool(
+        'nativeBleStreamingEnabled',
+        false,
+      );
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
       if (!keepBatchConfig) {
         await SharedPreferencesUtil().remove('nativeBleStreamConfig');
       }
-      Logger.debug('[BackgroundMode] disabled — keepBatchConfig=$keepBatchConfig');
+      Logger.debug(
+        '[BackgroundMode] disabled — keepBatchConfig=$keepBatchConfig',
+      );
       notifyListeners();
       return true;
     }
@@ -1178,7 +1375,10 @@ class CaptureController extends ChangeNotifier
       );
       // Defensive: ensure prefs stay false and remove any stale config.
       SharedPreferencesUtil().backgroundModeEnabled = false;
-      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool(
+        'nativeBleStreamingEnabled',
+        false,
+      );
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
       await SharedPreferencesUtil().remove('nativeBleStreamConfig');
       notifyListeners();
@@ -1193,7 +1393,9 @@ class CaptureController extends ChangeNotifier
     SharedPreferencesUtil().backgroundModeEnabled = true;
     final device = _recordingDevice!;
     final codec = await _getAudioCodec(device.id);
-    final wasForegroundReady = SharedPreferencesUtil().getBool('nativeBleForegroundReady');
+    final wasForegroundReady = SharedPreferencesUtil().getBool(
+      'nativeBleForegroundReady',
+    );
     await _saveNativeBleStreamConfig(device, codec);
     if (wasForegroundReady) {
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
@@ -1209,7 +1411,9 @@ class CaptureController extends ChangeNotifier
   Future<void> _initiateDevicePhotoStreaming() async {
     if (_recordingDevice == null) return;
     final deviceId = _recordingDevice!.id;
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(
+          deviceId,
+        );
     if (connection == null) return;
 
     await connection.performCameraStartPhotoController();
@@ -1220,7 +1424,13 @@ class CaptureController extends ChangeNotifier
         final String base64Image = base64Encode(rotatedImageBytes);
 
         // Add placeholder to UI for immediate feedback
-        photos.add(ConversationPhoto(id: tempId, base64: base64Image, createdAt: DateTime.now()));
+        photos.add(
+          ConversationPhoto(
+            id: tempId,
+            base64: base64Image,
+            createdAt: DateTime.now(),
+          ),
+        );
         photos = List.from(photos);
         _segmentsPhotosVersion++;
         notifyListeners();
@@ -1245,7 +1455,9 @@ class CaptureController extends ChangeNotifier
           if (_socket?.state == SocketServiceState.connected) {
             _socket?.send(payload); // Send the JSON string
           }
-          await Future.delayed(const Duration(milliseconds: 20)); // Small delay to prevent flooding
+          await Future.delayed(
+            const Duration(milliseconds: 20),
+          ); // Small delay to prevent flooding
         }
       },
     );
@@ -1285,18 +1497,27 @@ class CaptureController extends ChangeNotifier
   }
 
   Future _closeBleStream({bool disableNativeBackground = false}) async {
+    _storageAudioTailRestartTimer?.cancel();
     await _bleBytesStream?.cancel();
+    await _ringAudioTailSession?.cancel();
+    _bleBytesStream = null;
+    _ringAudioTailSession = null;
     await _blePhotoStream?.cancel();
     await _bleButtonStream?.cancel();
     _stopMetricsTracking();
     if (disableNativeBackground) {
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
-      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      await SharedPreferencesUtil().saveBool(
+        'nativeBleStreamingEnabled',
+        false,
+      );
     } else {
       await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
     }
     if (_recordingDevice != null) {
-      var connection = await ServiceManager.instance().device.ensureConnection(_recordingDevice!.id);
+      var connection = await ServiceManager.instance().device.ensureConnection(
+            _recordingDevice!.id,
+          );
       if (connection != null && await connection.hasPhotoStreamingCharacteristic()) {
         await connection.performCameraStopPhotoController();
       }
@@ -1306,7 +1527,9 @@ class CaptureController extends ChangeNotifier
 
   @override
   void dispose() {
+    _storageAudioTailRestartTimer?.cancel();
     _bleBytesStream?.cancel();
+    _ringAudioTailSession?.cancel();
     _blePhotoStream?.cancel();
     _bleButtonStream?.cancel();
     _socket?.unsubscribe(this);
@@ -1316,7 +1539,9 @@ class CaptureController extends ChangeNotifier
     _metrics.dispose();
     _autoSyncFallbackTimer?.cancel();
     _peopleRefreshFuture = null; // Clear in-flight tracker
-    BleBridge.instance.removeBatchRecordingFinalizedListener(_onOfflineRecordingFinalized);
+    BleBridge.instance.removeBatchRecordingFinalizedListener(
+      _onOfflineRecordingFinalized,
+    );
 
     super.dispose();
   }
@@ -1349,13 +1574,18 @@ class CaptureController extends ChangeNotifier
     updateRecordingState(RecordingState.initialising);
     final micPermission = await Permission.microphone.request();
     if (!micPermission.isGranted) {
-      Logger.error('[CaptureProvider] microphone permission denied, not starting phone mic');
+      Logger.error(
+        '[CaptureProvider] microphone permission denied, not starting phone mic',
+      );
       updateRecordingState(RecordingState.stop);
       return;
     }
 
     // prepare
-    await changeAudioRecordProfile(audioCodec: BleAudioCodec.pcm16, sampleRate: 16000);
+    await changeAudioRecordProfile(
+      audioCodec: BleAudioCodec.pcm16,
+      sampleRate: 16000,
+    );
 
     // Initialize WAL for phone mic recording
     _activeSource = PhoneMicSource();
@@ -1446,7 +1676,9 @@ class CaptureController extends ChangeNotifier
     updateRecordingState(RecordingState.initialising);
     final micPermission = await Permission.microphone.request();
     if (!micPermission.isGranted) {
-      Logger.error('[CaptureProvider] microphone permission denied, not starting phone mic batch');
+      Logger.error(
+        '[CaptureProvider] microphone permission denied, not starting phone mic batch',
+      );
       updateRecordingState(RecordingState.stop);
       return;
     }
@@ -1564,7 +1796,10 @@ class CaptureController extends ChangeNotifier
       updateRecordingState(RecordingState.interrupted);
       final ctx = globalNavigatorKey.currentContext;
       if (ctx != null) {
-        AppSnackbar.showSnackbar(ctx.l10n.transcriptionPausedReconnecting, duration: const Duration(seconds: 3));
+        AppSnackbar.showSnackbar(
+          ctx.l10n.transcriptionPausedReconnecting,
+          duration: const Duration(seconds: 3),
+        );
       }
     }
 
@@ -1598,14 +1833,19 @@ class CaptureController extends ChangeNotifier
       }
 
       if (!AuthService.instance.isSignedIn()) {
-        Logger.debug("[Provider] keep alive - user not signed in, cancelling reconnect");
+        Logger.debug(
+          "[Provider] keep alive - user not signed in, cancelling reconnect",
+        );
         t.cancel();
         return;
       }
 
       if (_recordingDevice != null) {
         BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-        await _initiateWebsocket(audioCodec: codec, source: _getConversationSourceFromDevice());
+        await _initiateWebsocket(
+          audioCodec: codec,
+          source: _getConversationSourceFromDevice(),
+        );
         return;
       }
       if (recordingState == RecordingState.record || recordingState == RecordingState.interrupted) {
@@ -1658,9 +1898,12 @@ class CaptureController extends ChangeNotifier
 
     _stopInProgressConversationRefresh();
     _inProgressConversationRefreshAttempts = 0;
-    _inProgressConversationRefreshTimer = Timer.periodic(_inProgressConversationRefreshInterval, (_) {
-      _refreshInProgressConversationTick();
-    });
+    _inProgressConversationRefreshTimer = Timer.periodic(
+      _inProgressConversationRefreshInterval,
+      (_) {
+        _refreshInProgressConversationTick();
+      },
+    );
   }
 
   void _stopInProgressConversationRefresh() {
@@ -1703,7 +1946,9 @@ class CaptureController extends ChangeNotifier
 
     List<String>? messages;
     try {
-      messages = await _nativeBleTranscriptChannel.invokeListMethod<String>('drain');
+      messages = await _nativeBleTranscriptChannel.invokeListMethod<String>(
+        'drain',
+      );
     } on MissingPluginException {
       return;
     } catch (e) {
@@ -1735,12 +1980,17 @@ class CaptureController extends ChangeNotifier
     }
 
     if (jsonEvent is Map && jsonEvent.containsKey('type')) {
-      onMessageEventReceived(MessageEvent.fromJson(Map<String, dynamic>.from(jsonEvent)));
+      onMessageEventReceived(
+        MessageEvent.fromJson(Map<String, dynamic>.from(jsonEvent)),
+      );
     }
   }
 
   Future _loadInProgressConversation() async {
-    var convos = await getConversations(statuses: [ConversationStatus.in_progress], limit: 1);
+    var convos = await getConversations(
+      statuses: [ConversationStatus.in_progress],
+      limit: 1,
+    );
     _conversation = convos.isNotEmpty ? convos.first : null;
     if (_conversation != null) {
       segments = _conversation!.transcriptSegments;
@@ -1775,7 +2025,10 @@ class CaptureController extends ChangeNotifier
 
       // Force-drain tail buffer, stamp WALs with conversation ID, then clear state.
       // Store the future so the coordinated transfer wake waits for the stamp.
-      _pendingFinalizeAndStamp = _finalizeAndStampSession(_sessionStartSeconds, event.memory.id);
+      _pendingFinalizeAndStamp = _finalizeAndStampSession(
+        _sessionStartSeconds,
+        event.memory.id,
+      );
 
       _resetStateVariables();
 
@@ -1786,7 +2039,9 @@ class CaptureController extends ChangeNotifier
           final convId = _pendingAutoSyncConversationId!;
           _pendingAutoSyncSessionStart = 0;
           _pendingAutoSyncConversationId = null;
-          Logger.debug('Auto-sync fallback timer fired — syncing WALs to conversation $convId');
+          Logger.debug(
+            'Auto-sync fallback timer fired — syncing WALs to conversation $convId',
+          );
           _autoSyncSessionWals();
         }
       });
@@ -1796,7 +2051,10 @@ class CaptureController extends ChangeNotifier
     if (event is ConversationEvent) {
       event.memory.isNew = true;
       externalActions.removeProcessingConversation(event.memory.id);
-      _processConversationCreated(event.memory, event.messages.cast<ServerMessage>());
+      _processConversationCreated(
+        event.memory,
+        event.messages.cast<ServerMessage>(),
+      );
       _autoSyncFallbackTimer?.cancel();
       if (_pendingAutoSyncSessionStart > 0) {
         _pendingAutoSyncSessionStart = 0;
@@ -1830,7 +2088,9 @@ class CaptureController extends ChangeNotifier
       // Handle freemium threshold event via status field
       if (event.status == 'freemium_threshold_reached') {
         // Parse as FreemiumThresholdReachedEvent for consistent handling
-        final thresholdEvent = FreemiumThresholdReachedEvent.fromJson({'status_text': event.statusText});
+        final thresholdEvent = FreemiumThresholdReachedEvent.fromJson({
+          'status_text': event.statusText,
+        });
         _handleFreemiumThresholdReached(thresholdEvent);
         return;
       }
@@ -1909,7 +2169,10 @@ class CaptureController extends ChangeNotifier
 
       // Stamp WALs with conversation ID and auto-sync
       if (sessionStart > 0 && result.conversation != null) {
-        await phoneSync.stampConversationId(sessionStart, result.conversation!.id);
+        await phoneSync.stampConversationId(
+          sessionStart,
+          result.conversation!.id,
+        );
         _autoSyncSessionWals();
       }
     });
@@ -1919,12 +2182,18 @@ class CaptureController extends ChangeNotifier
 
   /// Force-drain tail buffer and stamp all session WALs with conversation ID.
   /// Called from synchronous onMessageEventReceived — fire-and-forget async.
-  Future<void> _finalizeAndStampSession(int sessionStartSeconds, String conversationId) async {
+  Future<void> _finalizeAndStampSession(
+    int sessionStartSeconds,
+    String conversationId,
+  ) async {
     try {
       final phoneSync = _wal.getSyncs().phone;
       await phoneSync.finalizeCurrentSession();
       if (sessionStartSeconds > 0) {
-        await phoneSync.stampConversationId(sessionStartSeconds, conversationId);
+        await phoneSync.stampConversationId(
+          sessionStartSeconds,
+          conversationId,
+        );
       }
     } catch (e) {
       Logger.debug('_finalizeAndStampSession error: $e');
@@ -1939,10 +2208,15 @@ class CaptureController extends ChangeNotifier
     }
     // The stamped conversation id stays on the WAL; the single transfer owner
     // will reconcile first and then offer retryable bytes through `syncAll`.
-    await RecordingTransferCoordinator.instance.wake(WakeTrigger.cooldownElapsed);
+    await RecordingTransferCoordinator.instance.wake(
+      WakeTrigger.cooldownElapsed,
+    );
   }
 
-  Future<void> _processConversationCreated(ServerConversation? conversation, List<ServerMessage> messages) async {
+  Future<void> _processConversationCreated(
+    ServerConversation? conversation,
+    List<ServerMessage> messages,
+  ) async {
     if (conversation == null) return;
 
     // Star the conversation if it was marked for starring
@@ -1979,7 +2253,10 @@ class CaptureController extends ChangeNotifier
       Logger.debug("Received ${translatedSegments.length} translated segments");
 
       // Update the segments with the translated ones
-      var remainSegments = TranscriptSegment.updateSegments(segments, translatedSegments);
+      var remainSegments = TranscriptSegment.updateSegments(
+        segments,
+        translatedSegments,
+      );
       if (remainSegments.isNotEmpty) {
         Logger.debug("Adding ${remainSegments.length} new translated segments");
       }
@@ -1995,7 +2272,9 @@ class CaptureController extends ChangeNotifier
     if (event.segmentIds.isEmpty) return;
 
     segments.removeWhere((segment) => event.segmentIds.contains(segment.id));
-    suggestionsBySegmentId.removeWhere((key, value) => event.segmentIds.contains(key));
+    suggestionsBySegmentId.removeWhere(
+      (key, value) => event.segmentIds.contains(key),
+    );
     taggingSegmentIds.removeWhere((id) => event.segmentIds.contains(id));
     hasTranscripts = segments.isNotEmpty;
     _segmentsPhotosVersion++;
@@ -2017,7 +2296,12 @@ class CaptureController extends ChangeNotifier
     final isUser = event.personId == 'user';
     if (!isUser && event.personId.isNotEmpty && SharedPreferencesUtil().getPersonById(event.personId) == null) {
       SharedPreferencesUtil().addCachedPerson(
-        Person(id: event.personId, name: event.personName, createdAt: DateTime.now(), updatedAt: DateTime.now()),
+        Person(
+          id: event.personId,
+          name: event.personName,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
       );
     }
 
@@ -2061,7 +2345,12 @@ class CaptureController extends ChangeNotifier
           finalPersonId != 'user' &&
           SharedPreferencesUtil().getPersonById(finalPersonId) == null) {
         SharedPreferencesUtil().addCachedPerson(
-          Person(id: finalPersonId, name: personName, createdAt: DateTime.now(), updatedAt: DateTime.now()),
+          Person(
+            id: finalPersonId,
+            name: personName,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
         );
       }
 
@@ -2100,7 +2389,9 @@ class CaptureController extends ChangeNotifier
       }
 
       // Remove all suggestions for this speakerId
-      suggestionsBySegmentId.removeWhere((key, value) => value.speakerId == speakerId);
+      suggestionsBySegmentId.removeWhere(
+        (key, value) => value.speakerId == speakerId,
+      );
     } finally {
       taggingSegmentIds = [];
       notifyListeners();
@@ -2116,7 +2407,9 @@ class CaptureController extends ChangeNotifier
     _processNewSegmentReceived(newSegments);
   }
 
-  Future<void> _processNewSegmentReceived(List<TranscriptSegment> newSegments) async {
+  Future<void> _processNewSegmentReceived(
+    List<TranscriptSegment> newSegments,
+  ) async {
     if (newSegments.isEmpty) return;
 
     if (segments.isEmpty && !_isLoadingInProgressConversation) {
@@ -2129,7 +2422,10 @@ class CaptureController extends ChangeNotifier
       }
     }
 
-    final remainSegments = TranscriptSegment.updateSegments(segments, newSegments);
+    final remainSegments = TranscriptSegment.updateSegments(
+      segments,
+      newSegments,
+    );
     segments.addAll(remainSegments);
 
     // Refresh people cache if we see unknown personIds (backend-created persons)
@@ -2192,8 +2488,12 @@ class CaptureController extends ChangeNotifier
 
     // Write mute state first — before BLE cancel which may fire other events
     await BatteryWidgetService().updateMuteState(true);
+    _storageAudioTailRestartTimer?.cancel();
     // Pause the BLE stream but keep the device connection
     await _bleBytesStream?.cancel();
+    await _ringAudioTailSession?.cancel();
+    _bleBytesStream = null;
+    _ringAudioTailSession = null;
     await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
     await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
     _isPaused = true;

--- a/app/lib/services/capture/capture_start_gate.dart
+++ b/app/lib/services/capture/capture_start_gate.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+bool canReuseActiveDeviceCapture({
+  required String? activeDeviceId,
+  required String? requestedDeviceId,
+  required bool recordingActive,
+  required bool audioPathActive,
+}) =>
+    activeDeviceId != null && requestedDeviceId == activeDeviceId && recordingActive && audioPathActive;
+
+/// Coalesces concurrent requests to rebuild the capture transport.
+///
+/// Device readiness can be reported by more than one observer during startup.
+/// Opening two forced transcription sockets gives each backend runtime a
+/// different recording-session owner even though the UI shows one pendant.
+class CaptureStartGate {
+  Future<void>? _inFlight;
+
+  Future<void> run(Future<void> Function() start) {
+    final existing = _inFlight;
+    if (existing != null) return existing;
+
+    final future = Future<void>.sync(start);
+    _inFlight = future;
+    return future.whenComplete(() {
+      if (identical(_inFlight, future)) _inFlight = null;
+    });
+  }
+}

--- a/app/lib/services/capture/conversation_capture_window.dart
+++ b/app/lib/services/capture/conversation_capture_window.dart
@@ -1,0 +1,38 @@
+import 'dart:math';
+
+import 'package:omi/backend/schema/transcript_segment.dart';
+
+class ConversationCaptureWindow {
+  const ConversationCaptureWindow({
+    required this.startSeconds,
+    required this.endSeconds,
+  });
+
+  final int startSeconds;
+  final int endSeconds;
+
+  static bool hasServerSpeechProof(List<TranscriptSegment> segments) =>
+      segments.any((segment) => segment.text.trim().isNotEmpty && segment.end > segment.start);
+
+  factory ConversationCaptureWindow.fromTranscript({
+    required int sessionOriginSeconds,
+    required int fallbackStartSeconds,
+    required int fallbackEndSeconds,
+    required List<TranscriptSegment> segments,
+    int transcriptMarginSeconds = 2,
+  }) {
+    if (segments.isEmpty) {
+      return ConversationCaptureWindow(
+        startSeconds: fallbackStartSeconds,
+        endSeconds: fallbackEndSeconds,
+      );
+    }
+
+    final firstSpeechOffset = segments.map((segment) => segment.start).reduce(min).floor();
+    final lastSpeechOffset = segments.map((segment) => segment.end).reduce(max).ceil();
+    return ConversationCaptureWindow(
+      startSeconds: sessionOriginSeconds + firstSpeechOffset - transcriptMarginSeconds,
+      endSeconds: sessionOriginSeconds + lastSpeechOffset + transcriptMarginSeconds,
+    );
+  }
+}

--- a/app/lib/services/capture/conversation_session_window.dart
+++ b/app/lib/services/capture/conversation_session_window.dart
@@ -1,0 +1,68 @@
+class ConversationSessionWindow {
+  final List<_ConversationSessionBoundary> _pending = [];
+  int? _unboundStartSeconds;
+
+  int ensureStarted(int nowSeconds) {
+    if (_pending.isNotEmpty) return _pending.first.startedAtSeconds;
+    return _unboundStartSeconds ??= nowSeconds;
+  }
+
+  int observe({
+    required String conversationId,
+    required int nowSeconds,
+  }) {
+    if (_pending.any((entry) => entry.conversationId == conversationId)) {
+      return _pending.first.startedAtSeconds;
+    }
+
+    final startedAtSeconds = _pending.isEmpty ? (_unboundStartSeconds ?? nowSeconds) : nowSeconds;
+    _pending.add(
+      _ConversationSessionBoundary(
+        conversationId: conversationId,
+        startedAtSeconds: startedAtSeconds,
+      ),
+    );
+    _unboundStartSeconds = null;
+    return _pending.first.startedAtSeconds;
+  }
+
+  int complete({
+    required String conversationId,
+    required int fallbackStartSeconds,
+  }) {
+    if (_pending.isEmpty) {
+      final start = _unboundStartSeconds ?? fallbackStartSeconds;
+      _unboundStartSeconds = null;
+      return start;
+    }
+
+    final completedIndex = _pending.indexWhere((entry) => entry.conversationId == conversationId);
+    if (completedIndex < 0) {
+      final start = fallbackStartSeconds > 0 ? fallbackStartSeconds : _pending.first.startedAtSeconds;
+      _pending.clear();
+      _unboundStartSeconds = null;
+      return start;
+    }
+
+    final start = _pending.first.startedAtSeconds;
+    _pending.removeRange(0, completedIndex + 1);
+    return start;
+  }
+
+  int? get nextStartSeconds => _pending.isEmpty ? null : _pending.first.startedAtSeconds;
+
+  void reset() {
+    _pending.clear();
+    _unboundStartSeconds = null;
+  }
+}
+
+class _ConversationSessionBoundary {
+  const _ConversationSessionBoundary({
+    required this.conversationId,
+    required this.startedAtSeconds,
+  });
+
+  final String conversationId;
+  final int startedAtSeconds;
+}

--- a/app/lib/services/capture/device_audio_streaming_policy.dart
+++ b/app/lib/services/capture/device_audio_streaming_policy.dart
@@ -1,0 +1,18 @@
+/// Owns the decision to consume audio from a connected device.
+///
+/// Storage-authoritative firmware keeps recording on the pendant while the
+/// phone cannot transcribe. Draining that ring without a ready transcription
+/// service only moves thousands of immutable transfer ranges onto the phone;
+/// it cannot produce a live preview and needlessly spends BLE bandwidth and
+/// battery. Intentional Transcribe Later mode is the exception because local
+/// capture is the requested destination.
+abstract final class DeviceAudioStreamingPolicy {
+  static bool shouldConsumeDeviceAudio({
+    required bool usesStorageAuthoritativeAudio,
+    required bool transcribeLaterEnabled,
+    required bool transcriptionServiceReady,
+  }) {
+    if (!usesStorageAuthoritativeAudio) return true;
+    return transcribeLaterEnabled || transcriptionServiceReady;
+  }
+}

--- a/app/lib/services/capture/live_audio_frame_pacer.dart
+++ b/app/lib/services/capture/live_audio_frame_pacer.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+import 'dart:collection';
+
+class LiveAudioFrameDelivery {
+  const LiveAudioFrameDelivery._({
+    required this.accepted,
+    required this.completed,
+  });
+
+  final bool accepted;
+  final Future<bool> completed;
+
+  factory LiveAudioFrameDelivery.rejected() => LiveAudioFrameDelivery._(
+        accepted: false,
+        completed: Future<bool>.value(false),
+      );
+
+  factory LiveAudioFrameDelivery.accepted(Future<bool> completed) => LiveAudioFrameDelivery._(
+        accepted: true,
+        completed: completed,
+      );
+}
+
+class _PendingLiveAudioBatch {
+  _PendingLiveAudioBatch(List<List<int>> frames) : frames = frames.map(List<int>.from).toList(growable: false);
+
+  final List<List<int>> frames;
+  final Completer<bool> completer = Completer<bool>();
+  int nextFrame = 0;
+
+  int get remainingFrames => frames.length - nextFrame;
+}
+
+/// Delivers storage-backed audio at the cadence encoded by the negotiated
+/// codec instead of dumping a completed BLE read into the live STT socket.
+///
+/// The pendant/phone WAL remains the durable source of truth. This queue owns
+/// only the low-latency preview lane. A batch is complete only after every
+/// frame has entered the socket; rejection leaves its durable WAL retryable.
+class LiveAudioFramePacer {
+  LiveAudioFramePacer({
+    required this.framesPerSecond,
+    required this.canSend,
+    required this.send,
+    this.maxBufferedSeconds = 120,
+  })  : assert(framesPerSecond > 0),
+        assert(maxBufferedSeconds > 0);
+
+  final int framesPerSecond;
+  final bool Function() canSend;
+  final void Function(List<int> frame) send;
+  final int maxBufferedSeconds;
+
+  final ListQueue<_PendingLiveAudioBatch> _batches = ListQueue<_PendingLiveAudioBatch>();
+  Timer? _timer;
+  int _bufferedFrames = 0;
+
+  int get bufferedFrames => _bufferedFrames;
+  bool get isActive => _timer?.isActive ?? false;
+
+  /// Accepts one immutable WAL batch for live preview.
+  ///
+  /// [LiveAudioFrameDelivery.completed] resolves true only after the final
+  /// frame was sent. A socket loss or explicit reset resolves every pending
+  /// batch false; callers must retain those WALs for replay/canonical repair.
+  LiveAudioFrameDelivery enqueue(List<List<int>> frames) {
+    final nonEmptyFrames = frames.where((frame) => frame.isNotEmpty).toList();
+    if (nonEmptyFrames.isEmpty) {
+      return LiveAudioFrameDelivery.accepted(Future<bool>.value(true));
+    }
+    if (!canSend()) {
+      rejectPending();
+      return LiveAudioFrameDelivery.rejected();
+    }
+
+    final maximumFrames = framesPerSecond * maxBufferedSeconds;
+    if (_bufferedFrames + nonEmptyFrames.length > maximumFrames) {
+      return LiveAudioFrameDelivery.rejected();
+    }
+
+    final batch = _PendingLiveAudioBatch(nonEmptyFrames);
+    _batches.add(batch);
+    _bufferedFrames += batch.remainingFrames;
+    _start();
+    return LiveAudioFrameDelivery.accepted(batch.completer.future);
+  }
+
+  void _start() {
+    if (_batches.isEmpty || _timer?.isActive == true) return;
+    final interval = Duration(
+      microseconds: (Duration.microsecondsPerSecond / framesPerSecond).round(),
+    );
+    _timer = Timer.periodic(interval, (_) {
+      if (!canSend()) {
+        rejectPending();
+        return;
+      }
+      if (_batches.isEmpty) {
+        _timer?.cancel();
+        _timer = null;
+        return;
+      }
+
+      final batch = _batches.first;
+      send(batch.frames[batch.nextFrame]);
+      batch.nextFrame += 1;
+      _bufferedFrames -= 1;
+      if (batch.remainingFrames == 0) {
+        _batches.removeFirst();
+        if (!batch.completer.isCompleted) batch.completer.complete(true);
+      }
+    });
+  }
+
+  void rejectPending() {
+    _timer?.cancel();
+    _timer = null;
+    while (_batches.isNotEmpty) {
+      final batch = _batches.removeFirst();
+      if (!batch.completer.isCompleted) batch.completer.complete(false);
+    }
+    _bufferedFrames = 0;
+  }
+
+  void reset() => rejectPending();
+
+  void dispose() => rejectPending();
+}

--- a/app/lib/services/capture/live_transcript_preview.dart
+++ b/app/lib/services/capture/live_transcript_preview.dart
@@ -1,0 +1,31 @@
+import 'package:omi/backend/schema/transcript_segment.dart';
+
+/// Reconciles an eventually-consistent server snapshot with the segments
+/// already visible in the live capture UI.
+///
+/// Reconnect is not a conversation boundary. An empty or stale HTTP snapshot
+/// must therefore never erase segments already received from the socket.
+class LiveTranscriptPreview {
+  const LiveTranscriptPreview._();
+
+  static List<TranscriptSegment> reconcile({
+    required List<TranscriptSegment> current,
+    required List<TranscriptSegment> serverSnapshot,
+  }) {
+    if (serverSnapshot.isEmpty) {
+      return List<TranscriptSegment>.from(current);
+    }
+
+    final merged = List<TranscriptSegment>.from(current);
+    final additions = TranscriptSegment.updateSegments(
+      merged,
+      serverSnapshot,
+    );
+    merged.addAll(additions);
+    merged.sort((left, right) {
+      final start = left.start.compareTo(right.start);
+      return start != 0 ? start : left.end.compareTo(right.end);
+    });
+    return merged;
+  }
+}

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
@@ -10,6 +11,7 @@ import 'package:omi/services/devices/discovery/rayban_meta_discoverer.dart';
 import 'package:omi/services/devices/discovery/device_discoverer.dart';
 import 'package:omi/services/devices/discovery/native_bluetooth_discoverer.dart';
 import 'package:omi/services/devices/errors.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/mutex.dart';
@@ -17,6 +19,26 @@ import 'package:omi/utils/mutex.dart';
 enum DeviceServiceStatus { init, ready, scanning, stop }
 
 enum DeviceConnectionState { connected, connecting, disconnected }
+
+typedef DfuReconnectDelay = Future<void> Function(Duration delay);
+
+/// Bounded retry policy for reclaiming normal BLE ownership after DFU.
+class DfuReconnectRetryPolicy {
+  const DfuReconnectRetryPolicy({required this.retryDelays});
+
+  /// Delay after each failed attempt. The number of attempts is one greater
+  /// than this list's length.
+  final List<Duration> retryDelays;
+
+  int get maxAttempts => retryDelays.length + 1;
+
+  static const production = DfuReconnectRetryPolicy(
+    retryDelays: [
+      Duration(milliseconds: 500),
+      Duration(milliseconds: 1500),
+    ],
+  );
+}
 
 /// Feature flags for Omi device capabilities
 /// Must match the firmware definitions in features.h
@@ -42,8 +64,16 @@ abstract class IDeviceServiceSubsciption {
 }
 
 class DeviceService {
+  DeviceService({
+    DfuReconnectRetryPolicy dfuReconnectRetryPolicy = DfuReconnectRetryPolicy.production,
+    DfuReconnectDelay? dfuReconnectDelay,
+  })  : _dfuReconnectRetryPolicy = dfuReconnectRetryPolicy,
+        _dfuReconnectDelay = dfuReconnectDelay ?? Future<void>.delayed;
+
   DeviceServiceStatus _status = DeviceServiceStatus.init;
   List<BtDevice> _devices = [];
+  final DfuReconnectRetryPolicy _dfuReconnectRetryPolicy;
+  final DfuReconnectDelay _dfuReconnectDelay;
 
   final List<DeviceDiscoverer> _discoverers = [
     NativeBluetoothDiscoverer(),
@@ -54,6 +84,9 @@ class DeviceService {
   final Map<Object, IDeviceServiceSubsciption> _subscriptions = {};
 
   DeviceConnection? _connection;
+  String? _dfuSuspendedDeviceId;
+  Future<void>? _dfuSuspendFuture;
+  Future<void>? _dfuResumeFuture;
   List<BtDevice> get devices => _devices;
 
   DeviceServiceStatus get status => _status;
@@ -272,6 +305,120 @@ class DeviceService {
       await _connection?.disconnect();
       _connection = null;
     }
+  }
+
+  /// Temporarily relinquishes normal BLE ownership so a DFU plugin can use the
+  /// peripheral. Repeated prepares for the same device share the in-flight
+  /// disconnect; a different device cannot replace the captured owner.
+  Future<void> suspendConnectionForDfu(String deviceId) {
+    if (_dfuSuspendedDeviceId != null) {
+      if (_dfuSuspendedDeviceId != deviceId) {
+        throw StateError('A different device is already suspended for DFU');
+      }
+      return _dfuSuspendFuture ?? Future<void>.value();
+    }
+
+    _dfuSuspendedDeviceId = deviceId;
+    final suspendFuture = _suspendConnectionForDfu();
+    _dfuSuspendFuture = suspendFuture;
+    return suspendFuture;
+  }
+
+  Future<void> _suspendConnectionForDfu() async {
+    final suspendedConnection = _connection;
+    try {
+      await disconnectDevice();
+      // disconnectDevice clears the service's reference but intentionally keeps
+      // transports alive for ordinary native reconnect. DFU is different: its
+      // plugin becomes the sole owner, so unregister the retired Dart bridge
+      // before a fresh exact-device connection is created on resume.
+      await releaseSuspendedConnectionTransportForDfu(suspendedConnection);
+    } finally {
+      _dfuSuspendFuture = null;
+    }
+  }
+
+  /// Seams the post-disconnect transport release so suspend rollback can be
+  /// exercised without a live BLE stack.
+  @protected
+  Future<void> releaseSuspendedConnectionTransportForDfu(DeviceConnection? connection) async {
+    if (connection == null) return;
+    await releaseTransportForExclusiveOperation(connection.transport);
+  }
+
+  /// Reclaims normal BLE ownership for the exact device captured at suspend.
+  ///
+  /// Success, failure, plugin double callbacks, and page disposal all share one
+  /// bounded retry loop.
+  Future<void> resumeConnectionAfterDfu() {
+    final inFlight = _dfuResumeFuture;
+    if (inFlight != null) return inFlight;
+
+    final deviceId = _dfuSuspendedDeviceId;
+    if (deviceId == null) return Future<void>.value();
+
+    final resumeFuture = _resumeConnectionAfterDfu(deviceId);
+    _dfuResumeFuture = resumeFuture;
+    return resumeFuture;
+  }
+
+  Future<void> _resumeConnectionAfterDfu(String deviceId) async {
+    var resumed = false;
+    Object? lastError;
+    StackTrace? lastStackTrace;
+    try {
+      final suspendFuture = _dfuSuspendFuture;
+      if (suspendFuture != null) {
+        await suspendFuture;
+      }
+      if (_dfuSuspendedDeviceId != deviceId) return;
+
+      for (var attempt = 1; attempt <= _dfuReconnectRetryPolicy.maxAttempts; attempt++) {
+        try {
+          resumed = await reconnectSuspendedDeviceForDfu(deviceId);
+          if (resumed) break;
+          lastError = DeviceConnectionException(
+            'Failed to reclaim the DFU-suspended device $deviceId '
+            '(attempt $attempt/${_dfuReconnectRetryPolicy.maxAttempts})',
+          );
+          lastStackTrace = StackTrace.current;
+        } catch (error, stackTrace) {
+          lastError = error;
+          lastStackTrace = stackTrace;
+        }
+
+        if (attempt < _dfuReconnectRetryPolicy.maxAttempts) {
+          Logger.warning(
+            'DeviceService: DFU reclaim attempt $attempt/'
+            '${_dfuReconnectRetryPolicy.maxAttempts} failed for $deviceId; retrying',
+          );
+          await _dfuReconnectDelay(_dfuReconnectRetryPolicy.retryDelays[attempt - 1]);
+        }
+      }
+
+      if (!resumed) {
+        Logger.error(
+          'DeviceService: exhausted ${_dfuReconnectRetryPolicy.maxAttempts} '
+          'DFU reclaim attempts for $deviceId; retaining the exact-device lease',
+        );
+        Error.throwWithStackTrace(
+          lastError ?? DeviceConnectionException('Failed to reclaim the DFU-suspended device $deviceId'),
+          lastStackTrace ?? StackTrace.current,
+        );
+      }
+    } finally {
+      // Successful reclaim releases the lease. Exhaustion deliberately retains
+      // it so a later explicit retry can only target the same pendant.
+      if (resumed && _dfuSuspendedDeviceId == deviceId) {
+        _dfuSuspendedDeviceId = null;
+      }
+      _dfuResumeFuture = null;
+    }
+  }
+
+  @protected
+  Future<bool> reconnectSuspendedDeviceForDfu(String deviceId) async {
+    return await ensureConnection(deviceId, force: true) != null;
   }
 
   Future<void> forgetDevice(String deviceId) async {

--- a/app/lib/services/devices/ble_packet_continuity.dart
+++ b/app/lib/services/devices/ble_packet_continuity.dart
@@ -1,0 +1,104 @@
+enum BlePacketDisposition {
+  first,
+  contiguous,
+  gap,
+  duplicate,
+  reset,
+  malformed,
+}
+
+class BlePacketContinuityObservation {
+  final BlePacketDisposition disposition;
+  final int? packetId;
+  final int missingPackets;
+
+  const BlePacketContinuityObservation(this.disposition, {this.packetId, this.missingPackets = 0});
+
+  bool get shouldForward =>
+      disposition != BlePacketDisposition.duplicate && disposition != BlePacketDisposition.malformed;
+}
+
+/// Tracks Omi's 16-bit little-endian live-audio packet ID.
+///
+/// BLE notifications are ordered within a connection, so an exactly repeated
+/// packet is a duplicate and a forward delta greater than one is a measurable
+/// gap. The half-range modular rule distinguishes forward progress from reset:
+/// some high-ID-to-low-ID jumps are inherently ambiguous and are reported as
+/// gaps, but all anomalies except exact adjacent duplicates are forwarded.
+class BlePacketContinuityTracker {
+  int? _lastPacketId;
+  List<int>? _lastPacket;
+
+  BlePacketContinuityObservation observe(List<int> packet) {
+    if (packet.length < 3) {
+      return const BlePacketContinuityObservation(BlePacketDisposition.malformed);
+    }
+
+    final packetId = (packet[0] & 0xFF) | ((packet[1] & 0xFF) << 8);
+    final previous = _lastPacketId;
+    if (previous == null) {
+      _lastPacketId = packetId;
+      _lastPacket = List<int>.from(packet);
+      return BlePacketContinuityObservation(BlePacketDisposition.first, packetId: packetId);
+    }
+
+    final delta = (packetId - previous) & 0xFFFF;
+    if (delta == 0) {
+      if (_packetsEqual(packet, _lastPacket!)) {
+        return BlePacketContinuityObservation(BlePacketDisposition.duplicate, packetId: packetId);
+      }
+
+      // A repeated 16-bit ID with different index/payload can be a firmware
+      // counter reset or another fragment from legacy firmware. Preserve it.
+      _lastPacket = List<int>.from(packet);
+      return BlePacketContinuityObservation(BlePacketDisposition.reset, packetId: packetId);
+    }
+
+    _lastPacketId = packetId;
+    _lastPacket = List<int>.from(packet);
+    if (delta == 1) {
+      return BlePacketContinuityObservation(BlePacketDisposition.contiguous, packetId: packetId);
+    }
+    if (delta < 0x8000) {
+      return BlePacketContinuityObservation(
+        BlePacketDisposition.gap,
+        packetId: packetId,
+        missingPackets: delta - 1,
+      );
+    }
+    return BlePacketContinuityObservation(BlePacketDisposition.reset, packetId: packetId);
+  }
+
+  bool _packetsEqual(List<int> left, List<int> right) {
+    if (left.length != right.length) return false;
+    for (var index = 0; index < left.length; index++) {
+      if (left[index] != right[index]) return false;
+    }
+    return true;
+  }
+}
+
+/// Coalesces continuity warnings so a damaged stream cannot enqueue a log write
+/// for every BLE notification.
+class BlePacketAnomalyLogLimiter {
+  final Duration interval;
+  DateTime? _lastEmission;
+  int _pendingEvents = 0;
+
+  BlePacketAnomalyLogLimiter({this.interval = const Duration(seconds: 10)});
+
+  /// Returns the number of coalesced anomaly events when a warning should be
+  /// emitted, or null when this event should be folded into the next warning.
+  int? record(DateTime now) {
+    _pendingEvents++;
+    final lastEmission = _lastEmission;
+    if (lastEmission != null && now.isBefore(lastEmission.add(interval))) {
+      return null;
+    }
+
+    final events = _pendingEvents;
+    _pendingEvents = 0;
+    _lastEmission = now;
+    return events;
+  }
+}

--- a/app/lib/services/devices/connectors/omi_connection.dart
+++ b/app/lib/services/devices/connectors/omi_connection.dart
@@ -8,6 +8,7 @@ import 'package:version/version.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/ble_packet_continuity.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
@@ -119,10 +120,24 @@ class OmiDeviceConnection extends DeviceConnection {
   }) async {
     try {
       final stream = transport.getCharacteristicStream(omiServiceUuid, audioDataStreamCharacteristicUuid);
+      final continuity = BlePacketContinuityTracker();
+      final anomalyLogLimiter = BlePacketAnomalyLogLimiter();
 
       Logger.debug('Subscribed to audioBytes stream from Omi Device');
       final subscription = stream.listen((value) {
-        if (value.isNotEmpty) onAudioBytesReceived(value);
+        final observation = continuity.observe(value);
+        if (observation.disposition != BlePacketDisposition.first &&
+            observation.disposition != BlePacketDisposition.contiguous) {
+          final coalescedEvents = anomalyLogLimiter.record(DateTime.now());
+          if (coalescedEvents != null) {
+            Logger.warning(
+              'Omi BLE audio continuity anomaly: type=${observation.disposition.name} '
+              'packetId=${observation.packetId} missing=${observation.missingPackets} '
+              'coalescedEvents=$coalescedEvents bytes=${value.length}',
+            );
+          }
+        }
+        if (observation.shouldForward) onAudioBytesReceived(value);
       });
 
       return subscription;

--- a/app/lib/services/devices/connectors/omi_connection.dart
+++ b/app/lib/services/devices/connectors/omi_connection.dart
@@ -12,8 +12,58 @@ import 'package:omi/services/devices/ble_packet_continuity.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/utils/logger.dart';
+
+/// Serializes setup work associated with reconnect generations.
+///
+/// Duplicate delivery of one generation shares the same future. A newer
+/// generation waits behind an older in-flight action, so an older clock write
+/// can never complete after the newer generation's write and rewind the device
+/// timestamp.
+class _ReadyGenerationActionRunner {
+  int _lastScheduledGeneration = 0;
+  int _lastCompletedGeneration = 0;
+  Future<void> _tail = Future<void>.value();
+  final Map<int, Future<void>> _inFlight = {};
+
+  Future<void> run(int generation, Future<void> Function() action) {
+    if (generation <= _lastCompletedGeneration) return Future<void>.value();
+
+    final existing = _inFlight[generation];
+    if (existing != null) return existing;
+
+    if (generation < _lastScheduledGeneration) {
+      return Future<void>.value();
+    }
+    _lastScheduledGeneration = generation;
+
+    final completer = Completer<void>();
+    _inFlight[generation] = completer.future;
+    final predecessor = _tail;
+    final execution = () async {
+      try {
+        await predecessor;
+      } catch (_) {
+        // A failed generation must not prevent a later reconnect from syncing.
+      }
+      await action();
+    }();
+
+    _tail = execution.catchError((_) {});
+    execution
+        .then(
+      (_) => completer.complete(),
+      onError: (Object error, StackTrace stackTrace) => completer.completeError(error, stackTrace),
+    )
+        .whenComplete(() {
+      _lastCompletedGeneration = max(_lastCompletedGeneration, generation);
+      _inFlight.remove(generation);
+    });
+    return completer.future;
+  }
+}
 
 class OmiDeviceConnection extends DeviceConnection {
   static const String settingsServiceUuid = '19b10010-e8f2-537e-4f6c-d104768a1214';
@@ -23,20 +73,46 @@ class OmiDeviceConnection extends DeviceConnection {
   static const String featuresServiceUuid = '19b10020-e8f2-537e-4f6c-d104768a1214';
   static const String featuresCharacteristicUuid = '19b10021-e8f2-537e-4f6c-d104768a1214';
 
-  OmiDeviceConnection(super.device, super.transport);
+  final DateTime Function() _now;
+  final _ReadyGenerationActionRunner _readyGenerationRunner = _ReadyGenerationActionRunner();
+  StreamSubscription<int>? _readyGenerationSubscription;
+  int _fallbackReadyGeneration = 0;
+
+  OmiDeviceConnection(super.device, super.transport, {DateTime Function()? now}) : _now = now ?? DateTime.now {
+    final readySource = transport is DeviceReadyGenerationSource ? transport as DeviceReadyGenerationSource : null;
+    if (readySource != null) {
+      _readyGenerationSubscription = readySource.readyGenerationStream.listen((generation) {
+        unawaited(_syncTimeForReadyGeneration(generation));
+      });
+    }
+  }
 
   get deviceId => device.id;
 
   @override
   Future<void> connect({Function(String deviceId, DeviceConnectionState state)? onConnectionStateChanged}) async {
     await super.connect(onConnectionStateChanged: onConnectionStateChanged);
+    final readySource = transport is DeviceReadyGenerationSource ? transport as DeviceReadyGenerationSource : null;
+    final generation = readySource?.readyGeneration ?? ++_fallbackReadyGeneration;
+    await _syncTimeForReadyGeneration(generation);
+  }
 
-    await performSyncTime();
+  Future<void> _syncTimeForReadyGeneration(int generation) {
+    return _readyGenerationRunner.run(generation, () async {
+      await performSyncTime();
+    });
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _readyGenerationSubscription?.cancel();
+    _readyGenerationSubscription = null;
+    await super.disconnect();
   }
 
   Future<bool> performSyncTime() async {
     try {
-      final epochSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+      final epochSeconds = _now().toUtc().millisecondsSinceEpoch ~/ 1000;
       final byteData = ByteData(4)..setUint32(0, epochSeconds, Endian.little);
 
       await transport.writeCharacteristic(

--- a/app/lib/services/devices/connectors/omi_connection.dart
+++ b/app/lib/services/devices/connectors/omi_connection.dart
@@ -487,6 +487,11 @@ class OmiDeviceConnection extends DeviceConnection {
 
       sub = stream.listen((value) {
         if (completer.isCompleted) return;
+        final ackStatus = RingProtocol.parseAckStatus(value);
+        if (ackStatus != null && ackStatus != RingProtocol.statusOk) {
+          completer.completeError(RingCommandRejectedException(command: 'ring info', status: ackStatus));
+          return;
+        }
         final info = RingProtocol.parseInfoNotification(value);
         if (info == null) return;
         Logger.debug('OmiDeviceConnection: $info');
@@ -503,6 +508,9 @@ class OmiDeviceConnection extends DeviceConnection {
         Logger.debug('OmiDeviceConnection: getRingInfo timeout');
         return null;
       });
+    } on RingCommandRejectedException catch (e) {
+      Logger.debug('OmiDeviceConnection: Ring info rejected: $e');
+      rethrow;
     } catch (e) {
       Logger.debug('OmiDeviceConnection: Error getting ring info: $e');
       return null;

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -16,7 +16,7 @@ import 'package:omi/services/devices/connectors/device_connection.dart';
 ///     0x01 ACK         [0x01][status]
 ///     0x02 INFO        [0x02][read:u64][write:u64][cap:u32][dropped:u64][pkt_size:u16]
 ///     0x03 DATA        [0x03][raw_bytes...]   <-- not aligned to record boundaries
-///     0x04 DONE        [0x04][status][next_seq:u64]
+///     0x04 DONE        [0x04][status][next_seq:u64](optional [crc32:u32])
 ///     0x05 READ_BEGIN  [0x05][transfer_start_seq:u64][packet_count:u32]
 ///
 ///   Each ring record (packet_size = 444 bytes):
@@ -71,7 +71,11 @@ class RingProtocol {
   static DoneNotification? parseDoneNotification(List<int> value) {
     if (value.isEmpty || value[0] != notifyDone || value.length < 10) return null;
     final bd = ByteData.sublistView(Uint8List.fromList(value));
-    return DoneNotification(status: bd.getUint8(1), nextSeq: bd.getUint64(2, Endian.big));
+    return DoneNotification(
+      status: bd.getUint8(1),
+      nextSeq: bd.getUint64(2, Endian.big),
+      transferCrc32: value.length >= 14 ? bd.getUint32(10, Endian.big) : null,
+    );
   }
 
   /// Parse a NOTIFY_READ_BEGIN (0x05) notification.
@@ -111,6 +115,15 @@ class RingProtocol {
     return (record[0] << 24) | (record[1] << 16) | (record[2] << 8) | record[3];
   }
 
+  /// Record timestamps survive a reboot where the device's current RTC-valid
+  /// flag may be false. Trust plausible embedded capture time rather than
+  /// collapsing old audio onto the retry time.
+  static bool isPlausibleRecordTimestamp(int timestamp, {required int nowSeconds}) {
+    const earliestSupportedTimestamp = 1704067200;
+    const maximumFutureSkewSeconds = 24 * 60 * 60;
+    return timestamp >= earliestSupportedTimestamp && timestamp <= nowSeconds + maximumFutureSkewSeconds;
+  }
+
   /// The pendant may discard records only after the complete transfer reached
   /// durable phone storage. A BLE TX completion or a partial stream is not an
   /// acknowledgement.
@@ -120,8 +133,16 @@ class RingProtocol {
     required bool flushError,
     required bool isCancelled,
     required bool receivedCompleteRange,
+    required bool protocolError,
+    required bool crcVerified,
   }) {
-    return reachedDone && doneOk && !flushError && !isCancelled && receivedCompleteRange;
+    return reachedDone &&
+        doneOk &&
+        !flushError &&
+        !isCancelled &&
+        receivedCompleteRange &&
+        !protocolError &&
+        crcVerified;
   }
 
   /// Validate that READ_BEGIN, DATA, and DONE describe one complete contiguous
@@ -146,10 +167,10 @@ class RingProtocol {
   /// A leading byte of 0 is a no-op padding marker; otherwise it is the
   /// length of the next frame.
   ///
-  /// Boundary uses `>=` to match the firmware's overflow rule in
-  /// transport.c:write_to_storage — at the boundary the firmware writes a
-  /// trailing size byte without its frame (the frame goes to the next 440B
-  /// block); the bytes after it are stale and must not be parsed.
+  /// Boundary uses `>=` for compatibility with legacy 3.0.20 records. That
+  /// firmware can flush a record after writing only a size marker at the exact
+  /// boundary, leaving stale bytes where the frame would be. New firmware
+  /// preserves this no-exact-fit wire invariant.
   static List<List<int>> parseAudioPayload(List<int> audio) {
     final frames = <List<int>>[];
     int offset = 0;
@@ -173,10 +194,30 @@ class RingProtocol {
 class DoneNotification {
   final int status;
   final int nextSeq;
+  final int? transferCrc32;
 
-  const DoneNotification({required this.status, required this.nextSeq});
+  const DoneNotification({required this.status, required this.nextSeq, this.transferCrc32});
 
   bool get isOk => status == 0;
+}
+
+/// Incremental IEEE CRC-32 over raw NOTIFY_DATA payload bytes.
+///
+/// New firmware includes this value in DONE. Legacy 3.0.20 firmware omits it,
+/// so callers verify when present while retaining read compatibility.
+class RingTransferCrc32 {
+  int _crc = 0xFFFFFFFF;
+
+  void add(List<int> bytes) {
+    for (final byte in bytes) {
+      _crc ^= byte & 0xFF;
+      for (var bit = 0; bit < 8; bit++) {
+        _crc = (_crc & 1) != 0 ? (_crc >> 1) ^ 0xEDB88320 : _crc >> 1;
+      }
+    }
+  }
+
+  int get value => (_crc ^ 0xFFFFFFFF) & 0xFFFFFFFF;
 }
 
 /// Decoded NOTIFY_READ_BEGIN payload.

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -223,7 +223,25 @@ class RingProtocol {
   static ({int start, int end})? parseRecoverySourceRange(String? sourceId) {
     final raw = parseSourceRange(sourceId);
     if (raw != null || sourceId == null) return raw;
-    final match = RegExp(r'^archive_ring_(\d+)_(\d+)_\d+$').firstMatch(sourceId);
+    final match = RegExp(r'^(?:archive|archive2)_ring_(\d+)_(\d+)_\d+$').firstMatch(sourceId);
+    if (match == null) return null;
+    final start = int.parse(match.group(1)!);
+    final end = int.parse(match.group(2)!);
+    if (end <= start) return null;
+    return (start: start, end: end);
+  }
+
+  /// Parse only source identities that prove contiguous durable ring coverage.
+  ///
+  /// Legacy `archive_ring_*` files may have been produced by a greedy grouper
+  /// that spanned sequence gaps, so they remain valid recovery/upload inputs
+  /// but can never authorize a device ADVANCE after an app upgrade.
+  static ({int start, int end})? parseDurableCoverageSourceRange(
+    String? sourceId,
+  ) {
+    final raw = parseSourceRange(sourceId);
+    if (raw != null || sourceId == null) return raw;
+    final match = RegExp(r'^archive2_ring_(\d+)_(\d+)_\d+$').firstMatch(sourceId);
     if (match == null) return null;
     final start = int.parse(match.group(1)!);
     final end = int.parse(match.group(2)!);

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -129,7 +129,10 @@ class RingProtocol {
   /// Record timestamps survive a reboot where the device's current RTC-valid
   /// flag may be false. Trust plausible embedded capture time rather than
   /// collapsing old audio onto the retry time.
-  static bool isPlausibleRecordTimestamp(int timestamp, {required int nowSeconds}) {
+  static bool isPlausibleRecordTimestamp(
+    int timestamp, {
+    required int nowSeconds,
+  }) {
     const earliestSupportedTimestamp = 1704067200;
     const maximumFutureSkewSeconds = 24 * 60 * 60;
     return timestamp >= earliestSupportedTimestamp && timestamp <= nowSeconds + maximumFutureSkewSeconds;
@@ -199,6 +202,85 @@ class RingProtocol {
     }
     return frames;
   }
+
+  /// Parse the immutable source identity written by the ring recovery path.
+  /// The half-open range is `[start, end)`.
+  static ({int start, int end})? parseSourceRange(String? sourceId) {
+    if (sourceId == null) return null;
+    final match = RegExp(r'^ring_(\d+)_(\d+)$').firstMatch(sourceId);
+    if (match == null) return null;
+    final start = int.parse(match.group(1)!);
+    final end = int.parse(match.group(2)!);
+    if (end <= start) return null;
+    return (start: start, end: end);
+  }
+}
+
+/// In-memory index of ring ranges already durably represented on the phone.
+///
+/// This is sequence identity, not audio-content deduplication. It lets the app
+/// fetch the live head before an old backlog, then advance the pendant only
+/// when the historical gap closes.
+class RingSequenceCoverage {
+  final List<({int start, int end})> _ranges = [];
+
+  RingSequenceCoverage([Iterable<({int start, int end})> ranges = const []]) {
+    for (final range in ranges) {
+      add(range.start, range.end);
+    }
+  }
+
+  void add(int start, int end) {
+    if (end <= start) return;
+    var mergedStart = start;
+    var mergedEnd = end;
+    var index = 0;
+    while (index < _ranges.length && _ranges[index].end < mergedStart) {
+      index += 1;
+    }
+    while (index < _ranges.length && _ranges[index].start <= mergedEnd) {
+      final range = _ranges.removeAt(index);
+      if (range.start < mergedStart) mergedStart = range.start;
+      if (range.end > mergedEnd) mergedEnd = range.end;
+    }
+    _ranges.insert(index, (start: mergedStart, end: mergedEnd));
+  }
+
+  /// Highest sequence covered without a gap beginning at [start].
+  int contiguousEndFrom(int start) {
+    var end = start;
+    for (final range in _ranges) {
+      if (range.end <= end) continue;
+      if (range.start > end) break;
+      end = range.end;
+    }
+    return end;
+  }
+
+  /// First covered range beginning at or after [start].
+  ({int start, int end})? firstRangeAtOrAfter(int start) {
+    for (final range in _ranges) {
+      if (range.end <= start) continue;
+      return range;
+    }
+    return null;
+  }
+
+  /// First uncovered sequence in `[start, end)`, or [end] if fully covered.
+  int firstUncovered(int start, int end) {
+    var cursor = start;
+    for (final range in _ranges) {
+      if (range.end <= cursor) continue;
+      if (range.start > cursor) return cursor;
+      if (range.end > cursor) cursor = range.end;
+      if (cursor >= end) return end;
+    }
+    return cursor;
+  }
+
+  bool covers(int start, int end) => end <= contiguousEndFrom(start);
+
+  List<({int start, int end})> get ranges => List.unmodifiable(_ranges);
 }
 
 class RingStorageException implements Exception {
@@ -211,12 +293,16 @@ class RingStorageException implements Exception {
 }
 
 class RingCommandRejectedException extends RingStorageException {
-  const RingCommandRejectedException({required this.command, required this.status})
-      : super(status == RingProtocol.statusStorageNotReady
-            ? 'Device storage is not ready'
-            : status == RingProtocol.statusStorageFailed
-                ? 'Device storage needs attention'
-                : 'Device rejected $command (status $status)');
+  const RingCommandRejectedException({
+    required this.command,
+    required this.status,
+  }) : super(
+          status == RingProtocol.statusStorageNotReady
+              ? 'Device storage is not ready'
+              : status == RingProtocol.statusStorageFailed
+                  ? 'Device storage needs attention'
+                  : 'Device rejected $command (status $status)',
+        );
 
   final String command;
   final int status;
@@ -275,7 +361,11 @@ class DoneNotification {
   final int nextSeq;
   final int? transferCrc32;
 
-  const DoneNotification({required this.status, required this.nextSeq, this.transferCrc32});
+  const DoneNotification({
+    required this.status,
+    required this.nextSeq,
+    this.transferCrc32,
+  });
 
   bool get isOk => status == 0;
 }
@@ -304,7 +394,10 @@ class ReadBeginNotification {
   final int transferStartSeq;
   final int packetCount;
 
-  const ReadBeginNotification({required this.transferStartSeq, required this.packetCount});
+  const ReadBeginNotification({
+    required this.transferStartSeq,
+    required this.packetCount,
+  });
 }
 
 /// Reassembles unaligned NOTIFY_DATA byte chunks into 444-byte ring records.

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -111,6 +111,36 @@ class RingProtocol {
     return (record[0] << 24) | (record[1] << 16) | (record[2] << 8) | record[3];
   }
 
+  /// The pendant may discard records only after the complete transfer reached
+  /// durable phone storage. A BLE TX completion or a partial stream is not an
+  /// acknowledgement.
+  static bool canAdvance({
+    required bool reachedDone,
+    required bool doneOk,
+    required bool flushError,
+    required bool isCancelled,
+    required bool receivedCompleteRange,
+  }) {
+    return reachedDone && doneOk && !flushError && !isCancelled && receivedCompleteRange;
+  }
+
+  /// Validate that READ_BEGIN, DATA, and DONE describe one complete contiguous
+  /// record range. This catches missing notification bytes before a cumulative
+  /// ADVANCE command could discard the corresponding SD records.
+  static bool receivedCompleteRange({
+    required int? transferStartSeq,
+    required int? announcedPacketCount,
+    required int? doneNextSeq,
+    required int receivedPacketCount,
+    required int pendingBytes,
+  }) {
+    if (transferStartSeq == null || announcedPacketCount == null || doneNextSeq == null) return false;
+    return announcedPacketCount >= 0 &&
+        doneNextSeq == transferStartSeq + announcedPacketCount &&
+        receivedPacketCount == announcedPacketCount &&
+        pendingBytes == 0;
+  }
+
   /// Parse the 440-byte audio payload of a ring record into opus frames.
   /// Format: [size:1][frame:size]... with zero padding allowed at any point.
   /// A leading byte of 0 is a no-op padding marker; otherwise it is the

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -214,6 +214,22 @@ class RingProtocol {
     if (end <= start) return null;
     return (start: start, end: end);
   }
+
+  /// Sequence identity retained by both immutable ring fragments and a local
+  /// archive assembled from those fragments.
+  ///
+  /// Archives remain eligible for a later exact conversation repair when the
+  /// server completion arrives after the two-minute local close boundary.
+  static ({int start, int end})? parseRecoverySourceRange(String? sourceId) {
+    final raw = parseSourceRange(sourceId);
+    if (raw != null || sourceId == null) return raw;
+    final match = RegExp(r'^archive_ring_(\d+)_(\d+)_\d+$').firstMatch(sourceId);
+    if (match == null) return null;
+    final start = int.parse(match.group(1)!);
+    final end = int.parse(match.group(2)!);
+    if (end <= start) return null;
+    return (start: start, end: end);
+  }
 }
 
 /// In-memory index of ring ranges already durably represented on the phone.
@@ -276,6 +292,33 @@ class RingSequenceCoverage {
       if (cursor >= end) return end;
     }
     return cursor;
+  }
+
+  /// Newest uncovered range ending at or before [end], bounded to [maxCount].
+  ///
+  /// VAD makes record count an audio-duration measure rather than a wall
+  /// clock. Recent recovery therefore walks backward from the live head and
+  /// stops based on the timestamps found in the records.
+  ({int start, int end})? lastUncoveredBefore(
+    int lowerBound,
+    int end, {
+    required int maxCount,
+  }) {
+    if (maxCount <= 0 || end <= lowerBound) return null;
+    var cursor = end;
+    for (var index = _ranges.length - 1; index >= 0; index--) {
+      final range = _ranges[index];
+      if (range.start >= cursor) continue;
+      if (range.end < cursor) {
+        final gapLowerBound = lowerBound > range.end ? lowerBound : range.end;
+        final start = (cursor - maxCount).clamp(gapLowerBound, cursor);
+        return start < cursor ? (start: start, end: cursor) : null;
+      }
+      if (range.start < cursor) cursor = range.start;
+      if (cursor <= lowerBound) return null;
+    }
+    final start = (cursor - maxCount).clamp(lowerBound, cursor);
+    return start < cursor ? (start: start, end: cursor) : null;
   }
 
   bool covers(int start, int end) => end <= contiguousEndFrom(start);

--- a/app/lib/services/devices/ring_protocol.dart
+++ b/app/lib/services/devices/ring_protocol.dart
@@ -39,6 +39,17 @@ class RingProtocol {
   static const int cmdClear = 0x13;
   static const int cmdStop = 0x03;
 
+  static const int statusOk = 0;
+  static const int statusStorageNotReady = 9;
+  static const int statusSequenceOutOfRange = 10;
+  static const int statusStorageFailed = 11;
+
+  /// Parse a two-byte ACK notification. Returns null for every other frame.
+  static int? parseAckStatus(List<int> value) {
+    if (value.length < 2 || value[0] != notifyAck) return null;
+    return value[1];
+  }
+
   /// Parse the 16-byte status read into a RingStatus. Returns null if the
   /// payload is too short.
   static RingStatus? parseStatus(List<int> value) {
@@ -187,6 +198,74 @@ class RingProtocol {
       offset += size + 1;
     }
     return frames;
+  }
+}
+
+class RingStorageException implements Exception {
+  const RingStorageException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class RingCommandRejectedException extends RingStorageException {
+  const RingCommandRejectedException({required this.command, required this.status})
+      : super(status == RingProtocol.statusStorageNotReady
+            ? 'Device storage is not ready'
+            : status == RingProtocol.statusStorageFailed
+                ? 'Device storage needs attention'
+                : 'Device rejected $command (status $status)');
+
+  final String command;
+  final int status;
+
+  bool get isRetryable => status == RingProtocol.statusStorageNotReady;
+}
+
+class RingInfoUnavailableException extends RingStorageException {
+  const RingInfoUnavailableException() : super('Device storage did not provide ring information');
+}
+
+/// Bounded retry for the ring snapshot handshake.
+///
+/// Firmware waits for its SD remount before replying, but a remount can finish
+/// immediately after that deadline. Retry only the explicit retryable status
+/// (or a missing response), and always stop after [maxAttempts].
+class RingInfoRetryPolicy {
+  const RingInfoRetryPolicy({
+    this.maxAttempts = 3,
+    this.backoff = const [Duration(milliseconds: 500), Duration(seconds: 1)],
+  }) : assert(maxAttempts > 0);
+
+  final int maxAttempts;
+  final List<Duration> backoff;
+
+  Future<RingInfo> run(
+    Future<RingInfo?> Function() request, {
+    Future<void> Function(Duration delay)? wait,
+  }) async {
+    final waitFor = wait ?? Future<void>.delayed;
+    RingStorageException lastError = const RingInfoUnavailableException();
+
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        final info = await request();
+        if (info != null) return info;
+        lastError = const RingInfoUnavailableException();
+      } on RingCommandRejectedException catch (error) {
+        if (!error.isRetryable) rethrow;
+        lastError = error;
+      }
+
+      if (attempt + 1 < maxAttempts) {
+        final delay = backoff.isEmpty ? Duration.zero : backoff[attempt.clamp(0, backoff.length - 1)];
+        await waitFor(delay);
+      }
+    }
+
+    throw lastError;
   }
 }
 

--- a/app/lib/services/devices/transports/device_transport.dart
+++ b/app/lib/services/devices/transports/device_transport.dart
@@ -25,4 +25,51 @@ abstract class DeviceTransport {
   Future<void> dispose();
 }
 
+/// Optional capability for transports that own a reconnecting connection.
+///
+/// A generation is published only after the transport has installed the
+/// services for a newly ready connection. Consumers can use it to repeat
+/// per-connection setup without treating a native auto-reconnect as a new
+/// [connect] call.
+abstract interface class DeviceReadyGenerationSource {
+  int get readyGeneration;
+  Stream<int> get readyGenerationStream;
+}
+
+/// A transport whose background ownership must be released before another
+/// client, such as a DFU plugin, can exclusively manage the device.
+abstract interface class ExclusiveOperationTransport {
+  Future<void> releaseForExclusiveOperation();
+}
+
+/// Releases background ownership, then retires the Dart transport.
+///
+/// Disposal is attempted even when exclusive release fails, while the first
+/// failure remains authoritative for transactional rollback.
+Future<void> releaseTransportForExclusiveOperation(DeviceTransport transport) async {
+  Object? firstError;
+  StackTrace? firstStackTrace;
+
+  final exclusiveTransport = transport is ExclusiveOperationTransport ? transport as ExclusiveOperationTransport : null;
+  if (exclusiveTransport != null) {
+    try {
+      await exclusiveTransport.releaseForExclusiveOperation();
+    } catch (error, stackTrace) {
+      firstError = error;
+      firstStackTrace = stackTrace;
+    }
+  }
+
+  try {
+    await transport.dispose();
+  } catch (error, stackTrace) {
+    firstError ??= error;
+    firstStackTrace ??= stackTrace;
+  }
+
+  if (firstError != null) {
+    Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
+}
+
 enum DeviceTransportState { disconnected, connecting, connected, disconnecting }

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -10,12 +10,13 @@ import 'device_transport.dart';
 /// Uses the intent-based manageDevice/unmanageDevice API.
 /// Native owns the connection lifecycle (retry, reconnect, bonding).
 /// This transport is long-lived
-class NativeBleTransport extends DeviceTransport {
+class NativeBleTransport extends DeviceTransport implements DeviceReadyGenerationSource, ExclusiveOperationTransport {
   final String _peripheralUuid;
   final bool requiresBond;
-  final BleHostApi _hostApi = BleHostApi();
+  final BleHostApi _hostApi;
   final StreamController<DeviceTransportState> _connectionStateController =
       StreamController<DeviceTransportState>.broadcast();
+  final StreamController<int> _readyGenerationController = StreamController<int>.broadcast();
 
   /// Characteristic notification streams, keyed by "serviceUuid:charUuid" (lowercased).
   final Map<String, StreamController<List<int>>> _streamControllers = {};
@@ -26,8 +27,11 @@ class NativeBleTransport extends DeviceTransport {
   Completer<List<BleService>>? _deviceReadyCompleter;
 
   DeviceTransportState _state = DeviceTransportState.disconnected;
+  int _readyGeneration = 0;
+  bool _hasManageIntent = false;
 
-  NativeBleTransport(this._peripheralUuid, {this.requiresBond = false}) {
+  NativeBleTransport(this._peripheralUuid, {this.requiresBond = false, BleHostApi? hostApi})
+      : _hostApi = hostApi ?? BleHostApi() {
     BleBridge.instance.registerPeripheral(
       peripheralUuid: _peripheralUuid,
       onConnectionState: _handleConnectionState,
@@ -42,6 +46,12 @@ class NativeBleTransport extends DeviceTransport {
   @override
   Stream<DeviceTransportState> get connectionStateStream => _connectionStateController.stream;
 
+  @override
+  int get readyGeneration => _readyGeneration;
+
+  @override
+  Stream<int> get readyGenerationStream => _readyGenerationController.stream;
+
   // MARK: - Connection
 
   @override
@@ -53,7 +63,8 @@ class NativeBleTransport extends DeviceTransport {
     _deviceReadyCompleter = Completer<List<BleService>>();
 
     try {
-      _hostApi.manageDevice(_peripheralUuid, requiresBond);
+      await _hostApi.manageDevice(_peripheralUuid, requiresBond);
+      _hasManageIntent = true;
     } catch (e) {
       Logger.debug('[NativeBleTransport] manageDevice failed: $e');
       _deviceReadyCompleter = null;
@@ -68,6 +79,7 @@ class NativeBleTransport extends DeviceTransport {
       );
       _deviceReadyCompleter = null;
       _updateState(DeviceTransportState.connected);
+      _publishReadyGeneration();
     } catch (e) {
       Logger.debug('[NativeBleTransport] connect failed: $e');
       _deviceReadyCompleter = null;
@@ -77,17 +89,21 @@ class NativeBleTransport extends DeviceTransport {
   }
 
   @override
-  Future<void> disconnect() async {
-    if (_state == DeviceTransportState.disconnected) return;
+  Future<void> disconnect() => _releaseManagedConnection(propagateUnmanageFailure: false);
 
-    _updateState(DeviceTransportState.disconnecting);
+  @override
+  Future<void> releaseForExclusiveOperation() => _releaseManagedConnection(propagateUnmanageFailure: true);
 
+  Future<void> _releaseManagedConnection({required bool propagateUnmanageFailure}) async {
+    if (_state != DeviceTransportState.disconnected) {
+      _updateState(DeviceTransportState.disconnecting);
+    }
     // Unsubscribe all active streams
     for (final key in _streamControllers.keys.toList()) {
       final parts = key.split(':');
       if (parts.length == 2) {
         try {
-          _hostApi.unsubscribeCharacteristic(_peripheralUuid, parts[0], parts[1]);
+          await _hostApi.unsubscribeCharacteristic(_peripheralUuid, parts[0], parts[1]);
         } catch (_) {}
       }
     }
@@ -95,13 +111,23 @@ class NativeBleTransport extends DeviceTransport {
     _closeAllStreams();
     _services = [];
 
-    try {
-      _hostApi.unmanageDevice(_peripheralUuid);
-    } catch (e) {
-      Logger.debug('[NativeBleTransport] unmanageDevice failed: $e');
+    Object? unmanageError;
+    StackTrace? unmanageStackTrace;
+    if (_hasManageIntent) {
+      try {
+        await _hostApi.unmanageDevice(_peripheralUuid);
+        _hasManageIntent = false;
+      } catch (error, stackTrace) {
+        unmanageError = error;
+        unmanageStackTrace = stackTrace;
+        Logger.debug('[NativeBleTransport] unmanageDevice failed: $error');
+      }
     }
 
     _updateState(DeviceTransportState.disconnected);
+    if (propagateUnmanageFailure && unmanageError != null) {
+      Error.throwWithStackTrace(unmanageError, unmanageStackTrace!);
+    }
   }
 
   @override
@@ -200,6 +226,7 @@ class NativeBleTransport extends DeviceTransport {
     BleBridge.instance.unregisterPeripheral(_peripheralUuid);
     _closeAllStreams();
     await _connectionStateController.close();
+    await _readyGenerationController.close();
   }
 
   // MARK: - Private Helpers
@@ -209,6 +236,11 @@ class NativeBleTransport extends DeviceTransport {
       _state = newState;
       _connectionStateController.add(_state);
     }
+  }
+
+  void _publishReadyGeneration() {
+    _readyGeneration++;
+    _readyGenerationController.add(_readyGeneration);
   }
 
   void _closeAllStreams() {
@@ -281,6 +313,7 @@ class NativeBleTransport extends DeviceTransport {
       }
 
       _updateState(DeviceTransportState.connected);
+      _publishReadyGeneration();
     } catch (e) {
       Logger.debug('[NativeBleTransport] Failed to re-subscribe after reconnect: $e');
       _updateState(DeviceTransportState.disconnected);

--- a/app/lib/services/sockets.dart
+++ b/app/lib/services/sockets.dart
@@ -19,6 +19,7 @@ abstract class ISocketService {
     required String language,
     bool force = false,
     String? source,
+    String? clientConversationId,
     CustomSttConfig? customSttConfig,
   });
 
@@ -55,6 +56,7 @@ class SocketServicePool extends ISocketService {
     required String language,
     bool force = false,
     String? source,
+    String? clientConversationId,
     CustomSttConfig? customSttConfig,
   }) async {
     await _mutex.acquire();
@@ -66,6 +68,7 @@ class SocketServicePool extends ISocketService {
           _socket?.codec == codec &&
           _socket?.sampleRate == sampleRate &&
           _socket?.state == SocketServiceState.connected &&
+          _socket?.clientConversationId == clientConversationId &&
           _socket?.sttConfigId == sttConfigId) {
         Logger.debug("Reusing existing socket connection");
         return _socket;
@@ -85,6 +88,7 @@ class SocketServicePool extends ISocketService {
           language,
           customSttConfig,
           source: source,
+          clientConversationId: clientConversationId,
         );
       } else {
         _socket = TranscriptSocketServiceFactory.createDefault(
@@ -92,6 +96,7 @@ class SocketServicePool extends ISocketService {
           codec,
           language,
           source: source,
+          clientConversationId: clientConversationId,
           sttConfigId: sttConfigId,
         );
       }
@@ -114,6 +119,7 @@ class SocketServicePool extends ISocketService {
     required String language,
     bool force = false,
     String? source,
+    String? clientConversationId,
     CustomSttConfig? customSttConfig,
   }) async {
     Logger.debug(
@@ -125,6 +131,7 @@ class SocketServicePool extends ISocketService {
       language: language,
       force: force,
       source: source,
+      clientConversationId: clientConversationId,
       customSttConfig: customSttConfig,
     );
   }

--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -41,6 +41,16 @@ class PureSocketMessage {
 
 typedef SocketHeadersProvider = Future<Map<String, String>> Function();
 
+String redactSocketUrlForLogs(String value) {
+  final uri = Uri.tryParse(value);
+  if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+    return '<invalid-socket-url>';
+  }
+  final host = uri.host.contains(':') ? '[${uri.host}]' : uri.host;
+  final port = uri.hasPort ? ':${uri.port}' : '';
+  return '${uri.scheme}://$host$port${uri.path}';
+}
+
 class PureSocket implements IPureSocket {
   WebSocketChannel? _channel;
   WebSocketChannel get channel {
@@ -58,6 +68,7 @@ class PureSocket implements IPureSocket {
 
   String url;
   final SocketHeadersProvider _headersProvider;
+  String get _logUrl => redactSocketUrlForLogs(url);
 
   PureSocket(this.url, {SocketHeadersProvider? headersProvider})
       : _headersProvider = headersProvider ?? (() => buildHeaders(requireAuthCheck: true));
@@ -73,7 +84,7 @@ class PureSocket implements IPureSocket {
       return false;
     }
 
-    Logger.debug("request wss $url");
+    Logger.debug("request wss $_logUrl");
     final Map<String, String> headers;
     try {
       headers = await _headersProvider();
@@ -99,13 +110,13 @@ class PureSocket implements IPureSocket {
       await channel.ready;
     } on TimeoutException catch (e) {
       err = e;
-      DebugLogManager.logWarning('pure_socket_connect_timeout', {'url': url, 'error': e.toString()});
+      DebugLogManager.logWarning('pure_socket_connect_timeout', {'url': _logUrl, 'error': e.toString()});
     } on SocketException catch (e) {
       err = e;
-      DebugLogManager.logWarning('pure_socket_connect_socket_error', {'url': url, 'error': e.toString()});
+      DebugLogManager.logWarning('pure_socket_connect_socket_error', {'url': _logUrl, 'error': e.toString()});
     } on WebSocketChannelException catch (e) {
       err = e;
-      DebugLogManager.logWarning('pure_socket_connect_websocket_error', {'url': url, 'error': e.toString()});
+      DebugLogManager.logWarning('pure_socket_connect_websocket_error', {'url': _logUrl, 'error': e.toString()});
     }
     if (err != null) {
       Logger.debug("[Socket] Connect error: $err");
@@ -113,7 +124,7 @@ class PureSocket implements IPureSocket {
       return false;
     }
     _status = PureSocketStatus.connected;
-    DebugLogManager.logEvent('pure_socket_connected', {'url': url});
+    DebugLogManager.logEvent('pure_socket_connected', {'url': _logUrl});
     onConnected();
 
     final that = this;
@@ -143,7 +154,7 @@ class PureSocket implements IPureSocket {
 
   @override
   Future disconnect() async {
-    DebugLogManager.logEvent('pure_socket_disconnecting', {'url': url, 'current_status': _status.toString()});
+    DebugLogManager.logEvent('pure_socket_disconnecting', {'url': _logUrl, 'current_status': _status.toString()});
     if (_status == PureSocketStatus.connected) {
       // Warn: should not use await cause dead end by socket closed.
       _channel?.sink.close(socket_channel_status.normalClosure);
@@ -155,7 +166,7 @@ class PureSocket implements IPureSocket {
 
   @override
   Future stop() async {
-    DebugLogManager.logEvent('pure_socket_stopping', {'url': url});
+    DebugLogManager.logEvent('pure_socket_stopping', {'url': _logUrl});
     await disconnect();
   }
 
@@ -168,7 +179,7 @@ class PureSocket implements IPureSocket {
     DebugLogManager.logEvent('pure_socket_closed', {
       'close_code': closeCode ?? -1,
       'close_reason': closeReason,
-      'url': url,
+      'url': _logUrl,
     });
 
     _listener?.onClosed(closeCode);
@@ -200,7 +211,7 @@ class PureSocket implements IPureSocket {
     _status = PureSocketStatus.disconnected;
     Logger.debug("[Socket] Error: $err");
 
-    DebugLogManager.logError(err, trace, 'pure_socket_error', {'url': url});
+    DebugLogManager.logError(err, trace, 'pure_socket_error', {'url': _logUrl});
 
     _listener?.onError(err, trace);
     PlatformManager.instance.crashReporter.reportCrash(err, trace);

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -55,12 +55,18 @@ class ConversationTranscriptSegmentSocketService extends TranscriptSegmentSocket
     super.language, {
     super.source,
     super.customSttMode,
+    super.clientConversationId,
   }) : super.create(includeSpeechProfile: true);
 }
 
 class CustomSttTranscriptSegmentSocketService extends TranscriptSegmentSocketService {
-  CustomSttTranscriptSegmentSocketService.create(super.sampleRate, super.codec, super.language, {super.source})
-      : super.create(includeSpeechProfile: true, customSttMode: true);
+  CustomSttTranscriptSegmentSocketService.create(
+    super.sampleRate,
+    super.codec,
+    super.language, {
+    super.source,
+    super.clientConversationId,
+  }) : super.create(includeSpeechProfile: true, customSttMode: true);
 }
 
 enum SocketServiceState { connected, disconnected }
@@ -68,12 +74,22 @@ enum SocketServiceState { connected, disconnected }
 class TranscriptSegmentSocketService implements IPureSocketListener {
   late IPureSocket _socket;
   final Map<Object, ITransctiptSegmentSocketServiceListener> _listeners = {};
+  ConversationSessionEvent? _lastConversationSessionEvent;
+  MessageServiceStatusEvent? _lastServiceStatusEvent;
+  final Completer<bool> _serverReadyCompleter = Completer<bool>();
+  bool _serverReady = false;
 
   /// Access to the underlying socket (for composite service creation)
   IPureSocket get socket => _socket;
 
   SocketServiceState get state =>
       _socket.status == PureSocketStatus.connected ? SocketServiceState.connected : SocketServiceState.disconnected;
+
+  /// True only after the backend has accepted the session and emitted its
+  /// `service_status=ready` event. A connected WebSocket transport alone is
+  /// not sufficient: audio sent while the STT provider is still initiating
+  /// may be discarded before it reaches the live transcript.
+  bool get serverReady => state == SocketServiceState.connected && _serverReady;
 
   int sampleRate;
   BleAudioCodec codec;
@@ -82,6 +98,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
   String? source;
   bool customSttMode;
   String? sttConfigId;
+  String? clientConversationId;
 
   bool onboardingMode;
 
@@ -93,6 +110,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     this.source,
     this.customSttMode = false,
     this.sttConfigId,
+    this.clientConversationId,
     this.onboardingMode = false,
   }) {
     var params = '?language=$language&sample_rate=$sampleRate&codec=$codec&uid=${SharedPreferencesUtil().uid}'
@@ -101,6 +119,10 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
 
     if (source != null && source!.isNotEmpty) {
       params += '&source=${Uri.encodeComponent(source!)}';
+    }
+
+    if (clientConversationId != null && clientConversationId!.isNotEmpty) {
+      params += '&client_conversation_id=${Uri.encodeComponent(clientConversationId!)}';
     }
 
     if (customSttMode) {
@@ -123,8 +145,8 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
       params += '&vad_gate=enabled';
     }
 
-    String url =
-        Env.apiBaseUrl!.replaceFirst('https://', 'wss://').replaceFirst('http://', 'ws://') + 'v4/listen$params';
+    final socketBaseUrl = Env.apiBaseUrl!.replaceFirst('https://', 'wss://').replaceFirst('http://', 'ws://');
+    final url = '${socketBaseUrl}v4/listen$params';
 
     _socket = PureSocket(url);
     _socket.setListener(this);
@@ -139,6 +161,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     this.source,
     this.customSttMode = false,
     this.sttConfigId,
+    this.clientConversationId,
     this.onboardingMode = false,
   }) {
     _socket = socket;
@@ -148,6 +171,14 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
   void subscribe(Object context, ITransctiptSegmentSocketServiceListener listener) {
     _listeners.remove(context.hashCode);
     _listeners.putIfAbsent(context.hashCode, () => listener);
+    final sessionEvent = _lastConversationSessionEvent;
+    if (sessionEvent != null) {
+      listener.onMessageEventReceived(sessionEvent);
+    }
+    final serviceStatusEvent = _lastServiceStatusEvent;
+    if (serviceStatusEvent != null) {
+      listener.onMessageEventReceived(serviceStatusEvent);
+    }
   }
 
   void unsubscribe(Object context) {
@@ -167,9 +198,26 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     }
   }
 
+  Future<bool> waitUntilServerReady({
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    if (serverReady) return true;
+    if (state != SocketServiceState.connected) return false;
+    if (_serverReadyCompleter.isCompleted) return _serverReady;
+    try {
+      return await _serverReadyCompleter.future.timeout(timeout);
+    } on TimeoutException {
+      return false;
+    }
+  }
+
   Future stop({String? reason}) async {
+    _completeServerReady(false);
     await _socket.stop();
     _listeners.clear();
+    _lastConversationSessionEvent = null;
+    _lastServiceStatusEvent = null;
+    _serverReady = false;
 
     if (reason != null) {
       Logger.debug(reason);
@@ -189,6 +237,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
 
   @override
   void onClosed([int? closeCode]) {
+    _completeServerReady(false);
     _listeners.forEach((k, v) {
       v.onClosed(closeCode);
     });
@@ -197,6 +246,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
 
   @override
   void onError(Object err, StackTrace trace) {
+    _completeServerReady(false);
     _listeners.forEach((k, v) {
       v.onError(err);
     });
@@ -233,6 +283,19 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     // Message event
     if (jsonEvent.containsKey("type")) {
       var event = MessageEvent.fromJson(jsonEvent);
+      if (event is ConversationSessionEvent) {
+        _lastConversationSessionEvent = event;
+      }
+      if (event is MessageServiceStatusEvent) {
+        _lastServiceStatusEvent = event;
+        if (event.status == 'ready') {
+          _serverReady = true;
+          _completeServerReady(true);
+        } else if (event.status == 'stt_failed') {
+          _serverReady = false;
+          _completeServerReady(false);
+        }
+      }
       _listeners.forEach((k, v) {
         v.onMessageEventReceived(event);
       });
@@ -282,6 +345,13 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
       'include_speech_profile': includeSpeechProfile,
     });
   }
+
+  void _completeServerReady(bool ready) {
+    _serverReady = ready;
+    if (!_serverReadyCompleter.isCompleted) {
+      _serverReadyCompleter.complete(ready);
+    }
+  }
 }
 
 class TranscriptSocketServiceFactory {
@@ -308,6 +378,7 @@ class TranscriptSocketServiceFactory {
     bool includeSpeechProfile = true,
     String? source,
     String? sttConfigId,
+    String? clientConversationId,
   }) {
     return TranscriptSegmentSocketService.create(
       sampleRate,
@@ -315,6 +386,7 @@ class TranscriptSocketServiceFactory {
       language,
       includeSpeechProfile: includeSpeechProfile,
       source: source,
+      clientConversationId: clientConversationId,
       sttConfigId: sttConfigId ?? 'omi:default',
     );
   }
@@ -337,6 +409,7 @@ class TranscriptSocketServiceFactory {
     String language,
     CustomSttConfig config, {
     String? source,
+    String? clientConversationId,
   }) {
     if (!config.isEnabled) {
       return createDefault(sampleRate, codec, language, source: source);
@@ -361,6 +434,7 @@ class TranscriptSocketServiceFactory {
       effectiveLang,
       primarySocket: primarySocket,
       source: source,
+      clientConversationId: clientConversationId,
       sttConfigId: sttConfigId,
       sttProvider: config.provider.name,
     );
@@ -487,6 +561,7 @@ class TranscriptSocketServiceFactory {
     String language, {
     required IPureSocket primarySocket,
     String? source,
+    String? clientConversationId,
     String? sttConfigId,
     String? sttProvider,
   }) {
@@ -495,6 +570,7 @@ class TranscriptSocketServiceFactory {
       codec,
       language,
       source: source,
+      clientConversationId: clientConversationId,
     );
     final compositeSocket = CompositeTranscriptionSocket(
       primarySocket: primarySocket,
@@ -507,6 +583,7 @@ class TranscriptSocketServiceFactory {
       language,
       compositeSocket,
       source: source,
+      clientConversationId: clientConversationId,
       customSttMode: true,
       sttConfigId: sttConfigId,
     );

--- a/app/lib/services/wals.dart
+++ b/app/lib/services/wals.dart
@@ -20,6 +20,7 @@ export 'wals/wal_interfaces.dart';
 export 'wals/local_wal_sync.dart';
 export 'wals/sdcard_wal_sync.dart';
 export 'wals/flash_page_wal_sync.dart';
+export 'wals/device_storage_routing.dart';
 export 'wals/wal_syncs.dart';
 export 'wals/wal_service.dart';
 export 'wals/sync_reconciler.dart';

--- a/app/lib/services/wals/conversation_audio_assembler.dart
+++ b/app/lib/services/wals/conversation_audio_assembler.dart
@@ -22,6 +22,7 @@ class ConversationAudioAssembly {
     required this.file,
     required this.timerStart,
     required this.totalFrames,
+    required this.captureEndSeconds,
     required this.hadLiveGap,
     required this.sourceWals,
   });
@@ -29,6 +30,7 @@ class ConversationAudioAssembly {
   final File file;
   final int timerStart;
   final int totalFrames;
+  final double captureEndSeconds;
   final bool hadLiveGap;
   final List<Wal> sourceWals;
 }
@@ -51,17 +53,19 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     throw ArgumentError.value(parts, 'parts', 'must not be empty');
   }
 
-  final orderedSources = List<ConversationAudioPart>.from(parts)
-    ..sort((left, right) {
-      final leftRange = RingProtocol.parseRecoverySourceRange(left.wal.sourceId);
-      final rightRange = RingProtocol.parseRecoverySourceRange(right.wal.sourceId);
-      if (leftRange == null || rightRange == null) {
-        throw StateError('Canonical assembly requires pendant sequence identity');
-      }
-      final startCompare = leftRange.start.compareTo(rightRange.start);
-      if (startCompare != 0) return startCompare;
-      return rightRange.end.compareTo(leftRange.end);
-    });
+  final rangedSources = parts.map((part) {
+    final range = RingProtocol.parseRecoverySourceRange(part.wal.sourceId);
+    if (range == null) {
+      throw StateError('Canonical assembly requires pendant sequence identity');
+    }
+    return _RangedConversationAudioPart(
+      part: part,
+      start: range.start,
+      end: range.end,
+    );
+  }).toList()
+    ..sort(_compareRangedParts);
+  final orderedSources = rangedSources.map((source) => source.part).toList(growable: false);
 
   final formatReference = orderedSources.first.wal;
   if (!formatReference.codec.isOpusSupported()) {
@@ -72,12 +76,8 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     throw StateError('Canonical assembly requires a positive frame rate');
   }
 
-  for (final part in orderedSources) {
-    final wal = part.wal;
-    final range = RingProtocol.parseRecoverySourceRange(wal.sourceId);
-    if (range == null) {
-      throw StateError('Canonical assembly requires pendant sequence identity');
-    }
+  for (final source in rangedSources) {
+    final wal = source.part.wal;
     if (wal.device != formatReference.device ||
         wal.codec != formatReference.codec ||
         wal.sampleRate != formatReference.sampleRate ||
@@ -89,49 +89,28 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
 
   /*
    * Reconnect replay can durably rediscover a range using different timestamp
-   * chunk boundaries. For example, [10, 20) + [20, 30) may later be replayed
-   * as [10, 30). The sequence union is identical, but treating every immutable
-   * durability artifact as independent audio duplicates speech and permanently
-   * blocks canonical assembly.
+   * chunk boundaries. Select a non-overlapping path that tiles each contiguous
+   * sequence-union component exactly. Greedily removing a covered artifact is
+   * unsafe: removing [10, 20) from [10, 20), [10, 15), [15, 21), [20, 30)
+   * leaves an overlap even though [10, 20) + [20, 30) is a lossless tiling.
    *
-   * Remove a source only when the remaining sources still cover its complete
-   * sequence range. Longest-first removal resolves both containing replays and
-   * crossing replay ranges while preserving the exact union. Any irreducible
-   * partial overlap still fails closed below.
+   * Every immutable source remains in [sourceWals] for lifecycle accounting;
+   * only the exact tiling is copied into the canonical audio file. A component
+   * without an exact tiling fails closed rather than duplicating or dropping
+   * pendant sequence.
    */
-  final ordered = List<ConversationAudioPart>.from(orderedSources);
-  final removalCandidates = List<ConversationAudioPart>.from(orderedSources)
-    ..sort((left, right) {
-      final leftRange = RingProtocol.parseRecoverySourceRange(left.wal.sourceId)!;
-      final rightRange = RingProtocol.parseRecoverySourceRange(right.wal.sourceId)!;
-      return (rightRange.end - rightRange.start).compareTo(
-        leftRange.end - leftRange.start,
-      );
-    });
-  for (final candidate in removalCandidates) {
-    if (!ordered.any((part) => identical(part, candidate))) continue;
-    final candidateRange = RingProtocol.parseRecoverySourceRange(candidate.wal.sourceId)!;
-    final remainingCoverage = RingSequenceCoverage(
-      ordered
-          .where((part) => !identical(part, candidate))
-          .map((part) => RingProtocol.parseRecoverySourceRange(part.wal.sourceId)!),
-    );
-    if (remainingCoverage.covers(candidateRange.start, candidateRange.end)) {
-      ordered.removeWhere((part) => identical(part, candidate));
-    }
-  }
+  final ordered = _selectExactSequenceTiling(rangedSources);
 
-  var expectedSequence = RingProtocol.parseRecoverySourceRange(ordered.first.wal.sourceId)!.start;
+  var expectedSequence = ordered.first.start;
   var hadLiveGap = orderedSources.any((part) => part.wal.status == WalStatus.miss);
-  for (final part in ordered) {
-    final range = RingProtocol.parseRecoverySourceRange(part.wal.sourceId)!;
-    if (range.start < expectedSequence) {
+  for (final source in ordered) {
+    if (source.start < expectedSequence) {
       throw StateError('Canonical assembly found irreducible overlapping pendant sequence');
     }
-    hadLiveGap = hadLiveGap || range.start > expectedSequence;
-    expectedSequence = range.end;
+    hadLiveGap = hadLiveGap || source.start > expectedSequence;
+    expectedSequence = source.end;
   }
-  final first = ordered.first.wal;
+  final first = ordered.first.part.wal;
 
   final partial = File('${destination.path}.partial');
   if (await destination.exists()) await destination.delete();
@@ -141,15 +120,19 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
   var sinkClosed = false;
   var totalFrames = 0;
   List<int>? silenceFrame;
+  _RangedConversationAudioPart? previousSource;
 
   try {
-    for (final part in ordered) {
+    for (final source in ordered) {
+      final part = source.part;
       final wal = part.wal;
-      final expectedStart = first.timerStart + totalFrames / fps;
-      final gapSeconds = wal.timerStart - expectedStart;
-      if (gapSeconds >= conversationBoundarySeconds) {
+      final previousWal = previousSource?.part.wal;
+      final wallGapSeconds = previousWal == null ? 0 : wal.timerStart - previousWal.wallClockEndSeconds;
+      if (wallGapSeconds >= conversationBoundarySeconds) {
         throw StateError('Canonical assembly crossed a conversation boundary');
       }
+      final expectedStart = first.timerStart + totalFrames / fps;
+      final gapSeconds = wal.timerStart - expectedStart;
       final silenceFrames = gapSeconds > 0 ? (gapSeconds * fps).round() : 0;
       if (silenceFrames > 0) {
         silenceFrame ??= silenceFrameFactory(first.codec);
@@ -172,6 +155,7 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
       sink.add(bytes);
       totalFrames += framesInFile;
       hadLiveGap = hadLiveGap || wal.status == WalStatus.miss;
+      previousSource = source;
     }
 
     await sink.flush();
@@ -195,9 +179,141 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     file: destination,
     timerStart: first.timerStart,
     totalFrames: totalFrames,
+    captureEndSeconds: ordered.map((source) => source.part.wal.wallClockEndSeconds).reduce(
+          (left, right) => left > right ? left : right,
+        ),
     hadLiveGap: hadLiveGap,
     sourceWals: orderedSources.map((part) => part.wal).toList(growable: false),
   );
+}
+
+class _RangedConversationAudioPart {
+  const _RangedConversationAudioPart({
+    required this.part,
+    required this.start,
+    required this.end,
+  });
+
+  final ConversationAudioPart part;
+  final int start;
+  final int end;
+}
+
+class _TilingState {
+  const _TilingState.root()
+      : previous = null,
+        source = null,
+        partCount = 0,
+        syncedCount = 0;
+
+  _TilingState.extend(
+    _TilingState predecessor,
+    _RangedConversationAudioPart next,
+  )   : previous = predecessor,
+        source = next,
+        partCount = predecessor.partCount + 1,
+        syncedCount = predecessor.syncedCount + (next.part.wal.status == WalStatus.synced ? 1 : 0);
+
+  final _TilingState? previous;
+  final _RangedConversationAudioPart? source;
+  final int partCount;
+  final int syncedCount;
+}
+
+int _compareRangedParts(
+  _RangedConversationAudioPart left,
+  _RangedConversationAudioPart right,
+) {
+  final startCompare = left.start.compareTo(right.start);
+  if (startCompare != 0) return startCompare;
+  final endCompare = left.end.compareTo(right.end);
+  if (endCompare != 0) return endCompare;
+  final statusCompare = _statusPreference(left.part.wal.status).compareTo(
+    _statusPreference(right.part.wal.status),
+  );
+  if (statusCompare != 0) return statusCompare;
+  final sourceCompare = left.part.wal.sourceId!.compareTo(right.part.wal.sourceId!);
+  if (sourceCompare != 0) return sourceCompare;
+  return left.part.file.path.compareTo(right.part.file.path);
+}
+
+int _statusPreference(WalStatus status) {
+  if (status == WalStatus.synced) return 0;
+  return status.index + 1;
+}
+
+List<_RangedConversationAudioPart> _selectExactSequenceTiling(
+  List<_RangedConversationAudioPart> orderedSources,
+) {
+  final selected = <_RangedConversationAudioPart>[];
+  var componentStart = 0;
+  while (componentStart < orderedSources.length) {
+    var componentEnd = componentStart + 1;
+    var unionEnd = orderedSources[componentStart].end;
+    while (componentEnd < orderedSources.length && orderedSources[componentEnd].start <= unionEnd) {
+      if (orderedSources[componentEnd].end > unionEnd) {
+        unionEnd = orderedSources[componentEnd].end;
+      }
+      componentEnd++;
+    }
+
+    final component = orderedSources.sublist(componentStart, componentEnd);
+    final bestAt = <int, _TilingState>{
+      component.first.start: const _TilingState.root(),
+    };
+    for (final source in component) {
+      final prefix = bestAt[source.start];
+      if (prefix == null) continue;
+      final candidate = _TilingState.extend(prefix, source);
+      final incumbent = bestAt[source.end];
+      if (incumbent == null || _compareTilingStates(candidate, incumbent) < 0) {
+        bestAt[source.end] = candidate;
+      }
+    }
+
+    final winner = bestAt[unionEnd];
+    if (winner == null) {
+      throw StateError('Canonical assembly found irreducible overlapping pendant sequence');
+    }
+    final reversedTiling = <_RangedConversationAudioPart>[];
+    _TilingState? cursor = winner;
+    while (cursor?.source != null) {
+      reversedTiling.add(cursor!.source!);
+      cursor = cursor.previous;
+    }
+    selected.addAll(reversedTiling.reversed);
+    componentStart = componentEnd;
+  }
+  return selected;
+}
+
+int _compareTilingStates(_TilingState left, _TilingState right) {
+  final lengthCompare = left.partCount.compareTo(right.partCount);
+  if (lengthCompare != 0) return lengthCompare;
+
+  final syncedCompare = right.syncedCount.compareTo(left.syncedCount);
+  if (syncedCompare != 0) return syncedCompare;
+
+  /*
+   * Both paths have the same length. Walking from leaf to root and replacing
+   * the comparison whenever an earlier part differs produces the same result
+   * as a forward lexicographic comparison without allocating either prefix.
+   */
+  var lexicographicCompare = 0;
+  _TilingState? leftCursor = left;
+  _TilingState? rightCursor = right;
+  while (leftCursor?.source != null && rightCursor?.source != null) {
+    final sourceCompare = _compareRangedParts(
+      leftCursor!.source!,
+      rightCursor!.source!,
+    );
+    if (sourceCompare != 0) {
+      lexicographicCompare = sourceCompare;
+    }
+    leftCursor = leftCursor.previous;
+    rightCursor = rightCursor.previous;
+  }
+  return lexicographicCompare;
 }
 
 Uint8List _lengthPrefix(int length) {

--- a/app/lib/services/wals/conversation_audio_assembler.dart
+++ b/app/lib/services/wals/conversation_audio_assembler.dart
@@ -53,8 +53,8 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
 
   final ordered = List<ConversationAudioPart>.from(parts)
     ..sort((left, right) {
-      final leftRange = RingProtocol.parseSourceRange(left.wal.sourceId);
-      final rightRange = RingProtocol.parseSourceRange(right.wal.sourceId);
+      final leftRange = RingProtocol.parseRecoverySourceRange(left.wal.sourceId);
+      final rightRange = RingProtocol.parseRecoverySourceRange(right.wal.sourceId);
       if (leftRange == null || rightRange == null) {
         throw StateError('Canonical assembly requires pendant sequence identity');
       }
@@ -70,13 +70,15 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     throw StateError('Canonical assembly requires a positive frame rate');
   }
 
-  var expectedSequence = RingProtocol.parseSourceRange(first.sourceId)!.start;
+  var expectedSequence = RingProtocol.parseRecoverySourceRange(first.sourceId)!.start;
+  var hadLiveGap = false;
   for (final part in ordered) {
     final wal = part.wal;
-    final range = RingProtocol.parseSourceRange(wal.sourceId);
-    if (range == null || range.start != expectedSequence) {
-      throw StateError('Canonical assembly found a missing pendant sequence');
+    final range = RingProtocol.parseRecoverySourceRange(wal.sourceId);
+    if (range == null || range.start < expectedSequence) {
+      throw StateError('Canonical assembly found overlapping pendant sequence');
     }
+    hadLiveGap = hadLiveGap || range.start > expectedSequence;
     if (wal.device != first.device ||
         wal.codec != first.codec ||
         wal.sampleRate != first.sampleRate ||
@@ -94,7 +96,6 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
   final sink = partial.openWrite();
   var sinkClosed = false;
   var totalFrames = 0;
-  var hadLiveGap = false;
   List<int>? silenceFrame;
 
   try {

--- a/app/lib/services/wals/conversation_audio_assembler.dart
+++ b/app/lib/services/wals/conversation_audio_assembler.dart
@@ -197,13 +197,15 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     rethrow;
   }
 
+  final latestSourceEnd = ordered.map((source) => source.part.wal.wallClockEndSeconds).reduce(
+        (left, right) => left > right ? left : right,
+      );
+  final playableEnd = first.timerStart + totalFrames / fps;
   return ConversationAudioAssembly(
     file: destination,
     timerStart: first.timerStart,
     totalFrames: totalFrames,
-    captureEndSeconds: ordered.map((source) => source.part.wal.wallClockEndSeconds).reduce(
-          (left, right) => left > right ? left : right,
-        ),
+    captureEndSeconds: latestSourceEnd > playableEnd ? latestSourceEnd : playableEnd,
     hadLiveGap: hadLiveGap,
     sourceWals: orderedSources.map((part) => part.wal).toList(growable: false),
   );

--- a/app/lib/services/wals/conversation_audio_assembler.dart
+++ b/app/lib/services/wals/conversation_audio_assembler.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
+import 'package:omi/services/wals/wal.dart';
+
+typedef OpusSilenceFrameFactory = List<int> Function(BleAudioCodec codec);
+
+class ConversationAudioPart {
+  const ConversationAudioPart({
+    required this.wal,
+    required this.file,
+  });
+
+  final Wal wal;
+  final File file;
+}
+
+class ConversationAudioAssembly {
+  const ConversationAudioAssembly({
+    required this.file,
+    required this.timerStart,
+    required this.totalFrames,
+    required this.hadLiveGap,
+    required this.sourceWals,
+  });
+
+  final File file;
+  final int timerStart;
+  final int totalFrames;
+  final bool hadLiveGap;
+  final List<Wal> sourceWals;
+}
+
+/// Builds the one canonical phone-side recording for a completed pendant
+/// conversation.
+///
+/// Source WALs are immutable durability records. They are ordered by the
+/// pendant's sequence, validated as length-prefixed Opus, and copied into one
+/// file. Timestamp discontinuities shorter than the conversation boundary are
+/// represented by encoded silence so a recovered gap keeps its wall-clock
+/// position instead of compressing the transcript timeline.
+Future<ConversationAudioAssembly> assembleConversationAudio({
+  required List<ConversationAudioPart> parts,
+  required File destination,
+  required OpusSilenceFrameFactory silenceFrameFactory,
+  int conversationBoundarySeconds = 120,
+}) async {
+  if (parts.isEmpty) {
+    throw ArgumentError.value(parts, 'parts', 'must not be empty');
+  }
+
+  final ordered = List<ConversationAudioPart>.from(parts)
+    ..sort((left, right) {
+      final leftRange = RingProtocol.parseSourceRange(left.wal.sourceId);
+      final rightRange = RingProtocol.parseSourceRange(right.wal.sourceId);
+      if (leftRange == null || rightRange == null) {
+        throw StateError('Canonical assembly requires pendant sequence identity');
+      }
+      return leftRange.start.compareTo(rightRange.start);
+    });
+
+  final first = ordered.first.wal;
+  if (!first.codec.isOpusSupported()) {
+    throw StateError('Canonical assembly supports Opus pendant audio only');
+  }
+  final fps = first.codec.getFramesPerSecond();
+  if (fps <= 0) {
+    throw StateError('Canonical assembly requires a positive frame rate');
+  }
+
+  var expectedSequence = RingProtocol.parseSourceRange(first.sourceId)!.start;
+  for (final part in ordered) {
+    final wal = part.wal;
+    final range = RingProtocol.parseSourceRange(wal.sourceId);
+    if (range == null || range.start != expectedSequence) {
+      throw StateError('Canonical assembly found a missing pendant sequence');
+    }
+    if (wal.device != first.device ||
+        wal.codec != first.codec ||
+        wal.sampleRate != first.sampleRate ||
+        wal.channel != first.channel ||
+        wal.frameSize != first.frameSize) {
+      throw StateError('Canonical assembly found incompatible audio formats');
+    }
+    expectedSequence = range.end;
+  }
+
+  final partial = File('${destination.path}.partial');
+  if (await destination.exists()) await destination.delete();
+  if (await partial.exists()) await partial.delete();
+
+  final sink = partial.openWrite();
+  var sinkClosed = false;
+  var totalFrames = 0;
+  var hadLiveGap = false;
+  List<int>? silenceFrame;
+
+  try {
+    for (final part in ordered) {
+      final wal = part.wal;
+      final expectedStart = first.timerStart + totalFrames / fps;
+      final gapSeconds = wal.timerStart - expectedStart;
+      if (gapSeconds >= conversationBoundarySeconds) {
+        throw StateError('Canonical assembly crossed a conversation boundary');
+      }
+      final silenceFrames = gapSeconds > 0 ? (gapSeconds * fps).round() : 0;
+      if (silenceFrames > 0) {
+        silenceFrame ??= silenceFrameFactory(first.codec);
+        if (silenceFrame.isEmpty) {
+          throw StateError('Canonical assembly could not encode silence');
+        }
+        final prefix = _lengthPrefix(silenceFrame.length);
+        for (var index = 0; index < silenceFrames; index++) {
+          sink.add(prefix);
+          sink.add(silenceFrame);
+        }
+        totalFrames += silenceFrames;
+      }
+
+      final bytes = await part.file.readAsBytes();
+      final framesInFile = _validateLengthPrefixedOpus(bytes);
+      if (wal.totalFrames > 0 && framesInFile != wal.totalFrames) {
+        throw StateError('Canonical assembly frame count does not match its WAL');
+      }
+      sink.add(bytes);
+      totalFrames += framesInFile;
+      hadLiveGap = hadLiveGap || wal.status == WalStatus.miss;
+    }
+
+    await sink.flush();
+    await sink.close();
+    sinkClosed = true;
+    await partial.rename(destination.path);
+  } catch (_) {
+    if (!sinkClosed) {
+      try {
+        await sink.close();
+      } catch (_) {
+        // Preserve the assembly failure; cleanup is best-effort.
+      }
+    }
+    if (await partial.exists()) await partial.delete();
+    if (await destination.exists()) await destination.delete();
+    rethrow;
+  }
+
+  return ConversationAudioAssembly(
+    file: destination,
+    timerStart: first.timerStart,
+    totalFrames: totalFrames,
+    hadLiveGap: hadLiveGap,
+    sourceWals: ordered.map((part) => part.wal).toList(growable: false),
+  );
+}
+
+Uint8List _lengthPrefix(int length) {
+  final prefix = ByteData(4)..setUint32(0, length, Endian.little);
+  return prefix.buffer.asUint8List();
+}
+
+int _validateLengthPrefixedOpus(Uint8List bytes) {
+  var offset = 0;
+  var frames = 0;
+  while (offset < bytes.length) {
+    if (bytes.length - offset < 4) {
+      throw StateError('Canonical assembly found a truncated frame prefix');
+    }
+    final length = ByteData.sublistView(bytes, offset, offset + 4).getUint32(0, Endian.little);
+    offset += 4;
+    if (length <= 0 || length > 65536 || offset + length > bytes.length) {
+      throw StateError('Canonical assembly found an invalid Opus frame');
+    }
+    offset += length;
+    frames++;
+  }
+  if (frames == 0) {
+    throw StateError('Canonical assembly found no Opus frames');
+  }
+  return frames;
+}

--- a/app/lib/services/wals/conversation_audio_assembler.dart
+++ b/app/lib/services/wals/conversation_audio_assembler.dart
@@ -51,43 +51,87 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     throw ArgumentError.value(parts, 'parts', 'must not be empty');
   }
 
-  final ordered = List<ConversationAudioPart>.from(parts)
+  final orderedSources = List<ConversationAudioPart>.from(parts)
     ..sort((left, right) {
       final leftRange = RingProtocol.parseRecoverySourceRange(left.wal.sourceId);
       final rightRange = RingProtocol.parseRecoverySourceRange(right.wal.sourceId);
       if (leftRange == null || rightRange == null) {
         throw StateError('Canonical assembly requires pendant sequence identity');
       }
-      return leftRange.start.compareTo(rightRange.start);
+      final startCompare = leftRange.start.compareTo(rightRange.start);
+      if (startCompare != 0) return startCompare;
+      return rightRange.end.compareTo(leftRange.end);
     });
 
-  final first = ordered.first.wal;
-  if (!first.codec.isOpusSupported()) {
+  final formatReference = orderedSources.first.wal;
+  if (!formatReference.codec.isOpusSupported()) {
     throw StateError('Canonical assembly supports Opus pendant audio only');
   }
-  final fps = first.codec.getFramesPerSecond();
+  final fps = formatReference.codec.getFramesPerSecond();
   if (fps <= 0) {
     throw StateError('Canonical assembly requires a positive frame rate');
   }
 
-  var expectedSequence = RingProtocol.parseRecoverySourceRange(first.sourceId)!.start;
-  var hadLiveGap = false;
-  for (final part in ordered) {
+  for (final part in orderedSources) {
     final wal = part.wal;
     final range = RingProtocol.parseRecoverySourceRange(wal.sourceId);
-    if (range == null || range.start < expectedSequence) {
-      throw StateError('Canonical assembly found overlapping pendant sequence');
+    if (range == null) {
+      throw StateError('Canonical assembly requires pendant sequence identity');
     }
-    hadLiveGap = hadLiveGap || range.start > expectedSequence;
-    if (wal.device != first.device ||
-        wal.codec != first.codec ||
-        wal.sampleRate != first.sampleRate ||
-        wal.channel != first.channel ||
-        wal.frameSize != first.frameSize) {
+    if (wal.device != formatReference.device ||
+        wal.codec != formatReference.codec ||
+        wal.sampleRate != formatReference.sampleRate ||
+        wal.channel != formatReference.channel ||
+        wal.frameSize != formatReference.frameSize) {
       throw StateError('Canonical assembly found incompatible audio formats');
     }
+  }
+
+  /*
+   * Reconnect replay can durably rediscover a range using different timestamp
+   * chunk boundaries. For example, [10, 20) + [20, 30) may later be replayed
+   * as [10, 30). The sequence union is identical, but treating every immutable
+   * durability artifact as independent audio duplicates speech and permanently
+   * blocks canonical assembly.
+   *
+   * Remove a source only when the remaining sources still cover its complete
+   * sequence range. Longest-first removal resolves both containing replays and
+   * crossing replay ranges while preserving the exact union. Any irreducible
+   * partial overlap still fails closed below.
+   */
+  final ordered = List<ConversationAudioPart>.from(orderedSources);
+  final removalCandidates = List<ConversationAudioPart>.from(orderedSources)
+    ..sort((left, right) {
+      final leftRange = RingProtocol.parseRecoverySourceRange(left.wal.sourceId)!;
+      final rightRange = RingProtocol.parseRecoverySourceRange(right.wal.sourceId)!;
+      return (rightRange.end - rightRange.start).compareTo(
+        leftRange.end - leftRange.start,
+      );
+    });
+  for (final candidate in removalCandidates) {
+    if (!ordered.any((part) => identical(part, candidate))) continue;
+    final candidateRange = RingProtocol.parseRecoverySourceRange(candidate.wal.sourceId)!;
+    final remainingCoverage = RingSequenceCoverage(
+      ordered
+          .where((part) => !identical(part, candidate))
+          .map((part) => RingProtocol.parseRecoverySourceRange(part.wal.sourceId)!),
+    );
+    if (remainingCoverage.covers(candidateRange.start, candidateRange.end)) {
+      ordered.removeWhere((part) => identical(part, candidate));
+    }
+  }
+
+  var expectedSequence = RingProtocol.parseRecoverySourceRange(ordered.first.wal.sourceId)!.start;
+  var hadLiveGap = orderedSources.any((part) => part.wal.status == WalStatus.miss);
+  for (final part in ordered) {
+    final range = RingProtocol.parseRecoverySourceRange(part.wal.sourceId)!;
+    if (range.start < expectedSequence) {
+      throw StateError('Canonical assembly found irreducible overlapping pendant sequence');
+    }
+    hadLiveGap = hadLiveGap || range.start > expectedSequence;
     expectedSequence = range.end;
   }
+  final first = ordered.first.wal;
 
   final partial = File('${destination.path}.partial');
   if (await destination.exists()) await destination.delete();
@@ -152,7 +196,7 @@ Future<ConversationAudioAssembly> assembleConversationAudio({
     timerStart: first.timerStart,
     totalFrames: totalFrames,
     hadLiveGap: hadLiveGap,
-    sourceWals: ordered.map((part) => part.wal).toList(growable: false),
+    sourceWals: orderedSources.map((part) => part.wal).toList(growable: false),
   );
 }
 

--- a/app/lib/services/wals/conversation_audio_assembler.dart
+++ b/app/lib/services/wals/conversation_audio_assembler.dart
@@ -1,11 +1,33 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:opus_dart/opus_dart.dart';
+
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/wals/wal.dart';
 
 typedef OpusSilenceFrameFactory = List<int> Function(BleAudioCodec codec);
+
+/// Encodes one silent Opus frame in the same format used by CV1 capture.
+///
+/// Conversation assembly and user-visible playback must share this encoder so
+/// an on-demand preview cannot compress wall-clock gaps differently from the
+/// canonical upload artifact.
+List<int> encodeOpusSilenceFrame(BleAudioCodec codec) {
+  final encoder = SimpleOpusEncoder(
+    sampleRate: 16000,
+    channels: 1,
+    application: Application.voip,
+  );
+  try {
+    return encoder.encode(
+      input: Int16List(codec.getFrameSize()),
+    );
+  } finally {
+    encoder.destroy();
+  }
+}
 
 class ConversationAudioPart {
   const ConversationAudioPart({

--- a/app/lib/services/wals/device_storage_routing.dart
+++ b/app/lib/services/wals/device_storage_routing.dart
@@ -5,7 +5,13 @@ import 'package:omi/backend/schema/bt_device/bt_device.dart';
 /// Firmware generations reuse the same BLE characteristics with incompatible
 /// payloads, so probing more than one implementation is unsafe: a ring ACK can
 /// otherwise be mistaken for a legacy SD packet.
-enum DeviceStorageProtocol { none, legacySdCard, multiFile, ringBuffer, limitlessFlash }
+enum DeviceStorageProtocol {
+  none,
+  legacySdCard,
+  multiFile,
+  ringBuffer,
+  limitlessFlash,
+}
 
 class DeviceStorageProtocolPolicy {
   static String? resolveFirmware(String? enriched, String? raw) {
@@ -14,12 +20,17 @@ class DeviceStorageProtocolPolicy {
     return null;
   }
 
-  static DeviceStorageProtocol classify(BtDevice? device, {String? firmwareVersion}) {
+  static DeviceStorageProtocol classify(
+    BtDevice? device, {
+    String? firmwareVersion,
+  }) {
     if (device == null) return DeviceStorageProtocol.none;
     if (device.type == DeviceType.limitless) return DeviceStorageProtocol.limitlessFlash;
     if (device.type != DeviceType.omi) return DeviceStorageProtocol.none;
 
-    final version = _parseVersion(resolveFirmware(firmwareVersion, device.firmwareRevision));
+    final version = _parseVersion(
+      resolveFirmware(firmwareVersion, device.firmwareRevision),
+    );
     if (version == null) return DeviceStorageProtocol.none;
     if (_atLeast(version, const (3, 0, 20))) return DeviceStorageProtocol.ringBuffer;
     if (_atLeast(version, const (3, 0, 17))) return DeviceStorageProtocol.multiFile;
@@ -29,6 +40,15 @@ class DeviceStorageProtocolPolicy {
   static bool isRingBufferFirmware(String? version) {
     final parsed = _parseVersion(version);
     return parsed != null && _atLeast(parsed, const (3, 0, 20));
+  }
+
+  /// Firmware 3.0.29 is the storage-authoritative CV1 test line: audio is read
+  /// from the sequenced SD ring even while connected. Keep this exact until the
+  /// protocol exposes a capability bit; treating every later version as this
+  /// mode would silently disable the legacy live characteristic if a release
+  /// changes direction.
+  static bool usesStorageAuthoritativeAudio(String? version) {
+    return _parseVersion(version) == const (3, 0, 29);
   }
 
   static bool supportsModernStorage(String? version) {
@@ -80,11 +100,20 @@ class DeviceStorageRouter {
   DeviceStorageProtocol protocol = DeviceStorageProtocol.none;
 
   void bind(BtDevice? device, {String? firmwareVersion}) {
-    protocol = DeviceStorageProtocolPolicy.classify(device, firmwareVersion: firmwareVersion);
+    protocol = DeviceStorageProtocolPolicy.classify(
+      device,
+      firmwareVersion: firmwareVersion,
+    );
 
-    _bindLegacySdCard(protocol == DeviceStorageProtocol.legacySdCard ? device : null);
+    _bindLegacySdCard(
+      protocol == DeviceStorageProtocol.legacySdCard ? device : null,
+    );
     _bindMultiFile(protocol == DeviceStorageProtocol.multiFile ? device : null);
-    _bindRingBuffer(protocol == DeviceStorageProtocol.ringBuffer ? device : null);
-    _bindLimitlessFlash(protocol == DeviceStorageProtocol.limitlessFlash ? device : null);
+    _bindRingBuffer(
+      protocol == DeviceStorageProtocol.ringBuffer ? device : null,
+    );
+    _bindLimitlessFlash(
+      protocol == DeviceStorageProtocol.limitlessFlash ? device : null,
+    );
   }
 }

--- a/app/lib/services/wals/device_storage_routing.dart
+++ b/app/lib/services/wals/device_storage_routing.dart
@@ -1,5 +1,7 @@
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 
+const bool _blackboxHarnessEnabled = bool.fromEnvironment('OMI_BLACKBOX_HARNESS');
+
 /// The one offline-storage protocol allowed to own a connected device.
 ///
 /// Firmware generations reuse the same BLE characteristics with incompatible
@@ -47,8 +49,12 @@ class DeviceStorageProtocolPolicy {
   /// protocol exposes a capability bit; treating every later version as this
   /// mode would silently disable the legacy live characteristic if a release
   /// changes direction.
-  static bool usesStorageAuthoritativeAudio(String? version) {
-    return _parseVersion(version) == const (3, 0, 29);
+  static bool usesStorageAuthoritativeAudio(
+    String? version, {
+    bool allowBlackboxDiagnosticsFirmware = _blackboxHarnessEnabled,
+  }) {
+    final parsed = _parseVersion(version);
+    return parsed == const (3, 0, 29) || (allowBlackboxDiagnosticsFirmware && parsed == const (3, 0, 30));
   }
 
   static bool supportsModernStorage(String? version) {

--- a/app/lib/services/wals/device_storage_routing.dart
+++ b/app/lib/services/wals/device_storage_routing.dart
@@ -1,0 +1,90 @@
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+
+/// The one offline-storage protocol allowed to own a connected device.
+///
+/// Firmware generations reuse the same BLE characteristics with incompatible
+/// payloads, so probing more than one implementation is unsafe: a ring ACK can
+/// otherwise be mistaken for a legacy SD packet.
+enum DeviceStorageProtocol { none, legacySdCard, multiFile, ringBuffer, limitlessFlash }
+
+class DeviceStorageProtocolPolicy {
+  static String? resolveFirmware(String? enriched, String? raw) {
+    if (enriched != null && enriched.isNotEmpty && enriched != 'Unknown') return enriched;
+    if (raw != null && raw.isNotEmpty && raw != 'Unknown') return raw;
+    return null;
+  }
+
+  static DeviceStorageProtocol classify(BtDevice? device, {String? firmwareVersion}) {
+    if (device == null) return DeviceStorageProtocol.none;
+    if (device.type == DeviceType.limitless) return DeviceStorageProtocol.limitlessFlash;
+    if (device.type != DeviceType.omi) return DeviceStorageProtocol.none;
+
+    final version = _parseVersion(resolveFirmware(firmwareVersion, device.firmwareRevision));
+    if (version == null) return DeviceStorageProtocol.none;
+    if (_atLeast(version, const (3, 0, 20))) return DeviceStorageProtocol.ringBuffer;
+    if (_atLeast(version, const (3, 0, 17))) return DeviceStorageProtocol.multiFile;
+    return DeviceStorageProtocol.legacySdCard;
+  }
+
+  static bool isRingBufferFirmware(String? version) {
+    final parsed = _parseVersion(version);
+    return parsed != null && _atLeast(parsed, const (3, 0, 20));
+  }
+
+  static bool supportsModernStorage(String? version) {
+    final parsed = _parseVersion(version);
+    return parsed != null && _atLeast(parsed, const (3, 0, 17));
+  }
+
+  static (int, int, int)? _parseVersion(String? version) {
+    if (version == null) return null;
+    final match = RegExp(r'^(\d+)\.(\d+)\.(\d+)').firstMatch(version.trim());
+    if (match == null) return null;
+    return (
+      int.parse(match.group(1)!),
+      int.parse(match.group(2)!),
+      int.parse(match.group(3)!),
+    );
+  }
+
+  static bool _atLeast((int, int, int) value, (int, int, int) minimum) {
+    if (value.$1 != minimum.$1) return value.$1 > minimum.$1;
+    if (value.$2 != minimum.$2) return value.$2 > minimum.$2;
+    return value.$3 >= minimum.$3;
+  }
+}
+
+typedef DeviceStorageBinder = void Function(BtDevice? device);
+
+/// Compiler-visible ownership boundary for mutually incompatible device stores.
+///
+/// Every transition explicitly disconnects all inactive implementations before
+/// binding the selected one. Callers receive no child binders, so they cannot
+/// accidentally initialize both legacy and ring parsing for one connection.
+class DeviceStorageRouter {
+  DeviceStorageRouter({
+    required DeviceStorageBinder bindLegacySdCard,
+    required DeviceStorageBinder bindMultiFile,
+    required DeviceStorageBinder bindRingBuffer,
+    required DeviceStorageBinder bindLimitlessFlash,
+  })  : _bindLegacySdCard = bindLegacySdCard,
+        _bindMultiFile = bindMultiFile,
+        _bindRingBuffer = bindRingBuffer,
+        _bindLimitlessFlash = bindLimitlessFlash;
+
+  final DeviceStorageBinder _bindLegacySdCard;
+  final DeviceStorageBinder _bindMultiFile;
+  final DeviceStorageBinder _bindRingBuffer;
+  final DeviceStorageBinder _bindLimitlessFlash;
+
+  DeviceStorageProtocol protocol = DeviceStorageProtocol.none;
+
+  void bind(BtDevice? device, {String? firmwareVersion}) {
+    protocol = DeviceStorageProtocolPolicy.classify(device, firmwareVersion: firmwareVersion);
+
+    _bindLegacySdCard(protocol == DeviceStorageProtocol.legacySdCard ? device : null);
+    _bindMultiFile(protocol == DeviceStorageProtocol.multiFile ? device : null);
+    _bindRingBuffer(protocol == DeviceStorageProtocol.ringBuffer ? device : null);
+    _bindLimitlessFlash(protocol == DeviceStorageProtocol.limitlessFlash ? device : null);
+  }
+}

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -106,6 +106,22 @@ SyncUploadLane _syncLaneForWal(Wal wal, int nowSeconds) => syncUploadLaneForTime
       hasServerCaptureProof: wal.conversationId != null || wal.uploadIntent == WalUploadIntent.liveContinuity,
     );
 
+bool isLiveCaptureWal(Wal wal, int nowSeconds) =>
+    wal.conversationId != null &&
+    _syncLaneForWal(wal, nowSeconds) == SyncUploadLane.fresh &&
+    nowSeconds - wal.timerStart <= _freshSyncCutoffSeconds;
+
+/// The server capture manifest is immutable for one conversation. Claim it
+/// only when this upload owns every currently pending WAL for that owner;
+/// claiming a partial batch would permanently strand the siblings.
+@visibleForTesting
+bool canClaimLiveCapture(
+  List<Wal> batch,
+  List<Wal> pendingForConversation,
+  int nowSeconds,
+) =>
+    batch.isNotEmpty && isLiveCaptureWal(batch.first, nowSeconds) && pendingForConversation.length <= batch.length;
+
 bool _isUnboundStorageContinuity(Wal wal) =>
     wal.uploadIntent == WalUploadIntent.liveContinuity &&
     wal.originalStorage == WalStorage.sdcard &&
@@ -158,12 +174,12 @@ List<List<Wal>> _continuousRingRecoveryGroups(
   final groups = <List<Wal>>[];
   for (final bucket in buckets.values) {
     bucket.sort((left, right) {
-      final timeCompare = left.timerStart.compareTo(right.timerStart);
-      if (timeCompare != 0) return timeCompare;
       final leftRange = RingProtocol.parseRecoverySourceRange(left.sourceId);
       final rightRange = RingProtocol.parseRecoverySourceRange(right.sourceId);
       final sequenceCompare = (leftRange?.start ?? 0).compareTo(rightRange?.start ?? 0);
       if (sequenceCompare != 0) return sequenceCompare;
+      final timeCompare = left.timerStart.compareTo(right.timerStart);
+      if (timeCompare != 0) return timeCompare;
       return left.id.compareTo(right.id);
     });
 
@@ -844,9 +860,16 @@ class LocalWalSyncImpl implements LocalWalSync {
         .map((candidate) => candidate.wal.conversationId!)
         .toSet();
     if (nearestOwners.length != 1) {
-      throw StateError(
-        'Recovered ring range ${recovered.id} has ambiguous canonical conversation ownership',
+      DebugLogManager.logWarning(
+        'LocalWalSync: recovered ring range has ambiguous canonical ownership; preserving it unowned',
+        {
+          'walId': recovered.id,
+          'sourceId': recovered.sourceId,
+          'candidateOwnerCount': nearestOwners.length,
+          'nearestGapSeconds': nearestGap,
+        },
       );
+      return;
     }
     recovered.conversationId = nearestOwners.single;
   }
@@ -2547,6 +2570,7 @@ class LocalWalSyncImpl implements LocalWalSync {
     final attemptedWalIds = <String>{};
     final blockedLanes = <SyncUploadLane>{};
     final forcedBackfillConversationIds = <String>{};
+    final unclaimableConversationIds = <String>{};
     final trackedManualConversationId = trackedManualWal?.conversationId;
     if (trackedManualConversationId != null) {
       final pendingConversationCount = _wals
@@ -2606,6 +2630,17 @@ class LocalWalSyncImpl implements LocalWalSync {
           batch.first.conversationId != null && forcedBackfillConversationIds.contains(batch.first.conversationId)
               ? SyncUploadLane.backfill
               : _syncLaneForWal(batch.first, batchNowSeconds);
+      final batchConversationId = batch.first.conversationId;
+      final claimLiveCapture = batchLane == SyncUploadLane.fresh &&
+          !unclaimableConversationIds.contains(batchConversationId) &&
+          canClaimLiveCapture(
+            batch,
+            candidates.where((wal) => wal.conversationId == batchConversationId).toList(),
+            batchNowSeconds,
+          );
+      if (!claimLiveCapture && batchConversationId != null) {
+        unclaimableConversationIds.add(batchConversationId);
+      }
       if (_isCancelled) {
         Logger.debug("LocalWalSync: Upload cancelled");
         DebugLogManager.logWarning('Local upload cancelled', {
@@ -2720,6 +2755,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           preparedUpload.files,
           lane: batchLane,
           conversationId: batchWals.first.conversationId,
+          claimLiveCapture: claimLiveCapture,
           replaceTranscript: batchWals.first.canonicalReplacement,
         );
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -28,7 +28,7 @@ import 'package:omi/utils/wal_file_manager.dart';
 /// below ('failed' with totalSegments==0) as the durable signal.
 const _kBackendBusyErrorHint = 'background worker likely died';
 const _freshSyncCutoffSeconds = 6 * 60 * 60;
-const _conversationBoundarySeconds = 2 * 60;
+const _defaultConversationBoundarySeconds = 2 * 60;
 const _captureUploadWalLimit = 2000;
 
 /// Legacy/historical files per upload batch. A conversation-bound capture uses
@@ -39,6 +39,33 @@ const _syncUploadBatchLimit = 20;
 typedef WalPersister = Future<bool> Function(List<Wal> wals);
 typedef WalPathResolver = Future<String?> Function(String? pathOrName);
 typedef SyncJobStatusFetcher = Future<SyncJobFetch> Function(String jobId);
+typedef ConversationBoundarySecondsProvider = int Function();
+
+class AuthorizedRecoverySyncResult {
+  const AuthorizedRecoverySyncResult({
+    required this.response,
+    required this.hasDeferredRecovery,
+  });
+
+  final SyncLocalFilesResponse? response;
+
+  /// Retryable raw/archive work inside the receipt still exists locally.
+  ///
+  /// A recent range remains deferred until the configured conversation close;
+  /// a failed upload remains deferred until a later retry. Newer and unrelated
+  /// backfill is deliberately outside this result.
+  final bool hasDeferredRecovery;
+}
+
+class _AuthorizedRecoveryScope {
+  const _AuthorizedRecoveryScope({
+    required this.deviceId,
+    required this.targetWriteSeq,
+  });
+
+  final String deviceId;
+  final int targetWriteSeq;
+}
 
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 
@@ -85,18 +112,321 @@ bool _isUnboundStorageContinuity(Wal wal) =>
     wal.originalStorage == WalStorage.sdcard &&
     wal.conversationId == null;
 
-double _walEndSeconds(Wal wal) {
-  final fps = wal.codec.getFramesPerSecond();
-  final preciseDuration = fps > 0 && wal.totalFrames > 0 ? wal.totalFrames / fps : wal.seconds.toDouble();
-  return wal.timerStart + preciseDuration;
-}
+double _walEndSeconds(Wal wal) => wal.wallClockEndSeconds;
 
 bool _isRawRingFragment(Wal wal) => wal.originalStorage == WalStorage.sdcard && _ringSourceRange(wal) != null;
 
 bool _isRingRecoveryArtifact(Wal wal) =>
     wal.originalStorage == WalStorage.sdcard && RingProtocol.parseRecoverySourceRange(wal.sourceId) != null;
 
+bool _isDurableRingCoverageArtifact(Wal wal) =>
+    wal.originalStorage == WalStorage.sdcard && RingProtocol.parseDurableCoverageSourceRange(wal.sourceId) != null;
+
+bool _isLegacyRingArchive(Wal wal) =>
+    _isRingRecoveryArtifact(wal) &&
+    !_isDurableRingCoverageArtifact(wal) &&
+    wal.sourceId?.startsWith('archive_ring_') == true;
+
 bool _isUnassembledConversationRepair(Wal wal) => wal.conversationId != null && _isRingRecoveryArtifact(wal);
+
+bool _sameRingEncoding(Wal left, Wal right) =>
+    left.device == right.device &&
+    left.codec == right.codec &&
+    left.sampleRate == right.sampleRate &&
+    left.channel == right.channel &&
+    left.frameSize == right.frameSize;
+
+String _ringEncodingBucket(Wal wal) => [
+      wal.device,
+      wal.codec.name,
+      wal.sampleRate,
+      wal.channel,
+      wal.frameSize,
+    ].join('|');
+
+List<List<Wal>> _continuousRingRecoveryGroups(
+  Iterable<Wal> wals, {
+  required int conversationBoundarySeconds,
+  int? maxWallSeconds,
+  bool requireContiguousSequence = false,
+  int? sequenceBoundary,
+}) {
+  final buckets = <String, List<Wal>>{};
+  for (final wal in wals) {
+    buckets.putIfAbsent(_ringEncodingBucket(wal), () => []).add(wal);
+  }
+
+  final groups = <List<Wal>>[];
+  for (final bucket in buckets.values) {
+    bucket.sort((left, right) {
+      final timeCompare = left.timerStart.compareTo(right.timerStart);
+      if (timeCompare != 0) return timeCompare;
+      final leftRange = RingProtocol.parseRecoverySourceRange(left.sourceId);
+      final rightRange = RingProtocol.parseRecoverySourceRange(right.sourceId);
+      final sequenceCompare = (leftRange?.start ?? 0).compareTo(rightRange?.start ?? 0);
+      if (sequenceCompare != 0) return sequenceCompare;
+      return left.id.compareTo(right.id);
+    });
+
+    for (final wal in bucket) {
+      if (groups.isEmpty || !_sameRingEncoding(groups.last.last, wal)) {
+        groups.add([wal]);
+        continue;
+      }
+      final group = groups.last;
+      final wallGap = wal.timerStart - _walEndSeconds(group.last);
+      final wallSpan = _walEndSeconds(wal) - group.first.timerStart;
+      final sequenceJoins = !requireContiguousSequence || _sequenceRangeTouchesGroup(group, wal);
+      final boundaryJoins = sequenceBoundary == null || _sameSequenceBoundarySide(group, wal, sequenceBoundary);
+      if (wallGap < conversationBoundarySeconds &&
+          (maxWallSeconds == null || wallSpan <= maxWallSeconds) &&
+          sequenceJoins &&
+          boundaryJoins) {
+        group.add(wal);
+      } else {
+        groups.add([wal]);
+      }
+    }
+  }
+  return groups;
+}
+
+int _sequenceBoundarySide(Wal wal, int boundary) {
+  final range = RingProtocol.parseRecoverySourceRange(wal.sourceId);
+  if (range == null || (range.start < boundary && range.end > boundary)) {
+    return 0;
+  }
+  return range.end <= boundary ? -1 : 1;
+}
+
+bool _sameSequenceBoundarySide(List<Wal> group, Wal candidate, int boundary) {
+  final candidateSide = _sequenceBoundarySide(candidate, boundary);
+  if (candidateSide == 0) return false;
+  return group.every((wal) => _sequenceBoundarySide(wal, boundary) == candidateSide);
+}
+
+bool _sequenceRangeTouchesGroup(List<Wal> group, Wal candidate) {
+  final candidateRange = RingProtocol.parseRecoverySourceRange(candidate.sourceId);
+  if (candidateRange == null) return false;
+  final firstRange = RingProtocol.parseRecoverySourceRange(group.first.sourceId);
+  if (firstRange == null) return false;
+  var groupStart = firstRange.start;
+  var groupEnd = firstRange.end;
+  for (final wal in group.skip(1)) {
+    final range = RingProtocol.parseRecoverySourceRange(wal.sourceId);
+    if (range == null) return false;
+    if (range.start < groupStart) groupStart = range.start;
+    if (range.end > groupEnd) groupEnd = range.end;
+  }
+  return candidateRange.start <= groupEnd && candidateRange.end >= groupStart;
+}
+
+List<({int start, int end})> _orderedRecoveryRanges(List<Wal> wals) {
+  final ranges = wals
+      .map((wal) => RingProtocol.parseRecoverySourceRange(wal.sourceId))
+      .whereType<({int start, int end})>()
+      .toList()
+    ..sort((left, right) {
+      final startCompare = left.start.compareTo(right.start);
+      return startCompare != 0 ? startCompare : left.end.compareTo(right.end);
+    });
+  return ranges;
+}
+
+bool _hasNonOverlappingRecoverySequence(List<Wal> group) {
+  final ranges = _orderedRecoveryRanges(group);
+  if (ranges.length != group.length) return false;
+  for (var index = 1; index < ranges.length; index++) {
+    if (ranges[index].start < ranges[index - 1].end) return false;
+  }
+  return true;
+}
+
+Set<Wal>? _exactRecoveryUploadTile(List<Wal> group) {
+  final ranges = <Wal, ({int start, int end})>{};
+  for (final wal in group) {
+    final range = RingProtocol.parseRecoverySourceRange(wal.sourceId);
+    if (range == null || range.end <= range.start) return null;
+    ranges[wal] = range;
+  }
+  if (ranges.isEmpty) return <Wal>{};
+
+  final start = ranges.values.map((range) => range.start).reduce(min);
+  final end = ranges.values.map((range) => range.end).reduce(max);
+  final byStart = <int, List<Wal>>{};
+  for (final entry in ranges.entries) {
+    byStart.putIfAbsent(entry.value.start, () => []).add(entry.key);
+  }
+  for (final candidates in byStart.values) {
+    candidates.sort((left, right) {
+      final durableCompare = (_isLegacyRingArchive(left) ? 1 : 0).compareTo(_isLegacyRingArchive(right) ? 1 : 0);
+      if (durableCompare != 0) return durableCompare;
+      final endCompare = ranges[right]!.end.compareTo(ranges[left]!.end);
+      return endCompare != 0 ? endCompare : left.id.compareTo(right.id);
+    });
+  }
+
+  final best = <int, ({List<Wal> wals, int legacyCount})>{
+    start: (wals: const <Wal>[], legacyCount: 0),
+  };
+  final points = ranges.values.expand((range) => [range.start, range.end]).toSet().toList()..sort();
+  for (final point in points) {
+    final prefix = best[point];
+    if (prefix == null) continue;
+    for (final candidate in byStart[point] ?? const <Wal>[]) {
+      final candidateEnd = ranges[candidate]!.end;
+      final next = (
+        wals: [...prefix.wals, candidate],
+        legacyCount: prefix.legacyCount + (_isLegacyRingArchive(candidate) ? 1 : 0),
+      );
+      final current = best[candidateEnd];
+      if (current == null ||
+          next.legacyCount < current.legacyCount ||
+          (next.legacyCount == current.legacyCount && next.wals.length < current.wals.length)) {
+        best[candidateEnd] = next;
+      }
+    }
+  }
+  return best[end]?.wals.toSet();
+}
+
+List<List<Wal>> _recoverySequenceComponents(List<Wal> group) {
+  final ordered = List<Wal>.from(group)
+    ..sort((left, right) {
+      final leftRange = RingProtocol.parseRecoverySourceRange(left.sourceId)!;
+      final rightRange = RingProtocol.parseRecoverySourceRange(right.sourceId)!;
+      final startCompare = leftRange.start.compareTo(rightRange.start);
+      return startCompare != 0 ? startCompare : leftRange.end.compareTo(rightRange.end);
+    });
+  final components = <List<Wal>>[];
+  var componentEnd = -1;
+  for (final wal in ordered) {
+    final range = RingProtocol.parseRecoverySourceRange(wal.sourceId)!;
+    if (components.isEmpty || range.start > componentEnd) {
+      components.add([wal]);
+      componentEnd = range.end;
+      continue;
+    }
+    components.last.add(wal);
+    if (range.end > componentEnd) componentEnd = range.end;
+  }
+  return components;
+}
+
+Set<Wal> _blockedUnassembledRecoveryArtifacts(
+  List<Wal> pending, {
+  required int conversationBoundarySeconds,
+}) {
+  final blocked = Set<Wal>.identity();
+  final recoveryGroups = _continuousRingRecoveryGroups(
+    pending.where(
+      (wal) => wal.conversationId == null && _isRingRecoveryArtifact(wal),
+    ),
+    conversationBoundarySeconds: conversationBoundarySeconds,
+  );
+  for (final group in recoveryGroups) {
+    for (final component in _recoverySequenceComponents(group)) {
+      // A raw sibling means compaction has not yet committed this exact
+      // sequence component. Independent components in the same wall-time
+      // conversation remain eligible.
+      if (component.any(_isRawRingFragment)) {
+        blocked.addAll(component);
+        continue;
+      }
+      if (component.any(_isLegacyRingArchive)) {
+        // Old manifests can contain cumulative overlapping archives. Select
+        // one exact, nonduplicating path for upload, but never treat that
+        // legacy range as durable ADVANCE coverage.
+        final exactTile = _exactRecoveryUploadTile(component);
+        if (exactTile == null) {
+          blocked.addAll(component);
+        } else {
+          blocked.addAll(
+            component.where((wal) => !exactTile.contains(wal)),
+          );
+        }
+        continue;
+      }
+      if (!_hasNonOverlappingRecoverySequence(component)) {
+        blocked.addAll(component);
+      }
+    }
+  }
+  return blocked;
+}
+
+Set<Wal> _permanentlyBlockedLegacyRecoveryArtifacts(
+  List<Wal> pending, {
+  required int conversationBoundarySeconds,
+}) {
+  final blocked = Set<Wal>.identity();
+  final recoveryGroups = _continuousRingRecoveryGroups(
+    pending.where(
+      (wal) => wal.conversationId == null && _isRingRecoveryArtifact(wal),
+    ),
+    conversationBoundarySeconds: conversationBoundarySeconds,
+  );
+  for (final group in recoveryGroups) {
+    for (final component in _recoverySequenceComponents(group)) {
+      if (component.any(_isRawRingFragment) || !component.any(_isLegacyRingArchive)) {
+        continue;
+      }
+      if (_exactRecoveryUploadTile(component) == null) {
+        blocked.addAll(component);
+      }
+    }
+  }
+  return blocked;
+}
+
+Set<Wal> _legacyAliasesCoveredByBatch(
+  List<Wal> pending,
+  List<Wal> batch, {
+  required int conversationBoundarySeconds,
+}) {
+  final batchSet = Set<Wal>.identity()..addAll(batch);
+  final coveredAliases = Set<Wal>.identity();
+  final recoveryGroups = _continuousRingRecoveryGroups(
+    pending.where(
+      (wal) => wal.conversationId == null && _isRingRecoveryArtifact(wal),
+    ),
+    conversationBoundarySeconds: conversationBoundarySeconds,
+  );
+  for (final group in recoveryGroups) {
+    for (final component in _recoverySequenceComponents(group)) {
+      if (!component.any(_isLegacyRingArchive) || component.any(_isRawRingFragment)) {
+        continue;
+      }
+      final exactTile = _exactRecoveryUploadTile(component);
+      if (exactTile == null || !exactTile.every(batchSet.contains)) continue;
+      coveredAliases.addAll(
+        component.where((wal) => !exactTile.contains(wal)),
+      );
+    }
+  }
+  return coveredAliases;
+}
+
+bool _isAuthorizedHistoricalRecovery(
+  Wal wal,
+  _AuthorizedRecoveryScope? scope,
+) {
+  if (scope == null || wal.device != scope.deviceId || wal.conversationId != null || !_isRingRecoveryArtifact(wal)) {
+    return false;
+  }
+  final range = RingProtocol.parseRecoverySourceRange(wal.sourceId)!;
+  return range.end <= scope.targetWriteSeq;
+}
+
+bool _isEligibleForDrain(
+  Wal wal, {
+  required int nowSeconds,
+  required bool includeBackfill,
+  required _AuthorizedRecoveryScope? authorizedRecovery,
+}) =>
+    includeBackfill ||
+    _syncLaneForWal(wal, nowSeconds) == SyncUploadLane.fresh ||
+    _isAuthorizedHistoricalRecovery(wal, authorizedRecovery);
 
 @visibleForTesting
 Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
@@ -118,16 +448,24 @@ List<Wal> nextSyncUploadBatch(
   List<Wal> pending,
   int nowSeconds, {
   Set<String> forcedBackfillConversationIds = const {},
+  int conversationBoundarySeconds = _defaultConversationBoundarySeconds,
 }) {
   SyncUploadLane effectiveLane(Wal wal) =>
       wal.conversationId != null && forcedBackfillConversationIds.contains(wal.conversationId)
           ? SyncUploadLane.backfill
           : _syncLaneForWal(wal, nowSeconds);
 
+  final blockedRecoveryArtifacts = _blockedUnassembledRecoveryArtifacts(
+    pending,
+    conversationBoundarySeconds: conversationBoundarySeconds,
+  );
   final ordered = pending
       .where(
         (wal) =>
-            !_isUnboundStorageContinuity(wal) && !_isRawRingFragment(wal) && !_isUnassembledConversationRepair(wal),
+            !_isUnboundStorageContinuity(wal) &&
+            !_isRawRingFragment(wal) &&
+            !_isUnassembledConversationRepair(wal) &&
+            !blockedRecoveryArtifacts.contains(wal),
       )
       .toList()
     ..sort((a, b) {
@@ -149,6 +487,18 @@ List<Wal> nextSyncUploadBatch(
             wal.canonicalReplacement == canonicalReplacement,
       )
       .toList();
+  if (conversationId == null && _isRingRecoveryArtifact(ordered.first)) {
+    final recoveryRun = _continuousRingRecoveryGroups(
+      matching.where(_isRingRecoveryArtifact),
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    ).firstWhere(
+      (run) => run.any((wal) => identical(wal, ordered.first)),
+    );
+    // Physical archives remain bounded, but every configured-timeout logical
+    // conversation is one ordered multipart job. The backend therefore sees
+    // one capture instead of one conversation per arbitrary archive boundary.
+    return recoveryRun;
+  }
   return matching.take(conversationId == null ? _syncUploadBatchLimit : _captureUploadWalLimit).toList();
 }
 
@@ -239,6 +589,10 @@ class _HistoricalRingArchive {
   final File? createdFile;
 }
 
+class _CanonicalSourceSnapshotChanged implements Exception {
+  const _CanonicalSourceSnapshotChanged();
+}
+
 class LocalWalSyncImpl implements LocalWalSync {
   List<Wal> _wals = [];
 
@@ -274,7 +628,12 @@ class LocalWalSyncImpl implements LocalWalSync {
   final WalPathResolver _walPathResolver;
   final OpusSilenceFrameFactory _silenceFrameFactory;
   final SyncJobStatusFetcher _syncJobStatusFetcher;
+  final ConversationBoundarySecondsProvider _conversationBoundarySecondsProvider;
   final Mutex _syncMutex = Mutex();
+  final Mutex _walAssemblyMutex = Mutex();
+  int _externalWalRegistrationsInFlight = 0;
+  int _externalWalRegistrationEpoch = 0;
+  Completer<void>? _externalWalRegistrationsIdle;
   Future<void>? _freshUploadWake;
   bool _freshUploadWakePending = false;
   String? _freshUploadWakeWalId;
@@ -288,11 +647,39 @@ class LocalWalSyncImpl implements LocalWalSync {
     WalPathResolver? walPathResolver,
     OpusSilenceFrameFactory? silenceFrameFactory,
     SyncJobStatusFetcher? syncJobStatusFetcher,
+    ConversationBoundarySecondsProvider? conversationBoundarySecondsProvider,
   })  : _uploadGateOverride = uploadGate,
         _walPersisterOverride = walPersister,
         _walPathResolver = walPathResolver ?? Wal.getFilePath,
         _silenceFrameFactory = silenceFrameFactory ?? _encodeOpusSilenceFrame,
-        _syncJobStatusFetcher = syncJobStatusFetcher ?? fetchSyncJobStatus;
+        _syncJobStatusFetcher = syncJobStatusFetcher ?? fetchSyncJobStatus,
+        _conversationBoundarySecondsProvider =
+            conversationBoundarySecondsProvider ?? (() => SharedPreferencesUtil().conversationSilenceDuration);
+
+  int _conversationBoundarySeconds() {
+    return effectiveConversationBoundarySeconds(
+      _conversationBoundarySecondsProvider(),
+    );
+  }
+
+  Future<T> _serializeWalAssembly<T>(
+    Future<T> Function() operation,
+  ) async {
+    await _walAssemblyMutex.acquire();
+    try {
+      return await operation();
+    } finally {
+      _walAssemblyMutex.release();
+    }
+  }
+
+  Future<void> _waitForExternalWalRegistrations() async {
+    while (_externalWalRegistrationsInFlight > 0) {
+      final idle = _externalWalRegistrationsIdle;
+      if (idle == null) continue;
+      await idle.future;
+    }
+  }
 
   static List<int> _encodeOpusSilenceFrame(BleAudioCodec codec) {
     final encoder = SimpleOpusEncoder(
@@ -331,12 +718,38 @@ class LocalWalSyncImpl implements LocalWalSync {
     Wal wal, {
     bool scheduleUpload = true,
   }) async {
+    if (_externalWalRegistrationsInFlight++ == 0) {
+      _externalWalRegistrationsIdle = Completer<void>();
+    }
+    try {
+      return await _addExternalWal(
+        wal,
+        scheduleUpload: scheduleUpload,
+      );
+    } finally {
+      _externalWalRegistrationsInFlight--;
+      _externalWalRegistrationEpoch++;
+      if (_externalWalRegistrationsInFlight == 0) {
+        final idle = _externalWalRegistrationsIdle;
+        _externalWalRegistrationsIdle = null;
+        if (idle != null && !idle.isCompleted) idle.complete();
+      }
+    }
+  }
+
+  Future<ExternalWalRegistration> _addExternalWal(
+    Wal wal, {
+    required bool scheduleUpload,
+  }) async {
+    _inheritCanonicalConversationOwner(wal);
     final existingIndex = _wals.indexWhere((w) => w.id == wal.id);
     if (existingIndex >= 0) {
       final existing = _wals[existingIndex];
       if (!await _hasIdenticalFile(existing, wal)) {
         throw StateError('External WAL identity collision for ${wal.id}');
       }
+      await _upgradeConversationOwnerMetadata(existing, wal);
+      await _upgradeCaptureEndMetadata(existing, wal);
       Logger.debug("LocalWalSync: WAL ${wal.id} already durably registered");
       await _deleteDuplicateExternalFile(existing, wal);
       if (scheduleUpload && existing.status == WalStatus.miss && _mayAutoUploadExternalWal(existing)) {
@@ -354,6 +767,12 @@ class LocalWalSyncImpl implements LocalWalSync {
           existing.codec == wal.codec &&
           existing.originalStorage == wal.originalStorage &&
           await _hasIdenticalFile(existing, wal)) {
+        // Legacy archives are valid audio/upload inputs, but their source
+        // range may span a sequence hole. They cannot suppress a truthful raw
+        // reread after upgrade even when their bytes happen to match.
+        if (_isLegacyRingArchive(existing) && _isDurableRingCoverageArtifact(wal)) {
+          continue;
+        }
         // Old builds could overwrite a timestamp-named file after it had been
         // marked synced. Without the upload-time hash, its current bytes are
         // not proof of what reached the server. Re-register that legacy data
@@ -367,6 +786,8 @@ class LocalWalSyncImpl implements LocalWalSync {
         Logger.debug(
           "LocalWalSync: external WAL ${wal.id} matches legacy durable WAL ${existing.id}",
         );
+        await _upgradeConversationOwnerMetadata(existing, wal);
+        await _upgradeCaptureEndMetadata(existing, wal);
         await _deleteDuplicateExternalFile(existing, wal);
         return ExternalWalRegistration.alreadyRegistered;
       }
@@ -392,6 +813,86 @@ class LocalWalSyncImpl implements LocalWalSync {
       _scheduleFreshUpload(wal);
     }
     return ExternalWalRegistration.added;
+  }
+
+  void _inheritCanonicalConversationOwner(Wal recovered) {
+    if (recovered.conversationId != null || !_isRingRecoveryArtifact(recovered)) {
+      return;
+    }
+    final boundarySeconds = _conversationBoundarySeconds();
+    final candidates = <({Wal wal, double gap})>[];
+    for (final canonical in _wals) {
+      if (canonical.device != recovered.device ||
+          canonical.conversationId == null ||
+          canonical.sourceId?.startsWith('canonical_') != true) {
+        continue;
+      }
+      final gap = _wallIntervalGapSeconds(canonical, recovered);
+      if (gap < boundarySeconds) {
+        candidates.add((wal: canonical, gap: gap));
+      }
+    }
+    if (candidates.isEmpty) return;
+    candidates.sort((left, right) => left.gap.compareTo(right.gap));
+    final nearestGap = candidates.first.gap;
+    final nearestOwners = candidates
+        .where((candidate) => candidate.gap == nearestGap)
+        .map((candidate) => candidate.wal.conversationId!)
+        .toSet();
+    if (nearestOwners.length != 1) {
+      throw StateError(
+        'Recovered ring range ${recovered.id} has ambiguous canonical conversation ownership',
+      );
+    }
+    recovered.conversationId = nearestOwners.single;
+  }
+
+  double _wallIntervalGapSeconds(Wal left, Wal right) {
+    if (right.timerStart > left.wallClockEndSeconds) {
+      return right.timerStart - left.wallClockEndSeconds;
+    }
+    if (left.timerStart > right.wallClockEndSeconds) {
+      return left.timerStart - right.wallClockEndSeconds;
+    }
+    return 0;
+  }
+
+  Future<void> _upgradeConversationOwnerMetadata(
+    Wal existing,
+    Wal recovered,
+  ) async {
+    final recoveredOwner = recovered.conversationId;
+    if (recoveredOwner == null || existing.conversationId == recoveredOwner) {
+      return;
+    }
+    if (existing.conversationId != null) {
+      throw StateError(
+        'External WAL ${existing.id} conflicts with canonical conversation ownership',
+      );
+    }
+    existing.conversationId = recoveredOwner;
+    try {
+      await _saveWalsToFile();
+    } catch (_) {
+      existing.conversationId = null;
+      rethrow;
+    }
+    listener.onWalUpdated();
+  }
+
+  Future<void> _upgradeCaptureEndMetadata(Wal existing, Wal recovered) async {
+    if (existing.validatedCaptureEndSeconds != null) return;
+    final recoveredEnd = recovered.validatedCaptureEndSeconds;
+    if (recoveredEnd == null) return;
+    final previous = existing.captureEndSeconds;
+    existing.captureEndSeconds = recoveredEnd;
+    try {
+      await _saveWalsToFile();
+    } catch (_) {
+      existing.captureEndSeconds = previous;
+      rethrow;
+    }
+    listener.onWalUpdated();
   }
 
   bool _mayAutoUploadExternalWal(Wal wal) {
@@ -592,11 +1093,35 @@ class LocalWalSyncImpl implements LocalWalSync {
   @visibleForTesting
   Future<void> prepareHistoricalRingFragments({
     required int nowSeconds,
+    String? recoveryDeviceId,
+    int? recoverySequenceBoundary,
+    int? conversationBoundarySeconds,
   }) {
+    if ((recoveryDeviceId == null) != (recoverySequenceBoundary == null)) {
+      throw ArgumentError('Recovery compaction boundary requires both device and sequence');
+    }
+    final boundarySeconds = conversationBoundarySeconds ?? _conversationBoundarySeconds();
     final inFlight = _historicalCompaction;
-    if (inFlight != null) return inFlight;
+    if (inFlight != null) {
+      if (recoveryDeviceId == null) return inFlight;
+      return inFlight.then(
+        (_) => prepareHistoricalRingFragments(
+          nowSeconds: nowSeconds,
+          recoveryDeviceId: recoveryDeviceId,
+          recoverySequenceBoundary: recoverySequenceBoundary,
+          conversationBoundarySeconds: boundarySeconds,
+        ),
+      );
+    }
     late final Future<void> operation;
-    operation = _prepareHistoricalRingFragments(nowSeconds: nowSeconds).whenComplete(() {
+    operation = _serializeWalAssembly(
+      () => _prepareHistoricalRingFragments(
+        nowSeconds: nowSeconds,
+        recoveryDeviceId: recoveryDeviceId,
+        recoverySequenceBoundary: recoverySequenceBoundary,
+        conversationBoundarySeconds: boundarySeconds,
+      ),
+    ).whenComplete(() {
       if (identical(_historicalCompaction, operation)) {
         _historicalCompaction = null;
       }
@@ -607,12 +1132,15 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   Future<void> _prepareHistoricalRingFragments({
     required int nowSeconds,
+    required String? recoveryDeviceId,
+    required int? recoverySequenceBoundary,
+    required int conversationBoundarySeconds,
   }) async {
     final candidates = _wals
         .where(
           (wal) =>
               wal.conversationId == null &&
-              _isRawRingFragment(wal) &&
+              _isDurableRingCoverageArtifact(wal) &&
               wal.storage == WalStorage.disk &&
               (wal.status == WalStatus.miss || wal.status == WalStatus.synced),
         )
@@ -636,17 +1164,46 @@ class LocalWalSyncImpl implements LocalWalSync {
         if (timeCompare != 0) return timeCompare;
         return left.id.compareTo(right.id);
       });
-      for (final capture in _continuousRingGroups(bucket)) {
+      for (final capture in _continuousRingRecoveryGroups(
+        bucket,
+        conversationBoundarySeconds: conversationBoundarySeconds,
+      )) {
         final captureEnd = capture.map(_walEndSeconds).reduce(max);
-        if (nowSeconds - captureEnd < _conversationBoundarySeconds) {
+        if (nowSeconds - captureEnd < conversationBoundarySeconds) {
           continue;
         }
-        for (final group in _continuousRingGroups(
+        final sequenceBoundary = capture.first.device == recoveryDeviceId ? recoverySequenceBoundary : null;
+        for (final group in _continuousRingRecoveryGroups(
           capture,
+          conversationBoundarySeconds: conversationBoundarySeconds,
           maxWallSeconds: 30 * 60,
+          requireContiguousSequence: true,
+          sequenceBoundary: sequenceBoundary,
         )) {
+          if (sequenceBoundary != null &&
+              group.any(
+                (wal) => _sequenceBoundarySide(wal, sequenceBoundary) == 0,
+              )) {
+            // A source file itself straddles the receipt. Without per-record
+            // byte offsets it cannot be sliced safely, so retain it verbatim
+            // for a later receipt rather than manufacturing false coverage.
+            continue;
+          }
+          // A bounded archive is already the desired physical representation.
+          // It remains part of the logical capture above so a later adjacent
+          // archive/raw range can roll it forward, but it need not be rewritten
+          // on every compaction pass.
+          if (group.length == 1 && !_isRawRingFragment(group.single)) {
+            continue;
+          }
           try {
-            archives.add(await _prepareHistoricalRingArchive(group));
+            archives.add(
+              await _prepareHistoricalRingArchive(
+                group,
+                sequenceBoundary: sequenceBoundary,
+                conversationBoundarySeconds: conversationBoundarySeconds,
+              ),
+            );
           } catch (error) {
             Logger.debug(
               'LocalWalSync: historical archive group remains retryable: $error',
@@ -657,8 +1214,28 @@ class LocalWalSyncImpl implements LocalWalSync {
     }
     if (archives.isEmpty) return;
 
-    final before = _wals;
-    final compactedSources = archives.expand((archive) => archive.sources).toSet();
+    final producedCoverage = <String, RingSequenceCoverage>{};
+    for (final archive in archives) {
+      final range = RingProtocol.parseDurableCoverageSourceRange(archive.wal.sourceId)!;
+      producedCoverage.putIfAbsent(_ringEncodingBucket(archive.wal), RingSequenceCoverage.new).add(
+            range.start,
+            range.end,
+          );
+    }
+    final supersededLegacyArchives = _wals.where((wal) {
+      if (wal.conversationId != null ||
+          wal.storage != WalStorage.disk ||
+          (wal.status != WalStatus.miss && wal.status != WalStatus.synced) ||
+          !_isLegacyRingArchive(wal)) {
+        return false;
+      }
+      final range = RingProtocol.parseRecoverySourceRange(wal.sourceId)!;
+      return producedCoverage[_ringEncodingBucket(wal)]?.covers(range.start, range.end) == true;
+    }).toSet();
+    final compactedSources = {
+      ...archives.expand((archive) => archive.sources),
+      ...supersededLegacyArchives,
+    };
     _wals = [
       ..._wals.where((wal) => !compactedSources.contains(wal)),
       ...archives.map((archive) => archive.wal),
@@ -666,8 +1243,26 @@ class LocalWalSyncImpl implements LocalWalSync {
     try {
       await _saveWalsToFile();
     } catch (_) {
-      _wals = before;
-      await _deleteHistoricalArchiveFiles(archives);
+      // Publishing the manifest is the archive ownership commit. Restore the
+      // immutable sources without replacing the whole list: an external WAL
+      // may have registered while the failed archive write awaited disk.
+      final archiveWals = archives.map((archive) => archive.wal).toSet();
+      final restored = _wals.where((wal) => !archiveWals.contains(wal)).toList();
+      final tracked = Set<Wal>.identity()..addAll(restored);
+      for (final source in compactedSources) {
+        if (tracked.add(source)) restored.add(source);
+      }
+      _wals = restored;
+      try {
+        // WalFileManager serializes snapshots in invocation order. A
+        // registration that started while the failed archive write awaited
+        // may already have queued a newer snapshot containing that
+        // uncommitted archive. Queue restored ownership after it as the final
+        // durable barrier before removing the archive artifact.
+        await _saveWalsToFile();
+      } finally {
+        await _deleteHistoricalArchiveFiles(archives);
+      }
       rethrow;
     }
 
@@ -688,49 +1283,44 @@ class LocalWalSyncImpl implements LocalWalSync {
     DebugLogManager.logEvent('historical_ring_archive_compacted', {
       'source_fragment_count': compactedSources.length,
       'archive_artifact_count': archives.length,
+      'legacy_archive_retired_count': supersededLegacyArchives.length,
     });
     listener.onWalUpdated();
   }
 
-  List<List<Wal>> _continuousRingGroups(
-    List<Wal> ordered, {
-    int? maxWallSeconds,
-  }) {
-    final groups = <List<Wal>>[];
-    for (final wal in ordered) {
-      if (groups.isEmpty) {
-        groups.add([wal]);
-        continue;
-      }
-      final group = groups.last;
-      final wallGap = wal.timerStart - _walEndSeconds(group.last);
-      final wallSpan = _walEndSeconds(wal) - group.first.timerStart;
-      if (wallGap < _conversationBoundarySeconds && (maxWallSeconds == null || wallSpan <= maxWallSeconds)) {
-        group.add(wal);
-      } else {
-        groups.add([wal]);
-      }
-    }
-    return groups;
-  }
-
   Future<_HistoricalRingArchive> _prepareHistoricalRingArchive(
-    List<Wal> sources,
-  ) async {
+    List<Wal> sources, {
+    int? sequenceBoundary,
+    required int conversationBoundarySeconds,
+  }) async {
     if (sources.isEmpty) {
       throw ArgumentError.value(sources, 'sources', 'must not be empty');
     }
+    final contiguousRanges = _orderedRecoveryRanges(sources);
+    if (contiguousRanges.length != sources.length) {
+      throw StateError('Historical archive requires pendant sequence identity');
+    }
+    var coveredEnd = contiguousRanges.first.end;
+    for (final range in contiguousRanges.skip(1)) {
+      if (range.start > coveredEnd) {
+        throw StateError('Historical archive cannot claim an uncovered pendant sequence');
+      }
+      if (range.end > coveredEnd) coveredEnd = range.end;
+    }
+    if (sequenceBoundary != null && contiguousRanges.first.start < sequenceBoundary && coveredEnd > sequenceBoundary) {
+      throw StateError('Historical archive cannot cross an authorized receipt boundary');
+    }
     final orderedBySequence = List<Wal>.from(sources)
       ..sort(
-        (left, right) => _ringSourceRange(left)!.start.compareTo(
-              _ringSourceRange(right)!.start,
+        (left, right) => RingProtocol.parseRecoverySourceRange(left.sourceId)!.start.compareTo(
+              RingProtocol.parseRecoverySourceRange(right.sourceId)!.start,
             ),
       );
     final first = orderedBySequence.first;
-    final last = orderedBySequence.last;
-    final firstRange = _ringSourceRange(first)!;
-    final lastRange = _ringSourceRange(last)!;
-    final archiveSourceId = 'archive_ring_${firstRange.start}_${lastRange.end}_${first.timerStart}';
+    final sourceRanges = orderedBySequence.map((wal) => RingProtocol.parseRecoverySourceRange(wal.sourceId)!).toList();
+    final archiveStart = sourceRanges.map((range) => range.start).reduce(min);
+    final archiveEnd = sourceRanges.map((range) => range.end).reduce(max);
+    final archiveSourceId = 'archive2_ring_${archiveStart}_${archiveEnd}_${first.timerStart}';
     final archiveStatus = sources.any((wal) => wal.status == WalStatus.miss) ? WalStatus.miss : WalStatus.synced;
 
     if (sources.length == 1) {
@@ -742,6 +1332,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           filePath: first.filePath,
           timerStart: first.timerStart,
           totalFrames: first.totalFrames,
+          captureEndSeconds: first.wallClockEndSeconds,
           status: archiveStatus,
         ),
       );
@@ -766,7 +1357,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       parts: parts,
       destination: destination,
       silenceFrameFactory: _silenceFrameFactory,
-      conversationBoundarySeconds: _conversationBoundarySeconds,
+      conversationBoundarySeconds: conversationBoundarySeconds,
     );
     final fps = first.codec.getFramesPerSecond();
     return _HistoricalRingArchive(
@@ -778,6 +1369,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         filePath: assembly.file.path.split('/').last,
         timerStart: assembly.timerStart,
         totalFrames: assembly.totalFrames,
+        captureEndSeconds: assembly.captureEndSeconds,
         seconds: fps > 0 ? (assembly.totalFrames + fps - 1) ~/ fps : 0,
         status: archiveStatus,
       ),
@@ -790,6 +1382,7 @@ class LocalWalSyncImpl implements LocalWalSync {
     required String? filePath,
     required int timerStart,
     required int totalFrames,
+    required double captureEndSeconds,
     required WalStatus status,
     int? seconds,
   }) {
@@ -800,6 +1393,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       channel: first.channel,
       sampleRate: first.sampleRate,
       seconds: seconds ?? (fps > 0 ? (totalFrames + fps - 1) ~/ fps : first.seconds),
+      captureEndSeconds: captureEndSeconds,
       totalFrames: totalFrames,
       status: status,
       storage: WalStorage.disk,
@@ -917,7 +1511,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         }
       }
       Logger.debug(
-        "${low} - ${high} - ${syncedOffset} - ${chunkFrameCount} - ${_framesPerSecond}",
+        "$low - $high - $syncedOffset - $chunkFrameCount - $_framesPerSecond",
       );
 
       Wal wal;
@@ -1171,66 +1765,211 @@ class LocalWalSyncImpl implements LocalWalSync {
       );
       return;
     }
-    final now = sessionEndSeconds ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    int stamped = 0;
-    final ringSources = <Wal>[];
-    for (final wal in _wals) {
-      final inSession = _walEndSeconds(wal) >= sessionStartSeconds && wal.timerStart <= now;
-      final ringContinuity =
-          wal.originalStorage == WalStorage.sdcard && RingProtocol.parseRecoverySourceRange(wal.sourceId) != null;
-      if (inSession &&
-          wal.conversationId == null &&
-          (wal.status == WalStatus.miss || (ringContinuity && wal.status == WalStatus.synced))) {
-        wal.conversationId = conversationId;
-        stamped++;
-      }
-      if (inSession &&
-          ringContinuity &&
-          wal.conversationId == conversationId &&
-          (wal.status == WalStatus.miss || wal.status == WalStatus.synced)) {
-        ringSources.add(wal);
-      }
-    }
-    if (stamped > 0 || ringSources.isNotEmpty) {
-      try {
-        await _compactRingConversation(
-          conversationId,
-          ringSources,
+    final sessionEnd = sessionEndSeconds ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    var stamped = 0;
+    await _serializeWalAssembly(() async {
+      await _waitForExternalWalRegistrations();
+      final ringDeviceScope = _wals
+          .where(
+            (wal) =>
+                _isRingRecoveryArtifact(wal) &&
+                (wal.conversationId == null || wal.conversationId == conversationId) &&
+                _isInBoundedSession(
+                  wal,
+                  sessionStartSeconds: sessionStartSeconds,
+                  sessionEndSeconds: sessionEnd,
+                ),
+          )
+          .map((wal) => wal.device)
+          .toSet();
+      while (true) {
+        await _waitForExternalWalRegistrations();
+        final registrationEpoch = _externalWalRegistrationEpoch;
+        stamped += _stampBoundedSessionWals(
+          sessionStartSeconds: sessionStartSeconds,
+          sessionEndSeconds: sessionEnd,
+          conversationId: conversationId,
+          ringDeviceScope: ringDeviceScope,
         );
-      } catch (error) {
-        // Every immutable source remains in place. Persist its conversation
-        // owner, but never upload raw fragments. A later serialized sync pass
-        // retries canonical assembly.
-        await _saveWalsToFile();
-        Logger.debug(
-          'stampConversationId: canonical assembly failed for $conversationId: $error',
+        final ringSources = _boundedRingSourcesForConversation(
+          sessionStartSeconds: sessionStartSeconds,
+          sessionEndSeconds: sessionEnd,
+          conversationId: conversationId,
+          ringDeviceScope: ringDeviceScope,
         );
-      }
-      Logger.debug(
-        'stampConversationId: stamped $stamped WALs with conversation $conversationId',
-      );
-      Wal? uploadWakeWal;
-      for (final wal in _wals) {
-        if (wal.status == WalStatus.miss && wal.conversationId == conversationId && !_isRingRecoveryArtifact(wal)) {
-          uploadWakeWal = wal;
+        if (ringSources.isEmpty) {
+          if (stamped > 0) await _saveWalsToFile();
+          break;
+        }
+        if (_canonicalWalsForConversation(conversationId).isNotEmpty) {
+          // A canonical WAL intentionally drops its source sequence ranges.
+          // Without that proof, appending a late range can duplicate audio;
+          // replacing it can erase the already-complete transcript. Retain the
+          // bound range for a future merge contract instead of guessing.
+          await _saveWalsToFile();
+          Logger.debug(
+            'stampConversationId: retained late bound ring audio for $conversationId because its canonical owner cannot be safely extended',
+          );
+          break;
+        }
+
+        final sourceSnapshot = List<Wal>.from(ringSources);
+        try {
+          await _compactRingConversation(
+            conversationId,
+            sourceSnapshot,
+            sourceSnapshotIsStable: () =>
+                _externalWalRegistrationsInFlight == 0 &&
+                _externalWalRegistrationEpoch == registrationEpoch &&
+                !_hasUnownedWalInBoundedSession(
+                  sessionStartSeconds: sessionStartSeconds,
+                  sessionEndSeconds: sessionEnd,
+                  ringDeviceScope: ringDeviceScope,
+                ) &&
+                _sameIdentityWalSet(
+                  sourceSnapshot,
+                  _boundedRingSourcesForConversation(
+                    sessionStartSeconds: sessionStartSeconds,
+                    sessionEndSeconds: sessionEnd,
+                    conversationId: conversationId,
+                    ringDeviceScope: ringDeviceScope,
+                  ),
+                ),
+          );
+          break;
+        } on _CanonicalSourceSnapshotChanged {
+          // A tail registration completed while disk assembly was in flight.
+          // Its timestamp belongs to this already-closed server session, so
+          // rebuild from the expanded exact source set before publishing.
+          continue;
+        } catch (error) {
+          // Every immutable source remains in place. Persist its conversation
+          // owner, but never upload raw fragments.
+          await _saveWalsToFile();
+          Logger.debug(
+            'stampConversationId: canonical assembly failed for $conversationId: $error',
+          );
           break;
         }
       }
-      if (uploadWakeWal != null) {
-        // Active-conversation repair is independent of opt-in historical
-        // sync. The exact server owner is known, so wake one serialized drain.
-        _scheduleFreshUpload(uploadWakeWal);
+    });
+
+    Logger.debug(
+      'stampConversationId: stamped $stamped WALs with conversation $conversationId',
+    );
+    Wal? uploadWakeWal;
+    for (final wal in _wals) {
+      if (wal.status == WalStatus.miss && wal.conversationId == conversationId && !_isRingRecoveryArtifact(wal)) {
+        uploadWakeWal = wal;
+        break;
       }
     }
+    if (uploadWakeWal != null) {
+      // Active-conversation repair is independent of opt-in historical sync.
+      // The exact server owner is known, so wake one serialized drain.
+      _scheduleFreshUpload(uploadWakeWal);
+    }
+  }
+
+  bool _isInBoundedSession(
+    Wal wal, {
+    required int sessionStartSeconds,
+    required int sessionEndSeconds,
+  }) =>
+      _walEndSeconds(wal) >= sessionStartSeconds && wal.timerStart <= sessionEndSeconds;
+
+  bool _isStampableSessionWal(Wal wal) {
+    final ringContinuity = _isRingRecoveryArtifact(wal);
+    return wal.status == WalStatus.miss || (ringContinuity && wal.status == WalStatus.synced);
+  }
+
+  int _stampBoundedSessionWals({
+    required int sessionStartSeconds,
+    required int sessionEndSeconds,
+    required String conversationId,
+    required Set<String> ringDeviceScope,
+  }) {
+    var stamped = 0;
+    for (final wal in _wals) {
+      if (wal.conversationId == null &&
+          _isStampableSessionWal(wal) &&
+          (!_isRingRecoveryArtifact(wal) || ringDeviceScope.contains(wal.device)) &&
+          _isInBoundedSession(
+            wal,
+            sessionStartSeconds: sessionStartSeconds,
+            sessionEndSeconds: sessionEndSeconds,
+          )) {
+        wal.conversationId = conversationId;
+        stamped++;
+      }
+    }
+    return stamped;
+  }
+
+  bool _hasUnownedWalInBoundedSession({
+    required int sessionStartSeconds,
+    required int sessionEndSeconds,
+    required Set<String> ringDeviceScope,
+  }) =>
+      _wals.any(
+        (wal) =>
+            wal.conversationId == null &&
+            _isStampableSessionWal(wal) &&
+            (!_isRingRecoveryArtifact(wal) || ringDeviceScope.contains(wal.device)) &&
+            _isInBoundedSession(
+              wal,
+              sessionStartSeconds: sessionStartSeconds,
+              sessionEndSeconds: sessionEndSeconds,
+            ),
+      );
+
+  List<Wal> _boundedRingSourcesForConversation({
+    required int sessionStartSeconds,
+    required int sessionEndSeconds,
+    required String conversationId,
+    required Set<String> ringDeviceScope,
+  }) =>
+      _wals
+          .where(
+            (wal) =>
+                wal.conversationId == conversationId &&
+                _isRingRecoveryArtifact(wal) &&
+                ringDeviceScope.contains(wal.device) &&
+                (wal.status == WalStatus.miss || wal.status == WalStatus.synced) &&
+                _isInBoundedSession(
+                  wal,
+                  sessionStartSeconds: sessionStartSeconds,
+                  sessionEndSeconds: sessionEndSeconds,
+                ),
+          )
+          .toList();
+
+  List<Wal> _canonicalWalsForConversation(String conversationId) => _wals
+      .where(
+        (wal) => wal.conversationId == conversationId && wal.sourceId?.startsWith('canonical_') == true,
+      )
+      .toList();
+
+  bool _sameIdentityWalSet(List<Wal> left, List<Wal> right) {
+    if (left.length != right.length) return false;
+    final identities = Set<Wal>.identity()..addAll(left);
+    return right.every(identities.contains);
   }
 
   Future<void> _compactRingConversation(
     String conversationId,
-    List<Wal> sourceWals,
-  ) async {
+    List<Wal> sourceWals, {
+    int? conversationBoundarySeconds,
+    bool Function()? sourceSnapshotIsStable,
+  }) async {
     if (sourceWals.isEmpty) {
       await _saveWalsToFile();
       return;
+    }
+    if (_canonicalWalsForConversation(conversationId).isNotEmpty) {
+      throw StateError(
+        'Canonical conversation $conversationId already exists; refusing an unprovable partial replacement',
+      );
     }
 
     final byDevice = <String, List<Wal>>{};
@@ -1241,6 +1980,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       throw StateError('Canonical assembly requires one pendant per conversation');
     }
 
+    final boundarySeconds = conversationBoundarySeconds ?? _conversationBoundarySeconds();
     final canonicalWals = <Wal>[];
     final canonicalFiles = <File>[];
     final compactedSources = <Wal>{};
@@ -1279,7 +2019,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           parts: parts,
           destination: destination,
           silenceFrameFactory: _silenceFrameFactory,
-          conversationBoundarySeconds: _conversationBoundarySeconds,
+          conversationBoundarySeconds: boundarySeconds,
         );
         canonicalFiles.add(assembly.file);
         compactedSources.addAll(assembly.sourceWals);
@@ -1292,6 +2032,7 @@ class LocalWalSyncImpl implements LocalWalSync {
             channel: first.channel,
             sampleRate: first.sampleRate,
             seconds: fps > 0 ? (assembly.totalFrames + fps - 1) ~/ fps : 0,
+            captureEndSeconds: assembly.captureEndSeconds,
             totalFrames: assembly.totalFrames,
             status: assembly.hadLiveGap ? WalStatus.miss : WalStatus.synced,
             storage: WalStorage.disk,
@@ -1307,14 +2048,44 @@ class LocalWalSyncImpl implements LocalWalSync {
         );
       }
 
-      // Assembly performs asynchronous disk reads. Preserve WALs registered by
-      // the BLE drain while those reads were in flight; replacing the original
-      // snapshot here could orphan already-acknowledged pendant records.
+      if (sourceWals.any((source) => !_wals.any((wal) => identical(wal, source))) ||
+          _canonicalWalsForConversation(conversationId).isNotEmpty ||
+          (sourceSnapshotIsStable != null && !sourceSnapshotIsStable())) {
+        throw const _CanonicalSourceSnapshotChanged();
+      }
+
+      // Assembly performs asynchronous disk reads. Preserve WALs outside the
+      // exact, synchronously revalidated source snapshot.
       _wals = [
         ..._wals.where((wal) => !compactedSources.contains(wal)),
         ...canonicalWals,
       ];
-      await _saveWalsToFile();
+      try {
+        await _saveWalsToFile();
+      } catch (_) {
+        // Publishing the manifest is the ownership commit. If it fails, put
+        // the immutable sources back without replacing the whole list: an
+        // external registration may have completed while persistence awaited.
+        final restored = _wals
+            .where(
+              (wal) => !canonicalWals.any(
+                (canonical) => identical(canonical, wal),
+              ),
+            )
+            .toList();
+        final tracked = Set<Wal>.identity()..addAll(restored);
+        for (final source in compactedSources) {
+          if (tracked.add(source)) restored.add(source);
+        }
+        _wals = restored;
+        // WalFileManager serializes snapshots in invocation order. A
+        // registration that started while the failed canonical write awaited
+        // may already have queued a newer snapshot containing that uncommitted
+        // canonical. Queue the restored ownership state after it as the final
+        // barrier before the canonical file is removed.
+        await _saveWalsToFile();
+        rethrow;
+      }
     } catch (_) {
       for (final file in canonicalFiles) {
         if (await file.exists()) await file.delete();
@@ -1433,6 +2204,89 @@ class LocalWalSyncImpl implements LocalWalSync {
   }) =>
       _syncAll(progress: progress, includeBackfill: false);
 
+  Future<AuthorizedRecoverySyncResult> syncAuthorizedRecovery({
+    required String deviceId,
+    required int targetWriteSeq,
+    IWalSyncProgressListener? progress,
+    int? nowSeconds,
+  }) async {
+    if (deviceId.isEmpty) {
+      throw ArgumentError.value(deviceId, 'deviceId', 'must not be empty');
+    }
+    if (targetWriteSeq < 0) {
+      throw ArgumentError.value(targetWriteSeq, 'targetWriteSeq', 'must not be negative');
+    }
+    final scope = _AuthorizedRecoveryScope(
+      deviceId: deviceId,
+      targetWriteSeq: targetWriteSeq,
+    );
+    final conversationBoundarySeconds = _conversationBoundarySeconds();
+    await _syncMutex.acquire();
+    try {
+      final response = await _syncAllOwned(
+        progress: progress,
+        includeBackfill: false,
+        authorizedRecovery: scope,
+        nowSecondsOverride: nowSeconds,
+        manualWal: null,
+        conversationBoundarySecondsOverride: conversationBoundarySeconds,
+      );
+      return AuthorizedRecoverySyncResult(
+        response: response,
+        hasDeferredRecovery: _hasDeferredAuthorizedRecovery(
+          scope,
+          conversationBoundarySeconds: conversationBoundarySeconds,
+        ),
+      );
+    } finally {
+      _syncMutex.release();
+    }
+  }
+
+  bool _hasDeferredAuthorizedRecovery(
+    _AuthorizedRecoveryScope scope, {
+    required int conversationBoundarySeconds,
+  }) {
+    final candidates = _wals
+        .where(
+          (wal) =>
+              wal.storage == WalStorage.disk &&
+              (wal.status == WalStatus.miss || wal.status == WalStatus.uploaded) &&
+              _isAuthorizedHistoricalRecovery(wal, scope),
+        )
+        .toList();
+    final permanentlyBlocked = _permanentlyBlockedLegacyRecoveryArtifacts(
+      candidates.where((wal) => wal.status == WalStatus.miss).toList(),
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    );
+    return candidates.any(
+      (wal) => wal.status == WalStatus.uploaded || !permanentlyBlocked.contains(wal),
+    );
+  }
+
+  Set<String> _manualSyncWalIds(
+    Wal selected, {
+    required int conversationBoundarySeconds,
+  }) {
+    if (selected.conversationId != null || !_isRingRecoveryArtifact(selected)) {
+      return {selected.id};
+    }
+    final groups = _continuousRingRecoveryGroups(
+      _wals.where(
+        (wal) =>
+            wal.status == WalStatus.miss &&
+            wal.storage == WalStorage.disk &&
+            wal.conversationId == null &&
+            _isRingRecoveryArtifact(wal),
+      ),
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    );
+    final selectedGroup = groups.where(
+      (group) => group.any((wal) => identical(wal, selected)),
+    );
+    return selectedGroup.isEmpty ? {selected.id} : selectedGroup.single.map((wal) => wal.id).toSet();
+  }
+
   Future<SyncLocalFilesResponse?> _syncAll({
     IWalSyncProgressListener? progress,
     required bool includeBackfill,
@@ -1442,6 +2296,10 @@ class LocalWalSyncImpl implements LocalWalSync {
       return await _syncAllOwned(
         progress: progress,
         includeBackfill: includeBackfill,
+        authorizedRecovery: null,
+        nowSecondsOverride: null,
+        manualWal: null,
+        conversationBoundarySecondsOverride: null,
       );
     } finally {
       _syncMutex.release();
@@ -1451,22 +2309,104 @@ class LocalWalSyncImpl implements LocalWalSync {
   Future<SyncLocalFilesResponse?> _syncAllOwned({
     IWalSyncProgressListener? progress,
     required bool includeBackfill,
+    required _AuthorizedRecoveryScope? authorizedRecovery,
+    required int? nowSecondsOverride,
+    required Wal? manualWal,
+    required int? conversationBoundarySecondsOverride,
   }) async {
+    int nowSeconds() => nowSecondsOverride ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final conversationBoundarySeconds = conversationBoundarySecondsOverride ?? _conversationBoundarySeconds();
+
     await _flush();
-    await prepareHistoricalRingFragments(
-      nowSeconds: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-    );
-    await _repairBoundRingConversations();
+    Wal? selectedManualWal = manualWal;
+    if (manualWal != null) {
+      final isTracked = _wals.any(
+        (candidate) => identical(candidate, manualWal),
+      );
+      if (!isTracked) {
+        DebugLogManager.logInfo(
+          'Single WAL upload skipped — WAL no longer tracked',
+          {'walId': manualWal.id},
+        );
+        return null;
+      }
+      if (_isUnassembledConversationRepair(manualWal)) {
+        final conversationId = manualWal.conversationId!;
+        final repairSources = _wals
+            .where(
+              (candidate) =>
+                  candidate.conversationId == conversationId &&
+                  _isRingRecoveryArtifact(candidate) &&
+                  (candidate.status == WalStatus.miss || candidate.status == WalStatus.synced),
+            )
+            .toList();
+        try {
+          await _serializeWalAssembly(
+            () => _compactRingConversation(
+              conversationId,
+              repairSources,
+              conversationBoundarySeconds: conversationBoundarySeconds,
+            ),
+          );
+          selectedManualWal = _wals.firstWhere(
+            (candidate) =>
+                candidate.conversationId == conversationId && candidate.sourceId?.startsWith('canonical_') == true,
+          )..canonicalReplacement = true;
+        } catch (error) {
+          Logger.debug(
+            'LocalWalSync: selected canonical repair remains local for $conversationId: $error',
+          );
+        }
+      }
+    } else {
+      await prepareHistoricalRingFragments(
+        nowSeconds: nowSeconds(),
+        recoveryDeviceId: authorizedRecovery?.deviceId,
+        recoverySequenceBoundary: authorizedRecovery?.targetWriteSeq,
+        conversationBoundarySeconds: conversationBoundarySeconds,
+      );
+      await _repairBoundRingConversations(
+        conversationBoundarySeconds: conversationBoundarySeconds,
+      );
+    }
     _isCancelled = false;
     _accumulatedResponse = null;
 
-    final initialNowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final initialNowSeconds = nowSeconds();
+    Wal? trackedManualWal;
+    if (selectedManualWal != null) {
+      for (final candidate in _wals) {
+        if (identical(candidate, selectedManualWal)) {
+          trackedManualWal = candidate;
+          break;
+        }
+      }
+    }
+    if (selectedManualWal != null && trackedManualWal == null) {
+      DebugLogManager.logInfo(
+        'Single WAL upload skipped — WAL no longer tracked',
+        {'walId': selectedManualWal.id},
+      );
+      return null;
+    }
+    final manualWalIds = trackedManualWal == null
+        ? null
+        : _manualSyncWalIds(
+            trackedManualWal,
+            conversationBoundarySeconds: conversationBoundarySeconds,
+          );
     var wals = _wals
         .where(
           (wal) =>
               wal.status == WalStatus.miss &&
               wal.storage == WalStorage.disk &&
-              (includeBackfill || _syncLaneForWal(wal, initialNowSeconds) == SyncUploadLane.fresh),
+              (manualWalIds?.contains(wal.id) ??
+                  _isEligibleForDrain(
+                    wal,
+                    nowSeconds: initialNowSeconds,
+                    includeBackfill: includeBackfill,
+                    authorizedRecovery: authorizedRecovery,
+                  )),
         )
         .toList();
     if (wals.isEmpty) {
@@ -1498,14 +2438,28 @@ class LocalWalSyncImpl implements LocalWalSync {
     final attemptedWalIds = <String>{};
     final blockedLanes = <SyncUploadLane>{};
     final forcedBackfillConversationIds = <String>{};
+    final trackedManualConversationId = trackedManualWal?.conversationId;
+    if (trackedManualConversationId != null) {
+      final pendingConversationCount = _wals
+          .where(
+            (wal) => wal.status == WalStatus.miss && wal.conversationId == trackedManualConversationId,
+          )
+          .length;
+      if (pendingConversationCount > (manualWalIds?.length ?? 0)) {
+        forcedBackfillConversationIds.add(trackedManualConversationId);
+      }
+    }
     while (true) {
       // Re-snapshot between batches so a newly captured WAL can preempt an
       // hours-long historical drain without waiting for the original list.
-      final batchNowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final batchNowSeconds = nowSeconds();
       final candidates = _wals
           .where(
             (wal) =>
-                wal.status == WalStatus.miss && wal.storage == WalStorage.disk && !attemptedWalIds.contains(wal.id),
+                wal.status == WalStatus.miss &&
+                wal.storage == WalStorage.disk &&
+                !attemptedWalIds.contains(wal.id) &&
+                (manualWalIds == null || manualWalIds.contains(wal.id)),
           )
           .toList();
       forcedBackfillConversationIds.addAll(
@@ -1518,7 +2472,10 @@ class LocalWalSyncImpl implements LocalWalSync {
       final pending = candidates
           .where(
             (wal) =>
-                (includeBackfill || effectiveLane(wal) == SyncUploadLane.fresh) &&
+                (manualWalIds != null ||
+                    includeBackfill ||
+                    effectiveLane(wal) == SyncUploadLane.fresh ||
+                    _isAuthorizedHistoricalRecovery(wal, authorizedRecovery)) &&
                 !blockedLanes.contains(effectiveLane(wal)),
           )
           .toList();
@@ -1527,8 +2484,14 @@ class LocalWalSyncImpl implements LocalWalSync {
         pending,
         batchNowSeconds,
         forcedBackfillConversationIds: forcedBackfillConversationIds,
+        conversationBoundarySeconds: conversationBoundarySeconds,
       );
       if (batch.isEmpty) break;
+      final coveredLegacyAliases = _legacyAliasesCoveredByBatch(
+        pending,
+        batch,
+        conversationBoundarySeconds: conversationBoundarySeconds,
+      );
       attemptedWalIds.addAll(batch.map((wal) => wal.id));
       final batchLane =
           batch.first.conversationId != null && forcedBackfillConversationIds.contains(batch.first.conversationId)
@@ -1611,8 +2574,16 @@ class LocalWalSyncImpl implements LocalWalSync {
         }
       }
 
-      if (files.isEmpty) {
-        Logger.debug("Files are empty");
+      if (batchWals.length != batch.length) {
+        // A logical recovery transaction is all-or-nothing. Uploading the
+        // surviving subset would turn a missing local file into a permanent
+        // transcript hole and could incorrectly retire overlapping legacy
+        // aliases.
+        for (final wal in batchWals) {
+          wal.isSyncing = false;
+        }
+        await _saveWalsToFile();
+        listener.onWalUpdated();
         continue;
       }
 
@@ -1656,7 +2627,7 @@ class LocalWalSyncImpl implements LocalWalSync {
               (id) => !resp.updatedConversationIds.contains(id) && !resp.newConversationIds.contains(id),
             ),
           );
-          for (final wal in batchWals) {
+          for (final wal in [...batchWals, ...coveredLegacyAliases]) {
             wal.status = WalStatus.synced;
             wal.isSyncing = false;
             wal.syncStartedAt = null;
@@ -1669,7 +2640,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           // synced / miss(retry) / corrupted out of the critical path. The
           // local file is retained until confirmed synced.
           final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-          for (final wal in batchWals) {
+          for (final wal in [...batchWals, ...coveredLegacyAliases]) {
             wal.status = WalStatus.uploaded;
             wal.jobId = result.jobId;
             wal.uploadedAt = now;
@@ -1719,7 +2690,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         listener.onWalUpdated();
         continue;
       } catch (e) {
-        print(
+        Logger.debug(
           'Local WAL upload batch failed: $e, pausing ${batchLane.name} lane',
         );
         batchesFailed++;
@@ -1745,6 +2716,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           wal.syncStartedAt = null;
           wal.syncEtaSeconds = null;
         }
+        if (manualWal != null) rethrow;
       } finally {
         if (preparedUpload != null) {
           await _deleteTemporaryUploadFiles(preparedUpload.temporaryFiles);
@@ -1768,7 +2740,18 @@ class LocalWalSyncImpl implements LocalWalSync {
     return resp;
   }
 
-  Future<void> _repairBoundRingConversations() async {
+  Future<void> _repairBoundRingConversations({
+    required int conversationBoundarySeconds,
+  }) =>
+      _serializeWalAssembly(
+        () => _repairBoundRingConversationsOwned(
+          conversationBoundarySeconds: conversationBoundarySeconds,
+        ),
+      );
+
+  Future<void> _repairBoundRingConversationsOwned({
+    required int conversationBoundarySeconds,
+  }) async {
     final sourcesByConversation = <String, List<Wal>>{};
     final existingCanonicalOwners = <String>{};
     for (final wal in _wals) {
@@ -1784,7 +2767,11 @@ class LocalWalSyncImpl implements LocalWalSync {
     for (final entry in sourcesByConversation.entries) {
       if (existingCanonicalOwners.contains(entry.key)) continue;
       try {
-        await _compactRingConversation(entry.key, entry.value);
+        await _compactRingConversation(
+          entry.key,
+          entry.value,
+          conversationBoundarySeconds: conversationBoundarySeconds,
+        );
       } catch (error) {
         Logger.debug(
           'LocalWalSync: canonical repair remains local for ${entry.key}: $error',
@@ -1798,177 +2785,19 @@ class LocalWalSyncImpl implements LocalWalSync {
     required Wal wal,
     IWalSyncProgressListener? progress,
   }) async {
-    await _flush();
-
-    final matches = _wals.where((w) => w == wal).toList();
-    if (matches.isEmpty) {
-      DebugLogManager.logInfo(
-        'Single WAL upload skipped — WAL no longer tracked',
-        {'walId': wal.id},
-      );
-      return null;
-    }
-    final walToSync = matches.first;
-
-    var resp = SyncLocalFilesResponse(
-      newConversationIds: [],
-      updatedConversationIds: [],
-    );
-
-    DebugLogManager.logInfo('Single WAL upload started', {
-      'walId': wal.id,
-      'seconds': wal.seconds,
-      'codec': wal.codec.toString(),
-    });
-
-    File? walFile;
-    if (wal.filePath == null) {
-      Logger.debug("file path is not found. wal id ${wal.id}");
-      wal.markCorrupted();
-      DebugLogManager.logWarning('Single WAL corrupted: file path missing', {
-        'walId': wal.id,
-      });
-    } else {
-      try {
-        final fullPath = await Wal.getFilePath(wal.filePath);
-        if (fullPath == null) {
-          Logger.debug("could not construct file path for wal id ${wal.id}");
-          wal.markCorrupted();
-          DebugLogManager.logWarning(
-            'Single WAL corrupted: cannot construct path',
-            {'walId': wal.id},
-          );
-        } else {
-          File file = File(fullPath);
-          if (!file.existsSync()) {
-            Logger.debug("file $fullPath does not exist");
-            wal.markCorrupted();
-            DebugLogManager.logWarning('Single WAL corrupted: file not found', {
-              'walId': wal.id,
-            });
-          } else {
-            walFile = file;
-            wal.isSyncing = true;
-          }
-        }
-      } catch (e) {
-        wal.markCorrupted();
-        print(e.toString());
-        DebugLogManager.logError(
-          e,
-          null,
-          'Single WAL corrupted: unexpected error - ${e.toString()}',
-          {'walId': wal.id},
-        );
-      }
-    }
-
-    listener.onWalUpdated();
-
-    // File unusable — nothing to upload (avoids a LateInit crash on walFile).
-    if (walFile == null) {
-      await _saveWalsToFile();
-      listener.onWalUpdated();
-      return resp;
-    }
-
+    await _syncMutex.acquire();
     try {
-      // Upload only — no poll-to-terminal. Reconciler resolves the job later.
-      var lane = _syncLaneForWal(
-        walToSync,
-        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      return await _syncAllOwned(
+        progress: progress,
+        includeBackfill: false,
+        authorizedRecovery: null,
+        nowSecondsOverride: null,
+        manualWal: wal,
+        conversationBoundarySecondsOverride: null,
       );
-      if (lane == SyncUploadLane.fresh && walToSync.conversationId != null) {
-        final pendingForConversation = _wals.where(
-          (candidate) => candidate.status == WalStatus.miss && candidate.conversationId == walToSync.conversationId,
-        );
-        // syncWal uploads one file. Claiming an immutable fresh manifest for
-        // it would strand any sibling WAL; the multi-file drain owns fresh
-        // conversation batching.
-        if (pendingForConversation.length > 1) lane = SyncUploadLane.backfill;
-      }
-      final result = await _uploadGate.upload(
-        [walFile],
-        lane: lane,
-        conversationId: walToSync.conversationId,
-      );
-
-      if (result.completed != null) {
-        final r = result.completed!;
-        resp.newConversationIds.addAll(
-          r.newConversationIds.where(
-            (id) => !resp.newConversationIds.contains(id),
-          ),
-        );
-        resp.updatedConversationIds.addAll(
-          r.updatedConversationIds.where(
-            (id) => !resp.updatedConversationIds.contains(id) && !resp.newConversationIds.contains(id),
-          ),
-        );
-        walToSync.status = WalStatus.synced;
-        walToSync.isSyncing = false;
-        walToSync.syncStartedAt = null;
-        walToSync.syncEtaSeconds = null;
-        DebugLogManager.logInfo('Single WAL upload succeeded (fast-path)', {
-          'walId': wal.id,
-        });
-        listener.onWalSynced(wal);
-      } else {
-        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-        walToSync.status = WalStatus.uploaded;
-        walToSync.jobId = result.jobId;
-        walToSync.uploadedAt = now;
-        walToSync.isSyncing = false;
-        walToSync.syncStartedAt = null;
-        walToSync.syncEtaSeconds = null;
-        DebugLogManager.logInfo('Single WAL uploaded; reconciler will finish', {
-          'walId': wal.id,
-        });
-        listener.onWalUpdated();
-      }
-    } on SyncRateLimitedException {
-      // Account-level rate limit — leave the WAL pending without consuming its
-      // retry budget. The global upload gate owns the cooldown.
-      DebugLogManager.logEvent('single_wal_rate_limited', {'walId': wal.id});
-      walToSync.isSyncing = false;
-      walToSync.syncStartedAt = null;
-      walToSync.syncEtaSeconds = null;
-      await _saveWalsToFile();
-      listener.onWalUpdated();
-      return resp;
-    } on SyncRecoveryWindowExceededException {
-      // Terminal: older than the server's automatic-recovery window. A manual
-      // retry cannot succeed either, so stop presenting it as retryable work.
-      walToSync.isSyncing = false;
-      walToSync.syncStartedAt = null;
-      walToSync.syncEtaSeconds = null;
-      final retired = _retireOutsideRecoveryWindow([walToSync]);
-      DebugLogManager.logEvent('single_wal_outside_recovery_window', {
-        'walId': wal.id,
-        'retiredWalIds': retired.map((w) => w.id).toList(),
-      });
-      await _saveWalsToFile();
-      listener.onWalUpdated();
-      return resp;
-    } catch (e) {
-      Logger.debug('Single WAL upload failed: $e');
-      DebugLogManager.logError(
-        e,
-        null,
-        'Single WAL upload failed: ${e.toString()}',
-        {'walId': wal.id},
-      );
-      walToSync.isSyncing = false;
-      walToSync.syncStartedAt = null;
-      walToSync.syncEtaSeconds = null;
-      rethrow;
+    } finally {
+      _syncMutex.release();
     }
-
-    await _saveWalsToFile();
-    listener.onWalUpdated();
-
-    progress?.onWalSyncedProgress(1.0);
-    return resp;
   }
 
   /// Retires the recordings a `backfill_lookback_exceeded` rejection proves the

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -2532,6 +2532,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           (wal) =>
               wal.status == WalStatus.miss &&
               wal.storage == WalStorage.disk &&
+              (manualWalIds != null || wal.retryCount < walMaxAutoRetries) &&
               (manualWalIds?.contains(wal.id) ??
                   _isEligibleForDrain(
                     wal,
@@ -2592,6 +2593,7 @@ class LocalWalSyncImpl implements LocalWalSync {
                 wal.status == WalStatus.miss &&
                 wal.storage == WalStorage.disk &&
                 !attemptedWalIds.contains(wal.id) &&
+                (manualWalIds != null || wal.retryCount < walMaxAutoRetries) &&
                 (manualWalIds == null || manualWalIds.contains(wal.id)),
           )
           .toList();
@@ -2803,6 +2805,44 @@ class LocalWalSyncImpl implements LocalWalSync {
               (w) => w.status == WalStatus.uploaded || w.status == WalStatus.synced,
             )
             .length;
+      } on SyncUploadTooLargeException catch (error) {
+        batchesFailed++;
+        final artifactSizes = <int>[];
+        for (final file in preparedUpload?.files ?? const <File>[]) {
+          try {
+            artifactSizes.add(await file.length());
+          } catch (_) {
+            artifactSizes.add(-1);
+          }
+        }
+        final now = nowSeconds();
+        final rejectedWals = Set<Wal>.identity()
+          ..addAll(batchWals)
+          ..addAll(coveredLegacyAliases);
+        for (final wal in rejectedWals) {
+          wal.retryCount = walMaxAutoRetries;
+          wal.lastRetryAt = now;
+          wal.isSyncing = false;
+          wal.syncStartedAt = null;
+          wal.syncEtaSeconds = null;
+          wal.syncSpeedKBps = null;
+        }
+        DebugLogManager.logError(
+          error,
+          null,
+          'Local upload batch exceeded the request boundary; source audio retained',
+          {
+            'batchWalIds': batchWals.map((wal) => wal.id).toList(),
+            'artifactBytes': artifactSizes,
+            'totalArtifactBytes': artifactSizes.where((size) => size >= 0).fold<int>(0, (sum, size) => sum + size),
+          },
+        );
+        await _saveWalsToFile();
+        listener.onWalUpdated();
+        if (manualWal != null) rethrow;
+        // A deterministic 413 applies only to this immutable transaction.
+        // Keep later healthy recordings moving instead of pausing the lane.
+        continue;
       } on SyncRateLimitedException {
         // Pause only this lane. The other lane remains eligible in this drain.
         DebugLogManager.logEvent('local_upload_rate_limited', {

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
-import 'package:opus_dart/opus_dart.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/models/sync_state.dart';
@@ -651,7 +650,7 @@ class LocalWalSyncImpl implements LocalWalSync {
   })  : _uploadGateOverride = uploadGate,
         _walPersisterOverride = walPersister,
         _walPathResolver = walPathResolver ?? Wal.getFilePath,
-        _silenceFrameFactory = silenceFrameFactory ?? _encodeOpusSilenceFrame,
+        _silenceFrameFactory = silenceFrameFactory ?? encodeOpusSilenceFrame,
         _syncJobStatusFetcher = syncJobStatusFetcher ?? fetchSyncJobStatus,
         _conversationBoundarySecondsProvider =
             conversationBoundarySecondsProvider ?? (() => SharedPreferencesUtil().conversationSilenceDuration);
@@ -678,21 +677,6 @@ class LocalWalSyncImpl implements LocalWalSync {
       final idle = _externalWalRegistrationsIdle;
       if (idle == null) continue;
       await idle.future;
-    }
-  }
-
-  static List<int> _encodeOpusSilenceFrame(BleAudioCodec codec) {
-    final encoder = SimpleOpusEncoder(
-      sampleRate: 16000,
-      channels: 1,
-      application: Application.voip,
-    );
-    try {
-      return encoder.encode(
-        input: Int16List(codec.getFrameSize()),
-      );
-    } finally {
-      encoder.destroy();
     }
   }
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -31,6 +31,8 @@ const _syncUploadBatchLimit = 5;
 
 typedef WalPersister = Future<bool> Function(List<Wal> wals);
 typedef WalPathResolver = Future<String?> Function(String? pathOrName);
+typedef FreshUploadBatchDelay = Future<void> Function();
+typedef SyncJobStatusFetcher = Future<SyncJobFetch> Function(String jobId);
 
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 
@@ -150,8 +152,11 @@ class LocalWalSyncImpl implements LocalWalSync {
   SyncUploadGate get _uploadGate => _uploadGateOverride ?? SyncUploadGate.instance;
   final WalPersister? _walPersisterOverride;
   final WalPathResolver _walPathResolver;
+  final FreshUploadBatchDelay _freshUploadBatchDelay;
+  final SyncJobStatusFetcher _syncJobStatusFetcher;
   Future<void>? _freshUploadWake;
   bool _freshUploadWakePending = false;
+  bool _freshUploadWakeNeedsBatchDelay = false;
   String? _freshUploadWakeWalId;
 
   LocalWalSyncImpl(
@@ -159,9 +164,15 @@ class LocalWalSyncImpl implements LocalWalSync {
     SyncUploadGate? uploadGate,
     WalPersister? walPersister,
     WalPathResolver? walPathResolver,
+    FreshUploadBatchDelay? freshUploadBatchDelay,
+    SyncJobStatusFetcher? syncJobStatusFetcher,
   })  : _uploadGateOverride = uploadGate,
         _walPersisterOverride = walPersister,
-        _walPathResolver = walPathResolver ?? Wal.getFilePath;
+        _walPathResolver = walPathResolver ?? Wal.getFilePath,
+        _freshUploadBatchDelay = freshUploadBatchDelay ?? _defaultFreshUploadBatchDelay,
+        _syncJobStatusFetcher = syncJobStatusFetcher ?? fetchSyncJobStatus;
+
+  static Future<void> _defaultFreshUploadBatchDelay() => Future<void>.delayed(const Duration(seconds: 5));
 
   @visibleForTesting
   List<WalFrame> get testFrames => _frames;
@@ -249,12 +260,24 @@ class LocalWalSyncImpl implements LocalWalSync {
   void _scheduleFreshUpload(Wal wal) {
     _freshUploadWakePending = true;
     _freshUploadWakeWalId = wal.id;
+    if (_shouldBatchRecoveredLiveWal(wal)) {
+      _freshUploadWakeNeedsBatchDelay = true;
+    }
     if (_freshUploadWake != null) return;
     _startFreshUploadWake();
   }
 
+  bool _shouldBatchRecoveredLiveWal(Wal wal) =>
+      wal.uploadIntent == WalUploadIntent.liveContinuity &&
+      wal.originalStorage == WalStorage.sdcard &&
+      wal.conversationId == null;
+
   void _startFreshUploadWake() {
-    final wake = _drainFreshUploadWakes();
+    final needsBatchDelay = _freshUploadWakeNeedsBatchDelay;
+    _freshUploadWakeNeedsBatchDelay = false;
+    final wake = _drainFreshUploadWake(
+      needsBatchDelay: needsBatchDelay,
+    );
     _freshUploadWake = wake;
     unawaited(
       wake.whenComplete(() {
@@ -267,20 +290,26 @@ class LocalWalSyncImpl implements LocalWalSync {
     );
   }
 
-  Future<void> _drainFreshUploadWakes() async {
-    do {
-      _freshUploadWakePending = false;
-      final walId = _freshUploadWakeWalId;
-      try {
-        // Device-storage recovery persists one WAL at a time. Coalesce wakes
-        // so a fast BLE drain cannot start duplicate upload loops.
-        await syncFreshOnly();
-      } catch (error) {
-        Logger.debug(
-          'LocalWalSync: fresh upload wake failed for $walId: $error',
-        );
-      }
-    } while (_freshUploadWakePending);
+  Future<void> _drainFreshUploadWake({
+    required bool needsBatchDelay,
+  }) async {
+    if (needsBatchDelay) {
+      // Storage-authoritative live fallback arrives as independently durable
+      // 1–3 second ranges. Give adjacent ranges a short collection window so
+      // one backend job can run VAD, chronological assignment, and
+      // conversation reprocessing over the whole passage. The live socket is
+      // unaffected; this applies only when it did not own the frames.
+      await _freshUploadBatchDelay();
+    }
+    _freshUploadWakePending = false;
+    final walId = _freshUploadWakeWalId;
+    try {
+      await syncFreshOnly();
+    } catch (error) {
+      Logger.debug(
+        'LocalWalSync: fresh upload wake failed for $walId: $error',
+      );
+    }
   }
 
   Future<bool> _hasIdenticalFile(Wal existing, Wal candidate) async {
@@ -1050,9 +1079,15 @@ class LocalWalSyncImpl implements LocalWalSync {
         continue;
       } catch (e) {
         print(
-          'Local WAL upload batch failed: $e, continuing with remaining files',
+          'Local WAL upload batch failed: $e, pausing ${batchLane.name} lane',
         );
         batchesFailed++;
+        // A transport/backend failure applies to the lane, not just the
+        // current files. Walking every pending batch while offline turns a
+        // large durable backlog into a tight network, CPU, and battery storm.
+        // Keep every WAL retryable and let the connectivity/cooldown
+        // coordinator wake a later drain.
+        blockedLanes.add(batchLane);
         DebugLogManager.logError(
           e,
           null,
@@ -1327,8 +1362,9 @@ class LocalWalSyncImpl implements LocalWalSync {
     for (var i = 0; i < entries.length; i += maxConcurrent) {
       final slice = entries.sublist(i, min(i + maxConcurrent, entries.length));
       final fetched = await Future.wait(
-        slice.map((e) async => (e.value, await fetchSyncJobStatus(e.key))),
+        slice.map((e) async => (e.value, await _syncJobStatusFetcher(e.key))),
       );
+      var transientFailureSeen = false;
 
       for (final (members, fetch) in fetched) {
         final jobId = members.first.jobId;
@@ -1336,6 +1372,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         switch (fetch.outcome) {
           case SyncJobFetchOutcome.transient:
             // Network/5xx — leave as `uploaded`, retry on the next pass.
+            transientFailureSeen = true;
             DebugLogManager.logEvent('reconcile_poll', {
               'jobId': jobId,
               'memberWalIds': memberWalIds,
@@ -1446,6 +1483,13 @@ class LocalWalSyncImpl implements LocalWalSync {
             }
             break;
         }
+      }
+      if (transientFailureSeen) {
+        // One unavailable fetch is enough evidence to stop this pass. With a
+        // large uploaded backlog, probing every job while offline created
+        // hundreds of doomed requests per wake. At most the bounded
+        // concurrent slice is attempted; all remaining jobs stay durable.
+        break;
       }
     }
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -745,6 +745,26 @@ class LocalWalSyncImpl implements LocalWalSync {
     final existingIndex = _wals.indexWhere((w) => w.id == wal.id);
     if (existingIndex >= 0) {
       final existing = _wals[existingIndex];
+      if (existing.status == WalStatus.corrupted &&
+          _isDurableRingCoverageArtifact(existing) &&
+          _isDurableRingCoverageArtifact(wal) &&
+          _sameRingEncoding(existing, wal)) {
+        _wals[existingIndex] = wal;
+        try {
+          await _saveWalsToFile();
+        } catch (_) {
+          _wals[existingIndex] = existing;
+          rethrow;
+        }
+        listener.onWalUpdated();
+        Logger.debug(
+          "LocalWalSync: Replaced unavailable ring WAL ${wal.id} from device storage",
+        );
+        if (scheduleUpload && wal.status == WalStatus.miss && _mayAutoUploadExternalWal(wal)) {
+          _scheduleFreshUpload(wal);
+        }
+        return ExternalWalRegistration.added;
+      }
       if (!await _hasIdenticalFile(existing, wal)) {
         throw StateError('External WAL identity collision for ${wal.id}');
       }
@@ -1136,7 +1156,7 @@ class LocalWalSyncImpl implements LocalWalSync {
     required int? recoverySequenceBoundary,
     required int conversationBoundarySeconds,
   }) async {
-    final candidates = _wals
+    final candidateSnapshot = _wals
         .where(
           (wal) =>
               wal.conversationId == null &&
@@ -1145,6 +1165,44 @@ class LocalWalSyncImpl implements LocalWalSync {
               (wal.status == WalStatus.miss || wal.status == WalStatus.synced),
         )
         .toList();
+    final candidates = <Wal>[];
+    final unavailable = <Wal>[];
+    final unavailableStatuses = <Wal, WalStatus>{};
+    for (final wal in candidateSnapshot) {
+      try {
+        final path = await _walPathResolver(wal.filePath);
+        if (path != null) {
+          final file = File(path);
+          if (await file.exists() && await file.length() > 0) {
+            candidates.add(wal);
+            continue;
+          }
+        }
+      } catch (_) {
+        // A local source that cannot be opened is not retryable compaction
+        // work. The pendant's immutable sequence remains the recovery owner.
+      }
+      unavailableStatuses[wal] = wal.status;
+      unavailable.add(wal);
+    }
+    if (unavailable.isNotEmpty) {
+      for (final wal in unavailable) {
+        wal.markCorrupted();
+      }
+      try {
+        await _saveWalsToFile();
+      } catch (_) {
+        for (final wal in unavailable) {
+          wal.status = unavailableStatuses[wal]!;
+        }
+        rethrow;
+      }
+      DebugLogManager.logWarning(
+        'Historical ring sources unavailable; waiting for pendant recovery',
+        {'count': unavailable.length},
+      );
+      listener.onWalUpdated();
+    }
     final buckets = <String, List<Wal>>{};
     for (final wal in candidates) {
       final key = [
@@ -1232,9 +1290,20 @@ class LocalWalSyncImpl implements LocalWalSync {
       final range = RingProtocol.parseRecoverySourceRange(wal.sourceId)!;
       return producedCoverage[_ringEncodingBucket(wal)]?.covers(range.start, range.end) == true;
     }).toSet();
+    final supersededCorruptedArtifacts = _wals.where((wal) {
+      if (wal.conversationId != null ||
+          wal.storage != WalStorage.disk ||
+          wal.status != WalStatus.corrupted ||
+          !_isDurableRingCoverageArtifact(wal)) {
+        return false;
+      }
+      final range = RingProtocol.parseDurableCoverageSourceRange(wal.sourceId)!;
+      return producedCoverage[_ringEncodingBucket(wal)]?.covers(range.start, range.end) == true;
+    }).toSet();
     final compactedSources = {
       ...archives.expand((archive) => archive.sources),
       ...supersededLegacyArchives,
+      ...supersededCorruptedArtifacts,
     };
     _wals = [
       ..._wals.where((wal) => !compactedSources.contains(wal)),
@@ -1284,6 +1353,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       'source_fragment_count': compactedSources.length,
       'archive_artifact_count': archives.length,
       'legacy_archive_retired_count': supersededLegacyArchives.length,
+      'corrupted_artifact_recovered_count': supersededCorruptedArtifacts.length,
     });
     listener.onWalUpdated();
   }
@@ -1766,6 +1836,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       return;
     }
     final sessionEnd = sessionEndSeconds ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final conversationBoundarySeconds = _conversationBoundarySeconds();
     var stamped = 0;
     await _serializeWalAssembly(() async {
       await _waitForExternalWalRegistrations();
@@ -1790,12 +1861,14 @@ class LocalWalSyncImpl implements LocalWalSync {
           sessionEndSeconds: sessionEnd,
           conversationId: conversationId,
           ringDeviceScope: ringDeviceScope,
+          conversationBoundarySeconds: conversationBoundarySeconds,
         );
         final ringSources = _boundedRingSourcesForConversation(
           sessionStartSeconds: sessionStartSeconds,
           sessionEndSeconds: sessionEnd,
           conversationId: conversationId,
           ringDeviceScope: ringDeviceScope,
+          conversationBoundarySeconds: conversationBoundarySeconds,
         );
         if (ringSources.isEmpty) {
           if (stamped > 0) await _saveWalsToFile();
@@ -1824,7 +1897,9 @@ class LocalWalSyncImpl implements LocalWalSync {
                 !_hasUnownedWalInBoundedSession(
                   sessionStartSeconds: sessionStartSeconds,
                   sessionEndSeconds: sessionEnd,
+                  conversationId: conversationId,
                   ringDeviceScope: ringDeviceScope,
+                  conversationBoundarySeconds: conversationBoundarySeconds,
                 ) &&
                 _sameIdentityWalSet(
                   sourceSnapshot,
@@ -1833,6 +1908,7 @@ class LocalWalSyncImpl implements LocalWalSync {
                     sessionEndSeconds: sessionEnd,
                     conversationId: conversationId,
                     ringDeviceScope: ringDeviceScope,
+                    conversationBoundarySeconds: conversationBoundarySeconds,
                   ),
                 ),
           );
@@ -1883,22 +1959,63 @@ class LocalWalSyncImpl implements LocalWalSync {
     return wal.status == WalStatus.miss || (ringContinuity && wal.status == WalStatus.synced);
   }
 
+  Set<Wal> _ringConversationWindowSources({
+    required int sessionStartSeconds,
+    required int sessionEndSeconds,
+    required String conversationId,
+    required Set<String> ringDeviceScope,
+    required int conversationBoundarySeconds,
+  }) {
+    final selected = Set<Wal>.identity();
+    final eligible = _wals.where(
+      (wal) =>
+          _isRingRecoveryArtifact(wal) &&
+          ringDeviceScope.contains(wal.device) &&
+          (wal.conversationId == null || wal.conversationId == conversationId) &&
+          _isStampableSessionWal(wal),
+    );
+    for (final group in _continuousRingRecoveryGroups(
+      eligible,
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    )) {
+      final belongsToSession = group.any(
+        (wal) =>
+            wal.conversationId == conversationId ||
+            _isInBoundedSession(
+              wal,
+              sessionStartSeconds: sessionStartSeconds,
+              sessionEndSeconds: sessionEndSeconds,
+            ),
+      );
+      if (belongsToSession) selected.addAll(group);
+    }
+    return selected;
+  }
+
   int _stampBoundedSessionWals({
     required int sessionStartSeconds,
     required int sessionEndSeconds,
     required String conversationId,
     required Set<String> ringDeviceScope,
+    required int conversationBoundarySeconds,
   }) {
+    final ringSessionSources = _ringConversationWindowSources(
+      sessionStartSeconds: sessionStartSeconds,
+      sessionEndSeconds: sessionEndSeconds,
+      conversationId: conversationId,
+      ringDeviceScope: ringDeviceScope,
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    );
     var stamped = 0;
     for (final wal in _wals) {
-      if (wal.conversationId == null &&
-          _isStampableSessionWal(wal) &&
-          (!_isRingRecoveryArtifact(wal) || ringDeviceScope.contains(wal.device)) &&
-          _isInBoundedSession(
-            wal,
-            sessionStartSeconds: sessionStartSeconds,
-            sessionEndSeconds: sessionEndSeconds,
-          )) {
+      final belongsToSession = _isRingRecoveryArtifact(wal)
+          ? ringSessionSources.contains(wal)
+          : _isInBoundedSession(
+              wal,
+              sessionStartSeconds: sessionStartSeconds,
+              sessionEndSeconds: sessionEndSeconds,
+            );
+      if (wal.conversationId == null && _isStampableSessionWal(wal) && belongsToSession) {
         wal.conversationId = conversationId;
         stamped++;
       }
@@ -1909,40 +2026,48 @@ class LocalWalSyncImpl implements LocalWalSync {
   bool _hasUnownedWalInBoundedSession({
     required int sessionStartSeconds,
     required int sessionEndSeconds,
+    required String conversationId,
     required Set<String> ringDeviceScope,
-  }) =>
-      _wals.any(
-        (wal) =>
-            wal.conversationId == null &&
-            _isStampableSessionWal(wal) &&
-            (!_isRingRecoveryArtifact(wal) || ringDeviceScope.contains(wal.device)) &&
-            _isInBoundedSession(
-              wal,
-              sessionStartSeconds: sessionStartSeconds,
-              sessionEndSeconds: sessionEndSeconds,
-            ),
+    required int conversationBoundarySeconds,
+  }) {
+    final ringSessionSources = _ringConversationWindowSources(
+      sessionStartSeconds: sessionStartSeconds,
+      sessionEndSeconds: sessionEndSeconds,
+      conversationId: conversationId,
+      ringDeviceScope: ringDeviceScope,
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    );
+    return _wals.any((wal) {
+      if (wal.conversationId != null || !_isStampableSessionWal(wal)) {
+        return false;
+      }
+      if (_isRingRecoveryArtifact(wal)) {
+        return ringSessionSources.contains(wal);
+      }
+      return _isInBoundedSession(
+        wal,
+        sessionStartSeconds: sessionStartSeconds,
+        sessionEndSeconds: sessionEndSeconds,
       );
+    });
+  }
 
   List<Wal> _boundedRingSourcesForConversation({
     required int sessionStartSeconds,
     required int sessionEndSeconds,
     required String conversationId,
     required Set<String> ringDeviceScope,
-  }) =>
-      _wals
-          .where(
-            (wal) =>
-                wal.conversationId == conversationId &&
-                _isRingRecoveryArtifact(wal) &&
-                ringDeviceScope.contains(wal.device) &&
-                (wal.status == WalStatus.miss || wal.status == WalStatus.synced) &&
-                _isInBoundedSession(
-                  wal,
-                  sessionStartSeconds: sessionStartSeconds,
-                  sessionEndSeconds: sessionEndSeconds,
-                ),
-          )
-          .toList();
+    required int conversationBoundarySeconds,
+  }) {
+    final ringSessionSources = _ringConversationWindowSources(
+      sessionStartSeconds: sessionStartSeconds,
+      sessionEndSeconds: sessionEndSeconds,
+      conversationId: conversationId,
+      ringDeviceScope: ringDeviceScope,
+      conversationBoundarySeconds: conversationBoundarySeconds,
+    );
+    return ringSessionSources.where((wal) => wal.conversationId == conversationId).toList();
+  }
 
   List<Wal> _canonicalWalsForConversation(String conversationId) => _wals
       .where(

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -69,7 +69,7 @@ SyncUploadLane syncUploadLaneForTimestamp(
 SyncUploadLane _syncLaneForWal(Wal wal, int nowSeconds) => syncUploadLaneForTimestamp(
       wal.timerStart,
       nowSeconds,
-      hasServerCaptureProof: wal.conversationId != null,
+      hasServerCaptureProof: wal.conversationId != null || wal.uploadIntent == WalUploadIntent.liveContinuity,
     );
 
 @visibleForTesting

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -91,44 +91,12 @@ double _walEndSeconds(Wal wal) {
   return wal.timerStart + preciseDuration;
 }
 
-bool _isClosedUnboundCapture(Wal wal, int nowSeconds) =>
-    _isUnboundStorageContinuity(wal) && nowSeconds - _walEndSeconds(wal) >= _conversationBoundarySeconds;
+bool _isRawRingFragment(Wal wal) => wal.originalStorage == WalStorage.sdcard && _ringSourceRange(wal) != null;
 
-List<Wal> _latestClosedUnboundCapture(List<Wal> ordered, int nowSeconds) {
-  final anchor = ordered.first;
-  final candidates = ordered
-      .where(
-        (wal) =>
-            _isClosedUnboundCapture(wal, nowSeconds) &&
-            wal.device == anchor.device &&
-            wal.codec == anchor.codec &&
-            wal.sampleRate == anchor.sampleRate &&
-            wal.channel == anchor.channel,
-      )
-      .toList()
-    ..sort((a, b) {
-      final timeCompare = b.timerStart.compareTo(a.timerStart);
-      if (timeCompare != 0) return timeCompare;
-      return b.id.compareTo(a.id);
-    });
+bool _isRingRecoveryArtifact(Wal wal) =>
+    wal.originalStorage == WalStorage.sdcard && RingProtocol.parseRecoverySourceRange(wal.sourceId) != null;
 
-  final capture = <Wal>[];
-  double? nextStart;
-  for (final wal in candidates) {
-    if (capture.isEmpty) {
-      capture.add(wal);
-      nextStart = wal.timerStart.toDouble();
-      continue;
-    }
-    if (nextStart! - _walEndSeconds(wal) > _conversationBoundarySeconds) {
-      break;
-    }
-    capture.add(wal);
-    nextStart = wal.timerStart.toDouble();
-    if (capture.length == _captureUploadWalLimit) break;
-  }
-  return capture;
-}
+bool _isUnassembledConversationRepair(Wal wal) => wal.conversationId != null && _isRingRecoveryArtifact(wal);
 
 @visibleForTesting
 Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
@@ -158,7 +126,8 @@ List<Wal> nextSyncUploadBatch(
 
   final ordered = pending
       .where(
-        (wal) => !_isUnboundStorageContinuity(wal) || _isClosedUnboundCapture(wal, nowSeconds),
+        (wal) =>
+            !_isUnboundStorageContinuity(wal) && !_isRawRingFragment(wal) && !_isUnassembledConversationRepair(wal),
       )
       .toList()
     ..sort((a, b) {
@@ -169,9 +138,6 @@ List<Wal> nextSyncUploadBatch(
       return b.timerStart.compareTo(a.timerStart);
     });
   if (ordered.isEmpty) return const [];
-  if (_isUnboundStorageContinuity(ordered.first)) {
-    return _latestClosedUnboundCapture(ordered, nowSeconds);
-  }
   final lane = effectiveLane(ordered.first);
   final conversationId = ordered.first.conversationId;
   final canonicalReplacement = ordered.first.canonicalReplacement;
@@ -261,6 +227,18 @@ class _PreparedUploadFiles {
   final List<File> temporaryFiles;
 }
 
+class _HistoricalRingArchive {
+  const _HistoricalRingArchive({
+    required this.sources,
+    required this.wal,
+    this.createdFile,
+  });
+
+  final List<Wal> sources;
+  final Wal wal;
+  final File? createdFile;
+}
+
 class LocalWalSyncImpl implements LocalWalSync {
   List<Wal> _wals = [];
 
@@ -300,6 +278,8 @@ class LocalWalSyncImpl implements LocalWalSync {
   Future<void>? _freshUploadWake;
   bool _freshUploadWakePending = false;
   String? _freshUploadWakeWalId;
+  Timer? _historicalCompactionTimer;
+  Future<void>? _historicalCompaction;
 
   LocalWalSyncImpl(
     this.listener, {
@@ -422,7 +402,7 @@ class LocalWalSyncImpl implements LocalWalSync {
     // summaries. Keep the bytes durable on the phone until
     // stampConversationId() binds the complete session to its authoritative
     // backend conversation.
-    return wal.uploadIntent != WalUploadIntent.liveContinuity || wal.conversationId != null;
+    return !_isRawRingFragment(wal);
   }
 
   void _scheduleFreshUpload(Wal wal) {
@@ -569,6 +549,10 @@ class LocalWalSyncImpl implements LocalWalSync {
         await _flush();
       },
     );
+    _historicalCompactionTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => _scheduleHistoricalCompaction(),
+    );
   }
 
   Future<void> _initializeWals() async {
@@ -600,18 +584,269 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     // Fix any inconsistent WAL states from old implementations
     await WalFileManager.migrateInconsistentWals(_wals);
-
     if (!_walReady.isCompleted) _walReady.complete();
     listener.onWalUpdated();
+    _scheduleHistoricalCompaction();
+  }
+
+  @visibleForTesting
+  Future<void> prepareHistoricalRingFragments({
+    required int nowSeconds,
+  }) {
+    final inFlight = _historicalCompaction;
+    if (inFlight != null) return inFlight;
+    late final Future<void> operation;
+    operation = _prepareHistoricalRingFragments(nowSeconds: nowSeconds).whenComplete(() {
+      if (identical(_historicalCompaction, operation)) {
+        _historicalCompaction = null;
+      }
+    });
+    _historicalCompaction = operation;
+    return operation;
+  }
+
+  Future<void> _prepareHistoricalRingFragments({
+    required int nowSeconds,
+  }) async {
+    final candidates = _wals
+        .where(
+          (wal) =>
+              wal.conversationId == null &&
+              _isRawRingFragment(wal) &&
+              wal.storage == WalStorage.disk &&
+              (wal.status == WalStatus.miss || wal.status == WalStatus.synced),
+        )
+        .toList();
+    final buckets = <String, List<Wal>>{};
+    for (final wal in candidates) {
+      final key = [
+        wal.device,
+        wal.codec.name,
+        wal.sampleRate,
+        wal.channel,
+        wal.frameSize,
+      ].join('|');
+      buckets.putIfAbsent(key, () => []).add(wal);
+    }
+
+    final archives = <_HistoricalRingArchive>[];
+    for (final bucket in buckets.values) {
+      bucket.sort((left, right) {
+        final timeCompare = left.timerStart.compareTo(right.timerStart);
+        if (timeCompare != 0) return timeCompare;
+        return left.id.compareTo(right.id);
+      });
+      for (final capture in _continuousRingGroups(bucket)) {
+        final captureEnd = capture.map(_walEndSeconds).reduce(max);
+        if (nowSeconds - captureEnd < _conversationBoundarySeconds) {
+          continue;
+        }
+        for (final group in _continuousRingGroups(
+          capture,
+          maxWallSeconds: 30 * 60,
+        )) {
+          try {
+            archives.add(await _prepareHistoricalRingArchive(group));
+          } catch (error) {
+            Logger.debug(
+              'LocalWalSync: historical archive group remains retryable: $error',
+            );
+          }
+        }
+      }
+    }
+    if (archives.isEmpty) return;
+
+    final before = _wals;
+    final compactedSources = archives.expand((archive) => archive.sources).toSet();
+    _wals = [
+      ..._wals.where((wal) => !compactedSources.contains(wal)),
+      ...archives.map((archive) => archive.wal),
+    ];
+    try {
+      await _saveWalsToFile();
+    } catch (_) {
+      _wals = before;
+      await _deleteHistoricalArchiveFiles(archives);
+      rethrow;
+    }
+
+    final retainedPaths = archives.map((archive) => archive.wal.filePath).whereType<String>().toSet();
+    for (final source in compactedSources) {
+      if (retainedPaths.contains(source.filePath)) continue;
+      final path = await _walPathResolver(source.filePath);
+      if (path == null) continue;
+      try {
+        final file = File(path);
+        if (await file.exists()) await file.delete();
+      } catch (error) {
+        Logger.debug(
+          'LocalWalSync: historical source cleanup failed: $error',
+        );
+      }
+    }
+    DebugLogManager.logEvent('historical_ring_archive_compacted', {
+      'source_fragment_count': compactedSources.length,
+      'archive_artifact_count': archives.length,
+    });
+    listener.onWalUpdated();
+  }
+
+  List<List<Wal>> _continuousRingGroups(
+    List<Wal> ordered, {
+    int? maxWallSeconds,
+  }) {
+    final groups = <List<Wal>>[];
+    for (final wal in ordered) {
+      if (groups.isEmpty) {
+        groups.add([wal]);
+        continue;
+      }
+      final group = groups.last;
+      final wallGap = wal.timerStart - _walEndSeconds(group.last);
+      final wallSpan = _walEndSeconds(wal) - group.first.timerStart;
+      if (wallGap < _conversationBoundarySeconds && (maxWallSeconds == null || wallSpan <= maxWallSeconds)) {
+        group.add(wal);
+      } else {
+        groups.add([wal]);
+      }
+    }
+    return groups;
+  }
+
+  Future<_HistoricalRingArchive> _prepareHistoricalRingArchive(
+    List<Wal> sources,
+  ) async {
+    if (sources.isEmpty) {
+      throw ArgumentError.value(sources, 'sources', 'must not be empty');
+    }
+    final orderedBySequence = List<Wal>.from(sources)
+      ..sort(
+        (left, right) => _ringSourceRange(left)!.start.compareTo(
+              _ringSourceRange(right)!.start,
+            ),
+      );
+    final first = orderedBySequence.first;
+    final last = orderedBySequence.last;
+    final firstRange = _ringSourceRange(first)!;
+    final lastRange = _ringSourceRange(last)!;
+    final archiveSourceId = 'archive_ring_${firstRange.start}_${lastRange.end}_${first.timerStart}';
+    final archiveStatus = sources.any((wal) => wal.status == WalStatus.miss) ? WalStatus.miss : WalStatus.synced;
+
+    if (sources.length == 1) {
+      return _HistoricalRingArchive(
+        sources: sources,
+        wal: _historicalArchiveWal(
+          first: first,
+          sourceId: archiveSourceId,
+          filePath: first.filePath,
+          timerStart: first.timerStart,
+          totalFrames: first.totalFrames,
+          status: archiveStatus,
+        ),
+      );
+    }
+
+    final firstPath = await _walPathResolver(first.filePath);
+    if (firstPath == null) {
+      throw StateError('Historical archive destination is unavailable');
+    }
+    final destination = File(
+      '${File(firstPath).parent.path}/${first.getFileNameByTimeStarts(first.timerStart, sourceId: archiveSourceId)}',
+    );
+    final parts = <ConversationAudioPart>[];
+    for (final wal in sources) {
+      final path = await _walPathResolver(wal.filePath);
+      if (path == null || !await File(path).exists()) {
+        throw StateError('Historical archive source is unavailable');
+      }
+      parts.add(ConversationAudioPart(wal: wal, file: File(path)));
+    }
+    final assembly = await assembleConversationAudio(
+      parts: parts,
+      destination: destination,
+      silenceFrameFactory: _silenceFrameFactory,
+      conversationBoundarySeconds: _conversationBoundarySeconds,
+    );
+    final fps = first.codec.getFramesPerSecond();
+    return _HistoricalRingArchive(
+      sources: sources,
+      createdFile: assembly.file,
+      wal: _historicalArchiveWal(
+        first: first,
+        sourceId: archiveSourceId,
+        filePath: assembly.file.path.split('/').last,
+        timerStart: assembly.timerStart,
+        totalFrames: assembly.totalFrames,
+        seconds: fps > 0 ? (assembly.totalFrames + fps - 1) ~/ fps : 0,
+        status: archiveStatus,
+      ),
+    );
+  }
+
+  Wal _historicalArchiveWal({
+    required Wal first,
+    required String sourceId,
+    required String? filePath,
+    required int timerStart,
+    required int totalFrames,
+    required WalStatus status,
+    int? seconds,
+  }) {
+    final fps = first.codec.getFramesPerSecond();
+    return Wal(
+      timerStart: timerStart,
+      codec: first.codec,
+      channel: first.channel,
+      sampleRate: first.sampleRate,
+      seconds: seconds ?? (fps > 0 ? (totalFrames + fps - 1) ~/ fps : first.seconds),
+      totalFrames: totalFrames,
+      status: status,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: filePath,
+      device: first.device,
+      deviceModel: first.deviceModel,
+      sourceId: sourceId,
+      uploadIntent: WalUploadIntent.historicalBackfill,
+      retryCount: first.retryCount,
+      lastRetryAt: first.lastRetryAt,
+    );
+  }
+
+  Future<void> _deleteHistoricalArchiveFiles(
+    List<_HistoricalRingArchive> archives,
+  ) async {
+    for (final archive in archives) {
+      final file = archive.createdFile;
+      if (file == null) continue;
+      try {
+        if (await file.exists()) await file.delete();
+      } catch (_) {}
+    }
+  }
+
+  void _scheduleHistoricalCompaction() {
+    unawaited(
+      prepareHistoricalRingFragments(
+        nowSeconds: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      ).catchError((Object error) {
+        Logger.debug(
+          'LocalWalSync: historical compaction remains retryable: $error',
+        );
+      }),
+    );
   }
 
   @override
   Future stop() async {
     _chunkingTimer?.cancel();
     _flushingTimer?.cancel();
+    _historicalCompactionTimer?.cancel();
 
     await _chunk();
     await _flush();
+    await _historicalCompaction;
 
     _frames = [];
     _frameSynced = [];
@@ -814,6 +1049,14 @@ class LocalWalSyncImpl implements LocalWalSync {
     return _wals.where((w) => w.status == WalStatus.miss).toList();
   }
 
+  @override
+  Future<Wal?> getWalById(String id) async {
+    for (final wal in _wals) {
+      if (wal.id == id) return wal;
+    }
+    return null;
+  }
+
   /// Returns unsynced WALs whose timerStart falls within [sessionStartSeconds, now].
   /// Used by the live capture screen to show inline audio safety indicators.
   List<Wal> getSessionUnsyncedWals(int sessionStartSeconds) {
@@ -918,16 +1161,23 @@ class LocalWalSyncImpl implements LocalWalSync {
   /// retaining or submitting thousands of one-second files.
   Future<void> stampConversationId(
     int sessionStartSeconds,
-    String conversationId,
-  ) async {
-    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    String conversationId, {
+    required bool hasServerSpeechProof,
+    int? sessionEndSeconds,
+  }) async {
+    if (!hasServerSpeechProof) {
+      Logger.debug(
+        'stampConversationId: retained audio locally because the conversation has no server speech proof',
+      );
+      return;
+    }
+    final now = sessionEndSeconds ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
     int stamped = 0;
     final ringSources = <Wal>[];
     for (final wal in _wals) {
-      final inSession = wal.timerStart >= sessionStartSeconds && wal.timerStart <= now;
-      final ringContinuity = wal.uploadIntent == WalUploadIntent.liveContinuity &&
-          wal.originalStorage == WalStorage.sdcard &&
-          RingProtocol.parseSourceRange(wal.sourceId) != null;
+      final inSession = _walEndSeconds(wal) >= sessionStartSeconds && wal.timerStart <= now;
+      final ringContinuity =
+          wal.originalStorage == WalStorage.sdcard && RingProtocol.parseRecoverySourceRange(wal.sourceId) != null;
       if (inSession &&
           wal.conversationId == null &&
           (wal.status == WalStatus.miss || (ringContinuity && wal.status == WalStatus.synced))) {
@@ -949,8 +1199,8 @@ class LocalWalSyncImpl implements LocalWalSync {
         );
       } catch (error) {
         // Every immutable source remains in place. Persist its conversation
-        // owner and fall back to the gap-only uploader instead of risking
-        // either data loss or an unbounded retry loop.
+        // owner, but never upload raw fragments. A later serialized sync pass
+        // retries canonical assembly.
         await _saveWalsToFile();
         Logger.debug(
           'stampConversationId: canonical assembly failed for $conversationId: $error',
@@ -961,7 +1211,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       );
       Wal? uploadWakeWal;
       for (final wal in _wals) {
-        if (wal.status == WalStatus.miss && wal.conversationId == conversationId) {
+        if (wal.status == WalStatus.miss && wal.conversationId == conversationId && !_isRingRecoveryArtifact(wal)) {
           uploadWakeWal = wal;
           break;
         }
@@ -1011,8 +1261,8 @@ class LocalWalSyncImpl implements LocalWalSync {
 
         final first = entry.value.reduce(
           (left, right) {
-            final leftRange = RingProtocol.parseSourceRange(left.sourceId)!;
-            final rightRange = RingProtocol.parseSourceRange(right.sourceId)!;
+            final leftRange = RingProtocol.parseRecoverySourceRange(left.sourceId)!;
+            final rightRange = RingProtocol.parseRecoverySourceRange(right.sourceId)!;
             return leftRange.start <= rightRange.start ? left : right;
           },
         );
@@ -1203,6 +1453,10 @@ class LocalWalSyncImpl implements LocalWalSync {
     required bool includeBackfill,
   }) async {
     await _flush();
+    await prepareHistoricalRingFragments(
+      nowSeconds: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+    await _repairBoundRingConversations();
     _isCancelled = false;
     _accumulatedResponse = null;
 
@@ -1512,6 +1766,31 @@ class LocalWalSyncImpl implements LocalWalSync {
     resp.localUploadFailures = batchesFailed;
     progress?.onWalSyncedProgress(1.0);
     return resp;
+  }
+
+  Future<void> _repairBoundRingConversations() async {
+    final sourcesByConversation = <String, List<Wal>>{};
+    final existingCanonicalOwners = <String>{};
+    for (final wal in _wals) {
+      final conversationId = wal.conversationId;
+      if (conversationId == null) continue;
+      if (wal.sourceId?.startsWith('canonical_') == true) {
+        existingCanonicalOwners.add(conversationId);
+      } else if (wal.originalStorage == WalStorage.sdcard &&
+          RingProtocol.parseRecoverySourceRange(wal.sourceId) != null) {
+        sourcesByConversation.putIfAbsent(conversationId, () => []).add(wal);
+      }
+    }
+    for (final entry in sourcesByConversation.entries) {
+      if (existingCanonicalOwners.contains(entry.key)) continue;
+      try {
+        await _compactRingConversation(entry.key, entry.value);
+      } catch (error) {
+        Logger.debug(
+          'LocalWalSync: canonical repair remains local for ${entry.key}: $error',
+        );
+      }
+    }
   }
 
   @override

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -4,18 +4,22 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
+import 'package:opus_dart/opus_dart.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
+import 'package:omi/services/wals/conversation_audio_assembler.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 import 'package:omi/services/wals/sync_upload_gate.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/mutex.dart';
 import 'package:omi/utils/wal_file_manager.dart';
 
 /// Error string the backend's stale guard sets when a job sits queued past
@@ -24,14 +28,16 @@ import 'package:omi/utils/wal_file_manager.dart';
 /// below ('failed' with totalSegments==0) as the durable signal.
 const _kBackendBusyErrorHint = 'background worker likely died';
 const _freshSyncCutoffSeconds = 6 * 60 * 60;
+const _conversationBoundarySeconds = 2 * 60;
+const _captureUploadWalLimit = 2000;
 
-/// One batch is one server-side sync job, and a job must finish inside the
-/// backend's 600s stale guard (backend/database/sync_jobs.py).
-const _syncUploadBatchLimit = 5;
+/// Legacy/historical files per upload batch. A conversation-bound capture uses
+/// [_captureUploadWalLimit] so its immutable recovery units remain one server
+/// transaction instead of racing as many independent jobs.
+const _syncUploadBatchLimit = 20;
 
 typedef WalPersister = Future<bool> Function(List<Wal> wals);
 typedef WalPathResolver = Future<String?> Function(String? pathOrName);
-typedef FreshUploadBatchDelay = Future<void> Function();
 typedef SyncJobStatusFetcher = Future<SyncJobFetch> Function(String jobId);
 
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
@@ -74,6 +80,56 @@ SyncUploadLane _syncLaneForWal(Wal wal, int nowSeconds) => syncUploadLaneForTime
       hasServerCaptureProof: wal.conversationId != null || wal.uploadIntent == WalUploadIntent.liveContinuity,
     );
 
+bool _isUnboundStorageContinuity(Wal wal) =>
+    wal.uploadIntent == WalUploadIntent.liveContinuity &&
+    wal.originalStorage == WalStorage.sdcard &&
+    wal.conversationId == null;
+
+double _walEndSeconds(Wal wal) {
+  final fps = wal.codec.getFramesPerSecond();
+  final preciseDuration = fps > 0 && wal.totalFrames > 0 ? wal.totalFrames / fps : wal.seconds.toDouble();
+  return wal.timerStart + preciseDuration;
+}
+
+bool _isClosedUnboundCapture(Wal wal, int nowSeconds) =>
+    _isUnboundStorageContinuity(wal) && nowSeconds - _walEndSeconds(wal) >= _conversationBoundarySeconds;
+
+List<Wal> _latestClosedUnboundCapture(List<Wal> ordered, int nowSeconds) {
+  final anchor = ordered.first;
+  final candidates = ordered
+      .where(
+        (wal) =>
+            _isClosedUnboundCapture(wal, nowSeconds) &&
+            wal.device == anchor.device &&
+            wal.codec == anchor.codec &&
+            wal.sampleRate == anchor.sampleRate &&
+            wal.channel == anchor.channel,
+      )
+      .toList()
+    ..sort((a, b) {
+      final timeCompare = b.timerStart.compareTo(a.timerStart);
+      if (timeCompare != 0) return timeCompare;
+      return b.id.compareTo(a.id);
+    });
+
+  final capture = <Wal>[];
+  double? nextStart;
+  for (final wal in candidates) {
+    if (capture.isEmpty) {
+      capture.add(wal);
+      nextStart = wal.timerStart.toDouble();
+      continue;
+    }
+    if (nextStart! - _walEndSeconds(wal) > _conversationBoundarySeconds) {
+      break;
+    }
+    capture.add(wal);
+    nextStart = wal.timerStart.toDouble();
+    if (capture.length == _captureUploadWalLimit) break;
+  }
+  return capture;
+}
+
 @visibleForTesting
 Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
   final counts = <String, int>{};
@@ -86,7 +142,7 @@ Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
       );
     }
   }
-  return counts.entries.where((entry) => entry.value > 20).map((entry) => entry.key).toSet();
+  return counts.entries.where((entry) => entry.value > _captureUploadWalLimit).map((entry) => entry.key).toSet();
 }
 
 @visibleForTesting
@@ -100,7 +156,11 @@ List<Wal> nextSyncUploadBatch(
           ? SyncUploadLane.backfill
           : _syncLaneForWal(wal, nowSeconds);
 
-  final ordered = List<Wal>.from(pending)
+  final ordered = pending
+      .where(
+        (wal) => !_isUnboundStorageContinuity(wal) || _isClosedUnboundCapture(wal, nowSeconds),
+      )
+      .toList()
     ..sort((a, b) {
       final laneCompare = effectiveLane(
         a,
@@ -109,14 +169,96 @@ List<Wal> nextSyncUploadBatch(
       return b.timerStart.compareTo(a.timerStart);
     });
   if (ordered.isEmpty) return const [];
+  if (_isUnboundStorageContinuity(ordered.first)) {
+    return _latestClosedUnboundCapture(ordered, nowSeconds);
+  }
   final lane = effectiveLane(ordered.first);
   final conversationId = ordered.first.conversationId;
-  return ordered
+  final canonicalReplacement = ordered.first.canonicalReplacement;
+  final matching = ordered
       .where(
-        (wal) => effectiveLane(wal) == lane && wal.conversationId == conversationId,
+        (wal) =>
+            effectiveLane(wal) == lane &&
+            wal.conversationId == conversationId &&
+            wal.canonicalReplacement == canonicalReplacement,
       )
-      .take(_syncUploadBatchLimit)
       .toList();
+  return matching.take(conversationId == null ? _syncUploadBatchLimit : _captureUploadWalLimit).toList();
+}
+
+({int start, int end})? _ringSourceRange(Wal wal) {
+  final match = RegExp(r'^ring_(\d+)_(\d+)$').firstMatch(wal.sourceId ?? '');
+  if (match == null) return null;
+  final start = int.tryParse(match.group(1)!);
+  final end = int.tryParse(match.group(2)!);
+  if (start == null || end == null || end <= start) return null;
+  return (start: start, end: end);
+}
+
+bool _sameUploadEncoding(Wal left, Wal right) =>
+    left.device == right.device &&
+    left.codec == right.codec &&
+    left.sampleRate == right.sampleRate &&
+    left.channel == right.channel &&
+    left.frameSize == right.frameSize &&
+    left.conversationId == right.conversationId &&
+    left.uploadIntent == right.uploadIntent;
+
+/// Immutable source WALs stay as the acknowledgement/retry records. This
+/// grouping only determines the larger derived artifacts exposed to STT.
+@visibleForTesting
+List<List<Wal>> contiguousWalUploadRuns(
+  List<Wal> wals, {
+  int maxArtifactSeconds = 300,
+}) {
+  final ordered = List<Wal>.from(wals)
+    ..sort((a, b) {
+      final left = _ringSourceRange(a);
+      final right = _ringSourceRange(b);
+      if (left != null && right != null && a.device == b.device) {
+        final sourceCompare = left.start.compareTo(right.start);
+        if (sourceCompare != 0) return sourceCompare;
+      }
+      final timeCompare = a.timerStart.compareTo(b.timerStart);
+      if (timeCompare != 0) return timeCompare;
+      return a.id.compareTo(b.id);
+    });
+
+  final runs = <List<Wal>>[];
+  for (final wal in ordered) {
+    final source = _ringSourceRange(wal);
+    if (runs.isEmpty || source == null) {
+      runs.add([wal]);
+      continue;
+    }
+
+    final run = runs.last;
+    final previous = run.last;
+    final previousSource = _ringSourceRange(previous);
+    final fps = wal.codec.getFramesPerSecond();
+    final runFrames = run.fold<int>(0, (sum, member) => sum + member.totalFrames);
+    final nextDuration = fps > 0 ? (runFrames + wal.totalFrames) / fps : double.infinity;
+    final wallGap = wal.timerStart - _walEndSeconds(previous);
+    final joins = previousSource != null &&
+        previousSource.end == source.start &&
+        _sameUploadEncoding(previous, wal) &&
+        wallGap >= -2 &&
+        wallGap <= 2 &&
+        nextDuration <= maxArtifactSeconds;
+    if (joins) {
+      run.add(wal);
+    } else {
+      runs.add([wal]);
+    }
+  }
+  return runs;
+}
+
+class _PreparedUploadFiles {
+  const _PreparedUploadFiles(this.files, this.temporaryFiles);
+
+  final List<File> files;
+  final List<File> temporaryFiles;
 }
 
 class LocalWalSyncImpl implements LocalWalSync {
@@ -152,11 +294,11 @@ class LocalWalSyncImpl implements LocalWalSync {
   SyncUploadGate get _uploadGate => _uploadGateOverride ?? SyncUploadGate.instance;
   final WalPersister? _walPersisterOverride;
   final WalPathResolver _walPathResolver;
-  final FreshUploadBatchDelay _freshUploadBatchDelay;
+  final OpusSilenceFrameFactory _silenceFrameFactory;
   final SyncJobStatusFetcher _syncJobStatusFetcher;
+  final Mutex _syncMutex = Mutex();
   Future<void>? _freshUploadWake;
   bool _freshUploadWakePending = false;
-  bool _freshUploadWakeNeedsBatchDelay = false;
   String? _freshUploadWakeWalId;
 
   LocalWalSyncImpl(
@@ -164,15 +306,28 @@ class LocalWalSyncImpl implements LocalWalSync {
     SyncUploadGate? uploadGate,
     WalPersister? walPersister,
     WalPathResolver? walPathResolver,
-    FreshUploadBatchDelay? freshUploadBatchDelay,
+    OpusSilenceFrameFactory? silenceFrameFactory,
     SyncJobStatusFetcher? syncJobStatusFetcher,
   })  : _uploadGateOverride = uploadGate,
         _walPersisterOverride = walPersister,
         _walPathResolver = walPathResolver ?? Wal.getFilePath,
-        _freshUploadBatchDelay = freshUploadBatchDelay ?? _defaultFreshUploadBatchDelay,
+        _silenceFrameFactory = silenceFrameFactory ?? _encodeOpusSilenceFrame,
         _syncJobStatusFetcher = syncJobStatusFetcher ?? fetchSyncJobStatus;
 
-  static Future<void> _defaultFreshUploadBatchDelay() => Future<void>.delayed(const Duration(seconds: 5));
+  static List<int> _encodeOpusSilenceFrame(BleAudioCodec codec) {
+    final encoder = SimpleOpusEncoder(
+      sampleRate: 16000,
+      channels: 1,
+      application: Application.voip,
+    );
+    try {
+      return encoder.encode(
+        input: Int16List(codec.getFrameSize()),
+      );
+    } finally {
+      encoder.destroy();
+    }
+  }
 
   @visibleForTesting
   List<WalFrame> get testFrames => _frames;
@@ -204,7 +359,7 @@ class LocalWalSyncImpl implements LocalWalSync {
       }
       Logger.debug("LocalWalSync: WAL ${wal.id} already durably registered");
       await _deleteDuplicateExternalFile(existing, wal);
-      if (scheduleUpload && existing.status == WalStatus.miss) {
+      if (scheduleUpload && existing.status == WalStatus.miss && _mayAutoUploadExternalWal(existing)) {
         _scheduleFreshUpload(existing);
       }
       return ExternalWalRegistration.alreadyRegistered;
@@ -248,7 +403,9 @@ class LocalWalSyncImpl implements LocalWalSync {
     Logger.debug(
       "LocalWalSync: Added external WAL ${wal.id} (${wal.seconds}s)",
     );
-    if (scheduleUpload && _syncLaneForWal(wal, DateTime.now().millisecondsSinceEpoch ~/ 1000) == SyncUploadLane.fresh) {
+    if (scheduleUpload &&
+        _mayAutoUploadExternalWal(wal) &&
+        _syncLaneForWal(wal, DateTime.now().millisecondsSinceEpoch ~/ 1000) == SyncUploadLane.fresh) {
       // Registration is the durability boundary used by device-storage sync:
       // once the manifest is committed, the device may advance its read
       // pointer. Cloud latency must not hold that acknowledgement hostage.
@@ -257,27 +414,26 @@ class LocalWalSyncImpl implements LocalWalSync {
     return ExternalWalRegistration.added;
   }
 
+  bool _mayAutoUploadExternalWal(Wal wal) {
+    // Ring-tail fallback ranges are transport recovery units, not independent
+    // conversations. Uploading them before the live session receives its
+    // server conversation id creates parallel jobs of 1–3 second utterances;
+    // those jobs race conversation assignment and repeatedly reprocess
+    // summaries. Keep the bytes durable on the phone until
+    // stampConversationId() binds the complete session to its authoritative
+    // backend conversation.
+    return wal.uploadIntent != WalUploadIntent.liveContinuity || wal.conversationId != null;
+  }
+
   void _scheduleFreshUpload(Wal wal) {
     _freshUploadWakePending = true;
     _freshUploadWakeWalId = wal.id;
-    if (_shouldBatchRecoveredLiveWal(wal)) {
-      _freshUploadWakeNeedsBatchDelay = true;
-    }
     if (_freshUploadWake != null) return;
     _startFreshUploadWake();
   }
 
-  bool _shouldBatchRecoveredLiveWal(Wal wal) =>
-      wal.uploadIntent == WalUploadIntent.liveContinuity &&
-      wal.originalStorage == WalStorage.sdcard &&
-      wal.conversationId == null;
-
   void _startFreshUploadWake() {
-    final needsBatchDelay = _freshUploadWakeNeedsBatchDelay;
-    _freshUploadWakeNeedsBatchDelay = false;
-    final wake = _drainFreshUploadWake(
-      needsBatchDelay: needsBatchDelay,
-    );
+    final wake = _drainFreshUploadWakes();
     _freshUploadWake = wake;
     unawaited(
       wake.whenComplete(() {
@@ -290,26 +446,20 @@ class LocalWalSyncImpl implements LocalWalSync {
     );
   }
 
-  Future<void> _drainFreshUploadWake({
-    required bool needsBatchDelay,
-  }) async {
-    if (needsBatchDelay) {
-      // Storage-authoritative live fallback arrives as independently durable
-      // 1–3 second ranges. Give adjacent ranges a short collection window so
-      // one backend job can run VAD, chronological assignment, and
-      // conversation reprocessing over the whole passage. The live socket is
-      // unaffected; this applies only when it did not own the frames.
-      await _freshUploadBatchDelay();
-    }
-    _freshUploadWakePending = false;
-    final walId = _freshUploadWakeWalId;
-    try {
-      await syncFreshOnly();
-    } catch (error) {
-      Logger.debug(
-        'LocalWalSync: fresh upload wake failed for $walId: $error',
-      );
-    }
+  Future<void> _drainFreshUploadWakes() async {
+    do {
+      _freshUploadWakePending = false;
+      final walId = _freshUploadWakeWalId;
+      try {
+        // Device-storage recovery persists one WAL at a time. Coalesce wakes
+        // so a fast BLE drain cannot start duplicate upload loops.
+        await syncFreshOnly();
+      } catch (error) {
+        Logger.debug(
+          'LocalWalSync: fresh upload wake failed for $walId: $error',
+        );
+      }
+    } while (_freshUploadWakePending);
   }
 
   Future<bool> _hasIdenticalFile(Wal existing, Wal candidate) async {
@@ -334,6 +484,72 @@ class LocalWalSyncImpl implements LocalWalSync {
     if (candidatePath == null) return;
     final candidateFile = File(candidatePath);
     if (await candidateFile.exists()) await candidateFile.delete();
+  }
+
+  Future<_PreparedUploadFiles> _prepareUploadFiles(
+    List<Wal> wals,
+    List<File> sourceFiles,
+  ) async {
+    final filesByWal = Map<Wal, File>.identity();
+    for (var index = 0; index < wals.length; index++) {
+      filesByWal[wals[index]] = sourceFiles[index];
+    }
+
+    final uploadFiles = <File>[];
+    final temporaryFiles = <File>[];
+    for (final run in contiguousWalUploadRuns(wals)) {
+      if (run.length == 1) {
+        uploadFiles.add(filesByWal[run.single]!);
+        continue;
+      }
+
+      final first = run.first;
+      final firstRange = _ringSourceRange(first)!;
+      final lastRange = _ringSourceRange(run.last)!;
+      final filename = first.getFileNameByTimeStarts(
+        first.timerStart,
+        sourceId: 'assembled_${firstRange.start}_${lastRange.end}_$pid',
+      );
+      final artifact = File('${Directory.systemTemp.path}/$filename');
+      final partial = File('${artifact.path}.partial');
+      if (await artifact.exists()) await artifact.delete();
+      if (await partial.exists()) await partial.delete();
+      final sink = partial.openWrite();
+      var sinkClosed = false;
+      try {
+        for (final wal in run) {
+          await sink.addStream(filesByWal[wal]!.openRead());
+        }
+        await sink.flush();
+        await sink.close();
+        sinkClosed = true;
+        await partial.rename(artifact.path);
+      } catch (_) {
+        if (!sinkClosed) {
+          try {
+            await sink.close();
+          } catch (_) {
+            // Preserve the assembly failure; cleanup is best-effort.
+          }
+        }
+        if (await partial.exists()) await partial.delete();
+        if (await artifact.exists()) await artifact.delete();
+        rethrow;
+      }
+      uploadFiles.add(artifact);
+      temporaryFiles.add(artifact);
+    }
+    return _PreparedUploadFiles(uploadFiles, temporaryFiles);
+  }
+
+  Future<void> _deleteTemporaryUploadFiles(List<File> files) async {
+    for (final file in files) {
+      try {
+        if (await file.exists()) await file.delete();
+      } catch (error) {
+        Logger.debug('LocalWalSync: failed to delete derived upload artifact: $error');
+      }
+    }
   }
 
   @override
@@ -697,28 +913,177 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   /// Stamp all session WALs with the given conversationId and persist to disk.
-  /// This makes WAL→conversation linkage survive app kill.
+  /// Ring-backed live ranges are compacted into one canonical recording before
+  /// upload. This makes WAL→conversation linkage survive app kill without
+  /// retaining or submitting thousands of one-second files.
   Future<void> stampConversationId(
     int sessionStartSeconds,
     String conversationId,
   ) async {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     int stamped = 0;
+    final ringSources = <Wal>[];
     for (final wal in _wals) {
-      if (wal.status == WalStatus.miss &&
-          wal.timerStart >= sessionStartSeconds &&
-          wal.timerStart <= now &&
-          wal.conversationId == null) {
+      final inSession = wal.timerStart >= sessionStartSeconds && wal.timerStart <= now;
+      final ringContinuity = wal.uploadIntent == WalUploadIntent.liveContinuity &&
+          wal.originalStorage == WalStorage.sdcard &&
+          RingProtocol.parseSourceRange(wal.sourceId) != null;
+      if (inSession &&
+          wal.conversationId == null &&
+          (wal.status == WalStatus.miss || (ringContinuity && wal.status == WalStatus.synced))) {
         wal.conversationId = conversationId;
         stamped++;
       }
+      if (inSession &&
+          ringContinuity &&
+          wal.conversationId == conversationId &&
+          (wal.status == WalStatus.miss || wal.status == WalStatus.synced)) {
+        ringSources.add(wal);
+      }
     }
-    if (stamped > 0) {
-      await _saveWalsToFile();
+    if (stamped > 0 || ringSources.isNotEmpty) {
+      try {
+        await _compactRingConversation(
+          conversationId,
+          ringSources,
+        );
+      } catch (error) {
+        // Every immutable source remains in place. Persist its conversation
+        // owner and fall back to the gap-only uploader instead of risking
+        // either data loss or an unbounded retry loop.
+        await _saveWalsToFile();
+        Logger.debug(
+          'stampConversationId: canonical assembly failed for $conversationId: $error',
+        );
+      }
       Logger.debug(
         'stampConversationId: stamped $stamped WALs with conversation $conversationId',
       );
+      Wal? uploadWakeWal;
+      for (final wal in _wals) {
+        if (wal.status == WalStatus.miss && wal.conversationId == conversationId) {
+          uploadWakeWal = wal;
+          break;
+        }
+      }
+      if (uploadWakeWal != null) {
+        // Active-conversation repair is independent of opt-in historical
+        // sync. The exact server owner is known, so wake one serialized drain.
+        _scheduleFreshUpload(uploadWakeWal);
+      }
     }
+  }
+
+  Future<void> _compactRingConversation(
+    String conversationId,
+    List<Wal> sourceWals,
+  ) async {
+    if (sourceWals.isEmpty) {
+      await _saveWalsToFile();
+      return;
+    }
+
+    final byDevice = <String, List<Wal>>{};
+    for (final wal in sourceWals) {
+      byDevice.putIfAbsent(wal.device, () => <Wal>[]).add(wal);
+    }
+    if (byDevice.length != 1) {
+      throw StateError('Canonical assembly requires one pendant per conversation');
+    }
+
+    final canonicalWals = <Wal>[];
+    final canonicalFiles = <File>[];
+    final compactedSources = <Wal>{};
+    try {
+      for (final entry in byDevice.entries) {
+        final parts = <ConversationAudioPart>[];
+        for (final wal in entry.value) {
+          final path = await _walPathResolver(wal.filePath);
+          if (path == null) {
+            throw StateError('Canonical source path is unavailable');
+          }
+          final file = File(path);
+          if (!await file.exists()) {
+            throw StateError('Canonical source file is unavailable');
+          }
+          parts.add(ConversationAudioPart(wal: wal, file: file));
+        }
+
+        final first = entry.value.reduce(
+          (left, right) {
+            final leftRange = RingProtocol.parseSourceRange(left.sourceId)!;
+            final rightRange = RingProtocol.parseSourceRange(right.sourceId)!;
+            return leftRange.start <= rightRange.start ? left : right;
+          },
+        );
+        final filename = first.getFileNameByTimeStarts(
+          first.timerStart,
+          sourceId: 'canonical_${conversationId}_$pid',
+        );
+        final firstPath = await _walPathResolver(first.filePath);
+        if (firstPath == null) {
+          throw StateError('Canonical destination directory is unavailable');
+        }
+        final destination = File('${File(firstPath).parent.path}/$filename');
+        final assembly = await assembleConversationAudio(
+          parts: parts,
+          destination: destination,
+          silenceFrameFactory: _silenceFrameFactory,
+          conversationBoundarySeconds: _conversationBoundarySeconds,
+        );
+        canonicalFiles.add(assembly.file);
+        compactedSources.addAll(assembly.sourceWals);
+
+        final fps = first.codec.getFramesPerSecond();
+        canonicalWals.add(
+          Wal(
+            timerStart: assembly.timerStart,
+            codec: first.codec,
+            channel: first.channel,
+            sampleRate: first.sampleRate,
+            seconds: fps > 0 ? (assembly.totalFrames + fps - 1) ~/ fps : 0,
+            totalFrames: assembly.totalFrames,
+            status: assembly.hadLiveGap ? WalStatus.miss : WalStatus.synced,
+            storage: WalStorage.disk,
+            originalStorage: WalStorage.sdcard,
+            filePath: assembly.file.path.split('/').last,
+            device: first.device,
+            deviceModel: first.deviceModel,
+            sourceId: 'canonical_${conversationId}_$pid',
+            conversationId: conversationId,
+            uploadIntent: WalUploadIntent.liveContinuity,
+            canonicalReplacement: assembly.hadLiveGap,
+          ),
+        );
+      }
+
+      // Assembly performs asynchronous disk reads. Preserve WALs registered by
+      // the BLE drain while those reads were in flight; replacing the original
+      // snapshot here could orphan already-acknowledged pendant records.
+      _wals = [
+        ..._wals.where((wal) => !compactedSources.contains(wal)),
+        ...canonicalWals,
+      ];
+      await _saveWalsToFile();
+    } catch (_) {
+      for (final file in canonicalFiles) {
+        if (await file.exists()) await file.delete();
+      }
+      rethrow;
+    }
+
+    for (final source in compactedSources) {
+      final sourcePath = await _walPathResolver(source.filePath);
+      if (sourcePath == null) continue;
+      final sourceFile = File(sourcePath);
+      if (canonicalFiles.any((file) => file.path == sourceFile.path)) continue;
+      try {
+        if (await sourceFile.exists()) await sourceFile.delete();
+      } catch (error) {
+        Logger.debug('Canonical assembly could not delete compacted source: $error');
+      }
+    }
+    listener.onWalUpdated();
   }
 
   /// Returns WALs that have a conversationId but haven't been synced yet.
@@ -819,6 +1184,21 @@ class LocalWalSyncImpl implements LocalWalSync {
       _syncAll(progress: progress, includeBackfill: false);
 
   Future<SyncLocalFilesResponse?> _syncAll({
+    IWalSyncProgressListener? progress,
+    required bool includeBackfill,
+  }) async {
+    await _syncMutex.acquire();
+    try {
+      return await _syncAllOwned(
+        progress: progress,
+        includeBackfill: includeBackfill,
+      );
+    } finally {
+      _syncMutex.release();
+    }
+  }
+
+  Future<SyncLocalFilesResponse?> _syncAllOwned({
     IWalSyncProgressListener? progress,
     required bool includeBackfill,
   }) async {
@@ -991,15 +1371,22 @@ class LocalWalSyncImpl implements LocalWalSync {
       );
 
       listener.onWalUpdated();
+      _PreparedUploadFiles? preparedUpload;
       try {
+        preparedUpload = await _prepareUploadFiles(batchWals, files);
+        DebugLogManager.logEvent('local_upload_prepared', {
+          'sourceWalCount': batchWals.length,
+          'uploadArtifactCount': preparedUpload.files.length,
+        });
         // Upload only — return as soon as the server acknowledges. We do NOT
         // wait for server-side processing here; the reconciler resolves the
         // job_id later. Only WALs that actually became files (batchWals) are
         // mutated — corrupted ones already short-circuited above.
         final result = await _uploadGate.upload(
-          files,
+          preparedUpload.files,
           lane: batchLane,
           conversationId: batchWals.first.conversationId,
+          replaceTranscript: batchWals.first.canonicalReplacement,
         );
 
         if (result.completed != null) {
@@ -1103,6 +1490,10 @@ class LocalWalSyncImpl implements LocalWalSync {
           wal.isSyncing = false;
           wal.syncStartedAt = null;
           wal.syncEtaSeconds = null;
+        }
+      } finally {
+        if (preparedUpload != null) {
+          await _deleteTemporaryUploadFiles(preparedUpload.temporaryFiles);
         }
       }
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -29,6 +29,9 @@ const _liveCaptureMaxAgeSeconds = 6 * 60 * 60;
 /// backend's 600s stale guard (backend/database/sync_jobs.py).
 const _syncUploadBatchLimit = 5;
 
+typedef WalPersister = Future<bool> Function(List<Wal> wals);
+typedef WalPathResolver = Future<String?> Function(String? pathOrName);
+
 enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 
 /// The shared WAL acknowledgement boundary for async sync jobs.
@@ -99,8 +102,20 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   final SyncUploadGate? _uploadGateOverride;
   SyncUploadGate get _uploadGate => _uploadGateOverride ?? SyncUploadGate.instance;
+  final WalPersister? _walPersisterOverride;
+  final WalPathResolver _walPathResolver;
+  Future<void>? _freshUploadWake;
+  bool _freshUploadWakePending = false;
+  String? _freshUploadWakeWalId;
 
-  LocalWalSyncImpl(this.listener, {SyncUploadGate? uploadGate}) : _uploadGateOverride = uploadGate;
+  LocalWalSyncImpl(
+    this.listener, {
+    SyncUploadGate? uploadGate,
+    WalPersister? walPersister,
+    WalPathResolver? walPathResolver,
+  })  : _uploadGateOverride = uploadGate,
+        _walPersisterOverride = walPersister,
+        _walPathResolver = walPathResolver ?? Wal.getFilePath;
 
   @visibleForTesting
   List<WalFrame> get testFrames => _frames;
@@ -120,16 +135,116 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   @override
-  Future<void> addExternalWal(Wal wal) async {
+  Future<ExternalWalRegistration> addExternalWal(Wal wal) async {
     final existingIndex = _wals.indexWhere((w) => w.id == wal.id);
     if (existingIndex >= 0) {
-      Logger.debug("LocalWalSync: WAL ${wal.id} already exists, skipping");
-      return;
+      final existing = _wals[existingIndex];
+      if (!await _hasIdenticalFile(existing, wal)) {
+        throw StateError('External WAL identity collision for ${wal.id}');
+      }
+      Logger.debug("LocalWalSync: WAL ${wal.id} already durably registered");
+      await _deleteDuplicateExternalFile(existing, wal);
+      return ExternalWalRegistration.alreadyRegistered;
     }
+
+    // Older ring-sync builds keyed recovered WALs only by timestamp. If one of
+    // those files is byte-identical, it is already durable (and may already
+    // be uploaded); do not manufacture a second conversation from the retry.
+    for (final existing in _wals) {
+      if (existing.device == wal.device &&
+          existing.timerStart == wal.timerStart &&
+          existing.codec == wal.codec &&
+          existing.originalStorage == wal.originalStorage &&
+          await _hasIdenticalFile(existing, wal)) {
+        // Old builds could overwrite a timestamp-named file after it had been
+        // marked synced. Without the upload-time hash, its current bytes are
+        // not proof of what reached the server. Re-register that legacy data
+        // conservatively; source-aware WALs below are immutable and idempotent.
+        if (existing.sourceId == null && existing.status == WalStatus.synced) {
+          Logger.debug("LocalWalSync: synced legacy WAL ${existing.id} has no immutable upload proof; retaining retry");
+          continue;
+        }
+        Logger.debug("LocalWalSync: external WAL ${wal.id} matches legacy durable WAL ${existing.id}");
+        await _deleteDuplicateExternalFile(existing, wal);
+        return ExternalWalRegistration.alreadyRegistered;
+      }
+    }
+
     _wals.add(wal);
-    await _saveWalsToFile();
+    try {
+      await _saveWalsToFile();
+    } catch (_) {
+      _wals.removeWhere((candidate) => identical(candidate, wal));
+      rethrow;
+    }
     listener.onWalUpdated();
     Logger.debug("LocalWalSync: Added external WAL ${wal.id} (${wal.seconds}s)");
+    if (_syncLaneForWal(wal, DateTime.now().millisecondsSinceEpoch ~/ 1000) == SyncUploadLane.fresh) {
+      // Registration is the durability boundary used by device-storage sync:
+      // once the manifest is committed, the device may advance its read
+      // pointer. Cloud latency must not hold that acknowledgement hostage.
+      _scheduleFreshUpload(wal);
+    }
+    return ExternalWalRegistration.added;
+  }
+
+  void _scheduleFreshUpload(Wal wal) {
+    _freshUploadWakePending = true;
+    _freshUploadWakeWalId = wal.id;
+    if (_freshUploadWake != null) return;
+    _startFreshUploadWake();
+  }
+
+  void _startFreshUploadWake() {
+    final wake = _drainFreshUploadWakes();
+    _freshUploadWake = wake;
+    unawaited(
+      wake.whenComplete(() {
+        if (!identical(_freshUploadWake, wake)) return;
+        _freshUploadWake = null;
+        // A registration can land after the drain's final pending check but
+        // before this completion callback. Preserve that wake as a new drain.
+        if (_freshUploadWakePending) _startFreshUploadWake();
+      }),
+    );
+  }
+
+  Future<void> _drainFreshUploadWakes() async {
+    do {
+      _freshUploadWakePending = false;
+      final walId = _freshUploadWakeWalId;
+      try {
+        // Device-storage recovery persists one WAL at a time. Coalesce wakes
+        // so a fast BLE drain cannot start duplicate upload loops.
+        await syncFreshOnly();
+      } catch (error) {
+        Logger.debug('LocalWalSync: fresh upload wake failed for $walId: $error');
+      }
+    } while (_freshUploadWakePending);
+  }
+
+  Future<bool> _hasIdenticalFile(Wal existing, Wal candidate) async {
+    if (existing.filePath == null || candidate.filePath == null) return false;
+    final existingPath = await _walPathResolver(existing.filePath);
+    final candidatePath = await _walPathResolver(candidate.filePath);
+    if (existingPath == null || candidatePath == null) return false;
+    final existingFile = File(existingPath);
+    final candidateFile = File(candidatePath);
+    if (!await existingFile.exists() || !await candidateFile.exists()) return false;
+    if (await existingFile.length() != await candidateFile.length()) return false;
+    if (existingPath == candidatePath) return true;
+
+    final existingBytes = await existingFile.readAsBytes();
+    final candidateBytes = await candidateFile.readAsBytes();
+    return listEquals(existingBytes, candidateBytes);
+  }
+
+  Future<void> _deleteDuplicateExternalFile(Wal existing, Wal candidate) async {
+    if (existing.filePath == null || candidate.filePath == null || existing.filePath == candidate.filePath) return;
+    final candidatePath = await _walPathResolver(candidate.filePath);
+    if (candidatePath == null) return;
+    final candidateFile = File(candidatePath);
+    if (await candidateFile.exists()) await candidateFile.delete();
   }
 
   @override
@@ -340,7 +455,10 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   Future<void> _saveWalsToFile() async {
     Logger.debug('Saving WALs to file');
-    await WalFileManager.saveWals(_wals);
+    final saved = await (_walPersisterOverride?.call(_wals) ?? WalFileManager.saveWals(_wals));
+    if (!saved) {
+      throw StateError('WAL manifest persistence failed');
+    }
   }
 
   Future<bool> _deleteWal(Wal wal) async {

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -23,7 +23,7 @@ import 'package:omi/utils/wal_file_manager.dart';
 /// #7469 — if this string changes, update here and keep the structural check
 /// below ('failed' with totalSegments==0) as the durable signal.
 const _kBackendBusyErrorHint = 'background worker likely died';
-const _liveCaptureMaxAgeSeconds = 6 * 60 * 60;
+const _freshSyncCutoffSeconds = 6 * 60 * 60;
 
 /// One batch is one server-side sync job, and a job must finish inside the
 /// backend's 600s stale guard (backend/database/sync_jobs.py).
@@ -40,7 +40,10 @@ enum SyncJobTerminalPolicy { wait, acknowledge, retry }
 /// terminally synced. Partial and full failures deliberately take the retry
 /// path so the retained WAL remains recoverable.
 @visibleForTesting
-SyncJobTerminalPolicy syncJobTerminalPolicy({required String status, required bool isTerminal}) {
+SyncJobTerminalPolicy syncJobTerminalPolicy({
+  required String status,
+  required bool isTerminal,
+}) {
   if (!isTerminal) return SyncJobTerminalPolicy.wait;
   return status == 'completed' ? SyncJobTerminalPolicy.acknowledge : SyncJobTerminalPolicy.retry;
 }
@@ -54,21 +57,64 @@ bool syncJobIsBackendBusy(SyncJobStatusResponse status) {
   return status.status == 'failed' && status.totalSegments == 0 && (reasonCode == null || reasonCode.isEmpty);
 }
 
-bool isLiveCaptureWal(Wal wal, int nowSeconds) =>
-    wal.conversationId != null && nowSeconds - wal.timerStart <= _liveCaptureMaxAgeSeconds;
+SyncUploadLane syncUploadLaneForTimestamp(
+  int captureSeconds,
+  int nowSeconds, {
+  required bool hasServerCaptureProof,
+}) =>
+    hasServerCaptureProof && nowSeconds - captureSeconds <= _freshSyncCutoffSeconds
+        ? SyncUploadLane.fresh
+        : SyncUploadLane.backfill;
 
-/// The capture manifest is immutable per conversation, so claiming one for a
-/// partial batch strands the siblings that did not fit.
-@visibleForTesting
-bool canClaimLiveCapture(List<Wal> batch, List<Wal> pendingForConversation, int nowSeconds) =>
-    batch.isNotEmpty && isLiveCaptureWal(batch.first, nowSeconds) && pendingForConversation.length <= batch.length;
+SyncUploadLane _syncLaneForWal(Wal wal, int nowSeconds) => syncUploadLaneForTimestamp(
+      wal.timerStart,
+      nowSeconds,
+      hasServerCaptureProof: wal.conversationId != null,
+    );
 
 @visibleForTesting
-List<Wal> nextSyncUploadBatch(List<Wal> pending, int nowSeconds) {
-  final ordered = List<Wal>.from(pending)..sort((a, b) => b.timerStart.compareTo(a.timerStart));
+Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
+  final counts = <String, int>{};
+  for (final wal in pending) {
+    if (wal.conversationId != null && _syncLaneForWal(wal, nowSeconds) == SyncUploadLane.fresh) {
+      counts.update(
+        wal.conversationId!,
+        (count) => count + 1,
+        ifAbsent: () => 1,
+      );
+    }
+  }
+  return counts.entries.where((entry) => entry.value > 20).map((entry) => entry.key).toSet();
+}
+
+@visibleForTesting
+List<Wal> nextSyncUploadBatch(
+  List<Wal> pending,
+  int nowSeconds, {
+  Set<String> forcedBackfillConversationIds = const {},
+}) {
+  SyncUploadLane effectiveLane(Wal wal) =>
+      wal.conversationId != null && forcedBackfillConversationIds.contains(wal.conversationId)
+          ? SyncUploadLane.backfill
+          : _syncLaneForWal(wal, nowSeconds);
+
+  final ordered = List<Wal>.from(pending)
+    ..sort((a, b) {
+      final laneCompare = effectiveLane(
+        a,
+      ).index.compareTo(effectiveLane(b).index);
+      if (laneCompare != 0) return laneCompare;
+      return b.timerStart.compareTo(a.timerStart);
+    });
   if (ordered.isEmpty) return const [];
+  final lane = effectiveLane(ordered.first);
   final conversationId = ordered.first.conversationId;
-  return ordered.where((wal) => wal.conversationId == conversationId).take(_syncUploadBatchLimit).toList();
+  return ordered
+      .where(
+        (wal) => effectiveLane(wal) == lane && wal.conversationId == conversationId,
+      )
+      .take(_syncUploadBatchLimit)
+      .toList();
 }
 
 class LocalWalSyncImpl implements LocalWalSync {
@@ -135,7 +181,10 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   @override
-  Future<ExternalWalRegistration> addExternalWal(Wal wal) async {
+  Future<ExternalWalRegistration> addExternalWal(
+    Wal wal, {
+    bool scheduleUpload = true,
+  }) async {
     final existingIndex = _wals.indexWhere((w) => w.id == wal.id);
     if (existingIndex >= 0) {
       final existing = _wals[existingIndex];
@@ -144,6 +193,9 @@ class LocalWalSyncImpl implements LocalWalSync {
       }
       Logger.debug("LocalWalSync: WAL ${wal.id} already durably registered");
       await _deleteDuplicateExternalFile(existing, wal);
+      if (scheduleUpload && existing.status == WalStatus.miss) {
+        _scheduleFreshUpload(existing);
+      }
       return ExternalWalRegistration.alreadyRegistered;
     }
 
@@ -161,10 +213,14 @@ class LocalWalSyncImpl implements LocalWalSync {
         // not proof of what reached the server. Re-register that legacy data
         // conservatively; source-aware WALs below are immutable and idempotent.
         if (existing.sourceId == null && existing.status == WalStatus.synced) {
-          Logger.debug("LocalWalSync: synced legacy WAL ${existing.id} has no immutable upload proof; retaining retry");
+          Logger.debug(
+            "LocalWalSync: synced legacy WAL ${existing.id} has no immutable upload proof; retaining retry",
+          );
           continue;
         }
-        Logger.debug("LocalWalSync: external WAL ${wal.id} matches legacy durable WAL ${existing.id}");
+        Logger.debug(
+          "LocalWalSync: external WAL ${wal.id} matches legacy durable WAL ${existing.id}",
+        );
         await _deleteDuplicateExternalFile(existing, wal);
         return ExternalWalRegistration.alreadyRegistered;
       }
@@ -178,8 +234,10 @@ class LocalWalSyncImpl implements LocalWalSync {
       rethrow;
     }
     listener.onWalUpdated();
-    Logger.debug("LocalWalSync: Added external WAL ${wal.id} (${wal.seconds}s)");
-    if (_syncLaneForWal(wal, DateTime.now().millisecondsSinceEpoch ~/ 1000) == SyncUploadLane.fresh) {
+    Logger.debug(
+      "LocalWalSync: Added external WAL ${wal.id} (${wal.seconds}s)",
+    );
+    if (scheduleUpload && _syncLaneForWal(wal, DateTime.now().millisecondsSinceEpoch ~/ 1000) == SyncUploadLane.fresh) {
       // Registration is the durability boundary used by device-storage sync:
       // once the manifest is committed, the device may advance its read
       // pointer. Cloud latency must not hold that acknowledgement hostage.
@@ -218,7 +276,9 @@ class LocalWalSyncImpl implements LocalWalSync {
         // so a fast BLE drain cannot start duplicate upload loops.
         await syncFreshOnly();
       } catch (error) {
-        Logger.debug('LocalWalSync: fresh upload wake failed for $walId: $error');
+        Logger.debug(
+          'LocalWalSync: fresh upload wake failed for $walId: $error',
+        );
       }
     } while (_freshUploadWakePending);
   }
@@ -250,14 +310,20 @@ class LocalWalSyncImpl implements LocalWalSync {
   @override
   void start() {
     _initializeWals();
-    _chunkingTimer = Timer.periodic(const Duration(seconds: chunkSizeInSeconds + newFrameSyncDelaySeconds), (t) async {
-      await _chunk();
-    });
-    _flushingTimer = Timer.periodic(const Duration(seconds: flushIntervalInSeconds + newFrameSyncDelaySeconds), (
-      t,
-    ) async {
-      await _flush();
-    });
+    _chunkingTimer = Timer.periodic(
+      const Duration(seconds: chunkSizeInSeconds + newFrameSyncDelaySeconds),
+      (t) async {
+        await _chunk();
+      },
+    );
+    _flushingTimer = Timer.periodic(
+      const Duration(
+        seconds: flushIntervalInSeconds + newFrameSyncDelaySeconds,
+      ),
+      (t) async {
+        await _flush();
+      },
+    );
   }
 
   Future<void> _initializeWals() async {
@@ -274,12 +340,17 @@ class LocalWalSyncImpl implements LocalWalSync {
     });
 
     // Run migrations for legacy Limitless files
-    final migratedCount = await WalFileManager.migrateLegacyLimitlessFiles(_wals);
+    final migratedCount = await WalFileManager.migrateLegacyLimitlessFiles(
+      _wals,
+    );
     if (migratedCount > 0) {
       // Reload WALs after migration
       _wals = await WalFileManager.loadWals();
       Logger.debug("wal service after migration: ${_wals.length}");
-      DebugLogManager.logInfo('WAL migration completed', {'migratedCount': migratedCount, 'totalAfter': _wals.length});
+      DebugLogManager.logInfo('WAL migration completed', {
+        'migratedCount': migratedCount,
+        'totalAfter': _wals.length,
+      });
     }
 
     // Fix any inconsistent WAL states from old implementations
@@ -365,7 +436,9 @@ class LocalWalSyncImpl implements LocalWalSync {
           break;
         }
       }
-      Logger.debug("${low} - ${high} - ${syncedOffset} - ${chunkFrameCount} - ${_framesPerSecond}");
+      Logger.debug(
+        "${low} - ${high} - ${syncedOffset} - ${chunkFrameCount} - ${_framesPerSecond}",
+      );
 
       Wal wal;
       var walIdx = _wals.indexWhere(
@@ -416,10 +489,12 @@ class LocalWalSyncImpl implements LocalWalSync {
       if (wal.storage == WalStorage.mem) {
         String? filePath = await Wal.getFilePath(wal.getFileName());
         if (filePath == null) {
-          DebugLogManager.logError('LocalWalSync flush error: Flush failed: cannot get file path', null, null, {
-            'walId': wal.id,
-            'timerStart': wal.timerStart,
-          });
+          DebugLogManager.logError(
+            'LocalWalSync flush error: Flush failed: cannot get file path',
+            null,
+            null,
+            {'walId': wal.id, 'timerStart': wal.timerStart},
+          );
           throw Exception('Flushing to storage failed. Cannot get file path.');
         }
 
@@ -447,7 +522,9 @@ class LocalWalSyncImpl implements LocalWalSync {
     }
 
     if (flushedCount > 0) {
-      DebugLogManager.logInfo('Flushed WALs from memory to disk', {'count': flushedCount});
+      DebugLogManager.logInfo('Flushed WALs from memory to disk', {
+        'count': flushedCount,
+      });
     }
 
     await _saveWalsToFile();
@@ -513,6 +590,9 @@ class LocalWalSyncImpl implements LocalWalSync {
     await _saveWalsToFile();
     listener.onWalUpdated();
   }
+
+  @override
+  Future<void> markExternalWalSynced(Wal wal) => markWalSyncedAndPersist(wal);
 
   /// Force-drain all in-flight frames (including the tail buffer that _chunk() normally
   /// keeps in memory) and flush everything to disk. Call this when a capture session ends
@@ -582,12 +662,17 @@ class LocalWalSyncImpl implements LocalWalSync {
     // Flush all in-memory WALs to disk immediately
     await _flush();
     listener.onWalUpdated();
-    Logger.debug('finalizeCurrentSession: drained $chunkFrameCount frames (stored=$shouldStored), flushed to disk');
+    Logger.debug(
+      'finalizeCurrentSession: drained $chunkFrameCount frames (stored=$shouldStored), flushed to disk',
+    );
   }
 
   /// Stamp all session WALs with the given conversationId and persist to disk.
   /// This makes WAL→conversation linkage survive app kill.
-  Future<void> stampConversationId(int sessionStartSeconds, String conversationId) async {
+  Future<void> stampConversationId(
+    int sessionStartSeconds,
+    String conversationId,
+  ) async {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     int stamped = 0;
     for (final wal in _wals) {
@@ -601,7 +686,9 @@ class LocalWalSyncImpl implements LocalWalSync {
     }
     if (stamped > 0) {
       await _saveWalsToFile();
-      Logger.debug('stampConversationId: stamped $stamped WALs with conversation $conversationId');
+      Logger.debug(
+        'stampConversationId: stamped $stamped WALs with conversation $conversationId',
+      );
     }
   }
 
@@ -692,13 +779,20 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) =>
-      _syncAll(progress: progress, liveCaptureOnly: false);
+  Future<SyncLocalFilesResponse?> syncAll({
+    IWalSyncProgressListener? progress,
+  }) =>
+      _syncAll(progress: progress, includeBackfill: true);
 
-  Future<SyncLocalFilesResponse?> syncLiveCaptureOnly({IWalSyncProgressListener? progress}) =>
-      _syncAll(progress: progress, liveCaptureOnly: true);
+  Future<SyncLocalFilesResponse?> syncFreshOnly({
+    IWalSyncProgressListener? progress,
+  }) =>
+      _syncAll(progress: progress, includeBackfill: false);
 
-  Future<SyncLocalFilesResponse?> _syncAll({IWalSyncProgressListener? progress, required bool liveCaptureOnly}) async {
+  Future<SyncLocalFilesResponse?> _syncAll({
+    IWalSyncProgressListener? progress,
+    required bool includeBackfill,
+  }) async {
     await _flush();
     _isCancelled = false;
     _accumulatedResponse = null;
@@ -709,7 +803,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           (wal) =>
               wal.status == WalStatus.miss &&
               wal.storage == WalStorage.disk &&
-              (!liveCaptureOnly || isLiveCaptureWal(wal, initialNowSeconds)),
+              (includeBackfill || _syncLaneForWal(wal, initialNowSeconds) == SyncUploadLane.fresh),
         )
         .toList();
     if (wals.isEmpty) {
@@ -726,7 +820,10 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     DebugLogManager.logEvent('local_upload_started', {'walCount': wals.length});
 
-    var resp = SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    var resp = SyncLocalFilesResponse(
+      newConversationIds: [],
+      updatedConversationIds: [],
+    );
     _accumulatedResponse = resp;
 
     int batchesCompleted = 0;
@@ -736,10 +833,8 @@ class LocalWalSyncImpl implements LocalWalSync {
     final totalFilesToUpload = wals.length;
 
     final attemptedWalIds = <String>{};
-    // A conversation whose first batch uploaded unclaimed stays unclaimable for
-    // the rest of the drain: the manifest is immutable per conversation, so a
-    // later remainder must not claim one covering only part of it.
-    final unclaimableConversationIds = <String>{};
+    final blockedLanes = <SyncUploadLane>{};
+    final forcedBackfillConversationIds = <String>{};
     while (true) {
       // Re-snapshot between batches so a newly captured WAL can preempt an
       // hours-long historical drain without waiting for the original list.
@@ -750,21 +845,32 @@ class LocalWalSyncImpl implements LocalWalSync {
                 wal.status == WalStatus.miss && wal.storage == WalStorage.disk && !attemptedWalIds.contains(wal.id),
           )
           .toList();
-      final pending = candidates.where((wal) => !liveCaptureOnly || isLiveCaptureWal(wal, batchNowSeconds)).toList();
+      forcedBackfillConversationIds.addAll(
+        oversizedFreshConversationIds(candidates, batchNowSeconds),
+      );
+      SyncUploadLane effectiveLane(Wal wal) =>
+          wal.conversationId != null && forcedBackfillConversationIds.contains(wal.conversationId)
+              ? SyncUploadLane.backfill
+              : _syncLaneForWal(wal, batchNowSeconds);
+      final pending = candidates
+          .where(
+            (wal) =>
+                (includeBackfill || effectiveLane(wal) == SyncUploadLane.fresh) &&
+                !blockedLanes.contains(effectiveLane(wal)),
+          )
+          .toList();
       if (pending.isEmpty) break;
-      final batch = nextSyncUploadBatch(pending, batchNowSeconds);
+      final batch = nextSyncUploadBatch(
+        pending,
+        batchNowSeconds,
+        forcedBackfillConversationIds: forcedBackfillConversationIds,
+      );
       if (batch.isEmpty) break;
       attemptedWalIds.addAll(batch.map((wal) => wal.id));
-      final batchConversationId = batch.first.conversationId;
-      final claimLiveCapture = !unclaimableConversationIds.contains(batchConversationId) &&
-          canClaimLiveCapture(
-            batch,
-            candidates.where((wal) => wal.conversationId == batchConversationId).toList(),
-            batchNowSeconds,
-          );
-      if (!claimLiveCapture && batchConversationId != null) {
-        unclaimableConversationIds.add(batchConversationId);
-      }
+      final batchLane =
+          batch.first.conversationId != null && forcedBackfillConversationIds.contains(batch.first.conversationId)
+              ? SyncUploadLane.backfill
+              : _syncLaneForWal(batch.first, batchNowSeconds);
       if (_isCancelled) {
         Logger.debug("LocalWalSync: Upload cancelled");
         DebugLogManager.logWarning('Local upload cancelled', {
@@ -795,7 +901,9 @@ class LocalWalSyncImpl implements LocalWalSync {
           Logger.debug("file path is not found. wal id ${wal.id}");
           wal.markCorrupted();
           corruptedCount++;
-          DebugLogManager.logWarning('WAL corrupted: file path missing', {'walId': wal.id});
+          DebugLogManager.logWarning('WAL corrupted: file path missing', {
+            'walId': wal.id,
+          });
           continue;
         }
 
@@ -807,7 +915,9 @@ class LocalWalSyncImpl implements LocalWalSync {
             Logger.debug("could not construct file path for wal id ${wal.id}");
             wal.markCorrupted();
             corruptedCount++;
-            DebugLogManager.logWarning('WAL corrupted: cannot construct path', {'walId': wal.id});
+            DebugLogManager.logWarning('WAL corrupted: cannot construct path', {
+              'walId': wal.id,
+            });
             continue;
           }
 
@@ -816,10 +926,10 @@ class LocalWalSyncImpl implements LocalWalSync {
             Logger.debug("file $fullPath does not exist");
             wal.markCorrupted();
             corruptedCount++;
-            DebugLogManager.logWarning('WAL corrupted: file not found on disk', {
-              'walId': wal.id,
-              'filePath': wal.filePath ?? '',
-            });
+            DebugLogManager.logWarning(
+              'WAL corrupted: file not found on disk',
+              {'walId': wal.id, 'filePath': wal.filePath ?? ''},
+            );
             continue;
           }
           files.add(file);
@@ -829,7 +939,12 @@ class LocalWalSyncImpl implements LocalWalSync {
           wal.markCorrupted();
           corruptedCount++;
           Logger.debug(e.toString());
-          DebugLogManager.logError(e, null, 'WAL corrupted: unexpected error - ${e.toString()}', {'walId': wal.id});
+          DebugLogManager.logError(
+            e,
+            null,
+            'WAL corrupted: unexpected error - ${e.toString()}',
+            {'walId': wal.id},
+          );
         }
       }
 
@@ -854,14 +969,18 @@ class LocalWalSyncImpl implements LocalWalSync {
         // mutated — corrupted ones already short-circuited above.
         final result = await _uploadGate.upload(
           files,
+          lane: batchLane,
           conversationId: batchWals.first.conversationId,
-          claimLiveCapture: claimLiveCapture,
         );
 
         if (result.completed != null) {
           // 200 fast-path: server processed synchronously and returned a result.
           final r = result.completed!;
-          resp.newConversationIds.addAll(r.newConversationIds.where((id) => !resp.newConversationIds.contains(id)));
+          resp.newConversationIds.addAll(
+            r.newConversationIds.where(
+              (id) => !resp.newConversationIds.contains(id),
+            ),
+          );
           resp.updatedConversationIds.addAll(
             r.updatedConversationIds.where(
               (id) => !resp.updatedConversationIds.contains(id) && !resp.newConversationIds.contains(id),
@@ -893,10 +1012,17 @@ class LocalWalSyncImpl implements LocalWalSync {
 
         batchesCompleted++;
         // Count WALs no longer needing upload (uploaded or already synced).
-        filesUploaded = wals.where((w) => w.status == WalStatus.uploaded || w.status == WalStatus.synced).length;
+        filesUploaded = wals
+            .where(
+              (w) => w.status == WalStatus.uploaded || w.status == WalStatus.synced,
+            )
+            .length;
       } on SyncRateLimitedException {
-        // The cooldown is account-global, so every remaining batch would hit it too.
-        DebugLogManager.logEvent('local_upload_rate_limited', {'until': '${SyncRateLimiter.instance.until}'});
+        // Pause only this lane. The other lane remains eligible in this drain.
+        DebugLogManager.logEvent('local_upload_rate_limited', {
+          'until': '${SyncRateLimiter.instance.until}',
+        });
+        blockedLanes.add(batchLane);
         for (final wal in batchWals) {
           wal.isSyncing = false;
           wal.syncStartedAt = null;
@@ -904,7 +1030,7 @@ class LocalWalSyncImpl implements LocalWalSync {
         }
         await _saveWalsToFile();
         listener.onWalUpdated();
-        break;
+        continue;
       } on SyncRecoveryWindowExceededException {
         // Clear the in-flight flag on the whole batch first: the members the
         // rejection does NOT prove too old stay `miss` and must not be left
@@ -923,12 +1049,19 @@ class LocalWalSyncImpl implements LocalWalSync {
         listener.onWalUpdated();
         continue;
       } catch (e) {
-        print('Local WAL upload batch failed: $e, continuing with remaining files');
+        print(
+          'Local WAL upload batch failed: $e, continuing with remaining files',
+        );
         batchesFailed++;
-        DebugLogManager.logError(e, null, 'Local upload batch failed: ${e.toString()}', {
-          'batchIndex': batchesCompleted + batchesFailed,
-          'filesInBatch': files.length,
-        });
+        DebugLogManager.logError(
+          e,
+          null,
+          'Local upload batch failed: ${e.toString()}',
+          {
+            'batchIndex': batchesCompleted + batchesFailed,
+            'filesInBatch': files.length,
+          },
+        );
         // Upload failed: clear the transient flag, leave status `miss` so the
         // batch is retried on the next sync.
         for (final wal in batchWals) {
@@ -956,17 +1089,26 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
+  Future<SyncLocalFilesResponse?> syncWal({
+    required Wal wal,
+    IWalSyncProgressListener? progress,
+  }) async {
     await _flush();
 
     final matches = _wals.where((w) => w == wal).toList();
     if (matches.isEmpty) {
-      DebugLogManager.logInfo('Single WAL upload skipped — WAL no longer tracked', {'walId': wal.id});
+      DebugLogManager.logInfo(
+        'Single WAL upload skipped — WAL no longer tracked',
+        {'walId': wal.id},
+      );
       return null;
     }
     final walToSync = matches.first;
 
-    var resp = SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    var resp = SyncLocalFilesResponse(
+      newConversationIds: [],
+      updatedConversationIds: [],
+    );
 
     DebugLogManager.logInfo('Single WAL upload started', {
       'walId': wal.id,
@@ -978,20 +1120,27 @@ class LocalWalSyncImpl implements LocalWalSync {
     if (wal.filePath == null) {
       Logger.debug("file path is not found. wal id ${wal.id}");
       wal.markCorrupted();
-      DebugLogManager.logWarning('Single WAL corrupted: file path missing', {'walId': wal.id});
+      DebugLogManager.logWarning('Single WAL corrupted: file path missing', {
+        'walId': wal.id,
+      });
     } else {
       try {
         final fullPath = await Wal.getFilePath(wal.filePath);
         if (fullPath == null) {
           Logger.debug("could not construct file path for wal id ${wal.id}");
           wal.markCorrupted();
-          DebugLogManager.logWarning('Single WAL corrupted: cannot construct path', {'walId': wal.id});
+          DebugLogManager.logWarning(
+            'Single WAL corrupted: cannot construct path',
+            {'walId': wal.id},
+          );
         } else {
           File file = File(fullPath);
           if (!file.existsSync()) {
             Logger.debug("file $fullPath does not exist");
             wal.markCorrupted();
-            DebugLogManager.logWarning('Single WAL corrupted: file not found', {'walId': wal.id});
+            DebugLogManager.logWarning('Single WAL corrupted: file not found', {
+              'walId': wal.id,
+            });
           } else {
             walFile = file;
             wal.isSyncing = true;
@@ -1000,9 +1149,12 @@ class LocalWalSyncImpl implements LocalWalSync {
       } catch (e) {
         wal.markCorrupted();
         print(e.toString());
-        DebugLogManager.logError(e, null, 'Single WAL corrupted: unexpected error - ${e.toString()}', {
-          'walId': wal.id,
-        });
+        DebugLogManager.logError(
+          e,
+          null,
+          'Single WAL corrupted: unexpected error - ${e.toString()}',
+          {'walId': wal.id},
+        );
       }
     }
 
@@ -1017,24 +1169,32 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     try {
       // Upload only — no poll-to-terminal. Reconciler resolves the job later.
-      final claimLiveCapture = canClaimLiveCapture(
-        [walToSync],
-        _wals
-            .where(
-              (candidate) => candidate.status == WalStatus.miss && candidate.conversationId == walToSync.conversationId,
-            )
-            .toList(),
+      var lane = _syncLaneForWal(
+        walToSync,
         DateTime.now().millisecondsSinceEpoch ~/ 1000,
       );
+      if (lane == SyncUploadLane.fresh && walToSync.conversationId != null) {
+        final pendingForConversation = _wals.where(
+          (candidate) => candidate.status == WalStatus.miss && candidate.conversationId == walToSync.conversationId,
+        );
+        // syncWal uploads one file. Claiming an immutable fresh manifest for
+        // it would strand any sibling WAL; the multi-file drain owns fresh
+        // conversation batching.
+        if (pendingForConversation.length > 1) lane = SyncUploadLane.backfill;
+      }
       final result = await _uploadGate.upload(
         [walFile],
+        lane: lane,
         conversationId: walToSync.conversationId,
-        claimLiveCapture: claimLiveCapture,
       );
 
       if (result.completed != null) {
         final r = result.completed!;
-        resp.newConversationIds.addAll(r.newConversationIds.where((id) => !resp.newConversationIds.contains(id)));
+        resp.newConversationIds.addAll(
+          r.newConversationIds.where(
+            (id) => !resp.newConversationIds.contains(id),
+          ),
+        );
         resp.updatedConversationIds.addAll(
           r.updatedConversationIds.where(
             (id) => !resp.updatedConversationIds.contains(id) && !resp.newConversationIds.contains(id),
@@ -1044,7 +1204,9 @@ class LocalWalSyncImpl implements LocalWalSync {
         walToSync.isSyncing = false;
         walToSync.syncStartedAt = null;
         walToSync.syncEtaSeconds = null;
-        DebugLogManager.logInfo('Single WAL upload succeeded (fast-path)', {'walId': wal.id});
+        DebugLogManager.logInfo('Single WAL upload succeeded (fast-path)', {
+          'walId': wal.id,
+        });
         listener.onWalSynced(wal);
       } else {
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -1054,7 +1216,9 @@ class LocalWalSyncImpl implements LocalWalSync {
         walToSync.isSyncing = false;
         walToSync.syncStartedAt = null;
         walToSync.syncEtaSeconds = null;
-        DebugLogManager.logInfo('Single WAL uploaded; reconciler will finish', {'walId': wal.id});
+        DebugLogManager.logInfo('Single WAL uploaded; reconciler will finish', {
+          'walId': wal.id,
+        });
         listener.onWalUpdated();
       }
     } on SyncRateLimitedException {
@@ -1083,7 +1247,12 @@ class LocalWalSyncImpl implements LocalWalSync {
       return resp;
     } catch (e) {
       Logger.debug('Single WAL upload failed: $e');
-      DebugLogManager.logError(e, null, 'Single WAL upload failed: ${e.toString()}', {'walId': wal.id});
+      DebugLogManager.logError(
+        e,
+        null,
+        'Single WAL upload failed: ${e.toString()}',
+        {'walId': wal.id},
+      );
       walToSync.isSyncing = false;
       walToSync.syncStartedAt = null;
       walToSync.syncEtaSeconds = null;
@@ -1137,7 +1306,10 @@ class LocalWalSyncImpl implements LocalWalSync {
   /// `miss` WALs, so the two never contend for the same recording. WALs are
   /// grouped by their shared `jobId` (batched upload → one job : N WALs).
   Future<SyncLocalFilesResponse> reconcileUploadedWals() async {
-    final resp = SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    final resp = SyncLocalFilesResponse(
+      newConversationIds: [],
+      updatedConversationIds: [],
+    );
 
     final byJob = <String, List<Wal>>{};
     for (final w in _wals) {
@@ -1154,7 +1326,9 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     for (var i = 0; i < entries.length; i += maxConcurrent) {
       final slice = entries.sublist(i, min(i + maxConcurrent, entries.length));
-      final fetched = await Future.wait(slice.map((e) async => (e.value, await fetchSyncJobStatus(e.key))));
+      final fetched = await Future.wait(
+        slice.map((e) async => (e.value, await fetchSyncJobStatus(e.key))),
+      );
 
       for (final (members, fetch) in fetched) {
         final jobId = members.first.jobId;
@@ -1194,7 +1368,10 @@ class LocalWalSyncImpl implements LocalWalSync {
             break;
           case SyncJobFetchOutcome.ok:
             final s = fetch.status!;
-            final terminalPolicy = syncJobTerminalPolicy(status: s.status, isTerminal: s.isTerminal);
+            final terminalPolicy = syncJobTerminalPolicy(
+              status: s.status,
+              isTerminal: s.isTerminal,
+            );
             if (terminalPolicy == SyncJobTerminalPolicy.wait) {
               DebugLogManager.logEvent('reconcile_poll', {
                 'jobId': jobId,
@@ -1208,7 +1385,9 @@ class LocalWalSyncImpl implements LocalWalSync {
             }
             if (s.result != null) {
               resp.newConversationIds.addAll(
-                s.result!.newConversationIds.where((id) => !resp.newConversationIds.contains(id)),
+                s.result!.newConversationIds.where(
+                  (id) => !resp.newConversationIds.contains(id),
+                ),
               );
               resp.updatedConversationIds.addAll(
                 s.result!.updatedConversationIds.where(

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -6,7 +6,25 @@ import 'package:omi/utils/logger.dart';
 ///
 /// All recording recovery paths use this closed set so a wake can be audited
 /// without introducing a second recovery owner.
-enum WakeTrigger { startup, foregrounded, connectivityRestored, deviceConnected, cooldownElapsed, userRetry }
+enum WakeTrigger {
+  startup,
+  foregrounded,
+  connectivityRestored,
+  deviceConnected,
+  cooldownElapsed,
+
+  /// A new explicit tap may authorize one new device snapshot.
+  userRetry,
+
+  /// Retry phone/cloud work already authorized by an earlier explicit tap.
+  ///
+  /// This must never start or expand a device backlog read.
+  userRetryLocalUpload,
+
+  /// A bounded automatic ring snapshot is durable and eligible for its
+  /// sequence-scoped phone/cloud pass.
+  ringBacklogSnapshotCompleted,
+}
 
 /// Result reported by the production drain seam.
 ///
@@ -19,6 +37,8 @@ class RecordingTransferDrainResult {
     required this.failed,
     required this.needsReconciliation,
     this.contended = false,
+    this.deferred = false,
+    this.hasDeviceSnapshotReceipt = false,
   });
 
   /// Nothing eligible to drain (empty backlog). Not a retry signal.
@@ -26,23 +46,34 @@ class RecordingTransferDrainResult {
       : attempted = false,
         failed = false,
         needsReconciliation = false,
-        contended = false;
+        contended = false,
+        deferred = false,
+        hasDeviceSnapshotReceipt = false;
 
   /// Drain could not run because another sync owned the seam. Retry later.
   const RecordingTransferDrainResult.contended()
       : attempted = false,
         failed = false,
         needsReconciliation = false,
-        contended = true;
+        contended = true,
+        deferred = false,
+        hasDeviceSnapshotReceipt = false;
 
   final bool attempted;
   final bool failed;
   final bool needsReconciliation;
   final bool contended;
+
+  /// Sequence-scoped work exists but is not yet a complete upload unit.
+  final bool deferred;
+
+  /// A manual device snapshot has already yielded a bounded receipt. Any
+  /// retry must keep phone-upload authority without arming a newer snapshot.
+  final bool hasDeviceSnapshotReceipt;
 }
 
 typedef RecordingTransferPass = Future<void> Function();
-typedef RecordingTransferDrain = Future<RecordingTransferDrainResult> Function();
+typedef RecordingTransferDrain = Future<RecordingTransferDrainResult> Function(WakeTrigger trigger);
 typedef RecordingTransferCooldownScheduler = void Function(Duration delay, void Function() callback);
 
 /// The single owner for recording recovery.
@@ -86,7 +117,8 @@ class RecordingTransferCoordinator {
   static final RecordingTransferCoordinator instance = RecordingTransferCoordinator._singleton();
 
   static Future<void> _noop() async {}
-  static Future<RecordingTransferDrainResult> _skippedDrain() async => const RecordingTransferDrainResult.skipped();
+  static Future<RecordingTransferDrainResult> _skippedDrain(WakeTrigger _) async =>
+      const RecordingTransferDrainResult.skipped();
   static bool _disabled() => false;
 
   static const List<Duration> _failureBackoff = [
@@ -213,10 +245,25 @@ class RecordingTransferCoordinator {
   }
 
   WakeTrigger _preferWake(WakeTrigger? existing, WakeTrigger incoming) {
-    if (existing == WakeTrigger.userRetry || incoming != WakeTrigger.userRetry) {
-      return existing ?? incoming;
+    if (existing == null) return incoming;
+    return _wakePriority(incoming) > _wakePriority(existing) ? incoming : existing;
+  }
+
+  int _wakePriority(WakeTrigger trigger) {
+    switch (trigger) {
+      case WakeTrigger.userRetry:
+        return 3;
+      case WakeTrigger.userRetryLocalUpload:
+        return 2;
+      case WakeTrigger.ringBacklogSnapshotCompleted:
+        return 1;
+      case WakeTrigger.startup:
+      case WakeTrigger.foregrounded:
+      case WakeTrigger.connectivityRestored:
+      case WakeTrigger.deviceConnected:
+      case WakeTrigger.cooldownElapsed:
+        return 0;
     }
-    return incoming;
   }
 
   Future<void> _run(WakeTrigger firstWake) async {
@@ -238,13 +285,14 @@ class RecordingTransferCoordinator {
       await _discover();
       await _refreshPending();
 
-      final mayUpload = trigger == WakeTrigger.userRetry || _autoUploadEnabled();
+      final mayUpload =
+          trigger == WakeTrigger.userRetry || trigger == WakeTrigger.userRetryLocalUpload || _autoUploadEnabled();
       if (!mayUpload) {
-        if (reconcileFailed) _scheduleRetry('reconcile pass failed');
+        if (reconcileFailed) _scheduleRetry('reconcile pass failed', trigger);
         return;
       }
 
-      final result = await _drain();
+      final result = await _drain(trigger);
       await _refreshPending();
 
       // Partial upload success still leaves `uploaded` WALs that need the
@@ -255,21 +303,44 @@ class RecordingTransferCoordinator {
       }
 
       if (result.failed) {
-        _scheduleRetry('eligible WAL upload returned a retryable failure');
+        _scheduleRetry(
+          'eligible WAL upload returned a retryable failure',
+          trigger,
+          hasDeviceSnapshotReceipt: result.hasDeviceSnapshotReceipt,
+        );
         return;
       }
       if (result.contended) {
-        _scheduleRetry('eligible WAL drain was contended');
+        _scheduleRetry(
+          'eligible WAL drain was contended',
+          trigger,
+          hasDeviceSnapshotReceipt: result.hasDeviceSnapshotReceipt,
+        );
+        return;
+      }
+      if (result.deferred) {
+        _scheduleRetry(
+          'authorized ring recovery is not yet a complete upload unit',
+          trigger,
+          hasDeviceSnapshotReceipt: result.hasDeviceSnapshotReceipt,
+        );
         return;
       }
       if (reconcileFailed) {
-        _scheduleRetry('reconcile pass failed');
+        _scheduleRetry(
+          'reconcile pass failed',
+          trigger,
+          hasDeviceSnapshotReceipt: result.hasDeviceSnapshotReceipt,
+        );
         return;
       }
-      _failureStreak = 0;
+      _clearRetryState();
     } catch (error, stackTrace) {
       Logger.debug('RecordingTransferCoordinator: $trigger pass failed: $error\n$stackTrace');
-      _scheduleRetry('pass threw while recovering recording transfers');
+      _scheduleRetry(
+        'pass threw while recovering recording transfers',
+        trigger,
+      );
     }
   }
 
@@ -284,7 +355,11 @@ class RecordingTransferCoordinator {
     }
   }
 
-  void _scheduleRetry(String reason) {
+  void _scheduleRetry(
+    String reason,
+    WakeTrigger trigger, {
+    bool hasDeviceSnapshotReceipt = false,
+  }) {
     if (!_foreground) return;
     final index = _failureStreak.clamp(0, _failureBackoff.length - 1);
     final delay = _failureBackoff[index];
@@ -298,7 +373,11 @@ class RecordingTransferCoordinator {
       if (!_foreground || generation != _cooldownGeneration) return;
       _cooldownTimer = null;
       nextCooldownAt = null;
-      unawaited(wake(WakeTrigger.cooldownElapsed));
+      final retryTrigger = _retryTrigger(
+        trigger,
+        hasDeviceSnapshotReceipt: hasDeviceSnapshotReceipt,
+      );
+      unawaited(wake(retryTrigger));
     }
 
     final scheduler = _scheduleCooldown;
@@ -307,6 +386,27 @@ class RecordingTransferCoordinator {
     } else {
       _cooldownTimer = Timer(delay, fire);
     }
+  }
+
+  WakeTrigger _retryTrigger(
+    WakeTrigger trigger, {
+    required bool hasDeviceSnapshotReceipt,
+  }) {
+    if (trigger == WakeTrigger.userRetry) {
+      return hasDeviceSnapshotReceipt ? WakeTrigger.userRetryLocalUpload : WakeTrigger.userRetry;
+    }
+    if (trigger == WakeTrigger.userRetryLocalUpload || trigger == WakeTrigger.ringBacklogSnapshotCompleted) {
+      return trigger;
+    }
+    return WakeTrigger.cooldownElapsed;
+  }
+
+  void _clearRetryState() {
+    _failureStreak = 0;
+    _cooldownGeneration++;
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
+    nextCooldownAt = null;
   }
 
   void dispose() {

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -45,7 +45,7 @@ typedef RecordingTransferPass = Future<void> Function();
 typedef RecordingTransferDrain = Future<RecordingTransferDrainResult> Function();
 typedef RecordingTransferCooldownScheduler = void Function(Duration delay, void Function() callback);
 
-/// The single foreground owner for recording recovery.
+/// The single owner for recording recovery.
 ///
 /// It deliberately knows no provider or transport details. Production wires
 /// the seams once, while tests use the same coordinator with fake connectivity,
@@ -57,6 +57,7 @@ class RecordingTransferCoordinator {
     required RecordingTransferPass refreshPending,
     required RecordingTransferDrain drain,
     required bool Function() autoUploadEnabled,
+    bool Function()? backgroundDeviceRecoveryEnabled,
     Stream<bool>? connectivityChanges,
     bool initiallyConnected = true,
     DateTime Function()? clock,
@@ -66,6 +67,7 @@ class RecordingTransferCoordinator {
         _refreshPending = refreshPending,
         _drain = drain,
         _autoUploadEnabled = autoUploadEnabled,
+        _backgroundDeviceRecoveryEnabled = backgroundDeviceRecoveryEnabled ?? _disabled,
         _clock = clock ?? DateTime.now,
         _scheduleCooldown = scheduleCooldown {
     _configured = true;
@@ -78,6 +80,7 @@ class RecordingTransferCoordinator {
         _refreshPending = _noop,
         _drain = _skippedDrain,
         _autoUploadEnabled = _disabled,
+        _backgroundDeviceRecoveryEnabled = _disabled,
         _clock = DateTime.now;
 
   static final RecordingTransferCoordinator instance = RecordingTransferCoordinator._singleton();
@@ -98,6 +101,7 @@ class RecordingTransferCoordinator {
   RecordingTransferPass _refreshPending;
   RecordingTransferDrain _drain;
   bool Function() _autoUploadEnabled;
+  bool Function() _backgroundDeviceRecoveryEnabled;
   final DateTime Function() _clock;
   RecordingTransferCooldownScheduler? _scheduleCooldown;
 
@@ -125,6 +129,7 @@ class RecordingTransferCoordinator {
     required RecordingTransferPass refreshPending,
     required RecordingTransferDrain drain,
     required bool Function() autoUploadEnabled,
+    required bool Function() backgroundDeviceRecoveryEnabled,
     required Stream<bool> connectivityChanges,
     required bool initiallyConnected,
   }) {
@@ -133,6 +138,7 @@ class RecordingTransferCoordinator {
     _refreshPending = refreshPending;
     _drain = drain;
     _autoUploadEnabled = autoUploadEnabled;
+    _backgroundDeviceRecoveryEnabled = backgroundDeviceRecoveryEnabled;
     _configured = true;
     _listenToConnectivity(connectivityChanges, initiallyConnected);
 
@@ -170,15 +176,21 @@ class RecordingTransferCoordinator {
   /// Coalesces concurrent events into a single extra serial pass. Five wakes
   /// during one pass therefore run at most two passes and never parallel drains.
   Future<void> wake(WakeTrigger trigger) {
-    // Recovery is foreground-only. Persisted WAL state is recovered by the
-    // foreground wake, so background connectivity/device callbacks must not
-    // start discovery or a whole-WAL drain.
-    if (!_foreground) return Future.value();
-
     if (!_configured) {
       _wakeBeforeConfigured = _preferWake(_wakeBeforeConfigured, trigger);
       return Future.value();
     }
+
+    // Android's persistent BLE mode is an explicit user opt-in. Its native
+    // reconnect callback may run one recovery pass while Dart is still alive
+    // in the background, but only when automatic uploads are also enabled.
+    // Every other background wake remains suppressed; persisted state is
+    // recovered by the next foreground wake.
+    final allowedBackgroundDeviceReconnect = !_foreground &&
+        trigger == WakeTrigger.deviceConnected &&
+        _backgroundDeviceRecoveryEnabled() &&
+        _autoUploadEnabled();
+    if (!_foreground && !allowedBackgroundDeviceReconnect) return Future.value();
 
     final active = _inFlight;
     if (active != null) {

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -143,6 +143,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   static const int defaultPacketsPerRead = 1800;
   static const Duration defaultInactivityTimeout = Duration(seconds: 15);
   static const int _backlogPacketsPerSlice = 96;
+  static const int _fastSyncPacketsPerSlice = 900;
   static const Duration _livePollInterval = Duration(seconds: 1);
   static const Duration _partialLiveRangeDeadline = Duration(seconds: 1);
   static const int _liveFreshnessSeconds = 5;
@@ -160,6 +161,8 @@ class RingStorageSyncImpl implements RingStorageSync {
   int? _requestedBacklogDrainGeneration;
   String? _requestedBacklogDrainDeviceId;
   int? _requestedBacklogTargetSeq;
+  int? _requestedBacklogStartSeq;
+  IWalSyncProgressListener? _requestedBacklogProgress;
 
   IWalSyncListener listener;
   LocalWalSync? _localSync;
@@ -178,6 +181,8 @@ class RingStorageSyncImpl implements RingStorageSync {
   bool get isSyncing => _isSyncing;
   @override
   bool get isAudioTailActive => _tailOwnerGeneration != null;
+  @override
+  bool get isFastSyncActive => _requestedBacklogDrain?.isCompleted == false && _requestedBacklogTargetSeq != null;
 
   int _totalBytesDownloaded = 0;
   DateTime? _downloadStartTime;
@@ -652,14 +657,18 @@ class RingStorageSyncImpl implements RingStorageSync {
     return RingSequenceCoverage(ranges);
   }
 
-  /// Ask the active live scheduler to drain the pendant backlog that existed
-  /// at the next safe ring snapshot.
+  /// Ask the active live scheduler to fast-drain the pendant backlog that
+  /// existed at the next safe ring snapshot.
   ///
-  /// The scheduler remains the sole BLE reader and continues to fetch the live
-  /// head before each bounded historical slice. Concurrent manual Sync taps
-  /// share one request, so they cannot start duplicate reads or uploads.
+  /// The scheduler remains the sole BLE reader. Once the immutable target is
+  /// latched, preview delivery pauses while larger sequential ranges are made
+  /// durable on the phone and acknowledged to the pendant. Audio recorded
+  /// after the target stays in the ring and live delivery resumes immediately
+  /// after completion, cancellation, or a recoverable drain failure.
   @override
-  Future<RingBacklogDrainReceipt?>? requestAudioTailBacklogDrain() {
+  Future<RingBacklogDrainReceipt?>? requestAudioTailBacklogDrain({
+    IWalSyncProgressListener? progress,
+  }) {
     final deviceId = _device?.id;
     final generation = _tailOwnerGeneration;
     final existing = _requestedBacklogDrain;
@@ -668,6 +677,7 @@ class RingStorageSyncImpl implements RingStorageSync {
         if (generation != null) {
           _requestedBacklogDrainGeneration = generation;
         }
+        _requestedBacklogProgress ??= progress;
         return existing.future;
       }
       cancelRequestedAudioTailBacklogDrain();
@@ -678,6 +688,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     _requestedBacklogDrainGeneration = generation;
     _requestedBacklogDrainDeviceId = deviceId;
     _requestedBacklogTargetSeq = null;
+    _requestedBacklogStartSeq = null;
+    _requestedBacklogProgress = progress;
     return request.future;
   }
 
@@ -713,6 +725,12 @@ class RingStorageSyncImpl implements RingStorageSync {
     if (!_hasRequestedBacklogDrain(generation)) return;
     if (_requestedBacklogTargetSeq != null) return;
     _requestedBacklogTargetSeq = info.writeSeq;
+    _requestedBacklogStartSeq = info.readSeq;
+    _requestedBacklogProgress?.onWalSyncedProgress(
+      info.readSeq >= info.writeSeq ? 1.0 : 0.0,
+      phase: SyncPhase.downloadingFromDevice,
+      speedKBps: currentSpeedKBps,
+    );
     Logger.debug(
       'RingStorageSync: manual backlog snapshot latched '
       'device=${_requestedBacklogDrainDeviceId!} '
@@ -734,8 +752,34 @@ class RingStorageSyncImpl implements RingStorageSync {
       'RingStorageSync: manual backlog snapshot completed '
       'device=$deviceId read_seq=${info.readSeq} target_write_seq=$target',
     );
+    _requestedBacklogProgress?.onWalSyncedProgress(
+      1.0,
+      phase: SyncPhase.downloadingFromDevice,
+      speedKBps: currentSpeedKBps,
+    );
     _clearRequestedBacklogDrainState();
     request.complete(receipt);
+  }
+
+  void _reportRequestedBacklogProgress(int generation, int readSeq) {
+    if (!_hasRequestedBacklogDrain(generation)) return;
+    final start = _requestedBacklogStartSeq;
+    final target = _requestedBacklogTargetSeq;
+    if (start == null || target == null) return;
+    final total = target - start;
+    final completed = (readSeq - start).clamp(0, total).toInt();
+    _requestedBacklogProgress?.onWalSyncedProgress(
+      total <= 0 ? 1.0 : completed / total,
+      phase: SyncPhase.downloadingFromDevice,
+      speedKBps: currentSpeedKBps,
+    );
+  }
+
+  void _cancelRequestedBacklogDrainAfterFailure(int generation) {
+    if (!_hasRequestedBacklogDrain(generation)) return;
+    final request = _requestedBacklogDrain!;
+    _clearRequestedBacklogDrainState();
+    request.complete(null);
   }
 
   void _clearRequestedBacklogDrainState() {
@@ -743,6 +787,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     _requestedBacklogDrainGeneration = null;
     _requestedBacklogDrainDeviceId = null;
     _requestedBacklogTargetSeq = null;
+    _requestedBacklogStartSeq = null;
+    _requestedBacklogProgress = null;
   }
 
   Future<bool> _advanceLiveTailOrStop({
@@ -858,6 +904,89 @@ class RingStorageSyncImpl implements RingStorageSync {
           reportAutomaticBacklogCompletion(info);
         }
 
+        final requestedTarget = _hasRequestedBacklogDrain(generation) ? _requestedBacklogTargetSeq : null;
+        if (requestedTarget != null && info.readSeq < requestedTarget) {
+          final nextCovered = coverage.firstRangeAtOrAfter(info.readSeq);
+          var fastSyncEnd = nextCovered?.start ?? requestedTarget;
+          if (fastSyncEnd > requestedTarget) fastSyncEnd = requestedTarget;
+          final available = fastSyncEnd - info.readSeq;
+          final sliceLimit = _packetsPerRead < _fastSyncPacketsPerSlice ? _packetsPerRead : _fastSyncPacketsPerSlice;
+          final count = available > sliceLimit ? sliceLimit : available;
+          if (count > 0) {
+            try {
+              final result = await _syncRange(
+                connection,
+                wal,
+                uploadIntent: WalUploadIntent.historicalBackfill,
+                startSeq: info.readSeq,
+                packetCount: count,
+                fallbackAnchor: fallbackAnchor,
+                fallbackFramesBefore: (info.readSeq - sourceReadSeq) * sourceFramesPerRecord,
+                completedRecords: info.readSeq - (_requestedBacklogStartSeq ?? info.readSeq),
+                totalRecords: requestedTarget - (_requestedBacklogStartSeq ?? info.readSeq),
+                advanceAfterCommit: false,
+                scheduleHistoricalUpload: false,
+                conversationTimeoutSeconds: conversationTimeoutSeconds,
+              );
+              if (result == null) {
+                throw const RingStorageException('Fast ring snapshot range did not complete');
+              }
+              coverage.add(info.readSeq, result.nextSeq);
+              final advanced = await _advanceLiveTailOrStop(
+                generation: generation,
+                deviceId: deviceId,
+                connection: connection,
+                nextSeq: result.nextSeq,
+                rejectionMessage: 'Device rejected a fast-sync covered-prefix advance',
+              );
+              if (!advanced) return;
+              DebugLogManager.logEvent('ring_fast_sync_advanced', {
+                'nextSeq': result.nextSeq,
+                'targetWriteSeq': requestedTarget,
+                'records': result.nextSeq - info.readSeq,
+              });
+              info = RingInfo(
+                readSeq: result.nextSeq,
+                writeSeq: info.writeSeq,
+                capacityPackets: info.capacityPackets,
+                droppedPackets: info.droppedPackets,
+                packetSize: info.packetSize,
+              );
+              _reportRequestedBacklogProgress(generation, info.readSeq);
+              _completeRequestedBacklogDrainIfReady(generation, info);
+              if (!_hasRequestedBacklogDrain(generation)) {
+                // Capture audio produced while Fast Sync owned BLE before
+                // returning to the live lane; do not wait for the normal poll.
+                info = await _ringInfoRetryPolicy.run(connection.getRingInfo);
+                lastSnapshotAt = DateTime.now();
+              }
+              continue;
+            } catch (error, stackTrace) {
+              DebugLogManager.logError(
+                error,
+                stackTrace,
+                'Fast ring snapshot failed; resuming live audio',
+                {'device': deviceId, 'targetWriteSeq': requestedTarget},
+              );
+              var connected = false;
+              try {
+                connected = await connection.isConnected();
+              } catch (_) {
+                // A stale native connection can fail the state query itself.
+              }
+              if (!connected) {
+                // Preserve the immutable request across a real disconnect so
+                // a replacement tail for this exact device can adopt it.
+                rethrow;
+              }
+              _cancelRequestedBacklogDrainAfterFailure(generation);
+              // Fast Sync is optional user-requested work. If the transport
+              // itself is healthy, abandon this request and immediately give
+              // BLE ownership back to live transcription.
+            }
+          }
+        }
+
         final livePackets = _livePacketsPerRead(codec);
         final desiredLiveStart =
             info.writeSeq - info.readSeq > livePackets ? info.writeSeq - livePackets : info.readSeq;
@@ -868,6 +997,7 @@ class RingStorageSyncImpl implements RingStorageSync {
         // cloud jobs. A growing read catches up in one bounded transaction;
         // it must never manufacture a new hole merely to shave latency.
         var liveStart = liveCursor ?? desiredLiveStart;
+        if (liveStart < info.readSeq) liveStart = info.readSeq;
         // A reconnect deliberately re-reads recent `miss` ranges so they can
         // enter the replacement STT socket. They are already durable and
         // therefore present in [coverage], but not yet delivered.
@@ -1005,46 +1135,61 @@ class RingStorageSyncImpl implements RingStorageSync {
         // One recovery transfer per live poll. A slow BLE link must not queue a
         // recent repair and an old-history drain ahead of newly captured audio.
         final liveRecoveryCaughtUp = liveCursor == null || liveCursor >= info.writeSeq;
-        final deepBacklogAuthorized = _deepBacklogPolicy() || _hasRequestedBacklogDrain(generation);
+        final deepBacklogAuthorized = _deepBacklogPolicy();
         if (liveRecoveryCaughtUp && !recoveredRecentSlice && deepBacklogAuthorized && backlogEnd > info.readSeq) {
           final available = backlogEnd - info.readSeq;
           final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
-          final result = await _syncRange(
-            connection,
-            wal,
-            uploadIntent: WalUploadIntent.historicalBackfill,
-            startSeq: info.readSeq,
-            packetCount: count,
-            fallbackAnchor: fallbackAnchor,
-            fallbackFramesBefore: (info.readSeq - sourceReadSeq) * sourceFramesPerRecord,
-            completedRecords: 0,
-            totalRecords: info.unreadPackets,
-            advanceAfterCommit: false,
-            conversationTimeoutSeconds: conversationTimeoutSeconds,
-          );
-          if (result == null) {
-            throw const RingStorageException(
-              'Backlog ring range did not complete',
+          _RingRangeResult? result;
+          try {
+            result = await _syncRange(
+              connection,
+              wal,
+              uploadIntent: WalUploadIntent.historicalBackfill,
+              startSeq: info.readSeq,
+              packetCount: count,
+              fallbackAnchor: fallbackAnchor,
+              fallbackFramesBefore: (info.readSeq - sourceReadSeq) * sourceFramesPerRecord,
+              completedRecords: 0,
+              totalRecords: info.unreadPackets,
+              advanceAfterCommit: false,
+              conversationTimeoutSeconds: conversationTimeoutSeconds,
+            );
+          } catch (error, stackTrace) {
+            DebugLogManager.logError(
+              error,
+              stackTrace,
+              'Optional backlog range failed; live audio remains active',
+              {'device': deviceId},
             );
           }
-          coverage.add(info.readSeq, result.nextSeq);
-          final advanced = await _advanceLiveTailOrStop(
-            generation: generation,
-            deviceId: deviceId,
-            connection: connection,
-            nextSeq: result.nextSeq,
-            rejectionMessage: 'Device rejected a backlog covered-prefix advance',
-          );
-          if (!advanced) return;
-          info = RingInfo(
-            readSeq: result.nextSeq,
-            writeSeq: info.writeSeq,
-            capacityPackets: info.capacityPackets,
-            droppedPackets: info.droppedPackets,
-            packetSize: info.packetSize,
-          );
-          _completeRequestedBacklogDrainIfReady(generation, info);
-          reportAutomaticBacklogCompletion(info);
+          if (result == null) {
+            // Historical auto-sync is optional work. It must never tear down
+            // the live transcription owner and create a reconnect loop.
+            automaticBacklogTargetSeq = null;
+            automaticBacklogCompletionReported = true;
+            DebugLogManager.logWarning(
+              'RingStorageSync: optional backlog range did not complete; live audio remains active',
+              {'device': deviceId},
+            );
+          } else {
+            coverage.add(info.readSeq, result.nextSeq);
+            final advanced = await _advanceLiveTailOrStop(
+              generation: generation,
+              deviceId: deviceId,
+              connection: connection,
+              nextSeq: result.nextSeq,
+              rejectionMessage: 'Device rejected a backlog covered-prefix advance',
+            );
+            if (!advanced) return;
+            info = RingInfo(
+              readSeq: result.nextSeq,
+              writeSeq: info.writeSeq,
+              capacityPackets: info.capacityPackets,
+              droppedPackets: info.droppedPackets,
+              packetSize: info.packetSize,
+            );
+            reportAutomaticBacklogCompletion(info);
+          }
         }
 
         if (_tailGeneration != generation || _isCancelled) break;
@@ -1375,8 +1520,20 @@ class RingStorageSyncImpl implements RingStorageSync {
               );
             }
           }
-        } catch (e) {
+        } catch (e, stackTrace) {
           Logger.debug('RingStorageSync._syncRing: flush error: $e');
+          DebugLogManager.logError(
+            e,
+            stackTrace,
+            'RingStorageSync: durable range flush failed',
+            {
+              'startSeq': sourceStartSeq,
+              'endSeq': sourceEndSeq,
+              'sourceId': sourceId,
+              'frameCount': frames.length,
+              'uploadIntent': effectiveUploadIntent.name,
+            },
+          );
           flushError = true;
           rethrow;
         }
@@ -1595,8 +1752,18 @@ class RingStorageSyncImpl implements RingStorageSync {
     if (transportComplete) {
       try {
         await flushValidatedRange();
-      } catch (e) {
+      } catch (e, stackTrace) {
         Logger.debug('RingStorageSync: final flush error: $e');
+        DebugLogManager.logError(
+          e,
+          stackTrace,
+          'RingStorageSync: validated range could not become durable',
+          {
+            'startSeq': startSeq,
+            'requestedRecords': packetCount,
+            'receivedRecords': recordsConsumed,
+          },
+        );
       }
     }
 
@@ -1629,6 +1796,25 @@ class RingStorageSyncImpl implements RingStorageSync {
         newestTimestamp: newestTimestamp!,
       );
     } else {
+      DebugLogManager.logWarning(
+        'RingStorageSync: bounded range rejected before durable commit',
+        {
+          'startSeq': startSeq,
+          'requestedRecords': packetCount,
+          'transferStartSeq': transferStartSeq,
+          'announcedRecords': announcedPacketCount,
+          'doneNextSeq': doneNextSeq,
+          'receivedRecords': recordsConsumed,
+          'pendingBytes': reassembler.pendingBytes,
+          'reachedDone': reachedDone,
+          'doneOk': doneOk,
+          'flushError': flushError,
+          'cancelled': _isCancelled,
+          'completeRange': receivedCompleteRange,
+          'protocolError': protocolError,
+          'crcVerified': crcVerified,
+        },
+      );
       Logger.debug(
         'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError '
         'cancelled=$_isCancelled completeRange=$receivedCompleteRange protocolError=$protocolError '

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -595,7 +595,13 @@ class RingStorageSyncImpl implements RingStorageSync {
         final livePackets = _livePacketsPerRead(codec);
         final desiredLiveStart =
             info.writeSeq - info.readSeq > livePackets ? info.writeSeq - livePackets : info.readSeq;
-        var liveStart = liveCursor != null && liveCursor > desiredLiveStart ? liveCursor : desiredLiveStart;
+        // Bootstrap near the live head once, then preserve sequence order.
+        // Re-snapping to `writeSeq - livePackets` on every poll skipped the
+        // records produced while the previous BLE transaction was in flight.
+        // Those holes became alternating 1–3 second fallback WALs and separate
+        // cloud jobs. A growing read catches up in one bounded transaction;
+        // it must never manufacture a new hole merely to shave latency.
+        var liveStart = liveCursor ?? desiredLiveStart;
         liveStart = coverage.firstUncovered(liveStart, info.writeSeq);
         final liveCount = info.writeSeq - liveStart;
 

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -467,7 +468,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
-    final pendingRecords = <_RecoveredRingRecord>[];
+    final pendingRecords = ListQueue<_RecoveredRingRecord>();
     int recordsConsumed = 0;
     int segment = 0;
     int? previousRecordTimestamp;
@@ -494,7 +495,7 @@ class RingStorageSyncImpl implements RingStorageSync {
         var frameCount = 0;
         while (pendingRecords.isNotEmpty && pendingRecords.first.segment == firstSegment) {
           if (frameCount >= chunkFrames) break;
-          final record = pendingRecords.removeAt(0);
+          final record = pendingRecords.removeFirst();
           chunkRecords.add(record);
           frameCount += record.frames.length;
         }
@@ -753,14 +754,19 @@ class RingStorageSyncImpl implements RingStorageSync {
     final directory = await _documentsDirectoryProvider();
     final filePath = '${directory.path}/${wal.getFileNameByTimeStarts(timerStart, sourceId: sourceId)}';
 
-    final List<int> data = [];
+    var dataLength = 0;
     for (final frame in frames) {
-      final byteFrame = ByteData(frame.length);
-      for (int j = 0; j < frame.length; j++) {
-        byteFrame.setUint8(j, frame[j]);
-      }
-      data.addAll(Uint32List.fromList([frame.length]).buffer.asUint8List());
-      data.addAll(byteFrame.buffer.asUint8List());
+      dataLength += Uint32List.bytesPerElement + frame.length;
+    }
+
+    final data = Uint8List(dataLength);
+    final writer = ByteData.sublistView(data);
+    var offset = 0;
+    for (final frame in frames) {
+      writer.setUint32(offset, frame.length, Endian.little);
+      offset += Uint32List.bytesPerElement;
+      data.setRange(offset, offset + frame.length, frame);
+      offset += frame.length;
     }
 
     final file = File(filePath);

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -39,6 +39,24 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 typedef RingConnectionResolver = Future<DeviceConnection?> Function(String deviceId);
 typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
 typedef RingLiveFramesHandler = bool Function(List<List<int>> frames);
+typedef RingDeepBacklogPolicy = bool Function();
+
+@visibleForTesting
+int ringRecentRecoveryFloor({
+  required int readSeq,
+  required int writeSeq,
+  required int framesPerRecord,
+  required int framesPerSecond,
+  int recoverySeconds = 120,
+}) {
+  if (writeSeq <= readSeq || framesPerRecord <= 0 || framesPerSecond <= 0 || recoverySeconds <= 0) {
+    return readSeq;
+  }
+  final recentFrames = recoverySeconds * framesPerSecond;
+  final recentRecords = (recentFrames + framesPerRecord - 1) ~/ framesPerRecord;
+  final candidate = writeSeq - recentRecords;
+  return candidate > readSeq ? candidate : readSeq;
+}
 
 class RingAudioTailSession {
   RingAudioTailSession._(this.done, this._cancel) {
@@ -77,6 +95,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   static const Duration _livePollInterval = Duration(seconds: 1);
   static const Duration _partialLiveRangeDeadline = Duration(seconds: 1);
   static const int _liveFreshnessSeconds = 5;
+  static const int _recentRecoverySeconds = 120;
 
   List<Wal> _wals = [];
   BtDevice? _device;
@@ -91,6 +110,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   LocalWalSync? _localSync;
   final RingConnectionResolver? _connectionResolverOverride;
   final RingDocumentsDirectoryProvider _documentsDirectoryProvider;
+  final RingDeepBacklogPolicy _deepBacklogPolicy;
   final int _packetsPerRead;
   final Duration _inactivityTimeout;
   final int Function() _nowSeconds;
@@ -110,11 +130,13 @@ class RingStorageSyncImpl implements RingStorageSync {
     this.listener, {
     RingConnectionResolver? connectionResolver,
     RingDocumentsDirectoryProvider? documentsDirectoryProvider,
+    RingDeepBacklogPolicy? deepBacklogPolicy,
     int packetsPerRead = defaultPacketsPerRead,
     Duration inactivityTimeout = defaultInactivityTimeout,
     int Function()? nowSeconds,
   })  : _connectionResolverOverride = connectionResolver,
         _documentsDirectoryProvider = documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
+        _deepBacklogPolicy = deepBacklogPolicy ?? (() => true),
         _packetsPerRead = packetsPerRead,
         _inactivityTimeout = inactivityTimeout,
         _nowSeconds = nowSeconds ?? _systemNowSeconds {
@@ -569,6 +591,49 @@ class RingStorageSyncImpl implements RingStorageSync {
           partialLiveSince = null;
         }
 
+        /*
+         * Recover the most recent two minutes before spending bandwidth on an
+         * hours-old prefix. These ranges keep their original timestamps and
+         * use the WAL/backfill path; only the newest five seconds can feed the
+         * live socket.
+         */
+        final recentFloor = ringRecentRecoveryFloor(
+          readSeq: info.readSeq,
+          writeSeq: info.writeSeq,
+          framesPerRecord: sourceFramesPerRecord,
+          framesPerSecond: codec.getFramesPerSecond(),
+          recoverySeconds: _recentRecoverySeconds,
+        );
+        final recentStart = coverage.firstUncovered(
+          recentFloor,
+          info.writeSeq,
+        );
+        if (recentStart < info.writeSeq) {
+          final nextRecentCovered = coverage.firstRangeAtOrAfter(recentStart);
+          final recentEnd = nextRecentCovered?.start ?? info.writeSeq;
+          if (recentEnd > recentStart) {
+            final available = recentEnd - recentStart;
+            final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
+            final result = await _syncRange(
+              connection,
+              wal,
+              startSeq: recentStart,
+              packetCount: count,
+              fallbackAnchor: wal.timerStart,
+              fallbackFramesBefore: (recentStart - sourceReadSeq) * sourceFramesPerRecord,
+              completedRecords: 0,
+              totalRecords: info.unreadPackets,
+              advanceAfterCommit: false,
+            );
+            if (result == null) {
+              throw const RingStorageException(
+                'Recent ring recovery did not complete',
+              );
+            }
+            coverage.add(recentStart, result.nextSeq);
+          }
+        }
+
         final prefixAfterLive = coverage.contiguousEndFrom(info.readSeq);
         if (prefixAfterLive > info.readSeq) {
           final advanced = await connection.advanceRing(prefixAfterLive);
@@ -588,7 +653,7 @@ class RingStorageSyncImpl implements RingStorageSync {
 
         final nextCovered = coverage.firstRangeAtOrAfter(info.readSeq);
         final backlogEnd = nextCovered?.start ?? info.writeSeq;
-        if (backlogEnd > info.readSeq) {
+        if (_deepBacklogPolicy() && backlogEnd > info.readSeq) {
           final available = backlogEnd - info.readSeq;
           final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
           final result = await _syncRange(
@@ -1251,7 +1316,7 @@ class RingStorageSyncImpl implements RingStorageSync {
       );
     }
     final fps = wal.codec.getFramesPerSecond();
-    final seconds = fps > 0 ? frameCount ~/ fps : 0;
+    final seconds = fps > 0 ? (frameCount + fps - 1) ~/ fps : 0;
 
     final localWal = Wal(
       codec: wal.codec,

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -11,6 +11,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/models/sync_state.dart';
+import 'package:omi/services/capture/live_audio_frame_pacer.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/services.dart';
@@ -38,7 +39,9 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 /// previously advanced ranges never need to be downloaded again.
 typedef RingConnectionResolver = Future<DeviceConnection?> Function(String deviceId);
 typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
-typedef RingLiveFramesHandler = bool Function(List<List<int>> frames);
+typedef RingLiveFramesHandler = LiveAudioFrameDelivery Function(
+  List<List<int>> frames,
+);
 typedef RingDeepBacklogPolicy = bool Function();
 
 bool ringShouldDrainDeepBacklog({
@@ -47,21 +50,43 @@ bool ringShouldDrainDeepBacklog({
 }) =>
     autoSyncEnabled || isCharging;
 
-@visibleForTesting
-int ringRecentRecoveryFloor({
+/// Chooses the first sequence that must be replayed into a replacement live
+/// transcription socket.
+///
+/// A pendant can have hours of unread history behind its durable read cursor.
+/// Reconnecting at that cursor starves the active conversation behind old
+/// backlog. Recent live-continuity WALs describe the correct boundary: replay
+/// from the earliest recent range that never completed socket delivery, or
+/// continue after the newest recently delivered range when none are pending.
+int? ringLiveResumeSequence({
+  required Iterable<Wal> wals,
+  required String deviceId,
   required int readSeq,
   required int writeSeq,
-  required int framesPerRecord,
-  required int framesPerSecond,
-  int recoverySeconds = 120,
+  required int nowSeconds,
+  int recentSeconds = 120,
 }) {
-  if (writeSeq <= readSeq || framesPerRecord <= 0 || framesPerSecond <= 0 || recoverySeconds <= 0) {
-    return readSeq;
+  int? earliestPending;
+  int? newestDeliveredEnd;
+  final cutoff = nowSeconds - recentSeconds;
+  for (final wal in wals) {
+    if (wal.device != deviceId ||
+        wal.uploadIntent != WalUploadIntent.liveContinuity ||
+        wal.timerStart + wal.seconds < cutoff) {
+      continue;
+    }
+    final range = RingProtocol.parseSourceRange(wal.sourceId);
+    if (range == null || range.end < readSeq || range.start >= writeSeq) continue;
+    if (wal.status == WalStatus.miss) {
+      final start = range.start.clamp(readSeq, writeSeq).toInt();
+      if (earliestPending == null || start < earliestPending) earliestPending = start;
+    }
+    final end = range.end.clamp(readSeq, writeSeq).toInt();
+    if (newestDeliveredEnd == null || end > newestDeliveredEnd) {
+      newestDeliveredEnd = end;
+    }
   }
-  final recentFrames = recoverySeconds * framesPerSecond;
-  final recentRecords = (recentFrames + framesPerRecord - 1) ~/ framesPerRecord;
-  final candidate = writeSeq - recentRecords;
-  return candidate > readSeq ? candidate : readSeq;
+  return earliestPending ?? newestDeliveredEnd;
 }
 
 class RingAudioTailSession {
@@ -410,6 +435,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   /// cumulative device ADVANCE.
   Future<RingAudioTailSession?> startAudioTail({
     required RingLiveFramesHandler onLiveFrames,
+    bool resumeLiveContinuity = false,
   }) async {
     final device = _device;
     if (device == null) return null;
@@ -431,6 +457,15 @@ class RingStorageSyncImpl implements RingStorageSync {
       initialInfo,
     );
     final coverage = await _loadDurableCoverage(device.id);
+    final resumeLiveSeq = resumeLiveContinuity
+        ? ringLiveResumeSequence(
+            wals: await _localSync?.getAllWals() ?? const <Wal>[],
+            deviceId: device.id,
+            readSeq: initialInfo.readSeq,
+            writeSeq: initialInfo.writeSeq,
+            nowSeconds: _nowSeconds(),
+          )
+        : null;
 
     final future = _runAudioTail(
       generation: generation,
@@ -441,6 +476,8 @@ class RingStorageSyncImpl implements RingStorageSync {
       initialInfo: initialInfo,
       coverage: coverage,
       onLiveFrames: onLiveFrames,
+      resumeLiveContinuity: resumeLiveContinuity,
+      resumeLiveSeq: resumeLiveSeq,
     );
     _tailFuture = future;
     unawaited(
@@ -560,6 +597,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     required RingInfo initialInfo,
     required RingSequenceCoverage coverage,
     required RingLiveFramesHandler onLiveFrames,
+    required bool resumeLiveContinuity,
+    required int? resumeLiveSeq,
   }) async {
     _isSyncing = true;
     _downloadStartTime = DateTime.now();
@@ -567,7 +606,9 @@ class RingStorageSyncImpl implements RingStorageSync {
     var info = initialInfo;
     final sourceReadSeq = initialInfo.readSeq;
     final sourceFramesPerRecord = _framesPerRecord(codec);
-    int? liveCursor;
+    int? liveCursor = resumeLiveSeq;
+    int? recentCursor;
+    var recentRecoveryExhausted = resumeLiveContinuity;
     DateTime? partialLiveSince;
     var lastSnapshotAt = DateTime.now();
 
@@ -602,8 +643,16 @@ class RingStorageSyncImpl implements RingStorageSync {
         // cloud jobs. A growing read catches up in one bounded transaction;
         // it must never manufacture a new hole merely to shave latency.
         var liveStart = liveCursor ?? desiredLiveStart;
-        liveStart = coverage.firstUncovered(liveStart, info.writeSeq);
-        final liveCount = info.writeSeq - liveStart;
+        // A reconnect deliberately re-reads recent `miss` ranges so they can
+        // enter the replacement STT socket. They are already durable and
+        // therefore present in [coverage], but not yet delivered.
+        if (!resumeLiveContinuity) {
+          liveStart = coverage.firstUncovered(liveStart, info.writeSeq);
+        }
+        final availableLiveCount = info.writeSeq - liveStart;
+        final liveCount = resumeLiveContinuity && availableLiveCount > _backlogPacketsPerSlice
+            ? _backlogPacketsPerSlice
+            : availableLiveCount;
 
         if (liveCount > 0) {
           partialLiveSince ??= DateTime.now();
@@ -622,6 +671,7 @@ class RingStorageSyncImpl implements RingStorageSync {
               completedRecords: 0,
               totalRecords: info.unreadPackets,
               onLiveFrames: onLiveFrames,
+              forceLiveDelivery: resumeLiveContinuity,
               advanceAfterCommit: false,
             );
             if (result == null) {
@@ -638,47 +688,40 @@ class RingStorageSyncImpl implements RingStorageSync {
         }
 
         /*
-         * Recover the most recent two minutes before spending bandwidth on an
-         * hours-old prefix. These ranges keep their original timestamps and
-         * use the WAL/backfill path; only the newest five seconds can feed the
-         * live socket.
+         * Recover backward from the live head until embedded capture
+         * timestamps cross the conversation boundary. "Two minutes of audio
+         * frames" can span hours under VAD and must not be treated as recent.
          */
-        final recentFloor = ringRecentRecoveryFloor(
-          readSeq: info.readSeq,
-          writeSeq: info.writeSeq,
-          framesPerRecord: sourceFramesPerRecord,
-          framesPerSecond: codec.getFramesPerSecond(),
-          recoverySeconds: _recentRecoverySeconds,
-        );
-        final recentStart = coverage.firstUncovered(
-          recentFloor,
-          info.writeSeq,
-        );
+        recentCursor ??= desiredLiveStart;
         var recoveredRecentSlice = false;
-        if (recentStart < info.writeSeq) {
-          final nextRecentCovered = coverage.firstRangeAtOrAfter(recentStart);
-          final recentEnd = nextRecentCovered?.start ?? info.writeSeq;
-          if (recentEnd > recentStart) {
-            final available = recentEnd - recentStart;
-            final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
+        if (!recentRecoveryExhausted) {
+          final recentRange = coverage.lastUncoveredBefore(
+            info.readSeq,
+            recentCursor,
+            maxCount: _backlogPacketsPerSlice,
+          );
+          if (recentRange != null) {
             final result = await _syncRange(
               connection,
               wal,
               uploadIntent: WalUploadIntent.liveContinuity,
-              startSeq: recentStart,
-              packetCount: count,
+              startSeq: recentRange.start,
+              packetCount: recentRange.end - recentRange.start,
               fallbackAnchor: wal.timerStart,
-              fallbackFramesBefore: (recentStart - sourceReadSeq) * sourceFramesPerRecord,
+              fallbackFramesBefore: (recentRange.start - sourceReadSeq) * sourceFramesPerRecord,
               completedRecords: 0,
               totalRecords: info.unreadPackets,
               advanceAfterCommit: false,
+              scheduleHistoricalUpload: false,
             );
             if (result == null) {
               throw const RingStorageException(
                 'Recent ring recovery did not complete',
               );
             }
-            coverage.add(recentStart, result.nextSeq);
+            coverage.add(recentRange.start, result.nextSeq);
+            recentCursor = recentRange.start;
+            recentRecoveryExhausted = result.oldestTimestamp < _nowSeconds() - _recentRecoverySeconds;
             recoveredRecentSlice = true;
           }
         }
@@ -706,7 +749,8 @@ class RingStorageSyncImpl implements RingStorageSync {
         final backlogEnd = nextCovered?.start ?? info.writeSeq;
         // One recovery transfer per live poll. A slow BLE link must not queue a
         // recent repair and an old-history drain ahead of newly captured audio.
-        if (!recoveredRecentSlice && _deepBacklogPolicy() && backlogEnd > info.readSeq) {
+        final liveRecoveryCaughtUp = liveCursor == null || liveCursor >= info.writeSeq;
+        if (liveRecoveryCaughtUp && !recoveredRecentSlice && _deepBacklogPolicy() && backlogEnd > info.readSeq) {
           final available = backlogEnd - info.readSeq;
           final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
           final result = await _syncRange(
@@ -971,7 +1015,9 @@ class RingStorageSyncImpl implements RingStorageSync {
     required int totalRecords,
     IWalSyncProgressListener? progress,
     RingLiveFramesHandler? onLiveFrames,
+    bool forceLiveDelivery = false,
     bool advanceAfterCommit = true,
+    bool scheduleHistoricalUpload = true,
   }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
@@ -979,6 +1025,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     int recordsConsumed = 0;
     int segment = 0;
     int? previousRecordTimestamp;
+    int? oldestTimestamp;
+    int? newestTimestamp;
     int fallbackFrames = 0;
     final fps = wal.codec.getFramesPerSecond();
     final chunkFrames = sdcardChunkSizeSecs * fps;
@@ -1014,9 +1062,15 @@ class RingStorageSyncImpl implements RingStorageSync {
         final sourceEndSeq = chunkRecords.last.sequence + 1;
         final sourceId = 'ring_${sourceStartSeq}_$sourceEndSeq';
         final now = _nowSeconds();
-        final isLiveRange = onLiveFrames != null &&
-            chunkRecords.first.timestamp >= now - _liveFreshnessSeconds &&
-            chunkRecords.last.timestamp <= now + _liveFreshnessSeconds;
+        final effectiveUploadIntent =
+            uploadIntent == WalUploadIntent.liveContinuity && chunkRecords.last.timestamp < now - _recentRecoverySeconds
+                ? WalUploadIntent.historicalBackfill
+                : uploadIntent;
+        final isLiveRange = effectiveUploadIntent == WalUploadIntent.liveContinuity &&
+            onLiveFrames != null &&
+            (forceLiveDelivery ||
+                (chunkRecords.first.timestamp >= now - _liveFreshnessSeconds &&
+                    chunkRecords.last.timestamp <= now + _liveFreshnessSeconds));
         try {
           final file = await _flushToDisk(wal, frames, timerStart, sourceId);
           final registered = await _registerWithLocalSync(
@@ -1025,26 +1079,34 @@ class RingStorageSyncImpl implements RingStorageSync {
             timerStart,
             frames.length,
             sourceId,
-            uploadIntent: uploadIntent,
-            scheduleUpload: !isLiveRange,
+            uploadIntent: effectiveUploadIntent,
+            scheduleUpload: !isLiveRange &&
+                (effectiveUploadIntent != WalUploadIntent.historicalBackfill || scheduleHistoricalUpload),
           );
-          if (isLiveRange && registered.registration == ExternalWalRegistration.added) {
-            var delivered = false;
+          if (isLiveRange &&
+              (registered.registration == ExternalWalRegistration.added || registered.wal.status == WalStatus.miss)) {
+            LiveAudioFrameDelivery delivery = LiveAudioFrameDelivery.rejected();
             try {
-              delivered = onLiveFrames(frames);
+              delivery = onLiveFrames(frames);
             } catch (error) {
               Logger.debug(
                 'RingStorageSync: live frame delivery failed for $sourceId: $error',
               );
             }
-            if (delivered) {
-              await _localSync!.markExternalWalSynced(registered.wal);
+            if (delivery.accepted) {
+              unawaited(
+                delivery.completed.then((sent) async {
+                  if (sent) {
+                    await _localSync!.markExternalWalSynced(registered.wal);
+                  }
+                }),
+              );
             } else {
-              // No live socket ownership: leave the durable WAL retryable and
-              // wake the normal uploader instead of discarding the sequence.
+              // A raw ring range is never an independent cloud upload. Leave
+              // it durable and retryable for live replay/canonical assembly.
               await _localSync!.addExternalWal(
                 registered.wal,
-                scheduleUpload: true,
+                scheduleUpload: false,
               );
             }
           }
@@ -1170,6 +1232,8 @@ class RingStorageSyncImpl implements RingStorageSync {
           final effectiveTimestamp = RingProtocol.isPlausibleRecordTimestamp(ts, nowSeconds: now)
               ? ts
               : fallbackAnchor + (fallbackFramesBefore + fallbackFrames) ~/ (fps == 0 ? 1 : fps);
+          oldestTimestamp ??= effectiveTimestamp;
+          newestTimestamp = effectiveTimestamp;
 
           if (previousRecordTimestamp != null &&
               (effectiveTimestamp < previousRecordTimestamp! || effectiveTimestamp > previousRecordTimestamp! + 2)) {
@@ -1296,6 +1360,8 @@ class RingStorageSyncImpl implements RingStorageSync {
       return _RingRangeResult(
         nextSeq: doneNextSeq!,
         frameCount: fallbackFrames,
+        oldestTimestamp: oldestTimestamp!,
+        newestTimestamp: newestTimestamp!,
       );
     } else {
       Logger.debug(
@@ -1400,11 +1466,12 @@ class RingStorageSyncImpl implements RingStorageSync {
       localWal,
       scheduleUpload: scheduleUpload,
     );
+    final durableWal = await _localSync!.getWalById(localWal.id) ?? localWal;
     Logger.debug(
       'RingStorageSync: registered chunk (source=$sourceId, ts=$timerStart, ${seconds}s, '
       '$frameCount frames, result=${registration.name})',
     );
-    return (registration: registration, wal: localWal);
+    return (registration: registration, wal: durableWal);
   }
 }
 
@@ -1425,6 +1492,13 @@ class _RecoveredRingRecord {
 class _RingRangeResult {
   final int nextSeq;
   final int frameCount;
+  final int oldestTimestamp;
+  final int newestTimestamp;
 
-  const _RingRangeResult({required this.nextSeq, required this.frameCount});
+  const _RingRangeResult({
+    required this.nextSeq,
+    required this.frameCount,
+    required this.oldestTimestamp,
+    required this.newestTimestamp,
+  });
 }

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -52,9 +52,8 @@ typedef RingBacklogSnapshotCompleted = void Function(
 
 bool ringShouldDrainDeepBacklog({
   required bool autoSyncEnabled,
-  required bool isCharging,
 }) =>
-    autoSyncEnabled || isCharging;
+    autoSyncEnabled;
 
 /// Chooses the first sequence that must be replayed into a replacement live
 /// transcription socket.
@@ -190,7 +189,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     this.listener, {
     RingConnectionResolver? connectionResolver,
     RingDocumentsDirectoryProvider? documentsDirectoryProvider,
-    RingDeepBacklogPolicy? deepBacklogPolicy,
+    required RingDeepBacklogPolicy deepBacklogPolicy,
     RingConversationTimeoutSecondsProvider? conversationTimeoutSecondsProvider,
     RingBacklogSnapshotCompleted? onBacklogSnapshotCompleted,
     int packetsPerRead = defaultPacketsPerRead,
@@ -198,7 +197,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     int Function()? nowSeconds,
   })  : _connectionResolverOverride = connectionResolver,
         _documentsDirectoryProvider = documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
-        _deepBacklogPolicy = deepBacklogPolicy ?? (() => true),
+        _deepBacklogPolicy = deepBacklogPolicy,
         _conversationTimeoutSecondsProvider =
             conversationTimeoutSecondsProvider ?? (() => SharedPreferencesUtil().conversationSilenceDuration),
         _onBacklogSnapshotCompleted = onBacklogSnapshotCompleted,

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -68,6 +68,8 @@ int? ringLiveResumeSequence({
 }) {
   int? earliestPending;
   int? newestDeliveredEnd;
+  final deliveredCoverage = RingSequenceCoverage();
+  final pendingRanges = <({int start, int end})>[];
   final cutoff = nowSeconds - recentSeconds;
   for (final wal in wals) {
     if (wal.device != deviceId ||
@@ -77,13 +79,26 @@ int? ringLiveResumeSequence({
     }
     final range = RingProtocol.parseSourceRange(wal.sourceId);
     if (range == null || range.end < readSeq || range.start >= writeSeq) continue;
-    if (wal.status == WalStatus.miss) {
-      final start = range.start.clamp(readSeq, writeSeq).toInt();
-      if (earliestPending == null || start < earliestPending) earliestPending = start;
-    }
+    final start = range.start.clamp(readSeq, writeSeq).toInt();
     final end = range.end.clamp(readSeq, writeSeq).toInt();
-    if (newestDeliveredEnd == null || end > newestDeliveredEnd) {
-      newestDeliveredEnd = end;
+    if (wal.status == WalStatus.miss) {
+      if (start < end) pendingRanges.add((start: start, end: end));
+      continue;
+    }
+    if (wal.status == WalStatus.synced) {
+      if (start < end) deliveredCoverage.add(start, end);
+      if (newestDeliveredEnd == null || end > newestDeliveredEnd) {
+        newestDeliveredEnd = end;
+      }
+    }
+  }
+  for (final pending in pendingRanges) {
+    final uncovered = deliveredCoverage.firstUncovered(
+      pending.start,
+      pending.end,
+    );
+    if (uncovered < pending.end && (earliestPending == null || uncovered < earliestPending)) {
+      earliestPending = uncovered;
     }
   }
   return earliestPending ?? newestDeliveredEnd;
@@ -650,9 +665,27 @@ class RingStorageSyncImpl implements RingStorageSync {
           liveStart = coverage.firstUncovered(liveStart, info.writeSeq);
         }
         final availableLiveCount = info.writeSeq - liveStart;
-        final liveCount = resumeLiveContinuity && availableLiveCount > _backlogPacketsPerSlice
+        var liveCount = resumeLiveContinuity && availableLiveCount > _backlogPacketsPerSlice
             ? _backlogPacketsPerSlice
             : availableLiveCount;
+        if (resumeLiveContinuity && liveCount > 0) {
+          final proposedEnd = liveStart + liveCount;
+          final coveredEnd = coverage.contiguousEndFrom(liveStart);
+          if (coveredEnd > liveStart && coveredEnd < proposedEnd) {
+            // Finish the durable replay before reading newly uncovered audio.
+            // Otherwise a reconnect can persist one range that crosses the
+            // old/new boundary and cannot be reduced without duplicating or
+            // discarding audio during canonical assembly.
+            liveCount = coveredEnd - liveStart;
+          } else if (coveredEnd == liveStart) {
+            final nextCovered = coverage.firstRangeAtOrAfter(liveStart);
+            if (nextCovered != null && nextCovered.start > liveStart && nextCovered.start < proposedEnd) {
+              // Symmetric case: finish the uncovered prefix before entering
+              // an already durable island.
+              liveCount = nextCovered.start - liveStart;
+            }
+          }
+        }
 
         if (liveCount > 0) {
           partialLiveSince ??= DateTime.now();

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:path_provider/path_provider.dart';
@@ -9,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/models/sync_state.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/wals/wal.dart';
@@ -25,14 +27,21 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 ///   0x01 ACK             [0x01][status]
 ///   0x02 INFO            [0x02][read:u64 BE][write:u64 BE][cap:u32 BE][dropped:u64 BE][pkt_size:u16 BE]
 ///   0x03 DATA            [0x03][raw_bytes...]   <-- not aligned to record boundaries
-///   0x04 DONE            [0x04][status][next_seq:u64 BE]
+///   0x04 DONE            [0x04][status][next_seq:u64 BE](optional [crc32:u32 BE])
 ///   0x05 READ_BEGIN      [0x05][transfer_start_seq:u64 BE][packet_count:u32 BE]
 ///
-/// Data-safety invariant: CMD_RING_ADVANCE is sent ONLY after NOTIFY_DONE arrives
-/// AND every chunk we received during the transfer has been handed to LocalWalSync.
-/// On any failure (cancel, BLE drop, NOTIFY_DONE error status) the ring is left
-/// untouched — the next sync session resumes from the same read_seq.
+/// Data-safety invariant: each bounded source-sequence range is registered in
+/// the atomically persisted local WAL manifest only after READ_BEGIN, byte
+/// count, DONE, and optional CRC all agree. CMD_RING_ADVANCE is sent after that
+/// durable registration. On any failure the current range stays on the device;
+/// previously advanced ranges never need to be downloaded again.
+typedef RingConnectionResolver = Future<DeviceConnection?> Function(String deviceId);
+typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
+
 class RingStorageSyncImpl implements RingStorageSync {
+  static const int defaultPacketsPerRead = 1800;
+  static const Duration defaultInactivityTimeout = Duration(seconds: 15);
+
   List<Wal> _wals = [];
   BtDevice? _device;
 
@@ -42,6 +51,11 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   IWalSyncListener listener;
   LocalWalSync? _localSync;
+  final RingConnectionResolver? _connectionResolverOverride;
+  final RingDocumentsDirectoryProvider _documentsDirectoryProvider;
+  final int _packetsPerRead;
+  final Duration _inactivityTimeout;
+  final int Function() _nowSeconds;
 
   bool _isCancelled = false;
   bool _isSyncing = false;
@@ -54,7 +68,28 @@ class RingStorageSyncImpl implements RingStorageSync {
   @override
   double get currentSpeedKBps => _currentSpeedKBps;
 
-  RingStorageSyncImpl(this.listener);
+  RingStorageSyncImpl(
+    this.listener, {
+    RingConnectionResolver? connectionResolver,
+    RingDocumentsDirectoryProvider? documentsDirectoryProvider,
+    int packetsPerRead = defaultPacketsPerRead,
+    Duration inactivityTimeout = defaultInactivityTimeout,
+    int Function()? nowSeconds,
+  })  : _connectionResolverOverride = connectionResolver,
+        _documentsDirectoryProvider = documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
+        _packetsPerRead = packetsPerRead,
+        _inactivityTimeout = inactivityTimeout,
+        _nowSeconds = nowSeconds ?? _systemNowSeconds {
+    if (packetsPerRead <= 0) throw ArgumentError.value(packetsPerRead, 'packetsPerRead', 'must be positive');
+  }
+
+  static int _systemNowSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  Future<DeviceConnection?> _ensureConnection(String deviceId) {
+    final resolver = _connectionResolverOverride;
+    if (resolver != null) return resolver(deviceId);
+    return ServiceManager.instance().device.ensureConnection(deviceId);
+  }
 
   @override
   void setLocalSync(LocalWalSync localSync) {
@@ -87,7 +122,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     if (deviceId == null || deviceId.isEmpty) return;
 
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      final connection = await _ensureConnection(deviceId);
       if (connection == null) return;
       // CMD_STOP_SYNC (0x03) — does not persist progress; data stays in the ring.
       await connection.stopStorageSync();
@@ -123,7 +158,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<bool> hasFilesToSync() async {
     if (_device == null) return false;
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+      final connection = await _ensureConnection(_device!.id);
       if (connection == null) return false;
       final status = await connection.getRingStatus();
       final result = status != null && status.unreadPackets > 0;
@@ -154,7 +189,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     }
 
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+      final connection = await _ensureConnection(_device!.id);
       if (connection == null) return;
 
       final status = await connection.getRingStatus();
@@ -255,7 +290,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<void> _clearRingOnDevice() async {
     if (_device == null) return;
     try {
-      final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+      final connection = await _ensureConnection(_device!.id);
       if (connection == null) return;
       final ok = await connection.clearRing();
       Logger.debug('RingStorageSync._clearRingOnDevice: ok=$ok');
@@ -335,19 +370,21 @@ class RingStorageSyncImpl implements RingStorageSync {
     return SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
   }
 
-  /// Pull the unread ring contents from the device, parse opus frames, register
-  /// chunks with LocalWalSync, then advance the ring iff NOTIFY_DONE arrived.
-  /// Returns true if the transfer ran to completion (DONE received and acted on).
+  /// Drain the ring in bounded, independently durable transactions.
+  ///
+  /// A full CV1 can take well over an hour to transfer. Keeping one cumulative
+  /// ADVANCE behind the entire backlog means any disconnect replays everything.
+  /// Each range is small enough to retry cheaply, and advances only after that
+  /// exact range is durably represented by local WALs.
   Future<bool> _syncRing(Wal wal, {IWalSyncProgressListener? progress}) async {
     if (_device == null) return false;
-    final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+    final connection = await _ensureConnection(_device!.id);
     if (connection == null) throw Exception('Device not connected');
 
     _activeSyncDeviceId = _device!.id;
     _downloadStartTime = DateTime.now();
     _totalBytesDownloaded = 0;
 
-    // Snapshot ring state so we know what range we're consuming.
     final ringInfo = await connection.getRingInfo();
     if (ringInfo == null) {
       Logger.debug('RingStorageSync._syncRing: getRingInfo returned null');
@@ -362,46 +399,131 @@ class RingStorageSyncImpl implements RingStorageSync {
         'ringInfo': ringInfo.toString(),
       });
     }
-    final status = await connection.getRingStatus();
-    final rtcValid = status?.isRtcValid ?? false;
+    final targetWriteSeq = ringInfo.writeSeq;
+    final totalRecords = targetWriteSeq - ringInfo.readSeq;
+    final fps = wal.codec.getFramesPerSecond();
+    final fallbackAnchor = await _resolveFallbackAnchor(wal, ringInfo.readSeq, fps);
+    var nextReadSeq = ringInfo.readSeq;
+    var completedRecords = 0;
+    var completedFrames = 0;
 
+    while (!_isCancelled && nextReadSeq < targetWriteSeq) {
+      final remaining = targetWriteSeq - nextReadSeq;
+      final packetCount = remaining > _packetsPerRead ? _packetsPerRead : remaining;
+      final advancedTo = await _syncRange(
+        connection,
+        wal,
+        startSeq: nextReadSeq,
+        packetCount: packetCount,
+        fallbackAnchor: fallbackAnchor,
+        fallbackFramesBefore: completedFrames,
+        completedRecords: completedRecords,
+        totalRecords: totalRecords,
+        progress: progress,
+      );
+      if (advancedTo == null) return false;
+      nextReadSeq = advancedTo.nextSeq;
+      completedRecords += packetCount;
+      completedFrames += advancedTo.frameCount;
+    }
+
+    return !_isCancelled && nextReadSeq == targetWriteSeq;
+  }
+
+  Future<int> _resolveFallbackAnchor(Wal virtualWal, int initialReadSeq, int fps) async {
+    final localSync = _localSync;
+    if (localSync == null) return virtualWal.timerStart;
+
+    final sourcePattern = RegExp(r'^ring_(\d+)_(\d+)$');
+    Wal? predecessor;
+    for (final wal in await localSync.getAllWals()) {
+      if (wal.device != virtualWal.device || wal.sourceId == null) continue;
+      final match = sourcePattern.firstMatch(wal.sourceId!);
+      if (match == null) continue;
+      final startSeq = int.parse(match.group(1)!);
+      final endSeq = int.parse(match.group(2)!);
+      if (startSeq == initialReadSeq) return wal.timerStart;
+      if (endSeq == initialReadSeq &&
+          (predecessor == null || wal.timerStart + wal.seconds > predecessor.timerStart + predecessor.seconds)) {
+        predecessor = wal;
+      }
+    }
+    if (predecessor != null) {
+      return predecessor.timerStart + predecessor.totalFrames ~/ (fps == 0 ? 1 : fps);
+    }
+    return virtualWal.timerStart;
+  }
+
+  Future<_RingRangeResult?> _syncRange(
+    DeviceConnection connection,
+    Wal wal, {
+    required int startSeq,
+    required int packetCount,
+    required int fallbackAnchor,
+    required int fallbackFramesBefore,
+    required int completedRecords,
+    required int totalRecords,
+    IWalSyncProgressListener? progress,
+  }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
-    final List<List<int>> bytesData = []; // parsed opus frames awaiting flush
+    final pendingRecords = <_RecoveredRingRecord>[];
     int recordsConsumed = 0;
-    int? firstRecordTs;
-    int chunkTimerStart = 0; // updated as chunks flush
+    int segment = 0;
+    int? previousRecordTimestamp;
+    int fallbackFrames = 0;
     final fps = wal.codec.getFramesPerSecond();
     final chunkFrames = sdcardChunkSizeSecs * fps;
     int? doneNextSeq;
     int? transferStartSeq;
     int? announcedPacketCount;
     bool doneOk = false;
+    bool protocolError = false;
+    bool crcVerified = true;
     bool flushError = false;
-    Future<void>? inFlightFlush;
-    Timer? firstDataTimer;
-    bool firstDataReceived = false;
+    Timer? inactivityTimer;
+    final transferCrc = RingTransferCrc32();
 
     DateTime lastProgressUpdate = DateTime.now();
     const progressInterval = Duration(milliseconds: 200);
 
-    // Flush exactly [chunkFrames] frames at a time; on DONE, flush whatever is left.
-    Future<void> flushChunks({required bool finalFlush}) async {
-      while (bytesData.length >= chunkFrames || (finalFlush && bytesData.isNotEmpty)) {
-        final take = bytesData.length >= chunkFrames ? chunkFrames : bytesData.length;
-        final chunk = bytesData.sublist(0, take);
-        bytesData.removeRange(0, take);
+    Future<void> flushValidatedRange() async {
+      while (pendingRecords.isNotEmpty) {
+        final firstSegment = pendingRecords.first.segment;
+        final chunkRecords = <_RecoveredRingRecord>[];
+        var frameCount = 0;
+        while (pendingRecords.isNotEmpty && pendingRecords.first.segment == firstSegment) {
+          if (frameCount >= chunkFrames) break;
+          final record = pendingRecords.removeAt(0);
+          chunkRecords.add(record);
+          frameCount += record.frames.length;
+        }
+        if (chunkRecords.isEmpty) break;
+
+        final frames = chunkRecords.expand((record) => record.frames).toList(growable: false);
+        final timerStart = chunkRecords.first.timestamp;
+        final sourceStartSeq = chunkRecords.first.sequence;
+        final sourceEndSeq = chunkRecords.last.sequence + 1;
+        final sourceId = 'ring_${sourceStartSeq}_$sourceEndSeq';
         try {
-          final file = await _flushToDisk(wal, chunk, chunkTimerStart);
-          await _registerWithLocalSync(wal, file, chunkTimerStart, chunk.length);
+          final file = await _flushToDisk(wal, frames, timerStart, sourceId);
+          await _registerWithLocalSync(wal, file, timerStart, frames.length, sourceId);
         } catch (e) {
           Logger.debug('RingStorageSync._syncRing: flush error: $e');
           flushError = true;
           rethrow;
         }
-        chunkTimerStart += chunk.length ~/ (fps == 0 ? 1 : fps);
-        if (finalFlush && bytesData.isEmpty) break;
       }
+    }
+
+    void armInactivityTimer() {
+      inactivityTimer?.cancel();
+      inactivityTimer = Timer(_inactivityTimeout, () {
+        if (!completer.isCompleted) {
+          Logger.debug('RingStorageSync: range inactive for ${_inactivityTimeout.inSeconds}s');
+          completer.complete(false);
+        }
+      });
     }
 
     await _notifyStream?.cancel();
@@ -414,6 +536,7 @@ class RingStorageSyncImpl implements RingStorageSync {
           return;
         }
         if (value.isEmpty) return;
+        armInactivityTimer();
 
         final opcode = value[0];
         if (opcode == RingProtocol.notifyAck) {
@@ -426,16 +549,20 @@ class RingStorageSyncImpl implements RingStorageSync {
         }
         if (opcode == RingProtocol.notifyReadBegin) {
           final begin = RingProtocol.parseReadBeginNotification(value);
-          if (begin != null) {
+          if (begin == null || begin.transferStartSeq != startSeq || begin.packetCount != packetCount) {
+            protocolError = true;
+            Logger.debug('RingStorageSync: invalid READ_BEGIN for requested range start=$startSeq count=$packetCount');
+            if (!completer.isCompleted) completer.complete(false);
+          } else if (transferStartSeq != null &&
+              (transferStartSeq != begin.transferStartSeq || announcedPacketCount != begin.packetCount)) {
+            protocolError = true;
+            if (!completer.isCompleted) completer.complete(false);
+          } else {
             transferStartSeq = begin.transferStartSeq;
             announcedPacketCount = begin.packetCount;
             Logger.debug(
               'RingStorageSync: NOTIFY_READ_BEGIN start=${begin.transferStartSeq} count=${begin.packetCount}',
             );
-            if (!firstDataReceived) {
-              firstDataReceived = true;
-              firstDataTimer?.cancel();
-            }
           }
           return;
         }
@@ -448,6 +575,14 @@ class RingStorageSyncImpl implements RingStorageSync {
           }
           doneNextSeq = done.nextSeq;
           doneOk = done.isOk;
+          if (done.transferCrc32 != null) {
+            crcVerified = done.transferCrc32 == transferCrc.value;
+            if (!crcVerified) {
+              Logger.debug(
+                'RingStorageSync: transfer CRC mismatch expected=${done.transferCrc32} actual=${transferCrc.value}',
+              );
+            }
+          }
           Logger.debug('RingStorageSync: NOTIFY_DONE status=${done.status} next_seq=$doneNextSeq');
           if (!completer.isCompleted) completer.complete(true);
           return;
@@ -460,31 +595,45 @@ class RingStorageSyncImpl implements RingStorageSync {
         // NOTIFY_DATA: append payload (skip the leading opcode byte) to the
         // reassembler. The firmware does NOT align chunks to record boundaries.
         final payload = value.sublist(1);
-        if (!firstDataReceived) {
-          firstDataReceived = true;
-          firstDataTimer?.cancel();
+        if (transferStartSeq == null) {
+          protocolError = true;
+          Logger.debug('RingStorageSync: DATA arrived before READ_BEGIN');
+          if (!completer.isCompleted) completer.complete(false);
+          return;
         }
+        transferCrc.add(payload);
         reassembler.append(payload);
         _updateSpeed(payload.length);
 
         for (final record in reassembler.drainRecords()) {
           final ts = RingProtocol.readRecordTimestamp(record);
-
-          // Anchor timerStart on the first usable timestamp.
-          if (firstRecordTs == null) {
-            if (rtcValid && ts > 0) {
-              firstRecordTs = ts;
-              chunkTimerStart = ts;
-            } else {
-              // Fallback: now - estimated duration of the unread region.
-              final estSecs = wal.totalFrames ~/ (fps == 0 ? 1 : fps);
-              firstRecordTs = DateTime.now().millisecondsSinceEpoch ~/ 1000 - estSecs;
-              chunkTimerStart = firstRecordTs!;
-            }
+          final frames = RingProtocol.parseAudioPayload(record.sublist(RingProtocol.timestampBytes));
+          if (frames.isEmpty) {
+            protocolError = true;
+            Logger.debug('RingStorageSync: record ${transferStartSeq! + recordsConsumed} has no decodable frames');
           }
+          final now = _nowSeconds();
+          final effectiveTimestamp = RingProtocol.isPlausibleRecordTimestamp(ts, nowSeconds: now)
+              ? ts
+              : fallbackAnchor + (fallbackFramesBefore + fallbackFrames) ~/ (fps == 0 ? 1 : fps);
 
-          final audio = record.sublist(RingProtocol.timestampBytes);
-          bytesData.addAll(RingProtocol.parseAudioPayload(audio));
+          if (previousRecordTimestamp != null &&
+              (effectiveTimestamp < previousRecordTimestamp! || effectiveTimestamp > previousRecordTimestamp! + 2)) {
+            segment += 1;
+          }
+          previousRecordTimestamp = effectiveTimestamp;
+
+          if (frames.isNotEmpty) {
+            pendingRecords.add(
+              _RecoveredRingRecord(
+                sequence: transferStartSeq! + recordsConsumed,
+                timestamp: effectiveTimestamp,
+                segment: segment,
+                frames: frames,
+              ),
+            );
+          }
+          fallbackFrames += frames.length;
           recordsConsumed += 1;
         }
 
@@ -492,9 +641,8 @@ class RingStorageSyncImpl implements RingStorageSync {
         final now = DateTime.now();
         if (now.difference(lastProgressUpdate) >= progressInterval) {
           lastProgressUpdate = now;
-          if (wal.storageTotalBytes > 0) {
-            final consumedBytes = recordsConsumed * RingProtocol.recordSize;
-            final pct = (consumedBytes / wal.storageTotalBytes).clamp(0.0, 1.0);
+          if (totalRecords > 0) {
+            final pct = ((completedRecords + recordsConsumed) / totalRecords).clamp(0.0, 1.0);
             progress?.onWalSyncedProgress(
               pct,
               speedKBps: _currentSpeedKBps,
@@ -503,28 +651,6 @@ class RingStorageSyncImpl implements RingStorageSync {
               totalFiles: 1,
             );
           }
-        }
-
-        // Flush full chunks as we go (data safety: even if BLE drops mid-stream,
-        // already-flushed chunks land in LocalWalSync and reach the cloud).
-        //
-        // Single in-flight flush at a time. flushChunks loops while bytesData
-        // has >= chunkFrames, so additional NOTIFY_DATA arriving during a flush
-        // are absorbed by the in-flight task's next iteration. Without this
-        // guard, two concurrent flush closures would both read chunkTimerStart
-        // before either updated it, producing overlapping timestamps in
-        // LocalWalSync. We hold the Future so the post-DONE final flush can
-        // await any flush still in flight before draining the tail.
-        if (inFlightFlush == null && bytesData.length >= chunkFrames) {
-          inFlightFlush = () async {
-            try {
-              await flushChunks(finalFlush: false);
-            } catch (_) {
-              if (!completer.isCompleted) completer.complete(false);
-            } finally {
-              inFlightFlush = null;
-            }
-          }();
         }
       },
     );
@@ -539,60 +665,32 @@ class RingStorageSyncImpl implements RingStorageSync {
       }
     });
 
-    firstDataTimer = Timer(const Duration(seconds: 5), () {
-      if (!firstDataReceived && !completer.isCompleted) {
-        Logger.debug('RingStorageSync: no data within 5s');
-        completer.completeError(TimeoutException('No data from device'));
-      }
-    });
+    armInactivityTimer();
 
-    // Kick off the read. No packet_count = stream everything from read_seq.
-    final readOk = await connection.readRingFromSeq(ringInfo.readSeq);
+    final readOk = await connection.readRingFromSeq(startSeq, packetCount: packetCount);
     if (!readOk) {
-      firstDataTimer.cancel();
+      inactivityTimer?.cancel();
       await _notifyStream?.cancel();
       _notifyStream = null;
       throw Exception('Failed to send CMD_RING_READ');
     }
 
     Logger.debug(
-      'RingStorageSync: reading from seq=${ringInfo.readSeq} (write=${ringInfo.writeSeq}, unread=${ringInfo.unreadPackets})',
+      'RingStorageSync: reading bounded range start=$startSeq count=$packetCount',
     );
 
     bool reachedDone = false;
     try {
-      reachedDone = await completer.future.timeout(const Duration(minutes: 30));
-    } on TimeoutException {
-      Logger.debug('RingStorageSync: overall transfer timeout (30m)');
+      reachedDone = await completer.future;
     } catch (e) {
       Logger.debug('RingStorageSync: transfer error: $e');
     } finally {
-      firstDataTimer.cancel();
+      inactivityTimer?.cancel();
       if (_isCancelled) {
         await _requestFirmwareStopSync();
       }
       await _notifyStream?.cancel();
       _notifyStream = null;
-    }
-
-    // Wait for any flush still in flight from the streaming phase before
-    // draining the tail — otherwise the final flush could race the in-flight
-    // one on bytesData and chunkTimerStart.
-    final pendingFlush = inFlightFlush;
-    if (pendingFlush != null) {
-      try {
-        await pendingFlush;
-      } catch (e) {
-        Logger.debug('RingStorageSync: in-flight flush error during settle: $e');
-      }
-    }
-
-    // Flush whatever frames are buffered, even on partial failure — those frames
-    // are safe to upload to cloud regardless. ADVANCE is gated separately.
-    try {
-      await flushChunks(finalFlush: true);
-    } catch (e) {
-      Logger.debug('RingStorageSync: final flush error: $e');
     }
 
     final receivedCompleteRange = RingProtocol.receivedCompleteRange(
@@ -602,12 +700,28 @@ class RingStorageSyncImpl implements RingStorageSync {
       receivedPacketCount: recordsConsumed,
       pendingBytes: reassembler.pendingBytes,
     );
+    final transportComplete =
+        reachedDone && doneOk && !protocolError && crcVerified && !_isCancelled && receivedCompleteRange;
+
+    // No bytes are registered before the complete range and optional CRC have
+    // been validated. A corrupt retry therefore cannot poison an immutable
+    // source identity that would block the next clean retry.
+    if (transportComplete) {
+      try {
+        await flushValidatedRange();
+      } catch (e) {
+        Logger.debug('RingStorageSync: final flush error: $e');
+      }
+    }
+
     final advancedOk = RingProtocol.canAdvance(
       reachedDone: reachedDone,
       doneOk: doneOk,
       flushError: flushError,
       isCancelled: _isCancelled,
       receivedCompleteRange: receivedCompleteRange,
+      protocolError: protocolError,
+      crcVerified: crcVerified,
     );
     if (advancedOk) {
       final ok = await connection.advanceRing(doneNextSeq!);
@@ -617,22 +731,27 @@ class RingStorageSyncImpl implements RingStorageSync {
         'next_seq': doneNextSeq,
         'advance_ok': ok,
       });
-      return ok;
+      return ok ? _RingRangeResult(nextSeq: doneNextSeq!, frameCount: fallbackFrames) : null;
     } else {
       Logger.debug(
         'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError '
-        'cancelled=$_isCancelled completeRange=$receivedCompleteRange records=$recordsConsumed '
-        'pendingBytes=${reassembler.pendingBytes})',
+        'cancelled=$_isCancelled completeRange=$receivedCompleteRange protocolError=$protocolError '
+        'crcVerified=$crcVerified records=$recordsConsumed pendingBytes=${reassembler.pendingBytes})',
       );
-      return false;
+      return null;
     }
   }
 
   /// Write opus frames to disk in WAL format: [frame_length_u32_le][frame_data]...
   /// Identical to StorageSyncImpl._flushToDisk for downstream compatibility.
-  Future<File> _flushToDisk(Wal wal, List<List<int>> frames, int timerStart) async {
-    final directory = await getApplicationDocumentsDirectory();
-    final filePath = '${directory.path}/${wal.getFileNameByTimeStarts(timerStart)}';
+  Future<File> _flushToDisk(
+    Wal wal,
+    List<List<int>> frames,
+    int timerStart,
+    String sourceId,
+  ) async {
+    final directory = await _documentsDirectoryProvider();
+    final filePath = '${directory.path}/${wal.getFileNameByTimeStarts(timerStart, sourceId: sourceId)}';
 
     final List<int> data = [];
     for (final frame in frames) {
@@ -645,15 +764,38 @@ class RingStorageSyncImpl implements RingStorageSync {
     }
 
     final file = File(filePath);
-    // The firmware advances its durable read watermark only after this transfer
-    // completes. Flush the file before registering it and sending that ACK so a
-    // process or OS crash cannot turn an acknowledged range into missing audio.
-    await file.writeAsBytes(data, flush: true);
+    if (await file.exists()) {
+      final existing = await file.readAsBytes();
+      if (!listEquals(existing, data)) {
+        throw StateError('Immutable ring WAL collision for $sourceId');
+      }
+      return file;
+    }
+
+    final temporaryFile = File('$filePath.tmp');
+    try {
+      if (await temporaryFile.exists()) await temporaryFile.delete();
+      await temporaryFile.writeAsBytes(data, flush: true);
+      await temporaryFile.rename(filePath);
+    } catch (_) {
+      if (await temporaryFile.exists()) {
+        try {
+          await temporaryFile.delete();
+        } catch (_) {}
+      }
+      rethrow;
+    }
     Logger.debug('RingStorageSync: wrote ${data.length}B (${frames.length} frames) to $filePath');
     return file;
   }
 
-  Future<void> _registerWithLocalSync(Wal wal, File file, int timerStart, int frameCount) async {
+  Future<void> _registerWithLocalSync(
+    Wal wal,
+    File file,
+    int timerStart,
+    int frameCount,
+    String sourceId,
+  ) async {
     if (_localSync == null) {
       throw StateError('LocalWalSync is unavailable; refusing to acknowledge device records');
     }
@@ -674,9 +816,34 @@ class RingStorageSyncImpl implements RingStorageSync {
       totalFrames: frameCount,
       syncedFrameOffset: 0,
       originalStorage: WalStorage.sdcard,
+      sourceId: sourceId,
     );
 
-    await _localSync!.addExternalWal(localWal);
-    Logger.debug('RingStorageSync: registered chunk (ts=$timerStart, ${seconds}s, $frameCount frames)');
+    final registration = await _localSync!.addExternalWal(localWal);
+    Logger.debug(
+      'RingStorageSync: registered chunk (source=$sourceId, ts=$timerStart, ${seconds}s, '
+      '$frameCount frames, result=${registration.name})',
+    );
   }
+}
+
+class _RecoveredRingRecord {
+  final int sequence;
+  final int timestamp;
+  final int segment;
+  final List<List<int>> frames;
+
+  const _RecoveredRingRecord({
+    required this.sequence,
+    required this.timestamp,
+    required this.segment,
+    required this.frames,
+  });
+}
+
+class _RingRangeResult {
+  final int nextSeq;
+  final int frameCount;
+
+  const _RingRangeResult({required this.nextSeq, required this.frameCount});
 }

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -374,6 +374,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     final fps = wal.codec.getFramesPerSecond();
     final chunkFrames = sdcardChunkSizeSecs * fps;
     int? doneNextSeq;
+    int? transferStartSeq;
+    int? announcedPacketCount;
     bool doneOk = false;
     bool flushError = false;
     Future<void>? inFlightFlush;
@@ -425,6 +427,8 @@ class RingStorageSyncImpl implements RingStorageSync {
         if (opcode == RingProtocol.notifyReadBegin) {
           final begin = RingProtocol.parseReadBeginNotification(value);
           if (begin != null) {
+            transferStartSeq = begin.transferStartSeq;
+            announcedPacketCount = begin.packetCount;
             Logger.debug(
               'RingStorageSync: NOTIFY_READ_BEGIN start=${begin.transferStartSeq} count=${begin.packetCount}',
             );
@@ -591,7 +595,20 @@ class RingStorageSyncImpl implements RingStorageSync {
       Logger.debug('RingStorageSync: final flush error: $e');
     }
 
-    final advancedOk = reachedDone && doneOk && !flushError && !_isCancelled && doneNextSeq != null;
+    final receivedCompleteRange = RingProtocol.receivedCompleteRange(
+      transferStartSeq: transferStartSeq,
+      announcedPacketCount: announcedPacketCount,
+      doneNextSeq: doneNextSeq,
+      receivedPacketCount: recordsConsumed,
+      pendingBytes: reassembler.pendingBytes,
+    );
+    final advancedOk = RingProtocol.canAdvance(
+      reachedDone: reachedDone,
+      doneOk: doneOk,
+      flushError: flushError,
+      isCancelled: _isCancelled,
+      receivedCompleteRange: receivedCompleteRange,
+    );
     if (advancedOk) {
       final ok = await connection.advanceRing(doneNextSeq!);
       Logger.debug('RingStorageSync: advance(seq=$doneNextSeq) -> $ok (records=$recordsConsumed)');
@@ -603,7 +620,9 @@ class RingStorageSyncImpl implements RingStorageSync {
       return ok;
     } else {
       Logger.debug(
-        'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError cancelled=$_isCancelled records=$recordsConsumed)',
+        'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError '
+        'cancelled=$_isCancelled completeRange=$receivedCompleteRange records=$recordsConsumed '
+        'pendingBytes=${reassembler.pendingBytes})',
       );
       return false;
     }
@@ -626,15 +645,17 @@ class RingStorageSyncImpl implements RingStorageSync {
     }
 
     final file = File(filePath);
-    await file.writeAsBytes(data);
+    // The firmware advances its durable read watermark only after this transfer
+    // completes. Flush the file before registering it and sending that ACK so a
+    // process or OS crash cannot turn an acknowledged range into missing audio.
+    await file.writeAsBytes(data, flush: true);
     Logger.debug('RingStorageSync: wrote ${data.length}B (${frames.length} frames) to $filePath');
     return file;
   }
 
   Future<void> _registerWithLocalSync(Wal wal, File file, int timerStart, int frameCount) async {
     if (_localSync == null) {
-      Logger.debug('RingStorageSync: WARNING - LocalWalSync not available, chunk will not be uploaded');
-      return;
+      throw StateError('LocalWalSync is unavailable; refusing to acknowledge device records');
     }
     final fps = wal.codec.getFramesPerSecond();
     final seconds = fps > 0 ? frameCount ~/ fps : 0;

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -38,12 +38,45 @@ import 'package:omi/services/wals/wal_interfaces.dart';
 /// previously advanced ranges never need to be downloaded again.
 typedef RingConnectionResolver = Future<DeviceConnection?> Function(String deviceId);
 typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
+typedef RingLiveFramesHandler = bool Function(List<List<int>> frames);
+
+class RingAudioTailSession {
+  RingAudioTailSession._(this.done, this._cancel) {
+    unawaited(
+      done.then<void>(
+        (_) => _isActive = false,
+        onError: (Object _, StackTrace __) => _isActive = false,
+      ),
+    );
+  }
+
+  final Future<void> done;
+  final Future<void> Function() _cancel;
+  bool _isActive = true;
+
+  bool get isActive => _isActive;
+
+  Future<void> cancel() async {
+    try {
+      await _cancel();
+    } catch (_) {
+      // The owner observes transfer failures through [done]. Teardown remains
+      // idempotent so a dead session cannot block the replacement session.
+    } finally {
+      _isActive = false;
+    }
+  }
+}
 
 class RingStorageSyncImpl implements RingStorageSync {
   static const RingInfoRetryPolicy _ringInfoRetryPolicy = RingInfoRetryPolicy();
 
   static const int defaultPacketsPerRead = 1800;
   static const Duration defaultInactivityTimeout = Duration(seconds: 15);
+  static const int _backlogPacketsPerSlice = 96;
+  static const Duration _livePollInterval = Duration(seconds: 1);
+  static const Duration _partialLiveRangeDeadline = Duration(seconds: 1);
+  static const int _liveFreshnessSeconds = 5;
 
   List<Wal> _wals = [];
   BtDevice? _device;
@@ -51,6 +84,8 @@ class RingStorageSyncImpl implements RingStorageSync {
   StreamSubscription? _notifyStream;
   String? _activeSyncDeviceId;
   bool _firmwareStopRequested = false;
+  int _tailGeneration = 0;
+  Future<void>? _tailFuture;
 
   IWalSyncListener listener;
   LocalWalSync? _localSync;
@@ -83,7 +118,13 @@ class RingStorageSyncImpl implements RingStorageSync {
         _packetsPerRead = packetsPerRead,
         _inactivityTimeout = inactivityTimeout,
         _nowSeconds = nowSeconds ?? _systemNowSeconds {
-    if (packetsPerRead <= 0) throw ArgumentError.value(packetsPerRead, 'packetsPerRead', 'must be positive');
+    if (packetsPerRead <= 0) {
+      throw ArgumentError.value(
+        packetsPerRead,
+        'packetsPerRead',
+        'must be positive',
+      );
+    }
   }
 
   static int _systemNowSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -101,6 +142,10 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   @override
   void setDevice(BtDevice? device) {
+    if (_device?.id != device?.id) {
+      _tailGeneration += 1;
+      cancelSync();
+    }
     _device = device;
     if (device == null) {
       _wals = [];
@@ -169,7 +214,9 @@ class RingStorageSyncImpl implements RingStorageSync {
       if (connection == null) return false;
       final status = await connection.getRingStatus();
       final result = status != null && status.unreadPackets > 0;
-      Logger.debug('RingStorageSync.hasFilesToSync: status=$status result=$result');
+      Logger.debug(
+        'RingStorageSync.hasFilesToSync: status=$status result=$result',
+      );
       return result;
     } catch (e) {
       Logger.debug('RingStorageSync.hasFilesToSync: error: $e');
@@ -181,7 +228,11 @@ class RingStorageSyncImpl implements RingStorageSync {
   /// Safe to call during sync — never touches BLE.
   @override
   Future<List<Wal>> getMissingWals() async {
-    return _wals.where((w) => w.status == WalStatus.miss && w.storage == WalStorage.sdcard).toList();
+    return _wals
+        .where(
+          (w) => w.status == WalStatus.miss && w.storage == WalStorage.sdcard,
+        )
+        .toList();
   }
 
   /// Discover unread ring data via BLE. Must be called BEFORE syncAll().
@@ -191,7 +242,9 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<void> refreshWalsFromDevice() async {
     if (_device == null) return;
     if (_isSyncing) {
-      Logger.debug('RingStorageSync.refreshWalsFromDevice: skipping — sync in progress');
+      Logger.debug(
+        'RingStorageSync.refreshWalsFromDevice: skipping — sync in progress',
+      );
       return;
     }
 
@@ -224,7 +277,9 @@ class RingStorageSyncImpl implements RingStorageSync {
 
       // Skip very small rings (<10s of audio) — same threshold as the file-based path.
       if (estimatedSecs < 10) {
-        Logger.debug('RingStorageSync.refreshWalsFromDevice: ring too small ($estimatedSecs s), skipping');
+        Logger.debug(
+          'RingStorageSync.refreshWalsFromDevice: ring too small ($estimatedSecs s), skipping',
+        );
         _wals = [];
         return;
       }
@@ -286,7 +341,9 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<void> deleteAllPendingWals() async {
     if (!_wals.any((w) => w.status == WalStatus.miss)) return;
     if (_isSyncing) {
-      Logger.debug('RingStorageSync.deleteAllPendingWals: skipping — sync in progress');
+      Logger.debug(
+        'RingStorageSync.deleteAllPendingWals: skipping — sync in progress',
+      );
       return;
     }
     await _clearRingOnDevice();
@@ -311,25 +368,316 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   @override
   Future stop() async {
+    _tailGeneration += 1;
     cancelSync();
     await _notifyStream?.cancel();
+    await _tailFuture;
+  }
+
+  /// Start the storage-authoritative audio scheduler.
+  ///
+  /// The newest second is fetched first for live transcription. Historical
+  /// ranges then consume the spare BLE bandwidth in bounded slices. Every
+  /// range reaches phone storage before it can be emitted or included in a
+  /// cumulative device ADVANCE.
+  Future<RingAudioTailSession?> startAudioTail({
+    required RingLiveFramesHandler onLiveFrames,
+  }) async {
+    final device = _device;
+    if (device == null) return null;
+
+    _tailGeneration += 1;
+    final generation = _tailGeneration;
+    _isCancelled = false;
+    _firmwareStopRequested = false;
+    _activeSyncDeviceId = device.id;
+
+    final connection = await _ensureConnection(device.id);
+    if (connection == null) return null;
+    final codec = await connection.getAudioCodec();
+    final initialInfo = await _ringInfoRetryPolicy.run(connection.getRingInfo);
+    final wal = _virtualWalForInfo(
+      device,
+      codec,
+      device.modelNumber.isNotEmpty ? device.modelNumber : 'Omi',
+      initialInfo,
+    );
+    final coverage = await _loadDurableCoverage(device.id);
+
+    final future = _runAudioTail(
+      generation: generation,
+      deviceId: device.id,
+      connection: connection,
+      wal: wal,
+      codec: codec,
+      initialInfo: initialInfo,
+      coverage: coverage,
+      onLiveFrames: onLiveFrames,
+    );
+    _tailFuture = future;
+    unawaited(
+      future.then<void>(
+        (_) {
+          if (identical(_tailFuture, future)) {
+            _tailFuture = null;
+            _isSyncing = false;
+          }
+        },
+        onError: (Object _, StackTrace __) {
+          if (identical(_tailFuture, future)) {
+            _tailFuture = null;
+            _isSyncing = false;
+          }
+        },
+      ),
+    );
+
+    return RingAudioTailSession._(future, () async {
+      if (_tailGeneration == generation) {
+        _tailGeneration += 1;
+        _isCancelled = true;
+        await _notifyStream?.cancel();
+        await _requestFirmwareStopSync();
+      }
+      await future;
+    });
+  }
+
+  Wal _virtualWalForInfo(
+    BtDevice device,
+    BleAudioCodec codec,
+    String deviceModel,
+    RingInfo info,
+  ) {
+    final framesPerRecord = _framesPerRecord(codec);
+    final totalFrames = framesPerRecord * info.unreadPackets;
+    final fps = codec.getFramesPerSecond();
+    final seconds = fps > 0 ? totalFrames ~/ fps : 0;
+    return Wal(
+      codec: codec,
+      timerStart: _nowSeconds() - seconds,
+      status: WalStatus.miss,
+      storage: WalStorage.sdcard,
+      seconds: seconds,
+      storageOffset: 0,
+      storageTotalBytes: info.unreadPackets * RingProtocol.recordSize,
+      fileNum: -1,
+      device: device.id,
+      deviceModel: deviceModel,
+      totalFrames: totalFrames,
+      syncedFrameOffset: 0,
+    );
+  }
+
+  int _framesPerRecord(BleAudioCodec codec) {
+    final frameLength = codec.getFramesLengthInBytes();
+    return frameLength > 0 ? RingProtocol.audioPayloadBytes ~/ (frameLength + 1) : 1;
+  }
+
+  int _livePacketsPerRead(BleAudioCodec codec) {
+    final framesPerRecord = _framesPerRecord(codec);
+    final fps = codec.getFramesPerSecond();
+    return framesPerRecord > 0 ? (fps + framesPerRecord - 1) ~/ framesPerRecord : 1;
+  }
+
+  Future<RingSequenceCoverage> _loadDurableCoverage(String deviceId) async {
+    final ranges = <({int start, int end})>[];
+    final localSync = _localSync;
+    if (localSync == null) return RingSequenceCoverage();
+    for (final wal in await localSync.getAllWals()) {
+      if (wal.device != deviceId) continue;
+      final range = RingProtocol.parseSourceRange(wal.sourceId);
+      if (range != null) ranges.add(range);
+    }
+    return RingSequenceCoverage(ranges);
+  }
+
+  Future<void> _runAudioTail({
+    required int generation,
+    required String deviceId,
+    required DeviceConnection connection,
+    required Wal wal,
+    required BleAudioCodec codec,
+    required RingInfo initialInfo,
+    required RingSequenceCoverage coverage,
+    required RingLiveFramesHandler onLiveFrames,
+  }) async {
+    _isSyncing = true;
+    _downloadStartTime = DateTime.now();
+    _totalBytesDownloaded = 0;
+    var info = initialInfo;
+    final sourceReadSeq = initialInfo.readSeq;
+    final sourceFramesPerRecord = _framesPerRecord(codec);
+    int? liveCursor;
+    DateTime? partialLiveSince;
+    var lastSnapshotAt = DateTime.now();
+
+    try {
+      while (_tailGeneration == generation && !_isCancelled && _device?.id == deviceId) {
+        final coveredPrefix = coverage.contiguousEndFrom(info.readSeq);
+        if (coveredPrefix > info.readSeq) {
+          final advanced = await connection.advanceRing(coveredPrefix);
+          if (!advanced) {
+            throw const RingStorageException(
+              'Device rejected a durable covered-prefix advance',
+            );
+          }
+          info = RingInfo(
+            readSeq: coveredPrefix,
+            writeSeq: info.writeSeq,
+            capacityPackets: info.capacityPackets,
+            droppedPackets: info.droppedPackets,
+            packetSize: info.packetSize,
+          );
+        }
+
+        final livePackets = _livePacketsPerRead(codec);
+        final desiredLiveStart =
+            info.writeSeq - info.readSeq > livePackets ? info.writeSeq - livePackets : info.readSeq;
+        var liveStart = liveCursor != null && liveCursor > desiredLiveStart ? liveCursor : desiredLiveStart;
+        liveStart = coverage.firstUncovered(liveStart, info.writeSeq);
+        final liveCount = info.writeSeq - liveStart;
+
+        if (liveCount > 0) {
+          partialLiveSince ??= DateTime.now();
+          final rangeReady = liveCount >= livePackets ||
+              DateTime.now().difference(partialLiveSince) >= _partialLiveRangeDeadline ||
+              info.readSeq < desiredLiveStart;
+          if (rangeReady) {
+            final result = await _syncRange(
+              connection,
+              wal,
+              startSeq: liveStart,
+              packetCount: liveCount,
+              fallbackAnchor: wal.timerStart,
+              fallbackFramesBefore: (liveStart - sourceReadSeq) * sourceFramesPerRecord,
+              completedRecords: 0,
+              totalRecords: info.unreadPackets,
+              onLiveFrames: onLiveFrames,
+              advanceAfterCommit: false,
+            );
+            if (result == null) {
+              throw const RingStorageException(
+                'Live ring range did not complete',
+              );
+            }
+            coverage.add(liveStart, result.nextSeq);
+            liveCursor = result.nextSeq;
+            partialLiveSince = null;
+          }
+        } else {
+          partialLiveSince = null;
+        }
+
+        final prefixAfterLive = coverage.contiguousEndFrom(info.readSeq);
+        if (prefixAfterLive > info.readSeq) {
+          final advanced = await connection.advanceRing(prefixAfterLive);
+          if (!advanced) {
+            throw const RingStorageException(
+              'Device rejected a live covered-prefix advance',
+            );
+          }
+          info = RingInfo(
+            readSeq: prefixAfterLive,
+            writeSeq: info.writeSeq,
+            capacityPackets: info.capacityPackets,
+            droppedPackets: info.droppedPackets,
+            packetSize: info.packetSize,
+          );
+        }
+
+        final nextCovered = coverage.firstRangeAtOrAfter(info.readSeq);
+        final backlogEnd = nextCovered?.start ?? info.writeSeq;
+        if (backlogEnd > info.readSeq) {
+          final available = backlogEnd - info.readSeq;
+          final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
+          final result = await _syncRange(
+            connection,
+            wal,
+            startSeq: info.readSeq,
+            packetCount: count,
+            fallbackAnchor: wal.timerStart,
+            fallbackFramesBefore: (info.readSeq - sourceReadSeq) * sourceFramesPerRecord,
+            completedRecords: 0,
+            totalRecords: info.unreadPackets,
+            advanceAfterCommit: false,
+          );
+          if (result == null) {
+            throw const RingStorageException(
+              'Backlog ring range did not complete',
+            );
+          }
+          coverage.add(info.readSeq, result.nextSeq);
+          final advanced = await connection.advanceRing(result.nextSeq);
+          if (!advanced) {
+            throw const RingStorageException(
+              'Device rejected a backlog covered-prefix advance',
+            );
+          }
+          info = RingInfo(
+            readSeq: result.nextSeq,
+            writeSeq: info.writeSeq,
+            capacityPackets: info.capacityPackets,
+            droppedPackets: info.droppedPackets,
+            packetSize: info.packetSize,
+          );
+        }
+
+        if (_tailGeneration != generation || _isCancelled) break;
+        final snapshotAge = DateTime.now().difference(lastSnapshotAt);
+        if (snapshotAge < _livePollInterval) {
+          await Future<void>.delayed(_livePollInterval - snapshotAge);
+        }
+        info = await _ringInfoRetryPolicy.run(connection.getRingInfo);
+        lastSnapshotAt = DateTime.now();
+        if (info.droppedPackets > 0) {
+          DebugLogManager.logWarning(
+            'RingStorageSync: ring reports ${info.droppedPackets} overwritten packets',
+            {'ringInfo': info.toString()},
+          );
+        }
+      }
+    } catch (error, stackTrace) {
+      if (_tailGeneration == generation && !_isCancelled) {
+        DebugLogManager.logError(
+          error,
+          stackTrace,
+          'Storage-authoritative audio tail failed',
+          {'device': deviceId},
+        );
+        rethrow;
+      }
+    } finally {
+      if (_tailGeneration == generation) {
+        _isSyncing = false;
+      }
+    }
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async {
+  Future<SyncLocalFilesResponse?> syncAll({
+    IWalSyncProgressListener? progress,
+  }) async {
     if (_device == null) {
       Logger.debug('RingStorageSync.syncAll: _device is null');
       return null;
     }
 
-    final wals = _wals.where((w) => w.status == WalStatus.miss && w.storage == WalStorage.sdcard).toList();
+    final wals = _wals
+        .where(
+          (w) => w.status == WalStatus.miss && w.storage == WalStorage.sdcard,
+        )
+        .toList();
     if (wals.isEmpty) return null;
 
     _resetSyncState();
     _isSyncing = true;
     DebugLogManager.logInfo('RingStorageSync: Starting sync');
 
-    final resp = SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    final resp = SyncLocalFilesResponse(
+      newConversationIds: [],
+      updatedConversationIds: [],
+    );
 
     try {
       for (final wal in wals) {
@@ -339,10 +687,14 @@ class RingStorageSyncImpl implements RingStorageSync {
           // Leave wal.status as miss so the next sync session retries it.
           // This preserves the "resume from same read_seq" guarantee — pairing
           // with the no-advance-on-failure invariant in _syncRing.
-          Logger.debug('RingStorageSync: Ring transfer incomplete; ring untouched, will resume next sync');
+          Logger.debug(
+            'RingStorageSync: Ring transfer incomplete; ring untouched, will resume next sync',
+          );
           listener.onWalUpdated();
           if (!_isCancelled) {
-            throw const RingStorageException('Device storage transfer did not complete');
+            throw const RingStorageException(
+              'Device storage transfer did not complete',
+            );
           }
           break;
         }
@@ -351,7 +703,9 @@ class RingStorageSyncImpl implements RingStorageSync {
       }
     } catch (e) {
       Logger.debug('RingStorageSync.syncAll: error: $e');
-      DebugLogManager.logError(e, null, 'RingStorageSync failed', {'device': _device?.id});
+      DebugLogManager.logError(e, null, 'RingStorageSync failed', {
+        'device': _device?.id,
+      });
       rethrow;
     } finally {
       _isSyncing = false;
@@ -364,7 +718,10 @@ class RingStorageSyncImpl implements RingStorageSync {
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
+  Future<SyncLocalFilesResponse?> syncWal({
+    required Wal wal,
+    IWalSyncProgressListener? progress,
+  }) async {
     _resetSyncState();
     _isSyncing = true;
     try {
@@ -374,7 +731,9 @@ class RingStorageSyncImpl implements RingStorageSync {
         wal.status = WalStatus.synced;
         progress?.onWalSyncedProgress(1.0, speedKBps: _currentSpeedKBps);
       } else if (!_isCancelled) {
-        throw const RingStorageException('Device storage transfer did not complete');
+        throw const RingStorageException(
+          'Device storage transfer did not complete',
+        );
       }
       listener.onWalUpdated();
     } catch (e) {
@@ -383,7 +742,10 @@ class RingStorageSyncImpl implements RingStorageSync {
     } finally {
       _isSyncing = false;
     }
-    return SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    return SyncLocalFilesResponse(
+      newConversationIds: [],
+      updatedConversationIds: [],
+    );
   }
 
   /// Drain the ring in bounded, independently durable transactions.
@@ -407,14 +769,19 @@ class RingStorageSyncImpl implements RingStorageSync {
       return true;
     }
     if (ringInfo.droppedPackets > 0) {
-      DebugLogManager.logWarning('RingStorageSync: ring overwrote ${ringInfo.droppedPackets} packets before sync', {
-        'ringInfo': ringInfo.toString(),
-      });
+      DebugLogManager.logWarning(
+        'RingStorageSync: ring overwrote ${ringInfo.droppedPackets} packets before sync',
+        {'ringInfo': ringInfo.toString()},
+      );
     }
     final targetWriteSeq = ringInfo.writeSeq;
     final totalRecords = targetWriteSeq - ringInfo.readSeq;
     final fps = wal.codec.getFramesPerSecond();
-    final fallbackAnchor = await _resolveFallbackAnchor(wal, ringInfo.readSeq, fps);
+    final fallbackAnchor = await _resolveFallbackAnchor(
+      wal,
+      ringInfo.readSeq,
+      fps,
+    );
     var nextReadSeq = ringInfo.readSeq;
     var completedRecords = 0;
     var completedFrames = 0;
@@ -442,7 +809,11 @@ class RingStorageSyncImpl implements RingStorageSync {
     return !_isCancelled && nextReadSeq == targetWriteSeq;
   }
 
-  Future<int> _resolveFallbackAnchor(Wal virtualWal, int initialReadSeq, int fps) async {
+  Future<int> _resolveFallbackAnchor(
+    Wal virtualWal,
+    int initialReadSeq,
+    int fps,
+  ) async {
     final localSync = _localSync;
     if (localSync == null) return virtualWal.timerStart;
 
@@ -476,6 +847,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     required int completedRecords,
     required int totalRecords,
     IWalSyncProgressListener? progress,
+    RingLiveFramesHandler? onLiveFrames,
+    bool advanceAfterCommit = true,
   }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
@@ -517,9 +890,40 @@ class RingStorageSyncImpl implements RingStorageSync {
         final sourceStartSeq = chunkRecords.first.sequence;
         final sourceEndSeq = chunkRecords.last.sequence + 1;
         final sourceId = 'ring_${sourceStartSeq}_$sourceEndSeq';
+        final now = _nowSeconds();
+        final isLiveRange = onLiveFrames != null &&
+            chunkRecords.first.timestamp >= now - _liveFreshnessSeconds &&
+            chunkRecords.last.timestamp <= now + _liveFreshnessSeconds;
         try {
           final file = await _flushToDisk(wal, frames, timerStart, sourceId);
-          await _registerWithLocalSync(wal, file, timerStart, frames.length, sourceId);
+          final registered = await _registerWithLocalSync(
+            wal,
+            file,
+            timerStart,
+            frames.length,
+            sourceId,
+            scheduleUpload: !isLiveRange,
+          );
+          if (isLiveRange && registered.registration == ExternalWalRegistration.added) {
+            var delivered = false;
+            try {
+              delivered = onLiveFrames(frames);
+            } catch (error) {
+              Logger.debug(
+                'RingStorageSync: live frame delivery failed for $sourceId: $error',
+              );
+            }
+            if (delivered) {
+              await _localSync!.markExternalWalSynced(registered.wal);
+            } else {
+              // No live socket ownership: leave the durable WAL retryable and
+              // wake the normal uploader instead of discarding the sequence.
+              await _localSync!.addExternalWal(
+                registered.wal,
+                scheduleUpload: true,
+              );
+            }
+          }
         } catch (e) {
           Logger.debug('RingStorageSync._syncRing: flush error: $e');
           flushError = true;
@@ -532,7 +936,9 @@ class RingStorageSyncImpl implements RingStorageSync {
       inactivityTimer?.cancel();
       inactivityTimer = Timer(_inactivityTimeout, () {
         if (!completer.isCompleted) {
-          Logger.debug('RingStorageSync: range inactive for ${_inactivityTimeout.inSeconds}s');
+          Logger.debug(
+            'RingStorageSync: range inactive for ${_inactivityTimeout.inSeconds}s',
+          );
           completer.complete(false);
         }
       });
@@ -563,7 +969,9 @@ class RingStorageSyncImpl implements RingStorageSync {
           final begin = RingProtocol.parseReadBeginNotification(value);
           if (begin == null || begin.transferStartSeq != startSeq || begin.packetCount != packetCount) {
             protocolError = true;
-            Logger.debug('RingStorageSync: invalid READ_BEGIN for requested range start=$startSeq count=$packetCount');
+            Logger.debug(
+              'RingStorageSync: invalid READ_BEGIN for requested range start=$startSeq count=$packetCount',
+            );
             if (!completer.isCompleted) completer.complete(false);
           } else if (transferStartSeq != null &&
               (transferStartSeq != begin.transferStartSeq || announcedPacketCount != begin.packetCount)) {
@@ -581,7 +989,9 @@ class RingStorageSyncImpl implements RingStorageSync {
         if (opcode == RingProtocol.notifyDone) {
           final done = RingProtocol.parseDoneNotification(value);
           if (done == null) {
-            Logger.debug('RingStorageSync: NOTIFY_DONE truncated (${value.length} bytes)');
+            Logger.debug(
+              'RingStorageSync: NOTIFY_DONE truncated (${value.length} bytes)',
+            );
             if (!completer.isCompleted) completer.complete(false);
             return;
           }
@@ -595,12 +1005,16 @@ class RingStorageSyncImpl implements RingStorageSync {
               );
             }
           }
-          Logger.debug('RingStorageSync: NOTIFY_DONE status=${done.status} next_seq=$doneNextSeq');
+          Logger.debug(
+            'RingStorageSync: NOTIFY_DONE status=${done.status} next_seq=$doneNextSeq',
+          );
           if (!completer.isCompleted) completer.complete(true);
           return;
         }
         if (opcode != RingProtocol.notifyData) {
-          Logger.debug('RingStorageSync: unknown notification opcode 0x${opcode.toRadixString(16)}');
+          Logger.debug(
+            'RingStorageSync: unknown notification opcode 0x${opcode.toRadixString(16)}',
+          );
           return;
         }
 
@@ -619,10 +1033,14 @@ class RingStorageSyncImpl implements RingStorageSync {
 
         for (final record in reassembler.drainRecords()) {
           final ts = RingProtocol.readRecordTimestamp(record);
-          final frames = RingProtocol.parseAudioPayload(record.sublist(RingProtocol.timestampBytes));
+          final frames = RingProtocol.parseAudioPayload(
+            record.sublist(RingProtocol.timestampBytes),
+          );
           if (frames.isEmpty) {
             protocolError = true;
-            Logger.debug('RingStorageSync: record ${transferStartSeq! + recordsConsumed} has no decodable frames');
+            Logger.debug(
+              'RingStorageSync: record ${transferStartSeq! + recordsConsumed} has no decodable frames',
+            );
           }
           final now = _nowSeconds();
           final effectiveTimestamp = RingProtocol.isPlausibleRecordTimestamp(ts, nowSeconds: now)
@@ -679,7 +1097,10 @@ class RingStorageSyncImpl implements RingStorageSync {
 
     armInactivityTimer();
 
-    final readOk = await connection.readRingFromSeq(startSeq, packetCount: packetCount);
+    final readOk = await connection.readRingFromSeq(
+      startSeq,
+      packetCount: packetCount,
+    );
     if (!readOk) {
       inactivityTimer?.cancel();
       await _notifyStream?.cancel();
@@ -736,14 +1157,22 @@ class RingStorageSyncImpl implements RingStorageSync {
       crcVerified: crcVerified,
     );
     if (advancedOk) {
-      final ok = await connection.advanceRing(doneNextSeq!);
-      Logger.debug('RingStorageSync: advance(seq=$doneNextSeq) -> $ok (records=$recordsConsumed)');
-      DebugLogManager.logEvent('ring_sync_advanced', {
-        'records': recordsConsumed,
-        'next_seq': doneNextSeq,
-        'advance_ok': ok,
-      });
-      return ok ? _RingRangeResult(nextSeq: doneNextSeq!, frameCount: fallbackFrames) : null;
+      if (advanceAfterCommit) {
+        final ok = await connection.advanceRing(doneNextSeq!);
+        Logger.debug(
+          'RingStorageSync: advance(seq=$doneNextSeq) -> $ok (records=$recordsConsumed)',
+        );
+        DebugLogManager.logEvent('ring_sync_advanced', {
+          'records': recordsConsumed,
+          'next_seq': doneNextSeq,
+          'advance_ok': ok,
+        });
+        if (!ok) return null;
+      }
+      return _RingRangeResult(
+        nextSeq: doneNextSeq!,
+        frameCount: fallbackFrames,
+      );
     } else {
       Logger.debug(
         'RingStorageSync: skipping advance (reachedDone=$reachedDone doneOk=$doneOk flushError=$flushError '
@@ -802,19 +1231,24 @@ class RingStorageSyncImpl implements RingStorageSync {
       }
       rethrow;
     }
-    Logger.debug('RingStorageSync: wrote ${data.length}B (${frames.length} frames) to $filePath');
+    Logger.debug(
+      'RingStorageSync: wrote ${data.length}B (${frames.length} frames) to $filePath',
+    );
     return file;
   }
 
-  Future<void> _registerWithLocalSync(
+  Future<({ExternalWalRegistration registration, Wal wal})> _registerWithLocalSync(
     Wal wal,
     File file,
     int timerStart,
     int frameCount,
-    String sourceId,
-  ) async {
+    String sourceId, {
+    bool scheduleUpload = true,
+  }) async {
     if (_localSync == null) {
-      throw StateError('LocalWalSync is unavailable; refusing to acknowledge device records');
+      throw StateError(
+        'LocalWalSync is unavailable; refusing to acknowledge device records',
+      );
     }
     final fps = wal.codec.getFramesPerSecond();
     final seconds = fps > 0 ? frameCount ~/ fps : 0;
@@ -836,11 +1270,15 @@ class RingStorageSyncImpl implements RingStorageSync {
       sourceId: sourceId,
     );
 
-    final registration = await _localSync!.addExternalWal(localWal);
+    final registration = await _localSync!.addExternalWal(
+      localWal,
+      scheduleUpload: scheduleUpload,
+    );
     Logger.debug(
       'RingStorageSync: registered chunk (source=$sourceId, ts=$timerStart, ${seconds}s, '
       '$frameCount frames, result=${registration.name})',
     );
+    return (registration: registration, wal: localWal);
   }
 }
 

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -40,6 +40,8 @@ typedef RingConnectionResolver = Future<DeviceConnection?> Function(String devic
 typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
 
 class RingStorageSyncImpl implements RingStorageSync {
+  static const RingInfoRetryPolicy _ringInfoRetryPolicy = RingInfoRetryPolicy();
+
   static const int defaultPacketsPerRead = 1800;
   static const Duration defaultInactivityTimeout = Duration(seconds: 15);
 
@@ -100,6 +102,10 @@ class RingStorageSyncImpl implements RingStorageSync {
   @override
   void setDevice(BtDevice? device) {
     _device = device;
+    if (device == null) {
+      _wals = [];
+      listener.onWalUpdated();
+    }
   }
 
   @override
@@ -335,6 +341,9 @@ class RingStorageSyncImpl implements RingStorageSync {
           // with the no-advance-on-failure invariant in _syncRing.
           Logger.debug('RingStorageSync: Ring transfer incomplete; ring untouched, will resume next sync');
           listener.onWalUpdated();
+          if (!_isCancelled) {
+            throw const RingStorageException('Device storage transfer did not complete');
+          }
           break;
         }
         wal.status = WalStatus.synced;
@@ -343,11 +352,14 @@ class RingStorageSyncImpl implements RingStorageSync {
     } catch (e) {
       Logger.debug('RingStorageSync.syncAll: error: $e');
       DebugLogManager.logError(e, null, 'RingStorageSync failed', {'device': _device?.id});
+      rethrow;
     } finally {
       _isSyncing = false;
     }
 
-    progress?.onWalSyncedProgress(1.0, speedKBps: _currentSpeedKBps);
+    if (!_isCancelled) {
+      progress?.onWalSyncedProgress(1.0, speedKBps: _currentSpeedKBps);
+    }
     return resp;
   }
 
@@ -360,11 +372,14 @@ class RingStorageSyncImpl implements RingStorageSync {
       final complete = await _syncRing(wal, progress: progress);
       if (complete) {
         wal.status = WalStatus.synced;
+        progress?.onWalSyncedProgress(1.0, speedKBps: _currentSpeedKBps);
+      } else if (!_isCancelled) {
+        throw const RingStorageException('Device storage transfer did not complete');
       }
-      progress?.onWalSyncedProgress(1.0, speedKBps: _currentSpeedKBps);
       listener.onWalUpdated();
     } catch (e) {
       Logger.debug('RingStorageSync.syncWal: error: $e');
+      rethrow;
     } finally {
       _isSyncing = false;
     }
@@ -386,11 +401,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     _downloadStartTime = DateTime.now();
     _totalBytesDownloaded = 0;
 
-    final ringInfo = await connection.getRingInfo();
-    if (ringInfo == null) {
-      Logger.debug('RingStorageSync._syncRing: getRingInfo returned null');
-      return false;
-    }
+    final ringInfo = await _ringInfoRetryPolicy.run(connection.getRingInfo);
     if (ringInfo.unreadPackets <= 0) {
       Logger.debug('RingStorageSync._syncRing: nothing to read');
       return true;

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -6,8 +6,10 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/models/sync_state.dart';
@@ -43,6 +45,10 @@ typedef RingLiveFramesHandler = LiveAudioFrameDelivery Function(
   List<List<int>> frames,
 );
 typedef RingDeepBacklogPolicy = bool Function();
+typedef RingConversationTimeoutSecondsProvider = int Function();
+typedef RingBacklogSnapshotCompleted = void Function(
+  RingBacklogDrainReceipt receipt,
+);
 
 bool ringShouldDrainDeepBacklog({
   required bool autoSyncEnabled,
@@ -64,7 +70,7 @@ int? ringLiveResumeSequence({
   required int readSeq,
   required int writeSeq,
   required int nowSeconds,
-  int recentSeconds = 120,
+  required int recentSeconds,
 }) {
   int? earliestPending;
   int? newestDeliveredEnd;
@@ -74,7 +80,7 @@ int? ringLiveResumeSequence({
   for (final wal in wals) {
     if (wal.device != deviceId ||
         wal.uploadIntent != WalUploadIntent.liveContinuity ||
-        wal.timerStart + wal.seconds < cutoff) {
+        wal.wallClockEndSeconds < cutoff) {
       continue;
     }
     final range = RingProtocol.parseSourceRange(wal.sourceId);
@@ -141,7 +147,6 @@ class RingStorageSyncImpl implements RingStorageSync {
   static const Duration _livePollInterval = Duration(seconds: 1);
   static const Duration _partialLiveRangeDeadline = Duration(seconds: 1);
   static const int _liveFreshnessSeconds = 5;
-  static const int _recentRecoverySeconds = 120;
 
   List<Wal> _wals = [];
   BtDevice? _device;
@@ -150,13 +155,20 @@ class RingStorageSyncImpl implements RingStorageSync {
   String? _activeSyncDeviceId;
   bool _firmwareStopRequested = false;
   int _tailGeneration = 0;
+  int? _tailOwnerGeneration;
   Future<void>? _tailFuture;
+  Completer<RingBacklogDrainReceipt?>? _requestedBacklogDrain;
+  int? _requestedBacklogDrainGeneration;
+  String? _requestedBacklogDrainDeviceId;
+  int? _requestedBacklogTargetSeq;
 
   IWalSyncListener listener;
   LocalWalSync? _localSync;
   final RingConnectionResolver? _connectionResolverOverride;
   final RingDocumentsDirectoryProvider _documentsDirectoryProvider;
   final RingDeepBacklogPolicy _deepBacklogPolicy;
+  final RingConversationTimeoutSecondsProvider _conversationTimeoutSecondsProvider;
+  final RingBacklogSnapshotCompleted? _onBacklogSnapshotCompleted;
   final int _packetsPerRead;
   final Duration _inactivityTimeout;
   final int Function() _nowSeconds;
@@ -165,6 +177,8 @@ class RingStorageSyncImpl implements RingStorageSync {
   bool _isSyncing = false;
   @override
   bool get isSyncing => _isSyncing;
+  @override
+  bool get isAudioTailActive => _tailOwnerGeneration != null;
 
   int _totalBytesDownloaded = 0;
   DateTime? _downloadStartTime;
@@ -177,12 +191,17 @@ class RingStorageSyncImpl implements RingStorageSync {
     RingConnectionResolver? connectionResolver,
     RingDocumentsDirectoryProvider? documentsDirectoryProvider,
     RingDeepBacklogPolicy? deepBacklogPolicy,
+    RingConversationTimeoutSecondsProvider? conversationTimeoutSecondsProvider,
+    RingBacklogSnapshotCompleted? onBacklogSnapshotCompleted,
     int packetsPerRead = defaultPacketsPerRead,
     Duration inactivityTimeout = defaultInactivityTimeout,
     int Function()? nowSeconds,
   })  : _connectionResolverOverride = connectionResolver,
         _documentsDirectoryProvider = documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
         _deepBacklogPolicy = deepBacklogPolicy ?? (() => true),
+        _conversationTimeoutSecondsProvider =
+            conversationTimeoutSecondsProvider ?? (() => SharedPreferencesUtil().conversationSilenceDuration),
+        _onBacklogSnapshotCompleted = onBacklogSnapshotCompleted,
         _packetsPerRead = packetsPerRead,
         _inactivityTimeout = inactivityTimeout,
         _nowSeconds = nowSeconds ?? _systemNowSeconds {
@@ -197,6 +216,10 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   static int _systemNowSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
+  int _snapshotConversationTimeoutSeconds() => effectiveConversationBoundarySeconds(
+        _conversationTimeoutSecondsProvider(),
+      );
+
   Future<DeviceConnection?> _ensureConnection(String deviceId) {
     final resolver = _connectionResolverOverride;
     if (resolver != null) return resolver(deviceId);
@@ -210,7 +233,17 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   @override
   void setDevice(BtDevice? device) {
-    if (_device?.id != device?.id) {
+    final previousDeviceId = _device?.id;
+    final nextDeviceId = device?.id;
+    if (previousDeviceId != nextDeviceId) {
+      // Android reports a transport loss as setDevice(null). Preserve the
+      // immutable request through that detached state; only a subsequently
+      // identified different pendant revokes the original user's authority.
+      if (nextDeviceId != null &&
+          _requestedBacklogDrainDeviceId != null &&
+          _requestedBacklogDrainDeviceId != nextDeviceId) {
+        cancelRequestedAudioTailBacklogDrain();
+      }
       _tailGeneration += 1;
       cancelSync();
     }
@@ -436,6 +469,7 @@ class RingStorageSyncImpl implements RingStorageSync {
 
   @override
   Future stop() async {
+    cancelRequestedAudioTailBacklogDrain();
     _tailGeneration += 1;
     cancelSync();
     await _notifyStream?.cancel();
@@ -457,70 +491,99 @@ class RingStorageSyncImpl implements RingStorageSync {
 
     _tailGeneration += 1;
     final generation = _tailGeneration;
+    _tailOwnerGeneration = generation;
     _isCancelled = false;
     _firmwareStopRequested = false;
     _activeSyncDeviceId = device.id;
-
-    final connection = await _ensureConnection(device.id);
-    if (connection == null) return null;
-    final codec = await connection.getAudioCodec();
-    final initialInfo = await _ringInfoRetryPolicy.run(connection.getRingInfo);
-    final wal = _virtualWalForInfo(
-      device,
-      codec,
-      device.modelNumber.isNotEmpty ? device.modelNumber : 'Omi',
-      initialInfo,
-    );
-    final coverage = await _loadDurableCoverage(device.id);
-    final resumeLiveSeq = resumeLiveContinuity
-        ? ringLiveResumeSequence(
-            wals: await _localSync?.getAllWals() ?? const <Wal>[],
-            deviceId: device.id,
-            readSeq: initialInfo.readSeq,
-            writeSeq: initialInfo.writeSeq,
-            nowSeconds: _nowSeconds(),
-          )
-        : null;
-
-    final future = _runAudioTail(
-      generation: generation,
-      deviceId: device.id,
-      connection: connection,
-      wal: wal,
-      codec: codec,
-      initialInfo: initialInfo,
-      coverage: coverage,
-      onLiveFrames: onLiveFrames,
-      resumeLiveContinuity: resumeLiveContinuity,
-      resumeLiveSeq: resumeLiveSeq,
-    );
-    _tailFuture = future;
-    unawaited(
-      future.then<void>(
-        (_) {
-          if (identical(_tailFuture, future)) {
-            _tailFuture = null;
-            _isSyncing = false;
-          }
-        },
-        onError: (Object _, StackTrace __) {
-          if (identical(_tailFuture, future)) {
-            _tailFuture = null;
-            _isSyncing = false;
-          }
-        },
-      ),
-    );
-
-    return RingAudioTailSession._(future, () async {
-      if (_tailGeneration == generation) {
-        _tailGeneration += 1;
-        _isCancelled = true;
-        await _notifyStream?.cancel();
-        await _requestFirmwareStopSync();
+    final conversationTimeoutSeconds = _snapshotConversationTimeoutSeconds();
+    _adoptRequestedBacklogDrain(generation, device.id);
+    var transferredToTail = false;
+    try {
+      final connection = await _ensureConnection(device.id);
+      if (connection == null || _tailGeneration != generation || _device?.id != device.id) {
+        return null;
       }
-      await future;
-    });
+      final codec = await connection.getAudioCodec();
+      if (_tailGeneration != generation || _device?.id != device.id) return null;
+      final initialInfo = await _ringInfoRetryPolicy.run(connection.getRingInfo);
+      if (_tailGeneration != generation || _device?.id != device.id) return null;
+      final wal = _virtualWalForInfo(
+        device,
+        codec,
+        device.modelNumber.isNotEmpty ? device.modelNumber : 'Omi',
+        initialInfo,
+      );
+      final coverage = await _loadDurableCoverage(device.id);
+      if (_tailGeneration != generation || _device?.id != device.id) return null;
+      final fallbackAnchor = await _resolveFallbackAnchor(
+        wal,
+        initialInfo.readSeq,
+        codec.getFramesPerSecond(),
+      );
+      if (_tailGeneration != generation || _device?.id != device.id) return null;
+      final resumeLiveSeq = resumeLiveContinuity
+          ? ringLiveResumeSequence(
+              wals: await _localSync?.getAllWals() ?? const <Wal>[],
+              deviceId: device.id,
+              readSeq: initialInfo.readSeq,
+              writeSeq: initialInfo.writeSeq,
+              nowSeconds: _nowSeconds(),
+              recentSeconds: conversationTimeoutSeconds,
+            )
+          : null;
+      if (_tailGeneration != generation || _device?.id != device.id) return null;
+
+      final future = _runAudioTail(
+        generation: generation,
+        deviceId: device.id,
+        connection: connection,
+        wal: wal,
+        codec: codec,
+        initialInfo: initialInfo,
+        coverage: coverage,
+        onLiveFrames: onLiveFrames,
+        resumeLiveContinuity: resumeLiveContinuity,
+        resumeLiveSeq: resumeLiveSeq,
+        conversationTimeoutSeconds: conversationTimeoutSeconds,
+        fallbackAnchor: fallbackAnchor,
+      );
+      _tailFuture = future;
+      transferredToTail = true;
+      unawaited(
+        future.then<void>(
+          (_) => _releaseAudioTailOwner(generation, future),
+          onError: (Object _, StackTrace __) => _releaseAudioTailOwner(generation, future),
+        ),
+      );
+
+      return RingAudioTailSession._(future, () async {
+        if (_tailGeneration == generation) {
+          _tailGeneration += 1;
+          _isCancelled = true;
+          await _notifyStream?.cancel();
+          await _requestFirmwareStopSync();
+        }
+        await future;
+      });
+    } finally {
+      if (!transferredToTail) {
+        _releaseAudioTailReservation(generation);
+      }
+    }
+  }
+
+  void _releaseAudioTailOwner(int generation, Future<void> future) {
+    if (identical(_tailFuture, future)) {
+      _tailFuture = null;
+      _isSyncing = false;
+    }
+    _releaseAudioTailReservation(generation);
+  }
+
+  void _releaseAudioTailReservation(int generation) {
+    if (_tailOwnerGeneration != generation) return;
+    _tailOwnerGeneration = null;
+    _detachRequestedBacklogDrain(generation);
   }
 
   Wal _virtualWalForInfo(
@@ -564,12 +627,123 @@ class RingStorageSyncImpl implements RingStorageSync {
     final ranges = <({int start, int end})>[];
     final localSync = _localSync;
     if (localSync == null) return RingSequenceCoverage();
+    Directory? documentsDirectory;
     for (final wal in await localSync.getAllWals()) {
-      if (wal.device != deviceId) continue;
-      final range = RingProtocol.parseSourceRange(wal.sourceId);
-      if (range != null) ranges.add(range);
+      if (wal.device != deviceId ||
+          wal.storage != WalStorage.disk ||
+          wal.status == WalStatus.corrupted ||
+          wal.status == WalStatus.inProgress ||
+          wal.filePath == null ||
+          wal.filePath!.isEmpty) {
+        continue;
+      }
+      final range = RingProtocol.parseDurableCoverageSourceRange(wal.sourceId);
+      if (range == null) continue;
+      try {
+        documentsDirectory ??= await _documentsDirectoryProvider();
+        final file = File(
+          path.join(documentsDirectory.path, path.basename(wal.filePath!)),
+        );
+        if (!await file.exists() || await file.length() <= 0) continue;
+      } catch (_) {
+        continue;
+      }
+      ranges.add(range);
     }
     return RingSequenceCoverage(ranges);
+  }
+
+  /// Ask the active live scheduler to drain the pendant backlog that existed
+  /// at the next safe ring snapshot.
+  ///
+  /// The scheduler remains the sole BLE reader and continues to fetch the live
+  /// head before each bounded historical slice. Concurrent manual Sync taps
+  /// share one request, so they cannot start duplicate reads or uploads.
+  @override
+  Future<RingBacklogDrainReceipt?>? requestAudioTailBacklogDrain() {
+    final deviceId = _device?.id;
+    final generation = _tailOwnerGeneration;
+    final existing = _requestedBacklogDrain;
+    if (existing != null && !existing.isCompleted) {
+      if (deviceId != null && _requestedBacklogDrainDeviceId == deviceId) {
+        if (generation != null) {
+          _requestedBacklogDrainGeneration = generation;
+        }
+        return existing.future;
+      }
+      cancelRequestedAudioTailBacklogDrain();
+    }
+    if (generation == null || deviceId == null) return null;
+    final request = Completer<RingBacklogDrainReceipt?>();
+    _requestedBacklogDrain = request;
+    _requestedBacklogDrainGeneration = generation;
+    _requestedBacklogDrainDeviceId = deviceId;
+    _requestedBacklogTargetSeq = null;
+    return request.future;
+  }
+
+  /// Revoke an explicit backlog request without stopping live capture.
+  @override
+  void cancelRequestedAudioTailBacklogDrain() {
+    final request = _requestedBacklogDrain;
+    if (request == null || request.isCompleted) return;
+    _clearRequestedBacklogDrainState();
+    request.complete(null);
+  }
+
+  void _adoptRequestedBacklogDrain(int generation, String deviceId) {
+    final request = _requestedBacklogDrain;
+    if (request == null || request.isCompleted || _requestedBacklogDrainDeviceId != deviceId) {
+      return;
+    }
+    _requestedBacklogDrainGeneration = generation;
+  }
+
+  void _detachRequestedBacklogDrain(int generation) {
+    if (_requestedBacklogDrainGeneration == generation) {
+      _requestedBacklogDrainGeneration = null;
+    }
+  }
+
+  bool _hasRequestedBacklogDrain(int generation) =>
+      _requestedBacklogDrainGeneration == generation &&
+      _requestedBacklogDrainDeviceId == _device?.id &&
+      _requestedBacklogDrain?.isCompleted == false;
+
+  void _captureRequestedBacklogTarget(int generation, RingInfo info) {
+    if (!_hasRequestedBacklogDrain(generation)) return;
+    if (_requestedBacklogTargetSeq != null) return;
+    _requestedBacklogTargetSeq = info.writeSeq;
+    Logger.debug(
+      'RingStorageSync: manual backlog snapshot latched '
+      'device=${_requestedBacklogDrainDeviceId!} '
+      'read_seq=${info.readSeq} target_write_seq=${info.writeSeq}',
+    );
+  }
+
+  void _completeRequestedBacklogDrainIfReady(int generation, RingInfo info) {
+    if (!_hasRequestedBacklogDrain(generation)) return;
+    final target = _requestedBacklogTargetSeq;
+    if (target == null || info.readSeq < target) return;
+    final request = _requestedBacklogDrain!;
+    final deviceId = _requestedBacklogDrainDeviceId!;
+    final receipt = RingBacklogDrainReceipt(
+      deviceId: deviceId,
+      targetWriteSeq: target,
+    );
+    Logger.debug(
+      'RingStorageSync: manual backlog snapshot completed '
+      'device=$deviceId read_seq=${info.readSeq} target_write_seq=$target',
+    );
+    _clearRequestedBacklogDrainState();
+    request.complete(receipt);
+  }
+
+  void _clearRequestedBacklogDrainState() {
+    _requestedBacklogDrain = null;
+    _requestedBacklogDrainGeneration = null;
+    _requestedBacklogDrainDeviceId = null;
+    _requestedBacklogTargetSeq = null;
   }
 
   Future<bool> _advanceLiveTailOrStop({
@@ -614,6 +788,8 @@ class RingStorageSyncImpl implements RingStorageSync {
     required RingLiveFramesHandler onLiveFrames,
     required bool resumeLiveContinuity,
     required int? resumeLiveSeq,
+    required int conversationTimeoutSeconds,
+    required int fallbackAnchor,
   }) async {
     _isSyncing = true;
     _downloadStartTime = DateTime.now();
@@ -626,9 +802,42 @@ class RingStorageSyncImpl implements RingStorageSync {
     var recentRecoveryExhausted = resumeLiveContinuity;
     DateTime? partialLiveSince;
     var lastSnapshotAt = DateTime.now();
+    int? automaticBacklogTargetSeq;
+    var automaticBacklogCompletionReported = false;
+
+    void captureAutomaticBacklogTarget(RingInfo snapshot) {
+      if (automaticBacklogTargetSeq != null || automaticBacklogCompletionReported) return;
+      if (_deepBacklogPolicy()) {
+        automaticBacklogTargetSeq = snapshot.writeSeq;
+      }
+    }
+
+    void reportAutomaticBacklogCompletion(RingInfo snapshot) {
+      final target = automaticBacklogTargetSeq;
+      if (automaticBacklogCompletionReported || target == null || snapshot.readSeq < target) {
+        return;
+      }
+      automaticBacklogCompletionReported = true;
+      try {
+        _onBacklogSnapshotCompleted?.call(
+          RingBacklogDrainReceipt(
+            deviceId: deviceId,
+            targetWriteSeq: target,
+          ),
+        );
+      } catch (error) {
+        Logger.debug(
+          'RingStorageSync: backlog completion callback failed: $error',
+        );
+      }
+    }
 
     try {
       while (_tailGeneration == generation && !_isCancelled && _device?.id == deviceId) {
+        captureAutomaticBacklogTarget(info);
+        _captureRequestedBacklogTarget(generation, info);
+        _completeRequestedBacklogDrainIfReady(generation, info);
+        reportAutomaticBacklogCompletion(info);
         final coveredPrefix = coverage.contiguousEndFrom(info.readSeq);
         if (coveredPrefix > info.readSeq) {
           final advanced = await _advanceLiveTailOrStop(
@@ -646,6 +855,8 @@ class RingStorageSyncImpl implements RingStorageSync {
             droppedPackets: info.droppedPackets,
             packetSize: info.packetSize,
           );
+          _completeRequestedBacklogDrainIfReady(generation, info);
+          reportAutomaticBacklogCompletion(info);
         }
 
         final livePackets = _livePacketsPerRead(codec);
@@ -699,13 +910,14 @@ class RingStorageSyncImpl implements RingStorageSync {
               uploadIntent: WalUploadIntent.liveContinuity,
               startSeq: liveStart,
               packetCount: liveCount,
-              fallbackAnchor: wal.timerStart,
+              fallbackAnchor: fallbackAnchor,
               fallbackFramesBefore: (liveStart - sourceReadSeq) * sourceFramesPerRecord,
               completedRecords: 0,
               totalRecords: info.unreadPackets,
               onLiveFrames: onLiveFrames,
               forceLiveDelivery: resumeLiveContinuity,
               advanceAfterCommit: false,
+              conversationTimeoutSeconds: conversationTimeoutSeconds,
             );
             if (result == null) {
               throw const RingStorageException(
@@ -740,12 +952,13 @@ class RingStorageSyncImpl implements RingStorageSync {
               uploadIntent: WalUploadIntent.liveContinuity,
               startSeq: recentRange.start,
               packetCount: recentRange.end - recentRange.start,
-              fallbackAnchor: wal.timerStart,
+              fallbackAnchor: fallbackAnchor,
               fallbackFramesBefore: (recentRange.start - sourceReadSeq) * sourceFramesPerRecord,
               completedRecords: 0,
               totalRecords: info.unreadPackets,
               advanceAfterCommit: false,
               scheduleHistoricalUpload: false,
+              conversationTimeoutSeconds: conversationTimeoutSeconds,
             );
             if (result == null) {
               throw const RingStorageException(
@@ -754,7 +967,7 @@ class RingStorageSyncImpl implements RingStorageSync {
             }
             coverage.add(recentRange.start, result.nextSeq);
             recentCursor = recentRange.start;
-            recentRecoveryExhausted = result.oldestTimestamp < _nowSeconds() - _recentRecoverySeconds;
+            recentRecoveryExhausted = result.oldestTimestamp < _nowSeconds() - conversationTimeoutSeconds;
             recoveredRecentSlice = true;
           }
         }
@@ -776,14 +989,25 @@ class RingStorageSyncImpl implements RingStorageSync {
             droppedPackets: info.droppedPackets,
             packetSize: info.packetSize,
           );
+          _completeRequestedBacklogDrainIfReady(generation, info);
+          reportAutomaticBacklogCompletion(info);
         }
 
         final nextCovered = coverage.firstRangeAtOrAfter(info.readSeq);
-        final backlogEnd = nextCovered?.start ?? info.writeSeq;
+        var backlogEnd = nextCovered?.start ?? info.writeSeq;
+        final manualTarget = _hasRequestedBacklogDrain(generation) ? _requestedBacklogTargetSeq : null;
+        if (manualTarget != null && manualTarget > info.readSeq && manualTarget < backlogEnd) {
+          backlogEnd = manualTarget;
+        }
+        final automaticTarget = automaticBacklogCompletionReported ? null : automaticBacklogTargetSeq;
+        if (automaticTarget != null && automaticTarget > info.readSeq && automaticTarget < backlogEnd) {
+          backlogEnd = automaticTarget;
+        }
         // One recovery transfer per live poll. A slow BLE link must not queue a
         // recent repair and an old-history drain ahead of newly captured audio.
         final liveRecoveryCaughtUp = liveCursor == null || liveCursor >= info.writeSeq;
-        if (liveRecoveryCaughtUp && !recoveredRecentSlice && _deepBacklogPolicy() && backlogEnd > info.readSeq) {
+        final deepBacklogAuthorized = _deepBacklogPolicy() || _hasRequestedBacklogDrain(generation);
+        if (liveRecoveryCaughtUp && !recoveredRecentSlice && deepBacklogAuthorized && backlogEnd > info.readSeq) {
           final available = backlogEnd - info.readSeq;
           final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
           final result = await _syncRange(
@@ -792,11 +1016,12 @@ class RingStorageSyncImpl implements RingStorageSync {
             uploadIntent: WalUploadIntent.historicalBackfill,
             startSeq: info.readSeq,
             packetCount: count,
-            fallbackAnchor: wal.timerStart,
+            fallbackAnchor: fallbackAnchor,
             fallbackFramesBefore: (info.readSeq - sourceReadSeq) * sourceFramesPerRecord,
             completedRecords: 0,
             totalRecords: info.unreadPackets,
             advanceAfterCommit: false,
+            conversationTimeoutSeconds: conversationTimeoutSeconds,
           );
           if (result == null) {
             throw const RingStorageException(
@@ -819,6 +1044,8 @@ class RingStorageSyncImpl implements RingStorageSync {
             droppedPackets: info.droppedPackets,
             packetSize: info.packetSize,
           );
+          _completeRequestedBacklogDrainIfReady(generation, info);
+          reportAutomaticBacklogCompletion(info);
         }
 
         if (_tailGeneration != generation || _isCancelled) break;
@@ -846,6 +1073,7 @@ class RingStorageSyncImpl implements RingStorageSync {
         rethrow;
       }
     } finally {
+      _detachRequestedBacklogDrain(generation);
       if (_tailGeneration == generation) {
         _isSyncing = false;
       }
@@ -973,6 +1201,7 @@ class RingStorageSyncImpl implements RingStorageSync {
       );
     }
     final targetWriteSeq = ringInfo.writeSeq;
+    final conversationTimeoutSeconds = _snapshotConversationTimeoutSeconds();
     final totalRecords = targetWriteSeq - ringInfo.readSeq;
     final fps = wal.codec.getFramesPerSecond();
     final fallbackAnchor = await _resolveFallbackAnchor(
@@ -998,6 +1227,7 @@ class RingStorageSyncImpl implements RingStorageSync {
         completedRecords: completedRecords,
         totalRecords: totalRecords,
         progress: progress,
+        conversationTimeoutSeconds: conversationTimeoutSeconds,
       );
       if (advancedTo == null) return false;
       nextReadSeq = advancedTo.nextSeq;
@@ -1016,22 +1246,21 @@ class RingStorageSyncImpl implements RingStorageSync {
     final localSync = _localSync;
     if (localSync == null) return virtualWal.timerStart;
 
-    final sourcePattern = RegExp(r'^ring_(\d+)_(\d+)$');
     Wal? predecessor;
     for (final wal in await localSync.getAllWals()) {
       if (wal.device != virtualWal.device || wal.sourceId == null) continue;
-      final match = sourcePattern.firstMatch(wal.sourceId!);
-      if (match == null) continue;
-      final startSeq = int.parse(match.group(1)!);
-      final endSeq = int.parse(match.group(2)!);
-      if (startSeq == initialReadSeq) return wal.timerStart;
-      if (endSeq == initialReadSeq &&
-          (predecessor == null || wal.timerStart + wal.seconds > predecessor.timerStart + predecessor.seconds)) {
+      final range = RingProtocol.parseDurableCoverageSourceRange(
+        wal.sourceId,
+      );
+      if (range == null) continue;
+      if (range.start == initialReadSeq) return wal.timerStart;
+      if (range.end == initialReadSeq &&
+          (predecessor == null || wal.wallClockEndSeconds > predecessor.wallClockEndSeconds)) {
         predecessor = wal;
       }
     }
     if (predecessor != null) {
-      return predecessor.timerStart + predecessor.totalFrames ~/ (fps == 0 ? 1 : fps);
+      return predecessor.wallClockEndSeconds.floor();
     }
     return virtualWal.timerStart;
   }
@@ -1051,6 +1280,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     bool forceLiveDelivery = false,
     bool advanceAfterCommit = true,
     bool scheduleHistoricalUpload = true,
+    required int conversationTimeoutSeconds,
   }) async {
     final completer = Completer<bool>();
     final reassembler = RingRecordReassembler();
@@ -1095,8 +1325,10 @@ class RingStorageSyncImpl implements RingStorageSync {
         final sourceEndSeq = chunkRecords.last.sequence + 1;
         final sourceId = 'ring_${sourceStartSeq}_$sourceEndSeq';
         final now = _nowSeconds();
+        final lastRecord = chunkRecords.last;
+        final captureEndSeconds = lastRecord.timestamp.toDouble() + (fps > 0 ? lastRecord.frames.length / fps : 0.0);
         final effectiveUploadIntent =
-            uploadIntent == WalUploadIntent.liveContinuity && chunkRecords.last.timestamp < now - _recentRecoverySeconds
+            uploadIntent == WalUploadIntent.liveContinuity && captureEndSeconds < now - conversationTimeoutSeconds
                 ? WalUploadIntent.historicalBackfill
                 : uploadIntent;
         final isLiveRange = effectiveUploadIntent == WalUploadIntent.liveContinuity &&
@@ -1112,6 +1344,7 @@ class RingStorageSyncImpl implements RingStorageSync {
             timerStart,
             frames.length,
             sourceId,
+            captureEndSeconds: captureEndSeconds,
             uploadIntent: effectiveUploadIntent,
             scheduleUpload: !isLiveRange &&
                 (effectiveUploadIntent != WalUploadIntent.historicalBackfill || scheduleHistoricalUpload),
@@ -1466,6 +1699,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     int timerStart,
     int frameCount,
     String sourceId, {
+    required double captureEndSeconds,
     required WalUploadIntent uploadIntent,
     bool scheduleUpload = true,
   }) async {
@@ -1488,6 +1722,7 @@ class RingStorageSyncImpl implements RingStorageSync {
       device: wal.device,
       deviceModel: wal.deviceModel,
       seconds: seconds,
+      captureEndSeconds: captureEndSeconds,
       totalFrames: frameCount,
       syncedFrameOffset: 0,
       originalStorage: WalStorage.sdcard,

--- a/app/lib/services/wals/ring_storage_sync.dart
+++ b/app/lib/services/wals/ring_storage_sync.dart
@@ -41,6 +41,12 @@ typedef RingDocumentsDirectoryProvider = Future<Directory> Function();
 typedef RingLiveFramesHandler = bool Function(List<List<int>> frames);
 typedef RingDeepBacklogPolicy = bool Function();
 
+bool ringShouldDrainDeepBacklog({
+  required bool autoSyncEnabled,
+  required bool isCharging,
+}) =>
+    autoSyncEnabled || isCharging;
+
 @visibleForTesting
 int ringRecentRecoveryFloor({
   required int readSeq,
@@ -514,6 +520,37 @@ class RingStorageSyncImpl implements RingStorageSync {
     return RingSequenceCoverage(ranges);
   }
 
+  Future<bool> _advanceLiveTailOrStop({
+    required int generation,
+    required String deviceId,
+    required DeviceConnection connection,
+    required int nextSeq,
+    required String rejectionMessage,
+  }) async {
+    if (await connection.advanceRing(nextSeq)) return true;
+
+    /*
+     * A Bluetooth shutdown can reject the in-flight ADVANCE before the
+     * provider's disconnect callback invalidates this tail. The range is
+     * already durable locally, and the device cursor was not advanced, so a
+     * replacement session can safely retry without loss or duplication.
+     *
+     * Keep a rejection on a live transport fatal: that is a real firmware or
+     * protocol contract failure, not an expected connection transition.
+     */
+    if (_tailGeneration != generation || _isCancelled || _device?.id != deviceId) {
+      return false;
+    }
+    try {
+      if (!await connection.isConnected()) return false;
+    } catch (_) {
+      // A stale native session can fail the state query itself. It has the
+      // same retry semantics as an explicitly disconnected transport.
+      return false;
+    }
+    throw RingStorageException(rejectionMessage);
+  }
+
   Future<void> _runAudioTail({
     required int generation,
     required String deviceId,
@@ -538,12 +575,14 @@ class RingStorageSyncImpl implements RingStorageSync {
       while (_tailGeneration == generation && !_isCancelled && _device?.id == deviceId) {
         final coveredPrefix = coverage.contiguousEndFrom(info.readSeq);
         if (coveredPrefix > info.readSeq) {
-          final advanced = await connection.advanceRing(coveredPrefix);
-          if (!advanced) {
-            throw const RingStorageException(
-              'Device rejected a durable covered-prefix advance',
-            );
-          }
+          final advanced = await _advanceLiveTailOrStop(
+            generation: generation,
+            deviceId: deviceId,
+            connection: connection,
+            nextSeq: coveredPrefix,
+            rejectionMessage: 'Device rejected a durable covered-prefix advance',
+          );
+          if (!advanced) return;
           info = RingInfo(
             readSeq: coveredPrefix,
             writeSeq: info.writeSeq,
@@ -569,6 +608,7 @@ class RingStorageSyncImpl implements RingStorageSync {
             final result = await _syncRange(
               connection,
               wal,
+              uploadIntent: WalUploadIntent.liveContinuity,
               startSeq: liveStart,
               packetCount: liveCount,
               fallbackAnchor: wal.timerStart,
@@ -608,6 +648,7 @@ class RingStorageSyncImpl implements RingStorageSync {
           recentFloor,
           info.writeSeq,
         );
+        var recoveredRecentSlice = false;
         if (recentStart < info.writeSeq) {
           final nextRecentCovered = coverage.firstRangeAtOrAfter(recentStart);
           final recentEnd = nextRecentCovered?.start ?? info.writeSeq;
@@ -617,6 +658,7 @@ class RingStorageSyncImpl implements RingStorageSync {
             final result = await _syncRange(
               connection,
               wal,
+              uploadIntent: WalUploadIntent.liveContinuity,
               startSeq: recentStart,
               packetCount: count,
               fallbackAnchor: wal.timerStart,
@@ -631,17 +673,20 @@ class RingStorageSyncImpl implements RingStorageSync {
               );
             }
             coverage.add(recentStart, result.nextSeq);
+            recoveredRecentSlice = true;
           }
         }
 
         final prefixAfterLive = coverage.contiguousEndFrom(info.readSeq);
         if (prefixAfterLive > info.readSeq) {
-          final advanced = await connection.advanceRing(prefixAfterLive);
-          if (!advanced) {
-            throw const RingStorageException(
-              'Device rejected a live covered-prefix advance',
-            );
-          }
+          final advanced = await _advanceLiveTailOrStop(
+            generation: generation,
+            deviceId: deviceId,
+            connection: connection,
+            nextSeq: prefixAfterLive,
+            rejectionMessage: 'Device rejected a live covered-prefix advance',
+          );
+          if (!advanced) return;
           info = RingInfo(
             readSeq: prefixAfterLive,
             writeSeq: info.writeSeq,
@@ -653,12 +698,15 @@ class RingStorageSyncImpl implements RingStorageSync {
 
         final nextCovered = coverage.firstRangeAtOrAfter(info.readSeq);
         final backlogEnd = nextCovered?.start ?? info.writeSeq;
-        if (_deepBacklogPolicy() && backlogEnd > info.readSeq) {
+        // One recovery transfer per live poll. A slow BLE link must not queue a
+        // recent repair and an old-history drain ahead of newly captured audio.
+        if (!recoveredRecentSlice && _deepBacklogPolicy() && backlogEnd > info.readSeq) {
           final available = backlogEnd - info.readSeq;
           final count = available > _backlogPacketsPerSlice ? _backlogPacketsPerSlice : available;
           final result = await _syncRange(
             connection,
             wal,
+            uploadIntent: WalUploadIntent.historicalBackfill,
             startSeq: info.readSeq,
             packetCount: count,
             fallbackAnchor: wal.timerStart,
@@ -673,12 +721,14 @@ class RingStorageSyncImpl implements RingStorageSync {
             );
           }
           coverage.add(info.readSeq, result.nextSeq);
-          final advanced = await connection.advanceRing(result.nextSeq);
-          if (!advanced) {
-            throw const RingStorageException(
-              'Device rejected a backlog covered-prefix advance',
-            );
-          }
+          final advanced = await _advanceLiveTailOrStop(
+            generation: generation,
+            deviceId: deviceId,
+            connection: connection,
+            nextSeq: result.nextSeq,
+            rejectionMessage: 'Device rejected a backlog covered-prefix advance',
+          );
+          if (!advanced) return;
           info = RingInfo(
             readSeq: result.nextSeq,
             writeSeq: info.writeSeq,
@@ -857,6 +907,7 @@ class RingStorageSyncImpl implements RingStorageSync {
       final advancedTo = await _syncRange(
         connection,
         wal,
+        uploadIntent: WalUploadIntent.historicalBackfill,
         startSeq: nextReadSeq,
         packetCount: packetCount,
         fallbackAnchor: fallbackAnchor,
@@ -905,6 +956,7 @@ class RingStorageSyncImpl implements RingStorageSync {
   Future<_RingRangeResult?> _syncRange(
     DeviceConnection connection,
     Wal wal, {
+    required WalUploadIntent uploadIntent,
     required int startSeq,
     required int packetCount,
     required int fallbackAnchor,
@@ -967,6 +1019,7 @@ class RingStorageSyncImpl implements RingStorageSync {
             timerStart,
             frames.length,
             sourceId,
+            uploadIntent: uploadIntent,
             scheduleUpload: !isLiveRange,
           );
           if (isLiveRange && registered.registration == ExternalWalRegistration.added) {
@@ -1308,6 +1361,7 @@ class RingStorageSyncImpl implements RingStorageSync {
     int timerStart,
     int frameCount,
     String sourceId, {
+    required WalUploadIntent uploadIntent,
     bool scheduleUpload = true,
   }) async {
     if (_localSync == null) {
@@ -1333,6 +1387,7 @@ class RingStorageSyncImpl implements RingStorageSync {
       syncedFrameOffset: 0,
       originalStorage: WalStorage.sdcard,
       sourceId: sourceId,
+      uploadIntent: uploadIntent,
     );
 
     final registration = await _localSync!.addExternalWal(

--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -14,9 +14,42 @@ import 'package:omi/services/services.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 
+/// Ends the legacy first-packet deadline only for payloads that the legacy
+/// parser can consume. Ring firmware replies with two-byte ACKs on the same
+/// characteristic; accepting one as data would disable the timeout forever.
+class LegacyStorageFirstPacketDeadline {
+  LegacyStorageFirstPacketDeadline({required this.timeout, required this.onTimeout});
+
+  final Duration timeout;
+  final void Function() onTimeout;
+  Timer? _timer;
+  bool _acceptedPacket = false;
+
+  static bool accepts(List<int> value) => value.length == 1 || value.length == 83 || value.length == 440;
+
+  void start() {
+    _timer = Timer(timeout, () {
+      if (!_acceptedPacket) onTimeout();
+    });
+    if (_acceptedPacket) _timer?.cancel();
+  }
+
+  bool observe(List<int> value) {
+    if (!accepts(value)) return false;
+    if (!_acceptedPacket) {
+      _acceptedPacket = true;
+      _timer?.cancel();
+    }
+    return true;
+  }
+
+  void cancel() => _timer?.cancel();
+}
+
 class SDCardWalSyncImpl implements SDCardWalSync {
   List<Wal> _wals = [];
   BtDevice? _device;
+  int _deviceBindingGeneration = 0;
 
   StreamSubscription? _storageStream;
 
@@ -276,18 +309,29 @@ class SDCardWalSyncImpl implements SDCardWalSync {
     await _storageStream?.cancel();
     final completer = Completer<bool>();
     bool hasError = false;
-    bool firstDataReceived = false;
-    Timer? timeoutTimer;
+    late final LegacyStorageFirstPacketDeadline firstPacketDeadline;
+    firstPacketDeadline = LegacyStorageFirstPacketDeadline(
+      timeout: const Duration(seconds: 5),
+      onTimeout: () {
+        if (completer.isCompleted) return;
+        hasError = true;
+        final error = TimeoutException('No data received from SD card within 5 seconds');
+        Logger.debug('SD card read timeout: ${error.message}');
+        DebugLogManager.logWarning('SD card BLE read timeout: no data in 5s', {'offset': offset});
+        completer.completeError(error);
+      },
+    );
 
     _storageStream = await _getBleStorageBytesListener(
       deviceId,
       onStorageBytesReceived: (List<int> value) async {
         if (value.isEmpty || hasError) return;
 
-        if (!firstDataReceived) {
-          firstDataReceived = true;
-          timeoutTimer?.cancel();
+        if (firstPacketDeadline.observe(value)) {
           Logger.debug('First data received, timeout cancelled');
+        } else {
+          Logger.debug('Ignoring unsupported legacy SD notification (${value.length} bytes)');
+          return;
         }
 
         if (value.length == 1) {
@@ -345,15 +389,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
     await _writeToStorage(deviceId, fileNum, 0, offset);
 
-    timeoutTimer = Timer(const Duration(seconds: 5), () {
-      if (!firstDataReceived && !completer.isCompleted) {
-        hasError = true;
-        final error = TimeoutException('No data received from SD card within 5 seconds');
-        Logger.debug('SD card read timeout: ${error.message}');
-        DebugLogManager.logWarning('SD card BLE read timeout: no data in 5s', {'offset': offset});
-        completer.completeError(error);
-      }
-    });
+    firstPacketDeadline.start();
 
     try {
       await completer.future;
@@ -361,7 +397,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       rethrow;
     } finally {
       await _storageStream?.cancel();
-      timeoutTimer.cancel();
+      firstPacketDeadline.cancel();
     }
 
     // After download: compute accurate duration from actual frame count
@@ -415,18 +451,29 @@ class SDCardWalSyncImpl implements SDCardWalSync {
     await _storageStream?.cancel();
     final completer = Completer<bool>();
     bool hasError = false;
-    bool firstDataReceived = false;
-    Timer? timeoutTimer;
+    late final LegacyStorageFirstPacketDeadline firstPacketDeadline;
+    firstPacketDeadline = LegacyStorageFirstPacketDeadline(
+      timeout: const Duration(seconds: 5),
+      onTimeout: () {
+        if (completer.isCompleted) return;
+        hasError = true;
+        final error = TimeoutException('No data received from SD card within 5 seconds');
+        Logger.debug('SD card read timeout: ${error.message}');
+        DebugLogManager.logWarning('SD card BLE read timeout: no data in 5s', {'offset': offset});
+        completer.completeError(error);
+      },
+    );
 
     _storageStream = await _getBleStorageBytesListener(
       deviceId,
       onStorageBytesReceived: (List<int> value) async {
         if (value.isEmpty || hasError) return;
 
-        if (!firstDataReceived) {
-          firstDataReceived = true;
-          timeoutTimer?.cancel();
+        if (firstPacketDeadline.observe(value)) {
           Logger.debug('First data received, timeout cancelled');
+        } else {
+          Logger.debug('Ignoring unsupported legacy SD notification (${value.length} bytes)');
+          return;
         }
 
         if (value.length == 1) {
@@ -555,15 +602,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
     await _writeToStorage(deviceId, fileNum, 0, offset);
 
-    timeoutTimer = Timer(const Duration(seconds: 5), () {
-      if (!firstDataReceived && !completer.isCompleted) {
-        hasError = true;
-        final error = TimeoutException('No data received from SD card within 5 seconds');
-        Logger.debug('SD card read timeout: ${error.message}');
-        DebugLogManager.logWarning('SD card BLE read timeout: no data in 5s', {'offset': offset});
-        completer.completeError(error);
-      }
-    });
+    firstPacketDeadline.start();
 
     try {
       await completer.future;
@@ -571,7 +610,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       rethrow;
     } finally {
       await _storageStream?.cancel();
-      timeoutTimer.cancel();
+      firstPacketDeadline.cancel();
     }
 
     // Flush remaining data, respecting any unprocessed timestamp markers
@@ -866,9 +905,12 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
   @override
   void setDevice(BtDevice? device) async {
+    final generation = ++_deviceBindingGeneration;
     _device = device;
     final syncingWal = _wals.where((w) => w.isSyncing).firstOrNull;
-    _wals = await _getMissingWals();
+    final discoveredWals = await _getMissingWals();
+    if (generation != _deviceBindingGeneration) return;
+    _wals = discoveredWals;
     // Re-add the syncing WAL if it was lost
     if (syncingWal != null && !_wals.any((w) => w.id == syncingWal.id)) {
       _wals = [syncingWal, ..._wals];

--- a/app/lib/services/wals/storage_sync.dart
+++ b/app/lib/services/wals/storage_sync.dart
@@ -51,6 +51,10 @@ class StorageSyncImpl implements StorageSync {
   @override
   void setDevice(BtDevice? device) {
     _device = device;
+    if (device == null) {
+      _wals = [];
+      listener.onWalUpdated();
+    }
   }
 
   @override

--- a/app/lib/services/wals/sync_upload_gate.dart
+++ b/app/lib/services/wals/sync_upload_gate.dart
@@ -8,6 +8,8 @@ import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 import 'package:omi/utils/mutex.dart';
 
+export 'package:omi/backend/http/api/conversations.dart' show SyncUploadLane;
+
 typedef SyncFilesUploader = Future<UploadFilesResult> Function(
   List<File> files, {
   UploadProgressCallback? onUploadProgress,

--- a/app/lib/services/wals/sync_upload_gate.dart
+++ b/app/lib/services/wals/sync_upload_gate.dart
@@ -13,6 +13,8 @@ typedef SyncFilesUploader = Future<UploadFilesResult> Function(
   UploadProgressCallback? onUploadProgress,
   String? conversationId,
   bool claimLiveCapture,
+  SyncUploadLane syncLane,
+  bool replaceTranscript,
 });
 typedef FairUseStatusLoader = Future<Map<String, dynamic>?> Function();
 
@@ -92,6 +94,8 @@ class SyncUploadGate {
     UploadProgressCallback? onUploadProgress,
     String? conversationId,
     bool claimLiveCapture = false,
+    SyncUploadLane lane = SyncUploadLane.fresh,
+    bool replaceTranscript = false,
   }) async {
     await _uploadMutex.acquire();
     try {
@@ -117,6 +121,8 @@ class SyncUploadGate {
           onUploadProgress: onUploadProgress,
           conversationId: conversationId,
           claimLiveCapture: claimLiveCapture,
+          syncLane: lane,
+          replaceTranscript: replaceTranscript,
         );
         _limiter.clear();
         return result;

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -30,6 +30,14 @@ enum WalStorage { mem, disk, sdcard, flashPage }
 
 enum SyncMethod { ble }
 
+/// Why this recording is entering the cloud-upload queue.
+///
+/// [liveContinuity] is assigned only by a source transport that knows the
+/// recording belongs to the current/recent capture window. It may use the
+/// latency-sensitive upload lane even before the server assigns a conversation
+/// id. [historicalBackfill] is always background work.
+enum WalUploadIntent { liveContinuity, historicalBackfill }
+
 /// User-facing sync state for a single recording, derived from [Wal.status],
 /// [Wal.isSyncing] and [Wal.retryCount]. This is what the sync UI renders so a
 /// recording is never shown as an indistinct row — every state is explicit.
@@ -132,6 +140,12 @@ class Wal {
   /// arrives so WALs survive app kill and can be recovered on startup.
   String? conversationId;
 
+  /// Durable upload-lane ownership assigned by the source transport.
+  ///
+  /// Legacy WALs leave this null and retain the conservative rule that only a
+  /// server conversation id proves they belong to the fresh lane.
+  WalUploadIntent? uploadIntent;
+
   /// Number of sync retry attempts for this WAL.
   int retryCount;
 
@@ -217,6 +231,7 @@ class Wal {
     this.originalStorage,
     this.sourceId,
     this.conversationId,
+    this.uploadIntent,
     this.retryCount = 0,
     this.lastRetryAt = 0,
     this.jobId,
@@ -246,6 +261,7 @@ class Wal {
           json['original_storage'] != null ? WalStorage.values.asNameMap()[json['original_storage']] : null,
       sourceId: json['source_id'],
       conversationId: json['conversation_id'],
+      uploadIntent: json['upload_intent'] != null ? WalUploadIntent.values.asNameMap()[json['upload_intent']] : null,
       retryCount: json['retry_count'] ?? 0,
       lastRetryAt: json['last_retry_at'] ?? 0,
       jobId: json['job_id'],
@@ -273,6 +289,7 @@ class Wal {
       'original_storage': originalStorage?.name,
       'source_id': sourceId,
       'conversation_id': conversationId,
+      'upload_intent': uploadIntent?.name,
       'retry_count': retryCount,
       'last_retry_at': lastRetryAt,
       'job_id': jobId,

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -146,6 +146,11 @@ class Wal {
   /// server conversation id proves they belong to the fresh lane.
   WalUploadIntent? uploadIntent;
 
+  /// This file is the complete, sequence-ordered phone reconstruction of a
+  /// live pendant conversation. The server replaces the realtime preview
+  /// transcript atomically instead of appending duplicate fragments.
+  bool canonicalReplacement;
+
   /// Number of sync retry attempts for this WAL.
   int retryCount;
 
@@ -232,6 +237,7 @@ class Wal {
     this.sourceId,
     this.conversationId,
     this.uploadIntent,
+    this.canonicalReplacement = false,
     this.retryCount = 0,
     this.lastRetryAt = 0,
     this.jobId,
@@ -262,6 +268,7 @@ class Wal {
       sourceId: json['source_id'],
       conversationId: json['conversation_id'],
       uploadIntent: json['upload_intent'] != null ? WalUploadIntent.values.asNameMap()[json['upload_intent']] : null,
+      canonicalReplacement: json['canonical_replacement'] ?? false,
       retryCount: json['retry_count'] ?? 0,
       lastRetryAt: json['last_retry_at'] ?? 0,
       jobId: json['job_id'],
@@ -290,6 +297,7 @@ class Wal {
       'source_id': sourceId,
       'conversation_id': conversationId,
       'upload_intent': uploadIntent?.name,
+      'canonical_replacement': canonicalReplacement,
       'retry_count': retryCount,
       'last_retry_at': lastRetryAt,
       'job_id': jobId,

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -8,6 +8,21 @@ const sdcardChunkSizeSecs = 180;
 const newFrameSyncDelaySeconds = 15;
 const framesPerFlashPage = 8;
 const secondsPerFlashPage = 1.4;
+const _maximumPersistedCaptureFutureSkewSeconds = 24 * 60 * 60;
+const _minimumEffectiveConversationBoundarySeconds = 2 * 60;
+const _unlimitedConversationBoundarySeconds = 4 * 60 * 60;
+
+/// Mirrors the single-channel backend conversation timeout contract.
+///
+/// The settings UI uses `-1` for the four-hour option, while the backend
+/// clamps every shorter value to two minutes.
+int effectiveConversationBoundarySeconds(int configured) {
+  if (configured == -1) return _unlimitedConversationBoundarySeconds;
+  if (configured < _minimumEffectiveConversationBoundarySeconds) {
+    return _minimumEffectiveConversationBoundarySeconds;
+  }
+  return configured;
+}
 
 /// Sync lifecycle of a recording.
 ///
@@ -104,6 +119,14 @@ class Wal {
   int channel;
   int sampleRate;
   int seconds;
+
+  /// Wall-clock end of captured audio, in Unix seconds.
+  ///
+  /// Pendant VAD can omit silence between records, so [seconds] remains the
+  /// playable audio duration and cannot describe when the capture ended.
+  /// Legacy manifests leave this null and use [wallClockEndSeconds]'s duration
+  /// fallback.
+  double? captureEndSeconds;
   String device;
   String? deviceModel;
 
@@ -167,6 +190,29 @@ class Wal {
 
   String get id => sourceId == null ? '${device}_$timerStart' : '${device}_$sourceId';
 
+  /// Valid persisted wall-clock end, or null for legacy/corrupt metadata.
+  double? get validatedCaptureEndSeconds {
+    final persistedEnd = captureEndSeconds;
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch / 1000;
+    if (persistedEnd == null ||
+        !persistedEnd.isFinite ||
+        persistedEnd < timerStart ||
+        persistedEnd > nowSeconds + _maximumPersistedCaptureFutureSkewSeconds) {
+      return null;
+    }
+    return persistedEnd;
+  }
+
+  /// Best available wall-clock end for recency and conversation boundaries.
+  double get wallClockEndSeconds {
+    final persistedEnd = validatedCaptureEndSeconds;
+    if (persistedEnd != null) return persistedEnd;
+    final framesPerSecond = codec.getFramesPerSecond();
+    final playableDuration =
+        framesPerSecond > 0 && totalFrames > 0 ? totalFrames / framesPerSecond : seconds.toDouble();
+    return timerStart + playableDuration;
+  }
+
   /// Single source of truth for how this recording's sync state is shown to the
   /// user. The sync page renders an explicit label + icon for every value so a
   /// not-yet-synced recording is never visually identical to a failed one.
@@ -220,6 +266,7 @@ class Wal {
     required this.timerStart,
     required this.codec,
     required this.seconds,
+    this.captureEndSeconds,
     this.sampleRate = 16000,
     this.channel = 1,
     this.status = WalStatus.inProgress,
@@ -256,6 +303,7 @@ class Wal {
       storage: WalStorage.values.asNameMap()[json['storage']] ?? WalStorage.mem,
       filePath: json['file_path'],
       seconds: json['seconds'] ?? chunkSizeInSeconds,
+      captureEndSeconds: json['capture_end_seconds'] is num ? (json['capture_end_seconds'] as num).toDouble() : null,
       device: json['device'] ?? "phone",
       deviceModel: json['device_model'],
       storageOffset: json['storage_offset'] ?? 0,
@@ -277,6 +325,7 @@ class Wal {
   }
 
   Map<String, dynamic> toJson() {
+    final persistedCaptureEnd = validatedCaptureEndSeconds;
     return {
       'timer_start': timerStart,
       'codec': codec.toString(),
@@ -286,6 +335,7 @@ class Wal {
       'storage': storage.name,
       'file_path': filePath,
       'seconds': seconds,
+      if (persistedCaptureEnd != null) 'capture_end_seconds': persistedCaptureEnd,
       'device': device,
       'device_model': deviceModel,
       'storage_offset': storageOffset,
@@ -308,7 +358,7 @@ class Wal {
   static List<Wal> fromJsonList(List<dynamic> jsonList) => jsonList.map((e) => Wal.fromJson(e)).toList();
 
   getFileName() {
-    return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs${frameSize}_${timerStart}.bin";
+    return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs${frameSize}_$timerStart.bin";
   }
 
   getFileNameByTimeStarts(int timestarts, {String? sourceId}) {

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -121,6 +121,13 @@ class Wal {
 
   WalStorage? originalStorage;
 
+  /// Stable identity assigned by the durable source transport.
+  ///
+  /// Device-storage recovery uses the source sequence range here so a retry is
+  /// idempotent even when another recording has the same second-resolution
+  /// timestamp. Legacy WALs leave this null and retain their historical ID.
+  String? sourceId;
+
   /// The conversation this WAL belongs to. Stamped when ConversationProcessingStartedEvent
   /// arrives so WALs survive app kill and can be recovered on startup.
   String? conversationId;
@@ -139,7 +146,7 @@ class Wal {
   /// Unix timestamp (seconds) when the audio was uploaded (202 received).
   int uploadedAt;
 
-  String get id => '${device}_$timerStart';
+  String get id => sourceId == null ? '${device}_$timerStart' : '${device}_$sourceId';
 
   /// Single source of truth for how this recording's sync state is shown to the
   /// user. The sync page renders an explicit label + icon for every value so a
@@ -208,6 +215,7 @@ class Wal {
     this.totalFrames = 0,
     this.syncedFrameOffset = 0,
     this.originalStorage,
+    this.sourceId,
     this.conversationId,
     this.retryCount = 0,
     this.lastRetryAt = 0,
@@ -236,6 +244,7 @@ class Wal {
       syncedFrameOffset: json['synced_frame_offset'] ?? 0,
       originalStorage:
           json['original_storage'] != null ? WalStorage.values.asNameMap()[json['original_storage']] : null,
+      sourceId: json['source_id'],
       conversationId: json['conversation_id'],
       retryCount: json['retry_count'] ?? 0,
       lastRetryAt: json['last_retry_at'] ?? 0,
@@ -262,6 +271,7 @@ class Wal {
       'total_frames': totalFrames,
       'synced_frame_offset': syncedFrameOffset,
       'original_storage': originalStorage?.name,
+      'source_id': sourceId,
       'conversation_id': conversationId,
       'retry_count': retryCount,
       'last_retry_at': lastRetryAt,
@@ -276,8 +286,13 @@ class Wal {
     return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs${frameSize}_${timerStart}.bin";
   }
 
-  getFileNameByTimeStarts(int timestarts) {
-    return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs${frameSize}_${timestarts}.bin";
+  getFileNameByTimeStarts(int timestarts, {String? sourceId}) {
+    final sourceSuffix = sourceId == null ? '' : '_${sourceId.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), "")}';
+    // Backend timestamp parsing treats the final underscore-delimited token as
+    // capture epoch seconds, so source identity must precede the timestamp.
+    return "audio_${device.replaceAll(RegExp(r'[^a-zA-Z0-9]'), "").toLowerCase()}_${codec}_${sampleRate}_${channel}_fs$frameSize"
+        "$sourceSuffix"
+        "_$timestarts.bin";
   }
 
   static Future<String?> getFilePath(String? pathOrName) async {

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -9,6 +9,7 @@ const newFrameSyncDelaySeconds = 15;
 const framesPerFlashPage = 8;
 const secondsPerFlashPage = 1.4;
 const _maximumPersistedCaptureFutureSkewSeconds = 24 * 60 * 60;
+const _maximumCaptureEndRoundingShortfallSeconds = 2.0;
 const _minimumEffectiveConversationBoundarySeconds = 2 * 60;
 const _unlimitedConversationBoundarySeconds = 4 * 60 * 60;
 
@@ -194,9 +195,14 @@ class Wal {
   double? get validatedCaptureEndSeconds {
     final persistedEnd = captureEndSeconds;
     final nowSeconds = DateTime.now().millisecondsSinceEpoch / 1000;
+    final framesPerSecond = codec.getFramesPerSecond();
+    final minimumPlayableEnd = framesPerSecond > 0 && totalFrames > 0
+        ? timerStart + totalFrames / framesPerSecond - _maximumCaptureEndRoundingShortfallSeconds
+        : timerStart.toDouble();
     if (persistedEnd == null ||
         !persistedEnd.isFinite ||
         persistedEnd < timerStart ||
+        persistedEnd < minimumPlayableEnd ||
         persistedEnd > nowSeconds + _maximumPersistedCaptureFutureSkewSeconds) {
       return null;
     }

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -14,7 +14,8 @@ export 'package:omi/backend/http/api/conversations.dart'
         SyncJobFetchOutcome,
         SyncRateLimitedException,
         SyncRateLimitKind,
-        SyncRecoveryWindowExceededException;
+        SyncRecoveryWindowExceededException,
+        SyncUploadTooLargeException;
 
 abstract class IWalSyncProgressListener {
   void onWalSyncedProgress(

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -67,6 +67,21 @@ enum WalServiceStatus { init, ready, stop }
 
 enum ExternalWalRegistration { added, alreadyRegistered }
 
+/// Proof that the live ring owner durably consumed one bounded device snapshot.
+///
+/// Cloud retries carry this receipt instead of asking the pendant for another
+/// snapshot, so newly recorded audio cannot silently expand an older manual or
+/// automatic backlog request.
+class RingBacklogDrainReceipt {
+  const RingBacklogDrainReceipt({
+    required this.deviceId,
+    required this.targetWriteSeq,
+  });
+
+  final String deviceId;
+  final int targetWriteSeq;
+}
+
 // Forward declarations for sync types
 abstract class LocalWalSync implements IWalSync {
   Future<ExternalWalRegistration> addExternalWal(
@@ -122,9 +137,12 @@ abstract class RingStorageSync implements IWalSync {
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();
   bool get isSyncing;
+  bool get isAudioTailActive;
   double get currentSpeedKBps;
   Future<bool> hasFilesToSync();
   Future<void> refreshWalsFromDevice();
+  Future<RingBacklogDrainReceipt?>? requestAudioTailBacklogDrain();
+  void cancelRequestedAudioTailBacklogDrain();
 }
 
 abstract class FlashPageWalSync implements IWalSync {

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -138,10 +138,13 @@ abstract class RingStorageSync implements IWalSync {
   Future<void> deleteAllPendingWals();
   bool get isSyncing;
   bool get isAudioTailActive;
+  bool get isFastSyncActive;
   double get currentSpeedKBps;
   Future<bool> hasFilesToSync();
   Future<void> refreshWalsFromDevice();
-  Future<RingBacklogDrainReceipt?>? requestAudioTailBacklogDrain();
+  Future<RingBacklogDrainReceipt?>? requestAudioTailBacklogDrain({
+    IWalSyncProgressListener? progress,
+  });
   void cancelRequestedAudioTailBacklogDrain();
 }
 

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -41,7 +41,10 @@ abstract class IWalSync {
   Future<List<Wal>> getMissingWals();
   Future deleteWal(Wal wal);
   Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress});
-  Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress});
+  Future<SyncLocalFilesResponse?> syncWal({
+    required Wal wal,
+    IWalSyncProgressListener? progress,
+  });
   void cancelSync();
 
   void start();
@@ -66,11 +69,15 @@ enum ExternalWalRegistration { added, alreadyRegistered }
 
 // Forward declarations for sync types
 abstract class LocalWalSync implements IWalSync {
-  Future<ExternalWalRegistration> addExternalWal(Wal wal);
+  Future<ExternalWalRegistration> addExternalWal(
+    Wal wal, {
+    bool scheduleUpload = true,
+  });
   Future<List<Wal>> getAllWals();
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();
   Future<void> deleteAllCorruptedWals();
+  Future<void> markExternalWalSynced(Wal wal);
 
   /// Ingest a pre-processed audio frame from an AudioSource.
   /// The frame contains headerless payload and a source-specific sync key.

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -74,6 +74,7 @@ abstract class LocalWalSync implements IWalSync {
     bool scheduleUpload = true,
   });
   Future<List<Wal>> getAllWals();
+  Future<Wal?> getWalById(String id);
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();
   Future<void> deleteAllCorruptedWals();

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -62,9 +62,11 @@ abstract class IWalService {
 
 enum WalServiceStatus { init, ready, stop }
 
+enum ExternalWalRegistration { added, alreadyRegistered }
+
 // Forward declarations for sync types
 abstract class LocalWalSync implements IWalSync {
-  Future<void> addExternalWal(Wal wal);
+  Future<ExternalWalRegistration> addExternalWal(Wal wal);
   Future<List<Wal>> getAllWals();
   Future<void> deleteAllSyncedWals();
   Future<void> deleteAllPendingWals();

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -7,6 +7,7 @@ import 'package:omi/models/sync_state.dart';
 import 'package:omi/services/wals/device_storage_routing.dart';
 import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/services/wals/ring_storage_sync.dart';
 import 'package:omi/services/wals/sdcard_wal_sync.dart';
 import 'package:omi/services/wals/storage_sync.dart';
@@ -34,6 +35,7 @@ class WalSyncs implements IWalSync {
   BtDevice? _device;
   String? _firmwareVersion;
   bool _deviceCharging = false;
+  final Map<String, RingBacklogDrainReceipt> _automaticRingBacklogReceipts = {};
 
   /// Called from DeviceProvider when a device connects/disconnects so the
   /// firmware-version gate in syncAll() can route to the right Phase-0 sync.
@@ -79,6 +81,53 @@ class WalSyncs implements IWalSync {
     );
   }
 
+  /// The storage-authoritative live scheduler is a long-lived capture owner,
+  /// not a conflicting user-visible sync.
+  bool get isRingAudioTailActive => _ringSync.isAudioTailActive;
+
+  /// Latch one manual backlog snapshot onto the active live scheduler.
+  ///
+  /// Returns null when no live scheduler owns the ring, in which case the
+  /// caller should use the ordinary device-storage sync path.
+  Future<RingBacklogDrainReceipt?>? requestActiveRingBacklogDrain() => _ringSync.requestAudioTailBacklogDrain();
+
+  RingBacklogDrainReceipt? get pendingAutomaticRingBacklogReceipt =>
+      _automaticRingBacklogReceipts.isEmpty ? null : _automaticRingBacklogReceipts.values.first;
+
+  void completeAutomaticRingBacklogReceipt(
+    RingBacklogDrainReceipt receipt,
+  ) {
+    final current = _automaticRingBacklogReceipts[receipt.deviceId];
+    if (current?.targetWriteSeq != receipt.targetWriteSeq) return;
+    _automaticRingBacklogReceipts.remove(receipt.deviceId);
+    if (_automaticRingBacklogReceipts.isNotEmpty) {
+      unawaited(
+        RecordingTransferCoordinator.instance.wake(
+          WakeTrigger.ringBacklogSnapshotCompleted,
+        ),
+      );
+    }
+  }
+
+  /// Upload WALs that are already durable on the phone without starting a
+  /// second device-storage reader. LocalWalSync's mutex keeps fresh upload
+  /// wakes and this explicit drain idempotent.
+  Future<SyncLocalFilesResponse?> syncPhoneWals({
+    IWalSyncProgressListener? progress,
+    bool includeBackfill = false,
+  }) =>
+      includeBackfill ? _phoneSync.syncAll(progress: progress) : _phoneSync.syncFreshOnly(progress: progress);
+
+  Future<AuthorizedRecoverySyncResult> syncAuthorizedRingRecovery({
+    required RingBacklogDrainReceipt receipt,
+    IWalSyncProgressListener? progress,
+  }) =>
+      _phoneSync.syncAuthorizedRecovery(
+        deviceId: receipt.deviceId,
+        targetWriteSeq: receipt.targetWriteSeq,
+        progress: progress,
+      );
+
   WalSyncs(this.listener) {
     _phoneSync = LocalWalSyncImpl(listener);
     _sdcardSync = SDCardWalSyncImpl(listener);
@@ -90,6 +139,21 @@ class WalSyncs implements IWalSync {
         autoSyncEnabled: SharedPreferencesUtil().autoSyncOfflineRecordings,
         isCharging: _deviceCharging,
       ),
+      onBacklogSnapshotCompleted: (receipt) {
+        final preferences = SharedPreferencesUtil();
+        if (!preferences.autoSyncOfflineRecordings || preferences.useCustomStt) {
+          return;
+        }
+        final current = _automaticRingBacklogReceipts[receipt.deviceId];
+        if (current == null || receipt.targetWriteSeq > current.targetWriteSeq) {
+          _automaticRingBacklogReceipts[receipt.deviceId] = receipt;
+        }
+        unawaited(
+          RecordingTransferCoordinator.instance.wake(
+            WakeTrigger.ringBacklogSnapshotCompleted,
+          ),
+        );
+      },
     );
     _deviceStorageRouter = DeviceStorageRouter(
       bindLegacySdCard: _sdcardSync.setDevice,
@@ -473,7 +537,14 @@ class WalSyncs implements IWalSync {
   @override
   void cancelSync() {
     _isCancelled = true;
-    _ringSync.cancelSync();
+    final ringTailWasActive = _ringSync.isAudioTailActive;
+    // The manual request can outlive a disconnected tail. Explicit user
+    // cancellation must always resolve its Future even when no BLE owner is
+    // currently attached.
+    _ringSync.cancelRequestedAudioTailBacklogDrain();
+    if (!ringTailWasActive) {
+      _ringSync.cancelSync();
+    }
     _storageSync.cancelSync();
     _sdcardSync.cancelSync();
     _flashPageSync.cancelSync();

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -68,11 +68,15 @@ class WalSyncs implements IWalSync {
 
   Future<RingAudioTailSession?> startStorageAuthoritativeAudioTail({
     required RingLiveFramesHandler onLiveFrames,
+    bool resumeLiveContinuity = false,
   }) {
     if (!usesStorageAuthoritativeAudio || _deviceStorageRouter.protocol != DeviceStorageProtocol.ringBuffer) {
       return Future.value(null);
     }
-    return _ringSync.startAudioTail(onLiveFrames: onLiveFrames);
+    return _ringSync.startAudioTail(
+      onLiveFrames: onLiveFrames,
+      resumeLiveContinuity: resumeLiveContinuity,
+    );
   }
 
   WalSyncs(this.listener) {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -48,8 +48,23 @@ class WalSyncs implements IWalSync {
 
   /// Best available firmware for discovery routing: the enriched value if it
   /// resolved, otherwise whatever the raw connect object carries.
-  String? get _resolvedFirmware =>
-      DeviceStorageProtocolPolicy.resolveFirmware(_firmwareVersion, _device?.firmwareRevision);
+  String? get _resolvedFirmware => DeviceStorageProtocolPolicy.resolveFirmware(
+        _firmwareVersion,
+        _device?.firmwareRevision,
+      );
+
+  bool get usesStorageAuthoritativeAudio => DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio(
+        _resolvedFirmware,
+      );
+
+  Future<RingAudioTailSession?> startStorageAuthoritativeAudioTail({
+    required RingLiveFramesHandler onLiveFrames,
+  }) {
+    if (!usesStorageAuthoritativeAudio || _deviceStorageRouter.protocol != DeviceStorageProtocol.ringBuffer) {
+      return Future.value(null);
+    }
+    return _ringSync.startAudioTail(onLiveFrames: onLiveFrames);
+  }
 
   WalSyncs(this.listener) {
     _phoneSync = LocalWalSyncImpl(listener);
@@ -115,7 +130,10 @@ class WalSyncs implements IWalSync {
     final fw = (firmwareVersion != null && firmwareVersion.isNotEmpty && firmwareVersion != 'Unknown')
         ? firmwareVersion
         : _resolvedFirmware;
-    switch (DeviceStorageProtocolPolicy.classify(_device, firmwareVersion: fw)) {
+    switch (DeviceStorageProtocolPolicy.classify(
+      _device,
+      firmwareVersion: fw,
+    )) {
       case DeviceStorageProtocol.ringBuffer:
         await _ringSync.refreshWalsFromDevice();
       case DeviceStorageProtocol.multiFile:
@@ -237,26 +255,41 @@ class WalSyncs implements IWalSync {
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async {
+  Future<SyncLocalFilesResponse?> syncAll({
+    IWalSyncProgressListener? progress,
+  }) async {
     _isCancelled = false;
-    var resp = SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+    var resp = SyncLocalFilesResponse(
+      newConversationIds: [],
+      updatedConversationIds: [],
+    );
 
     final allMissing = await getMissingWals();
     DebugLogManager.logEvent('sync_started', {
       'totalMissingWals': allMissing.length,
       'sdcard': allMissing.where((w) => w.storage == WalStorage.sdcard).length,
       'flashPage': allMissing.where((w) => w.storage == WalStorage.flashPage).length,
-      'phone': allMissing.where((w) => w.storage == WalStorage.disk || w.storage == WalStorage.mem).length,
+      'phone': allMissing
+          .where(
+            (w) => w.storage == WalStorage.disk || w.storage == WalStorage.mem,
+          )
+          .length,
     });
 
-    // Protect the live path before a potentially multi-hour device drain.
-    Logger.debug("WalSyncs: Phase -1 - Uploading already-local live-capture recordings");
-    DebugLogManager.logInfo('Sync Phase -1: Uploading live-capture phone files first');
+    // Protect the live path before a potentially multi-hour device drain. The
+    // phone scheduler is lane-aware and sends recent WALs first; its one-job
+    // backfill window prevents this pass from flooding historical work.
+    Logger.debug(
+      "WalSyncs: Phase -1 - Uploading already-local fresh recordings",
+    );
+    DebugLogManager.logInfo('Sync Phase -1: Uploading fresh phone files first');
     progress?.onWalSyncedProgress(0.0, phase: SyncPhase.uploadingToCloud);
-    final preDrainResult = await _phoneSync.syncLiveCaptureOnly(progress: progress);
+    final preDrainResult = await _phoneSync.syncFreshOnly(progress: progress);
     if (preDrainResult != null) {
       resp.newConversationIds.addAll(
-        preDrainResult.newConversationIds.where((id) => !resp.newConversationIds.contains(id)),
+        preDrainResult.newConversationIds.where(
+          (id) => !resp.newConversationIds.contains(id),
+        ),
       );
       resp.updatedConversationIds.addAll(
         preDrainResult.updatedConversationIds.where(
@@ -278,17 +311,29 @@ class WalSyncs implements IWalSync {
         final ringMissing = await _ringSync.getMissingWals();
         if (ringMissing.isNotEmpty) {
           Logger.debug("WalSyncs: Phase 0 - Ring-buffer sync (fw=$fwVersion)");
-          DebugLogManager.logInfo('Sync Phase 0: Ring-buffer sync', {'fw': fwVersion ?? ''});
-          progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+          DebugLogManager.logInfo('Sync Phase 0: Ring-buffer sync', {
+            'fw': fwVersion ?? '',
+          });
+          progress?.onWalSyncedProgress(
+            0.0,
+            phase: SyncPhase.downloadingFromDevice,
+          );
           await _ringSync.syncAll(progress: progress);
         }
       case DeviceStorageProtocol.multiFile:
         await _storageSync.refreshWalsFromDevice();
         final storageMissing = await _storageSync.getMissingWals();
         if (storageMissing.isNotEmpty) {
-          Logger.debug("WalSyncs: Phase 0 - Downloading ${storageMissing.length} multi-file storage files to phone");
-          DebugLogManager.logInfo('Sync Phase 0: Multi-file storage sync', {'fw': fwVersion ?? ''});
-          progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+          Logger.debug(
+            "WalSyncs: Phase 0 - Downloading ${storageMissing.length} multi-file storage files to phone",
+          );
+          DebugLogManager.logInfo('Sync Phase 0: Multi-file storage sync', {
+            'fw': fwVersion ?? '',
+          });
+          progress?.onWalSyncedProgress(
+            0.0,
+            phase: SyncPhase.downloadingFromDevice,
+          );
           await _storageSync.syncAll(progress: progress);
         }
       case DeviceStorageProtocol.none:
@@ -306,12 +351,19 @@ class WalSyncs implements IWalSync {
     // reuse these characteristics with incompatible framing.
     if (storageProtocol == DeviceStorageProtocol.legacySdCard) {
       Logger.debug("WalSyncs: Phase 1a - Downloading SD card data to phone");
-      DebugLogManager.logInfo('Sync Phase 1a: Downloading SD card data to phone');
-      progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+      DebugLogManager.logInfo(
+        'Sync Phase 1a: Downloading SD card data to phone',
+      );
+      progress?.onWalSyncedProgress(
+        0.0,
+        phase: SyncPhase.downloadingFromDevice,
+      );
       final missingSDCardWals = (await _sdcardSync.getMissingWals()).where((w) => w.status == WalStatus.miss).toList();
 
       if (missingSDCardWals.isNotEmpty) {
-        DebugLogManager.logInfo('SD card sync over BLE', {'walCount': missingSDCardWals.length});
+        DebugLogManager.logInfo('SD card sync over BLE', {
+          'walCount': missingSDCardWals.length,
+        });
         await _sdcardSync.syncAll(progress: progress);
       }
     }
@@ -324,14 +376,19 @@ class WalSyncs implements IWalSync {
 
     // Phase 1b: Download flash page data to phone
     Logger.debug("WalSyncs: Phase 1b - Downloading flash page data to phone");
-    DebugLogManager.logInfo('Sync Phase 1b: Downloading flash page data to phone');
+    DebugLogManager.logInfo(
+      'Sync Phase 1b: Downloading flash page data to phone',
+    );
     // Re-enumerate from the device first (mirrors the ring/storage phases
     // above) so a repeat Sync tap resumes from the device's current flash-page
     // pointer instead of a stale cached WAL — no app relaunch needed.
     await _flashPageSync.refreshWalsFromDevice();
     final flashMissing = (await _flashPageSync.getMissingWals()).where((w) => w.status == WalStatus.miss).toList();
     if (flashMissing.isNotEmpty) {
-      progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+      progress?.onWalSyncedProgress(
+        0.0,
+        phase: SyncPhase.downloadingFromDevice,
+      );
       await _flashPageSync.syncAll(progress: progress);
     }
 
@@ -348,7 +405,9 @@ class WalSyncs implements IWalSync {
     var partialRes = await _phoneSync.syncAll(progress: progress);
     if (partialRes != null) {
       resp.newConversationIds.addAll(
-        partialRes.newConversationIds.where((id) => !resp.newConversationIds.contains(id)),
+        partialRes.newConversationIds.where(
+          (id) => !resp.newConversationIds.contains(id),
+        ),
       );
       resp.updatedConversationIds.addAll(
         partialRes.updatedConversationIds.where(
@@ -367,15 +426,24 @@ class WalSyncs implements IWalSync {
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
+  Future<SyncLocalFilesResponse?> syncWal({
+    required Wal wal,
+    IWalSyncProgressListener? progress,
+  }) async {
     if (wal.storage == WalStorage.sdcard) {
-      progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+      progress?.onWalSyncedProgress(
+        0.0,
+        phase: SyncPhase.downloadingFromDevice,
+      );
       if (wal.fileNum == -1) {
         return _ringSync.syncWal(wal: wal, progress: progress);
       }
       return _sdcardSync.syncWal(wal: wal, progress: progress);
     } else if (wal.storage == WalStorage.flashPage) {
-      progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+      progress?.onWalSyncedProgress(
+        0.0,
+        phase: SyncPhase.downloadingFromDevice,
+      );
       return _flashPageSync.syncWal(wal: wal, progress: progress);
     } else {
       progress?.onWalSyncedProgress(0.0, phase: SyncPhase.uploadingToCloud);

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -33,6 +33,7 @@ class WalSyncs implements IWalSync {
   bool _isCancelled = false;
   BtDevice? _device;
   String? _firmwareVersion;
+  bool _deviceCharging = false;
 
   /// Called from DeviceProvider when a device connects/disconnects so the
   /// firmware-version gate in syncAll() can route to the right Phase-0 sync.
@@ -44,7 +45,14 @@ class WalSyncs implements IWalSync {
   void setDevice(BtDevice? device, {String? firmwareVersion}) {
     _device = device;
     _firmwareVersion = firmwareVersion;
+    if (device == null) {
+      _deviceCharging = false;
+    }
     _deviceStorageRouter.bind(device, firmwareVersion: firmwareVersion);
+  }
+
+  void setDeviceCharging(bool charging) {
+    _deviceCharging = charging;
   }
 
   /// Best available firmware for discovery routing: the enriched value if it
@@ -74,7 +82,10 @@ class WalSyncs implements IWalSync {
     _storageSync = StorageSyncImpl(listener);
     _ringSync = RingStorageSyncImpl(
       listener,
-      deepBacklogPolicy: () => SharedPreferencesUtil().autoSyncOfflineRecordings,
+      deepBacklogPolicy: () => ringShouldDrainDeepBacklog(
+        autoSyncEnabled: SharedPreferencesUtil().autoSyncOfflineRecordings,
+        isCharging: _deviceCharging,
+      ),
     );
     _deviceStorageRouter = DeviceStorageRouter(
       bindLegacySdCard: _sdcardSync.setDevice,

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -34,7 +34,6 @@ class WalSyncs implements IWalSync {
   bool _isCancelled = false;
   BtDevice? _device;
   String? _firmwareVersion;
-  bool _deviceCharging = false;
   final Map<String, RingBacklogDrainReceipt> _automaticRingBacklogReceipts = {};
 
   /// Called from DeviceProvider when a device connects/disconnects so the
@@ -47,14 +46,7 @@ class WalSyncs implements IWalSync {
   void setDevice(BtDevice? device, {String? firmwareVersion}) {
     _device = device;
     _firmwareVersion = firmwareVersion;
-    if (device == null) {
-      _deviceCharging = false;
-    }
     _deviceStorageRouter.bind(device, firmwareVersion: firmwareVersion);
-  }
-
-  void setDeviceCharging(bool charging) {
-    _deviceCharging = charging;
   }
 
   /// Best available firmware for discovery routing: the enriched value if it
@@ -137,7 +129,6 @@ class WalSyncs implements IWalSync {
       listener,
       deepBacklogPolicy: () => ringShouldDrainDeepBacklog(
         autoSyncEnabled: SharedPreferencesUtil().autoSyncOfflineRecordings,
-        isCharging: _deviceCharging,
       ),
       onBacklogSnapshotCompleted: (receipt) {
         final preferences = SharedPreferencesUtil();

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/models/sync_state.dart';
@@ -71,7 +72,10 @@ class WalSyncs implements IWalSync {
     _sdcardSync = SDCardWalSyncImpl(listener);
     _flashPageSync = FlashPageWalSyncImpl(listener);
     _storageSync = StorageSyncImpl(listener);
-    _ringSync = RingStorageSyncImpl(listener);
+    _ringSync = RingStorageSyncImpl(
+      listener,
+      deepBacklogPolicy: () => SharedPreferencesUtil().autoSyncOfflineRecordings,
+    );
     _deviceStorageRouter = DeviceStorageRouter(
       bindLegacySdCard: _sdcardSync.setDevice,
       bindMultiFile: _storageSync.setDevice,

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/models/sync_state.dart';
+import 'package:omi/services/wals/device_storage_routing.dart';
 import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/ring_storage_sync.dart';
@@ -18,16 +19,13 @@ class WalSyncs implements IWalSync {
   LocalWalSyncImpl get phone => _phoneSync;
 
   late SDCardWalSyncImpl _sdcardSync;
-  SDCardWalSyncImpl get sdcard => _sdcardSync;
 
   late FlashPageWalSyncImpl _flashPageSync;
-  FlashPageWalSyncImpl get flashPage => _flashPageSync;
 
   late StorageSyncImpl _storageSync;
-  StorageSyncImpl get storage => _storageSync;
 
   late RingStorageSyncImpl _ringSync;
-  RingStorageSyncImpl get ring => _ringSync;
+  late DeviceStorageRouter _deviceStorageRouter;
 
   final IWalSyncListener listener;
 
@@ -45,32 +43,13 @@ class WalSyncs implements IWalSync {
   void setDevice(BtDevice? device, {String? firmwareVersion}) {
     _device = device;
     _firmwareVersion = firmwareVersion;
+    _deviceStorageRouter.bind(device, firmwareVersion: firmwareVersion);
   }
 
   /// Best available firmware for discovery routing: the enriched value if it
   /// resolved, otherwise whatever the raw connect object carries.
-  String? get _resolvedFirmware => resolveDiscoveryFirmware(_firmwareVersion, _device?.firmwareRevision);
-
-  /// Prefer the enriched firmware over the raw connect-object value, which is
-  /// frequently still 'Unknown'. A missing/'Unknown' enriched value falls back
-  /// to the raw one so behavior is never worse than before.
-  static String? resolveDiscoveryFirmware(String? enriched, String? raw) {
-    if (enriched != null && enriched.isNotEmpty && enriched != 'Unknown') return enriched;
-    return raw;
-  }
-
-  /// Firmware >= 3.0.20 speaks the ring-buffer protocol; older multi-file
-  /// firmware (3.0.17–3.0.19) keeps using StorageSync.
-  static bool isRingBufferFirmware(String? version) {
-    if (version == null || version.isEmpty || version == 'Unknown') return false;
-    final parts = version.split('.').map((p) => int.tryParse(p) ?? 0).toList();
-    if (parts.length < 3) return false;
-    if (parts[0] > 3) return true;
-    if (parts[0] < 3) return false;
-    if (parts[1] > 0) return true;
-    if (parts[1] < 0) return false;
-    return parts[2] >= 20;
-  }
+  String? get _resolvedFirmware =>
+      DeviceStorageProtocolPolicy.resolveFirmware(_firmwareVersion, _device?.firmwareRevision);
 
   WalSyncs(this.listener) {
     _phoneSync = LocalWalSyncImpl(listener);
@@ -78,6 +57,12 @@ class WalSyncs implements IWalSync {
     _flashPageSync = FlashPageWalSyncImpl(listener);
     _storageSync = StorageSyncImpl(listener);
     _ringSync = RingStorageSyncImpl(listener);
+    _deviceStorageRouter = DeviceStorageRouter(
+      bindLegacySdCard: _sdcardSync.setDevice,
+      bindMultiFile: _storageSync.setDevice,
+      bindRingBuffer: _ringSync.setDevice,
+      bindLimitlessFlash: _flashPageSync.setDevice,
+    );
 
     _sdcardSync.setLocalSync(_phoneSync);
     _flashPageSync.setLocalSync(_phoneSync);
@@ -130,10 +115,15 @@ class WalSyncs implements IWalSync {
     final fw = (firmwareVersion != null && firmwareVersion.isNotEmpty && firmwareVersion != 'Unknown')
         ? firmwareVersion
         : _resolvedFirmware;
-    if (isRingBufferFirmware(fw)) {
-      await _ringSync.refreshWalsFromDevice();
-    } else {
-      await _storageSync.refreshWalsFromDevice();
+    switch (DeviceStorageProtocolPolicy.classify(_device, firmwareVersion: fw)) {
+      case DeviceStorageProtocol.ringBuffer:
+        await _ringSync.refreshWalsFromDevice();
+      case DeviceStorageProtocol.multiFile:
+        await _storageSync.refreshWalsFromDevice();
+      case DeviceStorageProtocol.none:
+      case DeviceStorageProtocol.legacySdCard:
+      case DeviceStorageProtocol.limitlessFlash:
+        break;
     }
     await _flashPageSync.refreshWalsFromDevice();
   }
@@ -281,25 +271,30 @@ class WalSyncs implements IWalSync {
     //   fw 3.0.17–.19 -> multi-file LittleFS protocol (StorageSync)
     //   fw < 3.0.17   -> falls through to Phase 1a legacy SD-card path
     final fwVersion = _resolvedFirmware;
-    final useRing = isRingBufferFirmware(fwVersion);
-    if (useRing) {
-      await _ringSync.refreshWalsFromDevice();
-      final ringMissing = await _ringSync.getMissingWals();
-      if (ringMissing.isNotEmpty) {
-        Logger.debug("WalSyncs: Phase 0 - Ring-buffer sync (fw=$fwVersion)");
-        DebugLogManager.logInfo('Sync Phase 0: Ring-buffer sync', {'fw': fwVersion ?? ''});
-        progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
-        await _ringSync.syncAll(progress: progress);
-      }
-    } else {
-      await _storageSync.refreshWalsFromDevice();
-      final storageMissing = await _storageSync.getMissingWals();
-      if (storageMissing.isNotEmpty) {
-        Logger.debug("WalSyncs: Phase 0 - Downloading ${storageMissing.length} multi-file storage files to phone");
-        DebugLogManager.logInfo('Sync Phase 0: Multi-file storage sync', {'fw': fwVersion ?? ''});
-        progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
-        await _storageSync.syncAll(progress: progress);
-      }
+    final storageProtocol = _deviceStorageRouter.protocol;
+    switch (storageProtocol) {
+      case DeviceStorageProtocol.ringBuffer:
+        await _ringSync.refreshWalsFromDevice();
+        final ringMissing = await _ringSync.getMissingWals();
+        if (ringMissing.isNotEmpty) {
+          Logger.debug("WalSyncs: Phase 0 - Ring-buffer sync (fw=$fwVersion)");
+          DebugLogManager.logInfo('Sync Phase 0: Ring-buffer sync', {'fw': fwVersion ?? ''});
+          progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+          await _ringSync.syncAll(progress: progress);
+        }
+      case DeviceStorageProtocol.multiFile:
+        await _storageSync.refreshWalsFromDevice();
+        final storageMissing = await _storageSync.getMissingWals();
+        if (storageMissing.isNotEmpty) {
+          Logger.debug("WalSyncs: Phase 0 - Downloading ${storageMissing.length} multi-file storage files to phone");
+          DebugLogManager.logInfo('Sync Phase 0: Multi-file storage sync', {'fw': fwVersion ?? ''});
+          progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+          await _storageSync.syncAll(progress: progress);
+        }
+      case DeviceStorageProtocol.none:
+      case DeviceStorageProtocol.legacySdCard:
+      case DeviceStorageProtocol.limitlessFlash:
+        break;
     }
 
     if (_isCancelled) {
@@ -307,15 +302,18 @@ class WalSyncs implements IWalSync {
       return resp;
     }
 
-    // Phase 1a: Download SD card data to phone (legacy firmware)
-    Logger.debug("WalSyncs: Phase 1a - Downloading SD card data to phone");
-    DebugLogManager.logInfo('Sync Phase 1a: Downloading SD card data to phone');
-    progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
-    final missingSDCardWals = (await _sdcardSync.getMissingWals()).where((w) => w.status == WalStatus.miss).toList();
+    // Phase 1a is exclusive to legacy firmware. Ring and multi-file firmware
+    // reuse these characteristics with incompatible framing.
+    if (storageProtocol == DeviceStorageProtocol.legacySdCard) {
+      Logger.debug("WalSyncs: Phase 1a - Downloading SD card data to phone");
+      DebugLogManager.logInfo('Sync Phase 1a: Downloading SD card data to phone');
+      progress?.onWalSyncedProgress(0.0, phase: SyncPhase.downloadingFromDevice);
+      final missingSDCardWals = (await _sdcardSync.getMissingWals()).where((w) => w.status == WalStatus.miss).toList();
 
-    if (missingSDCardWals.isNotEmpty) {
-      DebugLogManager.logInfo('SD card sync over BLE', {'walCount': missingSDCardWals.length});
-      await _sdcardSync.syncAll(progress: progress);
+      if (missingSDCardWals.isNotEmpty) {
+        DebugLogManager.logInfo('SD card sync over BLE', {'walCount': missingSDCardWals.length});
+        await _sdcardSync.syncAll(progress: progress);
+      }
     }
 
     if (_isCancelled) {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -77,11 +77,16 @@ class WalSyncs implements IWalSync {
   /// not a conflicting user-visible sync.
   bool get isRingAudioTailActive => _ringSync.isAudioTailActive;
 
+  bool get isFastRingSyncActive => _ringSync.isFastSyncActive;
+
   /// Latch one manual backlog snapshot onto the active live scheduler.
   ///
   /// Returns null when no live scheduler owns the ring, in which case the
   /// caller should use the ordinary device-storage sync path.
-  Future<RingBacklogDrainReceipt?>? requestActiveRingBacklogDrain() => _ringSync.requestAudioTailBacklogDrain();
+  Future<RingBacklogDrainReceipt?>? requestActiveRingBacklogDrain({
+    IWalSyncProgressListener? progress,
+  }) =>
+      _ringSync.requestAudioTailBacklogDrain(progress: progress);
 
   RingBacklogDrainReceipt? get pendingAutomaticRingBacklogReceipt =>
       _automaticRingBacklogReceipts.isEmpty ? null : _automaticRingBacklogReceipts.values.first;

--- a/app/lib/utils/audio_player_utils.dart
+++ b/app/lib/utils/audio_player_utils.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter_sound/flutter_sound.dart';
@@ -39,6 +40,20 @@ List<Uint8List> parseLengthPrefixedFrames(Uint8List data) {
   return frames;
 }
 
+/// Keeps the platform audio-session transition ordered ahead of playback.
+///
+/// On iOS, opening a player does not make its route authoritative after the
+/// recorder, a video, or another app owned the shared audio session. Starting
+/// first can therefore advance the player while producing no audible output.
+@visibleForTesting
+Future<void> startPlaybackAfterActivatingSession({
+  required Future<void> Function() activateSession,
+  required Future<void> Function() startPlayer,
+}) async {
+  await activateSession();
+  await startPlayer();
+}
+
 class AudioPlayerUtils extends ChangeNotifier {
   // Singleton pattern
   static final AudioPlayerUtils _instance = AudioPlayerUtils._internal();
@@ -51,6 +66,7 @@ class AudioPlayerUtils extends ChangeNotifier {
   FlutterSoundPlayer? _audioPlayer;
   String? _currentPlayingId;
   bool _isProcessingAudio = false;
+  bool _playbackSessionActive = false;
 
   Duration _currentPosition = Duration.zero;
   Duration _totalDuration = Duration.zero;
@@ -113,12 +129,12 @@ class AudioPlayerUtils extends ChangeNotifier {
   }
 
   Future<void> _stopPlayback() async {
-    await _audioPlayer?.stopPlayer();
-    _currentPlayingId = null;
-    _currentPosition = Duration.zero;
-    _totalDuration = Duration.zero;
-    _positionSubscription?.cancel();
-    notifyListeners();
+    try {
+      await _audioPlayer?.stopPlayer();
+    } finally {
+      await _deactivatePlaybackSession();
+      _resetPlaybackState();
+    }
   }
 
   Future<void> _startPlayback(Wal wal) async {
@@ -127,31 +143,72 @@ class AudioPlayerUtils extends ChangeNotifier {
     _totalDuration = Duration.zero;
     notifyListeners();
 
-    // Initialize player lazily on first use
-    await _ensurePlayerInitialized();
+    try {
+      // Initialize player lazily on first use.
+      await _ensurePlayerInitialized();
 
-    final audioFilePath = await _getOrCreateAudioFile(wal);
-    if (audioFilePath == null) {
+      final audioFilePath = await _getOrCreateAudioFile(wal);
+      if (audioFilePath == null) {
+        throw StateError('Unable to create a playable audio file');
+      }
+
+      await startPlaybackAfterActivatingSession(
+        activateSession: _activatePlaybackSession,
+        startPlayer: () async {
+          await _audioPlayer?.startPlayer(
+            fromURI: audioFilePath,
+            whenFinished: _onPlaybackFinished,
+          );
+        },
+      );
+
+      _currentPlayingId = wal.id;
+      _isProcessingAudio = false;
+      _setupPositionTracking(wal);
+    } catch (error, stackTrace) {
+      await _deactivatePlaybackSession();
       _resetPlaybackState();
-      Logger.error('AudioPlayerUtils: Unable to create playable audio file for WAL ${wal.id}');
+      Logger.handle(
+        error,
+        stackTrace,
+        message: 'AudioPlayerUtils: Unable to play WAL ${wal.id}',
+      );
       AppSnackbar.showSnackbarError(
         globalNavigatorKey.currentContext?.l10n.audioPlaybackFailed ??
             'Unable to play audio. The file may be corrupted or missing.',
       );
-      return;
     }
-
-    _currentPlayingId = wal.id;
-    _isProcessingAudio = false;
-
-    await _audioPlayer?.startPlayer(fromURI: audioFilePath, whenFinished: () => _onPlaybackFinished());
-
-    _setupPositionTracking(wal);
   }
 
   void _onPlaybackFinished() {
     Logger.debug('Audio playback finished');
+    unawaited(_deactivatePlaybackSession());
     _resetPlaybackState();
+  }
+
+  Future<void> _activatePlaybackSession() async {
+    final session = await AudioSession.instance;
+    await session.configure(
+      const AudioSessionConfiguration.speech().copyWith(
+        avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
+      ),
+    );
+    final activated = await session.setActive(true);
+    if (!activated) {
+      throw StateError('The platform audio session refused playback activation');
+    }
+    _playbackSessionActive = true;
+  }
+
+  Future<void> _deactivatePlaybackSession() async {
+    if (!_playbackSessionActive) return;
+    _playbackSessionActive = false;
+    try {
+      final session = await AudioSession.instance;
+      await session.setActive(false);
+    } catch (error) {
+      Logger.debug('AudioPlayerUtils: audio session deactivation failed: $error');
+    }
   }
 
   void _resetPlaybackState() {

--- a/app/lib/utils/debug_log_manager.dart
+++ b/app/lib/utils/debug_log_manager.dart
@@ -2,10 +2,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'package:omi/backend/preferences.dart';
+
+typedef DebugLogPhysicalMutationRunner = Future<void> Function(
+  Future<void> Function() mutation,
+);
 
 /// Lightweight debug log manager to persist important diagnostics when
 /// developer debug logging is enabled.
@@ -24,41 +29,51 @@ class DebugLogManager {
 
   static File? _file;
   static final DateFormat _ts = DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-  static bool _initializing = false;
   static bool _prunedOnce = false;
+  static Future<void> _ioTail = Future<void>.value();
+  static DebugLogPhysicalMutationRunner? _physicalMutationRunner;
 
   static bool get isEnabled => SharedPreferencesUtil().devLogsToFileEnabled;
 
-  static Future<File> _ensureFile() async {
-    if (_file != null) return _file!;
-    if (_initializing) {
-      // Wait briefly if concurrent init
-      for (int i = 0; i < 10 && _file == null; i++) {
-        await Future.delayed(const Duration(milliseconds: 50));
-      }
-      if (_file != null) return _file!;
-    }
-    _initializing = true;
+  static Future<T> _serializeIo<T>(Future<T> Function() operation) async {
+    final previous = _ioTail;
+    final release = Completer<void>();
+    _ioTail = release.future;
+    await previous;
     try {
-      final dir = await getApplicationDocumentsDirectory();
-      if (!_prunedOnce) {
-        await _pruneOldLogs(retainDays: 3);
-        _prunedOnce = true;
-      }
-      final f = File('${dir.path}/${_dailyFileName()}');
-      if (!(await f.exists())) {
-        await f.create(recursive: true);
-      }
-      _file = f;
-      return f;
+      return await operation();
     } finally {
-      _initializing = false;
+      release.complete();
     }
+  }
+
+  static Future<void> _runPhysicalMutation(
+    Future<void> Function() mutation,
+  ) {
+    final runner = _physicalMutationRunner;
+    return runner == null ? mutation() : runner(mutation);
+  }
+
+  static Future<File> _ensureFileOwned() async {
+    if (_file != null) return _file!;
+    final dir = await getApplicationDocumentsDirectory();
+    if (!_prunedOnce) {
+      await _pruneOldLogsOwned(retainDays: 3);
+      _prunedOnce = true;
+    }
+    final f = File('${dir.path}/${_dailyFileName()}');
+    if (!(await f.exists())) {
+      await _runPhysicalMutation(
+        () => f.create(recursive: true),
+      );
+    }
+    _file = f;
+    return f;
   }
 
   static Future<File?> getLogFile() async {
     try {
-      return await _ensureFile();
+      return await _serializeIo(_ensureFileOwned);
     } catch (_) {
       return null;
     }
@@ -67,37 +82,49 @@ class DebugLogManager {
   static Future<void> setEnabled(bool enabled) async {
     SharedPreferencesUtil().devLogsToFileEnabled = enabled;
     if (!enabled) return;
-    await _ensureFile();
-    await _pruneOldLogs(retainDays: 3);
+    await _serializeIo(() async {
+      await _ensureFileOwned();
+      await _pruneOldLogsOwned(retainDays: 3);
+    });
   }
 
   static String _timestamp() => _ts.format(DateTime.now().toUtc());
 
-  static Future<void> _rotateIfNeeded(File f) async {
+  static Future<void> _rotateIfNeededOwned(File f) async {
     try {
       final len = await f.length();
       if (len <= _maxFileBytes) return;
       // Simple rotation: delete old file
-      await f.writeAsString('', mode: FileMode.write, flush: true);
+      await _runPhysicalMutation(
+        () => f.writeAsString('', mode: FileMode.write, flush: true),
+      );
     } catch (_) {}
   }
 
   static Future<void> _append(String line) async {
     if (!isEnabled) return;
-    try {
-      final f = await _ensureFile();
-      await _rotateIfNeeded(f);
-      await f.writeAsString('$line\n', mode: FileMode.append, flush: false);
-    } catch (_) {
-      // Swallow to avoid impacting app flow
-    }
+    await _serializeIo(() async {
+      try {
+        final f = await _ensureFileOwned();
+        await _rotateIfNeededOwned(f);
+        await _runPhysicalMutation(
+          () => f.writeAsString('$line\n', mode: FileMode.append, flush: false),
+        );
+      } catch (_) {
+        // Swallow to avoid impacting app flow
+      }
+    });
   }
 
   static Future<void> clear() async {
-    try {
-      final f = await _ensureFile();
-      await f.writeAsString('', mode: FileMode.write, flush: true);
-    } catch (_) {}
+    await _serializeIo(() async {
+      try {
+        final f = await _ensureFileOwned();
+        await _runPhysicalMutation(
+          () => f.writeAsString('', mode: FileMode.write, flush: true),
+        );
+      } catch (_) {}
+    });
   }
 
   /// Returns available debug log files (within retention), sorted newest first.
@@ -125,7 +152,7 @@ class DebugLogManager {
     }
   }
 
-  static Future<void> _pruneOldLogs({int retainDays = 3}) async {
+  static Future<void> _pruneOldLogsOwned({int retainDays = 3}) async {
     try {
       final dir = await getApplicationDocumentsDirectory();
       final now = DateTime.now().toUtc();
@@ -145,11 +172,22 @@ class DebugLogManager {
         final age = now.difference(fileDate).inDays;
         if (age > retainDays) {
           try {
-            await entity.delete();
+            await _runPhysicalMutation(entity.delete);
           } catch (_) {}
         }
       }
     } catch (_) {}
+  }
+
+  @visibleForTesting
+  static Future<void> resetForTesting({
+    DebugLogPhysicalMutationRunner? physicalMutationRunner,
+  }) async {
+    await _ioTail;
+    _file = null;
+    _prunedOnce = false;
+    _physicalMutationRunner = physicalMutationRunner;
+    _ioTail = Future<void>.value();
   }
 
   static Future<void> logError(

--- a/app/lib/utils/omi_mcu_dfu_policy.dart
+++ b/app/lib/utils/omi_mcu_dfu_policy.dart
@@ -1,0 +1,16 @@
+import 'package:mcumgr_flutter/mcumgr_flutter.dart' as mcumgr;
+
+/// Production MCUboot upgrade policy for Omi pendants.
+class OmiMcuDfuPolicy {
+  const OmiMcuDfuPolicy._();
+
+  static mcumgr.FirmwareUpgradeConfiguration createConfiguration() {
+    return const mcumgr.FirmwareUpgradeConfiguration(
+      estimatedSwapTime: Duration.zero,
+      // A routine firmware upgrade is not a factory-reset action. Preserve
+      // device-owned settings and offline-state metadata across the reboot.
+      eraseAppSettings: false,
+      pipelineDepth: 1,
+    );
+  }
+}

--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -16,6 +16,7 @@ class WalFileManager {
 
   static File? _walFile;
   static File? _walBackupFile;
+  static Future<void> _saveBarrier = Future.value();
 
   static Future<void> init() async {
     final directory = await getApplicationDocumentsDirectory();
@@ -29,14 +30,14 @@ class WalFileManager {
     }
 
     if (_walFile == null || !_walFile!.existsSync()) {
-      Logger.debug('WAL file does not exist, returning empty list');
-      return [];
+      Logger.debug('WAL file does not exist, trying backup');
+      return await _loadFromBackup();
     }
 
     final content = await _walFile!.readAsString();
     if (content.isEmpty) {
-      Logger.debug('WAL file is empty, returning empty list');
-      return [];
+      Logger.debug('WAL file is empty, trying backup');
+      return await _loadFromBackup();
     }
 
     dynamic jsonData;
@@ -47,15 +48,25 @@ class WalFileManager {
       return await _loadFromBackup();
     }
     if (jsonData is! Map<String, dynamic> || jsonData['wals'] is! List) {
-      Logger.debug('Invalid WAL file format, returning empty list');
-      return [];
+      Logger.debug('Invalid WAL file format, trying backup');
+      return await _loadFromBackup();
     }
 
     final walsList = jsonData['wals'] as List;
     return Wal.fromJsonList(walsList);
   }
 
-  static Future<bool> saveWals(List<Wal> wals) async {
+  static Future<bool> saveWals(List<Wal> wals) {
+    // Capture the caller's state before yielding, then serialize rewrites so
+    // concurrent capture/upload callbacks cannot contend for the same temp
+    // file or let an older manifest finish after a newer one.
+    final snapshot = wals.map((wal) => wal.toJson()).toList(growable: false);
+    final operation = _saveBarrier.then((_) => _saveWalsAtomic(snapshot));
+    _saveBarrier = operation.then<void>((_) {}, onError: (error, stackTrace) {});
+    return operation;
+  }
+
+  static Future<bool> _saveWalsAtomic(List<Map<String, dynamic>> snapshot) async {
     if (_walFile == null) {
       await init();
     }
@@ -65,29 +76,43 @@ class WalFileManager {
       return false;
     }
 
-    await _createBackup();
-
     final jsonData = {
       'version': 1,
       'timestamp': DateTime.now().millisecondsSinceEpoch,
-      'wals': wals.map((wal) => wal.toJson()).toList(),
+      'wals': snapshot,
     };
 
     final jsonString = jsonEncode(jsonData);
-    await _walFile!.writeAsString(jsonString);
-
-    Logger.debug('Successfully saved ${wals.length} WALs to file');
-    return true;
-  }
-
-  static Future<void> _createBackup() async {
+    final temporaryFile = File('${_walFile!.path}.tmp');
+    final backupTemporaryFile = _walBackupFile == null ? null : File('${_walBackupFile!.path}.tmp');
     try {
-      if (_walFile != null && _walFile!.existsSync() && _walBackupFile != null) {
-        await _walFile!.copy(_walBackupFile!.path);
+      if (await temporaryFile.exists()) await temporaryFile.delete();
+      await temporaryFile.writeAsString(jsonString, flush: true);
+      // The temporary file lives beside the manifest, so rename is atomic on
+      // the Android/iOS filesystems. Readers see either the previous complete
+      // JSON document or the new complete document, never a partial rewrite.
+      await temporaryFile.rename(_walFile!.path);
+      if (backupTemporaryFile != null && _walBackupFile != null) {
+        if (await backupTemporaryFile.exists()) await backupTemporaryFile.delete();
+        await backupTemporaryFile.writeAsString(jsonString, flush: true);
+        await backupTemporaryFile.rename(_walBackupFile!.path);
       }
-    } on FileSystemException catch (e) {
-      Logger.debug('WalFileManager: Failed to create backup: $e');
+    } catch (_) {
+      if (await temporaryFile.exists()) {
+        try {
+          await temporaryFile.delete();
+        } catch (_) {}
+      }
+      if (backupTemporaryFile != null && await backupTemporaryFile.exists()) {
+        try {
+          await backupTemporaryFile.delete();
+        } catch (_) {}
+      }
+      rethrow;
     }
+
+    Logger.debug('Successfully saved ${snapshot.length} WALs to file');
+    return true;
   }
 
   /// Load WALs from backup file

--- a/app/scripts/physical_test_customer_plane.sh
+++ b/app/scripts/physical_test_customer_plane.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Single executable authority for authenticated physical-device acceptance.
+# Android and iOS use isolated development package identities, but exercise the
+# customer data plane so auth, live transcription, and sync evidence are real.
+# shellcheck disable=SC2034 # Consumed by scripts that source this contract.
+OMI_PHYSICAL_TEST_API_BASE_URL="https://api.omi.me/"
+OMI_PHYSICAL_TEST_FIREBASE_PROJECT_ID="based-hardware"

--- a/app/scripts/test_verify_android_physical_test_auth_config.sh
+++ b/app/scripts/test_verify_android_physical_test_auth_config.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/omi-physical-auth-test.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/lib" "$fixture/android/app/src/dev"
+
+write_valid_fixture() {
+  cat >"$fixture/.dev.env" <<'EOF'
+API_BASE_URL=https://api.omiapi.com/
+USE_WEB_AUTH=true
+USE_AUTH_CUSTOM_TOKEN=true
+EOF
+  cat >"$fixture/lib/firebase_options_dev.dart" <<'EOF'
+class DefaultFirebaseOptions {
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'fixture',
+    appId: 'fixture',
+    projectId: 'based-hardware',
+  );
+}
+EOF
+  cat >"$fixture/android/app/src/dev/google-services.json" <<'EOF'
+{
+  "project_info": {"project_id": "based-hardware"},
+  "client": [
+    {
+      "client_info": {
+        "android_client_info": {"package_name": "com.friend.ios.dev"}
+      }
+    }
+  ]
+}
+EOF
+  python3 - "$fixture/lib/env/dev_env.g.dart" <<'PY'
+import sys
+from pathlib import Path
+
+url = "https://api.omiapi.com/"
+keys = [0] * len(url)
+data = [ord(char) for char in url]
+Path(sys.argv[1]).parent.mkdir(parents=True, exist_ok=True)
+Path(sys.argv[1]).write_text(
+    "static const List<int> _enviedkeyapiBaseUrl = <int>["
+    + ",".join(map(str, keys))
+    + "];\n"
+    + "static const List<int> _envieddataapiBaseUrl = <int>["
+    + ",".join(map(str, data))
+    + "];\n",
+    encoding="utf-8",
+)
+PY
+}
+
+expect_failure() {
+  if OMI_PHYSICAL_TEST_APP_ROOT="$fixture" \
+    bash "$script_dir/verify_android_physical_test_auth_config.sh" >/dev/null 2>&1; then
+    echo "expected physical-test auth preflight failure" >&2
+    exit 1
+  fi
+}
+
+write_valid_fixture
+OMI_PHYSICAL_TEST_APP_ROOT="$fixture" \
+  bash "$script_dir/verify_android_physical_test_auth_config.sh" >/dev/null
+
+sed -i.bak 's#https://api.omiapi.com/##' "$fixture/.dev.env"
+expect_failure
+rm -f "$fixture/.dev.env.bak"
+
+write_valid_fixture
+sed -i.bak 's/based-hardware/based-hardware-dev/g' \
+  "$fixture/android/app/src/dev/google-services.json"
+expect_failure
+rm -f "$fixture/android/app/src/dev/google-services.json.bak"
+
+write_valid_fixture
+sed -i.bak "s/projectId: 'based-hardware'/projectId: 'based-hardware-dev'/" \
+  "$fixture/lib/firebase_options_dev.dart"
+expect_failure
+
+write_valid_fixture
+python3 - "$fixture/lib/env/dev_env.g.dart" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+path.write_text(
+    re.sub(
+        r"(_envieddataapiBaseUrl = <int>)\[[^\]]*\]",
+        r"\1[]",
+        source,
+    ),
+    encoding="utf-8",
+)
+PY
+expect_failure
+
+echo "Android physical-test auth preflight tests: PASS"

--- a/app/scripts/test_verify_android_physical_test_auth_config.sh
+++ b/app/scripts/test_verify_android_physical_test_auth_config.sh
@@ -5,11 +5,11 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/omi-physical-auth-test.XXXXXX")"
 trap 'rm -rf "$fixture"' EXIT
 
-mkdir -p "$fixture/lib" "$fixture/android/app/src/dev"
+mkdir -p "$fixture/lib" "$fixture/android/app/src/dev" "$fixture/setup/prebuilt"
 
 write_valid_fixture() {
   cat >"$fixture/.dev.env" <<'EOF'
-API_BASE_URL=https://api.omiapi.com/
+API_BASE_URL=https://api.omi.me/
 USE_WEB_AUTH=true
 USE_AUTH_CUSTOM_TOKEN=true
 EOF
@@ -22,6 +22,16 @@ class DefaultFirebaseOptions {
   );
 }
 EOF
+  cat >"$fixture/lib/firebase_options_prod.dart" <<'EOF'
+class DefaultFirebaseOptions {}
+EOF
+  cat >"$fixture/android/key.properties" <<'EOF'
+keyAlias=androiddebugkey
+keyPassword=android
+storeFile=../../setup/prebuilt/debug.keystore
+storePassword=android
+EOF
+  : >"$fixture/setup/prebuilt/debug.keystore"
   cat >"$fixture/android/app/src/dev/google-services.json" <<'EOF'
 {
   "project_info": {"project_id": "based-hardware"},
@@ -38,7 +48,7 @@ EOF
 import sys
 from pathlib import Path
 
-url = "https://api.omiapi.com/"
+url = "https://api.omi.me/"
 keys = [0] * len(url)
 data = [ord(char) for char in url]
 Path(sys.argv[1]).parent.mkdir(parents=True, exist_ok=True)
@@ -66,7 +76,17 @@ write_valid_fixture
 OMI_PHYSICAL_TEST_APP_ROOT="$fixture" \
   bash "$script_dir/verify_android_physical_test_auth_config.sh" >/dev/null
 
-sed -i.bak 's#https://api.omiapi.com/##' "$fixture/.dev.env"
+rm -f "$fixture/lib/firebase_options_prod.dart"
+expect_failure
+
+write_valid_fixture
+sed -i.bak 's#../../setup/prebuilt/debug.keystore#debug.keystore#' \
+  "$fixture/android/key.properties"
+expect_failure
+rm -f "$fixture/android/key.properties.bak"
+
+write_valid_fixture
+sed -i.bak 's#https://api.omi.me/#https://api.omiapi.com/#' "$fixture/.dev.env"
 expect_failure
 rm -f "$fixture/.dev.env.bak"
 

--- a/app/scripts/test_verify_ios_physical_test_auth_config.sh
+++ b/app/scripts/test_verify_ios_physical_test_auth_config.sh
@@ -9,7 +9,7 @@ mkdir -p "$fixture/lib" "$fixture/ios/Config/Dev"
 
 write_valid_fixture() {
   cat >"$fixture/.dev.env" <<'EOF'
-API_BASE_URL=https://api.omiapi.com/
+API_BASE_URL=https://api.omi.me/
 USE_WEB_AUTH=true
 USE_AUTH_CUSTOM_TOKEN=true
 EOF
@@ -40,7 +40,7 @@ PY
 import sys
 from pathlib import Path
 
-url = "https://api.omiapi.com/"
+url = "https://api.omi.me/"
 keys = [0] * len(url)
 data = [ord(char) for char in url]
 Path(sys.argv[1]).parent.mkdir(parents=True, exist_ok=True)
@@ -68,7 +68,7 @@ write_valid_fixture
 OMI_PHYSICAL_TEST_APP_ROOT="$fixture" \
   bash "$script_dir/verify_ios_physical_test_auth_config.sh" >/dev/null
 
-sed -i.bak 's#https://api.omiapi.com/##' "$fixture/.dev.env"
+sed -i.bak 's#https://api.omi.me/#https://api.omiapi.com/#' "$fixture/.dev.env"
 expect_failure
 rm -f "$fixture/.dev.env.bak"
 

--- a/app/scripts/test_verify_ios_physical_test_auth_config.sh
+++ b/app/scripts/test_verify_ios_physical_test_auth_config.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/omi-ios-physical-auth-test.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/lib" "$fixture/ios/Config/Dev"
+
+write_valid_fixture() {
+  cat >"$fixture/.dev.env" <<'EOF'
+API_BASE_URL=https://api.omiapi.com/
+USE_WEB_AUTH=true
+USE_AUTH_CUSTOM_TOKEN=true
+EOF
+  cat >"$fixture/lib/firebase_options_dev.dart" <<'EOF'
+class DefaultFirebaseOptions {
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'fixture',
+    appId: '1:123:ios:fixture',
+    projectId: 'based-hardware',
+  );
+}
+EOF
+  python3 - "$fixture/ios/Config/Dev/GoogleService-Info.plist" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+with Path(sys.argv[1]).open("wb") as stream:
+    plistlib.dump(
+        {
+            "PROJECT_ID": "based-hardware",
+            "GOOGLE_APP_ID": "1:123:ios:fixture",
+        },
+        stream,
+    )
+PY
+  python3 - "$fixture/lib/env/dev_env.g.dart" <<'PY'
+import sys
+from pathlib import Path
+
+url = "https://api.omiapi.com/"
+keys = [0] * len(url)
+data = [ord(char) for char in url]
+Path(sys.argv[1]).parent.mkdir(parents=True, exist_ok=True)
+Path(sys.argv[1]).write_text(
+    "static const List<int> _enviedkeyapiBaseUrl = <int>["
+    + ",".join(map(str, keys))
+    + "];\n"
+    + "static const List<int> _envieddataapiBaseUrl = <int>["
+    + ",".join(map(str, data))
+    + "];\n",
+    encoding="utf-8",
+)
+PY
+}
+
+expect_failure() {
+  if OMI_PHYSICAL_TEST_APP_ROOT="$fixture" \
+    bash "$script_dir/verify_ios_physical_test_auth_config.sh" >/dev/null 2>&1; then
+    echo "expected iOS physical-test auth preflight failure" >&2
+    exit 1
+  fi
+}
+
+write_valid_fixture
+OMI_PHYSICAL_TEST_APP_ROOT="$fixture" \
+  bash "$script_dir/verify_ios_physical_test_auth_config.sh" >/dev/null
+
+sed -i.bak 's#https://api.omiapi.com/##' "$fixture/.dev.env"
+expect_failure
+rm -f "$fixture/.dev.env.bak"
+
+write_valid_fixture
+python3 - "$fixture/ios/Config/Dev/GoogleService-Info.plist" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open("rb") as stream:
+    config = plistlib.load(stream)
+config["PROJECT_ID"] = "based-hardware-dev"
+with path.open("wb") as stream:
+    plistlib.dump(config, stream)
+PY
+expect_failure
+
+write_valid_fixture
+python3 - "$fixture/ios/Config/Dev/GoogleService-Info.plist" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open("rb") as stream:
+    config = plistlib.load(stream)
+config["GOOGLE_APP_ID"] = "1:123:android:fixture"
+with path.open("wb") as stream:
+    plistlib.dump(config, stream)
+PY
+expect_failure
+
+write_valid_fixture
+sed -i.bak "s/projectId: 'based-hardware'/projectId: 'based-hardware-dev'/" \
+  "$fixture/lib/firebase_options_dev.dart"
+expect_failure
+rm -f "$fixture/lib/firebase_options_dev.dart.bak"
+
+write_valid_fixture
+sed -i.bak "s/:ios:/:android:/" "$fixture/lib/firebase_options_dev.dart"
+expect_failure
+rm -f "$fixture/lib/firebase_options_dev.dart.bak"
+
+write_valid_fixture
+python3 - "$fixture/lib/env/dev_env.g.dart" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+path.write_text(
+    re.sub(
+        r"(_envieddataapiBaseUrl = <int>)\[[^\]]*\]",
+        r"\1[]",
+        source,
+    ),
+    encoding="utf-8",
+)
+PY
+expect_failure
+
+echo "iOS physical-test auth preflight tests: PASS"

--- a/app/scripts/verify_android_physical_test_auth_config.sh
+++ b/app/scripts/verify_android_physical_test_auth_config.sh
@@ -2,25 +2,44 @@
 set -euo pipefail
 
 app_root="${OMI_PHYSICAL_TEST_APP_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$script_dir/physical_test_customer_plane.sh"
 env_file="$app_root/.dev.env"
 firebase_dart="$app_root/lib/firebase_options_dev.dart"
+prod_firebase_dart="$app_root/lib/firebase_options_prod.dart"
 google_services="$app_root/android/app/src/dev/google-services.json"
 generated_env="$app_root/lib/env/dev_env.g.dart"
+key_properties="$app_root/android/key.properties"
+debug_keystore="$app_root/setup/prebuilt/debug.keystore"
 
 fail() {
   echo "Android physical-test auth preflight FAILED: $*" >&2
   exit 1
 }
 
-for required in "$env_file" "$firebase_dart" "$google_services" "$generated_env"; do
+for required in \
+  "$env_file" \
+  "$firebase_dart" \
+  "$prod_firebase_dart" \
+  "$google_services" \
+  "$generated_env" \
+  "$key_properties" \
+  "$debug_keystore"; do
   [[ -f "$required" ]] || fail "missing $required"
 done
 
-api_base_url="$(awk -F= '$1 == "API_BASE_URL" { print substr($0, index($0, "=") + 1) }' "$env_file")"
-[[ "$api_base_url" == "https://api.omiapi.com/" ]] ||
-  fail ".dev.env targets '${api_base_url:-<empty>}' instead of the production API"
+grep -Fxq 'keyAlias=androiddebugkey' "$key_properties" ||
+  fail "android/key.properties does not select the shared debug alias"
+grep -Fxq 'storeFile=../../setup/prebuilt/debug.keystore' "$key_properties" ||
+  fail "android/key.properties does not select the shared physical-test keystore"
 
-python3 - "$google_services" "$firebase_dart" "$generated_env" <<'PY'
+api_base_url="$(awk -F= '$1 == "API_BASE_URL" { print substr($0, index($0, "=") + 1) }' "$env_file")"
+[[ "$api_base_url" == "$OMI_PHYSICAL_TEST_API_BASE_URL" ]] ||
+  fail ".dev.env targets '${api_base_url:-<empty>}' instead of the canonical customer API $OMI_PHYSICAL_TEST_API_BASE_URL"
+
+python3 - "$google_services" "$firebase_dart" "$generated_env" \
+  "$OMI_PHYSICAL_TEST_API_BASE_URL" "$OMI_PHYSICAL_TEST_FIREBASE_PROJECT_ID" <<'PY'
 import json
 import re
 import sys
@@ -29,6 +48,8 @@ from pathlib import Path
 google_services = Path(sys.argv[1])
 firebase_dart = Path(sys.argv[2])
 generated_env = Path(sys.argv[3])
+expected_api_url = sys.argv[4]
+expected_project_id = sys.argv[5]
 
 config = json.loads(google_services.read_text(encoding="utf-8"))
 project_id = config.get("project_info", {}).get("project_id")
@@ -36,10 +57,10 @@ packages = {
     client.get("client_info", {}).get("android_client_info", {}).get("package_name")
     for client in config.get("client", [])
 }
-if project_id != "based-hardware":
+if project_id != expected_project_id:
     raise SystemExit(
         "Android physical-test auth preflight FAILED: "
-        f"google-services project is {project_id!r}, expected 'based-hardware'"
+        f"google-services project is {project_id!r}, expected {expected_project_id!r}"
     )
 if "com.friend.ios.dev" not in packages:
     raise SystemExit(
@@ -53,7 +74,7 @@ android_block = re.search(
     source,
     re.DOTALL,
 )
-if android_block is None or "projectId: 'based-hardware'" not in android_block.group(1):
+if android_block is None or f"projectId: '{expected_project_id}'" not in android_block.group(1):
     raise SystemExit(
         "Android physical-test auth preflight FAILED: "
         "firebase_options_dev.dart Android options do not target based-hardware"
@@ -77,7 +98,7 @@ def envied_ints(name: str) -> list[int]:
 keys = envied_ints("_enviedkeyapiBaseUrl")
 data = envied_ints("_envieddataapiBaseUrl")
 decoded_api_url = "".join(chr(value ^ keys[index]) for index, value in enumerate(data))
-if decoded_api_url != "https://api.omiapi.com/":
+if decoded_api_url != expected_api_url:
     raise SystemExit(
         "Android physical-test auth preflight FAILED: "
         "generated dev_env.g.dart does not embed the production API; "
@@ -85,4 +106,4 @@ if decoded_api_url != "https://api.omiapi.com/":
     )
 PY
 
-echo "Android physical-test auth preflight: PASS (generated prod API + prod Firebase, dev package)"
+echo "Android physical-test auth preflight: PASS (canonical production API + prod Firebase, dev package)"

--- a/app/scripts/verify_android_physical_test_auth_config.sh
+++ b/app/scripts/verify_android_physical_test_auth_config.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_root="${OMI_PHYSICAL_TEST_APP_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+env_file="$app_root/.dev.env"
+firebase_dart="$app_root/lib/firebase_options_dev.dart"
+google_services="$app_root/android/app/src/dev/google-services.json"
+generated_env="$app_root/lib/env/dev_env.g.dart"
+
+fail() {
+  echo "Android physical-test auth preflight FAILED: $*" >&2
+  exit 1
+}
+
+for required in "$env_file" "$firebase_dart" "$google_services" "$generated_env"; do
+  [[ -f "$required" ]] || fail "missing $required"
+done
+
+api_base_url="$(awk -F= '$1 == "API_BASE_URL" { print substr($0, index($0, "=") + 1) }' "$env_file")"
+[[ "$api_base_url" == "https://api.omiapi.com/" ]] ||
+  fail ".dev.env targets '${api_base_url:-<empty>}' instead of the production API"
+
+python3 - "$google_services" "$firebase_dart" "$generated_env" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+google_services = Path(sys.argv[1])
+firebase_dart = Path(sys.argv[2])
+generated_env = Path(sys.argv[3])
+
+config = json.loads(google_services.read_text(encoding="utf-8"))
+project_id = config.get("project_info", {}).get("project_id")
+packages = {
+    client.get("client_info", {}).get("android_client_info", {}).get("package_name")
+    for client in config.get("client", [])
+}
+if project_id != "based-hardware":
+    raise SystemExit(
+        "Android physical-test auth preflight FAILED: "
+        f"google-services project is {project_id!r}, expected 'based-hardware'"
+    )
+if "com.friend.ios.dev" not in packages:
+    raise SystemExit(
+        "Android physical-test auth preflight FAILED: "
+        "google-services has no com.friend.ios.dev client"
+    )
+
+source = firebase_dart.read_text(encoding="utf-8")
+android_block = re.search(
+    r"static const FirebaseOptions android = FirebaseOptions\((.*?)\n  \);",
+    source,
+    re.DOTALL,
+)
+if android_block is None or "projectId: 'based-hardware'" not in android_block.group(1):
+    raise SystemExit(
+        "Android physical-test auth preflight FAILED: "
+        "firebase_options_dev.dart Android options do not target based-hardware"
+    )
+
+generated_source = generated_env.read_text(encoding="utf-8")
+
+def envied_ints(name: str) -> list[int]:
+    match = re.search(
+        rf"static const List<int> {re.escape(name)} = <int>\[(.*?)\];",
+        generated_source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise SystemExit(
+            "Android physical-test auth preflight FAILED: "
+            f"generated dev env has no {name}"
+        )
+    return [int(value) for value in re.findall(r"\d+", match.group(1))]
+
+keys = envied_ints("_enviedkeyapiBaseUrl")
+data = envied_ints("_envieddataapiBaseUrl")
+decoded_api_url = "".join(chr(value ^ keys[index]) for index, value in enumerate(data))
+if decoded_api_url != "https://api.omiapi.com/":
+    raise SystemExit(
+        "Android physical-test auth preflight FAILED: "
+        "generated dev_env.g.dart does not embed the production API; "
+        "run `dart run build_runner clean` before regenerating"
+    )
+PY
+
+echo "Android physical-test auth preflight: PASS (generated prod API + prod Firebase, dev package)"

--- a/app/scripts/verify_ios_physical_test_auth_config.sh
+++ b/app/scripts/verify_ios_physical_test_auth_config.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_root="${OMI_PHYSICAL_TEST_APP_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+env_file="$app_root/.dev.env"
+firebase_dart="$app_root/lib/firebase_options_dev.dart"
+google_services="$app_root/ios/Config/Dev/GoogleService-Info.plist"
+generated_env="$app_root/lib/env/dev_env.g.dart"
+
+fail() {
+  echo "iOS physical-test auth preflight FAILED: $*" >&2
+  exit 1
+}
+
+for required in "$env_file" "$firebase_dart" "$google_services" "$generated_env"; do
+  [[ -f "$required" ]] || fail "missing $required"
+done
+
+api_base_url="$(awk -F= '$1 == "API_BASE_URL" { print substr($0, index($0, "=") + 1) }' "$env_file")"
+[[ "$api_base_url" == "https://api.omiapi.com/" ]] ||
+  fail ".dev.env targets '${api_base_url:-<empty>}' instead of the production API"
+
+python3 - "$google_services" "$firebase_dart" "$generated_env" <<'PY'
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+google_services = Path(sys.argv[1])
+firebase_dart = Path(sys.argv[2])
+generated_env = Path(sys.argv[3])
+
+with google_services.open("rb") as stream:
+    config = plistlib.load(stream)
+
+project_id = config.get("PROJECT_ID")
+google_app_id = config.get("GOOGLE_APP_ID")
+if project_id != "based-hardware":
+    raise SystemExit(
+        "iOS physical-test auth preflight FAILED: "
+        f"GoogleService-Info project is {project_id!r}, expected 'based-hardware'"
+    )
+if not isinstance(google_app_id, str) or ":ios:" not in google_app_id:
+    raise SystemExit(
+        "iOS physical-test auth preflight FAILED: "
+        "GoogleService-Info GOOGLE_APP_ID is not an iOS Firebase registration"
+    )
+
+source = firebase_dart.read_text(encoding="utf-8")
+ios_block = re.search(
+    r"static const FirebaseOptions ios = FirebaseOptions\((.*?)\n  \);",
+    source,
+    re.DOTALL,
+)
+if ios_block is None or "projectId: 'based-hardware'" not in ios_block.group(1):
+    raise SystemExit(
+        "iOS physical-test auth preflight FAILED: "
+        "firebase_options_dev.dart iOS options do not target based-hardware"
+    )
+app_id_match = re.search(r"appId:\s*'([^']+)'", ios_block.group(1))
+if app_id_match is None or ":ios:" not in app_id_match.group(1):
+    raise SystemExit(
+        "iOS physical-test auth preflight FAILED: "
+        "firebase_options_dev.dart iOS appId is not an iOS Firebase registration"
+    )
+
+generated_source = generated_env.read_text(encoding="utf-8")
+
+
+def envied_ints(name: str) -> list[int]:
+    match = re.search(
+        rf"static const List<int> {re.escape(name)} = <int>\[(.*?)\];",
+        generated_source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise SystemExit(
+            "iOS physical-test auth preflight FAILED: "
+            f"generated dev env has no {name}"
+        )
+    return [int(value) for value in re.findall(r"\d+", match.group(1))]
+
+
+keys = envied_ints("_enviedkeyapiBaseUrl")
+data = envied_ints("_envieddataapiBaseUrl")
+decoded_api_url = "".join(chr(value ^ keys[index]) for index, value in enumerate(data))
+if decoded_api_url != "https://api.omiapi.com/":
+    raise SystemExit(
+        "iOS physical-test auth preflight FAILED: "
+        "generated dev_env.g.dart does not embed the production API; "
+        "run `dart run build_runner clean` before regenerating"
+    )
+PY
+
+echo "iOS physical-test auth preflight: PASS (generated prod API + prod Firebase, isolated dev app)"

--- a/app/scripts/verify_ios_physical_test_auth_config.sh
+++ b/app/scripts/verify_ios_physical_test_auth_config.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 app_root="${OMI_PHYSICAL_TEST_APP_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$script_dir/physical_test_customer_plane.sh"
 env_file="$app_root/.dev.env"
 firebase_dart="$app_root/lib/firebase_options_dev.dart"
 google_services="$app_root/ios/Config/Dev/GoogleService-Info.plist"
@@ -17,10 +20,11 @@ for required in "$env_file" "$firebase_dart" "$google_services" "$generated_env"
 done
 
 api_base_url="$(awk -F= '$1 == "API_BASE_URL" { print substr($0, index($0, "=") + 1) }' "$env_file")"
-[[ "$api_base_url" == "https://api.omiapi.com/" ]] ||
-  fail ".dev.env targets '${api_base_url:-<empty>}' instead of the production API"
+[[ "$api_base_url" == "$OMI_PHYSICAL_TEST_API_BASE_URL" ]] ||
+  fail ".dev.env targets '${api_base_url:-<empty>}' instead of the canonical customer API $OMI_PHYSICAL_TEST_API_BASE_URL"
 
-python3 - "$google_services" "$firebase_dart" "$generated_env" <<'PY'
+python3 - "$google_services" "$firebase_dart" "$generated_env" \
+  "$OMI_PHYSICAL_TEST_API_BASE_URL" "$OMI_PHYSICAL_TEST_FIREBASE_PROJECT_ID" <<'PY'
 import plistlib
 import re
 import sys
@@ -29,16 +33,18 @@ from pathlib import Path
 google_services = Path(sys.argv[1])
 firebase_dart = Path(sys.argv[2])
 generated_env = Path(sys.argv[3])
+expected_api_url = sys.argv[4]
+expected_project_id = sys.argv[5]
 
 with google_services.open("rb") as stream:
     config = plistlib.load(stream)
 
 project_id = config.get("PROJECT_ID")
 google_app_id = config.get("GOOGLE_APP_ID")
-if project_id != "based-hardware":
+if project_id != expected_project_id:
     raise SystemExit(
         "iOS physical-test auth preflight FAILED: "
-        f"GoogleService-Info project is {project_id!r}, expected 'based-hardware'"
+        f"GoogleService-Info project is {project_id!r}, expected {expected_project_id!r}"
     )
 if not isinstance(google_app_id, str) or ":ios:" not in google_app_id:
     raise SystemExit(
@@ -52,7 +58,7 @@ ios_block = re.search(
     source,
     re.DOTALL,
 )
-if ios_block is None or "projectId: 'based-hardware'" not in ios_block.group(1):
+if ios_block is None or f"projectId: '{expected_project_id}'" not in ios_block.group(1):
     raise SystemExit(
         "iOS physical-test auth preflight FAILED: "
         "firebase_options_dev.dart iOS options do not target based-hardware"
@@ -84,7 +90,7 @@ def envied_ints(name: str) -> list[int]:
 keys = envied_ints("_enviedkeyapiBaseUrl")
 data = envied_ints("_envieddataapiBaseUrl")
 decoded_api_url = "".join(chr(value ^ keys[index]) for index, value in enumerate(data))
-if decoded_api_url != "https://api.omiapi.com/":
+if decoded_api_url != expected_api_url:
     raise SystemExit(
         "iOS physical-test auth preflight FAILED: "
         "generated dev_env.g.dart does not embed the production API; "
@@ -92,4 +98,4 @@ if decoded_api_url != "https://api.omiapi.com/":
     )
 PY
 
-echo "iOS physical-test auth preflight: PASS (generated prod API + prod Firebase, isolated dev app)"
+echo "iOS physical-test auth preflight: PASS (canonical production API + prod Firebase, isolated dev app)"

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -1181,10 +1181,12 @@ void main() {
     test('connectivity flicker does not toggle readiness of a ready socket', () {
       final provider = CaptureProvider();
 
-      // Drive the provider into the socket-subscribed state (the scenario the
-      // old getter got wrong): onConnected mirrors the transcript WebSocket
-      // subscribing, which sets _transcriptServiceReady = true.
+      // Drive the provider through the production readiness boundary. A raw
+      // WebSocket connection is not sufficient: the STT service must publish
+      // its explicit ready status before audio or UI claims the session works.
       provider.onConnected();
+      expect(provider.transcriptServiceReady, isFalse);
+      provider.onMessageEventReceived(MessageServiceStatusEvent(status: 'ready'));
       expect(provider.transcriptServiceReady, isTrue);
 
       // A connectivity flicker must not toggle readiness off. Before the fix

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -609,6 +609,41 @@ void main() {
   });
 
   group('terminal live transcription status', () {
+    test('reports an abnormal live transport close as retrying until ready', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(
+        _device(id: 'cv1-a', type: DeviceType.omi),
+      );
+      provider.updateRecordingState(RecordingState.deviceRecord);
+
+      provider.onClosed(1006);
+
+      final failure = provider.terminalTranscriptionFailure;
+      expect(failure?.status, 'stt_failed');
+      expect(failure?.provider, 'transport');
+      expect(failure?.outcome, 'transport_unavailable');
+      expect(failure?.reason, 'socket_closed');
+      expect(failure?.retryable, isTrue);
+
+      provider.onMessageEventReceived(MessageServiceStatusEvent(status: 'ready'));
+      expect(provider.terminalTranscriptionFailure, isNull);
+      provider.dispose();
+    });
+
+    test('reports a live transport error as retrying', () {
+      final provider = CaptureProvider();
+      provider.updateRecordingDevice(
+        _device(id: 'cv1-a', type: DeviceType.omi),
+      );
+      provider.updateRecordingState(RecordingState.deviceRecord);
+
+      provider.onError(StateError('socket failed'));
+
+      expect(provider.terminalTranscriptionFailure?.reason, 'socket_error');
+      expect(provider.terminalTranscriptionFailure?.retryable, isTrue);
+      provider.dispose();
+    });
+
     test('preserves server STT failure across socket close until ready', () {
       final provider = CaptureProvider();
       final failure = MessageServiceStatusEvent(

--- a/app/test/providers/device_provider_test.dart
+++ b/app/test/providers/device_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -6,6 +8,8 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/providers/device_provider.dart';
+import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/analytics/analytics_adapter.dart';
 import 'package:omi/utils/analytics/analytics_manager.dart';
@@ -351,6 +355,316 @@ void main() {
       expect(flag2, true, reason: 'Exactly 20% should not reset flag (needs > 20)');
     });
   });
+
+  group('DFU connection ownership', () {
+    const noRetryPolicy = DfuReconnectRetryPolicy(retryDelays: []);
+    late _DfuTestDeviceService deviceService;
+    late DeviceProvider provider;
+
+    setUp(() {
+      deviceService = _DfuTestDeviceService(retryPolicy: noRetryPolicy);
+      provider = DeviceProvider(deviceService: deviceService)
+        ..connectedDevice = BtDevice(name: 'Omi', id: 'device-123', type: DeviceType.omi, rssi: -40);
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    test('awaits one disconnect then force-reconnects the captured device exactly once', () async {
+      final disconnectGate = Completer<void>();
+      final reconnectGate = Completer<void>();
+      deviceService
+        ..disconnectGate = disconnectGate
+        ..reconnectGate = reconnectGate;
+
+      var prepareCompleted = false;
+      final firstPrepare = provider.prepareDFU().then((_) => prepareCompleted = true);
+      final duplicatePrepare = provider.prepareDFU();
+      await pumpEventQueue();
+
+      expect(deviceService.events, ['disconnect']);
+      expect(prepareCompleted, isFalse);
+      expect(provider.isFirmwareUpdateInProgress, isTrue);
+
+      disconnectGate.complete();
+      await Future.wait([firstPrepare, duplicatePrepare]);
+
+      final firstResume = provider.resumeConnectionAfterDFU();
+      final duplicateResume = provider.resumeConnectionAfterDFU();
+      await pumpEventQueue();
+
+      expect(deviceService.events, ['disconnect', 'release transport', 'reconnect:device-123:true']);
+      expect(provider.isFirmwareUpdateInProgress, isTrue);
+
+      reconnectGate.complete();
+      await Future.wait([firstResume, duplicateResume]);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+
+      await provider.resumeConnectionAfterDFU();
+      expect(deviceService.events, ['disconnect', 'release transport', 'reconnect:device-123:true']);
+    });
+
+    test('a failed disconnect rolls the exact owner back and permits a later DFU', () async {
+      deviceService.disconnectError = StateError('disconnect failed');
+
+      await expectLater(provider.prepareDFU(), throwsStateError);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+      expect(deviceService.events, ['disconnect', 'reconnect:device-123:true']);
+
+      deviceService.disconnectError = null;
+      await provider.prepareDFU();
+      await provider.resumeConnectionAfterDFU();
+
+      expect(deviceService.events, [
+        'disconnect',
+        'reconnect:device-123:true',
+        'disconnect',
+        'release transport',
+        'reconnect:device-123:true',
+      ]);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+    });
+
+    test('a failed exact-device reconnect retains its lease for a later retry', () async {
+      deviceService.reconnectError = StateError('reconnect failed');
+      await provider.prepareDFU();
+
+      await expectLater(provider.resumeConnectionAfterDFU(), throwsStateError);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+
+      deviceService.reconnectError = null;
+      await provider.resumeConnectionAfterDFU();
+      expect(deviceService.events, [
+        'disconnect',
+        'release transport',
+        'reconnect:device-123:true',
+        'reconnect:device-123:true',
+      ]);
+    });
+
+    test('production reclaim retries a transient null result and then releases the exact-device lease', () async {
+      final delays = <Duration>[];
+      provider.dispose();
+      deviceService = _DfuTestDeviceService(
+        retryPolicy: const DfuReconnectRetryPolicy(retryDelays: [Duration(milliseconds: 500)]),
+        reconnectDelay: (delay) async => delays.add(delay),
+      )..nullReconnectsRemaining = 1;
+      provider = DeviceProvider(deviceService: deviceService)
+        ..connectedDevice = BtDevice(name: 'Omi', id: 'device-retry', type: DeviceType.omi, rssi: -40);
+
+      await provider.prepareDFU();
+      await provider.resumeConnectionAfterDFU();
+      await provider.resumeConnectionAfterDFU();
+
+      expect(deviceService.events, [
+        'disconnect',
+        'release transport',
+        'reconnect:device-retry:true',
+        'reconnect:device-retry:true',
+      ]);
+      expect(delays, [const Duration(milliseconds: 500)]);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+    });
+
+    test('duplicate resume callers share one bounded fail-then-success retry loop', () async {
+      final retryGate = Completer<void>();
+      provider.dispose();
+      deviceService = _DfuTestDeviceService(
+        retryPolicy: const DfuReconnectRetryPolicy(retryDelays: [Duration(milliseconds: 500)]),
+        reconnectDelay: (_) => retryGate.future,
+      )..nullReconnectsRemaining = 1;
+      provider = DeviceProvider(deviceService: deviceService)
+        ..connectedDevice = BtDevice(name: 'Omi', id: 'device-duplicate', type: DeviceType.omi, rssi: -40);
+
+      await provider.prepareDFU();
+      final terminalCallback = provider.resumeConnectionAfterDFU();
+      final pageDisposal = provider.resumeConnectionAfterDFU();
+      await pumpEventQueue();
+
+      expect(
+        deviceService.events.where((event) => event.startsWith('reconnect:')),
+        hasLength(1),
+      );
+
+      retryGate.complete();
+      await Future.wait([terminalCallback, pageDisposal]);
+
+      expect(
+        deviceService.events.where((event) => event.startsWith('reconnect:')),
+        hasLength(2),
+      );
+      await provider.resumeConnectionAfterDFU();
+      expect(
+        deviceService.events.where((event) => event.startsWith('reconnect:')),
+        hasLength(2),
+      );
+    });
+
+    test('exhausted bounded reclaim reports failure and retains the lease for a later explicit retry', () async {
+      final delays = <Duration>[];
+      provider.dispose();
+      deviceService = _DfuTestDeviceService(
+        retryPolicy: const DfuReconnectRetryPolicy(
+          retryDelays: [Duration(milliseconds: 500), Duration(milliseconds: 1500)],
+        ),
+        reconnectDelay: (delay) async => delays.add(delay),
+      )..nullReconnectsRemaining = 3;
+      provider = DeviceProvider(deviceService: deviceService)
+        ..connectedDevice = BtDevice(name: 'Omi', id: 'device-exhausted', type: DeviceType.omi, rssi: -40);
+
+      await provider.prepareDFU();
+      await expectLater(
+        provider.resumeConnectionAfterDFU(),
+        throwsA(isA<DeviceConnectionException>()),
+      );
+
+      expect(
+        deviceService.events.where((event) => event.startsWith('reconnect:')),
+        hasLength(3),
+      );
+      expect(
+        delays,
+        [
+          const Duration(milliseconds: 500),
+          const Duration(milliseconds: 1500),
+        ],
+      );
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+
+      await provider.resumeConnectionAfterDFU();
+      expect(
+        deviceService.events.where((event) => event.startsWith('reconnect:')),
+        hasLength(4),
+      );
+    });
+
+    test('post-disconnect release failure rolls back once and rethrows the original error to duplicate callers',
+        () async {
+      final releaseGate = Completer<void>();
+      final releaseError = StateError('transport release failed');
+      deviceService
+        ..releaseGate = releaseGate
+        ..releaseError = releaseError;
+
+      final firstPrepare = provider.prepareDFU();
+      final duplicatePrepare = provider.prepareDFU();
+      final firstExpectation = expectLater(firstPrepare, throwsA(same(releaseError)));
+      final duplicateExpectation = expectLater(duplicatePrepare, throwsA(same(releaseError)));
+      await pumpEventQueue();
+
+      expect(deviceService.events, ['disconnect', 'release transport']);
+      expect(provider.isFirmwareUpdateInProgress, isTrue);
+
+      releaseGate.complete();
+      await Future.wait([firstExpectation, duplicateExpectation]);
+
+      expect(deviceService.events, ['disconnect', 'release transport', 'reconnect:device-123:true']);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+    });
+
+    test('rollback failure never replaces the original post-disconnect release error', () async {
+      final releaseError = StateError('transport release failed');
+      deviceService
+        ..releaseError = releaseError
+        ..reconnectError = StateError('rollback reconnect failed');
+
+      await expectLater(provider.prepareDFU(), throwsA(same(releaseError)));
+
+      expect(deviceService.events, ['disconnect', 'release transport', 'reconnect:device-123:true']);
+      expect(provider.isFirmwareUpdateInProgress, isFalse);
+    });
+
+    test('a null force-reconnect result is a failure and remains retryable', () async {
+      final nullReconnectService = _NullReconnectDeviceService();
+      final nullReconnectProvider = DeviceProvider(deviceService: nullReconnectService)
+        ..connectedDevice = BtDevice(name: 'Omi', id: 'device-null', type: DeviceType.omi, rssi: -40);
+      addTearDown(nullReconnectProvider.dispose);
+
+      await nullReconnectProvider.prepareDFU();
+
+      await expectLater(
+        nullReconnectProvider.resumeConnectionAfterDFU(),
+        throwsA(isA<DeviceConnectionException>()),
+      );
+      await expectLater(
+        nullReconnectProvider.resumeConnectionAfterDFU(),
+        throwsA(isA<DeviceConnectionException>()),
+      );
+
+      expect(nullReconnectService.reconnectAttempts, 2);
+      expect(nullReconnectProvider.isFirmwareUpdateInProgress, isFalse);
+    });
+  });
+}
+
+class _DfuTestDeviceService extends DeviceService {
+  _DfuTestDeviceService({
+    required DfuReconnectRetryPolicy retryPolicy,
+    DfuReconnectDelay? reconnectDelay,
+  }) : super(
+          dfuReconnectRetryPolicy: retryPolicy,
+          dfuReconnectDelay: reconnectDelay,
+        );
+
+  final List<String> events = [];
+  Completer<void>? disconnectGate;
+  Completer<void>? releaseGate;
+  Completer<void>? reconnectGate;
+  Object? disconnectError;
+  Object? releaseError;
+  Object? reconnectError;
+  int nullReconnectsRemaining = 0;
+
+  @override
+  Future<void> disconnectDevice() async {
+    events.add('disconnect');
+    final error = disconnectError;
+    if (error != null) throw error;
+    await disconnectGate?.future;
+  }
+
+  @override
+  Future<void> releaseSuspendedConnectionTransportForDfu(DeviceConnection? connection) async {
+    events.add('release transport');
+    await releaseGate?.future;
+    final error = releaseError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<bool> reconnectSuspendedDeviceForDfu(String deviceId) async {
+    events.add('reconnect:$deviceId:true');
+    final error = reconnectError;
+    if (error != null) throw error;
+    await reconnectGate?.future;
+    if (nullReconnectsRemaining > 0) {
+      nullReconnectsRemaining--;
+      return false;
+    }
+    return true;
+  }
+}
+
+class _NullReconnectDeviceService extends DeviceService {
+  _NullReconnectDeviceService()
+      : super(
+          dfuReconnectRetryPolicy: const DfuReconnectRetryPolicy(retryDelays: []),
+        );
+
+  int reconnectAttempts = 0;
+
+  @override
+  Future<void> disconnectDevice() async {}
+
+  @override
+  Future<void> releaseSuspendedConnectionTransportForDfu(DeviceConnection? connection) async {}
+
+  @override
+  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false}) async {
+    reconnectAttempts++;
+    return null;
+  }
 }
 
 class _TestAnalyticsAdapter implements AnalyticsAdapter {

--- a/app/test/providers/device_provider_test.dart
+++ b/app/test/providers/device_provider_test.dart
@@ -6,13 +6,35 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/gen/pigeon_communicator.g.dart';
+import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/services/devices.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/analytics/analytics_adapter.dart';
 import 'package:omi/utils/analytics/analytics_manager.dart';
+import 'package:omi/utils/enums.dart';
+
+class _CaptureReconnectSpy extends CaptureProvider {
+  final List<String> events = [];
+
+  @override
+  bool get hasActiveDeviceAudioStream => true;
+
+  @override
+  Future streamDeviceRecording({BtDevice? device}) async {
+    events.add('start:${device?.id}');
+  }
+
+  @override
+  Future<void> resumeDeviceRecordingAfterReconnect({
+    required BtDevice device,
+  }) async {
+    events.add('resume:${device.id}');
+  }
+}
 
 class _TestConnectivityPlatform extends ConnectivityPlatform {
   @override
@@ -272,6 +294,47 @@ void main() {
 
       expect(result, true);
       expect(notifyCount, 2);
+    });
+  });
+
+  group('capture ownership after BLE reconnect', () {
+    late DeviceProvider provider;
+    late _CaptureReconnectSpy capture;
+    late BtDevice device;
+
+    setUp(() {
+      capture = _CaptureReconnectSpy();
+      provider = DeviceProvider()..captureProvider = capture;
+      device = BtDevice(
+        name: 'Omi',
+        id: 'device-123',
+        type: DeviceType.omi,
+        rssi: -40,
+      );
+    });
+
+    tearDown(() {
+      provider.dispose();
+      capture.dispose();
+    });
+
+    test('cold connection starts a new capture session', () async {
+      capture.updateRecordingState(RecordingState.stop);
+
+      await provider.startOrResumeCaptureForTesting(device);
+
+      expect(capture.events, ['start:device-123']);
+    });
+
+    test('transient BLE reconnect resumes the existing live preview', () async {
+      capture
+        ..segments = [_testSegment()]
+        ..updateRecordingState(RecordingState.deviceRecord);
+
+      await provider.startOrResumeCaptureForTesting(device);
+
+      expect(capture.events, ['resume:device-123']);
+      expect(capture.segments.single.text, 'existing preview');
     });
   });
 
@@ -597,6 +660,17 @@ void main() {
     });
   });
 }
+
+TranscriptSegment _testSegment() => TranscriptSegment(
+      id: 'segment-1',
+      text: 'existing preview',
+      speaker: 'SPEAKER_00',
+      isUser: false,
+      personId: null,
+      start: 0,
+      end: 1,
+      translations: const [],
+    );
 
 class _DfuTestDeviceService extends DeviceService {
   _DfuTestDeviceService({

--- a/app/test/providers/sync_provider_startup_reconciliation_test.dart
+++ b/app/test/providers/sync_provider_startup_reconciliation_test.dart
@@ -25,7 +25,12 @@ void main() {
         statusCalls++;
         return {'stage': 'none'};
       },
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async =>
+      uploader: (files,
+              {onUploadProgress,
+              conversationId,
+              claimLiveCapture = false,
+              syncLane = SyncUploadLane.fresh,
+              replaceTranscript = false}) async =>
           UploadFilesResult.queued('unused'),
     );
     final provider = SyncProvider(walService: WalService(), uploadGate: gate, startBackgroundSync: false);
@@ -46,7 +51,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async =>
+      uploader: (files,
+              {onUploadProgress,
+              conversationId,
+              claimLiveCapture = false,
+              syncLane = SyncUploadLane.fresh,
+              replaceTranscript = false}) async =>
           UploadFilesResult.queued('unused'),
     );
     var startupWakes = 0;

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -587,6 +587,18 @@ void main() {
     expect(provider.logicalRingArchiveMembersForTest(logical), archives);
     expect(logical.seconds, 3000, reason: 'display duration is the wall-clock span, not compressed audio sum');
     expect(provider.pendingStatusCount, 1);
+    expect(provider.readyToSyncRecordingCount, 1);
+    expect(provider.processingRecordingCount, 0);
+    expect(provider.missingWals, hasLength(10), reason: 'physical transport accounting remains independent');
+
+    for (final archive in archives) {
+      archive.status = WalStatus.uploaded;
+    }
+    await provider.refreshWals();
+
+    expect(provider.readyToSyncRecordingCount, 0);
+    expect(provider.processingRecordingCount, 1);
+    expect(provider.uploadedWals, hasLength(10), reason: 'server reconciliation still retains every physical member');
   });
 
   test('backend-minimum silence boundary joins inside the boundary and splits at it', () async {

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -4,6 +4,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 import 'package:omi/services/wals/wal.dart';
@@ -15,8 +16,23 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _FakeSyncs {
   final List<Wal> wals;
   int syncWalCalls = 0;
+  int deleteWalCalls = 0;
+  final List<Wal> selectedSyncWals = [];
+  int syncAllCalls = 0;
+  int syncPhoneWalsCalls = 0;
+  int syncAuthorizedRingRecoveryCalls = 0;
+  int requestedRingDrains = 0;
+  bool ringAudioTailActive = false;
+  bool storageSyncing = false;
+  int nextRingTargetSeq = 200;
   SyncLocalFilesResponse? nextSyncResult;
   Completer<SyncLocalFilesResponse?>? hangSyncWal;
+  Object? syncWalError;
+  Completer<RingBacklogDrainReceipt?>? ringBacklogDrain;
+  RingBacklogDrainReceipt? pendingAutomaticRingBacklogReceipt;
+  final List<AuthorizedRecoverySyncResult> authorizedRecoveryResults = [];
+  final List<RingBacklogDrainReceipt> authorizedReceipts = [];
+  final List<bool> phoneSyncIncludeBackfill = [];
 
   _FakeSyncs(this.wals);
 
@@ -24,15 +40,77 @@ class _FakeSyncs {
 
   Future<void> refreshWalsFromDevice({String? firmwareVersion}) async {}
 
-  bool get isStorageSyncing => false;
+  bool get isStorageSyncing => storageSyncing;
   bool get isSdCardSyncing => false;
+  bool get isRingAudioTailActive => ringAudioTailActive;
 
   SyncLocalFilesResponse? get accumulatedResponse => null;
 
   void cancelSync() {}
 
+  Future<RingBacklogDrainReceipt?>? requestActiveRingBacklogDrain() {
+    if (!ringAudioTailActive) return null;
+    requestedRingDrains++;
+    return ringBacklogDrain?.future ??
+        Future<RingBacklogDrainReceipt?>.value(
+          RingBacklogDrainReceipt(
+            deviceId: 'cv1-test',
+            targetWriteSeq: nextRingTargetSeq,
+          ),
+        );
+  }
+
+  Future<SyncLocalFilesResponse?> syncPhoneWals({
+    IWalSyncProgressListener? progress,
+    bool includeBackfill = false,
+  }) async {
+    syncPhoneWalsCalls++;
+    phoneSyncIncludeBackfill.add(includeBackfill);
+    for (final wal in wals.where((wal) => wal.status == WalStatus.miss)) {
+      wal.status = WalStatus.uploaded;
+      wal.jobId = 'job-phone-only';
+    }
+    return SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+  }
+
+  Future<AuthorizedRecoverySyncResult> syncAuthorizedRingRecovery({
+    required RingBacklogDrainReceipt receipt,
+    IWalSyncProgressListener? progress,
+  }) async {
+    syncAuthorizedRingRecoveryCalls++;
+    authorizedReceipts.add(receipt);
+    final result = authorizedRecoveryResults.isEmpty
+        ? const AuthorizedRecoverySyncResult(
+            response: null,
+            hasDeferredRecovery: false,
+          )
+        : authorizedRecoveryResults.removeAt(0);
+    if ((result.response?.localUploadFailures ?? 0) == 0 && !result.hasDeferredRecovery) {
+      for (final wal in wals.where((wal) => wal.status == WalStatus.miss)) {
+        wal.status = WalStatus.synced;
+      }
+    }
+    return result;
+  }
+
+  void completeAutomaticRingBacklogReceipt(
+    RingBacklogDrainReceipt receipt,
+  ) {
+    if (identical(pendingAutomaticRingBacklogReceipt, receipt)) {
+      pendingAutomaticRingBacklogReceipt = null;
+    }
+  }
+
+  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async {
+    syncAllCalls++;
+    return SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
+  }
+
   Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
     syncWalCalls++;
+    selectedSyncWals.add(wal);
+    final error = syncWalError;
+    if (error != null) throw error;
     final hang = hangSyncWal;
     if (hang != null) return hang.future;
     final result = nextSyncResult ?? SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
@@ -42,6 +120,11 @@ class _FakeSyncs {
       wal.jobId = 'job-202';
     }
     return result;
+  }
+
+  Future<void> deleteWal(Wal wal) async {
+    deleteWalCalls++;
+    wals.remove(wal);
   }
 }
 
@@ -134,7 +217,7 @@ void main() {
     provider.dispose();
   });
 
-  test('syncWal during an in-flight sync wakes the coordinator instead of racing', () async {
+  test('syncWal during an in-flight sync queues the exact row instead of widening authority', () async {
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
     SyncRateLimiter.instance.clear();
@@ -161,13 +244,19 @@ void main() {
     expect(provider.isSyncing, isTrue);
     expect(syncs.syncWalCalls, 1);
 
-    await provider.syncWal(other);
+    final second = provider.syncWal(other);
+    await Future<void>.delayed(Duration.zero);
 
     expect(syncs.syncWalCalls, 1, reason: 'contended syncWal must not start a parallel upload');
-    expect(wakes, [WakeTrigger.userRetry]);
+    expect(wakes, isEmpty);
 
+    syncs.hangSyncWal = null;
     hang.complete(SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []));
     await first;
+    await second;
+
+    expect(syncs.syncWalCalls, 2);
+    expect(wakes, [WakeTrigger.cooldownElapsed, WakeTrigger.cooldownElapsed]);
     provider.dispose();
   });
 
@@ -183,7 +272,6 @@ void main() {
 
     final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
     final syncs = _FakeSyncs([wal]);
-
     final provider = SyncProvider(
       walService: _FakeWalService(syncs),
       startBackgroundSync: true,
@@ -199,4 +287,452 @@ void main() {
     expect(syncs.syncWalCalls, 1, reason: 'device recovery must stay available during an upload cooldown');
     provider.dispose();
   });
+
+  test('single-row retry during an active tail preserves exact phone row identity', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+    );
+    final syncs = _FakeSyncs([wal])..ringAudioTailActive = true;
+    final wakes = <WakeTrigger>[];
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async => wakes.add(trigger),
+    );
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(wakes, [WakeTrigger.cooldownElapsed]);
+    expect(syncs.syncWalCalls, 1);
+    expect(syncs.requestedRingDrains, 0);
+    expect(syncs.syncAllCalls, 0);
+    provider.dispose();
+  });
+
+  test('failed-row retry does not widen into a manual device snapshot', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+    );
+    final syncs = _FakeSyncs([wal])..syncWalError = StateError('row upload failed');
+    final wakes = <WakeTrigger>[];
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async => wakes.add(trigger),
+    );
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+    expect(provider.failedWal, same(wal));
+
+    syncs
+      ..syncWalError = null
+      ..ringAudioTailActive = true;
+    await provider.retrySync();
+
+    expect(syncs.syncWalCalls, 2);
+    expect(syncs.requestedRingDrains, 0);
+    expect(syncs.syncAllCalls, 0);
+    expect(wakes, [WakeTrigger.cooldownElapsed]);
+    provider.dispose();
+  });
+
+  test('selected device row stays scoped while the audio tail owns BLE', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.sdcard,
+      fileNum: -1,
+    );
+    final syncs = _FakeSyncs([wal])
+      ..ringAudioTailActive = true
+      ..storageSyncing = true;
+    final wakes = <WakeTrigger>[];
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async => wakes.add(trigger),
+    );
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(provider.failedWal, same(wal));
+    expect(syncs.syncWalCalls, 0);
+    expect(syncs.requestedRingDrains, 0);
+    expect(syncs.syncAllCalls, 0);
+    expect(wakes, isEmpty);
+    provider.dispose();
+  });
+
+  test('manual ring sync with auto-sync off waits for tail snapshot then uploads phone-only', () async {
+    SharedPreferences.setMockInitialValues({'autoSyncOfflineRecordings': false});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      sourceId: 'archive_ring_100_200_1000',
+    );
+    final tailDrain = Completer<RingBacklogDrainReceipt?>();
+    final syncs = _FakeSyncs([wal])
+      ..ringAudioTailActive = true
+      ..storageSyncing = true
+      ..ringBacklogDrain = tailDrain;
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: false,
+    );
+    await provider.initialized;
+    final coordinator = RecordingTransferCoordinator(
+      reconcile: () async {},
+      discover: () async {},
+      refreshPending: provider.refreshWals,
+      drain: provider.drainEligibleWalsForTest,
+      autoUploadEnabled: () => SharedPreferencesUtil().autoSyncOfflineRecordings,
+    );
+    addTearDown(coordinator.dispose);
+    addTearDown(provider.dispose);
+
+    final manualSync = coordinator.wake(WakeTrigger.userRetry);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(syncs.requestedRingDrains, 1);
+    expect(syncs.syncPhoneWalsCalls, 0);
+    expect(syncs.syncAllCalls, 0);
+
+    tailDrain.complete(
+      const RingBacklogDrainReceipt(
+        deviceId: 'cv1-test',
+        targetWriteSeq: 200,
+      ),
+    );
+    await manualSync;
+
+    expect(syncs.syncAuthorizedRingRecoveryCalls, 1);
+    expect(syncs.syncPhoneWalsCalls, 0);
+    expect(syncs.syncAllCalls, 0, reason: 'the active tail must remain the only ring reader');
+    expect(wal.status, WalStatus.synced);
+  });
+
+  test('cloud retry reuses one completed manual snapshot receipt', () async {
+    SharedPreferences.setMockInitialValues({'autoSyncOfflineRecordings': false});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      sourceId: 'ring_100_200',
+      device: 'cv1-test',
+    );
+    final syncs = _FakeSyncs([wal])
+      ..ringAudioTailActive = true
+      ..storageSyncing = true
+      ..authorizedRecoveryResults.add(
+        AuthorizedRecoverySyncResult(
+          response: SyncLocalFilesResponse(
+            newConversationIds: [],
+            updatedConversationIds: [],
+            localUploadFailures: 1,
+          ),
+          hasDeferredRecovery: true,
+        ),
+      )
+      ..authorizedRecoveryResults.add(
+        const AuthorizedRecoverySyncResult(
+          response: null,
+          hasDeferredRecovery: false,
+        ),
+      );
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: false,
+    );
+    await provider.initialized;
+    void Function()? retry;
+    final coordinator = RecordingTransferCoordinator(
+      reconcile: () async {},
+      discover: () async {},
+      refreshPending: provider.refreshWals,
+      drain: provider.drainEligibleWalsForTest,
+      autoUploadEnabled: () => false,
+      scheduleCooldown: (_, callback) => retry = callback,
+    );
+    addTearDown(coordinator.dispose);
+    addTearDown(provider.dispose);
+
+    await coordinator.wake(WakeTrigger.userRetry);
+
+    expect(syncs.requestedRingDrains, 1);
+    expect(syncs.syncAuthorizedRingRecoveryCalls, 1);
+    expect(retry, isNotNull);
+
+    syncs.nextRingTargetSeq = 999;
+    retry!();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(syncs.requestedRingDrains, 1, reason: 'backend retry must not latch a newer pendant writeSeq');
+    expect(syncs.syncAuthorizedRingRecoveryCalls, 2);
+    expect(
+      syncs.authorizedReceipts.map((receipt) => receipt.targetWriteSeq),
+      [200, 200],
+    );
+    expect(syncs.syncAllCalls, 0);
+  });
+
+  test('foreground wake consumes a completed automatic receipt without a second reader', () async {
+    SharedPreferences.setMockInitialValues({'autoSyncOfflineRecordings': true});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    const receipt = RingBacklogDrainReceipt(
+      deviceId: 'cv1-test',
+      targetWriteSeq: 300,
+    );
+    final wal = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      sourceId: 'archive2_ring_200_300_1000',
+      device: 'cv1-test',
+    );
+    final syncs = _FakeSyncs([wal])
+      ..ringAudioTailActive = true
+      ..storageSyncing = true
+      ..pendingAutomaticRingBacklogReceipt = receipt;
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    final result = await provider.drainEligibleWalsForTest(
+      WakeTrigger.foregrounded,
+    );
+
+    expect(result.failed, isFalse);
+    expect(syncs.syncAuthorizedRingRecoveryCalls, 1);
+    expect(syncs.authorizedReceipts, [receipt]);
+    expect(syncs.syncAllCalls, 0);
+    expect(syncs.requestedRingDrains, 0);
+    expect(syncs.pendingAutomaticRingBacklogReceipt, isNull);
+  });
+
+  test('ten adjacent physical ring archives present as one logical pending recording', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 120});
+    await SharedPreferencesUtil.init();
+    final archives = List.generate(
+      10,
+      (index) => _ringArchive(
+        timerStart: 1000 + index * 300,
+        startSequence: index * 100,
+        endSequence: (index + 1) * 100,
+        playableSeconds: 5,
+      ),
+    );
+    final syncs = _FakeSyncs(archives);
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    expect(provider.userVisibleWals, hasLength(1));
+    final logical = provider.userVisibleWals.single;
+    expect(provider.isLogicalRingArchiveDisplayWal(logical), isTrue);
+    expect(provider.logicalRingArchiveMembersForTest(logical), archives);
+    expect(logical.seconds, 3000, reason: 'display duration is the wall-clock span, not compressed audio sum');
+    expect(provider.pendingStatusCount, 1);
+  });
+
+  test('backend-minimum silence boundary joins inside the boundary and splits at it', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 30});
+    await SharedPreferencesUtil.init();
+    final archives = [
+      _ringArchive(timerStart: 1000, startSequence: 0, endSequence: 100),
+      _ringArchive(timerStart: 1390, startSequence: 100, endSequence: 200),
+      _ringArchive(timerStart: 1810, startSequence: 200, endSequence: 300),
+    ];
+    final provider = SyncProvider(
+      walService: _FakeWalService(_FakeSyncs(archives)),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    expect(provider.userVisibleWals, hasLength(2));
+    expect(provider.pendingStatusCount, 2);
+    expect(provider.userVisibleWals.every(provider.isLogicalRingArchiveDisplayWal), isTrue);
+    expect(provider.logicalRingArchiveMembersForTest(provider.userVisibleWals.first), archives.take(2));
+  });
+
+  test('unlimited conversation setting uses the shared four-hour boundary', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': -1});
+    await SharedPreferencesUtil.init();
+    final archives = [
+      _ringArchive(timerStart: 1000, startSequence: 0, endSequence: 100),
+      _ringArchive(timerStart: 12100, startSequence: 100, endSequence: 200),
+    ];
+    final provider = SyncProvider(
+      walService: _FakeWalService(_FakeSyncs(archives)),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    expect(provider.userVisibleWals, hasLength(1));
+    expect(provider.logicalRingArchiveMembersForTest(provider.userVisibleWals.single), archives);
+  });
+
+  test('conversation boundary preference change invalidates every logical display cache', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 120});
+    await SharedPreferencesUtil.init();
+    final archives = [
+      _ringArchive(timerStart: 1000, startSequence: 0, endSequence: 100),
+      _ringArchive(timerStart: 1420, startSequence: 100, endSequence: 200),
+    ];
+    final provider = SyncProvider(
+      walService: _FakeWalService(_FakeSyncs(archives)),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    expect(provider.userVisibleWals, hasLength(2));
+    expect(provider.pendingWals, hasLength(2));
+    expect(provider.pendingStatusCount, 2);
+    expect(provider.displaySortedWals, hasLength(2));
+
+    SharedPreferencesUtil().conversationSilenceDuration = -1;
+
+    expect(provider.userVisibleWals, hasLength(1));
+    expect(provider.pendingWals, hasLength(1));
+    expect(provider.pendingStatusCount, 1);
+    expect(provider.displaySortedWals, hasLength(1));
+    expect(provider.logicalRingArchiveMembersForTest(provider.displaySortedWals.single), archives);
+  });
+
+  test('logical archive surfaces corruption ahead of pending and uploaded members', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 120});
+    await SharedPreferencesUtil.init();
+    final archives = [
+      _ringArchive(timerStart: 1000, startSequence: 0, endSequence: 100)..status = WalStatus.uploaded,
+      _ringArchive(timerStart: 1300, startSequence: 100, endSequence: 200)..status = WalStatus.miss,
+      _ringArchive(timerStart: 1600, startSequence: 200, endSequence: 300)..status = WalStatus.corrupted,
+    ];
+    final provider = SyncProvider(
+      walService: _FakeWalService(_FakeSyncs(archives)),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    final logical = provider.userVisibleWals.single;
+    expect(logical.status, WalStatus.corrupted);
+    expect(logical.syncDisplayState, WalSyncDisplayState.corrupted);
+    expect(provider.corruptedStatusCount, 1);
+    expect(provider.pendingStatusCount, 0);
+  });
+
+  test('logical ring archive row cannot delete one physical part and sync resolves through its complete group',
+      () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 120});
+    await SharedPreferencesUtil.init();
+    final archives = List.generate(
+      10,
+      (index) => _ringArchive(
+        timerStart: 1000 + index * 300,
+        startSequence: index * 100,
+        endSequence: (index + 1) * 100,
+      ),
+    );
+    archives.first.status = WalStatus.synced;
+    final syncs = _FakeSyncs(archives);
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+    final logical = provider.userVisibleWals.single;
+
+    await provider.deleteWal(logical);
+
+    expect(syncs.deleteWalCalls, 0);
+    expect(syncs.wals, archives);
+    expect(provider.canDeleteWal(logical), isFalse);
+
+    await provider.syncWal(logical);
+
+    expect(provider.logicalRingArchiveMembersForTest(logical), archives);
+    expect(syncs.syncWalCalls, 1);
+    expect(logical.status, WalStatus.miss);
+    expect(syncs.selectedSyncWals.single, same(archives[1]));
+    expect(syncs.selectedSyncWals.single, isNot(same(logical)));
+  });
 }
+
+Wal _ringArchive({
+  required int timerStart,
+  required int startSequence,
+  required int endSequence,
+  int playableSeconds = 300,
+}) =>
+    Wal(
+      timerStart: timerStart,
+      codec: BleAudioCodec.opus,
+      seconds: playableSeconds,
+      captureEndSeconds: timerStart + 300,
+      totalFrames: 30000,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      device: 'cv1-test',
+      sourceId: 'archive2_ring_${startSequence}_${endSequence}_$timerStart',
+      filePath: 'archive-$startSequence-$endSequence.bin',
+      uploadIntent: WalUploadIntent.historicalBackfill,
+    );

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -48,7 +48,9 @@ class _FakeSyncs {
 
   void cancelSync() {}
 
-  Future<RingBacklogDrainReceipt?>? requestActiveRingBacklogDrain() {
+  Future<RingBacklogDrainReceipt?>? requestActiveRingBacklogDrain({
+    IWalSyncProgressListener? progress,
+  }) {
     if (!ringAudioTailActive) return null;
     requestedRingDrains++;
     return ringBacklogDrain?.future ??

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -664,6 +664,34 @@ void main() {
     expect(provider.logicalRingArchiveMembersForTest(provider.userVisibleWals.first), archives.take(2));
   });
 
+  test('a backwards device clock step keeps logical playback in pendant sequence order', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 120});
+    await SharedPreferencesUtil.init();
+    final beforeRollback = _ringArchive(
+      timerStart: 2000,
+      startSequence: 0,
+      endSequence: 100,
+    );
+    final afterRollback = _ringArchive(
+      timerStart: 1000,
+      startSequence: 100,
+      endSequence: 200,
+    );
+    final provider = SyncProvider(
+      walService: _FakeWalService(_FakeSyncs([beforeRollback, afterRollback])),
+      startBackgroundSync: false,
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    expect(provider.userVisibleWals, hasLength(1));
+    expect(
+      provider.logicalRingArchiveMembersForTest(provider.userVisibleWals.single),
+      [beforeRollback, afterRollback],
+      reason: 'display order follows immutable pendant sequence, not the corrected RTC',
+    );
+  });
+
   test('unlimited conversation setting uses the shared four-hour boundary', () async {
     SharedPreferences.setMockInitialValues({'conversationSilenceDuration': -1});
     await SharedPreferencesUtil.init();

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -601,6 +601,46 @@ void main() {
     expect(provider.uploadedWals, hasLength(10), reason: 'server reconciliation still retains every physical member');
   });
 
+  test('logical recording opens one materialized playback artifact', () async {
+    SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 120});
+    await SharedPreferencesUtil.init();
+    final archives = [
+      _ringArchive(timerStart: 1000, startSequence: 0, endSequence: 100),
+      _ringArchive(timerStart: 1300, startSequence: 100, endSequence: 200),
+    ];
+    var materializationCalls = 0;
+    List<Wal>? materializedMembers;
+    final provider = SyncProvider(
+      walService: _FakeWalService(_FakeSyncs(archives)),
+      startBackgroundSync: false,
+      logicalArchivePlaybackMaterializer: (logicalWal, members) async {
+        materializationCalls++;
+        materializedMembers = members;
+        return Wal(
+          timerStart: logicalWal.timerStart,
+          codec: logicalWal.codec,
+          seconds: logicalWal.seconds,
+          status: logicalWal.status,
+          storage: WalStorage.disk,
+          filePath: 'logical-playback.bin',
+          device: logicalWal.device,
+          sourceId: logicalWal.sourceId,
+        );
+      },
+    );
+    addTearDown(provider.dispose);
+    await provider.initialized;
+
+    final logical = provider.userVisibleWals.single;
+    final first = await provider.resolveWalForDetail(logical);
+    final second = await provider.resolveWalForDetail(logical);
+
+    expect(materializedMembers, archives);
+    expect(first, same(second));
+    expect(provider.canPlayOrShareWal(first!), isTrue);
+    expect(materializationCalls, 1);
+  });
+
   test('backend-minimum silence boundary joins inside the boundary and splits at it', () async {
     SharedPreferences.setMockInitialValues({'conversationSilenceDuration': 30});
     await SharedPreferencesUtil.init();

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -73,7 +73,12 @@ Wal _wal({required int timerStart, required String? filePath}) {
 SyncUploadGate _offlineGate() {
   return SyncUploadGate(
     limiter: SyncRateLimiter.instance,
-    uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+    uploader: (files,
+        {onUploadProgress,
+        conversationId,
+        claimLiveCapture = false,
+        syncLane = SyncUploadLane.fresh,
+        replaceTranscript = false}) async {
       throw StateError('unexpected upload in terminal WAL-state test');
     },
     fairUseStatusLoader: () async => {'stage': 'none'},

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -333,6 +333,7 @@ void main() {
         files, {
         onUploadProgress,
         conversationId,
+        claimLiveCapture = false,
         syncLane = SyncUploadLane.fresh,
         replaceTranscript = false,
       }) async {

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -207,4 +207,44 @@ void main() {
 
     expect(syncProvider.allWals, isEmpty, reason: 'Clear All must still be able to remove it');
   });
+
+  test('raw pendant transfer ranges stay hidden until assembled', () async {
+    final rawRange = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      device: 'cv1',
+      filePath: 'raw.bin',
+      sourceId: 'ring_10_11',
+    );
+    final assembledArchive = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      device: 'cv1',
+      filePath: 'archive.bin',
+      sourceId: 'archive_ring_10_40_1000',
+    );
+    localSync.testWals = [rawRange, assembledArchive];
+
+    final syncProvider = SyncProvider(
+      walService: _WalService(_LocalSyncs(localSync)),
+      uploadGate: _offlineGate(),
+      startBackgroundSync: false,
+    );
+    provider = syncProvider;
+    await syncProvider.initialized;
+
+    expect(syncProvider.allWals, [rawRange, assembledArchive]);
+    expect(syncProvider.userVisibleWals, [assembledArchive]);
+    expect(syncProvider.pendingWals, [assembledArchive]);
+    expect(syncProvider.displaySortedWals, [assembledArchive]);
+    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.all), [assembledArchive]);
+  });
 }

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -1,13 +1,18 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/sync_page.dart';
 import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/providers/user_provider.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 import 'package:omi/services/wals/sync_upload_gate.dart';
@@ -257,6 +262,65 @@ void main() {
     expect(syncProvider.pendingWals, [logicalArchive]);
     expect(syncProvider.displaySortedWals, [logicalArchive]);
     expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.all), [logicalArchive]);
+    expect(syncProvider.readyToSyncRecordingCount, 1);
+    expect(syncProvider.processingRecordingCount, 0);
+    expect(syncProvider.missingWals, hasLength(2), reason: 'raw transfer ranges remain internal accounting only');
+  });
+
+  testWidgets('Sync status card counts logical recordings instead of raw pendant ranges', (tester) async {
+    final rawRange = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      device: 'cv1',
+      filePath: 'raw.bin',
+      sourceId: 'ring_10_11',
+    );
+    final assembledArchive = Wal(
+      timerStart: 1000,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      device: 'cv1',
+      filePath: 'archive.bin',
+      sourceId: 'archive_ring_10_40_1000',
+    );
+    localSync.testWals = [rawRange, assembledArchive];
+    final syncProvider = SyncProvider(
+      walService: _WalService(_LocalSyncs(localSync)),
+      uploadGate: _offlineGate(),
+      startBackgroundSync: false,
+    );
+    provider = syncProvider;
+    await syncProvider.initialized;
+    final userProvider = UserProvider(
+      privateCloudSyncFetcher: () async => false,
+      privateCloudSyncSetter: (_) async => true,
+    );
+    addTearDown(userProvider.dispose);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<SyncProvider>.value(value: syncProvider),
+          ChangeNotifierProvider<UserProvider>.value(value: userProvider),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SyncPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('1 recording ready to sync'), findsOneWidget);
+    expect(find.text('2 recordings ready to sync'), findsNothing);
   });
 
   test('logical archive sync submits every physical part in one job while row deletion stays non-destructive',

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -35,6 +35,14 @@ class _LocalSyncs {
   Future<void> deleteAllPendingWals() => phone.deleteAllPendingWals();
 
   Future<void> deleteAllCorruptedWals() => phone.deleteAllCorruptedWals();
+
+  Future<void> deleteWal(Wal wal) => phone.deleteWal(wal);
+
+  Future<SyncLocalFilesResponse?> syncWal({
+    required Wal wal,
+    IWalSyncProgressListener? progress,
+  }) =>
+      phone.syncWal(wal: wal, progress: progress);
 }
 
 class _WalService implements IWalService {
@@ -242,9 +250,80 @@ void main() {
     await syncProvider.initialized;
 
     expect(syncProvider.allWals, [rawRange, assembledArchive]);
-    expect(syncProvider.userVisibleWals, [assembledArchive]);
-    expect(syncProvider.pendingWals, [assembledArchive]);
-    expect(syncProvider.displaySortedWals, [assembledArchive]);
-    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.all), [assembledArchive]);
+    expect(syncProvider.userVisibleWals, hasLength(1));
+    final logicalArchive = syncProvider.userVisibleWals.single;
+    expect(syncProvider.isLogicalRingArchiveDisplayWal(logicalArchive), isTrue);
+    expect(syncProvider.logicalRingArchiveMembersForTest(logicalArchive), [assembledArchive]);
+    expect(syncProvider.pendingWals, [logicalArchive]);
+    expect(syncProvider.displaySortedWals, [logicalArchive]);
+    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.all), [logicalArchive]);
+  });
+
+  test('logical archive sync submits every physical part in one job while row deletion stays non-destructive',
+      () async {
+    SharedPreferencesUtil().conversationSilenceDuration = 120;
+    final uploadedBatches = <List<String>>[];
+    final gate = SyncUploadGate(
+      limiter: SyncRateLimiter.instance,
+      uploader: (
+        files, {
+        onUploadProgress,
+        conversationId,
+        syncLane = SyncUploadLane.fresh,
+        replaceTranscript = false,
+      }) async {
+        uploadedBatches.add(files.map((file) => file.path).toList());
+        return UploadFilesResult.done(
+          SyncLocalFilesResponse(
+            newConversationIds: ['logical-archive-conversation'],
+            updatedConversationIds: [],
+          ),
+        );
+      },
+      fairUseStatusLoader: () async => {'stage': 'none'},
+    );
+    localSync = LocalWalSyncImpl(_Listener(), uploadGate: gate);
+    final archives = <Wal>[];
+    for (var index = 0; index < 10; index++) {
+      final timerStart = 1000 + index * 300;
+      final fileName = 'logical-archive-$index.bin';
+      File('${tempDir.path}/$fileName').writeAsBytesSync([1, 0, 0, 0, index]);
+      archives.add(
+        Wal(
+          timerStart: timerStart,
+          codec: BleAudioCodec.opus,
+          seconds: 300,
+          captureEndSeconds: timerStart + 300,
+          totalFrames: 1,
+          status: WalStatus.miss,
+          storage: WalStorage.disk,
+          originalStorage: WalStorage.sdcard,
+          device: 'cv1',
+          filePath: fileName,
+          sourceId: 'archive2_ring_${index * 100}_${(index + 1) * 100}_$timerStart',
+          uploadIntent: WalUploadIntent.historicalBackfill,
+        ),
+      );
+    }
+    localSync.testWals = archives;
+    final syncProvider = SyncProvider(
+      walService: _WalService(_LocalSyncs(localSync)),
+      uploadGate: gate,
+      startBackgroundSync: false,
+    );
+    provider = syncProvider;
+    await syncProvider.initialized;
+    final logical = syncProvider.userVisibleWals.single;
+
+    await syncProvider.deleteWal(logical);
+
+    expect(localSync.testWals, archives);
+    expect(archives.every((wal) => File('${tempDir.path}/${wal.filePath}').existsSync()), isTrue);
+
+    await syncProvider.syncWal(logical);
+
+    expect(uploadedBatches, hasLength(1));
+    expect(uploadedBatches.single, hasLength(10));
+    expect(archives.every((wal) => wal.status == WalStatus.synced), isTrue);
   });
 }

--- a/app/test/services/capture/capture_start_gate_test.dart
+++ b/app/test/services/capture/capture_start_gate_test.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/capture/capture_start_gate.dart';
+
+void main() {
+  test('reuses a healthy exact-device capture instead of resetting it', () {
+    expect(
+      canReuseActiveDeviceCapture(
+        activeDeviceId: 'device-a',
+        requestedDeviceId: 'device-a',
+        recordingActive: true,
+        audioPathActive: true,
+      ),
+      isTrue,
+    );
+    expect(
+      canReuseActiveDeviceCapture(
+        activeDeviceId: 'device-a',
+        requestedDeviceId: 'device-b',
+        recordingActive: true,
+        audioPathActive: true,
+      ),
+      isFalse,
+    );
+    expect(
+      canReuseActiveDeviceCapture(
+        activeDeviceId: 'device-a',
+        requestedDeviceId: 'device-a',
+        recordingActive: true,
+        audioPathActive: false,
+      ),
+      isFalse,
+    );
+  });
+
+  test('concurrent device-ready callbacks share one socket and tail start', () async {
+    final gate = CaptureStartGate();
+    final release = Completer<void>();
+    var starts = 0;
+
+    Future<void> start() async {
+      starts++;
+      await release.future;
+    }
+
+    final first = gate.run(start);
+    final second = gate.run(start);
+    expect(starts, 1);
+
+    release.complete();
+    await Future.wait([first, second]);
+    expect(starts, 1);
+
+    await gate.run(() async => starts++);
+    expect(starts, 2);
+  });
+}

--- a/app/test/services/capture/conversation_capture_window_test.dart
+++ b/app/test/services/capture/conversation_capture_window_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/services/capture/conversation_capture_window.dart';
+
+void main() {
+  test('anchors recovered audio to the actual transcript span, not socket age', () {
+    final window = ConversationCaptureWindow.fromTranscript(
+      sessionOriginSeconds: 1000,
+      fallbackStartSeconds: 1000,
+      fallbackEndSeconds: 5000,
+      segments: [
+        _segment(start: 2400.5, end: 2410.2),
+        _segment(start: 2500.1, end: 2510.8),
+      ],
+    );
+
+    expect(window.startSeconds, 3398);
+    expect(window.endSeconds, 3513);
+  });
+
+  test('uses the durable session bounds when no transcript is available', () {
+    final window = ConversationCaptureWindow.fromTranscript(
+      sessionOriginSeconds: 1000,
+      fallbackStartSeconds: 900,
+      fallbackEndSeconds: 1200,
+      segments: const [],
+    );
+
+    expect(window.startSeconds, 900);
+    expect(window.endSeconds, 1200);
+  });
+
+  test('requires non-empty timed transcript text as server speech proof', () {
+    expect(
+      ConversationCaptureWindow.hasServerSpeechProof([
+        _segment(start: 0, end: 1, text: '   '),
+        _segment(start: 1, end: 1, text: 'click'),
+      ]),
+      isFalse,
+    );
+    expect(
+      ConversationCaptureWindow.hasServerSpeechProof([
+        _segment(start: 1, end: 2, text: 'spoken words'),
+      ]),
+      isTrue,
+    );
+  });
+}
+
+TranscriptSegment _segment({
+  required double start,
+  required double end,
+  String text = 'speech',
+}) =>
+    TranscriptSegment(
+      id: '',
+      text: text,
+      speaker: 'SPEAKER_00',
+      isUser: false,
+      personId: null,
+      start: start,
+      end: end,
+      translations: const [],
+    );

--- a/app/test/services/capture/conversation_session_window_test.dart
+++ b/app/test/services/capture/conversation_session_window_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/capture/conversation_session_window.dart';
+
+void main() {
+  group('ConversationSessionWindow', () {
+    test('binds audio captured before the initial server session event', () {
+      final window = ConversationSessionWindow();
+
+      expect(window.ensureStarted(100), 100);
+      expect(window.observe(conversationId: 'conversation-a', nowSeconds: 102), 100);
+      expect(
+        window.complete(
+          conversationId: 'conversation-a',
+          fallbackStartSeconds: 0,
+        ),
+        100,
+      );
+    });
+
+    test('folds empty server owners into the next completed conversation', () {
+      final window = ConversationSessionWindow();
+
+      window.ensureStarted(100);
+      window.observe(conversationId: 'empty-a', nowSeconds: 101);
+      window.observe(conversationId: 'empty-b', nowSeconds: 120);
+      window.observe(conversationId: 'voiced-c', nowSeconds: 140);
+
+      expect(
+        window.complete(
+          conversationId: 'voiced-c',
+          fallbackStartSeconds: 140,
+        ),
+        100,
+      );
+      expect(window.nextStartSeconds, isNull);
+    });
+
+    test('keeps a later rollover boundary after an earlier conversation completes', () {
+      final window = ConversationSessionWindow();
+
+      window.observe(conversationId: 'conversation-a', nowSeconds: 100);
+      window.observe(conversationId: 'conversation-b', nowSeconds: 220);
+
+      expect(
+        window.complete(
+          conversationId: 'conversation-a',
+          fallbackStartSeconds: 100,
+        ),
+        100,
+      );
+      expect(window.nextStartSeconds, 220);
+      expect(
+        window.complete(
+          conversationId: 'conversation-b',
+          fallbackStartSeconds: 220,
+        ),
+        220,
+      );
+    });
+
+    test('does not duplicate a replayed session boundary', () {
+      final window = ConversationSessionWindow();
+
+      window.observe(conversationId: 'conversation-a', nowSeconds: 100);
+      window.observe(conversationId: 'conversation-a', nowSeconds: 180);
+
+      expect(
+        window.complete(
+          conversationId: 'conversation-a',
+          fallbackStartSeconds: 180,
+        ),
+        100,
+      );
+      expect(window.nextStartSeconds, isNull);
+    });
+  });
+}

--- a/app/test/services/capture/device_audio_streaming_policy_test.dart
+++ b/app/test/services/capture/device_audio_streaming_policy_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/capture/device_audio_streaming_policy.dart';
+
+void main() {
+  group('DeviceAudioStreamingPolicy', () {
+    test('legacy live audio keeps flowing while transcription reconnects', () {
+      expect(
+        DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+          usesStorageAuthoritativeAudio: false,
+          transcribeLaterEnabled: false,
+          transcriptionServiceReady: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('storage-authoritative live tail waits for transcription readiness', () {
+      expect(
+        DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+          usesStorageAuthoritativeAudio: true,
+          transcribeLaterEnabled: false,
+          transcriptionServiceReady: false,
+        ),
+        isFalse,
+      );
+      expect(
+        DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+          usesStorageAuthoritativeAudio: true,
+          transcribeLaterEnabled: false,
+          transcriptionServiceReady: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('Transcribe Later intentionally consumes storage audio without STT', () {
+      expect(
+        DeviceAudioStreamingPolicy.shouldConsumeDeviceAudio(
+          usesStorageAuthoritativeAudio: true,
+          transcribeLaterEnabled: true,
+          transcriptionServiceReady: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/app/test/services/capture/live_audio_frame_pacer_test.dart
+++ b/app/test/services/capture/live_audio_frame_pacer_test.dart
@@ -1,0 +1,132 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/capture/live_audio_frame_pacer.dart';
+
+void main() {
+  test('paces a completed BLE batch at the codec frame interval', () {
+    fakeAsync((async) {
+      final sent = <List<int>>[];
+      final pacer = LiveAudioFramePacer(
+        framesPerSecond: 50,
+        canSend: () => true,
+        send: sent.add,
+      );
+
+      final delivery = pacer.enqueue([
+        [1],
+        [2],
+        [3],
+      ]);
+      expect(delivery.accepted, isTrue);
+      var completed = false;
+      delivery.completed.then((sent) => completed = sent);
+      expect(sent, isEmpty);
+
+      async.elapse(const Duration(milliseconds: 19));
+      expect(sent, isEmpty);
+      async.elapse(const Duration(milliseconds: 1));
+      expect(sent, [
+        [1],
+      ]);
+      async.elapse(const Duration(milliseconds: 40));
+      expect(sent, [
+        [1],
+        [2],
+        [3],
+      ]);
+      async.flushMicrotasks();
+      expect(completed, isTrue);
+    });
+  });
+
+  test('disconnect rejects the queued batch so its durable WAL stays retryable', () {
+    fakeAsync((async) {
+      var connected = true;
+      final sent = <List<int>>[];
+      final pacer = LiveAudioFramePacer(
+        framesPerSecond: 50,
+        canSend: () => connected,
+        send: sent.add,
+      );
+
+      final delivery = pacer.enqueue(List.generate(20, (index) => [index]));
+      bool? delivered;
+      delivery.completed.then((sent) => delivered = sent);
+      async.elapse(const Duration(milliseconds: 40));
+      expect(sent, [
+        [0],
+        [1],
+      ]);
+
+      connected = false;
+      async.elapse(const Duration(milliseconds: 20));
+      async.flushMicrotasks();
+      expect(pacer.bufferedFrames, 0);
+      expect(pacer.isActive, isFalse);
+      expect(delivered, isFalse);
+      expect(
+          pacer.enqueue([
+            [99]
+          ]).accepted,
+          isFalse);
+    });
+  });
+
+  test('rejects a whole overflow batch instead of truncating audio', () {
+    fakeAsync((async) {
+      final sent = <List<int>>[];
+      final pacer = LiveAudioFramePacer(
+        framesPerSecond: 2,
+        maxBufferedSeconds: 2,
+        canSend: () => true,
+        send: sent.add,
+      );
+
+      final delivery = pacer.enqueue(List.generate(10, (index) => [index]));
+      expect(delivery.accepted, isFalse);
+      expect(pacer.bufferedFrames, 0);
+
+      async.elapse(const Duration(seconds: 2));
+      expect(sent, isEmpty);
+    });
+  });
+
+  test('accepts a second batch without dropping the first batch boundary', () {
+    fakeAsync((async) {
+      final sent = <List<int>>[];
+      final pacer = LiveAudioFramePacer(
+        framesPerSecond: 2,
+        maxBufferedSeconds: 3,
+        canSend: () => true,
+        send: sent.add,
+      );
+
+      final first = pacer.enqueue([
+        [1],
+        [2],
+      ]);
+      final second = pacer.enqueue([
+        [3],
+        [4],
+      ]);
+      bool? firstDelivered;
+      bool? secondDelivered;
+      first.completed.then((sent) => firstDelivered = sent);
+      second.completed.then((sent) => secondDelivered = sent);
+      expect(first.accepted, isTrue);
+      expect(second.accepted, isTrue);
+
+      async.elapse(const Duration(seconds: 2));
+      async.flushMicrotasks();
+      expect(sent, [
+        [1],
+        [2],
+        [3],
+        [4],
+      ]);
+      expect(firstDelivered, isTrue);
+      expect(secondDelivered, isTrue);
+    });
+  });
+}

--- a/app/test/services/capture/live_transcript_preview_test.dart
+++ b/app/test/services/capture/live_transcript_preview_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/services/capture/live_transcript_preview.dart';
+
+void main() {
+  test('an empty reconnect snapshot cannot erase the visible preview', () {
+    final current = [_segment('socket-a', 0, 2, 'before disconnect')];
+
+    final merged = LiveTranscriptPreview.reconcile(
+      current: current,
+      serverSnapshot: const [],
+    );
+
+    expect(merged.map((segment) => segment.id), ['socket-a']);
+    expect(merged, isNot(same(current)));
+  });
+
+  test('a stale snapshot updates known segments and keeps newer socket data', () {
+    final current = [
+      _segment('shared', 0, 2, 'interim'),
+      _segment('socket-new', 2, 4, 'after reconnect'),
+    ];
+
+    final merged = LiveTranscriptPreview.reconcile(
+      current: current,
+      serverSnapshot: [
+        _segment('shared', 0, 2.5, 'final'),
+        _segment('server-middle', 1.5, 2, 'persisted'),
+      ],
+    );
+
+    expect(
+      merged.map((segment) => segment.id),
+      ['shared', 'server-middle', 'socket-new'],
+    );
+    expect(merged.first.text, 'final');
+  });
+}
+
+TranscriptSegment _segment(
+  String id,
+  double start,
+  double end,
+  String text,
+) =>
+    TranscriptSegment(
+      id: id,
+      text: text,
+      speaker: 'SPEAKER_00',
+      isUser: false,
+      personId: null,
+      start: start,
+      end: end,
+      translations: const [],
+    );

--- a/app/test/services/devices/ring_info_handshake_test.dart
+++ b/app/test/services/devices/ring_info_handshake_test.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/services/devices/connectors/omi_connection.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+class _FakeTransport extends DeviceTransport {
+  final StreamController<List<int>> notifications = StreamController<List<int>>.broadcast();
+  final StreamController<DeviceTransportState> states = StreamController<DeviceTransportState>.broadcast();
+  List<int>? response;
+  int writeCount = 0;
+
+  @override
+  String get deviceId => 'cv1';
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await notifications.close();
+    await states.close();
+  }
+
+  @override
+  Stream<DeviceTransportState> get connectionStateStream => states.stream;
+
+  @override
+  Stream<List<int>> getCharacteristicStream(String serviceUuid, String characteristicUuid) => notifications.stream;
+
+  @override
+  Future<bool> isConnected() async => true;
+
+  @override
+  Future<bool> ping() async => true;
+
+  @override
+  Future<List<int>> readCharacteristic(String serviceUuid, String characteristicUuid) async => [];
+
+  @override
+  Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {
+    writeCount++;
+    final value = response;
+    if (value != null) notifications.add(value);
+  }
+}
+
+BtDevice _device() => BtDevice(name: 'Omi', id: 'cv1', type: DeviceType.omi, rssi: -40);
+
+void main() {
+  test('ring-info STORAGE_NOT_READY ACK fails immediately with its typed status', () async {
+    final transport = _FakeTransport()..response = [RingProtocol.notifyAck, RingProtocol.statusStorageNotReady];
+    final connection = OmiDeviceConnection(_device(), transport);
+
+    await expectLater(
+      connection.performGetRingInfo(),
+      throwsA(
+        isA<RingCommandRejectedException>()
+            .having((error) => error.status, 'status', RingProtocol.statusStorageNotReady)
+            .having((error) => error.isRetryable, 'retryable', isTrue),
+      ),
+    );
+    expect(transport.writeCount, 1);
+    await transport.dispose();
+  });
+
+  test('ring-info retry is bounded and succeeds after a transient not-ready response', () async {
+    var attempts = 0;
+    final delays = <Duration>[];
+    final expected = RingInfo(readSeq: 4, writeSeq: 9, capacityPackets: 100, droppedPackets: 0, packetSize: 444);
+    const policy = RingInfoRetryPolicy(maxAttempts: 3);
+
+    final result = await policy.run(
+      () async {
+        attempts++;
+        if (attempts == 1) {
+          throw const RingCommandRejectedException(
+            command: 'ring info',
+            status: RingProtocol.statusStorageNotReady,
+          );
+        }
+        return expected;
+      },
+      wait: (delay) async => delays.add(delay),
+    );
+
+    expect(result, same(expected));
+    expect(attempts, 2);
+    expect(delays, [const Duration(milliseconds: 500)]);
+  });
+
+  test('ring-info retry stops after the configured attempt budget', () async {
+    var attempts = 0;
+    const policy = RingInfoRetryPolicy(maxAttempts: 3, backoff: [Duration.zero]);
+
+    await expectLater(
+      policy.run(
+        () async {
+          attempts++;
+          throw const RingCommandRejectedException(
+            command: 'ring info',
+            status: RingProtocol.statusStorageNotReady,
+          );
+        },
+        wait: (_) async {},
+      ),
+      throwsA(isA<RingCommandRejectedException>()),
+    );
+
+    expect(attempts, 3);
+  });
+}

--- a/app/test/services/sockets/transcription_service_session_test.dart
+++ b/app/test/services/sockets/transcription_service_session_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/message_event.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/services/sockets/pure_socket.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({'uid': 'user-a'});
+    await SharedPreferencesUtil.init();
+    Env.init(_TestEnvFields());
+  });
+
+  test('reconnect URL reclaims the existing conversation id', () {
+    final service = TranscriptSocketServiceFactory.createDefault(
+      16000,
+      BleAudioCodec.opus,
+      'en',
+      clientConversationId: '8fd118f7-9f5c-4d55-9caf-678ad6d3acb7',
+    );
+
+    final url = (service.socket as PureSocket).url;
+    final uri = Uri.parse(url);
+    expect(
+      uri.queryParameters['client_conversation_id'],
+      '8fd118f7-9f5c-4d55-9caf-678ad6d3acb7',
+    );
+  });
+
+  test('replays the initial conversation session to a late subscriber', () {
+    final socket = _FakePureSocket();
+    final service = TranscriptSegmentSocketService.withSocket(
+      16000,
+      BleAudioCodec.opus,
+      'en',
+      socket,
+    );
+
+    service.onMessage(
+      '''
+      {
+        "type": "conversation_session",
+        "conversation_id": "conversation-a",
+        "status": "in_progress",
+        "recording_session_id": "recording-a",
+        "lifecycle_version": 1,
+        "lifecycle_phase": "in_progress",
+        "lifecycle_sequence": 2
+      }
+      ''',
+    );
+
+    final listener = _RecordingListener();
+    service.subscribe(listener, listener);
+
+    expect(listener.events, hasLength(1));
+    final event = listener.events.single as ConversationSessionEvent;
+    expect(event.conversationId, 'conversation-a');
+    expect(event.recordingSessionId, 'recording-a');
+    expect(event.lifecycleVersion, 1);
+    expect(event.lifecyclePhase, 'in_progress');
+    expect(event.lifecycleSequence, 2);
+    expect(event.isInProgress, isTrue);
+  });
+
+  test('does not replay a stopped socket session into a later capture', () async {
+    final socket = _FakePureSocket();
+    final service = TranscriptSegmentSocketService.withSocket(
+      16000,
+      BleAudioCodec.opus,
+      'en',
+      socket,
+    );
+    service.onMessage(
+      '{"type":"conversation_session","conversation_id":"old","status":"in_progress"}',
+    );
+
+    await service.stop();
+    final listener = _RecordingListener();
+    service.subscribe(listener, listener);
+
+    expect(listener.events, isEmpty);
+  });
+
+  test('does not report server ready from the transport connection alone', () async {
+    final socket = _FakePureSocket();
+    final service = TranscriptSegmentSocketService.withSocket(
+      16000,
+      BleAudioCodec.opus,
+      'en',
+      socket,
+    );
+
+    expect(service.serverReady, isFalse);
+    expect(
+      await service.waitUntilServerReady(timeout: const Duration(milliseconds: 1)),
+      isFalse,
+    );
+  });
+
+  test('waits for and replays the server ready status', () async {
+    final socket = _FakePureSocket();
+    final service = TranscriptSegmentSocketService.withSocket(
+      16000,
+      BleAudioCodec.opus,
+      'en',
+      socket,
+    );
+
+    final ready = service.waitUntilServerReady();
+    service.onMessage('{"type":"service_status","status":"ready"}');
+
+    expect(await ready, isTrue);
+    expect(service.serverReady, isTrue);
+
+    final listener = _RecordingListener();
+    service.subscribe(listener, listener);
+    expect(listener.events, hasLength(1));
+    expect((listener.events.single as MessageServiceStatusEvent).status, 'ready');
+  });
+
+  test('STT failure rejects readiness and is replayed to a late subscriber', () async {
+    final socket = _FakePureSocket();
+    final service = TranscriptSegmentSocketService.withSocket(
+      16000,
+      BleAudioCodec.opus,
+      'en',
+      socket,
+    );
+
+    final ready = service.waitUntilServerReady();
+    service.onMessage(
+      '{"type":"service_status","status":"stt_failed","retryable":true}',
+    );
+
+    expect(await ready, isFalse);
+    expect(service.serverReady, isFalse);
+
+    final listener = _RecordingListener();
+    service.subscribe(listener, listener);
+    expect(listener.events, hasLength(1));
+    final failure = listener.events.single as MessageServiceStatusEvent;
+    expect(failure.status, 'stt_failed');
+    expect(failure.retryable, isTrue);
+  });
+}
+
+class _TestEnvFields implements EnvFields {
+  @override
+  String? get apiBaseUrl => 'https://api.omi.me/';
+  @override
+  String? get googleClientId => null;
+  @override
+  String? get googleClientSecret => null;
+  @override
+  String? get googleMapsApiKey => null;
+  @override
+  String? get intercomAppId => null;
+  @override
+  String? get intercomIOSApiKey => null;
+  @override
+  String? get intercomAndroidApiKey => null;
+  @override
+  String? get openAIAPIKey => null;
+  @override
+  String? get posthogApiKey => null;
+  @override
+  bool? get useAuthCustomToken => false;
+  @override
+  bool? get useWebAuth => false;
+}
+
+class _RecordingListener implements ITransctiptSegmentSocketServiceListener {
+  final List<MessageEvent> events = [];
+
+  @override
+  void onMessageEventReceived(MessageEvent event) => events.add(event);
+
+  @override
+  void onClosed([int? closeCode]) {}
+
+  @override
+  void onConnected() {}
+
+  @override
+  void onError(Object err) {}
+
+  @override
+  void onSegmentReceived(List<TranscriptSegment> segments) {}
+}
+
+class _FakePureSocket implements IPureSocket {
+  IPureSocketListener? listener;
+
+  @override
+  PureSocketStatus get status => PureSocketStatus.connected;
+
+  @override
+  Future<bool> connect() async => true;
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  void onClosed() => listener?.onClosed();
+
+  @override
+  void onConnected() => listener?.onConnected();
+
+  @override
+  void onError(Object err, StackTrace trace) => listener?.onError(err, trace);
+
+  @override
+  void onMessage(message) => listener?.onMessage(message);
+
+  @override
+  void send(message) {}
+
+  @override
+  void setListener(IPureSocketListener listener) {
+    this.listener = listener;
+  }
+
+  @override
+  Future<void> stop() async {}
+}

--- a/app/test/services/wals/legacy_storage_first_packet_deadline_test.dart
+++ b/app/test/services/wals/legacy_storage_first_packet_deadline_test.dart
@@ -1,0 +1,35 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/wals/sdcard_wal_sync.dart';
+
+void main() {
+  test('a ring ACK cannot disable the legacy SD first-packet timeout', () {
+    fakeAsync((async) {
+      var timedOut = false;
+      final deadline = LegacyStorageFirstPacketDeadline(
+        timeout: const Duration(seconds: 5),
+        onTimeout: () => timedOut = true,
+      )..start();
+
+      expect(deadline.observe([0x01, 0x09]), isFalse);
+      async.elapse(const Duration(seconds: 5));
+
+      expect(timedOut, isTrue);
+    });
+  });
+
+  test('a supported legacy packet satisfies the deadline', () {
+    fakeAsync((async) {
+      var timedOut = false;
+      final deadline = LegacyStorageFirstPacketDeadline(
+        timeout: const Duration(seconds: 5),
+        onTimeout: () => timedOut = true,
+      )..start();
+
+      expect(deadline.observe(List<int>.filled(83, 0)), isTrue);
+      async.elapse(const Duration(seconds: 10));
+
+      expect(timedOut, isFalse);
+    });
+  });
+}

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -130,6 +130,68 @@ void main() {
       expect(harness.drainPasses, 1);
     });
 
+    test('opted-in background device reconnect runs one recovery pass', () async {
+      final harness = _TransferHarness()..backgroundDeviceRecoveryEnabled = true;
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.deviceConnected);
+
+      expect(harness.reconcilePasses, 1);
+      expect(harness.discoveryPasses, 1);
+      expect(harness.drainPasses, 1);
+    });
+
+    test('background device reconnect requires persistent BLE and auto-upload opt-ins', () async {
+      final noPersistentBle = _TransferHarness();
+      final noAutoUpload = _TransferHarness(autoUploadEnabled: false)..backgroundDeviceRecoveryEnabled = true;
+      addTearDown(noPersistentBle.dispose);
+      addTearDown(noAutoUpload.dispose);
+
+      noPersistentBle.coordinator.setForeground(false);
+      noAutoUpload.coordinator.setForeground(false);
+      await noPersistentBle.coordinator.wake(WakeTrigger.deviceConnected);
+      await noAutoUpload.coordinator.wake(WakeTrigger.deviceConnected);
+
+      expect(noPersistentBle.discoveryPasses, 0);
+      expect(noPersistentBle.drainPasses, 0);
+      expect(noAutoUpload.discoveryPasses, 0);
+      expect(noAutoUpload.drainPasses, 0);
+    });
+
+    test('persistent BLE opt-in does not authorize other background wakes', () async {
+      final harness = _TransferHarness()..backgroundDeviceRecoveryEnabled = true;
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.connectivityRestored);
+      await harness.coordinator.wake(WakeTrigger.cooldownElapsed);
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+
+      expect(harness.reconcilePasses, 0);
+      expect(harness.discoveryPasses, 0);
+      expect(harness.drainPasses, 0);
+    });
+
+    test('failed background reconnect pass persists for foreground retry without a timer', () async {
+      final harness = _TransferHarness()
+        ..backgroundDeviceRecoveryEnabled = true
+        ..drainFails = true;
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.deviceConnected);
+
+      expect(harness.drainPasses, 1);
+      expect(harness.walState, 'miss');
+      expect(harness.scheduledCooldowns, isEmpty);
+      expect(harness.coordinator.nextCooldownAt, isNull);
+
+      harness.coordinator.setForeground(true);
+      await harness.coordinator.wake(WakeTrigger.foregrounded);
+      expect(harness.drainPasses, 2);
+    });
+
     test('startup resumes a pending backlog once without loss or duplication', () async {
       final sharedBacklog = <String>['pending-wal'];
       final drainedWalIds = <String>[];
@@ -218,6 +280,7 @@ class _TransferHarness {
       refreshPending: _refreshPending,
       drain: _drain,
       autoUploadEnabled: () => _autoUploadEnabled,
+      backgroundDeviceRecoveryEnabled: () => backgroundDeviceRecoveryEnabled,
       connectivityChanges: connectivity.stream,
       initiallyConnected: true,
       clock: () => DateTime.utc(2026, 1, 1),
@@ -238,6 +301,7 @@ class _TransferHarness {
   bool drainNeedsReconciliation = false;
   bool drainContended = false;
   bool uploadedWalAwaitingReconcile = false;
+  bool backgroundDeviceRecoveryEnabled = false;
   bool reconciledUploadedWal = false;
   bool reofferedUploadedWal = false;
   String walState = 'miss';

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -257,6 +257,67 @@ void main() {
       expect(harness.scheduledCooldowns, hasLength(1));
       expect(harness.coordinator.nextCooldownAt, DateTime.utc(2026, 1, 1, 0, 0, 5));
     });
+
+    test('auto-sync opt-out preserves manual authority across repeated contention', () async {
+      final harness = _TransferHarness(autoUploadEnabled: false)..drainContended = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+      expect(harness.drainPasses, 1);
+      expect(harness.drainTriggers, [WakeTrigger.userRetry]);
+      expect(harness.scheduledCooldowns.single.delay, const Duration(seconds: 5));
+
+      harness.scheduledCooldowns.single.callback();
+      await _settle();
+      expect(harness.drainPasses, 2);
+      expect(harness.drainTriggers, [
+        WakeTrigger.userRetry,
+        WakeTrigger.userRetry,
+      ]);
+      expect(harness.scheduledCooldowns.last.delay, const Duration(seconds: 10));
+
+      harness.drainContended = false;
+      harness.scheduledCooldowns.last.callback();
+      await _settle();
+
+      expect(harness.drainPasses, 3);
+      expect(harness.drainTriggers.last, WakeTrigger.userRetry);
+      expect(harness.backlog, isEmpty);
+    });
+
+    test('completed device snapshot retries as local upload without rearming', () async {
+      final harness = _TransferHarness(autoUploadEnabled: false)
+        ..drainFails = true
+        ..drainHasDeviceSnapshotReceipt = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+      harness.scheduledCooldowns.single.callback();
+      await _settle();
+
+      expect(
+        harness.drainTriggers,
+        [WakeTrigger.userRetry, WakeTrigger.userRetryLocalUpload],
+      );
+    });
+
+    test('later success invalidates an older scheduled cooldown callback', () async {
+      final harness = _TransferHarness()..drainContended = true;
+      addTearDown(harness.dispose);
+
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+      final staleCooldown = harness.scheduledCooldowns.single;
+
+      harness.drainContended = false;
+      await harness.coordinator.wake(WakeTrigger.userRetry);
+      expect(harness.drainPasses, 2);
+      expect(harness.coordinator.nextCooldownAt, isNull);
+
+      staleCooldown.callback();
+      await _settle();
+
+      expect(harness.drainPasses, 2);
+    });
   });
 }
 
@@ -300,6 +361,7 @@ class _TransferHarness {
   bool drainFails = false;
   bool drainNeedsReconciliation = false;
   bool drainContended = false;
+  bool drainHasDeviceSnapshotReceipt = false;
   bool uploadedWalAwaitingReconcile = false;
   bool backgroundDeviceRecoveryEnabled = false;
   bool reconciledUploadedWal = false;
@@ -309,6 +371,7 @@ class _TransferHarness {
   int discoveryPasses = 0;
   int pendingRefreshes = 0;
   int drainPasses = 0;
+  final List<WakeTrigger> drainTriggers = [];
   int _concurrentDrains = 0;
   int maximumConcurrentDrains = 0;
 
@@ -333,9 +396,10 @@ class _TransferHarness {
     pendingRefreshes++;
   }
 
-  Future<RecordingTransferDrainResult> _drain() async {
+  Future<RecordingTransferDrainResult> _drain(WakeTrigger trigger) async {
     if (backlog.isEmpty) return const RecordingTransferDrainResult.skipped();
     drainPasses++;
+    drainTriggers.add(trigger);
     _concurrentDrains++;
     maximumConcurrentDrains = maximumConcurrentDrains < _concurrentDrains ? _concurrentDrains : maximumConcurrentDrains;
     try {
@@ -351,6 +415,7 @@ class _TransferHarness {
           attempted: true,
           failed: true,
           needsReconciliation: drainNeedsReconciliation,
+          hasDeviceSnapshotReceipt: drainHasDeviceSnapshotReceipt,
         );
       }
       drainedWalIds.addAll(backlog);

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -1,0 +1,400 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
+import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/ring_storage_sync.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+
+void main() {
+  late Directory directory;
+  late _Listener listener;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('omi-ring-sync-test-');
+    listener = _Listener();
+  });
+
+  tearDown(() async {
+    if (await directory.exists()) await directory.delete(recursive: true);
+  });
+
+  LocalWalSyncImpl localSync({WalPersister? persister}) {
+    return LocalWalSyncImpl(
+      listener,
+      walPersister: persister ?? (_) async => true,
+      walPathResolver: (path) async => path == null ? null : '${directory.path}/${path.split('/').last}',
+    );
+  }
+
+  RingStorageSyncImpl ringSync(
+    _FakeRingConnection connection,
+    LocalWalSync local, {
+    int packetsPerRead = 2,
+    int? nowSeconds,
+  }) {
+    final sync = RingStorageSyncImpl(
+      listener,
+      connectionResolver: (_) async => connection,
+      documentsDirectoryProvider: () async => directory,
+      packetsPerRead: packetsPerRead,
+      inactivityTimeout: const Duration(milliseconds: 100),
+      nowSeconds: () => nowSeconds ?? _FakeRingConnection.baseTimestamp + 10000,
+    );
+    sync.setDevice(_device());
+    sync.setLocalSync(local);
+    return sync;
+  }
+
+  Wal virtualWal(int records) => Wal(
+        timerStart: _FakeRingConnection.baseTimestamp,
+        codec: BleAudioCodec.opus,
+        seconds: records,
+        status: WalStatus.miss,
+        storage: WalStorage.sdcard,
+        device: 'cv1-test',
+        deviceModel: 'Omi',
+        storageTotalBytes: records * RingProtocol.recordSize,
+        totalFrames: records,
+      );
+
+  test('large backlog drains as independently durable bounded ranges', () async {
+    final connection = _FakeRingConnection(readSeq: 100, writeSeq: 107);
+    final local = localSync();
+    final wal = virtualWal(7);
+
+    await ringSync(connection, local).syncWal(wal: wal);
+
+    expect(connection.reads,
+        [(start: 100, count: 2), (start: 102, count: 2), (start: 104, count: 2), (start: 106, count: 1)]);
+    expect(connection.successfulAdvances, [102, 104, 106, 107]);
+    expect(local.testWals.map((wal) => wal.sourceId), [
+      'ring_100_102',
+      'ring_102_104',
+      'ring_104_106',
+      'ring_106_107',
+    ]);
+    expect(wal.status, WalStatus.synced);
+  });
+
+  test('interrupted range keeps its cursor and retry resumes after the last durable advance', () async {
+    final local = localSync();
+    final firstConnection = _FakeRingConnection(readSeq: 200, writeSeq: 205, truncateStartSeq: 202);
+    final wal = virtualWal(5);
+
+    await ringSync(firstConnection, local).syncWal(wal: wal);
+
+    expect(firstConnection.successfulAdvances, [202]);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_200_202']);
+    expect(wal.status, WalStatus.miss);
+
+    final resumedConnection = _FakeRingConnection(readSeq: 202, writeSeq: 205);
+    await ringSync(resumedConnection, local).syncWal(wal: wal);
+
+    expect(resumedConnection.reads, [(start: 202, count: 2), (start: 204, count: 1)]);
+    expect(resumedConnection.successfulAdvances, [204, 205]);
+    expect(local.testWals.map((wal) => wal.sourceId), [
+      'ring_200_202',
+      'ring_202_204',
+      'ring_204_205',
+    ]);
+    expect(wal.status, WalStatus.synced);
+  });
+
+  test('failed manifest persistence rolls back registration and prevents ADVANCE', () async {
+    final connection = _FakeRingConnection(readSeq: 300, writeSeq: 301);
+    final local = localSync(persister: (_) async => false);
+    final wal = virtualWal(1);
+
+    await ringSync(connection, local).syncWal(wal: wal);
+
+    expect(connection.advanceAttempts, isEmpty);
+    expect(local.testWals, isEmpty);
+    expect(wal.status, WalStatus.miss);
+  });
+
+  test('CRC mismatch prevents registration and ADVANCE', () async {
+    final connection = _FakeRingConnection(readSeq: 400, writeSeq: 402, corruptCrc: true);
+    final local = localSync();
+    final wal = virtualWal(2);
+
+    await ringSync(connection, local).syncWal(wal: wal);
+
+    expect(connection.advanceAttempts, isEmpty);
+    expect(local.testWals, isEmpty);
+    expect(wal.status, WalStatus.miss);
+
+    final retry = _FakeRingConnection(readSeq: 400, writeSeq: 402);
+    await ringSync(retry, local).syncWal(wal: wal);
+
+    expect(retry.successfulAdvances, [402]);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_400_402']);
+  });
+
+  test('capture timestamp discontinuity becomes a separate immutable WAL segment', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 500,
+      writeSeq: 502,
+      timestamps: {
+        500: _FakeRingConnection.baseTimestamp + 500,
+        501: _FakeRingConnection.baseTimestamp + 620,
+      },
+    );
+    final local = localSync();
+
+    await ringSync(connection, local).syncWal(wal: virtualWal(2));
+
+    expect(local.testWals.map((wal) => wal.timerStart), [
+      _FakeRingConnection.baseTimestamp + 500,
+      _FakeRingConnection.baseTimestamp + 620,
+    ]);
+    expect(connection.successfulAdvances, [502]);
+  });
+
+  test('failed ADVANCE retries the immutable range without duplicating its WAL', () async {
+    final local = localSync();
+    final firstConnection = _FakeRingConnection(readSeq: 600, writeSeq: 602, failAdvance: true);
+    final wal = virtualWal(2);
+
+    await ringSync(firstConnection, local).syncWal(wal: wal);
+
+    expect(firstConnection.advanceAttempts, [602]);
+    expect(firstConnection.successfulAdvances, isEmpty);
+    expect(local.testWals, hasLength(1));
+    final originalBytes = await File('${directory.path}/${local.testWals.single.filePath}').readAsBytes();
+
+    final retryConnection = _FakeRingConnection(readSeq: 600, writeSeq: 602);
+    await ringSync(retryConnection, local).syncWal(wal: wal);
+
+    expect(retryConnection.successfulAdvances, [602]);
+    expect(local.testWals, hasLength(1));
+    expect(await File('${directory.path}/${local.testWals.single.filePath}').readAsBytes(), originalBytes);
+  });
+
+  test('invalid RTC fallback is monotonic across ranges and sequence identity survives retry time changes', () async {
+    final local = localSync();
+    final invalidTimestamps = {for (var seq = 700; seq < 704; seq++) seq: 0};
+    final firstConnection = _FakeRingConnection(
+      readSeq: 700,
+      writeSeq: 704,
+      timestamps: invalidTimestamps,
+      framesPerRecord: 100,
+      failAdvance: true,
+    );
+    final wal = virtualWal(4)
+      ..totalFrames = 400
+      ..timerStart = 1799999996;
+
+    await ringSync(firstConnection, local, nowSeconds: 1800000000).syncWal(wal: wal);
+
+    expect(local.testWals.single.sourceId, 'ring_700_702');
+    expect(local.testWals.single.timerStart, 1799999996);
+
+    final retry = _FakeRingConnection(
+      readSeq: 700,
+      writeSeq: 704,
+      timestamps: invalidTimestamps,
+      framesPerRecord: 100,
+    );
+    await ringSync(retry, local, nowSeconds: 1800000100).syncWal(wal: wal);
+
+    expect(retry.successfulAdvances, [702, 704]);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_700_702', 'ring_702_704']);
+    expect(local.testWals.map((wal) => wal.timerStart), [1799999996, 1799999998]);
+  });
+
+  test('byte-identical legacy timestamp WAL is reused instead of uploaded twice', () async {
+    final local = localSync();
+    final legacyFile = File('${directory.path}/legacy.bin')..writeAsBytesSync([1, 2, 3, 4]);
+    final candidateFile = File('${directory.path}/range.bin')..writeAsBytesSync([1, 2, 3, 4]);
+    local.testWals = [
+      Wal(
+        timerStart: 1700000800,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        device: 'cv1-test',
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: legacyFile.path.split('/').last,
+      ),
+    ];
+    final candidate = Wal(
+      timerStart: 1700000800,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      device: 'cv1-test',
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: candidateFile.path.split('/').last,
+      sourceId: 'ring_800_802',
+    );
+
+    final result = await local.addExternalWal(candidate);
+
+    expect(result, ExternalWalRegistration.alreadyRegistered);
+    expect(local.testWals, hasLength(1));
+    expect(await candidateFile.exists(), isFalse);
+  });
+
+  test('synced legacy WAL without immutable upload proof is conservatively registered again', () async {
+    final local = localSync();
+    File('${directory.path}/legacy.bin').writeAsBytesSync([1, 2, 3, 4]);
+    File('${directory.path}/range.bin').writeAsBytesSync([1, 2, 3, 4]);
+    local.testWals = [
+      Wal(
+        timerStart: 1700000900,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        device: 'cv1-test',
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: 'legacy.bin',
+      ),
+    ];
+    final candidate = Wal(
+      timerStart: 1700000900,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      device: 'cv1-test',
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: 'range.bin',
+      sourceId: 'ring_900_902',
+    );
+
+    final result = await local.addExternalWal(candidate);
+
+    expect(result, ExternalWalRegistration.added);
+    expect(local.testWals, hasLength(2));
+    expect(await File('${directory.path}/range.bin').exists(), isTrue);
+  });
+}
+
+BtDevice _device() => BtDevice(name: 'Omi', id: 'cv1-test', type: DeviceType.omi, rssi: -40);
+
+class _Listener implements IWalSyncListener {
+  @override
+  void onWalSynced(Wal wal, {ServerConversation? conversation}) {}
+
+  @override
+  void onWalUpdated() {}
+}
+
+class _FakeRingConnection implements DeviceConnection {
+  static const int baseTimestamp = 1710000000;
+
+  int readSeq;
+  final int writeSeq;
+  final int? truncateStartSeq;
+  final bool corruptCrc;
+  final bool failAdvance;
+  final int framesPerRecord;
+  final Map<int, int> timestamps;
+  final reads = <({int start, int count})>[];
+  final advanceAttempts = <int>[];
+  final successfulAdvances = <int>[];
+  final StreamController<List<int>> _notifications = StreamController<List<int>>.broadcast(sync: true);
+
+  _FakeRingConnection({
+    required this.readSeq,
+    required this.writeSeq,
+    this.truncateStartSeq,
+    this.corruptCrc = false,
+    this.failAdvance = false,
+    this.framesPerRecord = 1,
+    this.timestamps = const {},
+  });
+
+  @override
+  Future<RingInfo?> getRingInfo() async => RingInfo(
+        readSeq: readSeq,
+        writeSeq: writeSeq,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      );
+
+  @override
+  Future<StreamSubscription?> getBleStorageBytesListener({
+    required void Function(List<int>) onStorageBytesReceived,
+  }) async =>
+      _notifications.stream.listen(onStorageBytesReceived);
+
+  @override
+  Future<bool> readRingFromSeq(int startSeq, {int? packetCount}) async {
+    final count = packetCount!;
+    reads.add((start: startSeq, count: count));
+    scheduleMicrotask(() {
+      _notifications.add(_readBegin(startSeq, count));
+      final requested = <int>[];
+      for (var seq = startSeq; seq < startSeq + count; seq++) {
+        requested.addAll(_record(seq, timestamps[seq] ?? baseTimestamp + seq));
+      }
+      final sent =
+          truncateStartSeq == startSeq ? requested.sublist(0, requested.length - RingProtocol.recordSize) : requested;
+      final crc = RingTransferCrc32()..add(sent);
+      for (var offset = 0; offset < sent.length; offset += 137) {
+        final end = (offset + 137).clamp(0, sent.length);
+        _notifications.add([RingProtocol.notifyData, ...sent.sublist(offset, end)]);
+      }
+      _notifications.add(_done(startSeq + count, corruptCrc ? crc.value ^ 0xFFFFFFFF : crc.value));
+    });
+    return true;
+  }
+
+  @override
+  Future<bool> advanceRing(int newReadSeq) async {
+    advanceAttempts.add(newReadSeq);
+    if (failAdvance) return false;
+    readSeq = newReadSeq;
+    successfulAdvances.add(newReadSeq);
+    return true;
+  }
+
+  @override
+  Future<bool> stopStorageSync() async => true;
+
+  static List<int> _readBegin(int startSeq, int count) {
+    final bytes = ByteData(13)
+      ..setUint8(0, RingProtocol.notifyReadBegin)
+      ..setUint64(1, startSeq, Endian.big)
+      ..setUint32(9, count, Endian.big);
+    return bytes.buffer.asUint8List();
+  }
+
+  static List<int> _done(int nextSeq, int crc) {
+    final bytes = ByteData(14)
+      ..setUint8(0, RingProtocol.notifyDone)
+      ..setUint8(1, 0)
+      ..setUint64(2, nextSeq, Endian.big)
+      ..setUint32(10, crc, Endian.big);
+    return bytes.buffer.asUint8List();
+  }
+
+  List<int> _record(int sequence, int timestamp) {
+    final bytes = Uint8List(RingProtocol.recordSize);
+    ByteData.sublistView(bytes).setUint32(0, timestamp, Endian.big);
+    var offset = RingProtocol.timestampBytes;
+    for (var frame = 0; frame < framesPerRecord; frame++) {
+      bytes[offset++] = 3;
+      bytes[offset++] = sequence & 0xFF;
+      bytes[offset++] = (sequence >> 8) & 0xFF;
+      bytes[offset++] = frame & 0xFF;
+    }
+    return bytes;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -84,6 +84,101 @@ void main() {
     expect(wal.status, WalStatus.synced);
   });
 
+  test('storage-authoritative scheduler persists the live head before draining backlog', () async {
+    final timestamps = {for (var seq = 0; seq < 1000; seq++) seq: _FakeRingConnection.baseTimestamp + 1000};
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 1000,
+      timestamps: timestamps,
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: _FakeRingConnection.baseTimestamp + 1000,
+    );
+    final liveDelivered = Completer<void>();
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (frames) {
+        if (!liveDelivered.isCompleted) liveDelivered.complete();
+        return true;
+      },
+    );
+
+    expect(session, isNotNull);
+    await liveDelivered.future.timeout(const Duration(seconds: 1));
+    expect(connection.reads.first, (start: 980, count: 20));
+    expect(connection.advanceAttempts, isEmpty);
+
+    await connection.firstAdvance.future.timeout(const Duration(seconds: 3));
+    expect(connection.reads[1], (start: 0, count: 96));
+    expect(connection.successfulAdvances.first, 96);
+    expect(connection.successfulAdvances, isNot(contains(1000)));
+
+    await session!.cancel();
+    expect(session.isActive, isFalse);
+    expect(local.testWals.any((wal) => wal.sourceId == 'ring_980_1000'), isTrue);
+  });
+
+  test('interrupted live-head read leaves backlog cursor untouched', () async {
+    final timestamps = {for (var seq = 0; seq < 1000; seq++) seq: _FakeRingConnection.baseTimestamp + 1000};
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 1000,
+      truncateStartSeq: 980,
+      timestamps: timestamps,
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: _FakeRingConnection.baseTimestamp + 1000,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+
+    expect(session, isNotNull);
+    await expectLater(session!.done, throwsA(isA<RingStorageException>()));
+    expect(session.isActive, isFalse);
+    await expectLater(session.cancel(), completes);
+    expect(connection.reads, [(start: 980, count: 20)]);
+    expect(connection.advanceAttempts, isEmpty);
+    expect(local.testWals, isEmpty);
+  });
+
+  test('storage-authoritative scheduler preserves chronology when the pendant RTC is invalid', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 1000,
+      framesPerRecord: 5,
+      timestamps: {for (var seq = 0; seq < 1000; seq++) seq: 0},
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: _FakeRingConnection.baseTimestamp + 1000,
+    );
+    final liveDelivered = Completer<void>();
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) {
+        if (!liveDelivered.isCompleted) liveDelivered.complete();
+        return true;
+      },
+    );
+
+    await liveDelivered.future.timeout(const Duration(seconds: 1));
+    await connection.firstAdvance.future.timeout(const Duration(seconds: 3));
+    await session!.cancel();
+
+    final liveWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_980_1000');
+    final firstBacklogWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_0_96');
+    expect(firstBacklogWal.timerStart, _FakeRingConnection.baseTimestamp + 950);
+    expect(liveWal.timerStart, _FakeRingConnection.baseTimestamp + 999);
+  });
+
   test('durable ring WAL uses exact little-endian length-prefixed frame bytes', () async {
     const startSeq = 0x1234;
     final connection = _FakeRingConnection(readSeq: startSeq, writeSeq: startSeq + 2, framesPerRecord: 2);
@@ -361,6 +456,7 @@ class _FakeRingConnection implements DeviceConnection {
   final reads = <({int start, int count})>[];
   final advanceAttempts = <int>[];
   final successfulAdvances = <int>[];
+  final Completer<void> firstAdvance = Completer<void>();
   final StreamController<List<int>> _notifications = StreamController<List<int>>.broadcast(sync: true);
 
   _FakeRingConnection({
@@ -416,8 +512,12 @@ class _FakeRingConnection implements DeviceConnection {
     if (failAdvance) return false;
     readSeq = newReadSeq;
     successfulAdvances.add(newReadSeq);
+    if (!firstAdvance.isCompleted) firstAdvance.complete();
     return true;
   }
+
+  @override
+  Future<BleAudioCodec> getAudioCodec() async => BleAudioCodec.opus;
 
   @override
   Future<bool> stopStorageSync() async => true;

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -43,12 +43,17 @@ void main() {
     int packetsPerRead = 2,
     int? nowSeconds,
     bool deepBacklogEnabled = true,
+    RingConnectionResolver? connectionResolver,
+    RingConversationTimeoutSecondsProvider? conversationTimeoutSecondsProvider,
+    RingBacklogSnapshotCompleted? onBacklogSnapshotCompleted,
   }) {
     final sync = RingStorageSyncImpl(
       listener,
-      connectionResolver: (_) async => connection,
+      connectionResolver: connectionResolver ?? (_) async => connection,
       documentsDirectoryProvider: () async => directory,
       deepBacklogPolicy: () => deepBacklogEnabled,
+      conversationTimeoutSecondsProvider: conversationTimeoutSecondsProvider ?? () => 120,
+      onBacklogSnapshotCompleted: onBacklogSnapshotCompleted,
       packetsPerRead: packetsPerRead,
       inactivityTimeout: const Duration(milliseconds: 100),
       nowSeconds: () => nowSeconds ?? _FakeRingConnection.baseTimestamp + 10000,
@@ -90,6 +95,28 @@ void main() {
     expect(wal.status, WalStatus.synced);
   });
 
+  test('ring registration persists the last record wall-clock end across VAD pauses', () async {
+    const firstTimestamp = _FakeRingConnection.baseTimestamp + 100;
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 102,
+      timestamps: {
+        100: firstTimestamp,
+        101: firstTimestamp + 2,
+      },
+      framesPerRecord: 100,
+    );
+    final local = localSync();
+
+    await ringSync(connection, local).syncWal(wal: virtualWal(2));
+
+    final recovered = local.testWals.single;
+    expect(recovered.timerStart, firstTimestamp);
+    expect(recovered.seconds, 2);
+    expect(recovered.captureEndSeconds, firstTimestamp + 3);
+    expect(recovered.wallClockEndSeconds, firstTimestamp + 3);
+  });
+
   test('deep backlog runs only by opt-in or while charging', () {
     expect(
       ringShouldDrainDeepBacklog(
@@ -112,6 +139,12 @@ void main() {
       ),
       isTrue,
     );
+  });
+
+  test('conversation timeout mirrors backend minimum and four-hour sentinel', () {
+    expect(effectiveConversationBoundarySeconds(30), 120);
+    expect(effectiveConversationBoundarySeconds(300), 300);
+    expect(effectiveConversationBoundarySeconds(-1), 4 * 60 * 60);
   });
 
   test('storage-authoritative scheduler persists the live head before draining backlog', () async {
@@ -195,6 +228,599 @@ void main() {
     await session!.cancel();
   });
 
+  test('manual Sync drains one tail-owned snapshot while preserving live priority', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final timestamps = {
+      for (var seq = 0; seq < 192; seq++) seq: now - 1000,
+      for (var seq = 192; seq < 212; seq++) seq: now,
+    };
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 212,
+      timestamps: timestamps,
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+    final liveDelivered = Completer<void>();
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) {
+        if (!liveDelivered.isCompleted) liveDelivered.complete();
+        return _delivered();
+      },
+    );
+
+    await liveDelivered.future.timeout(const Duration(seconds: 1));
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    final firstRequest = sync.requestAudioTailBacklogDrain();
+    final repeatedTap = sync.requestAudioTailBacklogDrain();
+
+    expect(firstRequest, isNotNull);
+    expect(repeatedTap, same(firstRequest));
+    final receipt = await firstRequest!.timeout(const Duration(seconds: 5));
+
+    expect(receipt?.targetWriteSeq, 212);
+    expect(receipt?.deviceId, 'cv1-test');
+    expect(connection.reads.take(3), [
+      (start: 192, count: 20),
+      (start: 96, count: 96),
+      (start: 0, count: 96),
+    ]);
+    expect(connection.successfulAdvances, [96, 212]);
+    expect(sync.isAudioTailActive, isTrue);
+
+    await session!.cancel();
+  });
+
+  test('manual snapshot caps a deep READ at its captured write sequence', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final infoGate = Completer<RingInfo?>();
+    final connection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 212,
+      ringInfoGate: infoGate,
+      growWriteSeqAfterFirstReadBy: 30,
+      timestamps: {
+        for (var seq = 212; seq < 242; seq++) seq: now,
+      },
+    );
+    final local = localSync();
+    File('${directory.path}/future-coverage.bin').writeAsBytesSync([1, 2, 3]);
+    local.testWals = [
+      // Live resume metadata deliberately has no durable file. It suppresses
+      // replay but cannot authorize ADVANCE.
+      Wal(
+        timerStart: now - 1,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'ring_201_212',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+      // A later durable island makes the unconstrained backlog end 300. The
+      // old manual receipt may authorize only [200, 212), never [212, 300).
+      Wal(
+        timerStart: now + 100,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'archive2_ring_300_320_${now + 100}',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+        filePath: 'future-coverage.bin',
+        seconds: 2,
+      ),
+    ];
+    final liveRangeStored = Completer<void>();
+    listener.onWalUpdatedCallback = () {
+      if (!liveRangeStored.isCompleted && local.testWals.any((wal) => wal.sourceId == 'ring_212_242')) {
+        liveRangeStored.complete();
+      }
+    };
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+
+    final start = sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+      resumeLiveContinuity: true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    final request = sync.requestAudioTailBacklogDrain();
+    infoGate.complete(
+      RingInfo(
+        readSeq: 200,
+        writeSeq: 212,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      ),
+    );
+
+    final session = await start;
+    final receipt = await request!.timeout(const Duration(seconds: 1));
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    await liveRangeStored.future.timeout(const Duration(seconds: 1));
+
+    expect(receipt?.targetWriteSeq, 212);
+    expect(connection.reads.take(2), [
+      (start: 200, count: 12),
+      (start: 212, count: 30),
+    ]);
+    expect(connection.successfulAdvances, [212]);
+    expect(
+      local.testWals.singleWhere((wal) => wal.sourceId == 'ring_200_212').uploadIntent,
+      WalUploadIntent.historicalBackfill,
+    );
+    expect(
+      local.testWals.singleWhere((wal) => wal.sourceId == 'ring_212_242').uploadIntent,
+      WalUploadIntent.liveContinuity,
+    );
+    expect(
+      local.testWals.where(
+        (wal) =>
+            wal.uploadIntent == WalUploadIntent.historicalBackfill &&
+            (RingProtocol.parseSourceRange(wal.sourceId)?.start ?? 0) >= 212,
+      ),
+      isEmpty,
+      reason: 'a later writeSeq may be streamed live but must not expand the completed manual snapshot',
+    );
+    await session!.cancel();
+  });
+
+  test('captured manual snapshot survives same-device tail replacement without expanding', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final firstInfo = Completer<RingInfo?>();
+    final firstConnection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 212,
+      ringInfoGate: firstInfo,
+      rejectRead: true,
+    );
+    final replacementConnection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 242,
+      timestamps: {
+        for (var seq = 212; seq < 242; seq++) seq: now,
+      },
+    );
+    var activeConnection = firstConnection;
+    final local = localSync();
+    local.testWals = [
+      Wal(
+        timerStart: now - 1,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'ring_201_212',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+    ];
+    final sync = ringSync(
+      firstConnection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+      connectionResolver: (_) async => activeConnection,
+    );
+
+    final firstStart = sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+      resumeLiveContinuity: true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    final originalRequest = sync.requestAudioTailBacklogDrain();
+    firstInfo.complete(
+      RingInfo(
+        readSeq: 200,
+        writeSeq: 212,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      ),
+    );
+    final firstSession = await firstStart;
+    await expectLater(firstSession!.done, throwsA(isA<Exception>()));
+    expect(firstConnection.reads, [(start: 200, count: 12)]);
+
+    // Android's disconnect callback clears the bound device before the
+    // capture controller starts the replacement tail.
+    sync.setDevice(null);
+    activeConnection = replacementConnection;
+    sync.setDevice(_device());
+    final replacementSession = await sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+      resumeLiveContinuity: true,
+    );
+    final receipt = await originalRequest!.timeout(const Duration(seconds: 5));
+
+    expect(receipt?.deviceId, 'cv1-test');
+    expect(receipt?.targetWriteSeq, 212);
+    expect(replacementConnection.reads.take(2), [
+      (start: 212, count: 30),
+      (start: 200, count: 12),
+    ]);
+    expect(replacementConnection.successfulAdvances, [212]);
+    expect(
+      local.testWals.where(
+        (wal) =>
+            wal.uploadIntent == WalUploadIntent.historicalBackfill &&
+            (RingProtocol.parseSourceRange(wal.sourceId)?.start ?? 0) >= 212,
+      ),
+      isEmpty,
+    );
+    await replacementSession!.cancel();
+  });
+
+  test('pending manual snapshot is never adopted by a different device', () async {
+    final firstInfo = Completer<RingInfo?>();
+    final firstConnection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 212,
+      ringInfoGate: firstInfo,
+      rejectRead: true,
+    );
+    final otherConnection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+    );
+    final local = localSync();
+    local.testWals = [
+      Wal(
+        timerStart: _FakeRingConnection.baseTimestamp + 9999,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-other',
+        sourceId: 'ring_119_120',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+    ];
+    final sync = ringSync(
+      firstConnection,
+      local,
+      deepBacklogEnabled: false,
+      connectionResolver: (deviceId) async => deviceId == 'cv1-test' ? firstConnection : otherConnection,
+    );
+
+    final firstStart = sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await Future<void>.delayed(Duration.zero);
+    final request = sync.requestAudioTailBacklogDrain()!;
+    firstInfo.complete(
+      RingInfo(
+        readSeq: 200,
+        writeSeq: 212,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      ),
+    );
+    final firstSession = await firstStart;
+    await expectLater(firstSession!.done, throwsA(isA<Exception>()));
+
+    sync.setDevice(null);
+    sync.setDevice(_device('cv1-other'));
+    expect(await request, isNull);
+
+    final otherSession = await sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+      resumeLiveContinuity: true,
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(otherConnection.reads, isEmpty);
+    await otherSession!.cancel();
+  });
+
+  test('explicit cancellation resolves a request while its device is detached', () async {
+    final firstInfo = Completer<RingInfo?>();
+    final connection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 212,
+      ringInfoGate: firstInfo,
+      rejectRead: true,
+    );
+    final sync = ringSync(
+      connection,
+      localSync(),
+      deepBacklogEnabled: false,
+    );
+
+    final start = sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await Future<void>.delayed(Duration.zero);
+    final request = sync.requestAudioTailBacklogDrain()!;
+    firstInfo.complete(
+      RingInfo(
+        readSeq: 200,
+        writeSeq: 212,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      ),
+    );
+    final session = await start;
+    await expectLater(session!.done, throwsA(isA<Exception>()));
+
+    sync.setDevice(null);
+    // WalSyncs.cancelSync invokes this even when isAudioTailActive is false.
+    sync.cancelRequestedAudioTailBacklogDrain();
+    expect(await request, isNull);
+  });
+
+  test('cancelling manual Sync revokes deep drain without stopping live capture', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 10000,
+      timestamps: {
+        for (var seq = 0; seq < 9980; seq++) seq: now - 1000,
+        for (var seq = 9980; seq < 10000; seq++) seq: now,
+      },
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    final request = sync.requestAudioTailBacklogDrain();
+    sync.cancelRequestedAudioTailBacklogDrain();
+
+    expect(await request, isNull);
+    await Future<void>.delayed(const Duration(milliseconds: 1200));
+    expect(connection.reads, [
+      (start: 9980, count: 20),
+      (start: 9884, count: 96),
+    ]);
+    expect(sync.isAudioTailActive, isTrue);
+
+    await session!.cancel();
+  });
+
+  test('restart advances archive-backed coverage without rereading it', () async {
+    final connection = _FakeRingConnection(readSeq: 100, writeSeq: 120);
+    final local = localSync();
+    File('${directory.path}/archive.bin').writeAsBytesSync([1, 2, 3]);
+    local.testWals = [
+      Wal(
+        timerStart: _FakeRingConnection.baseTimestamp,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'archive2_ring_100_120_${_FakeRingConnection.baseTimestamp}',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+        filePath: 'archive.bin',
+        seconds: 2,
+      ),
+    ];
+    final sync = ringSync(
+      connection,
+      local,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await connection.firstAdvance.future.timeout(const Duration(seconds: 1));
+
+    expect(connection.advanceAttempts, [120]);
+    expect(connection.reads, isEmpty);
+
+    await session!.cancel();
+  });
+
+  test('legacy archive identity is never trusted for device ADVANCE', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      rejectRead: true,
+    );
+    final local = localSync();
+    File('${directory.path}/legacy-archive.bin').writeAsBytesSync([1, 2, 3]);
+    local.testWals = [
+      Wal(
+        timerStart: _FakeRingConnection.baseTimestamp,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'archive_ring_100_120_${_FakeRingConnection.baseTimestamp}',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+        filePath: 'legacy-archive.bin',
+        seconds: 2,
+      ),
+    ];
+    final sync = ringSync(
+      connection,
+      local,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await expectLater(session!.done, throwsA(isA<Exception>()));
+
+    expect(connection.reads, [(start: 100, count: 20)]);
+    expect(connection.advanceAttempts, isEmpty);
+  });
+
+  for (final invalidProof in [
+    'corrupted',
+    'non-disk',
+    'null-path',
+    'missing-file',
+    'empty-file',
+  ]) {
+    test('$invalidProof recovery WAL cannot authorize device ADVANCE', () async {
+      final connection = _FakeRingConnection(
+        readSeq: 100,
+        writeSeq: 120,
+        rejectRead: true,
+      );
+      final local = localSync();
+      final fileName = '$invalidProof.bin';
+      if (invalidProof != 'missing-file' && invalidProof != 'null-path') {
+        File('${directory.path}/$fileName').writeAsBytesSync(
+          invalidProof == 'empty-file' ? [] : [1, 2, 3],
+        );
+      }
+      local.testWals = [
+        Wal(
+          timerStart: _FakeRingConnection.baseTimestamp,
+          codec: BleAudioCodec.opus,
+          status: invalidProof == 'corrupted' ? WalStatus.corrupted : WalStatus.miss,
+          storage: invalidProof == 'non-disk' ? WalStorage.mem : WalStorage.disk,
+          originalStorage: WalStorage.sdcard,
+          device: 'cv1-test',
+          sourceId: 'archive2_ring_100_120_${_FakeRingConnection.baseTimestamp}',
+          uploadIntent: WalUploadIntent.historicalBackfill,
+          filePath: invalidProof == 'null-path' ? null : fileName,
+          seconds: 2,
+        ),
+      ];
+      final sync = ringSync(
+        connection,
+        local,
+        deepBacklogEnabled: false,
+      );
+
+      final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+      await expectLater(session!.done, throwsA(isA<Exception>()));
+
+      expect(connection.reads, [(start: 100, count: 20)]);
+      expect(connection.advanceAttempts, isEmpty);
+    });
+  }
+
+  test('tail ownership is visible while connection setup is pending and clears on null', () async {
+    final connectionGate = Completer<DeviceConnection?>();
+    final local = localSync();
+    final sync = RingStorageSyncImpl(
+      listener,
+      connectionResolver: (_) => connectionGate.future,
+      documentsDirectoryProvider: () async => directory,
+      deepBacklogPolicy: () => false,
+      conversationTimeoutSecondsProvider: () => 120,
+      inactivityTimeout: const Duration(milliseconds: 100),
+    )
+      ..setDevice(_device())
+      ..setLocalSync(local);
+
+    final start = sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await Future<void>.delayed(Duration.zero);
+
+    expect(sync.isAudioTailActive, isTrue);
+    connectionGate.complete(null);
+    expect(await start, isNull);
+    expect(sync.isAudioTailActive, isFalse);
+  });
+
+  test('tail ownership clears when setup throws', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      codecError: StateError('codec failed'),
+    );
+    final sync = ringSync(
+      connection,
+      localSync(),
+      deepBacklogEnabled: false,
+    );
+
+    await expectLater(
+      sync.startAudioTail(onLiveFrames: (_) => _delivered()),
+      throwsA(isA<StateError>()),
+    );
+    expect(sync.isAudioTailActive, isFalse);
+  });
+
+  test('manual request shares reserved owner while ring info is pending', () async {
+    final infoGate = Completer<RingInfo?>();
+    final connection = _FakeRingConnection(
+      readSeq: 120,
+      writeSeq: 120,
+      ringInfoGate: infoGate,
+    );
+    final sync = ringSync(
+      connection,
+      localSync(),
+      deepBacklogEnabled: false,
+    );
+
+    final start = sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await Future<void>.delayed(Duration.zero);
+    final request = sync.requestAudioTailBacklogDrain();
+
+    expect(sync.isAudioTailActive, isTrue);
+    expect(request, isNotNull);
+    expect(connection.ringInfoCalls, 1);
+    expect(connection.reads, isEmpty);
+
+    infoGate.complete(
+      RingInfo(
+        readSeq: 120,
+        writeSeq: 120,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      ),
+    );
+    final session = await start;
+    final receipt = await request;
+
+    expect(receipt?.targetWriteSeq, 120);
+    expect(connection.reads, isEmpty);
+    await session!.cancel();
+  });
+
+  test('automatic deep snapshot reports one bounded cloud-work receipt', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 212,
+      timestamps: {
+        for (var seq = 0; seq < 212; seq++) seq: now - 1000,
+      },
+    );
+    final completion = Completer<RingBacklogDrainReceipt>();
+    final sync = ringSync(
+      connection,
+      localSync(),
+      nowSeconds: now,
+      onBacklogSnapshotCompleted: (receipt) {
+        if (!completion.isCompleted) completion.complete(receipt);
+      },
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    final receipt = await completion.future.timeout(const Duration(seconds: 5));
+
+    expect(receipt.deviceId, 'cv1-test');
+    expect(receipt.targetWriteSeq, 212);
+    await session!.cancel();
+  });
+
   test('sparse old VAD records stop recent recovery after one timestamp probe', () async {
     const now = _FakeRingConnection.baseTimestamp + 10000;
     final timestamps = {
@@ -248,6 +874,58 @@ void main() {
     expect(connection.reads[1], (start: 120, count: 30));
     expect(connection.reads[1].start, connection.reads[0].start + connection.reads[0].count);
 
+    await session!.cancel();
+  });
+
+  test('tail snapshots a five-minute conversation timeout before asynchronous setup', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final infoGate = Completer<RingInfo?>();
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      ringInfoGate: infoGate,
+      timestamps: {
+        for (var seq = 100; seq < 120; seq++) seq: now - 180,
+      },
+    );
+    var configuredTimeout = 300;
+    final local = localSync();
+    final stored = Completer<void>();
+    listener.onWalUpdatedCallback = () {
+      if (!stored.isCompleted && local.testWals.any((wal) => wal.sourceId == 'ring_100_120')) {
+        stored.complete();
+      }
+    };
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+      conversationTimeoutSecondsProvider: () => configuredTimeout,
+    );
+
+    final start = sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+      resumeLiveContinuity: true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    configuredTimeout = 120;
+    infoGate.complete(
+      RingInfo(
+        readSeq: 100,
+        writeSeq: 120,
+        capacityPackets: 1000000,
+        droppedPackets: 0,
+        packetSize: RingProtocol.recordSize,
+      ),
+    );
+
+    final session = await start;
+    await stored.future.timeout(const Duration(seconds: 3));
+    expect(
+      local.testWals.singleWhere((wal) => wal.sourceId == 'ring_100_120').uploadIntent,
+      WalUploadIntent.liveContinuity,
+    );
     await session!.cancel();
   });
 
@@ -337,8 +1015,74 @@ void main() {
         readSeq: 0,
         writeSeq: 10000,
         nowSeconds: now,
+        recentSeconds: 120,
       ),
       9920,
+    );
+  });
+
+  test('live reconnect recency uses persisted capture end instead of compressed duration', () {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final vadSpanningWal = Wal(
+      timerStart: now - 1000,
+      codec: BleAudioCodec.opus,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      device: 'cv1-test',
+      sourceId: 'ring_9800_9900',
+      uploadIntent: WalUploadIntent.liveContinuity,
+      seconds: 2,
+      captureEndSeconds: now - 10,
+    );
+
+    expect(
+      ringLiveResumeSequence(
+        wals: [vadSpanningWal],
+        deviceId: 'cv1-test',
+        readSeq: 9000,
+        writeSeq: 10000,
+        nowSeconds: now,
+        recentSeconds: 120,
+      ),
+      9800,
+    );
+  });
+
+  test('live reconnect honors a configured five-minute open conversation', () {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final openConversationWal = Wal(
+      timerStart: now - 1000,
+      codec: BleAudioCodec.opus,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      device: 'cv1-test',
+      sourceId: 'ring_9800_9900',
+      uploadIntent: WalUploadIntent.liveContinuity,
+      seconds: 2,
+      captureEndSeconds: now - 180,
+    );
+
+    expect(
+      ringLiveResumeSequence(
+        wals: [openConversationWal],
+        deviceId: 'cv1-test',
+        readSeq: 9000,
+        writeSeq: 10000,
+        nowSeconds: now,
+        recentSeconds: 300,
+      ),
+      9800,
+    );
+    expect(
+      ringLiveResumeSequence(
+        wals: [openConversationWal],
+        deviceId: 'cv1-test',
+        readSeq: 9000,
+        writeSeq: 10000,
+        nowSeconds: now,
+        recentSeconds: 120,
+      ),
+      isNull,
     );
   });
 
@@ -384,6 +1128,7 @@ void main() {
         readSeq: 90,
         writeSeq: 130,
         nowSeconds: now,
+        recentSeconds: 120,
       ),
       120,
     );
@@ -396,6 +1141,8 @@ void main() {
       writeSeq: 130,
     );
     final local = localSync();
+    File('${directory.path}/range-100-110.bin').writeAsBytesSync([1, 2, 3]);
+    File('${directory.path}/range-110-120.bin').writeAsBytesSync([4, 5, 6]);
     local.testWals = [
       Wal(
         timerStart: now - 2,
@@ -405,6 +1152,7 @@ void main() {
         originalStorage: WalStorage.sdcard,
         device: 'cv1-test',
         sourceId: 'ring_100_110',
+        filePath: 'range-100-110.bin',
         uploadIntent: WalUploadIntent.liveContinuity,
         seconds: 1,
       ),
@@ -416,6 +1164,7 @@ void main() {
         originalStorage: WalStorage.sdcard,
         device: 'cv1-test',
         sourceId: 'ring_110_120',
+        filePath: 'range-110-120.bin',
         uploadIntent: WalUploadIntent.liveContinuity,
         seconds: 1,
       ),
@@ -459,6 +1208,7 @@ void main() {
         readSeq: 1000,
         writeSeq: 1200,
         nowSeconds: now,
+        recentSeconds: 120,
       ),
       1000,
     );
@@ -785,6 +1535,83 @@ void main() {
     expect(local.testWals.map((wal) => wal.timerStart), [1799999996, 1799999998]);
   });
 
+  test('invalid RTC fallback continues from the predecessor wall-clock capture end', () async {
+    final local = localSync();
+    local.testWals = [
+      Wal(
+        timerStart: 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 100,
+        captureEndSeconds: 2000.75,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'ring_100_200',
+      ),
+    ];
+    final connection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 201,
+      timestamps: const {200: 0},
+      framesPerRecord: 100,
+    );
+
+    await ringSync(connection, local, nowSeconds: 3000).syncWal(wal: virtualWal(1));
+
+    final recovered = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_200_201');
+    expect(recovered.timerStart, 2000);
+    expect(recovered.captureEndSeconds, 2001);
+  });
+
+  test('tail restart continues invalid RTC chronology from an archive2 predecessor', () async {
+    final local = localSync();
+    File('${directory.path}/archive2-predecessor.bin').writeAsBytesSync([1, 2, 3]);
+    local.testWals = [
+      Wal(
+        timerStart: 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 100,
+        captureEndSeconds: 2000.75,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'archive2_ring_100_200_1000',
+        filePath: 'archive2-predecessor.bin',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+      ),
+    ];
+    final stored = Completer<void>();
+    listener.onWalUpdatedCallback = () {
+      if (!stored.isCompleted && local.testWals.any((wal) => wal.sourceId == 'ring_200_201')) {
+        stored.complete();
+      }
+    };
+    final connection = _FakeRingConnection(
+      readSeq: 200,
+      writeSeq: 201,
+      timestamps: const {200: 0},
+      framesPerRecord: 100,
+    );
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: 3000,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await stored.future.timeout(const Duration(seconds: 3));
+
+    final recovered = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_200_201');
+    expect(recovered.timerStart, 2000);
+    expect(recovered.captureEndSeconds, 2001);
+    await session!.cancel();
+  });
+
   test('byte-identical legacy timestamp WAL is reused instead of uploaded twice', () async {
     final local = localSync();
     final legacyFile = File('${directory.path}/legacy.bin')..writeAsBytesSync([1, 2, 3, 4]);
@@ -817,6 +1644,42 @@ void main() {
 
     expect(result, ExternalWalRegistration.alreadyRegistered);
     expect(local.testWals, hasLength(1));
+    expect(await candidateFile.exists(), isFalse);
+  });
+
+  test('byte-identical retry upgrades legacy capture-end metadata before acknowledgment', () async {
+    final local = localSync();
+    final legacyFile = File('${directory.path}/legacy-upgrade.bin')..writeAsBytesSync([1, 2, 3, 4]);
+    final candidateFile = File('${directory.path}/range-upgrade.bin')..writeAsBytesSync([1, 2, 3, 4]);
+    final legacy = Wal(
+      timerStart: 1700000850,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      device: 'cv1-test',
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: legacyFile.path.split('/').last,
+    );
+    local.testWals = [legacy];
+    final candidate = Wal(
+      timerStart: 1700000850,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      captureEndSeconds: 1700000860.5,
+      device: 'cv1-test',
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: candidateFile.path.split('/').last,
+      sourceId: 'ring_850_852',
+    );
+
+    final result = await local.addExternalWal(candidate);
+
+    expect(result, ExternalWalRegistration.alreadyRegistered);
+    expect(legacy.captureEndSeconds, 1700000860.5);
+    expect(local.testWals, [legacy]);
     expect(await candidateFile.exists(), isFalse);
   });
 
@@ -856,14 +1719,16 @@ void main() {
   });
 }
 
-BtDevice _device() => BtDevice(name: 'Omi', id: 'cv1-test', type: DeviceType.omi, rssi: -40);
+BtDevice _device([String id = 'cv1-test']) => BtDevice(name: 'Omi', id: id, type: DeviceType.omi, rssi: -40);
 
 class _Listener implements IWalSyncListener {
+  void Function()? onWalUpdatedCallback;
+
   @override
   void onWalSynced(Wal wal, {ServerConversation? conversation}) {}
 
   @override
-  void onWalUpdated() {}
+  void onWalUpdated() => onWalUpdatedCallback?.call();
 }
 
 class _FakeRingConnection implements DeviceConnection {
@@ -876,6 +1741,9 @@ class _FakeRingConnection implements DeviceConnection {
   final bool corruptCrc;
   final bool failAdvance;
   final bool connected;
+  final bool rejectRead;
+  final Object? codecError;
+  final Completer<RingInfo?>? ringInfoGate;
   final int framesPerRecord;
   final Map<int, int> timestamps;
   final reads = <({int start, int count})>[];
@@ -885,6 +1753,7 @@ class _FakeRingConnection implements DeviceConnection {
   final Completer<void> secondRead = Completer<void>();
   final Completer<void> thirdRead = Completer<void>();
   final StreamController<List<int>> _notifications = StreamController<List<int>>.broadcast(sync: true);
+  int ringInfoCalls = 0;
 
   _FakeRingConnection({
     required this.readSeq,
@@ -894,18 +1763,26 @@ class _FakeRingConnection implements DeviceConnection {
     this.corruptCrc = false,
     this.failAdvance = false,
     this.connected = true,
+    this.rejectRead = false,
+    this.codecError,
+    this.ringInfoGate,
     this.framesPerRecord = 1,
     this.timestamps = const {},
   });
 
   @override
-  Future<RingInfo?> getRingInfo() async => RingInfo(
-        readSeq: readSeq,
-        writeSeq: writeSeq,
-        capacityPackets: 1000000,
-        droppedPackets: 0,
-        packetSize: RingProtocol.recordSize,
-      );
+  Future<RingInfo?> getRingInfo() async {
+    ringInfoCalls++;
+    final gate = ringInfoGate;
+    if (gate != null && ringInfoCalls == 1) return gate.future;
+    return RingInfo(
+      readSeq: readSeq,
+      writeSeq: writeSeq,
+      capacityPackets: 1000000,
+      droppedPackets: 0,
+      packetSize: RingProtocol.recordSize,
+    );
+  }
 
   @override
   Future<StreamSubscription?> getBleStorageBytesListener({
@@ -917,6 +1794,7 @@ class _FakeRingConnection implements DeviceConnection {
   Future<bool> readRingFromSeq(int startSeq, {int? packetCount}) async {
     final count = packetCount!;
     reads.add((start: startSeq, count: count));
+    if (rejectRead) return false;
     if (reads.length == 1 && growWriteSeqAfterFirstReadBy > 0) {
       writeSeq += growWriteSeqAfterFirstReadBy;
     }
@@ -954,7 +1832,11 @@ class _FakeRingConnection implements DeviceConnection {
   Future<bool> isConnected() async => connected;
 
   @override
-  Future<BleAudioCodec> getAudioCodec() async => BleAudioCodec.opus;
+  Future<BleAudioCodec> getAudioCodec() async {
+    final error = codecError;
+    if (error != null) throw error;
+    return BleAudioCodec.opus;
+  }
 
   @override
   Future<bool> stopStorageSync() async => true;

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -342,6 +342,103 @@ void main() {
     );
   });
 
+  test('delivered replay coverage suppresses an older overlapping pending range', () {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final wals = [
+      Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_100_120',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 2,
+      ),
+      Wal(
+        timerStart: now - 9,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_100_110',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+      Wal(
+        timerStart: now - 8,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_110_120',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+    ];
+
+    expect(
+      ringLiveResumeSequence(
+        wals: wals,
+        deviceId: 'cv1-test',
+        readSeq: 90,
+        writeSeq: 130,
+        nowSeconds: now,
+      ),
+      120,
+    );
+  });
+
+  test('reconnect reads durable replay and uncovered tail as separate ranges', () async {
+    const now = _FakeRingConnection.baseTimestamp + 130;
+    final connection = _FakeRingConnection(
+      readSeq: 90,
+      writeSeq: 130,
+    );
+    final local = localSync();
+    local.testWals = [
+      Wal(
+        timerStart: now - 2,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'ring_100_110',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+      Wal(
+        timerStart: now - 1,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1-test',
+        sourceId: 'ring_110_120',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 1,
+      ),
+    ];
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+      resumeLiveContinuity: true,
+    );
+
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    expect(connection.reads[0], (start: 100, count: 20));
+    expect(connection.reads[1], (start: 120, count: 10));
+
+    await session!.cancel();
+  });
+
   test('recent delivery ending at the device cursor resumes that cursor instead of the head', () {
     const now = _FakeRingConnection.baseTimestamp + 10000;
     final delivered = Wal(

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -84,6 +84,48 @@ void main() {
     expect(wal.status, WalStatus.synced);
   });
 
+  test('durable ring WAL uses exact little-endian length-prefixed frame bytes', () async {
+    const startSeq = 0x1234;
+    final connection = _FakeRingConnection(readSeq: startSeq, writeSeq: startSeq + 2, framesPerRecord: 2);
+    final local = localSync();
+
+    await ringSync(connection, local).syncWal(wal: virtualWal(2));
+
+    expect(connection.successfulAdvances, [startSeq + 2]);
+    expect(local.testWals, hasLength(1));
+    final bytes = await File('${directory.path}/${local.testWals.single.filePath}').readAsBytes();
+    expect(bytes, [
+      3,
+      0,
+      0,
+      0,
+      0x34,
+      0x12,
+      0,
+      3,
+      0,
+      0,
+      0,
+      0x34,
+      0x12,
+      1,
+      3,
+      0,
+      0,
+      0,
+      0x35,
+      0x12,
+      0,
+      3,
+      0,
+      0,
+      0,
+      0x35,
+      0x12,
+      1,
+    ]);
+  });
+
   test('interrupted range keeps its cursor and retry resumes after the last durable advance', () async {
     final local = localSync();
     final firstConnection = _FakeRingConnection(readSeq: 200, writeSeq: 205, truncateStartSeq: 202);

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -268,6 +268,49 @@ void main() {
     await session!.cancel();
   });
 
+  test('new live audio preempts the next manual backlog slice', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 500,
+      growWriteSeqAfterFirstReadBy: 20,
+      growWriteSeqAfterReadNumber: 3,
+      timestamps: {
+        for (var seq = 0; seq < 480; seq++) seq: now - 1000,
+        for (var seq = 480; seq < 520; seq++) seq: now,
+      },
+    );
+    final sync = ringSync(
+      connection,
+      localSync(),
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) => _delivered(),
+    );
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    final request = sync.requestAudioTailBacklogDrain();
+
+    expect(request, isNotNull);
+    await connection.thirdRead.future.timeout(const Duration(seconds: 3));
+    await connection.fourthRead.future.timeout(const Duration(seconds: 3));
+
+    expect(connection.reads.take(4), [
+      (start: 480, count: 20),
+      (start: 384, count: 96),
+      (start: 0, count: 96),
+      // Twenty records arrived while the preceding backlog slice was in
+      // flight. They must preempt the next historical slice.
+      (start: 500, count: 20),
+    ]);
+
+    sync.cancelRequestedAudioTailBacklogDrain();
+    expect(await request, isNull);
+    await session!.cancel();
+  });
+
   test('manual snapshot caps a deep READ at its captured write sequence', () async {
     const now = _FakeRingConnection.baseTimestamp + 10000;
     final infoGate = Completer<RingInfo?>();
@@ -1728,6 +1771,7 @@ class _FakeRingConnection implements DeviceConnection {
   int readSeq;
   int writeSeq;
   final int growWriteSeqAfterFirstReadBy;
+  final int growWriteSeqAfterReadNumber;
   final int? truncateStartSeq;
   final bool corruptCrc;
   final bool failAdvance;
@@ -1743,6 +1787,7 @@ class _FakeRingConnection implements DeviceConnection {
   final Completer<void> firstAdvance = Completer<void>();
   final Completer<void> secondRead = Completer<void>();
   final Completer<void> thirdRead = Completer<void>();
+  final Completer<void> fourthRead = Completer<void>();
   final StreamController<List<int>> _notifications = StreamController<List<int>>.broadcast(sync: true);
   int ringInfoCalls = 0;
 
@@ -1750,6 +1795,7 @@ class _FakeRingConnection implements DeviceConnection {
     required this.readSeq,
     required this.writeSeq,
     this.growWriteSeqAfterFirstReadBy = 0,
+    this.growWriteSeqAfterReadNumber = 1,
     this.truncateStartSeq,
     this.corruptCrc = false,
     this.failAdvance = false,
@@ -1786,11 +1832,12 @@ class _FakeRingConnection implements DeviceConnection {
     final count = packetCount!;
     reads.add((start: startSeq, count: count));
     if (rejectRead) return false;
-    if (reads.length == 1 && growWriteSeqAfterFirstReadBy > 0) {
+    if (reads.length == growWriteSeqAfterReadNumber && growWriteSeqAfterFirstReadBy > 0) {
       writeSeq += growWriteSeqAfterFirstReadBy;
     }
     if (reads.length == 2 && !secondRead.isCompleted) secondRead.complete();
     if (reads.length == 3 && !thirdRead.isCompleted) thirdRead.complete();
+    if (reads.length == 4 && !fourthRead.isCompleted) fourthRead.complete();
     scheduleMicrotask(() {
       _notifications.add(_readBegin(startSeq, count));
       final requested = <int>[];

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -229,6 +229,29 @@ void main() {
     await session!.cancel();
   });
 
+  test('live cursor catches up sequentially instead of skipping records produced during a read', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      growWriteSeqAfterFirstReadBy: 30,
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    expect(connection.reads[0], (start: 100, count: 20));
+    expect(connection.reads[1], (start: 120, count: 30));
+    expect(connection.reads[1].start, connection.reads[0].start + connection.reads[0].count);
+
+    await session!.cancel();
+  });
+
   test('interrupted live-head read leaves backlog cursor untouched', () async {
     final timestamps = {for (var seq = 0; seq < 1000; seq++) seq: _FakeRingConnection.baseTimestamp + 1000};
     final connection = _FakeRingConnection(
@@ -601,7 +624,8 @@ class _FakeRingConnection implements DeviceConnection {
   static const int baseTimestamp = 1710000000;
 
   int readSeq;
-  final int writeSeq;
+  int writeSeq;
+  final int growWriteSeqAfterFirstReadBy;
   final int? truncateStartSeq;
   final bool corruptCrc;
   final bool failAdvance;
@@ -619,6 +643,7 @@ class _FakeRingConnection implements DeviceConnection {
   _FakeRingConnection({
     required this.readSeq,
     required this.writeSeq,
+    this.growWriteSeqAfterFirstReadBy = 0,
     this.truncateStartSeq,
     this.corruptCrc = false,
     this.failAdvance = false,
@@ -646,6 +671,9 @@ class _FakeRingConnection implements DeviceConnection {
   Future<bool> readRingFromSeq(int startSeq, {int? packetCount}) async {
     final count = packetCount!;
     reads.add((start: startSeq, count: count));
+    if (reads.length == 1 && growWriteSeqAfterFirstReadBy > 0) {
+      writeSeq += growWriteSeqAfterFirstReadBy;
+    }
     if (reads.length == 2 && !secondRead.isCompleted) secondRead.complete();
     if (reads.length == 3 && !thirdRead.isCompleted) thirdRead.complete();
     scheduleMicrotask(() {

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -6,12 +6,15 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/services/capture/live_audio_frame_pacer.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/ring_storage_sync.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
+
+LiveAudioFrameDelivery _delivered() => LiveAudioFrameDelivery.accepted(Future<bool>.value(true));
 
 void main() {
   late Directory directory;
@@ -87,27 +90,6 @@ void main() {
     expect(wal.status, WalStatus.synced);
   });
 
-  test('recent recovery floor covers two minutes without forcing the deep prefix', () {
-    expect(
-      ringRecentRecoveryFloor(
-        readSeq: 100,
-        writeSeq: 1000,
-        framesPerRecord: 20,
-        framesPerSecond: 50,
-      ),
-      700,
-    );
-    expect(
-      ringRecentRecoveryFloor(
-        readSeq: 800,
-        writeSeq: 1000,
-        framesPerRecord: 20,
-        framesPerSecond: 50,
-      ),
-      800,
-    );
-  });
-
   test('deep backlog runs only by opt-in or while charging', () {
     expect(
       ringShouldDrainDeepBacklog(
@@ -152,7 +134,7 @@ void main() {
     final session = await sync.startAudioTail(
       onLiveFrames: (frames) {
         if (!liveDelivered.isCompleted) liveDelivered.complete();
-        return true;
+        return _delivered();
       },
     );
 
@@ -162,18 +144,10 @@ void main() {
     expect(connection.advanceAttempts, isEmpty);
 
     await connection.secondRead.future.timeout(const Duration(seconds: 3));
-    final framesPerRecord = RingProtocol.audioPayloadBytes ~/ (BleAudioCodec.opus.getFramesLengthInBytes() + 1);
-    final recentFloor = ringRecentRecoveryFloor(
-      readSeq: 0,
-      writeSeq: 10000,
-      framesPerRecord: framesPerRecord,
-      framesPerSecond: BleAudioCodec.opus.getFramesPerSecond(),
-    );
-    expect(connection.reads[1], (start: recentFloor, count: 96));
+    expect(connection.reads[1], (start: 9884, count: 96));
 
     await connection.thirdRead.future.timeout(const Duration(seconds: 3));
-    expect(connection.reads[2], (start: recentFloor + 96, count: 96));
-    expect(connection.reads.where((read) => read.start < recentFloor), isEmpty);
+    expect(connection.reads[2], (start: 9788, count: 96));
     expect(connection.advanceAttempts, isEmpty);
 
     await session!.cancel();
@@ -209,24 +183,49 @@ void main() {
     final session = await sync.startAudioTail(
       onLiveFrames: (_) {
         if (!liveDelivered.isCompleted) liveDelivered.complete();
-        return true;
+        return _delivered();
       },
     );
 
     await liveDelivered.future.timeout(const Duration(seconds: 1));
     await connection.secondRead.future.timeout(const Duration(seconds: 3));
-    final framesPerRecord = RingProtocol.audioPayloadBytes ~/ (BleAudioCodec.opus.getFramesLengthInBytes() + 1);
-    final recentFloor = ringRecentRecoveryFloor(
-      readSeq: 0,
-      writeSeq: 10000,
-      framesPerRecord: framesPerRecord,
-      framesPerSecond: BleAudioCodec.opus.getFramesPerSecond(),
-    );
     expect(connection.reads.first, (start: 9980, count: 20));
-    expect(connection.reads[1], (start: recentFloor, count: 96));
-    expect(connection.reads.where((read) => read.start < recentFloor), isEmpty);
+    expect(connection.reads[1], (start: 9884, count: 96));
 
     await session!.cancel();
+  });
+
+  test('sparse old VAD records stop recent recovery after one timestamp probe', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final timestamps = {
+      for (var seq = 0; seq < 9980; seq++) seq: now - 1000,
+      for (var seq = 9980; seq < 10000; seq++) seq: now,
+    };
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 10000,
+      timestamps: timestamps,
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await session!.cancel();
+
+    expect(connection.reads, [
+      (start: 9980, count: 20),
+      (start: 9884, count: 96),
+    ]);
+    final probeWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_9884_9980');
+    expect(probeWal.uploadIntent, WalUploadIntent.historicalBackfill);
+    expect(probeWal.status, WalStatus.miss);
   });
 
   test('live cursor catches up sequentially instead of skipping records produced during a read', () async {
@@ -242,12 +241,161 @@ void main() {
       deepBacklogEnabled: false,
     );
 
-    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
 
     await connection.secondRead.future.timeout(const Duration(seconds: 3));
     expect(connection.reads[0], (start: 100, count: 20));
     expect(connection.reads[1], (start: 120, count: 30));
     expect(connection.reads[1].start, connection.reads[0].start + connection.reads[0].count);
+
+    await session!.cancel();
+  });
+
+  test('reconnect without recent delivery history prioritizes the live head over old backlog', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 250,
+      timestamps: {
+        for (var seq = 230; seq < 250; seq++) seq: now,
+      },
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+    );
+
+    final liveDelivered = Completer<void>();
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) {
+        if (!liveDelivered.isCompleted) liveDelivered.complete();
+        return _delivered();
+      },
+      resumeLiveContinuity: true,
+    );
+
+    await liveDelivered.future.timeout(const Duration(seconds: 1));
+    expect(connection.reads[0], (start: 230, count: 20));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(connection.reads, hasLength(1));
+
+    await session!.cancel();
+  });
+
+  test('live reconnect resumes at earliest recent undelivered range', () {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final wals = [
+      Wal(
+        timerStart: now - 8,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_9900_9920',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 2,
+      ),
+      Wal(
+        timerStart: now - 6,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_9920_9940',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 2,
+      ),
+      Wal(
+        timerStart: now - 4,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_9940_9960',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 2,
+      ),
+      Wal(
+        timerStart: now - 1000,
+        codec: BleAudioCodec.opus,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        device: 'cv1-test',
+        sourceId: 'ring_100_200',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        seconds: 10,
+      ),
+    ];
+
+    expect(
+      ringLiveResumeSequence(
+        wals: wals,
+        deviceId: 'cv1-test',
+        readSeq: 0,
+        writeSeq: 10000,
+        nowSeconds: now,
+      ),
+      9920,
+    );
+  });
+
+  test('recent delivery ending at the device cursor resumes that cursor instead of the head', () {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final delivered = Wal(
+      timerStart: now - 10,
+      codec: BleAudioCodec.opus,
+      status: WalStatus.synced,
+      storage: WalStorage.disk,
+      device: 'cv1-test',
+      sourceId: 'ring_980_1000',
+      uploadIntent: WalUploadIntent.liveContinuity,
+      seconds: 2,
+    );
+
+    expect(
+      ringLiveResumeSequence(
+        wals: [delivered],
+        deviceId: 'cv1-test',
+        readSeq: 1000,
+        writeSeq: 1200,
+        nowSeconds: now,
+      ),
+      1000,
+    );
+  });
+
+  test('live WAL stays retryable until every accepted preview frame is sent', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      timestamps: {
+        for (var seq = 100; seq < 120; seq++) seq: _FakeRingConnection.baseTimestamp + 10000,
+      },
+    );
+    final local = localSync();
+    final sync = ringSync(connection, local, deepBacklogEnabled: false);
+    final previewCompleted = Completer<bool>();
+    final previewAccepted = Completer<void>();
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) {
+        if (!previewAccepted.isCompleted) previewAccepted.complete();
+        return LiveAudioFrameDelivery.accepted(previewCompleted.future);
+      },
+    );
+
+    await previewAccepted.future.timeout(const Duration(seconds: 1));
+    final liveWal = local.testWals.singleWhere(
+      (wal) => wal.sourceId == 'ring_100_120',
+    );
+    expect(liveWal.status, WalStatus.miss);
+
+    previewCompleted.complete(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(liveWal.status, WalStatus.synced);
 
     await session!.cancel();
   });
@@ -267,7 +415,7 @@ void main() {
       nowSeconds: _FakeRingConnection.baseTimestamp + 1000,
     );
 
-    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
 
     expect(session, isNotNull);
     await expectLater(session!.done, throwsA(isA<RingStorageException>()));
@@ -288,7 +436,7 @@ void main() {
     final local = localSync();
     final sync = ringSync(connection, local);
 
-    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
 
     expect(session, isNotNull);
     await expectLater(session!.done, completes);
@@ -306,7 +454,7 @@ void main() {
     final local = localSync();
     final sync = ringSync(connection, local);
 
-    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
 
     expect(session, isNotNull);
     await expectLater(
@@ -342,17 +490,18 @@ void main() {
     final session = await sync.startAudioTail(
       onLiveFrames: (_) {
         if (!liveDelivered.isCompleted) liveDelivered.complete();
-        return true;
+        return _delivered();
       },
     );
 
     await liveDelivered.future.timeout(const Duration(seconds: 1));
-    await connection.firstAdvance.future.timeout(const Duration(seconds: 3));
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
     await session!.cancel();
 
     final liveWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_980_1000');
-    final firstBacklogWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_0_96');
-    expect(firstBacklogWal.timerStart, _FakeRingConnection.baseTimestamp + 950);
+    final recentWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_884_980');
+    expect(recentWal.timerStart, _FakeRingConnection.baseTimestamp + 994);
     expect(liveWal.timerStart, _FakeRingConnection.baseTimestamp + 999);
   });
 

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -39,11 +39,13 @@ void main() {
     LocalWalSync local, {
     int packetsPerRead = 2,
     int? nowSeconds,
+    bool deepBacklogEnabled = true,
   }) {
     final sync = RingStorageSyncImpl(
       listener,
       connectionResolver: (_) async => connection,
       documentsDirectoryProvider: () async => directory,
+      deepBacklogPolicy: () => deepBacklogEnabled,
       packetsPerRead: packetsPerRead,
       inactivityTimeout: const Duration(milliseconds: 100),
       nowSeconds: () => nowSeconds ?? _FakeRingConnection.baseTimestamp + 10000,
@@ -81,7 +83,29 @@ void main() {
       'ring_104_106',
       'ring_106_107',
     ]);
+    expect(local.testWals.every((wal) => wal.seconds > 0), isTrue);
     expect(wal.status, WalStatus.synced);
+  });
+
+  test('recent recovery floor covers two minutes without forcing the deep prefix', () {
+    expect(
+      ringRecentRecoveryFloor(
+        readSeq: 100,
+        writeSeq: 1000,
+        framesPerRecord: 20,
+        framesPerSecond: 50,
+      ),
+      700,
+    );
+    expect(
+      ringRecentRecoveryFloor(
+        readSeq: 800,
+        writeSeq: 1000,
+        framesPerRecord: 20,
+        framesPerSecond: 50,
+      ),
+      800,
+    );
   });
 
   test('storage-authoritative scheduler persists the live head before draining backlog', () async {
@@ -111,14 +135,66 @@ void main() {
     expect(connection.reads.first, (start: 980, count: 20));
     expect(connection.advanceAttempts, isEmpty);
 
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    final framesPerRecord = RingProtocol.audioPayloadBytes ~/ (BleAudioCodec.opus.getFramesLengthInBytes() + 1);
+    final recentFloor = ringRecentRecoveryFloor(
+      readSeq: 0,
+      writeSeq: 1000,
+      framesPerRecord: framesPerRecord,
+      framesPerSecond: BleAudioCodec.opus.getFramesPerSecond(),
+    );
+    expect(connection.reads[1], (start: recentFloor, count: 96));
+
     await connection.firstAdvance.future.timeout(const Duration(seconds: 3));
-    expect(connection.reads[1], (start: 0, count: 96));
+    await connection.thirdRead.future.timeout(const Duration(seconds: 3));
+    expect(connection.reads[2], (start: 96, count: 96));
     expect(connection.successfulAdvances.first, 96);
     expect(connection.successfulAdvances, isNot(contains(1000)));
 
     await session!.cancel();
     expect(session.isActive, isFalse);
     expect(local.testWals.any((wal) => wal.sourceId == 'ring_980_1000'), isTrue);
+  });
+
+  test('disabled auto-sync recovers recent gap but does not start the deep prefix', () async {
+    final timestamps = {
+      for (var seq = 9980; seq < 10000; seq++) seq: _FakeRingConnection.baseTimestamp + 10000,
+    };
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 10000,
+      timestamps: timestamps,
+    );
+    final local = localSync();
+    final sync = ringSync(
+      connection,
+      local,
+      nowSeconds: _FakeRingConnection.baseTimestamp + 10000,
+      deepBacklogEnabled: false,
+    );
+    final liveDelivered = Completer<void>();
+
+    final session = await sync.startAudioTail(
+      onLiveFrames: (_) {
+        if (!liveDelivered.isCompleted) liveDelivered.complete();
+        return true;
+      },
+    );
+
+    await liveDelivered.future.timeout(const Duration(seconds: 1));
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    final framesPerRecord = RingProtocol.audioPayloadBytes ~/ (BleAudioCodec.opus.getFramesLengthInBytes() + 1);
+    final recentFloor = ringRecentRecoveryFloor(
+      readSeq: 0,
+      writeSeq: 10000,
+      framesPerRecord: framesPerRecord,
+      framesPerSecond: BleAudioCodec.opus.getFramesPerSecond(),
+    );
+    expect(connection.reads.first, (start: 9980, count: 20));
+    expect(connection.reads[1], (start: recentFloor, count: 96));
+    expect(connection.reads.where((read) => read.start < recentFloor), isEmpty);
+
+    await session!.cancel();
   });
 
   test('interrupted live-head read leaves backlog cursor untouched', () async {
@@ -457,6 +533,8 @@ class _FakeRingConnection implements DeviceConnection {
   final advanceAttempts = <int>[];
   final successfulAdvances = <int>[];
   final Completer<void> firstAdvance = Completer<void>();
+  final Completer<void> secondRead = Completer<void>();
+  final Completer<void> thirdRead = Completer<void>();
   final StreamController<List<int>> _notifications = StreamController<List<int>>.broadcast(sync: true);
 
   _FakeRingConnection({
@@ -488,6 +566,8 @@ class _FakeRingConnection implements DeviceConnection {
   Future<bool> readRingFromSeq(int startSeq, {int? packetCount}) async {
     final count = packetCount!;
     reads.add((start: startSeq, count: count));
+    if (reads.length == 2 && !secondRead.isCompleted) secondRead.complete();
+    if (reads.length == 3 && !thirdRead.isCompleted) thirdRead.complete();
     scheduleMicrotask(() {
       _notifications.add(_readBegin(startSeq, count));
       final requested = <int>[];

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -117,25 +117,16 @@ void main() {
     expect(recovered.wallClockEndSeconds, firstTimestamp + 3);
   });
 
-  test('deep backlog runs only by opt-in or while charging', () {
+  test('deep backlog runs only after explicit automatic-sync opt-in', () {
     expect(
       ringShouldDrainDeepBacklog(
         autoSyncEnabled: false,
-        isCharging: false,
       ),
       isFalse,
     );
     expect(
       ringShouldDrainDeepBacklog(
         autoSyncEnabled: true,
-        isCharging: false,
-      ),
-      isTrue,
-    );
-    expect(
-      ringShouldDrainDeepBacklog(
-        autoSyncEnabled: false,
-        isCharging: true,
       ),
       isTrue,
     );

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -131,7 +131,10 @@ void main() {
     final firstConnection = _FakeRingConnection(readSeq: 200, writeSeq: 205, truncateStartSeq: 202);
     final wal = virtualWal(5);
 
-    await ringSync(firstConnection, local).syncWal(wal: wal);
+    await expectLater(
+      ringSync(firstConnection, local).syncWal(wal: wal),
+      throwsA(isA<RingStorageException>()),
+    );
 
     expect(firstConnection.successfulAdvances, [202]);
     expect(local.testWals.map((wal) => wal.sourceId), ['ring_200_202']);
@@ -155,7 +158,10 @@ void main() {
     final local = localSync(persister: (_) async => false);
     final wal = virtualWal(1);
 
-    await ringSync(connection, local).syncWal(wal: wal);
+    await expectLater(
+      ringSync(connection, local).syncWal(wal: wal),
+      throwsA(isA<RingStorageException>()),
+    );
 
     expect(connection.advanceAttempts, isEmpty);
     expect(local.testWals, isEmpty);
@@ -167,7 +173,10 @@ void main() {
     final local = localSync();
     final wal = virtualWal(2);
 
-    await ringSync(connection, local).syncWal(wal: wal);
+    await expectLater(
+      ringSync(connection, local).syncWal(wal: wal),
+      throwsA(isA<RingStorageException>()),
+    );
 
     expect(connection.advanceAttempts, isEmpty);
     expect(local.testWals, isEmpty);
@@ -205,7 +214,10 @@ void main() {
     final firstConnection = _FakeRingConnection(readSeq: 600, writeSeq: 602, failAdvance: true);
     final wal = virtualWal(2);
 
-    await ringSync(firstConnection, local).syncWal(wal: wal);
+    await expectLater(
+      ringSync(firstConnection, local).syncWal(wal: wal),
+      throwsA(isA<RingStorageException>()),
+    );
 
     expect(firstConnection.advanceAttempts, [602]);
     expect(firstConnection.successfulAdvances, isEmpty);
@@ -234,7 +246,10 @@ void main() {
       ..totalFrames = 400
       ..timerStart = 1799999996;
 
-    await ringSync(firstConnection, local, nowSeconds: 1800000000).syncWal(wal: wal);
+    await expectLater(
+      ringSync(firstConnection, local, nowSeconds: 1800000000).syncWal(wal: wal),
+      throwsA(isA<RingStorageException>()),
+    );
 
     expect(local.testWals.single.sourceId, 'ring_700_702');
     expect(local.testWals.single.timerStart, 1799999996);

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -108,18 +108,44 @@ void main() {
     );
   });
 
+  test('deep backlog runs only by opt-in or while charging', () {
+    expect(
+      ringShouldDrainDeepBacklog(
+        autoSyncEnabled: false,
+        isCharging: false,
+      ),
+      isFalse,
+    );
+    expect(
+      ringShouldDrainDeepBacklog(
+        autoSyncEnabled: true,
+        isCharging: false,
+      ),
+      isTrue,
+    );
+    expect(
+      ringShouldDrainDeepBacklog(
+        autoSyncEnabled: false,
+        isCharging: true,
+      ),
+      isTrue,
+    );
+  });
+
   test('storage-authoritative scheduler persists the live head before draining backlog', () async {
-    final timestamps = {for (var seq = 0; seq < 1000; seq++) seq: _FakeRingConnection.baseTimestamp + 1000};
+    final timestamps = {
+      for (var seq = 0; seq < 10000; seq++) seq: _FakeRingConnection.baseTimestamp + 10000,
+    };
     final connection = _FakeRingConnection(
       readSeq: 0,
-      writeSeq: 1000,
+      writeSeq: 10000,
       timestamps: timestamps,
     );
     final local = localSync();
     final sync = ringSync(
       connection,
       local,
-      nowSeconds: _FakeRingConnection.baseTimestamp + 1000,
+      nowSeconds: _FakeRingConnection.baseTimestamp + 10000,
     );
     final liveDelivered = Completer<void>();
 
@@ -132,28 +158,34 @@ void main() {
 
     expect(session, isNotNull);
     await liveDelivered.future.timeout(const Duration(seconds: 1));
-    expect(connection.reads.first, (start: 980, count: 20));
+    expect(connection.reads.first, (start: 9980, count: 20));
     expect(connection.advanceAttempts, isEmpty);
 
     await connection.secondRead.future.timeout(const Duration(seconds: 3));
     final framesPerRecord = RingProtocol.audioPayloadBytes ~/ (BleAudioCodec.opus.getFramesLengthInBytes() + 1);
     final recentFloor = ringRecentRecoveryFloor(
       readSeq: 0,
-      writeSeq: 1000,
+      writeSeq: 10000,
       framesPerRecord: framesPerRecord,
       framesPerSecond: BleAudioCodec.opus.getFramesPerSecond(),
     );
     expect(connection.reads[1], (start: recentFloor, count: 96));
 
-    await connection.firstAdvance.future.timeout(const Duration(seconds: 3));
     await connection.thirdRead.future.timeout(const Duration(seconds: 3));
-    expect(connection.reads[2], (start: 96, count: 96));
-    expect(connection.successfulAdvances.first, 96);
-    expect(connection.successfulAdvances, isNot(contains(1000)));
+    expect(connection.reads[2], (start: recentFloor + 96, count: 96));
+    expect(connection.reads.where((read) => read.start < recentFloor), isEmpty);
+    expect(connection.advanceAttempts, isEmpty);
 
     await session!.cancel();
     expect(session.isActive, isFalse);
-    expect(local.testWals.any((wal) => wal.sourceId == 'ring_980_1000'), isTrue);
+    final liveWal = local.testWals.singleWhere((wal) => wal.sourceId == 'ring_9980_10000');
+    expect(liveWal.uploadIntent, WalUploadIntent.liveContinuity);
+    expect(
+      local.testWals.where((wal) => wal.sourceId != 'ring_9980_10000').every(
+            (wal) => wal.uploadIntent == WalUploadIntent.liveContinuity,
+          ),
+      isTrue,
+    );
   });
 
   test('disabled auto-sync recovers recent gap but does not start the deep prefix', () async {
@@ -221,6 +253,52 @@ void main() {
     expect(connection.reads, [(start: 980, count: 20)]);
     expect(connection.advanceAttempts, isEmpty);
     expect(local.testWals, isEmpty);
+  });
+
+  test('disconnect racing a durable live ADVANCE ends cleanly and leaves the device cursor retryable', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      failAdvance: true,
+      connected: false,
+    );
+    final local = localSync();
+    final sync = ringSync(connection, local);
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+
+    expect(session, isNotNull);
+    await expectLater(session!.done, completes);
+    expect(connection.advanceAttempts, [120]);
+    expect(connection.successfulAdvances, isEmpty);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_100_120']);
+  });
+
+  test('live ADVANCE rejection on a connected transport remains a protocol failure', () async {
+    final connection = _FakeRingConnection(
+      readSeq: 100,
+      writeSeq: 120,
+      failAdvance: true,
+    );
+    final local = localSync();
+    final sync = ringSync(connection, local);
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => true);
+
+    expect(session, isNotNull);
+    await expectLater(
+      session!.done,
+      throwsA(
+        isA<RingStorageException>().having(
+          (error) => error.message,
+          'message',
+          contains('live covered-prefix'),
+        ),
+      ),
+    );
+    expect(connection.advanceAttempts, [120]);
+    expect(connection.successfulAdvances, isEmpty);
+    expect(local.testWals.map((wal) => wal.sourceId), ['ring_100_120']);
   });
 
   test('storage-authoritative scheduler preserves chronology when the pendant RTC is invalid', () async {
@@ -527,6 +605,7 @@ class _FakeRingConnection implements DeviceConnection {
   final int? truncateStartSeq;
   final bool corruptCrc;
   final bool failAdvance;
+  final bool connected;
   final int framesPerRecord;
   final Map<int, int> timestamps;
   final reads = <({int start, int count})>[];
@@ -543,6 +622,7 @@ class _FakeRingConnection implements DeviceConnection {
     this.truncateStartSeq,
     this.corruptCrc = false,
     this.failAdvance = false,
+    this.connected = true,
     this.framesPerRecord = 1,
     this.timestamps = const {},
   });
@@ -595,6 +675,9 @@ class _FakeRingConnection implements DeviceConnection {
     if (!firstAdvance.isCompleted) firstAdvance.complete();
     return true;
   }
+
+  @override
+  Future<bool> isConnected() async => connected;
 
   @override
   Future<BleAudioCodec> getAudioCodec() async => BleAudioCodec.opus;

--- a/app/test/services/wals/ring_storage_sync_test.dart
+++ b/app/test/services/wals/ring_storage_sync_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/models/sync_state.dart';
 import 'package:omi/services/capture/live_audio_frame_pacer.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/ring_protocol.dart';
@@ -219,7 +220,7 @@ void main() {
     await session!.cancel();
   });
 
-  test('manual Sync drains one tail-owned snapshot while preserving live priority', () async {
+  test('manual Fast Sync drains one fixed snapshot before returning to live', () async {
     const now = _FakeRingConnection.baseTimestamp + 10000;
     final timestamps = {
       for (var seq = 0; seq < 192; seq++) seq: now - 1000,
@@ -236,6 +237,7 @@ void main() {
       local,
       nowSeconds: now,
       deepBacklogEnabled: false,
+      packetsPerRead: 1800,
     );
     final liveDelivered = Completer<void>();
 
@@ -248,7 +250,8 @@ void main() {
 
     await liveDelivered.future.timeout(const Duration(seconds: 1));
     await connection.secondRead.future.timeout(const Duration(seconds: 3));
-    final firstRequest = sync.requestAudioTailBacklogDrain();
+    final progress = _ProgressListener();
+    final firstRequest = sync.requestAudioTailBacklogDrain(progress: progress);
     final repeatedTap = sync.requestAudioTailBacklogDrain();
 
     expect(firstRequest, isNotNull);
@@ -263,12 +266,17 @@ void main() {
       (start: 0, count: 96),
     ]);
     expect(connection.successfulAdvances, [96, 212]);
+    expect(progress.values.first, 0);
+    expect(progress.values.last, 1);
+    for (var index = 1; index < progress.values.length; index++) {
+      expect(progress.values[index], greaterThanOrEqualTo(progress.values[index - 1]));
+    }
     expect(sync.isAudioTailActive, isTrue);
 
     await session!.cancel();
   });
 
-  test('new live audio preempts the next manual backlog slice', () async {
+  test('audio captured during Fast Sync waits behind its fixed snapshot', () async {
     const now = _FakeRingConnection.baseTimestamp + 10000;
     final connection = _FakeRingConnection(
       readSeq: 0,
@@ -285,6 +293,7 @@ void main() {
       localSync(),
       nowSeconds: now,
       deepBacklogEnabled: false,
+      packetsPerRead: 1800,
     );
 
     final session = await sync.startAudioTail(
@@ -300,14 +309,14 @@ void main() {
     expect(connection.reads.take(4), [
       (start: 480, count: 20),
       (start: 384, count: 96),
-      (start: 0, count: 96),
-      // Twenty records arrived while the preceding backlog slice was in
-      // flight. They must preempt the next historical slice.
+      // The request owns one immutable [0, 500) snapshot. New records remain
+      // safe in the pendant ring until that snapshot is durable on the phone.
+      (start: 0, count: 384),
       (start: 500, count: 20),
     ]);
 
-    sync.cancelRequestedAudioTailBacklogDrain();
-    expect(await request, isNull);
+    expect((await request)?.targetWriteSeq, 500);
+    expect(sync.isAudioTailActive, isTrue);
     await session!.cancel();
   });
 
@@ -365,6 +374,7 @@ void main() {
       local,
       nowSeconds: now,
       deepBacklogEnabled: false,
+      packetsPerRead: 1800,
     );
 
     final start = sync.startAudioTail(
@@ -422,6 +432,7 @@ void main() {
       writeSeq: 212,
       ringInfoGate: firstInfo,
       rejectRead: true,
+      connected: false,
     );
     final replacementConnection = _FakeRingConnection(
       readSeq: 200,
@@ -451,6 +462,7 @@ void main() {
       nowSeconds: now,
       deepBacklogEnabled: false,
       connectionResolver: (_) async => activeConnection,
+      packetsPerRead: 1800,
     );
 
     final firstStart = sync.startAudioTail(
@@ -482,12 +494,15 @@ void main() {
       resumeLiveContinuity: true,
     );
     final receipt = await originalRequest!.timeout(const Duration(seconds: 5));
+    await replacementConnection.secondRead.future.timeout(
+      const Duration(seconds: 3),
+    );
 
     expect(receipt?.deviceId, 'cv1-test');
     expect(receipt?.targetWriteSeq, 212);
     expect(replacementConnection.reads.take(2), [
-      (start: 212, count: 30),
       (start: 200, count: 12),
+      (start: 212, count: 30),
     ]);
     expect(replacementConnection.successfulAdvances, [212]);
     expect(
@@ -508,6 +523,7 @@ void main() {
       writeSeq: 212,
       ringInfoGate: firstInfo,
       rejectRead: true,
+      connected: false,
     );
     final otherConnection = _FakeRingConnection(
       readSeq: 100,
@@ -569,6 +585,7 @@ void main() {
       writeSeq: 212,
       ringInfoGate: firstInfo,
       rejectRead: true,
+      connected: false,
     );
     final sync = ringSync(
       connection,
@@ -628,6 +645,49 @@ void main() {
     ]);
     expect(sync.isAudioTailActive, isTrue);
 
+    await session!.cancel();
+  });
+
+  test('cancelling an in-flight Fast Sync finishes one slice then resumes live', () async {
+    const now = _FakeRingConnection.baseTimestamp + 10000;
+    final fastReadGate = Completer<void>();
+    final connection = _FakeRingConnection(
+      readSeq: 0,
+      writeSeq: 500,
+      growWriteSeqAfterFirstReadBy: 20,
+      growWriteSeqAfterReadNumber: 3,
+      gatedReadNumber: 3,
+      readGate: fastReadGate,
+      timestamps: {
+        for (var seq = 0; seq < 480; seq++) seq: now - 1000,
+        for (var seq = 480; seq < 520; seq++) seq: now,
+      },
+    );
+    final sync = ringSync(
+      connection,
+      localSync(),
+      nowSeconds: now,
+      deepBacklogEnabled: false,
+      packetsPerRead: 1800,
+    );
+
+    final session = await sync.startAudioTail(onLiveFrames: (_) => _delivered());
+    await connection.secondRead.future.timeout(const Duration(seconds: 3));
+    final request = sync.requestAudioTailBacklogDrain()!;
+    await connection.thirdRead.future.timeout(const Duration(seconds: 3));
+
+    sync.cancelRequestedAudioTailBacklogDrain();
+    expect(await request, isNull);
+    fastReadGate.complete();
+    await connection.fourthRead.future.timeout(const Duration(seconds: 3));
+
+    expect(connection.reads.take(4), [
+      (start: 480, count: 20),
+      (start: 384, count: 96),
+      (start: 0, count: 384),
+      (start: 500, count: 20),
+    ]);
+    expect(sync.isAudioTailActive, isTrue);
     await session!.cancel();
   });
 
@@ -1765,6 +1825,23 @@ class _Listener implements IWalSyncListener {
   void onWalUpdated() => onWalUpdatedCallback?.call();
 }
 
+class _ProgressListener implements IWalSyncProgressListener {
+  final List<double> values = [];
+
+  @override
+  void onWalSyncedProgress(
+    double percentage, {
+    double? speedKBps,
+    SyncPhase? phase,
+    int? currentFile,
+    int? totalFiles,
+    int? uploadedBytes,
+    int? totalBytesToUpload,
+  }) {
+    values.add(percentage);
+  }
+}
+
 class _FakeRingConnection implements DeviceConnection {
   static const int baseTimestamp = 1710000000;
 
@@ -1777,6 +1854,8 @@ class _FakeRingConnection implements DeviceConnection {
   final bool failAdvance;
   final bool connected;
   final bool rejectRead;
+  final int? gatedReadNumber;
+  final Completer<void>? readGate;
   final Object? codecError;
   final Completer<RingInfo?>? ringInfoGate;
   final int framesPerRecord;
@@ -1801,6 +1880,8 @@ class _FakeRingConnection implements DeviceConnection {
     this.failAdvance = false,
     this.connected = true,
     this.rejectRead = false,
+    this.gatedReadNumber,
+    this.readGate,
     this.codecError,
     this.ringInfoGate,
     this.framesPerRecord = 1,
@@ -1838,6 +1919,9 @@ class _FakeRingConnection implements DeviceConnection {
     if (reads.length == 2 && !secondRead.isCompleted) secondRead.complete();
     if (reads.length == 3 && !thirdRead.isCompleted) thirdRead.complete();
     if (reads.length == 4 && !fourthRead.isCompleted) fourthRead.complete();
+    if (reads.length == gatedReadNumber) {
+      await readGate?.future;
+    }
     scheduleMicrotask(() {
       _notifications.add(_readBegin(startSeq, count));
       final requested = <int>[];

--- a/app/test/services/wals/wal_syncs_firmware_routing_test.dart
+++ b/app/test/services/wals/wal_syncs_firmware_routing_test.dart
@@ -15,6 +15,24 @@ void main() {
       expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('Unknown'), isFalse);
     });
 
+    test('internal harness admits 3.0.30 without widening production policy', () {
+      expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('3.0.30'), isFalse);
+      expect(
+        DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio(
+          '3.0.30+110',
+          allowBlackboxDiagnosticsFirmware: true,
+        ),
+        isTrue,
+      );
+      expect(
+        DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio(
+          '3.0.31',
+          allowBlackboxDiagnosticsFirmware: true,
+        ),
+        isFalse,
+      );
+    });
+
     test('enriched firmware wins over a raw Unknown connect object', () {
       expect(DeviceStorageProtocolPolicy.resolveFirmware('3.0.20', 'Unknown'), '3.0.20');
       expect(

--- a/app/test/services/wals/wal_syncs_firmware_routing_test.dart
+++ b/app/test/services/wals/wal_syncs_firmware_routing_test.dart
@@ -7,6 +7,14 @@ BtDevice _device(DeviceType type, {String firmware = 'Unknown'}) =>
 
 void main() {
   group('DeviceStorageProtocolPolicy', () {
+    test('storage-authoritative audio is exact to the 3.0.29 test line', () {
+      expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('3.0.28'), isFalse);
+      expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('3.0.29'), isTrue);
+      expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('3.0.29+7'), isTrue);
+      expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('3.0.30'), isFalse);
+      expect(DeviceStorageProtocolPolicy.usesStorageAuthoritativeAudio('Unknown'), isFalse);
+    });
+
     test('enriched firmware wins over a raw Unknown connect object', () {
       expect(DeviceStorageProtocolPolicy.resolveFirmware('3.0.20', 'Unknown'), '3.0.20');
       expect(

--- a/app/test/services/wals/wal_syncs_firmware_routing_test.dart
+++ b/app/test/services/wals/wal_syncs_firmware_routing_test.dart
@@ -1,36 +1,101 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:omi/services/wals/wal_syncs.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/wals/device_storage_routing.dart';
 
-// Regression: background/auto-sync discovery read firmware off the raw connect
-// object, which is frequently 'Unknown'. isRingBufferFirmware('Unknown') is
-// false, so ring-buffer devices (fw >= 3.0.20 — current firmware) were routed
-// to the multi-file enumerator and their offline recordings were never
-// enumerated, uploaded, or turned into conversations (#10033). The fix resolves
-// the enriched firmware first; only the Auto Sync page used to pass it.
+BtDevice _device(DeviceType type, {String firmware = 'Unknown'}) =>
+    BtDevice(name: type.name, id: 'device-id', type: type, rssi: -40, firmwareRevision: firmware);
+
 void main() {
-  group('resolveDiscoveryFirmware', () {
-    test('enriched value wins over a raw Unknown connect object', () {
-      expect(WalSyncs.resolveDiscoveryFirmware('3.0.20', 'Unknown'), '3.0.20');
+  group('DeviceStorageProtocolPolicy', () {
+    test('enriched firmware wins over a raw Unknown connect object', () {
+      expect(DeviceStorageProtocolPolicy.resolveFirmware('3.0.20', 'Unknown'), '3.0.20');
+      expect(
+        DeviceStorageProtocolPolicy.classify(_device(DeviceType.omi), firmwareVersion: '3.0.20'),
+        DeviceStorageProtocol.ringBuffer,
+      );
     });
 
-    test('falls back to raw when enriched is Unknown/empty/null', () {
-      expect(WalSyncs.resolveDiscoveryFirmware('Unknown', '3.0.20'), '3.0.20');
-      expect(WalSyncs.resolveDiscoveryFirmware('', '3.0.20'), '3.0.20');
-      expect(WalSyncs.resolveDiscoveryFirmware(null, '3.0.17'), '3.0.17');
+    test('routes each supported Omi firmware generation to exactly one protocol', () {
+      expect(
+        DeviceStorageProtocolPolicy.classify(_device(DeviceType.omi, firmware: '3.0.16')),
+        DeviceStorageProtocol.legacySdCard,
+      );
+      expect(
+        DeviceStorageProtocolPolicy.classify(_device(DeviceType.omi, firmware: '3.0.19')),
+        DeviceStorageProtocol.multiFile,
+      );
+      expect(
+        DeviceStorageProtocolPolicy.classify(_device(DeviceType.omi, firmware: '3.0.20')),
+        DeviceStorageProtocol.ringBuffer,
+      );
+      expect(
+        DeviceStorageProtocolPolicy.classify(_device(DeviceType.omi, firmware: '3.0.28+4')),
+        DeviceStorageProtocol.ringBuffer,
+      );
+    });
+
+    test('unknown firmware fails closed instead of probing the legacy protocol', () {
+      expect(
+        DeviceStorageProtocolPolicy.classify(_device(DeviceType.omi)),
+        DeviceStorageProtocol.none,
+      );
     });
   });
 
-  group('end-to-end routing decision', () {
-    test('a ring-buffer device with a raw Unknown object now routes to ring', () {
-      // Before the fix this classified false (raw 'Unknown') -> multi-file
-      // enumerator -> recordings never discovered.
-      final resolved = WalSyncs.resolveDiscoveryFirmware('3.0.20', 'Unknown');
-      expect(WalSyncs.isRingBufferFirmware(resolved), isTrue);
+  group('DeviceStorageRouter ownership', () {
+    late List<BtDevice?> legacyBindings;
+    late List<BtDevice?> multiFileBindings;
+    late List<BtDevice?> ringBindings;
+    late List<BtDevice?> limitlessBindings;
+    late DeviceStorageRouter router;
+
+    setUp(() {
+      legacyBindings = [];
+      multiFileBindings = [];
+      ringBindings = [];
+      limitlessBindings = [];
+      router = DeviceStorageRouter(
+        bindLegacySdCard: legacyBindings.add,
+        bindMultiFile: multiFileBindings.add,
+        bindRingBuffer: ringBindings.add,
+        bindLimitlessFlash: limitlessBindings.add,
+      );
     });
 
-    test('older multi-file firmware still routes to storage', () {
-      final resolved = WalSyncs.resolveDiscoveryFirmware('3.0.18', 'Unknown');
-      expect(WalSyncs.isRingBufferFirmware(resolved), isFalse);
+    test('ring firmware disconnects every incompatible parser', () {
+      final device = _device(DeviceType.omi, firmware: '3.0.28');
+
+      router.bind(device);
+
+      expect(router.protocol, DeviceStorageProtocol.ringBuffer);
+      expect(legacyBindings, [null]);
+      expect(multiFileBindings, [null]);
+      expect(ringBindings, [same(device)]);
+      expect(limitlessBindings, [null]);
+    });
+
+    test('switching devices clears the previous owner before binding the new owner', () {
+      final ring = _device(DeviceType.omi, firmware: '3.0.28');
+      final limitless = _device(DeviceType.limitless);
+
+      router.bind(ring);
+      router.bind(limitless);
+
+      expect(ringBindings, [same(ring), null]);
+      expect(limitlessBindings, [null, same(limitless)]);
+      expect(legacyBindings, [null, null]);
+      expect(multiFileBindings, [null, null]);
+    });
+
+    test('disconnect clears every protocol owner', () {
+      router.bind(_device(DeviceType.omi, firmware: '3.0.16'));
+      router.bind(null);
+
+      expect(router.protocol, DeviceStorageProtocol.none);
+      expect(legacyBindings.last, isNull);
+      expect(multiFileBindings.last, isNull);
+      expect(ringBindings.last, isNull);
+      expect(limitlessBindings.last, isNull);
     });
   });
 }

--- a/app/test/unit/audio_player_utils_test.dart
+++ b/app/test/unit/audio_player_utils_test.dart
@@ -173,4 +173,31 @@ void main() {
       expect(parsed.length, equals(0));
     });
   });
+
+  group('platform audio session ordering', () {
+    test('activates the platform route before starting recovered-audio playback', () async {
+      final calls = <String>[];
+
+      await startPlaybackAfterActivatingSession(
+        activateSession: () async => calls.add('activate'),
+        startPlayer: () async => calls.add('start'),
+      );
+
+      expect(calls, ['activate', 'start']);
+    });
+
+    test('does not advance an inaudible player when route activation fails', () async {
+      var playerStarted = false;
+
+      await expectLater(
+        startPlaybackAfterActivatingSession(
+          activateSession: () async => throw StateError('route unavailable'),
+          startPlayer: () async => playerStarted = true,
+        ),
+        throwsStateError,
+      );
+
+      expect(playerStarted, isFalse);
+    });
+  });
 }

--- a/app/test/unit/ble_packet_continuity_test.dart
+++ b/app/test/unit/ble_packet_continuity_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/devices/ble_packet_continuity.dart';
+
+List<int> _packet(int id) => [id & 0xFF, (id >> 8) & 0xFF, 0, 0xAA];
+
+void main() {
+  group('BlePacketContinuityTracker', () {
+    test('accepts contiguous IDs across the uint16 wrap', () {
+      final tracker = BlePacketContinuityTracker();
+
+      expect(tracker.observe(_packet(0xFFFE)).disposition, BlePacketDisposition.first);
+      expect(tracker.observe(_packet(0xFFFF)).disposition, BlePacketDisposition.contiguous);
+      expect(tracker.observe(_packet(0)).disposition, BlePacketDisposition.contiguous);
+    });
+
+    test('reports the exact number of missing packets', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(100));
+
+      final observation = tracker.observe(_packet(104));
+
+      expect(observation.disposition, BlePacketDisposition.gap);
+      expect(observation.missingPackets, 3);
+      expect(observation.shouldForward, isTrue);
+    });
+
+    test('suppresses an exact adjacent duplicate without moving the cursor', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(200));
+
+      final duplicate = tracker.observe(_packet(200));
+      final next = tracker.observe(_packet(201));
+
+      expect(duplicate.disposition, BlePacketDisposition.duplicate);
+      expect(duplicate.shouldForward, isFalse);
+      expect(next.disposition, BlePacketDisposition.contiguous);
+    });
+
+    test('forwards a reused ID when the index or payload differs', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(200));
+
+      final reused = tracker.observe([200, 0, 1, 0xBB]);
+
+      expect(reused.disposition, BlePacketDisposition.reset);
+      expect(reused.shouldForward, isTrue);
+    });
+
+    test('forwards a backward reset instead of creating a long outage', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(5000));
+
+      final reset = tracker.observe(_packet(1));
+
+      expect(reset.disposition, BlePacketDisposition.reset);
+      expect(reset.shouldForward, isTrue);
+      expect(tracker.observe(_packet(2)).disposition, BlePacketDisposition.contiguous);
+    });
+
+    test('uses modular half-range classification for ambiguous high-ID wrap gaps', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(50000));
+
+      final ambiguous = tracker.observe(_packet(1));
+
+      expect(ambiguous.disposition, BlePacketDisposition.gap);
+      expect(ambiguous.missingPackets, 15536);
+      expect(ambiguous.shouldForward, isTrue);
+    });
+
+    test('rejects malformed packets without changing continuity', () {
+      final tracker = BlePacketContinuityTracker();
+      tracker.observe(_packet(10));
+
+      expect(tracker.observe([1, 2]).disposition, BlePacketDisposition.malformed);
+      expect(tracker.observe(_packet(11)).disposition, BlePacketDisposition.contiguous);
+    });
+  });
+
+  group('BlePacketAnomalyLogLimiter', () {
+    test('emits immediately then coalesces notification-rate anomalies', () {
+      final limiter = BlePacketAnomalyLogLimiter(interval: const Duration(seconds: 10));
+      final start = DateTime.utc(2026, 1, 1);
+
+      expect(limiter.record(start), 1);
+      expect(limiter.record(start.add(const Duration(seconds: 1))), isNull);
+      expect(limiter.record(start.add(const Duration(seconds: 9))), isNull);
+      expect(limiter.record(start.add(const Duration(seconds: 10))), 3);
+    });
+  });
+}

--- a/app/test/unit/conversation_audio_assembler_test.dart
+++ b/app/test/unit/conversation_audio_assembler_test.dart
@@ -31,12 +31,14 @@ void main() {
       sourceId: 'ring_10_11',
       filePath: firstFile.path,
       status: WalStatus.synced,
+      captureEndSeconds: 1000.25,
     );
     final second = _wal(
       timerStart: 1001,
       sourceId: 'ring_11_12',
       filePath: secondFile.path,
       status: WalStatus.miss,
+      captureEndSeconds: 1001.75,
     );
     final destination = File('${directory.path}/canonical.bin');
 
@@ -51,6 +53,7 @@ void main() {
 
     expect(result.timerStart, 1000);
     expect(result.totalFrames, 101);
+    expect(result.captureEndSeconds, 1001.75);
     expect(result.hadLiveGap, isTrue);
     expect(result.sourceWals, [first, second]);
     expect(_frames(await destination.readAsBytes()), [
@@ -144,6 +147,243 @@ void main() {
     expect(result.sourceWals, [first, replay, second]);
   });
 
+  test('finds a lossless exact tiling instead of greedily removing its required range', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final firstGapFile = File('${directory.path}/first_gap.bin');
+    final secondGapFile = File('${directory.path}/second_gap.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1]), flush: true);
+    await firstGapFile.writeAsBytes(_frame([9]), flush: true);
+    await secondGapFile.writeAsBytes(_frame([8]), flush: true);
+    await secondFile.writeAsBytes(_frame([2]), flush: true);
+    final first = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_10_20',
+      filePath: firstFile.path,
+      status: WalStatus.synced,
+    );
+    final firstGap = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_10_15',
+      filePath: firstGapFile.path,
+      status: WalStatus.miss,
+    );
+    final secondGap = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_15_21',
+      filePath: secondGapFile.path,
+      status: WalStatus.miss,
+    );
+    final second = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_20_30',
+      filePath: secondFile.path,
+      status: WalStatus.synced,
+    );
+    final destination = File('${directory.path}/canonical.bin');
+
+    final result = await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(wal: secondGap, file: secondGapFile),
+        ConversationAudioPart(wal: second, file: secondFile),
+        ConversationAudioPart(wal: first, file: firstFile),
+        ConversationAudioPart(wal: firstGap, file: firstGapFile),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(_frames(await destination.readAsBytes()), [
+      [1],
+      [2],
+    ]);
+    expect(result.totalFrames, 2);
+    expect(result.hadLiveGap, isTrue);
+    expect(result.sourceWals, [firstGap, first, secondGap, second]);
+  });
+
+  test('prefers fewer exact parts before preferring synced sources', () async {
+    final wholeFile = File('${directory.path}/whole.bin');
+    final firstFile = File('${directory.path}/first.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await wholeFile.writeAsBytes(_frame([1]), flush: true);
+    await firstFile.writeAsBytes(_frame([2]), flush: true);
+    await secondFile.writeAsBytes(_frame([3]), flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_10_30',
+            filePath: wholeFile.path,
+            status: WalStatus.miss,
+          ),
+          file: wholeFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_10_20',
+            filePath: firstFile.path,
+            status: WalStatus.synced,
+          ),
+          file: firstFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_20_30',
+            filePath: secondFile.path,
+            status: WalStatus.synced,
+          ),
+          file: secondFile,
+        ),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(_frames(await destination.readAsBytes()), [
+      [1],
+    ]);
+  });
+
+  test('prefers synced sources between equal-size exact tilings', () async {
+    final syncedFirstFile = File('${directory.path}/synced_first.bin');
+    final syncedSecondFile = File('${directory.path}/synced_second.bin');
+    final missedFirstFile = File('${directory.path}/missed_first.bin');
+    final missedSecondFile = File('${directory.path}/missed_second.bin');
+    await syncedFirstFile.writeAsBytes(_frame([1]), flush: true);
+    await syncedSecondFile.writeAsBytes(_frame([2]), flush: true);
+    await missedFirstFile.writeAsBytes(_frame([9]), flush: true);
+    await missedSecondFile.writeAsBytes(_frame([8]), flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_10_20',
+            filePath: syncedFirstFile.path,
+            status: WalStatus.synced,
+          ),
+          file: syncedFirstFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_20_30',
+            filePath: syncedSecondFile.path,
+            status: WalStatus.synced,
+          ),
+          file: syncedSecondFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_10_15',
+            filePath: missedFirstFile.path,
+            status: WalStatus.miss,
+          ),
+          file: missedFirstFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_15_30',
+            filePath: missedSecondFile.path,
+            status: WalStatus.miss,
+          ),
+          file: missedSecondFile,
+        ),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(_frames(await destination.readAsBytes()), [
+      [1],
+      [2],
+    ]);
+  });
+
+  test('breaks equal-cost tiling ties by the earliest sequence part', () async {
+    Future<ConversationAudioPart> part(
+      String name,
+      String sourceId,
+      int payload,
+    ) async {
+      final file = File('${directory.path}/$name.bin');
+      await file.writeAsBytes(_frame([payload]), flush: true);
+      return ConversationAudioPart(
+        wal: _wal(
+          timerStart: 1000,
+          sourceId: sourceId,
+          filePath: file.path,
+          status: WalStatus.synced,
+        ),
+        file: file,
+      );
+    }
+
+    final earlierPath = [
+      await part('earlier_1', 'ring_10_20', 1),
+      await part('earlier_2', 'ring_20_40', 2),
+      await part('earlier_3', 'ring_40_60', 3),
+    ];
+    final laterPath = [
+      await part('later_1', 'ring_10_30', 9),
+      await part('later_2', 'ring_30_35', 8),
+      await part('later_3', 'ring_35_60', 7),
+    ];
+    final destination = File('${directory.path}/canonical.bin');
+
+    await assembleConversationAudio(
+      parts: [...laterPath, ...earlierPath],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(_frames(await destination.readAsBytes()), [
+      [1],
+      [2],
+      [3],
+    ]);
+  });
+
+  test('tiles ten thousand fragments without retaining every path prefix', () async {
+    const fragmentCount = 10000;
+    final source = File('${directory.path}/shared.bin');
+    final encodedFrame = _frame([7]);
+    await source.writeAsBytes(encodedFrame, flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+    final parts = List.generate(
+      fragmentCount,
+      (index) => ConversationAudioPart(
+        wal: _wal(
+          timerStart: 1000,
+          sourceId: 'ring_${index + 10}_${index + 11}',
+          filePath: source.path,
+          status: WalStatus.synced,
+        ),
+        file: source,
+      ),
+    );
+
+    final result = await assembleConversationAudio(
+      parts: parts,
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(result.totalFrames, fragmentCount);
+    expect(result.sourceWals, hasLength(fragmentCount));
+    expect(await destination.length(), encodedFrame.length * fragmentCount);
+  }, timeout: const Timeout(Duration(seconds: 30)));
+
   test('refuses an overlap that cannot be removed without losing a sequence', () async {
     final firstFile = File('${directory.path}/first.bin');
     final secondFile = File('${directory.path}/second.bin');
@@ -223,11 +463,13 @@ Wal _wal({
   required String sourceId,
   required String filePath,
   required WalStatus status,
+  double? captureEndSeconds,
 }) =>
     Wal(
       timerStart: timerStart,
       codec: BleAudioCodec.opus,
       seconds: 1,
+      captureEndSeconds: captureEndSeconds,
       totalFrames: 1,
       status: status,
       storage: WalStorage.disk,

--- a/app/test/unit/conversation_audio_assembler_test.dart
+++ b/app/test/unit/conversation_audio_assembler_test.dart
@@ -147,6 +147,44 @@ void main() {
     expect(await secondFile.exists(), isTrue);
   });
 
+  test('canonical capture end never precedes its playable payload', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1]), flush: true);
+    await secondFile.writeAsBytes(_frame([2]), flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    final result = await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_10_11',
+            filePath: firstFile.path,
+            status: WalStatus.synced,
+            captureEndSeconds: 1000,
+          ),
+          file: firstFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_11_12',
+            filePath: secondFile.path,
+            status: WalStatus.miss,
+            captureEndSeconds: 1000,
+          ),
+          file: secondFile,
+        ),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(result.totalFrames, 2);
+    expect(result.captureEndSeconds, closeTo(1000.02, 0.0001));
+  });
+
   test('removes a replay overlap when the original ranges preserve the complete sequence', () async {
     final firstFile = File('${directory.path}/first.bin');
     final replayFile = File('${directory.path}/replay.bin');

--- a/app/test/unit/conversation_audio_assembler_test.dart
+++ b/app/test/unit/conversation_audio_assembler_test.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/wals/conversation_audio_assembler.dart';
+import 'package:omi/services/wals/wal.dart';
+
+void main() {
+  late Directory directory;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('omi_conversation_assembler_');
+  });
+
+  tearDown(() async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+  });
+
+  test('reorders pendant ranges and inserts silence to preserve wall-clock time', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1, 2]), flush: true);
+    await secondFile.writeAsBytes(_frame([3]), flush: true);
+
+    final first = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_10_11',
+      filePath: firstFile.path,
+      status: WalStatus.synced,
+    );
+    final second = _wal(
+      timerStart: 1001,
+      sourceId: 'ring_11_12',
+      filePath: secondFile.path,
+      status: WalStatus.miss,
+    );
+    final destination = File('${directory.path}/canonical.bin');
+
+    final result = await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(wal: second, file: secondFile),
+        ConversationAudioPart(wal: first, file: firstFile),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(result.timerStart, 1000);
+    expect(result.totalFrames, 101);
+    expect(result.hadLiveGap, isTrue);
+    expect(result.sourceWals, [first, second]);
+    expect(_frames(await destination.readAsBytes()), [
+      [1, 2],
+      ...List.generate(99, (_) => [0]),
+      [3],
+    ]);
+  });
+
+  test('refuses to compact across a missing pendant sequence', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1]), flush: true);
+    await secondFile.writeAsBytes(_frame([2]), flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    await expectLater(
+      assembleConversationAudio(
+        parts: [
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 1000,
+              sourceId: 'ring_10_11',
+              filePath: firstFile.path,
+              status: WalStatus.synced,
+            ),
+            file: firstFile,
+          ),
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 1001,
+              sourceId: 'ring_12_13',
+              filePath: secondFile.path,
+              status: WalStatus.miss,
+            ),
+            file: secondFile,
+          ),
+        ],
+        destination: destination,
+        silenceFrameFactory: (_) => [0],
+      ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(await destination.exists(), isFalse);
+    expect(await firstFile.exists(), isTrue);
+    expect(await secondFile.exists(), isTrue);
+  });
+
+  test('refuses malformed source audio without publishing a partial file', () async {
+    final source = File('${directory.path}/malformed.bin');
+    await source.writeAsBytes([4, 0, 0, 0, 1], flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    await expectLater(
+      assembleConversationAudio(
+        parts: [
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 1000,
+              sourceId: 'ring_10_11',
+              filePath: source.path,
+              status: WalStatus.miss,
+            ),
+            file: source,
+          ),
+        ],
+        destination: destination,
+        silenceFrameFactory: (_) => [0],
+      ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(await destination.exists(), isFalse);
+    expect(await File('${destination.path}.partial').exists(), isFalse);
+    expect(await source.exists(), isTrue);
+  });
+}
+
+Wal _wal({
+  required int timerStart,
+  required String sourceId,
+  required String filePath,
+  required WalStatus status,
+}) =>
+    Wal(
+      timerStart: timerStart,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      totalFrames: 1,
+      status: status,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: filePath,
+      device: 'cv1',
+      sourceId: sourceId,
+      uploadIntent: WalUploadIntent.liveContinuity,
+    );
+
+List<int> _frame(List<int> payload) {
+  final prefix = ByteData(4)..setUint32(0, payload.length, Endian.little);
+  return [...prefix.buffer.asUint8List(), ...payload];
+}
+
+List<List<int>> _frames(List<int> bytes) {
+  final result = <List<int>>[];
+  var offset = 0;
+  while (offset < bytes.length) {
+    final length = ByteData.sublistView(
+      Uint8List.fromList(bytes),
+      offset,
+      offset + 4,
+    ).getUint32(0, Endian.little);
+    offset += 4;
+    result.add(bytes.sublist(offset, offset + length));
+    offset += length;
+  }
+  return result;
+}

--- a/app/test/unit/conversation_audio_assembler_test.dart
+++ b/app/test/unit/conversation_audio_assembler_test.dart
@@ -63,6 +63,52 @@ void main() {
     ]);
   });
 
+  test('never turns two contiguous one-second ranges into a 17-minute recording', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1]), flush: true);
+    await secondFile.writeAsBytes(_frame([2]), flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    await expectLater(
+      assembleConversationAudio(
+        parts: [
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 1000,
+              sourceId: 'ring_10_11',
+              filePath: firstFile.path,
+              status: WalStatus.synced,
+              captureEndSeconds: 1001,
+            ),
+            file: firstFile,
+          ),
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 2020,
+              sourceId: 'ring_11_12',
+              filePath: secondFile.path,
+              status: WalStatus.miss,
+              captureEndSeconds: 2021,
+            ),
+            file: secondFile,
+          ),
+        ],
+        destination: destination,
+        silenceFrameFactory: (_) => [0],
+        conversationBoundarySeconds: 120,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('conversation boundary'),
+        ),
+      ),
+    );
+    expect(await destination.exists(), isFalse);
+  });
+
   test('marks a missing pendant sequence as a repair instead of fragmenting the upload', () async {
     final firstFile = File('${directory.path}/first.bin');
     final secondFile = File('${directory.path}/second.bin');

--- a/app/test/unit/conversation_audio_assembler_test.dart
+++ b/app/test/unit/conversation_audio_assembler_test.dart
@@ -98,6 +98,96 @@ void main() {
     expect(await secondFile.exists(), isTrue);
   });
 
+  test('removes a replay overlap when the original ranges preserve the complete sequence', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final replayFile = File('${directory.path}/replay.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1]), flush: true);
+    await replayFile.writeAsBytes(_frame([9]), flush: true);
+    await secondFile.writeAsBytes(_frame([2]), flush: true);
+    final first = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_10_20',
+      filePath: firstFile.path,
+      status: WalStatus.synced,
+    );
+    final replay = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_15_25',
+      filePath: replayFile.path,
+      status: WalStatus.miss,
+    );
+    final second = _wal(
+      timerStart: 1000,
+      sourceId: 'ring_20_30',
+      filePath: secondFile.path,
+      status: WalStatus.synced,
+    );
+    final destination = File('${directory.path}/canonical.bin');
+
+    final result = await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(wal: replay, file: replayFile),
+        ConversationAudioPart(wal: second, file: secondFile),
+        ConversationAudioPart(wal: first, file: firstFile),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
+    );
+
+    expect(_frames(await destination.readAsBytes()), [
+      [1],
+      [2],
+    ]);
+    expect(result.totalFrames, 2);
+    expect(result.hadLiveGap, isTrue);
+    expect(result.sourceWals, [first, replay, second]);
+  });
+
+  test('refuses an overlap that cannot be removed without losing a sequence', () async {
+    final firstFile = File('${directory.path}/first.bin');
+    final secondFile = File('${directory.path}/second.bin');
+    await firstFile.writeAsBytes(_frame([1]), flush: true);
+    await secondFile.writeAsBytes(_frame([2]), flush: true);
+    final destination = File('${directory.path}/canonical.bin');
+
+    await expectLater(
+      assembleConversationAudio(
+        parts: [
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 1000,
+              sourceId: 'ring_10_20',
+              filePath: firstFile.path,
+              status: WalStatus.miss,
+            ),
+            file: firstFile,
+          ),
+          ConversationAudioPart(
+            wal: _wal(
+              timerStart: 1000,
+              sourceId: 'ring_15_25',
+              filePath: secondFile.path,
+              status: WalStatus.miss,
+            ),
+            file: secondFile,
+          ),
+        ],
+        destination: destination,
+        silenceFrameFactory: (_) => [0],
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('irreducible overlapping pendant sequence'),
+        ),
+      ),
+    );
+
+    expect(await destination.exists(), isFalse);
+  });
+
   test('refuses malformed source audio without publishing a partial file', () async {
     final source = File('${directory.path}/malformed.bin');
     await source.writeAsBytes([4, 0, 0, 0, 1], flush: true);

--- a/app/test/unit/conversation_audio_assembler_test.dart
+++ b/app/test/unit/conversation_audio_assembler_test.dart
@@ -60,42 +60,40 @@ void main() {
     ]);
   });
 
-  test('refuses to compact across a missing pendant sequence', () async {
+  test('marks a missing pendant sequence as a repair instead of fragmenting the upload', () async {
     final firstFile = File('${directory.path}/first.bin');
     final secondFile = File('${directory.path}/second.bin');
     await firstFile.writeAsBytes(_frame([1]), flush: true);
     await secondFile.writeAsBytes(_frame([2]), flush: true);
     final destination = File('${directory.path}/canonical.bin');
 
-    await expectLater(
-      assembleConversationAudio(
-        parts: [
-          ConversationAudioPart(
-            wal: _wal(
-              timerStart: 1000,
-              sourceId: 'ring_10_11',
-              filePath: firstFile.path,
-              status: WalStatus.synced,
-            ),
-            file: firstFile,
+    final result = await assembleConversationAudio(
+      parts: [
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1000,
+            sourceId: 'ring_10_11',
+            filePath: firstFile.path,
+            status: WalStatus.synced,
           ),
-          ConversationAudioPart(
-            wal: _wal(
-              timerStart: 1001,
-              sourceId: 'ring_12_13',
-              filePath: secondFile.path,
-              status: WalStatus.miss,
-            ),
-            file: secondFile,
+          file: firstFile,
+        ),
+        ConversationAudioPart(
+          wal: _wal(
+            timerStart: 1001,
+            sourceId: 'ring_12_13',
+            filePath: secondFile.path,
+            status: WalStatus.miss,
           ),
-        ],
-        destination: destination,
-        silenceFrameFactory: (_) => [0],
-      ),
-      throwsA(isA<StateError>()),
+          file: secondFile,
+        ),
+      ],
+      destination: destination,
+      silenceFrameFactory: (_) => [0],
     );
 
-    expect(await destination.exists(), isFalse);
+    expect(result.hadLiveGap, isTrue);
+    expect(await destination.exists(), isTrue);
     expect(await firstFile.exists(), isTrue);
     expect(await secondFile.exists(), isTrue);
   });

--- a/app/test/unit/debug_log_manager_test.dart
+++ b/app/test/unit/debug_log_manager_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/utils/debug_log_manager.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel(
+    'plugins.flutter.io/path_provider',
+  );
+  late Directory tempDir;
+  var activeMutations = 0;
+  var maximumActiveMutations = 0;
+
+  Future<void> observePhysicalMutation(
+    Future<void> Function() mutation,
+  ) async {
+    activeMutations++;
+    if (activeMutations > maximumActiveMutations) {
+      maximumActiveMutations = activeMutations;
+    }
+    // Give every concurrently admitted mutation a deterministic chance to
+    // overlap before touching the file.
+    await Future<void>.delayed(Duration.zero);
+    try {
+      await mutation();
+    } finally {
+      activeMutations--;
+    }
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'devLogsToFileEnabled': true,
+    });
+    await SharedPreferencesUtil.init();
+    tempDir = await Directory.systemTemp.createTemp('debug_log_manager_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(pathProviderChannel,
+        (call) async {
+      if (call.method == 'getApplicationDocumentsDirectory') {
+        return tempDir.path;
+      }
+      return null;
+    });
+    activeMutations = 0;
+    maximumActiveMutations = 0;
+    await DebugLogManager.resetForTesting(
+      physicalMutationRunner: observePhysicalMutation,
+    );
+  });
+
+  tearDown(() async {
+    await DebugLogManager.resetForTesting();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('concurrent events are written once as valid JSON by one physical writer', () async {
+    const eventCount = 200;
+
+    await Future.wait([
+      for (var index = 0; index < eventCount; index++)
+        DebugLogManager.logEvent('concurrent_write', {
+          'record_id': index,
+        }),
+    ]);
+
+    final file = await DebugLogManager.getLogFile();
+    expect(file, isNotNull);
+    final lines = await file!.readAsLines();
+    expect(lines, hasLength(eventCount));
+    final records = lines.map((line) => jsonDecode(line) as Map<String, dynamic>).toList(growable: false);
+    expect(
+      records.map((record) => record['type']).toSet(),
+      {'concurrent_write'},
+    );
+    final ids = records.map((record) => record['record_id'] as int).toList();
+    expect(ids.toSet(), {for (var index = 0; index < eventCount; index++) index});
+    expect(maximumActiveMutations, 1);
+  });
+
+  test('clear is ordered between earlier and later appends', () async {
+    await Future.wait([
+      DebugLogManager.logEvent('before_clear', {'record_id': 1}),
+      DebugLogManager.clear(),
+      DebugLogManager.logEvent('after_clear', {'record_id': 2}),
+    ]);
+
+    final file = await DebugLogManager.getLogFile();
+    final lines = await file!.readAsLines();
+    expect(lines, hasLength(1));
+    expect(jsonDecode(lines.single), containsPair('type', 'after_clear'));
+    expect(maximumActiveMutations, 1);
+  });
+}

--- a/app/test/unit/device_transport_exclusive_release_test.dart
+++ b/app/test/unit/device_transport_exclusive_release_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+void main() {
+  test('exclusive release runs even when the transport is already disconnected', () async {
+    final transport = _ExclusiveFakeTransport();
+
+    await releaseTransportForExclusiveOperation(transport);
+
+    expect(transport.events, ['release native ownership', 'dispose Dart transport']);
+  });
+
+  test('release failure still disposes and remains the authoritative error', () async {
+    final releaseError = StateError('unmanage failed');
+    final transport = _ExclusiveFakeTransport()
+      ..releaseError = releaseError
+      ..disposeError = StateError('dispose failed');
+
+    await expectLater(
+      releaseTransportForExclusiveOperation(transport),
+      throwsA(same(releaseError)),
+    );
+
+    expect(transport.events, ['release native ownership', 'dispose Dart transport']);
+  });
+}
+
+class _ExclusiveFakeTransport extends DeviceTransport implements ExclusiveOperationTransport {
+  final events = <String>[];
+  Object? releaseError;
+  Object? disposeError;
+
+  @override
+  String get deviceId => 'exclusive-fake';
+
+  @override
+  Stream<DeviceTransportState> get connectionStateStream => const Stream.empty();
+
+  @override
+  Future<void> releaseForExclusiveOperation() async {
+    events.add('release native ownership');
+    final error = releaseError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<void> dispose() async {
+    events.add('dispose Dart transport');
+    final error = disposeError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<bool> isConnected() async => false;
+
+  @override
+  Future<bool> ping() async => false;
+
+  @override
+  Stream<List<int>> getCharacteristicStream(String serviceUuid, String characteristicUuid) => const Stream.empty();
+
+  @override
+  Future<List<int>> readCharacteristic(String serviceUuid, String characteristicUuid) async => const [];
+
+  @override
+  Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {}
+}

--- a/app/test/unit/firmware_dfu_connection_handoff_test.dart
+++ b/app/test/unit/firmware_dfu_connection_handoff_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/home/firmware_mixin.dart';
+
+void main() {
+  test('success and duplicate terminal callbacks release then resume exactly once', () async {
+    final events = <String>[];
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: () async => events.add('release updater'),
+      resumeDeviceConnection: () async => events.add('resume device'),
+    );
+
+    await Future.wait([handoff.finish(), handoff.finish()]);
+    await handoff.finish();
+
+    expect(events, ['release updater', 'resume device']);
+  });
+
+  test('page disposal and a later terminal callback share the in-flight reclaim', () async {
+    final releaseGate = Completer<void>();
+    final events = <String>[];
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: () async {
+        events.add('release updater');
+        await releaseGate.future;
+      },
+      resumeDeviceConnection: () async => events.add('resume device'),
+    );
+
+    final pageDisposal = handoff.finish();
+    final terminalCallback = handoff.finish();
+    await pumpEventQueue();
+    expect(events, ['release updater']);
+
+    releaseGate.complete();
+    await Future.wait([pageDisposal, terminalCallback]);
+
+    expect(events, ['release updater', 'resume device']);
+  });
+
+  test('release failure still resumes and is memoized for later callbacks', () async {
+    final events = <String>[];
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: () async {
+        events.add('release updater');
+        throw StateError('release failed');
+      },
+      resumeDeviceConnection: () async => events.add('resume device'),
+    );
+
+    await expectLater(handoff.finish(), throwsStateError);
+    await expectLater(handoff.finish(), throwsStateError);
+
+    expect(events, ['release updater', 'resume device']);
+  });
+
+  test('resume failure is returned identically without a second reconnect', () async {
+    var reconnectAttempts = 0;
+    final handoff = FirmwareDfuConnectionHandoff(
+      releaseUpdater: () async {},
+      resumeDeviceConnection: () async {
+        reconnectAttempts++;
+        throw StateError('reconnect failed');
+      },
+    );
+
+    await expectLater(handoff.finish(), throwsStateError);
+    await expectLater(handoff.finish(), throwsStateError);
+
+    expect(reconnectAttempts, 1);
+  });
+}

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -284,7 +284,7 @@ void main() {
       expect(isLiveCaptureWal(at(7 * 60 * 60, conversationId: 'c'), now), isFalse);
     });
 
-    test('active unbound continuity stays local until the two-minute conversation boundary', () {
+    test('active unbound continuity stays local without a server conversation owner', () {
       const now = 2000000000;
       final historical = Wal(
         timerStart: now - 7 * 60 * 60,
@@ -308,7 +308,7 @@ void main() {
       expect(batch, [historical]);
     });
 
-    test('closed unbound continuity is selected as one conversation ahead of history', () {
+    test('closed unbound continuity never uploads without a server conversation owner', () {
       const now = 2000000000;
       final historical = Wal(
         timerStart: now - 7 * 60 * 60,
@@ -335,7 +335,40 @@ void main() {
 
       final batch = nextSyncUploadBatch([historical, ...closedConversation], now);
 
-      expect(batch.toSet(), closedConversation.toSet());
+      expect(batch, [historical]);
+    });
+
+    test('bound archive waits for canonical repair while unbound archive remains opt-in backfill', () {
+      const now = 2000000000;
+      final unboundArchive = Wal(
+        timerStart: now - 300,
+        codec: BleAudioCodec.opus,
+        seconds: 30,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1',
+        sourceId: 'archive_ring_100_200_1999999700',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+      );
+      final boundArchive = Wal(
+        timerStart: now - 300,
+        codec: BleAudioCodec.opus,
+        seconds: 30,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        device: 'cv1',
+        sourceId: 'archive_ring_200_300_1999999700',
+        conversationId: 'server-owner',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+      );
+
+      expect(
+        nextSyncUploadBatch([unboundArchive, boundArchive], now),
+        [unboundArchive],
+      );
+      expect(nextSyncUploadBatch([boundArchive], now), isEmpty);
     });
 
     test('upload artifacts join only sequence- and time-contiguous ring WALs', () {
@@ -465,6 +498,233 @@ void main() {
       final fixedResult = headerlessPayload;
       expect(fixedResult, [0xAA, 0xBB, 0xCC, 0xDD]); // All audio preserved
       expect(fixedResult.length, buggyResult.length + 3); // 3 bytes recovered
+    });
+  });
+
+  group('historical ring archive migration', () {
+    test('replaces many raw fragments with one playable local artifact', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_archive_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final firstFile = File('${directory.path}/first.bin');
+      final secondFile = File('${directory.path}/second.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+
+      final persistedSizes = <int>[];
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (wals) async {
+          persistedSizes.add(wals.length);
+          return true;
+        },
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      );
+      archiveSync.testWals = [
+        _historicalRingWal(
+          timerStart: 1000,
+          sourceId: 'ring_10_11',
+          filePath: firstFile.path.split('/').last,
+        ),
+        _historicalRingWal(
+          timerStart: 1002,
+          sourceId: 'ring_12_13',
+          filePath: secondFile.path.split('/').last,
+        )..status = WalStatus.synced,
+      ];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+
+      expect(persistedSizes, [1]);
+      expect(archiveSync.testWals, hasLength(1));
+      final archive = archiveSync.testWals.single;
+      expect(archive.sourceId, startsWith('archive_ring_10_13_'));
+      expect(archive.uploadIntent, WalUploadIntent.historicalBackfill);
+      expect(archive.status, WalStatus.miss);
+      expect(archive.totalFrames, 201);
+      expect(await File('${directory.path}/${archive.filePath}').exists(), isTrue);
+      expect(await firstFile.exists(), isFalse);
+      expect(await secondFile.exists(), isFalse);
+    });
+
+    test('keeps every source when the archive manifest commit fails', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_archive_failure_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final firstFile = File('${directory.path}/first.bin');
+      final secondFile = File('${directory.path}/second.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => false,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      );
+      final sources = [
+        _historicalRingWal(
+          timerStart: 1000,
+          sourceId: 'ring_10_11',
+          filePath: firstFile.path.split('/').last,
+        ),
+        _historicalRingWal(
+          timerStart: 1002,
+          sourceId: 'ring_12_13',
+          filePath: secondFile.path.split('/').last,
+        ),
+      ];
+      archiveSync.testWals = sources;
+
+      await expectLater(
+        archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(archiveSync.testWals, sources);
+      expect(await firstFile.exists(), isTrue);
+      expect(await secondFile.exists(), isTrue);
+      expect(
+        directory.listSync().whereType<File>().where((file) => file.path.contains('archive_ring_')),
+        isEmpty,
+      );
+    });
+
+    test('does not archive the old prefix of a still-active conversation', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_archive_open_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final sources = <Wal>[];
+      for (final entry in [
+        (timestamp: 1000, sourceId: 'ring_10_11'),
+        (timestamp: 1100, sourceId: 'ring_11_12'),
+        (timestamp: 1190, sourceId: 'ring_12_13'),
+      ]) {
+        final fileName = '${entry.sourceId}.bin';
+        await File('${directory.path}/$fileName').writeAsBytes(
+          [1, 0, 0, 0, 1],
+          flush: true,
+        );
+        sources.add(
+          _historicalRingWal(
+            timerStart: entry.timestamp,
+            sourceId: entry.sourceId,
+            filePath: fileName,
+          )..uploadIntent = WalUploadIntent.liveContinuity,
+        );
+      }
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      );
+      archiveSync.testWals = sources;
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 1250);
+
+      expect(archiveSync.testWals, sources);
+      expect(
+        archiveSync.testWals.map((wal) => wal.uploadIntent),
+        everyElement(WalUploadIntent.liveContinuity),
+      );
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 1400);
+
+      expect(archiveSync.testWals, hasLength(1));
+      expect(
+        archiveSync.testWals.single.uploadIntent,
+        WalUploadIntent.historicalBackfill,
+      );
+    });
+
+    test('late server completion can reclaim a compacted archive as one canonical repair', () async {
+      SyncRateLimiter.instance.clear();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final prefix = 'omi_ring_archive_reclaim_${DateTime.now().microsecondsSinceEpoch}';
+      final firstFile = File('${Directory.systemTemp.path}/${prefix}_first.bin');
+      final secondFile = File('${Directory.systemTemp.path}/${prefix}_second.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+      final uploads = <({String? conversationId, bool replaceTranscript, int files})>[];
+      final uploadStarted = Completer<void>();
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files,
+            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+          uploads.add(
+            (
+              conversationId: conversationId,
+              replaceTranscript: replaceTranscript,
+              files: files.length,
+            ),
+          );
+          if (!uploadStarted.isCompleted) uploadStarted.complete();
+          return UploadFilesResult.queued('archive-repair-job');
+        },
+      );
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${Directory.systemTemp.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      );
+      addTearDown(() async {
+        for (final file in [
+          firstFile,
+          secondFile,
+          ...archiveSync.testWals
+              .map((wal) => wal.filePath)
+              .whereType<String>()
+              .map((path) => File('${Directory.systemTemp.path}/$path')),
+        ]) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+      archiveSync.testWals = [
+        _historicalRingWal(
+          timerStart: now - 300,
+          sourceId: 'ring_10_11',
+          filePath: firstFile.path.split('/').last,
+        )..uploadIntent = WalUploadIntent.liveContinuity,
+        _historicalRingWal(
+          timerStart: now - 298,
+          sourceId: 'ring_12_13',
+          filePath: secondFile.path.split('/').last,
+        )..uploadIntent = WalUploadIntent.liveContinuity,
+      ];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: now);
+      expect(archiveSync.testWals.single.sourceId, startsWith('archive_ring_'));
+      expect(archiveSync.testWals.single.status, WalStatus.miss);
+
+      await archiveSync.stampConversationId(
+        now - 400,
+        'late-conversation',
+        hasServerSpeechProof: true,
+        sessionEndSeconds: now,
+      );
+      expect(archiveSync.testWals.single.status, WalStatus.miss);
+      expect(archiveSync.testWals.single.canonicalReplacement, isTrue);
+      await uploadStarted.future.timeout(const Duration(seconds: 1));
+
+      expect(uploads, [
+        (
+          conversationId: 'late-conversation',
+          replaceTranscript: true,
+          files: 1,
+        ),
+      ]);
+      expect(
+        archiveSync.testWals.single.sourceId,
+        startsWith('canonical_late-conversation_'),
+      );
     });
   });
 
@@ -646,7 +906,7 @@ void main() {
         originalStorage: WalStorage.sdcard,
         filePath: fileName,
         device: 'test-device',
-        sourceId: 'ring_1_2',
+        sourceId: 'external_1',
         conversationId: 'conversation-1',
       );
 
@@ -677,7 +937,7 @@ void main() {
         originalStorage: WalStorage.sdcard,
         filePath: secondFileName,
         device: 'test-device',
-        sourceId: 'ring_2_3',
+        sourceId: 'external_2',
         conversationId: 'conversation-1',
       );
       expect(
@@ -760,7 +1020,11 @@ void main() {
       expect(uploadedFiles, isEmpty);
       expect(uploadLanes, isEmpty);
 
-      await externalSync.stampConversationId(liveWal.timerStart, 'conversation-1');
+      await externalSync.stampConversationId(
+        liveWal.timerStart,
+        'conversation-1',
+        hasServerSpeechProof: true,
+      );
       await uploadStarted.future.timeout(const Duration(seconds: 1));
 
       expect(uploadedFiles.single, contains('canonical_conversation-1'));
@@ -854,7 +1118,11 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(uploadedBatches, isEmpty);
 
-      await externalSync.stampConversationId(now - 2, 'conversation-1');
+      await externalSync.stampConversationId(
+        now - 2,
+        'conversation-1',
+        hasServerSpeechProof: true,
+      );
       await uploadStarted.future.timeout(const Duration(seconds: 1));
 
       expect(uploadedBatches, hasLength(1));
@@ -867,6 +1135,57 @@ void main() {
       expect(uploadedReplaceModes, [isTrue]);
       expect(externalSync.testWals, hasLength(1));
       expect(externalSync.testWals.single.canonicalReplacement, isTrue);
+    });
+
+    test('conversation ownership without speech proof cannot create an upload job', () async {
+      SyncRateLimiter.instance.clear();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final fileName = 'no_speech_proof_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final file = File('${Directory.systemTemp.path}/$fileName');
+      await file.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+      var uploadCalls = 0;
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files,
+            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+          uploadCalls++;
+          return UploadFilesResult.queued('must-not-upload');
+        },
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+      );
+      final wal = Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: fileName,
+        device: 'test-device',
+        sourceId: 'ring_1_2',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      await externalSync.addExternalWal(wal, scheduleUpload: false);
+
+      await externalSync.stampConversationId(
+        now - 20,
+        'noise-only-conversation',
+        hasServerSpeechProof: false,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(uploadCalls, 0);
+      expect(externalSync.testWals, [wal]);
+      expect(wal.conversationId, isNull);
     });
 
     test('one thousand one-second repairs become one job instead of one thousand jobs', () async {
@@ -937,7 +1256,11 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(uploadedArtifactSizes, isEmpty);
 
-      await externalSync.stampConversationId(now - 1000, 'conversation-1000');
+      await externalSync.stampConversationId(
+        now - 1000,
+        'conversation-1000',
+        hasServerSpeechProof: true,
+      );
       await uploadStarted.future.timeout(const Duration(seconds: 5));
 
       expect(uploadedArtifactSizes, hasLength(1));
@@ -1013,7 +1336,11 @@ void main() {
         ExternalWalRegistration.added,
       );
 
-      final stamp = externalSync.stampConversationId(now - 20, 'conversation-race');
+      final stamp = externalSync.stampConversationId(
+        now - 20,
+        'conversation-race',
+        hasServerSpeechProof: true,
+      );
       await resolverStarted.future.timeout(const Duration(seconds: 1));
       expect(
         await externalSync.addExternalWal(late, scheduleUpload: false),
@@ -1055,3 +1382,22 @@ void main() {
     });
   });
 }
+
+Wal _historicalRingWal({
+  required int timerStart,
+  required String sourceId,
+  required String filePath,
+}) =>
+    Wal(
+      timerStart: timerStart,
+      codec: BleAudioCodec.opus,
+      seconds: 1,
+      totalFrames: 1,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      originalStorage: WalStorage.sdcard,
+      filePath: filePath,
+      device: 'test-device',
+      sourceId: sourceId,
+      uploadIntent: WalUploadIntent.historicalBackfill,
+    );

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -11,6 +12,8 @@ import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
 
@@ -497,6 +500,109 @@ void main() {
       await freshSync.addExternalWal(wal);
 
       expect(freshSync.testWals.map((w) => w.id), contains(wal.id));
+    });
+
+    test('external registration waits for manifest, not upload, and coalesces the next wake', () async {
+      SyncRateLimiter.instance.clear();
+      final manifestCommit = Completer<bool>();
+      final uploadStarted = Completer<void>();
+      final secondUploadStarted = Completer<void>();
+      final releaseUpload = Completer<void>();
+      final backgroundManifestSaved = Completer<void>();
+      final uploadBatches = <List<String>>[];
+      var manifestWrites = 0;
+      final fileName = 'external_wal_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final secondFileName = 'external_wal_next_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final file = File('${Directory.systemTemp.path}/$fileName');
+      final secondFile = File('${Directory.systemTemp.path}/$secondFileName');
+      await file.writeAsBytes([1, 2, 3], flush: true);
+      await secondFile.writeAsBytes([4, 5, 6], flush: true);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+        if (await secondFile.exists()) await secondFile.delete();
+      });
+
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+          uploadBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
+          if (uploadBatches.length == 1) uploadStarted.complete();
+          if (uploadBatches.length == 2) secondUploadStarted.complete();
+          await releaseUpload.future;
+          return UploadFilesResult.queued('test-job-${uploadBatches.length}');
+        },
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) {
+          manifestWrites++;
+          if (manifestWrites == 1) return manifestCommit.future;
+          if (manifestWrites >= 5 && !backgroundManifestSaved.isCompleted) {
+            backgroundManifestSaved.complete();
+          }
+          return Future.value(true);
+        },
+      );
+      final wal = Wal(
+        timerStart: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: fileName,
+        device: 'test-device',
+        sourceId: 'ring_1_2',
+        conversationId: 'conversation-1',
+      );
+
+      var registrationCompleted = false;
+      final registrationFuture = externalSync.addExternalWal(wal).whenComplete(() => registrationCompleted = true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(manifestWrites, 1);
+      expect(registrationCompleted, isFalse);
+
+      manifestCommit.complete(true);
+      expect(
+        await registrationFuture.timeout(const Duration(seconds: 1)),
+        ExternalWalRegistration.added,
+      );
+      await uploadStarted.future.timeout(const Duration(seconds: 1));
+      expect(releaseUpload.isCompleted, isFalse);
+      expect(uploadBatches, [
+        [fileName],
+      ]);
+
+      final secondWal = Wal(
+        timerStart: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: secondFileName,
+        device: 'test-device',
+        sourceId: 'ring_2_3',
+        conversationId: 'conversation-1',
+      );
+      expect(
+        await externalSync.addExternalWal(secondWal).timeout(const Duration(seconds: 1)),
+        ExternalWalRegistration.added,
+      );
+      expect(uploadBatches, [
+        [fileName],
+      ]);
+
+      releaseUpload.complete();
+      await secondUploadStarted.future.timeout(const Duration(seconds: 1));
+      await backgroundManifestSaved.future.timeout(const Duration(seconds: 1));
+      expect(uploadBatches, [
+        [fileName],
+        [secondFileName],
+      ]);
     });
   });
 

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -275,14 +275,15 @@ void main() {
       expect(batch.map((wal) => wal.timerStart), [liveNewest.timerStart, liveOlder.timerStart]);
     });
 
-    test('only a conversation-bound recent WAL counts as live capture', () {
+    test('only recent WALs with server capture proof use the fresh lane', () {
       const now = 2000000000;
-      Wal at(int ageSeconds, {String? conversationId}) =>
-          Wal(timerStart: now - ageSeconds, codec: BleAudioCodec.opus, seconds: 60, conversationId: conversationId);
 
-      expect(isLiveCaptureWal(at(60), now), isFalse);
-      expect(isLiveCaptureWal(at(60, conversationId: 'c'), now), isTrue);
-      expect(isLiveCaptureWal(at(7 * 60 * 60, conversationId: 'c'), now), isFalse);
+      expect(syncUploadLaneForTimestamp(now - 60, now, hasServerCaptureProof: false), SyncUploadLane.backfill);
+      expect(syncUploadLaneForTimestamp(now - 60, now, hasServerCaptureProof: true), SyncUploadLane.fresh);
+      expect(
+        syncUploadLaneForTimestamp(now - 7 * 60 * 60, now, hasServerCaptureProof: true),
+        SyncUploadLane.backfill,
+      );
     });
 
     test('active unbound continuity stays local without a server conversation owner', () {
@@ -337,6 +338,32 @@ void main() {
       final batch = nextSyncUploadBatch([historical, ...closedConversation], now);
 
       expect(batch, [historical]);
+    });
+
+    test('live capture claim requires every pending WAL for one recent server owner', () {
+      const now = 2000000000;
+      Wal owned(int offset) => Wal(
+            timerStart: now - offset,
+            codec: BleAudioCodec.opus,
+            seconds: 2,
+            status: WalStatus.miss,
+            storage: WalStorage.disk,
+            conversationId: 'server-owner',
+            uploadIntent: WalUploadIntent.liveContinuity,
+          );
+      final first = owned(2);
+      final second = owned(1);
+
+      expect(canClaimLiveCapture([first, second], [first, second], now), isTrue);
+      expect(canClaimLiveCapture([second], [first, second], now), isFalse);
+      expect(
+        canClaimLiveCapture(
+          [owned(7 * 60 * 60)],
+          [owned(7 * 60 * 60)],
+          now,
+        ),
+        isFalse,
+      );
     });
 
     test('bound archive waits for canonical repair while unbound archive remains opt-in backfill', () {
@@ -882,6 +909,7 @@ void main() {
           files, {
           onUploadProgress,
           conversationId,
+          claimLiveCapture = false,
           syncLane = SyncUploadLane.fresh,
           replaceTranscript = false,
         }) async {
@@ -983,6 +1011,42 @@ void main() {
   });
 
   group('historical ring archive migration', () {
+    test('sequence order survives a backward RTC correction between contiguous ranges', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_rtc_correction_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      await File('${directory.path}/before.bin').writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await File('${directory.path}/after.bin').writeAsBytes([1, 0, 0, 0, 2], flush: true);
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+        conversationBoundarySecondsProvider: () => 120,
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 2000,
+            captureEndSeconds: 2001,
+            sourceId: 'ring_10_20',
+            filePath: 'before.bin',
+          ),
+          _historicalRingWal(
+            timerStart: 1000,
+            captureEndSeconds: 1001,
+            sourceId: 'ring_20_30',
+            filePath: 'after.bin',
+          ),
+        ];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 3000);
+
+      expect(archiveSync.testWals, hasLength(1));
+      expect(archiveSync.testWals.single.sourceId, 'archive2_ring_10_30_2000');
+      expect(archiveSync.testWals.single.timerStart, 2000);
+      expect(archiveSync.testWals.single.seconds, 1);
+    });
+
     test('sub-two-second VAD pauses stay one open conversation until the true capture end closes', () async {
       final directory = await Directory.systemTemp.createTemp('omi_ring_vad_wall_clock_');
       addTearDown(() async {
@@ -1683,7 +1747,11 @@ void main() {
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
         uploader: (files,
-            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploads.add(
             (
               conversationId: conversationId,
@@ -1904,7 +1972,11 @@ void main() {
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
         uploader: (files,
-            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploadBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
           if (uploadBatches.length == 1) uploadStarted.complete();
           if (uploadBatches.length == 2) secondUploadStarted.complete();
@@ -2001,7 +2073,11 @@ void main() {
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
         uploader: (files,
-            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploadedFiles.addAll(files.map((candidate) => candidate.uri.pathSegments.last));
           uploadLanes.add(syncLane);
           uploadedReplaceModes.add(replaceTranscript);
@@ -2065,6 +2141,7 @@ void main() {
       final uploadedPayloads = <List<int>>[];
       final uploadedConversationIds = <String?>[];
       final uploadedReplaceModes = <bool>[];
+      final uploadedClaimModes = <bool>[];
       final uploadStarted = Completer<void>();
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       const firstFileName = 'audio_test_opus_16000_1_fs320_ring_1_2_1700000001.bin';
@@ -2088,11 +2165,16 @@ void main() {
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
         uploader: (files,
-            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploadedBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
           uploadedPayloads.add(await files.single.readAsBytes());
           uploadedConversationIds.add(conversationId);
           uploadedReplaceModes.add(replaceTranscript);
+          uploadedClaimModes.add(claimLiveCapture);
           if (!uploadStarted.isCompleted) uploadStarted.complete();
           return UploadFilesResult.queued('batched-recovery-job');
         },
@@ -2164,6 +2246,7 @@ void main() {
       expect(uploadedPayloads.single.skip(1393), [3, 0, 0, 0, 4, 5, 6]);
       expect(uploadedConversationIds, ['conversation-1']);
       expect(uploadedReplaceModes, [isTrue]);
+      expect(uploadedClaimModes, [isTrue]);
       expect(externalSync.testWals, hasLength(1));
       expect(externalSync.testWals.single.canonicalReplacement, isTrue);
       expect(externalSync.testWals.single.captureEndSeconds, now - 0.25);
@@ -2263,7 +2346,11 @@ void main() {
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
         uploader: (files,
-            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploadCalls++;
           return UploadFilesResult.queued('must-not-upload');
         },
@@ -2320,7 +2407,11 @@ void main() {
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
         uploader: (artifacts,
-            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploadedArtifactSizes.add(
             await Future.wait(artifacts.map((artifact) => artifact.length())),
           );
@@ -2713,6 +2804,7 @@ void main() {
           files, {
           onUploadProgress,
           conversationId,
+          claimLiveCapture = false,
           syncLane = SyncUploadLane.fresh,
           replaceTranscript = false,
         }) async {
@@ -2767,6 +2859,74 @@ void main() {
       );
       expect(await canonicalFile.readAsBytes(), [1, 0, 0, 0, 7]);
     });
+
+    test('ambiguous canonical ownership preserves recovered ring audio unowned', () async {
+      final recovered = Wal(
+        timerStart: 1001,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: 1002,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: 'ambiguous-recovered.bin',
+        device: 'same-device',
+        sourceId: 'ring_20_21',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+      );
+      final firstOwner = Wal(
+        timerStart: 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: 1001,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: 'first-owner.bin',
+        device: 'same-device',
+        sourceId: 'canonical_first-owner_test',
+        conversationId: 'first-owner',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      final secondOwner = Wal(
+        timerStart: 1002,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: 1003,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: 'second-owner.bin',
+        device: 'same-device',
+        sourceId: 'canonical_second-owner_test',
+        conversationId: 'second-owner',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      var persistCalls = 0;
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async {
+          persistCalls++;
+          return true;
+        },
+        conversationBoundarySecondsProvider: () => 120,
+      )..testWals = [firstOwner, secondOwner];
+
+      expect(
+        await externalSync.addExternalWal(
+          recovered,
+          scheduleUpload: false,
+        ),
+        ExternalWalRegistration.added,
+      );
+
+      expect(recovered.conversationId, isNull);
+      expect(externalSync.testWals, contains(recovered));
+      expect(persistCalls, 1);
+    });
   });
 
   group('syncWal — orphan WAL guard', () {
@@ -2793,6 +2953,7 @@ void main() {
           artifacts, {
           onUploadProgress,
           conversationId,
+          claimLiveCapture = false,
           syncLane = SyncUploadLane.fresh,
           replaceTranscript = false,
         }) async {
@@ -2875,6 +3036,7 @@ void main() {
 
       final uploadedConversationIds = <String?>[];
       final uploadedReplaceModes = <bool>[];
+      final uploadedClaimModes = <bool>[];
       final gate = SyncUploadGate(
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
@@ -2882,11 +3044,13 @@ void main() {
           files, {
           onUploadProgress,
           conversationId,
+          claimLiveCapture = false,
           syncLane = SyncUploadLane.fresh,
           replaceTranscript = false,
         }) async {
           uploadedConversationIds.add(conversationId);
           uploadedReplaceModes.add(replaceTranscript);
+          uploadedClaimModes.add(claimLiveCapture);
           return UploadFilesResult.done(
             SyncLocalFilesResponse(
               newConversationIds: [],
@@ -2921,6 +3085,7 @@ void main() {
 
       expect(uploadedConversationIds, ['conversation-repair']);
       expect(uploadedReplaceModes, [isTrue]);
+      expect(uploadedClaimModes, [isTrue]);
       expect(canonical.status, WalStatus.synced);
     });
 
@@ -2940,6 +3105,7 @@ void main() {
           files, {
           onUploadProgress,
           conversationId,
+          claimLiveCapture = false,
           syncLane = SyncUploadLane.fresh,
           replaceTranscript = false,
         }) async {
@@ -3047,6 +3213,7 @@ SyncUploadGate _completedUploadGate(List<List<String>> uploads) => SyncUploadGat
         files, {
         onUploadProgress,
         conversationId,
+        claimLiveCapture = false,
         syncLane = SyncUploadLane.fresh,
         replaceTranscript = false,
       }) async {

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
+import 'package:omi/services/devices/ring_protocol.dart';
 import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
@@ -429,6 +430,240 @@ void main() {
       expect(batch.map((wal) => wal.timerStart), historical.take(20).map((wal) => wal.timerStart));
     });
 
+    test('one recovery conversation stays one ordered transaction beyond the legacy 20-file batch', () {
+      const now = 2000000000;
+      final recoveryConversation = List.generate(
+        25,
+        (index) => _historicalRingWal(
+          timerStart: now - 600 + index * 3,
+          sourceId: 'archive_ring_${index * 10}_${(index + 1) * 10}_${now - 600 + index * 3}',
+          filePath: 'archive_$index.bin',
+          seconds: 3,
+          totalFrames: 300,
+        ),
+      );
+
+      final batch = nextSyncUploadBatch(
+        recoveryConversation.reversed.toList(),
+        now,
+      );
+
+      expect(batch, recoveryConversation);
+      expect(batch.length, greaterThan(20));
+    });
+
+    test('an exact two-minute recovery gap starts a separate upload transaction', () {
+      const now = 2000000000;
+      final older = _historicalRingWal(
+        timerStart: now - 600,
+        sourceId: 'archive_ring_100_200_${now - 600}',
+        filePath: 'older.bin',
+        seconds: 60,
+        totalFrames: 6000,
+      );
+      final newer = _historicalRingWal(
+        timerStart: now - 420,
+        sourceId: 'archive_ring_200_300_${now - 420}',
+        filePath: 'newer.bin',
+        seconds: 60,
+        totalFrames: 6000,
+      );
+
+      final batch = nextSyncUploadBatch([older, newer], now);
+
+      expect(batch, [newer]);
+    });
+
+    test('recovery grouping honors configured 60s and 300s conversation boundaries', () {
+      const now = 2000000000;
+      for (final boundary in [60, 300]) {
+        final older = _historicalRingWal(
+          timerStart: now - 1000,
+          sourceId: 'archive2_ring_100_200_${now - 1000}',
+          filePath: 'older_$boundary.bin',
+          seconds: 10,
+          totalFrames: 1000,
+        );
+        final inside = _historicalRingWal(
+          timerStart: now - 1000 + 10 + boundary - 1,
+          sourceId: 'archive2_ring_200_300_${now - 1000 + boundary + 9}',
+          filePath: 'inside_$boundary.bin',
+          seconds: 10,
+          totalFrames: 1000,
+        );
+        final exactBoundary = _historicalRingWal(
+          timerStart: inside.timerStart + inside.seconds + boundary,
+          sourceId: 'archive2_ring_300_400_${inside.timerStart + inside.seconds + boundary}',
+          filePath: 'boundary_$boundary.bin',
+          seconds: 10,
+          totalFrames: 1000,
+        );
+
+        expect(
+          nextSyncUploadBatch(
+            [older, inside],
+            now,
+            conversationBoundarySeconds: boundary,
+          ),
+          [older, inside],
+        );
+        expect(
+          nextSyncUploadBatch(
+            [older, inside, exactBoundary],
+            now,
+            conversationBoundarySeconds: boundary,
+          ),
+          [exactBoundary],
+        );
+      }
+    });
+
+    test('overlapping legacy archives upload one exact nonduplicating tile', () {
+      const now = 2000000000;
+      final prefix = _historicalRingWal(
+        timerStart: now - 600,
+        sourceId: 'archive_ring_100_200_${now - 600}',
+        filePath: 'prefix.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final suffix = _historicalRingWal(
+        timerStart: now - 570,
+        sourceId: 'archive_ring_200_300_${now - 570}',
+        filePath: 'suffix.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final rolledForward = _historicalRingWal(
+        timerStart: now - 600,
+        sourceId: 'archive_ring_100_300_${now - 600}',
+        filePath: 'rolled_forward.bin',
+        seconds: 60,
+        totalFrames: 6000,
+      );
+
+      expect(
+        nextSyncUploadBatch([prefix, suffix, rolledForward], now),
+        [rolledForward],
+      );
+    });
+
+    test('legacy aliases share the exact-tile acknowledgement and never reupload', () async {
+      SyncRateLimiter.instance.clear();
+      final prefixName = 'legacy_alias_${DateTime.now().microsecondsSinceEpoch}';
+      final prefixFile = File('${Directory.systemTemp.path}/${prefixName}_prefix.bin');
+      final suffixFile = File('${Directory.systemTemp.path}/${prefixName}_suffix.bin');
+      final rolledFile = File('${Directory.systemTemp.path}/${prefixName}_rolled.bin');
+      for (final file in [prefixFile, suffixFile, rolledFile]) {
+        await file.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      }
+      addTearDown(() async {
+        for (final file in [prefixFile, suffixFile, rolledFile]) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+
+      final uploads = <List<String>>[];
+      final legacySync = LocalWalSyncImpl(
+        listener,
+        uploadGate: _completedUploadGate(uploads),
+        walPersister: (_) async => true,
+      );
+      final prefix = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'archive_ring_100_200_1000',
+        filePath: prefixFile.uri.pathSegments.last,
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final suffix = _historicalRingWal(
+        timerStart: 1030,
+        sourceId: 'archive_ring_200_300_1030',
+        filePath: suffixFile.uri.pathSegments.last,
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final rolled = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'archive_ring_100_300_1000',
+        filePath: rolledFile.uri.pathSegments.last,
+        seconds: 60,
+        totalFrames: 6000,
+      );
+      legacySync.testWals = [prefix, suffix, rolled];
+
+      await legacySync.syncAll();
+      await legacySync.syncAll();
+
+      expect(uploads, hasLength(1));
+      expect(uploads.single.single, rolledFile.path);
+      expect(
+        legacySync.testWals.map((wal) => wal.status),
+        everyElement(WalStatus.synced),
+      );
+    });
+
+    test('irreducible legacy overlap does not block exact independent components', () {
+      const now = 2000000000;
+      final overlapA = _historicalRingWal(
+        timerStart: now - 600,
+        sourceId: 'archive_ring_100_220_${now - 600}',
+        filePath: 'overlap_a.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final overlapB = _historicalRingWal(
+        timerStart: now - 570,
+        sourceId: 'archive_ring_200_300_${now - 570}',
+        filePath: 'overlap_b.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final gapA = _historicalRingWal(
+        timerStart: now - 539,
+        sourceId: 'archive_ring_400_500_${now - 539}',
+        filePath: 'gap_a.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final gapB = _historicalRingWal(
+        timerStart: now - 509,
+        sourceId: 'archive_ring_520_600_${now - 509}',
+        filePath: 'gap_b.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+
+      expect(nextSyncUploadBatch([overlapA, overlapB], now), isEmpty);
+      expect(
+        nextSyncUploadBatch(
+          [overlapA, overlapB, gapA, gapB],
+          now,
+        ),
+        [gapA, gapB],
+      );
+    });
+
+    test('an archive stays local while an adjacent raw recovery fragment is unassembled', () {
+      const now = 2000000000;
+      final archive = _historicalRingWal(
+        timerStart: now - 600,
+        sourceId: 'archive_ring_100_200_${now - 600}',
+        filePath: 'archive.bin',
+        seconds: 60,
+        totalFrames: 6000,
+      );
+      final raw = _historicalRingWal(
+        timerStart: now - 539,
+        sourceId: 'ring_200_210',
+        filePath: 'raw.bin',
+        seconds: 3,
+        totalFrames: 300,
+      )..uploadIntent = WalUploadIntent.liveContinuity;
+
+      expect(nextSyncUploadBatch([archive, raw], now), isEmpty);
+    });
+
     test('an extraordinarily large fresh conversation is downgraded as one unit', () {
       const now = 2000000000;
       final oversized = List.generate(
@@ -450,6 +685,252 @@ void main() {
       // capture transaction rather than split into 20-file async jobs.
       expect(batch.length, 2000);
       expect(batch.every((wal) => wal.conversationId == 'oversized-conversation'), isTrue);
+    });
+  });
+
+  group('authorized recovery receipt drain', () {
+    test('irreducible legacy overlap stays pending without pinning the receipt', () async {
+      const now = 2000000000;
+      final overlapA = _historicalRingWal(
+        timerStart: now - 600,
+        sourceId: 'archive_ring_100_220_${now - 600}',
+        filePath: 'irreducible_a.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final overlapB = _historicalRingWal(
+        timerStart: now - 570,
+        sourceId: 'archive_ring_200_300_${now - 570}',
+        filePath: 'irreducible_b.bin',
+        seconds: 30,
+        totalFrames: 3000,
+      );
+      final receiptSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+      )..testWals = [overlapA, overlapB];
+
+      final result = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 300,
+        nowSeconds: now,
+      );
+
+      expect(result.hasDeferredRecovery, isFalse);
+      expect(receiptSync.testWals, [overlapA, overlapB]);
+      expect(receiptSync.testWals.map((wal) => wal.status), everyElement(WalStatus.miss));
+    });
+
+    test('splits at the receipt target and leaves newer recovery untouched', () async {
+      SyncRateLimiter.instance.clear();
+      const now = 2000000000;
+      final prefix = 'omi_authorized_split_${DateTime.now().microsecondsSinceEpoch}';
+      final firstFile = File('${Directory.systemTemp.path}/${prefix}_first.bin');
+      final secondFile = File('${Directory.systemTemp.path}/${prefix}_second.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+      addTearDown(() async {
+        for (final file in [firstFile, secondFile]) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+
+      final uploads = <List<String>>[];
+      final receiptSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: _completedUploadGate(uploads),
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${Directory.systemTemp.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: now - 500,
+            sourceId: 'ring_100_200',
+            filePath: firstFile.path.split('/').last,
+          ),
+          _historicalRingWal(
+            timerStart: now - 499,
+            sourceId: 'ring_200_300',
+            filePath: secondFile.path.split('/').last,
+          ),
+        ];
+
+      final result = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: now,
+      );
+
+      expect(uploads, hasLength(1));
+      expect(uploads.single, [firstFile.path]);
+      final authorized = receiptSync.testWals.singleWhere(
+        (wal) => wal.sourceId == 'archive2_ring_100_200_${now - 500}',
+      );
+      final newer = receiptSync.testWals.singleWhere(
+        (wal) => wal.sourceId == 'archive2_ring_200_300_${now - 499}',
+      );
+      expect(authorized.status, WalStatus.synced);
+      expect(newer.status, WalStatus.miss);
+      expect(result.hasDeferredRecovery, isFalse);
+    });
+
+    test('recent authorized raw stays deferred until its configured close', () async {
+      SyncRateLimiter.instance.clear();
+      const captureStart = 1000;
+      final prefix = 'omi_authorized_recent_${DateTime.now().microsecondsSinceEpoch}';
+      final sourceFile = File('${Directory.systemTemp.path}/${prefix}_source.bin');
+      await sourceFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      addTearDown(() async {
+        if (await sourceFile.exists()) await sourceFile.delete();
+      });
+
+      final uploads = <List<String>>[];
+      final receiptSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: _completedUploadGate(uploads),
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${Directory.systemTemp.path}/$path',
+        silenceFrameFactory: (_) => [0],
+        conversationBoundarySecondsProvider: () => 300,
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: captureStart,
+            sourceId: 'ring_100_200',
+            filePath: sourceFile.path.split('/').last,
+          ),
+        ];
+
+      final deferred = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: captureStart + 300,
+      );
+
+      expect(uploads, isEmpty);
+      expect(receiptSync.testWals.single.sourceId, 'ring_100_200');
+      expect(deferred.hasDeferredRecovery, isTrue);
+
+      final closed = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: captureStart + 301,
+      );
+
+      expect(uploads, hasLength(1));
+      expect(receiptSync.testWals.single.sourceId, 'archive2_ring_100_200_$captureStart');
+      expect(receiptSync.testWals.single.status, WalStatus.synced);
+      expect(closed.hasDeferredRecovery, isFalse);
+    });
+
+    test('local close timing mirrors the backend minimum conversation timeout', () async {
+      SyncRateLimiter.instance.clear();
+      const captureStart = 1000;
+      final fileName = 'effective_timeout_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final sourceFile = File('${Directory.systemTemp.path}/$fileName');
+      await sourceFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      addTearDown(() async {
+        if (await sourceFile.exists()) await sourceFile.delete();
+      });
+      final uploads = <List<String>>[];
+      final receiptSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: _completedUploadGate(uploads),
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${Directory.systemTemp.path}/$path',
+        silenceFrameFactory: (_) => [0],
+        conversationBoundarySecondsProvider: () => 30,
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: captureStart,
+            sourceId: 'ring_100_200',
+            filePath: fileName,
+          ),
+        ];
+
+      final stillOpen = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: captureStart + 61,
+      );
+      expect(stillOpen.hasDeferredRecovery, isTrue);
+      expect(uploads, isEmpty);
+
+      final closed = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: captureStart + 121,
+      );
+      expect(closed.hasDeferredRecovery, isFalse);
+      expect(uploads, hasLength(1));
+    });
+
+    test('uploaded receipt work retains authority through reconciliation and retry', () async {
+      SyncRateLimiter.instance.clear();
+      const now = 2000000000;
+      final prefix = 'omi_authorized_pending_${DateTime.now().microsecondsSinceEpoch}';
+      final sourceFile = File('${Directory.systemTemp.path}/${prefix}_source.bin');
+      await sourceFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      addTearDown(() async {
+        if (await sourceFile.exists()) await sourceFile.delete();
+      });
+
+      final uploads = <List<String>>[];
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (
+          files, {
+          onUploadProgress,
+          conversationId,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false,
+        }) async {
+          uploads.add(files.map((file) => file.path).toList());
+          return UploadFilesResult.queued('authorized-retry-job');
+        },
+      );
+      final pending = _historicalRingWal(
+        timerStart: now - 500,
+        sourceId: 'archive2_ring_100_200_${now - 500}',
+        filePath: sourceFile.path.split('/').last,
+      )
+        ..status = WalStatus.uploaded
+        ..jobId = 'pending-job';
+      final receiptSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${Directory.systemTemp.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [pending];
+
+      final waiting = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: now,
+      );
+      expect(uploads, isEmpty);
+      expect(waiting.hasDeferredRecovery, isTrue);
+
+      pending.status = WalStatus.synced;
+      final completed = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: now,
+      );
+      expect(completed.hasDeferredRecovery, isFalse);
+
+      pending
+        ..status = WalStatus.miss
+        ..jobId = null;
+      final retried = await receiptSync.syncAuthorizedRecovery(
+        deviceId: 'test-device',
+        targetWriteSeq: 200,
+        nowSeconds: now,
+      );
+      expect(uploads, hasLength(1));
+      expect(pending.status, WalStatus.uploaded);
+      expect(retried.hasDeferredRecovery, isTrue);
     });
   });
 
@@ -502,6 +983,220 @@ void main() {
   });
 
   group('historical ring archive migration', () {
+    test('sub-two-second VAD pauses stay one open conversation until the true capture end closes', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_vad_wall_clock_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      await File('${directory.path}/first.bin').writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await File('${directory.path}/second.bin').writeAsBytes([1, 0, 0, 0, 2], flush: true);
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'ring_10_20',
+            filePath: 'first.bin',
+            captureEndSeconds: 1100,
+          ),
+          _historicalRingWal(
+            timerStart: 1219,
+            sourceId: 'ring_20_30',
+            filePath: 'second.bin',
+            captureEndSeconds: 1300,
+          ),
+        ];
+
+      // The playable files contain only two 10 ms speech frames, but their
+      // record timestamps show one VAD-spanning conversation whose latest
+      // capture is only 50 seconds old.
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 1350);
+
+      expect(archiveSync.testWals.map((wal) => wal.sourceId), ['ring_10_20', 'ring_20_30']);
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 1421);
+
+      expect(archiveSync.testWals, hasLength(1));
+      expect(archiveSync.testWals.single.sourceId, 'archive2_ring_10_30_1000');
+      expect(archiveSync.testWals.single.captureEndSeconds, 1300);
+      expect(archiveSync.testWals.single.wallClockEndSeconds, 1300);
+    });
+
+    test('rolls adjacent bounded archives forward when later recovery data arrives', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_archive_roll_forward_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+
+      Future<Wal> writeRecoveryWal({
+        required int timerStart,
+        required int seconds,
+        required String sourceId,
+        required String fileName,
+      }) async {
+        const codec = BleAudioCodec.opusFS320;
+        final totalFrames = seconds * codec.getFramesPerSecond();
+        final bytes = <int>[];
+        for (var index = 0; index < totalFrames; index++) {
+          bytes.addAll([1, 0, 0, 0, 1]);
+        }
+        await File('${directory.path}/$fileName').writeAsBytes(bytes, flush: true);
+        return Wal(
+          timerStart: timerStart,
+          codec: codec,
+          seconds: seconds,
+          totalFrames: totalFrames,
+          status: WalStatus.miss,
+          storage: WalStorage.disk,
+          originalStorage: WalStorage.sdcard,
+          filePath: fileName,
+          device: 'test-device',
+          sourceId: sourceId,
+          uploadIntent:
+              sourceId.startsWith('ring_') ? WalUploadIntent.liveContinuity : WalUploadIntent.historicalBackfill,
+        );
+      }
+
+      final first = await writeRecoveryWal(
+        timerStart: 1000,
+        seconds: 275,
+        sourceId: 'archive2_ring_100_200_1000',
+        fileName: 'first.bin',
+      );
+      final second = await writeRecoveryWal(
+        timerStart: 1275,
+        seconds: 79,
+        sourceId: 'archive2_ring_200_300_1275',
+        fileName: 'second.bin',
+      );
+      final laterRaw = await writeRecoveryWal(
+        timerStart: 1354,
+        seconds: 336,
+        sourceId: 'ring_300_400',
+        fileName: 'later.bin',
+      );
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [first, second, laterRaw];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+
+      expect(archiveSync.testWals, hasLength(1));
+      final rolledForward = archiveSync.testWals.single;
+      expect(rolledForward.sourceId, 'archive2_ring_100_400_1000');
+      expect(rolledForward.seconds, 690);
+      expect(rolledForward.totalFrames, 34500);
+      expect(await File('${directory.path}/${rolledForward.filePath}').exists(), isTrue);
+      expect(await File('${directory.path}/first.bin').exists(), isFalse);
+      expect(await File('${directory.path}/second.bin').exists(), isFalse);
+      expect(await File('${directory.path}/later.bin').exists(), isFalse);
+    });
+
+    test('never lets an archive claim sequence records missing from the phone', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_archive_sequence_gap_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final firstFile = File('${directory.path}/first.bin');
+      final secondFile = File('${directory.path}/second.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'ring_100_200',
+            filePath: firstFile.path.split('/').last,
+          ),
+          _historicalRingWal(
+            timerStart: 1001,
+            sourceId: 'ring_220_300',
+            filePath: secondFile.path.split('/').last,
+          ),
+        ];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+
+      expect(archiveSync.testWals, hasLength(2));
+      expect(
+        archiveSync.testWals.map((wal) => wal.sourceId).toSet(),
+        {'archive2_ring_100_200_1000', 'archive2_ring_220_300_1001'},
+      );
+      expect(
+        archiveSync.testWals.any((wal) => wal.sourceId == 'archive2_ring_100_300_1000'),
+        isFalse,
+      );
+      final restartCoverage = RingSequenceCoverage(
+        archiveSync.testWals.map(
+          (wal) => RingProtocol.parseRecoverySourceRange(wal.sourceId)!,
+        ),
+      );
+      expect(restartCoverage.contiguousEndFrom(100), 200);
+      expect(restartCoverage.firstUncovered(100, 300), 200);
+
+      // Timestamp continuity still owns the cloud transaction: the server gets
+      // one ordered conversation job, while restart coverage retains the hole.
+      expect(
+        nextSyncUploadBatch(archiveSync.testWals, 2000),
+        archiveSync.testWals,
+      );
+    });
+
+    test('a legacy archive cannot suppress its truthful raw reread after upgrade', () async {
+      final directory = await Directory.systemTemp.createTemp('omi_ring_archive_upgrade_');
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final legacyFile = File('${directory.path}/legacy.bin');
+      final rawFile = File('${directory.path}/raw.bin');
+      const bytes = [1, 0, 0, 0, 1];
+      await legacyFile.writeAsBytes(bytes, flush: true);
+      await rawFile.writeAsBytes(bytes, flush: true);
+
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'archive_ring_100_200_1000',
+            filePath: legacyFile.path.split('/').last,
+          ),
+        ];
+      final truthfulRaw = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'ring_100_200',
+        filePath: rawFile.path.split('/').last,
+      );
+
+      final registration = await archiveSync.addExternalWal(
+        truthfulRaw,
+        scheduleUpload: false,
+      );
+      expect(registration, ExternalWalRegistration.added);
+      expect(archiveSync.testWals, hasLength(2));
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+
+      expect(archiveSync.testWals, hasLength(1));
+      expect(archiveSync.testWals.single.sourceId, 'archive2_ring_100_200_1000');
+      expect(await legacyFile.exists(), isFalse);
+      expect(await rawFile.exists(), isTrue);
+    });
+
     test('replaces many raw fragments with one playable local artifact', () async {
       final directory = await Directory.systemTemp.createTemp('omi_ring_archive_');
       addTearDown(() async {
@@ -530,7 +1225,7 @@ void main() {
         ),
         _historicalRingWal(
           timerStart: 1002,
-          sourceId: 'ring_12_13',
+          sourceId: 'ring_11_12',
           filePath: secondFile.path.split('/').last,
         )..status = WalStatus.synced,
       ];
@@ -540,13 +1235,87 @@ void main() {
       expect(persistedSizes, [1]);
       expect(archiveSync.testWals, hasLength(1));
       final archive = archiveSync.testWals.single;
-      expect(archive.sourceId, startsWith('archive_ring_10_13_'));
+      expect(archive.sourceId, startsWith('archive2_ring_10_12_'));
       expect(archive.uploadIntent, WalUploadIntent.historicalBackfill);
       expect(archive.status, WalStatus.miss);
       expect(archive.totalFrames, 201);
       expect(await File('${directory.path}/${archive.filePath}').exists(), isTrue);
       expect(await firstFile.exists(), isFalse);
       expect(await secondFile.exists(), isFalse);
+    });
+
+    test('serializes historical compaction with canonical conversation stamping', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'omi_ring_archive_stamp_race_',
+      );
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final firstFile = File('${directory.path}/first.bin');
+      final secondFile = File('${directory.path}/second.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+
+      final resolverStarted = Completer<void>();
+      final releaseResolver = Completer<void>();
+      var heldCompaction = false;
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async {
+          if (path == 'first.bin' && !heldCompaction) {
+            heldCompaction = true;
+            resolverStarted.complete();
+            await releaseResolver.future;
+          }
+          return path == null ? null : '${directory.path}/$path';
+        },
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'ring_10_11',
+            filePath: 'first.bin',
+          )..status = WalStatus.synced,
+          _historicalRingWal(
+            timerStart: 1002,
+            sourceId: 'ring_11_12',
+            filePath: 'second.bin',
+          )..status = WalStatus.synced,
+        ];
+
+      final compaction = archiveSync.prepareHistoricalRingFragments(
+        nowSeconds: 2000,
+      );
+      await resolverStarted.future.timeout(const Duration(seconds: 1));
+      var stampCompleted = false;
+      final stamp = archiveSync
+          .stampConversationId(
+            900,
+            'serialized-conversation',
+            hasServerSpeechProof: true,
+            sessionEndSeconds: 1100,
+          )
+          .whenComplete(() => stampCompleted = true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(stampCompleted, isFalse);
+      releaseResolver.complete();
+      await Future.wait([compaction, stamp]).timeout(
+        const Duration(seconds: 2),
+      );
+
+      final canonical = archiveSync.testWals.single;
+      expect(
+        canonical.sourceId,
+        startsWith('canonical_serialized-conversation'),
+      );
+      expect(canonical.conversationId, 'serialized-conversation');
+      expect(canonical.totalFrames, 201);
+      expect(
+        await File('${directory.path}/${canonical.filePath}').exists(),
+        isTrue,
+      );
     });
 
     test('keeps every source when the archive manifest commit fails', () async {
@@ -588,7 +1357,132 @@ void main() {
       expect(await firstFile.exists(), isTrue);
       expect(await secondFile.exists(), isTrue);
       expect(
-        directory.listSync().whereType<File>().where((file) => file.path.contains('archive_ring_')),
+        directory.listSync().whereType<File>().where((file) => file.path.contains('archive2_ring_')),
+        isEmpty,
+      );
+    });
+
+    test('failed archive persistence restores sources and preserves concurrent registration', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'omi_ring_archive_persist_failure_',
+      );
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final firstFile = File('${directory.path}/first.bin');
+      final secondFile = File('${directory.path}/second.bin');
+      final concurrentFile = File('${directory.path}/concurrent.bin');
+      await firstFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      await secondFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+      await concurrentFile.writeAsBytes([1, 0, 0, 0, 3], flush: true);
+
+      final archivePersistStarted = Completer<void>();
+      final releaseArchivePersist = Completer<void>();
+      final concurrentSaveQueued = Completer<void>();
+      var rejectedArchiveCommit = false;
+      var persistenceCallCount = 0;
+      var persistenceBarrier = Future<void>.value();
+      var durableSourceIds = <String>[];
+      final persistedSnapshots = <List<String>>[];
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (wals) {
+          final call = ++persistenceCallCount;
+          final snapshot = wals.map((wal) => wal.sourceId!).toList(growable: false);
+          persistedSnapshots.add(snapshot);
+          if (call == 2) concurrentSaveQueued.complete();
+          final operation = persistenceBarrier.then((_) async {
+            final hasArchive = snapshot.any(
+              (sourceId) => sourceId.startsWith('archive2_ring_'),
+            );
+            if (hasArchive && !rejectedArchiveCommit) {
+              rejectedArchiveCommit = true;
+              archivePersistStarted.complete();
+              await releaseArchivePersist.future;
+              return false;
+            }
+            durableSourceIds = snapshot;
+            return true;
+          });
+          persistenceBarrier = operation.then<void>(
+            (_) {},
+            onError: (error, stackTrace) {},
+          );
+          return operation;
+        },
+        walPathResolver: (path) async => path == null ? null : '${directory.path}/$path',
+        silenceFrameFactory: (_) => [0],
+      );
+      final first = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'ring_10_11',
+        filePath: 'first.bin',
+      );
+      final second = _historicalRingWal(
+        timerStart: 1002,
+        sourceId: 'ring_11_12',
+        filePath: 'second.bin',
+      );
+      final concurrent = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'ring_90_91',
+        filePath: 'concurrent.bin',
+      )..device = 'other-device';
+      archiveSync.testWals = [first, second];
+
+      final compaction = archiveSync.prepareHistoricalRingFragments(
+        nowSeconds: 2000,
+      );
+      await archivePersistStarted.future.timeout(const Duration(seconds: 1));
+      final concurrentRegistration = archiveSync.addExternalWal(
+        concurrent,
+        scheduleUpload: false,
+      );
+      await concurrentSaveQueued.future.timeout(const Duration(seconds: 1));
+      expect(
+        persistedSnapshots[1],
+        containsAll(<String>[
+          'archive2_ring_10_12_1000',
+          'ring_90_91',
+        ]),
+      );
+
+      releaseArchivePersist.complete();
+      expect(
+        await concurrentRegistration,
+        ExternalWalRegistration.added,
+      );
+      await expectLater(
+        compaction.timeout(const Duration(seconds: 2)),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(rejectedArchiveCommit, isTrue);
+      expect(
+        archiveSync.testWals,
+        containsAllInOrder([concurrent, first, second]),
+      );
+      expect(
+        archiveSync.testWals.any(
+          (wal) => wal.sourceId?.startsWith('archive2_ring_') == true,
+        ),
+        isFalse,
+      );
+      expect(await firstFile.exists(), isTrue);
+      expect(await secondFile.exists(), isTrue);
+      expect(await concurrentFile.exists(), isTrue);
+      expect(
+        durableSourceIds.toSet(),
+        {'ring_10_11', 'ring_11_12', 'ring_90_91'},
+      );
+      expect(
+        persistedSnapshots.last.toSet(),
+        {'ring_10_11', 'ring_11_12', 'ring_90_91'},
+      );
+      expect(
+        directory.listSync().whereType<File>().where(
+              (file) => file.path.contains('archive2_ring_'),
+            ),
         isEmpty,
       );
     });
@@ -695,13 +1589,13 @@ void main() {
         )..uploadIntent = WalUploadIntent.liveContinuity,
         _historicalRingWal(
           timerStart: now - 298,
-          sourceId: 'ring_12_13',
+          sourceId: 'ring_11_12',
           filePath: secondFile.path.split('/').last,
         )..uploadIntent = WalUploadIntent.liveContinuity,
       ];
 
       await archiveSync.prepareHistoricalRingFragments(nowSeconds: now);
-      expect(archiveSync.testWals.single.sourceId, startsWith('archive_ring_'));
+      expect(archiveSync.testWals.single.sourceId, startsWith('archive2_ring_'));
       expect(archiveSync.testWals.single.status, WalStatus.miss);
 
       await archiveSync.stampConversationId(
@@ -1079,11 +1973,13 @@ void main() {
         required int timerStart,
         required String fileName,
         required String sourceId,
+        required double captureEndSeconds,
       }) =>
           Wal(
             timerStart: timerStart,
             codec: BleAudioCodec.opus,
             seconds: 1,
+            captureEndSeconds: captureEndSeconds,
             status: WalStatus.miss,
             storage: WalStorage.disk,
             originalStorage: WalStorage.sdcard,
@@ -1100,6 +1996,7 @@ void main() {
             timerStart: now - 2,
             fileName: firstFileName,
             sourceId: 'ring_1_2',
+            captureEndSeconds: now - 1.25,
           ),
         ),
         ExternalWalRegistration.added,
@@ -1110,6 +2007,7 @@ void main() {
             timerStart: now - 1,
             fileName: secondFileName,
             sourceId: 'ring_2_3',
+            captureEndSeconds: now - 0.25,
           ),
         ),
         ExternalWalRegistration.added,
@@ -1135,6 +2033,7 @@ void main() {
       expect(uploadedReplaceModes, [isTrue]);
       expect(externalSync.testWals, hasLength(1));
       expect(externalSync.testWals.single.canonicalReplacement, isTrue);
+      expect(externalSync.testWals.single.captureEndSeconds, now - 0.25);
     });
 
     test('conversation ownership without speech proof cannot create an upload job', () async {
@@ -1358,9 +2257,531 @@ void main() {
         hasLength(1),
       );
     });
+
+    test('canonical commit rescans and includes a same-device WAL registered during assembly', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final sourceName = 'canonical_same_device_source_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final lateName = 'canonical_same_device_late_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final sourceFile = File('${Directory.systemTemp.path}/$sourceName');
+      final lateFile = File('${Directory.systemTemp.path}/$lateName');
+      await sourceFile.writeAsBytes([1, 0, 0, 0, 7], flush: true);
+      await lateFile.writeAsBytes([1, 0, 0, 0, 8], flush: true);
+      addTearDown(() async {
+        for (final file in [sourceFile, lateFile]) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+
+      final resolverStarted = Completer<void>();
+      final releaseResolver = Completer<void>();
+      var heldFirstAssembly = false;
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async {
+          if (path == sourceName && !heldFirstAssembly) {
+            heldFirstAssembly = true;
+            resolverStarted.complete();
+            await releaseResolver.future;
+          }
+          return path == null ? null : '${Directory.systemTemp.path}/$path';
+        },
+      );
+      addTearDown(() async {
+        for (final wal in externalSync.testWals) {
+          final path = wal.filePath;
+          if (path == null || !path.contains('canonical_conversation-same-device')) continue;
+          final file = File('${Directory.systemTemp.path}/$path');
+          if (await file.exists()) await file.delete();
+        }
+      });
+      final source = Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: now - 9.99,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: sourceName,
+        device: 'same-device',
+        sourceId: 'ring_10_11',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      final late = Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: now - 9.99,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: lateName,
+        device: 'same-device',
+        sourceId: 'ring_11_12',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      await externalSync.addExternalWal(source, scheduleUpload: false);
+
+      final stamp = externalSync.stampConversationId(
+        now - 20,
+        'conversation-same-device',
+        hasServerSpeechProof: true,
+        sessionEndSeconds: now,
+      );
+      await resolverStarted.future.timeout(const Duration(seconds: 1));
+      await externalSync.addExternalWal(late, scheduleUpload: false);
+      releaseResolver.complete();
+      await stamp.timeout(const Duration(seconds: 2));
+
+      final canonical = externalSync.testWals.single;
+      expect(canonical.sourceId, startsWith('canonical_conversation-same-device'));
+      expect(canonical.conversationId, 'conversation-same-device');
+      expect(canonical.totalFrames, 2);
+      expect(await File('${Directory.systemTemp.path}/${canonical.filePath}').length(), 10);
+    });
+
+    test('failed canonical persistence restores sources and preserves concurrent registration', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'omi_canonical_persist_failure_',
+      );
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final sourceFile = File('${directory.path}/source.bin');
+      final concurrentFile = File('${directory.path}/concurrent.bin');
+      await sourceFile.writeAsBytes([1, 0, 0, 0, 7], flush: true);
+      await concurrentFile.writeAsBytes([1, 0, 0, 0, 8], flush: true);
+
+      final canonicalPersistStarted = Completer<void>();
+      final releaseCanonicalPersist = Completer<void>();
+      final concurrentSaveQueued = Completer<void>();
+      var rejectedCanonicalCommit = false;
+      var persistenceCallCount = 0;
+      var persistenceBarrier = Future<void>.value();
+      var durableSourceIds = <String>[];
+      final persistedSnapshots = <List<String>>[];
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (wals) {
+          final call = ++persistenceCallCount;
+          final snapshot = wals.map((wal) => wal.sourceId!).toList(growable: false);
+          persistedSnapshots.add(snapshot);
+          if (call == 2) concurrentSaveQueued.complete();
+          final operation = persistenceBarrier.then((_) async {
+            final hasCanonical = snapshot.any(
+              (sourceId) => sourceId.startsWith('canonical_'),
+            );
+            if (hasCanonical && !rejectedCanonicalCommit) {
+              rejectedCanonicalCommit = true;
+              canonicalPersistStarted.complete();
+              await releaseCanonicalPersist.future;
+              return false;
+            }
+            durableSourceIds = snapshot;
+            return true;
+          });
+          persistenceBarrier = operation.then<void>(
+            (_) {},
+            onError: (error, stackTrace) {},
+          );
+          return operation;
+        },
+        walPathResolver: (path) async {
+          return path == null ? null : '${directory.path}/$path';
+        },
+        silenceFrameFactory: (_) => [0],
+      );
+      final source = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'ring_10_11',
+        filePath: 'source.bin',
+      )
+        ..status = WalStatus.synced
+        ..uploadIntent = WalUploadIntent.liveContinuity;
+      final concurrent = Wal(
+        timerStart: 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: 'concurrent.bin',
+        device: 'other-device',
+        sourceId: 'ring_90_91',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+      );
+      externalSync.testWals = [source];
+
+      final stamp = externalSync.stampConversationId(
+        900,
+        'persist-failure',
+        hasServerSpeechProof: true,
+        sessionEndSeconds: 1100,
+      );
+      await canonicalPersistStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      final concurrentRegistration = externalSync.addExternalWal(
+        concurrent,
+        scheduleUpload: false,
+      );
+      await concurrentSaveQueued.future.timeout(const Duration(seconds: 1));
+      expect(
+        persistedSnapshots[1].any(
+          (sourceId) => sourceId.startsWith('canonical_'),
+        ),
+        isTrue,
+      );
+      expect(persistedSnapshots[1], contains('ring_90_91'));
+      releaseCanonicalPersist.complete();
+      expect(
+        await concurrentRegistration,
+        ExternalWalRegistration.added,
+      );
+      await stamp.timeout(const Duration(seconds: 2));
+
+      expect(rejectedCanonicalCommit, isTrue);
+      expect(
+        externalSync.testWals.any(
+          (wal) => wal.sourceId?.startsWith('canonical_') == true,
+        ),
+        isFalse,
+      );
+      expect(externalSync.testWals, containsAllInOrder([concurrent, source]));
+      expect(source.conversationId, 'persist-failure');
+      expect(concurrent.conversationId, isNull);
+      expect(await sourceFile.exists(), isTrue);
+      expect(await concurrentFile.exists(), isTrue);
+      expect(
+        durableSourceIds.toSet(),
+        {'ring_10_11', 'ring_90_91'},
+      );
+      expect(
+        persistedSnapshots.last.toSet(),
+        {'ring_10_11', 'ring_90_91'},
+      );
+      expect(
+        persistedSnapshots.last.any(
+          (sourceId) => sourceId.startsWith('canonical_'),
+        ),
+        isFalse,
+      );
+      expect(
+        directory.listSync().whereType<File>().where(
+              (file) => file.path.contains('canonical_persist-failure'),
+            ),
+        isEmpty,
+      );
+    });
+
+    test('post-commit late ring audio inherits canonical ownership and never uploads alone', () async {
+      SyncRateLimiter.instance.clear();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final canonicalName = 'canonical_post_commit_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final lateName = 'canonical_post_commit_late_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final canonicalFile = File('${Directory.systemTemp.path}/$canonicalName');
+      final lateFile = File('${Directory.systemTemp.path}/$lateName');
+      await canonicalFile.writeAsBytes([1, 0, 0, 0, 7], flush: true);
+      await lateFile.writeAsBytes([1, 0, 0, 0, 8], flush: true);
+      addTearDown(() async {
+        for (final file in [canonicalFile, lateFile]) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+      var uploadCalls = 0;
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (
+          files, {
+          onUploadProgress,
+          conversationId,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false,
+        }) async {
+          uploadCalls++;
+          return UploadFilesResult.queued('must-not-upload-gap');
+        },
+      );
+      final canonical = Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: now - 9,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: canonicalName,
+        device: 'same-device',
+        sourceId: 'canonical_conversation-post-commit_test',
+        conversationId: 'conversation-post-commit',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      final late = Wal(
+        timerStart: now - 8,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        captureEndSeconds: now - 7,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: lateName,
+        device: 'same-device',
+        sourceId: 'ring_11_12',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+      )..testWals = [canonical];
+
+      await externalSync.addExternalWal(late, scheduleUpload: false);
+      await externalSync.syncWal(wal: late);
+
+      expect(late.conversationId, 'conversation-post-commit');
+      expect(late.status, WalStatus.miss);
+      expect(uploadCalls, 0);
+      expect(
+        externalSync.testWals.where((wal) => wal.sourceId?.startsWith('canonical_') == true),
+        [canonical],
+      );
+      expect(await canonicalFile.readAsBytes(), [1, 0, 0, 0, 7]);
+    });
   });
 
   group('syncWal — orphan WAL guard', () {
+    test('selected ring row uploads its configured-boundary run only', () async {
+      SyncRateLimiter.instance.clear();
+      final prefix = 'manual_ring_run_${DateTime.now().microsecondsSinceEpoch}';
+      final files = <String, File>{};
+      for (final name in ['selected', 'adjacent', 'boundary', 'unrelated']) {
+        final file = File('${Directory.systemTemp.path}/${prefix}_$name.bin');
+        await file.writeAsBytes([1, 0, 0, 0, name.length], flush: true);
+        files[name] = file;
+      }
+      addTearDown(() async {
+        for (final file in files.values) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+
+      final uploadCalls = <List<String>>[];
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (
+          artifacts, {
+          onUploadProgress,
+          conversationId,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false,
+        }) async {
+          uploadCalls.add(
+            artifacts.map((file) => file.uri.pathSegments.last).toList(),
+          );
+          return UploadFilesResult.done(
+            SyncLocalFilesResponse(
+              newConversationIds: ['manual-run'],
+              updatedConversationIds: [],
+            ),
+          );
+        },
+      );
+      final manualSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+        conversationBoundarySecondsProvider: () => 300,
+      );
+      final selected = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'archive2_ring_100_200_1000',
+        filePath: files['selected']!.uri.pathSegments.last,
+        seconds: 300,
+        totalFrames: 30000,
+      );
+      final adjacent = _historicalRingWal(
+        timerStart: 1599,
+        sourceId: 'archive2_ring_200_300_1599',
+        filePath: files['adjacent']!.uri.pathSegments.last,
+        seconds: 300,
+        totalFrames: 30000,
+      );
+      final exactBoundary = _historicalRingWal(
+        timerStart: 2199,
+        sourceId: 'archive2_ring_300_400_2199',
+        filePath: files['boundary']!.uri.pathSegments.last,
+        seconds: 300,
+        totalFrames: 30000,
+      );
+      final unrelated = _historicalRingWal(
+        timerStart: 1599,
+        sourceId: 'archive2_ring_900_1000_1599',
+        filePath: files['unrelated']!.uri.pathSegments.last,
+        seconds: 300,
+        totalFrames: 30000,
+      )..device = 'other-device';
+      manualSync.testWals = [
+        selected,
+        adjacent,
+        exactBoundary,
+        unrelated,
+      ];
+
+      await manualSync.syncWal(wal: selected);
+
+      expect(uploadCalls, hasLength(1));
+      expect(
+        uploadCalls.single.toSet(),
+        {
+          files['selected']!.uri.pathSegments.last,
+          files['adjacent']!.uri.pathSegments.last,
+        },
+      );
+      expect(selected.status, WalStatus.synced);
+      expect(adjacent.status, WalStatus.synced);
+      expect(exactBoundary.status, WalStatus.miss);
+      expect(unrelated.status, WalStatus.miss);
+    });
+
+    test('canonical single-row retry preserves replaceTranscript', () async {
+      SyncRateLimiter.instance.clear();
+      final filename = 'canonical_retry_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final file = File('${Directory.systemTemp.path}/$filename');
+      await file.writeAsBytes([1, 0, 0, 0, 7], flush: true);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+
+      final uploadedConversationIds = <String?>[];
+      final uploadedReplaceModes = <bool>[];
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (
+          files, {
+          onUploadProgress,
+          conversationId,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false,
+        }) async {
+          uploadedConversationIds.add(conversationId);
+          uploadedReplaceModes.add(replaceTranscript);
+          return UploadFilesResult.done(
+            SyncLocalFilesResponse(
+              newConversationIds: [],
+              updatedConversationIds: ['conversation-repair'],
+            ),
+          );
+        },
+      );
+      final manualSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+      );
+      final canonical = Wal(
+        timerStart: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 30,
+        totalFrames: 3000,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: filename,
+        device: 'test-device',
+        sourceId: 'canonical_conversation-repair_test',
+        conversationId: 'conversation-repair',
+        uploadIntent: WalUploadIntent.liveContinuity,
+        canonicalReplacement: true,
+      );
+      manualSync.testWals = [canonical];
+
+      await manualSync.syncWal(wal: canonical);
+
+      expect(uploadedConversationIds, ['conversation-repair']);
+      expect(uploadedReplaceModes, [isTrue]);
+      expect(canonical.status, WalStatus.synced);
+    });
+
+    test('bound ring row retry repairs and retargets the canonical replacement', () async {
+      SyncRateLimiter.instance.clear();
+      final filename = 'bound_retry_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final file = File('${Directory.systemTemp.path}/$filename');
+      await file.writeAsBytes([1, 0, 0, 0, 9], flush: true);
+
+      final uploadedFiles = <String>[];
+      final uploadedConversationIds = <String?>[];
+      final uploadedReplaceModes = <bool>[];
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (
+          files, {
+          onUploadProgress,
+          conversationId,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false,
+        }) async {
+          uploadedFiles.addAll(
+            files.map((candidate) => candidate.uri.pathSegments.last),
+          );
+          uploadedConversationIds.add(conversationId);
+          uploadedReplaceModes.add(replaceTranscript);
+          return UploadFilesResult.done(
+            SyncLocalFilesResponse(
+              newConversationIds: [],
+              updatedConversationIds: ['bound-conversation'],
+            ),
+          );
+        },
+      );
+      final manualSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+        silenceFrameFactory: (_) => [0],
+      );
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+        for (final wal in manualSync.testWals) {
+          final path = wal.filePath;
+          if (path == null || !path.contains('canonical_bound-conversation')) {
+            continue;
+          }
+          final canonicalFile = File('${Directory.systemTemp.path}/$path');
+          if (await canonicalFile.exists()) await canonicalFile.delete();
+        }
+      });
+      final bound = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'ring_100_200',
+        filePath: filename,
+        seconds: 1,
+        totalFrames: 1,
+      )..conversationId = 'bound-conversation';
+      manualSync.testWals = [bound];
+
+      await manualSync.syncWal(wal: bound);
+
+      expect(uploadedFiles.single, contains('canonical_bound-conversation'));
+      expect(uploadedConversationIds, ['bound-conversation']);
+      expect(uploadedReplaceModes, [isTrue]);
+      expect(manualSync.testWals, hasLength(1));
+      expect(
+        manualSync.testWals.single.sourceId,
+        startsWith('canonical_bound-conversation'),
+      );
+      expect(manualSync.testWals.single.status, WalStatus.synced);
+    });
+
     // A WAL the user taps "sync" on may already be gone from `_wals` (a
     // concurrent delete/reload). Previously `.first` on the empty match list
     // threw an uncaught StateError; the guard now bails out to null instead.
@@ -1387,12 +2808,16 @@ Wal _historicalRingWal({
   required int timerStart,
   required String sourceId,
   required String filePath,
+  int seconds = 1,
+  int totalFrames = 1,
+  double? captureEndSeconds,
 }) =>
     Wal(
       timerStart: timerStart,
       codec: BleAudioCodec.opus,
-      seconds: 1,
-      totalFrames: 1,
+      seconds: seconds,
+      captureEndSeconds: captureEndSeconds,
+      totalFrames: totalFrames,
       status: WalStatus.miss,
       storage: WalStorage.disk,
       originalStorage: WalStorage.sdcard,
@@ -1400,4 +2825,24 @@ Wal _historicalRingWal({
       device: 'test-device',
       sourceId: sourceId,
       uploadIntent: WalUploadIntent.historicalBackfill,
+    );
+
+SyncUploadGate _completedUploadGate(List<List<String>> uploads) => SyncUploadGate(
+      limiter: SyncRateLimiter.instance,
+      fairUseStatusLoader: () async => {'stage': 'none'},
+      uploader: (
+        files, {
+        onUploadProgress,
+        conversationId,
+        syncLane = SyncUploadLane.fresh,
+        replaceTranscript = false,
+      }) async {
+        uploads.add(files.map((file) => file.path).toList());
+        return UploadFilesResult.done(
+          SyncLocalFilesResponse(
+            newConversationIds: ['authorized-conversation-${uploads.length}'],
+            updatedConversationIds: [],
+          ),
+        );
+      },
     );

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -1244,6 +1244,139 @@ void main() {
       expect(await secondFile.exists(), isFalse);
     });
 
+    test('quarantines a missing archive once and accepts truthful pendant recovery', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'omi_ring_archive_missing_',
+      );
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final adjacentFile = File('${directory.path}/adjacent.bin');
+      await adjacentFile.writeAsBytes([1, 0, 0, 0, 2], flush: true);
+      final persistedSnapshots = <List<WalStatus>>[];
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (wals) async {
+          persistedSnapshots.add(
+            wals.map((wal) => wal.status).toList(growable: false),
+          );
+          return true;
+        },
+        walPathResolver: (path) async {
+          return path == null ? null : '${directory.path}/$path';
+        },
+        silenceFrameFactory: (_) => [0],
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'archive2_ring_10_11_1000',
+            filePath: 'missing.bin',
+          ),
+          _historicalRingWal(
+            timerStart: 1002,
+            sourceId: 'ring_11_12',
+            filePath: 'adjacent.bin',
+          ),
+        ];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+
+      expect(persistedSnapshots, hasLength(2));
+      expect(
+        archiveSync.testWals
+            .singleWhere(
+              (wal) => wal.sourceId == 'archive2_ring_10_11_1000',
+            )
+            .status,
+        WalStatus.corrupted,
+      );
+      expect(
+        archiveSync.testWals.any(
+          (wal) => wal.sourceId == 'archive2_ring_11_12_1002',
+        ),
+        isTrue,
+      );
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+      expect(
+        persistedSnapshots,
+        hasLength(2),
+        reason: 'a quarantined source must not retry every compaction timer',
+      );
+
+      final recoveredFile = File('${directory.path}/recovered.bin');
+      await recoveredFile.writeAsBytes([1, 0, 0, 0, 1], flush: true);
+      expect(
+        await archiveSync.addExternalWal(
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'ring_10_11',
+            filePath: 'recovered.bin',
+          ),
+          scheduleUpload: false,
+        ),
+        ExternalWalRegistration.added,
+      );
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+
+      expect(archiveSync.testWals, hasLength(1));
+      expect(
+        archiveSync.testWals.single.sourceId,
+        'archive2_ring_10_12_1000',
+      );
+      expect(archiveSync.testWals.single.status, WalStatus.miss);
+      expect(
+        archiveSync.testWals.any(
+          (wal) => wal.status == WalStatus.corrupted,
+        ),
+        isFalse,
+      );
+    });
+
+    test('replaces a quarantined raw range with the exact pendant reread', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'omi_ring_raw_reread_',
+      );
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      final archiveSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async {
+          return path == null ? null : '${directory.path}/$path';
+        },
+      )..testWals = [
+          _historicalRingWal(
+            timerStart: 1000,
+            sourceId: 'ring_10_11',
+            filePath: 'missing.bin',
+          ),
+        ];
+
+      await archiveSync.prepareHistoricalRingFragments(nowSeconds: 2000);
+      expect(archiveSync.testWals.single.status, WalStatus.corrupted);
+
+      final recoveredFile = File('${directory.path}/recovered.bin');
+      await recoveredFile.writeAsBytes([1, 0, 0, 0, 7], flush: true);
+      final recovered = _historicalRingWal(
+        timerStart: 1000,
+        sourceId: 'ring_10_11',
+        filePath: 'recovered.bin',
+      );
+      expect(
+        await archiveSync.addExternalWal(
+          recovered,
+          scheduleUpload: false,
+        ),
+        ExternalWalRegistration.added,
+      );
+
+      expect(archiveSync.testWals, [recovered]);
+      expect(archiveSync.testWals.single.status, WalStatus.miss);
+      expect(await recoveredFile.exists(), isTrue);
+    });
+
     test('serializes historical compaction with canonical conversation stamping', () async {
       final directory = await Directory.systemTemp.createTemp(
         'omi_ring_archive_stamp_race_',
@@ -2034,6 +2167,86 @@ void main() {
       expect(externalSync.testWals, hasLength(1));
       expect(externalSync.testWals.single.canonicalReplacement, isTrue);
       expect(externalSync.testWals.single.captureEndSeconds, now - 0.25);
+    });
+
+    test('conversation stamping claims the complete configured ring window', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'omi_ring_conversation_window_',
+      );
+      addTearDown(() async {
+        if (await directory.exists()) await directory.delete(recursive: true);
+      });
+      for (final entry in {
+        'before.bin': 1,
+        'session.bin': 2,
+        'after.bin': 3,
+        'boundary.bin': 4,
+      }.entries) {
+        await File('${directory.path}/${entry.key}').writeAsBytes(
+          [1, 0, 0, 0, entry.value],
+          flush: true,
+        );
+      }
+      final sources = [
+        _historicalRingWal(
+          timerStart: 1000,
+          sourceId: 'ring_10_11',
+          filePath: 'before.bin',
+          captureEndSeconds: 1001,
+        ),
+        _historicalRingWal(
+          timerStart: 1110,
+          sourceId: 'ring_11_12',
+          filePath: 'session.bin',
+          captureEndSeconds: 1111,
+        ),
+        _historicalRingWal(
+          timerStart: 1220,
+          sourceId: 'ring_12_13',
+          filePath: 'after.bin',
+          captureEndSeconds: 1221,
+        ),
+        _historicalRingWal(
+          timerStart: 1341,
+          sourceId: 'ring_13_14',
+          filePath: 'boundary.bin',
+          captureEndSeconds: 1342,
+        ),
+      ];
+      for (final source in sources) {
+        source
+          ..status = WalStatus.synced
+          ..uploadIntent = WalUploadIntent.liveContinuity;
+      }
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async {
+          return path == null ? null : '${directory.path}/$path';
+        },
+        silenceFrameFactory: (_) => [0],
+        conversationBoundarySecondsProvider: () => 120,
+      )..testWals = sources;
+
+      await externalSync.stampConversationId(
+        1110,
+        'complete-window',
+        hasServerSpeechProof: true,
+        sessionEndSeconds: 1111,
+      );
+
+      expect(externalSync.testWals, hasLength(2));
+      final canonical = externalSync.testWals.singleWhere(
+        (wal) => wal.sourceId?.startsWith('canonical_complete-window_') == true,
+      );
+      expect(canonical.conversationId, 'complete-window');
+      expect(canonical.timerStart, 1000);
+      expect(canonical.captureEndSeconds, 1221);
+      expect(canonical.status, WalStatus.synced);
+      final outside = externalSync.testWals.singleWhere(
+        (wal) => wal.sourceId == 'ring_13_14',
+      );
+      expect(outside.conversationId, isNull);
     });
 
     test('conversation ownership without speech proof cannot create an upload job', () async {

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -284,7 +284,30 @@ void main() {
       expect(isLiveCaptureWal(at(7 * 60 * 60, conversationId: 'c'), now), isFalse);
     });
 
-    test('a backlog smaller than the limit drains in one batch', () {
+    test('device-owned live continuity preempts historical WALs before a conversation id exists', () {
+      const now = 2000000000;
+      final historical = Wal(
+        timerStart: now - 7 * 60 * 60,
+        codec: BleAudioCodec.opus,
+        seconds: 60,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+      );
+      final liveContinuity = Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        seconds: 2,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+
+      final batch = nextSyncUploadBatch([historical, liveContinuity], now);
+
+      expect(batch, [liveContinuity]);
+    });
+
+    test('a small historical backlog drains in one batch instead of a few files at a time', () {
       const now = 2000000000;
       final historical = List.generate(
         3,
@@ -603,6 +626,66 @@ void main() {
         [fileName],
         [secondFileName],
       ]);
+    });
+
+    test('fresh external WAL wakes ahead of a large historical queue without a conversation id', () async {
+      SyncRateLimiter.instance.clear();
+      final uploadStarted = Completer<void>();
+      final uploadedFiles = <String>[];
+      final uploadLanes = <SyncUploadLane>[];
+      final fileName = 'external_live_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final file = File('${Directory.systemTemp.path}/$fileName');
+      await file.writeAsBytes([1, 2, 3], flush: true);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+          uploadedFiles.addAll(files.map((candidate) => candidate.uri.pathSegments.last));
+          uploadLanes.add(syncLane);
+          if (!uploadStarted.isCompleted) uploadStarted.complete();
+          return UploadFilesResult.queued('fresh-priority-job');
+        },
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+      );
+      externalSync.testWals = List.generate(
+        1000,
+        (index) => Wal(
+          timerStart: 1000 + index,
+          codec: BleAudioCodec.opus,
+          seconds: 60,
+          status: WalStatus.miss,
+          storage: WalStorage.disk,
+          filePath: 'historical_$index.bin',
+          device: 'test-device',
+          uploadIntent: WalUploadIntent.historicalBackfill,
+        ),
+      );
+      final liveWal = Wal(
+        timerStart: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 2,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: fileName,
+        device: 'test-device',
+        sourceId: 'ring_1000_1020',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+
+      expect(await externalSync.addExternalWal(liveWal), ExternalWalRegistration.added);
+      await uploadStarted.future.timeout(const Duration(seconds: 1));
+
+      expect(uploadedFiles, [fileName]);
+      expect(uploadLanes, [SyncUploadLane.fresh]);
     });
   });
 

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -284,7 +284,7 @@ void main() {
       expect(isLiveCaptureWal(at(7 * 60 * 60, conversationId: 'c'), now), isFalse);
     });
 
-    test('device-owned live continuity preempts historical WALs before a conversation id exists', () {
+    test('active unbound continuity stays local until the two-minute conversation boundary', () {
       const now = 2000000000;
       final historical = Wal(
         timerStart: now - 7 * 60 * 60,
@@ -299,12 +299,76 @@ void main() {
         seconds: 2,
         status: WalStatus.miss,
         storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
         uploadIntent: WalUploadIntent.liveContinuity,
       );
 
       final batch = nextSyncUploadBatch([historical, liveContinuity], now);
 
-      expect(batch, [liveContinuity]);
+      expect(batch, [historical]);
+    });
+
+    test('closed unbound continuity is selected as one conversation ahead of history', () {
+      const now = 2000000000;
+      final historical = Wal(
+        timerStart: now - 7 * 60 * 60,
+        codec: BleAudioCodec.opus,
+        seconds: 60,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+      );
+      final closedConversation = List.generate(
+        30,
+        (index) => Wal(
+          timerStart: now - 300 + index * 2,
+          codec: BleAudioCodec.opus,
+          seconds: 2,
+          totalFrames: 100,
+          status: WalStatus.miss,
+          storage: WalStorage.disk,
+          originalStorage: WalStorage.sdcard,
+          device: 'cv1',
+          sourceId: 'ring_${index * 10}_${(index + 1) * 10}',
+          uploadIntent: WalUploadIntent.liveContinuity,
+        ),
+      );
+
+      final batch = nextSyncUploadBatch([historical, ...closedConversation], now);
+
+      expect(batch.toSet(), closedConversation.toSet());
+    });
+
+    test('upload artifacts join only sequence- and time-contiguous ring WALs', () {
+      Wal ringWal(int startSeq, int endSeq, int timestamp) => Wal(
+            timerStart: timestamp,
+            codec: BleAudioCodec.opus,
+            seconds: 2,
+            totalFrames: 100,
+            status: WalStatus.miss,
+            storage: WalStorage.disk,
+            originalStorage: WalStorage.sdcard,
+            device: 'cv1',
+            sourceId: 'ring_${startSeq}_$endSeq',
+            uploadIntent: WalUploadIntent.liveContinuity,
+          );
+
+      final contiguousA = ringWal(100, 110, 1000);
+      final contiguousB = ringWal(110, 120, 1002);
+      final deliveredLiveGap = ringWal(130, 140, 1004);
+      final silenceBoundary = ringWal(140, 150, 1010);
+
+      final runs = contiguousWalUploadRuns([
+        silenceBoundary,
+        contiguousB,
+        deliveredLiveGap,
+        contiguousA,
+      ]);
+
+      expect(runs, [
+        [contiguousA, contiguousB],
+        [deliveredLiveGap],
+        [silenceBoundary],
+      ]);
     });
 
     test('a small historical backlog drains in one batch instead of a few files at a time', () {
@@ -319,7 +383,7 @@ void main() {
       expect(batch.length, 3);
     });
 
-    test('a batch never exceeds the limit that keeps a job inside the backend stale guard', () {
+    test('historical batches are bounded by the shared upload batch limit, newest first', () {
       const now = 2000000000;
       final historical = List.generate(
         25,
@@ -328,14 +392,14 @@ void main() {
 
       final batch = nextSyncUploadBatch(historical.reversed.toList(), now);
 
-      expect(batch.length, 5);
-      expect(batch.map((wal) => wal.timerStart), historical.take(5).map((wal) => wal.timerStart));
+      expect(batch.length, 20);
+      expect(batch.map((wal) => wal.timerStart), historical.take(20).map((wal) => wal.timerStart));
     });
 
-    test('a conversation too large for one batch does not claim a manifest', () {
+    test('an extraordinarily large fresh conversation is downgraded as one unit', () {
       const now = 2000000000;
       final oversized = List.generate(
-        6,
+        2001,
         (index) => Wal(
           timerStart: now - index,
           codec: BleAudioCodec.opus,
@@ -343,12 +407,16 @@ void main() {
           conversationId: 'oversized-conversation',
         ),
       );
+      final maximumFresh = oversized.take(2000).toList();
+      expect(oversizedFreshConversationIds(maximumFresh, now), isEmpty);
+      final forcedBackfill = oversizedFreshConversationIds(oversized, now);
+      expect(forcedBackfill, {'oversized-conversation'});
 
-      final batch = nextSyncUploadBatch(oversized, now);
-
-      expect(batch.length, 5);
-      expect(canClaimLiveCapture(batch, oversized, now), isFalse);
-      expect(canClaimLiveCapture(batch, oversized.take(5).toList(), now), isTrue);
+      final batch = nextSyncUploadBatch(oversized, now, forcedBackfillConversationIds: forcedBackfill);
+      // Downgraded to the backfill rate-limit domain, but kept as one bounded
+      // capture transaction rather than split into 20-file async jobs.
+      expect(batch.length, 2000);
+      expect(batch.every((wal) => wal.conversationId == 'oversized-conversation'), isTrue);
     });
   });
 
@@ -548,7 +616,8 @@ void main() {
       final gate = SyncUploadGate(
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+        uploader: (files,
+            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
           uploadBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
           if (uploadBatches.length == 1) uploadStarted.complete();
           if (uploadBatches.length == 2) secondUploadStarted.complete();
@@ -633,9 +702,10 @@ void main() {
       final uploadStarted = Completer<void>();
       final uploadedFiles = <String>[];
       final uploadLanes = <SyncUploadLane>[];
+      final uploadedReplaceModes = <bool>[];
       final fileName = 'external_live_${DateTime.now().microsecondsSinceEpoch}.bin';
       final file = File('${Directory.systemTemp.path}/$fileName');
-      await file.writeAsBytes([1, 2, 3], flush: true);
+      await file.writeAsBytes([3, 0, 0, 0, 1, 2, 3], flush: true);
       addTearDown(() async {
         if (await file.exists()) await file.delete();
       });
@@ -643,9 +713,11 @@ void main() {
       final gate = SyncUploadGate(
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+        uploader: (files,
+            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
           uploadedFiles.addAll(files.map((candidate) => candidate.uri.pathSegments.last));
           uploadLanes.add(syncLane);
+          uploadedReplaceModes.add(replaceTranscript);
           if (!uploadStarted.isCompleted) uploadStarted.complete();
           return UploadFilesResult.queued('fresh-priority-job');
         },
@@ -654,7 +726,6 @@ void main() {
         listener,
         uploadGate: gate,
         walPersister: (_) async => true,
-        freshUploadBatchDelay: () async {},
       );
       externalSync.testWals = List.generate(
         1000,
@@ -683,24 +754,40 @@ void main() {
       );
 
       expect(await externalSync.addExternalWal(liveWal), ExternalWalRegistration.added);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(uploadStarted.isCompleted, isFalse);
+      expect(uploadedFiles, isEmpty);
+      expect(uploadLanes, isEmpty);
+
+      await externalSync.stampConversationId(liveWal.timerStart, 'conversation-1');
       await uploadStarted.future.timeout(const Duration(seconds: 1));
 
-      expect(uploadedFiles, [fileName]);
+      expect(uploadedFiles.single, contains('canonical_conversation-1'));
       expect(uploadLanes, [SyncUploadLane.fresh]);
+      expect(uploadedReplaceModes, [isTrue]);
     });
 
-    test('recovered live ranges batch before fallback upload without delaying durable registration', () async {
+    test('recovered live ranges stay local until their session has a conversation id', () async {
       SyncRateLimiter.instance.clear();
-      final releaseBatchWindow = Completer<void>();
-      final uploadStarted = Completer<void>();
       final uploadedBatches = <List<String>>[];
+      final uploadedPayloads = <List<int>>[];
+      final uploadedConversationIds = <String?>[];
+      final uploadedReplaceModes = <bool>[];
+      final uploadStarted = Completer<void>();
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       const firstFileName = 'audio_test_opus_16000_1_fs320_ring_1_2_1700000001.bin';
       const secondFileName = 'audio_test_opus_16000_1_fs320_ring_2_3_1700000002.bin';
       final firstFile = File('${Directory.systemTemp.path}/$firstFileName');
       final secondFile = File('${Directory.systemTemp.path}/$secondFileName');
-      await firstFile.writeAsBytes([1, 2, 3], flush: true);
-      await secondFile.writeAsBytes([4, 5, 6], flush: true);
+      await firstFile.writeAsBytes(
+        List.generate(100, (_) => [3, 0, 0, 0, 1, 2, 3]).expand((frame) => frame).toList(),
+        flush: true,
+      );
+      await secondFile.writeAsBytes(
+        List.generate(100, (_) => [3, 0, 0, 0, 4, 5, 6]).expand((frame) => frame).toList(),
+        flush: true,
+      );
       addTearDown(() async {
         if (await firstFile.exists()) await firstFile.delete();
         if (await secondFile.exists()) await secondFile.delete();
@@ -709,8 +796,12 @@ void main() {
       final gate = SyncUploadGate(
         limiter: SyncRateLimiter.instance,
         fairUseStatusLoader: () async => {'stage': 'none'},
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+        uploader: (files,
+            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
           uploadedBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
+          uploadedPayloads.add(await files.single.readAsBytes());
+          uploadedConversationIds.add(conversationId);
+          uploadedReplaceModes.add(replaceTranscript);
           if (!uploadStarted.isCompleted) uploadStarted.complete();
           return UploadFilesResult.queued('batched-recovery-job');
         },
@@ -719,7 +810,6 @@ void main() {
         listener,
         uploadGate: gate,
         walPersister: (_) async => true,
-        freshUploadBatchDelay: () => releaseBatchWindow.future,
       );
       Wal recoveredWal({
         required int timerStart,
@@ -735,6 +825,7 @@ void main() {
             originalStorage: WalStorage.sdcard,
             filePath: fileName,
             device: 'test-device',
+            totalFrames: 100,
             sourceId: sourceId,
             uploadIntent: WalUploadIntent.liveContinuity,
           );
@@ -742,7 +833,7 @@ void main() {
       expect(
         await externalSync.addExternalWal(
           recoveredWal(
-            timerStart: now,
+            timerStart: now - 2,
             fileName: firstFileName,
             sourceId: 'ring_1_2',
           ),
@@ -752,7 +843,7 @@ void main() {
       expect(
         await externalSync.addExternalWal(
           recoveredWal(
-            timerStart: now + 1,
+            timerStart: now - 1,
             fileName: secondFileName,
             sourceId: 'ring_2_3',
           ),
@@ -760,13 +851,185 @@ void main() {
         ExternalWalRegistration.added,
       );
       expect(externalSync.testWals, hasLength(2));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(uploadedBatches, isEmpty);
 
-      releaseBatchWindow.complete();
+      await externalSync.stampConversationId(now - 2, 'conversation-1');
       await uploadStarted.future.timeout(const Duration(seconds: 1));
 
       expect(uploadedBatches, hasLength(1));
-      expect(uploadedBatches.single.toSet(), {firstFileName, secondFileName});
+      expect(uploadedBatches.single, hasLength(1));
+      expect(uploadedBatches.single.single, contains('canonical_conversation-1'));
+      expect(uploadedPayloads.single, hasLength(1400));
+      expect(uploadedPayloads.single.take(7), [3, 0, 0, 0, 1, 2, 3]);
+      expect(uploadedPayloads.single.skip(1393), [3, 0, 0, 0, 4, 5, 6]);
+      expect(uploadedConversationIds, ['conversation-1']);
+      expect(uploadedReplaceModes, [isTrue]);
+      expect(externalSync.testWals, hasLength(1));
+      expect(externalSync.testWals.single.canonicalReplacement, isTrue);
+    });
+
+    test('one thousand one-second repairs become one job instead of one thousand jobs', () async {
+      SyncRateLimiter.instance.clear();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final prefix = 'repair_${DateTime.now().microsecondsSinceEpoch}';
+      final files = <File>[];
+      final uploadedArtifactSizes = <List<int>>[];
+      final uploadedConversationIds = <String?>[];
+      final uploadedReplaceModes = <bool>[];
+      final uploadStarted = Completer<void>();
+
+      addTearDown(() async {
+        for (final file in files) {
+          if (await file.exists()) await file.delete();
+        }
+      });
+
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (artifacts,
+            {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh, replaceTranscript = false}) async {
+          uploadedArtifactSizes.add(
+            await Future.wait(artifacts.map((artifact) => artifact.length())),
+          );
+          uploadedConversationIds.add(conversationId);
+          uploadedReplaceModes.add(replaceTranscript);
+          if (!uploadStarted.isCompleted) uploadStarted.complete();
+          return UploadFilesResult.queued('single-repair-job');
+        },
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+      );
+
+      final repairs = <Wal>[];
+      for (var index = 0; index < 1000; index++) {
+        final filename = '${prefix}_$index.bin';
+        final file = File('${Directory.systemTemp.path}/$filename');
+        await file.writeAsBytes(
+          List.generate(100, (_) => [1, 0, 0, 0, index & 0xff]).expand((frame) => frame).toList(),
+          flush: true,
+        );
+        files.add(file);
+        final wal = Wal(
+          timerStart: now - 1000 + index,
+          codec: BleAudioCodec.opus,
+          seconds: 1,
+          totalFrames: 100,
+          status: WalStatus.miss,
+          storage: WalStorage.disk,
+          originalStorage: WalStorage.sdcard,
+          filePath: filename,
+          device: 'test-device',
+          sourceId: 'ring_${index}_${index + 1}',
+          uploadIntent: WalUploadIntent.liveContinuity,
+        );
+        repairs.add(wal);
+        expect(
+          await externalSync.addExternalWal(wal),
+          ExternalWalRegistration.added,
+        );
+      }
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(uploadedArtifactSizes, isEmpty);
+
+      await externalSync.stampConversationId(now - 1000, 'conversation-1000');
+      await uploadStarted.future.timeout(const Duration(seconds: 5));
+
+      expect(uploadedArtifactSizes, hasLength(1));
+      expect(uploadedArtifactSizes.single, [500000]);
+      expect(uploadedConversationIds, ['conversation-1000']);
+      expect(uploadedReplaceModes, [isTrue]);
+      expect(externalSync.testWals, hasLength(1));
+      expect(externalSync.testWals.single.jobId, 'single-repair-job');
+    });
+
+    test('canonical commit preserves a WAL registered while assembly reads disk', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final sourceName = 'canonical_race_source_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final lateName = 'canonical_race_late_${DateTime.now().microsecondsSinceEpoch}.bin';
+      final sourceFile = File('${Directory.systemTemp.path}/$sourceName');
+      final lateFile = File('${Directory.systemTemp.path}/$lateName');
+      await sourceFile.writeAsBytes([1, 0, 0, 0, 7], flush: true);
+      await lateFile.writeAsBytes([1, 0, 0, 0, 8], flush: true);
+      addTearDown(() async {
+        if (await sourceFile.exists()) await sourceFile.delete();
+        if (await lateFile.exists()) await lateFile.delete();
+      });
+
+      final resolverStarted = Completer<void>();
+      final releaseResolver = Completer<void>();
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        walPersister: (_) async => true,
+        walPathResolver: (path) async {
+          if (path == sourceName && !resolverStarted.isCompleted) {
+            resolverStarted.complete();
+            await releaseResolver.future;
+          }
+          return path == null ? null : '${Directory.systemTemp.path}/$path';
+        },
+      );
+      addTearDown(() async {
+        for (final wal in externalSync.testWals) {
+          final path = wal.filePath;
+          if (path == null || !path.contains('canonical_conversation-race')) continue;
+          final file = File('${Directory.systemTemp.path}/$path');
+          if (await file.exists()) await file.delete();
+        }
+      });
+      final source = Wal(
+        timerStart: now - 10,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: sourceName,
+        device: 'test-device',
+        sourceId: 'ring_10_11',
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+      final late = Wal(
+        timerStart: now - 5,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        totalFrames: 1,
+        status: WalStatus.synced,
+        storage: WalStorage.disk,
+        originalStorage: WalStorage.sdcard,
+        filePath: lateName,
+        device: 'other-device',
+        sourceId: 'ring_90_91',
+        uploadIntent: WalUploadIntent.historicalBackfill,
+      );
+      expect(
+        await externalSync.addExternalWal(source, scheduleUpload: false),
+        ExternalWalRegistration.added,
+      );
+
+      final stamp = externalSync.stampConversationId(now - 20, 'conversation-race');
+      await resolverStarted.future.timeout(const Duration(seconds: 1));
+      expect(
+        await externalSync.addExternalWal(late, scheduleUpload: false),
+        ExternalWalRegistration.added,
+      );
+      releaseResolver.complete();
+      await stamp.timeout(const Duration(seconds: 1));
+
+      expect(
+        externalSync.testWals.map((wal) => wal.id),
+        contains(late.id),
+      );
+      expect(
+        externalSync.testWals.where((wal) => wal.conversationId == 'conversation-race'),
+        hasLength(1),
+      );
     });
   });
 

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -2249,7 +2249,11 @@ void main() {
       expect(uploadedClaimModes, [isTrue]);
       expect(externalSync.testWals, hasLength(1));
       expect(externalSync.testWals.single.canonicalReplacement, isTrue);
-      expect(externalSync.testWals.single.captureEndSeconds, now - 0.25);
+      expect(
+        externalSync.testWals.single.captureEndSeconds,
+        now,
+        reason: 'canonical metadata cannot end before its complete two-second payload',
+      );
     });
 
     test('conversation stamping claims the complete configured ring window', () async {

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -654,6 +654,7 @@ void main() {
         listener,
         uploadGate: gate,
         walPersister: (_) async => true,
+        freshUploadBatchDelay: () async {},
       );
       externalSync.testWals = List.generate(
         1000,
@@ -686,6 +687,86 @@ void main() {
 
       expect(uploadedFiles, [fileName]);
       expect(uploadLanes, [SyncUploadLane.fresh]);
+    });
+
+    test('recovered live ranges batch before fallback upload without delaying durable registration', () async {
+      SyncRateLimiter.instance.clear();
+      final releaseBatchWindow = Completer<void>();
+      final uploadStarted = Completer<void>();
+      final uploadedBatches = <List<String>>[];
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      const firstFileName = 'audio_test_opus_16000_1_fs320_ring_1_2_1700000001.bin';
+      const secondFileName = 'audio_test_opus_16000_1_fs320_ring_2_3_1700000002.bin';
+      final firstFile = File('${Directory.systemTemp.path}/$firstFileName');
+      final secondFile = File('${Directory.systemTemp.path}/$secondFileName');
+      await firstFile.writeAsBytes([1, 2, 3], flush: true);
+      await secondFile.writeAsBytes([4, 5, 6], flush: true);
+      addTearDown(() async {
+        if (await firstFile.exists()) await firstFile.delete();
+        if (await secondFile.exists()) await secondFile.delete();
+      });
+
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+          uploadedBatches.add(files.map((file) => file.uri.pathSegments.last).toList());
+          if (!uploadStarted.isCompleted) uploadStarted.complete();
+          return UploadFilesResult.queued('batched-recovery-job');
+        },
+      );
+      final externalSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+        walPersister: (_) async => true,
+        freshUploadBatchDelay: () => releaseBatchWindow.future,
+      );
+      Wal recoveredWal({
+        required int timerStart,
+        required String fileName,
+        required String sourceId,
+      }) =>
+          Wal(
+            timerStart: timerStart,
+            codec: BleAudioCodec.opus,
+            seconds: 1,
+            status: WalStatus.miss,
+            storage: WalStorage.disk,
+            originalStorage: WalStorage.sdcard,
+            filePath: fileName,
+            device: 'test-device',
+            sourceId: sourceId,
+            uploadIntent: WalUploadIntent.liveContinuity,
+          );
+
+      expect(
+        await externalSync.addExternalWal(
+          recoveredWal(
+            timerStart: now,
+            fileName: firstFileName,
+            sourceId: 'ring_1_2',
+          ),
+        ),
+        ExternalWalRegistration.added,
+      );
+      expect(
+        await externalSync.addExternalWal(
+          recoveredWal(
+            timerStart: now + 1,
+            fileName: secondFileName,
+            sourceId: 'ring_2_3',
+          ),
+        ),
+        ExternalWalRegistration.added,
+      );
+      expect(externalSync.testWals, hasLength(2));
+      expect(uploadedBatches, isEmpty);
+
+      releaseBatchWindow.complete();
+      await uploadStarted.future.timeout(const Duration(seconds: 1));
+
+      expect(uploadedBatches, hasLength(1));
+      expect(uploadedBatches.single.toSet(), {firstFileName, secondFileName});
     });
   });
 

--- a/app/test/unit/native_ble_transport_exclusive_release_test.dart
+++ b/app/test/unit/native_ble_transport_exclusive_release_test.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/gen/pigeon_communicator.g.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/transports/native_ble_transport.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('exclusive release unmanages native intent after a transient disconnect', () async {
+    const deviceId = 'exclusive-native-test';
+    final hostApi = _FakeBleHostApi();
+    final transport = NativeBleTransport(deviceId, hostApi: hostApi);
+    addTearDown(transport.dispose);
+
+    final connectFuture = transport.connect();
+    await pumpEventQueue();
+    BleBridge.instance.onDeviceReady(
+      deviceId,
+      [BleService(uuid: 'service', characteristicUuids: const [])],
+    );
+    await connectFuture;
+
+    BleBridge.instance.onPeripheralDisconnected(deviceId, 'transient link loss');
+    await pumpEventQueue();
+    await transport.releaseForExclusiveOperation();
+
+    expect(hostApi.events, ['manage:$deviceId', 'unmanage:$deviceId']);
+  });
+
+  test('transient disconnect retires old streams and reconnect exposes a fresh subscribed stream', () async {
+    const deviceId = 'reconnect-stream-test';
+    const serviceUuid = 'service';
+    const characteristicUuid = 'audio';
+    final hostApi = _FakeBleHostApi();
+    final transport = NativeBleTransport(deviceId, hostApi: hostApi);
+
+    final connectFuture = transport.connect();
+    await pumpEventQueue();
+    BleBridge.instance.onDeviceReady(
+      deviceId,
+      [
+        BleService(
+          uuid: serviceUuid,
+          characteristicUuids: const [characteristicUuid],
+        ),
+      ],
+    );
+    await connectFuture;
+
+    final oldValues = <List<int>>[];
+    final oldStreamDone = Completer<void>();
+    transport.getCharacteristicStream(serviceUuid, characteristicUuid).listen(
+          oldValues.add,
+          onDone: oldStreamDone.complete,
+        );
+
+    BleBridge.instance.onPeripheralDisconnected(deviceId, 'transient link loss');
+    await oldStreamDone.future;
+    BleBridge.instance.onDeviceReady(
+      deviceId,
+      [
+        BleService(
+          uuid: serviceUuid,
+          characteristicUuids: const [characteristicUuid],
+        ),
+      ],
+    );
+    await pumpEventQueue();
+
+    final newValues = <List<int>>[];
+    final newStreamDone = Completer<void>();
+    transport.getCharacteristicStream(serviceUuid, characteristicUuid).listen(
+          newValues.add,
+          onDone: newStreamDone.complete,
+        );
+    BleBridge.instance.onCharacteristicValueUpdated(
+      deviceId,
+      serviceUuid,
+      characteristicUuid,
+      Uint8List.fromList([1, 2, 3]),
+    );
+    await pumpEventQueue();
+
+    expect(oldValues, isEmpty);
+    expect(newValues, [
+      [1, 2, 3],
+    ]);
+    expect(
+      hostApi.events.where((event) => event.startsWith('subscribe:')),
+      hasLength(2),
+    );
+
+    await transport.dispose();
+    await newStreamDone.future;
+  });
+}
+
+class _FakeBleHostApi extends BleHostApi {
+  final events = <String>[];
+
+  @override
+  Future<void> manageDevice(String uuid, bool requiresBond) async {
+    events.add('manage:$uuid');
+  }
+
+  @override
+  Future<void> unmanageDevice(String uuid) async {
+    events.add('unmanage:$uuid');
+  }
+
+  @override
+  Future<void> subscribeCharacteristic(
+    String peripheralUuid,
+    String serviceUuid,
+    String characteristicUuid,
+  ) async {
+    events.add('subscribe:$peripheralUuid:$serviceUuid:$characteristicUuid');
+  }
+}

--- a/app/test/unit/offline_sync_policy_test.dart
+++ b/app/test/unit/offline_sync_policy_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+
+void main() {
+  test('historical offline auto-sync defaults off but preserves explicit opt-in', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+
+    expect(SharedPreferencesUtil().autoSyncOfflineRecordings, isFalse);
+
+    SharedPreferencesUtil().autoSyncOfflineRecordings = true;
+    expect(SharedPreferencesUtil().autoSyncOfflineRecordings, isTrue);
+  });
+}

--- a/app/test/unit/omi_audio_continuity_binding_test.dart
+++ b/app/test/unit/omi_audio_continuity_binding_test.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/connectors/omi_connection.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+class _FakeOmiTransport extends DeviceTransport {
+  final _audio = StreamController<List<int>>.broadcast();
+  final _state = StreamController<DeviceTransportState>.broadcast();
+
+  void emitAudio(List<int> packet) => _audio.add(packet);
+
+  @override
+  String get deviceId => 'fake-omi';
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _audio.close();
+    await _state.close();
+  }
+
+  @override
+  Stream<List<int>> getCharacteristicStream(String serviceUuid, String characteristicUuid) => _audio.stream;
+
+  @override
+  Stream<DeviceTransportState> get connectionStateStream => _state.stream;
+
+  @override
+  Future<bool> isConnected() async => true;
+
+  @override
+  Future<bool> ping() async => true;
+
+  @override
+  Future<List<int>> readCharacteristic(String serviceUuid, String characteristicUuid) async => const [];
+
+  @override
+  Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('Omi audio binding suppresses only malformed and exact adjacent duplicates', () async {
+    final transport = _FakeOmiTransport();
+    final device = BtDevice(name: 'Omi', id: 'fake-omi', type: DeviceType.omi, rssi: -50);
+    final connection = OmiDeviceConnection(device, transport);
+    final received = <List<int>>[];
+    final subscription = await connection.performGetBleAudioBytesListener(onAudioBytesReceived: received.add);
+    const first = [10, 0, 0, 0xAA];
+    const sameIdDifferentIndex = [10, 0, 1, 0xBB];
+
+    transport.emitAudio(first);
+    transport.emitAudio(first);
+    transport.emitAudio(sameIdDifferentIndex);
+    transport.emitAudio([1, 2]);
+    transport.emitAudio([11, 0, 0, 0xCC]);
+    await pumpEventQueue();
+
+    expect(received, [
+      first,
+      sameIdDifferentIndex,
+      [11, 0, 0, 0xCC]
+    ]);
+
+    await subscription?.cancel();
+    await connection.disconnect();
+    await transport.dispose();
+  });
+}

--- a/app/test/unit/omi_mcu_dfu_policy_test.dart
+++ b/app/test/unit/omi_mcu_dfu_policy_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/omi_mcu_dfu_policy.dart';
+
+void main() {
+  test('routine MCU firmware upgrades preserve pendant application settings', () {
+    final configuration = OmiMcuDfuPolicy.createConfiguration();
+
+    expect(configuration.eraseAppSettings, isFalse);
+    expect(configuration.estimatedSwapTime, Duration.zero);
+    expect(configuration.pipelineDepth, 1);
+  });
+}

--- a/app/test/unit/omi_ready_generation_time_sync_test.dart
+++ b/app/test/unit/omi_ready_generation_time_sync_test.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/connectors/omi_connection.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _ReadyFakeTransport transport;
+  late OmiDeviceConnection connection;
+  late int clockTick;
+
+  setUp(() {
+    clockTick = 0;
+    transport = _ReadyFakeTransport();
+    connection = OmiDeviceConnection(
+      BtDevice(name: 'Omi', id: 'fake-omi', type: DeviceType.omi, rssi: -40),
+      transport,
+      now: () => DateTime.utc(2026, 7, 25, 12, 0, clockTick++),
+    );
+  });
+
+  tearDown(() async {
+    await connection.disconnect();
+    await transport.dispose();
+  });
+
+  test('initial connect syncs once even though connect and ready observe the same generation', () async {
+    await connection.connect();
+    await _waitFor(() => transport.timeWrites.length == 1);
+
+    expect(transport.timeWrites, [_epoch(DateTime.utc(2026, 7, 25, 12))]);
+
+    transport.emitCurrentReadyGenerationAgain();
+    await pumpEventQueue();
+    expect(transport.timeWrites, hasLength(1));
+  });
+
+  test('native reconnect syncs every new ready generation after an earlier write error', () async {
+    transport.failNextTimeWrite = true;
+    await connection.connect();
+    expect(transport.timeWriteAttempts, 1);
+    expect(transport.timeWrites, isEmpty);
+
+    transport.emitReconnect();
+    await _waitFor(() => transport.timeWrites.length == 1);
+
+    expect(transport.timeWriteAttempts, 2);
+    expect(transport.timeWrites.single, _epoch(DateTime.utc(2026, 7, 25, 12, 0, 1)));
+  });
+
+  test('stale generations are serialized so an older clock write cannot finish last', () async {
+    await connection.connect();
+    final secondGenerationGate = Completer<void>();
+    transport.nextTimeWriteGate = secondGenerationGate;
+
+    transport.emitReconnect();
+    await _waitFor(() => transport.timeWriteAttempts == 2);
+    expect(transport.activeTimeWrites, 1);
+
+    transport.emitReconnect();
+    await pumpEventQueue();
+    expect(transport.timeWriteAttempts, 2, reason: 'generation 3 must wait behind generation 2');
+
+    secondGenerationGate.complete();
+    await _waitFor(() => transport.timeWriteAttempts == 3);
+    await _waitFor(() => transport.activeTimeWrites == 0);
+
+    expect(transport.maxConcurrentTimeWrites, 1);
+    expect(
+      transport.timeWrites,
+      [
+        _epoch(DateTime.utc(2026, 7, 25, 12)),
+        _epoch(DateTime.utc(2026, 7, 25, 12, 0, 1)),
+        _epoch(DateTime.utc(2026, 7, 25, 12, 0, 2)),
+      ],
+    );
+  });
+}
+
+int _epoch(DateTime value) => value.millisecondsSinceEpoch ~/ 1000;
+
+Future<void> _waitFor(bool Function() condition) async {
+  for (var i = 0; i < 20; i++) {
+    if (condition()) return;
+    await pumpEventQueue();
+  }
+  expect(condition(), isTrue);
+}
+
+class _ReadyFakeTransport extends DeviceTransport implements DeviceReadyGenerationSource {
+  final _stateController = StreamController<DeviceTransportState>.broadcast();
+  final _readyController = StreamController<int>.broadcast();
+  final List<int> timeWrites = [];
+
+  @override
+  int readyGeneration = 0;
+
+  int timeWriteAttempts = 0;
+  int activeTimeWrites = 0;
+  int maxConcurrentTimeWrites = 0;
+  bool failNextTimeWrite = false;
+  Completer<void>? nextTimeWriteGate;
+  bool _connected = false;
+
+  @override
+  String get deviceId => 'fake-omi';
+
+  @override
+  Stream<DeviceTransportState> get connectionStateStream => _stateController.stream;
+
+  @override
+  Stream<int> get readyGenerationStream => _readyController.stream;
+
+  @override
+  Future<void> connect() async {
+    _stateController.add(DeviceTransportState.connecting);
+    _emitReady();
+  }
+
+  void emitReconnect() {
+    _connected = false;
+    _stateController.add(DeviceTransportState.disconnected);
+    _stateController.add(DeviceTransportState.connecting);
+    _emitReady();
+  }
+
+  void emitCurrentReadyGenerationAgain() {
+    _readyController.add(readyGeneration);
+  }
+
+  void _emitReady() {
+    _connected = true;
+    readyGeneration++;
+    _stateController.add(DeviceTransportState.connected);
+    _readyController.add(readyGeneration);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    if (!_connected) return;
+    _connected = false;
+    _stateController.add(DeviceTransportState.disconnected);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _stateController.close();
+    await _readyController.close();
+  }
+
+  @override
+  Future<bool> isConnected() async => _connected;
+
+  @override
+  Future<bool> ping() async => _connected;
+
+  @override
+  Stream<List<int>> getCharacteristicStream(String serviceUuid, String characteristicUuid) => const Stream.empty();
+
+  @override
+  Future<List<int>> readCharacteristic(String serviceUuid, String characteristicUuid) async => const [];
+
+  @override
+  Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {
+    timeWriteAttempts++;
+    activeTimeWrites++;
+    maxConcurrentTimeWrites = activeTimeWrites > maxConcurrentTimeWrites ? activeTimeWrites : maxConcurrentTimeWrites;
+    try {
+      if (failNextTimeWrite) {
+        failNextTimeWrite = false;
+        throw StateError('simulated GATT write failure');
+      }
+      final gate = nextTimeWriteGate;
+      nextTimeWriteGate = null;
+      if (gate != null) await gate.future;
+      timeWrites.add(ByteData.sublistView(Uint8List.fromList(data)).getUint32(0, Endian.little));
+    } finally {
+      activeTimeWrites--;
+    }
+  }
+}

--- a/app/test/unit/pure_socket_auth_test.dart
+++ b/app/test/unit/pure_socket_auth_test.dart
@@ -5,6 +5,16 @@ import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/services/sockets/pure_socket.dart';
 
 void main() {
+  test('socket logs omit authentication and conversation query values', () {
+    expect(
+      redactSocketUrlForLogs(
+        'wss://api.omi.me/v4/listen?uid=user-secret&client_conversation_id=conversation-secret',
+      ),
+      'wss://api.omi.me/v4/listen',
+    );
+    expect(redactSocketUrlForLogs('not a socket URL'), '<invalid-socket-url>');
+  });
+
   test('unavailable auth blocks a socket before opening the network', () async {
     final socket = PureSocket(
       'wss://example.invalid',

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -135,11 +135,43 @@ void main() {
       expect(coverage.covers(100, 160), isTrue);
     });
 
+    test('recent recovery selects newest missing ranges backward from the live head', () {
+      final coverage = RingSequenceCoverage([
+        (start: 980, end: 1000),
+        (start: 850, end: 900),
+      ]);
+
+      expect(
+        coverage.lastUncoveredBefore(0, 980, maxCount: 96),
+        (start: 900, end: 980),
+      );
+      coverage.add(900, 980);
+      expect(
+        coverage.lastUncoveredBefore(0, 900, maxCount: 96),
+        (start: 754, end: 850),
+      );
+    });
+
     test('parses only valid immutable ring source identities', () {
       expect(RingProtocol.parseSourceRange('ring_42_84'), (start: 42, end: 84));
       expect(RingProtocol.parseSourceRange('ring_84_42'), isNull);
       expect(RingProtocol.parseSourceRange('legacy_42_84'), isNull);
       expect(RingProtocol.parseSourceRange(null), isNull);
+    });
+
+    test('retains sequence identity after local historical compaction', () {
+      expect(
+        RingProtocol.parseRecoverySourceRange('archive_ring_42_84_1700000000'),
+        (start: 42, end: 84),
+      );
+      expect(
+        RingProtocol.parseRecoverySourceRange('ring_42_84'),
+        (start: 42, end: 84),
+      );
+      expect(
+        RingProtocol.parseRecoverySourceRange('archive_ring_84_42_1700000000'),
+        isNull,
+      );
     });
   });
 

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -149,6 +149,114 @@ void main() {
     });
   });
 
+  group('RingProtocol.canAdvance', () {
+    test('allows deletion only after a complete durable transfer', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: false,
+          isCancelled: false,
+          receivedCompleteRange: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects transport completion without application completion', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: false,
+          doneOk: false,
+          flushError: false,
+          isCancelled: false,
+          receivedCompleteRange: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a completed transfer when durable flush failed', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: true,
+          isCancelled: false,
+          receivedCompleteRange: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a cancelled transfer', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: false,
+          isCancelled: true,
+          receivedCompleteRange: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('RingProtocol.receivedCompleteRange', () {
+    test('accepts an exact contiguous READ_BEGIN through DONE range', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 120,
+          receivedPacketCount: 20,
+          pendingBytes: 0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a missing record even when DONE arrived', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 120,
+          receivedPacketCount: 19,
+          pendingBytes: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects trailing partial record bytes', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 120,
+          receivedPacketCount: 20,
+          pendingBytes: 17,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects DONE watermark inconsistent with announced count', () {
+      expect(
+        RingProtocol.receivedCompleteRange(
+          transferStartSeq: 100,
+          announcedPacketCount: 20,
+          doneNextSeq: 121,
+          receivedPacketCount: 20,
+          pendingBytes: 0,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('RingProtocol.readRecordTimestamp', () {
     test('reads 4-byte big-endian timestamp prefix', () {
       // 0x6824B5C0 = epoch 2026-05-13 21:47:12 UTC

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -169,7 +169,26 @@ void main() {
         (start: 42, end: 84),
       );
       expect(
+        RingProtocol.parseRecoverySourceRange('archive2_ring_42_84_1700000000'),
+        (start: 42, end: 84),
+      );
+      expect(
         RingProtocol.parseRecoverySourceRange('archive_ring_84_42_1700000000'),
+        isNull,
+      );
+    });
+
+    test('device ADVANCE trusts raw ranges and truthful v2 archives only', () {
+      expect(
+        RingProtocol.parseDurableCoverageSourceRange('ring_42_84'),
+        (start: 42, end: 84),
+      );
+      expect(
+        RingProtocol.parseDurableCoverageSourceRange('archive2_ring_42_84_1700000000'),
+        (start: 42, end: 84),
+      );
+      expect(
+        RingProtocol.parseDurableCoverageSourceRange('archive_ring_42_84_1700000000'),
         isNull,
       );
     });

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -79,6 +79,18 @@ void main() {
       expect(done.status, 0);
       expect(done.nextSeq, 12345);
       expect(done.isOk, isTrue);
+      expect(done.transferCrc32, isNull);
+    });
+
+    test('decodes optional transfer CRC32 extension', () {
+      final bd = ByteData(14)
+        ..setUint8(0, 0x04)
+        ..setUint8(1, 0)
+        ..setUint64(2, 12345, Endian.big)
+        ..setUint32(10, 0xCBF43926, Endian.big);
+      final done = RingProtocol.parseDoneNotification(bd.buffer.asUint8List())!;
+      expect(done.nextSeq, 12345);
+      expect(done.transferCrc32, 0xCBF43926);
     });
 
     test('non-zero status surfaces as isOk=false', () {
@@ -158,6 +170,8 @@ void main() {
           flushError: false,
           isCancelled: false,
           receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: true,
         ),
         isTrue,
       );
@@ -171,6 +185,8 @@ void main() {
           flushError: false,
           isCancelled: false,
           receivedCompleteRange: false,
+          protocolError: false,
+          crcVerified: true,
         ),
         isFalse,
       );
@@ -184,6 +200,8 @@ void main() {
           flushError: true,
           isCancelled: false,
           receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: true,
         ),
         isFalse,
       );
@@ -197,9 +215,37 @@ void main() {
           flushError: false,
           isCancelled: true,
           receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: true,
         ),
         isFalse,
       );
+    });
+
+    test('rejects a CRC mismatch', () {
+      expect(
+        RingProtocol.canAdvance(
+          reachedDone: true,
+          doneOk: true,
+          flushError: false,
+          isCancelled: false,
+          receivedCompleteRange: true,
+          protocolError: false,
+          crcVerified: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('RingTransferCrc32', () {
+    test('matches the standard IEEE CRC-32 golden vector across fragments', () {
+      final crc = RingTransferCrc32()
+        ..add('123'.codeUnits)
+        ..add('456'.codeUnits)
+        ..add('789'.codeUnits);
+
+      expect(crc.value, 0xCBF43926);
     });
   });
 
@@ -315,21 +361,16 @@ void main() {
       expect(frames, isEmpty);
     });
 
-    test('drops a frame that would end exactly at the buffer boundary (firmware overflow guard)', () {
-      // [size=2][0xAA, 0xBB] — the frame would end exactly at audio.length.
-      // The firmware (transport.c:write_to_storage) never writes a frame ending
-      // exactly at the last byte: a size byte at the boundary with no room for
-      // its frame is an overflow artifact, and the bytes after it are stale from
-      // a previous write. The parser's >= guard drops it; parsing the stale
-      // region as opus otherwise yields OpusException -4 "corrupted stream".
+    test('drops a boundary-aligned frame for legacy record compatibility', () {
+      // Legacy 3.0.20 may leave a size marker followed by stale bytes when a
+      // frame would consume the complete payload.
       final frames = RingProtocol.parseAudioPayload([2, 0xAA, 0xBB]);
       expect(frames, isEmpty);
     });
 
-    test('drops the boundary-aligned last frame in tightly-packed input (440B exactly)', () {
-      // 40 frames of [size=10][10B] = 40 * 11 = 440 bytes — the 40th frame would
-      // end precisely at audio.length. The firmware never emits such a frame, so
-      // the >= boundary guard drops it: 39 frames survive, the last being #38.
+    test('drops the boundary-aligned last frame in tightly-packed legacy input', () {
+      // 40 frames of [size=10][10B] = 440 bytes. The final frame shape is
+      // indistinguishable from a legacy stale-tail artifact and is rejected.
       final audio = <int>[];
       for (int i = 0; i < 40; i++) {
         audio.add(10);

--- a/app/test/unit/ring_protocol_test.dart
+++ b/app/test/unit/ring_protocol_test.dart
@@ -107,6 +107,42 @@ void main() {
     });
   });
 
+  group('RingSequenceCoverage', () {
+    test('merges fetched live head with backlog only after the gap closes', () {
+      final coverage = RingSequenceCoverage();
+
+      coverage.add(980, 1000);
+      expect(coverage.contiguousEndFrom(0), 0);
+      expect(coverage.firstRangeAtOrAfter(0), (start: 980, end: 1000));
+
+      coverage.add(0, 500);
+      expect(coverage.contiguousEndFrom(0), 500);
+
+      coverage.add(500, 980);
+      expect(coverage.contiguousEndFrom(0), 1000);
+      expect(coverage.ranges, [(start: 0, end: 1000)]);
+    });
+
+    test('sequence identity skips an already durable head without content matching', () {
+      final coverage = RingSequenceCoverage([
+        (start: 100, end: 120),
+        (start: 140, end: 160),
+      ]);
+
+      expect(coverage.firstUncovered(100, 160), 120);
+      coverage.add(120, 140);
+      expect(coverage.firstUncovered(100, 160), 160);
+      expect(coverage.covers(100, 160), isTrue);
+    });
+
+    test('parses only valid immutable ring source identities', () {
+      expect(RingProtocol.parseSourceRange('ring_42_84'), (start: 42, end: 84));
+      expect(RingProtocol.parseSourceRange('ring_84_42'), isNull);
+      expect(RingProtocol.parseSourceRange('legacy_42_84'), isNull);
+      expect(RingProtocol.parseSourceRange(null), isNull);
+    });
+  });
+
   group('RingProtocol.parseReadBeginNotification', () {
     test('decodes start_seq + count', () {
       final bd = ByteData(13)

--- a/app/test/unit/sync_manifest_claim_drain_test.dart
+++ b/app/test/unit/sync_manifest_claim_drain_test.dart
@@ -48,7 +48,12 @@ void main() {
       _Listener(),
       uploadGate: SyncUploadGate(
         limiter: SyncRateLimiter.instance,
-        uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+        uploader: (files,
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           claims.add(claimLiveCapture);
           return UploadFilesResult.queued('job-${claims.length}');
         },
@@ -82,14 +87,26 @@ void main() {
   }
 
   test('a conversation split across batches never claims a manifest for a remainder', () async {
-    // The capture manifest is immutable per conversation. Seven WALs drain as
-    // 5 + 2; the first batch cannot claim it, and the second must not either —
-    // a claim covering only the remainder splits one conversation's audio
-    // across both server meters and spends the claim on a subset.
+    // The capture manifest is immutable per conversation. Cross the real
+    // 2,000-WAL logical-capture boundary by one; the first batch cannot claim
+    // it, and the remainder must not either. Reuse one tiny fixture file so
+    // the test exercises production batching without 2,001 filesystem writes.
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    sync.testWals = [
-      for (var index = 0; index < 7; index++) await writeWal(now - index, conversationId: 'c1'),
-    ];
+    const fixtureName = 'audio_split_capture.bin';
+    await File('${tempDir.path}/$fixtureName').writeAsBytes(List<int>.filled(64, 1));
+    sync.testWals = List.generate(
+      2001,
+      (index) => Wal(
+        timerStart: now - index,
+        codec: BleAudioCodec.opus,
+        seconds: 1,
+        status: WalStatus.miss,
+        storage: WalStorage.disk,
+        device: 'omi',
+        filePath: fixtureName,
+        conversationId: 'c1',
+      ),
+    );
 
     await sync.syncAll();
 

--- a/app/test/unit/sync_upload_gate_test.dart
+++ b/app/test/unit/sync_upload_gate_test.dart
@@ -23,7 +23,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         return UploadFilesResult.queued('job-1');
       },
@@ -43,7 +48,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'throttle'},
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         return UploadFilesResult.queued('job-after-expiry');
       },
@@ -63,7 +73,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => null,
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         return UploadFilesResult.queued('unexpected');
       },
@@ -82,7 +97,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'future_stage'},
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         return UploadFilesResult.queued('unexpected');
       },
@@ -106,7 +126,12 @@ void main() {
         statusCalls++;
         throw Exception('offline');
       },
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         return UploadFilesResult.queued('legacy-cleared');
       },
@@ -129,7 +154,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'restrict'},
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         return UploadFilesResult.queued('unexpected');
       },
@@ -154,7 +184,12 @@ void main() {
         statusCalls++;
         return response.future;
       },
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async =>
+      uploader: (files,
+              {onUploadProgress,
+              conversationId,
+              claimLiveCapture = false,
+              syncLane = SyncUploadLane.fresh,
+              replaceTranscript = false}) async =>
           UploadFilesResult.queued('job'),
     );
 
@@ -174,7 +209,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async =>
+      uploader: (files,
+              {onUploadProgress,
+              conversationId,
+              claimLiveCapture = false,
+              syncLane = SyncUploadLane.fresh,
+              replaceTranscript = false}) async =>
           UploadFilesResult.queued('job'),
     );
 
@@ -189,7 +229,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => null,
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         throw SyncRateLimitedException(
           kind: SyncRateLimitKind.backendCapacity,
@@ -219,7 +264,12 @@ void main() {
         statusCalls++;
         return {'stage': 'none'};
       },
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         uploads++;
         throw SyncRateLimitedException(kind: SyncRateLimitKind.fairUse, retryAfterSeconds: 30 * 24 * 60 * 60);
       },
@@ -243,7 +293,12 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => null,
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         claims.add(claimLiveCapture);
         return UploadFilesResult.queued('job');
       },
@@ -255,6 +310,61 @@ void main() {
     expect(claims, [true, false]);
   });
 
+  test('backfill pacing persists without blocking a fresh upload', () async {
+    final uploadedLanes = <SyncUploadLane>[];
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => {'stage': 'none'},
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
+        uploadedLanes.add(syncLane);
+        return UploadFilesResult.queued('fresh-job');
+      },
+    );
+    limiter.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backfillPaced);
+
+    await expectLater(
+      gate.upload([], lane: SyncUploadLane.backfill),
+      throwsA(
+        isA<SyncRateLimitedException>().having(
+          (error) => error.kind,
+          'kind',
+          SyncRateLimitKind.backfillPaced,
+        ),
+      ),
+    );
+    final fresh = await gate.upload([], lane: SyncUploadLane.fresh);
+
+    expect(fresh.jobId, 'fresh-job');
+    expect(uploadedLanes, [SyncUploadLane.fresh]);
+    expect(limiter.isBackfillLimited, isTrue);
+  });
+
+  test('backfill responses are passed to the uploader as a lane hint', () async {
+    SyncUploadLane? seenLane;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => null,
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
+        seenLane = syncLane;
+        return UploadFilesResult.queued('backfill-job');
+      },
+    );
+
+    await gate.upload([], lane: SyncUploadLane.backfill);
+
+    expect(seenLane, SyncUploadLane.backfill);
+  });
+
   test('a capacity cooldown does not persist across a restart', () async {
     // #10948: the retired backfill cooldown persisted, so a 30s server pause
     // outlived every relaunch the user tried.
@@ -264,5 +374,33 @@ void main() {
 
     expect(SharedPreferencesUtil().getInt('syncRateLimitedUntilMs'), 0);
     expect(SharedPreferencesUtil().getInt('syncBackfillLimitedUntilMs'), 0);
+  });
+
+  test('canonical replacement intent survives the serialized upload gate', () async {
+    String? seenConversationId;
+    bool? seenReplacement;
+    final gate = SyncUploadGate(
+      limiter: limiter,
+      fairUseStatusLoader: () async => null,
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
+        seenConversationId = conversationId;
+        seenReplacement = replaceTranscript;
+        return UploadFilesResult.queued('canonical-job');
+      },
+    );
+
+    await gate.upload(
+      [],
+      conversationId: 'conversation-1',
+      replaceTranscript: true,
+    );
+
+    expect(seenConversationId, 'conversation-1');
+    expect(seenReplacement, isTrue);
   });
 }

--- a/app/test/unit/sync_upload_gate_test.dart
+++ b/app/test/unit/sync_upload_gate_test.dart
@@ -310,40 +310,6 @@ void main() {
     expect(claims, [true, false]);
   });
 
-  test('backfill pacing persists without blocking a fresh upload', () async {
-    final uploadedLanes = <SyncUploadLane>[];
-    final gate = SyncUploadGate(
-      limiter: limiter,
-      fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files,
-          {onUploadProgress,
-          conversationId,
-          claimLiveCapture = false,
-          syncLane = SyncUploadLane.fresh,
-          replaceTranscript = false}) async {
-        uploadedLanes.add(syncLane);
-        return UploadFilesResult.queued('fresh-job');
-      },
-    );
-    limiter.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backfillPaced);
-
-    await expectLater(
-      gate.upload([], lane: SyncUploadLane.backfill),
-      throwsA(
-        isA<SyncRateLimitedException>().having(
-          (error) => error.kind,
-          'kind',
-          SyncRateLimitKind.backfillPaced,
-        ),
-      ),
-    );
-    final fresh = await gate.upload([], lane: SyncUploadLane.fresh);
-
-    expect(fresh.jobId, 'fresh-job');
-    expect(uploadedLanes, [SyncUploadLane.fresh]);
-    expect(limiter.isBackfillLimited, isTrue);
-  });
-
   test('backfill responses are passed to the uploader as a lane hint', () async {
     SyncUploadLane? seenLane;
     final gate = SyncUploadGate(

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -64,6 +64,19 @@ void main() {
       expect(wal.retryCount, 0);
       expect(wal.lastRetryAt, 0);
     });
+
+    test('device-owned upload intent persists across restart', () {
+      final wal = Wal(
+        timerStart: 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 2,
+        uploadIntent: WalUploadIntent.liveContinuity,
+      );
+
+      final restored = Wal.fromJson(wal.toJson());
+
+      expect(restored.uploadIntent, WalUploadIntent.liveContinuity);
+    });
   });
 
   group('Wal source identity', () {

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -122,6 +122,24 @@ void main() {
         expect(restored.toJson(), isNot(contains('capture_end_seconds')));
       }
     });
+
+    test('capture end cannot claim less wall time than the encoded payload', () {
+      final restored = Wal.fromJson({
+        'timer_start': 1000,
+        'codec': 'BleAudioCodec.opus',
+        'seconds': 10,
+        'total_frames': 500,
+        'capture_end_seconds': 1001,
+      });
+
+      expect(restored.validatedCaptureEndSeconds, isNull);
+      expect(restored.wallClockEndSeconds, 1005);
+      expect(
+        restored.toJson(),
+        isNot(contains('capture_end_seconds')),
+        reason: 'a truncated wall span must not survive the next manifest rewrite',
+      );
+    });
   });
 
   group('Wal source identity', () {

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -66,6 +66,38 @@ void main() {
     });
   });
 
+  group('Wal source identity', () {
+    test('sequence-range sourceId persists and owns retry identity', () {
+      final wal = Wal(
+        timerStart: 1700000000,
+        codec: BleAudioCodec.opus,
+        seconds: 10,
+        device: 'cv1',
+        sourceId: 'ring_100_200',
+      );
+
+      final restored = Wal.fromJson(wal.toJson());
+
+      expect(restored.sourceId, 'ring_100_200');
+      expect(restored.id, 'cv1_ring_100_200');
+    });
+
+    test('legacy WAL identity remains timestamp-based when sourceId is absent', () {
+      final wal = Wal(timerStart: 1700000000, codec: BleAudioCodec.opus, seconds: 10, device: 'cv1');
+
+      expect(wal.id, 'cv1_1700000000');
+    });
+
+    test('source-aware filename keeps backend timestamp as the final token', () {
+      final wal = Wal(timerStart: 1700000000, codec: BleAudioCodec.opus, seconds: 10, device: 'cv1');
+
+      final filename = wal.getFileNameByTimeStarts(1700000000, sourceId: 'ring_100_200');
+
+      expect(filename, endsWith('_ring_100_200_1700000000.bin'));
+      expect(int.parse(filename.split('_').last.replaceFirst('.bin', '')), 1700000000);
+    });
+  });
+
   group('stampConversationId', () {
     late LocalWalSyncImpl sync;
     late _FakeListener listener;

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -169,7 +169,11 @@ void main() {
         ),
       ];
 
-      await sync.stampConversationId(now - 150, 'conv-xyz');
+      await sync.stampConversationId(
+        now - 150,
+        'conv-xyz',
+        hasServerSpeechProof: true,
+      );
 
       expect(sync.testWals[0].conversationId, 'conv-xyz');
       expect(sync.testWals[1].conversationId, 'conv-xyz');
@@ -190,7 +194,11 @@ void main() {
         ),
       ];
 
-      await sync.stampConversationId(now - 100, 'new-conv');
+      await sync.stampConversationId(
+        now - 100,
+        'new-conv',
+        hasServerSpeechProof: true,
+      );
 
       expect(sync.testWals[0].conversationId, 'old-conv');
     });
@@ -471,7 +479,11 @@ void main() {
       ];
 
       // Session started at now - 100, so only wal at now - 50 qualifies
-      await sync.stampConversationId(now - 100, 'conv-boundary');
+      await sync.stampConversationId(
+        now - 100,
+        'conv-boundary',
+        hasServerSpeechProof: true,
+      );
 
       expect(sync.testWals[0].conversationId, isNull); // timerStart < sessionStart
       expect(sync.testWals[1].conversationId, 'conv-boundary');
@@ -489,7 +501,11 @@ void main() {
         ),
       ];
 
-      await sync.stampConversationId(now - 100, 'conv-exact');
+      await sync.stampConversationId(
+        now - 100,
+        'conv-exact',
+        hasServerSpeechProof: true,
+      );
 
       expect(sync.testWals[0].conversationId, 'conv-exact');
     });

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -77,6 +77,51 @@ void main() {
 
       expect(restored.uploadIntent, WalUploadIntent.liveContinuity);
     });
+
+    test('wall-clock capture end persists while playable duration remains independent', () {
+      final wal = Wal(
+        timerStart: 1000,
+        codec: BleAudioCodec.opus,
+        seconds: 2,
+        totalFrames: 200,
+        captureEndSeconds: 1007.75,
+      );
+
+      final restored = Wal.fromJson(wal.toJson());
+
+      expect(restored.seconds, 2);
+      expect(restored.captureEndSeconds, 1007.75);
+      expect(restored.wallClockEndSeconds, 1007.75);
+    });
+
+    test('legacy manifest derives wall-clock capture end from playable duration', () {
+      final restored = Wal.fromJson({
+        'timer_start': 1000,
+        'codec': 'BleAudioCodec.opus',
+        'seconds': 9,
+        'total_frames': 250,
+      });
+
+      expect(restored.captureEndSeconds, isNull);
+      expect(restored.wallClockEndSeconds, 1002.5);
+      expect(restored.toJson(), isNot(contains('capture_end_seconds')));
+    });
+
+    test('invalid persisted capture ends fail closed to the legacy duration fallback', () {
+      final farFuture = DateTime.now().millisecondsSinceEpoch / 1000 + const Duration(days: 2).inSeconds;
+      for (final invalidEnd in <Object>['not-a-number', double.nan, double.infinity, 999, farFuture]) {
+        final restored = Wal.fromJson({
+          'timer_start': 1000,
+          'codec': 'BleAudioCodec.opus',
+          'seconds': 9,
+          'total_frames': 200,
+          'capture_end_seconds': invalidEnd,
+        });
+
+        expect(restored.wallClockEndSeconds, 1002);
+        expect(restored.toJson(), isNot(contains('capture_end_seconds')));
+      }
+    });
   });
 
   group('Wal source identity', () {

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -92,7 +92,12 @@ void main() {
       listener,
       uploadGate: SyncUploadGate(
         limiter: SyncRateLimiter.instance,
-        uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+        uploader: (files,
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           throw uploadFailure;
         },
         fairUseStatusLoader: () async => {'stage': 'none'},
@@ -377,7 +382,12 @@ void main() {
       var uploadAttempts = 0;
       final gate = SyncUploadGate(
         limiter: SyncRateLimiter.instance,
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+        uploader: (files,
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
           uploadAttempts++;
           throw StateError('offline');
         },

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:omi/backend/http/api/conversations.dart' show SyncJobFetch, SyncJobFetchOutcome, SyncUploadLane;
+import 'package:omi/backend/http/api/conversations.dart'
+    show SyncJobFetch, SyncJobFetchOutcome, SyncUploadLane, SyncUploadTooLargeException, UploadFilesResult;
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
@@ -457,14 +458,7 @@ void main() {
       expect(stuck.isSyncing, false, reason: 'isSyncing must be cleared so the WAL is eligible for the next attempt');
     });
 
-    test('KNOWN GAP: syncAll picks up miss WAL regardless of retryCount', () async {
-      // getOrphanedWals() gates on retryCount < 3 (line 438), but syncAll()
-      // at line 504 filters ONLY on status==miss && storage==disk.
-      // A WAL that has already failed 100 times is treated identically to one
-      // that has never been tried.
-      //
-      // Fix needed: syncAll() should skip WALs with retryCount >= N,
-      // or _autoUploadPendingPhoneFiles should apply the cap before calling syncAll().
+    test('automatic sync skips a miss WAL whose retry budget is exhausted', () async {
       const filename = 'high_retry_7000.bin';
       final file = File('${tempDir.path}/$filename');
       await file.writeAsBytes([0xAA, 0xBB]);
@@ -473,18 +467,61 @@ void main() {
       wal.retryCount = 50; // Has failed 50 times already
       sync.testWals = [wal];
 
-      // syncAll will still attempt the upload — retryCount is never consulted.
-      // We verify by observing that isSyncing is cleared after the attempt,
-      // meaning syncAll processed the WAL (not skipped it).
       final result = await sync.syncAll();
 
-      expect(result?.localUploadFailures, 1);
-      expect(
-        sync.testWals.first.isSyncing,
-        false,
-        reason: 'isSyncing cleared confirms syncAll processed this WAL, '
-            'despite retryCount=50 — no cap is enforced',
+      expect(result, isNull);
+      expect(sync.testWals.first.retryCount, 50);
+      expect(file.existsSync(), isTrue, reason: 'exhausting automatic retries never deletes source audio');
+    });
+
+    test('an oversized transaction is quarantined without blocking later healthy audio', () async {
+      var uploadAttempts = 0;
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        uploader: (files,
+            {onUploadProgress,
+            conversationId,
+            claimLiveCapture = false,
+            syncLane = SyncUploadLane.fresh,
+            replaceTranscript = false}) async {
+          uploadAttempts++;
+          if (uploadAttempts == 1) {
+            throw const SyncUploadTooLargeException();
+          }
+          return UploadFilesResult.done(
+            SyncLocalFilesResponse(
+              newConversationIds: ['healthy-conversation'],
+              updatedConversationIds: [],
+            ),
+          );
+        },
+        fairUseStatusLoader: () async => {'stage': 'none'},
       );
+      final oversizedSync = LocalWalSyncImpl(listener, uploadGate: gate);
+      final wals = <Wal>[];
+      for (var index = 0; index < 21; index++) {
+        final filename = 'oversized_queue_$index.bin';
+        await File('${tempDir.path}/$filename').writeAsBytes([index], flush: true);
+        wals.add(_makeWal(timerStart: 10000 + index, filePath: filename));
+      }
+      oversizedSync.testWals = wals;
+
+      final result = await oversizedSync.syncAll();
+
+      expect(uploadAttempts, 2, reason: 'the healthy tail must upload in the same drain');
+      expect(result?.localUploadFailures, 1);
+      expect(wals.where((wal) => wal.status == WalStatus.synced), hasLength(1));
+      final quarantined = wals.where((wal) => wal.status == WalStatus.miss).toList();
+      expect(quarantined, hasLength(20));
+      expect(quarantined.every((wal) => wal.retryCount == walMaxAutoRetries), isTrue);
+      expect(
+        quarantined.every((wal) => File('${tempDir.path}/${wal.filePath}').existsSync()),
+        isTrue,
+        reason: '413 handling must retain every rejected source file',
+      );
+
+      await oversizedSync.syncAll();
+      expect(uploadAttempts, 2, reason: 'the same deterministic 413 batch must not auto-retry forever');
     });
   });
 

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -47,6 +47,7 @@ Wal _makeWal({
   WalStatus status = WalStatus.miss,
   WalStorage storage = WalStorage.disk,
   String? filePath = 'audio_1000.bin',
+  String? sourceId,
 }) {
   return Wal(
     timerStart: timerStart,
@@ -56,6 +57,7 @@ Wal _makeWal({
     storage: storage,
     device: 'omi',
     filePath: filePath,
+    sourceId: sourceId,
   );
 }
 
@@ -109,6 +111,62 @@ void main() {
   // -------------------------------------------------------------------------
   // getMissingWals — status filter
   // -------------------------------------------------------------------------
+
+  group('atomic WAL manifest', () {
+    test('failed temporary write preserves the previous complete manifest', () async {
+      final original = _makeWal(timerStart: 1000);
+      expect(await WalFileManager.saveWals([original]), isTrue);
+
+      // A directory at the temporary-file path deterministically fails the
+      // rewrite before rename. The production manifest must remain readable.
+      await Directory('${tempDir.path}/wals.json.tmp').create();
+
+      await expectLater(WalFileManager.saveWals([_makeWal(timerStart: 2000)]), throwsA(isA<FileSystemException>()));
+
+      final restored = await WalFileManager.loadWals();
+      expect(restored.map((wal) => wal.timerStart), [1000]);
+    });
+
+    test('successful rewrite leaves no partial manifest beside the committed file', () async {
+      expect(await WalFileManager.saveWals([_makeWal(timerStart: 3000)]), isTrue);
+
+      expect(File('${tempDir.path}/wals.json').existsSync(), isTrue);
+      expect(File('${tempDir.path}/wals.json.tmp').existsSync(), isFalse);
+      expect(File('${tempDir.path}/wals_backup.json.tmp').existsSync(), isFalse);
+      expect((await WalFileManager.loadWals()).single.timerStart, 3000);
+    });
+
+    test('backup recovery retains the newest durably acknowledged ring range', () async {
+      final first = _makeWal(timerStart: 3000, sourceId: 'ring_100_200');
+      final acknowledged = _makeWal(timerStart: 4000, sourceId: 'ring_200_300');
+
+      expect(await WalFileManager.saveWals([first]), isTrue);
+      expect(await WalFileManager.saveWals([first, acknowledged]), isTrue);
+      await File('${tempDir.path}/wals.json').writeAsString('{corrupted', flush: true);
+
+      final recovered = await WalFileManager.loadWals();
+      expect(recovered.map((wal) => wal.sourceId), ['ring_100_200', 'ring_200_300']);
+    });
+
+    test('backup recovery retains the newest range when the primary manifest is missing', () async {
+      final acknowledged = _makeWal(timerStart: 5000, sourceId: 'ring_300_400');
+
+      expect(await WalFileManager.saveWals([acknowledged]), isTrue);
+      await File('${tempDir.path}/wals.json').delete();
+
+      final recovered = await WalFileManager.loadWals();
+      expect(recovered.single.sourceId, 'ring_300_400');
+    });
+
+    test('concurrent callers commit in invocation order without sharing a temp writer', () async {
+      final olderWrite = WalFileManager.saveWals([_makeWal(timerStart: 4000)]);
+      final newerWrite = WalFileManager.saveWals([_makeWal(timerStart: 5000)]);
+
+      await Future.wait([olderWrite, newerWrite]);
+
+      expect((await WalFileManager.loadWals()).single.timerStart, 5000);
+    });
+  });
 
   group('getMissingWals', () {
     test('returns only miss WALs, excludes synced and corrupted', () async {

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/http/api/conversations.dart' show SyncJobFetch, SyncJobFetchOutcome, SyncUploadLane;
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
@@ -346,6 +347,67 @@ void main() {
   // -------------------------------------------------------------------------
 
   group('zombie miss: upload failure leaves WAL stuck as miss', () {
+    test('transient reconciliation failure stops after one bounded slice', () async {
+      final fetchedJobs = <String>[];
+      final reconcileSync = LocalWalSyncImpl(
+        listener,
+        syncJobStatusFetcher: (jobId) async {
+          fetchedJobs.add(jobId);
+          return const SyncJobFetch(SyncJobFetchOutcome.transient);
+        },
+      );
+      final uploaded = List.generate(
+        8,
+        (index) => _makeWal(
+          timerStart: 2000 + index,
+          status: WalStatus.uploaded,
+          filePath: null,
+        )..jobId = 'offline-job-$index',
+      );
+      reconcileSync.testWals = uploaded;
+
+      await reconcileSync.reconcileUploadedWals();
+
+      expect(fetchedJobs, hasLength(3));
+      expect(uploaded.every((wal) => wal.status == WalStatus.uploaded), isTrue);
+      expect(uploaded.every((wal) => wal.jobId != null), isTrue);
+    });
+
+    test('one failed batch pauses its lane instead of hammering the whole backlog', () async {
+      var uploadAttempts = 0;
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+          uploadAttempts++;
+          throw StateError('offline');
+        },
+        fairUseStatusLoader: () async => {'stage': 'none'},
+      );
+      final laneSync = LocalWalSyncImpl(
+        listener,
+        uploadGate: gate,
+      );
+      final wals = <Wal>[];
+      for (var index = 0; index < 21; index++) {
+        final filename = 'offline_backlog_$index.bin';
+        await File('${tempDir.path}/$filename').writeAsBytes([index], flush: true);
+        wals.add(
+          _makeWal(
+            timerStart: 1000 + index,
+            filePath: filename,
+          ),
+        );
+      }
+      laneSync.testWals = wals;
+
+      final result = await laneSync.syncAll();
+
+      expect(uploadAttempts, 1);
+      expect(result?.localUploadFailures, 1);
+      expect(wals.every((wal) => wal.status == WalStatus.miss), isTrue);
+      expect(wals.every((wal) => !wal.isSyncing), isTrue);
+    });
+
     test('failed upload leaves WAL as miss with retryCount unchanged', () async {
       // Simulates what the user observes: a recording that exists on disk,
       // gets picked up by syncAll(), upload attempt fails (network/server error),

--- a/app/test/widgets/device_storage_card_test.dart
+++ b/app/test/widgets/device_storage_card_test.dart
@@ -72,4 +72,24 @@ void main() {
     final indicator = tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
     expect(indicator.value, 0.0);
   });
+
+  testWidgets('shows fixed-snapshot drain progress without falsifying the cached storage total', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        DeviceStorageCard(
+          status: _status(usedMb: 338, freeMb: 131),
+          drainProgress: 0.42,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Downloading from your device'), findsOneWidget);
+    expect(find.text('42%'), findsOneWidget);
+    final progress = tester.widget<LinearProgressIndicator>(
+      find.byKey(const ValueKey('device-storage-drain-progress')),
+    );
+    expect(progress.value, 0.42);
+    expect(find.textContaining('338 MB of 469 MB used'), findsOneWidget);
+  });
 }

--- a/app/test/widgets/sync_row_recovery_window_test.dart
+++ b/app/test/widgets/sync_row_recovery_window_test.dart
@@ -66,7 +66,12 @@ class _WalService implements IWalService {
 
 SyncUploadGate _offlineGate() => SyncUploadGate(
       limiter: SyncRateLimiter.instance,
-      uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+      uploader: (files,
+          {onUploadProgress,
+          conversationId,
+          claimLiveCapture = false,
+          syncLane = SyncUploadLane.fresh,
+          replaceTranscript = false}) async {
         throw StateError('unexpected upload in a widget test');
       },
       fairUseStatusLoader: () async => {'stage': 'none'},

--- a/app/test/widgets/transcription_paused_warning_test.dart
+++ b/app/test/widgets/transcription_paused_warning_test.dart
@@ -182,6 +182,26 @@ void main() {
       expect(find.byIcon(Icons.cloud_off), findsNothing);
     });
 
+    testWidgets('shows reconnecting after an abnormal device live-socket close', (tester) async {
+      final captureProvider = CaptureProvider();
+      captureProvider.updateRecordingDevice(
+        BtDevice(id: 'test-device', name: 'Test Omi', type: DeviceType.omi, rssi: -50),
+      );
+      captureProvider.updateRecordingState(RecordingState.deviceRecord);
+
+      await pumpCaptureWidget(tester, captureProvider);
+      captureProvider.onClosed(1006);
+      await tester.pump();
+
+      final context = tester.element(find.byType(ConversationCaptureWidget));
+      expect(
+        find.text(AppLocalizations.of(context).transcriptionReconnecting),
+        findsWidgets,
+      );
+      expect(find.text(AppLocalizations.of(context).listening), findsNothing);
+      captureProvider.dispose();
+    });
+
     testWidgets('paused state overrides Listening during device recording', (tester) async {
       final captureProvider = CaptureProvider();
       addTearDown(captureProvider.dispose);

--- a/app/test/widgets/transcription_paused_warning_test.dart
+++ b/app/test/widgets/transcription_paused_warning_test.dart
@@ -87,7 +87,7 @@ void main() {
   }
 
   group('simplified status indicators (#6672)', () {
-    testWidgets('shows terminal live STT failure until the backend is ready again', (tester) async {
+    testWidgets('distinguishes retryable STT recovery from terminal unavailability', (tester) async {
       final captureProvider = CaptureProvider();
       addTearDown(captureProvider.dispose);
       captureProvider.updateRecordingState(RecordingState.record);
@@ -108,6 +108,21 @@ void main() {
       expect(captureProvider.recordingState, RecordingState.record);
       expect(captureProvider.terminalTranscriptionFailure?.status, 'stt_failed');
       final context = tester.element(find.byType(ConversationCaptureWidget));
+      expect(find.text(AppLocalizations.of(context).transcriptionReconnecting), findsWidgets);
+      expect(find.text(AppLocalizations.of(context).transcriptionUnavailable), findsNothing);
+
+      captureProvider.onMessageEventReceived(
+        MessageServiceStatusEvent(
+          status: 'stt_failed',
+          outcome: 'upstream_error',
+          provider: 'deepgram',
+          retryable: false,
+          reason: 'unsupported_codec',
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(AppLocalizations.of(context).transcriptionReconnecting), findsNothing);
       expect(find.text(AppLocalizations.of(context).transcriptionUnavailable), findsWidgets);
 
       captureProvider.onMessageEventReceived(MessageServiceStatusEvent(status: 'ready'));

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -392,6 +392,9 @@ def test_mobile_generated_files_only_run_for_codegen_or_localization_changes():
     assert """run: printf 'flutter.sdk=%s\\n' "$FLUTTER_ROOT" > android/local.properties""" in android
     assert 'run: gradle -p android testDevDebugUnitTest' in android
     assert './android/gradlew' not in android
+    android_gradle = (repo / "app" / "android" / "app" / "build.gradle").read_text()
+    assert 'if (codemagicKeystorePath)' in android_gradle
+    assert 'if (System.getenv()["CI"])' not in android_gradle
     assert 'fetch-depth: 0' in changes
 
 

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -388,6 +388,8 @@ def test_mobile_generated_files_only_run_for_codegen_or_localization_changes():
     assert 'fetch-depth: 1' in generated
     assert 'fetch-depth: 1' in android
     assert "gradle-version: '8.14.2'" in android
+    assert "- name: Configure Flutter SDK for Gradle" in android
+    assert """run: printf 'flutter.sdk=%s\\n' "$FLUTTER_ROOT" > android/local.properties""" in android
     assert 'run: gradle -p android testDevDebugUnitTest' in android
     assert './android/gradlew' not in android
     assert 'fetch-depth: 0' in changes

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -387,6 +387,9 @@ def test_mobile_generated_files_only_run_for_codegen_or_localization_changes():
     assert "if: needs.changes.outputs.has_app_l10n == 'true'" in generated
     assert 'fetch-depth: 1' in generated
     assert 'fetch-depth: 1' in android
+    assert "gradle-version: '8.14.2'" in android
+    assert 'run: gradle -p android testDevDebugUnitTest' in android
+    assert './android/gradlew' not in android
     assert 'fetch-depth: 0' in changes
 
 

--- a/docs/product/invariants/README.md
+++ b/docs/product/invariants/README.md
@@ -28,6 +28,7 @@ rules stay in [`AGENTS.md`](../../../AGENTS.md). Product north star:
 | INV-DATA-1 | Production-family customer data-plane continuity | proposed | [data-plane-continuity.md](./data-plane-continuity.md) |
 | INV-NAV-1 | Feature parity across desktop shells | proposed | [desktop-shell-feature-parity.md](./desktop-shell-feature-parity.md) |
 | INV-TASK-1 | Complete dated task buckets with bounded No Deadline paging | proposed | [task-dated-bucket-completeness.md](./task-dated-bucket-completeness.md) |
+| INV-CAPTURE-1 | One durable conversation timeline | proposed | [capture-continuity.md](./capture-continuity.md) |
 | INV-VOICE-1 | One desktop voice-turn lifecycle owner | locked | [desktop-voice-turns.md](./desktop-voice-turns.md) |
 
 ## File template

--- a/docs/product/invariants/capture-continuity.md
+++ b/docs/product/invariants/capture-continuity.md
@@ -1,0 +1,118 @@
+# INV-CAPTURE-1: One durable conversation timeline
+
+**Status:** proposed
+
+**Statement:** Pendant storage records, BLE packets, retry ranges, local files,
+live transcript messages, and backend jobs are transport artifacts of one
+chronological conversation timeline. They must never become independent
+user-visible conversations merely because capture crossed a storage boundary,
+a connection dropped, an app restarted, or a transfer was retried.
+
+## Authoritative flow
+
+1. The pendant durably records ordered audio with enough sequence and capture
+   time information to recover a missing range. Pendant storage is capture
+   authority until the next layer has durably accepted the same coverage.
+2. The companion app assembles ordered coverage into the current logical
+   conversation before presenting, uploading, or deleting it. Physical ring
+   ranges and fixed-duration archives remain internal.
+3. Live preview is a projection of that open conversation. Reconnect reclaims
+   the same conversation identity and reconciles preview segments; it does not
+   start a new conversation solely because BLE or the transcription socket
+   changed sessions.
+4. The app uploads one idempotent logical artifact or multipart job for one
+   conversation window. Retries reuse its identity and source coverage. VAD may
+   classify assembled audio, but individual noise fragments are not independent
+   upload jobs.
+5. The backend monotonically projects the accepted timeline into transcript,
+   conversation, and summary state. Late recovery inside the conversation
+   boundary updates the same conversation in timestamp order and invalidates
+   derived work that depended on the incomplete transcript.
+
+The configured conversation-silence duration is the semantic boundary. A BLE
+disconnect, WebSocket close, five-minute archive rollover, app lifecycle event,
+or upload retry is not a conversation boundary.
+
+## Scheduling and power
+
+- Live capture owns the next available BLE transfer slice.
+- Missing coverage in the still-open conversation may be repaired
+  automatically because it restores the active user experience.
+- Older history requires an explicit Sync action or the existing Auto Sync
+  opt-in. Charging increases the budget for authorized work; it does not grant
+  authority to drain history.
+- Authorized historical transfer runs in bounded slices and yields whenever
+  live coverage is available. If concurrent transfer cannot preserve live
+  transcription on a platform/device pair, historical transfer pauses.
+- Audio is acknowledged or deleted from the pendant only after the next
+  authoritative layer has durably stored its identity and coverage.
+
+## User-visible contract
+
+- **Connected** means the paired pendant has a usable capture path. Bluetooth
+  attachment without ready GATT/audio ownership is connecting or degraded.
+- **Listening** means the live transcription service accepted the session and
+  the app is feeding it ordered audio. If audio is being retained for recovery
+  while STT reconnects, the UI says so; it must not claim Listening.
+- Sync shows logical conversations, not physical storage fragments. A logical
+  row has playable audio or an explicit retained/remote-only explanation.
+- Retry reports a bounded reason and keeps durable data. Refreshing one surface
+  must not make a newer conversation disappear because another projection is
+  stale.
+- Android, iOS, and desktop share the same conversation, scheduling, retry, and
+  projection policy. Native code owns transport mechanics only. A surface that
+  has not implemented durable ring recovery must say so; it cannot claim
+  parity.
+
+## MUST NOT
+
+- Upload, transcribe, summarize, or render raw one-to-nine-second ring/storage
+  fragments as separate conversations solely because those files exist.
+- Run automatic deep backlog transfer by default, including while charging.
+- Let backlog transfer delay or disable live capture.
+- Acknowledge a range before durable acceptance, or create a new retry identity
+  for the same range.
+- Clear the live preview or create a new conversation solely on transport
+  reconnect.
+- Show Listening after the live socket closes or before server readiness.
+- Apply platform-specific conversation boundaries or backlog policy.
+
+## Guard tests
+
+- `app/test/unit/conversation_audio_assembler_test.dart` — ordered assembly,
+  overlap/deduplication, and conversation-window grouping.
+- `app/test/unit/local_wal_sync_test.dart` — raw-fragment exclusion, logical
+  upload grouping, idempotent coverage, and bounded historical batches.
+- `app/test/providers/sync_provider_sync_wal_wake_test.dart` — explicit backlog
+  authority and live-priority scheduling.
+- `app/test/services/capture/conversation_session_window_test.dart` and
+  `app/test/services/capture/live_transcript_preview_test.dart` — conversation
+  identity and preview continuity.
+- `app/test/providers/capture_provider_test.dart` and
+  `app/test/widgets/transcription_paused_warning_test.dart` — honest live
+  readiness state and reconnect recovery.
+- `app/test/services/capture/device_audio_streaming_policy_test.dart` — no live
+  tail consumption before transcription readiness.
+- `app/e2e/BLE_RELIABILITY_ACCEPTANCE.md` — Android/iOS physical-device parity,
+  disconnect recovery, logical backlog, throughput, and deterministic audio.
+
+## Path globs
+
+- `omi/firmware/**`
+- `app/lib/services/capture/**`
+- `app/lib/services/wals/**`
+- `app/lib/providers/sync_provider.dart`
+- `app/lib/pages/conversations/**`
+- `app/android/**/ble/**`
+- `app/ios/**/Ble/**`
+- `desktop/**`
+- `backend/routers/transcribe.py`
+- `backend/routers/sync.py`
+- `backend/utils/stt/**`
+
+## PR rule
+
+Name `INV-CAPTURE-1` in every PR that changes a path above and state which
+authoritative boundary and physical acceptance rows the change preserves. The
+invariant remains proposed until its behavior and guard surfaces are unchanged
+for seven days.

--- a/docs/product/invariants/capture-continuity.md
+++ b/docs/product/invariants/capture-continuity.md
@@ -35,15 +35,23 @@ or upload retry is not a conversation boundary.
 
 ## Scheduling and power
 
-- Live capture owns the next available BLE transfer slice.
+- Live capture owns the next available BLE transfer slice unless the user has
+  explicitly started Fast Sync.
 - Missing coverage in the still-open conversation may be repaired
   automatically because it restores the active user experience.
 - Older history requires an explicit Sync action or the existing Auto Sync
   opt-in. Charging increases the budget for authorized work; it does not grant
   authority to drain history.
-- Authorized historical transfer runs in bounded slices and yields whenever
-  live coverage is available. If concurrent transfer cannot preserve live
-  transcription on a platform/device pair, historical transfer pauses.
+- Automatic historical transfer runs in bounded slices and yields whenever
+  live coverage is available. Explicit Fast Sync instead latches one immutable
+  write-sequence target, pauses preview delivery, and drains that fixed target
+  with larger sequential reads while the pendant keeps recording newer audio
+  to its ring. Completion, cancellation, or a recoverable transfer failure
+  returns BLE ownership to live capture immediately; it never expands the
+  target to chase newly recorded audio.
+- Fast Sync progress is measured against that immutable target. A cached
+  device used/free byte sample remains labeled as storage state and must not be
+  rewritten as a synthetic transfer counter while newer audio enters the ring.
 - Audio is acknowledged or deleted from the pendant only after the next
   authoritative layer has durably stored its identity and coverage.
 
@@ -69,7 +77,9 @@ or upload retry is not a conversation boundary.
 - Upload, transcribe, summarize, or render raw one-to-nine-second ring/storage
   fragments as separate conversations solely because those files exist.
 - Run automatic deep backlog transfer by default, including while charging.
-- Let backlog transfer delay or disable live capture.
+- Let automatic backlog transfer delay or disable live capture, or let an
+  explicit Fast Sync remain latched after completion, cancellation, or a
+  recoverable failure.
 - Acknowledge a range before durable acceptance, or create a new retry identity
   for the same range.
 - Clear the live preview or create a new conversation solely on transport
@@ -82,7 +92,11 @@ or upload retry is not a conversation boundary.
 - `app/test/unit/conversation_audio_assembler_test.dart` — ordered assembly,
   overlap/deduplication, and conversation-window grouping.
 - `app/test/unit/local_wal_sync_test.dart` — raw-fragment exclusion, logical
-  upload grouping, idempotent coverage, and bounded historical batches.
+  upload grouping, sequence-first RTC correction, live-capture proof,
+  idempotent coverage, and bounded historical batches.
+- `app/test/services/wals/ring_storage_sync_test.dart` — fixed Fast Sync
+  snapshots, progress, disconnect adoption, bounded cancellation, and return
+  to live capture.
 - `app/test/providers/sync_provider_sync_wal_wake_test.dart` — explicit backlog
   authority and live-priority scheduling.
 - `app/test/services/capture/conversation_session_window_test.dart` and

--- a/scripts/flutter-with-clean-git-env
+++ b/scripts/flutter-with-clean-git-env
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This wrapper owns the app working directory as well as the environment
+# boundary. Hook callers must not reproduce either setup step.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT/app"
+
+# Git exports repository-local GIT_* variables to hooks. Flutter invokes Git to
+# determine its own SDK version; inheriting the caller's GIT_DIR makes Flutter
+# inspect the Omi worktree instead and report 0.0.0-unknown. Clear only Git's
+# documented repository-local variables, then execute the real Flutter SDK.
+while IFS= read -r variable; do
+  unset "$variable"
+done < <(git rev-parse --local-env-vars)
+
+exec flutter "$@"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -5,7 +5,8 @@ set -eo pipefail
 # Git runs hooks with the working directory at the top of the invoking work
 # tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
 # work tree. This keeps linked worktrees from aborting into a --no-verify push.
-cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
 
 # shellcheck source=dev-harness/_resolve_python.sh
 source scripts/dev-harness/_resolve_python.sh
@@ -357,16 +358,12 @@ check_flutter_generated_if_needed() {
     fi
     echo "==> Flutter build_runner generated-output check"
     (
-      # Git exports linked-worktree metadata to hooks. Flutter resolves its own
-      # SDK version through Git, so those variables must not leak into Flutter.
-      unset GIT_DIR GIT_WORK_TREE
-      cd app
-      flutter pub run build_runner build --delete-conflicting-outputs
-      git diff --exit-code -- lib || {
+      "$REPO_ROOT/scripts/flutter-with-clean-git-env" pub run build_runner build --delete-conflicting-outputs
+      git diff --exit-code -- app/lib || {
         echo "FAIL: generated Dart files are stale. Run: cd app && flutter pub run build_runner build --delete-conflicting-outputs" >&2
         exit 1
       }
-      untracked=$(git ls-files --others --exclude-standard -- lib)
+      untracked=$(git ls-files --others --exclude-standard -- app/lib)
       if [ -n "$untracked" ]; then
         echo "FAIL: generated Dart files are stale; untracked generated files were produced:" >&2
         echo "$untracked" >&2
@@ -385,15 +382,12 @@ check_flutter_generated_if_needed() {
     fi
     echo "==> Flutter l10n generated-output check"
     (
-      # Keep Flutter's SDK-version Git lookup isolated from hook worktree state.
-      unset GIT_DIR GIT_WORK_TREE
-      cd app
-      flutter gen-l10n
-      git diff --exit-code -- lib/l10n || {
+      "$REPO_ROOT/scripts/flutter-with-clean-git-env" gen-l10n
+      git diff --exit-code -- app/lib/l10n || {
         echo "FAIL: generated localization files are stale. Run: cd app && flutter gen-l10n" >&2
         exit 1
       }
-      untracked=$(git ls-files --others --exclude-standard -- lib/l10n)
+      untracked=$(git ls-files --others --exclude-standard -- app/lib/l10n)
       if [ -n "$untracked" ]; then
         echo "FAIL: generated localization files are stale; untracked generated files were produced:" >&2
         echo "$untracked" >&2

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -159,12 +159,16 @@ git init -q --bare "$TMPDIR/fallback-bare.git"
 # This contract also runs beneath `make preflight`; suppress nested Make's
 # directory banner so stdout remains the resolver value under both entrypoints.
 out="$(cd "$FB_ROOT" && env -u PYTHON GIT_DIR="$TMPDIR/fallback-bare.git" make --no-print-directory print-resolved-python 2>/dev/null)"
-# Resolve the physical path because Git Bash exposes /tmp as a logical mount
-# while BASH_SOURCE resolves the same directory through its Windows path.
+# Resolve both sides to physical paths because macOS exposes /tmp as a logical
+# alias for /private/tmp, while Git Bash can expose the same directory through
+# a Windows path. Comparing only one normalized side makes the test itself
+# platform-dependent.
+actual_path="${out#PYTHON=}"
+actual="PYTHON=$(cd "$(dirname "$actual_path")" && pwd -P)/$(basename "$actual_path")"
 expected="PYTHON=$(cd "$FB_ROOT" && pwd -P)/backend/.venv/bin/python"
-if [ "$out" != "$expected" ]; then
+if [ "$actual" != "$expected" ]; then
   echo "FAIL: Makefile repo-root resolution collapsed when show-toplevel could not resolve a work tree." >&2
-  printf 'Expected: %s\nGot:      %s\n' "$expected" "$out" >&2
+  printf 'Expected: %s\nGot:      %s\n' "$expected" "$actual" >&2
   exit 1
 fi
 echo "linked-worktree repo-root fallback test passed."

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -204,3 +204,59 @@ for spelling in yes on 1 TRUE; do
   fi
 done
 echo "repair-git-primary-worktree boolean-spelling test passed."
+
+# Git hooks export the invoking repository's GIT_* variables. Flutter shells
+# out to Git to determine its SDK version, so inheriting those variables makes
+# it inspect this repository and report 0.0.0-unknown. Exercise the production
+# wrapper through a fake Flutter binary and prove both environment cleanup and
+# argument forwarding.
+mkdir -p "$TMPDIR/flutter-bin"
+cat >"$TMPDIR/flutter-bin/flutter" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+for variable in \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES \
+  GIT_COMMON_DIR \
+  GIT_CONFIG \
+  GIT_CONFIG_COUNT \
+  GIT_DIR \
+  GIT_INDEX_FILE \
+  GIT_OBJECT_DIRECTORY \
+  GIT_WORK_TREE; do
+  if printenv "$variable" >/dev/null 2>&1; then
+    echo "FAIL: Flutter inherited $variable from the Git hook." >&2
+    exit 42
+  fi
+done
+printf '%s\n' "$*" >"$FLUTTER_ENV_PROBE"
+printf '%s\n' "$PWD" >"$FLUTTER_CWD_PROBE"
+EOF
+chmod +x "$TMPDIR/flutter-bin/flutter"
+
+flutter_probe="$TMPDIR/flutter-args.txt"
+flutter_cwd_probe="$TMPDIR/flutter-cwd.txt"
+env \
+  PATH="$TMPDIR/flutter-bin:$PATH" \
+  FLUTTER_ENV_PROBE="$flutter_probe" \
+  FLUTTER_CWD_PROBE="$flutter_cwd_probe" \
+  GIT_CONFIG_COUNT=0 \
+  GIT_DIR="$TMPDIR/repo/.git" \
+  GIT_WORK_TREE="$TMPDIR/repo" \
+  "$ROOT/scripts/flutter-with-clean-git-env" \
+  pub run build_runner build --delete-conflicting-outputs
+
+expected_flutter_args="pub run build_runner build --delete-conflicting-outputs"
+actual_flutter_args="$(cat "$flutter_probe")"
+if [ "$actual_flutter_args" != "$expected_flutter_args" ]; then
+  echo "FAIL: Flutter Git-env wrapper changed command arguments." >&2
+  printf 'Expected: %s\nGot:      %s\n' "$expected_flutter_args" "$actual_flutter_args" >&2
+  exit 1
+fi
+expected_flutter_cwd="$ROOT/app"
+actual_flutter_cwd="$(cat "$flutter_cwd_probe")"
+if [ "$actual_flutter_cwd" != "$expected_flutter_cwd" ]; then
+  echo "FAIL: Flutter hook wrapper did not own the app working directory." >&2
+  printf 'Expected: %s\nGot:      %s\n' "$expected_flutter_cwd" "$actual_flutter_cwd" >&2
+  exit 1
+fi
+echo "Flutter hook environment cleanup test passed."


### PR DESCRIPTION
## Summary

Companion-app support for the storage-authoritative CV1 `3.0.29` firmware in #10654.

The operating contract is now explicit and shared by Android and iOS:

- normal connected operation is live capture;
- the app may automatically repair a gap inside the still-open conversation;
- historical pendant backlog drains only after a **Sync** tap or the existing **Auto Sync** opt-in;
- charging is capacity, not transfer authority, and never starts a deep drain;
- if transcription is unavailable, durable audio remains on the pendant instead of becoming an unbounded phone-side queue.

Physical five-minute archives and bounded ring reads are transport boundaries, not conversation boundaries. The app assembles adjacent, provably ordered ranges within the configured silence window into one logical recording and one upload job.

The proposed `INV-CAPTURE-1` contract now records this end-to-end behavior in the repository: pendant storage → shared companion policy → live preview → idempotent upload → backend conversation projection. Native Android/iOS code owns transport mechanics, not conversation boundaries.

This remains a team-test draft. It is not ready for public beta promotion.

## Root cause

Live notifications, recent-gap repair, historical sync, BLE restoration, and WebSocket recovery previously had overlapping authority.

That allowed several regressions:

1. reconnect work could compete with the current live cursor;
2. bounded device reads could surface as hundreds of tiny phone recordings;
3. historical backlog could drain merely because the pendant was charging;
4. a storage-authoritative tail could keep consuming data while no transcription session was ready;
5. iOS CoreBluetooth restoration could retain the one-connection pendant in a background-launched process and prevent Android from acquiring it;
6. the physical-test runbooks independently encoded backend identity, and both preflights certified `api.omiapi.com` as production even though that live socket closed before readiness.

The charging behavior entered this feature stack in `47be02d84c`; it was not a pre-existing product invariant. This PR removes it from the authority boundary.

## What changed

### Durable storage and conversation assembly

- append every complete bounded ring read before `ADVANCE`;
- retain device/range identity, capture timestamps, sequence coverage, and upload intent across restart;
- keep live audio and active-conversation gaps ahead of old history;
- latch one immutable write-sequence target per manual Sync request;
- make the deep-backlog policy required and fail closed;
- group adjacent physical archives using the configured conversation boundary;
- compact only overlaps whose exact sequence union is provable;
- preserve one canonical recording/upload owner while keeping physical members for acknowledgement and retry;
- materialize that logical recording on demand when the user opens it, so grouped rows remain playable without exposing physical fragments;
- pace complete Opus batches without truncating them under socket congestion;
- preserve preview segments, conversation identity, and timing ownership across retryable reconnects.

### Explicit live/backlog authority

- Auto Sync is the only automatic deep-backlog authority;
- one Sync tap authorizes one bounded snapshot;
- authorized history runs in bounded slices, and newly arrived live audio preempts the next historical slice;
- charging no longer changes sync authority;
- recent gap repair remains enabled when Auto Sync is off;
- storage-authoritative audio waits on explicit STT readiness;
- socket close/error cancels the phone-side live tail while the pendant keeps recording;
- socket close/error is shown as **Reconnecting transcription**, never as a false **Listening** state;
- Transcribe Later remains an intentional local-capture exception.

The policy lives in shared Dart code, so Android and iOS cannot silently choose different live/backlog behavior.

### BLE ownership

- serialize Android GATT work and bind completions to the active connection session;
- serialize iOS notification ownership and republish readiness for an already-connected restored peripheral;
- reclaim the exact pendant after DFU;
- when iOS Background Mode is disabled, release the exact OS-restored peripheral and defer reconnect until real foreground activation;
- when Background Mode is enabled, preserve CoreBluetooth restoration as the user's explicit opt-in.

### Diagnostics and developer fixtures

- serialize debug-log initialization, rotation, append, clear, and pruning;
- redact WebSocket query values;
- source Android/iOS physical-test identity from one executable customer-plane contract;
- reject any authenticated hardware build whose generated environment is not `https://api.omi.me/`, even when Firebase auth would succeed;
- document the exact maintainer toolchain, isolated iOS bundle, and physical acceptance matrix.

## Regression coverage

The tests pin these contracts:

- Auto Sync off still recovers the recent conversation window but never starts the deep prefix;
- charging cannot authorize a deep drain;
- manual Sync owns one immutable snapshot while live capture stays prioritized;
- audio arriving during a backlog slice is fetched before any subsequent historical slice;
- a repeated Sync tap shares the in-flight request;
- cancellation revokes only the manual historical authority, not live capture;
- a snapshot survives same-device reconnect without expanding and is never adopted by another pendant;
- storage-authoritative capture does not consume device audio before STT is ready;
- abnormal live-socket close/error renders a retryable reconnect state and server readiness clears it;
- a grouped logical Sync row materializes one ordered, memoized, playable artifact;
- legacy BLE and Transcribe Later retain their intended behavior;
- iOS restoration releases without Background Mode, preserves an opted-in restoration, and does not treat `.inactive` launch state as foreground;
- Android/iOS transport handoff, DFU, session-bound GATT, sequence, assembly, dedupe, upload, and preview contracts remain covered by the existing focused suites.

## Physical Android evidence

Authenticated dev build, exact paired CV1 on `3.0.29`, Auto Sync off:

- the installed isolated dev package was regenerated and verified against `https://api.omi.me/` plus the production Firebase account universe; the canonical live socket reached `ready` in about 0.72 seconds;
- a spoken marker produced live-preview segments before disruption;
- Bluetooth off/on reconnected the exact pendant without force-stop or app restart;
- live preview resumed about 3.7 seconds after BLE reconnected and continued in the existing socket/conversation session;
- firmware `dropped` remained `0` in the completed recovery runs;
- the reconnect replay registered the overlapping first range idempotently, then recovered subsequent sequence ranges in order;
- the historical read pointer stayed fixed with about 10k packets still pending, proving Auto Sync off did not drain or advance old backlog;
- no local-file upload or historical-sync request ran during the live/reconnect test;
- hundreds of physical bounded ranges assembled into one logical conversation rather than independent one-second uploads;

The previous no-preview result was invalid hardware evidence: the dev APK targeted `api.omiapi.com`, whose WebSocket upgraded and then closed with code 1006 before its first service event. The same authenticated probe against `api.omi.me` reached `initiating` → `conversation_session` → `ready`; the corrected build then passed the physical live/reconnect path above.

Redacted evidence: `app/e2e/ANDROID_CV1_STORAGE_FIRST_RUN_2026-07-28.md`.

## Physical iOS evidence

Authenticated signed isolated dev build; the production app was not replaced:

- process-loss recovery reclaimed the exact pendant and recovered one contiguous pre/offline/post-reconnect source window;
- local and server inspection preserved the offline markers in order;
- an already-connected CoreBluetooth peripheral now republishes GATT readiness instead of leaving the UI connected but capture inert;
- two initial cross-host handoff policy variants failed and are recorded as failures;
- system logs proved `bluetoothd`/SpringBoard were restoring the physical link before Flutter foreground policy ran;
- the current candidate retrieves and cancels that exact restored peripheral when Background Mode is off.

The final four-leg iOS → restored-background-iOS → Android → foreground-iOS handoff remains unclaimed until the plugged-in iPhone is unlocked and all four legs pass.

Redacted evidence: `app/e2e/IOS_CV1_STORAGE_FIRST_RUN_2026-07-29.md`.

## Verification

- full app suite: **1,178 tests passed**;
- final rebased focused BLE/storage suite: **93 tests passed**;
- post-clarification ring scheduler suite: **51/51 tests passed**, including live arrival during an active manual drain;
- current focused capture/storage/DFU suite after the endpoint and playback fixes: **264 tests passed**;
- conversation-session and reconnect-preview contracts: **6 tests passed**;
- Android and iOS physical-auth mutation suites: passed; both reject `api.omiapi.com` and consume the same executable authority;
- analyzer ratchet: passed;
- iOS native BLE ownership suites: passed after the final rebase;
- Android authenticated `assembleDevDebug`: passed and installed in place;
- iOS authenticated profile build: passed, signed, installed in an isolated bundle, and retained auth/pairing;
- bounded pre-push gate passed with the documented shared-preflight hatch; mandatory failure-class guard, backend checks, generated-output checks, format checks, and desktop Swift debug compile all passed;
- `git diff --check`: passed;
- branch rebased onto current `BasedHardware/omi:main`;
- locked product invariants matched by path: none; proposed `INV-CAPTURE-1` is introduced and cited;
- failure-class validation: `FC-split-mutation-authority`.

The full local `make preflight` currently stops at the repository-wide `agents-md-lean` check because `web/admin/AGENTS.md` is 1,812 bytes against a 1,500-byte baseline. The file is byte-identical to current upstream `main` and is not part of this PR. All selected checks before that upstream-main blocker passed. This draft does not claim a green full preflight.

## Known limits before promotion

- final physical cross-host iOS handoff is pending the device unlock;
- Android grouped-recording playback has hermetic behavioral coverage but its final physical tap/play check is pending the phone PIN unlock;
- the active reconnect marker session was not finalized into the conversation-list API, so exact marker text identity remains unclaimed even though preview and sequence-recovery logs passed;
- `/v2/sync-local-files` still does not consume the app's canonical transcript replacement request, so recovered content can be correct while the final conversation duration/origin remains wrong;
- Remote VAD gates the live listener but does not yet gate offline sync-file uploads;
- a manual snapshot receipt is process-memory-only; process death loses authorization, not audio, and requires another Sync tap;
- full-day battery/thermal qualification and the bounded manual large-backlog interruption run remain pending.

Depends on firmware draft #10654.

## Product invariants affected

`INV-CAPTURE-1` (proposed): establishes the single durable conversation timeline, live-priority scheduling, explicit historical-sync authority, truthful live state, and cross-platform policy boundary. No locked invariant path is matched by this diff.

## Failure class

Failure-Class: FC-split-mutation-authority

---

## 2026-08-05 Fast Sync qualification update

Commit `34750cf763` closes the remaining app-side fixed-snapshot drain failures
found during the physical iPhone run.

### Behavior now pinned

- One explicit **Fast Sync** tap latches one immutable ring write-sequence
  target. Audio recorded afterward stays outside that target, so the drain can
  finish even while the pendant continues recording.
- Fast Sync exclusively owns BLE while that snapshot drains. Live preview is
  intentionally paused, then resumes immediately after completion,
  cancellation, or a recoverable transfer failure.
- Every bounded range is durably accepted on the phone before `ADVANCE`.
  Ambiguous recovered ranges remain durable and unowned instead of aborting
  the acknowledgement transaction.
- Same-device reconnect adopts the in-flight target; another pendant cannot.
- Local recovery orders sequence-addressed ranges by immutable ring sequence
  before wall-clock time, preventing RTC discontinuities from manufacturing
  long transcript gaps.
- The Sync page now shows determinate progress against the immutable target.
  Device used/free bytes remain an honest cached status sample rather than a
  synthetic transfer counter, because newer audio may continue entering the
  ring during the drain.

### Physical iOS result

Fixture: isolated authenticated dev bundle, exact pendant
`425529A3-6F68-F264-C0CA-DAC438DA1240`, internal firmware `3.0.30` build 110,
with `OMI_BLACKBOX_HARNESS=true` asserted at runtime.

- Cold launch reached automatic live preview without opening the listening
  card.
- The clean fixed-snapshot pass stayed in the download phase at +2, +18, and
  +60 seconds while the target drained.
- Device storage fell from 119 MB / 25% to 110 MB / 23%. The tester correctly
  identified that the byte card was stale until navigation; the new
  determinate target-progress UI addresses that observability defect without
  falsifying the cached byte sample.
- Cancellation returned the app to idle in under two seconds.
- Returning home showed **Listening** immediately, and a long spoken marker
  appeared automatically without tapping the card.
- A follow-up signed build preserved auth and pairing. Its already-covered
  target advanced to cloud upload in under nine seconds, so the intermediate
  percentage is regression-test pinned rather than claimed as a long physical
  observation.

Permanent redacted evidence, screenshots, hashes, and excluded invalid runs
are in:
`~/Omi-CV1-Reliability-Work/evidence/fast-sync-ios-2026-08-05/REPORT.md`.

### Verification

- `app/test.sh`: **1,260 tests passed**.
- `app/scripts/analyze_ratchet.sh`: passed.
- `git diff --check`: passed.
- Failure-class validation: passed; the PR declaration remains
  `FC-split-mutation-authority`.
- Repository-wide local preflight passed all selected lanes through
  `product-file-line-count-ratchet`, then stopped at the existing
  `agents-md-lean` debt: `backend/AGENTS.md` is 39,089 bytes against a
  39,000-byte budget. That file is outside this app commit. This update does
  not claim a green full preflight.
- The bounded pre-push rerun passed the mandatory failure-class ratchet,
  backend type/unit checks, runtime-image closure, OpenAPI compatibility,
  generated Flutter output, and desktop-flow metadata. Its unrelated desktop
  Swift lane then hit a local SwiftPM cache miss for FluidAudio commit
  `19600a485baa4998812e4654b70d2bab8f2c9949`; the documented app-only hatch was
  used rather than changing desktop dependency state in this PR.

### Promotion boundary

This remains a team-test draft. Voice gating is intentionally out of scope.
Public promotion still needs matched Android qualification, post-drain
duplicate/order/conversation-binding inspection, process-death ownership
coverage, and battery/thermal measurements.

### Standalone iOS dogfood handoff correction


The v5 physical session was valid while Flutter tooling was attached, but the
phone was incorrectly handed back with that debug/JIT artifact still
installed. It crashed after approximately 23 minutes and two SpringBoard
relaunches then failed in native notification-plugin registration before Dart
started. This was a build-mode/handoff failure, not a Fast Sync protocol
failure.

The branch now contains a reproducible physical-config bootstrap, signed iOS
profile builder, and guarded in-place dogfood installer. The installer refuses
Flutter artifacts containing `kernel_blob.bin`, verifies the exact Firebase,
bundle, signature, and application identifiers, preserves the app data
container, and proves a cold launch. The former v5 debug artifact was
physically rejected by the guard; signed v6 profile/AOT was installed over the
same bundle and remained running after cold launch, with no new Runner crash
report. The final unattended handoff rule and crash signature are documented
in `app/e2e/BLE_RELIABILITY_ACCEPTANCE.md` and the permanent evidence report.

The handoff boundary is now registered in `.github/checks-manifest.yaml` for
both Linux and macOS. Its hermetic core/error-path test accepts a signed AOT
fixture and rejects a JIT `kernel_blob.bin` fixture before any device command
can run. The same guard physically rejected the former v5 debug artifact and
accepted the signed v6 profile artifact. Personal team, signing, provisioning,
and device identities remain only in
`~/.config/omi-mobile-test/ios-physical-test.env`, never in the public branch.



---

## 2026-08-05 post-drain playback and upload correction

The completed physical Fast Sync drained the pendant from roughly 20% used to
1% used and transferred the fixed snapshot to the iPhone. Inspection then
separated failures that initially looked like corrupt recovered audio:

1. The recovered archive is valid mono PCM at 16 kHz. Offline transcription of
   the exact cached WAV recovered spoken test markers, so the pendant capture,
   BLE transfer, and logical materialization did not produce an empty file.
2. iOS playback started without first activating the shared speech audio
   session, which could yield a moving waveform with inaudible output after
   route changes. Playback now configures and activates the session before the
   player advances and releases only the session it owns.
3. One immutable logical upload was 66,663,240 bytes and received HTTP 413.
   That deterministic rejection blocked every later healthy recording behind
   it. HTTP 413 is now typed at the API boundary; automatic sync retains the
   rejected source and marks it exhausted while continuing with later jobs.
   Explicit row retry remains available.
4. Some recovered rows carried an RTC-derived capture end earlier than the
   duration proved by their encoded frames. Recovery now preserves immutable
   pendant sequence while publishing a canonical end no earlier than playable
   audio duration. This fixes misleading sparse 30–60 minute rows without
   splitting a sequence-contiguous archive at a wall-clock correction.

An app-only split of the 66.7 MB logical recording into independent cloud jobs
would violate conversation ownership and can create duplicate summaries. Full
cloud acceptance of recordings above the current request limit needs a
separate backend resumable/chunked-upload contract with one idempotent logical
recording identity. Until then the rejected source remains recoverable on the
phone and no longer stalls the queue.

### Regression coverage and evidence

- focused recovered-playback, WAL recovery, assembler, sync-provider, and
  upload-resilience suites: **139 tests passed**;
- full Flutter app suite after these corrections: **1,266 tests passed**;
- analyzer ratchet and `git diff --check`: passed;
- signed profile/AOT v7 build: codesign verified, guarded in-place install,
  auth/pairing preserved, and cold launch passed;
- bounded pre-push: mandatory failure-class ratchet, backend type/unit checks,
  runtime-image closure, OpenAPI compatibility, Flutter generated output,
  desktop-flow metadata, and formatting passed;
- repository `make preflight` cannot run its manifest contract under the host's
  system Python 3.9 because current repository syntax requires Python 3.10+;
- the unrelated desktop Swift compile remains locally uncertified because the
  SwiftPM cache lacks FluidAudio commit
  `19600a485baa4998812e4654b70d2bab8f2c9949`; the documented app-only hatch was
  used after every in-scope lane passed.

Physical audible playback from the newly installed profile build is the one
remaining user-observed assertion. The exact source audio's integrity is
already proven locally; this draft does not claim the iPhone speaker-route
result until that tap/play check is confirmed.
