### PR TITLE
fix(backend): terminalize processing conversations too large to stamp the admission fence

### DIFF
--- a/.github/failure-classes/FC-permanent-write-rejection-retried-forever.json
+++ b/.github/failure-classes/FC-permanent-write-rejection-retried-forever.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-permanent-write-rejection-retried-forever",
+  "violated_contract": "A storage rejection that no retry of the same write can ever satisfy (a Firestore document at its 1 MiB ceiling) must move its row to a path the storage still accepts; replaying the same growing write on every sweep strands the row in a non-terminal state for good.",
+  "canonical_prevention": "Classify the permanent rejection at the storage boundary (database._client.is_document_size_limit_error, beside is_expired_transaction_error) and give the recovery sweep a terminal that does not grow the document, fenced on the snapshot's server-owned update_time instead of the fence the document cannot carry.",
+  "evidence_prs": [
+    10730
+  ],
+  "scope_hints": [
+    "backend/database/**",
+    "backend/services/conversation_finalization.py"
+  ],
+  "canonical_prevention_artifact": [
+    "backend/database/_client.py"
+  ],
+  "status": "open"
+}

--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -15,6 +15,7 @@ __all__ = [
     "document_id_from_seed",
     "get_firestore_client",
     "get_users_uid",
+    "is_document_size_limit_error",
     "is_expired_transaction_error",
     "run_transactional",
 ]
@@ -58,6 +59,19 @@ _EXPIRED_TRANSACTION_MARKER = "transaction has expired"
 def is_expired_transaction_error(error: BaseException) -> bool:
     """True for the Firestore 400 that retires a transaction id mid-flight."""
     return isinstance(error, InvalidArgument) and _EXPIRED_TRANSACTION_MARKER in str(error).lower()
+
+
+_DOCUMENT_SIZE_LIMIT_MARKER = "exceeds the maximum allowed size"
+
+
+def is_document_size_limit_error(error: BaseException) -> bool:
+    """True for the Firestore 400 rejecting a write that would exceed the 1 MiB document ceiling.
+
+    Unlike contention or an expired transaction, this is permanent: retrying the
+    same growing write can never succeed, so callers must take a different path
+    rather than loop.
+    """
+    return isinstance(error, InvalidArgument) and _DOCUMENT_SIZE_LIMIT_MARKER in str(error).lower()
 
 
 def run_transactional(client: Any, transactional_callable: Any, *args: Any, attempts: int = 3, **kwargs: Any) -> Any:

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -1197,6 +1197,47 @@ def stamp_processing_admission_if_absent(uid: str, conversation_id: str, *, fire
     return transactional(transaction, _conversation_ref(client, uid, conversation_id), _now())
 
 
+def _complete_unstampable_orphan_conversation_txn(
+    transaction: Any, conversation_ref: Any, stale_before: datetime
+) -> bool:
+    """Terminalize a legacy orphan whose admission fence can never be stamped.
+
+    A conversation sitting at Firestore's 1 MiB document ceiling rejects every
+    growing write, so ``stamp_processing_admission_if_absent`` can never migrate
+    it: the row would stay ``processing`` for good while the sweep retries it
+    forever. The snapshot's server-owned ``update_time`` stands in for the fence
+    the document cannot carry — only a row no writer (including a live processor,
+    which is equally unable to write to it) has touched since ``stale_before`` is
+    terminalized. Every other ownership fence still applies, and the terminal
+    write only shrinks the document, so it fits where the stamp did not.
+    """
+    snapshot = conversation_ref.get(transaction=transaction)
+    if not getattr(snapshot, 'exists', False):
+        return False
+    data = snapshot.to_dict() or {}
+    if data.get('status') != 'processing':
+        return False
+    if data.get('discarded') or data.get('deferred') or data.get('finalization_job_id'):
+        return False
+    if isinstance(data.get('processing_admitted_at'), datetime):
+        return False  # no longer a legacy row: the admission-fenced path owns it
+    last_written = getattr(snapshot, 'update_time', None)
+    if not isinstance(last_written, datetime) or last_written > stale_before:
+        return False
+    transaction.update(conversation_ref, {'status': 'completed'})
+    return True
+
+
+def complete_unstampable_orphan_conversation(
+    uid: str, conversation_id: str, *, stale_after: timedelta, firestore_client: Any = None
+) -> bool:
+    """Terminalize a legacy orphan that is too large to accept the admission fence."""
+    client = _client(firestore_client)
+    transaction = client.transaction()
+    transactional = firestore.transactional(_complete_unstampable_orphan_conversation_txn)
+    return transactional(transaction, _conversation_ref(client, uid, conversation_id), _now() - stale_after)
+
+
 def _complete_orphan_conversation_txn(
     transaction: Any, conversation_ref: Any, expected_admitted_at: datetime | None, now: datetime
 ) -> bool:

--- a/backend/services/conversation_finalization.py
+++ b/backend/services/conversation_finalization.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from google.api_core.exceptions import InvalidArgument
+
 from database import conversation_finalization_jobs as jobs_db
+from database._client import is_document_size_limit_error
 from utils.cloud_tasks import (
     enqueue_listen_finalization_job,
     get_listen_finalization_tasks_max_attempts,
@@ -160,9 +163,36 @@ def reconcile_stale_processing_conversations(limit: int = 100, *, firestore_clie
                 # terminalize on first sight.  Only a successful stamp counts as
                 # ``migrated``; a CAS loss (already stamped / status changed /
                 # absent) is an expected ``skipped`` fencing, never a migration.
-                stamped = jobs_db.stamp_processing_admission_if_absent(
-                    uid, conversation_id, firestore_client=firestore_client
-                )
+                try:
+                    stamped = jobs_db.stamp_processing_admission_if_absent(
+                        uid, conversation_id, firestore_client=firestore_client
+                    )
+                except InvalidArgument as error:
+                    if not is_document_size_limit_error(error):
+                        raise
+                    # The row is at Firestore's 1 MiB document ceiling, so the
+                    # fence can never be stamped: migration would fail on every
+                    # future sweep and the conversation would stay `processing`
+                    # for good. Terminalize it on the server-owned last-write
+                    # instant instead — that shrinking write is the one update
+                    # the document still accepts.
+                    record_fallback(
+                        component='pusher',
+                        from_mode='admission_stamp',
+                        to_mode='unstampable_terminal',
+                        reason='other',
+                        outcome='degraded',
+                        log=logger,
+                    )
+                    if jobs_db.complete_unstampable_orphan_conversation(
+                        uid, conversation_id, stale_after=stale_after, firestore_client=firestore_client
+                    ):
+                        result['completed'] += 1
+                        LISTEN_FINALIZATION_STALE_PROCESSING_RECONCILIATIONS_TOTAL.labels(outcome='completed').inc()
+                    else:
+                        result['skipped'] += 1
+                        LISTEN_FINALIZATION_STALE_PROCESSING_RECONCILIATIONS_TOTAL.labels(outcome='skipped').inc()
+                    continue
                 if stamped:
                     result['migrated'] += 1
                     LISTEN_FINALIZATION_STALE_PROCESSING_RECONCILIATIONS_TOTAL.labels(outcome='migrated').inc()

--- a/backend/tests/unit/test_stale_processing_emulator_concurrency.py
+++ b/backend/tests/unit/test_stale_processing_emulator_concurrency.py
@@ -288,3 +288,50 @@ def test_deferred_reacquire_prevents_orphan_terminalization():
     assert final_data.get('processing_admitted_at') != old_admitted, 'lease should be renewed'
 
     _cleanup_conversation(uid, cid)
+
+
+# ---------------------------------------------------------------------------
+# 4. Unstampable (1 MiB) orphan: the server-owned update_time stands in for the
+#    admission fence the document is too large to carry
+# ---------------------------------------------------------------------------
+
+
+def test_unstampable_orphan_is_fenced_by_the_server_owned_update_time():
+    """A legacy row whose document rejects the admission stamp is terminalized
+    only once no writer has touched it for the staleness window. ``update_time``
+    is server-owned and read inside the transaction, so a live writer (or a row
+    that has since acquired a fence or a durable owner) is never terminalized.
+
+    The emulator does not enforce the 1 MiB document ceiling, so the oversize
+    rejection itself is covered hermetically in
+    ``test_stale_processing_reconciliation.py``; what only real Firestore can
+    prove is that the snapshot carries a usable ``update_time`` and that the
+    fences hold against it."""
+    uid = 'test-race-user'
+    cid = 'unstampable-conv-1'
+    _cleanup_conversation(uid, cid)
+
+    client = _client()
+    conv_ref = client.collection('users').document(uid).collection('conversations').document(cid)
+    conv_ref.set({'id': cid, 'status': 'processing', 'has_content': True})
+
+    # Just written: inside the staleness window, so it is fenced out.
+    assert jobs_db.complete_unstampable_orphan_conversation(uid, cid, stale_after=timedelta(seconds=900)) is False
+    assert (conv_ref.get().to_dict() or {}).get('status') == 'processing'
+
+    # A durable finalization owner fences it out even once stale.
+    conv_ref.update({'finalization_job_id': 'job-1'})
+    assert jobs_db.complete_unstampable_orphan_conversation(uid, cid, stale_after=timedelta(seconds=0)) is False
+    assert (conv_ref.get().to_dict() or {}).get('status') == 'processing'
+
+    # Unowned and untouched for the window: exactly one terminal, transcript intact.
+    conv_ref.update({'finalization_job_id': firestore.DELETE_FIELD})
+    assert jobs_db.complete_unstampable_orphan_conversation(uid, cid, stale_after=timedelta(seconds=0)) is True
+    final_data = conv_ref.get().to_dict() or {}
+    assert final_data.get('status') == 'completed'
+    assert final_data.get('has_content') is True
+
+    # A terminalized row is never terminalized twice.
+    assert jobs_db.complete_unstampable_orphan_conversation(uid, cid, stale_after=timedelta(seconds=0)) is False
+
+    _cleanup_conversation(uid, cid)

--- a/backend/tests/unit/test_stale_processing_reconciliation.py
+++ b/backend/tests/unit/test_stale_processing_reconciliation.py
@@ -16,9 +16,16 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
+from google.api_core.exceptions import InvalidArgument
+
 from services import conversation_finalization as service
 
 _ADMITTED = datetime.now(timezone.utc) - timedelta(seconds=1000)
+# Verbatim shape of the live prod rejection for a conversation at the 1 MiB ceiling.
+_OVERSIZED_DOCUMENT_MESSAGE = (
+    "400 Document 'projects/p/databases/(default)/documents/users/u/conversations/c' cannot be written "
+    'because its size (1,048,601 bytes) exceeds the maximum allowed size of 1,048,576 bytes.'
+)
 
 
 def _candidate(uid: str, cid: str, *, legacy: bool = False) -> dict:
@@ -101,6 +108,50 @@ def test_legacy_stamp_cas_loss_is_skipped_not_migrated(monkeypatch):
     assert result == {'completed': 0, 'migrated': 0, 'skipped': 1, 'error': 0}
     stamp.assert_called_once_with('uid', 'already-stamped-1', firestore_client=None)
     complete.assert_not_called()
+
+
+def test_legacy_row_too_large_to_stamp_is_terminalized_not_retried_forever(monkeypatch):
+    """A legacy row at Firestore's 1 MiB document ceiling rejects the admission
+    stamp permanently, so migration can never progress and the conversation
+    would stay ``processing`` for good. It is terminalized through the
+    unstampable path instead of being counted as an error on every sweep."""
+    stamp, complete = _install(monkeypatch, [_candidate('uid', 'oversized-1', legacy=True)])
+    stamp.side_effect = InvalidArgument(_OVERSIZED_DOCUMENT_MESSAGE)
+    unstampable = MagicMock(return_value=True)
+    monkeypatch.setattr(service.jobs_db, 'complete_unstampable_orphan_conversation', unstampable)
+
+    result = service.reconcile_stale_processing_conversations()
+
+    assert result == {'completed': 1, 'migrated': 0, 'skipped': 0, 'error': 0}
+    unstampable.assert_called_once_with('uid', 'oversized-1', stale_after=timedelta(seconds=900), firestore_client=None)
+    # The generation-fenced terminal is for stamped rows only.
+    complete.assert_not_called()
+
+
+def test_unstampable_row_still_owned_by_a_live_writer_is_skipped(monkeypatch):
+    """The unstampable terminal keeps its own fence: a row it declines to
+    terminalize is an expected skip, never a completion."""
+    stamp, _complete = _install(monkeypatch, [_candidate('uid', 'oversized-2', legacy=True)])
+    stamp.side_effect = InvalidArgument(_OVERSIZED_DOCUMENT_MESSAGE)
+    monkeypatch.setattr(service.jobs_db, 'complete_unstampable_orphan_conversation', MagicMock(return_value=False))
+
+    result = service.reconcile_stale_processing_conversations()
+
+    assert result == {'completed': 0, 'migrated': 0, 'skipped': 1, 'error': 0}
+
+
+def test_non_size_invalid_argument_stays_an_error(monkeypatch):
+    """Only the permanent document-size rejection reroutes; any other 400 is an
+    unexpected per-row failure and must keep counting as an error."""
+    stamp, _complete = _install(monkeypatch, [_candidate('uid', 'legacy-boom', legacy=True)])
+    stamp.side_effect = InvalidArgument('400 The referenced transaction has expired or is no longer valid.')
+    unstampable = MagicMock(return_value=True)
+    monkeypatch.setattr(service.jobs_db, 'complete_unstampable_orphan_conversation', unstampable)
+
+    result = service.reconcile_stale_processing_conversations()
+
+    assert result == {'completed': 0, 'migrated': 0, 'skipped': 0, 'error': 1}
+    unstampable.assert_not_called()
 
 
 def test_query_failure_is_fail_closed_and_records_an_error(monkeypatch):


### PR DESCRIPTION
## Bug (live in prod)

Six conversations belonging to six distinct users have been stuck in `status: processing` for months — the oldest since 2026-05-06 — and the stale-processing reconciler has been failing on them ~86 times per 24h:

```
File "/app/services/conversation_finalization.py", line 163, in reconcile_stale_processing_conversations
  stamped = jobs_db.stamp_processing_admission_if_absent(
File "/app/database/conversation_finalization_jobs.py", line 1197, in stamp_processing_admission_if_absent
google.api_core.exceptions.InvalidArgument: 400 Document
  '.../users/<uid>/conversations/<cid>' cannot be written because its size
  (1,048,601 bytes) exceeds the maximum allowed size of 1,048,576 bytes.
```

## Root cause

Those conversations accumulated a compressed transcript that put the document at Firestore's 1 MiB ceiling (~1,043,571 bytes of `transcript_segments` on the one I inspected), so **every growing write is rejected**.

The orphan sweep migrates a legacy pre-fence row by stamping the server-owned admission fence `processing_admitted_at` — a write that adds ~31 bytes. On these rows it can never succeed. The rejection was treated as an ordinary per-row failure, counted as `error`, and retried on the next sweep, forever. The conversation therefore never reaches a terminal: it stays `processing` in the user's app for good.

The class is a **permanent** storage rejection being replayed as if it were transient — the mirror image of #10721 (`FC-retired-transaction-treated-as-fatal`), where a recoverable rejection was treated as fatal.

## Fix

- `database/_client.is_document_size_limit_error` classifies the permanent 1 MiB rejection at the storage boundary, beside the existing `is_expired_transaction_error`. Every other `InvalidArgument` keeps raising.
- `complete_unstampable_orphan_conversation` gives the sweep a terminal the document still accepts: `processing` → `completed` **shrinks** the document, so it fits where the stamp did not. The snapshot's server-owned `update_time`, read inside the transaction, stands in for the fence the document cannot carry; every other ownership fence (status, `discarded`, `deferred`, `finalization_job_id`, already-stamped) still applies, so a live or durable-owned row is never terminalized.
- The branch emits `record_fallback(component=pusher, from=admission_stamp, to=unstampable_terminal, outcome=degraded)`.

The transcript is untouched — only `status` changes.

## What I tested

**Real Firestore (`based-hardware-dev`, where the 1 MiB limit is actually enforced; the emulator does not enforce it):**

- built a legacy `processing` conversation at the ceiling → `stamp_processing_admission_if_absent` was rejected with the verbatim prod error, and `is_document_size_limit_error` classified it
- a just-written row is fenced out (`False`, still `processing`)
- a row past the staleness window is terminalized (`True` → `completed`) with its 1,048,408-byte transcript intact
- a re-run is a skip, not a second terminal
- the full service branch through `reconcile_stale_processing_conversations` returned `{'completed': 1, 'migrated': 0, 'skipped': 0, 'error': 0}` and the conversation ended `completed`; scratch docs deleted afterwards

**Suites:**

- `backend/tests/unit/{test_stale_processing_reconciliation,test_conversation_finalization_jobs,test_conversation_segments_transaction_expiry}.py` → 60 passed (3 new regression tests: oversize → terminal, unstampable fence → skip, non-size `InvalidArgument` → still an error)
- `FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 pytest tests/unit/test_stale_processing_emulator_concurrency.py` → 5 passed, including the new `update_time` fence contract against real Firestore transaction semantics

## Product invariants affected

none

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

