### PR TITLE
fix(backend): serve legacy memories in chat for un-enrolled accounts

### DIFF
--- a/.github/failure-classes/FC-absent-rollout-state-as-denial.json
+++ b/.github/failure-classes/FC-absent-rollout-state-as-denial.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "FC-absent-rollout-state-as-denial",
+  "violated_contract": "An absent optional rollout-state document means the account was never enrolled, which is a served state rather than a denial; a fail-closed default-memory read gate must not refuse a read the account's authoritative legacy surface can serve.",
+  "canonical_prevention": "Interpret every default-memory read decision through the one shared legacy-fallback contract, which serves the legacy surface only for an explicit legacy-safe decision or a deny whose sole reason is the absent rollout-state document, and keeps every other deny reason fail-closed so an indeterminate state is never mistaken for never-enrolled.",
+  "canonical_prevention_artifact": [
+    "backend/utils/memory/default_read_rollout.py",
+    "backend/tests/unit/test_default_read_rollout_decision.py"
+  ],
+  "evidence_prs": [
+    10094,
+    10095,
+    10485
+  ],
+  "scope_hints": [
+    "backend/utils/memory/default_read_rollout.py",
+    "backend/utils/mcp_memories.py",
+    "backend/utils/retrieval/tool_services/**",
+    "backend/utils/retrieval/tools/**",
+    "backend/routers/developer.py"
+  ],
+  "status": "open"
+}

--- a/.github/lifecycle-header-baseline.txt
+++ b/.github/lifecycle-header-baseline.txt
@@ -12,7 +12,6 @@ backend/scripts/shared_ns2_legacy_isolation_readiness.py
 backend/scripts/v3_dev_cloud_readiness.py
 backend/scripts/vector_repair_outbox_oidc_iam_proof.py
 backend/scripts/vector_search_provider_readiness.py
-backend/utils/memory/default_read_rollout.py
 backend/utils/memory/memory_read_rollout_core.py
 backend/utils/memory/v3/compatibility.py
 backend/utils/memory/v3/limited_rollout_config.py

--- a/backend/tests/unit/test_chat_memory_adapter.py
+++ b/backend/tests/unit/test_chat_memory_adapter.py
@@ -42,6 +42,11 @@ def _enabled_rollout_doc(uid='u1'):
 
 
 def test_chat_memory_tool_wires_memory_adapter_before_legacy_vector_search():
+    # Static tripwire (source order, not behavior): the chat tool must consult the default-read
+    # decision before it can reach the legacy vector index. The decision is interpreted by the
+    # shared legacy-fallback contract, so an un-enrolled account reads legacy while every other
+    # deny reason stays fail-closed; behavior is covered in
+    # tests/unit/test_chat_memory_unenrolled_legacy_fallback.py.
     memory_tools_py = Path(__file__).resolve().parents[2] / 'utils' / 'retrieval' / 'tools' / 'memory_tools.py'
     contents = memory_tools_py.read_text(encoding='utf-8')
     rollout_call = 'search_memory_default_chat_memories_vector_decision_text('
@@ -50,7 +55,7 @@ def test_chat_memory_tool_wires_memory_adapter_before_legacy_vector_search():
     assert legacy_call in contents
     assert contents.index(rollout_call) < contents.index(legacy_call)
     assert 'if default_memories is not None:' not in contents
-    assert 'MemoryReadDecision.USE_LEGACY_SAFE' in contents
+    assert 'legacy_read_fallback_authorized(' in contents
 
 
 def test_chat_rollout_reader_supports_omi_chat_grant_without_reading_memory_items():

--- a/backend/tests/unit/test_chat_memory_unenrolled_legacy_fallback.py
+++ b/backend/tests/unit/test_chat_memory_unenrolled_legacy_fallback.py
@@ -1,0 +1,142 @@
+"""Omi chat serves legacy memories for un-enrolled accounts instead of hard-denying (#10736).
+
+An account with no ``users/{uid}/memory_control/state`` document resolves to
+``DENY_MEMORY`` / ``missing_rollout_state``. That is the expected state for the legacy
+cohort, not a failure: ``pin_memory_system`` has already resolved the account to LEGACY,
+so the legacy ``memories`` collection is its authoritative surface.
+
+The Developer API (#10094) and hosted MCP (#9892) already treat that signal as
+"un-enrolled, read legacy". The four chat retrieval entry points did not, so chat answered
+"No memories available for this request." while the memories list screen showed the same
+user's memories normally — it read as the assistant forgetting, not as an error.
+
+Both branches are asserted per surface, because the risk in relaxing a fail-closed check is
+relaxing it too far: an un-enrolled deny must reach legacy, and every other deny reason must
+still refuse to read it.
+"""
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+import utils.retrieval.tool_services.memories as memories_svc  # noqa: E402
+import utils.retrieval.tools.memory_tools as memory_tools  # noqa: E402
+from utils.memory.chat_memory_adapter import ChatMemorySearchResult  # noqa: E402
+from utils.memory.default_read_rollout import MemoryReadDecision  # noqa: E402
+from utils.memory.memory_system import MemorySystem  # noqa: E402
+
+UID = 'test-uid'
+QUERY = 'espresso'
+LEGACY_CONTENT = 'User has always been on the legacy memories collection.'
+DENY_TEXT = 'No memories available for this request.'
+
+# The un-enrolled signal that must now reach legacy.
+UNENROLLED_REASON = 'missing_rollout_state'
+# A deny that means "we could not establish this account's state" and must stay fail-closed.
+# Chat's grant denial is the chat-consumer reason; there is no app-key gate on this path.
+NON_RECOVERABLE_REASON = 'missing_chat_default_memory_grant'
+
+_TOOL_CONFIG = {"configurable": {"user_id": UID}}
+
+
+def _legacy_row():
+    now = datetime(2026, 7, 27, 12, 0, 0, tzinfo=timezone.utc)
+    return {
+        'id': 'legacy-1',
+        'uid': UID,
+        'content': LEGACY_CONTENT,
+        'created_at': now,
+        'updated_at': now,
+    }
+
+
+def _denied(reason):
+    """A decision carrying no text, so a hard deny surfaces the generic refusal string."""
+    return ChatMemorySearchResult(text=None, read_decision=MemoryReadDecision.DENY_MEMORY, fallback_reason=reason)
+
+
+def _stub_common(monkeypatch, module, reason, decision_attr):
+    """Pin the account to LEGACY and force the given default-read denial."""
+    monkeypatch.setattr(module, 'pin_memory_system', lambda *a, **k: MemorySystem.LEGACY)
+    monkeypatch.setattr(module, decision_attr, lambda **kwargs: _denied(reason))
+    monkeypatch.setattr(module.notification_db, 'get_user_time_zone', lambda uid: None)
+
+
+def _stub_legacy_list(monkeypatch, module, reads):
+    def _get_memories(uid, limit=50, offset=0, start_date=None, end_date=None):
+        reads.append(uid)
+        return [_legacy_row()]
+
+    monkeypatch.setattr(module.memory_db, 'get_memories', _get_memories)
+
+
+def _stub_legacy_vector(monkeypatch, module, reads):
+    def _find_similar(uid, query, threshold=0.0, limit=5):
+        reads.append(uid)
+        return [{'memory_id': 'legacy-1', 'score': 0.91}]
+
+    monkeypatch.setattr(module.vector_db, 'find_similar_memories', _find_similar)
+    monkeypatch.setattr(module.memory_db, 'get_memories_by_ids', lambda uid, ids: [_legacy_row()])
+
+
+def _run_service_list(monkeypatch, reason):
+    reads = []
+    _stub_common(monkeypatch, memories_svc, reason, 'list_default_chat_memories_decision_text')
+    _stub_legacy_list(monkeypatch, memories_svc, reads)
+    return memories_svc.get_memories_text(uid=UID), reads
+
+
+def _run_service_search(monkeypatch, reason):
+    reads = []
+    _stub_common(monkeypatch, memories_svc, reason, 'search_memory_default_chat_memories_vector_decision_text')
+    _stub_legacy_vector(monkeypatch, memories_svc, reads)
+    return memories_svc.search_memories_text(uid=UID, query=QUERY), reads
+
+
+def _run_tool_list(monkeypatch, reason):
+    reads = []
+    _stub_common(monkeypatch, memory_tools, reason, 'list_default_chat_memories_decision_text')
+    _stub_legacy_list(monkeypatch, memory_tools, reads)
+    return memory_tools.get_memories_tool.func(config=_TOOL_CONFIG), reads
+
+
+def _run_tool_search(monkeypatch, reason):
+    reads = []
+    _stub_common(monkeypatch, memory_tools, reason, 'search_memory_default_chat_memories_vector_decision_text')
+    _stub_legacy_vector(monkeypatch, memory_tools, reads)
+    return memory_tools.search_memories_tool.func(query=QUERY, config=_TOOL_CONFIG), reads
+
+
+# All four chat entry points that consult the default-read decision: the LangChain tools used
+# by mobile chat, and the shared services behind /v1/tools/* for desktop, web, and agents.
+CHAT_SURFACES = [
+    pytest.param(_run_service_list, id='service_list'),
+    pytest.param(_run_service_search, id='service_vector_search'),
+    pytest.param(_run_tool_list, id='tool_list'),
+    pytest.param(_run_tool_search, id='tool_vector_search'),
+]
+
+
+@pytest.mark.parametrize('run_surface', CHAT_SURFACES)
+def test_unenrolled_account_reads_legacy_memories_instead_of_refusing(monkeypatch, run_surface):
+    output, legacy_reads = run_surface(monkeypatch, UNENROLLED_REASON)
+
+    assert legacy_reads == [UID], 'un-enrolled deny must reach the legacy memories read'
+    assert LEGACY_CONTENT in output
+    assert DENY_TEXT not in output
+
+
+@pytest.mark.parametrize('run_surface', CHAT_SURFACES)
+def test_other_deny_reasons_still_refuse_without_reading_legacy(monkeypatch, run_surface):
+    output, legacy_reads = run_surface(monkeypatch, NON_RECOVERABLE_REASON)
+
+    assert legacy_reads == [], 'a non-un-enrolled deny must not read legacy memories'
+    assert output == DENY_TEXT
+    assert LEGACY_CONTENT not in output

--- a/backend/tests/unit/test_default_read_rollout_decision.py
+++ b/backend/tests/unit/test_default_read_rollout_decision.py
@@ -1,6 +1,11 @@
+from unittest.mock import patch
+
 from config.memory_rollout import PASSED, MemoryRolloutMode, MemoryRolloutStageGate
+import utils.observability as observability
 from utils.memory.default_read_rollout import (
     MemoryReadDecision,
+    UNENROLLED_LEGACY_FALLBACK_REASON,
+    legacy_read_fallback_authorized,
     DEFAULT_READ_ROLLOUT_SCHEMA_VERSION,
     DEFAULT_READ_ROLLOUT_TIMEOUT_SECONDS,
     GLOBAL_READ_GATE_PATH,
@@ -588,3 +593,69 @@ def test_shared_rollout_metrics_buckets_unknown_dynamic_fallback_reasons():
     assert (
         'default_read_rollout_decisions_total{consumer="mcp",outcome="fallback",fallback_reason="other"} 1' in metrics
     )
+
+
+# --- shared un-enrolled legacy-fallback contract (#9892) ---------------------
+# `legacy_read_fallback_authorized` is the single owner of "which denied default-memory
+# read may still serve the legacy collection". Every default-memory consumer routes
+# through it, so this matrix is the anti-drift guard: relaxing one consumer must not
+# silently relax another, and no new deny reason may become a legacy fallback by default.
+
+
+def _authorized(read_decision, fallback_reason=None):
+    # The contract imports record_fallback lazily to keep this module free of the
+    # fastapi import chain, so patch it at its source rather than on the module.
+    with patch.object(observability, 'record_fallback') as recorded:
+        allowed = legacy_read_fallback_authorized(read_decision, fallback_reason)
+    return allowed, recorded
+
+
+def test_legacy_read_fallback_allows_explicit_legacy_safe_without_fallback_telemetry():
+    allowed, recorded = _authorized(MemoryReadDecision.USE_LEGACY_SAFE)
+
+    assert allowed is True
+    # An explicit legacy-safe decision is the configured surface, not a recovery.
+    recorded.assert_not_called()
+
+
+def test_legacy_read_fallback_allows_unenrolled_deny_and_records_recovered_fallback():
+    allowed, recorded = _authorized(MemoryReadDecision.DENY_MEMORY, UNENROLLED_LEGACY_FALLBACK_REASON)
+
+    assert allowed is True
+    recorded.assert_called_once_with(
+        component='other',
+        from_mode='memory_default_read',
+        to_mode='legacy_memories',
+        reason='policy',
+        outcome='recovered',
+    )
+
+
+def test_legacy_read_fallback_fails_closed_for_every_other_deny_reason():
+    # Each of these means "we could not establish the account's state", which must never
+    # be read as "never enrolled" — that would serve legacy memories past a real denial.
+    for reason in (
+        'malformed_rollout_state',
+        'rollout_read_failed',
+        'missing_mcp_default_memory_grant',
+        'missing_chat_default_memory_grant',
+        'missing_developer_default_memory_grant',
+        'memory_reads_disabled',
+        'uid_mismatch',
+        'unsupported_consumer',
+        'unsupported_rollout_schema',
+        None,
+    ):
+        allowed, recorded = _authorized(MemoryReadDecision.DENY_MEMORY, reason)
+        assert allowed is False, reason
+        recorded.assert_not_called()
+
+
+def test_legacy_read_fallback_fails_closed_for_shadow_only_and_use_memory():
+    # SHADOW_ONLY is a compute-but-do-not-serve state, and USE_MEMORY is served from the
+    # memory surface; neither is a legacy-fallback decision even with the un-enrolled reason.
+    for read_decision in (MemoryReadDecision.SHADOW_ONLY, MemoryReadDecision.USE_MEMORY):
+        for reason in ('shadow_only', UNENROLLED_LEGACY_FALLBACK_REASON, None):
+            allowed, recorded = _authorized(read_decision, reason)
+            assert allowed is False, (read_decision, reason)
+            recorded.assert_not_called()

--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -300,7 +300,11 @@ def _force_legacy_memory_paths(module):
     from utils.memory import memory_service
     from utils.memory.memory_system import MemorySystem
 
-    legacy = SimpleNamespace(read_decision=MemoryReadDecision.USE_LEGACY_SAFE, memories=[], text=None)
+    # fallback_reason is declared on every real decision result (chat/MCP/developer), so the
+    # double carries it too — the legacy-fallback contract reads it alongside read_decision.
+    legacy = SimpleNamespace(
+        read_decision=MemoryReadDecision.USE_LEGACY_SAFE, memories=[], text=None, fallback_reason=None
+    )
     allowed_write = SimpleNamespace(allowed=True, detail={})
     module.pin_memory_system = MagicMock(return_value=MemorySystem.LEGACY)
     if hasattr(module, 'read_default_read_rollout'):

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -95,7 +95,11 @@ def _mcp_search_import_isolation():
         return SimpleNamespace(allowed=True, status_code=200, observability={})
 
     def _legacy_safe_vector_result(*_args, **_kwargs):
-        return SimpleNamespace(read_decision=mcp_router_mod.MemoryReadDecision.USE_LEGACY_SAFE, memories=[])
+        # fallback_reason is declared on the real McpMemorySearchResult, so the double carries
+        # it too — the legacy-fallback contract reads it alongside read_decision.
+        return SimpleNamespace(
+            read_decision=mcp_router_mod.MemoryReadDecision.USE_LEGACY_SAFE, memories=[], fallback_reason=None
+        )
 
     def _allow_legacy_write(*_args, **_kwargs):
         return SimpleNamespace(allowed=True, status_code=200, detail={})

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -217,6 +217,15 @@ read_rollout_stub = _stub_module("utils.memory.default_read_rollout")
 read_rollout_stub.MemoryReadDecision = types.SimpleNamespace(
     USE_MEMORY="use_memory",
     USE_LEGACY_SAFE="use_legacy_safe",
+    DENY_MEMORY="deny_memory",
+    SHADOW_ONLY="shadow_only",
+)
+read_rollout_stub.UNENROLLED_LEGACY_FALLBACK_REASON = "missing_rollout_state"
+# Mirrors the real shared contract against this stub's sentinels: an explicit legacy-safe
+# decision, or a deny whose only reason is an absent rollout doc, may read legacy.
+read_rollout_stub.legacy_read_fallback_authorized = lambda read_decision, fallback_reason: (
+    read_decision == "use_legacy_safe"
+    or (read_decision == "deny_memory" and fallback_reason == "missing_rollout_state")
 )
 
 memory_system_stub = _stub_module("utils.memory.memory_system")

--- a/backend/utils/mcp_memories.py
+++ b/backend/utils/mcp_memories.py
@@ -9,6 +9,7 @@ from utils.memory.default_read_rollout import (
     DefaultReadRolloutDecision,
     MemoryReadDecision,
     build_default_read_rollout_observability,
+    legacy_read_fallback_authorized,
 )
 from utils.memory.default_read_surface import (
     DefaultReadSearchResult,
@@ -17,7 +18,6 @@ from utils.memory.default_read_surface import (
     rollout_decision_from_legacy_args,
 )
 from utils.memory.product_memory_read_service import fetch_default_product_memory_search
-from utils.observability import record_fallback
 
 ACTIVITY_TAGS = {
     'activity',
@@ -124,19 +124,11 @@ def mcp_legacy_read_authorized(result: 'McpMemorySearchResult | McpMemoryListRes
     this only on the non-canonical branch after `pin_memory_system`, where the
     absent doc is the expected un-enrolled state and legacy reads are
     authoritative. Every other deny reason stays fail-closed.
+
+    Thin MCP-shaped wrapper over the shared `legacy_read_fallback_authorized`
+    contract, which owns the reason set and the fallback telemetry.
     """
-    if result.read_decision == MemoryReadDecision.USE_LEGACY_SAFE:
-        return True
-    if result.read_decision == MemoryReadDecision.DENY_MEMORY and result.fallback_reason == 'missing_rollout_state':
-        record_fallback(
-            component='other',
-            from_mode='memory_default_read',
-            to_mode='legacy_memories',
-            reason='policy',
-            outcome='recovered',
-        )
-        return True
-    return False
+    return legacy_read_fallback_authorized(result.read_decision, result.fallback_reason)
 
 
 def _mcp_search_result(result: DefaultReadSearchResult) -> McpMemorySearchResult:

--- a/backend/utils/memory/default_read_rollout.py
+++ b/backend/utils/memory/default_read_rollout.py
@@ -3,6 +3,8 @@
 Neutral ``default_read_rollout`` is the source of truth. Legacy ``default_read_rollout`` remains an importable alias.
 """
 
+# LIFECYCLE: permanent
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Iterable, Literal, Optional, cast
@@ -326,6 +328,46 @@ def legacy_safe_default_read_rollout_decision(
         reason=reason,
         explicit_read_decision=MemoryReadDecision.USE_LEGACY_SAFE,
     )
+
+
+UNENROLLED_LEGACY_FALLBACK_REASON = 'missing_rollout_state'
+
+
+def legacy_read_fallback_authorized(read_decision: MemoryReadDecision, fallback_reason: Optional[str]) -> bool:
+    """Whether a denied default-memory read may serve the legacy `memories` surface.
+
+    Single owner of the un-enrolled legacy-cohort contract (#9892) for every
+    consumer that reads default memories (MCP, Omi chat). True for an explicit
+    legacy-safe decision, and for a deny whose only reason is an absent
+    `memory_control/state` doc — the expected state for an account that was never
+    enrolled, whose authoritative surface is the legacy collection. Every other
+    deny reason stays fail-closed, so a malformed rollout doc, a missing consumer
+    grant, or a read failure can never be mistaken for "never enrolled".
+
+    Emits the legacy-fallback telemetry for the recovered branch so callers do not
+    each own a separate counter.
+
+    A missing reason is not the un-enrolled reason, so it fails closed. The
+    telemetry import is function-level on purpose: this module is the light
+    decision surface that read paths and admin routers import under heavy test
+    stubbing, and `utils.observability` reaches `utils.metrics` -> `fastapi`.
+    Keeping that out of module scope preserves this module's import-time purity.
+    """
+
+    if read_decision == MemoryReadDecision.USE_LEGACY_SAFE:
+        return True
+    if read_decision == MemoryReadDecision.DENY_MEMORY and fallback_reason == UNENROLLED_LEGACY_FALLBACK_REASON:
+        from utils.observability import record_fallback
+
+        record_fallback(
+            component='other',
+            from_mode='memory_default_read',
+            to_mode='legacy_memories',
+            reason='policy',
+            outcome='recovered',
+        )
+        return True
+    return False
 
 
 @dataclass(frozen=True)

--- a/backend/utils/retrieval/tool_services/memories.py
+++ b/backend/utils/retrieval/tool_services/memories.py
@@ -19,7 +19,7 @@ from utils.memory.chat_memory_adapter import (
     list_default_chat_memories_decision_text,
     search_memory_default_chat_memories_vector_decision_text,
 )
-from utils.memory.default_read_rollout import MemoryReadDecision
+from utils.memory.default_read_rollout import MemoryReadDecision, legacy_read_fallback_authorized
 from utils.retrieval.tool_services.conversations import parse_iso_date
 import logging
 
@@ -81,7 +81,7 @@ def get_memories_text(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("get_memories_text - using memory default chat memory list results")
         return default_memories.text or "No memory default memories found."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not legacy_read_fallback_authorized(default_memories.read_decision, default_memories.fallback_reason):
         logger.info(
             "get_memories_text - memory default memory list denied without legacy fallback: "
             f"{default_memories.fallback_reason}"
@@ -170,7 +170,7 @@ def search_memories_text(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("search_memories_text - using memory default chat vector memory results")
         return default_memories.text or f"No memory vector memories found matching '{query}'."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not legacy_read_fallback_authorized(default_memories.read_decision, default_memories.fallback_reason):
         logger.info(
             "search_memories_text - memory default memory vector search denied without legacy fallback: "
             f"{default_memories.fallback_reason}"

--- a/backend/utils/retrieval/tools/memory_tools.py
+++ b/backend/utils/retrieval/tools/memory_tools.py
@@ -21,7 +21,7 @@ from utils.memory.chat_memory_adapter import (
     list_default_chat_memories_decision_text,
     search_memory_default_chat_memories_vector_decision_text,
 )
-from utils.memory.default_read_rollout import MemoryReadDecision
+from utils.memory.default_read_rollout import MemoryReadDecision, legacy_read_fallback_authorized
 from utils.conversations.render import format_local_date, resolve_display_tz
 from utils.retrieval.hybrid import rrf_rerank
 from utils.retrieval.tools.result_bounds import cap_items_for_llm, bounded_result
@@ -217,7 +217,7 @@ def get_memories_tool(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("✅ get_memories_tool - using memory default chat memory list results")
         return default_memories.text or "No memory default memories found."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not legacy_read_fallback_authorized(default_memories.read_decision, default_memories.fallback_reason):
         logger.info(
             "🛑 get_memories_tool - memory chat memory list denied without legacy fallback: "
             f"{default_memories.fallback_reason}"
@@ -378,7 +378,7 @@ def search_memories_tool(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("✅ search_memories_tool - using memory default chat memory results")
         return default_memories.text or f"No memory vector memories found matching '{query}'."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not legacy_read_fallback_authorized(default_memories.read_decision, default_memories.fallback_reason):
         logger.info(
             "🛑 search_memories_tool - memory chat memory denied without legacy fallback: "
             f"{default_memories.fallback_reason}"


### PR DESCRIPTION
## Problem

An account with no `users/{uid}/memory_control/state` document resolves to `DENY_MEMORY` / `missing_rollout_state`. For the legacy cohort that is the expected un-enrolled state, not a failure — `pin_memory_system` has already resolved the account to LEGACY, so the legacy `memories` collection is its authoritative read surface.

All four Omi chat retrieval entry points compared the decision against `USE_LEGACY_SAFE` only, so an un-enrolled account fell into the hard-deny branch:

```python
if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
    return default_memories.text or "No memories available for this request."
```

Chat therefore answered "No memories available for this request." while the memories list screen showed the same user's memories normally. It is silent from the user's side: chat reads as the assistant forgetting rather than as an error.

The Developer API (#10094) and hosted MCP (#10095) already treat this signal as "un-enrolled, read legacy". Chat was the remaining consumer that did not.

## Change

**`refactor` commit** — the rule "which denied default-memory read may still serve the legacy collection" had no single owner: it lived inline inside MCP's `mcp_legacy_read_authorized`, including its own `record_fallback` emission, while the Developer API repeated the reason check at its own call site. This is the third fix against that same cause, so the contract is extracted rather than pasted a fourth time:

- New `legacy_read_fallback_authorized(read_decision, fallback_reason)` in `utils/memory/default_read_rollout.py`, beside the `MemoryReadDecision` enum it interprets. It owns the reason set and the recovered-branch fallback telemetry.
- `mcp_legacy_read_authorized` becomes a thin MCP-shaped wrapper over it. No behavior change.

**`fix` commit** — the four chat entry points route through that contract:

| File | Entry points |
|---|---|
| `utils/retrieval/tools/memory_tools.py` | `get_memories_tool`, `search_memories_tool` |
| `utils/retrieval/tool_services/memories.py` | `get_memories_text`, `search_memories_text` |

**`chore` commit** — registers `FC-absent-rollout-state-as-denial`, since `Failure-Class: new` is rejected unless the definition lands in the same range. It ships with its guard artifact, so it needs no ratchet allowlist entry.

## Scope of the relaxation

The contract allows a legacy read for exactly two decisions:

- `USE_LEGACY_SAFE` — the explicitly configured legacy surface (no telemetry; it is not a recovery).
- `DENY_MEMORY` + `missing_rollout_state` — never enrolled; records the recovered fallback.

Everything else stays fail-closed, because each means "we could not establish this account's state" and must never be read as "never enrolled": `malformed_rollout_state`, `rollout_read_failed`, `missing_chat_default_memory_grant`, `missing_mcp_default_memory_grant`, `missing_developer_default_memory_grant`, `memory_reads_disabled`, `uid_mismatch`, `unsupported_consumer`, `unsupported_rollout_schema`, a `None` reason, plus `SHADOW_ONLY` and `USE_MEMORY` under any reason.

The predicate is null-safe by construction: `fallback_reason` is a declared field on every real decision result (`ChatMemorySearchResult` requires it; `McpMemorySearchResult` / `McpMemoryListResult` default it to `None`), and a `None` reason simply is not the un-enrolled reason, so it fails closed rather than raising.

One correction to the issue's proposed fix: it gives `missing_app_key_scope_grant` as the example reason that must keep failing closed. That reason is not reachable on the chat path — there is no app-key gate in chat retrieval, and chat's grant denial is `missing_chat_default_memory_grant`. The tests use the reachable reason instead.

## Import purity

`record_fallback` is imported inside the predicate rather than at module scope. `utils/memory/default_read_rollout.py` is the light decision surface that read paths and admin routers import under heavy test stubbing, and `utils.observability` reaches `utils.metrics` → `from fastapi import Response`. A module-level import broke `test_non_active_route_admin_endpoint.py` and `test_product_memory_router.py`, which stub `fastapi`. Function-level keeps this module import-time pure and matches existing practice in `utils/readiness.py` and `routers/users.py`.

## Guard surface

Three fixes now share this cause (#10095 MCP, #10485 Developer API vector, this one). The reusable guard is the shared predicate plus a behavioral matrix test over it in `tests/unit/test_default_read_rollout_decision.py`, so relaxing one consumer cannot silently relax another and no newly added deny reason becomes a legacy fallback by default. That path is recorded as the failure class's `canonical_prevention_artifact`.

## Tests

Added `tests/unit/test_chat_memory_unenrolled_legacy_fallback.py`, parametrized over all four chat entry points. Both directions are asserted per surface, since the risk in relaxing a fail-closed check is relaxing it too far:

- un-enrolled deny reaches the legacy read and returns the memory — **4 failed before this change, pass after**
- every other deny reason refuses and performs **no** legacy read — passed before and after, so the relaxation is bounded

Added the shared-contract matrix test described above.

Three test doubles needed the real decision shape, because the shared contract reads `fallback_reason` where the old comparison short-circuited on `read_decision` alone. None of these changes touches an assertion, and the real types already declare the field:

- `test_lock_bypass_fixes.py`, `test_mcp_search_memories.py` — their `SimpleNamespace` doubles now carry `fallback_reason`.
- `test_tools_router.py` — its hand-built `default_read_rollout` stub now exposes the contract and the full decision enum.

The static tripwire in `test_chat_memory_adapter.py` asserted the old source text. It now asserts the shared contract and is labelled as a source-order tripwire, with behavior covered by the new test.

## Verification

Each commit was verified green in isolation so the history bisects cleanly; the `refactor` commit was checked out into a separate worktree and its nine affected files run there (262 passed).

```
BACKEND_UNIT_TEST_FILE_LIST=<11 files> bash test.sh   ->  295 passed, 0 failed
scripts/pr-preflight --pr-body-file ...               ->  21 checks PASS
scripts/failure-class validate --pr-body-file ...     ->  ok: true
```

| File | Result |
|---|---|
| `test_chat_memory_unenrolled_legacy_fallback.py` | 8 passed |
| `test_default_read_rollout_decision.py` | 21 passed |
| `test_chat_memory_adapter.py` | 11 passed |
| `test_mcp_memory_adapter.py` | 27 passed |
| `test_mcp_search_memories.py` | 20 passed |
| `test_non_active_route_admin_endpoint.py` | 17 passed |
| `test_product_memory_router.py` | 8 passed |
| `test_lock_bypass_fixes.py` | 61 passed |
| `test_tools_router.py` | 87 passed |
| `test_dev_api_canonical_grant_ordering.py` | 10 passed |
| `test_developer_memory_adapter.py` | 25 passed |

The existing MCP and Developer API characterization tests (`test_mcp_memory_adapter.py::test_mcp_legacy_read_authorized_only_for_explicit_or_unenrolled`, and `test_dev_api_canonical_grant_ordering.py`'s legacy-fallback and still-403 route tests) were not modified and pass unchanged, which is the evidence that neither existing consumer shifted.

Local runs used the `python3` fallback documented in `test.sh` (3.12.3 + pytest 9.0.3) because the pinned CPython 3.11.15 has no `linux-aarch64` build, so `scripts/sync-python-deps.sh` cannot create the pinned venv on this machine. CI on the pinned interpreter is the authoritative gate for this PR.

Duration guard: this machine trips `BACKEND_FAST_UNIT_FAIL_SECONDS=0.12` at exactly `0.12s` inside `test_dev_api_canonical_grant_ordering.py`, on a different test each run, and reproduces identically on untouched `origin/main`. Runs above therefore use the `1.0s` ceiling CI applies for cross-machine CPU differences. The new tests pass under the strict `0.12s` guard.

Closes #10736

Invariants: INV-MEM-1, INV-MEM-3
Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

