### PR TITLE
fix(backend): carry a partial PCM frame across VAD gate chunks

### DIFF
--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -2152,3 +2152,62 @@ class TestGatedSTTSocketPassthroughMode:
 
         mock_conn.send.assert_called_once_with(audio)
         mock_conn.finalize.assert_called_once()
+
+
+class TestMisalignedChunks:
+    """A chunk that ends mid-frame must not disable the gate (prod: 11 sessions/24h)."""
+
+    def _make_gate(self, channels=1):
+        return VADStreamingGate(
+            sample_rate=16000,
+            channels=channels,
+            mode='active',
+            uid='test',
+            session_id='test',
+        )
+
+    def test_odd_length_chunk_keeps_gate_active(self):
+        """np.frombuffer used to raise on a partial sample, failing the session open."""
+        mock_conn = MagicMock()
+        mock_conn.is_connection_dead = False
+        gate = self._make_gate()
+        gated = GatedDeepgramSocket(mock_conn, gate=gate)
+
+        gated.send(_make_pcm(30) + b'\x00', wall_time=1.0)
+
+        assert gated.is_gated
+        assert gate.mode == 'active'
+
+    def test_split_frame_keeps_sample_alignment(self):
+        """A frame split across two chunks must reach VAD as the same samples."""
+        pcm = struct.pack('<1600h', *[(i % 2000) - 1000 for i in range(1600)])
+        windows_whole: list[np.ndarray] = []
+        windows_split: list[np.ndarray] = []
+
+        def _record(into):
+            def _run(window, state, context):
+                into.append(np.array(window))
+                return 0.1, state, context
+
+            return _run
+
+        with patch('utils.stt.vad_gate.run_vad_window', side_effect=_record(windows_whole)):
+            self._make_gate().process_audio(pcm, 1.0)
+        with patch('utils.stt.vad_gate.run_vad_window', side_effect=_record(windows_split)):
+            gate = self._make_gate()
+            gate.process_audio(pcm[:513], 1.0)
+            gate.process_audio(pcm[513:], 1.03)
+
+        assert len(windows_split) == len(windows_whole) > 0
+        for split, whole in zip(windows_split, windows_whole):
+            assert np.array_equal(split, whole)
+
+    def test_stereo_partial_frame_is_carried(self):
+        """Stereo frames are 4 bytes; a 2-byte tail must not reach audioop.tomono."""
+        gate = self._make_gate(channels=2)
+        pcm = _make_pcm(30, channels=2)
+
+        gate.process_audio(pcm[:-2], 1.0)
+        out = gate.process_audio(pcm[-2:], 1.03)
+
+        assert out is not None

--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -1295,8 +1295,21 @@ class TestOnnxStateAndConcurrency:
                 assert errors[i] is None, f'Caller {i} got error: {errors[i]}'
                 assert results[i] is not None, f'Caller {i} got no result (deadlock?)'
 
+            # Calibrate the bound on this machine: under heavy CPU contention even bare
+            # sleeping threads take multiples of sleep_sec, so a fixed bound reports
+            # serialization that the gate did not cause.
+            baseline_threads = [threading.Thread(target=time.sleep, args=(sleep_sec,)) for _ in range(num_callers)]
+            baseline_start = time.perf_counter()
+            for t in baseline_threads:
+                t.start()
+            for t in baseline_threads:
+                t.join(timeout=10)
+            baseline = time.perf_counter() - baseline_start
+
             # ONNX is truly concurrent (no pool), so all should complete in ~1x sleep time
-            assert elapsed < sleep_sec * 3, f'Took {elapsed:.3f}s — unexpected serialization'
+            assert elapsed < max(
+                sleep_sec * 3, baseline * 1.5
+            ), f'Took {elapsed:.3f}s against a {baseline:.3f}s bare-thread baseline — unexpected serialization'
 
 
 @pytest.mark.slow

--- a/backend/utils/stt/vad_gate.py
+++ b/backend/utils/stt/vad_gate.py
@@ -174,6 +174,7 @@ class VADStreamingGate:
         _get_ort_session()
         self._vad_window_samples = VAD_WINDOW_SAMPLES  # 512 for 16kHz (Silero v6)
         self._vad_buffer = np.array([], dtype=np.float32)  # Buffer for cross-chunk accumulation
+        self._pcm_remainder = b''  # Trailing bytes of a frame split across chunks
         self._vad_state: np.ndarray[Any, Any]
         self._vad_context: np.ndarray[Any, Any]
         self._vad_state, self._vad_context = make_fresh_state()  # Per-connection ONNX recurrent state + context
@@ -230,6 +231,7 @@ class VADStreamingGate:
             # Reset VAD recurrent state and buffer for clean active-mode start
             self._vad_state, self._vad_context = make_fresh_state()
             self._vad_buffer = np.array([], dtype=np.float32)
+            self._pcm_remainder = b''
             # Sync mapper cursor: DG received all audio during shadow phase
             self.dg_wall_mapper._provider_cursor_sec = self._audio_cursor_ms / 1000.0  # type: ignore[reportPrivateUsage]  # sync internal mapper cursor
             logger.info(
@@ -250,8 +252,21 @@ class VADStreamingGate:
 
     def _convert_for_vad(self, pcm_data: bytes) -> np.ndarray[Any, Any]:
         """Convert audio to float32 at 16kHz mono for VAD."""
+        # A client may split PCM16 anywhere, so a chunk can end mid-frame. Carry
+        # those bytes into the next chunk: np.frombuffer rejects a partial sample,
+        # and dropping it would shift every later sample by one byte.
+        data = self._pcm_remainder + pcm_data if self._pcm_remainder else pcm_data
+        frame_bytes = self._sample_width * self.channels
+        leftover = len(data) % frame_bytes
+        if leftover:
+            self._pcm_remainder = data[len(data) - leftover :]
+            data = data[: len(data) - leftover]
+        else:
+            self._pcm_remainder = b''
+        if not data:
+            return np.array([], dtype=np.float32)
+
         # Convert to mono if stereo
-        data = pcm_data
         if self.channels == 2:
             data = audioop.tomono(data, self._sample_width, 0.5, 0.5)
 


### PR DESCRIPTION
## Bug

A client can split PCM16 anywhere on the wire, so an audio chunk reaching the VAD gate can end mid-frame. `VADStreamingGate._convert_for_vad` passed those bytes straight to `np.frombuffer(data, dtype=np.int16)`, which raises `ValueError: buffer size must be a multiple of element size`.

`GatedSTTSocket.send`'s fail-open handler catches it and disables the gate **for the rest of the session** (`self._gate = None`, `gate.mode = 'off'`). One odd-length chunk therefore costs a whole live session its silence gating: every byte is forwarded to the STT provider (billed), and timestamp remapping is off.

Live in prod — 11 sessions in the 24h to 2026-07-26T17:00Z, e.g.

```
ERROR:vad_gate:VAD gate process error, falling back to direct send uid=…
  File "/app/utils/stt/vad_gate.py", line 601, in send
  File "/app/utils/stt/vad_gate.py", line 257, in _convert_for_vad
    data_int16 = np.frombuffer(data, dtype=np.int16)
ValueError: buffer size must be a multiple of element size
```

The code already knows misaligned frames arrive — `GatedSTTSocket._counted` counts them into `OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL` — the VAD path just could not survive one.

## Fix

Keep the trailing partial frame in `self._pcm_remainder` and prepend it to the next chunk (cleared on `activate()`'s shadow→active reset). Truncating the odd byte instead would shift every later sample by one byte and feed VAD garbage; carrying it preserves the stream. Frame size is `sample_width * channels`, so stereo is covered too — a 2-byte tail no longer reaches `audioop.tomono`, which rejects a partial frame the same way. Forwarded audio is untouched.

## Verification

- `backend/tests/unit/test_vad_gate.py::TestMisalignedChunks` — 3 new regression tests (odd chunk keeps the gate active; a frame split across chunks reaches VAD as the same samples; stereo partial frame is carried). All 3 fail on `main` with the exact prod `ValueError`.
- Full file: 119 passed.
- Second commit (`test(backend): calibrate the VAD concurrency bound to the machine`) fixes a flake I hit here: `TestOnnxStateAndConcurrency::test_concurrent_sessions_no_deadlock` asserted four 50 ms mocked inferences finish inside a fixed 150 ms, but on a loaded machine four *bare sleeping threads* already take ~190 ms with no gate involved — it fails identically on an unmodified tree. The test now measures that bare-thread cost and takes the larger bound, so it still catches real serialization on an idle machine.
- Real-path exercise: the 4.9s 16 kHz speech probe (`backend/testing/release_fixtures/transcription-release-probe.wav`) through the **real** ONNX Silero VAD and a real `GatedSTTSocket`, fed in odd-boundary chunks (641/639/321/319 bytes):
  - before: the gate died on the very first chunk — `mode='off'`, 156960 bytes forwarded, 0 speech chunks;
  - after: identical to the frame-aligned feed — 155040 bytes forwarded, 135 speech chunks, gate still active.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

