### PR TITLE
fix(memory): honor authorized canonical list pin

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -370,7 +370,7 @@ def get_memories(
             lambda batch_offset, batch_limit: [
                 m.model_dump(mode='json')
                 for m in memorydb_list_with_locked_preview(
-                    MemoryService(db_client=db).read(uid, limit=batch_limit, offset=batch_offset)
+                    MemoryService(db_client=db).read_pinned(uid, memory_system, batch_limit, batch_offset)
                 )
             ],
             limit=limit,

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -364,7 +364,7 @@ def get_memories(
         filtered = collect_filtered_memories(
             lambda batch_offset, batch_limit: [
                 m.model_dump(mode='json')
-                for m in MemoryService(db_client=db).read(uid, limit=batch_limit, offset=batch_offset)
+                for m in MemoryService(db_client=db).read_pinned(uid, memory_system, batch_limit, batch_offset)
             ],
             limit=limit,
             offset=offset,

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -831,7 +831,7 @@ def execute_tool(
             filtered = collect_filtered_memories(
                 lambda batch_offset, batch_limit: [
                     m.model_dump(mode='json')
-                    for m in MemoryService(db_client=db).read(user_id, limit=batch_limit, offset=batch_offset)
+                    for m in MemoryService(db_client=db).read_pinned(user_id, memory_system, batch_limit, batch_offset)
                 ],
                 limit=limit,
                 offset=offset,

--- a/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
+++ b/backend/tests/unit/test_dev_api_canonical_grant_ordering.py
@@ -346,7 +346,7 @@ def test_get_memories_allowed_grant_canonical_lists():
     from datetime import datetime, timezone
 
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    # MemoryService.read() returns List[MemoryDB]; the router calls .dict() on each
+    # MemoryService.read_pinned() returns List[MemoryDB]; the router serializes each.
     from models.memories import MemoryDB
 
     canonical_memory = MemoryDB(
@@ -366,13 +366,94 @@ def test_get_memories_allowed_grant_canonical_lists():
 
     # MemoryService is a real class; mock its read method via patching the class
     with __import__('unittest.mock', fromlist=['patch']).patch.object(
-        developer_module.MemoryService, 'read', return_value=[canonical_memory]
+        developer_module.MemoryService, 'read_pinned', return_value=[canonical_memory]
     ):
         resp = client.get('/v1/dev/user/memories')
 
     assert resp.status_code == 200
     assert len(resp.json()) == 1
     assert resp.json()[0]['id'] == 'canon-1'
+
+
+def test_get_memories_uses_authorized_canonical_pin_for_new_schema_rows():
+    """The route must not re-resolve a canonical pin into a stale legacy read."""
+    from datetime import datetime, timezone
+
+    from models.memories import Evidence, MemoryDB, SubjectAttribution
+
+    old_at = datetime(2026, 5, 29, 2, 34, 56, tzinfo=timezone.utc)
+    new_at = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    old_schema_memory = MemoryDB(
+        id='canonical-old-schema',
+        uid='uid1',
+        content='old schema canonical memory',
+        category=_VALID_CATEGORY,
+        visibility='private',
+        tags=[],
+        created_at=old_at,
+        updated_at=old_at,
+        manually_added=False,
+    )
+    new_schema_memory = MemoryDB(
+        id='canonical-new-schema',
+        uid='uid1',
+        content='new schema canonical memory',
+        category=_VALID_CATEGORY,
+        visibility='private',
+        tags=[],
+        created_at=new_at,
+        updated_at=new_at,
+        manually_added=False,
+        predicate='prefers',
+        arguments={'thing': 'tea'},
+        subject_entity_id='user',
+        subject_attribution=SubjectAttribution.user,
+        evidence=[
+            Evidence(
+                evidence_id='evidence-new',
+                source_id='conversation-new',
+                source_type='conversation',
+                source_signal='transcription',
+                extractor_id='memory_extractor',
+                extractor_version='v2',
+                artifact_ref={},
+                capture_confidence=0.9,
+                independence_group='conversation-new',
+                redaction_status='none',
+                created_at=new_at,
+            )
+        ],
+        capture_confidence=0.9,
+        veracity=0.8,
+        uncertainty_reasons=['single_source'],
+    )
+    client = _build(deny_grant=False, canonical=True)
+
+    from utils.memory import memory_service as memory_service_module
+
+    with (
+        patch.object(
+            memory_service_module,
+            'canonical_read_enabled',
+            return_value=False,
+        ),
+        patch.object(
+            memory_service_module.LegacyMemoryBackend,
+            'read',
+            return_value=[old_schema_memory],
+        ) as legacy_read,
+        patch.object(
+            memory_service_module.CanonicalMemoryBackend,
+            'read',
+            return_value=[new_schema_memory, old_schema_memory],
+        ) as canonical_read,
+    ):
+        resp = client.get('/v1/dev/user/memories?limit=25')
+
+    assert resp.status_code == 200
+    assert [memory['id'] for memory in resp.json()] == ['canonical-new-schema', 'canonical-old-schema']
+    legacy_read.assert_not_called()
+    canonical_read.assert_called_once()
 
 
 def _denied_memory_result(fallback_reason):
@@ -456,15 +537,16 @@ def test_search_memories_vector_missing_rollout_state_falls_back_to_legacy():
 
     # search_memories_by_vector ranks a, then b; hydration returns them in the opposite
     # order — the response must follow the vector rank, not the hydration order.
-    with patch.object(
-        developer_module, 'search_memories_by_vector', return_value=['legacy-a', 'legacy-b']
-    ), patch.object(
-        developer_module.memories_db,
-        'get_memories_by_ids',
-        return_value=[
-            {'id': 'legacy-b', 'content': 'second', 'category': _VALID_CATEGORY},
-            {'id': 'legacy-a', 'content': 'first', 'category': _VALID_CATEGORY},
-        ],
+    with (
+        patch.object(developer_module, 'search_memories_by_vector', return_value=['legacy-a', 'legacy-b']),
+        patch.object(
+            developer_module.memories_db,
+            'get_memories_by_ids',
+            return_value=[
+                {'id': 'legacy-b', 'content': 'second', 'category': _VALID_CATEGORY},
+                {'id': 'legacy-a', 'content': 'first', 'category': _VALID_CATEGORY},
+            ],
+        ),
     ):
         resp = client.get('/v1/dev/user/memories/vector/search', params={'query': 'memory'})
 
@@ -479,10 +561,13 @@ def test_search_memories_vector_use_legacy_safe_falls_back_to_legacy():
     """The explicit USE_LEGACY_SAFE decision serves legacy too (was 403 before #10203)."""
     client = _build()  # default vector mock resolves to USE_LEGACY_SAFE
 
-    with patch.object(developer_module, 'search_memories_by_vector', return_value=['m1']), patch.object(
-        developer_module.memories_db,
-        'get_memories_by_ids',
-        return_value=[{'id': 'm1', 'content': 'hi', 'category': _VALID_CATEGORY}],
+    with (
+        patch.object(developer_module, 'search_memories_by_vector', return_value=['m1']),
+        patch.object(
+            developer_module.memories_db,
+            'get_memories_by_ids',
+            return_value=[{'id': 'm1', 'content': 'hi', 'category': _VALID_CATEGORY}],
+        ),
     ):
         resp = client.get('/v1/dev/user/memories/vector/search', params={'query': 'memory'})
 

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -181,7 +181,7 @@ def test_memory_list_has_one_auth_dependency_and_uses_its_authorized_uid():
     auth_context = SimpleNamespace(uid="auth-user")
     authorization = SimpleNamespace(allowed=True)
     memory_service = MagicMock()
-    memory_service.read.return_value = []
+    memory_service.read_pinned.return_value = []
     with (
         patch.object(rest, "authorize_memory_external_default_memory_read", return_value=authorization) as authorize,
         patch.object(rest, "pin_memory_system", return_value=rest.MemorySystem.CANONICAL) as pin,
@@ -191,7 +191,12 @@ def test_memory_list_has_one_auth_dependency_and_uses_its_authorized_uid():
 
     pin.assert_called_once_with("auth-user", db_client=rest.db)
     authorize.assert_called_once_with(auth_context, db_client=rest.db)
-    memory_service.read.assert_called_once_with("auth-user", limit=100, offset=0)
+    memory_service.read_pinned.assert_called_once_with(
+        "auth-user",
+        rest.MemorySystem.CANONICAL,
+        100,
+        0,
+    )
 
 
 async def _run_blocking_inline(_executor, func, *args, **kwargs):

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -482,6 +482,37 @@ class MemoryService:
             now=now,
         )
 
+    def read_pinned(
+        self,
+        uid: str,
+        memory_system: MemorySystem,
+        limit: int = 100,
+        offset: int = 0,
+        *,
+        device_scope_request: Optional[DeviceScopeRequest] = None,
+        include_pending_processing: bool = False,
+        now: Optional[datetime] = None,
+    ) -> List[MemoryDB]:
+        """Read from the backend already selected and authorized by a request route.
+
+        External list routes resolve their request-scoped memory-system pin only
+        after checking the caller's default-read grant. Re-running the rollout
+        control reader inside ``read`` can disagree with that pin and silently
+        serve the legacy store for a canonical account. This seam keeps the
+        route's authorized selection authoritative without weakening grants or
+        exposing canonical provenance fields.
+        """
+
+        backend = self._canonical if memory_system == MemorySystem.CANONICAL else self._legacy
+        return backend.read(
+            uid,
+            limit=limit,
+            offset=offset,
+            device_scope_request=device_scope_request,
+            include_pending_processing=include_pending_processing,
+            now=now,
+        )
+
     def search(
         self,
         uid: str,


### PR DESCRIPTION
## Problem

`GET /v1/dev/user/memories` authorized and pinned canonical accounts correctly, but its `MemoryService.read()` call independently reran the stricter rollout/control read decision. When those decisions diverged, the canonical route silently read the legacy collection and returned HTTP 200 with a stale pre-cutover prefix. The MCP list routes had the same double-routing boundary.

## Fix

- Add a narrow `MemoryService.read_pinned()` seam that reads the backend already selected by an authorized external list route.
- Use that seam for Developer API, MCP REST, and MCP SSE canonical list reads.
- Preserve the existing default-read grant ordering, canonical visibility filtering, public response projection, and legacy behavior for legacy-pinned accounts.
- Add a behavioral Developer API regression with old- and new-schema canonical rows, including predicate, subject attribution, evidence, veracity, and uncertainty fields. It proves the current row remains visible while raw provenance fields stay outside the Developer response.

PR #10646 changes legacy search and mutation/vector boundaries in `memory_service.py`; this PR does not overlap those hunks or duplicate its behavior.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

This is an isolated double-routing defect rather than an instance of a registered semantic failure class. The prevention artifact is the Developer route regression at `backend/tests/unit/test_dev_api_canonical_grant_ordering.py::test_get_memories_uses_authorized_canonical_pin_for_new_schema_rows`, backed by the explicit pinned-read service seam.

## Verification

- Prove-fail: with the Developer route restored to `MemoryService.read()`, the new regression returned only `canonical-old-schema` and failed because `canonical-new-schema` was absent.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_dev_api_canonical_grant_ordering.py backend/tests/unit/test_dev_api_memories_pagination.py backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_ws_l_surface_routing.py backend/tests/unit/test_memory_service_parity.py` — 82 passed.
- Diff-selected `backend/test.sh` lane — all 38 selected unit-test files passed.
- Pyright on the four changed production modules with the pinned Python 3.11 environment — 0 errors, 0 warnings.
- Black 24.4.2 check on all six changed Python files — clean.
- `make preflight` — passed after the final commit.

Closes SCA-185


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

