### PR TITLE
fix(dev): mount desktop Firestore credentials

### DIFF
--- a/.github/failure-classes/FC-runtime-binding-contract.json
+++ b/.github/failure-classes/FC-runtime-binding-contract.json
@@ -3,6 +3,10 @@
   "id": "FC-runtime-binding-contract",
   "violated_contract": "A service's checked-in Cloud Run runtime contract must classify every live binding as a declared secret, preserved secret, literal environment value, or retired binding; it must never synthesize a Secret Manager reference from an inherited environment variable.",
   "canonical_prevention": "Maintain one explicit, mutually exclusive runtime-binding contract. Candidate preflight validates declared and preserved Secret Manager bindings, while deployment automatically merges reviewed literal values and removes only enumerated retired bindings.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check-desktop-backend-release-policy.py",
+    ".github/scripts/test_check_desktop_backend_release_policy.py"
+  ],
   "evidence_prs": [9997],
   "scope_hints": [
     "config/public-build-contract.json",

--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -121,6 +121,8 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             "EXPECTED_GCP_PROJECT_ID: based-hardware-dev",
             "DEVELOPMENT_DESKTOP_BACKEND_URL: https://desktop-backend-dt5lrfkkoa-uc.a.run.app",
             'revision_suffix="${image_tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            "GOOGLE_APPLICATION_CREDENTIALS=/secrets/firebase/service-account.json",
+            "/secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest",
             "${{ secrets.GCP_SERVICE_ACCOUNT }}",
             'chmod 600 "$signer_file"',
             "base64 --decode",
@@ -129,6 +131,17 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
         ):
             if fragment not in text:
                 errors.append(f"{workflow}: missing development traffic guard {fragment!r}")
+        if any(
+            "--remove-env-vars" in line and "GOOGLE_APPLICATION_CREDENTIALS" in line
+            for line in text.splitlines()
+        ):
+            errors.append(
+                f"{workflow}: mounted Firestore credentials must not be removed from the candidate environment"
+            )
+        if "GCP_SERVICE_ACCOUNT:latest" in text or "GCP_SERVICE_ACCOUNT=GCP_SERVICE_ACCOUNT" in text:
+            errors.append(
+                f"{workflow}: the Firebase probe signer must never become desktop-backend runtime configuration"
+            )
     return errors
 
 

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -112,6 +112,32 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         self.assertTrue(any("DESKTOP_BACKEND_PROBE_SIGNER_FILE" in error for error in signer_errors), signer_errors)
         self.assertTrue(any("Mint candidate probe identity" in error for error in gate_errors), gate_errors)
 
+    def test_rejects_missing_or_conflicting_development_firestore_credentials(self) -> None:
+        missing_mount = self.dev.replace(
+            "            /secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest\n",
+            "",
+            1,
+        )
+        removed_env = self.dev.replace(
+            "--remove-env-vars=OMI_DESKTOP_RELEASE_TAG",
+            "--remove-env-vars=GOOGLE_APPLICATION_CREDENTIALS,OMI_DESKTOP_RELEASE_TAG",
+            1,
+        )
+        runtime_signer = self.dev.replace(
+            "            GEMINI_API_KEY=GEMINI_API_KEY:latest\n",
+            "            GCP_SERVICE_ACCOUNT=GCP_SERVICE_ACCOUNT:latest\n"
+            "            GEMINI_API_KEY=GEMINI_API_KEY:latest\n",
+            1,
+        )
+
+        missing_errors = POLICY.validate_deploy_workflow(missing_mount, production=False)
+        removed_errors = POLICY.validate_deploy_workflow(removed_env, production=False)
+        signer_errors = POLICY.validate_deploy_workflow(runtime_signer, production=False)
+
+        self.assertTrue(any("SERVICE_ACCOUNT_JSON" in error for error in missing_errors), missing_errors)
+        self.assertTrue(any("must not be removed" in error for error in removed_errors), removed_errors)
+        self.assertTrue(any("must never become" in error for error in signer_errors), signer_errors)
+
     def test_rejects_mutable_image_and_direct_traffic_deploy(self) -> None:
         mutated = self.prod.replace(
             "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}@${{ steps.build-image.outputs.digest }}",

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -188,13 +188,15 @@ jobs:
             --allow-unauthenticated
             --revision-suffix=${{ steps.candidate-identity.outputs.revision_suffix }}
             --tag=${{ env.CANDIDATE_TAG }}
-            --remove-env-vars=GOOGLE_APPLICATION_CREDENTIALS,OMI_DESKTOP_RELEASE_TAG,OMI_DESKTOP_RELEASE_SHA,OMI_DESKTOP_RELEASE_CHANNEL
+            --remove-env-vars=OMI_DESKTOP_RELEASE_TAG,OMI_DESKTOP_RELEASE_SHA,OMI_DESKTOP_RELEASE_CHANNEL
           env_vars: |
             FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
+            GOOGLE_APPLICATION_CREDENTIALS=/secrets/firebase/service-account.json
             BASE_API_URL=${{ steps.desktop-base-api-url.outputs.base_api_url }}
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.candidate-identity.outputs.source_sha }}
             OMI_DESKTOP_BACKEND_RELEASE_CHANNEL=development
           secrets: |
+            /secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             OPENAI_API_KEY=OPENAI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest


### PR DESCRIPTION
## Summary

- mount the existing development `SERVICE_ACCOUNT_JSON` Secret Manager value as a Cloud Run file
- point the Rust desktop backend at that file without baking credentials into the immutable image
- mutation-test the runtime binding, removal, and probe-signer separation contracts

## Root cause

Development run 30285052178 proved candidate readiness, image lineage, and Firebase probe-token minting before `GET /updates/latest` returned HTTP 500 (`firestore_read`). Its redacted deploy evidence showed `FIREBASE_PROJECT_ID=based-hardware`, removal of `GOOGLE_APPLICATION_CREDENTIALS`, and no runtime Firestore credential binding. The Rust Firestore service therefore fell back to the `based-hardware-dev` Cloud Run metadata identity while reading the `based-hardware` Firestore project.

This restores the source-managed runtime credential as a Secret Manager volume. It does not expose the separate `GCP_SERVICE_ACCOUNT` probe signer to the runtime.

## Safety

- development workflow only
- preserves the zero-traffic candidate, compatibility gates, provider probes, and promotion order
- no production workflow, traffic, IAM, secret value, or Firestore data changes

## Verification

- `python3 .github/scripts/test_check_desktop_backend_release_policy.py` — 16 tests passed
- `python3 .github/scripts/check-desktop-backend-release-policy.py` — passed
- `actionlint .github/workflows/desktop_backend_auto_dev.yml` — passed
- `git diff --check` — passed

Product-Invariants: none

Failure-Class: FC-runtime-binding-contract


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

