### PR TITLE
test(backend): decode integration telemetry probes as UTF-8

### DIFF
--- a/backend/tests/unit/test_integration_sync_telemetry.py
+++ b/backend/tests/unit/test_integration_sync_telemetry.py
@@ -31,7 +31,7 @@ def reset_posthog_client():
 
 
 def _function_calls(path: str, function_name: str) -> set[str]:
-    tree = ast.parse((BACKEND_DIR / path).read_text())
+    tree = ast.parse((BACKEND_DIR / path).read_text(encoding='utf-8'))
     for node in tree.body:
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == function_name:
             return {


### PR DESCRIPTION
## What changed and why

The integration telemetry source-call probes now read Python source as UTF-8 explicitly.

On Windows with a non-UTF-8 system locale, `Path.read_text()` used the locale codec (GBK on this host). Two probe tests crashed before parsing valid UTF-8 source files, so the same deterministic backend test file that passes in Linux CI could not run for Windows contributors.

## Product invariants affected

None.

## How it was verified

- Native Windows reproduction on current main: `test_integration_sync_telemetry.py` reported 3 passed / 2 failed with `UnicodeDecodeError` while reading `utils/x_connector.py` and `utils/conversations/calendar_linking.py`.
- After the change: `python -m pytest tests/unit/test_integration_sync_telemetry.py -q` -> 5 passed.
- `python -m black --check --line-length 120 --skip-string-normalization tests/unit/test_integration_sync_telemetry.py` -> passed.
- `git diff --check origin/main...HEAD` -> passed.

The full local manifest preflight is not executable on stock Windows current main because manifest commands invoke bare `python3`; the focused changed test and formatter are green.

## Tests

The existing telemetry source-call probes are the regression: they read repository UTF-8 source containing characters that are invalid under this machine's GBK locale.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

