### PR TITLE
feat(languages): offer Brazilian and European Portuguese on Windows desktop and web

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-portuguese-variants.json
+++ b/desktop/windows/changelog/unreleased/2026-07-portuguese-variants.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Portuguese (Brazil) and Portuguese (Portugal) are now separate language choices, so replies match your variant instead of defaulting to European Portuguese."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/TranscriptionTab.test.tsx
@@ -43,6 +43,17 @@ describe('TranscriptionTab', () => {
     expect(syncLanguage).toHaveBeenCalledWith('es')
   })
 
+  it('offers Brazilian Portuguese and persists its regional code (#7461)', () => {
+    renderTab()
+    const dropdown = screen.getByRole('combobox')
+    expect(Array.from(dropdown.querySelectorAll('option')).map((o) => o.textContent)).toContain(
+      'Portuguese (Brazil)'
+    )
+    fireEvent.change(dropdown, { target: { value: 'pt-BR' } })
+    expect(getPreferences().language).toBe('pt-BR')
+    expect(syncLanguage).toHaveBeenCalledWith('pt-BR')
+  })
+
   it('auto-detect maps to the multi sentinel and hides the dropdown', () => {
     renderTab()
     fireEvent.click(screen.getByText('Auto-detect (multi-language)'))

--- a/desktop/windows/src/renderer/src/lib/languages.test.ts
+++ b/desktop/windows/src/renderer/src/lib/languages.test.ts
@@ -25,6 +25,20 @@ describe('resolveLanguageCode', () => {
     expect(resolveLanguageCode('CHINESE')).toBe('zh')
   })
 
+  it('keeps regional Portuguese distinct from generic Portuguese (#7461)', () => {
+    expect(resolveLanguageCode('pt-BR')).toBe('pt-BR')
+    expect(resolveLanguageCode('Portuguese (Brazil)')).toBe('pt-BR')
+    expect(resolveLanguageCode('Brazilian Portuguese')).toBe('pt-BR')
+    expect(resolveLanguageCode('português do Brasil')).toBe('pt-BR')
+    expect(resolveLanguageCode('European Portuguese')).toBe('pt-PT')
+    expect(resolveLanguageCode('Portuguese')).toBe('pt')
+  })
+
+  it('returns the canonical casing of a region-qualified code', () => {
+    expect(resolveLanguageCode('pt-br')).toBe('pt-BR')
+    expect(resolveLanguageCode('  PT-PT ')).toBe('pt-PT')
+  })
+
   it('maps common autonyms and alternate spellings', () => {
     expect(resolveLanguageCode('español')).toBe('es')
     expect(resolveLanguageCode('espanol')).toBe('es')
@@ -58,5 +72,12 @@ describe('languageLabel', () => {
 
   it('returns the code itself for an unknown code', () => {
     expect(languageLabel('xx')).toBe('xx')
+  })
+
+  // The voice system instruction interpolates these labels, so a stored 'pt-BR'
+  // used to reach the model as the raw code instead of a language name (#7461).
+  it('labels region-qualified codes regardless of casing', () => {
+    expect(languageLabel('pt-BR')).toBe('Portuguese (Brazil)')
+    expect(languageLabel('pt-pt')).toBe('Portuguese (Portugal)')
   })
 })

--- a/desktop/windows/src/renderer/src/lib/languages.ts
+++ b/desktop/windows/src/renderer/src/lib/languages.ts
@@ -10,6 +10,11 @@ export const LANGUAGES: Language[] = [
   { code: 'fr', label: 'French' },
   { code: 'de', label: 'German' },
   { code: 'pt', label: 'Portuguese' },
+  // Brazilian and European Portuguese differ enough that a generic 'pt' reads as
+  // European to the model (#7461). Regional variants match the mobile app and
+  // macOS lists so the same account resolves to the same code on every surface.
+  { code: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { code: 'pt-PT', label: 'Portuguese (Portugal)' },
   { code: 'it', label: 'Italian' },
   { code: 'nl', label: 'Dutch' },
   { code: 'ja', label: 'Japanese' },
@@ -29,8 +34,15 @@ export const DEFAULT_LANGUAGE = 'en'
 // is a reasonable multilingual signal to the transcription backend.
 export const FALLBACK_LANGUAGE = 'multi'
 
+// Codes carry a region subtag ('pt-BR'), and preferences written by other Omi
+// surfaces don't guarantee its casing, so match without it.
+function findByCode(code: string): Language | undefined {
+  const normalized = code.trim().toLowerCase()
+  return LANGUAGES.find((l) => l.code.toLowerCase() === normalized)
+}
+
 export function languageLabel(code: string): string {
-  return LANGUAGES.find((l) => l.code === code)?.label ?? code
+  return findByCode(code)?.label ?? code
 }
 
 // Common autonyms and alternate spellings users are likely to type in the
@@ -50,6 +62,14 @@ const ALIASES: Record<string, string> = {
   portuguese: 'pt',
   portugues: 'pt',
   português: 'pt',
+  'brazilian portuguese': 'pt-BR',
+  'português do brasil': 'pt-BR',
+  'portugues do brasil': 'pt-BR',
+  'português brasileiro': 'pt-BR',
+  'portugues brasileiro': 'pt-BR',
+  'european portuguese': 'pt-PT',
+  'português europeu': 'pt-PT',
+  'portugues europeu': 'pt-PT',
   italian: 'it',
   italiano: 'it',
   dutch: 'nl',
@@ -70,18 +90,20 @@ const ALIASES: Record<string, string> = {
 }
 
 /**
- * Normalize free-text or code input to an ISO 639-1 language code the app can
- * use. Resolution order: exact known code → label match → alias map. Unknown
- * input falls back to {@link FALLBACK_LANGUAGE} ('multi') rather than passing an
- * untranslated language name (e.g. "Spanish") downstream, which the transcription
- * backend can't interpret. Empty input falls back to the default ('en').
+ * Normalize free-text or code input to a language code the app can use.
+ * Resolution order: known code → label match → alias map. Unknown input falls
+ * back to {@link FALLBACK_LANGUAGE} ('multi') rather than passing an untranslated
+ * language name (e.g. "Spanish") downstream, which the transcription backend
+ * can't interpret. Empty input falls back to the default ('en'). The canonical
+ * casing from {@link LANGUAGES} is returned, so 'pt-br' resolves to 'pt-BR'.
  */
 export function resolveLanguageCode(input: string): string {
   const raw = (input ?? '').trim()
   if (raw.length === 0) return DEFAULT_LANGUAGE
   const normalized = raw.toLowerCase()
   // Already a known code (covers 'multi' too).
-  if (LANGUAGES.some((l) => l.code === normalized)) return normalized
+  const byCode = findByCode(normalized)
+  if (byCode) return byCode.code
   // Matches a label, e.g. "Spanish".
   const byLabel = LANGUAGES.find((l) => l.label.toLowerCase() === normalized)
   if (byLabel) return byLabel.code

--- a/web/app/src/types/user.ts
+++ b/web/app/src/types/user.ts
@@ -246,6 +246,10 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   { code: 'de', name: 'German' },
   { code: 'it', name: 'Italian' },
   { code: 'pt', name: 'Portuguese' },
+  // Regional variants, matching the mobile app and desktop lists, so an account
+  // set to Brazilian Portuguese elsewhere still renders here (#7461).
+  { code: 'pt-BR', name: 'Portuguese (Brazil)' },
+  { code: 'pt-PT', name: 'Portuguese (Portugal)' },
   { code: 'nl', name: 'Dutch' },
   { code: 'pl', name: 'Polish' },
   { code: 'ru', name: 'Russian' },


### PR DESCRIPTION
## What

Adds **Portuguese (Brazil)** (`pt-BR`) and **Portuguese (Portugal)** (`pt-PT`) as selectable languages on the **Windows desktop** and **web** apps, and fixes Windows desktop's handling of region-qualified codes.

Fixes #7461.

## Why

The reporter asked for Brazilian Portuguese voice responses "instead of Portugal Portuguese only":

> Accents for Brazilian Portuguese are considerably different from Portugal Portuguese so it would be nice to have voice responses customized for Brazilian Portuguese as well instead of Portugal Portuguese only.

The language code the user picks is what reaches the response prompts as a locale token — `_language_instruction` in `backend/utils/llm/proactive_notification.py` interpolates it verbatim ("language/locale code: {lang}"), and `backend/utils/llm/external_integrations.py` does the same for summaries. `pt` alone reads as European Portuguese; `pt-BR` is what makes the reply Brazilian. `normalize_user_language` already preserves region subtags, so the backend accepts these codes today.

Two of the four client surfaces already offer the split:

- mobile — `app/lib/providers/home_provider.dart:45-47` (`pt`, `pt-BR`, `pt-PT`)
- macOS desktop — `AssistantSettings.swift:367-369` (same three)

Windows desktop (`desktop/windows/src/renderer/src/lib/languages.ts`) and web (`web/app/src/types/user.ts`) offered only generic `pt`.

**Windows desktop had a second, sharper defect:** its lookups matched codes by exact string, and every code in the list was lowercase. So an account already set to `pt-BR` on mobile or macOS hit `languageLabel('pt-BR')` → `'pt-BR'`, and that raw code was interpolated into the realtime voice system instruction (`lib/voice/systemInstruction.ts`) as *"The user speaks ONLY these languages: pt-BR"* instead of a language name. The same code also rendered as an unrecognized value in the Settings dropdown, and typing "Brazilian Portuguese" in onboarding free-text fell through to the `multi` sentinel. Code lookup is now case-insensitive and returns the canonical casing (`pt-br` → `pt-BR`).

## What I tested

Run from `desktop/windows` on Node 22.23.1 (the version `engines` pins).

**New regression tests fail against the pre-fix module and pass after** — verified by restoring `languages.ts` from `HEAD` and re-running:

```
# pre-fix
Tests  3 failed | 9 passed (12)
  ✗ keeps regional Portuguese distinct from generic Portuguese (#7461)
      expected 'multi' to be 'pt-BR'
  ✗ returns the canonical casing of a region-qualified code
  ✗ labels region-qualified codes regardless of casing
      expected 'pt-BR' to be 'Portuguese (Brazil)'

# with the fix
Tests  12 passed (12)
```

**Real Settings UI exercised** — `TranscriptionTab.test.tsx` renders the actual Settings → Transcription component and drives the dropdown a user would use; the new case asserts "Portuguese (Brazil)" is listed, then selects it and checks the preference persists as `pt-BR` and syncs to the backend as `pt-BR`.

```
vitest run TranscriptionTab.test.tsx languages.test.ts  →  17 passed (2 files)
npm test (full Windows desktop suite)                   →  5050 passed | 24 skipped, 0 failed
npm run typecheck (node + web projects)                 →  clean
eslint + prettier --check on the changed files          →  clean
web/app: npx tsc --noEmit                               →  exit 0
make preflight                                          →  12 checks passed
```

## What I did not test

I could not exercise the change in the running Windows desktop app. It is a Windows surface and no Windows host was available; the Electron dev build from this branch does launch on macOS (`npm run dev` → renderer at `localhost:5240`), but it stops at the `#/login` screen and every route including Settings is auth-gated, so I did not reach the dropdown in the real app. Coverage above is the real component rendered in jsdom, not the packaged app.

The web change is a two-entry addition to `SUPPORTED_LANGUAGES`; `web/app` has no test runner (lint/build only), so it is covered by `tsc --noEmit` and the existing `SettingsPage` option mapping, not by a test.

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

