### PR TITLE
test(desktop): make PTT HAL liveness deterministic

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -51,6 +51,7 @@ EXEMPT_DESKTOP_PATHS = {
 EXEMPT_DESKTOP_PATH_PREFIXES = (
     "desktop/macos/Backend-Rust/",
     "desktop/macos/tests/",
+    "desktop/macos/Desktop/Tests/",
     # Generated Swift (e.g. Sources/Generated/OmiApi.generated.swift) is
     # deterministically derived from the backend OpenAPI contract, never a
     # user-facing app note. Regenerating it after a spec change must not demand

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -84,6 +84,10 @@ class ChangelogRequirementTests(unittest.TestCase):
             # post-merge push run of the changelog gate reddened main (#10387).
             "desktop/macos/tests/test-qualify-desktop-beta-contract.sh",
             "desktop/macos/tests/some-other-desktop-test.sh",
+            # Swift package tests live under Desktop/Tests rather than the
+            # legacy lowercase tests directory.
+            "desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift",
+            "desktop/macos/Desktop/Tests/Services/SyncTests.swift",
             # Rust backend prefix.
             "desktop/macos/Backend-Rust/src/main.rs",
             # Generated Swift is derived from the OpenAPI contract, never a

--- a/desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift
@@ -19,9 +19,13 @@ final class PTTInputDeviceProbeTests: XCTestCase {
 
   /// A probe whose device lookup blocks until the test releases it, standing in for a
   /// wedged CoreAudio driver without sleeping on the wall clock.
-  private func stalledProbe(until release: DispatchSemaphore) -> PTTAudioDeviceProbe {
+  private func stalledProbe(
+    until release: DispatchSemaphore,
+    onStart: (@Sendable () -> Void)? = nil
+  ) -> PTTAudioDeviceProbe {
     PTTAudioDeviceProbe(
       inputDeviceID: { _ in
+        onStart?()
         release.wait()
         return 99
       },
@@ -55,36 +59,31 @@ final class PTTInputDeviceProbeTests: XCTestCase {
   /// the main thread does not satisfy this: it still parks the run loop for the whole
   /// budget. The turn-start read must not wait on CoreAudio at all.
   @MainActor
-  func testMainRunLoopKeepsPumpingWhileTheHALIsWedged() {
+  func testMainRunLoopKeepsPumpingWhileTheHALIsWedged() async {
     let release = DispatchSemaphore(value: 0)
+    let started = expectation(description: "HAL probe started")
     // Joined before returning: a probe still parked at teardown would publish its
     // snapshot into whichever test runs next.
     let finished = expectation(description: "parked probe finished")
     PTTInputDeviceRouting.refresh(
-      selectedUID: "wedged-uid", probe: stalledProbe(until: release)
+      selectedUID: "wedged-uid",
+      probe: stalledProbe(until: release) { started.fulfill() }
     ) { finished.fulfill() }
+    await fulfillment(of: [started], timeout: 5)
 
-    let ticker = Ticker()
-    let timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { _ in ticker.tick() }
-    RunLoop.main.add(timer, forMode: .common)
-    defer { timer.invalidate() }
-
-    let started = Date()
-    var reads = 0
-    while Date().timeIntervalSince(started) < 0.3 {
-      // The exact call PTT turn start makes, hammered while the HAL is wedged.
-      _ = PTTInputDeviceRouting.currentSnapshot(selectedUID: "wedged-uid")
-      reads += 1
-      RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+    let mainActorProgress = expectation(description: "main actor kept making progress")
+    mainActorProgress.expectedFulfillmentCount = 3
+    for _ in 0..<3 {
+      DispatchQueue.main.async {
+        // The exact call PTT turn start makes must complete while the HAL is wedged.
+        XCTAssertNil(PTTInputDeviceRouting.currentSnapshot(selectedUID: "wedged-uid"))
+        mainActorProgress.fulfill()
+      }
     }
-
-    XCTAssertGreaterThan(
-      ticker.count, 10,
-      "the main run loop must keep pumping while the HAL is wedged (got \(ticker.count) ticks)")
-    XCTAssertGreaterThan(reads, 10, "turn-start reads must keep completing")
+    await fulfillment(of: [mainActorProgress], timeout: 5)
 
     release.signal()
-    wait(for: [finished], timeout: 5)
+    await fulfillment(of: [finished], timeout: 5)
   }
 
   /// A wedged driver must not leak one parked thread per PTT turn.

--- a/desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTInputDeviceProbeTests.swift
@@ -73,14 +73,20 @@ final class PTTInputDeviceProbeTests: XCTestCase {
 
     let mainActorProgress = expectation(description: "main actor kept making progress")
     mainActorProgress.expectedFulfillmentCount = 3
+    let snapshotReads = expectation(description: "turn-start snapshot reads completed")
+    snapshotReads.expectedFulfillmentCount = 3
     for _ in 0..<3 {
       DispatchQueue.main.async {
-        // The exact call PTT turn start makes must complete while the HAL is wedged.
-        XCTAssertNil(PTTInputDeviceRouting.currentSnapshot(selectedUID: "wedged-uid"))
         mainActorProgress.fulfill()
       }
+      DispatchQueue.global().async {
+        // Exercise the exact turn-start read off-main so a regression times out
+        // without blocking the main actor that must release the wedged probe.
+        XCTAssertNil(PTTInputDeviceRouting.currentSnapshot(selectedUID: "wedged-uid"))
+        snapshotReads.fulfill()
+      }
     }
-    await fulfillment(of: [mainActorProgress], timeout: 5)
+    await fulfillment(of: [mainActorProgress, snapshotReads], timeout: 5)
 
     release.signal()
     await fulfillment(of: [finished], timeout: 5)


### PR DESCRIPTION
Fixes #10724.

## What changed and why

- wait until the injected CoreAudio probe has actually entered its wedged semaphore before checking responsiveness
- replace the fixed `> 10` timer/read throughput requirements in a 300 ms window with three explicit main-actor heartbeat completions and three explicit `currentSnapshot` completions
- keep snapshot reads off-main so a blocking regression times out without preventing the test from releasing and joining the parked HAL probe
- exempt the real Swift package test path, `desktop/macos/Desktop/Tests/`, from the user-facing changelog gate and cover that path classification with regression cases

`testMainRunLoopKeepsPumpingWhileTheHALIsWedged` was testing a binary liveness contract with host-throughput thresholds. Under macOS runner contention, the main actor and snapshot path still made progress, but the isolated suite completed too few iterations. The production contract is that the main actor and turn-start snapshot reads both keep completing while the HAL probe remains blocked off-main, so the new test observes those two completions independently instead of measuring scheduler throughput.

The changelog gate already exempts internal test paths because its post-merge push run cannot see a PR-only `no-changelog-needed` label. It covered the legacy lowercase `desktop/macos/tests/` directory but not the Swift package tests under `Desktop/Tests/`, so this test-only patch exposed the same open failure class on the actual Swift test path.

## Failure evidence

- current `main`: [run 30276084659](https://github.com/BasedHardware/omi/actions/runs/30276084659), `reads == 10`
- unrelated #10574 head: [run 30280746072](https://github.com/BasedHardware/omi/actions/runs/30280746072), `ticker.count == 5`, `reads == 4`
- unrelated #10574 rerun: [run 30283186121](https://github.com/BasedHardware/omi/actions/runs/30283186121), `ticker.count == 7`, `reads == 7`

All sibling `PTTInputDeviceProbeTests` cases passed in those failures.

## Product invariants affected

none

## How it was verified

- `python3 .github/scripts/test_desktop_changelog.py` passed: 4 tests
- `python3 .github/scripts/check-desktop-changelog.py --base origin/main --head HEAD` passed: no desktop changes require a changelog entry
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` passed
- `git diff --check origin/main...HEAD` passed
- reviewed the semaphore ordering: `started` is fulfilled immediately before `release.wait()`, main-actor heartbeat and snapshot-read expectations settle before `release.signal()`, and `finished` is awaited afterward

This contribution was prepared on Windows, so the local commit hook could not run the Xcode-only `swift-format` command (`xcrun` is unavailable). Desktop Swift CI is the authoritative compile, formatter, and XCTest verification for the Swift test change.

## Tests

- `ChangelogRequirementTests` now covers both a top-level and nested Swift package test path.
- The rewritten PTT test is the regression proof for the three linked flaky runs; it fails in bounded time if either the main actor stalls or snapshot reads block while the injected HAL probe is parked.

## Failure class (fixes)

Failure-Class: FC-push-gate-internal-path-scope

## Scoped cleanups

The changelog path exemption is a separate commit because the initial test-only head demonstrated that relying on `no-changelog-needed` would pass only the PR lane and could still redden the post-merge push lane.