### PR TITLE
test(desktop-windows): honor locale in conversation date grouping

### DIFF
--- a/desktop/windows/src/renderer/src/lib/conversations/filtering.test.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/filtering.test.ts
@@ -179,7 +179,12 @@ describe('groupConversationsByDate', () => {
       row({ id: 'older', sortAt: new Date(2026, 0, 5, 10).getTime() })
     ]
     const sections = groupConversationsByDate(rows, NOW)
-    expect(sections.map((s) => s.label)).toEqual(['Today', 'Yesterday', 'Jan 5, 2026'])
+    const olderLabel = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(new Date(2026, 0, 5))
+    expect(sections.map((s) => s.label)).toEqual(['Today', 'Yesterday', olderLabel])
     // Within Today, newest first.
     expect(sections[0].rows.map((r) => r.id)).toEqual(['today-pm', 'today-am'])
   })

--- a/desktop/windows/src/renderer/src/lib/conversations/filtering.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/filtering.ts
@@ -127,7 +127,7 @@ export function buildConversationQuery(
 export type DateSection = {
   /** Stable React key (the day's local-midnight epoch ms). */
   key: string
-  /** "Today" | "Yesterday" | "Jan 5, 2026". */
+  /** "Today" | "Yesterday" | a locale-formatted date. */
   label: string
   rows: ConversationRow[]
 }


### PR DESCRIPTION
## Summary

- derive the older conversation-section label assertion from the runtime locale
- document that non-relative section labels are locale-formatted
- preserve the existing product behavior instead of forcing English output

## Root cause

`groupConversationsByDate()` deliberately formats older section labels with `toLocaleDateString(undefined, ...)`, so the operating-system locale controls the rendered date. The test hard-coded `Jan 5, 2026`, which passes on an English CI host but fails on a Chinese Windows locale where the correct product output is `2026年1月5日`.

Native Windows reproduction on current `main`:

```text
filtering.test.ts: 22 passed, 1 failed
expected: Jan 5, 2026
received: 2026年1月5日
```

## Durable guard

The assertion now computes the expected older label with `Intl.DateTimeFormat` using the same runtime locale. It still pins the `Today` and `Yesterday` special labels, section order, and newest-first row ordering, while allowing the dated label to follow the user's locale.

## Validation

- `vitest run src/renderer/src/lib/conversations/filtering.test.ts` -> 23 passed
- ESLint on both changed files -> passed
- renderer TypeScript check -> passed
- `git diff --check` -> passed

## Product invariants affected

None. This changes a platform-dependent test expectation and its type documentation only.

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

