### PR TITLE
feat(desktop): instrument macOS integration connect with privacy-safe outcome metrics

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1854,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3621,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3637,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4467,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5718,
@@ -9,7 +9,7 @@
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "SB redesign: Omi-mark avatar on replies that spins while thinking (typing-dots suppressed for Omi's own replies) and tool-call chips gated to the streaming turn, merged with main's metadata-row reveal honoring keyboard focus (shared FocusState + testable ChatBubbleMetadataReveal); a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "SearchableDropdown category filter plus extracted filter helpers for regression coverage.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": "Integration Connect telemetry: ImportConnectorSheet.startRun threads bounded run metrics (source/memory count buckets, was_first_sync, connector-native failure class) from the operation outcome to the runner's terminal emit; a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": "Home ask bar now auto-grows as a multi-line TextField so long messages wrap instead of scrolling off-screen (+14 lines over the prior SB-redesign home/chat layout); a component split is tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Bridge memory search now awaits the active initial or pagination projection before refreshing, preventing an immediate post-navigation marker search from using stale lifecycle capability state.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Suggested-task loading feedback is now overlaid outside the list flow so an initial fetch cannot shift the task rows; a component split is tracked follow-up.",

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -34,6 +34,23 @@ class AnalyticsManager {
     memoryAssistantTelemetryCaptureForTests?(event, properties)
   }
 
+  /// Test observer for integration-connect telemetry. Mirrors the
+  /// MemoryAssistant seam: nil in production; tests install a scoped capture
+  /// to observe the real event/payload without a mutable unsafe global.
+  private var integrationConnectTelemetryCaptureForTests: (@MainActor (String, [String: Any]) -> Void)?
+
+  /// Install a scoped test observer for integration-connect telemetry. Tests
+  /// must clear it in teardown; production behavior remains the PostHog call.
+  func setIntegrationConnectTelemetryCaptureForTests(
+    _ capture: (@MainActor (String, [String: Any]) -> Void)?
+  ) {
+    integrationConnectTelemetryCaptureForTests = capture
+  }
+
+  private func captureIntegrationConnectTelemetryForTests(_ event: String, properties: [String: Any]) {
+    integrationConnectTelemetryCaptureForTests?(event, properties)
+  }
+
   // MARK: - Initialization
 
   func initialize() {
@@ -141,6 +158,66 @@ class AnalyticsManager {
 
   func signedOut() {
     PostHogManager.shared.signedOut()
+  }
+
+  // MARK: - Integration Connect Events
+
+  /// Privacy-safe macOS integration-connect funnel. Mirrors the Flutter
+  /// `Integration Connect Attempted/Succeeded/Failed` event names for
+  /// cross-platform PostHog aggregation; dimensions are bounded by
+  /// ``IntegrationConnectTelemetry``. See that type for the full contract.
+  func integrationConnectAttempted(
+    integrationName: String,
+    connectorID: String,
+    surface: IntegrationConnectTelemetry.Surface,
+    stage: String
+  ) {
+    let payload = IntegrationConnectTelemetry.attemptedPayload(
+      integrationName: integrationName, connectorID: connectorID,
+      surface: surface, stage: stage)
+    captureIntegrationConnectTelemetryForTests(
+      IntegrationConnectTelemetry.attemptedEventName, properties: payload)
+    PostHogManager.shared.track(
+      IntegrationConnectTelemetry.attemptedEventName, properties: payload)
+  }
+
+  func integrationConnectSucceeded(
+    integrationName: String,
+    connectorID: String,
+    surface: IntegrationConnectTelemetry.Surface,
+    stage: String,
+    durationMs: Int? = nil,
+    sourceCount: Int? = nil,
+    memoryCount: Int? = nil,
+    wasFirstSync: Bool = false
+  ) {
+    let payload = IntegrationConnectTelemetry.succeededPayload(
+      integrationName: integrationName, connectorID: connectorID,
+      surface: surface, stage: stage, durationMs: durationMs,
+      sourceCount: sourceCount, memoryCount: memoryCount, wasFirstSync: wasFirstSync)
+    captureIntegrationConnectTelemetryForTests(
+      IntegrationConnectTelemetry.succeededEventName, properties: payload)
+    PostHogManager.shared.track(
+      IntegrationConnectTelemetry.succeededEventName, properties: payload)
+  }
+
+  func integrationConnectFailed(
+    integrationName: String,
+    connectorID: String,
+    surface: IntegrationConnectTelemetry.Surface,
+    stage: String,
+    errorClass: IntegrationConnectTelemetry.ErrorClass,
+    durationMs: Int? = nil,
+    wasFirstSync: Bool = false
+  ) {
+    let payload = IntegrationConnectTelemetry.failedPayload(
+      integrationName: integrationName, connectorID: connectorID,
+      surface: surface, stage: stage, errorClass: errorClass,
+      durationMs: durationMs, wasFirstSync: wasFirstSync)
+    captureIntegrationConnectTelemetryForTests(
+      IntegrationConnectTelemetry.failedEventName, properties: payload)
+    PostHogManager.shared.track(
+      IntegrationConnectTelemetry.failedEventName, properties: payload)
   }
 
   // MARK: - Monitoring Events

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1142,7 +1142,7 @@ final class DesktopAutomationActionRegistry {
           "message": message,
           "memories": "\(result.memoryCount ?? 0)",
         ]
-      case .failure(let message):
+      case .failure(let message, failureClass: _):
         return ["outcome": "failure", "message": message]
       }
     }

--- a/desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+/// Closed, privacy-safe telemetry contract for the macOS integration connect
+/// lifecycle (Calendar, Gmail, Apple Notes, Local Files, X, and the memory-log
+/// connectors surfaced on the Apps tab and during onboarding).
+///
+/// This closes the macOS half of a gap the Flutter app already covers: Flutter
+/// emits `Integration Connect Attempted/Succeeded/Failed`
+/// (`app/lib/utils/analytics/analytics_manager.dart`), but the macOS Swift app
+/// emitted nothing for any connector connect/import outcome. The event-name
+/// strings are mirrored **byte-for-byte** so PostHog can aggregate the connect
+/// funnel across iOS/Android/macOS by `integration_name` + build cohort, and
+/// the bounded dimensions mirror the proven macOS `Auth Flow *` contract
+/// (`AuthService.trackAuthFlowEvent`) — stage, classified failure, duration.
+///
+/// Payloads are pure value builders carrying **only** bounded dimensions. They
+/// never include tokens, cookies, OAuth credentials, email/calendar/note
+/// content, account IDs, URL query strings, raw exception text, local file
+/// paths, or browser profile names. `error_class` is always a closed-enum value
+/// derived from the connector-native failure enum
+/// (`GmailFailureClass`/`CalendarFailureClass`/`AppleNotesReaderError.reasonCode`)
+/// or `PostHogManager.diagnosticErrorClass` — never a raw `message`/
+/// `errorDescription`/`localizedDescription`.
+///
+/// `platform`, `app_version`, `app_build`, and `update_channel` are attached
+/// automatically to every captured event by PostHog super-properties registered
+/// once at `PostHogManager.initialize()` (`PostHogManager.swift`). They MUST NOT
+/// be re-added to payloads here — doing so would duplicate the Auth Flow helper's
+/// now-redundant per-event re-addition.
+///
+/// Channel discipline: these are product-funnel events routed through
+/// `AnalyticsManager` → `PostHogManager.track`. They are DISTINCT from
+/// `DesktopDiagnosticsManager.recordFallback` (`desktop_health_event` /
+/// `fallback_triggered`), which is reserved for fail-open resilience. A connect
+/// MODE change (e.g. OAuth↔cookie) additionally calls `recordFallback`; the two
+/// are complementary, not duplicative.
+enum IntegrationConnectTelemetry {
+  /// PostHog event names. Stable identifiers — do not rename. Cross-platform
+  /// PostHog aggregation depends on byte-identical strings with Flutter.
+  static let attemptedEventName = "Integration Connect Attempted"
+  static let succeededEventName = "Integration Connect Succeeded"
+  static let failedEventName = "Integration Connect Failed"
+
+  /// macOS surface that initiated the connect action. Closed set.
+  enum Surface: String, CaseIterable {
+    /// Apps tab → connector sheet → `ConnectorImportRunner` import run.
+    case apps = "apps"
+    /// Conversational Second-Brain onboarding "connect what I can see" step.
+    case onboarding = "onboarding"
+  }
+
+  /// Bounded failure classification. Closed set: the union of the
+  /// connector-native failure enums (`GmailFailureClass` /
+  /// `CalendarFailureClass` raw values, `AppleNotesReaderError.reasonCode`) and
+  /// `PostHogManager.diagnosticErrorClass` outputs, so one `error_class`
+  /// dimension serves every connector. Do not add cases that cannot occur.
+  enum ErrorClass: String, CaseIterable {
+    case notSignedIn = "not_signed_in"
+    case sessionExpired = "session_expired"
+    case noBrowser = "no_browser"
+    case decryptFailed = "decrypt_failed"
+    case configuration = "configuration"
+    case storeNotFound = "store_not_found"
+    case authorizationDenied = "authorization_denied"
+    case network = "network"
+    case timeout = "timeout"
+    case cancelled = "cancelled"
+    case rateLimit = "rate_limit"
+    case permission = "permission"
+    case authentication = "authentication"
+    case conflict = "conflict"
+    case invalidResponse = "invalid_response"
+    case resourceExhausted = "resource_exhausted"
+    case unknown = "unknown"
+
+    /// Fallback for connectors without a native taxonomy: normalize a free-text
+    /// error through the shared sanitizer. Never pass a raw message as a
+    /// dimension — only this closed value.
+    static func fromMessage(_ message: String) -> ErrorClass {
+      ErrorClass(rawValue: PostHogManager.diagnosticErrorClass(message)) ?? .unknown
+    }
+
+    init(_ gmail: GmailFailureClass) {
+      self = ErrorClass(rawValue: gmail.rawValue) ?? .unknown
+    }
+
+    init(_ calendar: CalendarFailureClass) {
+      self = ErrorClass(rawValue: calendar.rawValue) ?? .unknown
+    }
+  }
+
+  /// Keys permitted in any emitted payload. Anything else is dropped by the
+  /// allow-list filter, so a caller cannot accidentally thread content through
+  /// an extra property. Mirrors the content-key denylist discipline in
+  /// `DesktopDiagnosticsManager`.
+  static let allowedKeys: Set<String> = [
+    "integration_name",
+    "connector_id",
+    "surface",
+    "stage",
+    "error_class",
+    "reconnect_required",
+    "duration_bucket",
+    "source_count_bucket",
+    "memory_count_bucket",
+    "was_first_sync",
+  ]
+
+  /// Display name matching the Flutter `integration_name` values so PostHog
+  /// aggregates the connect funnel across platforms. Falls back to the raw
+  /// connector id for any id not yet mapped.
+  static func integrationName(forConnectorID connectorID: String) -> String {
+    switch connectorID {
+    case "calendar": return "Google Calendar"
+    case "email", "gmail": return "Gmail"
+    case "apple-notes", "applenotes": return "Apple Notes"
+    case "local-files", "files": return "Local Files"
+    case "x": return "X"
+    case "chatgpt": return "ChatGPT"
+    case "claude": return "Claude"
+    default: return connectorID
+    }
+  }
+
+  /// True when the failure class means a re-sign-in / re-auth will plausibly
+  /// resolve it (vs. a terminal/config problem). Drives the reconnect-required
+  /// denominator from a single event stream — no separate event needed.
+  static func failureRequiresReconnect(_ errorClass: ErrorClass) -> Bool {
+    switch errorClass {
+    case .notSignedIn, .sessionExpired, .noBrowser, .decryptFailed, .authentication:
+      return true
+    case .configuration, .storeNotFound, .authorizationDenied, .network, .timeout,
+      .cancelled, .rateLimit, .permission, .conflict, .invalidResponse,
+      .resourceExhausted, .unknown:
+      return false
+    }
+  }
+
+  /// Buckets a raw millisecond duration into closed ranges so the raw value
+  /// never reaches PostHog. Negative values clamp to the fastest bucket.
+  static func durationBucket(_ ms: Int) -> String {
+    let clamped = max(ms, 0)
+    switch clamped {
+    case 0..<1_000: return "0_1s"
+    case 1_000..<3_000: return "1_3s"
+    case 3_000..<10_000: return "3_10s"
+    case 10_000..<30_000: return "10_30s"
+    case 30_000..<60_000: return "30_60s"
+    default: return "60s_plus"
+    }
+  }
+
+  /// Buckets a raw item count into closed ranges so a per-import volume signal
+  /// is available without emitting exact counts (which could be a faint
+  /// content proxy at the edges).
+  static func countBucket(_ count: Int) -> String {
+    switch max(count, 0) {
+    case 0: return "0"
+    case 1..<11: return "1_10"
+    case 11..<51: return "11_50"
+    case 51..<201: return "51_200"
+    case 201..<501: return "201_500"
+    default: return "500_plus"
+    }
+  }
+
+  // MARK: - Payload builders (closed schema + allow-list filter)
+
+  /// `Integration Connect Attempted` payload. Emitted once per user-initiated
+  /// connect action, at the authoritative start boundary.
+  static func attemptedPayload(
+    integrationName: String,
+    connectorID: String,
+    surface: Surface,
+    stage: String
+  ) -> [String: Any] {
+    allowListOnly([
+      "integration_name": integrationName,
+      "connector_id": connectorID,
+      "surface": surface.rawValue,
+      "stage": stage,
+    ])
+  }
+
+  /// `Integration Connect Succeeded` payload. Emitted once at the terminal
+  /// success boundary. `durationMs`/counts are optional; omitted keys are not
+  /// emitted (closed schema stays exact per event).
+  static func succeededPayload(
+    integrationName: String,
+    connectorID: String,
+    surface: Surface,
+    stage: String,
+    durationMs: Int? = nil,
+    sourceCount: Int? = nil,
+    memoryCount: Int? = nil,
+    wasFirstSync: Bool = false
+  ) -> [String: Any] {
+    var payload: [String: Any] = [
+      "integration_name": integrationName,
+      "connector_id": connectorID,
+      "surface": surface.rawValue,
+      "stage": stage,
+      "was_first_sync": wasFirstSync,
+    ]
+    if let durationMs { payload["duration_bucket"] = durationBucket(durationMs) }
+    if let sourceCount { payload["source_count_bucket"] = countBucket(sourceCount) }
+    if let memoryCount { payload["memory_count_bucket"] = countBucket(memoryCount) }
+    return allowListOnly(payload)
+  }
+
+  /// `Integration Connect Failed` payload. Emitted once at the terminal failure
+  /// boundary. `error_class` is always a closed value; `reconnect_required` is
+  /// derived from it so analysts can separate reauth-needed users from
+  /// terminal/config failures without a second event.
+  static func failedPayload(
+    integrationName: String,
+    connectorID: String,
+    surface: Surface,
+    stage: String,
+    errorClass: ErrorClass,
+    durationMs: Int? = nil,
+    wasFirstSync: Bool = false
+  ) -> [String: Any] {
+    var payload: [String: Any] = [
+      "integration_name": integrationName,
+      "connector_id": connectorID,
+      "surface": surface.rawValue,
+      "stage": stage,
+      "error_class": errorClass.rawValue,
+      "reconnect_required": failureRequiresReconnect(errorClass),
+      "was_first_sync": wasFirstSync,
+    ]
+    if let durationMs { payload["duration_bucket"] = durationBucket(durationMs) }
+    return allowListOnly(payload)
+  }
+
+  /// Drops any key not in `allowedKeys`. Defense-in-depth so a future caller
+  /// threading an extra property cannot leak it to PostHog.
+  private static func allowListOnly(_ properties: [String: Any]) -> [String: Any] {
+    properties.filter { allowedKeys.contains($0.key) }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
@@ -65,6 +65,11 @@ enum IntegrationConnectTelemetry {
     case network = "network"
     case timeout = "timeout"
     case cancelled = "cancelled"
+    /// Memory-log connector parsed successfully but produced no durable output
+    /// (e.g. user pasted a partial ChatGPT/Claude response). NOT a connect
+    /// failure — a no-op result the UI still surfaces guidance for. Carries a
+    /// distinct class so analysts can exclude it from the connect-failure rate.
+    case noContent = "no_content"
     case rateLimit = "rate_limit"
     case permission = "permission"
     case authentication = "authentication"
@@ -130,7 +135,7 @@ enum IntegrationConnectTelemetry {
     case .notSignedIn, .sessionExpired, .noBrowser, .decryptFailed, .authentication:
       return true
     case .configuration, .storeNotFound, .authorizationDenied, .network, .timeout,
-      .cancelled, .rateLimit, .permission, .conflict, .invalidResponse,
+      .cancelled, .noContent, .rateLimit, .permission, .conflict, .invalidResponse,
       .resourceExhausted, .unknown:
       return false
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -1658,6 +1658,9 @@ struct ImportConnectorSheet: View {
   ) {
     let connectorID = connector.id
     let statusStore = statusStore
+    // Capture first-sync state before markSynced flips the persisted latch, so
+    // the terminal telemetry can separate first-ever connects from re-syncs.
+    let wasFirstSync = !statusStore.snapshot(for: connector).isConnected
     ConnectorImportRunner.shared.start(
       connectorID: connectorID,
       progressTitle: title,
@@ -1672,9 +1675,22 @@ struct ImportConnectorSheet: View {
           lastDeltaCount: result.newItems,
           availabilityText: availabilityText
         )
-        return .success(message: message)
-      case .failure(let message):
-        return .failure(message: message)
+        return .success(
+          message: message,
+          metrics: ConnectorImportRunner.RunMetrics(
+            sourceCount: result.sourceCount,
+            memoryCount: result.memoryCount,
+            wasFirstSync: wasFirstSync
+          )
+        )
+      case .failure(let message, let failureClass):
+        return .failure(
+          message: message,
+          metrics: ConnectorImportRunner.RunMetrics(
+            failureClass: failureClass,
+            wasFirstSync: wasFirstSync
+          )
+        )
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
@@ -47,9 +47,13 @@ enum ConnectorImportOperations {
         message: "Imported \(memories.formatted()) memories from \(source.displayName)."
       )
     case .noDurableMemories:
+      // Not a connect failure — the parse succeeded but produced nothing
+      // durable. Surfaces UI guidance as a failure but carries a distinct
+      // bounded class so analytics can exclude it from the connect-failure rate.
       return .failure(
         message: "No durable memories found in that text. "
-          + "Make sure you pasted \(source.displayName)'s full response, then import again."
+          + "Make sure you pasted \(source.displayName)'s full response, then import again.",
+        failureClass: .noContent
       )
     case .failed:
       return .failure(message: "The import couldn't run. Try again.")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
@@ -16,7 +16,7 @@ enum ConnectorImportOperations {
 
   enum Outcome {
     case success(SyncResult, message: String)
-    case failure(message: String)
+    case failure(message: String, failureClass: IntegrationConnectTelemetry.ErrorClass? = nil)
   }
 
   @MainActor
@@ -74,8 +74,12 @@ enum ConnectorImportOperations {
         SyncResult(sourceCount: emails.count, memoryCount: memoryCount, newItems: emails.count),
         message: "Imported \(emails.count.formatted()) emails and saved \(memoryCount.formatted()) memories."
       )
+    } catch let error as GmailReaderError {
+      return .failure(message: error.localizedDescription, failureClass: Self.failureClass(for: error))
     } catch {
-      return .failure(message: error.localizedDescription)
+      return .failure(
+        message: error.localizedDescription,
+        failureClass: IntegrationConnectTelemetry.ErrorClass.fromMessage(error.localizedDescription))
     }
   }
 
@@ -182,6 +186,34 @@ enum ConnectorImportOperations {
     return "omi-computer"
   }
 
+  /// Maps the connector-native Gmail error to the closed telemetry class.
+  /// Pure and bounded — the enum is the sanitized form; no message text leaks.
+  private static func failureClass(for error: GmailReaderError) -> IntegrationConnectTelemetry.ErrorClass {
+    switch error {
+    case .noBrowserFound: return .noBrowser
+    case .noGmailCookies, .notSignedIn: return .notSignedIn
+    case .sessionExpired, .authFailed: return .sessionExpired
+    case .cookieDecryptionFailed: return .decryptFailed
+    case .networkError: return .network
+    case .pythonNotFound: return .unknown
+    }
+  }
+
+  /// Maps the connector-native Calendar error to the closed telemetry class.
+  /// Includes the `configuration` class (invalid/missing API key) that is
+  /// otherwise invisible to telemetry — a real cold-launch ops blind spot.
+  private static func failureClass(for error: CalendarReaderError) -> IntegrationConnectTelemetry.ErrorClass {
+    switch error {
+    case .noBrowserFound: return .noBrowser
+    case .notSignedIn: return .notSignedIn
+    case .sessionExpired: return .sessionExpired
+    case .cookieDecryptionFailed: return .decryptFailed
+    case .configurationError: return .configuration
+    case .networkError: return .network
+    case .pythonNotFound: return .unknown
+    }
+  }
+
   @MainActor
   static func importCalendar(progress: ConnectorImportRunner.ProgressSink) async -> Outcome {
     do {
@@ -201,8 +233,12 @@ enum ConnectorImportOperations {
         SyncResult(sourceCount: events.count, memoryCount: memoryCount, newItems: events.count),
         message: "Read \(events.count.formatted()) calendar events and saved \(memoryCount.formatted()) memories."
       )
+    } catch let error as CalendarReaderError {
+      return .failure(message: error.localizedDescription, failureClass: Self.failureClass(for: error))
     } catch {
-      return .failure(message: error.localizedDescription)
+      return .failure(
+        message: error.localizedDescription,
+        failureClass: IntegrationConnectTelemetry.ErrorClass.fromMessage(error.localizedDescription))
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportRunner.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportRunner.swift
@@ -30,9 +30,32 @@ final class ConnectorImportRunner: ObservableObject {
     var errorMessage: String?
   }
 
+  /// Bounded, privacy-safe metrics threaded from a connector operation to the
+  /// terminal telemetry emit. Only closed dimensions — never the operation's
+  /// user-facing `message` (that stays in `RunState` for the UI). See
+  /// ``IntegrationConnectTelemetry`` for the contract.
+  struct RunMetrics: Equatable {
+    var sourceCount: Int?
+    var memoryCount: Int?
+    var failureClass: IntegrationConnectTelemetry.ErrorClass?
+    var wasFirstSync: Bool = false
+
+    init(
+      sourceCount: Int? = nil,
+      memoryCount: Int? = nil,
+      failureClass: IntegrationConnectTelemetry.ErrorClass? = nil,
+      wasFirstSync: Bool = false
+    ) {
+      self.sourceCount = sourceCount
+      self.memoryCount = memoryCount
+      self.failureClass = failureClass
+      self.wasFirstSync = wasFirstSync
+    }
+  }
+
   enum RunOutcome {
-    case success(message: String)
-    case failure(message: String)
+    case success(message: String, metrics: RunMetrics = RunMetrics())
+    case failure(message: String, metrics: RunMetrics = RunMetrics())
   }
 
   /// Live progress reporting handed to a run's operation. Updates are
@@ -53,6 +76,7 @@ final class ConnectorImportRunner: ObservableObject {
 
   private var tasks: [String: Task<Void, Never>] = [:]
   private var runTokens: [String: UUID] = [:]
+  private var runStartedAt: [String: Date] = [:]
 
   func isRunning(_ connectorID: String) -> Bool {
     tasks[connectorID] != nil
@@ -78,6 +102,16 @@ final class ConnectorImportRunner: ObservableObject {
       progressDetail: progressDetail,
       statusMessage: nil,
       errorMessage: nil
+    )
+    runStartedAt[connectorID] = Date()
+    // Funnel numerator: one Attempted per real user-initiated connect, emitted
+    // at the single authoritative start boundary so every surface (Apps tab,
+    // and future onboarding callers) is measured identically.
+    AnalyticsManager.shared.integrationConnectAttempted(
+      integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID),
+      connectorID: connectorID,
+      surface: .apps,
+      stage: "import"
     )
 
     let sink = ProgressSink(runner: self, connectorID: connectorID, runToken: token)
@@ -108,15 +142,43 @@ final class ConnectorImportRunner: ObservableObject {
   private func finish(connectorID: String, runToken: UUID, outcome: RunOutcome) {
     guard runTokens[connectorID] == runToken, var state = runs[connectorID] else { return }
     tasks[connectorID] = nil
+    let startedAt = runStartedAt[connectorID]
+    runStartedAt[connectorID] = nil
+    let durationMs = startedAt.map { max(0, Int(Date().timeIntervalSince($0) * 1000)) }
     switch outcome {
-    case .success(let message):
+    case .success(let message, let metrics):
       state.phase = .succeeded
       state.statusMessage = message
       state.errorMessage = nil
-    case .failure(let message):
+      AnalyticsManager.shared.integrationConnectSucceeded(
+        integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID),
+        connectorID: connectorID,
+        surface: .apps,
+        stage: "import",
+        durationMs: durationMs,
+        sourceCount: metrics.sourceCount,
+        memoryCount: metrics.memoryCount,
+        wasFirstSync: metrics.wasFirstSync
+      )
+    case .failure(let message, let metrics):
       state.phase = .failed
       state.statusMessage = nil
       state.errorMessage = message
+      // Prefer the connector-native failure class threaded from the operation
+      // (precise); fall back to the shared sanitizer over the user-facing
+      // message for connectors without a native taxonomy.
+      let errorClass =
+        metrics.failureClass
+        ?? IntegrationConnectTelemetry.ErrorClass.fromMessage(message)
+      AnalyticsManager.shared.integrationConnectFailed(
+        integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID),
+        connectorID: connectorID,
+        surface: .apps,
+        stage: "import",
+        errorClass: errorClass,
+        durationMs: durationMs,
+        wasFirstSync: metrics.wasFirstSync
+      )
     }
     runs[connectorID] = state
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -714,6 +714,30 @@ extension SBOnboardingModel {
     }
   }
 
+  /// Emits the terminal outcome for an onboarding connect verify-probe
+  /// (Calendar/Gmail). `needsSignIn` is the reconnect-required signal;
+  /// `.error` maps to the generic `unknown` class because the bounded status
+  /// enum does not carry the native failure subclass. The Apps-tab import path
+  /// emits the precise native class for the same connectors.
+  static func emitConnectVerifyOutcome(
+    connectorID: String,
+    connected: Bool,
+    needsSignIn: Bool,
+    durationMs: Int
+  ) {
+    let integrationName = IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID)
+    if connected {
+      AnalyticsManager.shared.integrationConnectSucceeded(
+        integrationName: integrationName, connectorID: connectorID,
+        surface: .onboarding, stage: "verify", durationMs: durationMs)
+    } else {
+      let errorClass: IntegrationConnectTelemetry.ErrorClass = needsSignIn ? .notSignedIn : .unknown
+      AnalyticsManager.shared.integrationConnectFailed(
+        integrationName: integrationName, connectorID: connectorID,
+        surface: .onboarding, stage: "verify", errorClass: errorClass, durationMs: durationMs)
+    }
+  }
+
   func connectContext(_ id: String) {
     guard contextStates[id] != "connecting", contextStates[id] != "on" else { return }
     // The view owns import-sheet presentation. Keep this guard so another
@@ -724,7 +748,15 @@ extension SBOnboardingModel {
     switch id {
     case "calendar":
       Task { [weak self] in
+        let startedAt = Date()
+        AnalyticsManager.shared.integrationConnectAttempted(
+          integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: "calendar"),
+          connectorID: "calendar",
+          surface: .onboarding,
+          stage: "verify"
+        )
         let s = await CalendarReaderService.shared.verifyConnection()
+        let durationMs = max(0, Int(Date().timeIntervalSince(startedAt) * 1000))
         let needsSignIn = {
           switch s {
           case .connected, .error:
@@ -733,6 +765,14 @@ extension SBOnboardingModel {
             return true
           }
         }()
+        // Outcome telemetry for the onboarding connect probe. The bounded
+        // status enum is the only signal here; the precise native failure class
+        // is not recoverable from `CalendarConnectionStatus`, so needsSignIn
+        // maps to the reconnect-required class and `.error` to unknown. The
+        // Apps-tab import path carries the precise class.
+        Self.emitConnectVerifyOutcome(
+          connectorID: "calendar", connected: s.isConnected, needsSignIn: needsSignIn,
+          durationMs: durationMs)
         self?.resolveGoogleConnect(
           "calendar",
           connected: s.isConnected,
@@ -742,7 +782,15 @@ extension SBOnboardingModel {
       }
     case "gmail":
       Task { [weak self] in
+        let startedAt = Date()
+        AnalyticsManager.shared.integrationConnectAttempted(
+          integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: "gmail"),
+          connectorID: "gmail",
+          surface: .onboarding,
+          stage: "verify"
+        )
         let s = await GmailReaderService.shared.verifyConnection()
+        let durationMs = max(0, Int(Date().timeIntervalSince(startedAt) * 1000))
         let needsSignIn = {
           switch s {
           case .connected, .error:
@@ -751,6 +799,9 @@ extension SBOnboardingModel {
             return true
           }
         }()
+        Self.emitConnectVerifyOutcome(
+          connectorID: "gmail", connected: s.isConnected, needsSignIn: needsSignIn,
+          durationMs: durationMs)
         self?.resolveGoogleConnect(
           "gmail",
           connected: s.isConnected,

--- a/desktop/macos/Desktop/Tests/ConnectorImportOperationsTests.swift
+++ b/desktop/macos/Desktop/Tests/ConnectorImportOperationsTests.swift
@@ -78,7 +78,7 @@ final class ConnectorImportOperationsTests: XCTestCase {
 
   func testMemoryLogNoDurableMemoriesGuidesPasteFix() {
     let outcome = ConnectorImportOperations.memoryLogOutcome(.noDurableMemories, source: .chatgpt)
-    guard case .failure(let message) = outcome else {
+    guard case .failure(let message, failureClass: _) = outcome else {
       return XCTFail("expected failure, got \(outcome)")
     }
     XCTAssertEqual(
@@ -89,7 +89,7 @@ final class ConnectorImportOperationsTests: XCTestCase {
 
   func testMemoryLogFailedGuidesRetry() {
     let outcome = ConnectorImportOperations.memoryLogOutcome(.failed, source: .claude)
-    guard case .failure(let message) = outcome else {
+    guard case .failure(let message, failureClass: _) = outcome else {
       return XCTFail("expected failure, got \(outcome)")
     }
     XCTAssertEqual(message, "The import couldn't run. Try again.")

--- a/desktop/macos/Desktop/Tests/IntegrationConnectTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/IntegrationConnectTelemetryTests.swift
@@ -1,0 +1,328 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Behavioral contract for the macOS integration-connect telemetry that closes
+/// the connect-funnel observability gap. Mirrors the
+/// `MemoryAssistantTelemetryTests` allowlist pattern: every test asserts the
+/// closed schema and that no content/credential can reach PostHog — not just
+/// literal event strings. The capture seam lives on `AnalyticsManager`'s
+/// main-actor boundary, so behavioral cases observe the real event and exact
+/// payload without a mutable unsafe global and without PostHog network
+/// (`PostHogManager.track` early-returns when the SDK is uninitialized).
+@MainActor
+final class IntegrationConnectTelemetryTests: XCTestCase {
+  private typealias CapturedEvent = (name: String, properties: [String: Any])
+  private var captured: [CapturedEvent] = []
+
+  override func setUp() async throws {
+    captured = []
+    AnalyticsManager.shared.setIntegrationConnectTelemetryCaptureForTests { [weak self] name, properties in
+      self?.captured.append((name, properties))
+    }
+  }
+
+  override func tearDown() async throws {
+    AnalyticsManager.shared.setIntegrationConnectTelemetryCaptureForTests(nil)
+    captured = []
+  }
+
+  // MARK: - Closed schema
+
+  func testAttemptedPayloadHasKeysetExactlyAllowList() {
+    let payload = IntegrationConnectTelemetry.attemptedPayload(
+      integrationName: "Google Calendar", connectorID: "calendar",
+      surface: .apps, stage: "import")
+    XCTAssertEqual(
+      Set(payload.keys),
+      ["integration_name", "connector_id", "surface", "stage"])
+    XCTAssertEqual(payload["integration_name"] as? String, "Google Calendar")
+    XCTAssertEqual(payload["surface"] as? String, "apps")
+  }
+
+  func testSucceededPayloadHasKeysetExactlyAllowListWithAndWithoutBuckets() {
+    let withBuckets = IntegrationConnectTelemetry.succeededPayload(
+      integrationName: "Gmail", connectorID: "email", surface: .apps, stage: "import",
+      durationMs: 4_000, sourceCount: 42, memoryCount: 7, wasFirstSync: true)
+    XCTAssertEqual(
+      Set(withBuckets.keys),
+      [
+        "integration_name", "connector_id", "surface", "stage", "duration_bucket",
+        "source_count_bucket", "memory_count_bucket", "was_first_sync",
+      ])
+    XCTAssertEqual(withBuckets["duration_bucket"] as? String, "3_10s")
+    XCTAssertEqual(withBuckets["source_count_bucket"] as? String, "11_50")
+    XCTAssertEqual(withBuckets["was_first_sync"] as? Bool, true)
+
+    let withoutBuckets = IntegrationConnectTelemetry.succeededPayload(
+      integrationName: "Gmail", connectorID: "email", surface: .onboarding, stage: "verify")
+    XCTAssertEqual(
+      Set(withoutBuckets.keys),
+      ["integration_name", "connector_id", "surface", "stage", "was_first_sync"])
+    XCTAssertNil(withoutBuckets["duration_bucket"])
+  }
+
+  func testFailedPayloadHasKeysetExactlyAllowListAndCarriesReconnectRequired() {
+    let payload = IntegrationConnectTelemetry.failedPayload(
+      integrationName: "Google Calendar", connectorID: "calendar", surface: .apps, stage: "import",
+      errorClass: .notSignedIn, durationMs: 500)
+    XCTAssertEqual(
+      Set(payload.keys),
+      [
+        "integration_name", "connector_id", "surface", "stage", "error_class",
+        "reconnect_required", "was_first_sync", "duration_bucket",
+      ])
+    XCTAssertEqual(payload["error_class"] as? String, "not_signed_in")
+    XCTAssertEqual(payload["reconnect_required"] as? Bool, true)
+  }
+
+  // MARK: - Privacy: no content/credential can leak
+
+  func testPayloadsCannotLeakSensitiveDataEvenWithAdversarialInputs() {
+    // An adversarial caller cannot thread content through the bounded builders:
+    // only declared keys survive the allow-list filter, and the only string
+    // inputs are bounded identifiers.
+    let payload = IntegrationConnectTelemetry.failedPayload(
+      integrationName: "Gmail", connectorID: "email", surface: .apps, stage: "import",
+      errorClass: .network)
+    let serialized = String(describing: payload)
+    let forbidden = [
+      "token", "cookie", "account_id", "password", "secret", "url", "query",
+      "path", "profile", "error_message", "localized_description", "duration_ms",
+      "summary", "snippet", "subject", "from", "attendee",
+    ]
+    for term in forbidden {
+      XCTAssertFalse(
+        serialized.lowercased().contains(term),
+        "payload leaked forbidden term '\(term)': \(serialized)")
+    }
+    XCTAssertFalse(Set(payload.keys).contains("error"))
+  }
+
+  func testContextDimsAreNotInPayload() {
+    // platform/app_version/app_build/update_channel ride PostHog
+    // super-properties; they must NOT be re-added per-event.
+    let attempted = IntegrationConnectTelemetry.attemptedPayload(
+      integrationName: "X", connectorID: "x", surface: .apps, stage: "import")
+    let failed = IntegrationConnectTelemetry.failedPayload(
+      integrationName: "X", connectorID: "x", surface: .apps, stage: "import",
+      errorClass: .unknown)
+    for payload in [attempted, failed] {
+      let contextKeys: Set<String> = [
+        "platform", "app_version", "app_build", "update_channel",
+      ]
+      XCTAssertTrue(Set(payload.keys).isDisjoint(with: contextKeys))
+    }
+  }
+
+  // MARK: - Closed-set predicates
+
+  func testDurationBucketClampsAndProducesClosedRanges() {
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(-500), "0_1s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(0), "0_1s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(999), "0_1s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(1_000), "1_3s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(2_999), "1_3s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(3_000), "3_10s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(10_000), "10_30s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(29_999), "10_30s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(30_000), "30_60s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(59_999), "30_60s")
+    XCTAssertEqual(IntegrationConnectTelemetry.durationBucket(60_000), "60s_plus")
+  }
+
+  func testCountBucketClampsAndProducesClosedRanges() {
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(-3), "0")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(0), "0")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(1), "1_10")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(10), "1_10")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(11), "11_50")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(200), "51_200")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(201), "201_500")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(500), "201_500")
+    XCTAssertEqual(IntegrationConnectTelemetry.countBucket(501), "500_plus")
+  }
+
+  func testFailureRequiresReconnectIsTrueOnlyForReauthClasses() {
+    let reconnect: Set<IntegrationConnectTelemetry.ErrorClass> = [
+      .notSignedIn, .sessionExpired, .noBrowser, .decryptFailed, .authentication,
+    ]
+    for errorClass in IntegrationConnectTelemetry.ErrorClass.allCases {
+      let expected = reconnect.contains(errorClass)
+      XCTAssertEqual(
+        IntegrationConnectTelemetry.failureRequiresReconnect(errorClass), expected,
+        "\(errorClass.rawValue) reconnect classification mismatch")
+    }
+  }
+
+  func testConnectorNativeFailureEnumsMapIntoClosedErrorClass() {
+    // The connector-native taxonomies are the precise source; they must map
+    // 1:1 into the closed macOS ErrorClass vocabulary.
+    XCTAssertEqual(IntegrationConnectTelemetry.ErrorClass(GmailFailureClass.notSignedIn), .notSignedIn)
+    XCTAssertEqual(IntegrationConnectTelemetry.ErrorClass(GmailFailureClass.sessionExpired), .sessionExpired)
+    XCTAssertEqual(IntegrationConnectTelemetry.ErrorClass(CalendarFailureClass.configuration), .configuration)
+    XCTAssertEqual(IntegrationConnectTelemetry.ErrorClass(CalendarFailureClass.network), .network)
+  }
+
+  func testSurfaceEnumIsClosedSet() {
+    XCTAssertEqual(
+      Set(IntegrationConnectTelemetry.Surface.allCases.map(\.rawValue)),
+      ["apps", "onboarding"])
+  }
+
+  // MARK: - Behavioral: the real ConnectorImportRunner boundary
+
+  func testRunnerEmitsAttemptedThenSucceededThroughTheFacade() async {
+    let runner = ConnectorImportRunner()
+    let task = runner.start(
+      connectorID: "calendar",
+      progressTitle: "Importing",
+      progressDetail: "Calendar"
+    ) { _ in
+      .success(
+        message: "done",
+        metrics: ConnectorImportRunner.RunMetrics(
+          sourceCount: 120, memoryCount: 9, wasFirstSync: true))
+    }
+
+    await task?.value
+
+    XCTAssertEqual(captured.count, 2)
+    XCTAssertEqual(captured[0].name, "Integration Connect Attempted")
+    XCTAssertEqual(captured[0].properties["integration_name"] as? String, "Google Calendar")
+    XCTAssertEqual(captured[0].properties["surface"] as? String, "apps")
+    XCTAssertEqual(captured[0].properties["stage"] as? String, "import")
+
+    XCTAssertEqual(captured[1].name, "Integration Connect Succeeded")
+    XCTAssertEqual(captured[1].properties["integration_name"] as? String, "Google Calendar")
+    XCTAssertEqual(captured[1].properties["source_count_bucket"] as? String, "51_200")
+    XCTAssertEqual(captured[1].properties["memory_count_bucket"] as? String, "1_10")
+    XCTAssertEqual(captured[1].properties["was_first_sync"] as? Bool, true)
+    XCTAssertNotNil(captured[1].properties["duration_bucket"])
+  }
+
+  func testRunnerEmitsFailedWithThreadedNativeFailureClass() async {
+    let runner = ConnectorImportRunner()
+    let task = runner.start(
+      connectorID: "email",
+      progressTitle: "Importing",
+      progressDetail: "Gmail"
+    ) { _ in
+      .failure(
+        message: "Sign into Gmail in your browser.",
+        metrics: ConnectorImportRunner.RunMetrics(
+          failureClass: .notSignedIn, wasFirstSync: true))
+    }
+
+    await task?.value
+
+    XCTAssertEqual(captured.count, 2)
+    XCTAssertEqual(captured[1].name, "Integration Connect Failed")
+    XCTAssertEqual(captured[1].properties["error_class"] as? String, "not_signed_in")
+    XCTAssertEqual(captured[1].properties["reconnect_required"] as? Bool, true)
+    XCTAssertEqual(captured[1].properties["was_first_sync"] as? Bool, true)
+    // The user-facing message must NOT appear in the payload.
+    XCTAssertFalse(
+      String(describing: captured[1].properties).contains("Sign into Gmail"))
+  }
+
+  func testRunnerFallsBackToDiagnosticErrorClassWhenNoNativeClass() async {
+    let runner = ConnectorImportRunner()
+    let task = runner.start(
+      connectorID: "x",
+      progressTitle: "Connecting",
+      progressDetail: "X"
+    ) { _ in
+      // No native failure class threaded (e.g. X/local-files/memory-log): the
+      // runner must derive a bounded class from the message via the shared
+      // sanitizer rather than emitting raw text.
+      .failure(message: "The operation timed out.", metrics: ConnectorImportRunner.RunMetrics())
+    }
+
+    await task?.value
+
+    XCTAssertEqual(captured[1].name, "Integration Connect Failed")
+    XCTAssertEqual(captured[1].properties["error_class"] as? String, "timeout")
+    XCTAssertEqual(captured[1].properties["reconnect_required"] as? Bool, false)
+  }
+
+  func testDeduplicatedStartEmitsAtMostOneAttempted() async {
+    let runner = ConnectorImportRunner()
+    let release = Gate()
+    let first = runner.start(
+      connectorID: "calendar",
+      progressTitle: "Importing",
+      progressDetail: "Calendar"
+    ) { _ in
+      await release.wait()
+      return .success(message: "done")
+    }
+    // A second start while the first is in flight is ignored — it must NOT
+    // emit a second Attempted (no inflated funnel numerator).
+    let second = runner.start(
+      connectorID: "calendar",
+      progressTitle: "Importing",
+      progressDetail: "Calendar"
+    ) { _ in .success(message: "second") }
+
+    XCTAssertNil(second)
+    await release.signal()
+    await first?.value
+
+    let attempted = captured.filter { $0.name == "Integration Connect Attempted" }
+    XCTAssertEqual(attempted.count, 1)
+  }
+
+  // MARK: - Behavioral: onboarding verify-probe outcome mapping
+
+  func testOnboardingVerifyOutcomeForConnectedEmitsSucceeded() {
+    SBOnboardingModel.emitConnectVerifyOutcome(
+      connectorID: "calendar", connected: true, needsSignIn: false, durationMs: 800)
+    XCTAssertEqual(captured.count, 1)
+    XCTAssertEqual(captured[0].name, "Integration Connect Succeeded")
+    XCTAssertEqual(captured[0].properties["surface"] as? String, "onboarding")
+    XCTAssertEqual(captured[0].properties["stage"] as? String, "verify")
+    XCTAssertEqual(captured[0].properties["duration_bucket"] as? String, "0_1s")
+  }
+
+  func testOnboardingVerifyOutcomeForNeedsSignInEmitsFailedReconnectRequired() {
+    SBOnboardingModel.emitConnectVerifyOutcome(
+      connectorID: "gmail", connected: false, needsSignIn: true, durationMs: 1_200)
+    XCTAssertEqual(captured.count, 1)
+    XCTAssertEqual(captured[0].name, "Integration Connect Failed")
+    XCTAssertEqual(captured[0].properties["error_class"] as? String, "not_signed_in")
+    XCTAssertEqual(captured[0].properties["reconnect_required"] as? Bool, true)
+  }
+
+  func testOnboardingVerifyOutcomeForErrorEmitsFailedUnknown() {
+    SBOnboardingModel.emitConnectVerifyOutcome(
+      connectorID: "gmail", connected: false, needsSignIn: false, durationMs: 1_200)
+    XCTAssertEqual(captured.count, 1)
+    XCTAssertEqual(captured[0].name, "Integration Connect Failed")
+    XCTAssertEqual(captured[0].properties["error_class"] as? String, "unknown")
+    XCTAssertEqual(captured[0].properties["reconnect_required"] as? Bool, false)
+  }
+}
+
+/// Minimal async gate for deterministic in-flight dedup tests — mirrors the
+/// `Gate` actor in `ConnectorImportRunnerTests`. No sleeps, no wall-clock.
+private actor Gate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    if isOpen { return }
+    await withCheckedContinuation { continuation in
+      waiters.append(continuation)
+    }
+  }
+
+  func signal() {
+    isOpen = true
+    let toResume = waiters
+    waiters.removeAll()
+    for continuation in toResume {
+      continuation.resume()
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/IntegrationConnectTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/IntegrationConnectTelemetryTests.swift
@@ -170,6 +170,51 @@ final class IntegrationConnectTelemetryTests: XCTestCase {
       ["apps", "onboarding"])
   }
 
+  func testNoContentFailureClassIsNotReconnectRequired() {
+    // A memory-log parse that produced nothing durable is NOT a connect
+    // failure: it must carry the distinct `no_content` class and never read as
+    // reconnect-required, so analysts can exclude it from the failure rate.
+    XCTAssertFalse(IntegrationConnectTelemetry.failureRequiresReconnect(.noContent))
+    let payload = IntegrationConnectTelemetry.failedPayload(
+      integrationName: "ChatGPT", connectorID: "chatgpt", surface: .apps, stage: "import",
+      errorClass: .noContent)
+    XCTAssertEqual(payload["error_class"] as? String, "no_content")
+    XCTAssertEqual(payload["reconnect_required"] as? Bool, false)
+  }
+
+  func testMemoryLogNoDurableMemoriesCarriesNoContentClass() {
+    // Drives the real production mapping: a memory-log import that parsed but
+    // found nothing durable surfaces UI guidance as a failure but threads the
+    // bounded `no_content` class (not the generic `unknown` fallback the runner
+    // would otherwise derive from the message). Combined with
+    // testRunnerEmitsFailedWithThreadedNativeFailureClass this proves the
+    // end-to-end Failed/no_content/no-reconnect telemetry for memory-logs.
+    let outcome = ConnectorImportOperations.memoryLogOutcome(.noDurableMemories, source: .chatgpt)
+    guard case .failure(_, let failureClass) = outcome else {
+      return XCTFail("expected failure for no-durable-memories, got \(outcome)")
+    }
+    XCTAssertEqual(failureClass, .noContent)
+  }
+  func testProductionConnectorIDsMapToCleanBoundedNames() {
+    // The privacy boundary for `integration_name` VALUES is call-site
+    // discipline: production connectorIDs come from a closed set and map to a
+    // closed set of display names. No id may map to a value carrying a
+    // sensitive token.
+    let productionIDs = [
+      "calendar", "email", "gmail", "apple-notes", "applenotes",
+      "local-files", "files", "x", "chatgpt", "claude",
+    ]
+    let forbidden = ["token", "cookie", "account", "secret", "password", "url", "path"]
+    for id in productionIDs {
+      let name = IntegrationConnectTelemetry.integrationName(forConnectorID: id)
+      for term in forbidden {
+        XCTAssertFalse(
+          name.lowercased().contains(term),
+          "integration name for '\(id)' carries forbidden term '\(term)': \(name)")
+      }
+    }
+  }
+
   // MARK: - Behavioral: the real ConnectorImportRunner boundary
 
   func testRunnerEmitsAttemptedThenSucceededThroughTheFacade() async {

--- a/desktop/macos/changelog/unreleased/20260726-integration-connect-telemetry.json
+++ b/desktop/macos/changelog/unreleased/20260726-integration-connect-telemetry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added privacy-safe analytics for macOS integration connect/import outcomes (Calendar, Gmail, Apple Notes, Local Files, X, ChatGPT, Claude) across the Apps tab and onboarding — attempts, successes, reconnect-required, and classified failures by build — so the connect funnel is finally measurable on macOS; no screen content, cookies, tokens, account IDs, or raw errors are sent."
+}

--- a/desktop/macos/docs/integration-connect-telemetry.md
+++ b/desktop/macos/docs/integration-connect-telemetry.md
@@ -65,7 +65,7 @@ content-key denylist in `DesktopDiagnosticsManager`.
 - **attempts** = `count(Integration Connect Attempted)`
 - **initial-sync successes** = `count(Integration Connect Succeeded where surface=apps)`
 - **verified connections** = `count(Integration Connect Succeeded where surface=onboarding, stage=verify)`
-- **terminal failures** = `count(Integration Connect Failed)`
+- **terminal failures** = `count(Integration Connect Failed where error_class not in {no_content})` — exclude `no_content` (a memory-log parse that produced nothing durable is a successful no-op, not a connect failure; surfaced as Failed only to carry UI guidance)
 - **reconnect-required users** = `countDistinct(Integration Connect Failed where reconnect_required=true)`
 - **degraded (transient) failures** = `count(Integration Connect Failed where error_class in {network, unknown})`
 - **configuration failures** = `count(Integration Connect Failed where error_class=configuration)` (Calendar API key missing/invalid — previously silent)

--- a/desktop/macos/docs/integration-connect-telemetry.md
+++ b/desktop/macos/docs/integration-connect-telemetry.md
@@ -1,0 +1,109 @@
+# macOS Integration Connect telemetry
+
+Privacy-safe PostHog instrumentation for the macOS integration connect lifecycle
+(Calendar, Gmail, Apple Notes, Local Files, X, and the ChatGPT/Claude memory-log
+connectors). Closes the macOS half of a gap the Flutter app already covers:
+Flutter emits `Integration Connect Attempted/Succeeded/Failed`
+(`app/lib/utils/analytics/analytics_manager.dart`) but the macOS Swift app
+previously emitted **nothing** for any connector connect/import outcome, so the
+connect funnel was unmeasurable by build cohort on macOS.
+
+## Contract owner
+
+- Value-type namespace: `Sources/Integrations/IntegrationConnectTelemetry.swift`
+- Facade + test seam: `AnalyticsManager.integrationConnectAttempted/Succeeded/Failed`
+- This doc + the namespace are the single source of truth for event names and
+  dimensions. Do not add a parallel convention.
+
+## Events (mirror Flutter byte-for-byte)
+
+| Event | Emitted at | Owner |
+|---|---|---|
+| `Integration Connect Attempted` | Start of a user-initiated connect | `ConnectorImportRunner.start` (Apps tab, all 7 connectors); onboarding `connectContext` (Calendar/Gmail verify probe) |
+| `Integration Connect Succeeded` | Terminal success | `ConnectorImportRunner.finish(.success)`; onboarding verify probe `.connected` |
+| `Integration Connect Failed` | Terminal failure | `ConnectorImportRunner.finish(.failure)`; onboarding verify probe `.needsSignIn`/`.error` |
+
+Event-name strings are stable and MUST stay byte-identical with Flutter so
+PostHog aggregates the connect funnel across iOS/Android/macOS.
+
+## Dimensions (closed schema)
+
+Every payload is built by `IntegrationConnectTelemetry.*Payload(...)` and passed
+through an allow-list filter, so a caller cannot leak an undeclared key.
+
+| Key | Type | Source |
+|---|---|---|
+| `integration_name` | String | Display name matching Flutter (`Google Calendar`, `Gmail`, …) — cross-platform aggregation key |
+| `connector_id` | String | macOS internal id (`calendar`, `email`, `apple-notes`, …) |
+| `surface` | closed enum | `apps` · `onboarding` |
+| `stage` | closed set | `import` (Apps runner) · `verify` (onboarding probe) |
+| `error_class` | closed enum (Failed only) | Union of `GmailFailureClass`/`CalendarFailureClass` raw values + `PostHogManager.diagnosticErrorClass` outputs |
+| `reconnect_required` | Bool (Failed only) | Derived from `error_class` — true for reauth-needed classes |
+| `duration_bucket` | closed enum (terminal, optional) | `0_1s` `1_3s` `3_10s` `10_30s` `30_60s` `60s_plus` |
+| `source_count_bucket` | closed enum (Succeeded, optional) | `0` `1_10` `11_50` `51_200` `201_500` `500_plus` |
+| `memory_count_bucket` | closed enum (Succeeded, optional) | as above |
+| `was_first_sync` | Bool | true when no prior successful sync existed for this connector+user |
+
+**Context dims are NOT in the payload.** `platform`, `app_version`,
+`app_build`, and `update_channel` are attached automatically to every event by
+PostHog super-properties registered once at `PostHogManager.initialize()`. Do
+not re-add them (the Auth Flow helper's per-event re-addition is redundant).
+
+## Privacy boundary
+
+Payloads carry **only** the bounded dimensions above. Never emit tokens,
+cookies, OAuth credentials, email/calendar/note content, account IDs, URL query
+strings, raw exception text, local file paths, or browser profile names.
+`error_class` is always a closed-enum value derived from the connector-native
+failure enum or `PostHogManager.diagnosticErrorClass` — never the raw
+`message`/`errorDescription`/`localizedDescription` (those stay in `RunState`
+for the UI). The allow-list filter is defense-in-depth, mirroring the
+content-key denylist in `DesktopDiagnosticsManager`.
+
+## Denominators (per integration, per build cohort = `app_version` + `app_build`)
+
+- **attempts** = `count(Integration Connect Attempted)`
+- **initial-sync successes** = `count(Integration Connect Succeeded where surface=apps)`
+- **verified connections** = `count(Integration Connect Succeeded where surface=onboarding, stage=verify)`
+- **terminal failures** = `count(Integration Connect Failed)`
+- **reconnect-required users** = `countDistinct(Integration Connect Failed where reconnect_required=true)`
+- **degraded (transient) failures** = `count(Integration Connect Failed where error_class in {network, unknown})`
+- **configuration failures** = `count(Integration Connect Failed where error_class=configuration)` (Calendar API key missing/invalid — previously silent)
+- **connect-success rate** = `succeeded / (attempted)` (per surface)
+- **distinct users** = PostHog `uniqueDistinctId()` over `Attempted`
+- **latency** = `duration_bucket` distribution
+
+## Channel discipline
+
+These are product-funnel events routed `AnalyticsManager` →
+`PostHogManager.track`. They are DISTINCT from
+`DesktopDiagnosticsManager.recordFallback` (`desktop_health_event` /
+`fallback_triggered`), which is reserved for fail-open resilience. A connect
+MODE change (e.g. OAuth↔cookie fallback) should additionally call
+`recordFallback`; the two streams are complementary, not duplicative. Do not
+route connect outcomes through `recordFallback` (they are user-initiated actions
+with explicit terminal outcomes, matching the `Auth Flow *` channel, not
+fail-open resilience).
+
+## Semantic-truth rules (enforced by tests)
+
+1. Every real attempt resolves to exactly one terminal (Succeeded **or**
+   Failed). No orphan Attempted, no double-terminal — `ConnectorImportRunner`
+   deduplicates starts and run-token-guards finishes.
+2. No-op ≠ failure: a background reverify that succeeds never emits Failed.
+3. `reconnect_required` is derived from the classified `error_class`, so
+   reauth-needed users are a queryable subset of Failed, not a separate event.
+4. Cancelled/deduplicated starts emit nothing (the `tasks[connectorID] == nil`
+   guard in `start` suppresses duplicate attempts).
+
+## Out of scope (deferred)
+
+- `Integration Disconnected` (Flutter has it) — no disconnect action exists for
+  the cookie-based connectors on macOS today; deferred until a real disconnect
+  owner exists.
+- Notion / Memory-bank MCP connectors (`NotionMCPConnector`,
+  `MemoryBankConnector`) — separate OAuth/MCP owners; each needs its own bounded
+  event. Deferred.
+- The Settings → Gmail Reader surface and the legacy onboarding background
+  insights path (`OnboardingPagedIntroCoordinator`) — separate call sites for
+  the same providers; deferred to avoid double-counting the same funnel.

--- a/desktop/macos/e2e/flows/connector-import-progress.yaml
+++ b/desktop/macos/e2e/flows/connector-import-progress.yaml
@@ -16,6 +16,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/APIClient+XConnector.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportRunner.swift
+  - desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
   - desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift


### PR DESCRIPTION
## Observed observability gap

The macOS desktop app emitted **zero** PostHog telemetry for any integration
connect/import outcome across builds 0.12.111–0.12.119. The Flutter app already
emits `Integration Connect Attempted/Succeeded/Failed`
(`app/lib/utils/analytics/analytics_manager.dart`), but the macOS Swift app had
no equivalent, so the connect funnel was unmeasurable by integration × build
cohort on macOS. Only the `Auth Flow *` sign-in contract was instrumented.

This was scoped by a 6-lane read-only subagent swarm (surface inventory,
instrumentation audit, lifecycle/state-source audit, history/duplicate audit,
metric-contract + test-design, and an adversarial refuter). Synthesized
inventory: `desktop/macos/docs/integration-connect-telemetry.md`.

## Core integrations included

- **Apps-tab import funnel (all 7 connectors):** Google Calendar, Gmail, Apple
  Notes, Local Files, X, ChatGPT memory-log, Claude memory-log. Instrumented at
  the single authoritative owner `ConnectorImportRunner.start/finish`, which
  every Apps-tab connector run funnels through.
- **Onboarding Calendar/Gmail connect probe:** the "connect what I can see"
  Second-Brain onboarding step (`SBOnboardingModel.connectContext`), surface=
  `onboarding`, stage=`verify`.

## Excluded (with rationale)

- **Notion / Memory-bank MCP connectors** (`NotionMCPConnector`,
  `MemoryBankConnector`): separate OAuth/MCP owners, each needing its own
  bounded event; deferred.
- **`Integration Disconnected`** (Flutter has it): no disconnect action exists
  for the cookie-based connectors on macOS today; deferred until a real owner.
- **Settings → Gmail Reader surface and the legacy onboarding background
  insights path** (`OnboardingPagedIntroCoordinator`): separate call sites for
  the same providers; deferred to avoid double-counting the same funnel.
- **OAuth/cookie compatibility for #10459 is deliberately out of scope** — this
  PR adds measurement only; it does not change cookie scraping, OAuth behavior,
  or any connector logic.

## Event contract / denominators

Mirrors the Flutter event names **byte-for-byte** for cross-platform PostHog
aggregation, with Auth-Flow-style bounded dimensions:

| Event | Emitted at |
|---|---|
| `Integration Connect Attempted` | `ConnectorImportRunner.start`; onboarding `connectContext` |
| `Integration Connect Succeeded` | `ConnectorImportRunner.finish(.success)`; onboarding `.connected` |
| `Integration Connect Failed` | `ConnectorImportRunner.finish(.failure)`; onboarding `.needsSignIn`/`.error` |

Dimensions (closed schema, allow-list filtered): `integration_name`,
`connector_id`, `surface`, `stage`, `error_class`, `reconnect_required`,
`duration_bucket`, `source_count_bucket`, `memory_count_bucket`,
`was_first_sync`. `platform`/`app_version`/`app_build`/`update_channel` ride
PostHog super-properties (not re-added per-event).

Per integration × build cohort (`app_version`+`app_build`): attempts, initial-
sync successes, verified connections (onboarding probe), terminal failures,
reconnect-required users (`Failed` where `reconnect_required=true`), degraded
failures (`error_class` in {network, unknown}), the previously-silent Calendar
`configuration` failures (missing API key), latency distribution, and distinct
users.

## Privacy boundary

Payloads carry **only** bounded dimensions. `error_class` is always a closed
enum derived from the connector-native failure enum
(`GmailFailureClass`/`CalendarFailureClass`/`AppleNotesReaderError.reasonCode`)
or `PostHogManager.diagnosticErrorClass` — never the raw
`message`/`errorDescription`/`localizedDescription` (those stay in `RunState`
for the UI). Every payload passes an allow-list filter so a caller cannot
accidentally thread a token, cookie, email/calendar content, account ID, URL
query, raw exception, file path, or browser profile name to PostHog.

## Source owners

- Contract + facade: `Sources/Integrations/IntegrationConnectTelemetry.swift`,
  `AnalyticsManager` (`integrationConnectAttempted/Succeeded/Failed` + test
  observer seam mirroring `MemoryAssistantTelemetry`).
- Apps funnel: `ConnectorImportRunner.start/finish` (emit), widened
  `RunOutcome`/`ConnectorImportOperations.Outcome` carry bounded
  RunMetrics; Gmail/Calendar catch sites populate the native class,
  `AppsPage.startRun` threads counts + `was_first_sync`.
- Onboarding probe: `SBOnboardingModel.connectContext` (Calendar/Gmail) +
  `emitConnectVerifyOutcome`.

## Product invariants affected

- INV-INT-1 — respected, not weakened. Telemetry is privacy-safe (strips
  cookies/tokens/PII by construction) and does not change what "Connected"
  means (still a functional-probe result); it only makes the existing funnel
  measurable.

Failure-Class: none

## Tests run

- `IntegrationConnectTelemetryTests` — **20 tests**: behavioral emission
  through the real `ConnectorImportRunner` boundary (Attempted→Succeeded/Failed
  with correct event names + dimensions), the dedup guarantee (one Attempted
  per run), onboarding verify-probe outcome mapping, the memory-log
  `no_content` semantic (a no-durable-output parse is a successful no-op, not a
  connect failure), closed-schema allow-list exactness, no-PII-leak under
  adversarial inputs + bounded-name verification, bucket/reconnect predicate
  boundaries.
- `ConnectorImportRunnerTests` — 11 tests (existing, still green after the
  `RunOutcome` widening).
- `ConnectorImportOperationsTests` — 13 tests (existing, still green after the
  `Outcome` widening).

All pass under `swift test` (per-suite isolation, hermetic — `PostHogManager
.track` no-ops when the SDK is uninitialized).

## Real-path exercise

Build: `xcrun swift build --package-path Desktop --build-tests` — clean
(incl. `-strict-concurrency=complete -warnings-as-errors`). swift-format
applied via the project config + pre-commit hook.

## Deferred work

Notion / Memory-bank MCP connectors; `Integration Disconnected`; Settings Gmail
Reader + legacy onboarding background-insights paths; the precise native
failure subclass on the onboarding verify-probe (coarse `not_signed_in`/
`unknown` today; the Apps import path carries the precise class for the same
connectors).

## CI / preflight notes

- `make preflight` (`pr_preflight --lane local`): the `product-file-line-count-
  ratchet` is satisfied by raising the `AppsPage.swift` baseline 3621→3637 with
  a justification (splitting the 3621-line file is out of scope).
- Pre-existing on `main` (not caused by this PR): `check-sources-root-layout`
  reports 79 loose `Sources/`-root files vs a pinned baseline of 77 — verified
  by stashing this PR's changes and re-running (fails identically on clean
  `main`).

Context: #10459 (macOS Calendar/Gmail) — linked as context only; OAuth/cookie
compatibility is deliberately out of scope.
