### PR TITLE
fix(backend): stop a permanently rejected app webhook from failing conversation finalization

### DIFF
--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -299,7 +299,7 @@ class TestDurableExternalIntegrationFanout:
 
         with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
             app_integrations, 'get_webhook_client', return_value=client
-        ):
+        ), patch.object(app_integrations, 'conversation_to_dict', return_value={}):
             await app_integrations.trigger_external_integrations(
                 'uid-1', conversation, idempotency_key='fanout-1', require_delivery=True
             )
@@ -317,7 +317,9 @@ class TestDurableExternalIntegrationFanout:
 
         with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
             app_integrations, 'get_webhook_client', return_value=client
-        ), pytest.raises(app_integrations.ExternalIntegrationFanoutError):
+        ), patch.object(app_integrations, 'conversation_to_dict', return_value={}), pytest.raises(
+            app_integrations.ExternalIntegrationFanoutError
+        ):
             await app_integrations.trigger_external_integrations(
                 'uid-1', conversation, idempotency_key='fanout-1', require_delivery=True
             )
@@ -335,7 +337,7 @@ class TestDurableExternalIntegrationFanout:
 
         with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
             app_integrations, 'get_webhook_client', return_value=client
-        ):
+        ), patch.object(app_integrations, 'conversation_to_dict', return_value={}):
             messages = await app_integrations.trigger_external_integrations(
                 'uid-1', conversation, idempotency_key='fanout-1', require_delivery=True
             )

--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -322,6 +322,27 @@ class TestDurableExternalIntegrationFanout:
                 'uid-1', conversation, idempotency_key='fanout-1', require_delivery=True
             )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('status_code', [400, 401, 404])
+    async def test_permanent_delivery_rejection_does_not_fail_finalization(self, status_code):
+        """A user's broken app (expired token, deleted target) must not strand the conversation."""
+        app = _make_app('app-1', 'https://app.test/hook')
+        app.triggers_on_conversation_creation.return_value = True
+        conversation = types.SimpleNamespace(id='conversation-1', discarded=False, is_locked=False, source=None)
+        response = MagicMock(status_code=status_code, text='rejected')
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=response)
+
+        with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
+            app_integrations, 'get_webhook_client', return_value=client
+        ):
+            messages = await app_integrations.trigger_external_integrations(
+                'uid-1', conversation, idempotency_key='fanout-1', require_delivery=True
+            )
+
+        assert messages == []
+        assert client.post.await_count == 1
+
 
 class TestAsyncTriggerRealtimeAudioBytes:
     """Test async audio bytes fan-out."""

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -20,6 +20,7 @@ from routers.conversation_finalization import _parse_task_payload
 import routers.conversation_finalization as finalization_router
 import routers.pusher as pusher_router
 from utils.conversations import lifecycle as lifecycle_service
+from utils import app_integrations
 from utils import cloud_tasks
 from utils.conversations.finalizer import ConversationFinalizationDisposition, ConversationFinalizationError
 import utils.conversations.finalizer as persisted_finalizer
@@ -1399,3 +1400,77 @@ async def test_finalizer_runs_derived_effects_only_after_winning_claim(monkeypat
     derived_runner.assert_called_once()
     integrations.assert_awaited_once()
     complete.assert_called_once_with('job-1', 2, 3)
+
+
+@pytest.mark.anyio
+async def test_finalizer_completes_when_an_app_permanently_rejects_the_delivery(monkeypatch):
+    """A user's broken app webhook (expired token, deleted target) answers every
+    retry identically, so it must not strand the conversation in `processing`
+    until the finalization job dead-letters. The real fanout runs here."""
+
+    async def inline_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    conversation = SimpleNamespace(
+        id='conversation-1',
+        status=ConversationStatus.processing,
+        language='en',
+        discarded=False,
+        is_locked=False,
+        source=None,
+    )
+    complete = MagicMock(return_value=True)
+
+    def contract_faithful_process(_uid, _lang, conv, **kwargs):
+        if observer := kwargs.get('persistence_observer'):
+            observer(True)
+        if effects_observer := kwargs.get('derived_effects_observer'):
+            effects_observer(MagicMock())
+        return conv
+
+    monkeypatch.setattr(persisted_finalizer, 'run_blocking', inline_run_blocking)
+    monkeypatch.setattr(
+        persisted_finalizer.conversations_db,
+        'get_conversation',
+        lambda *args: {'id': 'conversation-1', 'status': ConversationStatus.processing.value, 'discarded': False},
+    )
+    monkeypatch.setattr(persisted_finalizer, 'deserialize_conversation', lambda value: conversation)
+    monkeypatch.setattr(persisted_finalizer, 'get_cached_user_geolocation', lambda uid: None)
+    monkeypatch.setattr(persisted_finalizer, 'process_conversation', contract_faithful_process)
+    monkeypatch.setattr(persisted_finalizer, 'extract_memories', MagicMock())
+    monkeypatch.setattr(
+        persisted_finalizer.lifecycle_service,
+        'claim_finalization_fanout',
+        lambda *args: {'status': 'claimed', 'fanout_key': 'conversation:conversation-1:finalization'},
+    )
+    monkeypatch.setattr(persisted_finalizer.lifecycle_service, 'complete_finalization_fanout', complete)
+
+    app = MagicMock()
+    app.id = 'omi-google-drive-integration'
+    app.enabled = True
+    app.uid = None
+    app.external_integration.webhook_url = 'https://app.test/hook'
+    app.triggers_on_conversation_creation.return_value = True
+    webhook_client = AsyncMock()
+    webhook_client.post = AsyncMock(return_value=MagicMock(status_code=401, text='re-authenticate'))
+    monkeypatch.setattr(app_integrations, 'run_blocking', inline_run_blocking)
+    monkeypatch.setattr(app_integrations, 'get_available_apps', lambda uid: [app])
+    monkeypatch.setattr(app_integrations, 'conversation_to_dict', lambda conv: {'id': conv.id})
+    monkeypatch.setattr(app_integrations, 'get_webhook_client', lambda: webhook_client)
+    monkeypatch.setattr(app_integrations, 'is_app_webhook_disabled', lambda app_id: False)
+    record_failure = MagicMock(return_value=0)
+    monkeypatch.setattr(app_integrations, 'record_app_webhook_failure', record_failure)
+    monkeypatch.setattr(app_integrations, '_handle_webhook_health_action', MagicMock())
+
+    disposition = await persisted_finalizer.finalize_persisted_conversation(
+        'uid-1',
+        'conversation-1',
+        finalization_job_id='job-1',
+        dispatch_generation=2,
+        lease_epoch=3,
+    )
+
+    assert disposition == ConversationFinalizationDisposition.completed
+    complete.assert_called_once_with('job-1', 2, 3)
+    # The failure is still owned by webhook health, which disables the app after 72h.
+    record_failure.assert_called_once_with('omi-google-drive-integration', 401, 'HTTP 401')

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -64,6 +64,7 @@ import database.conversations as conversations_db
 from utils.conversations.render import conversation_to_dict, serialize_datetimes
 from utils.log_sanitizer import sanitize
 from utils.mentor_notifications import process_mentor_notification
+from utils.observability.fallback import record_fallback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,17 @@ logger = logging.getLogger(__name__)
 
 class ExternalIntegrationFanoutError(RuntimeError):
     """At least one durable finalization webhook did not acknowledge delivery."""
+
+
+# A retry only helps when the destination may answer differently next time.
+# Webhook health tracking (`record_app_webhook_failure`) owns the permanent
+# case: it warns the app owner and auto-disables the webhook after 72h.
+_RETRYABLE_DELIVERY_STATUSES = frozenset({408, 425, 429})
+
+
+def _delivery_failure_is_retryable(status_code: int) -> bool:
+    """Whether a non-2xx webhook response leaves the finalization job retryable."""
+    return status_code >= 500 or status_code in _RETRYABLE_DELIVERY_STATUSES
 
 
 def _notify_app_owner(app_id: str, title: str, body: str):
@@ -238,7 +250,21 @@ async def trigger_external_integrations(
                     f'App integration failed {app.id} status: {response.status_code} result: {sanitize(response.text[:100])}'
                 )
                 if require_delivery:
-                    failed_deliveries.append(app.id)
+                    if _delivery_failure_is_retryable(response.status_code):
+                        failed_deliveries.append(app.id)
+                    else:
+                        # The destination rejected this payload permanently (expired
+                        # OAuth token, deleted target, malformed for that app). Every
+                        # retry repeats it verbatim, so keeping the conversation's
+                        # finalization job retryable would only strand the
+                        # conversation until the job dead-letters.
+                        record_fallback(
+                            component='webhook',
+                            from_mode='durable_delivery',
+                            to_mode='dropped',
+                            reason='auth' if response.status_code in (401, 403) else 'policy',
+                            outcome='degraded',
+                        )
                 return
 
             cb.record_success()


### PR DESCRIPTION
## Bug (live in prod)

A conversation's durable finalization job calls `trigger_external_integrations(..., require_delivery=True)`. **Any** non-2xx response from a user's third-party app webhook was counted as an undelivered fanout, which raises `ExternalIntegrationFanoutError` → `ConversationFinalizationError('processing_failed')` → HTTP 500 on `POST /v1/conversation-finalization-jobs/run`. Cloud Tasks then retries the whole job until it dead-letters, so the conversation never finalizes.

The failures in prod are permanent, not transient. On 2026-07-26, over 11.5h of `based-hardware` logs, **335 of 336** app-integration failures were 4xx:

| app | status | count |
|---|---|---|
| `notion-crm` | 400 (`object_not_found`) | 181 |
| `omi-google-drive-integration` | 401 (`Please re-authenticate`) | 122 |
| `01KHY4N6AG8D4QAGP4E7AH5M0H` | 404 | 32 |
| `01KS2R9YFFXEDX6BDT4EQ5YRQZ` | 502 | 1 |

Blast radius over 24h: **86 distinct conversations across ≥10 users**, each burning all 5 attempts (`persisted conversation finalization failed uid=… failure=processing_failed`), plus 22 `backend-sync` 500s per 12h on the job route. Every retry also re-runs the derived-effect bundle (memory extraction, vector upsert, delivery to the user's *working* apps).

Correlated example (backend-sync, 2026-07-26T18:04:00Z):

```
App integration failed omi-google-drive-integration status: 401 result: {"error":"Unauthorized","message":"Please re-authenticate …
Plugin integration request failed app=omi-google-drive-integration error=RuntimeError
persisted conversation finalization failed uid=xar839kthBUuQvaFjTm2rRUhcgq2 conversation=d3942361-… failure=processing_failed
```

## Root cause

`require_delivery` conflated "not delivered" with "a retry may deliver". A retry only helps when the destination can answer differently next time; an expired OAuth token or a deleted Notion page answers every retry identically, so the owner of the conversation's terminal state spent its whole retry budget on a dependency's permanent decision.

## Fix

`backend/utils/app_integrations.py`: keep the finalization job retryable only for failures a retry can change — 5xx, 408, 425, 429 (network exceptions and an open circuit breaker stay retryable, unchanged). A permanent rejection is recorded via `record_fallback(component='webhook', to_mode='dropped', outcome='degraded')` and dropped. Webhook health tracking is untouched and still owns the permanent case: it warns the app owner and auto-disables the webhook after 72h of failures. The delivery outcome for the broken app is unchanged (it was dropped after 5 attempts anyway); the conversation now finalizes.

## Verification

Both new tests fail on `main` and pass with the fix (checked by stashing only the production change):

- `tests/unit/test_listen_finalization_cloud_tasks.py::test_finalizer_completes_when_an_app_permanently_rejects_the_delivery` — drives the real `finalize_persisted_conversation` with the **real** fanout and a webhook returning 401; asserts the disposition is `completed`, `complete_finalization_fanout` is called, and the webhook-health failure is still recorded. Before the fix: `ConversationFinalizationError`.
- `tests/unit/test_async_app_integrations.py::TestDurableExternalIntegrationFanout::test_permanent_delivery_rejection_does_not_fail_finalization[400/401/404]`.

```
$ .venv/bin/python -m pytest tests/unit/test_listen_finalization_cloud_tasks.py \
    tests/unit/test_async_app_integrations.py tests/unit/test_app_integrations_async.py -q
99 passed
$ .venv/bin/python -m pytest <same files> -q -k "permanent or Durable or fanout"
32 passed
$ black --line-length 120 --skip-string-normalization <touched files>   # 3 files unchanged
```

Not covered: a live prod conversation with a broken app integration — that needs a user's real third-party account, so the proof here is the hermetic finalizer path plus the prod log evidence above.

Failure-Class: FC-durable-terminal-projection

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->