### PR TITLE
fix(desktop): reject attestation descriptors in lineage gate (SCA-193, SCA-191)

### DIFF
--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -183,6 +183,38 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
                         manifest=manifest,
                     )
 
+    def test_rejects_attestation_descriptor_claiming_runtime_platform(self) -> None:
+        manifest = _buildx_index()
+        runtime_descriptor = manifest["manifests"][0]
+        runtime_descriptor["annotations"] = {"vnd.docker.reference.type": "attestation-manifest"}
+        with self.assertRaisesRegex(LINEAGE.LineageError, "attestation"):
+            LINEAGE.verify_lineage(
+                build_image_reference=f"{REPOSITORY}@{INDEX_DIGEST}",
+                runtime_image_reference=f"{REPOSITORY}@{RUNTIME_DIGEST}",
+                manifest=manifest,
+            )
+
+    def test_rejects_annotations_with_non_string_values(self) -> None:
+        manifest = _buildx_index()
+        runtime_descriptor = manifest["manifests"][0]
+        runtime_descriptor["annotations"] = {"vnd.docker.reference.type": 7}
+        with self.assertRaisesRegex(LINEAGE.LineageError, "string-to-string"):
+            LINEAGE.verify_lineage(
+                build_image_reference=f"{REPOSITORY}@{INDEX_DIGEST}",
+                runtime_image_reference=f"{REPOSITORY}@{RUNTIME_DIGEST}",
+                manifest=manifest,
+            )
+
+    def test_rejects_non_v2_manifest_schema(self) -> None:
+        manifest = _buildx_index()
+        manifest["schemaVersion"] = 1
+        with self.assertRaisesRegex(LINEAGE.LineageError, "schema version 2"):
+            LINEAGE.verify_lineage(
+                build_image_reference=f"{REPOSITORY}@{INDEX_DIGEST}",
+                runtime_image_reference=f"{REPOSITORY}@{RUNTIME_DIGEST}",
+                manifest=manifest,
+            )
+
     def test_rejects_candidate_evidence_bound_to_index_instead_of_runtime_child(self) -> None:
         mutated = self.dev.replace(
             '--expected-image-digest="${{ steps.verify-image-lineage.outputs.runtime_digest }}"',

--- a/.github/scripts/verify_desktop_backend_image_lineage.py
+++ b/.github/scripts/verify_desktop_backend_image_lineage.py
@@ -22,6 +22,7 @@ IMAGE_MEDIA_TYPES = {
 }
 RUNTIME_OS = "linux"
 RUNTIME_ARCHITECTURE = "amd64"
+ATTESTATION_REFERENCE_TYPE = "attestation-manifest"
 
 
 class LineageError(ValueError):
@@ -51,6 +52,8 @@ def verify_lineage(
         raise LineageError(
             f"runtime repository {runtime_repository!r} does not match build repository {build_repository!r}"
         )
+    if manifest.get("schemaVersion") != 2:
+        raise LineageError("build image manifest must use OCI/Docker schema version 2")
 
     media_type = manifest.get("mediaType")
     if media_type in INDEX_MEDIA_TYPES:
@@ -71,6 +74,15 @@ def verify_lineage(
                 f"(found {len(runtime_descriptors)})"
             )
         runtime_descriptor = runtime_descriptors[0]
+        annotations = runtime_descriptor.get("annotations")
+        if annotations is not None and not isinstance(annotations, dict):
+            raise LineageError("linux/amd64 runtime descriptor has malformed annotations")
+        if annotations is not None and any(
+            not isinstance(key, str) or not isinstance(value, str) for key, value in annotations.items()
+        ):
+            raise LineageError("linux/amd64 runtime descriptor annotations must be a string-to-string map")
+        if annotations and annotations.get("vnd.docker.reference.type") == ATTESTATION_REFERENCE_TYPE:
+            raise LineageError("linux/amd64 runtime descriptor is an attestation, not a runnable image")
         expected_runtime_digest = runtime_descriptor.get("digest")
         descriptor_media_type = runtime_descriptor.get("mediaType")
         if not isinstance(expected_runtime_digest, str) or not DIGEST_PATTERN.fullmatch(expected_runtime_digest):


### PR DESCRIPTION
## Summary

- reject a selected `linux/amd64` descriptor when it identifies itself as an attestation
- reject descriptor annotations that are not an OCI string-to-string map
- fail closed on non-v2 OCI/Docker manifest data before evaluating image lineage
- cover all cases with release-policy regression fixtures

## Root cause

The lineage verifier initially treated any `linux/amd64` image-manifest descriptor as runnable. It now rejects explicit attestation descriptors, and this exact-head repair closes the remaining fail-open where an invalid non-string annotation value (for example `vnd.docker.reference.type: 7`) was accepted.

## Safety

- immutable index deployment, repository equality, platform selection, and exact child-digest matching remain unchanged
- the gate still runs before the candidate URL, probes, and traffic promotion in both development and production workflows
- no production deployment, approval, traffic mutation, or production workflow was invoked

## Verification

- `python3 .github/scripts/test_check_desktop_backend_release_policy.py` — 14 passed
- `python3 .github/scripts/check-desktop-backend-release-policy.py` — passed
- `python3 -m py_compile .github/scripts/verify_desktop_backend_image_lineage.py` — passed
- `actionlint .github/workflows/desktop_backend_auto_dev.yml .github/workflows/desktop_backend_prod.yml` — passed
- `uvx black --check --line-length 120 --skip-string-normalization .github/scripts/verify_desktop_backend_image_lineage.py .github/scripts/test_check_desktop_backend_release_policy.py` — passed
- `git diff --check` — passed

## Product invariants

None.

Failure-Class: FC-runtime-image-lineage

Closes SCA-193
Related: SCA-191
