### PR TITLE
fix: make local M1 qualification proof portable

### DIFF
--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -36,9 +36,6 @@ jobs:
           git -C "$PROOF_STAGE/source" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           GIT_TERMINAL_PROMPT=0 git -C "$PROOF_STAGE/source" fetch --force --prune --tags origin
           git -C "$PROOF_STAGE/source" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
-      - name: Install local qualification proof prerequisites
-        working-directory: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}/source
-        run: make setup-backend
       - name: Prove offline qualification lifecycle before canonical dispatch
         working-directory: ${{ runner.temp }}/desktop-beta-local-proof/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -40,12 +40,16 @@ passing evidence.
 
 ## Local M1 lifecycle proof
 
-From the canonical repository on an Apple Silicon Mac, install the backend
-virtual environment once and check out the exact local release tag:
+On the Apple Silicon M1 qualification host, install the backend virtual
+environment once in the canonical repository at
+`~/workspace/omi/backend/.venv`, then create or enter a source-only checkout of
+the exact local release tag:
 
 ```bash
+cd ~/workspace/omi
 make setup-backend
-git checkout --detach refs/tags/vX.Y.Z+BUILD-macos
+git worktree add --detach /private/tmp/omi-qualification-proof refs/tags/vX.Y.Z+BUILD-macos
+cd /private/tmp/omi-qualification-proof
 desktop/macos/scripts/qualification-local-proof.sh \
   --offline \
   --fast \
@@ -53,11 +57,30 @@ desktop/macos/scripts/qualification-local-proof.sh \
   vX.Y.Z+BUILD-macos
 ```
 
-Prerequisites are `git`, Python 3, `nc`, `lsof`, `ps`, and the backend virtual
-environment created by `make setup-backend`. Fetch the tag before entering
-offline mode if it is not already local. The proof itself does not use GitHub
-Actions or Codemagic credentials, production credentials, release APIs, channel
-pointers, publication, Beta/Stable bundles, or `/Applications/Omi.app`.
+Prerequisites are `git`, Python 3, `nc`, `lsof`, `ps`, and the canonical shared
+backend virtual environment created by `make setup-backend`. The dependency
+interpreter is resolved in this fail-closed order: an executable path explicitly
+set with `OMI_QUALIFICATION_PYTHON`, the exact candidate worktree's
+`backend/.venv/bin/python`, then the executable canonical M1 path
+`~/workspace/omi/backend/.venv/bin/python`. An invalid explicit override aborts
+without falling back, and a missing interpreter reports every safe path it
+attempted before any lease or listener activity. The selected interpreter runs
+with the tag-pinned checkout as both its working directory and Python source
+owner; no virtual environment is copied into that immutable candidate.
+
+Fetch the tag and provision the canonical venv before entering offline mode if
+either is missing. The exact repeatable command for a source-only candidate is:
+
+```bash
+OMI_QUALIFICATION_PYTHON="$HOME/workspace/omi/backend/.venv/bin/python" \
+  desktop/macos/scripts/qualification-local-proof.sh --offline --fast \
+  --result /private/tmp/omi-local-qualification-proof.json \
+  vX.Y.Z+BUILD-macos
+```
+
+The proof itself does not use GitHub Actions or Codemagic credentials,
+production credentials, release APIs, channel pointers, publication,
+Beta/Stable bundles, or `/Applications/Omi.app`.
 
 A successful `0600` result has `status: "passed"`, `mode: "offline-fast"`,
 the tag's exact `source_sha`, `cleanup_status: "released"`, and these completed

--- a/desktop/macos/scripts/qualification-lease-command.sh
+++ b/desktop/macos/scripts/qualification-lease-command.sh
@@ -19,15 +19,48 @@ action="$1"
 shift
 lease_token=""
 
+resolve_qualification_python() {
+  local worktree="$1"
+  local override="${OMI_QUALIFICATION_PYTHON:-}"
+  local worktree_python="$worktree/backend/.venv/bin/python"
+  local shared_python=""
+
+  if [[ -n "${HOME:-}" ]]; then
+    shared_python="$HOME/workspace/omi/backend/.venv/bin/python"
+  fi
+
+  if [[ -n "$override" ]]; then
+    if [[ -f "$override" && -x "$override" ]]; then
+      printf '%s/%s\n' "$(cd "$(dirname "$override")" && pwd -P)" "$(basename "$override")"
+      return 0
+    fi
+    echo "qualification failed: OMI_QUALIFICATION_PYTHON is not an executable file: $override; attempted safe interpreter paths: OMI_QUALIFICATION_PYTHON=$override" >&2
+    return 127
+  fi
+
+  if [[ -f "$worktree_python" && -x "$worktree_python" ]]; then
+    printf '%s\n' "$worktree_python"
+    return 0
+  fi
+  if [[ -n "$shared_python" && -f "$shared_python" && -x "$shared_python" ]]; then
+    printf '%s\n' "$shared_python"
+    return 0
+  fi
+
+  if [[ -n "$shared_python" ]]; then
+    echo "qualification failed: no executable dependency interpreter; attempted safe interpreter paths: worktree=$worktree_python; shared=$shared_python; set OMI_QUALIFICATION_PYTHON to an executable path to override" >&2
+  else
+    echo "qualification failed: no executable dependency interpreter; attempted safe interpreter paths: worktree=$worktree_python; shared=<HOME-unavailable>/workspace/omi/backend/.venv/bin/python; set OMI_QUALIFICATION_PYTHON to an executable path to override" >&2
+  fi
+  return 127
+}
+
 run_lease_command() {
   local worktree="$1"
   shift
-  local lease_python="$worktree/backend/.venv/bin/python"
+  local lease_python
   local output status detail stderr_file
-  if [[ ! -x "$lease_python" ]]; then
-    echo "qualification failed: backend virtualenv is missing at $lease_python; lease ${action} cannot run" >&2
-    return 127
-  fi
+  lease_python="$(resolve_qualification_python "$worktree")" || return $?
 
   stderr_file="$(mktemp "${TMPDIR:-/tmp}/omi-qualification-lease-command.XXXXXX")" || {
     echo "qualification failed: could not capture lease ${action} diagnostics" >&2

--- a/desktop/macos/tests/test-qualification-lease-command.sh
+++ b/desktop/macos/tests/test-qualification-lease-command.sh
@@ -34,6 +34,17 @@ expected_worktree="$(cd "$expected_worktree" && pwd -P)"
   echo "qualification lease ran from $actual_worktree instead of $expected_worktree" >&2
   exit 66
 }
+if [[ -n "${QUALIFICATION_LEASE_EXPECTED_PYTHON:-}" ]]; then
+  actual_python="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
+  expected_python="$(cd "$(dirname "$QUALIFICATION_LEASE_EXPECTED_PYTHON")" && pwd -P)/$(basename "$QUALIFICATION_LEASE_EXPECTED_PYTHON")"
+  [[ "$actual_python" == "$expected_python" ]] || {
+    echo "qualification lease used $actual_python instead of $expected_python" >&2
+    exit 67
+  }
+fi
+if [[ -n "${QUALIFICATION_LEASE_EXECUTION_MARKER:-}" ]]; then
+  : > "$QUALIFICATION_LEASE_EXECUTION_MARKER"
+fi
 case "${QUALIFICATION_LEASE_FIXTURE_MODE:-}" in
   acquire-failure)
     printf '%s\n' 'Safety check failed: Qualification lease owner PID is not running: 424242'
@@ -63,6 +74,35 @@ case "${QUALIFICATION_LEASE_FIXTURE_MODE:-}" in
 esac
 SH
 chmod +x "$FIXTURE_PYTHON"
+
+EXPLICIT_PYTHON="$TMP_ROOT/explicit/bin/python"
+mkdir -p "$(dirname "$EXPLICIT_PYTHON")"
+cp "$FIXTURE_PYTHON" "$EXPLICIT_PYTHON"
+chmod +x "$EXPLICIT_PYTHON"
+QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" \
+  QUALIFICATION_LEASE_EXPECTED_PYTHON="$EXPLICIT_PYTHON" \
+  QUALIFICATION_LEASE_FIXTURE_MODE=acquire-success \
+  OMI_QUALIFICATION_PYTHON="$EXPLICIT_PYTHON" \
+  "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3 >"$TMP_ROOT/explicit.out"
+grep -Fxq '{"log_dir":"/tmp/qualification-log","token":"test-token"}' "$TMP_ROOT/explicit.out" \
+  || fail "explicit qualification interpreter did not preserve the lease capability"
+
+INVALID_PYTHON="$TMP_ROOT/invalid-python"
+EXECUTION_MARKER="$TMP_ROOT/invalid-override-executed"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 99' > "$INVALID_PYTHON"
+if QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" \
+  QUALIFICATION_LEASE_EXECUTION_MARKER="$EXECUTION_MARKER" \
+  QUALIFICATION_LEASE_FIXTURE_MODE=acquire-success \
+  OMI_QUALIFICATION_PYTHON="$INVALID_PYTHON" \
+  "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3 >"$TMP_ROOT/invalid.out" 2>"$TMP_ROOT/invalid.err"; then
+  fail "invalid explicit qualification interpreter unexpectedly fell back"
+fi
+grep -Fq "OMI_QUALIFICATION_PYTHON is not an executable file: $INVALID_PYTHON" "$TMP_ROOT/invalid.err" \
+  || fail "invalid explicit qualification interpreter was not diagnosed"
+grep -Fq "attempted safe interpreter paths: OMI_QUALIFICATION_PYTHON=$INVALID_PYTHON" "$TMP_ROOT/invalid.err" \
+  || fail "invalid override diagnostic omitted the attempted path"
+[[ ! -e "$EXECUTION_MARKER" ]] || fail "invalid override reached lease process activity"
+[[ ! -s "$TMP_ROOT/invalid.out" ]] || fail "invalid override wrote a JSON capability"
 
 if QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" QUALIFICATION_LEASE_FIXTURE_MODE=acquire-failure "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test 424242 1000 3 >"$TMP_ROOT/acquire.out" 2>"$TMP_ROOT/acquire.err"; then
   fail "lease acquire unexpectedly succeeded"
@@ -102,5 +142,33 @@ grep -Fxq '{"log_dir":"/tmp/qualification-log","token":"test-token"}' "$TMP_ROOT
   || fail "successful lease acquire with stderr did not preserve its JSON capability"
 [[ ! -s "$TMP_ROOT/success-with-stderr.err" ]] \
   || fail "successful lease acquire relayed diagnostics instead of isolating its JSON capability"
+
+SHARED_HOME="$TMP_ROOT/shared-home"
+SHARED_PYTHON="$SHARED_HOME/workspace/omi/backend/.venv/bin/python"
+mkdir -p "$(dirname "$SHARED_PYTHON")"
+cp "$FIXTURE_PYTHON" "$SHARED_PYTHON"
+chmod +x "$SHARED_PYTHON"
+rm "$FIXTURE_PYTHON"
+env -u OMI_QUALIFICATION_PYTHON \
+  HOME="$SHARED_HOME" \
+  QUALIFICATION_LEASE_EXPECTED_WORKTREE="$FIXTURE_WORKTREE" \
+  QUALIFICATION_LEASE_EXPECTED_PYTHON="$SHARED_PYTHON" \
+  QUALIFICATION_LEASE_FIXTURE_MODE=acquire-success \
+  "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3 >"$TMP_ROOT/shared.out"
+grep -Fxq '{"log_dir":"/tmp/qualification-log","token":"test-token"}' "$TMP_ROOT/shared.out" \
+  || fail "source-only worktree did not use the canonical shared interpreter"
+
+MISSING_HOME="$TMP_ROOT/missing-home"
+mkdir -p "$MISSING_HOME"
+if env -u OMI_QUALIFICATION_PYTHON \
+  HOME="$MISSING_HOME" \
+  "$LEASE_COMMAND" acquire "$FIXTURE_WORKTREE" qualification-test $$ 1000 3 >"$TMP_ROOT/missing.out" 2>"$TMP_ROOT/missing.err"; then
+  fail "missing qualification interpreters unexpectedly succeeded"
+fi
+grep -Fq "worktree=$FIXTURE_WORKTREE/backend/.venv/bin/python" "$TMP_ROOT/missing.err" \
+  || fail "missing interpreter diagnostic omitted the worktree path"
+grep -Fq "shared=$MISSING_HOME/workspace/omi/backend/.venv/bin/python" "$TMP_ROOT/missing.err" \
+  || fail "missing interpreter diagnostic omitted the shared path"
+[[ ! -s "$TMP_ROOT/missing.out" ]] || fail "missing interpreters wrote a JSON capability"
 
 echo "qualification lease command behavioral regression tests passed"

--- a/scripts/dev-harness/tests/test_qualification_local_proof.py
+++ b/scripts/dev-harness/tests/test_qualification_local_proof.py
@@ -62,9 +62,7 @@ def proof_repo(tmp_path: Path) -> Path:
     for name in SCRIPT_NAMES:
         shutil.copy2(REPO_ROOT / "desktop" / "macos" / "scripts" / name, scripts / name)
     shutil.copytree(REPO_ROOT / "scripts" / "dev-harness" / "dev_harness", repo / "scripts" / "dev-harness" / "dev_harness")
-    backend = repo / "backend"
-    backend.mkdir()
-    (backend / ".venv").symlink_to(REPO_ROOT / "backend" / ".venv", target_is_directory=True)
+    (repo / "backend").mkdir()
 
     commands = (
         ("git", "init", "--quiet"),
@@ -85,6 +83,7 @@ def _proof_env(tmp_path: Path) -> dict[str, str]:
     temporary.mkdir(exist_ok=True)
     return {
         **os.environ,
+        "OMI_QUALIFICATION_PYTHON": sys.executable,
         "OMI_QUALIFICATION_LEASE_ROOT": str(tmp_path / "qualification"),
         "TMPDIR": str(temporary),
     }
@@ -140,6 +139,7 @@ def _wait_until(predicate: Callable[[], bool], timeout: float = 5) -> None:
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="the local proof is an M1/macOS lifecycle command")
 def test_local_qualification_proof_completes_every_offline_boundary(proof_repo: Path, tmp_path: Path) -> None:
+    assert not (proof_repo / "backend" / ".venv").exists()
     completed, result_path = _run_proof(proof_repo, tmp_path)
 
     assert completed.returncode == 0, completed.stderr
@@ -157,6 +157,38 @@ def test_local_qualification_proof_completes_every_offline_boundary(proof_repo: 
     ]
     assert result["fault_listener_result"]["status"] == "passed"
     assert stat.S_IMODE(result_path.stat().st_mode) == 0o600
+    assert not (tmp_path / "qualification" / "qualification-lease.json").exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="the local proof is an M1/macOS lifecycle command")
+def test_local_qualification_proof_rejects_invalid_interpreter_override_before_lease(
+    proof_repo: Path, tmp_path: Path
+) -> None:
+    invalid_python = tmp_path / "not-executable-python"
+    invalid_python.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+    env = _proof_env(tmp_path)
+    env["OMI_QUALIFICATION_PYTHON"] = str(invalid_python)
+    result_path = tmp_path / "evidence" / "invalid-interpreter-proof.json"
+
+    completed = _run(
+        proof_repo / "desktop" / "macos" / "scripts" / "qualification-local-proof.sh",
+        "--offline",
+        "--fast",
+        "--result",
+        result_path,
+        RELEASE_TAG,
+        cwd=proof_repo,
+        env=env,
+    )
+
+    assert completed.returncode != 0
+    assert "OMI_QUALIFICATION_PYTHON is not an executable file" in completed.stderr
+    assert f"OMI_QUALIFICATION_PYTHON={invalid_python}" in completed.stderr
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "lease-acquisition-failed"
+    assert result["cleanup_status"] == "not-acquired"
+    assert result["completed_boundaries"] == ["release-tag-validation"]
     assert not (tmp_path / "qualification" / "qualification-lease.json").exists()
 
 


### PR DESCRIPTION
## Summary

- Resolve qualification lease commands through an explicit interpreter override, the tag-pinned worktree virtualenv, or the canonical M1 shared dependency virtualenv.
- Run the same local M1 proof from a source-only staged checkout without installing mutable dependencies into the immutable candidate source.
- Add behavioral coverage and document the offline local-proof prerequisite and command.

## Verification

- `bash desktop/macos/tests/test-qualification-lease-command.sh`
- `PYTHONPATH=scripts/dev-harness /Users/david/workspace/omi/backend/.venv/bin/python -m pytest -q scripts/dev-harness/tests/test_qualification_local_proof.py`
- `scripts/dev-harness/run-tests.sh` — 66 passed
- `actionlint .github/workflows/desktop_qualify_beta.yml`
- Real M1 offline source-only proof recorded by the implementation worker: all lifecycle boundaries passed and cleanup was released; it used only a local synthetic tag and made no release or cloud mutation.

## Product invariants affected

none

Failure-Class: none

## Changelog

No changelog needed: internal release-qualification infrastructure only; no user-visible behavior change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

