### PR TITLE
fix(release): reclaim idle M1 qualification cache

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -519,12 +519,12 @@ checks:
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
   - id: desktop-release-one-path-contract
     command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
-    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
   - id: desktop-qualification-bootstrap-contract
     command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]
-    triggers: ["desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "Trusted qualification requires an exact-SHA persistent source, isolated named-bundle, unchanged gates, and phase-bound bootstrap contracts"
@@ -536,10 +536,16 @@ checks:
     reason: "SCA-163 keeps lease command failures actionable while stdout remains reserved for the JSON lease capability"
   - id: desktop-qualification-swift-cache
     command: ["bash", "desktop/macos/tests/test-qualification-swift-cache.sh"]
-    triggers: ["desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test-qualification-swift-cache.sh", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test-qualification-swift-cache.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "Exact-source retries must keep stable absolute SwiftPM paths while rejecting stale provenance, symlinks, collisions, and incomplete entries"
+  - id: desktop-qualification-cache-reclaim
+    command: ["python3", "desktop/macos/tests/test_qualification_cache_reclaim.py"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test_qualification_cache_reclaim.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "Actions run 30215483845: preserve the 32 GiB M1 gate while reclaiming only old, exact-SHA, provably idle runner cache entries"
 
   - id: desktop-beta-qualification-retry
     command: ["python3", ".github/scripts/test_desktop_beta_qualification_retry.py"]

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -8,7 +8,6 @@ import json
 import subprocess
 import sys
 
-
 UNRELEASED_CHANGELOG_PREFIX = "desktop/macos/changelog/unreleased/"
 CHANGELOG_PREFIX = "desktop/macos/changelog/"
 DESKTOP_PREFIX = "desktop/macos/"
@@ -16,7 +15,10 @@ EXEMPT_DESKTOP_PATHS = {
     "desktop/macos/CHANGELOG.json",
     "desktop/macos/AGENTS.md",
     "desktop/macos/docs/release.md",
+    "desktop/macos/docs/qualification-environment.md",
     "desktop/macos/scripts/qualify-desktop-beta.sh",
+    # Capacity/lease authority for the same internal qualification runner.
+    "desktop/macos/scripts/qualification-cache-reclaim.py",
     # Sibling qualification-runner helper to qualify-desktop-beta.sh: internal
     # release infrastructure with no user-facing app surface.
     "desktop/macos/scripts/qualification-swift-cache.sh",
@@ -90,7 +92,9 @@ def validate_unreleased_fragment(head_ref: str, path: str) -> None:
 
     if isinstance(data.get("change"), str) and data["change"].strip():
         return
-    if isinstance(data.get("changes"), list) and any(isinstance(entry, str) and entry.strip() for entry in data["changes"]):
+    if isinstance(data.get("changes"), list) and any(
+        isinstance(entry, str) and entry.strip() for entry in data["changes"]
+    ):
         return
 
     raise SystemExit(f"FAIL: {path} must contain a non-empty 'change' string or 'changes' list")

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -16,9 +16,7 @@ import unittest
 import unittest.mock
 from pathlib import Path
 
-_SPEC = importlib.util.spec_from_file_location(
-    "desktop_changelog", Path(__file__).with_name("desktop-changelog.py")
-)
+_SPEC = importlib.util.spec_from_file_location("desktop_changelog", Path(__file__).with_name("desktop-changelog.py"))
 changelog = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(changelog)
 
@@ -71,7 +69,9 @@ class ChangelogRequirementTests(unittest.TestCase):
     def test_internal_release_controls_are_exempt_but_product_source_is_not(self) -> None:
         for path in (
             "desktop/macos/docs/release.md",
+            "desktop/macos/docs/qualification-environment.md",
             "desktop/macos/scripts/qualify-desktop-beta.sh",
+            "desktop/macos/scripts/qualification-cache-reclaim.py",
             # Sibling qualification-runner helper (EXEMPT_DESKTOP_PATHS).
             "desktop/macos/scripts/qualification-swift-cache.sh",
             "desktop/macos/scripts/qualification-lease-command.sh",

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -71,7 +71,12 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         git("config", "user.name", "Qualification Contract")
         git("config", "user.email", "qualification-contract@example.com")
         (source / "candidate.txt").write_text("immutable candidate\n", encoding="utf-8")
-        git("add", "candidate.txt")
+        reclaim_source = ROOT / "desktop/macos/scripts/qualification-cache-reclaim.py"
+        reclaim_target = source / "desktop/macos/scripts/qualification-cache-reclaim.py"
+        reclaim_target.parent.mkdir(parents=True)
+        reclaim_target.write_bytes(reclaim_source.read_bytes())
+        reclaim_target.chmod(0o755)
+        git("add", "candidate.txt", "desktop/macos/scripts/qualification-cache-reclaim.py")
         git("-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", "candidate")
         candidate_sha = git("rev-parse", "HEAD")
         git("tag", "-a", RELEASE_TAG, "-m", "candidate")
@@ -125,7 +130,9 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "if: always()",
             "qualification-lease-command.sh\" release",
             "runner-capacity.json",
-            "M1 qualification runner capacity guard refused to start",
+            "--minimum-age-seconds 21600",
+            "--max-entries 8",
+            "--max-reclaim-kib 67108864",
             "33554432",
             "desktop-qualification-evidence-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}",
             "overwrite: false",
@@ -135,7 +142,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
 
     def test_checkout_ignores_stale_shared_workspace_and_uses_fresh_run_source(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             server, candidate_sha = self._create_candidate_remote(root)
             runner_temp = root / "runner-temp"
             runner_temp.mkdir()
@@ -165,6 +172,8 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 "ref": RELEASE_TAG,
                 "OMI_QUALIFICATION_MINIMUM_FREE_KIB": "1",
                 "OMI_QUALIFICATION_MINIMUM_FREE_INODES": "1",
+                "OMI_QUALIFICATION_SWIFT_CACHE_ROOT": str(root / "qualification-swiftpm-v2"),
+                "OMI_QUALIFICATION_LEASE_ROOT": str(root / "omi-desktop-qualification"),
             }
             stage_result = self._run_workflow_script(
                 "Create run-isolated qualification staging",
@@ -172,8 +181,20 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 env=env,
             )
             self.assertEqual(stage_result.returncode, 0, stage_result.stderr)
+            authority_result = self._run_workflow_script(
+                "Checkout cache reclaim authority from exact candidate",
+                cwd=stale_workspace,
+                env=env,
+            )
+            self.assertEqual(authority_result.returncode, 0, authority_result.stderr)
+            capacity_result = self._run_workflow_script(
+                "Reclaim idle qualification cache and enforce runner capacity",
+                cwd=stale_workspace,
+                env=env,
+            )
+            self.assertEqual(capacity_result.returncode, 0, capacity_result.stderr)
             checkout_result = self._run_workflow_script(
-                "Checkout candidate into this run only",
+                "Expand exact candidate checkout",
                 cwd=stale_workspace,
                 env=env,
             )
@@ -199,7 +220,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
 
     def test_pre_checkout_failure_writes_cleanup_evidence_only_under_run_stage(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             runner_temp = root / "runner-temp"
             runner_temp.mkdir()
             run_id = "30179386741"
@@ -243,7 +264,8 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
 
     def test_low_runner_capacity_fails_before_checkout_with_durable_cleanup_inputs(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
+            server, _candidate_sha = self._create_candidate_remote(root)
             runner_temp = root / "runner-temp"
             runner_temp.mkdir()
             run_id = "30185755794"
@@ -255,18 +277,39 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 "GITHUB_RUN_ID": run_id,
                 "GITHUB_RUN_ATTEMPT": run_attempt,
                 "QUALIFICATION_STAGE": str(stage),
+                "GITHUB_SERVER_URL": server.as_uri(),
+                "GITHUB_REPOSITORY": "BasedHardware/omi",
+                "RELEASE_TAG": RELEASE_TAG,
+                "ref": RELEASE_TAG,
                 "OMI_QUALIFICATION_MINIMUM_FREE_KIB": str(2**63 - 1),
                 "OMI_QUALIFICATION_MINIMUM_FREE_INODES": "1",
+                "OMI_QUALIFICATION_SWIFT_CACHE_ROOT": str(root / "qualification-swiftpm-v2"),
+                "OMI_QUALIFICATION_LEASE_ROOT": str(root / "omi-desktop-qualification"),
             }
 
-            capacity_result = self._run_workflow_script(
+            stage_result = self._run_workflow_script(
                 "Create run-isolated qualification staging",
+                cwd=runner_temp,
+                env=env,
+            )
+            self.assertEqual(stage_result.returncode, 0, stage_result.stderr)
+            authority_result = self._run_workflow_script(
+                "Checkout cache reclaim authority from exact candidate",
+                cwd=runner_temp,
+                env=env,
+            )
+            self.assertEqual(authority_result.returncode, 0, authority_result.stderr)
+            capacity_result = self._run_workflow_script(
+                "Reclaim idle qualification cache and enforce runner capacity",
                 cwd=runner_temp,
                 env=env,
             )
             self.assertNotEqual(capacity_result.returncode, 0)
             self.assertIn("M1 qualification runner capacity guard refused to start", capacity_result.stdout)
-            self.assertFalse((stage / "source").exists(), "capacity failure must precede candidate checkout")
+            self.assertFalse(
+                (stage / "source/candidate.txt").exists(),
+                "capacity failure must precede expansion of the candidate checkout",
+            )
             capacity = json.loads((stage / "runner-capacity.json").read_text(encoding="utf-8"))
             self.assertEqual(capacity["status"], "failed")
             self.assertEqual(capacity["guard"], "runner-capacity-preflight")

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -35,53 +35,7 @@ jobs:
           (umask 077; mkdir -p "$QUALIFICATION_STAGE/assets")
           test ! -L "$QUALIFICATION_STAGE"
           test "$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$QUALIFICATION_STAGE")" = 700
-          # This must run before the candidate checkout: a terminal runner loss can
-          # prevent later `always()` steps from producing cleanup evidence.
-          # Detect constrained capacity early enough to preserve a per-run report.
-          # Keep the guard here instead of a checked-in helper because this workflow
-          # deliberately has no repository checkout before its candidate binding.
-          python3 - "$RUNNER_TEMP" "$QUALIFICATION_STAGE/runner-capacity.json" <<'PY'
-          import json
-          import os
-          import sys
-
-          path, report_path = sys.argv[1:]
-          minimum_free_kib = int(os.environ.get("OMI_QUALIFICATION_MINIMUM_FREE_KIB", "33554432"))
-          minimum_free_inodes = int(os.environ.get("OMI_QUALIFICATION_MINIMUM_FREE_INODES", "65536"))
-          if minimum_free_kib < 1 or minimum_free_inodes < 1:
-              raise SystemExit("Qualification capacity minimums must be positive")
-
-          filesystem = os.statvfs(path)
-          available_kib = (filesystem.f_bavail * filesystem.f_frsize) // 1024
-          available_inodes = filesystem.f_favail
-          failures = []
-          if available_kib < minimum_free_kib:
-              failures.append("insufficient-free-kib")
-          if available_inodes < minimum_free_inodes:
-              failures.append("insufficient-free-inodes")
-          report = {
-              "available_inodes": available_inodes,
-              "available_kib": available_kib,
-              "failure_reasons": failures,
-              "guard": "runner-capacity-preflight",
-              "minimum_free_inodes": minimum_free_inodes,
-              "minimum_free_kib": minimum_free_kib,
-              "schema_version": 1,
-              "status": "failed" if failures else "passed",
-          }
-          with open(report_path, "w", encoding="utf-8") as handle:
-              json.dump(report, handle, sort_keys=True)
-              handle.write("\n")
-
-          if failures:
-              print(
-                  "::error::M1 qualification runner capacity guard refused to start "
-                  f"(available_kib={available_kib}, required_kib={minimum_free_kib}, "
-                  f"available_inodes={available_inodes}, required_inodes={minimum_free_inodes})"
-              )
-              raise SystemExit(1)
-          PY
-      - name: Checkout candidate into this run only
+      - name: Checkout cache reclaim authority from exact candidate
         working-directory: ${{ runner.temp }}
         env:
           QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
@@ -96,7 +50,45 @@ jobs:
           test "$ref" = "$RELEASE_TAG"
           git init --quiet "$source_dir"
           git -C "$source_dir" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --prune --tags origin
+          git -C "$source_dir" sparse-checkout init --no-cone
+          git -C "$source_dir" sparse-checkout set desktop/macos/scripts/qualification-cache-reclaim.py
+          GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --depth=1 --filter=blob:none origin "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
+          test -x "$source_dir/desktop/macos/scripts/qualification-cache-reclaim.py"
+      - name: Reclaim idle qualification cache and enforce runner capacity
+        working-directory: ${{ runner.temp }}
+        env:
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
+          OMI_QUALIFICATION_MINIMUM_FREE_KIB: 33554432
+          OMI_QUALIFICATION_MINIMUM_FREE_INODES: 65536
+        run: |
+          set -euo pipefail
+          expected="$RUNNER_TEMP/desktop-beta-qualification/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$QUALIFICATION_STAGE" = "$expected"
+          test -d "$QUALIFICATION_STAGE/source"
+          cache_root="${OMI_QUALIFICATION_SWIFT_CACHE_ROOT:-$HOME/Library/Caches/OmiDesktop/qualification-swiftpm-v2}"
+          lease_root="${OMI_QUALIFICATION_LEASE_ROOT:-${TMPDIR:-/tmp}/omi-desktop-qualification}"
+          python3 "$QUALIFICATION_STAGE/source/desktop/macos/scripts/qualification-cache-reclaim.py" reclaim \
+            --cache-root "$cache_root" \
+            --qualification-lease-root "$lease_root" \
+            --capacity-path "$RUNNER_TEMP" \
+            --minimum-free-kib "${OMI_QUALIFICATION_MINIMUM_FREE_KIB:-33554432}" \
+            --minimum-free-inodes "${OMI_QUALIFICATION_MINIMUM_FREE_INODES:-65536}" \
+            --minimum-age-seconds 21600 \
+            --max-entries 8 \
+            --max-reclaim-kib 67108864 \
+            --report "$QUALIFICATION_STAGE/runner-capacity.json"
+      - name: Expand exact candidate checkout
+        working-directory: ${{ runner.temp }}
+        env:
+          QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          source_dir="$QUALIFICATION_STAGE/source"
+          test -d "$source_dir/.git"
+          GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --prune --tags --filter=blob:none origin
+          git -C "$source_dir" sparse-checkout disable
           git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
       - id: app-token
         uses: actions/create-github-app-token@v3
@@ -207,8 +199,12 @@ jobs:
           if [ -f "$context" ]; then
             worktree=$(jq -r .worktree "$context"); lease_id=$(jq -r .lease_id "$context"); token=$(jq -r .token "$context")
             retained=$(jq -r .retained_runs "$context"); age=$(jq -r .retention_age_seconds "$context")
+            cache_sha=$(jq -r .cache_source_sha "$context"); cache_lease_id=$(jq -r .cache_lease_id "$context")
+            cache_owner_pid=$(jq -r .cache_owner_pid "$context"); cache_token=$(jq -r .cache_token "$context")
             echo "::add-mask::$token"
+            echo "::add-mask::$cache_token"
             OMI_HARNESS_OWNERSHIP_TOKEN="$token" "$worktree/desktop/macos/scripts/qualification-lease-command.sh" release "$worktree" "$lease_id" "$token" "$retained" "$age"
+            "$worktree/desktop/macos/scripts/qualification-swift-cache.sh" release "$cache_sha" "$cache_lease_id" "$cache_owner_pid" "$cache_token"
             jq -n --arg lease_id "$lease_id" '{lease_id: $lease_id, cleanup_status: "released"}' > "$cleanup"
           else
             printf '%s\n' '{"cleanup_status":"no-lease-acquired"}' > "$cleanup"

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -15,6 +15,8 @@ ports and has no qualification lease.
 - `OMI_QUALIFICATION_RETAINED_RUNS` and
   `OMI_QUALIFICATION_RETENTION_AGE_SECONDS` — bounded retention for completed,
   sentinel-proven state/log pairs (defaults: 3 runs and 14 days).
+- `OMI_QUALIFICATION_SWIFT_CACHE_ROOT` — owner-only exact-SHA SwiftPM cache.
+  Defaults to `~/Library/Caches/OmiDesktop/qualification-swiftpm-v2`.
 - `OMI_HARNESS_PORT_OFFSET` and `OMI_HARNESS_{FIRESTORE,AUTH,BACKEND,DESKTOP_BACKEND,REDIS,TYPESENSE}_PORT` — dev-harness controls. The qualifier exports the offset; direct per-service overrides remain available for debugging.
 
 The offset applies to Firestore, Firebase Auth, backend, desktop backend,
@@ -23,16 +25,28 @@ ports fail before launch.
 
 ## Runner capacity preflight
 
-Before the candidate checkout, the M1-only workflow writes
-`runner-capacity.json` in its run-isolated stage and requires at least 32 GiB
-of free filesystem blocks plus 65,536 free inodes. This is intentionally ahead
-of the checkout because a terminal runner loss can prevent later `always()`
-steps from producing cleanup evidence. The report records only capacity observed
-by this guard; it does not attribute a prior incident to a runner or host cause.
-On a controlled capacity failure, the workflow fails closed before fetching
-candidate assets, then its normal finalizer writes cleanup evidence and uploads
-both evidence files. The guard only observes capacity; it never deletes shared
-runner state or prior qualification evidence.
+Before expanding the candidate checkout, the M1-only workflow loads the reclaim
+authority from the exact immutable candidate and writes `runner-capacity.json`
+in its run-isolated stage. The guard still requires at least 32 GiB of free
+filesystem blocks plus 65,536 free inodes.
+
+When capacity is low, reclaim considers only owner-only
+`qualification-swiftpm-v2/<40-character-SHA>` entries with a valid v2 manifest,
+completion marker, matching Git HEAD, and direct SwiftPM build directory. It
+orders entries by last use and SHA, requires six hours of age, and removes at
+most eight entries or 64 GiB per run, stopping as soon as the unchanged capacity
+threshold passes. The active harness lease, live cache leases, and live process
+references protect their exact worktrees. A malformed entry, symlink, unknown
+lock, ambiguous harness lease, or live qualifier without an authoritative lease
+refuses the entire plan before deletion. Run staging, cleanup artifacts,
+qualification evidence, and release assets are outside the cache root and are
+never reclaim targets.
+
+On a controlled capacity failure, the workflow fails closed before candidate
+assets or the full source checkout are fetched, then its normal finalizer writes
+cleanup evidence and uploads both evidence files. The capacity report records
+the before/after observations and the bounded exact-SHA deletion list; it does
+not attribute a prior incident to a runner or host cause.
 
 ## Cleanup safety
 
@@ -51,6 +65,13 @@ process first; lease release is the fail-closed fallback for interruption paths.
 Before signaling it, release revalidates the owner-only state files, lease token,
 PID/process group, command marker, loopback URL, and exact listener PID. A
 listener that fails any check is retained and never signaled.
+
+The exact-SHA SwiftPM worktree has a separate owner-only, token-bound cache lease
+from publication through harness cleanup. Normal exit and the workflow finalizer
+release it only after the harness lease is safely released. `--keep-stack`
+retains both authorities. A terminally interrupted lease is treated as stale
+only when its recorded owner PID is dead; the harness worktree pointer remains a
+separate preservation authority.
 
 The main qualification app receives a separate run-unique launch token. `run.sh`
 writes an owner-only launch signal, which the qualifier verifies against exactly

--- a/desktop/macos/scripts/qualification-cache-reclaim.py
+++ b/desktop/macos/scripts/qualification-cache-reclaim.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""Ownership-safe lifecycle and bounded reclaim for the M1 SwiftPM cache."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+CACHE_FORMAT = 2
+CACHE_LEASE_OWNER = "omi-desktop-qualification-swiftpm"
+CACHE_LEASE_SCHEMA_VERSION = 1
+HARNESS_LEASE_OWNER = "omi-desktop-qualification"
+HARNESS_LEASE_SCHEMA_VERSION = 1
+HARNESS_SENTINEL = ".omi-dev-harness-owned.json"
+RECLAIM_LOCK = ".reclaim.lock"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+LEASE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,95}$")
+QUALIFIER_MARKER = "qualify-desktop-beta.sh"
+
+
+class CacheSafetyError(RuntimeError):
+    """Cache ownership or idleness could not be proven."""
+
+
+@dataclass(frozen=True)
+class Capacity:
+    available_kib: int
+    available_inodes: int
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    source_sha: str
+    path: Path
+    last_used_at: int
+    size_kib: int
+    live_lease_owner_pids: frozenset[int]
+
+
+@dataclass(frozen=True)
+class ProcessRecord:
+    pid: int
+    command: str
+
+
+def _lstat(path: Path) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as error:
+        raise CacheSafetyError(f"cannot inspect {path.name}: {error}") from error
+
+
+def _require_owned_directory(path: Path, *, private: bool) -> os.stat_result:
+    info = _lstat(path)
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise CacheSafetyError(f"{path.name} is not an owned directory")
+    if info.st_uid != os.getuid():
+        raise CacheSafetyError(f"{path.name} is owned by a different user")
+    if private and stat.S_IMODE(info.st_mode) & 0o077:
+        raise CacheSafetyError(f"{path.name} is not owner-only")
+    return info
+
+
+def _require_owned_file(path: Path, *, private: bool) -> os.stat_result:
+    info = _lstat(path)
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise CacheSafetyError(f"{path.name} is not an owned regular file")
+    if info.st_uid != os.getuid():
+        raise CacheSafetyError(f"{path.name} is owned by a different user")
+    if private and stat.S_IMODE(info.st_mode) & 0o077:
+        raise CacheSafetyError(f"{path.name} is not owner-only")
+    return info
+
+
+def _read_json(path: Path, *, private: bool = False) -> dict[str, object]:
+    _require_owned_file(path, private=private)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CacheSafetyError(f"{path.name} is not valid JSON") from error
+    if not isinstance(payload, dict):
+        raise CacheSafetyError(f"{path.name} is not a JSON object")
+    return payload
+
+
+def _write_private_json(path: Path, payload: dict[str, object], *, exclusive: bool) -> None:
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_EXCL if exclusive else os.O_TRUNC
+    try:
+        descriptor = os.open(path, flags, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True)
+            handle.write("\n")
+    except OSError as error:
+        raise CacheSafetyError(f"cannot publish {path.name}: {error}") from error
+
+
+def _validate_cache_root(cache_root: Path, *, create: bool) -> Path:
+    root = cache_root.expanduser().absolute()
+    if root in {Path(root.anchor), Path.home().resolve()}:
+        raise CacheSafetyError("cache root is too broad")
+    current = Path(root.anchor)
+    for component in root.parts[1:]:
+        current /= component
+        if current.exists() and stat.S_ISLNK(_lstat(current).st_mode):
+            raise CacheSafetyError(f"cache path has a symlinked component: {current.name}")
+    if not root.exists():
+        if not create:
+            raise CacheSafetyError("cache root does not exist")
+        root.mkdir(mode=0o700, parents=True)
+    current = Path(root.anchor)
+    for component in root.parts[1:]:
+        current /= component
+        if stat.S_ISLNK(_lstat(current).st_mode):
+            raise CacheSafetyError(f"cache path has a symlinked component: {current.name}")
+    _require_owned_directory(root, private=True)
+    return root
+
+
+def _process_exists(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _process_snapshot() -> list[ProcessRecord]:
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,command="],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise CacheSafetyError("cannot inspect live runner processes") from error
+    records: list[ProcessRecord] = []
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(None, 1)
+        if not fields or not fields[0].isdigit():
+            continue
+        records.append(ProcessRecord(int(fields[0]), fields[1] if len(fields) == 2 else ""))
+    return records
+
+
+def _capacity(path: Path) -> Capacity:
+    try:
+        filesystem = os.statvfs(path)
+    except OSError as error:
+        raise CacheSafetyError("cannot inspect runner capacity") from error
+    return Capacity(
+        available_kib=(filesystem.f_bavail * filesystem.f_frsize) // 1024,
+        available_inodes=filesystem.f_favail,
+    )
+
+
+def _tree_size_kib(path: Path) -> int:
+    blocks = 0
+    try:
+        for root, directories, files in os.walk(path, topdown=True, followlinks=False):
+            root_path = Path(root)
+            blocks += root_path.lstat().st_blocks
+            for name in directories:
+                candidate = root_path / name
+                blocks += candidate.lstat().st_blocks
+            for name in files:
+                blocks += (root_path / name).lstat().st_blocks
+    except OSError as error:
+        raise CacheSafetyError(f"cannot size cache entry {path.name}") from error
+    return (blocks * 512 + 1023) // 1024
+
+
+def _git_head(source: Path) -> str:
+    environment = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=environment,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise CacheSafetyError(f"cannot validate source identity for {source.parent.name}") from error
+    return result.stdout.strip()
+
+
+def _cache_lease_records(entry: Path, source_sha: str) -> tuple[frozenset[int], set[int]]:
+    lease_root = entry / ".leases"
+    if not lease_root.exists():
+        return frozenset(), set()
+    _require_owned_directory(lease_root, private=True)
+    owner_pids: set[int] = set()
+    live_pids: set[int] = set()
+    for lease_path in sorted(lease_root.iterdir(), key=lambda path: path.name):
+        if lease_path.suffix != ".json" or not LEASE_ID_RE.fullmatch(lease_path.stem):
+            raise CacheSafetyError(f"unrecognized cache lease record in {source_sha}")
+        payload = _read_json(lease_path, private=True)
+        required = {
+            "schema_version": CACHE_LEASE_SCHEMA_VERSION,
+            "owner": CACHE_LEASE_OWNER,
+            "source_sha": source_sha,
+            "lease_id": lease_path.stem,
+        }
+        if any(payload.get(key) != value for key, value in required.items()):
+            raise CacheSafetyError(f"cache lease provenance mismatch in {source_sha}")
+        try:
+            owner_pid = int(payload.get("owner_pid", -1))
+            created_at = int(payload.get("created_at", -1))
+        except (TypeError, ValueError) as error:
+            raise CacheSafetyError(f"cache lease has invalid numeric provenance in {source_sha}") from error
+        token = payload.get("token")
+        if owner_pid <= 0 or created_at <= 0 or not isinstance(token, str) or len(token) < 32:
+            raise CacheSafetyError(f"cache lease is incomplete in {source_sha}")
+        owner_pids.add(owner_pid)
+        if _process_exists(owner_pid):
+            live_pids.add(owner_pid)
+    return frozenset(owner_pids), live_pids
+
+
+def _validate_entry(
+    entry: Path,
+    *,
+    git_head: Callable[[Path], str] = _git_head,
+    size_probe: Callable[[Path], int] = _tree_size_kib,
+) -> CacheEntry:
+    source_sha = entry.name
+    if not SHA_RE.fullmatch(source_sha):
+        raise CacheSafetyError(f"unrecognized cache entry {source_sha}")
+    entry_info = _require_owned_directory(entry, private=True)
+    complete = entry / "complete"
+    manifest_path = entry / "manifest.json"
+    complete_info = _require_owned_file(complete, private=False)
+    manifest_info = _require_owned_file(manifest_path, private=False)
+    try:
+        if complete.read_text(encoding="utf-8") != "complete\n":
+            raise CacheSafetyError(f"incomplete cache entry {source_sha}")
+    except OSError as error:
+        raise CacheSafetyError(f"cannot read completion marker for {source_sha}") from error
+    manifest = _read_json(manifest_path)
+    if manifest.get("cache_format") != CACHE_FORMAT or manifest.get("source_sha") != source_sha:
+        raise CacheSafetyError(f"cache provenance mismatch in {source_sha}")
+    source = entry / "source"
+    build = source / "desktop/macos/Desktop/.build"
+    _require_owned_directory(source, private=True)
+    _require_owned_directory(source / ".git", private=False)
+    _require_owned_directory(build, private=True)
+    if git_head(source) != source_sha:
+        raise CacheSafetyError(f"source HEAD mismatch in {source_sha}")
+    _owner_pids, live_pids = _cache_lease_records(entry, source_sha)
+    last_used_at = int(max(entry_info.st_mtime, complete_info.st_mtime, manifest_info.st_mtime))
+    return CacheEntry(source_sha, entry, last_used_at, size_probe(entry), frozenset(live_pids))
+
+
+def _protected_harness_worktree(cache_root: Path, lease_root: Path) -> tuple[set[str], set[int]]:
+    lease_root = lease_root.expanduser().resolve(strict=False)
+    if not lease_root.exists():
+        return set(), set()
+    _require_owned_directory(lease_root, private=False)
+    pointer = lease_root / "qualification-lease.json"
+    if not pointer.exists():
+        return set(), set()
+    lease = _read_json(pointer)
+    if lease.get("schema_version") != HARNESS_LEASE_SCHEMA_VERSION or lease.get("owner") != HARNESS_LEASE_OWNER:
+        raise CacheSafetyError("qualification harness lease provenance is unknown")
+    lease_id = lease.get("lease_id")
+    repo_root_value = lease.get("repo_root")
+    state_root_value = lease.get("state_root")
+    token = lease.get("token")
+    try:
+        owner_pid = int(lease.get("owner_pid", -1))
+    except (TypeError, ValueError) as error:
+        raise CacheSafetyError("qualification harness lease owner PID is invalid") from error
+    if (
+        not isinstance(lease_id, str)
+        or not LEASE_ID_RE.fullmatch(lease_id)
+        or not isinstance(repo_root_value, str)
+        or not isinstance(state_root_value, str)
+        or not isinstance(token, str)
+        or len(token) < 32
+        or owner_pid <= 0
+    ):
+        raise CacheSafetyError("qualification harness lease is incomplete")
+    state_root = Path(state_root_value).expanduser().resolve(strict=False)
+    expected_state = (lease_root / "state" / lease_id).resolve(strict=False)
+    if state_root != expected_state:
+        raise CacheSafetyError("qualification harness state root is not lease-bound")
+    _require_owned_directory(state_root, private=False)
+    sentinel = _read_json(state_root / HARNESS_SENTINEL)
+    repo_root = Path(repo_root_value).expanduser().resolve(strict=False)
+    expected_sentinel = {
+        "schema_version": 1,
+        "owner": "omi-local-dev-harness",
+        "instance": lease_id,
+        "repo_root": str(repo_root),
+    }
+    if any(sentinel.get(key) != value for key, value in expected_sentinel.items()):
+        raise CacheSafetyError("qualification harness sentinel does not bind its worktree")
+
+    protected: set[str] = set()
+    try:
+        relative = repo_root.relative_to(cache_root)
+    except ValueError:
+        relative = None
+    if relative is not None:
+        parts = relative.parts
+        if len(parts) != 2 or parts[1] != "source" or not SHA_RE.fullmatch(parts[0]):
+            raise CacheSafetyError("qualification harness worktree is ambiguously rooted in the cache")
+        protected.add(parts[0])
+    return protected, {owner_pid}
+
+
+def _inventory(cache_root: Path) -> list[CacheEntry]:
+    entries: list[CacheEntry] = []
+    for child in sorted(cache_root.iterdir(), key=lambda path: path.name):
+        if child.name == RECLAIM_LOCK:
+            continue
+        if child.name.startswith(".") and child.name.endswith(".lock"):
+            raise CacheSafetyError(f"cache operation lock is active: {child.name}")
+        if child.name.startswith(".") and ".prepare." in child.name:
+            raise CacheSafetyError(f"incomplete cache publication is present: {child.name}")
+        if child.name.startswith("."):
+            raise CacheSafetyError(f"unrecognized cache control state: {child.name}")
+        entries.append(_validate_entry(child))
+    return entries
+
+
+def _process_protection(
+    cache_root: Path,
+    entries: Iterable[CacheEntry],
+    represented_owner_pids: set[int],
+    processes: Iterable[ProcessRecord],
+) -> set[str]:
+    protected: set[str] = set()
+    current_pid = os.getpid()
+    entry_paths = {entry.source_sha: str(entry.path) for entry in entries}
+    cache_text = str(cache_root)
+    for process in processes:
+        if process.pid == current_pid:
+            continue
+        matched = {source_sha for source_sha, path in entry_paths.items() if path in process.command}
+        if matched:
+            protected.update(matched)
+            represented_owner_pids.add(process.pid)
+        elif cache_text in process.command:
+            raise CacheSafetyError("a live process references an unrecognized cache path")
+        if QUALIFIER_MARKER in process.command and process.pid not in represented_owner_pids:
+            raise CacheSafetyError("a live qualifier has no authoritative cache or harness lease")
+    return protected
+
+
+def _lock_payload(lock: Path) -> dict[str, object]:
+    payload = _read_json(lock / "owner.json", private=True)
+    if payload.get("schema_version") != 1 or payload.get("owner") != CACHE_LEASE_OWNER:
+        raise CacheSafetyError("cache reclaim lock provenance is unknown")
+    try:
+        owner_pid = int(payload.get("owner_pid", -1))
+    except (TypeError, ValueError) as error:
+        raise CacheSafetyError("cache reclaim lock owner PID is invalid") from error
+    if owner_pid <= 0:
+        raise CacheSafetyError("cache reclaim lock owner PID is invalid")
+    return payload
+
+
+def wait_for_reclaim(cache_root: Path, *, timeout_seconds: float) -> None:
+    root = _validate_cache_root(cache_root, create=True)
+    deadline = time.monotonic() + timeout_seconds
+    lock = root / RECLAIM_LOCK
+    while lock.exists():
+        try:
+            payload = _lock_payload(lock)
+        except CacheSafetyError:
+            if time.monotonic() < deadline and time.time() - _lstat(lock).st_mtime < 1:
+                time.sleep(0.05)
+                continue
+            raise
+        owner_pid = int(payload["owner_pid"])
+        if not _process_exists(owner_pid):
+            shutil.rmtree(lock)
+            return
+        if time.monotonic() >= deadline:
+            raise CacheSafetyError("timed out waiting for active cache reclaim")
+        time.sleep(0.05)
+
+
+class _ReclaimLock:
+    def __init__(self, cache_root: Path):
+        self.cache_root = cache_root
+        self.path = cache_root / RECLAIM_LOCK
+        self.acquired = False
+
+    def __enter__(self) -> None:
+        wait_for_reclaim(self.cache_root, timeout_seconds=0)
+        try:
+            self.path.mkdir(mode=0o700)
+            self.acquired = True
+            _write_private_json(
+                self.path / "owner.json",
+                {
+                    "schema_version": 1,
+                    "owner": CACHE_LEASE_OWNER,
+                    "owner_pid": os.getpid(),
+                    "created_at": int(time.time()),
+                },
+                exclusive=True,
+            )
+        except OSError as error:
+            raise CacheSafetyError("another cache operation acquired the reclaim lock") from error
+
+    def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        if self.acquired:
+            shutil.rmtree(self.path)
+
+
+def acquire_cache_lease(
+    cache_root: Path,
+    *,
+    source_sha: str,
+    lease_id: str,
+    owner_pid: int,
+    now: int | None = None,
+) -> dict[str, object]:
+    root = _validate_cache_root(cache_root, create=False)
+    if not SHA_RE.fullmatch(source_sha) or not LEASE_ID_RE.fullmatch(lease_id):
+        raise CacheSafetyError("cache lease identity is invalid")
+    if not _process_exists(owner_pid):
+        raise CacheSafetyError("cache lease owner PID is not running")
+    entry = _validate_entry(root / source_sha)
+    lease_root = entry.path / ".leases"
+    if not lease_root.exists():
+        lease_root.mkdir(mode=0o700)
+    _require_owned_directory(lease_root, private=True)
+    token = secrets.token_urlsafe(24)
+    payload: dict[str, object] = {
+        "schema_version": CACHE_LEASE_SCHEMA_VERSION,
+        "owner": CACHE_LEASE_OWNER,
+        "source_sha": source_sha,
+        "lease_id": lease_id,
+        "owner_pid": owner_pid,
+        "created_at": int(time.time() if now is None else now),
+        "token": token,
+    }
+    _write_private_json(lease_root / f"{lease_id}.json", payload, exclusive=True)
+    os.utime(entry.path, None)
+    return {**payload, "source": str(entry.path / "source")}
+
+
+def release_cache_lease(
+    cache_root: Path,
+    *,
+    source_sha: str,
+    lease_id: str,
+    owner_pid: int,
+    token: str,
+) -> None:
+    root = _validate_cache_root(cache_root, create=False)
+    if not SHA_RE.fullmatch(source_sha) or not LEASE_ID_RE.fullmatch(lease_id):
+        raise CacheSafetyError("cache lease identity is invalid")
+    entry = _validate_entry(root / source_sha)
+    lease_path = entry.path / ".leases" / f"{lease_id}.json"
+    if not lease_path.exists():
+        return
+    payload = _read_json(lease_path, private=True)
+    expected = {
+        "schema_version": CACHE_LEASE_SCHEMA_VERSION,
+        "owner": CACHE_LEASE_OWNER,
+        "source_sha": source_sha,
+        "lease_id": lease_id,
+        "owner_pid": owner_pid,
+        "token": token,
+    }
+    if any(payload.get(key) != value for key, value in expected.items()):
+        raise CacheSafetyError("cache lease release capability does not match")
+    lease_path.unlink()
+    os.utime(entry.path, None)
+
+
+def reclaim(
+    cache_root: Path,
+    *,
+    qualification_lease_root: Path,
+    capacity_path: Path,
+    minimum_free_kib: int,
+    minimum_free_inodes: int,
+    minimum_age_seconds: int,
+    max_entries: int,
+    max_reclaim_kib: int,
+    now: int | None = None,
+    capacity_probe: Callable[[Path], Capacity] = _capacity,
+    process_probe: Callable[[], list[ProcessRecord]] = _process_snapshot,
+) -> dict[str, object]:
+    for name, value in (
+        ("minimum_free_kib", minimum_free_kib),
+        ("minimum_free_inodes", minimum_free_inodes),
+        ("minimum_age_seconds", minimum_age_seconds),
+        ("max_entries", max_entries),
+        ("max_reclaim_kib", max_reclaim_kib),
+    ):
+        if value < 1:
+            raise CacheSafetyError(f"{name} must be positive")
+    root = _validate_cache_root(cache_root, create=True)
+    observed_at = int(time.time() if now is None else now)
+    before = capacity_probe(capacity_path)
+    deleted: list[dict[str, object]] = []
+    with _ReclaimLock(root):
+        entries = _inventory(root)
+        harness_shas, harness_owner_pids = _protected_harness_worktree(root, qualification_lease_root)
+        represented = set(harness_owner_pids)
+        protected = set(harness_shas)
+        for entry in entries:
+            represented.update(entry.live_lease_owner_pids)
+            if entry.live_lease_owner_pids:
+                protected.add(entry.source_sha)
+        protected.update(_process_protection(root, entries, represented, process_probe()))
+
+        eligible = sorted(
+            (
+                entry
+                for entry in entries
+                if entry.source_sha not in protected and observed_at - entry.last_used_at >= minimum_age_seconds
+            ),
+            key=lambda entry: (entry.last_used_at, entry.source_sha),
+        )
+        after = before
+        reclaimed_kib = 0
+        for entry in eligible:
+            if after.available_kib >= minimum_free_kib and after.available_inodes >= minimum_free_inodes:
+                break
+            if len(deleted) >= max_entries or reclaimed_kib + entry.size_kib > max_reclaim_kib:
+                break
+            shutil.rmtree(entry.path)
+            reclaimed_kib += entry.size_kib
+            deleted.append(
+                {
+                    "source_sha": entry.source_sha,
+                    "age_seconds": observed_at - entry.last_used_at,
+                    "size_kib": entry.size_kib,
+                }
+            )
+            after = capacity_probe(capacity_path)
+
+    failures: list[str] = []
+    if after.available_kib < minimum_free_kib:
+        failures.append("insufficient-free-kib")
+    if after.available_inodes < minimum_free_inodes:
+        failures.append("insufficient-free-inodes")
+    return {
+        "schema_version": 2,
+        "guard": "runner-capacity-preflight",
+        "status": "failed" if failures else "passed",
+        "failure_reasons": failures,
+        "minimum_free_kib": minimum_free_kib,
+        "minimum_free_inodes": minimum_free_inodes,
+        "available_kib": after.available_kib,
+        "available_inodes": after.available_inodes,
+        "before_reclaim_available_kib": before.available_kib,
+        "before_reclaim_available_inodes": before.available_inodes,
+        "reclaim": {
+            "policy": "oldest-idle-exact-sha-v1",
+            "minimum_age_seconds": minimum_age_seconds,
+            "max_entries": max_entries,
+            "max_reclaim_kib": max_reclaim_kib,
+            "deleted_entries": deleted,
+            "reclaimed_kib": sum(int(item["size_kib"]) for item in deleted),
+        },
+    }
+
+
+def _write_report(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    _write_private_json(temporary, payload, exclusive=True)
+    temporary.replace(path)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    wait = subcommands.add_parser("wait-for-reclaim")
+    wait.add_argument("--cache-root", type=Path, required=True)
+    wait.add_argument("--timeout-seconds", type=float, default=60)
+
+    acquire = subcommands.add_parser("lease-acquire")
+    acquire.add_argument("--cache-root", type=Path, required=True)
+    acquire.add_argument("--source-sha", required=True)
+    acquire.add_argument("--lease-id", required=True)
+    acquire.add_argument("--owner-pid", type=int, required=True)
+
+    release = subcommands.add_parser("lease-release")
+    release.add_argument("--cache-root", type=Path, required=True)
+    release.add_argument("--source-sha", required=True)
+    release.add_argument("--lease-id", required=True)
+    release.add_argument("--owner-pid", type=int, required=True)
+    release.add_argument("--token", required=True)
+
+    reclaim_parser = subcommands.add_parser("reclaim")
+    reclaim_parser.add_argument("--cache-root", type=Path, required=True)
+    reclaim_parser.add_argument("--qualification-lease-root", type=Path, required=True)
+    reclaim_parser.add_argument("--capacity-path", type=Path, required=True)
+    reclaim_parser.add_argument("--minimum-free-kib", type=int, required=True)
+    reclaim_parser.add_argument("--minimum-free-inodes", type=int, required=True)
+    reclaim_parser.add_argument("--minimum-age-seconds", type=int, default=6 * 60 * 60)
+    reclaim_parser.add_argument("--max-entries", type=int, default=8)
+    reclaim_parser.add_argument("--max-reclaim-kib", type=int, default=64 * 1024 * 1024)
+    reclaim_parser.add_argument("--report", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.command == "wait-for-reclaim":
+            wait_for_reclaim(args.cache_root, timeout_seconds=args.timeout_seconds)
+            return 0
+        if args.command == "lease-acquire":
+            print(
+                json.dumps(
+                    acquire_cache_lease(
+                        args.cache_root,
+                        source_sha=args.source_sha,
+                        lease_id=args.lease_id,
+                        owner_pid=args.owner_pid,
+                    ),
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.command == "lease-release":
+            release_cache_lease(
+                args.cache_root,
+                source_sha=args.source_sha,
+                lease_id=args.lease_id,
+                owner_pid=args.owner_pid,
+                token=args.token,
+            )
+            return 0
+
+        report = reclaim(
+            args.cache_root,
+            qualification_lease_root=args.qualification_lease_root,
+            capacity_path=args.capacity_path,
+            minimum_free_kib=args.minimum_free_kib,
+            minimum_free_inodes=args.minimum_free_inodes,
+            minimum_age_seconds=args.minimum_age_seconds,
+            max_entries=args.max_entries,
+            max_reclaim_kib=args.max_reclaim_kib,
+        )
+        _write_report(args.report, report)
+        if report["status"] != "passed":
+            print(
+                "::error::M1 qualification runner capacity guard refused to start "
+                f"(available_kib={report['available_kib']}, required_kib={report['minimum_free_kib']}, "
+                f"available_inodes={report['available_inodes']}, required_inodes={report['minimum_free_inodes']})"
+            )
+            return 1
+        print(
+            "M1 qualification runner capacity guard passed "
+            f"(available_kib={report['available_kib']}, reclaimed_kib={report['reclaim']['reclaimed_kib']})"
+        )
+        return 0
+    except CacheSafetyError as error:
+        if args.command == "reclaim":
+            failed_report = {
+                "schema_version": 2,
+                "guard": "runner-capacity-preflight",
+                "status": "failed",
+                "failure_reasons": ["cache-reclaim-unsafe"],
+                "minimum_free_kib": args.minimum_free_kib,
+                "minimum_free_inodes": args.minimum_free_inodes,
+                "reclaim": {
+                    "policy": "oldest-idle-exact-sha-v1",
+                    "status": "refused",
+                    "reason": str(error)[:300],
+                    "deleted_entries": [],
+                    "reclaimed_kib": 0,
+                },
+            }
+            _write_report(args.report, failed_report)
+        print(f"qualification cache reclaim refused: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/macos/scripts/qualification-swift-cache.sh
+++ b/desktop/macos/scripts/qualification-swift-cache.sh
@@ -7,9 +7,11 @@ umask 077
 
 usage() {
   cat <<'USAGE'
-Usage: qualification-swift-cache.sh prepare <40-char-source-sha> <source-repository>
+Usage:
+  qualification-swift-cache.sh prepare <40-char-source-sha> <source-repository> <lease-id> <owner-pid>
+  qualification-swift-cache.sh release <40-char-source-sha> <lease-id> <owner-pid> <lease-token>
 
-Prints the persistent exact-SHA source path on stdout. Diagnostics go to stderr.
+Prepare prints a JSON source/lease capability on stdout. Diagnostics go to stderr.
 
 Environment (test overrides are intentionally explicit):
   OMI_QUALIFICATION_SWIFT_CACHE_ROOT   Root (default: ~/Library/Caches/OmiDesktop/qualification-swiftpm-v2)
@@ -20,19 +22,53 @@ Environment (test overrides are intentionally explicit):
 USAGE
 }
 
-[[ $# -eq 3 && "$1" == "prepare" ]] || { usage >&2; exit 2; }
+[[ $# -eq 5 ]] || { usage >&2; exit 2; }
+ACTION="$1"
 SOURCE_SHA="$2"
-SOURCE_REPOSITORY="$3"
 [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
   echo "qualification Swift cache: invalid source SHA: $SOURCE_SHA" >&2
   exit 2
 }
+if [[ "$ACTION" == "prepare" ]]; then
+  SOURCE_REPOSITORY="$3"
+  LEASE_ID="$4"
+  OWNER_PID="$5"
+else
+  LEASE_ID="$3"
+  OWNER_PID="$4"
+  LEASE_TOKEN="$5"
+fi
+[[ "$LEASE_ID" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,95}$ ]] || {
+  echo "qualification Swift cache: invalid lease ID: $LEASE_ID" >&2
+  exit 2
+}
+[[ "$OWNER_PID" =~ ^[1-9][0-9]*$ ]] || {
+  echo "qualification Swift cache: invalid owner PID: $OWNER_PID" >&2
+  exit 2
+}
+
+CACHE_ROOT="${OMI_QUALIFICATION_SWIFT_CACHE_ROOT:-$HOME/Library/Caches/OmiDesktop/qualification-swiftpm-v2}"
+CACHE_CONTROL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/qualification-cache-reclaim.py"
+
+if [[ "$ACTION" == "release" ]]; then
+  [[ -x "$CACHE_CONTROL" ]] || {
+    echo "qualification Swift cache: missing cache lease authority: $CACHE_CONTROL" >&2
+    exit 1
+  }
+  python3 "$CACHE_CONTROL" lease-release \
+    --cache-root "$CACHE_ROOT" \
+    --source-sha "$SOURCE_SHA" \
+    --lease-id "$LEASE_ID" \
+    --owner-pid "$OWNER_PID" \
+    --token "$LEASE_TOKEN"
+  exit 0
+fi
+[[ "$ACTION" == "prepare" ]] || { usage >&2; exit 2; }
 git -C "$SOURCE_REPOSITORY" rev-parse --git-dir >/dev/null 2>&1 || {
   echo "qualification Swift cache: source repository is not Git: $SOURCE_REPOSITORY" >&2
   exit 1
 }
 
-CACHE_ROOT="${OMI_QUALIFICATION_SWIFT_CACHE_ROOT:-$HOME/Library/Caches/OmiDesktop/qualification-swiftpm-v2}"
 CACHE_DIR="$CACHE_ROOT/$SOURCE_SHA"
 PERSISTENT_SOURCE="$CACHE_DIR/source"
 PACKAGE_DIR="$PERSISTENT_SOURCE/desktop/macos/Desktop"
@@ -102,6 +138,11 @@ PY
   echo "qualification Swift cache: refusing symlinked cache path component: $symlinked_component" >&2
   exit 1
 }
+[[ -x "$CACHE_CONTROL" ]] || {
+  echo "qualification Swift cache: missing cache lease authority: $CACHE_CONTROL" >&2
+  exit 1
+}
+python3 "$CACHE_CONTROL" wait-for-reclaim --cache-root "$CACHE_ROOT" --timeout-seconds 60
 LOCK_DIR="$CACHE_ROOT/.${SOURCE_SHA}.lock"
 for _ in {1..1200}; do
   if mkdir "$LOCK_DIR" 2>/dev/null; then
@@ -246,5 +287,12 @@ else
   PERSISTENT_SOURCE="$CACHE_DIR/source"
 fi
 
+LEASE_JSON="$(
+  python3 "$CACHE_CONTROL" lease-acquire \
+    --cache-root "$CACHE_ROOT" \
+    --source-sha "$SOURCE_SHA" \
+    --lease-id "$LEASE_ID" \
+    --owner-pid "$OWNER_PID"
+)"
 echo "qualification Swift cache $CACHE_STATE: source=$SOURCE_SHA path=$PERSISTENT_SOURCE" >&2
-printf '%s\n' "$PERSISTENT_SOURCE"
+printf '%s\n' "$LEASE_JSON"

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -130,6 +130,9 @@ QUALIFICATION_CLEANUP_STATUS="not-acquired"
 QUALIFICATION_SUCCESS=0
 QUALIFICATION_LEASE_ID=""
 QUALIFICATION_LEASE_TOKEN=""
+QUALIFICATION_CACHE_LEASE_ID=""
+QUALIFICATION_CACHE_LEASE_TOKEN=""
+QUALIFICATION_CACHE_LEASE_RELEASED=0
 QUALIFICATION_LEASE_ROOT="${OMI_QUALIFICATION_LEASE_ROOT:-${TMPDIR:-/tmp}/omi-desktop-qualification}"
 QUALIFICATION_RETAINED_RUNS="${OMI_QUALIFICATION_RETAINED_RUNS:-3}"
 QUALIFICATION_RETENTION_AGE_SECONDS="${OMI_QUALIFICATION_RETENTION_AGE_SECONDS:-1209600}"
@@ -158,10 +161,54 @@ gh release view "$RELEASE_TAG" --repo BasedHardware/omi --json tagName,isDraft,i
 python3 "$KEYVALUE_PY" preflight-release "$RELEASE_FILE" "$RELEASE_TAG"
 
 SHA=$(git -C "$REPO_ROOT" rev-list -n1 "$RELEASE_TAG")
-WORKTREE="$("$SCRIPT_DIR/qualification-swift-cache.sh" prepare "$SHA" "$REPO_ROOT")"
 RUN_SCOPE="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-attempt}-${BASHPID:-$$}"
 RUN_SCOPE="${RUN_SCOPE//[^A-Za-z0-9]/-}"
 QUALIFICATION_LEASE_ID="qualification-${SHA:0:12}-${RUN_SCOPE:0:32}"
+QUALIFICATION_CACHE_LEASE_ID="cache-${SHA:0:12}-${RUN_SCOPE:0:32}"
+
+qualification_cache_field() {
+  local field="$1" cache_json="$2" value
+  if value="$(printf '%s' "$cache_json" | python3 -c '
+import json
+import sys
+
+field = sys.argv[1]
+value = json.loads(sys.stdin.read()).get(field)
+if not isinstance(value, str) or not value:
+    raise SystemExit(1)
+print(value)
+' "$field" 2>/dev/null)"; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  echo "qualification failed: Swift cache lease returned no valid ${field}" >&2
+  return 1
+}
+
+CACHE_JSON="$(
+  "$SCRIPT_DIR/qualification-swift-cache.sh" prepare \
+    "$SHA" "$REPO_ROOT" "$QUALIFICATION_CACHE_LEASE_ID" "$$"
+)"
+WORKTREE="$(qualification_cache_field source "$CACHE_JSON")"
+QUALIFICATION_CACHE_LEASE_TOKEN="$(qualification_cache_field token "$CACHE_JSON")"
+
+early_cleanup() {
+  local exit_code=$?
+  trap - EXIT
+  if [[ "$KEEP_STACK" -eq 0 && -n "$QUALIFICATION_LEASE_TOKEN" && -d "$WORKTREE" ]]; then
+    "$LEASE_COMMAND" release \
+      "$WORKTREE" "$QUALIFICATION_LEASE_ID" "$QUALIFICATION_LEASE_TOKEN" \
+      "$QUALIFICATION_RETAINED_RUNS" "$QUALIFICATION_RETENTION_AGE_SECONDS" || exit_code=1
+  fi
+  if [[ "$KEEP_STACK" -eq 0 && -n "$QUALIFICATION_CACHE_LEASE_TOKEN" && "$QUALIFICATION_CACHE_LEASE_RELEASED" -eq 0 ]]; then
+    "$SCRIPT_DIR/qualification-swift-cache.sh" release \
+      "$SHA" "$QUALIFICATION_CACHE_LEASE_ID" "$$" "$QUALIFICATION_CACHE_LEASE_TOKEN" || exit_code=1
+  fi
+  qualification_stage_remove "$QUALIFICATION_STAGE" || true
+  exit "$exit_code"
+}
+trap early_cleanup EXIT
+
 QUALIFICATION_PORT_OFFSET="${OMI_QUALIFICATION_PORT_OFFSET:-}"
 if [[ -z "$QUALIFICATION_PORT_OFFSET" ]]; then
   QUALIFICATION_PORT_OFFSET="$(python3 - "$SHA" "$QUALIFICATION_LEASE_ID" <<'PY'
@@ -252,12 +299,15 @@ DESKTOP_LAUNCH_RECORD="$QUALIFICATION_LOG_DIR/desktop-app.json"
 LAUNCH_SIGNAL_FILE="$QUALIFICATION_LOG_DIR/desktop-launch.signal"
 if [[ -n "$QUALIFICATION_CLEANUP_CONTEXT" ]]; then
   umask 077
-  python3 - "$QUALIFICATION_CLEANUP_CONTEXT" "$QUALIFICATION_LEASE_ID" "$QUALIFICATION_LEASE_TOKEN" "$WORKTREE" "$QUALIFICATION_RETAINED_RUNS" "$QUALIFICATION_RETENTION_AGE_SECONDS" <<'PY'
+  python3 - "$QUALIFICATION_CLEANUP_CONTEXT" "$QUALIFICATION_LEASE_ID" "$QUALIFICATION_LEASE_TOKEN" "$WORKTREE" "$QUALIFICATION_RETAINED_RUNS" "$QUALIFICATION_RETENTION_AGE_SECONDS" "$SHA" "$QUALIFICATION_CACHE_LEASE_ID" "$$" "$QUALIFICATION_CACHE_LEASE_TOKEN" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-path, lease_id, token, worktree, retained_runs, retention_age = map(str, sys.argv[1:])
+(
+    path, lease_id, token, worktree, retained_runs, retention_age,
+    cache_source_sha, cache_lease_id, cache_owner_pid, cache_token,
+) = map(str, sys.argv[1:])
 target = Path(path)
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(json.dumps({
@@ -266,6 +316,10 @@ target.write_text(json.dumps({
     "worktree": worktree,
     "retained_runs": int(retained_runs),
     "retention_age_seconds": int(retention_age),
+    "cache_source_sha": cache_source_sha,
+    "cache_lease_id": cache_lease_id,
+    "cache_owner_pid": int(cache_owner_pid),
+    "cache_token": cache_token,
 }, sort_keys=True) + "\n", encoding="utf-8")
 target.chmod(0o600)
 PY
@@ -546,6 +600,12 @@ run_qualification_cleanup() {
       QUALIFICATION_CLEANUP_STATUS="release-failed"
       return 1
     fi
+    if ! "$SCRIPT_DIR/qualification-swift-cache.sh" release \
+      "$SHA" "$QUALIFICATION_CACHE_LEASE_ID" "$$" "$QUALIFICATION_CACHE_LEASE_TOKEN"; then
+      QUALIFICATION_CLEANUP_STATUS="cache-release-failed"
+      return 1
+    fi
+    QUALIFICATION_CACHE_LEASE_RELEASED=1
     QUALIFICATION_CLEANUP_STATUS="released"
   elif [[ "$KEEP_STACK" -eq 1 && -n "$QUALIFICATION_LEASE_TOKEN" ]]; then
     echo "qualification stack retained under lease $QUALIFICATION_LEASE_ID for safe later reclamation"

--- a/desktop/macos/tests/test-qualification-swift-cache.sh
+++ b/desktop/macos/tests/test-qualification-swift-cache.sh
@@ -38,6 +38,16 @@ make_repo() {
   git -C "$path" commit -qm 'fixture'
 }
 
+source_from_json() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["source"])'
+}
+
+prepare_source() {
+  local source_sha="$1" repository="$2"
+  "$CACHE_HELPER" prepare "$source_sha" "$repository" "cache-test-${RANDOM}-${RANDOM}" "$$" \
+    | source_from_json
+}
+
 export OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$TMP_ROOT/cache"
 export OMI_QUALIFICATION_SWIFT_CACHE_XCODE="Xcode 16.4\nBuild version 16F6"
 export OMI_QUALIFICATION_SWIFT_CACHE_SWIFT="Apple Swift version 6.1"
@@ -73,12 +83,15 @@ exec "$OMI_TEST_REAL_MV" "$@"
 SH
 chmod +x "$MV_SHIM_DIR/mv"
 for process in {1..16}; do
-  env PATH="$MV_SHIM_DIR:$PATH" \
-    OMI_TEST_MV_BARRIER="$MV_BARRIER" \
-    OMI_TEST_REAL_MV="$REAL_MV" \
-    OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$CONCURRENT_CACHE" \
-    "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" \
-    >"$TMP_ROOT/concurrent-$process.out" 2>"$TMP_ROOT/concurrent-$process.err" &
+  (
+    env PATH="$MV_SHIM_DIR:$PATH" \
+      OMI_TEST_MV_BARRIER="$MV_BARRIER" \
+      OMI_TEST_REAL_MV="$REAL_MV" \
+      OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$CONCURRENT_CACHE" \
+      "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" "cache-concurrent-$process" "$$" \
+      2>"$TMP_ROOT/concurrent-$process.err" \
+      | source_from_json >"$TMP_ROOT/concurrent-$process.out"
+  ) &
   concurrent_pids[$process]=$!
 done
 for process in {1..16}; do
@@ -97,9 +110,9 @@ mkdir -p "$TMP_ROOT/symlink-ancestor-target"
 ln -s "$TMP_ROOT/symlink-ancestor-target" "$TMP_ROOT/symlink-ancestor"
 expect_rejected symlink-ancestor "refusing symlinked cache path component" \
   env OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$TMP_ROOT/symlink-ancestor/cache" \
-  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" cache-symlink-ancestor "$$"
 
-first_source="$($CACHE_HELPER prepare "$SHA_A" "$REPO_A")"
+first_source="$(prepare_source "$SHA_A" "$REPO_A")"
 expected_source="$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_A/source"
 [[ "$first_source" == "$expected_source" ]] || fail "prepare must return the stable exact-SHA source path"
 [[ -d "$first_source/desktop/macos/Desktop/.build" ]] || fail "prepare must create a direct persistent SwiftPM build path"
@@ -109,7 +122,7 @@ expected_source="$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_A/source"
 printf 'compiled-output\n' > "$first_source/desktop/macos/Desktop/.build/probe.o"
 printf 'remove-me\n' > "$first_source/untrusted-untracked-file"
 
-retry_source="$($CACHE_HELPER prepare "$SHA_A" "$REPO_A_OTHER_PATH")"
+retry_source="$(prepare_source "$SHA_A" "$REPO_A_OTHER_PATH")"
 [[ "$retry_source" == "$first_source" ]] || fail "caller checkout paths must not affect the persistent source path"
 [[ "$(cat "$retry_source/desktop/macos/Desktop/.build/probe.o")" == "compiled-output" ]] \
   || fail "same-SHA retry did not retain direct SwiftPM output"
@@ -118,7 +131,7 @@ retry_source="$($CACHE_HELPER prepare "$SHA_A" "$REPO_A_OTHER_PATH")"
 # A dirty tracked source cannot be trusted even if HEAD still names the exact SHA.
 printf '%s\n' '// stale package' > "$first_source/desktop/macos/Desktop/Package.swift"
 expect_rejected stale-package "persistent source has tracked changes" \
-  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" cache-stale-package "$$"
 git -C "$first_source" restore desktop/macos/Desktop/Package.swift
 
 MANIFEST="$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_A/manifest.json"
@@ -131,7 +144,7 @@ data["source_sha"] = "b" * 40
 open(p, "w", encoding="utf-8").write(json.dumps(data, indent=2, sort_keys=True) + "\n")
 PY
 expect_rejected wrong-sha "cache provenance mismatch" \
-  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" cache-wrong-sha "$$"
 cp "$TMP_ROOT/manifest.good" "$MANIFEST"
 
 for field in package_swift_sha256 package_resolved_sha256 xcode swift macos architecture; do
@@ -144,34 +157,34 @@ data[field] = "stale"
 open(p, "w", encoding="utf-8").write(json.dumps(data, indent=2, sort_keys=True) + "\n")
 PY
   expect_rejected "stale-$field" "cache provenance mismatch" \
-    "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A"
+    "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" "cache-stale-${field//_/-}" "$$"
 done
 cp "$TMP_ROOT/manifest.good" "$MANIFEST"
 
 for variable in XCODE SWIFT MACOS ARCH; do
   expect_rejected "changed-$variable" "cache provenance mismatch" \
     env "OMI_QUALIFICATION_SWIFT_CACHE_${variable}=different-host-identity" \
-    "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A"
+    "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" "cache-changed-$variable" "$$"
 done
 
 : > "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_A/complete"
 expect_rejected incomplete "incomplete exact-SHA cache entry" \
-  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" cache-incomplete "$$"
 printf '%s\n' complete > "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_A/complete"
 
 cp -R "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_A" "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_B"
 expect_rejected wrong-source "persistent source SHA $SHA_A does not match candidate $SHA_B" \
-  "$CACHE_HELPER" prepare "$SHA_B" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_B" "$REPO_A" cache-wrong-source "$$"
 rm -rf "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_B"
 
 mkdir -p "$TMP_ROOT/symlink-target"
 ln -s "$TMP_ROOT/symlink-target" "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_B"
 expect_rejected symlink "refusing symlinked exact-SHA cache entry" \
-  "$CACHE_HELPER" prepare "$SHA_B" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_B" "$REPO_A" cache-symlink "$$"
 
 SHA_C="cccccccccccccccccccccccccccccccccccccccc"
 printf collision > "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_C"
 expect_rejected collision "exact-SHA cache destination collision" \
-  "$CACHE_HELPER" prepare "$SHA_C" "$REPO_A"
+  "$CACHE_HELPER" prepare "$SHA_C" "$REPO_A" cache-collision "$$"
 
 echo "qualification Swift cache tests passed"

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -75,7 +75,11 @@ require_order "$QUALIFIER" \
   'if [[ "$GITHUB_ACTIONS_ARTIFACT" -eq 1 ]]'
 require_text 'terminate_qualification_desktop "$BUNDLE"'
 require_text '--json tagName,isDraft,isPrerelease,publishedAt,assets,body'
-require_text 'WORKTREE="$("$SCRIPT_DIR/qualification-swift-cache.sh" prepare "$SHA" "$REPO_ROOT")"'
+require_text '"$SCRIPT_DIR/qualification-swift-cache.sh" prepare'
+require_text 'QUALIFICATION_CACHE_LEASE_ID'
+require_text 'QUALIFICATION_CACHE_LEASE_TOKEN'
+require_text '"$SCRIPT_DIR/qualification-swift-cache.sh" release'
+require_text 'qualification-cache-reclaim.py' "$SWIFT_CACHE"
 require_text 'qualification-lease "$action"' "$LEASE_COMMAND"
 require_text 'acquire)' "$LEASE_COMMAND"
 require_text 'release)' "$LEASE_COMMAND"

--- a/desktop/macos/tests/test_qualification_cache_reclaim.py
+++ b/desktop/macos/tests/test_qualification_cache_reclaim.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for ownership-safe qualification cache reclaim."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "qualification-cache-reclaim.py"
+SPEC = importlib.util.spec_from_file_location("qualification_cache_reclaim", SCRIPT)
+assert SPEC and SPEC.loader
+reclaim = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = reclaim
+SPEC.loader.exec_module(reclaim)
+
+
+class QualificationCacheReclaimTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.cache_root = self.root / "qualification-swiftpm-v2"
+        self.cache_root.mkdir(mode=0o700)
+        self.lease_root = self.root / "omi-desktop-qualification"
+        self.capacity_path = self.root
+        self.now = 2_000_000_000
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _git(self, repository: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repository), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={name: value for name, value in os.environ.items() if not name.startswith("GIT_")},
+        ).stdout.strip()
+
+    def _entry(self, name: str, *, age_seconds: int, size_bytes: int = 4096) -> tuple[str, Path]:
+        staging = self.root / f"repo-{name}"
+        package = staging / "desktop/macos/Desktop"
+        package.mkdir(parents=True)
+        (package / "Package.swift").write_text(f"// {name}\n", encoding="utf-8")
+        (package / "Package.resolved").write_text('{"pins":[]}\n', encoding="utf-8")
+        self._git(staging, "init", "--quiet")
+        self._git(staging, "config", "user.name", "Qualification Cache Test")
+        self._git(staging, "config", "user.email", "qualification-cache@omi.invalid")
+        self._git(staging, "add", ".")
+        self._git(staging, "-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", name)
+        source_sha = self._git(staging, "rev-parse", "HEAD")
+        entry = self.cache_root / source_sha
+        source = entry / "source"
+        entry.mkdir(mode=0o700)
+        source.mkdir(mode=0o700)
+        for child in staging.iterdir():
+            target = source / child.name
+            if child.is_dir():
+                subprocess.run(["cp", "-R", str(child), str(target)], check=True)
+            else:
+                target.write_bytes(child.read_bytes())
+        build = source / "desktop/macos/Desktop/.build"
+        build.mkdir(mode=0o700)
+        (build / "payload.bin").write_bytes(b"x" * size_bytes)
+        (entry / "manifest.json").write_text(
+            json.dumps({"cache_format": 2, "source_sha": source_sha}) + "\n",
+            encoding="utf-8",
+        )
+        (entry / "complete").write_text("complete\n", encoding="utf-8")
+        timestamp = self.now - age_seconds
+        for path in (entry / "manifest.json", entry / "complete", entry):
+            os.utime(path, (timestamp, timestamp))
+        return source_sha, entry
+
+    def _capacity_probe(self, initial_entries: set[str], *, base_kib: int = 10) -> object:
+        def probe(_path: Path) -> reclaim.Capacity:
+            deleted = len([source_sha for source_sha in initial_entries if not (self.cache_root / source_sha).exists()])
+            return reclaim.Capacity(available_kib=base_kib + deleted * 100, available_inodes=1_000_000)
+
+        return probe
+
+    def _run(
+        self,
+        *,
+        minimum_free_kib: int,
+        capacity_probe: object,
+        max_entries: int = 8,
+        process_probe: object = lambda: [],
+    ) -> dict[str, object]:
+        return reclaim.reclaim(
+            self.cache_root,
+            qualification_lease_root=self.lease_root,
+            capacity_path=self.capacity_path,
+            minimum_free_kib=minimum_free_kib,
+            minimum_free_inodes=1,
+            minimum_age_seconds=6 * 60 * 60,
+            max_entries=max_entries,
+            max_reclaim_kib=64 * 1024 * 1024,
+            now=self.now,
+            capacity_probe=capacity_probe,
+            process_probe=process_probe,
+        )
+
+    def _harness_lease(self, source_sha: str, source: Path) -> None:
+        lease_id = "qualification-active"
+        state = self.lease_root / "state" / lease_id
+        state.mkdir(parents=True)
+        sentinel = {
+            "schema_version": 1,
+            "owner": "omi-local-dev-harness",
+            "instance": lease_id,
+            "repo_root": str(source),
+        }
+        (state / reclaim.HARNESS_SENTINEL).write_text(json.dumps(sentinel), encoding="utf-8")
+        self.lease_root.joinpath("qualification-lease.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "owner": "omi-desktop-qualification",
+                    "lease_id": lease_id,
+                    "owner_pid": os.getpid(),
+                    "repo_root": str(source),
+                    "state_root": str(state),
+                    "token": "t" * 32,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_deletes_oldest_idle_entries_until_capacity_passes_and_preserves_harness_worktree(self) -> None:
+        oldest_sha, oldest = self._entry("oldest", age_seconds=30 * 60 * 60)
+        next_sha, next_entry = self._entry("next", age_seconds=20 * 60 * 60)
+        active_sha, active = self._entry("active", age_seconds=40 * 60 * 60)
+        self._harness_lease(active_sha, active / "source")
+        initial = {oldest_sha, next_sha, active_sha}
+
+        report = self._run(minimum_free_kib=210, capacity_probe=self._capacity_probe(initial))
+
+        self.assertEqual(report["status"], "passed")
+        self.assertFalse(oldest.exists())
+        self.assertFalse(next_entry.exists())
+        self.assertTrue(active.exists())
+        deleted = report["reclaim"]["deleted_entries"]
+        self.assertEqual([item["source_sha"] for item in deleted], [oldest_sha, next_sha])
+
+    def test_live_cache_lease_preserves_entry_until_authenticated_release(self) -> None:
+        source_sha, entry = self._entry("leased", age_seconds=24 * 60 * 60)
+        lease = reclaim.acquire_cache_lease(
+            self.cache_root,
+            source_sha=source_sha,
+            lease_id="cache-live",
+            owner_pid=os.getpid(),
+            now=self.now,
+        )
+
+        report = self._run(
+            minimum_free_kib=100,
+            capacity_probe=self._capacity_probe({source_sha}),
+        )
+        self.assertEqual(report["status"], "failed")
+        self.assertTrue(entry.exists())
+
+        with self.assertRaises(reclaim.CacheSafetyError):
+            reclaim.release_cache_lease(
+                self.cache_root,
+                source_sha=source_sha,
+                lease_id="cache-live",
+                owner_pid=os.getpid(),
+                token="wrong-token",
+            )
+        reclaim.release_cache_lease(
+            self.cache_root,
+            source_sha=source_sha,
+            lease_id="cache-live",
+            owner_pid=os.getpid(),
+            token=str(lease["token"]),
+        )
+        # The qualifier's cleanup gate and the workflow always() finalizer may
+        # both observe the same authenticated context.
+        reclaim.release_cache_lease(
+            self.cache_root,
+            source_sha=source_sha,
+            lease_id="cache-live",
+            owner_pid=os.getpid(),
+            token=str(lease["token"]),
+        )
+        os.utime(entry, (self.now - 24 * 60 * 60, self.now - 24 * 60 * 60))
+        report = self._run(
+            minimum_free_kib=100,
+            capacity_probe=self._capacity_probe({source_sha}),
+        )
+        self.assertEqual(report["status"], "passed")
+        self.assertFalse(entry.exists())
+
+    def test_malformed_provenance_refuses_before_deleting_any_valid_entry(self) -> None:
+        valid_sha, valid = self._entry("valid", age_seconds=24 * 60 * 60)
+        bad_sha, bad = self._entry("bad", age_seconds=48 * 60 * 60)
+        (bad / "manifest.json").write_text(
+            json.dumps({"cache_format": 2, "source_sha": valid_sha}) + "\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(reclaim.CacheSafetyError, "cache provenance mismatch"):
+            self._run(
+                minimum_free_kib=1000,
+                capacity_probe=self._capacity_probe({valid_sha, bad_sha}),
+            )
+        self.assertTrue(valid.exists())
+        self.assertTrue(bad.exists())
+
+    def test_source_identity_ignores_calling_git_repository_environment(self) -> None:
+        source_sha, entry = self._entry("isolated-git", age_seconds=24 * 60 * 60)
+        caller_git_dir = self._git(Path.cwd(), "rev-parse", "--absolute-git-dir")
+
+        original_git_dir = os.environ.get("GIT_DIR")
+        try:
+            os.environ["GIT_DIR"] = caller_git_dir
+            self.assertEqual(reclaim._git_head(entry / "source"), source_sha)
+        finally:
+            if original_git_dir is None:
+                os.environ.pop("GIT_DIR", None)
+            else:
+                os.environ["GIT_DIR"] = original_git_dir
+
+    def test_unrepresented_live_qualifier_refuses_before_deletion(self) -> None:
+        source_sha, entry = self._entry("old", age_seconds=24 * 60 * 60)
+
+        with self.assertRaisesRegex(reclaim.CacheSafetyError, "no authoritative cache or harness lease"):
+            self._run(
+                minimum_free_kib=1000,
+                capacity_probe=self._capacity_probe({source_sha}),
+                process_probe=lambda: [reclaim.ProcessRecord(424242, "/bin/bash qualify-desktop-beta.sh")],
+            )
+        self.assertTrue(entry.exists())
+
+    def test_active_prepare_lock_refuses_before_deletion(self) -> None:
+        source_sha, entry = self._entry("old", age_seconds=24 * 60 * 60)
+        (self.cache_root / f".{source_sha}.lock").mkdir()
+
+        with self.assertRaisesRegex(reclaim.CacheSafetyError, "cache operation lock is active"):
+            self._run(
+                minimum_free_kib=1000,
+                capacity_probe=self._capacity_probe({source_sha}),
+            )
+        self.assertTrue(entry.exists())
+
+    def test_policy_is_bounded_and_never_touches_run_evidence(self) -> None:
+        first_sha, first = self._entry("first", age_seconds=30 * 60 * 60)
+        second_sha, second = self._entry("second", age_seconds=20 * 60 * 60)
+        third_sha, third = self._entry("third", age_seconds=10 * 60 * 60)
+        evidence = self.root / "desktop-beta-qualification/run/qualification-evidence.json"
+        evidence.parent.mkdir(parents=True)
+        evidence.write_text('{"immutable":true}\n', encoding="utf-8")
+        initial = {first_sha, second_sha, third_sha}
+
+        report = self._run(
+            minimum_free_kib=1000,
+            capacity_probe=self._capacity_probe(initial),
+            max_entries=2,
+        )
+
+        self.assertEqual(report["status"], "failed")
+        self.assertFalse(first.exists())
+        self.assertFalse(second.exists())
+        self.assertTrue(third.exists())
+        self.assertEqual(evidence.read_text(encoding="utf-8"), '{"immutable":true}\n')
+        self.assertEqual(len(report["reclaim"]["deleted_entries"]), 2)
+
+    def test_young_entry_and_symlinked_entry_are_never_reclaimed(self) -> None:
+        young_sha, young = self._entry("young", age_seconds=60)
+        target = self.root / "foreign-target"
+        target.mkdir()
+        symlink_sha = "f" * 40
+        (self.cache_root / symlink_sha).symlink_to(target, target_is_directory=True)
+
+        with self.assertRaisesRegex(reclaim.CacheSafetyError, "not an owned directory"):
+            self._run(
+                minimum_free_kib=1000,
+                capacity_probe=self._capacity_probe({young_sha, symlink_sha}),
+            )
+        self.assertTrue(young.exists())
+        self.assertTrue(target.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reclaim only old, exact-SHA, owner-controlled SwiftPM qualification cache entries before the unchanged M1 capacity preflight
- preserve live cache leases, the authenticated harness worktree, active process references, and run-isolated immutable evidence
- bind cache use to a token-bearing lease from preparation through both normal cleanup and the workflow finalizer
- preserve the listener-preflight lifecycle merged by #10663 while ordering reclaim ahead of the unchanged capacity gate

## Incident evidence

GitHub Actions run https://github.com/BasedHardware/omi/actions/runs/30215483845 failed candidate `v0.12.133+12133-macos` at `ccb489761c2a84d245796d59934df727a4122691` on the sole `omi-qual-m1-studio` job. The unchanged guard observed `available_kib=13244412`, `required_kib=33554432`, and sufficient inodes. Local read-only inspection found 43,181,140 KiB under `qualification-swiftpm-v2`; the production planner preserved the lease-bound `fc0b61ecd53393f68adcd3c124ada3d4014268f5` worktree and selected five old idle entries totaling 28,372,508 KiB.

This failure class is new and distinct from the provider HTTP error normalization repaired in #10664.

## Safety contract

- keeps the 32 GiB and 65,536-inode thresholds unchanged and fails closed if capacity remains insufficient
- never uses M4, never promotes Beta or Stable, and never touches release assets or prior run evidence
- validates cache ownership, exact-SHA manifest/Git provenance, completion, symlink boundaries, locks, leases, and live process references before any deletion
- orders by last use and SHA, requires six hours of age, and caps each run at eight entries and 64 GiB

## Verification

- `python3 desktop/macos/tests/test_qualification_cache_reclaim.py` — 8 passed, including caller Git-environment isolation
- `bash desktop/macos/tests/test-qualification-swift-cache.sh` — passed
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` — passed
- `bash desktop/macos/tests/test-qualification-lease-command.sh` — passed
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 8 passed
- `python3 .github/scripts/check-release-process-guards.py` — passed
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- `OMI_PR_BODY_FILE=/tmp/omi-m1-capacity-pr-body.md make preflight` — 67 selected checks passed in 101.46s after merging current `origin/main`
- `scripts/pr-preflight --pr-body-file /tmp/omi-m1-capacity-pr-body.md` — 67 selected checks passed in 65.81s
- push gate — passed with the documented Flutter and desktop-launcher hatches after the full preflight; the manifest-only Flutter route had no installed app dependencies, and an unrelated local SwiftPM checkout cache could not read third-party package trees

## Product invariants

None.

Failure-Class: none