### PR TITLE
fix(backend): clear the agentVm record when its GCE instance is gone (reaped VM strands agent chat)

### DIFF
--- a/.github/failure-classes/FC-agent-vm-stop-retains-disk.json
+++ b/.github/failure-classes/FC-agent-vm-stop-retains-disk.json
@@ -3,6 +3,9 @@
   "id": "FC-agent-vm-stop-retains-disk",
   "violated_contract": "An idle-stopped omi-agent GCE instance must not retain a billable boot disk indefinitely; stop is not delete, and autoDelete only runs on instance deletion.",
   "canonical_prevention": "Run a dry-run-first, workload-identity-bound reaper that deletes aged TERMINATED (and abandoned RUNNING) omi-agent instances on a schedule; keep the client NOT_FOUND → re-provision + DB re-upload path as the resume contract after delete.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_agent_vm_reaped_record_recovery.py"
+  ],
   "evidence_prs": [
     7596,
     10390

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from firebase_admin import auth, credentials, firestore
-from google.cloud.firestore import ArrayUnion
+from google.cloud.firestore import DELETE_FIELD, ArrayUnion
 from google.cloud.firestore_v1 import Query
 from utils.executors import (
     critical_executor,
@@ -138,6 +138,10 @@ def _refresh_vm(uid: str) -> Optional[Dict[str, Any]]:
 # --------------- GCE helpers ---------------
 
 
+class VmNotFoundError(Exception):
+    """The GCE instance backing the user's agentVm record no longer exists."""
+
+
 def _get_gce_access_token() -> str:
     """Get a GCE access token via Application Default Credentials."""
     creds, _ = google.auth.default(scopes=['https://www.googleapis.com/auth/cloud-platform'])  # type: ignore[reportUnknownMemberType]
@@ -146,11 +150,19 @@ def _get_gce_access_token() -> str:
 
 
 async def _check_gce_status(vm_name: str, zone: str) -> str:
-    """Check the actual GCE instance status."""
+    """Check the actual GCE instance status.
+
+    A 404 is reported as `NOT_FOUND` rather than folded into `UNKNOWN`: the
+    instance is gone (the agent-vm reaper deletes aged TERMINATED VMs), which
+    is unrecoverable here and needs the stale Firestore record cleared, while
+    `UNKNOWN` means "could not tell" and must leave the record alone.
+    """
     token = await run_blocking(critical_executor, _get_gce_access_token)
     url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+        if resp.status_code == 404:
+            return "NOT_FOUND"
         if resp.status_code != 200:
             return "UNKNOWN"
         return resp.json().get("status", "UNKNOWN")
@@ -168,6 +180,8 @@ async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
 
     async with httpx.AsyncClient(timeout=180) as client:
         instance_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
+        if instance_resp.status_code == 404:
+            raise VmNotFoundError(vm_name)
         already_running = instance_resp.status_code == 200 and instance_resp.json().get("status") == "RUNNING"
         if already_running:
             logger.info(f"[vm-start] {vm_name} is already RUNNING; resolving its external IP")
@@ -255,6 +269,19 @@ def _update_firestore_vm(uid: str, ip: str | None, status: str) -> None:
     _get_firestore_db().collection('users').document(uid).update(update)
 
 
+def _clear_agent_vm(uid: str) -> None:
+    """Delete the user's agentVm record once its GCE instance is gone.
+
+    The reaper deletes aged TERMINATED `omi-agent-*` instances but leaves the
+    Firestore record saying `ready` with the old IP, and nothing here can
+    recreate an instance. Keeping the record makes every later connect dial a
+    dead address and makes the desktop provision endpoint report `exists`, so
+    the user's agent stays broken forever. Clearing it is what lets a client
+    provision a new VM — the same repair `GET /v2/agent/status` already does.
+    """
+    _get_firestore_db().collection('users').document(uid).update({"agentVm": DELETE_FIELD})
+
+
 async def _reset_vm(vm_name: str, zone: str) -> None:
     """Hard-reset a RUNNING VM whose agent process is unresponsive."""
     token = await run_blocking(critical_executor, _get_gce_access_token)
@@ -296,6 +323,14 @@ async def _ensure_vm_running(uid: str, vm: Dict[str, Any], health_failed: bool =
         except Exception:
             return vm  # Can't check, assume it's fine
 
+        if gce_status == "NOT_FOUND":
+            # Instance reaped: neither restart nor reset can bring it back, and
+            # leaving the record makes the caller wait out the full health
+            # timeout before failing. Clear it so a client can provision anew.
+            logger.warning(f"[agent-proxy] VM {vm_name} no longer exists in GCE — clearing stale agentVm record")
+            await run_blocking(db_executor, _clear_agent_vm, uid)
+            return None
+
         if gce_status == "RUNNING":
             if health_failed:
                 # VM is RUNNING but agent process is dead — hard reset
@@ -322,6 +357,10 @@ async def _ensure_vm_running(uid: str, vm: Dict[str, Any], health_failed: bool =
         await run_blocking(db_executor, _update_firestore_vm, uid, ip, "ready")
         logger.info(f"[agent-proxy] VM {vm_name} restarted, ip={ip}")
         return await run_blocking(db_executor, _refresh_vm, uid)
+    except VmNotFoundError:
+        logger.warning(f"[agent-proxy] VM {vm_name} no longer exists in GCE — clearing stale agentVm record")
+        await run_blocking(db_executor, _clear_agent_vm, uid)
+        return None
     except Exception as e:
         logger.error(f"[agent-proxy] Failed to restart VM {vm_name}: {e}")
         await run_blocking(db_executor, _update_firestore_vm, uid, None, "error")

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -70,11 +70,18 @@ def _get_gce_access_token() -> str:
 
 
 async def _check_gce_status(vm_name: str, zone: str) -> str:
-    """Check the actual GCE instance status (RUNNING, TERMINATED, STOPPED, etc.)."""
+    """Check the actual GCE instance status (RUNNING, TERMINATED, STOPPED, etc.).
+
+    A 404 is reported as `NOT_FOUND`, not folded into `UNKNOWN`: the instance is
+    gone (the agent-vm reaper deletes aged TERMINATED VMs) and the stale record
+    must be cleared, whereas `UNKNOWN` means "could not tell" and must leave it.
+    """
     token = await run_blocking(db_executor, _get_gce_access_token)
     url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+        if resp.status_code == 404:
+            return "NOT_FOUND"
         if resp.status_code != 200:
             logger.error(f"[gce] Failed to get instance status: {resp.status_code} {sanitize(resp.text)}")
             return "UNKNOWN"
@@ -180,6 +187,19 @@ def _update_firestore_vm(uid: str, ip: str | None, status: str):
     firestore_db.collection('users').document(uid).update(update)
 
 
+def _clear_agent_vm(uid: str):
+    """Delete the user's agentVm record once its GCE instance is gone.
+
+    Nothing can restart a deleted instance, and while the record is present the
+    provision endpoint reports `exists`, so keeping it leaves the user's agent
+    permanently broken. Clearing it is what lets a replacement be provisioned.
+    """
+    from google.cloud import firestore
+    from database.users import db as firestore_db
+
+    firestore_db.collection('users').document(uid).update({"agentVm": firestore.DELETE_FIELD})
+
+
 async def _restart_vm_background(uid: str, vm_name: str, zone: str):
     """Background task: start stopped VM, update Firestore with new IP when ready."""
     try:
@@ -229,6 +249,14 @@ async def ensure_vm(background_tasks: BackgroundTasks, uid: str = Depends(get_cu
         except Exception as e:
             logger.error(f"[vm-ensure] GCE status check failed: {e}")
             return {"has_vm": True, "status": fs_status}
+
+        if gce_status == "NOT_FOUND":
+            # The instance was deleted (reaper), so no restart can recover it and
+            # reporting the stored status sends the client at a dead address for a
+            # full health timeout. Clear the record so a new VM can be provisioned.
+            logger.warning(f"[vm-ensure] VM {vm_name} no longer exists in GCE — clearing stale agentVm record")
+            await run_blocking(db_executor, _clear_agent_vm, uid)
+            return {"has_vm": False}
 
         if gce_status in ("TERMINATED", "STOPPED"):
             logger.info(f"[vm-ensure] VM {vm_name} is {gce_status}, restarting...")

--- a/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
+++ b/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
@@ -1,0 +1,182 @@
+"""A reaped agent VM must clear its Firestore record instead of stranding the user.
+
+``scripts/agent_vm_reaper.py`` deletes aged TERMINATED ``omi-agent-*`` instances but leaves
+``users/{uid}.agentVm`` saying ``ready`` with the deleted VM's IP. Both Python readers folded
+the GCE ``404`` into ``UNKNOWN``: ``_ensure_vm_running`` returned the stale record ("STAGING,
+etc. — let it be") so ``agent-proxy`` dialed a dead address and waited out the full 120s
+health timeout before answering "Agent VM is not responding", and ``POST /v1/agent/vm-ensure``
+reported ``ready``. Nothing repaired the record and the desktop provision endpoint reports
+``exists`` while it is present, so the user's agent chat stayed broken on every later attempt
+(20 distinct users in prod over 2026-07-25..26). Only a 404 may clear the record — ``UNKNOWN``
+means "could not tell" and must leave a live VM's record alone.
+"""
+
+import asyncio
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import firebase_admin
+import pytest
+from firebase_admin import firestore
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+AGENT_PROXY_DIR = BACKEND_DIR / "agent-proxy"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from tests.unit.test_tools_agent_route_response_shape import _install_route_stubs  # noqa: E402
+
+READY_VM = {"vmName": "omi-agent-reaped", "zone": "us-central1-a", "status": "ready", "ip": "34.135.118.144"}
+
+
+@pytest.fixture
+def agent_proxy(monkeypatch) -> ModuleType:
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.setattr(firebase_admin, "initialize_app", MagicMock(return_value=object()))
+    monkeypatch.setattr(firestore, "client", MagicMock(return_value=object()))
+
+    spec = importlib.util.spec_from_file_location("agent_proxy_reaped_record_test", AGENT_PROXY_DIR / "main.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeUserDoc:
+    def __init__(self):
+        self.updates = []
+
+    def update(self, payload):
+        self.updates.append(payload)
+
+
+def _stub_gce(agent_proxy, monkeypatch, instance_status_code: int, user_doc: _FakeUserDoc):
+    """Point the module's GCE + Firestore seams at a fake instance and user document."""
+
+    class Response:
+        status_code = instance_status_code
+
+        def json(self):
+            return {"status": "RUNNING", "networkInterfaces": [{"accessConfigs": [{"natIP": "34.9.9.9"}]}]}
+
+    class Client:
+        def __init__(self):
+            self.post_calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+        async def get(self, _url, *, headers=None):
+            return Response()
+
+        async def post(self, *_args, **_kwargs):
+            self.post_calls += 1
+            return Response()
+
+    client = Client()
+
+    async def direct_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    db = MagicMock()
+    db.collection.return_value.document.return_value = user_doc
+
+    monkeypatch.setattr(agent_proxy, "_get_gce_access_token", lambda: "test-token")
+    monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
+    monkeypatch.setattr(agent_proxy, "httpx", types.SimpleNamespace(AsyncClient=lambda **_kwargs: client))
+    monkeypatch.setattr(agent_proxy, "_get_firestore_db", lambda: db)
+    return client
+
+
+class TestAgentProxyClearsReapedRecord:
+    async def test_deleted_instance_clears_the_record_and_fails_fast(self, agent_proxy, monkeypatch):
+        user_doc = _FakeUserDoc()
+        client = _stub_gce(agent_proxy, monkeypatch, 404, user_doc)
+
+        result = await agent_proxy._ensure_vm_running("uid-reaped", dict(READY_VM), health_failed=True)
+
+        assert result is None, "a deleted instance must not be reported as usable"
+        assert user_doc.updates == [{"agentVm": agent_proxy.DELETE_FIELD}]
+        assert client.post_calls == 0, "no reset/start may be attempted against a deleted instance"
+
+    async def test_unknown_status_leaves_the_record_alone(self, agent_proxy, monkeypatch):
+        user_doc = _FakeUserDoc()
+        _stub_gce(agent_proxy, monkeypatch, 500, user_doc)
+
+        result = await agent_proxy._ensure_vm_running("uid-transient", dict(READY_VM), health_failed=False)
+
+        assert result == READY_VM, "an unreadable GCE status must leave the record untouched"
+        assert user_doc.updates == []
+
+    async def test_restart_path_clears_the_record_when_the_instance_is_gone(self, agent_proxy, monkeypatch):
+        user_doc = _FakeUserDoc()
+        _stub_gce(agent_proxy, monkeypatch, 404, user_doc)
+        errored_vm = dict(READY_VM, status="error")
+
+        result = await agent_proxy._ensure_vm_running("uid-errored", errored_vm)
+
+        assert result is None
+        assert {"agentVm": agent_proxy.DELETE_FIELD} in user_doc.updates
+
+    async def test_start_vm_and_wait_raises_vm_not_found_on_404(self, agent_proxy, monkeypatch):
+        _stub_gce(agent_proxy, monkeypatch, 404, _FakeUserDoc())
+
+        with pytest.raises(agent_proxy.VmNotFoundError):
+            await agent_proxy._start_vm_and_wait("omi-agent-reaped", "us-central1-a")
+
+
+@pytest.fixture
+def agent_tools(monkeypatch):
+    _install_route_stubs(monkeypatch)
+    agentic_mod = types.ModuleType('utils.retrieval.agentic')
+    agentic_mod.agent_config_context = types.SimpleNamespace(set=MagicMock())
+    agentic_mod.CORE_TOOLS = []
+    monkeypatch.setitem(sys.modules, 'utils.retrieval.agentic', agentic_mod)
+    sys.modules.pop('routers.agent_tools', None)
+    return importlib.import_module('routers.agent_tools')
+
+
+class TestVmEnsureClearsReapedRecord:
+    def test_deleted_instance_reports_no_vm_and_clears_the_record(self, agent_tools, monkeypatch):
+        from database.users import get_agent_vm
+
+        get_agent_vm.return_value = dict(READY_VM)
+        cleared = []
+
+        async def not_found(_vm_name, _zone):
+            return "NOT_FOUND"
+
+        monkeypatch.setattr(agent_tools, "_check_gce_status", not_found)
+        monkeypatch.setattr(agent_tools, "_clear_agent_vm", cleared.append)
+        background = MagicMock()
+
+        response = asyncio.run(agent_tools.ensure_vm(background, uid="uid-reaped"))
+
+        assert response == {"has_vm": False}
+        assert cleared == ["uid-reaped"]
+        background.add_task.assert_not_called()
+
+    def test_unknown_status_keeps_the_record(self, agent_tools, monkeypatch):
+        from database.users import get_agent_vm
+
+        get_agent_vm.return_value = dict(READY_VM)
+        cleared = []
+
+        async def unknown(_vm_name, _zone):
+            return "UNKNOWN"
+
+        monkeypatch.setattr(agent_tools, "_check_gce_status", unknown)
+        monkeypatch.setattr(agent_tools, "_clear_agent_vm", cleared.append)
+
+        response = asyncio.run(agent_tools.ensure_vm(MagicMock(), uid="uid-transient"))
+
+        assert response == {"has_vm": True, "status": "ready"}
+        assert cleared == []


### PR DESCRIPTION
## Bug (live prod)

`backend/scripts/agent_vm_reaper.py` (CronJob) deletes aged **TERMINATED** `omi-agent-*` instances to stop boot-disk billing, but it leaves `users/{uid}.agentVm` saying `status: ready` with the deleted VM's IP. Both Python readers folded the GCE `404` into `"UNKNOWN"`:

- `agent-proxy` `_ensure_vm_running` → `if gce_status not in ("TERMINATED", "STOPPED"): return vm  # STAGING, etc. — let it be` → returns the stale record → `agent_ws` then polls the dead IP for the full `_wait_for_vm_healthy` 120s window and answers `{"type":"error","message":"Agent VM is not responding"}`.
- `POST /v1/agent/vm-ensure` → falls through and answers `{"has_vm": true, "status": "ready"}`.

Nothing repairs the record, and `POST /v2/agent/provision` reports `exists` while it is present, so agent chat stays broken on **every** later attempt. Prod evidence (`based-hardware`, 2026-07-25..26): 20 distinct users whose `agentVm` points at a GCE instance that returns 404 (e.g. `omi-agent-5yc7omh3ffbg` — 20 lookups, `omi-agent-pkqlgn652iaf` — 19), plus the matching unhandled ASGI `WebSocketDisconnect` when the user gives up before the 120s wait ends (`main.py:432`, 12:41:10Z).

## Fix

Report a 404 as `NOT_FOUND` — distinct from `UNKNOWN` ("could not tell") — and, only for that status, delete the `agentVm` record so a client can provision a replacement. This is the resume contract `GET /v2/agent/status` already implements on the desktop Rust path (`desktop/macos/Backend-Rust/src/routes/agent.rs`), now extended to the two Python readers. `UNKNOWN` keeps the existing leave-it-alone behavior, so a transient GCE error can never delete a live VM's record.

- `agent-proxy/main.py`: `_check_gce_status` returns `NOT_FOUND` on 404; `_ensure_vm_running` clears the record and fails fast; `_start_vm_and_wait` raises `VmNotFoundError` on 404 so the non-`ready` restart path clears it too.
- `routers/agent_tools.py`: `vm-ensure` returns `{"has_vm": false}` and clears the record.
- `database/users.py`: `delete_agent_vm(uid)`.

## What I tested

**Real WS route** through the agent-proxy FastAPI app (`TestClient.websocket_connect("/v1/agent/ws")`, only Firebase/Firestore/GCE-HTTP edges faked, GCE instance GET → 404):

| | close latency | dead-IP health probes | last message to client | Firestore |
|---|---|---|---|---|
| before | **120.10s** | 41 | `Agent VM is not responding` | record untouched |
| after | **0.02s** | 1 | `Failed to start agent VM` | `agentVm` deleted |

**Regression tests** — `backend/tests/unit/test_agent_vm_reaped_record_recovery.py` (6 behavioral tests through the module seams): 4 fail on the pre-fix code (`git stash` of the three source files), all 6 pass after. Two of them assert the negative case — an `UNKNOWN` (500) status must leave the record intact.

**Suites run** (`pytest`): `test_agent_vm_reaped_record_recovery.py`, `test_agent_proxy_async_boundaries.py`, `test_agent_vm_async.py`, `test_agent_vm_reaper.py`, `test_tools_agent_route_response_shape.py`, `test_scan_async_blockers.py` → **63 passed**. `black --line-length 120 --skip-string-normalization` clean.

Product invariants affected: none (`scripts/pr-preflight --suggest`).

This is the stated resume contract of `FC-agent-vm-stop-retains-disk` ("keep the client NOT_FOUND → re-provision path
as the resume contract after delete") — the contract the Python readers never implemented. The new regression test is
recorded as that class's `canonical_prevention_artifact`.

Failure-Class: FC-agent-vm-stop-retains-disk

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

