### PR TITLE
fix(preflight): decode async scanner source as UTF-8

### DIFF
--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -496,7 +496,7 @@ def scan_dirs(dirs: Sequence[str]) -> Dict[str, Any]:
     files_scanned = 0
 
     for fpath in collect_py_files(dirs):
-        with open(fpath) as f:
+        with open(fpath, encoding="utf-8") as f:
             source = f.read()
         try:
             tree = ast.parse(source, filename=fpath)

--- a/backend/tests/unit/test_scan_async_blockers.py
+++ b/backend/tests/unit/test_scan_async_blockers.py
@@ -576,7 +576,7 @@ def test_diff_scope_includes_changed_transitive_helper_lines(scanner, tmp_path):
     finding = results["medium_file_io"][0]
     sink_line = finding["calls"][0]["sink_line"]
     scope = {
-        "ranges": {str(source_path): [(sink_line, sink_line)]},
+        "ranges": {scanner._normalize_path(str(source_path)): [(sink_line, sink_line)]},
         "import_changed_files": set(),
     }
 

--- a/backend/tests/unit/test_scan_async_blockers.py
+++ b/backend/tests/unit/test_scan_async_blockers.py
@@ -33,6 +33,23 @@ def _scan_agent_proxy_source(scanner: ModuleType, tmp_path: Path, source: str):
     return source_path, scanner.scan_dirs([str(service_dir)])
 
 
+def test_scan_dirs_reads_source_as_utf8(scanner, tmp_path, monkeypatch):
+    source_path = tmp_path / "unicode_source.py"
+    source_path.write_text('"""Unicode source - snowman: \u2603."""\n', encoding="utf-8")
+    real_open = open
+    opened = []
+
+    def tracked_open(path, *args, **kwargs):
+        opened.append((path, kwargs.get("encoding")))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", tracked_open)
+
+    scanner.scan_dirs([str(tmp_path)])
+
+    assert opened == [(str(source_path), "utf-8")]
+
+
 def test_direct_local_sync_wrapper_is_reported_at_async_call_site(scanner, tmp_path):
     _source_path, results = _scan_source(
         scanner,


### PR DESCRIPTION
## Summary

- decode Python source files as UTF-8 in the async blocker scanner
- add a regression test that records the explicit source encoding
- normalize an existing diff-scope fixture path so the scanner test suite runs natively on Windows

## Root cause

`scan_async_blockers.py` opened repository source files without an explicit encoding. On Windows, Python therefore used the active ANSI code page (GBK on the reproduced machine) and crashed on valid UTF-8 source before the preflight scan could run. The first observed failure was the em dash in `backend/agent-proxy/main.py`.

Repository Python sources are UTF-8, so the scanner now declares that contract at the file boundary. The regression test fails against the previous implementation on every platform because it verifies the encoding passed to `open`.

The adjacent scope test also constructed its key with native separators while production findings are normalized to POSIX separators. Normalizing the fixture removes an unrelated Windows-only failure and keeps the production path unchanged.

## Validation

- production scanner, without `PYTHONUTF8`: 452 `def` and 115 `async def` functions scanned; zero selected or legacy findings
- `backend/tests/unit/test_scan_async_blockers.py` and `backend/tests/unit/test_async_resource_correctness.py`: 33 passed
- Black and `git diff --check`
- `pr_preflight.py --suggest`: no product invariants; `Failure-Class: none`

## Failure class

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

