### PR TITLE
SCA-169: preflight M1 qualification listener cleanup

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -6,7 +6,7 @@
 checks:
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
-    triggers: ["scripts/dev-harness/**", ".github/checks-manifest.yaml"]
+    triggers: ["scripts/dev-harness/**", "desktop/macos/scripts/qualification-local-proof.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/scripts/omi-fault-inject.sh", "desktop/macos/scripts/release-keyvalue.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "the hermetic dev-harness stack backs release qualification; the Jul 22 2026 beta qualification outage added a docker/native typesense runtime that must stay behaviorally covered"
   - id: pre-push-final-pr-diff
@@ -524,7 +524,7 @@ checks:
     reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
   - id: desktop-qualification-bootstrap-contract
     command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]
-    triggers: ["desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-local-proof.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "Trusted qualification requires an exact-SHA persistent source, isolated named-bundle, unchanged gates, and phase-bound bootstrap contracts"

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -16,7 +16,68 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  local-proof-m1:
+    runs-on: [self-hosted, macos, omi-desktop-qualification, omi-qual-m1-studio]
+    permissions:
+      contents: read
+    steps:
+      - name: Create isolated local-proof staging
+        working-directory: ${{ runner.temp }}
+        env:
+          PROOF_STAGE: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          expected="$RUNNER_TEMP/desktop-beta-local-proof/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$PROOF_STAGE" = "$expected"
+          test ! -e "$PROOF_STAGE" || { echo "Refusing reused local-proof staging directory" >&2; exit 1; }
+          (umask 077; mkdir -p "$PROOF_STAGE/source")
+          git -C "$PROOF_STAGE/source" init --quiet
+          git -C "$PROOF_STAGE/source" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          GIT_TERMINAL_PROMPT=0 git -C "$PROOF_STAGE/source" fetch --force --prune --tags origin
+          git -C "$PROOF_STAGE/source" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
+      - name: Install local qualification proof prerequisites
+        working-directory: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}/source
+        run: make setup-backend
+      - name: Prove offline qualification lifecycle before canonical dispatch
+        working-directory: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}/source
+        env:
+          PROOF_STAGE: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          desktop/macos/scripts/qualification-local-proof.sh \
+            --offline \
+            --fast \
+            --result "$PROOF_STAGE/local-qualification-proof.json" \
+            "$RELEASE_TAG"
+      - name: Retain redacted local qualification proof
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: desktop-local-qualification-proof-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}/local-qualification-proof.json
+            ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}/local-qualification-proof-fault-listener.json
+          if-no-files-found: error
+          overwrite: false
+      - name: Remove isolated local-proof staging
+        if: always()
+        working-directory: ${{ runner.temp }}
+        env:
+          PROOF_STAGE: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          expected="$RUNNER_TEMP/desktop-beta-local-proof/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$PROOF_STAGE" = "$expected"
+          if [ -e "$PROOF_STAGE" ]; then
+            test -d "$PROOF_STAGE"
+            test ! -L "$PROOF_STAGE"
+            rm -rf "$PROOF_STAGE"
+          fi
+
   qualify-m1-studio:
+    needs: local-proof-m1
     runs-on: [self-hosted, macos, omi-desktop-qualification, omi-qual-m1-studio]
     permissions:
       contents: write

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -150,6 +150,8 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
           QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
           OMI_QUALIFICATION_CLEANUP_CONTEXT: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/lease-context.json
+          OMI_QUALIFICATION_TIMINGS_FILE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/phase-timings.json
+          OMI_QUALIFICATION_FAULT_PREFLIGHT_REPORT: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/fault-listener-preflight.json
         run: |
           set -euo pipefail
           desktop/macos/scripts/qualify-desktop-beta.sh --automatic --github-actions-artifact --signed-smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result.json" --candidate-gate-result "$QUALIFICATION_STAGE/candidate-gate.json" "$RELEASE_TAG"
@@ -220,6 +222,8 @@ jobs:
           path: |
             ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/runner-capacity.json
             ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/cleanup-evidence.json
+            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/fault-listener-preflight.json
+            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/phase-timings.json
           if-no-files-found: error
           overwrite: false
 

--- a/desktop/macos/changelog/unreleased/20260726-qualification-listener-preflight.json
+++ b/desktop/macos/changelog/unreleased/20260726-qualification-listener-preflight.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made macOS Beta qualification detect unsafe runner listener state before the long behavioral suite."
+}

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -36,6 +36,43 @@ All three classes remain fail-closed. The classification only makes a
 non-product host prerequisite precise and early; it does not convert it to
 passing evidence.
 
+## Local M1 lifecycle proof
+
+From the canonical repository on an Apple Silicon Mac, install the backend
+virtual environment once and check out the exact local release tag:
+
+```bash
+make setup-backend
+git checkout --detach refs/tags/vX.Y.Z+BUILD-macos
+desktop/macos/scripts/qualification-local-proof.sh \
+  --offline \
+  --fast \
+  --result "$PWD/.local/qualification-proof.json" \
+  vX.Y.Z+BUILD-macos
+```
+
+Prerequisites are `git`, Python 3, `nc`, `lsof`, `ps`, and the backend virtual
+environment created by `make setup-backend`. Fetch the tag before entering
+offline mode if it is not already local. The proof itself does not use GitHub
+Actions or Codemagic credentials, production credentials, release APIs, channel
+pointers, publication, Beta/Stable bundles, or `/Applications/Omi.app`.
+
+A successful `0600` result has `status: "passed"`, `mode: "offline-fast"`,
+the tag's exact `source_sha`, `cleanup_status: "released"`, and these completed
+boundaries in order: release-tag validation, lease/provenance acquisition,
+disposable fault-listener start, runner-hygiene preflight, and cleanup
+finalization. The adjacent
+`.local/qualification-proof-fault-listener.json` is the redacted provenance
+cleanup report. Missing or foreign listener provenance, an unreclaimable stale
+owned process, or incomplete cleanup fails closed before any long UI flow and
+retains the unknown process.
+
+The workflow runs this exact entry point as a separate fast M1 job. Only a
+passing proof dispatches the canonical qualification job; the result and
+fault-listener report are retained as an artifact even on failure. This proof
+does not run or replace signed-identity, Tier-2, behavioral fault, manifest, or
+evidence gates.
+
 ## Runner capacity preflight
 
 Before the candidate checkout, the M1-only workflow writes

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -21,6 +21,21 @@ The offset applies to Firestore, Firebase Auth, backend, desktop backend,
 Redis, and Typesense. The script also derives `OMI_AUTOMATION_PORT`; invalid
 ports fail before launch.
 
+## Gate phases
+
+The qualification timing report classifies every in-script gate without changing
+its authority:
+
+| Phase | Classification | Failure meaning |
+|---|---|---|
+| Candidate/release evidence, tag binding, lease acquisition, static self-check | Immutable artifact/security | The exact signed candidate, source identity, or trusted evidence cannot be established |
+| Automation bridge, Tier-2 user flows, fault user flow and both manifests | User-visible behavioral/fault coverage | The desktop UX or its required failure behavior did not pass |
+| Capacity, fault-listener preflight, desktop preparation/provenance, final cleanup | Runner hygiene/cleanup | The controlled M1 host cannot safely start or reclaim this run |
+
+All three classes remain fail-closed. The classification only makes a
+non-product host prerequisite precise and early; it does not convert it to
+passing evidence.
+
 ## Runner capacity preflight
 
 Before the candidate checkout, the M1-only workflow writes
@@ -52,6 +67,16 @@ Before signaling it, release revalidates the owner-only state files, lease token
 PID/process group, command marker, loopback URL, and exact listener PID. A
 listener that fails any check is retained and never signaled.
 
+Automatic qualification now exercises that same ownership boundary immediately
+after lease acquisition: it starts a disposable listener on the exact future
+fault-suite port, then asks the lease authority to re-prove and reclaim it. A
+known-owned listener produces `fault-listener-preflight.json` with `status:
+passed`. A missing, replaced, foreign, or unreclaimable listener produces a
+specific failed host-prerequisite result and stops before desktop preparation,
+Tier-2, or the fault flow. Unknown listeners are retained and never signaled.
+The real fault suite still runs later and its failing manifest still rejects
+qualification evidence.
+
 The main qualification app receives a separate run-unique launch token. `run.sh`
 writes an owner-only launch signal, which the qualifier verifies against exactly
 one token-bearing app process before writing a `0600` launch record. Cleanup
@@ -61,3 +86,12 @@ quits by bundle ID or name. After the owned app exits, the qualifier requires it
 automation port to be unbound. Missing provenance, changed process identity, an
 unreleased port, or lease-release failure retains the lease and fails before any
 success evidence is published.
+
+## Phase timing
+
+The automatic workflow uploads owner-only `phase-timings.json` with each phase's
+classification, status, and duration in milliseconds, plus an explicit
+`target_seconds: 1200`. Failed active phases and cleanup are recorded by the
+exit trap, so the report distinguishes time spent in artifact/security,
+user-visible behavior, and runner hygiene. The 20-minute target is measured from
+this report; no Tier-2 or fault UX gate is skipped to meet it.

--- a/desktop/macos/scripts/qualification-lease-command.sh
+++ b/desktop/macos/scripts/qualification-lease-command.sh
@@ -8,6 +8,7 @@ usage() {
   cat >&2 <<'USAGE'
 Usage:
   qualification-lease-command.sh acquire <worktree> <lease-id> <owner-pid> <port-offset> <retained-runs>
+  qualification-lease-command.sh preflight-fault-cleanup <worktree> <lease-id> <token> <result-path>
   qualification-lease-command.sh release <worktree> <lease-id> <token> <retained-runs> <retention-age-seconds>
 USAGE
   exit 2
@@ -70,6 +71,12 @@ case "$action" in
     [[ $# -eq 5 ]] || usage
     worktree="$1"
     run_lease_command "$worktree" --lease-id "$2" --owner-pid "$3" --port-offset "$4" --retained-runs "$5"
+    ;;
+  preflight-fault-cleanup)
+    [[ $# -eq 4 ]] || usage
+    worktree="$1"
+    lease_token="$3"
+    run_lease_command "$worktree" --lease-id "$2" --token "$3" --result "$4"
     ;;
   release)
     [[ $# -eq 5 ]] || usage

--- a/desktop/macos/scripts/qualification-local-proof.sh
+++ b/desktop/macos/scripts/qualification-local-proof.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Prove the offline M1 qualification lease/listener lifecycle without launching
+# a desktop app, reading release credentials, or mutating a release channel.
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LEASE_COMMAND="$SCRIPT_DIR/qualification-lease-command.sh"
+KEYVALUE_PY="$SCRIPT_DIR/release-keyvalue.py"
+FAULT_INJECTOR="$SCRIPT_DIR/omi-fault-inject.sh"
+
+OFFLINE=0
+FAST=0
+RESULT_PATH=""
+RELEASE_TAG=""
+LEASE_ID=""
+LEASE_TOKEN=""
+LEASE_ACQUIRED=0
+LEASE_RELEASE_ATTEMPTED=0
+CLEANUP_STATUS="not-acquired"
+FAILURE_REASON=""
+COMPLETED_BOUNDARIES=""
+FAULT_REPORT=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  qualification-local-proof.sh --offline [--fast] --result PATH <vX.Y.Z+BUILD-macos>
+
+Options:
+  --offline      Required: prohibit network/release authority and exercise only local lifecycle boundaries
+  --fast         Deterministic CI pre-dispatch mode; never launches the desktop UI or full user-flow suite
+  --result PATH  Write the redacted proof result JSON here
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --offline)
+      OFFLINE=1
+      shift
+      ;;
+    --fast)
+      FAST=1
+      shift
+      ;;
+    --result)
+      [[ $# -ge 2 && -n "${2:-}" && "${2:-}" != -* ]] || { echo "--result requires a path" >&2; exit 2; }
+      RESULT_PATH="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      [[ -z "$RELEASE_TAG" ]] || { echo "unexpected extra argument: $1" >&2; exit 2; }
+      RELEASE_TAG="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ "$OFFLINE" -eq 1 ]] || { echo "qualification local proof requires explicit --offline mode" >&2; exit 2; }
+[[ -n "$RESULT_PATH" ]] || { echo "qualification local proof requires --result" >&2; exit 2; }
+[[ -n "$RELEASE_TAG" ]] || { echo "qualification local proof requires a release tag" >&2; exit 2; }
+[[ "$(uname -s)" == Darwin ]] || { echo "qualification local proof requires macOS" >&2; exit 1; }
+
+RESULT_PATH="$(python3 -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).expanduser().resolve())' "$RESULT_PATH")"
+FAULT_REPORT="${RESULT_PATH%.json}-fault-listener.json"
+mkdir -p "$(dirname "$RESULT_PATH")"
+
+append_boundary() {
+  if [[ -n "$COMPLETED_BOUNDARIES" ]]; then
+    COMPLETED_BOUNDARIES+=","
+  fi
+  COMPLETED_BOUNDARIES+="$1"
+}
+
+write_result() {
+  local status="$1" reason="${2:-}" source_sha="${3:-}" mode="offline"
+  [[ "$FAST" -eq 0 ]] || mode="offline-fast"
+  umask 077
+  python3 - "$RESULT_PATH" "$status" "$reason" "$mode" "$RELEASE_TAG" "$source_sha" "$CLEANUP_STATUS" "$COMPLETED_BOUNDARIES" "$FAULT_REPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, status, reason, mode, release_tag, source_sha, cleanup_status, boundaries, fault_report = sys.argv[1:]
+fault_path = Path(fault_report)
+fault_result = None
+if fault_path.is_file():
+    observed = json.loads(fault_path.read_text(encoding="utf-8"))
+    fault_result = {
+        key: observed.get(key)
+        for key in ("schema_version", "gate", "classification", "status", "port", "failure_reason")
+    }
+payload = {
+    "schema_version": 1,
+    "proof": "local-qualification-lifecycle",
+    "mode": mode,
+    "release_tag": release_tag,
+    "source_sha": source_sha or None,
+    "status": status,
+    "failure_reason": reason or None,
+    "cleanup_status": cleanup_status,
+    "completed_boundaries": [item for item in boundaries.split(",") if item],
+    "fault_listener_result": fault_result,
+}
+target = Path(path)
+target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+target.chmod(0o600)
+PY
+}
+
+release_owned_lease() {
+  if [[ "$LEASE_ACQUIRED" -eq 0 ]]; then
+    return 0
+  fi
+  if [[ "$LEASE_RELEASE_ATTEMPTED" -eq 1 ]]; then
+    return 1
+  fi
+  LEASE_RELEASE_ATTEMPTED=1
+  if "$LEASE_COMMAND" release "$REPO_ROOT" "$LEASE_ID" "$LEASE_TOKEN" 3 1209600; then
+    LEASE_ACQUIRED=0
+    CLEANUP_STATUS="released"
+    append_boundary "cleanup-finalization"
+    return 0
+  fi
+  CLEANUP_STATUS="release-failed"
+  return 1
+}
+
+finalize() {
+  local exit_code=$?
+  trap - EXIT INT TERM HUP
+  if [[ "$LEASE_ACQUIRED" -eq 1 ]] && ! release_owned_lease; then
+    [[ -n "$FAILURE_REASON" ]] || FAILURE_REASON="cleanup-finalization-failed"
+    [[ "$exit_code" -ne 0 ]] || exit_code=1
+  fi
+  if [[ "$exit_code" -eq 0 ]]; then
+    write_result passed "" "${SOURCE_SHA:-}"
+  else
+    [[ -n "$FAILURE_REASON" ]] || FAILURE_REASON="local-proof-failed"
+    write_result failed "$FAILURE_REASON" "${SOURCE_SHA:-}"
+  fi
+  exit "$exit_code"
+}
+trap finalize EXIT
+trap 'FAILURE_REASON="interrupted"; exit 130' INT
+trap 'FAILURE_REASON="terminated"; exit 143' TERM
+trap 'FAILURE_REASON="hangup"; exit 129' HUP
+
+python3 "$KEYVALUE_PY" validate-tag "$RELEASE_TAG" >/dev/null
+SOURCE_SHA="$(git -C "$REPO_ROOT" rev-parse "refs/tags/${RELEASE_TAG}^{commit}")" || {
+  FAILURE_REASON="release-tag-not-local"
+  exit 1
+}
+if [[ "$SOURCE_SHA" != "$(git -C "$REPO_ROOT" rev-parse 'HEAD^{commit}')" ]]; then
+  FAILURE_REASON="checkout-does-not-match-release-tag"
+  echo "qualification local proof requires HEAD to match $RELEASE_TAG" >&2
+  exit 1
+fi
+append_boundary "release-tag-validation"
+
+RUN_SCOPE="${BASHPID:-$$}"
+LEASE_ID="qualification-proof-${SOURCE_SHA:0:12}-${RUN_SCOPE}"
+PORT_OFFSET="$(python3 - "$SOURCE_SHA" "$LEASE_ID" <<'PY'
+import hashlib
+import sys
+print(1000 + (int(hashlib.sha256(": ".join(sys.argv[1:]).encode()).hexdigest()[:8], 16) % 2000))
+PY
+)"
+FAULT_PORT="$((47777 + PORT_OFFSET + 2))"
+if (( FAULT_PORT > 65535 )); then
+  FAILURE_REASON="invalid-fault-port"
+  exit 1
+fi
+
+export OMI_LOCAL_STATE_ROOT="${OMI_QUALIFICATION_LEASE_ROOT:-${TMPDIR:-/tmp}/omi-desktop-qualification}/state"
+export OMI_LOCAL_INSTANCE="$LEASE_ID"
+export OMI_HARNESS_PORT_OFFSET="$PORT_OFFSET"
+
+ACQUIRE_ERROR="$(mktemp "${TMPDIR:-/tmp}/omi-qualification-local-proof-acquire.XXXXXX")"
+if ! LEASE_JSON="$("$LEASE_COMMAND" acquire "$REPO_ROOT" "$LEASE_ID" "$$" "$PORT_OFFSET" 3 2>"$ACQUIRE_ERROR")"; then
+  if grep -Fq "lineage is unproven" "$ACQUIRE_ERROR"; then
+    FAILURE_REASON="unproven-stale-listener"
+  else
+    FAILURE_REASON="lease-acquisition-failed"
+  fi
+  cat "$ACQUIRE_ERROR" >&2
+  rm -f "$ACQUIRE_ERROR"
+  exit 1
+fi
+rm -f "$ACQUIRE_ERROR"
+LEASE_TOKEN="$(printf '%s' "$LEASE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+LEASE_ACQUIRED=1
+CLEANUP_STATUS="pending"
+append_boundary "lease-provenance-acquisition"
+
+if ! OMI_FAULT_STATE_DIR="${OMI_LOCAL_STATE_ROOT}/${LEASE_ID}/fault" \
+  OMI_FAULT_OWNERSHIP_TOKEN="$LEASE_TOKEN" \
+  "$FAULT_INJECTOR" start error --port "$FAULT_PORT" >/dev/null; then
+  FAILURE_REASON="fault-listener-start-failed"
+  exit 1
+fi
+append_boundary "disposable-fault-listener-start"
+
+if ! "$LEASE_COMMAND" preflight-fault-cleanup "$REPO_ROOT" "$LEASE_ID" "$LEASE_TOKEN" "$FAULT_REPORT"; then
+  FAILURE_REASON="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("failure_reason") or "fault-listener-preflight-failed")' "$FAULT_REPORT")"
+  exit 1
+fi
+append_boundary "runner-hygiene-preflight"
+
+if ! release_owned_lease; then
+  FAILURE_REASON="cleanup-finalization-failed"
+  exit 1
+fi
+
+echo "qualification local proof passed: $RESULT_PATH"

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -136,6 +136,11 @@ QUALIFICATION_RETENTION_AGE_SECONDS="${OMI_QUALIFICATION_RETENTION_AGE_SECONDS:-
 QUALIFICATION_CLEANUP_CONTEXT="${OMI_QUALIFICATION_CLEANUP_CONTEXT:-}"
 QUALIFICATION_LOG_DIR=""
 QUALIFICATION_STAGE=""
+QUALIFICATION_TIMINGS_FILE="${OMI_QUALIFICATION_TIMINGS_FILE:-}"
+FAULT_PREFLIGHT_REPORT="${OMI_QUALIFICATION_FAULT_PREFLIGHT_REPORT:-}"
+ACTIVE_PHASE=""
+ACTIVE_PHASE_CLASS=""
+ACTIVE_PHASE_STARTED_NS=""
 # Cold, from-scratch rebuild of the exact tag compiles ~1190 SwiftPM modules
 # (FluidAudio, MarkdownUI, Firebase, ONNX, …) before the named bundle is even
 # packaged/signed/launched. On a self-hosted M1 that first cold build alone runs
@@ -151,6 +156,72 @@ BRIDGE_WAIT_SECS=900
 
 QUALIFICATION_STAGE="$(qualification_stage_create)"
 trap 'qualification_stage_remove "$QUALIFICATION_STAGE"' EXIT
+QUALIFICATION_TIMINGS_FILE="${QUALIFICATION_TIMINGS_FILE:-$QUALIFICATION_STAGE/phase-timings.json}"
+FAULT_PREFLIGHT_REPORT="${FAULT_PREFLIGHT_REPORT:-$QUALIFICATION_STAGE/fault-listener-preflight.json}"
+
+timing_now_ns() {
+  python3 -c 'import time; print(time.time_ns())'
+}
+
+initialize_phase_timings() {
+  umask 077
+  python3 - "$QUALIFICATION_TIMINGS_FILE" "$RELEASE_TAG" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, release_tag = sys.argv[1:]
+target = Path(path)
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(json.dumps({
+    "schema_version": 1,
+    "target_seconds": 1200,
+    "release_tag": release_tag,
+    "phases": [],
+}, sort_keys=True) + "\n", encoding="utf-8")
+target.chmod(0o600)
+PY
+}
+
+phase_begin() {
+  [[ -z "$ACTIVE_PHASE" ]] || { echo "qualification timing phase already active: $ACTIVE_PHASE" >&2; return 1; }
+  ACTIVE_PHASE="$1"
+  ACTIVE_PHASE_CLASS="$2"
+  ACTIVE_PHASE_STARTED_NS="$(timing_now_ns)"
+}
+
+phase_end() {
+  local status="${1:-passed}" ended_ns duration_ms
+  [[ -n "$ACTIVE_PHASE" && -n "$ACTIVE_PHASE_STARTED_NS" ]] || return 0
+  ended_ns="$(timing_now_ns)"
+  duration_ms=$(( (ended_ns - ACTIVE_PHASE_STARTED_NS) / 1000000 ))
+  python3 - "$QUALIFICATION_TIMINGS_FILE" "$ACTIVE_PHASE" "$ACTIVE_PHASE_CLASS" "$status" "$ACTIVE_PHASE_STARTED_NS" "$ended_ns" "$duration_ms" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, name, classification, status, started_ns, ended_ns, duration_ms = sys.argv[1:]
+target = Path(path)
+payload = json.loads(target.read_text(encoding="utf-8"))
+payload["phases"].append({
+    "name": name,
+    "classification": classification,
+    "status": status,
+    "started_unix_ns": int(started_ns),
+    "ended_unix_ns": int(ended_ns),
+    "duration_ms": int(duration_ms),
+})
+payload["elapsed_ms"] = sum(int(phase["duration_ms"]) for phase in payload["phases"])
+target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+  echo "qualification phase: $ACTIVE_PHASE classification=$ACTIVE_PHASE_CLASS status=$status duration_ms=$duration_ms"
+  ACTIVE_PHASE=""
+  ACTIVE_PHASE_CLASS=""
+  ACTIVE_PHASE_STARTED_NS=""
+}
+
+initialize_phase_timings
+phase_begin "candidate-and-lease-preflight" "immutable-artifact-security"
 RELEASE_FILE="$QUALIFICATION_STAGE/release.json"
 gh release view "$RELEASE_TAG" --repo BasedHardware/omi --json tagName,isDraft,isPrerelease,publishedAt,assets,body \
   > "$RELEASE_FILE"
@@ -271,6 +342,7 @@ target.chmod(0o600)
 PY
 fi
 LAUNCH_LOG="$QUALIFICATION_LOG_DIR/desktop-launch.log"
+phase_end passed
 
 resolve_automation_port() {
   (
@@ -555,9 +627,18 @@ run_qualification_cleanup() {
 
 cleanup() {
   local exit_code=$?
-  if ! run_qualification_cleanup; then
-    echo "qualification cleanup failed; preserving qualification lease and preventing success evidence" >&2
-    [[ "$exit_code" -ne 0 ]] || exit_code=1
+  if [[ -n "$ACTIVE_PHASE" ]]; then
+    phase_end failed
+  fi
+  if [[ "$QUALIFICATION_CLEANUP_DONE" -eq 0 ]]; then
+    phase_begin "final-cleanup" "runner-hygiene-cleanup"
+    if ! run_qualification_cleanup; then
+      phase_end failed
+      echo "qualification cleanup failed; preserving qualification lease and preventing success evidence" >&2
+      [[ "$exit_code" -ne 0 ]] || exit_code=1
+    else
+      phase_end passed
+    fi
   fi
   if [[ -n "$QUALIFICATION_LOG_DIR" ]]; then
     python3 - "$QUALIFICATION_LOG_DIR/cleanup.json" "$QUALIFICATION_LEASE_ID" "$QUALIFICATION_CLEANUP_STATUS" "$exit_code" <<'PY'
@@ -576,6 +657,49 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 trap 'exit 129' HUP
 
+if [[ "$AUTOMATIC" -eq 1 ]]; then
+  FAULT_PREFLIGHT_PORT="$((AUTOMATION_PORT + 2))"
+  if (( FAULT_PREFLIGHT_PORT > 65535 )); then
+    echo "qualification failed: fault-listener preflight port is invalid: $FAULT_PREFLIGHT_PORT" >&2
+    exit 2
+  fi
+  phase_begin "fault-listener-preflight" "runner-hygiene-cleanup"
+  if ! OMI_FAULT_STATE_DIR="$QUALIFICATION_LEASE_ROOT/state/$QUALIFICATION_LEASE_ID/fault" \
+    OMI_FAULT_OWNERSHIP_TOKEN="$QUALIFICATION_LEASE_TOKEN" \
+    "$WORKTREE/desktop/macos/scripts/omi-fault-inject.sh" start error --port "$FAULT_PREFLIGHT_PORT" >/dev/null; then
+    python3 - "$FAULT_PREFLIGHT_REPORT" "$QUALIFICATION_LEASE_ID" "$FAULT_PREFLIGHT_PORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, lease_id, port = sys.argv[1:]
+target = Path(path)
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(json.dumps({
+    "schema_version": 1,
+    "gate": "fault-listener-provenance-cleanup",
+    "classification": "runner-hygiene-cleanup",
+    "lease_id": lease_id,
+    "status": "failed",
+    "port": int(port),
+    "failure_reason": "listener-start-prerequisite-unmet",
+}, sort_keys=True) + "\n", encoding="utf-8")
+target.chmod(0o600)
+PY
+    phase_end failed
+    echo "qualification failed: host prerequisite could not start the disposable fault listener on port $FAULT_PREFLIGHT_PORT" >&2
+    exit 1
+  fi
+  if ! "$LEASE_COMMAND" preflight-fault-cleanup "$WORKTREE" "$QUALIFICATION_LEASE_ID" "$QUALIFICATION_LEASE_TOKEN" "$FAULT_PREFLIGHT_REPORT"; then
+    phase_end failed
+    failure_reason="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("failure_reason", "host-prerequisite-unmet"))' "$FAULT_PREFLIGHT_REPORT")"
+    echo "qualification failed: fault-listener host prerequisite was not established ($failure_reason); listener retained" >&2
+    exit 1
+  fi
+  phase_end passed
+fi
+
+phase_begin "desktop-preparation" "runner-hygiene-cleanup"
 "$SCRIPT_DIR/prepare-qualification-profile.sh" "$BUNDLE"
 rm -f "$LAUNCH_SIGNAL_FILE"
 
@@ -591,75 +715,103 @@ DESKTOP_LAUNCH_REQUESTED=1
 DESKTOP_LAUNCH_PID=$!
 
 if ! wait_for_desktop_launch "$LAUNCH_SIGNAL_FILE"; then
+  phase_end failed
   echo "--- last 80 lines of $LAUNCH_LOG ---" >&2
   tail -n 80 "$LAUNCH_LOG" >&2 || true
   exit 1
 fi
+phase_end passed
 
 # The bridge gets its complete post-launch readiness allowance; cold Rust,
 # agent-runtime, SwiftPM, packaging, and signing work consumed only the separate
 # bounded preparation phase above.
 SECONDS=0
 
+phase_begin "automation-bridge-readiness" "user-visible-behavioral-fault"
 if ! wait_for_bridge "$AUTOMATION_PORT"; then
+  phase_end failed
   echo "--- last 80 lines of $LAUNCH_LOG ---" >&2
   tail -n 80 "$LAUNCH_LOG" >&2 || true
   exit 1
 fi
 if ! record_owned_qualification_desktop; then
+  phase_end failed
   echo "qualification failed: could not establish owner-only desktop launch provenance" >&2
   exit 1
 fi
+phase_end passed
 
-(
-  cd "$WORKTREE/desktop/macos"
-  if [[ "$AUTOMATIC" -eq 1 ]]; then
+if [[ "$AUTOMATIC" -eq 1 ]]; then
+  phase_begin "static-self-check" "immutable-artifact-security"
+  if ! (
+    cd "$WORKTREE/desktop/macos"
     ./scripts/desktop-core-harness.sh --self-check --skip-backend-contracts
+  ); then
+    phase_end failed
+    exit 1
   fi
+  phase_end passed
+fi
+
+phase_begin "tier-2-user-flows" "user-visible-behavioral-fault"
+if ! (
+  cd "$WORKTREE/desktop/macos"
   ./scripts/desktop-core-harness.sh --tier 2 --bundle "$BUNDLE" --port "$AUTOMATION_PORT" --keep-stack
-)
+); then
+  phase_end failed
+  exit 1
+fi
 
 EVIDENCE=$(ls -td "$WORKTREE/desktop/macos/.harness/desktop-core"/* 2>/dev/null | head -1)
 if [[ -z "$EVIDENCE" || ! -f "$EVIDENCE/manifest.json" ]]; then
+  phase_end failed
   echo "qualification failed: missing harness evidence" >&2
   exit 1
 fi
 
 if ! python3 "$KEYVALUE_PY" check-manifest "$EVIDENCE/manifest.json"; then
+  phase_end failed
   echo "qualification failed: tier 2 harness did not pass; evidence: $EVIDENCE" >&2
   exit 1
 fi
+phase_end passed
 
 FAULT_EVIDENCE=""
 if [[ "$AUTOMATIC" -eq 1 ]]; then
-  (
+  phase_begin "fault-user-flow" "user-visible-behavioral-fault"
+  if ! (
     cd "$WORKTREE/desktop/macos"
     OMI_FAULT_PORT="$((AUTOMATION_PORT + 2))" \
       OMI_FAULT_STATE_DIR="$QUALIFICATION_LEASE_ROOT/state/$QUALIFICATION_LEASE_ID/fault" \
       OMI_FAULT_OWNERSHIP_TOKEN="$QUALIFICATION_LEASE_TOKEN" \
       ./scripts/desktop-core-harness.sh --fault-suite --port "$((AUTOMATION_PORT + 1))"
-  )
+  ); then
+    phase_end failed
+    exit 1
+  fi
   FAULT_EVIDENCE=$(ls -td "$WORKTREE/desktop/macos/.harness/desktop-core"/*-fault 2>/dev/null | head -1)
   if [[ -z "$FAULT_EVIDENCE" || ! -f "$FAULT_EVIDENCE/manifest.json" ]]; then
+    phase_end failed
     echo "automatic qualification failed: missing fault-suite evidence" >&2
     exit 1
   fi
-  python3 - "$FAULT_EVIDENCE/manifest.json" <<'PY'
-import json
-import sys
-
-manifest = json.load(open(sys.argv[1], encoding="utf-8"))
-if manifest.get("passed") is not True or manifest.get("tier") != "fault":
-    raise SystemExit("automatic qualification failed: fault-suite manifest did not pass")
-PY
+  if ! python3 "$KEYVALUE_PY" check-fault-manifest "$FAULT_EVIDENCE/manifest.json"; then
+    phase_end failed
+    echo "automatic qualification failed: fault-suite manifest did not pass" >&2
+    exit 1
+  fi
+  phase_end passed
 fi
 
 # Cleanup is a qualification gate, not best-effort EXIT housekeeping. Do this
 # before any trusted workflow artifact or release evidence can claim success.
+phase_begin "final-cleanup" "runner-hygiene-cleanup"
 if ! run_qualification_cleanup; then
+  phase_end failed
   echo "qualification cleanup failed; preserving qualification lease and preventing success evidence" >&2
   exit 1
 fi
+phase_end passed
 
 if [[ "$GITHUB_ACTIONS_ARTIFACT" -eq 1 ]]; then
   QUALIFICATION_SUCCESS=1

--- a/desktop/macos/scripts/release-keyvalue.py
+++ b/desktop/macos/scripts/release-keyvalue.py
@@ -104,6 +104,14 @@ def check_manifest(manifest_path: Path) -> None:
         raise SystemExit(f"manifest provider_mode must be 'offline', got {provider_mode!r}")
 
 
+def check_fault_manifest(manifest_path: Path) -> None:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("passed") is not True:
+        raise SystemExit("fault-suite manifest passed=false")
+    if manifest.get("tier") != "fault":
+        raise SystemExit(f"fault-suite manifest tier must be 'fault', got {manifest.get('tier')!r}")
+
+
 def update_qualification_keys(
     body_path: Path,
     *,
@@ -181,6 +189,10 @@ def _self_test() -> int:
         json.dumps({"passed": True, "tier": 1, "provider_mode": "offline"}),
         encoding="utf-8",
     )
+    passing_fault_manifest = Path("/tmp/release-keyvalue-pass-fault-manifest.json")
+    failing_fault_manifest = Path("/tmp/release-keyvalue-fail-fault-manifest.json")
+    passing_fault_manifest.write_text(json.dumps({"passed": True, "tier": "fault"}), encoding="utf-8")
+    failing_fault_manifest.write_text(json.dumps({"passed": False, "tier": "fault"}), encoding="utf-8")
 
     try:
         check_manifest(passing_manifest)
@@ -214,6 +226,21 @@ def _self_test() -> int:
             ok("check-manifest rejects non-T2 tier")
         else:
             fail("check-manifest wrong tier", f"unexpected exit: {exc}")
+
+    try:
+        check_fault_manifest(passing_fault_manifest)
+        ok("check-fault-manifest passing manifest exits 0")
+    except SystemExit as exc:
+        fail("check-fault-manifest passing manifest", f"unexpected exit {exc.code}: {exc}")
+
+    try:
+        check_fault_manifest(failing_fault_manifest)
+        fail("check-fault-manifest failing manifest", "expected SystemExit")
+    except SystemExit as exc:
+        if exc.code != 0 and str(exc) == "fault-suite manifest passed=false":
+            ok("check-fault-manifest rejects a failed user-visible fault flow")
+        else:
+            fail("check-fault-manifest failing manifest", f"unexpected exit {exc.code}: {exc}")
 
     sample_body = """Release notes
 
@@ -336,6 +363,8 @@ def main(argv: list[str] | None = None) -> int:
 
     check = sub.add_parser("check-manifest", help="Exit 0 when harness manifest passed")
     check.add_argument("manifest")
+    check_fault = sub.add_parser("check-fault-manifest", help="Exit 0 when the user-visible fault suite passed")
+    check_fault.add_argument("manifest")
 
     update = sub.add_parser(
         "update-qualified-beta",
@@ -356,6 +385,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == "check-manifest":
         check_manifest(Path(args.manifest))
+        return 0
+    if args.command == "check-fault-manifest":
+        check_fault_manifest(Path(args.manifest))
         return 0
     if args.command == "update-qualified-beta":
         update_qualification_keys(

--- a/desktop/macos/scripts/release-keyvalue.py
+++ b/desktop/macos/scripts/release-keyvalue.py
@@ -45,7 +45,13 @@ def format_keyvalue_lines(metadata: dict[str, str]) -> list[str]:
     return [f"{key}: {metadata[key]}" for key in metadata]
 
 
+def validate_macos_release_tag(tag: str) -> None:
+    if not MACOS_RELEASE_TAG_RE.fullmatch(tag):
+        raise SystemExit(f"not a macOS release tag: {tag}")
+
+
 def preflight_release(release_json_path: Path, tag: str) -> None:
+    validate_macos_release_tag(tag)
     release = json.loads(release_json_path.read_text(encoding="utf-8"))
     if not isinstance(release, dict):
         raise SystemExit("release JSON must be an object")
@@ -88,8 +94,6 @@ def preflight_release(release_json_path: Path, tag: str) -> None:
         raise SystemExit(f"candidate isLive must be false, got {metadata.get('isLive')!r}")
     if metadata.get("channel") == "beta" and is_live not in {"true", "1", "yes"}:
         raise SystemExit(f"beta isLive must be true, got {metadata.get('isLive')!r}")
-    if not MACOS_RELEASE_TAG_RE.match(tag):
-        raise SystemExit(f"not a macOS release tag: {tag}")
 
 
 def check_manifest(manifest_path: Path) -> None:
@@ -360,6 +364,8 @@ def main(argv: list[str] | None = None) -> int:
     preflight = sub.add_parser("preflight-release", help="Validate a macOS beta release from gh JSON")
     preflight.add_argument("release_json")
     preflight.add_argument("tag")
+    validate_tag = sub.add_parser("validate-tag", help="Validate canonical macOS release-tag syntax")
+    validate_tag.add_argument("tag")
 
     check = sub.add_parser("check-manifest", help="Exit 0 when harness manifest passed")
     check.add_argument("manifest")
@@ -382,6 +388,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "preflight-release":
         preflight_release(Path(args.release_json), args.tag)
         print("release preflight OK")
+        return 0
+    if args.command == "validate-tag":
+        validate_macos_release_tag(args.tag)
+        print("release tag OK")
         return 0
     if args.command == "check-manifest":
         check_manifest(Path(args.manifest))

--- a/desktop/macos/tests/test-qualification-lease-command.sh
+++ b/desktop/macos/tests/test-qualification-lease-command.sh
@@ -43,6 +43,12 @@ case "${QUALIFICATION_LEASE_FIXTURE_MODE:-}" in
     printf '%s\n' 'Safety check failed: Qualification lease token test-release-token does not match the active lease'
     exit 2
     ;;
+  preflight-failure)
+    printf '%s\n' 'Safety check failed: Qualification fault listener test-preflight-token lineage is unproven'
+    exit 2
+    ;;
+  preflight-success)
+    ;;
   acquire-success)
     printf '%s\n' '{"log_dir":"/tmp/qualification-log","token":"test-token"}'
     ;;
@@ -73,6 +79,16 @@ grep -Fq 'qualification failed: lease release exited 2: Safety check failed: Qua
 if grep -Fq 'test-release-token' "$TMP_ROOT/release.err"; then
   fail "lease release diagnostic leaked its capability token"
 fi
+
+if QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=preflight-failure "$LEASE_COMMAND" preflight-fault-cleanup "$FIXTURE_WORKTREE" qualification-test test-preflight-token "$TMP_ROOT/preflight.json" >"$TMP_ROOT/preflight.out" 2>"$TMP_ROOT/preflight.err"; then
+  fail "fault-listener preflight unexpectedly succeeded"
+fi
+grep -Fq 'qualification failed: lease preflight-fault-cleanup exited 2: Safety check failed: Qualification fault listener [redacted] lineage is unproven' "$TMP_ROOT/preflight.err" \
+  || fail "fault-listener preflight failure was not relayed precisely"
+if grep -Fq 'test-preflight-token' "$TMP_ROOT/preflight.err"; then
+  fail "fault-listener preflight diagnostic leaked its capability token"
+fi
+QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=preflight-success "$LEASE_COMMAND" preflight-fault-cleanup "$FIXTURE_WORKTREE" qualification-test test-preflight-token "$TMP_ROOT/preflight.json"
 
 QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=acquire-success "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3 >"$TMP_ROOT/success.out"
 grep -Fxq '{"log_dir":"/tmp/qualification-log","token":"test-token"}' "$TMP_ROOT/success.out" \

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -78,6 +78,7 @@ require_text '--json tagName,isDraft,isPrerelease,publishedAt,assets,body'
 require_text 'WORKTREE="$("$SCRIPT_DIR/qualification-swift-cache.sh" prepare "$SHA" "$REPO_ROOT")"'
 require_text 'qualification-lease "$action"' "$LEASE_COMMAND"
 require_text 'acquire)' "$LEASE_COMMAND"
+require_text 'preflight-fault-cleanup)' "$LEASE_COMMAND"
 require_text 'release)' "$LEASE_COMMAND"
 require_text 'qualification-lease-command.sh' "$QUALIFIER"
 require_text 'OMI_HARNESS_PORT_OFFSET="$QUALIFICATION_PORT_OFFSET"'
@@ -97,7 +98,7 @@ require_text './scripts/desktop-core-harness.sh --self-check --skip-backend-cont
 require_text './scripts/desktop-core-harness.sh --tier 2 --bundle "$BUNDLE" --port "$AUTOMATION_PORT" --keep-stack'
 require_text 'python3 "$KEYVALUE_PY" check-manifest "$EVIDENCE/manifest.json"'
 require_text './scripts/desktop-core-harness.sh --fault-suite --port "$((AUTOMATION_PORT + 1))"'
-require_text 'manifest.get("passed") is not True or manifest.get("tier") != "fault"'
+require_text 'python3 "$KEYVALUE_PY" check-fault-manifest "$FAULT_EVIDENCE/manifest.json"'
 require_text 'evidence["automatic_gates"] = ["signed-artifact", "static-self-check", "tier-2", "fault-suite"]'
 require_text 'if [[ "$LATEST_TAG" != "$RELEASE_TAG" ]]'
 require_text 'python3 "$KEYVALUE_PY" update-qualified-beta'
@@ -133,6 +134,23 @@ require_order "$RUN_SH" \
   'step "Starting app..."' \
   'open "$APP_PATH"' \
   'signal_desktop_launch'
+
+# Runner-only listener cleanup must prove its exact token/PID/port lineage before
+# the expensive app build or any user-flow suite. Unknown listeners still fail
+# closed, and phase timings make the 20-minute target measurable without
+# weakening artifact, Tier-2, or fault evidence.
+require_order "$QUALIFIER" \
+  'phase_begin "fault-listener-preflight" "runner-hygiene-cleanup"' \
+  '"$LEASE_COMMAND" preflight-fault-cleanup' \
+  'phase_begin "desktop-preparation" "runner-hygiene-cleanup"' \
+  'phase_begin "tier-2-user-flows" "user-visible-behavioral-fault"' \
+  'phase_begin "fault-user-flow" "user-visible-behavioral-fault"' \
+  'phase_begin "final-cleanup" "runner-hygiene-cleanup"'
+require_text '"target_seconds": 1200'
+require_text 'OMI_QUALIFICATION_TIMINGS_FILE' "$QUALIFIER"
+require_text 'OMI_QUALIFICATION_FAULT_PREFLIGHT_REPORT' "$QUALIFIER"
+require_text '/phase-timings.json' "$SCRIPT_DIR/../../../.github/workflows/desktop_qualify_beta.yml"
+require_text '/fault-listener-preflight.json' "$SCRIPT_DIR/../../../.github/workflows/desktop_qualify_beta.yml"
 
 if [[ ! -x "$PROFILE_PREP" ]]; then
   echo "FAIL: missing executable qualification profile preparation helper" >&2

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -7,8 +7,10 @@ CORE_HARNESS="$SCRIPT_DIR/../scripts/desktop-core-harness.sh"
 PROFILE_PREP="$SCRIPT_DIR/../scripts/prepare-qualification-profile.sh"
 SWIFT_CACHE="$SCRIPT_DIR/../scripts/qualification-swift-cache.sh"
 LEASE_COMMAND="$SCRIPT_DIR/../scripts/qualification-lease-command.sh"
+LOCAL_PROOF="$SCRIPT_DIR/../scripts/qualification-local-proof.sh"
 APP_CONFIG="$SCRIPT_DIR/../scripts/app-config.sh"
 RUN_SH="$SCRIPT_DIR/../run.sh"
+WORKFLOW="$SCRIPT_DIR/../../../.github/workflows/desktop_qualify_beta.yml"
 
 require_text() {
   local pattern="$1"
@@ -152,6 +154,27 @@ require_text 'OMI_QUALIFICATION_FAULT_PREFLIGHT_REPORT' "$QUALIFIER"
 require_text '/phase-timings.json' "$SCRIPT_DIR/../../../.github/workflows/desktop_qualify_beta.yml"
 require_text '/fault-listener-preflight.json' "$SCRIPT_DIR/../../../.github/workflows/desktop_qualify_beta.yml"
 
+# CI runs the same behavioral offline proof before it dispatches the expensive
+# canonical job, retaining its redacted result without duplicating Tier-2.
+require_order "$WORKFLOW" \
+  'local-proof-m1:' \
+  'qualification-local-proof.sh \' \
+  '--offline \' \
+  '--fast \' \
+  'qualify-m1-studio:' \
+  'needs: local-proof-m1'
+require_text 'local-qualification-proof.json' "$WORKFLOW"
+require_text 'local-qualification-proof-fault-listener.json' "$WORKFLOW"
+require_text 'python3 "$KEYVALUE_PY" validate-tag "$RELEASE_TAG"' "$LOCAL_PROOF"
+require_text '"$LEASE_COMMAND" acquire' "$LOCAL_PROOF"
+require_text '"$FAULT_INJECTOR" start error' "$LOCAL_PROOF"
+require_text '"$LEASE_COMMAND" preflight-fault-cleanup' "$LOCAL_PROOF"
+require_text '"$LEASE_COMMAND" release' "$LOCAL_PROOF"
+if grep -Fq 'qualify-desktop-beta.sh' "$LOCAL_PROOF"; then
+  echo "FAIL: local pre-dispatch proof must not duplicate the full qualification suite" >&2
+  exit 1
+fi
+
 if [[ ! -x "$PROFILE_PREP" ]]; then
   echo "FAIL: missing executable qualification profile preparation helper" >&2
   exit 1
@@ -162,6 +185,10 @@ if [[ ! -x "$SWIFT_CACHE" ]]; then
 fi
 if [[ ! -x "$LEASE_COMMAND" ]]; then
   echo "FAIL: missing executable qualification lease command helper" >&2
+  exit 1
+fi
+if [[ ! -x "$LOCAL_PROOF" ]]; then
+  echo "FAIL: missing executable local qualification proof helper" >&2
   exit 1
 fi
 

--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -985,6 +985,14 @@ def cmd_qualification_lease(args: argparse.Namespace) -> int:
             retention_age_seconds=args.retention_age_seconds,
         )
         return 0
+    if args.lease_action == "preflight-fault-cleanup":
+        qualification.preflight_fault_cleanup(
+            repo_root=repo_root,
+            lease_id=args.lease_id,
+            token=args.token,
+            result_path=Path(args.result),
+        )
+        return 0
     raise AssertionError(f"Unexpected qualification lease action {args.lease_action!r}")
 
 
@@ -1019,6 +1027,14 @@ def build_parser() -> argparse.ArgumentParser:
     release.add_argument("--retained-runs", type=int, default=qualification.DEFAULT_RETAINED_RUNS)
     release.add_argument("--retention-age-seconds", type=int, default=qualification.DEFAULT_RETENTION_MAX_AGE_SECONDS)
     release.set_defaults(func=cmd_qualification_lease)
+    fault_preflight = lease_sub.add_parser(
+        "preflight-fault-cleanup",
+        help="Validate and reclaim the exact lease-owned disposable fault listener",
+    )
+    fault_preflight.add_argument("--lease-id", required=True)
+    fault_preflight.add_argument("--token", required=True)
+    fault_preflight.add_argument("--result", required=True)
+    fault_preflight.set_defaults(func=cmd_qualification_lease)
     return parser
 
 

--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -325,6 +325,101 @@ def _stop_owned_fault_record(record: dict[str, object] | None) -> None:
         )
 
 
+def _write_fault_preflight_report(
+    path: Path,
+    *,
+    lease_id: str,
+    status: str,
+    port: int | None,
+    failure_reason: str | None = None,
+    detail: str | None = None,
+) -> None:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "gate": "fault-listener-provenance-cleanup",
+        "classification": "runner-hygiene-cleanup",
+        "lease_id": lease_id,
+        "status": status,
+        "port": port,
+        "failure_reason": failure_reason,
+    }
+    if detail:
+        payload["detail"] = detail
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _write_lease(path, payload)
+    path.chmod(0o600)
+
+
+def _fault_preflight_failure_reason(exc: Exception) -> str:
+    detail = str(exc).lower()
+    if "lineage is unproven" in detail or "ownership changed" in detail:
+        return "unproven-listener-lineage"
+    if "token" in detail:
+        return "lease-token-mismatch"
+    if "port still open" in detail or "process still running" in detail:
+        return "owned-listener-cleanup-incomplete"
+    if "state" in detail or "pid" in detail:
+        return "invalid-listener-provenance"
+    return "host-prerequisite-unmet"
+
+
+def preflight_fault_cleanup(*, repo_root: Path, lease_id: str, token: str, result_path: Path) -> dict[str, object]:
+    """Prove and reclaim a disposable listener before expensive qualification."""
+
+    root = _validate_root(lease_root_from_env(), repo_root)
+    observed_port: int | None = None
+    try:
+        with _locked(root):
+            path = _lease_path(root)
+            lease = _read_lease(path)
+            if lease is None:
+                raise QualificationLeaseError("Qualification fault-listener preflight requires an active lease")
+            recorded_id, state_root, recorded_repo, _owner_pid, recorded_token = _lease_provenance(lease, root)
+            if recorded_id != lease_id or recorded_token != token:
+                raise QualificationLeaseError("Qualification lease token does not match the active lease")
+            if recorded_repo != _real(repo_root):
+                raise QualificationLeaseError("Qualification lease belongs to a different source worktree")
+            fault_record = _validated_fault_record(state_root, recorded_token)
+            if fault_record is None:
+                raise QualificationLeaseError("Qualification fault-listener preflight found no recorded listener")
+            observed_port = int(fault_record["port"])
+            _stop_owned_fault_record(fault_record)
+            alive, listeners = _validate_fault_process(fault_record)
+            if alive or listeners:
+                raise QualificationLeaseError(
+                    "Qualification fault-listener preflight could not prove cleanup completion"
+                )
+            fault_state = state_root / FAULT_STATE_DIRNAME
+            for evidence in (fault_state / "pid", fault_state / "meta"):
+                evidence.unlink()
+            report = {
+                "schema_version": 1,
+                "gate": "fault-listener-provenance-cleanup",
+                "classification": "runner-hygiene-cleanup",
+                "lease_id": lease_id,
+                "status": "passed",
+                "port": observed_port,
+                "failure_reason": None,
+            }
+            _write_fault_preflight_report(
+                result_path,
+                lease_id=lease_id,
+                status="passed",
+                port=observed_port,
+            )
+            return report
+    except (QualificationLeaseError, safety.SafetyError) as exc:
+        _write_fault_preflight_report(
+            result_path,
+            lease_id=lease_id,
+            status="failed",
+            port=observed_port,
+            failure_reason=_fault_preflight_failure_reason(exc),
+            detail=str(exc),
+        )
+        raise
+
+
 def _is_exact_typesense_docker_proxy(record: dict[str, object], lease_id: str | None) -> bool:
     """Prove Docker's external port proxy belongs to this exact lease container."""
 

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -4,6 +4,7 @@ import json
 import os
 import signal
 import socket
+import stat
 import subprocess
 import sys
 import time
@@ -94,6 +95,106 @@ def test_release_stops_the_exact_lease_owned_fault_inject_listener(
     assert not safety.process_exists(pid)
     assert not (root / "qualification-lease.json").exists()
     assert (root / "state" / lease_id / qualification.COMPLETION_FILENAME).is_file()
+
+
+def test_fault_listener_preflight_proves_cleanup_before_retaining_the_active_lease(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "qualification"
+    lease_id = "qualification-owned-fault-preflight"
+    report_path = tmp_path / "fault-listener-preflight.json"
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
+    monkeypatch.setattr(qualification, "STOP_PHASES", ((signal.SIGTERM, 2), (signal.SIGKILL, 1)))
+    acquired = qualification.acquire(
+        repo_root=REPO_ROOT,
+        lease_id=lease_id,
+        owner_pid=os.getpid(),
+        port_offset=1000,
+    )
+    state = root / "state" / lease_id / qualification.FAULT_STATE_DIRNAME
+    state.mkdir(mode=0o700)
+    port = _free_port()
+    pid = _start_fault_injector(state, str(acquired["token"]), port)
+
+    report = qualification.preflight_fault_cleanup(
+        repo_root=REPO_ROOT,
+        lease_id=lease_id,
+        token=str(acquired["token"]),
+        result_path=report_path,
+    )
+
+    assert report["status"] == "passed"
+    assert report["port"] == port
+    assert json.loads(report_path.read_text(encoding="utf-8")) == report
+    assert stat.S_IMODE(report_path.stat().st_mode) == 0o600
+    assert not safety.listening_pids(port)
+    deadline = time.monotonic() + 2
+    while safety.process_exists(pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not safety.process_exists(pid)
+    assert not (state / "pid").exists()
+    assert not (state / "meta").exists()
+    assert (root / "qualification-lease.json").is_file()
+
+    qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+
+
+def test_fault_listener_preflight_retains_replaced_listener_and_reports_host_prerequisite(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "qualification"
+    lease_id = "qualification-foreign-fault-preflight"
+    report_path = tmp_path / "fault-listener-preflight.json"
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
+    acquired = qualification.acquire(
+        repo_root=REPO_ROOT,
+        lease_id=lease_id,
+        owner_pid=os.getpid(),
+        port_offset=1000,
+    )
+    state = root / "state" / lease_id / qualification.FAULT_STATE_DIRNAME
+    state.mkdir(mode=0o700)
+    port = _free_port()
+    owned_pid = _start_fault_injector(state, str(acquired["token"]), port)
+    os.killpg(owned_pid, signal.SIGTERM)
+    deadline = time.monotonic() + 5
+    while safety.process_exists(owned_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    foreign = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); "
+            "s.bind(('127.0.0.1',int(__import__('sys').argv[1]))); s.listen(); time.sleep(60)",
+            str(port),
+        ],
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while foreign.pid not in safety.listening_pids(port) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        with pytest.raises(qualification.QualificationLeaseError, match="lease lineage is unproven"):
+            qualification.preflight_fault_cleanup(
+                repo_root=REPO_ROOT,
+                lease_id=lease_id,
+                token=str(acquired["token"]),
+                result_path=report_path,
+            )
+
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        assert report["status"] == "failed"
+        assert report["failure_reason"] == "unproven-listener-lineage"
+        assert report["classification"] == "runner-hygiene-cleanup"
+        assert foreign.poll() is None
+        assert (root / "qualification-lease.json").is_file()
+        assert (state / "pid").is_file()
+        assert (state / "meta").is_file()
+        assert not (root / "state" / lease_id / qualification.COMPLETION_FILENAME).exists()
+    finally:
+        if foreign.poll() is None:
+            foreign.terminate()
+            foreign.wait(timeout=10)
 
 
 def test_release_refuses_and_retains_an_unproven_listener_on_the_recorded_fault_port(

--- a/scripts/dev-harness/tests/test_qualification_local_proof.py
+++ b/scripts/dev-harness/tests/test_qualification_local_proof.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import socket
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dev_harness import qualification, safety
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_NAMES = (
+    "qualification-local-proof.sh",
+    "qualification-lease-command.sh",
+    "release-keyvalue.py",
+    "omi-fault-inject.sh",
+)
+RELEASE_TAG = "v0.0.1+1-macos"
+INHERITED_GIT_CONTEXT = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_QUARANTINE_PATH",
+    "GIT_WORK_TREE",
+)
+
+
+def _run(*args: str | Path, cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    process_env = dict(os.environ if env is None else env)
+    for key in INHERITED_GIT_CONTEXT:
+        process_env.pop(key, None)
+    return subprocess.run(
+        [str(arg) for arg in args],
+        cwd=cwd,
+        env=process_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def proof_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "canonical-repo"
+    scripts = repo / "desktop" / "macos" / "scripts"
+    scripts.mkdir(parents=True)
+    for name in SCRIPT_NAMES:
+        shutil.copy2(REPO_ROOT / "desktop" / "macos" / "scripts" / name, scripts / name)
+    shutil.copytree(REPO_ROOT / "scripts" / "dev-harness" / "dev_harness", repo / "scripts" / "dev-harness" / "dev_harness")
+    backend = repo / "backend"
+    backend.mkdir()
+    (backend / ".venv").symlink_to(REPO_ROOT / "backend" / ".venv", target_is_directory=True)
+
+    commands = (
+        ("git", "init", "--quiet"),
+        ("git", "config", "user.email", "qualification-proof@example.invalid"),
+        ("git", "config", "user.name", "Qualification Proof Test"),
+        ("git", "add", "."),
+        ("git", "-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", "qualification proof fixture"),
+        ("git", "tag", RELEASE_TAG),
+    )
+    for command in commands:
+        completed = _run(*command, cwd=repo)
+        assert completed.returncode == 0, completed.stderr
+    return repo
+
+
+def _proof_env(tmp_path: Path) -> dict[str, str]:
+    temporary = tmp_path / "tmp"
+    temporary.mkdir(exist_ok=True)
+    return {
+        **os.environ,
+        "OMI_QUALIFICATION_LEASE_ROOT": str(tmp_path / "qualification"),
+        "TMPDIR": str(temporary),
+    }
+
+
+def _run_proof(repo: Path, tmp_path: Path) -> tuple[subprocess.CompletedProcess[str], Path]:
+    result = tmp_path / "evidence" / "local-qualification-proof.json"
+    completed = _run(
+        repo / "desktop" / "macos" / "scripts" / "qualification-local-proof.sh",
+        "--offline",
+        "--fast",
+        "--result",
+        result,
+        RELEASE_TAG,
+        cwd=repo,
+        env=_proof_env(tmp_path),
+    )
+    return completed, result
+
+
+def _free_port() -> int:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    port = int(listener.getsockname()[1])
+    listener.close()
+    return port
+
+
+def _start_owned_fault(repo: Path, state: Path, token: str, port: int, env: dict[str, str]) -> int:
+    completed = _run(
+        repo / "desktop" / "macos" / "scripts" / "omi-fault-inject.sh",
+        "start",
+        "error",
+        "--port",
+        str(port),
+        cwd=repo,
+        env={
+            **env,
+            "OMI_FAULT_STATE_DIR": str(state),
+            "OMI_FAULT_OWNERSHIP_TOKEN": token,
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    return int((state / "pid").read_text(encoding="utf-8"))
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 5) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert predicate()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="the local proof is an M1/macOS lifecycle command")
+def test_local_qualification_proof_completes_every_offline_boundary(proof_repo: Path, tmp_path: Path) -> None:
+    completed, result_path = _run_proof(proof_repo, tmp_path)
+
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["status"] == "passed"
+    assert result["mode"] == "offline-fast"
+    assert result["cleanup_status"] == "released"
+    assert result["source_sha"] == _run("git", "rev-parse", "HEAD", cwd=proof_repo).stdout.strip()
+    assert result["completed_boundaries"] == [
+        "release-tag-validation",
+        "lease-provenance-acquisition",
+        "disposable-fault-listener-start",
+        "runner-hygiene-preflight",
+        "cleanup-finalization",
+    ]
+    assert result["fault_listener_result"]["status"] == "passed"
+    assert stat.S_IMODE(result_path.stat().st_mode) == 0o600
+    assert not (tmp_path / "qualification" / "qualification-lease.json").exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="the local proof is an M1/macOS lifecycle command")
+def test_local_qualification_proof_refuses_foreign_stale_listener(
+    monkeypatch: pytest.MonkeyPatch, proof_repo: Path, tmp_path: Path
+) -> None:
+    env = _proof_env(tmp_path)
+    lease_root = Path(env["OMI_QUALIFICATION_LEASE_ROOT"])
+    lease_id = "qualification-stale-proof"
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(lease_root))
+    acquired = qualification.acquire(
+        repo_root=proof_repo,
+        lease_id=lease_id,
+        owner_pid=os.getpid(),
+        port_offset=1000,
+    )
+    state = lease_root / "state" / lease_id / qualification.FAULT_STATE_DIRNAME
+    state.mkdir(mode=0o700)
+    port = _free_port()
+    owned_pid = _start_owned_fault(proof_repo, state, str(acquired["token"]), port, env)
+    os.killpg(owned_pid, signal.SIGTERM)
+    _wait_until(lambda: not safety.process_exists(owned_pid))
+
+    foreign = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); "
+            "s.bind(('127.0.0.1',int(__import__('sys').argv[1]))); s.listen(); time.sleep(60)",
+            str(port),
+        ],
+        start_new_session=True,
+    )
+    try:
+        _wait_until(lambda: foreign.pid in safety.listening_pids(port))
+        lease_path = lease_root / "qualification-lease.json"
+        stale = json.loads(lease_path.read_text(encoding="utf-8"))
+        stale["owner_pid"] = 999999
+        lease_path.write_text(json.dumps(stale), encoding="utf-8")
+
+        completed, result_path = _run_proof(proof_repo, tmp_path)
+
+        assert completed.returncode != 0
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        assert result["status"] == "failed"
+        assert result["failure_reason"] == "unproven-stale-listener"
+        assert result["cleanup_status"] == "not-acquired"
+        assert result["completed_boundaries"] == ["release-tag-validation"]
+        assert foreign.poll() is None
+        assert lease_path.is_file()
+        assert (state / "pid").is_file()
+        assert (state / "meta").is_file()
+    finally:
+        if foreign.poll() is None:
+            foreign.terminate()
+            foreign.wait(timeout=10)
+        qualification.release(repo_root=proof_repo, lease_id=lease_id, token=str(acquired["token"]))


### PR DESCRIPTION
## Summary

- classify qualification gates as immutable artifact/security, user-visible behavioral/fault coverage, or runner hygiene/cleanup
- start and reclaim a disposable, token-bound fault listener immediately after lease acquisition so foreign/replaced listeners fail before desktop preparation
- add one exact-tag, explicit-offline M1 proof command that reuses release-tag validation, lease/provenance acquisition, disposable listener preflight, and authenticated finalization
- require that fast proof in a separate M1 workflow job before dispatching canonical qualification, and retain its redacted result/fault artifact on success or failure
- keep signing/identity, Tier-2, fault-flow, evidence, unknown-listener, cleanup, Beta, and Stable gates fail-closed

## Timing and gate evidence

- `local-qualification-proof.json` records the exact source SHA and each completed lifecycle boundary without credentials, release access, app launch, or channel mutation
- `phase-timings.json` records status and duration for the full canonical candidate/lease preflight, listener preflight, desktop preparation, bridge readiness, static checks, Tier-2 flows, fault flow, and final cleanup
- the behavioral suite is unchanged: passing Tier-2 and fault manifests remain mandatory before evidence publication
- no release tag, build, qualification, promotion, pointer, cloud, Beta break-glass, or Stable operation was triggered by this PR

## Verification

- `bash scripts/dev-harness/run-tests.sh` — 65 passed, including clean local proof and foreign-listener refusal
- `GIT_DIR=… GIT_WORK_TREE=… backend/.venv/bin/python -m pytest -q scripts/dev-harness/tests/test_qualification_local_proof.py` — 2 passed; fixture remained isolated from the parent repository
- `bash desktop/macos/tests/test-qualification-lease-command.sh`
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `python3 desktop/macos/scripts/release-keyvalue.py self-test`
- `bash desktop/macos/tests/test-fault-suite-launch-env.sh`
- `bash desktop/macos/tests/test-fault-suite-owned-app-cleanup.sh`
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 8 passed
- `actionlint -shellcheck '' .github/workflows/desktop_qualify_beta.yml`
- `make preflight`
- pre-push bounded gate — 66 manifest checks plus the macOS desktop launcher contracts passed; only unrelated Flutter generated-output verification used the documented no-toolchain hatch

Failure-Class: none

Closes SCA-169


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

