### PR TITLE
fix(desktop): normalize provider HTTP errors

### DIFF
--- a/.github/failure-classes/FC-provider-http-error-format.json
+++ b/.github/failure-classes/FC-provider-http-error-format.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-provider-http-error-format",
+  "violated_contract": "An Omi-owned adapter must surface provider HTTP failures with an explicit, stable HTTP status signal; dependency-specific error wording must not silently change the downstream product or qualification contract.",
+  "canonical_prevention": "Normalize dependency HTTP error wording at the adapter boundary while preserving the provider detail, and drive the real terminal provider-event seam with behavioral contract coverage.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/tests/pi-mono-adapter.test.ts"
+  ],
+  "evidence_prs": [
+    10251
+  ],
+  "scope_hints": [
+    "desktop/macos/agent/src/adapters/**",
+    "desktop/macos/agent/tests/*adapter*.test.ts"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -109,6 +109,13 @@ interface PiUsage {
   };
 }
 
+function normalizeProviderHTTPErrorMessage(message: string): string {
+  const trimmed = message.trim();
+  // Provider SDK wording is not our downstream contract: retain its detail,
+  // but make a leading HTTP failure status explicit and stable for Swift.
+  return /^[45]\d{2}(?=$|[\s:])/.test(trimmed) ? `HTTP ${trimmed}` : trimmed;
+}
+
 const REQUIRED_AGENT_CONTROL_TOOLS = new Set([
   "send_agent_message",
   "spawn_background_agent",
@@ -983,7 +990,9 @@ export class PiMonoAdapter implements HarnessAdapter {
     // Log key events for diagnostic visibility
     if (event.type === 'turn_end') {
       const msg = (event as any).message;
-      const errMsg = msg?.errorMessage;
+      const errMsg = typeof msg?.errorMessage === "string"
+        ? normalizeProviderHTTPErrorMessage(msg.errorMessage)
+        : undefined;
       if (errMsg) {
         process.stderr.write(`[pi-mono] turn_end ERROR: ${errMsg}\n`);
       }
@@ -1201,7 +1210,7 @@ export class PiMonoAdapter implements HarnessAdapter {
 
     const message = event.message as PiAssistantMessage | undefined;
     const errorMessage = typeof message?.errorMessage === "string" && message.errorMessage.trim()
-      ? message.errorMessage.trim()
+      ? normalizeProviderHTTPErrorMessage(message.errorMessage)
       : undefined;
     if (errorMessage) {
       this.finishPublicWebProgress(this.activePublicWebTurn, "failed");

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -655,6 +655,31 @@ describe("PiMonoAdapter prompt correlation", () => {
     );
   });
 
+  it("normalizes bare provider HTTP status errors before surfacing them", async () => {
+    const { adapter, events } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "fail with backend 5xx" }],
+      [],
+      "act",
+      (event) => events.push(event),
+      async () => ""
+    );
+
+    (adapter as any).handleEvent(JSON.stringify(makeErrorTurnEndEvent('500 "omi-fault-inject"')));
+
+    await expect(prompt).rejects.toThrow('HTTP 500 "omi-fault-inject"');
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: 'HTTP 500 "omi-fault-inject"',
+        adapterSessionId: "session-1",
+      })
+    );
+  });
+
   it("does not report success after a required agent-control operation fails", async () => {
     const { adapter, events } = createAdapter();
     seedSessions(adapter, "session-1");

--- a/desktop/macos/changelog/unreleased/20260726-normalize-chat-http-errors.json
+++ b/desktop/macos/changelog/unreleased/20260726-normalize-chat-http-errors.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat failures so backend status codes are clearly identified as HTTP errors"
+}


### PR DESCRIPTION
## Summary

- Normalize bare leading provider 4xx/5xx messages at the Omi-owned pi-mono adapter boundary (`500 ...` → `HTTP 500 ...`) while preserving the backend detail.
- Cover the production JSONL `turn_end` seam with the exact `500 "omi-fault-inject"` regression.
- Keep the qualification assertion and fail-closed behavior unchanged.

## Incident evidence

- GitHub Actions qualification run: https://github.com/BasedHardware/omi/actions/runs/30208861577
- Failed immutable candidate: `v0.12.131+12131-macos` at `fc0b61ecd53393f68adcd3c124ada3d4014268f5`
- T2 passed and the fault injector was reached with a healthy bridge. S5 failed only because the pi provider upgrade surfaced `500 "omi-fault-inject"` while Omi's downstream HTTP error contract requires `HTTP 500`.
- Current `origin/main` was inspected first. The v0.12.132 repair in #10652 authenticates fault-listener cleanup and is independent; this PR does not duplicate or alter it.

## Contract and guard

The dependency's provider-error wording is not a downstream product contract. `PiMonoAdapter` is the narrow Omi-owned boundary that translates the provider event into the Swift bridge error, so it now makes a leading HTTP status explicit and stable without reclassifying the failure or discarding detail.

The regression guard is adapter-local rather than a shared primitive because only pi-mono consumes this SDK-specific `turn_end.errorMessage` shape. The behavioral test drives the real JSONL `turn_end` seam and would have caught qualification run 30208861577. No qualification expectation was relaxed.

The new failure class records merged provider upgrade #10251 as evidence and names the adapter behavioral test as its canonical prevention artifact.

## Verification

- `npm --prefix desktop/macos/agent test -- --run tests/pi-mono-adapter.test.ts -t 'normalizes bare provider HTTP status errors before surfacing them'`
  - Before repair: failed with received `500 "omi-fault-inject"` instead of expected `HTTP 500 "omi-fault-inject"`
  - After repair: 1 passed
- `npm --prefix desktop/macos/agent run build` — passed
- `cd desktop/macos/agent && npm test` — 53 files / 601 tests passed
- `cd desktop/macos && ./scripts/agent-logic-harness.sh` — passed (Swift lifecycle/state, agent runtime, and exact pi-mono-extension package tests)
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --cross-surface-smoke` — passed (Swift, agent, and Rust contract smokes)
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- `cd desktop/macos && PATH="/Users/david/workspace/omi-qualification-fault-http-message/backend/.venv/bin:$PATH" ./scripts/desktop-core-harness.sh --fault-suite` — passed at `0bfd3fd7d67a5a472e9ad12641b5534b7e155ac9`; S1–S6 passed and logs surfaced `HTTP 500 "omi-fault-inject"`
- `make setup` — passed
- `OMI_PR_BODY_FILE=/tmp/omi-qualification-fault-http-message-pr.md make preflight` — 13 selected local checks passed
- `scripts/pr-preflight --pr-body-file /tmp/omi-qualification-fault-http-message-pr.md` — 13 selected CI-lane checks passed

## Product invariants

None.

## Failure class

Failure-Class: new

## Release impact

After merge, the automatic macOS release flow must cut a fresh higher candidate tag. The failed `v0.12.131+12131-macos` candidate remains immutable and must not be reused. This PR does not advance Beta or Stable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

