### PR TITLE
fix(ci): wire the desktop release manifest schema guard into a lane

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -69,6 +69,11 @@ checks:
     triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/desktop_release_manifest.py", ".github/scripts/test_desktop_release_manifest.py", ".github/scripts/fixtures/desktop_release_manifest/**"]
     lanes: ["local", "ci"]
     reason: "immutable desktop app/backend release-unit contract"
+  - id: desktop-release-manifest-schema-v1
+    command: ["python3", ".github/scripts/test_desktop_release_manifest_schema.py"]
+    triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/test_desktop_release_manifest_schema.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the Stable manifest schema must keep admitting exactly one app artifact pair; a beta_zip_url re-entering it is how a beta build becomes describable as Stable"
   - id: desktop-release-doctor-v1
     command: ["python3", ".github/scripts/test_desktop_release_doctor.py"]
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]

--- a/.github/scripts/test_desktop_release_manifest_schema.py
+++ b/.github/scripts/test_desktop_release_manifest_schema.py
@@ -1,22 +1,85 @@
+#!/usr/bin/env python3
+"""The desktop release manifest schema admits exactly one app artifact pair.
+
+`desktop-release-manifest-v1.schema.json` is what a published Stable manifest is
+validated against. The invariant it carries is that a Stable manifest describes
+*one* app: `zip_url`/`dmg_url` pointing at `Omi.zip`/`omi.dmg`, with no parallel
+beta artifact fields. A `beta_zip_url` re-entering the schema is how a beta build
+becomes describable as Stable, so the absence of those fields is load-bearing
+rather than tidiness.
+
+This suite is stdlib-only and unittest-style on purpose. It previously imported
+`jsonschema` and relied on pytest, and no lane in the repository installs either
+-- it had no manifest entry, no workflow step, and nothing referenced it, so it
+ran nowhere and could not fail. (#10351 is the same class: a guard whose
+self-suite has no blocking audience is a dead check.) Both `$defs` it exercises
+are plain `{"type": "string", "pattern": "^...$"}` schemas, and JSON Schema
+`pattern` semantics are a regex search -- anchored here -- so `re.search`
+validates them exactly as `Draft202012Validator` did, with nothing to install.
+"""
+
 from __future__ import annotations
 
 import json
+import re
+import unittest
 from pathlib import Path
-
-from jsonschema import Draft202012Validator
 
 SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schemas/desktop-release-manifest-v1.schema.json"
 
+STABLE_ZIP = "https://github.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/Omi.zip"
+STABLE_DMG = "https://github.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/omi.dmg"
 
-def test_artifact_schema_accepts_only_the_single_app_artifact_names():
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    definitions = schema["$defs"]
-    stable_zip = "https://github.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/Omi.zip"
-    stable_dmg = "https://github.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/omi.dmg"
 
-    Draft202012Validator(definitions["zipUrl"]).validate(stable_zip)
-    Draft202012Validator(definitions["dmgUrl"]).validate(stable_dmg)
-    assert "beta_zip_url" not in schema["properties"]
-    assert "beta_dmg_url" not in schema["properties"]
-    assert "betaZipUrl" not in definitions
-    assert "betaDmgUrl" not in definitions
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _matches(subschema: dict, value: str) -> bool:
+    """Validate `value` against a string-with-pattern subschema.
+
+    Mirrors the two keywords these `$defs` actually use. A richer subschema would
+    be silently under-validated, so the type is asserted rather than assumed.
+    """
+    assert subschema.get("type") == "string", f"expected a string subschema, got {subschema.get('type')!r}"
+    pattern = subschema["pattern"]
+    return isinstance(value, str) and re.search(pattern, value) is not None
+
+
+class ArtifactUrlDefinitions(unittest.TestCase):
+    def test_accepts_the_canonical_stable_artifact_urls(self):
+        defs = _load_schema()["$defs"]
+        self.assertTrue(_matches(defs["zipUrl"], STABLE_ZIP), "zipUrl rejected the canonical Stable zip")
+        self.assertTrue(_matches(defs["dmgUrl"], STABLE_DMG), "dmgUrl rejected the canonical Stable dmg")
+
+    def test_rejects_a_beta_named_artifact(self):
+        """The pattern, not just the field list, is what keeps a beta build out."""
+        defs = _load_schema()["$defs"]
+        beta_zip = "https://github.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/Omi-Beta.zip"
+        beta_dmg = "https://github.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/omi-beta.dmg"
+        self.assertFalse(_matches(defs["zipUrl"], beta_zip), "zipUrl accepted a beta-named zip")
+        self.assertFalse(_matches(defs["dmgUrl"], beta_dmg), "dmgUrl accepted a beta-named dmg")
+
+    def test_rejects_an_artifact_from_another_host_or_repo(self):
+        defs = _load_schema()["$defs"]
+        for bad in (
+            "https://example.com/BasedHardware/omi/releases/download/v0.12.64+12064-macos/Omi.zip",
+            "https://github.com/attacker/omi/releases/download/v0.12.64+12064-macos/Omi.zip",
+        ):
+            self.assertFalse(_matches(defs["zipUrl"], bad), f"zipUrl accepted {bad}")
+
+
+class BetaFieldsStayOutOfTheStableSchema(unittest.TestCase):
+    def test_no_beta_artifact_properties(self):
+        schema = _load_schema()
+        self.assertNotIn("beta_zip_url", schema["properties"])
+        self.assertNotIn("beta_dmg_url", schema["properties"])
+
+    def test_no_beta_artifact_definitions(self):
+        defs = _load_schema()["$defs"]
+        self.assertNotIn("betaZipUrl", defs)
+        self.assertNotIn("betaDmgUrl", defs)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_desktop_release_manifest_schema.py
+++ b/.github/scripts/test_desktop_release_manifest_schema.py
@@ -41,12 +41,18 @@ def _matches(subschema: dict, value: str) -> bool:
     Mirrors the two keywords these `$defs` actually use. A richer subschema would
     be silently under-validated, so the type is asserted rather than assumed.
     """
-    assert subschema.get("type") == "string", f"expected a string subschema, got {subschema.get('type')!r}"
+    assert set(subschema) == {"type", "pattern"}, f"unsupported string subschema shape: {subschema!r}"
+    assert subschema["type"] == "string", f"expected a string subschema, got {subschema['type']!r}"
     pattern = subschema["pattern"]
+    assert isinstance(pattern, str), f"expected a string pattern, got {type(pattern).__name__}"
     return isinstance(value, str) and re.search(pattern, value) is not None
 
 
 class ArtifactUrlDefinitions(unittest.TestCase):
+    def test_rejects_a_richer_subschema(self):
+        with self.assertRaisesRegex(AssertionError, "unsupported string subschema shape"):
+            _matches({"type": "string", "pattern": "^value$", "minLength": 1}, "value")
+
     def test_accepts_the_canonical_stable_artifact_urls(self):
         defs = _load_schema()["$defs"]
         self.assertTrue(_matches(defs["zipUrl"], STABLE_ZIP), "zipUrl rejected the canonical Stable zip")


### PR DESCRIPTION
## What

`.github/scripts/test_desktop_release_manifest_schema.py` **ran nowhere.** No entry in `.github/checks-manifest.yaml`, no workflow step, no reference anywhere under `.github/`:

```
$ grep -rn "test_desktop_release_manifest_schema" .github/ | grep -v '^.github/scripts/test_desktop_release_manifest_schema.py'
(no output)
```

A guard with no blocking audience is a dead check — the same class #10351 filed, and what AGENTS.md means by *"On-demand scripts and scheduled jobs with no blocking audience are dead checks."*

## Why it could not have been wired as written

It imported `jsonschema` and relied on pytest, and **no lane installs either** — it was 1 of only 2 suites in that directory that fail to run on a stock interpreter. Every other self-suite there is unittest-style and stdlib-only, invoked as `python3 <script>`. Its own sibling `test_desktop_release_manifest.py` **is** wired, and needs nothing.

## Why it matters

`desktop-release-manifest-v1.schema.json` is what a published **Stable** manifest is validated against. The absence of `beta_zip_url`/`beta_dmg_url` is what stops a beta build from being describable as Stable — load-bearing, not tidiness.

## Change

- **Ported to stdlib.** Both `$defs` it exercises are plain `{"type": "string", "pattern": "^...$"}`. JSON Schema `pattern` is a regex *search* and these are anchored, so `re.search` validates them exactly as `Draft202012Validator` did. `_matches` asserts the subschema really is that shape, so a richer one fails loudly rather than being silently under-validated.
- **Converted to unittest**, so `python3 <script>` runs it — matching the directory convention.
- **Added the rejection cases it lacked.** The original only asserted the canonical Stable URLs are *accepted*, so loosening the pattern to admit any artifact name passed it. It now also proves a beta-named artifact and a foreign host/repo are refused.
- **Registered** as `desktop-release-manifest-schema-v1` on the `local` and `ci` lanes, triggered by the schema and the suite.

## Verification

```
/usr/bin/python3 (3.9.6, no deps installed)   -> 5 tests, OK      (was: unrunnable)
mutation: add beta_zip_url to the schema      -> FAILED (1)
mutation: loosen zipUrl to accept any .zip    -> FAILED (2)        <- old suite PASSED this
schema restored                               -> OK, file unmodified
test_run_checks.py (manifest contract)        -> 26 passed
run_checks.py --lane local                    -> SELECTED and PASS
```

The second mutation is the one that matters: it is a real weakening of the release contract that the previous version of this suite could not catch, because it only tested the happy path.

## Scope

Two files: the suite and one manifest entry. The schema itself is untouched (verified `git status` clean after the mutation runs).

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

