### PR TITLE
fix(backend): cap the existing-node listing in the KG extraction prompt

### DIFF
--- a/.github/failure-classes/FC-unbounded-user-collection-in-prompt.json
+++ b/.github/failure-classes/FC-unbounded-user-collection-in-prompt.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-unbounded-user-collection-in-prompt",
+  "violated_contract": "A per-user collection that grows without limit must not be rendered whole into a provider request.",
+  "canonical_prevention": "Bound the listing at the point it is rendered \u2014 cap it by an explicit, ordered selection \u2014 and keep correctness that depended on the full set in code that still reads the full set.",
+  "evidence_prs": [
+    10691
+  ],
+  "scope_hints": [
+    "backend/**"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_kg_prompt_node_cap.py
+++ b/backend/tests/unit/test_kg_prompt_node_cap.py
@@ -1,0 +1,111 @@
+"""KG extraction must keep the existing-node listing out of provider-rejection territory.
+
+``extract_knowledge_from_memory`` embedded every node Firestore returned. A user with
+5,788 nodes produced a ~641k-character prompt, the provider answered 400, and every
+extraction for that user failed from then on — the richer the graph, the more certain
+the failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+from utils.llm import knowledge_graph as kg
+
+NOW = datetime(2026, 7, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _nodes(count: int) -> list[dict]:
+    return [
+        {
+            'id': f'node-{index:05d}',
+            'label': f'Entity {index}',
+            'node_type': 'concept',
+            'aliases': [f'alias-{index}'],
+            'updated_at': NOW - timedelta(minutes=index),
+        }
+        for index in range(count)
+    ]
+
+
+@pytest.fixture
+def captured_prompt(monkeypatch):
+    """Run extraction against a stub LLM and hand back the prompt it received."""
+    seen: dict[str, str] = {}
+
+    def fake_get_llm(feature: str):
+        client = MagicMock()
+
+        def invoke(prompt: str):
+            seen['prompt'] = prompt
+            return MagicMock(content=json.dumps({'nodes': [], 'edges': []}))
+
+        client.invoke.side_effect = invoke
+        return client
+
+    monkeypatch.setattr(kg, 'get_llm', fake_get_llm)
+    monkeypatch.setattr(kg, 'track_usage', lambda *args, **kwargs: nullcontext())
+    return seen
+
+
+def _prompt_nodes(prompt: str) -> list[dict]:
+    start = prompt.index('**EXISTING NODES IN USER\'S KNOWLEDGE GRAPH:**\n') + len(
+        '**EXISTING NODES IN USER\'S KNOWLEDGE GRAPH:**\n'
+    )
+    return json.loads(prompt[start : prompt.index('\n', start)])
+
+
+def test_prompt_node_listing_is_capped_for_large_graphs(monkeypatch, captured_prompt):
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_nodes', lambda uid, db_client=None: _nodes(5788))
+
+    kg.extract_knowledge_from_memory('uid-1', 'user likes coffee', 'memory-1')
+
+    # 5,788 nodes rendered ~641k characters before the cap and the provider rejected it.
+    assert len(captured_prompt['prompt']) < 200_000
+    listed = _prompt_nodes(captured_prompt['prompt'])
+    assert len(listed) == kg.MAX_PROMPT_EXISTING_NODES
+    # Newest first, so the nodes the user is actively building on stay in the prompt.
+    assert listed[0]['id'] == 'node-00000'
+
+
+def test_small_graphs_are_listed_in_full(monkeypatch, captured_prompt):
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_nodes', lambda uid, db_client=None: _nodes(12))
+
+    kg.extract_knowledge_from_memory('uid-1', 'user likes coffee', 'memory-1')
+
+    assert len(_prompt_nodes(captured_prompt['prompt'])) == 12
+
+
+def test_node_omitted_from_prompt_still_merges_into_its_existing_id(monkeypatch):
+    """Capping the listing must not create duplicates for the nodes it left out."""
+    existing = _nodes(5788)
+    oldest = existing[-1]
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_nodes', lambda uid, db_client=None: existing)
+
+    upserts: list[dict] = []
+    monkeypatch.setattr(
+        kg.kg_db,
+        'upsert_knowledge_node',
+        lambda uid, node_data, db_client=None: upserts.append(node_data) or node_data,
+    )
+    monkeypatch.setattr(kg, 'track_usage', lambda *args, **kwargs: nullcontext())
+
+    extraction = json.dumps({'nodes': [{'label': oldest['label'], 'node_type': 'concept', 'aliases': []}], 'edges': []})
+    client = MagicMock()
+    client.invoke.return_value = MagicMock(content=extraction)
+    monkeypatch.setattr(kg, 'get_llm', lambda feature: client)
+
+    kg.extract_knowledge_from_memory('uid-1', 'user likes coffee', 'memory-1')
+
+    assert [node['id'] for node in upserts] == [oldest['id']]

--- a/backend/utils/llm/knowledge_graph.py
+++ b/backend/utils/llm/knowledge_graph.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Dict, Any, Optional, cast
 import threading
 import uuid
@@ -34,6 +35,41 @@ class ExtractedEdge(BaseModel):
 class KnowledgeGraphExtraction(BaseModel):
     nodes: List[ExtractedNode] = Field(description="Entities mentioned in the memory", default=[])
     edges: List[ExtractedEdge] = Field(description="Relationships between entities", default=[])
+
+
+# The prompt lists the user's existing nodes so the model reuses their ids instead of
+# inventing duplicates. Firestore returns the whole collection and a mature graph runs
+# to thousands of nodes: at 5,788 nodes the rendered prompt reached ~641k characters and
+# the provider rejected it with a 400, so extraction failed permanently for exactly the
+# users with the richest graphs. Cap the listing — merging still resolves against every
+# existing node via label_to_node_id below, so a node left out of the prompt is still
+# deduplicated by label or alias.
+MAX_PROMPT_EXISTING_NODES = 500
+
+
+def _node_recency(node: Dict[str, Any]) -> float:
+    for key in ('updated_at', 'created_at'):
+        value = node.get(key)
+        if isinstance(value, datetime):
+            return value.timestamp()
+    return 0.0
+
+
+def _existing_nodes_prompt_json(existing_nodes: List[Dict[str, Any]]) -> str:
+    nodes = existing_nodes
+    if len(nodes) > MAX_PROMPT_EXISTING_NODES:
+        nodes = sorted(nodes, key=_node_recency, reverse=True)[:MAX_PROMPT_EXISTING_NODES]
+
+    summary = [
+        {
+            'id': node['id'],
+            'label': node['label'],
+            'type': node.get('node_type', 'concept'),
+            'aliases': node.get('aliases', []),
+        }
+        for node in nodes
+    ]
+    return json.dumps(summary) if summary else "None yet"
 
 
 EXTRACTION_PROMPT = """Analyze the following memory like a human brain processing new information. Extract key entities and their relationships, focusing on logical connections and cognitive patterns.
@@ -84,18 +120,7 @@ def extract_knowledge_from_memory(
     strict_parse: bool = False,
 ) -> Optional[Dict[str, Any]]:
     existing_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
-    existing_nodes_summary: List[Dict[str, Any]] = []
-    for node in existing_nodes:
-        existing_nodes_summary.append(
-            {
-                'id': node['id'],
-                'label': node['label'],
-                'type': node.get('node_type', 'concept'),
-                'aliases': node.get('aliases', []),
-            }
-        )
-
-    existing_nodes_json = json.dumps(existing_nodes_summary) if existing_nodes_summary else "None yet"
+    existing_nodes_json = _existing_nodes_prompt_json(existing_nodes)
 
     try:
         parser = PydanticOutputParser(pydantic_object=KnowledgeGraphExtraction)
@@ -189,18 +214,7 @@ def rebuild_knowledge_graph(
             return {'nodes': [], 'edges': []}
 
         existing_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
-        existing_nodes_summary: List[Dict[str, Any]] = []
-        for node in existing_nodes:
-            existing_nodes_summary.append(
-                {
-                    'id': node['id'],
-                    'label': node['label'],
-                    'type': node.get('node_type', 'concept'),
-                    'aliases': node.get('aliases', []),
-                }
-            )
-
-        existing_nodes_json = json.dumps(existing_nodes_summary) if existing_nodes_summary else "None yet"
+        existing_nodes_json = _existing_nodes_prompt_json(existing_nodes)
 
         try:
             parser = PydanticOutputParser(pydantic_object=KnowledgeGraphExtraction)


### PR DESCRIPTION
## Bug

`extract_knowledge_from_memory` renders the user's **entire** `knowledge_nodes` collection into the extraction prompt. The collection is unbounded, so the prompt grows with the graph. A live prod user with **5,788 nodes** produces a **641,173-character** prompt; the provider rejects it with a 400 and every knowledge-graph extraction for that user has failed since — the richer the graph, the more certain the failure.

In the last 12h, **48 of 79** llm-gateway error terminals were `lane=omi:auto:knowledge-graph`, plus the matching `ERROR:root:Error extracting knowledge graph from memory_id: …` tracebacks in `backend` and `backend-sync`.

> Note on the error label: prod's llm-gateway image (`3e415e0`) predates #58971af, which classifies provider rejections. That build maps *every* provider 4xx to `capability_mismatch`, which is why the logs say "capability_not_supported" for what is a payload-size rejection.

## Root cause

`get_knowledge_nodes(uid)` streams the whole collection and the result is serialized straight into `EXTRACTION_PROMPT`. Nothing bounds it. `rebuild_knowledge_graph` carried a second copy of the same inline listing.

## Fix

Cap the listing at the 500 most recently updated nodes, via one shared helper used by both call sites. Merging is unaffected: `label_to_node_id` is still built from **every** existing node, so a node left out of the prompt is still deduplicated by label or alias instead of being re-created.

## Tested

- `tests/unit/test_kg_prompt_node_cap.py` — 3 passed; the prompt-size assertion fails on the pre-fix module.
- The 5 kg / canonical-kg unit files — 34 passed.
- **Real prod path**, from a `prod-omi-backend-listen` pod against the live gateway lane, using the real 5,788-node graph:
  - before: 641,173-char prompt → `400 … capability_mismatch` (the exact prod error)
  - after: same graph through the 500-node cap → 59,099 chars, 200 OK, parsed nodes `['User', 'coffee']`, edge `('User', 'likes', 'coffee')`

## Product invariants

none

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

