### PR TITLE
fix(ci): use active Python for manifest checks on Windows

### DIFF
--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -296,6 +296,8 @@ def command_for_check(
                 command.append("--skip")
             continue
         command.append(replacements.get(token, token))
+    if command and command[0] == "python3":
+        command[0] = sys.executable
     return command
 
 

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -388,6 +388,41 @@ esac
                 )
             self.assertEqual(result, 1)
 
+    def test_python3_command_uses_current_interpreter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            marker = root / "interpreter.txt"
+            probe = root / "probe.py"
+            probe.write_text(
+                "from pathlib import Path\n"
+                "import sys\n"
+                f"Path({str(marker)!r}).write_text(sys.executable, encoding='utf-8')\n",
+                encoding="utf-8",
+            )
+            changed = root / "changed.txt"
+            changed.write_text("example.txt\n", encoding="utf-8")
+            body = root / "body.txt"
+            body.write_text("", encoding="utf-8")
+            check = Check("python", ("python3", str(probe)), ("all",), ("local",), "fixture")
+
+            with (
+                patch.dict(os.environ, {"PATH": ""}),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                result = execute_checks(
+                    root,
+                    [check],
+                    changed_files_path=changed,
+                    base="base",
+                    head="HEAD",
+                    pr_body_file=body,
+                )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(marker.read_text(encoding="utf-8"), sys.executable)
+
+    @unittest.skipIf(os.name == "nt", "requires a POSIX shell")
     def test_release_process_guard_uses_locked_pyyaml_in_every_declared_lane(self) -> None:
         """The guard must never depend on a runner-global PyYAML install."""
         manifest = load_manifest(MANIFEST_PATH)
@@ -547,9 +582,7 @@ class PlatformTests(unittest.TestCase):
     def test_invalid_platform_rejected_by_validation(self):
         manifest = Manifest(
             checks=(
-                Check(
-                    id="bad", command=("true",), triggers=("all",), lanes=("ci",), reason="t", platforms=("plan9",)
-                ),
+                Check(id="bad", command=("true",), triggers=("all",), lanes=("ci",), reason="t", platforms=("plan9",)),
             ),
             exempt=(),
         )


### PR DESCRIPTION
## What changed and why

Manifest entries that begin with `python3` now run with the interpreter already executing `run_checks.py`.

Follow-up to #10594: the runner can now detect Windows, but it still handed every Python check back to `PATH`. On a stock Windows installation, `python3.exe` is the Microsoft Store app-execution alias even when the contributor started the manifest with a working virtualenv Python. As a result, every local preflight failed at `check-manifest-contract` before any repository check ran.

The manifest remains declarative (`python3` stays in the YAML), while execution uses the known-working interpreter on every platform. The runner regression clears `PATH`, executes a real probe process, and proves the child used `sys.executable`. A shell-runner contract test is also marked POSIX-only, matching the existing shell-specific test in the same class, so Windows does not invoke the WSL `bash.exe` alias for a Git Bash fixture.

## Product invariants affected

none

## How it was verified

- Before the change on current `main`, native Windows local manifest execution failed its first selected check with `Python was not found` from the Microsoft Store alias.
- `python .github/scripts/test_run_checks.py` -> 31 tests passed, 2 POSIX-only tests skipped.
- `python .github/scripts/run_checks.py --lane local --base origin/main --head HEAD --skip-pr-body-checks` -> all 9 selected checks passed on Windows.
- `python -m black --check --line-length 120 --skip-string-normalization .github/scripts/run_checks.py .github/scripts/test_run_checks.py` -> passed.
- `git diff --check origin/main...HEAD` -> passed.

## Tests

`test_python3_command_uses_current_interpreter` removes `PATH`, runs a manifest-style `python3` check through `execute_checks`, and verifies the probe records the current interpreter path.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

