### PR TITLE
fix(backend): restart an expired Firestore transaction instead of killing the listen session

### DIFF
--- a/.github/failure-classes/FC-retired-transaction-treated-as-fatal.json
+++ b/.github/failure-classes/FC-retired-transaction-treated-as-fatal.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-retired-transaction-treated-as-fatal",
+  "violated_contract": "A Firestore commit rejected because its transaction id was retired wrote nothing and is recoverable; the storage boundary must restart it on a new transaction rather than raise a failure its caller cannot distinguish from a real write error.",
+  "canonical_prevention": "Run @firestore.transactional callables through database._client.run_transactional, which starts a fresh transaction on 'The referenced transaction has expired or is no longer valid' and re-raises every other InvalidArgument on the first attempt.",
+  "evidence_prs": [
+    10721
+  ],
+  "scope_hints": [
+    "backend/database/**"
+  ],
+  "canonical_prevention_artifact": [
+    "backend/database/_client.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/database/conversations.py": 1646,
+    "backend/database/conversations.py": 1645,
     "backend/database/users.py": 2046
   },
   "raise_justifications": {

--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -1,7 +1,9 @@
+import logging
 from threading import Lock
 from typing import Any
 
 import os
+from google.api_core.exceptions import InvalidArgument
 from google.cloud import firestore
 
 from database.document_ids import document_id_from_seed
@@ -13,7 +15,11 @@ __all__ = [
     "document_id_from_seed",
     "get_firestore_client",
     "get_users_uid",
+    "is_expired_transaction_error",
+    "run_transactional",
 ]
+
+logger = logging.getLogger(__name__)
 
 _firestore_client = None
 _firestore_client_lock = Lock()
@@ -44,6 +50,33 @@ def get_firestore_client() -> Any:
             if _firestore_client is None:
                 _firestore_client = _build_firestore_client()
     return _firestore_client
+
+
+_EXPIRED_TRANSACTION_MARKER = "transaction has expired"
+
+
+def is_expired_transaction_error(error: BaseException) -> bool:
+    """True for the Firestore 400 that retires a transaction id mid-flight."""
+    return isinstance(error, InvalidArgument) and _EXPIRED_TRANSACTION_MARKER in str(error).lower()
+
+
+def run_transactional(client: Any, transactional_callable: Any, *args: Any, attempts: int = 3, **kwargs: Any) -> Any:
+    """Run a ``@firestore.transactional`` callable, restarting it on an expired transaction.
+
+    ``_Transactional.__call__`` retries contention by replaying the *same* transaction id,
+    which is exactly what cannot work once Firestore has retired that id: the commit comes
+    back ``400 The referenced transaction has expired or is no longer valid`` and nothing
+    was written. The SDK treats that as fatal, so recovery requires a brand-new transaction
+    and belongs to this boundary rather than to every caller — callers that own a live
+    WebSocket session have no way to distinguish it from a real write failure.
+    """
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            return transactional_callable(client.transaction(), *args, **kwargs)
+        except InvalidArgument as error:
+            if attempt >= attempts or not is_expired_transaction_error(error):
+                raise
+            logger.warning('Firestore transaction expired, restarting attempt=%d/%d', attempt, attempts)
 
 
 class _LazyFirestoreClient:

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -18,7 +18,7 @@ from models.conversation_enums import ConversationStatus, PostProcessingModel, P
 from models.conversation_photo import ConversationPhoto
 from models.transcript_segment import TranscriptSegment
 from utils import encryption
-from ._client import db, delete_collection_recursive, get_firestore_client
+from ._client import db, delete_collection_recursive, get_firestore_client, run_transactional
 from .helpers import set_data_protection_level, prepare_for_write, prepare_for_read, with_photos
 from utils.other.storage import list_audio_chunks
 
@@ -1365,7 +1365,6 @@ def update_conversation_segments(
 ):
     client = firestore_client if firestore_client is not None else get_firestore_client()
     doc_ref = client.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
-    transaction = client.transaction()
 
     @firestore.transactional
     def _write_segments(transaction) -> bool:
@@ -1388,7 +1387,7 @@ def update_conversation_segments(
         transaction.update(doc_ref, prepared_payload)
         return True
 
-    return _write_segments(transaction)
+    return run_transactional(client, _write_segments)
 
 
 # ***********************************

--- a/backend/tests/unit/test_conversation_segments_transaction_expiry.py
+++ b/backend/tests/unit/test_conversation_segments_transaction_expiry.py
@@ -1,0 +1,161 @@
+"""Regression test: an expired Firestore transaction must not kill a live listen session.
+
+`update_conversation_segments` is the live transcript write, run every ~0.6s by the
+`stream_transcript` loop. Firestore retires a transaction id mid-flight and rejects the
+commit with `400 The referenced transaction has expired or is no longer valid`; the SDK's
+`@firestore.transactional` only retries `Aborted`, so the `InvalidArgument` escaped into
+the WebSocket task, which the supervisor classifies as a crash and tears the session down.
+Prod saw ~26 of these a day across 18 users — each one ending someone's recording.
+
+Nothing is written when the commit is rejected, so the recovery is a brand-new transaction.
+"""
+
+from __future__ import annotations
+
+import json
+import zlib
+from typing import Any, Dict, List
+
+import pytest
+from google.api_core.exceptions import InvalidArgument
+
+from database import conversations as conversations_db
+
+EXPIRED_MESSAGE = '400 The referenced transaction has expired or is no longer valid.'
+
+
+class _FakeSnapshot:
+    def __init__(self, data: Dict[str, Any] | None):
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self) -> Dict[str, Any] | None:
+        return dict(self._data) if self._data is not None else None
+
+
+class _FakeDocumentReference:
+    def __init__(self, client: "_FakeFirestoreClient"):
+        self._client = client
+
+    def get(self, transaction=None) -> _FakeSnapshot:
+        self._client.reads += 1
+        return _FakeSnapshot(self._client.document)
+
+    def collection(self, _collection_id: str) -> "_FakeCollectionReference":
+        return _FakeCollectionReference(self._client)
+
+
+class _FakeCollectionReference:
+    def __init__(self, client: "_FakeFirestoreClient"):
+        self._client = client
+
+    def document(self, _document_id: str) -> Any:
+        return self._client.doc_ref
+
+    def collection(self, _collection_id: str) -> "_FakeCollectionReference":
+        return self
+
+
+class _FakeTransaction:
+    """Implements the surface `_Transactional.__call__` drives on a real transaction."""
+
+    _max_attempts = 5
+    _read_only = False
+
+    def __init__(self, client: "_FakeFirestoreClient", index: int):
+        self._client = client
+        self._id = f'txn-{index}'.encode()
+        self.payload: Dict[str, Any] | None = None
+        self.rolled_back = False
+
+    def _clean_up(self) -> None:
+        pass
+
+    def _begin(self, retry_id=None) -> None:
+        pass
+
+    def _rollback(self) -> None:
+        self.rolled_back = True
+
+    def update(self, _doc_ref: Any, payload: Dict[str, Any]) -> None:
+        self.payload = payload
+
+    def _commit(self) -> None:
+        if self._client.commit_errors:
+            raise self._client.commit_errors.pop(0)
+        self._client.commits.append(self.payload)
+
+
+class _FakeFirestoreClient:
+    def __init__(self, document: Dict[str, Any] | None, commit_errors: List[BaseException] | None = None):
+        self.document = document
+        self.commit_errors = list(commit_errors or [])
+        self.commits: List[Dict[str, Any] | None] = []
+        self.transactions: List[_FakeTransaction] = []
+        self.reads = 0
+        self.doc_ref = _FakeDocumentReference(self)
+
+    def collection(self, _collection_id: str) -> _FakeCollectionReference:
+        return _FakeCollectionReference(self)
+
+    def transaction(self) -> _FakeTransaction:
+        transaction = _FakeTransaction(self, len(self.transactions))
+        self.transactions.append(transaction)
+        return transaction
+
+
+def _stored_segments(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    assert payload['transcript_segments_compressed'] is True
+    return json.loads(zlib.decompress(payload['transcript_segments']).decode('utf-8'))
+
+
+SEGMENTS = [{'id': 'seg-1', 'text': 'hello', 'start': 0.0, 'end': 1.0}]
+
+
+def _write(client: _FakeFirestoreClient) -> bool:
+    return conversations_db.update_conversation_segments(
+        'uid-1',
+        'conversation-1',
+        SEGMENTS,
+        data_protection_level='standard',
+        firestore_client=client,
+    )
+
+
+def test_expired_transaction_is_restarted_and_the_segments_land():
+    client = _FakeFirestoreClient({'has_content': False}, [InvalidArgument(EXPIRED_MESSAGE)])
+
+    assert _write(client) is True
+
+    assert len(client.transactions) == 2, 'the retry must use a fresh transaction, not the retired id'
+    assert client.transactions[0].rolled_back is True
+    assert len(client.commits) == 1
+    assert _stored_segments(client.commits[0]) == SEGMENTS
+    assert client.commits[0]['has_content'] is True
+
+
+def test_expired_transaction_gives_up_after_the_attempt_budget():
+    client = _FakeFirestoreClient({'has_content': False}, [InvalidArgument(EXPIRED_MESSAGE) for _ in range(3)])
+
+    with pytest.raises(InvalidArgument):
+        _write(client)
+
+    assert len(client.transactions) == 3
+    assert client.commits == []
+
+
+def test_other_invalid_argument_failures_are_not_retried():
+    too_large = InvalidArgument('400 The value of property transcript_segments is longer than 1048487 bytes.')
+    client = _FakeFirestoreClient({'has_content': False}, [too_large])
+
+    with pytest.raises(InvalidArgument):
+        _write(client)
+
+    assert len(client.transactions) == 1, 'only an expired transaction is recoverable by restarting'
+
+
+def test_missing_conversation_still_reports_no_write():
+    client = _FakeFirestoreClient(None)
+
+    assert _write(client) is False
+    assert client.commits == [None]


### PR DESCRIPTION
## Bug

`update_conversation_segments` is the live transcript write that the `stream_transcript` loop runs about every 0.6 s for every open `/v4/listen` session. Firestore sometimes retires a transaction id mid-flight and rejects the commit with `400 The referenced transaction has expired or is no longer valid`.

`@firestore.transactional` only retries `Aborted`, and it retries by replaying the **same** transaction id — exactly what cannot work once that id is gone. So the `InvalidArgument` escaped into the WebSocket background task. That task is registered as a *lifetime* task, so `WebSocketTaskSupervisor` reported `reason=crash` and tore the whole session down.

Prod, `prod-omi-backend-listen` (steady for at least two weeks, ~40–70/day):

```
ERROR:utils.async_tasks:BG task ws:pEEMqSrGwPXh8kgTzsGIEkZnqnH3:stream_transcript crashed:
  InvalidArgument('The referenced transaction has expired or is no longer valid.') [listen]
INFO:routers.listen.runtime:Listen supervisor exited reason=crash task=ws:pEEM…:stream_transcript
```

22 `stream_transcript` crashes across 14 distinct uids in 12 h (plus 4 in `lifecycle`). Each one ends a user's live recording mid-session.

## Root cause

Nothing is written when the commit is rejected, so the failure is fully recoverable — but only by a **brand-new** transaction, which the SDK will never start. The recovery belongs at the database boundary: a caller holding a live socket has no way to tell an expired transaction id apart from a real write failure, so it can only propagate it as fatal.

## Fix

`run_transactional` in `database/_client.py` runs a `@firestore.transactional` callable and restarts it on a fresh transaction when — and only when — the commit failed with an expired transaction (3 attempts). Any other `InvalidArgument` (e.g. a payload over Firestore's 1 MB document limit) still propagates on the first try. `update_conversation_segments` adopts it; other transactional writers can adopt the same surface.

## Verified

- `backend/tests/unit/test_conversation_segments_transaction_expiry.py` (4 tests) drives real production code through a fake client that implements the SDK's transaction protocol. It **fails on the pre-fix code** (one transaction, exception escapes) and passes after. Also covers attempt exhaustion, a non-expiry `InvalidArgument` not being retried, and the missing-conversation path.
- Against a **real Firestore** (emulator), poisoning only the first commit with the exact prod error: `transactions=2` and the segments actually land in the document.

  ```
  Firestore transaction expired, restarting attempt=1/3
  PASS: expired transaction restarted (transactions=2, commits=2);
        Firestore holds [{'id': 'seg-1', 'text': 'live transcript survived', ...}]
  ```
- `npm run test:listen-lifecycle:emulator` — the #9687 listen-lifecycle contention harness, which exercises this same write — passes.
- 121 related existing unit tests pass (`test_translation_persist_guard`, `test_sync_silent_failure`, `test_conversation_lifecycle_contract`, `test_check_conversation_lifecycle_writes`, sync decode suites).

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

