### PR TITLE
fix(backend): build the dev-key grant delete path as an escaped string

### DIFF
--- a/backend/database/memory_app_key_grants.py
+++ b/backend/database/memory_app_key_grants.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, cast
 
 import database._client as db_client_module
 from google.cloud import firestore
-from google.cloud.firestore_v1.field_path import FieldPath
 
 StatePayload = dict[str, Any]
 
@@ -228,6 +227,10 @@ def remove_developer_api_key_memory_grant(
     # If the grant document does not exist, there is nothing to remove.
     if not doc_ref.get().exists:
         return
+
+    # Imported here, not at module scope: several suites stub google.cloud.firestore_v1
+    # with a plain module, which makes a top-level submodule import fail at collection.
+    from google.cloud.firestore_v1.field_path import FieldPath
 
     # UUID key ids contain hyphens, so the nested path is escaped through FieldPath
     # before being passed as an update key. ``update()`` only accepts string keys —

--- a/backend/database/memory_app_key_grants.py
+++ b/backend/database/memory_app_key_grants.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, cast
 
 import database._client as db_client_module
 from google.cloud import firestore
+from google.cloud.firestore_v1.field_path import FieldPath
 
 StatePayload = dict[str, Any]
 
@@ -233,18 +234,18 @@ def remove_developer_api_key_memory_grant(
     if not doc_ref.get().exists:
         return
 
-    # UUID key ids contain hyphens; dotted field paths must use FieldPath so Firestore
-    # does not treat hyphen segments as invalid path components.
-    firestore_module = _firestore_module()
-    field_path = firestore_module.FieldPath(
+    # UUID key ids contain hyphens, so the nested path is escaped through FieldPath
+    # before being passed as an update key. ``update()`` only accepts string keys —
+    # a FieldPath instance raises — so the escaped API representation is used.
+    field_path = FieldPath(
         "grants",
         DEVELOPER_API_CONSUMER,
         "apps",
         DEVELOPER_API_DEFAULT_APP_ID,
         "keys",
         key_id,
-    )
-    doc_ref.update({field_path: firestore_module.DELETE_FIELD})
+    ).to_api_repr()
+    doc_ref.update({field_path: _firestore_module().DELETE_FIELD})
 
 
 __all__ = [

--- a/backend/database/memory_app_key_grants.py
+++ b/backend/database/memory_app_key_grants.py
@@ -1,6 +1,5 @@
 """Canonical app/key memory grant Firestore reader (WS-G7)."""
 
-import sys
 from dataclasses import dataclass
 from typing import Any, Optional, cast
 
@@ -37,10 +36,6 @@ def _looks_like_grants_contract(state: object) -> bool:
 
 def _default_db_client(db_client: Optional[Any]) -> Any:
     return db_client if db_client is not None else getattr(db_client_module, "db", None)
-
-
-def _firestore_module() -> Any:
-    return sys.modules.get("google.cloud.firestore", firestore)
 
 
 def read_app_key_memory_grants_state(uid: str, db_client: Any) -> AppKeyMemoryGrantStateRead:
@@ -245,7 +240,7 @@ def remove_developer_api_key_memory_grant(
         "keys",
         key_id,
     ).to_api_repr()
-    doc_ref.update({field_path: _firestore_module().DELETE_FIELD})
+    doc_ref.update({field_path: firestore.DELETE_FIELD})
 
 
 __all__ = [

--- a/backend/tests/unit/test_dev_key_memory_grant_seeding.py
+++ b/backend/tests/unit/test_dev_key_memory_grant_seeding.py
@@ -10,6 +10,9 @@ using a fake db_client that supports document().set(merge=True) and .update().
 
 import types
 
+import pytest
+from google.cloud import firestore
+
 from database.memory_app_key_grants import (
     APP_KEY_MEMORY_GRANT_SUBPATH,
     seed_developer_api_key_memory_grant,
@@ -22,7 +25,17 @@ from utils.memory.product_authorization import (
     authorize_app_key_scope_memory_grant,
 )
 
-_DELETE_SENTINEL = object()
+# The real sentinel, so the deletion path is exercised exactly as production does.
+_DELETE_SENTINEL = firestore.DELETE_FIELD
+
+
+def _split_escaped_field_path(path: str) -> list[str]:
+    """Split a Firestore API field path, unwrapping backtick-escaped segments.
+
+    Mirrors the server side of ``FieldPath.to_api_repr()``: segments that are not
+    simple identifiers (UUID key ids with hyphens) come back backtick-quoted.
+    """
+    return [seg[1:-1] if seg.startswith('`') and seg.endswith('`') else seg for seg in path.split('.')]
 
 
 def _deep_merge(base: dict, overlay: dict) -> None:
@@ -58,7 +71,11 @@ class _DocRef:
             self._store.data[self._path] = {}
         target = self._store.data[self._path]
         for dotted_path, value in fields.items():
-            parts = dotted_path.split('.') if isinstance(dotted_path, str) else list(dotted_path)
+            # Firestore only accepts string update keys; a FieldPath instance raises
+            # ``AttributeError: 'FieldPath' object has no attribute 'strip'``.
+            if not isinstance(dotted_path, str):
+                raise AttributeError(f"'{type(dotted_path).__name__}' object has no attribute 'strip'")
+            parts = _split_escaped_field_path(dotted_path)
             for part in parts[:-1]:
                 target = target.setdefault(part, {})
             if value is _DELETE_SENTINEL:
@@ -76,27 +93,6 @@ class FakeDbStore:
 
     def document(self, path):
         return _DocRef(self, path)
-
-
-def _install_fake_firestore():
-    """Patch google.cloud.firestore with DELETE_FIELD and FieldPath stand-ins."""
-    fake = types.ModuleType('google.cloud.firestore')
-    setattr(fake, 'DELETE_FIELD', _DELETE_SENTINEL)
-    setattr(fake, 'FieldPath', lambda *parts: parts)
-    original = sys_modules_set('google.cloud.firestore', fake)
-    return original
-
-
-def _restore_firestore(original):
-    sys_modules_set('google.cloud.firestore', original)
-
-
-def sys_modules_set(key, value):
-    import sys
-
-    prev = sys.modules.get(key)
-    sys.modules[key] = value
-    return prev
 
 
 def test_seed_read_only_grant_writes_default_read_contract():
@@ -168,14 +164,58 @@ def test_remove_grant_deletes_key_entry_only():
     seed_developer_api_key_memory_grant('uid1', 'key1', default_read=True, db_client=store)
     seed_developer_api_key_memory_grant('uid1', 'key2', default_read=True, db_client=store)
 
-    original = _install_fake_firestore()
-    try:
-        remove_developer_api_key_memory_grant('uid1', 'key1', db_client=store)
-    finally:
-        _restore_firestore(original)
+    remove_developer_api_key_memory_grant('uid1', 'key1', db_client=store)
 
     keys = store.data[f'users/uid1/{APP_KEY_MEMORY_GRANT_SUBPATH}']['grants']['developer_api']['apps']['developer_api'][
         'keys'
     ]
     assert 'key1' not in keys
     assert 'key2' in keys
+
+
+def test_remove_grant_uses_escaped_string_field_path_for_uuid_key_id():
+    """Regression: the delete key must be an escaped string, not a FieldPath instance.
+
+    ``google.cloud.firestore`` exposes no ``FieldPath`` attribute, and ``update()``
+    rejects FieldPath keys, so building the update key from one turned every
+    Developer API key deletion into a 500 after the key row was already removed.
+    """
+    key_id = '0f6a4d1c-9b2e-4a77-8c31-2f5c9a8d7e10'
+    store = FakeDbStore()
+    seed_developer_api_key_memory_grant('uid1', key_id, default_read=True, db_client=store)
+    seed_developer_api_key_memory_grant('uid1', 'key2', default_read=True, db_client=store)
+
+    remove_developer_api_key_memory_grant('uid1', key_id, db_client=store)
+
+    _path, fields = store.update_calls[-1]
+    (update_key,) = fields
+    assert isinstance(update_key, str)
+    assert update_key == f'grants.developer_api.apps.developer_api.keys.`{key_id}`'
+
+    keys = store.data[f'users/uid1/{APP_KEY_MEMORY_GRANT_SUBPATH}']['grants']['developer_api']['apps']['developer_api'][
+        'keys'
+    ]
+    assert key_id not in keys
+    assert 'key2' in keys
+
+
+def test_remove_grant_field_path_is_accepted_by_firestore_update_parser():
+    """The produced key must survive Firestore's own update-path parsing."""
+    from google.cloud.firestore_v1 import _helpers
+
+    key_id = '0f6a4d1c-9b2e-4a77-8c31-2f5c9a8d7e10'
+    store = FakeDbStore()
+    seed_developer_api_key_memory_grant('uid1', key_id, default_read=True, db_client=store)
+
+    remove_developer_api_key_memory_grant('uid1', key_id, db_client=store)
+
+    _path, fields = store.update_calls[-1]
+    extractor = _helpers.DocumentExtractorForUpdate(fields)
+    assert [p.to_api_repr() for p in extractor.top_level_paths] == list(fields)
+
+
+def test_fake_doc_ref_rejects_non_string_update_key():
+    """Guard the seam itself: a FieldPath-style key must fail like real Firestore."""
+    store = FakeDbStore()
+    with pytest.raises(AttributeError):
+        store.document('users/uid1/x').update({('grants', 'developer_api'): _DELETE_SENTINEL})


### PR DESCRIPTION
## Bug (live in prod)

`DELETE /v1/dev/keys/{key_id}` 500s, after the key row and its cache entry are already gone:

```
File "/app/routers/api_key_management.py", line 131, in delete_developer_key
File "/app/database/dev_api_key.py", line 181, in delete_dev_key
File "/app/database/memory_app_key_grants.py", line 239, in remove_developer_api_key_memory_grant
AttributeError: module 'google.cloud.firestore' has no attribute 'FieldPath'
```

Prod `backend` (Cloud Run), 2 occurrences in the last 30h — every Developer API key deletion that reaches a seeded grant document hits it.

## Root cause

`remove_developer_api_key_memory_grant()` built its Firestore update key with `firestore.FieldPath(...)` (59840bcfc6, which meant to escape hyphenated UUID key ids). Two problems:

1. `google.cloud.firestore` exposes no `FieldPath` attribute — it lives in `google.cloud.firestore_v1.field_path`. Confirmed on the pinned client.
2. Even with the right import, `update()` only accepts **string** keys; a `FieldPath` instance raises `'FieldPath' object has no attribute 'strip'` inside `DocumentExtractorForUpdate`.

Because `key_ref.delete()` and the strict cache invalidation run *before* this line, revocation itself succeeds but the caller gets a 500, `invalidate_developer_cache(uid)` is skipped, and the deleted key's grant stays in `users/{uid}/memory_control/app_key_memory_grants` permanently.

The unit fake hid it: `_install_fake_firestore()` installed a stand-in `google.cloud.firestore` module **with** a `FieldPath` attribute, and the fake `update()` accepted non-string keys. Same shape as legacy FC-6 (a lenient Firestore fake certifying code real Firestore rejects).

## Fix

Import `FieldPath` from `google.cloud.firestore_v1.field_path` and pass `.to_api_repr()` — the escaped string form `update()` parses — keeping the hyphen escaping the original commit intended. The test fake now uses the real `DELETE_FIELD` sentinel, rejects non-string keys like Firestore does, and unwraps backtick-escaped segments.

## Verified

- `tests/unit/test_dev_key_memory_grant_seeding.py` — 8 passed. On the **unfixed** source, 3 fail with the exact prod `AttributeError`.
- **Live Firestore** (`based-hardware-dev`, throwaway doc, cleaned up): the real `remove_developer_api_key_memory_grant()` deletes only the hyphenated UUID key entry and preserves its sibling. Update key: ``grants.developer_api.apps.developer_api.keys.`0f6a4d1c-9b2e-4a77-8c31-2f5c9a8d7e10` ``.
- Adjacent suites — `test_api_key_listability_contract`, `test_api_key_family_errors`, `test_api_key_observability`, `test_api_key_route_contract`, `test_app_key_memory_grant_assignment_readiness`, `test_mcp_api_key_auth_context`, `test_mcp_api_key_full_access`, `test_mcp_api_key_scope_readiness` — 38 passed.
- `make preflight` green.

## Product invariants affected

- INV-MEM-1 (path-matched; memory tiers and grant semantics are unchanged — only the Firestore field-path encoding of the delete)

## Failure class

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

