### PR TITLE
fix(backend): accept the non-JSON discard replies conv_discard returns

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -309,6 +309,9 @@ action_item_tools = _load_module_from_file(
 create_action_item_tool = action_item_tools.create_action_item_tool
 update_action_item_tool = action_item_tools.update_action_item_tool
 
+# discard_parser only needs pydantic and langchain_core, so load the real module.
+_load_module_from_file("utils.llm.discard_parser", BACKEND_DIR / "utils" / "llm" / "discard_parser.py")
+
 conversation_processing = _load_module_from_file(
     "utils.llm.conversation_processing",
     BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",

--- a/backend/tests/unit/test_conversation_discard_parsing.py
+++ b/backend/tests/unit/test_conversation_discard_parsing.py
@@ -1,0 +1,56 @@
+"""conv_discard must survive the non-JSON replies gpt-5-nano actually returns.
+
+Prod logs showed 450+ `Error determining memory discard: Invalid json output`
+per day, split between `{"discard": True}` (Python booleans) and the bare
+`discard = True` line the prompt asks for. Both raised, the caller failed open
+to False, and every conversation the model wanted to discard was kept.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.exceptions import OutputParserException
+
+from utils.llm import conversation_processing
+from utils.llm.discard_parser import DiscardConversation, LenientDiscardParser
+
+
+def _parser() -> LenientDiscardParser:
+    return LenientDiscardParser(pydantic_object=DiscardConversation)
+
+
+@pytest.mark.parametrize(
+    'text, expected',
+    [
+        ('{"discard": true}', True),  # valid JSON still parses
+        ('{"discard": false}', False),
+        ('{"discard": True}', True),  # prod shape: Python booleans
+        ('{"discard": False}', False),
+        ('discard = True', True),  # prod shape: the one-line format the prompt asks for
+        ('discard = False', False),
+        ('```json\n{"discard": True}\n```', True),
+    ],
+)
+def test_parser_accepts_shapes_seen_in_prod(text, expected):
+    assert _parser().parse(text).discard is expected
+
+
+def test_parser_still_raises_on_a_reply_with_no_decision():
+    with pytest.raises(OutputParserException):
+        _parser().parse('I am not sure about this conversation.')
+
+
+def test_should_discard_conversation_honors_python_boolean_reply(monkeypatch):
+    fake_llm = FakeMessagesListChatModel(responses=[AIMessage(content='{"discard": True}')])
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: fake_llm)
+
+    assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is True
+
+
+def test_should_discard_conversation_fails_open_when_reply_is_unusable(monkeypatch):
+    fake_llm = FakeMessagesListChatModel(responses=[AIMessage(content='no idea')])
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda feature, **kwargs: fake_llm)
+
+    assert conversation_processing.should_discard_conversation('hello there', duration_seconds=15) is False

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -131,6 +131,9 @@ _conversation_processing_stub = sys.modules.get("utils.llm.conversation_processi
 if _conversation_processing_stub is not None and not hasattr(_conversation_processing_stub, "_local_started_at_iso"):
     sys.modules.pop("utils.llm.conversation_processing", None)
 
+# discard_parser only needs pydantic and langchain_core, so load the real module.
+_load_module_from_file("utils.llm.discard_parser", BACKEND_DIR / "utils" / "llm" / "discard_parser.py")
+
 conv_proc = _load_module_from_file(
     "utils.llm.conversation_processing",
     BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -21,6 +21,7 @@ from models.conversation_photo import ConversationPhoto
 from models.structured import ActionItem, Event, Structured
 from models.structured_extraction import ActionItemsExtraction, StructuredExtraction
 from .clients import get_llm, get_llm_gateway_chat_structured, parser
+from .discard_parser import DiscardConversation, LenientDiscardParser
 from utils.byok import has_byok_keys
 from utils.llm.gateway_client import record_chat_extraction_gateway_result
 from utils.llm.gateway_observability import record_gateway_shadow_comparison
@@ -83,10 +84,6 @@ def _has_gpt56_cacheable_static_prefix(content: str) -> bool:
 # =============================================
 # The implementation moved to conversation_folder.py; that route still uses
 # get_llm('conv_folder') as the production model/provider plug-in seam.
-
-
-class DiscardConversation(BaseModel):
-    discard: bool = Field(description="If the conversation should be discarded or not")
 
 
 class SpeakerIdMatch(BaseModel):
@@ -595,7 +592,7 @@ Content:
 {format_instructions}'''.replace(
         '    ', ''
     ).strip()
-    custom_parser = PydanticOutputParser(pydantic_object=DiscardConversation)
+    custom_parser = LenientDiscardParser(pydantic_object=DiscardConversation)
     prompt_values = {
         'full_context': full_context,
         'duration_context': duration_context,

--- a/backend/utils/llm/discard_parser.py
+++ b/backend/utils/llm/discard_parser.py
@@ -1,0 +1,47 @@
+"""Parsing seam for the conv_discard decision.
+
+The model is asked for JSON but regularly answers with Python booleans
+(`{"discard": True}`) or the bare `discard = True` line the prompt also asks
+for. Both are invalid JSON, so the strict parser raised and the caller's
+fail-open kept every conversation the model wanted discarded.
+"""
+
+import re
+from typing import Any, List, Optional
+
+from langchain_core.output_parsers import PydanticOutputParser
+from pydantic import BaseModel, Field
+
+
+class DiscardConversation(BaseModel):
+    discard: bool = Field(description="If the conversation should be discarded or not")
+
+
+# Matches the decision in `{"discard": True}` and in the bare `discard = True`
+# line the prompt asks for — neither is valid JSON.
+_DISCARD_DECISION_PATTERN = re.compile(r'discard\W{0,4}(true|false)\b', re.IGNORECASE)
+
+
+def parse_discard_decision(text: str) -> Optional[bool]:
+    """Read the discard decision out of a non-JSON reply, or None if there is none."""
+    matches = _DISCARD_DECISION_PATTERN.findall(text)
+    if not matches:
+        return None
+    return matches[-1].lower() == 'true'
+
+
+class LenientDiscardParser(PydanticOutputParser):
+    """PydanticOutputParser that also accepts the shapes conv_discard actually returns.
+
+    A reply carrying no decision at all still raises, so the caller's fail-open
+    branch keeps covering genuine garbage.
+    """
+
+    def parse_result(self, result: List[Any], *, partial: bool = False) -> Any:
+        try:
+            return super().parse_result(result, partial=partial)
+        except Exception:
+            decision = parse_discard_decision(result[0].text if result else '')
+            if decision is None:
+                raise
+            return DiscardConversation(discard=decision)


### PR DESCRIPTION
## Bug

`should_discard_conversation` asks the `conv_discard` model whether a short conversation is worth saving and parses the reply with `PydanticOutputParser`. Prod (pusher, conversation processing) logs **453 `Error determining memory discard: Invalid json output` in 24h**, in two shapes:

- `{"discard": True}` — Python booleans, not JSON (254)
- `discard = False` / `discard = True` — the exact one-line format the prompt asks for (192)

Every rejection hits the `except` branch, which fails open with `return False`. **260 of those replies said `True`**, so conversations the model asked to discard were saved anyway.

## Root cause

The prompt asks for `discard = <True|False>` *and* appends the Pydantic JSON format instructions, so the model's two most common answers are both outside the parser's grammar; the fail-open default then inverts the decision instead of dropping it.

## Fix

`LenientDiscardParser` overrides `parse_result`: JSON first (unchanged), and on failure it reads the decision out of the reply. A reply with no decision at all still raises, so the fail-open path still covers genuine garbage. 34 lines of source + a regression test; no prompt or model change.

## What I tested

- `backend/tests/unit/test_conversation_discard_parsing.py` — drives the **production chain** (`prompt | llm | parser`) with a fake chat model returning the literal strings from the prod logs. The end-to-end case fails on `main` with the exact prod log line `Invalid json output: {"discard": True}` and passes here.
- `tests/unit/test_conversation_discard_parsing.py tests/unit/test_llm_gateway_chat_extraction_pilot.py tests/unit/test_process_conversation_usage_context.py tests/unit/test_kg_user_type_mismatch.py` → **67 passed**.
- Live run against the real OpenAI `conv_discard` route (gpt-4.1-nano and gpt-5-nano @ reasoning_effort=minimal): `'hello there' -> True`, `'okay yeah sure sorry' -> True`, `'remind me to call John before 5pm about the lease' -> False`. 10/10 sampled live replies were valid JSON, confirming the bad shapes are the intermittent tail the prod logs record.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

