### PR TITLE
SCA-180: selectively adopt macOS UI polish from #10672

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2638,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2586,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4829,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1854,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3637,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3569,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4467,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3298,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5718,

--- a/desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+
+private let chatMarkRestingOpacity = 0.95
+
+enum ChatMarkMotion: Equatable {
+  case gather
+  case wave
+
+  var cycle: Double {
+    switch self {
+    case .gather: return 1.6
+    case .wave: return 2.4
+    }
+  }
+
+  var spin: Double {
+    switch self {
+    case .gather: return 1.2
+    case .wave: return 0.6
+    }
+  }
+
+  static func forTool(_ toolName: String) -> ChatMarkMotion {
+    let cleaned =
+      toolName.hasPrefix("mcp__")
+      ? String(toolName.split(separator: "__").last ?? Substring(toolName))
+      : toolName
+    let lower = cleaned.lowercased()
+    let head =
+      lower.split(separator: ":").first.map(String.init)?
+      .trimmingCharacters(in: .whitespaces) ?? lower
+
+    let acting: Set<String> = [
+      "write", "edit", "multiedit", "notebookedit", "bash",
+      "spawn_agent", "run_agent_and_wait", "send_agent_message", "run_attempt",
+    ]
+    return acting.contains(head) ? .wave : .gather
+  }
+}
+
+struct ChatOmiMark: View {
+  enum Anchor {
+    case leading
+    case centered
+  }
+
+  var motion: ChatMarkMotion?
+  var size: CGFloat = 30
+  var anchor: Anchor = .leading
+
+  @State private var model = ChatMarkModel()
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  private var isWorking: Bool { motion != nil }
+
+  var body: some View {
+    TimelineView(
+      .animation(minimumInterval: isWorking ? nil : 1.0 / 20.0, paused: reduceMotion)
+    ) { timeline in
+      Canvas { context, canvasSize in
+        model.advance(
+          to: timeline.date,
+          motion: motion,
+          reduceMotion: reduceMotion
+        )
+        model.draw(into: &context, size: canvasSize, base: size, anchor: anchor)
+      }
+    }
+    .frame(width: size * ChatMarkModel.widthRatio, height: size)
+    .padding(.leading, anchor == .leading ? -size * ChatMarkModel.leftAnchor : 0)
+    .accessibilityHidden(true)
+  }
+}
+
+struct ChatMarkModelSnapshot: Equatable {
+  let intensity: Double
+  let phase: Double
+  let motion: ChatMarkMotion
+}
+
+@MainActor
+final class ChatMarkModel {
+  private static let count = 8
+  private static let dotDiameterRatio: CGFloat = 0.18
+  private static let ringRadiusRatio: CGFloat = 0.33
+  private static let startAngle = -Double.pi
+  private static let restingSpin: Double = 2 * .pi / 18
+
+  static let widthRatio: CGFloat = 1.7
+  static let centerX: CGFloat = 0.55
+  static let leftAnchor: CGFloat = 0.13
+
+  private var rotation: Double = 0
+  private var intensity: Double = 0
+  private var phase: Double = 0
+  private var motion: ChatMarkMotion = .gather
+  private var pendingMotion: ChatMarkMotion?
+  private var wasWorking = false
+  private var lastTime: CFTimeInterval?
+
+  var snapshot: ChatMarkModelSnapshot {
+    ChatMarkModelSnapshot(intensity: intensity, phase: phase, motion: motion)
+  }
+
+  func advance(to date: Date, motion requested: ChatMarkMotion?, reduceMotion: Bool) {
+    let now = date.timeIntervalSinceReferenceDate
+    let dt = lastTime.map { min(0.05, max(0, now - $0)) } ?? (1.0 / 60.0)
+    lastTime = now
+
+    let working = requested != nil && !reduceMotion
+
+    if let requested {
+      if !wasWorking {
+        motion = requested
+        pendingMotion = nil
+        phase = 0
+      } else if requested != motion {
+        pendingMotion = requested
+      } else {
+        pendingMotion = nil
+      }
+    }
+    wasWorking = working
+
+    intensity += ((working ? 1 : 0) - intensity) * min(1, dt * 3.2)
+    rotation += dt * (Self.restingSpin + motion.spin * intensity)
+
+    guard intensity > 0.001 else {
+      phase = 0
+      return
+    }
+    phase += dt / motion.cycle
+    if phase >= 1 {
+      phase -= 1
+      if let pendingMotion {
+        motion = pendingMotion
+        self.pendingMotion = nil
+      }
+    }
+  }
+
+  func draw(
+    into context: inout GraphicsContext,
+    size: CGSize,
+    base: CGFloat,
+    anchor: ChatOmiMark.Anchor
+  ) {
+    let dotDiameter = base * Self.dotDiameterRatio
+    let ringRadius = base * Self.ringRadiusRatio
+    let centerY = size.height / 2
+    let centerX = anchor == .leading ? base * Self.centerX : size.width / 2
+    let lineStart =
+      anchor == .leading
+      ? base * Self.leftAnchor + dotDiameter / 2
+      : dotDiameter / 2
+    let lineEnd = size.width - dotDiameter / 2
+    let lineStep = (lineEnd - lineStart) / CGFloat(Self.count - 1)
+
+    for index in 0..<Self.count {
+      let frame = frame(dot: index)
+      let angle =
+        2 * Double.pi * Double(index) / Double(Self.count)
+        + Self.startAngle + rotation
+      let ringX = centerX + ringRadius * CGFloat(frame.radiusX) * CGFloat(cos(angle))
+      let ringY = centerY + ringRadius * CGFloat(frame.radiusY) * CGFloat(sin(angle))
+      let lineX = lineStart + lineStep * CGFloat(index)
+
+      let x = ringX + (lineX - ringX) * CGFloat(frame.line)
+      let y =
+        ringY + (centerY - ringY) * CGFloat(frame.line)
+        + base * CGFloat(frame.offsetY)
+
+      let diameter = dotDiameter * CGFloat(frame.scale)
+      let rect = CGRect(
+        x: x - diameter / 2,
+        y: y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+      context.fill(Path(ellipseIn: rect), with: .color(.white.opacity(frame.opacity)))
+    }
+  }
+
+  private struct DotFrame {
+    var radiusX: Double = 1
+    var radiusY: Double = 1
+    var scale: Double = 1
+    var opacity: Double = chatMarkRestingOpacity
+    var line: Double = 0
+    var offsetY: Double = 0
+  }
+
+  private func frame(dot index: Int) -> DotFrame {
+    guard intensity > 0.001 else { return DotFrame() }
+    let working = motion == .gather ? gather(dot: index) : wave(dot: index)
+    let transition = intensity
+    return DotFrame(
+      radiusX: 1 + (working.radiusX - 1) * transition,
+      radiusY: 1 + (working.radiusY - 1) * transition,
+      scale: 1 + (working.scale - 1) * transition,
+      opacity: chatMarkRestingOpacity + (working.opacity - chatMarkRestingOpacity) * transition,
+      line: working.line * transition,
+      offsetY: working.offsetY * transition
+    )
+  }
+
+  private func gather(dot _: Int) -> DotFrame {
+    if phase < 0.45 {
+      let progress = Self.easeInOut(phase / 0.45)
+      return DotFrame(
+        radiusX: 1 - 0.68 * progress,
+        radiusY: 1 - 0.68 * progress,
+        scale: 1 + 0.24 * progress,
+        opacity: 0.62 + 0.38 * progress
+      )
+    }
+    if phase < 0.55 {
+      return DotFrame(radiusX: 0.32, radiusY: 0.32, scale: 1.24, opacity: 1)
+    }
+    let progress = (phase - 0.55) / 0.45
+    let radius = 0.32 + 0.68 * Self.easeOutBack(progress)
+    return DotFrame(
+      radiusX: radius,
+      radiusY: radius,
+      scale: 1.24 - 0.24 * Self.easeInOut(progress),
+      opacity: 1
+    )
+  }
+
+  private func wave(dot index: Int) -> DotFrame {
+    let line = Self.bump(phase, up: 0.30, down: 0.72)
+    let travel = sin(2 * .pi * phase * 2 - Double(index) * 0.9)
+    return DotFrame(
+      scale: 1,
+      opacity: 0.55 + 0.42 * (0.5 + 0.5 * travel),
+      line: line,
+      offsetY: 0.13 * travel * line
+    )
+  }
+
+  private static func easeInOut(_ value: Double) -> Double {
+    value * value * (3 - 2 * value)
+  }
+
+  private static func easeOutBack(_ value: Double) -> Double {
+    let c1 = 1.70158
+    let c3 = c1 + 1
+    let shifted = value - 1
+    return 1 + c3 * shifted * shifted * shifted + c1 * shifted * shifted
+  }
+
+  private static func bump(_ value: Double, up: Double, down: Double) -> Double {
+    if value < up { return easeInOut(value / up) }
+    if value < down { return 1 }
+    return 1 - easeInOut((value - down) / (1 - down))
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift
+++ b/desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift
@@ -62,3 +62,93 @@ struct TypingIndicator: View {
       .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
   }
 }
+
+enum ChatWorkingStatus {
+  static let idleLabel = "Thinking"
+
+  static func label(for message: ChatMessage?) -> String {
+    guard let name = inFlightToolName(for: message) else { return idleLabel }
+    return ChatContentBlock.displayName(for: name)
+  }
+
+  static func motion(for message: ChatMessage?) -> ChatMarkMotion {
+    guard let name = inFlightToolName(for: message) else { return .gather }
+    return ChatMarkMotion.forTool(name)
+  }
+
+  private static func inFlightToolName(for message: ChatMessage?) -> String? {
+    guard let message, message.sender == .ai else { return nil }
+    let inFlight = message.contentBlocks.last { block in
+      if case .toolCall(_, _, let status, _, _, _) = block {
+        return status.isInFlight
+      }
+      return false
+    }
+    guard case .toolCall(_, let name, _, _, _, _) = inFlight else { return nil }
+    return name
+  }
+}
+
+struct ChatWorkingIndicator: View {
+  let label: String?
+  let motion: ChatMarkMotion
+
+  var body: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      ChatOmiMark(motion: label == nil ? nil : motion)
+
+      if let label {
+        ShimmeringWorkingLabel(text: label)
+          .transition(.opacity)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .omiAnimation(.easeOut(duration: 0.2), value: label == nil)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(label ?? "Omi")
+    .accessibilityHidden(label == nil)
+  }
+}
+
+private struct ShimmeringWorkingLabel: View {
+  let text: String
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var travel: CGFloat = 0
+
+  var body: some View {
+    Text(text)
+      .scaledFont(size: OmiType.subheading, weight: .medium)
+      .foregroundStyle(OmiColors.textQuaternary)
+      .overlay {
+        if !reduceMotion {
+          GeometryReader { proxy in
+            let width = max(proxy.size.width, 1)
+            let bandWidth = width * 0.7
+            LinearGradient(
+              stops: [
+                .init(color: .clear, location: 0),
+                .init(color: OmiColors.textPrimary, location: 0.5),
+                .init(color: .clear, location: 1),
+              ],
+              startPoint: .leading,
+              endPoint: .trailing
+            )
+            .frame(width: bandWidth)
+            .offset(x: -bandWidth + travel * (width + bandWidth))
+          }
+          .mask {
+            Text(text)
+              .scaledFont(size: OmiType.subheading, weight: .medium)
+          }
+          .allowsHitTesting(false)
+        }
+      }
+      .onAppear {
+        guard !reduceMotion else { return }
+        withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+          travel = 1
+        }
+      }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -513,31 +513,28 @@ struct FloatingControlBarView: View {
 
   private var notchAgentLobe: some View {
     HStack(spacing: 0) {
-      if showingNotchWaveform {
-        VoiceWaveformBars(isActive: true)
-          .scaleEffect(0.72)
-          .frame(width: 28, height: 15)
-          .frame(width: 38, height: 27)
-      } else if showingNotchThinking {
-        NotchThinkingMark()
-          .frame(width: 24, height: 24)
-          .frame(width: notchSideWidth, height: notchChromeHeight, alignment: .trailing)
-          .padding(.trailing, OmiSpacing.hairline)
-      } else {
-        ZStack(alignment: .trailing) {
-          // The Omi mark always belongs to the compact notch header.
-          // Hover rows reveal below it; they must never borrow or
-          // animate this header identity into the expanded surface.
-          NotchAgentPillsRowView(manager: agentPills, barWindow: window)
-            .scaleEffect(notchLogoHovering ? 1.06 : 1.0)
-        }
-        .frame(width: notchSideWidth, height: notchChromeHeight, alignment: .trailing)
-        .padding(.trailing, OmiSpacing.hairline)
-        .contentShape(Rectangle())
-        .onHover { setNotchLogoHovering($0) }
-        .onTapGesture {
-          openAgentChatsFromNotchLogo()
-        }
+      ZStack(alignment: .trailing) {
+        // One always-mounted identity mark owns idle, PTT, and thinking
+        // presentation. The reducer still owns the voice lifecycle; this view
+        // only morphs its read-only projection at the mark's existing position.
+        NotchAgentPillsRowView(
+          manager: agentPills,
+          barWindow: window,
+          isVoiceListening: showingNotchWaveform,
+          isThinking: showingNotchThinking
+        )
+        .scaleEffect(notchLogoHovering ? 1.06 : 1.0)
+      }
+      .frame(width: notchSideWidth, height: notchChromeHeight, alignment: .trailing)
+      .padding(.trailing, OmiSpacing.hairline)
+      .contentShape(Rectangle())
+      .onHover { hovering in
+        guard !state.isVoicePresentationActive else { return }
+        setNotchLogoHovering(hovering)
+      }
+      .onTapGesture {
+        guard !state.isVoicePresentationActive else { return }
+        openAgentChatsFromNotchLogo()
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
@@ -1639,50 +1636,6 @@ private struct NotchResponseGlowView: View {
   }
 }
 
-private struct NotchOmiMark: View {
-  var dotColors: [Color] = []
-
-  private static let dotCount = 8
-  private static let dotDiameterRatio: CGFloat = 0.18
-  private static let ringRadiusRatio: CGFloat = 0.33
-
-  var body: some View {
-    GeometryReader { geometry in
-      let size = min(geometry.size.width, geometry.size.height)
-      let center = CGPoint(
-        x: geometry.size.width / 2,
-        y: geometry.size.height / 2
-      )
-      let dotDiameter = size * Self.dotDiameterRatio
-      let ringRadius = size * Self.ringRadiusRatio
-
-      ZStack {
-        ForEach(0..<Self.dotCount, id: \.self) { index in
-          let angle = Double(index) / Double(Self.dotCount) * Double.pi * 2 - Double.pi
-          Circle()
-            .fill(dotColors.indices.contains(index) ? dotColors[index] : Color.white.opacity(0.96))
-            .frame(width: dotDiameter, height: dotDiameter)
-            .position(
-              x: center.x + CGFloat(cos(angle)) * ringRadius,
-              y: center.y + CGFloat(sin(angle)) * ringRadius
-            )
-        }
-      }
-    }
-    .drawingGroup(opaque: false, colorMode: .linear)
-    .accessibilityHidden(true)
-  }
-}
-
-/// The Omi mark rendered as a spinning "thinking" indicator. The ring's dots
-/// carry a brightness trail (bright head → faint tail) so the continuous
-/// rotation reads as a sweeping comet rather than a static ring of dots.
-private struct NotchThinkingMark: View {
-  var body: some View {
-    OmiThinkingMark()
-  }
-}
-
 private struct SubagentChatPointer: Shape {
   func path(in rect: CGRect) -> Path {
     var path = Path()
@@ -2175,6 +2128,8 @@ private struct AgentStatusGlow: ViewModifier {
 private struct NotchAgentPillsRowView: View {
   @ObservedObject var manager: AgentPillsManager
   weak var barWindow: NSWindow?
+  let isVoiceListening: Bool
+  let isThinking: Bool
   @State private var pillStatusCancellables: [UUID: AnyCancellable] = [:]
   @State private var pillStatusChangeToken = 0
 
@@ -2184,15 +2139,21 @@ private struct NotchAgentPillsRowView: View {
 
   var body: some View {
     let _ = pillStatusChangeToken
-    NotchAgentOmiIndicatorView(pills: stackedPills)
-      .frame(width: 21, height: 21)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
-      .accessibilityLabel("Subagent status")
-      .accessibilityHint("Hover to fan out subagents, click to keep them open")
-      .onAppear { syncPillStatusObservers() }
-      .onChange(of: manager.pills.map(\.id)) { _, _ in
-        syncPillStatusObservers()
-      }
+    NotchVoiceMorphMark(
+      dotColors: stackedPills.prefix(NotchAgentStackMetrics.maxAgents).map {
+        NotchAgentStatusGroup(status: $0.status).color
+      },
+      isListening: isVoiceListening,
+      isThinking: isThinking
+    )
+    .frame(width: 28, height: 21)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+    .accessibilityLabel("Subagent status")
+    .accessibilityHint("Hover to fan out subagents, click to keep them open")
+    .onAppear { syncPillStatusObservers() }
+    .onChange(of: manager.pills.map(\.id)) { _, _ in
+      syncPillStatusObservers()
+    }
   }
 
   private func syncPillStatusObservers() {
@@ -2271,19 +2232,6 @@ private enum NotchAgentStackMetrics {
   /// The expanded-row identity mark uses the full orb size. The fixed header
   /// owns the compact Omi ring independently.
   static let logoDotScale: CGFloat = (logoFrameSize * logoDotDiameterRatio) / listOrbSize
-}
-
-private struct NotchAgentOmiIndicatorView: View {
-  let pills: [AgentPill]
-
-  private var visiblePills: [AgentPill] {
-    Array(pills.prefix(NotchAgentStackMetrics.maxAgents))
-  }
-
-  var body: some View {
-    NotchOmiMark(dotColors: visiblePills.map { NotchAgentStatusGroup(status: $0.status).color })
-      .contentShape(Rectangle())
-  }
 }
 
 /// The expanded agent rows live below the fixed notch header. Their status marks

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
@@ -1,0 +1,130 @@
+import OmiTheme
+import SwiftUI
+
+enum NotchVoiceMorphStage: Equatable {
+  case ring
+  case line
+  case waveform
+}
+
+enum NotchVoiceMorphGeometry {
+  static let lineBoundary: CGFloat = 0.55
+
+  static func targetProgress(isListening: Bool) -> CGFloat {
+    isListening ? 1 : 0
+  }
+
+  static func stage(progress rawProgress: CGFloat) -> NotchVoiceMorphStage {
+    let progress = clamp(rawProgress)
+    if progress <= 0.001 { return .ring }
+    return progress < 0.999 ? .line : .waveform
+  }
+
+  static func lineProgress(_ rawProgress: CGFloat) -> CGFloat {
+    smoothStep(clamp(rawProgress) / lineBoundary)
+  }
+
+  static func waveProgress(_ rawProgress: CGFloat, reduceMotion: Bool) -> CGFloat {
+    guard !reduceMotion else { return 0 }
+    let normalized = (clamp(rawProgress) - lineBoundary) / (1 - lineBoundary)
+    return smoothStep(clamp(normalized))
+  }
+
+  private static func smoothStep(_ value: CGFloat) -> CGFloat {
+    value * value * (3 - 2 * value)
+  }
+
+  private static func clamp(_ value: CGFloat) -> CGFloat {
+    min(max(value, 0), 1)
+  }
+}
+
+struct NotchVoiceMorphMark: View {
+  let dotColors: [Color]
+  let isListening: Bool
+  let isThinking: Bool
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var morphProgress: CGFloat = 0
+
+  private static let dotCount = 8
+  private static let dotDiameterRatio: CGFloat = 0.18
+  private static let ringRadiusRatio: CGFloat = 0.33
+
+  var body: some View {
+    TimelineView(.animation(paused: !isListening && !isThinking)) { timeline in
+      Canvas { context, size in
+        draw(into: &context, size: size, date: timeline.date)
+      }
+    }
+    .onAppear {
+      setMorphProgress(NotchVoiceMorphGeometry.targetProgress(isListening: isListening))
+    }
+    .onChange(of: isListening) { _, listening in
+      setMorphProgress(NotchVoiceMorphGeometry.targetProgress(isListening: listening))
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(isListening ? "Listening" : isThinking ? "Thinking" : "Omi")
+  }
+
+  private func setMorphProgress(_ progress: CGFloat) {
+    var transaction = Transaction()
+    transaction.animation = reduceMotion ? nil : .easeInOut(duration: 0.34)
+    withTransaction(transaction) {
+      morphProgress = progress
+    }
+  }
+
+  private func draw(into context: inout GraphicsContext, size: CGSize, date: Date) {
+    let base = min(size.width, size.height)
+    // Keep the resting ring at the exact trailing-aligned position used by the
+    // existing 21pt Omi mark while allowing the waveform to grow leftward.
+    let center = CGPoint(x: size.width - base / 2, y: size.height / 2)
+    let dotDiameter = base * Self.dotDiameterRatio
+    let ringRadius = base * Self.ringRadiusRatio
+    let lineStart = dotDiameter / 2
+    let lineEnd = size.width - dotDiameter / 2
+    let lineStep = (lineEnd - lineStart) / CGFloat(Self.dotCount - 1)
+    let lineProgress = NotchVoiceMorphGeometry.lineProgress(morphProgress)
+    let waveProgress = NotchVoiceMorphGeometry.waveProgress(
+      morphProgress,
+      reduceMotion: reduceMotion
+    )
+    let level = CGFloat(AudioLevelMonitor.shared.microphoneLevel)
+    let amplitude = base * 0.28 * waveProgress * min(max(level * 2.4, 0.12), 1)
+    let time = date.timeIntervalSinceReferenceDate
+    let thinkingRotation =
+      isThinking && !reduceMotion && morphProgress < 0.001
+      ? time * 2 * .pi / 0.9
+      : 0
+
+    for index in 0..<Self.dotCount {
+      let angle =
+        Double(index) / Double(Self.dotCount) * Double.pi * 2
+        - Double.pi + thinkingRotation
+      let ring = CGPoint(
+        x: center.x + CGFloat(cos(angle)) * ringRadius,
+        y: center.y + CGFloat(sin(angle)) * ringRadius
+      )
+      let lineX = lineStart + lineStep * CGFloat(index)
+      let waveY =
+        center.y
+        + CGFloat(sin(time * 9 - Double(index) * 0.82)) * amplitude
+      let position = CGPoint(
+        x: ring.x + (lineX - ring.x) * lineProgress,
+        y: ring.y + (waveY - ring.y) * lineProgress
+      )
+      let color =
+        dotColors.indices.contains(index)
+        ? dotColors[index]
+        : Color.white.opacity(0.96)
+      let rect = CGRect(
+        x: position.x - dotDiameter / 2,
+        y: position.y - dotDiameter / 2,
+        width: dotDiameter,
+        height: dotDiameter
+      )
+      context.fill(Path(ellipseIn: rect), with: .color(color))
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -98,6 +98,10 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// scrollbar doesn't clip right-aligned user pills when horizontalContentPadding
   /// is 0; the left edge stays aligned with the ask bar. Default 0.
   var trailingContentPadding: CGFloat = 0
+  /// Readable cap on the message column. The scroll view remains full-width so
+  /// the native scroller stays on the window edge and the prompt timeline can
+  /// occupy the resulting gutter without replacing it.
+  var contentColumnWidth: CGFloat? = nil
   @ViewBuilder var welcomeContent: () -> WelcomeContent
 
   /// IDs of messages that are near-duplicates of an earlier message in the same session.
@@ -160,12 +164,39 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// Used to detect conversation switches so session-scoped @State can be reset.
   @State private var trackedConversationId: String?
 
+  /// Measured transcript geometry for the prompt timeline. This view deliberately
+  /// does not observe the object; only the overlay subscribes, so scrolling does
+  /// not re-evaluate every message row.
+  @State private var transcriptGeometry = ChatTranscriptGeometry()
+
   var body: some View {
     ScrollViewReader { proxy in
       ZStack(alignment: .bottom) {
         scrollContent(proxy: proxy)
         scrollToBottomButton(proxy: proxy)
       }
+      .overlay(alignment: .trailing) {
+        ChatPromptTimelineOverlay(geometry: transcriptGeometry) { markID in
+          jumpToPrompt(markID, proxy: proxy)
+        }
+      }
+      .onGeometryChange(for: CGSize.self) {
+        $0.size
+      } action: { size in
+        transcriptGeometry.setViewport(size, columnWidth: contentColumnWidth)
+      }
+    }
+  }
+
+  /// A direct timeline choice leaves live-follow mode and places the selected
+  /// prompt at the top of the viewport.
+  private func jumpToPrompt(_ markID: String, proxy: ScrollViewProxy) {
+    cancelAllPendingScrolls()
+    userIsScrolling = false
+    scrollMode = .freeScrolling
+    hasActivityBelow = false
+    OmiMotion.withGated(ChatPromptTimelineMetrics.jumpAnimation) {
+      proxy.scrollTo(markID, anchor: .top)
     }
   }
 
@@ -179,10 +210,21 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       .padding(.horizontal, horizontalContentPadding)
       .padding(.trailing, trailingContentPadding)
       .padding(.vertical, verticalContentPadding)
+      .frame(maxWidth: contentColumnWidth ?? .infinity)
+      .frame(maxWidth: .infinity)
       // Do not enable text selection on the whole stack. SelectionOverlay on every
       // chrome Text (agent card headers, tool summaries, timestamps) can peg the
       // main thread in GraphHost layout. Message bodies opt in via OmiMarkdown.
       .background(scrollDetectors)
+      .coordinateSpace(name: ChatTranscriptSpace.content)
+      .onGeometryChange(for: ChatTranscriptContentFrame.self) { geometry in
+        ChatTranscriptContentFrame(
+          height: geometry.size.height,
+          scrollTop: -geometry.frame(in: .named(ChatTranscriptSpace.viewport)).minY
+        )
+      } action: { frame in
+        transcriptGeometry.setContent(height: frame.height, scrollTop: frame.scrollTop)
+      }
 
       // Invisible anchor lives OUTSIDE the LazyVStack so it is always
       // eagerly rendered. Inside LazyVStack it may not exist in the view
@@ -194,9 +236,17 @@ struct ChatMessagesView<WelcomeContent: View>: View {
           .id("bottom-anchor")
       }
     }
+    .coordinateSpace(name: ChatTranscriptSpace.viewport)
     // MARK: - React to message count changes
     .onChange(of: messages.count) { oldCount, newCount in
+      transcriptGeometry.setMessages(messages)
       handleMessagesCountChange(oldCount: oldCount, newCount: newCount, proxy: proxy)
+    }
+    // Refresh reply previews only once a streamed answer settles. Rebuilding
+    // sources for every token would re-walk the entire transcript.
+    .onChange(of: messages.last?.isStreaming) { wasStreaming, isStreaming in
+      guard wasStreaming == true, isStreaming != true else { return }
+      transcriptGeometry.setMessages(messages)
     }
     // A journal restore may be populated by background events while the
     // loader is still collecting its canonical snapshot. Reveal it only after
@@ -260,9 +310,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         scrollMode = .followingBottom
         userIsScrolling = false
         isUserAtBottom = true
+        transcriptGeometry.reset()
+        transcriptGeometry.setMessages(messages)
       }
     }
     .onAppear {
+      transcriptGeometry.setMessages(messages)
       if !isLoadingInitial, !messages.isEmpty {
         handleInitialRestore(proxy: proxy)
       }
@@ -485,6 +538,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
           onOpenAgentRef: onOpenAgentRef
         )
         .id(message.id)
+        .onGeometryChange(for: CGFloat.self) {
+          $0.frame(in: .named(ChatTranscriptSpace.content)).minY
+        } action: { offset in
+          guard message.sender == .user else { return }
+          transcriptGeometry.setRowOffset(offset, for: message.id)
+        }
       }
     }
   }
@@ -545,6 +604,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         scrollMode = .freeScrolling
         userIsScrolling = true
         hasActivityBelow = false
+        transcriptGeometry.releaseSelection()
         cancelAllPendingScrolls()
         let endWork = DispatchWorkItem {
           userIsScrolling = false

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -206,6 +206,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       LazyVStack(spacing: OmiSpacing.lg) {
         loadMoreButton
         messageContent
+        workingIndicator
       }
       .padding(.horizontal, horizontalContentPadding)
       .padding(.trailing, trailingContentPadding)
@@ -545,6 +546,17 @@ struct ChatMessagesView<WelcomeContent: View>: View {
           transcriptGeometry.setRowOffset(offset, for: message.id)
         }
       }
+    }
+  }
+
+  @ViewBuilder
+  private var workingIndicator: some View {
+    if contentColumnWidth != nil && (!messages.isEmpty || isSending) {
+      ChatWorkingIndicator(
+        label: isSending ? ChatWorkingStatus.label(for: messages.last) : nil,
+        motion: ChatWorkingStatus.motion(for: messages.last)
+      )
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimeline.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimeline.swift
@@ -112,9 +112,8 @@ enum ChatPromptTimelineMetrics {
     var best: (index: Int, distance: CGFloat)?
     for (index, position) in positions.enumerated() {
       let distance = abs(position - y)
-      if best == nil || distance < best!.distance {
-        best = (index, distance)
-      }
+      if let current = best, distance >= current.distance { continue }
+      best = (index, distance)
     }
     guard let best, best.distance <= selectionTolerance else { return nil }
     return best.index

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimeline.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimeline.swift
@@ -1,0 +1,372 @@
+import OmiTheme
+import SwiftUI
+
+/// Geometry for the prompt timeline, kept pure so the placement, the collision
+/// floor and the proximity ramp are all exercised without a hover.
+enum ChatPromptTimelineMetrics {
+  /// The strip the cursor has to enter. Wider than the marks themselves: the
+  /// marks are hairlines, and a hairline is not a hover target.
+  static let railWidth: CGFloat = 40
+  /// The rail only earns its place where the transcript's own column is not
+  /// already using the width. Sized so that a rail centred in the gutter still
+  /// clears the macOS overlay scroller riding the shell's edge.
+  static let minimumGutter: CGFloat = 56
+
+  static let restWidth: CGFloat = 8
+  static let proximityWidth: CGFloat = 20
+  static let hoveredWidth: CGFloat = 26
+  static let markHeight: CGFloat = 2
+
+  static let restOpacity: Double = 0.18
+  static let proximityOpacity: Double = 0.5
+  static let hoveredOpacity: Double = 0.95
+  /// The mark being read is coloured, not sized. Growing it would mean the rail
+  /// reshapes itself as the reader scrolls, and size is the language hover
+  /// already speaks — two meanings on one channel read as noise.
+  static let activeOpacity: Double = 1.0
+
+  /// The gap between marks. They read as one object at this distance — a short
+  /// stack of prompts, not a second scrollbar measuring the document.
+  static let markSpacing: CGFloat = 9
+  static let verticalPadding: CGFloat = 16
+  /// How far up and down the rail the cursor's pull reaches, measured in marks
+  /// rather than points — the group is only `markSpacing` apart, so a reach in
+  /// tens of points lifts the whole stack at once and the cursor stops pointing
+  /// at anything.
+  static let proximityFalloff: CGFloat = markSpacing * 5
+  /// Clicking or hovering resolves to a mark only within this much of it, so the
+  /// empty half of a sparse rail is not a giant hit target for one tick.
+  static let selectionTolerance: CGFloat = 14
+
+  static let previewWidth: CGFloat = 236
+  static let previewGap: CGFloat = 10
+  static let previewEdgeInset: CGFloat = 8
+
+  /// How far the rail's trailing edge sits from the transcript's, so the resting
+  /// marks land on the gutter's centre line. The marks are trailing-aligned in
+  /// the rail and grow leftwards from there, so it is the resting width that has
+  /// to be centred, not the strip that catches the cursor.
+  static func trailingOffset(gutter: CGFloat) -> CGFloat {
+    max(0, gutter / 2 - restWidth / 2)
+  }
+
+  static let proximityAnimation: Animation = .interactiveSpring(response: 0.18, dampingFraction: 0.86)
+  static let exitAnimation: Animation = .easeOut(duration: 0.18)
+  static let jumpAnimation: Animation = .spring(response: 0.35, dampingFraction: 0.8)
+
+  /// Where each mark sits: one evenly spaced group, centred on the rail.
+  ///
+  /// Spacing the marks by their real position in the document turns them into a
+  /// second scrollbar — sparse where the answers are long, smeared into a solid
+  /// bar where three questions land inside one. Grouping them says the one thing
+  /// the reader wants at a glance: how many questions there are, and which one
+  /// they are on. Where each prompt actually *is* is still honest, it is just
+  /// carried by the active mark rather than by the spacing.
+  ///
+  /// A long conversation compresses rather than overflowing.
+  static func positions(count: Int, railHeight: CGFloat) -> [CGFloat] {
+    guard count > 0 else { return [] }
+    guard count > 1 else { return [railHeight / 2] }
+
+    let usable = max(railHeight - 2 * verticalPadding, 0)
+    let spacing = min(markSpacing, usable / CGFloat(count - 1))
+    let total = spacing * CGFloat(count - 1)
+    let start = (railHeight - total) / 2
+    return (0..<count).map { start + spacing * CGFloat($0) }
+  }
+
+  /// 1 under the cursor, decaying to exactly 0 at the edge of its reach.
+  ///
+  /// Quadratic. Linear swells the whole group into one breathing blob; cubic
+  /// goes the other way and leaves only the mark under the cursor moving, which
+  /// loses the sense of a group responding. Squared gives the run a readable
+  /// order — roughly 1, 0.64, 0.36, 0.16, 0.04 across the reach — so two or
+  /// three marks either side clearly participate and the rest hold still.
+  static func proximity(distance: CGFloat) -> CGFloat {
+    let normalized = min(max(distance, 0) / proximityFalloff, 1)
+    let remaining = 1 - normalized
+    return remaining * remaining
+  }
+
+  /// Width answers one question only: where is the cursor. The mark being read
+  /// is the same size as every other.
+  static func markWidth(isHovered: Bool, proximity: CGFloat) -> CGFloat {
+    if isHovered { return hoveredWidth }
+    return restWidth + (proximityWidth - restWidth) * min(max(proximity, 0), 1)
+  }
+
+  static func markOpacity(isHovered: Bool, isActive: Bool, proximity: CGFloat) -> Double {
+    if isHovered { return hoveredOpacity }
+    // The active mark carries its own colour, so it has to stay legible even
+    // with the cursor nowhere near the rail.
+    if isActive { return activeOpacity }
+    return restOpacity + (proximityOpacity - restOpacity) * Double(min(max(proximity, 0), 1))
+  }
+
+  static func markColor(isActive: Bool) -> Color {
+    isActive ? OmiColors.error : .white
+  }
+
+  /// The mark the cursor is on, or nil in the gaps between them.
+  static func index(nearest y: CGFloat, positions: [CGFloat]) -> Int? {
+    var best: (index: Int, distance: CGFloat)?
+    for (index, position) in positions.enumerated() {
+      let distance = abs(position - y)
+      if best == nil || distance < best!.distance {
+        best = (index, distance)
+      }
+    }
+    guard let best, best.distance <= selectionTolerance else { return nil }
+    return best.index
+  }
+
+  /// Keeps the hover card inside the rail's height. It is mounted beside the
+  /// marks rather than inside them precisely so it can overhang, but overhanging
+  /// the window is a clipped card.
+  static func previewCenterY(anchorY: CGFloat, cardHeight: CGFloat, railHeight: CGFloat)
+    -> CGFloat
+  {
+    let half = cardHeight / 2 + previewEdgeInset
+    guard railHeight > half * 2 else { return railHeight / 2 }
+    return min(max(anchorY, half), railHeight - half)
+  }
+}
+
+/// A column of hairline marks floating in the empty gutter right of the
+/// transcript: one per user prompt, placed at that prompt's real position in the
+/// document. Marks grow leftwards as the cursor nears them, the one being read
+/// stays lit, and hovering shows the prompt with the start of its reply.
+///
+/// There is deliberately no track, no panel and no background. The marks sit on
+/// whatever the surface already is; anything more would put a second scrollbar
+/// beside the real one.
+struct ChatPromptTimeline: View {
+  let marks: [ChatPromptMark]
+  let activeMarkID: String?
+  let gutter: CGFloat
+  let onSelect: (String) -> Void
+
+  @State private var cursorY: CGFloat?
+  @State private var hoveredIndex: Int?
+  @State private var previewHeight: CGFloat = 0
+
+  /// `hoveredIndex` seeds the hover the rail would otherwise only reach through
+  /// a cursor. Production never passes it; a test cannot move a mouse, and the
+  /// card's effect on the rail's own width is the thing worth pinning down.
+  init(
+    marks: [ChatPromptMark],
+    activeMarkID: String?,
+    gutter: CGFloat,
+    hoveredIndex: Int? = nil,
+    onSelect: @escaping (String) -> Void
+  ) {
+    self.marks = marks
+    self.activeMarkID = activeMarkID
+    self.gutter = gutter
+    self.onSelect = onSelect
+    _hoveredIndex = State(initialValue: hoveredIndex)
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      let railHeight = geometry.size.height
+      let positions = ChatPromptTimelineMetrics.positions(
+        count: marks.count, railHeight: railHeight)
+
+      ZStack(alignment: .topTrailing) {
+        // The hover target. The marks are 2pt tall, so the strip is what the
+        // cursor actually meets.
+        Color.clear
+          .contentShape(Rectangle())
+
+        ForEach(Array(marks.enumerated()), id: \.element.id) { index, mark in
+          let position = positions.indices.contains(index) ? positions[index] : 0
+          markView(mark, at: position, index: index)
+        }
+      }
+      // The card is an overlay, never a sibling. A 236pt card inside the stack
+      // makes the stack 236pt wide the instant it appears, and the marks get
+      // shoved out of the gutter to centre it. An overlay cannot resize what it
+      // covers, so the marks hold still and the card floats over the transcript
+      // the way a tooltip should.
+      .overlay(alignment: .topTrailing) {
+        preview(positions: positions, railHeight: railHeight)
+      }
+      .onContinuousHover { phase in
+        switch phase {
+        case .active(let location):
+          OmiMotion.withGated(ChatPromptTimelineMetrics.proximityAnimation) {
+            cursorY = location.y
+            hoveredIndex = ChatPromptTimelineMetrics.index(nearest: location.y, positions: positions)
+          }
+        case .ended:
+          OmiMotion.withGated(ChatPromptTimelineMetrics.exitAnimation) {
+            cursorY = nil
+            hoveredIndex = nil
+          }
+        }
+      }
+      .onTapGesture { location in
+        guard let index = ChatPromptTimelineMetrics.index(nearest: location.y, positions: positions),
+          marks.indices.contains(index)
+        else { return }
+        onSelect(marks[index].id)
+      }
+    }
+    .frame(width: ChatPromptTimelineMetrics.railWidth, alignment: .trailing)
+    .padding(.trailing, ChatPromptTimelineMetrics.trailingOffset(gutter: gutter))
+    // The rail reports what the cursor is over; it never takes focus, and the
+    // marks are decoration for a transcript VoiceOver already reads in order.
+    .accessibilityHidden(true)
+  }
+
+  @ViewBuilder
+  private func markView(_ mark: ChatPromptMark, at position: CGFloat, index: Int) -> some View {
+    let isHovered = hoveredIndex == index
+    let isActive = activeMarkID == mark.id
+    let proximity =
+      cursorY.map { ChatPromptTimelineMetrics.proximity(distance: abs($0 - position)) } ?? 0
+    let height = ChatPromptTimelineMetrics.markHeight
+
+    Capsule(style: .continuous)
+      .fill(
+        ChatPromptTimelineMetrics.markColor(isActive: isActive)
+          .opacity(
+            ChatPromptTimelineMetrics.markOpacity(
+              isHovered: isHovered, isActive: isActive, proximity: proximity))
+      )
+      .frame(
+        width: ChatPromptTimelineMetrics.markWidth(isHovered: isHovered, proximity: proximity),
+        height: height
+      )
+      // Right edge pinned, so a mark only ever grows leftwards into the gutter.
+      .frame(width: ChatPromptTimelineMetrics.railWidth, alignment: .trailing)
+      .offset(y: position - height / 2)
+  }
+
+  @ViewBuilder
+  private func preview(positions: [CGFloat], railHeight: CGFloat) -> some View {
+    if let index = hoveredIndex, marks.indices.contains(index),
+      positions.indices.contains(index)
+    {
+      ChatPromptPreviewCard(mark: marks[index])
+        .onGeometryChange(for: CGFloat.self) {
+          $0.size.height
+        } action: {
+          previewHeight = $0
+        }
+        .offset(
+          x: -(ChatPromptTimelineMetrics.railWidth + ChatPromptTimelineMetrics.previewGap),
+          y: ChatPromptTimelineMetrics.previewCenterY(
+            anchorY: positions[index], cardHeight: previewHeight, railHeight: railHeight)
+            - previewHeight / 2
+        )
+        .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .trailing)))
+        .allowsHitTesting(false)
+    }
+  }
+}
+
+/// Mounts the timeline over a transcript, and decides whether it belongs there
+/// at all.
+///
+/// The rail is only ever drawn in space the transcript is not using: a surface
+/// whose column spans the whole width has no gutter, so it gets no rail and
+/// needs no flag saying so. That keeps the narrow panels — the task chat, the
+/// agent sheet — free of a rail jammed against their text, and hands one to any
+/// surface that later caps its column.
+struct ChatPromptTimelineOverlay: View {
+  @ObservedObject var geometry: ChatTranscriptGeometry
+  let onSelect: (String) -> Void
+
+  var body: some View {
+    if geometry.marks.count >= ChatPromptTimelineModel.minimumMarks,
+      geometry.gutter >= ChatPromptTimelineMetrics.minimumGutter
+    {
+      ChatPromptTimeline(
+        marks: geometry.marks,
+        activeMarkID: geometry.activeMarkID,
+        gutter: geometry.gutter,
+        onSelect: select
+      )
+      .background { stepShortcuts }
+    }
+  }
+
+  /// Lights the chosen mark before the scroll starts, and holds it there. The
+  /// jump is animated, so waiting for the transcript to arrive would leave the
+  /// rail unresponsive for the length of the spring.
+  private func select(_ markID: String) {
+    geometry.selectMark(markID)
+    onSelect(markID)
+  }
+
+  /// ⌘↑ / ⌘↓ walk the prompts without a mouse. Zero-sized and never focusable,
+  /// so they contribute a key equivalent and nothing else.
+  @ViewBuilder
+  private var stepShortcuts: some View {
+    Group {
+      shortcut(.upArrow, step: -1)
+      shortcut(.downArrow, step: 1)
+    }
+    .opacity(0)
+    .frame(width: 0, height: 0)
+    .accessibilityHidden(true)
+  }
+
+  private func shortcut(_ key: KeyEquivalent, step: Int) -> some View {
+    Button("") {
+      guard
+        let next = ChatPromptTimelineModel.steppedMarkID(
+          marks: geometry.marks, from: geometry.activeMarkID, by: step)
+      else { return }
+      select(next)
+    }
+    .buttonStyle(.plain)
+    .keyboardShortcut(key, modifiers: .command)
+  }
+}
+
+/// What a mark is: the question, and how omi started answering it.
+///
+/// Built as a floating panel rather than a filled rectangle. A solid dark fill
+/// on this canvas *is* the canvas — the first version was a near-black card on a
+/// near-black surface and read as a hole rather than as something on top. The
+/// blur plus a hairline edge and a real shadow is what macOS itself uses to say
+/// "this is in front", and it stays legible over a bubble as well as over bare
+/// background.
+private struct ChatPromptPreviewCard: View {
+  let mark: ChatPromptMark
+
+  private var shape: RoundedRectangle {
+    RoundedRectangle(cornerRadius: 10, style: .continuous)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(mark.prompt)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundColor(OmiColors.textPrimary)
+        .lineLimit(1)
+
+      if !mark.reply.isEmpty {
+        Text(mark.reply)
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(OmiColors.textSecondary)
+          .lineLimit(2)
+          .lineSpacing(1)
+      }
+    }
+    .multilineTextAlignment(.leading)
+    .padding(.horizontal, 11)
+    .padding(.vertical, 9)
+    .frame(width: ChatPromptTimelineMetrics.previewWidth, alignment: .leading)
+    .background(shape.fill(.ultraThinMaterial))
+    // The material alone samples too dark over a black canvas; the wash lifts it
+    // clear of whatever it happens to be covering.
+    .background(shape.fill(Color.white.opacity(0.07)))
+    .overlay(shape.stroke(Color.white.opacity(0.13), lineWidth: 1))
+    .shadow(color: .black.opacity(0.55), radius: 16, y: 6)
+    .fixedSize(horizontal: false, vertical: true)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimelineModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimelineModel.swift
@@ -1,0 +1,182 @@
+import CoreGraphics
+import Foundation
+
+/// One user prompt on the transcript timeline: the text the hover card shows,
+/// and where the prompt sits in the transcript as a fraction of the document's
+/// scrollable height.
+struct ChatPromptMark: Identifiable, Equatable {
+  let id: String
+  let prompt: String
+  let reply: String
+  /// 0 at the top of the document, 1 at its foot.
+  let fraction: CGFloat
+}
+
+/// One user prompt's text, paired with the reply it drew. Derived from the
+/// transcript alone, so it survives every scroll and every point the document
+/// grows while omi is answering.
+struct ChatPromptSource: Identifiable, Equatable {
+  let id: String
+  let prompt: String
+  let reply: String
+}
+
+/// Turns a transcript plus whatever row geometry has been measured into the
+/// marks the timeline draws. Pure, so the whole placement story is exercised
+/// without a scroll view.
+///
+/// The two halves are deliberately separate. Reading the transcript's text is
+/// linear in the whole conversation; placing the marks is arithmetic over the
+/// prompts alone. Only the second half reruns as the document grows.
+enum ChatPromptTimelineModel {
+  /// The timeline needs a second prompt before it says anything a reader could
+  /// not already see.
+  static let minimumMarks = 2
+
+  /// One entry per user turn, each carrying the assistant turn that answered it.
+  static func sources(messages: [ChatMessage]) -> [ChatPromptSource] {
+    let prompts = messages.enumerated().filter { $0.element.sender == .user }
+    guard prompts.count >= minimumMarks else { return [] }
+    return prompts.map { index, message in
+      ChatPromptSource(
+        id: message.id,
+        prompt: preview(message.text),
+        reply: preview(reply(after: index, in: messages))
+      )
+    }
+  }
+
+  /// Places each prompt at its real position in the document.
+  ///
+  /// `LazyVStack` lays out only the rows near the viewport, so a long transcript
+  /// that has not been scrolled yet has measured offsets for a handful of its
+  /// prompts and none for the rest. Dropping the unmeasured ones would make
+  /// ticks wink in and out as the reader scrolls, which is worse than a slightly
+  /// wrong position — so unmeasured prompts are interpolated between their
+  /// nearest measured neighbours. Every prompt therefore has a tick from the
+  /// first frame, and each one moves at most once, to its true position, when
+  /// the row it stands for is finally laid out.
+  static func marks(
+    sources: [ChatPromptSource],
+    offsets: [String: CGFloat],
+    documentHeight: CGFloat
+  ) -> [ChatPromptMark] {
+    guard sources.count >= minimumMarks else { return [] }
+
+    let resolved = resolvedOffsets(
+      measured: sources.map { offsets[$0.id] },
+      documentHeight: documentHeight
+    )
+
+    return sources.enumerated().map { position, source in
+      ChatPromptMark(
+        id: source.id,
+        prompt: source.prompt,
+        reply: source.reply,
+        fraction: documentHeight > 0
+          ? clamp(resolved[position] / documentHeight)
+          : evenFraction(position, of: sources.count)
+      )
+    }
+  }
+
+  /// The mark the reader is currently on: the last prompt at or above the
+  /// reading line, which sits a third of the way down the viewport rather than
+  /// at its very top. A prompt scrolled just past the top edge is still the one
+  /// being read; switching the moment it clips would make the marker flicker
+  /// between two ticks on every small scroll.
+  static let readingLine: CGFloat = 0.33
+
+  static func activeMarkID(
+    marks: [ChatPromptMark],
+    viewportTopFraction: CGFloat,
+    viewportHeightFraction: CGFloat
+  ) -> String? {
+    guard !marks.isEmpty else { return nil }
+    let probe = viewportTopFraction + viewportHeightFraction * readingLine
+    return marks.last(where: { $0.fraction <= probe })?.id ?? marks.first?.id
+  }
+
+  /// The mark ⌘↑ / ⌘↓ lands on. Stepping from nothing enters at the end the
+  /// reader is travelling towards, so the first press always moves.
+  static func steppedMarkID(marks: [ChatPromptMark], from current: String?, by step: Int)
+    -> String?
+  {
+    guard !marks.isEmpty, step != 0 else { return nil }
+    guard let current, let index = marks.firstIndex(where: { $0.id == current }) else {
+      return step < 0 ? marks.last?.id : marks.first?.id
+    }
+    let next = index + step
+    guard marks.indices.contains(next) else { return nil }
+    return marks[next].id
+  }
+
+  // MARK: - Internals
+
+  /// The assistant turn that answered a prompt, skipping any further user turns
+  /// (a reader can send twice before omi replies, and the second prompt owns
+  /// that reply).
+  private static func reply(after promptIndex: Int, in messages: [ChatMessage]) -> String {
+    for message in messages[(promptIndex + 1)...] {
+      if message.sender == .user { return "" }
+      if !message.text.isEmpty { return message.text }
+    }
+    return ""
+  }
+
+  /// A monotonic offset for every prompt: measured where the row was laid out,
+  /// interpolated between the nearest measured neighbours where it was not.
+  private static func resolvedOffsets(measured: [CGFloat?], documentHeight: CGFloat) -> [CGFloat] {
+    let count = measured.count
+    let known = measured.enumerated().compactMap { index, value in
+      value.map { (index: index, offset: $0) }
+    }
+    guard !known.isEmpty, documentHeight > 0 else {
+      return (0..<count).map { evenFraction($0, of: count) * max(documentHeight, 0) }
+    }
+
+    var resolved = [CGFloat](repeating: 0, count: count)
+    // Before the first measured row and after the last, the only anchors are the
+    // document's own ends.
+    var anchors = [(index: -1, offset: CGFloat(0))]
+    anchors.append(contentsOf: known)
+    anchors.append((index: count, offset: documentHeight))
+
+    for pair in zip(anchors, anchors.dropFirst()) {
+      let (low, high) = pair
+      let span = high.index - low.index
+      guard span > 0 else { continue }
+      for index in (low.index + 1)...high.index where index < count {
+        if let value = measured[index] {
+          resolved[index] = value
+        } else {
+          let travelled = CGFloat(index - low.index) / CGFloat(span)
+          resolved[index] = low.offset + (high.offset - low.offset) * travelled
+        }
+      }
+    }
+    // A measured row is authoritative even where interpolation disagreed.
+    for (index, value) in known { resolved[index] = value }
+    return resolved
+  }
+
+  /// Fallback spacing before anything has been measured. Inset from both ends so
+  /// a two-prompt transcript does not pin one tick to each extreme.
+  private static func evenFraction(_ position: Int, of count: Int) -> CGFloat {
+    guard count > 0 else { return 0 }
+    return (CGFloat(position) + 0.5) / CGFloat(count)
+  }
+
+  private static func clamp(_ value: CGFloat) -> CGFloat {
+    min(max(value, 0), 1)
+  }
+
+  /// One line of plain text for the hover card. Markdown fences, list bullets
+  /// and hard wraps all render as noise at 11pt on two lines.
+  private static func preview(_ text: String) -> String {
+    text
+      .split(whereSeparator: \.isWhitespace)
+      .joined(separator: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatTranscriptGeometry.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatTranscriptGeometry.swift
@@ -1,0 +1,155 @@
+import Combine
+import CoreGraphics
+import SwiftUI
+
+/// The two coordinate spaces the transcript measures itself in.
+///
+/// They live outside the view because `ChatMessagesView` is generic over its
+/// welcome content, and a generic type cannot hold a static — and because the
+/// geometry closures that read them are `Sendable`, which rules out reaching
+/// back into a main-actor view for a string.
+enum ChatTranscriptSpace {
+  /// Travels with the content, so a row's offset in it describes where the row
+  /// sits in the document and does not change when the reader scrolls.
+  static let content = "chatTranscriptContent"
+  /// The scroll view itself, where the content's origin is the scroll offset.
+  static let viewport = "chatTranscriptViewport"
+}
+
+/// One geometry read of the transcript's content: how tall it is, and how far
+/// it has travelled up past the top of the scroll view. Taken together so a
+/// scroll reports once rather than twice.
+struct ChatTranscriptContentFrame: Equatable {
+  let height: CGFloat
+  let scrollTop: CGFloat
+}
+
+/// The transcript's measured geometry, held off the view's own state.
+///
+/// Scroll position changes tens of times a second. Kept in `@State` on
+/// `ChatMessagesView` it would re-evaluate the whole transcript body on every
+/// one of those frames, which is the cost that view's comments already go out of
+/// their way to avoid. Here only the timeline overlay observes it, and only the
+/// two derived values it actually draws — the marks and which one is active —
+/// are published, each behind a did-it-really-change guard.
+@MainActor
+final class ChatTranscriptGeometry: ObservableObject {
+  /// Sub-pixel measurement noise must not re-enter layout through the values it
+  /// feeds. Both thresholds are below what a reader could see move.
+  private static let heightEpsilon: CGFloat = 4
+  private static let offsetEpsilon: CGFloat = 1
+
+  @Published private(set) var marks: [ChatPromptMark] = []
+  @Published private(set) var activeMarkID: String?
+  /// Width available outside the readable column, on one side.
+  @Published private(set) var gutter: CGFloat = 0
+
+  private var sources: [ChatPromptSource] = []
+  private var offsets: [String: CGFloat] = [:]
+  private var documentHeight: CGFloat = 0
+  private var scrollTop: CGFloat = 0
+  private var viewport: CGSize = .zero
+  /// A prompt the reader picked outright, which outranks what the reading line
+  /// happens to be over.
+  private var pinnedMarkID: String?
+
+  /// The prompt/reply text. Rebuilt only when the transcript itself changes:
+  /// it walks every message and normalises their text, which is far too much
+  /// work to repeat while a document is merely growing a few points at a time.
+  func setMessages(_ messages: [ChatMessage]) {
+    let rebuilt = ChatPromptTimelineModel.sources(messages: messages)
+    guard rebuilt != sources else { return }
+    sources = rebuilt
+    rebuildMarks()
+  }
+
+  func setRowOffset(_ offset: CGFloat, for id: String) {
+    if let existing = offsets[id], abs(existing - offset) < Self.offsetEpsilon { return }
+    offsets[id] = offset
+    rebuildMarks()
+  }
+
+  func setContent(height: CGFloat, scrollTop: CGFloat) {
+    let heightChanged = abs(documentHeight - height) >= Self.heightEpsilon
+    if heightChanged { documentHeight = height }
+    self.scrollTop = scrollTop
+    if heightChanged {
+      rebuildMarks()
+    } else {
+      refreshActiveMark()
+    }
+  }
+
+  func setViewport(_ size: CGSize, columnWidth: CGFloat?) {
+    let column = min(columnWidth ?? size.width, size.width)
+    let measured = max(0, (size.width - column) / 2)
+    if abs(viewport.height - size.height) >= Self.heightEpsilon {
+      viewport.height = size.height
+      refreshActiveMark()
+    }
+    viewport.width = size.width
+    if abs(gutter - measured) >= Self.offsetEpsilon { gutter = measured }
+  }
+
+  /// The reader picked a prompt, from the rail or from ⌘↑ / ⌘↓.
+  ///
+  /// Tracking alone gets this wrong, and correctly so: the jump puts the prompt
+  /// at the top of the viewport, and if its answer is short the *next* prompt is
+  /// already sitting on the reading line — so the mark that lights is the one
+  /// below the one that was clicked. An outright choice is not a guess to be
+  /// overruled by geometry, so it holds until the reader scrolls away from it.
+  func selectMark(_ id: String) {
+    pinnedMarkID = id
+    if activeMarkID != id { activeMarkID = id }
+  }
+
+  /// Physical scrolling hands authority back to the reading line. Called from
+  /// the transcript's user-scroll detector, which is the only thing that can
+  /// tell a reader's gesture from the jump the selection itself performed.
+  func releaseSelection() {
+    guard pinnedMarkID != nil else { return }
+    pinnedMarkID = nil
+    refreshActiveMark()
+  }
+
+  /// A conversation switch must not leave the previous transcript's rows on the
+  /// rail: the ids are gone, so their marks would never be measured again.
+  func reset() {
+    offsets.removeAll()
+    documentHeight = 0
+    scrollTop = 0
+    sources = []
+    pinnedMarkID = nil
+    if !marks.isEmpty { marks = [] }
+    if activeMarkID != nil { activeMarkID = nil }
+  }
+
+  private func rebuildMarks() {
+    let rebuilt = ChatPromptTimelineModel.marks(
+      sources: sources, offsets: offsets, documentHeight: documentHeight)
+    if rebuilt != marks { marks = rebuilt }
+    refreshActiveMark()
+  }
+
+  private func refreshActiveMark() {
+    // A pin that outlived its prompt (history pruned, conversation switched) is
+    // stale, not authoritative.
+    if let pinnedMarkID {
+      if marks.contains(where: { $0.id == pinnedMarkID }) {
+        if activeMarkID != pinnedMarkID { activeMarkID = pinnedMarkID }
+        return
+      }
+      self.pinnedMarkID = nil
+    }
+    guard documentHeight > 0, !marks.isEmpty else {
+      if activeMarkID != nil { activeMarkID = nil }
+      return
+    }
+    let resolved = ChatPromptTimelineModel.activeMarkID(
+      marks: marks,
+      viewportTopFraction: scrollTop / documentHeight,
+      viewportHeightFraction: viewport.height / documentHeight
+    )
+    if resolved != activeMarkID { activeMarkID = resolved }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -164,8 +164,8 @@ struct AppsPage: View {
       searchBar
         .padding()
 
-      Divider()
-        .background(OmiColors.backgroundTertiary)
+      Color.white.opacity(0.08)
+        .frame(height: 1)
 
       // Content
       if appProvider.isLoading {
@@ -493,52 +493,48 @@ struct AppsPage: View {
   }
 
   private var searchBar: some View {
-    ViewThatFits(in: .horizontal) {
-      HStack(spacing: OmiSpacing.sm) {
-        searchField
-          .layoutPriority(1)
-        filterControls
-        Spacer(minLength: 8)
-        createAppButton
-        dismissControl
-      }
-
-      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
-        HStack(spacing: OmiSpacing.sm) {
-          searchField
-          dismissControl
-        }
-
-        HStack(spacing: OmiSpacing.sm) {
-          filterControls
-          Spacer(minLength: 8)
-          createAppButton
-        }
-      }
-    }
+    AppsHeaderRow(
+      search: { searchField },
+      filters: { filterControls },
+      create: { createAppButton },
+      dismiss: { dismissControl }
+    )
   }
 
   private var searchField: some View {
-    HStack {
+    HStack(spacing: OmiSpacing.sm) {
       Image(systemName: "magnifyingglass")
+        .scaledFont(size: OmiType.body, weight: .medium)
+        .frame(width: AppsHeaderMetrics.controlIconSize, height: AppsHeaderMetrics.controlIconSize)
         .foregroundColor(OmiColors.textTertiary)
 
       TextField("Search apps...", text: $searchText)
         .textFieldStyle(.plain)
+        .scaledFont(size: OmiType.body)
         .foregroundColor(OmiColors.textPrimary)
         .accessibilityLabel("Search apps")
 
       if !searchText.isEmpty {
         Button(action: { searchText = "" }) {
           Image(systemName: "xmark.circle.fill")
+            .scaledFont(size: OmiType.body)
             .foregroundColor(OmiColors.textTertiary)
         }
         .buttonStyle(.plain)
+        .help("Clear search")
+        .accessibilityLabel("Clear search")
       }
     }
-    .padding(OmiSpacing.sm)
-    .background(OmiColors.backgroundSecondary)
-    .cornerRadius(OmiChrome.smallControlRadius)
+    .padding(.horizontal, OmiSpacing.md)
+    .frame(minHeight: AppsHeaderMetrics.controlHeight)
+    .background(
+      Capsule(style: .continuous)
+        .fill(Color.white.opacity(0.06))
+        .overlay(
+          Capsule(style: .continuous)
+            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    )
   }
 
   private var filterControls: some View {
@@ -1814,70 +1810,6 @@ struct ShimmerAppCard: View {
         .cornerRadius(OmiChrome.stripRadius)
     }
     .frame(width: 100)
-  }
-}
-
-// MARK: - Filter Toggle
-
-struct FilterToggle: View {
-  let icon: String
-  let label: String
-  let isActive: Bool
-  let action: () -> Void
-
-  var body: some View {
-    Button(action: action) {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: icon)
-          .scaledFont(size: OmiType.caption)
-        Text(label)
-          .scaledFont(size: OmiType.body)
-          .lineLimit(1)
-      }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .background(isActive ? Color.white : OmiColors.backgroundSecondary)
-      .foregroundColor(isActive ? Color.black : OmiColors.textSecondary)
-      .cornerRadius(OmiChrome.elementRadius)
-      .overlay(
-        RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-          .stroke(isActive ? OmiColors.border : Color.clear, lineWidth: 1)
-      )
-      .fixedSize(horizontal: true, vertical: false)
-    }
-    .buttonStyle(.plain)
-  }
-}
-
-// MARK: - Small Header Button
-
-struct SmallHeaderButton: View {
-  let icon: String
-  let label: String
-  let color: Color
-  let action: () -> Void
-
-  @State private var isHovering = false
-
-  var body: some View {
-    Button(action: action) {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: icon)
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(color)
-        Text(label)
-          .scaledFont(size: OmiType.caption, weight: .medium)
-          .foregroundColor(OmiColors.textSecondary)
-          .lineLimit(1)
-      }
-      .padding(.horizontal, OmiSpacing.sm)
-      .padding(.vertical, OmiSpacing.xs)
-      .background(isHovering ? OmiColors.backgroundTertiary : OmiColors.backgroundSecondary)
-      .cornerRadius(OmiChrome.badgeRadius)
-      .fixedSize(horizontal: true, vertical: false)
-    }
-    .buttonStyle(.plain)
-    .onHover { isHovering = $0 }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
@@ -1,0 +1,127 @@
+import OmiTheme
+import SwiftUI
+
+enum AppsHeaderMetrics {
+  static let searchFieldMaxWidth: CGFloat = 360
+  static let controlIconSize: CGFloat = 16
+  static let controlHeight: CGFloat = 44
+}
+
+/// Keeps the flexible search field from squeezing labelled controls. At compact
+/// widths the same controls stack instead of truncating.
+struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: View {
+  let search: Search
+  let filters: Filters
+  let create: Create
+  let dismiss: Dismiss
+
+  init(
+    @ViewBuilder search: () -> Search,
+    @ViewBuilder filters: () -> Filters,
+    @ViewBuilder create: () -> Create,
+    @ViewBuilder dismiss: () -> Dismiss
+  ) {
+    self.search = search()
+    self.filters = filters()
+    self.create = create()
+    self.dismiss = dismiss()
+  }
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: OmiSpacing.md) {
+        search
+          .frame(maxWidth: AppsHeaderMetrics.searchFieldMaxWidth)
+        filters
+          .fixedSize(horizontal: true, vertical: false)
+        create
+        dismiss
+      }
+
+      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+        HStack(spacing: OmiSpacing.sm) {
+          search
+          dismiss
+        }
+
+        HStack(spacing: OmiSpacing.sm) {
+          filters
+            .fixedSize(horizontal: true, vertical: false)
+          create
+        }
+      }
+    }
+  }
+}
+
+struct FilterToggle: View {
+  let icon: String
+  let label: String
+  let isActive: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: OmiSpacing.xs) {
+        Image(systemName: icon)
+          .scaledFont(size: OmiType.caption)
+          .frame(width: AppsHeaderMetrics.controlIconSize)
+        Text(label)
+          .scaledFont(size: OmiType.body)
+          .lineLimit(1)
+      }
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm)
+      .background(
+        Capsule(style: .continuous)
+          .fill(Color.white.opacity(isActive ? 0.14 : 0.06))
+          .overlay(
+            Capsule(style: .continuous)
+              .stroke(Color.white.opacity(isActive ? 0.2 : 0.08), lineWidth: 1)
+          )
+      )
+      .foregroundColor(isActive ? OmiColors.textPrimary : OmiColors.textSecondary)
+      .fixedSize(horizontal: true, vertical: false)
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+struct SmallHeaderButton: View {
+  let icon: String
+  let label: String
+  let color: Color
+  let action: () -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: OmiSpacing.xs) {
+        Image(systemName: icon)
+          .scaledFont(size: OmiType.caption)
+          .frame(width: AppsHeaderMetrics.controlIconSize)
+          .foregroundColor(color)
+        Text(label)
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundColor(OmiColors.textSecondary)
+          .lineLimit(1)
+      }
+      .padding(.horizontal, OmiSpacing.sm)
+      .padding(.vertical, OmiSpacing.xs)
+      .background(
+        Capsule(style: .continuous)
+          .fill(Color.white.opacity(isHovering ? 0.12 : 0.06))
+          .overlay(
+            Capsule(style: .continuous)
+              .stroke(Color.white.opacity(isHovering ? 0.18 : 0.08), lineWidth: 1)
+          )
+      )
+      .fixedSize(horizontal: true, vertical: false)
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      OmiMotion.withGated(.easeOut(duration: 0.12)) { isHovering = hovering }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -396,6 +396,7 @@ struct ChatPage: View {
       onOpenAgentRef: { ref, completion in
         FloatingControlBarManager.shared.openAgentChatFromTimeline(ref: ref, completion: completion)
       },
+      contentColumnWidth: 760,
       welcomeContent: {
         if let opener = chatProvider.onboardingOpener {
           OnboardingOpenerView(opener: opener, chatProvider: chatProvider)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -236,6 +236,7 @@ struct ConversationsPage: View {
       .padding(.horizontal, OmiSpacing.xxl)
       .padding(.top, OmiSpacing.lg)
       .padding(.bottom, OmiSpacing.md)
+      .background(OmiColors.backgroundPrimary)
 
       // The whole page below the header scrolls together. Floating action bars
       // (load-more, merge) stay pinned to the bottom via the ZStack overlay.
@@ -349,7 +350,7 @@ struct ConversationsPage: View {
         }
       }
     } label: {
-      HStack(spacing: OmiSpacing.xxs) {
+      HStack(spacing: OmiSpacing.xs) {
         Image(systemName: isMultiSelectMode ? "checkmark.circle" : "checkmark.circle.badge.questionmark")
           .scaledFont(size: OmiType.caption)
         Text(isMultiSelectMode ? "Done" : "Select")
@@ -370,7 +371,7 @@ struct ConversationsPage: View {
     Button {
       NotificationCenter.default.post(name: .navigateToRewindNotes, object: nil)
     } label: {
-      HStack(spacing: OmiSpacing.xxs) {
+      HStack(spacing: OmiSpacing.xs) {
         Image(systemName: "note.text")
           .scaledFont(size: OmiType.caption)
         Text("Quick Note")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -621,6 +621,7 @@ struct DashboardPage: View {
         onOpenAgentRef: { ref, completion in
           FloatingControlBarManager.shared.openAgentChatFromTimeline(ref: ref, completion: completion)
         },
+        contentColumnWidth: 760,
         welcomeContent: { dashboardChatWelcome }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1121,6 +1122,7 @@ struct DashboardPage: View {
         horizontalContentPadding: 0,
         verticalContentPadding: OmiSpacing.sm,
         trailingContentPadding: OmiSpacing.md,
+        contentColumnWidth: 760,
         welcomeContent: { dashboardChatWelcome }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -618,9 +618,7 @@ struct DashboardPage: View {
         onOpenAgent: { agentID, completion in
           FloatingControlBarManager.shared.openAgentChatFromTimeline(agentID: agentID, completion: completion)
         },
-        onOpenAgentRef: { ref, completion in
-          FloatingControlBarManager.shared.openAgentChatFromTimeline(ref: ref, completion: completion)
-        },
+        onOpenAgentRef: FloatingControlBarManager.shared.openAgentChatFromTimeline(ref:completion:),
         contentColumnWidth: 760,
         welcomeContent: { dashboardChatWelcome }
       )

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -321,8 +321,8 @@ import XCTest
     XCTAssertTrue(typingSource.contains("struct TypingIndicator: View"))
     XCTAssertTrue(typingSource.contains("OmiThinkingMark()"))
     XCTAssertTrue(typingSource.contains(".linear(duration: 0.9).repeatForever(autoreverses: false)"))
-    XCTAssertTrue(notchSource.contains("private struct NotchThinkingMark: View"))
-    XCTAssertTrue(notchSource.contains("OmiThinkingMark()"))
+    XCTAssertTrue(notchSource.contains("NotchVoiceMorphMark("))
+    XCTAssertTrue(notchSource.contains("isThinking: showingNotchThinking"))
     XCTAssertFalse(notchSource.contains("Text(\"Thinking\")"))
     XCTAssertFalse(typingSource.contains("animationPhase"))
     XCTAssertFalse(typingSource.contains("scaleEffect(animationPhase"))
@@ -430,7 +430,7 @@ import XCTest
         "let targetSize = self.currentSurfaceSizeForCurrentScreen(frameIncludesVoiceGlow: wasActive)"))
   }
 
-  func testNotchPTTUsesCompactWaveformOnly() throws {
+  func testNotchPTTUsesTheAlwaysMountedVoiceMorphMark() throws {
     let source = try floatingControlBarViewSource()
 
     guard let lobeRange = source.range(of: "private var notchAgentLobe: some View"),
@@ -440,7 +440,9 @@ import XCTest
     }
     let lobeSource = String(source[lobeRange.lowerBound..<controlRange.lowerBound])
 
-    XCTAssertTrue(lobeSource.contains("VoiceWaveformBars(isActive: true)"))
+    XCTAssertTrue(lobeSource.contains("NotchAgentPillsRowView("))
+    XCTAssertTrue(lobeSource.contains("isVoiceListening: showingNotchWaveform"))
+    XCTAssertFalse(lobeSource.contains("VoiceWaveformBars(isActive: true)"))
     XCTAssertFalse(lobeSource.contains("showingNotchPttHint"))
     XCTAssertTrue(source.contains("pttStatusBanner"))
     XCTAssertTrue(source.contains("state.isVoiceListening && state.pttHintText.isEmpty"))
@@ -451,8 +453,10 @@ import XCTest
     let view = try floatingControlBarViewSource()
     let response = try aiResponseViewSource()
     let waveformSites = view.components(separatedBy: "VoiceWaveformBars(").count - 1
-    // Chrome morph lobe + optional idle pill voiceListeningView.
-    XCTAssertEqual(waveformSites, 2)
+    // The always-mounted notch mark owns its waveform morph. The remaining
+    // bars belong only to the optional non-notch voiceListeningView.
+    XCTAssertEqual(waveformSites, 1)
+    XCTAssertTrue(view.contains("NotchVoiceMorphMark("))
     XCTAssertTrue(view.contains("private var notchAgentLobe: some View"))
     XCTAssertTrue(view.contains("private var voiceListeningView: some View"))
     XCTAssertTrue(
@@ -547,10 +551,10 @@ import XCTest
     XCTAssertTrue(windowSource.contains("state.isNotchHoverMenuVisible ? .openMenuRetention : .activationOnly"))
     XCTAssertTrue(source.contains("isChatChromePinned || shouldShowNotchHoverMenu"))
     XCTAssertTrue(source.contains("static let maxAgents = FloatingControlBarWindow.notchAgentListMaxVisibleAgents"))
-    XCTAssertTrue(source.contains("static let dotDiameterRatio: CGFloat = 0.18"))
-    XCTAssertTrue(source.contains("static let ringRadiusRatio: CGFloat = 0.33"))
-    XCTAssertTrue(source.contains("NotchAgentOmiIndicatorView(pills: stackedPills)"))
-    XCTAssertTrue(source.contains("NotchOmiMark(dotColors: visiblePills.map"))
+    XCTAssertTrue(source.contains("NotchVoiceMorphMark("))
+    XCTAssertTrue(source.contains("isListening: isVoiceListening"))
+    XCTAssertTrue(source.contains("isThinking: isThinking"))
+    XCTAssertTrue(source.contains("dotColors: stackedPills.prefix"))
     XCTAssertTrue(source.contains("NotchAgentMorphField("))
     XCTAssertTrue(source.contains("NotchAgentListRow("))
     XCTAssertTrue(source.contains("title: pill.title"))
@@ -611,7 +615,7 @@ import XCTest
     XCTAssertTrue(source.contains("@State private var notchLogoHovering = false"))
     XCTAssertTrue(source.contains("private func setNotchLogoHovering(_ hovering: Bool)"))
     XCTAssertTrue(source.contains("private var notchAgentLogoHitTarget: some View"))
-    XCTAssertTrue(source.contains("The Omi mark always belongs to the compact notch header."))
+    XCTAssertTrue(source.contains("One always-mounted identity mark owns idle, PTT, and thinking"))
     XCTAssertTrue(source.contains("ZStack(alignment: .trailing)"))
     XCTAssertTrue(source.contains("static let logoFrameSize: CGFloat = 21"))
     XCTAssertTrue(source.contains(".frame(width: 44, height: 44)"))

--- a/desktop/macos/Desktop/Tests/AppsHeaderRowLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsHeaderRowLayoutTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import OmiTheme
+@testable import Omi_Computer
+
+@MainActor
+final class AppsHeaderRowLayoutTests: XCTestCase {
+  func testSearchFieldIsCappedOnAWideWindow() {
+    let recorder = AppsHeaderLayoutRecorder()
+    layOut(width: 1000, recorder: recorder)
+
+    guard let search = recorder.frame(of: .search) else {
+      return XCTFail("the search field never laid out")
+    }
+    XCTAssertEqual(search.width, AppsHeaderMetrics.searchFieldMaxWidth, accuracy: 0.5)
+  }
+
+  func testLabelledFiltersRemainLegibleAtOrdinaryAndCompactWidths() {
+    let intrinsicFilterWidth = NSHostingView(
+      rootView: AppsHeaderFilterFixture().fixedSize()
+    ).fittingSize.width
+
+    for width in [720.0, 380.0] {
+      let recorder = AppsHeaderLayoutRecorder()
+      layOut(width: width, recorder: recorder)
+      guard let filters = recorder.frame(of: .filters) else {
+        return XCTFail("the filters never laid out at \(width)pt")
+      }
+      XCTAssertGreaterThanOrEqual(filters.width, intrinsicFilterWidth - 0.5)
+    }
+  }
+
+  private func layOut(width: CGFloat, recorder: AppsHeaderLayoutRecorder) {
+    let host = NSHostingView(
+      rootView: AppsHeaderRow(
+        search: {
+          AppsHeaderLayoutProbe(recorder: recorder, slot: .search) {
+            Color.clear.frame(maxWidth: .infinity).frame(height: AppsHeaderMetrics.controlHeight)
+          }
+        },
+        filters: {
+          AppsHeaderLayoutProbe(recorder: recorder, slot: .filters) {
+            AppsHeaderFilterFixture()
+          }
+        },
+        create: { Color.clear.frame(width: 100, height: AppsHeaderMetrics.controlHeight) },
+        dismiss: { EmptyView() }
+      )
+      .frame(width: width)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: width, height: 200)
+    host.layoutSubtreeIfNeeded()
+  }
+}
+
+private struct AppsHeaderFilterFixture: View {
+  var body: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      Text("Installed")
+        .padding(.horizontal, OmiSpacing.md)
+      Text("All Categories")
+        .padding(.horizontal, OmiSpacing.md)
+    }
+    .frame(height: AppsHeaderMetrics.controlHeight)
+  }
+}
+
+private enum AppsHeaderLayoutSlot {
+  case search
+  case filters
+}
+
+private final class AppsHeaderLayoutRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var frames: [AppsHeaderLayoutSlot: CGRect] = [:]
+
+  func record(_ slot: AppsHeaderLayoutSlot, _ frame: CGRect) {
+    lock.lock()
+    frames[slot] = frame
+    lock.unlock()
+  }
+
+  func frame(of slot: AppsHeaderLayoutSlot) -> CGRect? {
+    lock.lock()
+    defer { lock.unlock() }
+    return frames[slot]
+  }
+}
+
+private struct AppsHeaderLayoutProbe: Layout {
+  let recorder: AppsHeaderLayoutRecorder
+  let slot: AppsHeaderLayoutSlot
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    subviews.reduce(into: .zero) { size, subview in
+      let child = subview.sizeThatFits(proposal)
+      size.width = max(size.width, child.width)
+      size.height = max(size.height, child.height)
+    }
+  }
+
+  func placeSubviews(
+    in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+  ) {
+    recorder.record(slot, bounds)
+    for subview in subviews {
+      subview.place(
+        at: CGPoint(x: bounds.minX, y: bounds.minY),
+        anchor: .topLeading,
+        proposal: ProposedViewSize(width: bounds.width, height: bounds.height)
+      )
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatPromptTimelineTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatPromptTimelineTests.swift
@@ -1,0 +1,540 @@
+import AppKit
+import CoreGraphics
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+/// The hover card is 236pt wide and the rail is 40. Mounted as a sibling inside
+/// the rail's stack, the stack grew to the card's width the instant the card
+/// appeared and the marks were shoved out of the gutter — off the window on a
+/// narrow one. The card has to be an overlay, which cannot resize what it
+/// covers, and this is the layout pass that says so.
+@MainActor
+final class ChatPromptTimelineHoverLayoutTests: XCTestCase {
+  private let gutter: CGFloat = 120
+  private let marks = (0..<4).map {
+    ChatPromptMark(
+      id: "q\($0)",
+      prompt: "a question long enough to fill the card's whole width and then some",
+      reply: "an answer that is also long enough to wrap onto the card's second line",
+      fraction: CGFloat($0) / 3
+    )
+  }
+
+  func testShowingTheHoverCardDoesNotWidenTheRail() {
+    let resting = railWidth(hoveredIndex: nil)
+    let hovering = railWidth(hoveredIndex: 2)
+
+    XCTAssertEqual(
+      hovering, resting, accuracy: 0.5,
+      "the card widened the rail from \(resting)pt to \(hovering)pt, which shifts every mark")
+  }
+
+  /// The one that would have caught the shove. Width alone cannot see it — the
+  /// rail's frame stays 40pt while its contents slide inside — so this renders
+  /// the rail and asks where the marks actually landed.
+  func testShowingTheHoverCardDoesNotMoveTheMarks() throws {
+    let resting = try XCTUnwrap(markTrailingEdge(hoveredIndex: nil), "no marks were drawn")
+    let hovering = try XCTUnwrap(
+      markTrailingEdge(hoveredIndex: 2), "the marks vanished when the card appeared")
+
+    XCTAssertEqual(
+      hovering, resting, accuracy: 1,
+      "the marks slid from x=\(resting) to x=\(hovering) when the card appeared")
+  }
+
+  /// The rightmost column the marks paint, in pixels, or nil if they painted
+  /// nothing inside the rail at all.
+  private func markTrailingEdge(hoveredIndex: Int?) -> Int? {
+    let width =
+      ChatPromptTimelineMetrics.railWidth
+      + ChatPromptTimelineMetrics.trailingOffset(gutter: gutter)
+    let height: CGFloat = 600
+    let renderer = ImageRenderer(
+      content: ChatPromptTimeline(
+        marks: marks, activeMarkID: "q1", gutter: gutter, hoveredIndex: hoveredIndex
+      ) { _ in }
+      .frame(width: width, height: height)
+    )
+    renderer.scale = 1
+    guard let image = renderer.cgImage else { return nil }
+
+    let pixelWidth = image.width
+    let pixelHeight = image.height
+    var pixels = [UInt8](repeating: 0, count: pixelWidth * pixelHeight * 4)
+    guard
+      let context = CGContext(
+        data: &pixels,
+        width: pixelWidth,
+        height: pixelHeight,
+        bitsPerComponent: 8,
+        bytesPerRow: pixelWidth * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+
+    // Only the band the marks occupy. The card is taller than the group and
+    // sits to their left, so restricting the scan to the group's own rows keeps
+    // it out of the answer.
+    let positions = ChatPromptTimelineMetrics.positions(count: marks.count, railHeight: height)
+    let band = Set(positions.map { Int($0.rounded()) })
+
+    var rightmost: Int?
+    for y in 0..<pixelHeight where band.contains(y) {
+      for x in 0..<pixelWidth {
+        let alpha = pixels[(y * pixelWidth + x) * 4 + 3]
+        if alpha > 25 { rightmost = max(rightmost ?? 0, x) }
+      }
+    }
+    return rightmost
+  }
+
+  /// The rail is exactly as wide as it claims, so the marks land on the gutter's
+  /// centre line rather than wherever a stray child left them.
+  func testTheRailIsOnlyEverItsOwnWidth() {
+    let expected =
+      ChatPromptTimelineMetrics.railWidth
+      + ChatPromptTimelineMetrics.trailingOffset(gutter: gutter)
+
+    XCTAssertEqual(railWidth(hoveredIndex: nil), expected, accuracy: 0.5)
+    XCTAssertEqual(railWidth(hoveredIndex: 0), expected, accuracy: 0.5)
+  }
+
+  private func railWidth(hoveredIndex: Int?) -> CGFloat {
+    let host = NSHostingView(
+      rootView: ChatPromptTimeline(
+        marks: marks, activeMarkID: "q1", gutter: gutter, hoveredIndex: hoveredIndex
+      ) { _ in }
+      .frame(height: 600)
+      .fixedSize(horizontal: true, vertical: false)
+    )
+    host.layoutSubtreeIfNeeded()
+    return host.fittingSize.width
+  }
+}
+
+/// Reading a transcript into timeline marks.
+final class ChatPromptTimelineSourceTests: XCTestCase {
+  func testEachPromptCarriesTheReplyItDrew() {
+    let sources = ChatPromptTimelineModel.sources(messages: [
+      message("q1", "How do I set up SwiftPM?", .user),
+      message("a1", "Open Xcode, then File > Add Packages.", .ai),
+      message("q2", "And async/await?", .user),
+      message("a2", "It lets you write concurrent code without callbacks.", .ai),
+    ])
+
+    XCTAssertEqual(sources.map(\.id), ["q1", "q2"])
+    XCTAssertEqual(sources[0].prompt, "How do I set up SwiftPM?")
+    XCTAssertEqual(sources[0].reply, "Open Xcode, then File > Add Packages.")
+    XCTAssertEqual(sources[1].reply, "It lets you write concurrent code without callbacks.")
+  }
+
+  /// A reader can send twice before omi answers. The reply belongs to the second
+  /// prompt, and the first must not borrow it.
+  func testAPromptSentBeforeTheLastOneWasAnsweredShowsNoReply() {
+    let sources = ChatPromptTimelineModel.sources(messages: [
+      message("q1", "wait", .user),
+      message("q2", "actually, never mind", .user),
+      message("a2", "No problem.", .ai),
+    ])
+
+    XCTAssertEqual(sources[0].reply, "")
+    XCTAssertEqual(sources[1].reply, "No problem.")
+  }
+
+  /// A single prompt tells the reader nothing they cannot already see.
+  func testOnePromptEarnsNoTimeline() {
+    let sources = ChatPromptTimelineModel.sources(messages: [
+      message("q1", "hi", .user),
+      message("a1", "hello", .ai),
+    ])
+
+    XCTAssertTrue(sources.isEmpty)
+  }
+
+  /// Markdown fences and hard wraps render as noise on a two-line card.
+  func testThePreviewCollapsesTheTextToOneLine() {
+    let sources = ChatPromptTimelineModel.sources(messages: [
+      message("q1", "  fix   this\n\nplease  ", .user),
+      message("a1", "```swift\nlet x = 1\n```", .ai),
+      message("q2", "thanks", .user),
+    ])
+
+    XCTAssertEqual(sources[0].prompt, "fix this please")
+    XCTAssertEqual(sources[0].reply, "```swift let x = 1 ```")
+  }
+
+  private func message(_ id: String, _ text: String, _ sender: ChatSender) -> ChatMessage {
+    ChatMessage(id: id, text: text, sender: sender)
+  }
+}
+
+/// Placing the marks. `LazyVStack` lays out only the rows near the viewport, so
+/// the interesting cases are all about prompts whose rows have never been
+/// measured.
+final class ChatPromptTimelineMarkTests: XCTestCase {
+  private let sources = (0..<5).map {
+    ChatPromptSource(id: "q\($0)", prompt: "prompt \($0)", reply: "reply \($0)")
+  }
+
+  func testAFullyMeasuredTranscriptPlacesEveryMarkAtItsRealPosition() {
+    let marks = ChatPromptTimelineModel.marks(
+      sources: sources,
+      offsets: ["q0": 0, "q1": 250, "q2": 500, "q3": 750, "q4": 1000],
+      documentHeight: 1000
+    )
+
+    XCTAssertEqual(marks.map(\.fraction), [0, 0.25, 0.5, 0.75, 1.0])
+  }
+
+  /// Opening a long conversation: nothing is measured yet. Every prompt still
+  /// gets a mark, because ticks that appear and vanish while scrolling are worse
+  /// than ticks that are briefly approximate.
+  func testAnUnmeasuredTranscriptStillDrawsEveryMark() {
+    let marks = ChatPromptTimelineModel.marks(
+      sources: sources, offsets: [:], documentHeight: 1000)
+
+    XCTAssertEqual(marks.count, sources.count)
+    XCTAssertEqual(marks.map(\.id), sources.map(\.id))
+    XCTAssertEqual(marks.map(\.fraction), marks.map(\.fraction).sorted())
+  }
+
+  func testAMeasuredRowIsAuthoritativeAndItsNeighboursAreInterpolated() {
+    let marks = ChatPromptTimelineModel.marks(
+      sources: sources,
+      offsets: ["q1": 200, "q3": 800],
+      documentHeight: 1000
+    )
+
+    XCTAssertEqual(marks[1].fraction, 0.2, accuracy: 0.0001, "a measured row moved")
+    XCTAssertEqual(marks[3].fraction, 0.8, accuracy: 0.0001, "a measured row moved")
+    XCTAssertEqual(marks[2].fraction, 0.5, accuracy: 0.0001, "q2 sits midway between its neighbours")
+    XCTAssertGreaterThan(marks[2].fraction, marks[1].fraction)
+    XCTAssertLessThan(marks[2].fraction, marks[3].fraction)
+  }
+
+  /// Every mark must stay in transcript order whatever mix of measured and
+  /// estimated positions it is built from — an out-of-order rail would send a
+  /// click to the wrong prompt.
+  func testMarksNeverFallOutOfTranscriptOrder() {
+    for measured in [["q0": CGFloat(900)], ["q4": CGFloat(50)], ["q2": CGFloat(10), "q3": 990]] {
+      let marks = ChatPromptTimelineModel.marks(
+        sources: sources, offsets: measured, documentHeight: 1000)
+      XCTAssertEqual(
+        marks.map(\.fraction), marks.map(\.fraction).sorted(),
+        "offsets \(measured) produced an out-of-order rail")
+    }
+  }
+
+  /// The first layout pass reports nothing. Dividing by it would place every
+  /// mark at the same spot, or at NaN.
+  func testAnUnmeasuredDocumentDoesNotCollapseEveryMarkOntoOnePoint() {
+    let marks = ChatPromptTimelineModel.marks(
+      sources: sources, offsets: [:], documentHeight: 0)
+
+    XCTAssertEqual(Set(marks.map(\.fraction)).count, sources.count)
+    XCTAssertFalse(marks.contains { $0.fraction.isNaN })
+  }
+
+  func testFractionsStayInsideTheDocument() {
+    let marks = ChatPromptTimelineModel.marks(
+      sources: sources,
+      offsets: ["q0": -40, "q4": 4000],
+      documentHeight: 1000
+    )
+
+    XCTAssertTrue(marks.allSatisfy { $0.fraction >= 0 && $0.fraction <= 1 })
+  }
+}
+
+/// Which mark is lit, and where ⌘↑ / ⌘↓ go next.
+final class ChatPromptTimelineActiveMarkTests: XCTestCase {
+  private let marks = [
+    ChatPromptMark(id: "q0", prompt: "a", reply: "", fraction: 0.0),
+    ChatPromptMark(id: "q1", prompt: "b", reply: "", fraction: 0.4),
+    ChatPromptMark(id: "q2", prompt: "c", reply: "", fraction: 0.8),
+  ]
+
+  func testTheMarkBeingReadIsTheLastOneAboveTheReadingLine() {
+    XCTAssertEqual(active(top: 0.0), "q0")
+    XCTAssertEqual(active(top: 0.35), "q1")
+    XCTAssertEqual(active(top: 0.75), "q2")
+  }
+
+  /// The reading line sits inside the viewport, not at its top edge, so a prompt
+  /// scrolled just off the top is still the one being read.
+  func testAPromptJustPastTheTopEdgeIsStillTheActiveOne() {
+    XCTAssertEqual(active(top: 0.41), "q1", "q1 clipped by a hair and the marker jumped")
+  }
+
+  /// Scrolled above the first prompt there is nothing behind the reader, but the
+  /// rail must still show where they are.
+  func testScrolledAboveEverythingLightsTheFirstMark() {
+    XCTAssertEqual(active(top: -0.2), "q0")
+  }
+
+  func testSteppingWalksTheMarksAndStopsAtBothEnds() {
+    XCTAssertEqual(step(from: "q0", by: 1), "q1")
+    XCTAssertEqual(step(from: "q1", by: -1), "q0")
+    XCTAssertNil(step(from: "q2", by: 1), "stepping past the last prompt must not wrap")
+    XCTAssertNil(step(from: "q0", by: -1), "stepping before the first prompt must not wrap")
+  }
+
+  /// The first press has to move somewhere, and it should be the end the reader
+  /// is heading towards.
+  func testSteppingFromNowhereEntersAtTheEndBeingTravelledTowards() {
+    XCTAssertEqual(step(from: nil, by: 1), "q0")
+    XCTAssertEqual(step(from: nil, by: -1), "q2")
+  }
+
+  private func active(top: CGFloat) -> String? {
+    ChatPromptTimelineModel.activeMarkID(
+      marks: marks, viewportTopFraction: top, viewportHeightFraction: 0.3)
+  }
+
+  private func step(from current: String?, by step: Int) -> String? {
+    ChatPromptTimelineModel.steppedMarkID(marks: marks, from: current, by: step)
+  }
+}
+
+/// Which mark is lit once measurement, scrolling and an outright choice all
+/// have an opinion.
+@MainActor
+final class ChatTranscriptGeometrySelectionTests: XCTestCase {
+  /// Two prompts a short answer apart, which is the case that broke: jumping to
+  /// the first puts it at the very top of the viewport, and the second is
+  /// already sitting on the reading line — so tracking alone lights the wrong
+  /// one the moment the reader clicks.
+  private let documentHeight: CGFloat = 1000
+  private let viewport = CGSize(width: 900, height: 400)
+
+  func testClickingAPromptLightsThatPromptAndNotTheOneBelowIt() {
+    let geometry = loadedGeometry()
+    geometry.setContent(height: documentHeight, scrollTop: 0)
+
+    geometry.selectMark("q0")
+    // The jump lands q0 at the top of the viewport.
+    geometry.setContent(height: documentHeight, scrollTop: 0)
+
+    XCTAssertEqual(geometry.activeMarkID, "q0", "the prompt below the clicked one stole the mark")
+  }
+
+  func testTheChoiceLightsBeforeTheTranscriptHasMoved() {
+    let geometry = loadedGeometry()
+    geometry.setContent(height: documentHeight, scrollTop: 0)
+
+    geometry.selectMark("q2")
+
+    XCTAssertEqual(
+      geometry.activeMarkID, "q2", "the rail stayed unresponsive for the length of the jump")
+  }
+
+  /// A choice is not permanent. Once the reader scrolls, position is the truth
+  /// again.
+  func testScrollingReleasesTheChoiceBackToPositionTracking() {
+    let geometry = loadedGeometry()
+    geometry.selectMark("q0")
+    geometry.setContent(height: documentHeight, scrollTop: 700)
+
+    XCTAssertEqual(geometry.activeMarkID, "q0", "scrolling alone must not overrule a choice")
+
+    geometry.releaseSelection()
+
+    XCTAssertEqual(geometry.activeMarkID, "q2", "the rail never returned to tracking the reader")
+  }
+
+  /// Switching conversations retires the ids a pin was holding.
+  func testAChoiceDoesNotSurviveTheConversationItWasMadeIn() {
+    let geometry = loadedGeometry()
+    geometry.selectMark("q1")
+
+    geometry.reset()
+
+    XCTAssertNil(geometry.activeMarkID)
+  }
+
+  private func loadedGeometry() -> ChatTranscriptGeometry {
+    let geometry = ChatTranscriptGeometry()
+    geometry.setViewport(viewport, columnWidth: 600)
+    geometry.setMessages([
+      ChatMessage(id: "q0", text: "first", sender: .user),
+      ChatMessage(id: "a0", text: "short", sender: .ai),
+      ChatMessage(id: "q1", text: "second", sender: .user),
+      ChatMessage(id: "a1", text: "long", sender: .ai),
+      ChatMessage(id: "q2", text: "third", sender: .user),
+    ])
+    // q1 sits 40pt below q0 — well inside the reading line's reach.
+    geometry.setRowOffset(0, for: "q0")
+    geometry.setRowOffset(40, for: "q1")
+    geometry.setRowOffset(800, for: "q2")
+    return geometry
+  }
+}
+
+/// The rail's own geometry: spacing, the proximity ramp, and the hover card.
+final class ChatPromptTimelineMetricsTests: XCTestCase {
+  private let railHeight: CGFloat = 600
+
+  /// The marks are one group, evenly spaced and centred — not a second
+  /// scrollbar measuring the document.
+  func testTheMarksSitAsOneEvenlySpacedGroup() {
+    let positions = ChatPromptTimelineMetrics.positions(count: 5, railHeight: railHeight)
+
+    for pair in zip(positions, positions.dropFirst()) {
+      XCTAssertEqual(
+        pair.1 - pair.0, ChatPromptTimelineMetrics.markSpacing, accuracy: 0.001,
+        "the group is not evenly spaced: \(positions)")
+    }
+  }
+
+  func testTheGroupIsCentredOnTheRail() {
+    for count in [2, 5, 12] {
+      let positions = ChatPromptTimelineMetrics.positions(count: count, railHeight: railHeight)
+      let middle = ((positions.first ?? 0) + (positions.last ?? 0)) / 2
+      XCTAssertEqual(
+        middle, railHeight / 2, accuracy: 0.001, "\(count) marks drifted off centre")
+    }
+  }
+
+  func testASingleMarkSitsOnTheCentreLine() {
+    XCTAssertEqual(
+      ChatPromptTimelineMetrics.positions(count: 1, railHeight: railHeight), [railHeight / 2])
+  }
+
+  /// A long conversation compresses its spacing rather than running off the
+  /// ends of the rail.
+  func testALongConversationCompressesInsteadOfOverflowing() {
+    let positions = ChatPromptTimelineMetrics.positions(count: 400, railHeight: railHeight)
+
+    XCTAssertGreaterThanOrEqual(
+      positions.first ?? 0, ChatPromptTimelineMetrics.verticalPadding - 0.001)
+    XCTAssertLessThanOrEqual(
+      positions.last ?? 0, railHeight - ChatPromptTimelineMetrics.verticalPadding + 0.001)
+    XCTAssertEqual(positions, positions.sorted())
+  }
+
+  /// A transcript loaded into a pane too short to draw anything must not produce
+  /// negative geometry.
+  func testACollapsedRailDoesNotProduceNegativePositions() {
+    let positions = ChatPromptTimelineMetrics.positions(count: 3, railHeight: 4)
+
+    XCTAssertTrue(positions.allSatisfy { $0 >= 0 && $0 <= 4 }, "got \(positions)")
+  }
+
+  /// Centred in the gutter, so the resting stack sits midway between the
+  /// transcript's column and the shell's own scroller rather than pinned to
+  /// either.
+  func testTheRestingMarksSitOnTheGuttersCentreLine() {
+    let gutter: CGFloat = 120
+    let trailing = ChatPromptTimelineMetrics.trailingOffset(gutter: gutter)
+    let restingCentre = trailing + ChatPromptTimelineMetrics.restWidth / 2
+
+    XCTAssertEqual(restingCentre, gutter / 2, accuracy: 0.001)
+  }
+
+  func testAVanishingGutterNeverPushesTheRailOffTheTranscript() {
+    XCTAssertEqual(ChatPromptTimelineMetrics.trailingOffset(gutter: 0), 0)
+    XCTAssertGreaterThanOrEqual(ChatPromptTimelineMetrics.trailingOffset(gutter: 4), 0)
+  }
+
+  func testTheProximityRampPeaksUnderTheCursorAndDiesOffAtItsReach() {
+    XCTAssertEqual(ChatPromptTimelineMetrics.proximity(distance: 0), 1, accuracy: 0.001)
+    XCTAssertEqual(
+      ChatPromptTimelineMetrics.proximity(distance: ChatPromptTimelineMetrics.proximityFalloff),
+      0, accuracy: 0.001)
+    XCTAssertEqual(ChatPromptTimelineMetrics.proximity(distance: 400), 0, accuracy: 0.001)
+  }
+
+  /// The point of the ramp is a hierarchy: a few marks either side clearly
+  /// participate, in visibly decreasing order, and the far end of the group does
+  /// not move at all. Too gentle and the whole stack breathes as one; too steep
+  /// and only the mark under the cursor responds.
+  func testTheRampReadsAsADecreasingHierarchyAcrossNeighbours() {
+    let spacing = ChatPromptTimelineMetrics.markSpacing
+    let steps = (0...5).map { ChatPromptTimelineMetrics.proximity(distance: spacing * CGFloat($0)) }
+
+    for pair in zip(steps, steps.dropFirst()) {
+      XCTAssertGreaterThan(pair.0, pair.1, "the ramp is flat somewhere in \(steps)")
+    }
+    XCTAssertGreaterThan(steps[1], 0.4, "the mark next to the cursor barely reacts")
+    XCTAssertGreaterThan(steps[2], 0.2, "the second mark out barely reacts")
+    XCTAssertLessThan(steps[4], 0.1, "the fourth mark out still grows noticeably")
+    XCTAssertEqual(
+      steps[5], 0, accuracy: 0.0001,
+      "the far end of the group still reacts to a hover at the near end")
+  }
+
+  /// Linear decay makes the whole group swell as one: halfway to the edge of the
+  /// reach it would still be at half strength.
+  func testTheRampDecaysFasterThanLinearly() {
+    let half = ChatPromptTimelineMetrics.proximity(
+      distance: ChatPromptTimelineMetrics.proximityFalloff / 2)
+
+    XCTAssertLessThan(half, 0.5, "the ramp is linear or gentler, so the group swells as one")
+  }
+
+  func testAMarkOnlyGrowsAndBrightensAsTheCursorApproaches() {
+    let rest = ChatPromptTimelineMetrics.markWidth(isHovered: false, proximity: 0)
+    let near = ChatPromptTimelineMetrics.markWidth(isHovered: false, proximity: 0.6)
+    let hovered = ChatPromptTimelineMetrics.markWidth(isHovered: true, proximity: 1)
+
+    XCTAssertLessThan(rest, near)
+    XCTAssertLessThan(near, hovered)
+    XCTAssertLessThan(
+      ChatPromptTimelineMetrics.markOpacity(isHovered: false, isActive: false, proximity: 0),
+      ChatPromptTimelineMetrics.markOpacity(isHovered: false, isActive: false, proximity: 1))
+  }
+
+  /// Size means "the cursor is here" and nothing else. Sizing the active mark
+  /// too would have the rail reshape itself as the reader scrolls.
+  func testTheActiveMarkIsColouredRatherThanResized() {
+    XCTAssertEqual(
+      ChatPromptTimelineMetrics.markWidth(isHovered: false, proximity: 0),
+      ChatPromptTimelineMetrics.restWidth)
+    XCTAssertNotEqual(
+      ChatPromptTimelineMetrics.markColor(isActive: true),
+      ChatPromptTimelineMetrics.markColor(isActive: false))
+  }
+
+  /// With the cursor off the rail entirely, every other mark fades to its
+  /// resting wash — the active one still has to be findable.
+  func testTheActiveMarkStaysVisibleWithNoCursorOnTheRail() {
+    XCTAssertGreaterThan(
+      ChatPromptTimelineMetrics.markOpacity(isHovered: false, isActive: true, proximity: 0),
+      ChatPromptTimelineMetrics.markOpacity(isHovered: false, isActive: false, proximity: 0))
+  }
+
+  func testTheGapsBetweenMarksAreNotAHitTarget() {
+    let positions: [CGFloat] = [100, 400]
+
+    XCTAssertEqual(ChatPromptTimelineMetrics.index(nearest: 103, positions: positions), 0)
+    XCTAssertEqual(ChatPromptTimelineMetrics.index(nearest: 396, positions: positions), 1)
+    XCTAssertNil(
+      ChatPromptTimelineMetrics.index(nearest: 250, positions: positions),
+      "the empty middle of the rail resolved to a prompt")
+  }
+
+  /// The card is mounted beside the marks so it can overhang them. Overhanging
+  /// the window is a clipped card.
+  func testTheHoverCardIsHeldInsideTheRailAtBothEnds() {
+    let card: CGFloat = 70
+
+    let atTop = ChatPromptTimelineMetrics.previewCenterY(
+      anchorY: 2, cardHeight: card, railHeight: railHeight)
+    let atBottom = ChatPromptTimelineMetrics.previewCenterY(
+      anchorY: railHeight - 2, cardHeight: card, railHeight: railHeight)
+
+    XCTAssertGreaterThanOrEqual(atTop - card / 2, 0)
+    XCTAssertLessThanOrEqual(atBottom + card / 2, railHeight)
+  }
+
+  func testTheHoverCardTracksTheMarkWhereThereIsRoom() {
+    XCTAssertEqual(
+      ChatPromptTimelineMetrics.previewCenterY(
+        anchorY: 300, cardHeight: 70, railHeight: railHeight),
+      300, accuracy: 0.001)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatWorkingIndicatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatWorkingIndicatorTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ChatWorkingIndicatorTests: XCTestCase {
+  func testIdleAndNonAssistantMessagesUseThinkingProjection() {
+    XCTAssertEqual(ChatWorkingStatus.label(for: nil), "Thinking")
+    XCTAssertEqual(
+      ChatWorkingStatus.label(for: ChatMessage(text: "hello", sender: .user)),
+      "Thinking"
+    )
+    XCTAssertEqual(ChatWorkingStatus.motion(for: nil), .gather)
+  }
+
+  func testLatestInFlightToolDrivesTheVisibleLabel() {
+    let message = ChatMessage(
+      text: "",
+      sender: .ai,
+      contentBlocks: [
+        .toolCall(id: "done", name: "Read", status: .completed),
+        .toolCall(id: "fetch", name: "WebFetch", status: .running),
+      ]
+    )
+
+    XCTAssertEqual(ChatWorkingStatus.label(for: message), "Fetching page")
+    XCTAssertEqual(ChatWorkingStatus.motion(for: message), .gather)
+  }
+
+  func testLatestInFlightToolWinsAcrossSlowAndStalledStates() {
+    let message = ChatMessage(
+      text: "",
+      sender: .ai,
+      contentBlocks: [
+        .toolCall(id: "fetch", name: "WebFetch", status: .slow),
+        .toolCall(id: "write", name: "Write", status: .stalled),
+      ]
+    )
+
+    XCTAssertEqual(ChatWorkingStatus.label(for: message), "Writing file")
+    XCTAssertEqual(ChatWorkingStatus.motion(for: message), .wave)
+  }
+
+  func testToolMotionClassificationCoversReadWriteAndMCPNames() {
+    XCTAssertEqual(ChatMarkMotion.forTool("Read"), .gather)
+    XCTAssertEqual(ChatMarkMotion.forTool("WebFetch"), .gather)
+    XCTAssertEqual(ChatMarkMotion.forTool("Write"), .wave)
+    XCTAssertEqual(ChatMarkMotion.forTool("mcp__filesystem__edit"), .wave)
+  }
+
+  @MainActor
+  func testReduceMotionKeepsWorkingMarkAtRest() {
+    let model = ChatMarkModel()
+    let start = Date(timeIntervalSinceReferenceDate: 100)
+
+    for frame in 0..<120 {
+      model.advance(
+        to: start.addingTimeInterval(Double(frame) / 60),
+        motion: .wave,
+        reduceMotion: true
+      )
+    }
+
+    XCTAssertEqual(model.snapshot.intensity, 0, accuracy: 0.001)
+    XCTAssertEqual(model.snapshot.phase, 0, accuracy: 0.001)
+  }
+
+  @MainActor
+  func testWorkingMarkEntersAndReturnsToRest() {
+    let model = ChatMarkModel()
+    let start = Date(timeIntervalSinceReferenceDate: 200)
+
+    for frame in 0..<120 {
+      model.advance(
+        to: start.addingTimeInterval(Double(frame) / 60),
+        motion: .wave,
+        reduceMotion: false
+      )
+    }
+
+    XCTAssertGreaterThan(model.snapshot.intensity, 0.9)
+    XCTAssertGreaterThan(model.snapshot.phase, 0)
+    XCTAssertEqual(model.snapshot.motion, .wave)
+
+    for frame in 120..<420 {
+      model.advance(
+        to: start.addingTimeInterval(Double(frame) / 60),
+        motion: nil,
+        reduceMotion: false
+      )
+    }
+
+    XCTAssertEqual(model.snapshot.intensity, 0, accuracy: 0.001)
+    XCTAssertEqual(model.snapshot.phase, 0, accuracy: 0.001)
+  }
+}

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -268,7 +268,9 @@ final class DashboardCaptureStateTests: XCTestCase {
     XCTAssertTrue(source.contains("onSelectDestination(destination)"))
     XCTAssertTrue(source.contains("selectedExportDestination = destination"))
     XCTAssertTrue(source.contains("if appProvider.apps.isEmpty && !appProvider.isLoading"))
-    XCTAssertTrue(source.contains("ViewThatFits(in: .horizontal)"))
+    // Responsive layout was extracted into AppsHeaderRow (AppsPageHeaderControls.swift);
+    // AppsPage now delegates to it instead of inlining ViewThatFits.
+    XCTAssertTrue(source.contains("AppsHeaderRow("))
     XCTAssertTrue(source.contains("private var searchField: some View"))
     XCTAssertTrue(source.contains("private var filterControls: some View"))
     XCTAssertFalse(source.contains("struct AppsCatalogContent: View"))

--- a/desktop/macos/Desktop/Tests/NotchVoiceMorphMarkTests.swift
+++ b/desktop/macos/Desktop/Tests/NotchVoiceMorphMarkTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class NotchVoiceMorphMarkTests: XCTestCase {
+  func testListeningStateOwnsTheMorphTarget() {
+    XCTAssertEqual(NotchVoiceMorphGeometry.targetProgress(isListening: false), 0)
+    XCTAssertEqual(NotchVoiceMorphGeometry.targetProgress(isListening: true), 1)
+  }
+
+  func testMorphMovesThroughRingLineAndWaveformStages() {
+    XCTAssertEqual(NotchVoiceMorphGeometry.stage(progress: 0), .ring)
+    XCTAssertEqual(NotchVoiceMorphGeometry.stage(progress: 0.55), .line)
+    XCTAssertEqual(NotchVoiceMorphGeometry.stage(progress: 0.9), .line)
+    XCTAssertEqual(NotchVoiceMorphGeometry.stage(progress: 1), .waveform)
+  }
+
+  func testLineProgressIsMonotonicAndWaveWaitsForBoundary() {
+    let early = NotchVoiceMorphGeometry.lineProgress(0.2)
+    let middle = NotchVoiceMorphGeometry.lineProgress(0.4)
+    let complete = NotchVoiceMorphGeometry.lineProgress(0.55)
+
+    XCTAssertGreaterThan(early, 0)
+    XCTAssertGreaterThan(middle, early)
+    XCTAssertEqual(complete, 1, accuracy: 0.001)
+    XCTAssertEqual(
+      NotchVoiceMorphGeometry.waveProgress(0.5, reduceMotion: false),
+      0,
+      accuracy: 0.001
+    )
+    XCTAssertGreaterThan(
+      NotchVoiceMorphGeometry.waveProgress(0.8, reduceMotion: false),
+      0
+    )
+  }
+
+  func testReduceMotionSuppressesLiveWaveDisplacement() {
+    XCTAssertEqual(
+      NotchVoiceMorphGeometry.waveProgress(1, reduceMotion: true),
+      0,
+      accuracy: 0.001
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260726-chat-prompt-timeline.json
+++ b/desktop/macos/changelog/unreleased/20260726-chat-prompt-timeline.json
@@ -1,0 +1,3 @@
+{
+  "change": "A long chat now has a timeline in the transcript gutter: hover it to see your earlier prompts, click one to jump straight back to it"
+}

--- a/desktop/macos/changelog/unreleased/20260726-chat-working-voice-polish.json
+++ b/desktop/macos/changelog/unreleased/20260726-chat-working-voice-polish.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat now shows a polished Omi working mark for live tool activity, push-to-talk smoothly morphs the notch mark into its live waveform and back, and Conversations and Apps use cleaner neutral header controls"
+}

--- a/desktop/macos/e2e/flows/apps.yaml
+++ b/desktop/macos/e2e/flows/apps.yaml
@@ -5,6 +5,7 @@ description: Apps/Integrations marketplace flow — browse apps, filter by categ
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SearchableDropdown.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ManualInstallationDisclosure.swift
   - desktop/macos/Desktop/Sources/ConferencingApps.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -4,9 +4,14 @@ tier: 2
 description: Hermetic chat in Home tab — send/receive with Rust OMI_LLM_STUB=1 (v0.12.119+ redesign — chat is embedded in Home, not a separate tab)
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
+  - desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
   - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimeline.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ChatPromptTimelineModel.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ChatTranscriptGeometry.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -4,6 +4,7 @@ tier: 2
 description: Real push-to-talk start/release lifecycle through the automation bridge
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
   - desktop/macos/Desktop/Sources/Chat/APIClient+HigherModel.swift
   - desktop/macos/Desktop/Sources/Chat/ExternalSurfaceRunAuthority.swift
   - desktop/macos/Desktop/Sources/DefaultsKey.swift


### PR DESCRIPTION
## What changed and why

SCA-180 selectively adapts the bounded macOS polish from #10672 into the current shell:

- morph the existing trailing notch Omi mark through ring → line → live PTT waveform and back, while retaining the current reducer, shortcut, audio owner, geometry, and other notch states;
- add a real tool-state-driven Omi working mark and label to main chat without changing bubbles, composer, persistence, or task chat;
- add the prompt-history timeline in the native transcript gutter with hover previews, click-to-jump, native scroller retention, and live-edge release;
- make only narrow Conversations/Apps header, icon-spacing, and neutral-treatment adjustments.

Explicitly excluded: the donor PR's voice-first notch rewrite, notch-screen manager/shaped panel, Home/Dashboard shell, hidden title bar, two-row/segmented navigation shell, composer/bubble rewrite, global modal system, settings redesign, integration grants, notification migration, and all release/deploy work.

Base refetched immediately before final verification: `70b05c44ad5b67eb5cf8ec1c067ffbf685d6abf2`.

## Product invariants affected

- `INV-CHAT-1`: all main-window surfaces still project the same `ChatProvider` history; the working mark and timeline are read-only projections and task chat remains separately scoped.
- `INV-VOICE-1`: `VoiceTurnReducer` and the established PTT/audio lifecycle remain the sole turn owner; the new view consumes existing presentation state and `AudioLevelMonitor`.
- `INV-UI-1`: all new treatments use the existing neutral Omi palette; no purple or new accent family was introduced.

## How it was verified

- `python3 scripts/check_desktop_test_quality.py` → pass, baseline unchanged.
- `xcrun swift test --package-path Desktop --filter 'ChatPromptTimeline|ChatWorkingIndicatorTests|NotchVoiceMorphMarkTests|AppsHeaderRowLayoutTests'` → 46 tests, 0 failures.
- Four affected `AgentPillLifecycleTests` source-contract checks → 4 tests, 0 failures.
- `desktop/macos/scripts/agent-logic-harness.sh` → pass: 526 lifecycle/state tests plus runtime and pi-mono lanes.
- `xcrun swift build -c debug --package-path Desktop` → build complete.
- `scripts/pr-preflight --suggest` → expected desktop UI/chat gates selected.
- `scripts/pr-preflight --pr-body-file /tmp/pr10672-body.md` → 20 selected checks passed.
- `OMI_PR_BODY_FILE=/tmp/pr10672-body.md make preflight` → 20 selected checks passed from committed head.
- Named bundle `/Applications/omi-pr10672-polish.app`, bundle ID `com.omi.omi-pr10672-polish`, launched against the development backend on automation port 47782. Bridge health confirmed the exact bundle/process/log identity.

Real-path residual limit: the machine's Omi Dev auth seed contains no token and every installed non-production QA seed is expired or local-only. The named bundle therefore correctly remained `signed_out` (`has_id_token=false`, `has_refresh_token=false`). `agent-swift`, command-line screen capture, and the Computer Use workflow were also blocked by existing macOS Accessibility/Screen Recording permissions. I did not touch `Omi.app` or `Omi Beta.app`, alter OS security settings, bypass auth, or claim an authenticated natural PTT/tool/timeline/Conversations/Apps interaction that did not occur. The deterministic core-path tests and in-process bundle health evidence above are the available local verification.

## Tests

- `ChatWorkingIndicatorTests`: running/slow/stalled tool selection, human label mapping, gather/write motion classification, animation return to rest, and Reduce Motion.
- `NotchVoiceMorphMarkTests`: listening target, ring/line/waveform phase ordering, monotonic line morph, live-wave boundary, and Reduce Motion.
- `ChatPromptTimelineTests`: source grouping, document placement/interpolation, hover geometry, preview association, active selection, keyboard stepping, click/jump target model, and gutter collision limits.
- `AppsHeaderRowLayoutTests`: a real SwiftUI layout pass at wide, ordinary, and compact widths keeps labelled controls legible and caps the flexible search field.
- Updated existing notch source-contract checks to assert the always-mounted mark owns idle/PTT/thinking presentation while the pre-existing non-notch waveform site remains separate.

## Credit

Design and implementation credit: Yashwanth Reddy Katipally (`katipally`), source PR #10672.

- `21f91fa1960c` and `c9b839799ab2` were cherry-picked with `-x`, preserving original authorship for the prompt timeline and follow-up.
- `ChatOmiMark.swift`, `TypingIndicator.swift`, `ChatMessagesView.swift`, and the bounded PTT/shared-chrome ideas from `d97301b7719b`, `e2ce83e170b0`, `ed1b659b3702`, `231f2b3e90`, `9ed2531147`, `7bc3f7d04fbe`, `8b49c61b91c`, and `c4eefd4bb65e` were adapted to current main. The adaptation commit includes:
  `Co-authored-by: Yashwanth Reddy Katipally <yashwanthreddy3471@gmail.com>`.

## Failure class (fixes)

Failure-Class: none

The included donor follow-up only removes a force unwrap in the new timeline's nearest-mark search; it does not map to an existing recurring semantic failure class.
