### PR TITLE
fix(desktop): resolve PTT input routing off the main actor

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -3,7 +3,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2638,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4829,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2584,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2587,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1639
   },
@@ -11,7 +11,7 @@
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Agent completion presentation now follows the canonical terminal lifecycle used by PTT and chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "The Second Brain onboarding, reach-error, and notch-moment UI keeps the hover menu agent-only and routes idle notch taps through main chat.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Second Brain continuous-chat routing shares window geometry with agent-only hover sizing and canonical idle-notch chat ownership.",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "DEBUG owner-boundary tests need a capture-free effect-handler install seam; shared ensureAutomationBarConfigured() removes duplicated automation setup while adding that seam (BasedHardware/omi#10499).",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "DEBUG owner-boundary tests need a capture-free effect-handler install seam; shared ensureAutomationBarConfigured() removes duplicated automation setup while adding that seam (BasedHardware/omi#10499). Setup and both PTT entry points then warm the CoreAudio input-routing snapshot off the main thread so turn start never reads the HAL inline (BasedHardware/omi#10442).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds bounded realtime mint-failure outcome correlation and close-resolution telemetry so release health distinguishes started recovery from exhaustion; telemetry-only, no lifecycle change (#10425).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": "Strict concurrency annotations (Ticket 14) add Sendable conformances and isolation qualifiers; sendBackgroundAgentContext now confirms the provider send before returning true (exactly-once: no ack before delivery) and the session emits hubDidOpenInputWindow so a warm-idle completion is retried \u2014 both must live beside the file-private send/turn machinery."
   },

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -1411,6 +1411,7 @@ final class DesktopDiagnosticsManager {
     "task_workflow",
     "auth_storage",
     "state_authority",
+    "ptt_input_routing",
     "other",
   ]
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+InputDeviceRouting.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+InputDeviceRouting.swift
@@ -1,8 +1,30 @@
 @preconcurrency import CoreAudio
+import Foundation
+
+/// The CoreAudio reads PTT routing needs, behind a seam so a fault test can stall
+/// the HAL without a genuinely wedged driver.
+struct PTTAudioDeviceProbe: Sendable {
+  var inputDeviceID: @Sendable (String) -> AudioDeviceID?
+  var outputIsBluetooth: @Sendable () -> Bool
+  var builtInMicDeviceID: @Sendable () -> AudioDeviceID?
+
+  static let coreAudio = PTTAudioDeviceProbe(
+    inputDeviceID: { AudioCaptureService.inputDeviceID(forUID: $0) },
+    outputIsBluetooth: { AudioCaptureService.isDefaultOutputBluetooth() },
+    builtInMicDeviceID: { AudioCaptureService.findBuiltInMicDeviceID() }
+  )
+}
 
 /// Resolves the PTT microphone policy without coupling the selection policy to
 /// CoreAudio enumeration. An explicit user choice always wins; Automatic keeps
 /// Bluetooth output on A2DP by preferring the built-in microphone.
+///
+/// CoreAudio property reads have no deadline and no cancellation: against a wedged
+/// audio driver they block for as long as the driver stays wedged. PTT resolves its
+/// input device on the main actor at turn start, so those reads must never happen
+/// there — not even behind a bounded wait, which still freezes the run loop for the
+/// whole budget. The HAL is therefore read only on `probeQueue`, and the main actor
+/// reads the resulting snapshot under a lock.
 enum PTTInputDeviceRouting {
   static func overrideDeviceID(
     selectedDeviceID: AudioDeviceID?,
@@ -11,24 +33,131 @@ enum PTTInputDeviceRouting {
   ) -> AudioDeviceID? {
     selectedDeviceID ?? (outputIsBluetooth ? builtInDeviceID : nil)
   }
+
+  /// One completed HAL read. Carries the UID it was resolved for so a snapshot
+  /// taken before the user changed their microphone is never applied afterwards.
+  struct Snapshot: Sendable, Equatable {
+    let selectedUID: String
+    let selectedDeviceID: AudioDeviceID?
+    let outputIsBluetooth: Bool
+    let builtInDeviceID: AudioDeviceID?
+
+    var overrideDeviceID: AudioDeviceID? {
+      PTTInputDeviceRouting.overrideDeviceID(
+        selectedDeviceID: selectedDeviceID,
+        outputIsBluetooth: outputIsBluetooth,
+        builtInDeviceID: builtInDeviceID)
+    }
+  }
+
+  private static let store = SnapshotStore()
+
+  private static let probeQueue = DispatchQueue(
+    label: "com.omi.ptt.input-device-probe", qos: .userInitiated)
+
+  /// The routing resolved for `selectedUID`, or `nil` when no snapshot has landed for
+  /// it yet. Returning the whole snapshot rather than just the device ID lets a caller
+  /// tell a real "no override needed" answer from "the HAL has not answered yet" from a
+  /// single read, so the two cannot disagree across a concurrent refresh.
+  ///
+  /// Never touches CoreAudio, so it is safe on the main actor at PTT turn start.
+  static func currentSnapshot(selectedUID: String) -> Snapshot? {
+    store.snapshot(matching: selectedUID)
+  }
+
+  /// Reads the HAL off the main thread and publishes a new snapshot.
+  ///
+  /// Coalesced: while one read is outstanding, further calls are dropped. A wedged
+  /// driver therefore parks exactly one queue thread no matter how many PTT turns the
+  /// user starts, instead of leaking one per turn.
+  static func refresh(
+    selectedUID: String,
+    probe: PTTAudioDeviceProbe = .coreAudio,
+    completion: (@Sendable () -> Void)? = nil
+  ) {
+    guard store.beginRefresh() else {
+      completion?()
+      return
+    }
+    probeQueue.async {
+      let selectedDeviceID = selectedUID.isEmpty ? nil : probe.inputDeviceID(selectedUID)
+      let outputIsBluetooth = probe.outputIsBluetooth()
+      store.finishRefresh(
+        Snapshot(
+          selectedUID: selectedUID,
+          selectedDeviceID: selectedDeviceID,
+          outputIsBluetooth: outputIsBluetooth,
+          builtInDeviceID: outputIsBluetooth ? probe.builtInMicDeviceID() : nil
+        ))
+      completion?()
+    }
+  }
+
+  static func resetForTests() {
+    store.reset()
+  }
+}
+
+private final class SnapshotStore: @unchecked Sendable {
+  private let lock = NSLock()
+  private var stored: PTTInputDeviceRouting.Snapshot?
+  private var refreshing = false
+
+  func snapshot(matching selectedUID: String) -> PTTInputDeviceRouting.Snapshot? {
+    lock.lock()
+    defer { lock.unlock() }
+    guard let stored, stored.selectedUID == selectedUID else { return nil }
+    return stored
+  }
+
+  func beginRefresh() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    if refreshing { return false }
+    refreshing = true
+    return true
+  }
+
+  func finishRefresh(_ snapshot: PTTInputDeviceRouting.Snapshot) {
+    lock.lock()
+    defer { lock.unlock() }
+    stored = snapshot
+    refreshing = false
+  }
+
+  func reset() {
+    lock.lock()
+    defer { lock.unlock() }
+    stored = nil
+    refreshing = false
+  }
 }
 
 @MainActor
 extension PushToTalkManager {
+  /// Non-blocking. Kicks the next HAL read and answers from the last one that landed.
   func preferredPTTInputOverrideDeviceID() -> AudioDeviceID? {
     let selectedUID = ShortcutSettings.shared.pttInputDeviceUID
-    let selectedDeviceID =
-      selectedUID.isEmpty
-      ? nil
-      : AudioCaptureService.inputDeviceID(forUID: selectedUID)
-    if !selectedUID.isEmpty, selectedDeviceID == nil {
+    let snapshot = PTTInputDeviceRouting.currentSnapshot(selectedUID: selectedUID)
+    if let snapshot, !selectedUID.isEmpty, snapshot.selectedDeviceID == nil {
       log("PushToTalkManager: selected PTT microphone is unavailable — using Automatic")
     }
-    let outputIsBluetooth = AudioCaptureService.isDefaultOutputBluetooth()
-    return PTTInputDeviceRouting.overrideDeviceID(
-      selectedDeviceID: selectedDeviceID,
-      outputIsBluetooth: outputIsBluetooth,
-      builtInDeviceID: outputIsBluetooth ? AudioCaptureService.findBuiltInMicDeviceID() : nil
-    )
+    if snapshot == nil {
+      log("PushToTalkManager: PTT input routing not resolved yet — using the system default input")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "ptt_input_routing",
+        from: "resolved_routing",
+        to: "system_default_input",
+        reason: "timeout",
+        outcome: .degraded)
+    }
+    PTTInputDeviceRouting.refresh(selectedUID: selectedUID)
+    return snapshot?.overrideDeviceID
+  }
+
+  /// Warms the routing snapshot at the start of a turn, before the turn's own setup
+  /// work, so the HAL read overlaps that work instead of gating capture on it.
+  func warmPTTInputRouting() {
+    PTTInputDeviceRouting.refresh(selectedUID: ShortcutSettings.shared.pttInputDeviceUID)
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -319,6 +319,7 @@ class PushToTalkManager: ObservableObject {
     self.barState = barState
     configureVoiceTurnCoordinator(barState: barState)
     hasMicPermission = AudioCaptureService.checkPermission()
+    warmPTTInputRouting()
     installEventMonitors()
     // Realtime hub: wire it to the bar and warm the WS if it's enabled + BYOK-keyed,
     // so the persistent socket is ready before the first PTT (and stays warm after).
@@ -627,6 +628,7 @@ class PushToTalkManager: ObservableObject {
     if isBlockedByUsageLimit() { return }
     _ = voiceTurnCoordinator.begin(intent: .hold)
     RealtimeHubController.shared.prefetchVoiceContextSnapshotIfNeeded()
+    warmPTTInputRouting()
     // Reset the overflow flag under the buffer lock so it's atomic w.r.t. the
     // audio thread's appendBatchAudioBounded (fresh turn → allow the warning again).
     batchAudioLock.lock()
@@ -670,6 +672,7 @@ class PushToTalkManager: ObservableObject {
   private func enterLockedListening() {
     if isBlockedByUsageLimit() { return }
     RealtimeHubController.shared.prefetchVoiceContextSnapshotIfNeeded()
+    warmPTTInputRouting()
     FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     if ShortcutSettings.shared.pttMuteSystemAudio {
       SystemAudioMuteController.shared.muteForListening()

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -701,8 +701,10 @@ import XCTest
     }
 
     func testFallbackNamedAreasAreNotCollapsedToOther() throws {
-      for area in ["screen_capture", "memory_scope", "desktop_update", "tts_fallback", "task_workflow", "auth_storage"]
-      {
+      for area in [
+        "screen_capture", "memory_scope", "desktop_update", "tts_fallback", "task_workflow",
+        "auth_storage", "ptt_input_routing",
+      ] {
         DesktopDiagnosticsManager.shared.resetForTests()
         DesktopDiagnosticsManager.shared.recordFallback(
           area: area, from: "a", to: "b", reason: "capability_mismatch", outcome: .degraded)

--- a/desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift
@@ -1,0 +1,202 @@
+import CoreAudio
+import XCTest
+
+@testable import Omi_Computer
+
+/// Fault coverage for the CoreAudio routing snapshot behind PTT input selection.
+/// `ShortcutSettingsTests` pins the pure selection policy; these tests pin what the
+/// main actor sees while the HAL is slow, wedged, or has not answered yet.
+final class PTTInputDeviceProbeTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    PTTInputDeviceRouting.resetForTests()
+  }
+
+  override func tearDown() {
+    PTTInputDeviceRouting.resetForTests()
+    super.tearDown()
+  }
+
+  /// A probe whose device lookup blocks until the test releases it, standing in for a
+  /// wedged CoreAudio driver without sleeping on the wall clock.
+  private func stalledProbe(until release: DispatchSemaphore) -> PTTAudioDeviceProbe {
+    PTTAudioDeviceProbe(
+      inputDeviceID: { _ in
+        release.wait()
+        return 99
+      },
+      outputIsBluetooth: { true },
+      builtInMicDeviceID: { 42 }
+    )
+  }
+
+  private func probe(
+    selected: AudioDeviceID? = nil,
+    bluetooth: Bool = false,
+    builtIn: AudioDeviceID? = nil
+  ) -> PTTAudioDeviceProbe {
+    PTTAudioDeviceProbe(
+      inputDeviceID: { _ in selected },
+      outputIsBluetooth: { bluetooth },
+      builtInMicDeviceID: { builtIn }
+    )
+  }
+
+  /// Refresh and block the *test* until the snapshot lands. Production never does this.
+  private func refreshAndWait(selectedUID: String, probe: PTTAudioDeviceProbe) {
+    let landed = expectation(description: "routing snapshot landed")
+    PTTInputDeviceRouting.refresh(selectedUID: selectedUID, probe: probe) { landed.fulfill() }
+    wait(for: [landed], timeout: 5)
+  }
+
+  // MARK: - The issue #10442 acceptance criterion
+
+  /// "proving PTT startup and the main run loop remain responsive". A bounded wait on
+  /// the main thread does not satisfy this: it still parks the run loop for the whole
+  /// budget. The turn-start read must not wait on CoreAudio at all.
+  @MainActor
+  func testMainRunLoopKeepsPumpingWhileTheHALIsWedged() {
+    let release = DispatchSemaphore(value: 0)
+    // Joined before returning: a probe still parked at teardown would publish its
+    // snapshot into whichever test runs next.
+    let finished = expectation(description: "parked probe finished")
+    PTTInputDeviceRouting.refresh(
+      selectedUID: "wedged-uid", probe: stalledProbe(until: release)
+    ) { finished.fulfill() }
+
+    let ticker = Ticker()
+    let timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { _ in ticker.tick() }
+    RunLoop.main.add(timer, forMode: .common)
+    defer { timer.invalidate() }
+
+    let started = Date()
+    var reads = 0
+    while Date().timeIntervalSince(started) < 0.3 {
+      // The exact call PTT turn start makes, hammered while the HAL is wedged.
+      _ = PTTInputDeviceRouting.currentSnapshot(selectedUID: "wedged-uid")
+      reads += 1
+      RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+    }
+
+    XCTAssertGreaterThan(
+      ticker.count, 10,
+      "the main run loop must keep pumping while the HAL is wedged (got \(ticker.count) ticks)")
+    XCTAssertGreaterThan(reads, 10, "turn-start reads must keep completing")
+
+    release.signal()
+    wait(for: [finished], timeout: 5)
+  }
+
+  /// A wedged driver must not leak one parked thread per PTT turn.
+  func testConcurrentRefreshesCoalesceIntoASingleHALRead() {
+    let release = DispatchSemaphore(value: 0)
+    let starts = Ticker()
+    let counting = PTTAudioDeviceProbe(
+      inputDeviceID: { _ in
+        starts.tick()
+        release.wait()
+        return 99
+      },
+      outputIsBluetooth: { true },
+      builtInMicDeviceID: { 42 }
+    )
+
+    let finished = expectation(description: "every refresh call settled")
+    finished.expectedFulfillmentCount = 25
+    for _ in 0..<25 {
+      PTTInputDeviceRouting.refresh(selectedUID: "wedged-uid", probe: counting) {
+        finished.fulfill()
+      }
+    }
+    // Give the queue a chance to start anything it was going to start.
+    let settled = expectation(description: "settled")
+    DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { settled.fulfill() }
+    wait(for: [settled], timeout: 5)
+
+    XCTAssertEqual(
+      starts.count, 1,
+      "25 turn starts against a wedged driver must park exactly one probe thread")
+
+    release.signal()
+    wait(for: [finished], timeout: 5)
+  }
+
+  // MARK: - Policy preservation
+
+  func testResolvedSnapshotKeepsTheExplicitUserChoice() {
+    refreshAndWait(
+      selectedUID: "user-mic-uid", probe: probe(selected: 7, bluetooth: true, builtIn: 42))
+    XCTAssertEqual(
+      PTTInputDeviceRouting.currentSnapshot(selectedUID: "user-mic-uid")?.overrideDeviceID, 7)
+  }
+
+  func testResolvedSnapshotFallsBackToBuiltInMicOnBluetoothOutput() {
+    refreshAndWait(selectedUID: "", probe: probe(bluetooth: true, builtIn: 42))
+    XCTAssertEqual(PTTInputDeviceRouting.currentSnapshot(selectedUID: "")?.overrideDeviceID, 42)
+  }
+
+  func testResolvedSnapshotUsesTheSystemDefaultWhenOutputIsNotBluetooth() {
+    refreshAndWait(selectedUID: "", probe: probe())
+    let snapshot = PTTInputDeviceRouting.currentSnapshot(selectedUID: "")
+    XCTAssertNotNil(snapshot, "a resolved snapshot must exist")
+    XCTAssertNil(snapshot?.overrideDeviceID)
+  }
+
+  func testAnUnpluggedSelectedMicFallsBackToTheBluetoothBuiltInRule() {
+    refreshAndWait(
+      selectedUID: "unplugged-mic-uid", probe: probe(bluetooth: true, builtIn: 42))
+    XCTAssertEqual(
+      PTTInputDeviceRouting.currentSnapshot(selectedUID: "unplugged-mic-uid")?.overrideDeviceID,
+      42)
+  }
+
+  func testTheBuiltInMicIsNotEnumeratedWhenOutputIsNotBluetooth() {
+    let builtInReads = Ticker()
+    refreshAndWait(
+      selectedUID: "",
+      probe: PTTAudioDeviceProbe(
+        inputDeviceID: { _ in nil },
+        outputIsBluetooth: { false },
+        builtInMicDeviceID: {
+          builtInReads.tick()
+          return 42
+        }))
+
+    XCTAssertEqual(
+      builtInReads.count, 0,
+      "the built-in mic lookup is the most expensive HAL walk and is only needed for the "
+        + "Bluetooth A2DP fallback")
+  }
+
+  // MARK: - Cold and stale snapshots
+
+  func testAColdSnapshotReportsNoOverrideRatherThanGuessing() {
+    XCTAssertNil(PTTInputDeviceRouting.currentSnapshot(selectedUID: "user-mic-uid"))
+  }
+
+  /// A snapshot resolved for the previous microphone must never be applied after the
+  /// user picks a different one.
+  func testASnapshotForAnotherMicrophoneIsNotApplied() {
+    refreshAndWait(selectedUID: "old-mic-uid", probe: probe(selected: 7))
+    XCTAssertEqual(
+      PTTInputDeviceRouting.currentSnapshot(selectedUID: "old-mic-uid")?.overrideDeviceID, 7)
+    XCTAssertNil(PTTInputDeviceRouting.currentSnapshot(selectedUID: "new-mic-uid"))
+  }
+}
+
+private final class Ticker: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value = 0
+
+  func tick() {
+    lock.lock()
+    defer { lock.unlock() }
+    value += 1
+  }
+
+  var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260726-ptt-audio-device-probe.json
+++ b/desktop/macos/changelog/unreleased/20260726-ptt-audio-device-probe.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app freezing at the start of a push-to-talk turn when an audio driver stops responding"
+}


### PR DESCRIPTION
## Summary

Fixes #10442.

PTT resolved its input device from an `@MainActor` method that synchronously called three CoreAudio HAL reads (`inputDeviceID(forUID:)`, `isDefaultOutputBluetooth()`, `findBuiltInMicDeviceID()`) at turn start. Those reads have no deadline and no cancellation, so a wedged audio driver pinned the whole UI, not just PTT.

- Read the HAL only on a dedicated non-main queue and publish the result as a `Snapshot`. The main actor now reads that snapshot under a lock and never touches CoreAudio.
- Coalesce refreshes so a wedged driver parks exactly one probe thread no matter how many turns the user starts, instead of one per turn.
- Warm the snapshot in `setup()` and at both PTT entry points, so the read overlaps turn-start work that already happens rather than gating capture on it.
- Keep `PTTInputDeviceRouting.overrideDeviceID` byte-identical, so the selected-device and Bluetooth A2DP policy is unchanged.

The routing call stays synchronous and all four call sites are untouched, so turn-start ordering and reducer ownership do not change.

### Why this is larger than a bounded wait

The obvious reading of "bounded non-main executor" is a background queue plus a timeout on the main thread. I built that first and measured it against the issue's other requirement, that the main run loop stays responsive:

```
bounded wait:      RESOLUTION=timedOut ELAPSED=0.305s RUNLOOP_TICKS=0
snapshot read:     RUNLOOP_TICKS > 10
```

A bounded wait moves the CoreAudio work off the main thread but still parks the run loop for the whole budget, so it converts an unbounded freeze into a 250ms freeze on every turn start. `testMainRunLoopKeepsPumpingWhileTheHALIsWedged` fails on that design and passes on this one.

### Trade-off

With a slow but not wedged HAL, the previous code froze the UI and then routed correctly. This code stays responsive and may fall back to the system default input for a single turn, which on Bluetooth output means one turn on the headset mic. Warming at `setup()` plus both entry points reduced this to zero cold-snapshot fallbacks across every real turn I ran, including the first turn after launch, but the window is not provably zero on a slow machine. It self-corrects on the next turn and is recorded through `recordFallback(area: "ptt_input_routing")`.

## Verification

Desktop Swift, from `desktop/macos`:

- `xcrun swift build -c debug --package-path Desktop` : build complete, Swift 6 strict concurrency with warnings as errors.
- `xcrun swift test --package-path Desktop --filter 'PTTInputDeviceProbeTests|ShortcutSettingsTests'` : 15 tests, 0 failures. Run 10 consecutive times to confirm no ordering dependence.
- `./test.sh` : 387 Swift suites in isolation, all passed.
- `./scripts/agent-logic-harness.sh --swift-only` : passed, 526 lifecycle/state tests.
- `./scripts/swiftlint-wrapper.sh lint` : 0 violations across 902 files.
- `bash desktop/macos/scripts/swift-format-wrapper.sh lint-scope` : clean, pinned swift-format 602.0.0.
- `python3 .github/scripts/check_product_file_line_count_ratchet.py --changed-files <list>` : OK. `PushToTalkManager.swift` baseline raised 2584 to 2587 with a justification for the three warm-up lines.

Real path, named bundle `/Applications/omi-10442-ptt.app`, bundle id `com.omi.omi-10442-ptt`, development backend, driven by real `Option` holds because every automation bridge action sets `automationCaptureBypass` and returns before this code:

- 4 authenticated PTT turns, all `reason=success route=hub` with live transcripts and audio replies.
- 2 of those with AirPods Pro as the default input **and** output device, which is the case the A2DP rule exists for:
  - `PushToTalkManager: hub on Bluetooth output, capturing from built-in mic to keep A2DP`
  - `AudioCapture: Using override device ID 84`, confirmed against CoreAudio as `MacBook Pro Microphone`, not the AirPods mic.
  - AirPods output stayed at `48000 Hz` through both turns. An HFP flap would have dropped it to 16000.
- The AirPods were connected roughly 20 minutes after launch, and the first turn after connecting routed correctly with 0 cold-snapshot fallbacks, which exercises snapshot refresh across a device change.
- 0 occurrences of `PTT input routing not resolved yet` across every real turn.

Not verified on hardware: the wedged-driver branch itself. This machine's HAL is healthy, so that path is covered by fault injection only. The explicit user-selected-microphone branch was not re-tested on hardware because `overrideDeviceID` is unchanged from `main` and is covered by the existing `ShortcutSettingsTests`.

## Tests

`PTTInputDeviceProbeTests` (new, 9 tests):

- `testMainRunLoopKeepsPumpingWhileTheHALIsWedged` : the issue's acceptance criterion. Injects a HAL that never returns and asserts the main run loop keeps ticking while turn-start reads keep completing.
- `testConcurrentRefreshesCoalesceIntoASingleHALRead` : 25 turn starts against a wedged driver park exactly one probe thread.
- Policy preservation: explicit user choice, Bluetooth built-in fallback, system default when output is not Bluetooth, unplugged selected device, and that the expensive built-in enumeration is skipped when output is not Bluetooth.
- Cold and stale snapshots: a cold snapshot reports no override rather than guessing, and a snapshot resolved for a previous microphone is never applied after the user picks a different one.

Both fault tests join their parked probe before returning, so a late HAL answer cannot publish into whichever test runs next.

`DesktopDiagnosticsManagerTests.testFallbackNamedAreasAreNotCollapsedToOther` gains `ptt_input_routing`, which is the guard that the new area survives allowlist bucketing instead of silently collapsing to `other`.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Both are path matches rather than behavior changes. `PushToTalkManager+InputDeviceRouting.swift` and `PushToTalkManager.swift` sit under the `FloatingControlBar/**` glob, and `PushToTalkManager.swift` is named directly in the INV-VOICE-1 globs. The change adds no chat surface and no turn ownership: `VoiceTurnReducer` remains the sole turn owner and the four routing call sites are unchanged.

Failure-Class: none

No class in `.github/failure-classes/` describes an uncancellable external-subsystem call made on the owning actor. The closest sibling in-tree is `AppBuild.channelProbeMainThreadBudget`, a main-thread wait on a network probe, but one prior instance is not a recurring pattern, and opening a class is a separate registry PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

