### PR TITLE
fix(backend): keep the geolocation cache readable by every deployed reader

### DIFF
--- a/.github/failure-classes/FC-shared-cache-reader-format.json
+++ b/.github/failure-classes/FC-shared-cache-reader-format.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-shared-cache-reader-format",
+  "violated_contract": "A cache value written by one service and read by another must stay parseable by every reader that can be serving production, including readers on an older deployed image.",
+  "canonical_prevention": "Keep the serialized form within the intersection every deployed reader accepts, and cover the legacy reader's parse in the writer's own test rather than assuming readers deploy together.",
+  "evidence_prs": [
+    9214
+  ],
+  "scope_hints": [
+    "backend/database/redis_db.py"
+  ],
+  "status": "open"
+}

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -345,7 +345,14 @@ def get_cached_signed_url(blob_path: str) -> str:
 
 
 def cache_user_geolocation(uid: str, geolocation: Dict[str, Any]) -> None:
-    r.set(f'users:{uid}:geolocation', _serialize_cache_value(geolocation))
+    # Unset optional fields are dropped rather than serialized as JSON ``null``.
+    # This key is written by the API tier and read by pusher, which deploys on its
+    # own cadence; a reader still on the pre-JSON ``eval()`` reader raises
+    # ``NameError: name 'null' is not defined`` and discards the conversation it
+    # was finalizing. Every reader rebuilds ``Geolocation`` from this dict, whose
+    # optional fields already default to ``None`` when absent.
+    present_fields = {key: value for key, value in geolocation.items() if value is not None}
+    r.set(f'users:{uid}:geolocation', _serialize_cache_value(present_fields))
     r.expire(f'users:{uid}:geolocation', 60 * 30)  # FIXME: too much?
 
 

--- a/backend/tests/unit/test_redis_db_cache_serialization.py
+++ b/backend/tests/unit/test_redis_db_cache_serialization.py
@@ -65,6 +65,31 @@ def test_geolocation_json_round_trip(fake_redis: _FakeRedis) -> None:
     assert redis_db.get_cached_user_geolocation("uid-1") == geo
 
 
+def test_geolocation_omits_unset_optional_fields(fake_redis: _FakeRedis) -> None:
+    """A cached geolocation must stay parseable by a reader still using ``eval()``.
+
+    ``Geolocation.model_dump()`` carries ``None`` for google_place_id/address/
+    location_type. Serialized as JSON ``null`` those crashed pusher's legacy
+    reader with ``NameError: name 'null' is not defined``, and the failing
+    conversation was then marked discarded.
+    """
+    redis_db.cache_user_geolocation(
+        "uid-1",
+        {
+            "google_place_id": None,
+            "latitude": 37.77,
+            "longitude": -122.42,
+            "address": None,
+            "location_type": None,
+        },
+    )
+
+    raw = fake_redis._store["users:uid-1:geolocation"]
+    assert "null" not in raw
+    assert eval(raw) == {"latitude": 37.77, "longitude": -122.42}  # noqa: S307 — legacy reader
+    assert redis_db.get_cached_user_geolocation("uid-1") == {"latitude": 37.77, "longitude": -122.42}
+
+
 def test_geolocation_legacy_literal_round_trip(fake_redis: _FakeRedis) -> None:
     fake_redis._store["users:uid-legacy:geolocation"] = b"{'lat': 1.0, 'lng': 2.0}"
     assert redis_db.get_cached_user_geolocation("uid-legacy") == {"lat": 1.0, "lng": 2.0}


### PR DESCRIPTION
## Bug

`PATCH /v1/users/geolocation` caches `Geolocation.model_dump()`, which carries `None` for `google_place_id`, `address` and `location_type`. Since the writer moved from `str()` to `json.dumps` (#9214) those fields serialize as JSON `null` — and this Redis key is written by the API tier but read by **pusher**, a separate deployment on its own image cadence.

The pusher image serving prod today (`gcr.io/based-hardware/pusher:2ae7f78`, built 2026-06-30) still reads the key with `eval()`:

```python
# 2ae7f78:backend/database/redis_db.py:283
return eval(geolocation)
```

`eval()` rejects JSON's `null` literal. `routers/pusher.py` catches the resulting `NameError` around `process_conversation` and calls `set_conversation_as_discarded`, so the user's conversation is **thrown away instead of finalized**.

Prod is in that state right now: 73 `ERROR:routers.pusher:Error processing conversation: name 'null' is not defined` in the last 3h (~580 conversations/day), continuous since 2026-07-11.

## Root cause

The cache's wire format is a contract between two independently deployed readers, and the writer changed it to one that only the newer reader can parse. Nothing about the value requires `null`: the field is simply unset.

## Fix

Cache only the fields that have a value. That removes the `null` literal from the wire format without changing what any reader gets — every reader rebuilds `Geolocation` from this dict, and its optional fields already default to `None` when absent (`routers/users.py`, `routers/conversations.py`, `utils/conversations/finalizer.py`, `utils/retrieval/agentic.py`, `utils/retrieval/tools/app_tools.py`).

Redeploying pusher is still the durable fix for the reader side; this stops the data loss from the tier that deploys daily. Cached entries carry a 30-minute TTL, so the fix takes effect within 30 minutes of the deploy.

## Verified

- `tests/unit/test_redis_db_cache_serialization.py::test_geolocation_omits_unset_optional_fields` fails on the unfixed writer with the exact prod payload (`{"google_place_id": null, "latitude": 37.7749, ...}`) and passes with the fix. 9 passed in the file.
- End-to-end replay of the live chain — `GeolocationInput` → `validated_geolocation_or_none` → `model_dump` → `cache_user_geolocation` → the verbatim `eval()` reader from `2ae7f78:backend/database/redis_db.py` → `Geolocation(**geo)`:
  - before: `pusher CRASH -> NameError: name 'null' is not defined` (conversation gets discarded)
  - after: `pusher OK -> lat=37.7749 lon=-122.4194 address=None`, and the current JSON reader still returns the coordinates.
- `black --check --line-length 120 --skip-string-normalization` (26.5.1, the CI pin) clean on both files.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

