### PR TITLE
fix(desktop): keep chat and PTT turns responsive

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2216,
+    "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2215,
     "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4369
   },
   "raise_justifications": {

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -4,7 +4,6 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2638,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4829,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift": 1515,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1639
   },
@@ -13,9 +12,8 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "The Second Brain onboarding, reach-error, and notch-moment UI keeps the hover menu agent-only and routes idle notch taps through main chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Second Brain continuous-chat routing shares window geometry with agent-only hover sizing and canonical idle-notch chat ownership.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "DEBUG owner-boundary tests need a capture-free effect-handler install seam; shared ensureAutomationBarConfigured() removes duplicated automation setup while adding that seam (BasedHardware/omi#10499).",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift": "Pairs each provider close with its bounded active-turn outcome and immediate recovery decision for release-health analysis; the input-window open is now forwarded so a warm-idle background-agent completion is retried beside that close handling; telemetry and delivery only, no lifecycle change (#10425).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds bounded realtime mint-failure outcome correlation and close-resolution telemetry so release health distinguishes started recovery from exhaustion; telemetry-only, no lifecycle change (#10425).",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers; sendBackgroundAgentContext now confirms the provider send before returning true (exactly-once: no ack before delivery) and the session emits hubDidOpenInputWindow so a warm-idle completion is retried — both must live beside the file-private send/turn machinery."
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers; sendBackgroundAgentContext now confirms the provider send before returning true (exactly-once: no ack before delivery) and the session emits hubDidOpenInputWindow so a warm-idle completion is retried \u2014 both must live beside the file-private send/turn machinery."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Backend-Rust/src/routes/chat/route.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/route.rs
@@ -1,7 +1,7 @@
 use axum::{
     body::Body,
     extract::{DefaultBodyLimit, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode},
     response::Response,
     routing::post,
     Json, Router,
@@ -116,7 +116,7 @@ fn attach_request_id(response: &mut Response, request_id: &str) {
 fn attach_chat_contract_version(response: &mut Response) {
     response.headers_mut().insert(
         OMI_CHAT_CONTRACT_HEADER,
-        OMI_CHAT_CONTRACT_VERSION.parse().unwrap(),
+        HeaderValue::from_static(OMI_CHAT_CONTRACT_VERSION),
     );
 }
 

--- a/desktop/macos/Backend-Rust/src/routes/chat/route.rs
+++ b/desktop/macos/Backend-Rust/src/routes/chat/route.rs
@@ -64,6 +64,8 @@ const CHAT_COMPLETIONS_MAX_BODY_SIZE: usize = 16 * 1024 * 1024;
 
 const OMI_REQUEST_ID_HEADER: &str = "x-omi-request-id";
 const RESPONSE_REQUEST_ID_HEADER: &str = "x-request-id";
+const OMI_CHAT_CONTRACT_HEADER: &str = "x-omi-chat-contract-version";
+const OMI_CHAT_CONTRACT_VERSION: &str = "1";
 /// Per-turn effort directive from the desktop app (relayed by the pi-mono
 /// extension). Header wins over the OpenAI-compatible body field.
 const OMI_REASONING_EFFORT_HEADER: &str = "x-omi-reasoning-effort";
@@ -96,12 +98,26 @@ fn inbound_request_id(headers: &HeaderMap) -> String {
         .unwrap_or_else(|| ulid::Ulid::new().to_string())
 }
 
+fn supports_chat_contract(headers: &HeaderMap) -> bool {
+    headers
+        .get(OMI_CHAT_CONTRACT_HEADER)
+        .map(|value| value.as_bytes() == OMI_CHAT_CONTRACT_VERSION.as_bytes())
+        .unwrap_or(true)
+}
+
 fn attach_request_id(response: &mut Response, request_id: &str) {
     if let Ok(value) = request_id.parse() {
         response
             .headers_mut()
             .insert(RESPONSE_REQUEST_ID_HEADER, value);
     }
+}
+
+fn attach_chat_contract_version(response: &mut Response) {
+    response.headers_mut().insert(
+        OMI_CHAT_CONTRACT_HEADER,
+        OMI_CHAT_CONTRACT_VERSION.parse().unwrap(),
+    );
 }
 
 async fn chat_completions(
@@ -121,6 +137,7 @@ async fn chat_completions(
     let response = chat_completions_inner(state, user, headers, req).await;
     response.map(|mut response| {
         attach_request_id(&mut response, &request_id);
+        attach_chat_contract_version(&mut response);
         response
     })
 }
@@ -133,6 +150,15 @@ async fn chat_completions_inner(
 ) -> Result<Response, StatusCode> {
     let byok_stripped = user.byok_stripped;
     let user: AuthUser = user.into();
+
+    if !supports_chat_contract(&headers) {
+        tracing::warn!(
+            event = "chat_contract_version_unsupported",
+            version = ?headers.get(OMI_CHAT_CONTRACT_HEADER),
+            "chat completion rejected"
+        );
+        return Err(StatusCode::UPGRADE_REQUIRED);
+    }
 
     if llm_stub_enabled() {
         return Ok(stub_chat_completions_response(&req));
@@ -262,7 +288,9 @@ mod tests {
         response::Response,
     };
 
-    use super::{attach_request_id, inbound_request_id};
+    use super::{
+        attach_chat_contract_version, attach_request_id, inbound_request_id, supports_chat_contract,
+    };
 
     #[test]
     fn preserves_a_valid_opaque_request_id() {
@@ -292,5 +320,26 @@ mod tests {
         attach_request_id(&mut response, "req_01AB-cd");
 
         assert_eq!(response.headers()["x-request-id"], "req_01AB-cd");
+    }
+
+    #[test]
+    fn accepts_legacy_and_current_chat_contracts_but_rejects_unknown_versions() {
+        let mut headers = HeaderMap::new();
+        assert!(supports_chat_contract(&headers));
+
+        headers.insert("x-omi-chat-contract-version", HeaderValue::from_static("1"));
+        assert!(supports_chat_contract(&headers));
+
+        headers.insert("x-omi-chat-contract-version", HeaderValue::from_static("2"));
+        assert!(!supports_chat_contract(&headers));
+    }
+
+    #[test]
+    fn advertises_the_supported_chat_contract_on_responses() {
+        let mut response = Response::new(Body::empty());
+
+        attach_chat_contract_version(&mut response);
+
+        assert_eq!(response.headers()["x-omi-chat-contract-version"], "1");
     }
 }

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -1,24 +1,4 @@
-import CryptoKit
 import Foundation
-
-enum AgentContextRevision {
-  static func make(
-    source: AgentContextSource,
-    payload: [String: Any],
-    outcome: AgentContextSourceOutcome
-  ) throws -> String {
-    let material: [String: Any] = [
-      "source": source.rawValue,
-      "outcome": outcome.rawValue,
-      "payload": payload,
-    ]
-    guard JSONSerialization.isValidJSONObject(material) else {
-      throw BridgeError.agentError("Context source payload is not valid JSON")
-    }
-    let data = try JSONSerialization.data(withJSONObject: material, options: [.sortedKeys])
-    return "sha256:" + SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-  }
-}
 
 struct AgentExecutionProfile: Equatable, Sendable {
   enum CredentialScope: String, Sendable {

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -1431,6 +1431,25 @@ actor AgentBridge {
     )
   }
 
+  func repairJournalTurns(
+    surface: AgentSurfaceReference,
+    ownerID: String,
+    turnIDs: [String],
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async throws -> [KernelJournalTurn] {
+    let authorization = try resolveAuthorization(
+      authorizationSnapshot,
+      expectedOwnerID: ownerID)
+    try await start(authorizationSnapshot: authorization)
+    return try await runtime.repairJournalTurns(
+      clientId: clientId,
+      surface: surface,
+      ownerID: ownerID,
+      turnIDs: turnIDs,
+      authorizationSnapshot: authorization
+    )
+  }
+
   func listJournalTurns(
     surface: AgentSurfaceReference,
     ownerID: String? = nil,

--- a/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
@@ -259,6 +259,18 @@ enum AgentClient {
       )
     }
 
+    func repairJournalTurns(
+      surface: AgentSurfaceReference,
+      ownerID: String,
+      turnIDs: [String]
+    ) async throws -> [KernelJournalTurn] {
+      try await bridge.repairJournalTurns(
+        surface: surface,
+        ownerID: ownerID,
+        turnIDs: turnIDs
+      )
+    }
+
     func listJournalTurns(
       surface: AgentSurfaceReference,
       ownerID: String? = nil,

--- a/desktop/macos/Desktop/Sources/Chat/AgentContextRevision.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentContextRevision.swift
@@ -1,0 +1,21 @@
+import CryptoKit
+import Foundation
+
+enum AgentContextRevision {
+  static func make(
+    source: AgentContextSource,
+    payload: [String: Any],
+    outcome: AgentContextSourceOutcome
+  ) throws -> String {
+    let material: [String: Any] = [
+      "source": source.rawValue,
+      "outcome": outcome.rawValue,
+      "payload": payload,
+    ]
+    guard JSONSerialization.isValidJSONObject(material) else {
+      throw BridgeError.agentError("Context source payload is not valid JSON")
+    }
+    let data = try JSONSerialization.data(withJSONObject: material, options: [.sortedKeys])
+    return "sha256:" + SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeJournalContracts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeJournalContracts.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Sendable carrier for `[String: Any]` JSON payloads that must cross actor or
+/// isolation boundaries. The dictionary is parsed once and treated as immutable
+/// thereafter, so unchecked Sendable conformance is safe.
+struct RuntimeJSONPayloadBox: @unchecked Sendable {
+  let value: [String: Any]
+  init(_ value: [String: Any]) { self.value = value }
+}
+
+/// Journal writes use SQLite `BEGIN IMMEDIATE`, whose configured busy window is
+/// five seconds. Keep the client deadline strictly beyond that database window
+/// so a successful commit still has time to traverse the JSONL IPC boundary.
+struct AgentRuntimeJournalTimeoutPolicy {
+  static let sqliteBusyWindowNanoseconds: UInt64 = 5_000_000_000
+  static let ipcSlackNanoseconds: UInt64 = 5_000_000_000
+  static let deadlineNanoseconds = sqliteBusyWindowNanoseconds + ipcSlackNanoseconds
+
+  static func allowsCorrelatedResult(elapsedNanoseconds: UInt64) -> Bool {
+    elapsedNanoseconds < deadlineNanoseconds
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1,13 +1,6 @@
 import Foundation
 import OmiSupport
 
-/// Sendable carrier for `[String: Any]` JSON payloads that must cross actor or
-/// isolation boundaries. The dictionary is parsed once and treated as immutable
-/// thereafter, so unchecked Sendable conformance is safe.
-struct RuntimeJSONPayloadBox: @unchecked Sendable {
-  let value: [String: Any]
-  init(_ value: [String: Any]) { self.value = value }
-}
 extension Notification.Name {
   /// Posted on MainActor after the runtime handshake makes direct control
   /// tools admissible. Carries no owner id or request content.
@@ -99,19 +92,6 @@ final class AgentRuntimeStdoutChunkReader: @unchecked Sendable {
       nextSequence &+= 1
     }
     return (sequence, data)
-  }
-}
-
-/// Journal writes use SQLite `BEGIN IMMEDIATE`, whose configured busy window is
-/// five seconds. Keep the client deadline strictly beyond that database window
-/// so a successful commit still has time to traverse the JSONL IPC boundary.
-struct AgentRuntimeJournalTimeoutPolicy {
-  static let sqliteBusyWindowNanoseconds: UInt64 = 5_000_000_000
-  static let ipcSlackNanoseconds: UInt64 = 5_000_000_000
-  static let deadlineNanoseconds = sqliteBusyWindowNanoseconds + ipcSlackNanoseconds
-
-  static func allowsCorrelatedResult(elapsedNanoseconds: UInt64) -> Bool {
-    elapsedNanoseconds < deadlineNanoseconds
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1875,6 +1875,26 @@ actor AgentRuntimeProcess {
     return turn
   }
 
+  func repairJournalTurns(
+    clientId: String,
+    surface: AgentSurfaceReference,
+    ownerID: String,
+    turnIDs: [String],
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async throws -> [KernelJournalTurn] {
+    let result = try await journalOperation(
+      type: "journal_repair_turns",
+      operation: "repair",
+      clientId: clientId,
+      surface: surface,
+      ownerID: ownerID,
+      payload: ["turnIds": Array(Set(turnIDs)).sorted()],
+      authorizationSnapshot: authorizationSnapshot
+    )
+    result.turns.forEach(recordLifecycleJournalMutation)
+    return result.turns
+  }
+
   func listJournalTurns(
     clientId: String,
     surface: AgentSurfaceReference,

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -547,6 +547,32 @@ final class KernelTurnProjection {
     }
   }
 
+  @discardableResult
+  func repairNonterminalTurns(
+    surface: AgentSurfaceReference,
+    turnIDs: [String],
+    ownerID: String
+  ) async -> Int {
+    guard !turnIDs.isEmpty,
+      let lease = captureOwnerLease(ownerID: ownerID),
+      let host
+    else { return 0 }
+    guard await host.ensureBridgeStartedForKernel(), isCurrent(lease), let client else { return 0 }
+    do {
+      let repaired = try await client.repairJournalTurns(
+        surface: surface,
+        ownerID: lease.ownerID,
+        turnIDs: turnIDs
+      )
+      guard isCurrent(lease) else { return 0 }
+      _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
+      return isCurrent(lease) ? repaired.count : 0
+    } catch {
+      log("KernelTurnProjection: journal repair failed (code=journal_repair_failed)")
+      return 0
+    }
+  }
+
   /// The query result is the authoritative final material. The streaming row is
   /// an optimistic projection and can lag its terminal callback; use it only
   /// when the final result intentionally contains no text.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+EventAdmission.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+EventAdmission.swift
@@ -1,0 +1,47 @@
+import Foundation
+import VoiceTurnDomain
+
+extension RealtimeHubController {
+  func acceptsTurnEvent(
+    _ identity: RealtimeHubEventIdentity?,
+    source: RealtimeHubSession
+  ) -> Bool {
+    guard isCurrentSession(source), let identity else { return false }
+    guard VoiceTurnCoordinator.shared.requireCurrentOwner(for: identity.turnID) != nil else {
+      log("RealtimeHub: dropping provider event after authenticated owner changed")
+      return false
+    }
+    switch RealtimeHubEventOwnership.admission(
+      identity,
+      activeTurnID: VoiceTurnCoordinator.shared.activeTurnID,
+      activeResponseID: voiceResponseID
+    ) {
+    case .accept:
+      return true
+    case .dropStaleTurn:
+      log(
+        "RealtimeHub: dropping stale provider event turn=\(identity.turnID) "
+          + "response=\(identity.responseID)")
+      return false
+    case .rejectCurrentTurnResponse:
+      // A live session speaking for the current logical turn with the wrong
+      // response identity is a broken handoff, not an old-turn callback. Fail
+      // immediately so PTT never waits for the provider-no-response deadline.
+      log(
+        "RealtimeHub: rejecting current-turn provider response identity turn=\(identity.turnID) "
+          + "response=\(identity.responseID)")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "realtime_hub",
+        from: sessionProvider?.rawValue ?? "unbound",
+        to: "none",
+        reason: "response_identity_mismatch",
+        outcome: .exhausted,
+        extra: ["user_visible": true])
+      source.cancelActiveResponse()
+      VoiceTurnCoordinator.shared.publish(
+        .finish(turnID: identity.turnID, reason: .providerFailed))
+      exitVoiceUI(clearResponseGlow: true)
+      return false
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -41,18 +41,38 @@ extension RealtimeHubController {
       log("RealtimeHub: dropping provider event after authenticated owner changed")
       return false
     }
-    guard identity.turnID == VoiceTurnCoordinator.shared.activeTurnID,
-      RealtimeHubEventOwnership.accepts(
-        identity,
-        activeTurnID: VoiceTurnCoordinator.shared.activeTurnID,
-        activeResponseID: voiceResponseID)
-    else {
+    switch RealtimeHubEventOwnership.admission(
+      identity,
+      activeTurnID: VoiceTurnCoordinator.shared.activeTurnID,
+      activeResponseID: voiceResponseID
+    ) {
+    case .accept:
+      return true
+    case .dropStaleTurn:
       log(
         "RealtimeHub: dropping stale provider event turn=\(identity.turnID) "
           + "response=\(identity.responseID)")
       return false
+    case .rejectCurrentTurnResponse:
+      // A live session speaking for the current logical turn with the wrong
+      // response identity is a broken handoff, not an old-turn callback. Fail
+      // immediately so PTT never waits for the provider-no-response deadline.
+      log(
+        "RealtimeHub: rejecting current-turn provider response identity turn=\(identity.turnID) "
+          + "response=\(identity.responseID)")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "realtime_hub",
+        from: sessionProvider?.rawValue ?? "unbound",
+        to: "none",
+        reason: "response_identity_mismatch",
+        outcome: .exhausted,
+        extra: ["user_visible": true])
+      source.cancelActiveResponse()
+      VoiceTurnCoordinator.shared.publish(
+        .finish(turnID: identity.turnID, reason: .providerFailed))
+      exitVoiceUI(clearResponseGlow: true)
+      return false
     }
-    return true
   }
 
   func sendToolResultIfCurrent(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -32,49 +32,6 @@ extension RealtimeHubController {
     return true
   }
 
-  func acceptsTurnEvent(
-    _ identity: RealtimeHubEventIdentity?,
-    source: RealtimeHubSession
-  ) -> Bool {
-    guard isCurrentSession(source), let identity else { return false }
-    guard VoiceTurnCoordinator.shared.requireCurrentOwner(for: identity.turnID) != nil else {
-      log("RealtimeHub: dropping provider event after authenticated owner changed")
-      return false
-    }
-    switch RealtimeHubEventOwnership.admission(
-      identity,
-      activeTurnID: VoiceTurnCoordinator.shared.activeTurnID,
-      activeResponseID: voiceResponseID
-    ) {
-    case .accept:
-      return true
-    case .dropStaleTurn:
-      log(
-        "RealtimeHub: dropping stale provider event turn=\(identity.turnID) "
-          + "response=\(identity.responseID)")
-      return false
-    case .rejectCurrentTurnResponse:
-      // A live session speaking for the current logical turn with the wrong
-      // response identity is a broken handoff, not an old-turn callback. Fail
-      // immediately so PTT never waits for the provider-no-response deadline.
-      log(
-        "RealtimeHub: rejecting current-turn provider response identity turn=\(identity.turnID) "
-          + "response=\(identity.responseID)")
-      DesktopDiagnosticsManager.shared.recordFallback(
-        area: "realtime_hub",
-        from: sessionProvider?.rawValue ?? "unbound",
-        to: "none",
-        reason: "response_identity_mismatch",
-        outcome: .exhausted,
-        extra: ["user_visible": true])
-      source.cancelActiveResponse()
-      VoiceTurnCoordinator.shared.publish(
-        .finish(turnID: identity.turnID, reason: .providerFailed))
-      exitVoiceUI(clearResponseGlow: true)
-      return false
-    }
-  }
-
   func sendToolResultIfCurrent(
     source: RealtimeHubSession,
     callId: String,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -975,7 +975,9 @@ extension RealtimeHubController {
     // identity fence that guarded the original PTT turn.
     voiceResponseID = RealtimeHubReconnectIdentityPolicy.responseIDAfterSessionDetach(
       preservingReconnectAudio: preservingReconnectAudio,
-      pendingReconnect: reconnectAudioBuffer)
+      pendingReconnect: reconnectAudioBuffer,
+      preservingBargeInReplacement: preservingBargeInReplacement,
+      pendingBargeInReplacement: replacementAudioBuffer)
     sessionProvider = nil
     sessionAuth = nil
     sessionOwnerBinding = nil

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -832,10 +832,24 @@ struct RealtimeHubToolFailure: Equatable {
 enum RealtimeHubReconnectIdentityPolicy {
   static func responseIDAfterSessionDetach(
     preservingReconnectAudio: Bool,
-    pendingReconnect: RealtimeReconnectAudioBuffer?
+    pendingReconnect: RealtimeReconnectAudioBuffer?,
+    preservingBargeInReplacement: Bool,
+    pendingBargeInReplacement: RealtimeReplacementAudioBuffer?
   ) -> VoiceResponseID? {
-    guard preservingReconnectAudio, let pendingReconnect else { return nil }
-    return pendingReconnect.responseID
+    let reconnectResponseID =
+      preservingReconnectAudio ? pendingReconnect?.responseID : nil
+    let replacementResponseID =
+      preservingBargeInReplacement ? pendingBargeInReplacement?.responseID : nil
+    switch (reconnectResponseID, replacementResponseID) {
+    case (.some(let reconnect), .some(let replacement)):
+      // These buffers should never coexist. If they ever do, only an exact
+      // shared identity is safe to retain across the physical handoff.
+      return reconnect == replacement ? reconnect : nil
+    case (.some(let responseID), .none), (.none, .some(let responseID)):
+      return responseID
+    case (.none, .none):
+      return nil
+    }
   }
 
   /// Production boundary that admits/fences provider session callbacks before
@@ -861,13 +875,36 @@ enum RealtimeHubReconnectIdentityPolicy {
 }
 
 enum RealtimeHubEventOwnership {
+  enum Admission: Equatable {
+    case accept
+    case dropStaleTurn
+    case rejectCurrentTurnResponse
+  }
+
+  static func admission(
+    _ identity: RealtimeHubEventIdentity?,
+    activeTurnID: VoiceTurnID?,
+    activeResponseID: VoiceResponseID?
+  ) -> Admission {
+    guard let identity, identity.turnID == activeTurnID else {
+      return .dropStaleTurn
+    }
+    guard identity.responseID == activeResponseID else {
+      return .rejectCurrentTurnResponse
+    }
+    return .accept
+  }
+
   static func accepts(
     _ identity: RealtimeHubEventIdentity?,
     activeTurnID: VoiceTurnID?,
     activeResponseID: VoiceResponseID?
   ) -> Bool {
-    guard let identity else { return false }
-    return identity.turnID == activeTurnID && identity.responseID == activeResponseID
+    admission(
+      identity,
+      activeTurnID: activeTurnID,
+      activeResponseID: activeResponseID
+    ) == .accept
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+OrphanRepair.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+OrphanRepair.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension ChatProvider {
+  /// A released send lock is the UI's terminal boundary. A transport failure
+  /// can otherwise leave an old tool row marked streaming while `isSending`
+  /// is already false, which makes later chat/PTT turns look stuck.
+  static func terminalizeOrphanedStreamingMessages(
+    _ messages: inout [ChatMessage],
+    hasActiveSendLock: Bool
+  ) -> [String] {
+    guard !hasActiveSendLock else { return [] }
+    var terminalizedMessageIDs: [String] = []
+    for index in messages.indices where messages[index].sender == .ai && messages[index].isStreaming {
+      messages[index].isStreaming = false
+      ToolCallBlockUpdater.completeRemainingToolCalls(
+        in: &messages[index].contentBlocks,
+        terminalStatus: .failed
+      )
+      terminalizedMessageIDs.append(messages[index].id)
+    }
+    return terminalizedMessageIDs
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5178,26 +5178,6 @@ class ChatProvider: ObservableObject {
     }
   }
 
-  /// A released send lock is the UI's terminal boundary. A transport failure
-  /// can otherwise leave an old tool row marked streaming while `isSending`
-  /// is already false, which makes later chat/PTT turns look stuck.
-  static func terminalizeOrphanedStreamingMessages(
-    _ messages: inout [ChatMessage],
-    hasActiveSendLock: Bool
-  ) -> [String] {
-    guard !hasActiveSendLock else { return [] }
-    var terminalizedMessageIDs: [String] = []
-    for index in messages.indices where messages[index].sender == .ai && messages[index].isStreaming {
-      messages[index].isStreaming = false
-      ToolCallBlockUpdater.completeRemainingToolCalls(
-        in: &messages[index].contentBlocks,
-        terminalStatus: .failed
-      )
-      terminalizedMessageIDs.append(messages[index].id)
-    }
-    return terminalizedMessageIDs
-  }
-
   /// Generate a title for the session using LLM
   private func generateSessionTitle(sessionId: String) async {
     // Need at least 2 messages (user + AI) for meaningful title

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5140,8 +5140,28 @@ class ChatProvider: ObservableObject {
       &messages,
       hasActiveSendLock: sendLockOwnership.isHeld
     )
+    var repairGroups: [String: [String]] = [:]
     for messageID in terminalizedMessageIDs {
-      scheduleJournalUpdate(messageId: messageID)
+      if let ownerID = journalOwnerByMessageID[messageID] ?? runtimeOwnerId {
+        repairGroups[ownerID, default: []].append(messageID)
+      }
+    }
+    let repairSurface = mainChatSurfaceReference()
+    for (ownerID, messageIDs) in repairGroups {
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        let repaired = await self.kernelTurnProjection.repairNonterminalTurns(
+          surface: repairSurface,
+          turnIDs: messageIDs,
+          ownerID: ownerID
+        )
+        if repaired < messageIDs.count {
+          log(
+            "ChatProvider: canonical orphan repair deferred "
+              + "(requested=\(messageIDs.count), repaired=\(repaired))"
+          )
+        }
+      }
     }
     if !terminalizedMessageIDs.isEmpty {
       log("ChatProvider: terminalized \(terminalizedMessageIDs.count) orphaned streaming message(s) after send release")

--- a/desktop/macos/Desktop/Tests/RealtimeHubBargeInContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubBargeInContinuityTests.swift
@@ -669,7 +669,9 @@ final class RealtimeHubBargeInContinuityTests: XCTestCase {
 
     let retainedResponseID = RealtimeHubReconnectIdentityPolicy.responseIDAfterSessionDetach(
       preservingReconnectAudio: true,
-      pendingReconnect: pendingReconnect)
+      pendingReconnect: pendingReconnect,
+      preservingBargeInReplacement: false,
+      pendingBargeInReplacement: nil)
     XCTAssertEqual(retainedResponseID, responseID)
     XCTAssertTrue(
       RealtimeHubEventOwnership.accepts(
@@ -685,11 +687,58 @@ final class RealtimeHubBargeInContinuityTests: XCTestCase {
     XCTAssertNil(
       RealtimeHubReconnectIdentityPolicy.responseIDAfterSessionDetach(
         preservingReconnectAudio: false,
-        pendingReconnect: pendingReconnect))
+        pendingReconnect: pendingReconnect,
+        preservingBargeInReplacement: false,
+        pendingBargeInReplacement: nil))
     XCTAssertNil(
       RealtimeHubReconnectIdentityPolicy.responseIDAfterSessionDetach(
         preservingReconnectAudio: true,
-        pendingReconnect: nil))
+        pendingReconnect: nil,
+        preservingBargeInReplacement: false,
+        pendingBargeInReplacement: nil))
+  }
+
+  func testBargeInReplacementKeepsBufferedResponseIdentityForFreshSocket() {
+    let turnID = VoiceTurnID()
+    let responseID = VoiceResponseID("barge-in-response")
+    let pendingReplacement = RealtimeReplacementAudioBuffer(
+      turnID: turnID,
+      responseID: responseID,
+      identity: VoiceEffectIdentity(turnID: turnID, effectID: 1))
+
+    let retainedResponseID = RealtimeHubReconnectIdentityPolicy.responseIDAfterSessionDetach(
+      preservingReconnectAudio: false,
+      pendingReconnect: nil,
+      preservingBargeInReplacement: true,
+      pendingBargeInReplacement: pendingReplacement)
+
+    XCTAssertEqual(retainedResponseID, responseID)
+    XCTAssertEqual(
+      RealtimeHubEventOwnership.admission(
+        RealtimeHubEventIdentity(turnID: turnID, responseID: responseID),
+        activeTurnID: turnID,
+        activeResponseID: retainedResponseID),
+      .accept)
+  }
+
+  func testCurrentTurnResponseMismatchIsNotClassifiedAsAnOldTurnCallback() {
+    let turnID = VoiceTurnID()
+    let event = RealtimeHubEventIdentity(
+      turnID: turnID,
+      responseID: VoiceResponseID("provider-response"))
+
+    XCTAssertEqual(
+      RealtimeHubEventOwnership.admission(
+        event,
+        activeTurnID: turnID,
+        activeResponseID: nil),
+      .rejectCurrentTurnResponse)
+    XCTAssertEqual(
+      RealtimeHubEventOwnership.admission(
+        event,
+        activeTurnID: VoiceTurnID(),
+        activeResponseID: event.responseID),
+      .dropStaleTurn)
   }
 
   func testGeminiInputTranscriptCannotCrossCompletedTurnBoundary() {

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -350,6 +350,7 @@ function utf8ByteLength(text: string): number {
 
 type PublicWebTurnState = {
   bufferedText: string;
+  emittedText: string;
   /**
    * The Rust gateway resolves Anthropic's server-side web tool internally, so
    * Pi never receives a local tool lifecycle. This synthetic, query-scoped
@@ -447,8 +448,8 @@ export class PiMonoAdapter implements HarnessAdapter {
   private requiredAgentControlFailures = new Map<string, string>();
   private requiredControlInputs = new Map<string, Record<string, unknown>>();
   private currentAbortController: AbortController | null = null;
-  /** A public-web response is buffered until its gateway-routed terminal result,
-   * so false availability boilerplate never escapes before the search completes. */
+  /** State for projecting gateway-owned public-web progress without waiting for
+   * the terminal turn before forwarding model text. */
   private activePublicWebTurn: PublicWebTurnState | null = null;
   private piPath: string;
   private extensionPath: string;
@@ -713,7 +714,11 @@ export class PiMonoAdapter implements HarnessAdapter {
     const message = routePromptForPublicWeb(rawMessage);
     this.activePublicWebTurn = message === rawMessage
       ? null
-      : { bufferedText: "", progressToolUseId: `gateway-public-web-${generation}` };
+      : {
+          bufferedText: "",
+          emittedText: "",
+          progressToolUseId: `gateway-public-web-${generation}`,
+        };
     if (this.activePublicWebTurn) {
       this.eventHandler?.({
         type: "tool_activity",
@@ -1049,11 +1054,9 @@ export class PiMonoAdapter implements HarnessAdapter {
         if (msgEvent.delta) {
           if (this.activePublicWebTurn) {
             this.activePublicWebTurn.bufferedText += msgEvent.delta;
+            this.emitPublicWebText(this.activePublicWebTurn);
           } else {
-            this.eventHandler?.({
-              type: "text_delta",
-              text: msgEvent.delta,
-            });
+            this.eventHandler?.({ type: "text_delta", text: msgEvent.delta });
           }
         }
         break;
@@ -1267,10 +1270,8 @@ export class PiMonoAdapter implements HarnessAdapter {
       // provider interaction. Do not make this depend on local Pi tool events:
       // Anthropic's server-side web_search intentionally never exposes one.
       text = stripFalsePublicWebAvailabilityDisclaimers(text);
+      this.emitPublicWebText(publicWebTurn, true);
       this.finishPublicWebProgress(publicWebTurn, "completed");
-      if (text) {
-        this.eventHandler?.({ type: "text_delta", text });
-      }
     }
 
     // Extract usage
@@ -1307,6 +1308,41 @@ export class PiMonoAdapter implements HarnessAdapter {
       status,
       toolUseId: publicWebTurn.progressToolUseId,
     });
+  }
+
+  private emitPublicWebText(publicWebTurn: PublicWebTurnState, terminal = false): void {
+    const raw = publicWebTurn.bufferedText;
+    const normalized = raw.trimStart().toLowerCase();
+    const possibleDenialPrefixes = [
+      "i don't",
+      "i do not",
+      "i cannot",
+      "i can't",
+      "i can not",
+      "don't",
+      "do not",
+      "cannot",
+      "can't",
+      "can not",
+    ];
+    const mayBecomeAvailabilityDenial = possibleDenialPrefixes.some(
+      (prefix) => prefix.startsWith(normalized) || normalized.startsWith(prefix),
+    );
+    if (
+      !terminal
+      && publicWebTurn.emittedText.length === 0
+      && mayBecomeAvailabilityDenial
+      && !/[.!?]/.test(raw)
+      && !/\b(?:but|however)\b/i.test(raw)
+    ) {
+      return;
+    }
+
+    const sanitized = stripFalsePublicWebAvailabilityDisclaimers(raw);
+    if (!sanitized.startsWith(publicWebTurn.emittedText)) return;
+    const delta = sanitized.slice(publicWebTurn.emittedText.length);
+    publicWebTurn.emittedText = sanitized;
+    if (delta) this.eventHandler?.({ type: "text_delta", text: delta });
   }
 }
 

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -56,6 +56,7 @@ import type {
   JournalImportRemoteTurnMessage,
   JournalUpdateTurnMessage,
   JournalTerminalizeTurnMessage,
+  JournalRepairTurnsMessage,
   JournalListTurnsMessage,
   JournalClearTurnsMessage,
   EnsureAgentSpawnJournalMessage,
@@ -136,6 +137,7 @@ import {
   listJournalTurns,
   recordJournalExchange,
   recordJournalTurn,
+  repairOrphanedJournalTurns,
   settleClearedBackendTurnClaim,
   assertPublicJournalUpdatePolicy,
   terminalizeJournalTurn,
@@ -2432,6 +2434,55 @@ async function main(): Promise<void> {
               externalRefId: request.externalRefId,
               turn: journalTurnProjection(turn),
             });
+          }
+          pumpJournalOutbox();
+        } catch (error) {
+          const envelope = runtimeErrorEnvelope(error);
+          send({
+            type: "error",
+            protocolVersion: request.protocolVersion,
+            requestId: request.requestId,
+            clientId: request.clientId,
+            message: envelope.message,
+            failure: envelope.failure,
+          });
+        }
+        break;
+      }
+
+      case "journal_repair_turns": {
+        const request = msg as JournalRepairTurnsMessage;
+        try {
+          const ownerId = resolveActiveOwner(request.ownerId);
+          const turns = repairOrphanedJournalTurns(store, {
+            ownerId,
+            turnIds: Array.isArray(request.turnIds)
+              ? request.turnIds.filter((turnId): turnId is string => typeof turnId === "string")
+              : [],
+          });
+          send({
+            type: "journal_operation_result",
+            protocolVersion: request.protocolVersion,
+            requestId: request.requestId,
+            clientId: request.clientId,
+            operation: "repair",
+            conversationId: turns[0]?.conversationId ?? "",
+            surfaceKind: request.surfaceKind,
+            externalRefKind: request.externalRefKind,
+            externalRefId: request.externalRefId,
+            turns: turns.map(journalTurnProjection),
+            clearedCount: 0,
+            highWaterTurnSeq: 0,
+            generationBaseTurnSeq: 0,
+            conversationGeneration: 1,
+          });
+          for (const turn of turns) {
+            for (const wake of journalTurnChangedWakes(store, ownerId, turn)) {
+              send({
+                type: "journal_turn_changed",
+                ...wake,
+              });
+            }
           }
           pumpJournalOutbox();
         } catch (error) {

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -337,6 +337,14 @@ export interface JournalTerminalizeTurnMessage extends ProtocolEnvelope {
   };
 }
 
+export interface JournalRepairTurnsMessage extends ProtocolEnvelope {
+  type: "journal_repair_turns";
+  surfaceKind: string;
+  externalRefKind: string;
+  externalRefId: string;
+  turnIds: string[];
+}
+
 export function journalTerminalizationDisposition(input: unknown): "accept" | "discard" {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("Journal terminalization input must be an object");
@@ -452,6 +460,7 @@ export type InboundMessage =
   | JournalImportRemoteTurnMessage
   | JournalUpdateTurnMessage
   | JournalTerminalizeTurnMessage
+  | JournalRepairTurnsMessage
   | JournalListTurnsMessage
   | JournalClearTurnsMessage
   | EnsureAgentSpawnJournalMessage
@@ -877,7 +886,7 @@ export interface AgentSpawnJournalEnsuredMessage extends OutboundEnvelope {
 
 export interface JournalOperationResultMessage extends OutboundEnvelope {
   type: "journal_operation_result";
-  operation: "record" | "record_exchange" | "import_remote" | "update" | "list" | "clear";
+  operation: "record" | "record_exchange" | "import_remote" | "update" | "repair" | "list" | "clear";
   conversationId: string;
   surfaceKind: string;
   externalRefKind: string;

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -101,6 +101,12 @@ export interface UpdateJournalTurnInput {
   nowMs?: number;
 }
 
+export interface RepairOrphanedJournalTurnsInput {
+  ownerId: string;
+  turnIds: readonly string[];
+  nowMs?: number;
+}
+
 export interface TerminalizeJournalTurnInput {
   ownerId: string;
   conversationId: string;
@@ -616,6 +622,47 @@ export function bindProducingJournalTurn(
       nowMs: input.nowMs,
     });
   });
+}
+
+/**
+ * Repair assistant turns after their UI projection releases its send lock.
+ *
+ * Turn IDs are globally unique, so this resolves the canonical conversation
+ * from the producing turn instead of trusting the caller's selected surface.
+ * Active runs retain mutation authority.
+ */
+export function repairOrphanedJournalTurns(
+  store: AgentStore,
+  input: RepairOrphanedJournalTurnsInput,
+): ConversationTurn[] {
+  const turnIds = [...new Set(input.turnIds.map((turnId) => turnId.trim()).filter(Boolean))].slice(0, 100);
+  const repaired: ConversationTurn[] = [];
+  for (const turnId of turnIds) {
+    const current = findJournalTurnById(store, turnId);
+    if (!current) continue;
+    assertConversationOwner(store, current.conversationId, input.ownerId);
+    if (current.role !== "assistant" || terminalTurnStatus(current.status)) continue;
+
+    const producingRun = current.producingRunId === null
+      ? null
+      : store.getOptionalRow("SELECT status FROM runs WHERE run_id = ?", [current.producingRunId]);
+    const runStatus = producingRun ? String(producingRun.status) : null;
+    if (
+      runStatus !== null
+      && ["queued", "starting", "running", "waiting_input", "waiting_approval", "cancelling"].includes(runStatus)
+    ) {
+      continue;
+    }
+
+    repaired.push(updateJournalTurn(store, {
+      ownerId: input.ownerId,
+      conversationId: current.conversationId,
+      turnId,
+      status: runStatus === "succeeded" ? "completed" : "failed",
+      nowMs: input.nowMs,
+    }));
+  }
+  return repaired;
 }
 
 export function assertPublicJournalUpdatePolicy(

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -25,6 +25,7 @@ import {
   OUTBOX_CANONICAL_HASH_MISMATCH_CODE,
   recordJournalExchange,
   recordJournalTurn,
+  repairOrphanedJournalTurns,
   settleClearedBackendTurnClaim,
   assertPublicJournalUpdatePolicy,
   terminalizeJournalTurn,
@@ -41,6 +42,81 @@ afterEach(() => {
 });
 
 describe("kernel conversation journal", () => {
+  it("repairs an orphaned turn in its canonical conversation after the UI rebinds", () => {
+    const producingSurface = newSurface("main_chat", "chat", "repair-source");
+    const currentSurface = insertSurface(producingSurface.store, "main_chat", "chat", "repair-current");
+    recordJournalTurn(producingSurface.store, {
+      ownerId: producingSurface.ownerId,
+      conversationId: producingSurface.conversationId,
+      turnId: "turn-orphaned-after-rebind",
+      role: "assistant",
+      surfaceKind: "main_chat",
+      origin: "agent_runtime",
+      status: "streaming",
+      content: "partial",
+      contentBlocks: [{ type: "text", id: "partial", text: "partial" }],
+      createdAtMs: 2,
+    });
+    const activeRun = producingSurface.store.insertRun({
+      sessionId: producingSurface.sessionId,
+      runId: "run-active-during-repair",
+      clientId: "main-chat",
+      requestId: "active-during-repair",
+      status: "running",
+      mode: "act",
+    });
+    const activeAttempt = producingSurface.store.insertAttempt({
+      attemptId: "attempt-active-during-repair",
+      runId: activeRun.runId,
+      attemptNo: 1,
+      status: "running",
+      adapterId: "fake",
+      adapterInstanceId: "fake:repair",
+    });
+    recordJournalTurn(producingSurface.store, {
+      ownerId: producingSurface.ownerId,
+      conversationId: producingSurface.conversationId,
+      turnId: "turn-still-active",
+      role: "assistant",
+      surfaceKind: "main_chat",
+      origin: "agent_runtime",
+      status: "streaming",
+      content: "still running",
+      contentBlocks: [{ type: "text", id: "active", text: "still running" }],
+      producingRunId: activeRun.runId,
+      producingAttemptId: activeAttempt.attemptId,
+      createdAtMs: 2,
+    });
+
+    const repaired = repairOrphanedJournalTurns(producingSurface.store, {
+      ownerId: producingSurface.ownerId,
+      turnIds: [
+        "turn-orphaned-after-rebind",
+        "turn-orphaned-after-rebind",
+        "turn-still-active",
+        "missing",
+      ],
+      nowMs: 3,
+    });
+
+    expect(repaired).toMatchObject([{
+      conversationId: producingSurface.conversationId,
+      turnId: "turn-orphaned-after-rebind",
+      status: "failed",
+    }]);
+    expect(listJournalTurns(producingSurface.store, {
+      ownerId: producingSurface.ownerId,
+      conversationId: producingSurface.conversationId,
+    }).turns.find((turn) => turn.turnId === "turn-still-active")).toMatchObject({
+      status: "streaming",
+    });
+    expect(listJournalTurns(producingSurface.store, {
+      ownerId: producingSurface.ownerId,
+      conversationId: currentSurface.conversationId,
+    }).turns).toEqual([]);
+    producingSurface.store.close();
+  });
+
   it("projects shared chat revisions through the requesting binding with owner-fenced wakes", () => {
     const fixture = newSurface("main_chat", "chat", "default");
     const realtimeSession = fixture.store.insertSession({

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -286,11 +286,21 @@ describe("PiMonoAdapter prompt correlation", () => {
     );
 
     (adapter as any).handleMessageUpdate({
-      assistantMessageEvent: { type: "text_delta", delta: response },
+      assistantMessageEvent: { type: "text_delta", delta: "I don't have direct internet/" },
     });
+    expect(events.filter((event) => event.type === "text_delta")).toEqual([]);
+    (adapter as any).handleMessageUpdate({
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "web access, but I can get you real weather data via the terminal!\n\nCurrent weather: Sunny, 73 F.",
+      },
+    });
+    const expected = "I can get you real weather data via the terminal!\n\nCurrent weather: Sunny, 73 F.";
+    expect(events.filter((event) => event.type === "text_delta")).toEqual([
+      { type: "text_delta", text: expected },
+    ]);
     (adapter as any).handleTurnEnd(makeTurnEndEvent(response));
 
-    const expected = "I can get you real weather data via the terminal!\n\nCurrent weather: Sunny, 73 F.";
     await expect(prompt).resolves.toMatchObject({ text: expected });
     expect(events.filter((event) => event.type === "text_delta")).toEqual([
       { type: "text_delta", text: expected },

--- a/desktop/macos/changelog/unreleased/20260726-chat-voice-turn-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260726-chat-voice-turn-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat and push-to-talk turns that could remain stuck after web searches or rapid voice interruptions."
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -12,6 +12,8 @@ covers:
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentClient.swift
+  - desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -11,10 +11,13 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatProvider+OrphanRepair.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
   - desktop/macos/Desktop/Sources/Chat/AgentClient.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentContextRevision.swift
   - desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeJournalContracts.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift
 preconditions:

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
   - desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+EventAdmission.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -35,6 +35,8 @@ import {
   __resetOmiPipeForTest,
   omiRequestIdFromRelayContext,
   omiReasoningEffortFromRelayContext,
+  applyOmiProviderHeaders,
+  OMI_CHAT_CONTRACT_VERSION,
 } from "./index.ts";
 import type { ToolCallEvent } from "@earendil-works/pi-coding-agent";
 import { agentControlCapabilityManifest } from "../agent/src/runtime/control-tool-manifest.ts";
@@ -62,6 +64,22 @@ test("reasoning effort relay: strict two-token allowlist", () => {
   assert.equal(omiReasoningEffortFromRelayContext('{"reasoningEffort":"max"}'), undefined);
   assert.equal(omiReasoningEffortFromRelayContext('{"requestId":"req_1"}'), undefined);
   assert.equal(omiReasoningEffortFromRelayContext("not json"), undefined);
+});
+
+test("provider headers always advertise the versioned chat contract", () => {
+  const headers: Record<string, string> = {};
+  applyOmiProviderHeaders(headers, undefined);
+  assert.equal(headers["x-omi-chat-contract-version"], OMI_CHAT_CONTRACT_VERSION);
+
+  applyOmiProviderHeaders(
+    headers,
+    JSON.stringify({ requestId: "req_1", reasoningEffort: "adaptive" }),
+  );
+  assert.deepEqual(headers, {
+    "x-omi-chat-contract-version": "1",
+    "x-omi-request-id": "req_1",
+    "x-omi-reasoning-effort": "adaptive",
+  });
 });
 
 test("classifyBash: allows normal dev commands", () => {

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -577,6 +577,19 @@ async function omiRelayCapabilityRef(): Promise<string | undefined> {
 
 export const OMI_TOOL_TIMEOUT_MS = 30_000;
 export const OMI_LONG_CONTROL_TOOL_TIMEOUT_MS = 10 * 60_000;
+export const OMI_CHAT_CONTRACT_VERSION = "1";
+
+export function applyOmiProviderHeaders(
+  headers: Record<string, string>,
+  relayContextRaw: string | undefined,
+): void {
+  headers["x-omi-chat-contract-version"] = OMI_CHAT_CONTRACT_VERSION;
+  if (relayContextRaw === undefined) return;
+  const requestId = omiRequestIdFromRelayContext(relayContextRaw);
+  if (requestId) headers["x-omi-request-id"] = requestId;
+  const reasoningEffort = omiReasoningEffortFromRelayContext(relayContextRaw);
+  if (reasoningEffort) headers["x-omi-reasoning-effort"] = reasoningEffort;
+}
 
 export { isSafeSkillName };
 
@@ -841,14 +854,10 @@ export default function omiProvider(pi: ExtensionAPI): void {
   // which preserves one safe correlation id across an upstream retry chain.
   pi.on("before_provider_headers", async (event) => {
     const raw = await omiRelayContextRaw();
-    if (raw === undefined) return;
-    const requestId = omiRequestIdFromRelayContext(raw);
-    if (requestId) event.headers["x-omi-request-id"] = requestId;
     // Per-turn effort lane: typed chat runs "adaptive" (the model decides its
     // own thinking depth), PTT runs "fast" (thinking off, low effort). The
     // gateway translates this into Anthropic thinking/effort parameters.
-    const reasoningEffort = omiReasoningEffortFromRelayContext(raw);
-    if (reasoningEffort) event.headers["x-omi-reasoning-effort"] = reasoningEffort;
+    applyOmiProviderHeaders(event.headers, raw);
   });
 
   pi.on("tool_call", async (event): Promise<ToolCallEventResult | void> => {


### PR DESCRIPTION
## Summary

- Preserve the canonical PTT response identity across barge-in replacement, and fail a current-turn identity mismatch immediately instead of waiting for the provider deadline.
- Repair orphaned typed-chat turns through the journal's authoritative owner and turn ID while leaving live runs authoritative.
- Stream public-web text before `turn_end` and version the Pi-to-Rust chat contract so unsupported protocol revisions fail explicitly.

## Failure class

Failure-Class: FC-split-mutation-authority

Canonical prevention artifacts:

- `desktop/macos/Desktop/Tests/RealtimeHubBargeInContinuityTests.swift`
- `desktop/macos/agent/tests/conversation-journal.test.ts`
- `desktop/macos/pi-mono-extension/index.test.ts`
- `desktop/macos/Backend-Rust/src/routes/chat/route.rs`

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1
- INV-VOICE-1

## Verification

- `cd desktop/macos && ./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `cd desktop/macos && ./scripts/swift-test-suites.sh` — 385 suites passed.
- `cd desktop/macos/agent && npm test` — 601 tests passed.
- `cd desktop/macos/pi-mono-extension && npm test` — 108 tests passed.
- `cd desktop/macos/Backend-Rust && cargo test` — 384 tests passed.
- Focused `RealtimeHubBargeInContinuityTests` — 64 tests passed after extraction.
- Focused `ChatJournalWritePathTests` — 10 tests passed after extraction.
- Strict desktop E2E flow coverage — all 12 changed Swift production files covered.
- Isolated named bundle `omi-chat-turn-reliability`: three consecutive typed turns completed, including weather and stock public-web tool paths; a single PTT turn completed; a warm rapid three-turn PTT replacement burst completed without stale-response or identity-mismatch events.

## Follow-up evidence

A cold synthetic rapid PTT burst exposed a separate startup seam: local language identification took about 16 seconds while replacement readiness expires after 4 seconds. The turn terminalized safely and the warm replacement path passed. A follow-up should decouple optional language identification from replacement readiness without weakening the canonical persistence fence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

