### PR TITLE
SCA-196: move paid Actions jobs to standard runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,5 @@
 self-hosted-runner:
   labels:
-    - ubuntu-latest-m
     - macos
     - omi-desktop-qualification
     - omi-qual-m1-studio

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -239,6 +239,16 @@ checks:
     triggers: [".github/scripts/check_deployment_secret_boundary.py", ".github/scripts/test_check_deployment_secret_boundary.py"]
     lanes: ["local", "ci"]
     reason: "deployment secret-boundary fake-name fixtures must remain executable"
+  - id: github-runner-cost-policy
+    command: ["python3", ".github/scripts/check_runner_cost_policy.py"]
+    triggers: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml", ".github/actionlint.yaml", ".github/scripts/check_runner_cost_policy.py", ".github/scripts/test_check_runner_cost_policy.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "SCA-196: public-repository standard runners are free while the larger ubuntu-latest-m label caused recurring Linux 4-core charges"
+  - id: github-runner-cost-policy-fixtures
+    command: ["python3", ".github/scripts/test_check_runner_cost_policy.py"]
+    triggers: [".github/scripts/check_runner_cost_policy.py", ".github/scripts/test_check_runner_cost_policy.py"]
+    lanes: ["local", "ci"]
+    reason: "runner cost-policy fixtures must keep rejecting the paid larger-runner label"
   - id: telegram-deployment-notifier
     command: ["bash", ".github/actions/deployment-notifier/test-check-configuration.sh"]
     triggers: [".github/actions/deployment-notifier/**", ".github/checks-manifest.yaml"]

--- a/.github/scripts/check_runner_cost_policy.py
+++ b/.github/scripts/check_runner_cost_policy.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Reject paid GitHub-hosted runner labels in this public repository."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+PAID_RUNNER_LABELS = ("ubuntu-latest-m",)
+
+
+def validate(root: Path) -> list[str]:
+    workflows = root / ".github" / "workflows"
+    errors: list[str] = []
+    for path in sorted((*workflows.glob("*.yml"), *workflows.glob("*.yaml"))):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for label in PAID_RUNNER_LABELS:
+                if label in line:
+                    errors.append(
+                        f"{path.relative_to(root)}:{line_number}: paid runner label {label!r} "
+                        "is forbidden; public-repository jobs must use a standard runner"
+                    )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    errors = validate(args.root.resolve())
+    if errors:
+        print("\n".join(errors))
+        return 1
+    print("GitHub runner cost policy check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_backend_deploy_source_admission.py
+++ b/.github/scripts/test_check_backend_deploy_source_admission.py
@@ -253,8 +253,8 @@ class WorkflowContractTests(unittest.TestCase):
             ),
             (
                 "cloud authentication",
-                "    runs-on: ubuntu-latest-m\n    outputs:",
-                "    runs-on: ubuntu-latest-m\n    steps:\n      - uses: google-github-actions/auth@v3\n    outputs:",
+                "    runs-on: ubuntu-latest\n    outputs:",
+                "    runs-on: ubuntu-latest\n    steps:\n      - uses: google-github-actions/auth@v3\n    outputs:",
                 "auto backend scope decision must not authenticate to cloud services",
             ),
         )

--- a/.github/scripts/test_check_runner_cost_policy.py
+++ b/.github/scripts/test_check_runner_cost_policy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Unit tests for check_runner_cost_policy.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_runner_cost_policy import validate
+
+
+def write_workflow(root: Path, name: str, runs_on: str) -> None:
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / name).write_text(
+        f"name: fixture\njobs:\n  test:\n    runs-on: {runs_on}\n    steps: []\n",
+        encoding="utf-8",
+    )
+
+
+class RunnerCostPolicyTests(unittest.TestCase):
+    def test_accepts_standard_public_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_workflow(root, "standard.yml", "ubuntu-latest")
+            self.assertEqual(validate(root), [])
+
+    def test_rejects_paid_runner_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_workflow(root, "paid.yml", "ubuntu-latest-m")
+            self.assertEqual(
+                validate(root),
+                [
+                    ".github/workflows/paid.yml:4: paid runner label 'ubuntu-latest-m' "
+                    "is forbidden; public-repository jobs must use a standard runner"
+                ],
+            )
+
+    def test_checks_yaml_extension(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_workflow(root, "paid.yaml", "ubuntu-latest-m")
+            self.assertEqual(len(validate(root)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -41,7 +41,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -47,7 +47,7 @@ jobs:
       actions: 'read'
       contents: 'read'
       id-token: 'write'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -113,7 +113,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
         run: |
@@ -167,7 +167,7 @@ jobs:
     permissions:
       actions: 'read'
       contents: 'read'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     outputs:
       admitted_sha: ${{ steps.admitted_source.outputs.admitted_sha }}
       break_glass: ${{ steps.admitted_source.outputs.break_glass }}
@@ -338,7 +338,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
         run: |

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -27,7 +27,7 @@ jobs:
     # support a safe workflow-level paths filter, so inspect its immutable SHA.
     permissions:
       contents: 'read'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     outputs:
       applies: ${{ steps.scope.outputs.applies }}
     steps:
@@ -148,7 +148,7 @@ jobs:
     environment: development
     permissions:
       contents: 'read'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     outputs:
       admitted_sha: ${{ steps.admitted_source.outputs.admitted_sha }}
     steps:
@@ -244,7 +244,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       # To workaround "no space left on device" issue of GitHub-hosted runner
       - name: Delete huge unnecessary tools folder

--- a/.github/workflows/gcp_diarizer.yml
+++ b/.github/workflows/gcp_diarizer.yml
@@ -36,7 +36,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
         run: |

--- a/.github/workflows/gcp_firestore_indexes.yml
+++ b/.github/workflows/gcp_firestore_indexes.yml
@@ -30,7 +30,7 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     permissions:
       contents: 'read'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Firestore migration input
         env:

--- a/.github/workflows/gcp_models.yml
+++ b/.github/workflows/gcp_models.yml
@@ -39,7 +39,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
         run: |

--- a/.github/workflows/gcp_nllb_translation.yml
+++ b/.github/workflows/gcp_nllb_translation.yml
@@ -33,7 +33,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
         run: |

--- a/.github/workflows/gcp_parakeet.yml
+++ b/.github/workflows/gcp_parakeet.yml
@@ -32,7 +32,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
 
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
         run: |

--- a/.github/workflows/sync_ledger_fence_cutover.yml
+++ b/.github/workflows/sync_ledger_fence_cutover.yml
@@ -43,7 +43,7 @@ jobs:
       actions: read
       contents: read
       id-token: write
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout cutover controls
         uses: actions/checkout@v7
@@ -135,7 +135,7 @@ jobs:
       actions: read
       contents: read
       id-token: write
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout cutover controls
         uses: actions/checkout@v7


### PR DESCRIPTION
## What changed and why

Closes SCA-196.

Moves every `ubuntu-latest-m` job in the repository to the free standard
`ubuntu-latest` runner and removes the paid label from actionlint's custom-label
allowance. GitHub documents the public standard Linux runner as 4 CPU / 16 GB
RAM and free for public repositories, while the 4-core larger runner has the
same CPU/RAM, 150 GB storage, costs $0.012/minute, and remains billable in public
repositories:

- https://docs.github.com/en/actions/reference/runners/github-hosted-runners
- https://docs.github.com/en/billing/reference/actions-runner-pricing

The full 15-job inventory is:

| Workflow | Jobs changed | Trigger / caller |
| --- | --- | --- |
| `desktop_backend_auto_dev.yml` | `deploy` | `push` to `main` on desktop-backend/control paths; manual dispatch |
| `desktop_backend_prod.yml` | `deploy` | protected manual dispatch |
| `gcp_backend.yml` | `repair-traffic`, `firestore_readiness`, `deploy` | manual dispatch |
| `gcp_backend_auto_dev.yml` | `scope`, `firestore_readiness`, `deploy` | successful first-attempt `Release Eligibility` `workflow_run` on `main` |
| `gcp_diarizer.yml` | `deploy` | manual dispatch |
| `gcp_models.yml` | `deploy` | manual dispatch |
| `gcp_nllb_translation.yml` | `deploy` | manual dispatch |
| `gcp_parakeet.yml` | `deploy` | manual dispatch |
| `gcp_firestore_indexes.yml` | `reconcile` | protected manual dispatch |
| `sync_ledger_fence_cutover.yml` | `stage`, `activate` | protected manual dispatch |

No workflow uses `workflow_call`; repository search found no additional caller
or dispatch path for these files. Triggers, permissions, environments,
concurrency groups, immutable-SHA admission, credential ordering, build/cache
steps, rollout checks, and deployment behavior are unchanged.

### Resource and run evidence

- Control-plane-only jobs (`repair-traffic`, both Firestore readiness jobs,
  `scope`, `reconcile`, `stage`, and `activate`) do not build images and have no
  custom runner capability.
- Build/deploy jobs use ordinary Ubuntu/Docker/gcloud/Helm tooling. Recent paid
  runner logs report 4 CPUs and 15.61 GiB RAM, matching the standard public
  runner. The existing `/opt/hostedtoolcache` cleanup remains in every workflow
  that carried the historical disk-pressure workaround.
- Recent successful build contexts were 850.11 kB (desktop backend), 31.72 MB
  (backend), 11.10 kB (diarizer), 10.91 kB (NLLB), and 218.32 kB (Parakeet).
  Logged package-install disk additions topped out at 1,832 MB. No inspected
  run failed for CPU, memory, disk, networking, or runner capability.
- Relevant outcomes inspected: desktop auto run `30242749994` built and pushed
  successfully before a later probe-signing failure; manual backend run
  `30214280894`, auto backend run `30242076698`, diarizer run `27663998470`,
  NLLB run `29155185403`, and Parakeet run `29185093623` succeeded. Models run
  `27663992734` failed compiling `webrtcvad` because `stdlib.h` was missing,
  not because of runner capacity; prior run `25298499714` succeeded.
- Desktop prod, Firestore reconciliation, and sync-ledger cutover have no
  retained run history, but their runner-side work is either the same desktop
  build path proven above or lightweight control-plane commands.

No paid-runner exception remains. At the observed $0.012/minute rate,
$266.304 YTD equals 22,192 billed larger-runner minutes; July's $100 is about
8,333 minutes. After merge, these 15 jobs move from that paid SKU to the
free/unlimited public standard pool, so expected future Linux 4-core runner
charges from this label fall from the observed amount to $0 (100% reduction at
the same workload volume).

## Product invariants affected

None.

## How it was verified

- `make setup` — passed; refreshed `origin/main`, installed hooks, and synced
  the pinned backend environment.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck "" <10 changed workflows>` — passed.
- `python3 .github/scripts/check-deployment-concurrency.py` — passed for 24
  persistent writers and one run-scoped exemption.
- `python3 .github/scripts/check_backend_deploy_source_admission.py` and
  `python3 .github/scripts/test_check_backend_deploy_source_admission.py` —
  passed (28 fixtures).
- `python3 .github/scripts/check-desktop-backend-release-policy.py` and
  `python3 .github/scripts/test_check_desktop_backend_release_policy.py` —
  passed (15 fixtures).
- `python3 .github/scripts/check_deployment_secret_boundary.py --base origin/main`
  — passed.
- `python3 backend/scripts/runtime_image_contracts.py check` — passed for 10
  registered images.
- `make preflight` — passed all 79 diff-selected local/CI contract checks in
  354.95 seconds.
- `scripts/pr-preflight --pr-body-file ../pr-body.md --base origin/main` —
  passed all 79 CI-lane checks with the final PR metadata.
- The bounded pre-push gate passed, including 22 selected backend unit-test
  files. `PRE_PUSH_SKIP_FLUTTER_GENERATED=1` used the documented hatch because
  changing `.github/checks-manifest.yaml` selects that lane while `make setup`
  intentionally does not provision app dependencies; this PR changes no app or
  generated-output file, so that surface remains deferred to CI.

No workflow runtime was dispatched: that would perform an unauthorized
deployment or production write. Runtime evidence above comes from read-only
inspection of existing Actions runs and logs.

## Tests

Added `.github/scripts/check_runner_cost_policy.py` and three stdlib fixtures
covering the accepted standard label plus rejection in both `.yml` and `.yaml`
workflow files. Registered both the checker and fixtures in the deterministic
local/CI check manifest. Updated the existing backend source-admission mutation
fixture to anchor on the standard runner label.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

The runner-cost guard would have caught merged PRs #3301 and #3730, which
introduced `ubuntu-latest-m` without a documented hard requirement and led to
the SCA-196 billing incident. This is repository-local rather than a shared
primitive because it encodes Omi's public-repository billing policy and its
organization-specific larger-runner label.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

