### PR TITLE
fix(desktop): finalize phase timing on early candidate-and-lease failures

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -28,6 +28,16 @@ EXEMPT_DESKTOP_PATHS = {
     # Pre-tag readiness gate script: internal release infrastructure (runs on the
     # trusted M1 before tagging), no user-facing app surface.
     "desktop/macos/scripts/pre-tag-readiness.sh",
+    # CI-only offline M1 qualification lifecycle proof: internal release
+    # infrastructure (pre-dispatch before canonical qualification), no
+    # user-facing app surface.
+    "desktop/macos/scripts/qualification-local-proof.sh",
+    # Release-keyvalue metadata tooling: internal release-channel metadata,
+    # never ships in the desktop app.
+    "desktop/macos/scripts/release-keyvalue.py",
+    # Internal qualification environment documentation for CI runners; not a
+    # user-facing app note.
+    "desktop/macos/docs/qualification-environment.md",
     # CI-only flow-validation script and its shared action-source inventory do
     # not alter the desktop application a user receives.
     "desktop/macos/scripts/desktop-flow-lint.py",

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -224,6 +224,23 @@ PY
 }
 
 initialize_phase_timings
+
+# Before the full cleanup() function and its trap are installed (after lease
+# acquisition), install an early EXIT trap so a failed candidate-and-lease-
+# preflight phase still records a phase_end failed entry in phase-timings.json.
+# Without this the diagnostic contract would silently omit the phase whose
+# failures it is meant to classify. Replaced by the timing-aware cleanup() trap
+# once desktop/lease state is initialized.
+early_exit_finalize_timing() {
+  local exit_code=$?
+  if [[ -n "$ACTIVE_PHASE" ]]; then
+    phase_end failed
+  fi
+  qualification_stage_remove "$QUALIFICATION_STAGE" || true
+  exit "$exit_code"
+}
+trap early_exit_finalize_timing EXIT
+
 phase_begin "candidate-and-lease-preflight" "immutable-artifact-security"
 RELEASE_FILE="$QUALIFICATION_STAGE/release.json"
 gh release view "$RELEASE_TAG" --repo BasedHardware/omi --json tagName,isDraft,isPrerelease,publishedAt,assets,body \


### PR DESCRIPTION
## Summary

Follow-up to #10663 (merged before these review fixes landed). Addresses both unresolved Codex review threads from the original PR.

**Thread 1 — `PRRT_kwDOLkKqys6T4At4` (P2): Record failures during candidate-and-lease preflight**

The EXIT trap installed at qualification-stage creation only removes the stage directory. The timing-aware `cleanup()` trap is not installed until after lease acquisition — well after the `candidate-and-lease-preflight` phase begins. If `gh release view`, release validation, venv provisioning, or lease acquisition fails during that phase, `phase_end failed` is never called, so `phase-timings.json` omits the failed entry — contradicting the diagnostic contract this feature introduces.

Fix: install an `early_exit_finalize_timing` EXIT trap immediately after `initialize_phase_timings` that finalizes any active phase as `failed` before stage removal. The full `cleanup()` trap replaces this once desktop/lease state is initialized.

**Thread 2 — `PRRT_kwDOLkKqys6T4At5` (P2): Remove internal qualification changelog fragment**

The changelog fragment "Made macOS Beta qualification detect unsafe runner listener state before the long behavioral suite" exposes internal release-pipeline implementation details in the user-facing changelog. The original PR explicitly states no release operation was triggered.

Fix: remove the fragment and exempt the three internal qualification paths (`qualification-local-proof.sh`, `release-keyvalue.py`, `qualification-environment.md`) from the desktop changelog gate so they do not demand a user-facing note.

Failure-Class: none

## Verification

- `bash -n desktop/macos/scripts/qualify-desktop-beta.sh` — syntax OK
- `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD` — "No desktop changes require a changelog entry"
- `python3 .github/scripts/test_desktop_changelog.py` — 4 tests pass
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` — contract tests pass
- Isolated trap simulation confirmed `phase_end failed` is recorded when a command fails during `candidate-and-lease-preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://www.cubic.dev/pr/BasedHardware/omi/pull/10676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
