### PR TITLE
fix(desktop-windows): name the supported Node version instead of failing silently

### DIFF
--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.20",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
+  "engines": {
+    "node": ">=22.19.0 <23"
+  },
   "author": "Based Hardware",
   "homepage": "https://github.com/BasedHardware/omi",
   "scripts": {
@@ -34,6 +37,7 @@
     "build:win": "npm run build && electron-builder --win --x64 --config electron-builder.config.mjs --publish never",
     "build:mac": "electron-vite build && node scripts/bundle-pimono-extension.mjs && electron-builder --mac --config electron-builder.config.mjs --publish never",
     "build:linux": "electron-vite build && node scripts/bundle-pimono-extension.mjs && electron-builder --linux --config electron-builder.config.mjs --publish never",
+    "pretest": "node scripts/check-node-version.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "fixtures:audio": "node scripts/gen-audio-fixtures.mjs",

--- a/desktop/windows/scripts/check-node-version.mjs
+++ b/desktop/windows/scripts/check-node-version.mjs
@@ -1,0 +1,39 @@
+// Fail the test run early, and legibly, when Node is outside the supported range.
+//
+// Without this the failure is silent and deeply confusing: on Node >= 24 the
+// runtime ships its own experimental `localStorage` global that is `undefined`
+// unless `--localstorage-file` is passed, and it takes precedence over the one
+// jsdom installs. Every `// @vitest-environment jsdom` suite that touches
+// localStorage then dies with `Cannot read properties of undefined (reading
+// 'clear')` — 29 test files and 129 tests on Node 26.3.1, all green on Node
+// 22.16.0 with the same code and the same lockfile. CI pins Node 22, so the
+// breakage is invisible there and only ever hits a contributor's machine.
+//
+// The floor is not cosmetic either: `@earendil-works/pi-ai` declares
+// `engines.node >= 22.19.0`, so an older 22.x installs but is unsupported.
+//
+// Kept as a `pretest` hook rather than `engine-strict=true` in .npmrc: that flag
+// makes pnpm enforce the engines field of every transitive dependency, which is a
+// far larger blast radius than the problem this guards.
+
+const RANGE = '>=22.19.0 <23'
+
+const [major, minor] = process.versions.node.split('.').map(Number)
+const supported = major === 22 && minor >= 19
+
+if (!supported) {
+  const why =
+    major >= 24
+      ? "Node >= 24 provides its own `localStorage` global that shadows jsdom's and is undefined " +
+        'without --localstorage-file, so the jsdom test suites fail with confusing undefined errors.'
+      : 'This project depends on packages that require Node >= 22.19.0.'
+
+  process.stderr.write(
+    `\nUnsupported Node version for the Omi Windows desktop test suite.\n\n` +
+      `  required: ${RANGE}   (package.json "engines.node", and what CI pins)\n` +
+      `  running:  v${process.versions.node}\n\n` +
+      `${why}\n\n` +
+      `Switch with your version manager, e.g. \`nvm use 22\` or \`fnm use 22\`, then re-run.\n\n`
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
## What

`pnpm test` in `desktop/windows` fails **29 test files / 129 tests** on a current Node — with the same code and the same lockfile that is **fully green on Node 22**. Nothing in the package says which Node is required: there is no `engines` field, and no `.nvmrc` anywhere in the repo, while all five CI workflows pin `node-version: 22`. So the breakage is invisible in CI and lands only on a contributor's machine.

## Why it happens

It is not the tests. **Node >= 24 ships its own experimental `localStorage` global**, which is `undefined` unless `--localstorage-file` is passed, and it takes precedence over the one jsdom installs. Every `// @vitest-environment jsdom` suite that touches localStorage then dies with:

```
TypeError: Cannot read properties of undefined (reading 'clear')
   23| beforeEach(() => {
   24|   localStorage.clear()
(node:47032) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
```

That reads like a broken test, not a wrong runtime — which is exactly why it costs time.

## Fix

- **`engines.node` = `>=22.19.0 <23`.** The floor is real, not decorative: `@earendil-works/pi-ai` declares `engines.node >= 22.19.0`, so an older 22.x installs and is still unsupported.
- **A `pretest` guard** that names the required range, the running version, and the reason — so the first failure is one legible line instead of 129 assertions. It is wired at `pretest` because the symptom is a test-suite symptom.

## What I tried and rejected

`engine-strict=true` in `.npmrc`. It makes pnpm enforce the `engines` field of **every transitive dependency** — a far wider blast radius than this problem. In practice it rejected Node 22.16.0 over a dependency's floor while giving no hint that the test suite itself was fine. Declaring `engines` alone does not block anything under pnpm 10 (verified: install succeeded on Node 26), which is why the guard exists.

## Verification

Same tree, same lockfile — only the runtime changed:

```
Node 26.3.1   pnpm test  ->  29 files / 129 tests FAILED (localStorage undefined)
Node 22.23.1  pnpm test  ->  523 files / 5037 tests passed, 6 skipped

guard on v26.3.1   -> exit 1, explains the localStorage shadowing
guard on v22.16.0  -> exit 1, explains the >=22.19.0 dependency floor
guard on v22.23.1  -> exit 0
```

`v22.23.1` is what CI's `node-version: 22` resolves to today, so `pnpm test` in CI keeps passing — I verified the supported path explicitly rather than only the rejections, since a wrong guard here would break the lane for everyone.

## Scope

`desktop/windows` only: one `engines` field, one `pretest` entry, one guard script. No test or product code touched.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

