### PR TITLE
fix(backend): size the opus decode buffer to the format's max frame

### DIFF
--- a/.github/failure-classes/FC-negotiated-hint-as-hard-limit.json
+++ b/.github/failure-classes/FC-negotiated-hint-as-hard-limit.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-negotiated-hint-as-hard-limit",
+  "violated_contract": "A client-supplied format hint may size a buffer but must never be enforced as a hard limit on a self-describing wire format; the decoder's bound must come from the format's own maximum, so a client whose hint understates its data loses no frames.",
+  "canonical_prevention": "Size decode buffers from the codec's maximum legal unit (opus_decode_capacity() = 120 ms of samples) rather than from the negotiated codec/frame parameter, and cover the mismatch with a regression test that drives the real receive path with an oversized unit.",
+  "evidence_prs": [10701],
+  "scope_hints": ["backend/routers/listen/**", "backend/utils/transcribe_decisions.py"],
+  "status": "open"
+}

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -73,6 +73,21 @@ logger = logging.getLogger(__name__)
 # to terminate a zombie "Listening" session promptly, far below ws_receive_timeout.
 STT_DEATH_POLL_INTERVAL_SECONDS = 1.0
 
+# Longest frame the Opus format can carry, in milliseconds.
+OPUS_MAX_FRAME_MS = 120
+
+
+def opus_decode_capacity(sample_rate: int) -> int:
+    """Samples to hand `Decoder.decode` as its output-buffer size.
+
+    Opus packets are self-describing: `frame_size` is only the capacity of the buffer the
+    decoder writes into, and it never emits more samples than the packet actually holds, so
+    a 10 ms frame still decodes to 10 ms under a larger buffer. Sizing it to the negotiated
+    frame duration instead made libopus answer `buffer too small` for every longer frame a
+    client sent, and the receiver dropped the whole session's audio one frame at a time.
+    """
+    return sample_rate // 1000 * OPUS_MAX_FRAME_MS
+
 
 def _get_opuslib() -> Any:
     if opuslib is None:
@@ -362,7 +377,9 @@ class ListenReceiver:
         audio = data[1:]
         if request.codec == 'opus' and self.multi_opus_decoders[channel_index]:
             try:
-                audio = self.multi_opus_decoders[channel_index].decode(bytes(audio), request.sample_rate // 50)
+                audio = self.multi_opus_decoders[channel_index].decode(
+                    bytes(audio), opus_decode_capacity(request.sample_rate)
+                )
             except Exception as error:
                 logger.warning(
                     'Listen audio frame decode failed codec=opus channel=%s type=%s',
@@ -502,7 +519,9 @@ class ListenReceiver:
                     try:
                         decoded: bytes = data
                         if request.codec == 'opus':
-                            decoded = self.opus_decoder.decode(bytes(data), frame_size=self.host.frame_size)
+                            decoded = self.opus_decoder.decode(
+                                bytes(data), frame_size=opus_decode_capacity(request.sample_rate)
+                            )
                         elif request.codec == 'aac':
                             decoded = self.aac_decoder.decode(bytes(data))
                         elif request.codec == 'lc3':

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -116,7 +116,6 @@ class ListenSessionRuntime:
         self.private_cloud_sync_enabled = False
         self.has_speech_profile = False
         self.conversation_creation_timeout = request.conversation_timeout
-        self.frame_size = 160
         self.lc3_frame_duration_us: Optional[int] = None
         self.task_supervisor = WebSocketTaskSupervisor(
             uid=request.uid, label='listen', gauge=BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS
@@ -283,7 +282,6 @@ class ListenSessionRuntime:
         )
         decision = normalize_codec_frame(request.codec)
         self.request = replace(request, codec=decision.codec)
-        self.frame_size = decision.frame_size
         self.lc3_frame_duration_us = decision.lc3_frame_duration_us
         self._build_components()
         if not self.user_has_credits:

--- a/backend/tests/unit/test_listen_receiver_frame_recovery.py
+++ b/backend/tests/unit/test_listen_receiver_frame_recovery.py
@@ -67,7 +67,6 @@ async def test_receiver_drops_malformed_codec_frame_and_continues_to_custom_tran
         ),
         limits=SimpleNamespace(ws_receive_timeout=1.0),
         is_multi_channel=False,
-        frame_size=320,
         use_custom_stt=True,
         audio_bytes_send=None,
         transcripts=SimpleNamespace(enqueue=received_segments.extend),

--- a/backend/tests/unit/test_listen_receiver_opus_frame_capacity.py
+++ b/backend/tests/unit/test_listen_receiver_opus_frame_capacity.py
@@ -1,0 +1,153 @@
+"""Opus frames longer than the negotiated duration must still decode.
+
+`Decoder.decode(data, frame_size)` treats `frame_size` as the capacity of the output
+buffer, not as a declaration of the packet's frame length; libopus answers
+OPUS_BUFFER_TOO_SMALL when a packet holds more samples than fit. Passing the negotiated
+duration therefore dropped every frame of any session whose client sent longer frames
+than its `codec` query parameter implied — prod logged a sustained
+`Listen audio frame decode failed codec=opus type=OpusError` storm with no audio ever
+reaching STT, the ring buffer, or the audio-bytes consumers.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from routers.listen.receiver import ListenReceiver, opus_decode_capacity
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+class _BufferTooSmall(Exception):
+    """Stands in for opuslib.OpusError(b'buffer too small')."""
+
+
+class _ContractOpusDecoder:
+    """Mirrors libopus' decode contract for a fixed frame length.
+
+    Real `opuslib.Decoder.decode` writes at most `samples_per_frame` samples and raises
+    when the caller's buffer cannot hold them, so the buffer size only ever needs to be
+    large enough — a 10 ms packet under a 120 ms buffer still yields 10 ms of PCM.
+    """
+
+    def __init__(self, samples_per_frame: int):
+        self.samples_per_frame = samples_per_frame
+        self.rejected = 0
+
+    def decode(self, data: bytes, frame_size: int) -> bytes:
+        if frame_size < self.samples_per_frame:
+            self.rejected += 1
+            raise _BufferTooSmall('buffer too small')
+        return b'\x01\x02' * self.samples_per_frame
+
+
+class _FramesWebSocket:
+    def __init__(self, frames):
+        self.frames = iter(frames)
+
+    async def receive(self):
+        return next(self.frames)
+
+
+class _RingBuffer:
+    def __init__(self):
+        self.written = bytearray()
+
+    def write(self, pcm: bytes, _timestamp: float) -> None:
+        self.written.extend(pcm)
+
+
+def _host(websocket, sample_rate: int, ring_buffer, audio_bytes):
+    return SimpleNamespace(
+        request=SimpleNamespace(websocket=websocket, codec='opus', sample_rate=sample_rate),
+        state=SimpleNamespace(
+            active=True,
+            close_code=1001,
+            last_audio_received_time=None,
+            last_activity_time=None,
+            first_audio_byte_timestamp=None,
+            last_usage_record_timestamp=None,
+            audio_ring_buffer=ring_buffer,
+        ),
+        limits=SimpleNamespace(ws_receive_timeout=1.0),
+        is_multi_channel=False,
+        use_custom_stt=True,
+        audio_bytes_send=lambda pcm, _now: audio_bytes.extend(pcm),
+        transcripts=SimpleNamespace(enqueue=lambda _segments: None),
+        start_live_transcription=lambda: None,
+    )
+
+
+def test_opus_decode_capacity_covers_the_longest_opus_frame():
+    # 120 ms is the longest frame Opus can carry, so no legal packet can overflow it.
+    assert opus_decode_capacity(16000) == 1920
+    assert opus_decode_capacity(48000) == 5760
+    assert opus_decode_capacity(8000) == 960
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('frame_ms', [20, 40, 60])
+async def test_receiver_decodes_frames_longer_than_the_negotiated_duration(frame_ms):
+    sample_rate = 16000
+    samples_per_frame = sample_rate // 1000 * frame_ms
+    ring_buffer = _RingBuffer()
+    audio_bytes = bytearray()
+    websocket = _FramesWebSocket(
+        [
+            {'bytes': b'opus-frame-1'},
+            {'bytes': b'opus-frame-2'},
+            {'type': 'websocket.disconnect', 'code': 1000},
+        ]
+    )
+    decoder = _ContractOpusDecoder(samples_per_frame)
+    receiver = ListenReceiver(_host(websocket, sample_rate, ring_buffer, audio_bytes), [], {})
+    receiver.opus_decoder = decoder
+
+    await receiver.receive_data()
+
+    assert decoder.rejected == 0
+    assert len(ring_buffer.written) == 2 * samples_per_frame * 2
+    assert len(audio_bytes) == 2 * samples_per_frame * 2
+
+
+@pytest.mark.anyio
+async def test_receiver_still_decodes_the_negotiated_ten_millisecond_frame():
+    sample_rate = 16000
+    ring_buffer = _RingBuffer()
+    audio_bytes = bytearray()
+    websocket = _FramesWebSocket(
+        [
+            {'bytes': b'opus-frame-1'},
+            {'type': 'websocket.disconnect', 'code': 1000},
+        ]
+    )
+    receiver = ListenReceiver(_host(websocket, sample_rate, ring_buffer, audio_bytes), [], {})
+    receiver.opus_decoder = _ContractOpusDecoder(160)
+
+    await receiver.receive_data()
+
+    # A larger buffer never inflates the output: the packet's own frame length decides it.
+    assert len(ring_buffer.written) == 160 * 2
+    assert len(audio_bytes) == 160 * 2
+
+
+@pytest.mark.anyio
+async def test_multi_channel_receiver_decodes_frames_longer_than_twenty_milliseconds():
+    sample_rate = 16000
+    samples_per_frame = sample_rate // 1000 * 60
+    host = SimpleNamespace(
+        request=SimpleNamespace(codec='opus', sample_rate=sample_rate),
+        state=SimpleNamespace(fair_use_dg_budget_exhausted=False, fair_use_track_dg_usage=False),
+        use_custom_stt=True,
+        audio_bytes_send=None,
+    )
+    receiver = ListenReceiver(host, [SimpleNamespace()], {1: 0})
+    decoder = _ContractOpusDecoder(samples_per_frame)
+    receiver.multi_opus_decoders[0] = decoder
+
+    await receiver._handle_multi_channel_audio(b'\x01opus-frame-1')
+
+    assert decoder.rejected == 0

--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -49,19 +49,16 @@ def test_startup_decisions_pin_current_overrides():
 def test_codec_frame_normalization_pins_special_codecs():
     opus = normalize_codec_frame('opus_fs320')
     assert opus.codec == 'opus'
-    assert opus.frame_size == 320
     assert opus.lc3_chunk_size is None
     assert opus.lc3_frame_duration_us is None
 
     lc3 = normalize_codec_frame('lc3_fs1030')
     assert lc3.codec == 'lc3'
-    assert lc3.frame_size == 160
     assert lc3.lc3_chunk_size == 30
     assert lc3.lc3_frame_duration_us == 10000
 
     pcm = normalize_codec_frame('pcm8')
     assert pcm.codec == 'pcm8'
-    assert pcm.frame_size == 160
 
 
 def test_translation_language_gating():

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -39,7 +39,6 @@ class RecordingSessionReconnectAction(str, Enum):
 @dataclass(frozen=True)
 class CodecFrameDecision:
     codec: str
-    frame_size: int
     lc3_chunk_size: Optional[int]
     lc3_frame_duration_us: Optional[int]
 
@@ -73,15 +72,20 @@ def should_include_speech_profile(include_speech_profile: bool, is_multi_channel
 
 
 def normalize_codec_frame(codec: str) -> CodecFrameDecision:
-    frame_size = 160
+    """Map a client codec parameter onto the decoder to build.
+
+    The `_fsNNN` suffixes name the frame duration the client encodes with. Opus packets are
+    self-describing, so its variants collapse to the same decoder; only LC3 needs the frame
+    duration handed to it up front.
+    """
     lc3_chunk_size = None
     lc3_frame_duration_us = None
 
     if codec == 'opus_fs320':
-        return CodecFrameDecision('opus', 320, lc3_chunk_size, lc3_frame_duration_us)
+        return CodecFrameDecision('opus', lc3_chunk_size, lc3_frame_duration_us)
     if codec == 'lc3_fs1030':
-        return CodecFrameDecision('lc3', frame_size, 30, 10000)
-    return CodecFrameDecision(codec, frame_size, lc3_chunk_size, lc3_frame_duration_us)
+        return CodecFrameDecision('lc3', 30, 10000)
+    return CodecFrameDecision(codec, lc3_chunk_size, lc3_frame_duration_us)
 
 
 OPUS_SUPPORTED_SAMPLE_RATES = frozenset({8000, 12000, 16000, 24000, 48000})


### PR DESCRIPTION
## Bug

`backend-listen` is dropping live audio right now. Between `2026-07-27T04:44Z` and this PR the
prod listen workers went from **zero** `Listen audio frame decode failed codec=opus type=OpusError`
warnings to **~600–900/min** spread across pods (`prod-omi-backend-listen-74b88657b-*`, sampled
668/751/514/866 per minute). Every sampled line is `codec=opus`. There was no deploy behind it —
the same pod-template-hash has been serving all day — so a client simply started sending opus
frames longer than the duration its `codec` query parameter implies.

For a session in that state the loss is total and silent: the receiver logs the warning and
`continue`s, so **nothing** reaches the STT socket, the speaker-id ring buffer, or the
realtime-audio-bytes consumers for the entire session. The user sees a live session that never
transcribes.

## Root cause

`opuslib.Decoder.decode(data, frame_size)` — `frame_size` is the **capacity of the output buffer**,
not a declaration of the packet's frame length. libopus returns `OPUS_BUFFER_TOO_SMALL` when a
packet holds more samples than fit, and never writes more samples than the packet actually carries.

Both live decode sites passed the *negotiated* duration instead:

- `receiver.py` single-channel: `frame_size=self.host.frame_size` → 160 samples (10 ms) for bare
  `opus`, 320 for `opus_fs320`.
- `receiver.py` multi-channel: `request.sample_rate // 50` → 20 ms.

So a client that declared `codec=opus` and encoded 20 ms (or 40/60 ms) frames had **100 %** of its
frames rejected. Measured directly against libopus:

| packet | `frame_size=160` | `frame_size=320` | `frame_size=1920` |
|---|---|---|---|
| 10 ms | ok, 320 B | ok, 320 B | ok, 320 B |
| 20 ms | `buffer too small` | ok, 640 B | ok, 640 B |
| 40 ms | `buffer too small` | `buffer too small` | ok, 1280 B |
| 60 ms | `buffer too small` | `buffer too small` | ok, 1920 B |

Note the first row: an oversized buffer never inflates the output — the packet's own frame length
decides it. There is no downside to sizing for the maximum.

## Fix

Size both decode buffers to the longest frame Opus can carry (120 ms, `opus_decode_capacity()`).
No legal packet can overflow it, and the frames that already worked decode byte-identically.

That leaves the negotiated `frame_size` with no remaining reader, so the field and its plumbing
(`ListenHost.frame_size`, `CodecFrameDecision.frame_size`) are removed rather than left as dead
state. Opus frame duration is carried by the packets themselves; only LC3 still needs it declared
up front, and that path is untouched.

Out of scope, same class, not touched: the offline-sync decoder (`utils/sync/files.py`) takes its
`frame_size` from the `_fsNNN` filename the device wrote, so it is self-consistent, and changing it
would rewrite `test_sync_opus_decode.py`'s decoder contract.

## What I tested

- **New regression test** `backend/tests/unit/test_listen_receiver_opus_frame_capacity.py` drives
  the production `ListenReceiver.receive_data` and `_handle_multi_channel_audio` through a decoder
  that reproduces libopus' buffer-too-small contract. 4 of its 6 cases fail on the unfixed source,
  each logging the exact prod line (`Listen audio frame decode failed codec=opus type=…`), and all
  pass with the fix. One case pins that a 10 ms frame under the larger buffer still yields exactly
  10 ms of PCM.
- **Real libopus, real receive path.** Encoded 50 genuine 20 ms opus packets (1.00 s) with
  `opuslib.Encoder` and fed them through `ListenReceiver.receive_data` with a real
  `opuslib.Decoder(16000, 1)`:
  - before — `ring_buffer_bytes=0 audio_bytes_consumer=0`, 50 x `decode failed ... OpusError`
  - after — `ring_buffer_bytes=32000 audio_bytes_consumer=32000` (1.00 s recovered)
- `506 passed, 11 skipped` across every listen / audio / codec / transcribe unit test file.
- `make preflight` (local check manifest).

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

