### PR TITLE
SCA-194: bridge desktop production secret bindings

### DIFF
--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -19,6 +19,46 @@ def _ordered(text: str, fragments: tuple[str, ...], *, workflow: str) -> list[st
     return []
 
 
+def _validate_production_secret_bridge(text: str, *, workflow: str) -> list[str]:
+    errors: list[str] = []
+    for fragment in (
+        "Preflight production desktop secret resource names",
+        "# Temporary bridge pending Rust -> Python backend consolidation.",
+        'gcloud secrets describe "$secret"',
+        "--format='none'",
+        "GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest",
+        "FIREBASE_API_KEY=DESKTOP_FIREBASE_API_KEY:latest",
+        "REDIS_DB_PASSWORD=DESKTOP_REDIS_DB_PASSWORD:latest",
+        "REDIS_DB_HOST=DESKTOP_REDIS_DB_HOST:latest",
+        "REDIS_DB_PORT=DESKTOP_REDIS_DB_PORT:latest",
+        "--remove-secrets=PINECONE_API_KEY,PINECONE_HOST",
+    ):
+        if fragment not in text:
+            errors.append(f"{workflow}: missing temporary production secret bridge {fragment!r}")
+    for forbidden in (
+        "GEMINI_API_KEY=GEMINI_API_KEY:latest",
+        "FIREBASE_API_KEY=FIREBASE_API_KEY:latest",
+        "REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest",
+        "REDIS_DB_HOST=REDIS_DB_HOST:latest",
+        "REDIS_DB_PORT=REDIS_DB_PORT:latest",
+        "PINECONE_API_KEY=",
+        "PINECONE_HOST=",
+    ):
+        if forbidden in text:
+            errors.append(f"{workflow}: forbidden production secret binding {forbidden!r}")
+    errors.extend(
+        _ordered(
+            text,
+            (
+                "Preflight production desktop secret resource names",
+                "Build and push immutable Docker image",
+            ),
+            workflow=workflow,
+        )
+    )
+    return errors
+
+
 def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
     workflow = "desktop_backend_prod.yml" if production else "desktop_backend_auto_dev.yml"
     errors: list[str] = []
@@ -110,6 +150,7 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
                 errors.append(
                     f"{workflow}: desktop-backend must remain outside the Python backend vector: {forbidden!r}"
                 )
+        errors.extend(_validate_production_secret_bridge(text, workflow=workflow))
     else:
         for fragment in (
             "group: desktop-backend-auto-dev",

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -155,6 +155,45 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         errors = POLICY.validate_deploy_workflow(mutated, production=True)
         self.assertTrue(any("manual" in error or "outside" in error for error in errors), errors)
 
+    def test_rejects_legacy_production_secret_bindings(self) -> None:
+        generic_mappings = (
+            ("GEMINI_API_KEY", "DESKTOP_GEMINI_API_KEY"),
+            ("FIREBASE_API_KEY", "DESKTOP_FIREBASE_API_KEY"),
+            ("REDIS_DB_PASSWORD", "DESKTOP_REDIS_DB_PASSWORD"),
+            ("REDIS_DB_HOST", "DESKTOP_REDIS_DB_HOST"),
+            ("REDIS_DB_PORT", "DESKTOP_REDIS_DB_PORT"),
+        )
+        for environment_key, secret_name in generic_mappings:
+            legacy = f"{environment_key}={environment_key}:latest"
+            mutated = self.prod.replace(
+                f"{environment_key}={secret_name}:latest",
+                legacy,
+                1,
+            )
+            with self.subTest(legacy=legacy):
+                errors = POLICY.validate_deploy_workflow(mutated, production=True)
+                self.assertTrue(any(legacy in error for error in errors), errors)
+
+        for pinecone_key in ("PINECONE_API_KEY", "PINECONE_HOST"):
+            binding = f"{pinecone_key}={pinecone_key}:latest"
+            mutated = self.prod.replace(
+                "            ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest\n",
+                f"            {binding}\n"
+                "            ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest\n",
+                1,
+            )
+            with self.subTest(binding=binding):
+                errors = POLICY.validate_deploy_workflow(mutated, production=True)
+                self.assertTrue(any(f"{pinecone_key}=" in error for error in errors), errors)
+
+        missing_removal = self.prod.replace(
+            "            --remove-secrets=PINECONE_API_KEY,PINECONE_HOST\n",
+            "",
+            1,
+        )
+        errors = POLICY.validate_deploy_workflow(missing_removal, production=True)
+        self.assertTrue(any("--remove-secrets=PINECONE_API_KEY,PINECONE_HOST" in error for error in errors), errors)
+
     def test_rejects_missing_release_compatibility_gate(self) -> None:
         mutated = self.stable.replace("Verify live desktop-backend chat compatibility", "Compatibility omitted")
         errors = POLICY.validate_desktop_release_gates(self.qualification, mutated)

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -208,6 +208,23 @@ jobs:
               raise SystemExit("DESKTOP_GOOGLE_CALENDAR_API_KEY does not look like a Google API key")
           PY
 
+      - name: Preflight production desktop secret resource names
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          # Temporary bridge pending Rust -> Python backend consolidation.
+          for secret in \
+            DESKTOP_GEMINI_API_KEY \
+            DESKTOP_FIREBASE_API_KEY \
+            DESKTOP_REDIS_DB_PASSWORD \
+            DESKTOP_REDIS_DB_HOST \
+            DESKTOP_REDIS_DB_PORT; do
+            gcloud secrets describe "$secret" \
+              --project="$PROJECT_ID" \
+              --format='none'
+          done
+
       - name: Capture current serving revision
         id: previous-traffic
         env:
@@ -260,21 +277,20 @@ jobs:
             --revision-suffix=${{ steps.admitted-source.outputs.revision_suffix }}
             --tag=${{ env.CANDIDATE_TAG }}
             --remove-env-vars=GOOGLE_APPLICATION_CREDENTIALS,OMI_DESKTOP_RELEASE_TAG,OMI_DESKTOP_RELEASE_SHA,OMI_DESKTOP_RELEASE_CHANNEL
+            --remove-secrets=PINECONE_API_KEY,PINECONE_HOST
           env_vars: |
             FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
             BASE_API_URL=${{ env.PRODUCTION_DESKTOP_BACKEND_URL }}
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.admitted-source.outputs.source_sha }}
             OMI_DESKTOP_BACKEND_RELEASE_CHANNEL=production
           secrets: |
-            GEMINI_API_KEY=GEMINI_API_KEY:latest
+            GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest
             OPENAI_API_KEY=OPENAI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
-            REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
-            FIREBASE_API_KEY=FIREBASE_API_KEY:latest
-            PINECONE_API_KEY=PINECONE_API_KEY:latest
-            REDIS_DB_HOST=REDIS_DB_HOST:latest
-            REDIS_DB_PORT=REDIS_DB_PORT:latest
-            PINECONE_HOST=PINECONE_HOST:latest
+            REDIS_DB_PASSWORD=DESKTOP_REDIS_DB_PASSWORD:latest
+            FIREBASE_API_KEY=DESKTOP_FIREBASE_API_KEY:latest
+            REDIS_DB_HOST=DESKTOP_REDIS_DB_HOST:latest
+            REDIS_DB_PORT=DESKTOP_REDIS_DB_PORT:latest
             ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
             DESKTOP_LEGACY_ANTHROPIC_KEY=DESKTOP_LEGACY_ANTHROPIC_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest


### PR DESCRIPTION
## Summary

- restore the established `DESKTOP_*` Secret Manager bindings for Gemini, Firebase, and Redis in the independent production desktop-backend candidate
- remove Pinecone from the required candidate bindings and explicitly remove any inherited Pinecone secret environment bindings
- add a name-only Secret Manager preflight plus deterministic mutation coverage for the temporary Rust-to-Python bridge

## Verification

- `python3 .github/scripts/test_check_desktop_backend_release_policy.py`
- `python3 .github/scripts/check-desktop-backend-release-policy.py`
- `actionlint .github/workflows/desktop_backend_prod.yml`
- `make preflight`

## Failure class

Failure-Class: FC-runtime-binding-contract

The existing desktop release-policy checker and its mutation fixtures are the canonical prevention artifact. This extends them to reject every generic Gemini/Firebase/Redis mapping, both Pinecone bindings, and omission of the inherited-binding removal flag.

## Safety

This is a temporary bridge pending Rust-to-Python backend consolidation. It does not change runtime behavior, release eligibility, zero-traffic candidate admission, acceptance probes, promotion ordering, serving verification, rollback, protected-environment authority, or deployment concurrency.

No production workflow was triggered, approved, retried, or otherwise mutated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

