### PR TITLE
SCA-194: restore development Firebase probe signing

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -20,6 +20,7 @@ These rules apply to GitHub Actions workflows and custom actions under `.github/
   retained and ordering is not guaranteed. Deploy workflows must not assume
   that every intermediate commit will run.
 - Use immutable image tags for deploys. Build and push the short SHA tag, then deploy that exact tag.
+- Development desktop-backend acceptance must stage `GCP_SERVICE_ACCOUNT` only in a mode-0600 runner file for Firebase probe signing, validate that its project matches `FIREBASE_AUTH_PROJECT_ID`, and delete it after the probe; never copy it into the image or deploy it as runtime configuration.
 - Do not deploy Cloud Run services from an untagged image path; use `image:...:${SHORT_SHA}` so revisions show the source commit.
 - Do not let Helm chart-only deploys reset GKE workloads to `latest`. Preserve the currently deployed immutable tag or require an explicit tag input.
 - Every GKE Deployment deploy must wait for rollout completion with `kubectl rollout status ... --timeout=...` and fail on timeout.

--- a/.github/failure-classes/FC-release-probe-signer-identity.json
+++ b/.github/failure-classes/FC-release-probe-signer-identity.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-release-probe-signer-identity",
+  "violated_contract": "A Firebase release probe must sign its custom token with an explicitly selected service account from the same Firebase project as the API key and expected ID-token audience.",
+  "canonical_prevention": "Stage the environment-owned Firebase signer only as owner-readable transient runner material, reject signer-project drift before key use, keep bounded redacted failure classes, and enforce the signer-before-probe-before-traffic ordering in the deployment contract.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_firebase_release_probe_token.py",
+    ".github/scripts/test_check_desktop_backend_release_policy.py"
+  ],
+  "evidence_prs": [
+    10670
+  ],
+  "scope_hints": [
+    ".github/workflows/*desktop_backend*.yml",
+    "backend/scripts/firebase_release_probe_token.py",
+    "backend/tests/unit/test_firebase_release_probe_token.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -39,6 +39,8 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
         '--expected-contract-version="$CHAT_CONTRACT_VERSION"',
         "Capture current serving revision",
         "Resolve exact no-traffic candidate URL",
+        "Mint candidate probe identity",
+        "firebase_release_probe_token.py",
         "Restore prior traffic after a failed promotion",
         "DESKTOP_BACKEND_TRAFFIC_MUTATION_ATTEMPTED=true",
         "failure() && env.DESKTOP_BACKEND_TRAFFIC_MUTATION_ATTEMPTED == 'true'",
@@ -60,6 +62,14 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
         else "Route traffic to accepted desktop-backend revision"
     )
     verify_step = "Verify production serving identity" if production else "Verify development backend release identity"
+    probe_identity_steps = (
+        ("Mint candidate probe identity",)
+        if production
+        else (
+            "Stage candidate probe signer",
+            "Mint candidate probe identity",
+        )
+    )
     errors.extend(
         _ordered(
             text,
@@ -68,6 +78,7 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
                 "Wait for no-traffic candidate readiness",
                 "Verify candidate image lineage",
                 "Resolve exact no-traffic candidate URL",
+                *probe_identity_steps,
                 chat_step,
                 "Prove candidate managed realtime provider paths",
                 route_step,
@@ -110,6 +121,11 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             "EXPECTED_GCP_PROJECT_ID: based-hardware-dev",
             "DEVELOPMENT_DESKTOP_BACKEND_URL: https://desktop-backend-dt5lrfkkoa-uc.a.run.app",
             'revision_suffix="${image_tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            "${{ secrets.GCP_SERVICE_ACCOUNT }}",
+            'chmod 600 "$signer_file"',
+            "base64 --decode",
+            '--signer-credentials-file="$DESKTOP_BACKEND_PROBE_SIGNER_FILE"',
+            'rm -f "$DESKTOP_BACKEND_PROBE_SIGNER_FILE"',
         ):
             if fragment not in text:
                 errors.append(f"{workflow}: missing development traffic guard {fragment!r}")

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -96,6 +96,22 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         errors = POLICY.validate_deploy_workflow(mutated, production=False)
         self.assertTrue(any("missing ordered release step" in error for error in errors), errors)
 
+    def test_rejects_missing_or_bypassed_development_probe_signer(self) -> None:
+        missing_signer = self.dev.replace(
+            '--signer-credentials-file="$DESKTOP_BACKEND_PROBE_SIGNER_FILE" \\\n',
+            "",
+            1,
+        )
+        missing_gate = self.dev.replace(
+            "      - name: Mint candidate probe identity", "      - name: Probe identity omitted", 1
+        )
+
+        signer_errors = POLICY.validate_deploy_workflow(missing_signer, production=False)
+        gate_errors = POLICY.validate_deploy_workflow(missing_gate, production=False)
+
+        self.assertTrue(any("DESKTOP_BACKEND_PROBE_SIGNER_FILE" in error for error in signer_errors), signer_errors)
+        self.assertTrue(any("Mint candidate probe identity" in error for error in gate_errors), gate_errors)
+
     def test_rejects_mutable_image_and_direct_traffic_deploy(self) -> None:
         mutated = self.prod.replace(
             "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}@${{ steps.build-image.outputs.digest }}",

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -253,6 +253,19 @@ jobs:
             --tag="$CANDIDATE_TAG")"
           echo "url=$candidate_url" >> "$GITHUB_OUTPUT"
 
+      - name: Stage candidate probe signer
+        if: github.event.inputs.candidate_only != 'true'
+        env:
+          FIREBASE_PROBE_SIGNER_B64: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          signer_file="$(mktemp "$RUNNER_TEMP/omi-firebase-probe-signer.XXXXXX")"
+          trap 'rm -f "$signer_file"' ERR
+          chmod 600 "$signer_file"
+          printf '%s' "$FIREBASE_PROBE_SIGNER_B64" | base64 --decode > "$signer_file"
+          echo "DESKTOP_BACKEND_PROBE_SIGNER_FILE=$signer_file" >> "$GITHUB_ENV"
+          trap - ERR
+
       - name: Mint candidate probe identity
         if: github.event.inputs.candidate_only != 'true'
         env:
@@ -264,6 +277,7 @@ jobs:
           python3 backend/scripts/firebase_release_probe_token.py \
             --secret-project "$PROJECT_ID" \
             --firebase-project "$FIREBASE_AUTH_PROJECT_ID" \
+            --signer-credentials-file="$DESKTOP_BACKEND_PROBE_SIGNER_FILE" \
             --token-output "$token_file"
           echo "DESKTOP_BACKEND_PROBE_TOKEN_FILE=$token_file" >> "$GITHUB_ENV"
 
@@ -429,6 +443,9 @@ jobs:
         run: |
           if [[ -n "${DESKTOP_BACKEND_PROBE_TOKEN_FILE:-}" ]]; then
             rm -f "$DESKTOP_BACKEND_PROBE_TOKEN_FILE"
+          fi
+          if [[ -n "${DESKTOP_BACKEND_PROBE_SIGNER_FILE:-}" ]]; then
+            rm -f "$DESKTOP_BACKEND_PROBE_SIGNER_FILE"
           fi
 
       - name: Show Output

--- a/backend/scripts/firebase_release_probe_token.py
+++ b/backend/scripts/firebase_release_probe_token.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
-"""Mint an ephemeral Firebase ID token for the transcription release probe.
+"""Mint an ephemeral Firebase ID token for a release probe.
 
-The script uses the already authenticated deploy identity. It reads the existing
-Firebase web API key from Secret Manager, remotely signs a five-minute Firebase
-custom token for the fixed non-human release-probe UID, then exchanges it for a
-Firebase ID token. The caller separately names the expected Firebase auth
-project; the script rejects a mismatched token audience or issuer. It never
-prints a credential, request body, response body, or upstream error body. The
-ID token is written only to a mode-0600 file owned by the current runner
-process.
+The script reads the existing Firebase web API key from Secret Manager and
+creates a five-minute custom token for the fixed non-human release-probe UID.
+It can either sign remotely with the authenticated deploy identity or sign
+locally with an explicit mode-0600 service-account credential. The local path
+rejects a signer from a different Firebase project before using its key. The
+caller separately names the expected Firebase auth project, and the exchanged
+ID token must match that audience and issuer.
+
+The script never prints a credential, request body, response body, or upstream
+error body. The ID token is written only to a mode-0600 file owned by the
+current runner process.
 """
 
 from __future__ import annotations
@@ -21,6 +24,7 @@ import re
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -36,13 +40,15 @@ IDENTITY_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v1/accounts:signI
 CUSTOM_TOKEN_TTL_SECONDS = 300
 HTTP_TIMEOUT_SECONDS = 30
 MAX_TOKEN_CHARS = 8192
+MAX_SIGNER_CREDENTIAL_BYTES = 65536
 FIREBASE_PROJECT_ID_PATTERN = re.compile(r'^[a-z][a-z0-9-]{4,62}$')
 
 
 class ProbeTokenError(RuntimeError):
-    def __init__(self, stage: str):
+    def __init__(self, stage: str, error_class: str = 'operation_failed'):
         super().__init__(stage)
         self.stage = stage
+        self.error_class = error_class
 
 
 def _run_gcloud(args: Sequence[str], *, stage: str) -> str:
@@ -54,8 +60,10 @@ def _run_gcloud(args: Sequence[str], *, stage: str) -> str:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-    except (OSError, subprocess.CalledProcessError) as error:
-        raise ProbeTokenError(stage) from error
+    except OSError as error:
+        raise ProbeTokenError(stage, 'tool_unavailable') from error
+    except subprocess.CalledProcessError as error:
+        raise ProbeTokenError(stage, 'command_failed') from error
     return completed.stdout.strip()
 
 
@@ -97,6 +105,20 @@ def _access_token() -> str:
     return token
 
 
+def _http_error_class(status: int) -> str:
+    if status == 401:
+        return 'authentication_failed'
+    if status == 403:
+        return 'permission_denied'
+    if status == 404:
+        return 'resource_not_found'
+    if status == 429:
+        return 'rate_limited'
+    if 500 <= status <= 599:
+        return 'upstream_unavailable'
+    return 'upstream_rejected'
+
+
 def _request_json(
     url: str,
     *,
@@ -116,35 +138,34 @@ def _request_json(
     try:
         with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
             if int(response.status) != 200:
-                raise ProbeTokenError(stage)
+                raise ProbeTokenError(stage, _http_error_class(int(response.status)))
             payload = json.loads(response.read().decode('utf-8'))
-    except (
-        urllib.error.HTTPError,
-        urllib.error.URLError,
-        OSError,
-        TimeoutError,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-    ) as error:
-        raise ProbeTokenError(stage) from error
+    except urllib.error.HTTPError as error:
+        raise ProbeTokenError(stage, _http_error_class(int(error.code))) from error
+    except (urllib.error.URLError, OSError, TimeoutError) as error:
+        raise ProbeTokenError(stage, 'transport_error') from error
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProbeTokenError(stage, 'invalid_response') from error
     if not isinstance(payload, dict):
-        raise ProbeTokenError(stage)
+        raise ProbeTokenError(stage, 'invalid_response')
     return payload
 
 
-def _signed_custom_token(service_account: str, access_token: str) -> str:
+def _custom_token_claims(service_account: str) -> dict[str, Any]:
     now = int(time.time())
-    claims = {
+    return {
         'iss': service_account,
         'sub': service_account,
         'aud': CUSTOM_TOKEN_AUDIENCE,
         'iat': now,
         'exp': now + CUSTOM_TOKEN_TTL_SECONDS,
         'uid': PROBE_UID,
-        # Firebase custom-token developer claims are top-level JWT payload
-        # entries, not nested under a generic "claims" key.
-        'release_probe': True,
+        'claims': {'release_probe': True},
     }
+
+
+def _signed_custom_token(service_account: str, access_token: str) -> str:
+    claims = _custom_token_claims(service_account)
     quoted_account = urllib.parse.quote(service_account, safe='')
     payload = _request_json(
         f'{IAM_CREDENTIALS_URL}/projects/-/serviceAccounts/{quoted_account}:signJwt',
@@ -155,8 +176,118 @@ def _signed_custom_token(service_account: str, access_token: str) -> str:
     signed_jwt = payload.get('signedJwt')
     payload.clear()
     if not isinstance(signed_jwt, str) or not signed_jwt or len(signed_jwt) > MAX_TOKEN_CHARS:
-        raise ProbeTokenError('custom_token_signing')
+        raise ProbeTokenError('custom_token_signing', 'invalid_response')
     return signed_jwt
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode('ascii').rstrip('=')
+
+
+def _read_signer_credentials(path: Path, firebase_project: str) -> tuple[str, str, str]:
+    flags = os.O_RDONLY | getattr(os, 'O_NOFOLLOW', 0)
+    descriptor = -1
+    payload: dict[str, Any] = {}
+    try:
+        descriptor = os.open(path, flags)
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode) or stat.S_IMODE(file_stat.st_mode) & 0o077:
+            raise ProbeTokenError('signer_credentials', 'unsafe_permissions')
+        raw = os.read(descriptor, MAX_SIGNER_CREDENTIAL_BYTES + 1)
+        if not raw or len(raw) > MAX_SIGNER_CREDENTIAL_BYTES:
+            raise ProbeTokenError('signer_credentials', 'invalid_credentials')
+        try:
+            payload = json.loads(raw.decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ProbeTokenError('signer_credentials', 'invalid_credentials') from error
+        if not isinstance(payload, dict):
+            raise ProbeTokenError('signer_credentials', 'invalid_credentials')
+        service_account = payload.get('client_email')
+        signer_project = payload.get('project_id')
+        private_key_id = payload.get('private_key_id')
+        private_key = payload.get('private_key')
+        expected_suffix = f'@{firebase_project}.iam.gserviceaccount.com'
+        if signer_project != firebase_project:
+            raise ProbeTokenError('signer_credentials', 'project_mismatch')
+        if (
+            payload.get('type') != 'service_account'
+            or not isinstance(service_account, str)
+            or not service_account.endswith(expected_suffix)
+            or not isinstance(private_key_id, str)
+            or not private_key_id
+            or not isinstance(private_key, str)
+            or not private_key.startswith('-----BEGIN PRIVATE KEY-----')
+        ):
+            raise ProbeTokenError('signer_credentials', 'invalid_credentials')
+        return service_account, private_key_id, private_key
+    except OSError as error:
+        raise ProbeTokenError('signer_credentials', 'credential_unavailable') from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        payload.clear()
+
+
+def _signed_custom_token_locally(credentials_path: Path, firebase_project: str) -> str:
+    service_account = ''
+    private_key_id = ''
+    private_key = ''
+    key_path = ''
+    descriptor = -1
+    claims: dict[str, Any] = {}
+    header: dict[str, str] = {}
+    try:
+        service_account, private_key_id, private_key = _read_signer_credentials(credentials_path, firebase_project)
+        claims = _custom_token_claims(service_account)
+        header = {'alg': 'RS256', 'kid': private_key_id, 'typ': 'JWT'}
+        signing_input = (
+            f'{_base64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))}.'
+            f'{_base64url(json.dumps(claims, separators=(",", ":"), sort_keys=True).encode("utf-8"))}'
+        )
+        try:
+            descriptor, key_path = tempfile.mkstemp(
+                prefix='omi-firebase-probe-signer-',
+                dir=os.environ.get('RUNNER_TEMP'),
+            )
+            try:
+                os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, 'w', encoding='utf-8') as handle:
+                    descriptor = -1
+                    handle.write(private_key)
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+        except OSError as error:
+            raise ProbeTokenError('custom_token_signing', 'credential_unavailable') from error
+        try:
+            completed = subprocess.run(
+                ['openssl', 'dgst', '-sha256', '-sign', key_path],
+                input=signing_input.encode('ascii'),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as error:
+            raise ProbeTokenError('custom_token_signing', 'tool_unavailable') from error
+        except subprocess.CalledProcessError as error:
+            raise ProbeTokenError('custom_token_signing', 'local_signing_failed') from error
+        signed_jwt = f'{signing_input}.{_base64url(completed.stdout)}'
+        if len(signed_jwt) > MAX_TOKEN_CHARS:
+            raise ProbeTokenError('custom_token_signing', 'invalid_response')
+        return signed_jwt
+    finally:
+        if key_path:
+            try:
+                os.unlink(key_path)
+            except FileNotFoundError:
+                pass
+            except OSError as error:
+                raise ProbeTokenError('custom_token_signing', 'credential_cleanup_failed') from error
+        service_account = ''
+        private_key_id = ''
+        private_key = ''
+        claims.clear()
+        header.clear()
 
 
 def _exchange_custom_token(custom_token: str, firebase_api_key: str) -> str:
@@ -170,7 +301,7 @@ def _exchange_custom_token(custom_token: str, firebase_api_key: str) -> str:
     id_token = payload.get('idToken')
     payload.clear()
     if not isinstance(id_token, str) or not id_token or len(id_token) > MAX_TOKEN_CHARS:
-        raise ProbeTokenError('firebase_token_exchange')
+        raise ProbeTokenError('firebase_token_exchange', 'invalid_response')
     return id_token
 
 
@@ -205,7 +336,12 @@ def _validate_firebase_id_token_claims(id_token: str, firebase_project: str) -> 
         raise ProbeTokenError('firebase_token_claims')
 
 
-def mint_probe_token(secret_project: str, firebase_project: str) -> str:
+def mint_probe_token(
+    secret_project: str,
+    firebase_project: str,
+    *,
+    signer_credentials_file: Path | None = None,
+) -> str:
     firebase_api_key = ''
     service_account = ''
     access_token = ''
@@ -213,9 +349,12 @@ def mint_probe_token(secret_project: str, firebase_project: str) -> str:
     id_token = ''
     try:
         firebase_api_key = _access_secret(secret_project)
-        service_account = _active_service_account()
-        access_token = _access_token()
-        custom_token = _signed_custom_token(service_account, access_token)
+        if signer_credentials_file is None:
+            service_account = _active_service_account()
+            access_token = _access_token()
+            custom_token = _signed_custom_token(service_account, access_token)
+        else:
+            custom_token = _signed_custom_token_locally(signer_credentials_file, firebase_project)
         id_token = _exchange_custom_token(custom_token, firebase_api_key)
         _validate_firebase_id_token_claims(id_token, firebase_project)
         return id_token
@@ -253,6 +392,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--secret-project', required=True)
     parser.add_argument('--firebase-project', required=True)
+    parser.add_argument('--signer-credentials-file', type=Path)
     parser.add_argument('--token-output', required=True, type=Path)
     return parser.parse_args(argv)
 
@@ -263,10 +403,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if not FIREBASE_PROJECT_ID_PATTERN.fullmatch(args.firebase_project):
             raise ProbeTokenError('firebase_project')
-        token = mint_probe_token(args.secret_project, args.firebase_project)
+        token = mint_probe_token(
+            args.secret_project,
+            args.firebase_project,
+            signer_credentials_file=args.signer_credentials_file,
+        )
         write_token(args.token_output, token)
     except ProbeTokenError as error:
-        print(json.dumps({'suite': 'omi_firebase_release_probe_token', 'stage': error.stage, 'status': 'FAIL'}))
+        print(
+            json.dumps(
+                {
+                    'suite': 'omi_firebase_release_probe_token',
+                    'stage': error.stage,
+                    'error_class': error.error_class,
+                    'status': 'FAIL',
+                }
+            )
+        )
         return 1
     finally:
         token = ''

--- a/backend/tests/unit/test_firebase_release_probe_token.py
+++ b/backend/tests/unit/test_firebase_release_probe_token.py
@@ -1,8 +1,11 @@
 import importlib.util
 import base64
+import io
 import json
 import stat
+import subprocess
 import sys
+import urllib.error
 from pathlib import Path
 
 
@@ -61,8 +64,8 @@ def test_mint_probe_token_uses_fixed_uid_short_lived_custom_claims_and_discards_
     assert signing_access_token == 'gcp-access-token-that-must-not-leak'
     assert signing_stage == 'custom_token_signing'
     assert claims['uid'] == module.PROBE_UID
-    assert claims['release_probe'] is True
-    assert 'claims' not in claims
+    assert claims['claims'] == {'release_probe': True}
+    assert 'release_probe' not in claims
     assert claims['exp'] - claims['iat'] == module.CUSTOM_TOKEN_TTL_SECONDS
     exchange_url, exchange_body, exchange_access_token, exchange_stage = requests[1]
     assert 'firebase-api-key-that-must-not-leak' in exchange_url
@@ -77,7 +80,9 @@ def test_token_acquisition_failure_is_redacted_and_does_not_create_output(monkey
     monkeypatch.setattr(
         module,
         'mint_probe_token',
-        lambda _secret_project, _firebase_project: (_ for _ in ()).throw(module.ProbeTokenError('secret_access')),
+        lambda _secret_project, _firebase_project, **_kwargs: (_ for _ in ()).throw(
+            module.ProbeTokenError('secret_access')
+        ),
     )
 
     exit_code = module.main(
@@ -86,7 +91,12 @@ def test_token_acquisition_failure_is_redacted_and_does_not_create_output(monkey
 
     report = json.loads(capsys.readouterr().out)
     assert exit_code == 1
-    assert report == {'suite': 'omi_firebase_release_probe_token', 'stage': 'secret_access', 'status': 'FAIL'}
+    assert report == {
+        'suite': 'omi_firebase_release_probe_token',
+        'stage': 'secret_access',
+        'error_class': 'operation_failed',
+        'status': 'FAIL',
+    }
     assert not output.exists()
 
 
@@ -130,3 +140,127 @@ def test_mint_probe_token_rejects_a_token_for_a_different_firebase_auth_project(
         assert error.stage == 'firebase_token_claims'
     else:
         raise AssertionError('expected Firebase auth-project mismatch')
+
+
+def test_local_signer_uses_matching_service_account_without_remote_iam(monkeypatch, tmp_path):
+    module = _load_module()
+    credentials = tmp_path / 'firebase-signer.json'
+    credentials.write_text(
+        json.dumps(
+            {
+                'type': 'service_account',
+                'project_id': 'based-hardware',
+                'private_key_id': 'fixed-key-id',
+                'private_key': '-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n',
+                'client_email': 'firebase-probe@based-hardware.iam.gserviceaccount.com',
+            }
+        ),
+        encoding='utf-8',
+    )
+    credentials.chmod(0o600)
+    monkeypatch.setattr(
+        module.subprocess,
+        'run',
+        lambda *args, **kwargs: subprocess.CompletedProcess(args=args, returncode=0, stdout=b'signature', stderr=b''),
+    )
+    monkeypatch.setattr(module.time, 'time', lambda: 1_700_000_000)
+
+    token = module._signed_custom_token_locally(credentials, 'based-hardware')
+    header_part, claims_part, signature_part = token.split('.')
+    header = json.loads(base64.urlsafe_b64decode(header_part + '=' * (-len(header_part) % 4)))
+    claims = json.loads(base64.urlsafe_b64decode(claims_part + '=' * (-len(claims_part) % 4)))
+
+    assert header == {'alg': 'RS256', 'kid': 'fixed-key-id', 'typ': 'JWT'}
+    assert claims['iss'] == 'firebase-probe@based-hardware.iam.gserviceaccount.com'
+    assert claims['sub'] == claims['iss']
+    assert claims['uid'] == module.PROBE_UID
+    assert claims['claims'] == {'release_probe': True}
+    assert claims['exp'] - claims['iat'] == module.CUSTOM_TOKEN_TTL_SECONDS
+    assert base64.urlsafe_b64decode(signature_part + '=' * (-len(signature_part) % 4)) == b'signature'
+
+
+def test_local_signer_rejects_cross_project_credentials_before_signing(monkeypatch, tmp_path):
+    module = _load_module()
+    credentials = tmp_path / 'firebase-signer.json'
+    credentials.write_text(
+        json.dumps(
+            {
+                'type': 'service_account',
+                'project_id': 'based-hardware-dev',
+                'private_key_id': 'fixed-key-id',
+                'private_key': '-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n',
+                'client_email': 'firebase-probe@based-hardware-dev.iam.gserviceaccount.com',
+            }
+        ),
+        encoding='utf-8',
+    )
+    credentials.chmod(0o600)
+    monkeypatch.setattr(
+        module.subprocess,
+        'run',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('openssl must not run')),
+    )
+
+    try:
+        module._signed_custom_token_locally(credentials, 'based-hardware')
+    except module.ProbeTokenError as error:
+        assert error.stage == 'signer_credentials'
+        assert error.error_class == 'project_mismatch'
+    else:
+        raise AssertionError('expected signer project mismatch')
+
+
+def test_remote_signing_permission_denial_has_bounded_classification(monkeypatch):
+    module = _load_module()
+    upstream_body = io.BytesIO(b'credential and request details that must not be read or printed')
+    monkeypatch.setattr(
+        module.urllib.request,
+        'urlopen',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            urllib.error.HTTPError('https://iamcredentials.googleapis.com', 403, 'forbidden', {}, upstream_body)
+        ),
+    )
+
+    try:
+        module._request_json(
+            'https://iamcredentials.googleapis.com',
+            body={'payload': 'must-not-leak'},
+            access_token='must-not-leak',
+            stage='custom_token_signing',
+        )
+    except module.ProbeTokenError as error:
+        assert error.stage == 'custom_token_signing'
+        assert error.error_class == 'permission_denied'
+        assert upstream_body.tell() == 0
+    else:
+        raise AssertionError('expected permission denial')
+
+
+def test_mint_probe_token_prefers_explicit_local_signer(monkeypatch, tmp_path):
+    module = _load_module()
+    signer = tmp_path / 'signer.json'
+    signer.write_text('{}', encoding='utf-8')
+    calls = []
+    monkeypatch.setattr(module, '_access_secret', lambda project: calls.append(('secret', project)) or 'api-key')
+    monkeypatch.setattr(
+        module,
+        '_signed_custom_token_locally',
+        lambda path, project: calls.append(('local_signer', path, project)) or 'custom-token',
+    )
+    monkeypatch.setattr(
+        module,
+        '_active_service_account',
+        lambda: (_ for _ in ()).throw(AssertionError('active deploy identity must not be selected')),
+    )
+    monkeypatch.setattr(
+        module, '_exchange_custom_token', lambda token, key: calls.append(('exchange', token, key)) or _id_token()
+    )
+
+    assert (
+        module.mint_probe_token('based-hardware-dev', 'based-hardware', signer_credentials_file=signer) == _id_token()
+    )
+    assert calls == [
+        ('secret', 'based-hardware-dev'),
+        ('local_signer', signer, 'based-hardware'),
+        ('exchange', 'custom-token', 'api-key'),
+    ]


### PR DESCRIPTION
## Summary

- sign development Firebase release-probe tokens locally with the existing `based-hardware` service-account credential instead of the active `based-hardware-dev` deploy identity
- validate the signer project and owner-only file boundary before key use, then remove all transient signer and token material
- classify probe failures with bounded, redacted error classes and preserve the acceptance-before-traffic gate with workflow contract coverage
- encode Firebase developer claims under the documented `claims` object

## Root cause

The development workflow authenticated deployment commands as `local-development-joan@based-hardware-dev.iam.gserviceaccount.com` and the token helper selected that active account as the Firebase custom-token signer. It lacked `iam.serviceAccounts.signJwt`, and granting it self-signing would still produce a custom token for the wrong project: the development desktop backend validates Firebase ID tokens for `based-hardware`. The development environment already carries the matching `GCP_SERVICE_ACCOUNT` credential that the previous workflow used for this Firebase boundary. This change reuses it only as transient runner-side signing input; it is never copied into the image or deployed as runtime configuration.

## Testing

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_firebase_release_probe_token.py backend/tests/unit/test_workflow_contracts.py` — 33 passed
- `python3 .github/scripts/test_check_desktop_backend_release_policy.py` — 12 passed
- `python3 .github/scripts/check-desktop-backend-release-policy.py`
- `actionlint .github/workflows/desktop_backend_auto_dev.yml`
- `python3 .github/scripts/check_agents_md_lean.py`
- `uvx --from ruff==0.4.4 ruff check ...`
- generated-key OpenSSL signing exercise with RSA signature verification and transient-key cleanup assertion

## Safety

- Development deployment path only; production workflow behavior and production IAM are unchanged.
- No credential, token, request body, response body, or upstream error body is logged.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

