### PR TITLE
fix(backend): surface BYOK throttling as 429, not a credential rejection

### DIFF
--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -56,12 +56,17 @@ from llm_gateway.gateway.output_budget import OutputBudgetDecision, completion_s
 from llm_gateway.gateway.providers import ProviderFailure
 from llm_gateway.gateway.request_context import request_id_for
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, resolve_chat_completion_route
-from llm_gateway.gateway.schemas import RouteArtifact
+from llm_gateway.gateway.schemas import FailureClass, RouteArtifact
 from llm_gateway.gateway.sse import SSEEventDecoder
 from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
 
 router = APIRouter()
 _image_generation_client: httpx.AsyncClient | None = None
+
+# The provider throttled the caller's own key. These reach the router as a
+# credential failure, but they are not a bad credential: answering 401 tells
+# callers the key is invalid and makes a transient failure look permanent.
+_THROTTLED_FAILURE_CLASSES = frozenset({FailureClass.BYOK_RATE_LIMIT, FailureClass.BYOK_QUOTA})
 
 
 @router.post('/v1/chat/completions', response_model=None)
@@ -244,7 +249,7 @@ def _error_response(exc: GatewayError) -> JSONResponse:
     content: dict[str, object] = {
         'error': {
             'message': exc.message,
-            'type': _error_type_for_code(exc.code),
+            'type': _error_type_for_code(exc.code, exc.failure_class),
             'param': exc.param,
             'code': exc.code.value,
         }
@@ -255,13 +260,15 @@ def _error_response(exc: GatewayError) -> JSONResponse:
     )
 
 
-def _error_type_for_code(code: GatewayErrorCode) -> str:
+def _error_type_for_code(code: GatewayErrorCode, failure_class: FailureClass | None = None) -> str:
     """Map an internal error code to an OpenAI API error category.
 
     OpenAI distinguishes ``type`` (a broad error category) from ``code`` (the
     specific identifier). Without this distinction clients that categorize
     errors by ``type`` cannot classify them correctly.
     """
+    if failure_class in _THROTTLED_FAILURE_CLASSES:
+        return 'rate_limit_error'
     if code == GatewayErrorCode.CREDENTIAL_FAILURE:
         return 'authentication_error'
     if code in {
@@ -276,6 +283,8 @@ def _error_type_for_code(code: GatewayErrorCode) -> str:
 
 
 def _status_code_for_error(exc: GatewayError) -> int:
+    if exc.failure_class in _THROTTLED_FAILURE_CLASSES:
+        return 429
     if exc.code == GatewayErrorCode.MODEL_NOT_FOUND:
         return 404
     if exc.code in {

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -136,6 +136,52 @@ def test_provider_rejection_preserves_exact_terminal_class_and_bounded_member(
     assert error.provider_rejection == provider_rejection
 
 
+@pytest.mark.parametrize(
+    'failure_class',
+    [FailureClass.BYOK_RATE_LIMIT, FailureClass.BYOK_QUOTA],
+)
+def test_byok_throttling_is_not_reported_as_a_credential_rejection(monkeypatch, failure_class):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    provider = FakeChatCompletionProvider([ProviderFailure(failure_class)])
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    try:
+        response = TestClient(app).post(
+            '/v1/chat/completions',
+            json=valid_request(),
+            headers={
+                **auth_headers(),
+                'X-Omi-Byok-OpenAI-Key': 'sk-user-byok',
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 429
+    assert response.json()['error']['type'] == 'rate_limit_error'
+    assert response.json()['error']['message'] == f'provider request failed: {failure_class.value}'
+
+
+def test_byok_auth_failure_still_reports_a_credential_rejection(monkeypatch):
+    monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
+    provider = FakeChatCompletionProvider([ProviderFailure(FailureClass.BYOK_AUTH)])
+    app.dependency_overrides[dependencies.get_provider_registry] = lambda: ProviderRegistry({'openai': provider})
+    try:
+        response = TestClient(app).post(
+            '/v1/chat/completions',
+            json=valid_request(),
+            headers={
+                **auth_headers(),
+                'X-Omi-Byok-OpenAI-Key': 'sk-user-byok',
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 401
+    assert response.json()['error']['type'] == 'authentication_error'
+    assert response.json()['error']['code'] == 'credential_failure'
+
+
 def test_chat_completions_persists_cache_aware_attempt_with_authenticated_attribution(monkeypatch):
     monkeypatch.setenv('LLM_GATEWAY_SERVICE_TOKEN', 'shared-secret')
     persisted = []


### PR DESCRIPTION
## Bug

A BYOK user whose own provider key is rate limited gets told the key is invalid.

The LLM gateway maps every BYOK provider failure to `GatewayErrorCode.CREDENTIAL_FAILURE`, and the OpenAI-compatible router answered that code with `401 / authentication_error`. So a provider `429` — `byok_rate_limit` or `byok_quota`, the user's own key being throttled — reached callers as an authentication failure.

Live in prod, ~50 tracebacks/24h (`backend`, `backend-sync`; the gateway's own terminal line already records the correct class):

```
llm_gateway_terminal ... lane=omi:auto:knowledge-graph credential_source=service_forwarded_byok
  outcome=error error_class=credential_failure failure_class=byok_rate_limit
openai.AuthenticationError: Error code: 401 - {'error': {'message': 'provider request failed: byok_rate_limit',
  'type': 'authentication_error', 'param': 'provider', 'code': 'credential_failure'}}
```

## Root cause

`_status_code_for_error` / `_error_type_for_code` in `llm_gateway/routers/openai_compatible.py` branch only on `GatewayErrorCode`, which is the same value for a bad key, an exhausted quota and a rate limit. The failure class that distinguishes them is already on the error object and was ignored.

Downstream, `utils/llm/byok_errors.classify_byok_llm_error()` classifies by status code: `401` → `'invalid'` → a push notification reading *"Your Openai BYOK key was rejected. Update it in Omi settings to restore AI features."* to a user whose key is fine — plus a 24h Redis notification lock that then suppresses the correct message. The transient failure also looks permanent to any caller that retries on `429` but not on `401`.

## Fix

Answer `429 / rate_limit_error` when the failure class is `byok_rate_limit` or `byok_quota`. Every other credential failure, `byok_auth` included, keeps its `401 / authentication_error`.

After the fix `classify_byok_llm_error` returns `None` for a rate limit (transient, no notification) and `'quota'` for an exhausted quota (the correct "out of quota" copy).

## What I tested

Live end-to-end, not compile-only: a real gateway process (`uvicorn llm_gateway.main:app`) with `OPENAI_BASE_URL` pointed at a fake upstream returning `429`, driven through the real backend BYOK client (`get_or_create_omi_gateway_llm_for_byok` → LangChain → openai SDK), then the raised exception fed to the real `classify_byok_llm_error`:

| | exception | status | classified as |
|---|---|---|---|
| before | `AuthenticationError` | 401 | `invalid` → false "key was rejected" push |
| after | `RateLimitError` | 429 | `None` → no notification |

The before-fix response body is byte-identical to the prod error above.

- New regression cases fail on `main`, pass here:
  `test_byok_throttling_is_not_reported_as_a_credential_rejection[byok_rate_limit|byok_quota]`, plus `test_byok_auth_failure_still_reports_a_credential_rejection` guarding the unchanged `byok_auth` path.
- `pytest tests/unit/test_*gateway*.py tests/unit/test_byok*.py` → **432 passed**.
- `black --line-length 120 --skip-string-normalization` clean; `make preflight` green.

## Product invariants affected

none

Failure-Class: FC-provider-http-error-format

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

