### PR TITLE
fix(backend): report denied MCP memory reads instead of an empty success

### DIFF
--- a/.github/failure-classes/FC-denial-rendered-as-empty-success.json
+++ b/.github/failure-classes/FC-denial-rendered-as-empty-success.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-denial-rendered-as-empty-success",
+  "violated_contract": "A read refused by authorization or an indeterminate rollout state must be reported as a refusal carrying its reason; it must not be returned as a successful empty collection, which the caller cannot distinguish from a genuinely empty account.",
+  "canonical_prevention": "Classify a refused read once at the shared boundary into report-with-reason versus legitimately-empty, and have every serving surface raise from that single classification instead of each deciding on its own to return an empty collection.",
+  "canonical_prevention_artifact": [
+    "backend/utils/mcp_memories.py",
+    "backend/tests/unit/test_mcp_data_endpoints.py"
+  ],
+  "evidence_prs": [
+    10743
+  ],
+  "scope_hints": [
+    "backend/routers/mcp.py",
+    "backend/routers/mcp_sse.py",
+    "backend/utils/mcp_memories.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2373,
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2263,
-    "backend/routers/mcp_sse.py": 1858,
+    "backend/routers/mcp_sse.py": 1865,
     "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2076
   },
@@ -11,7 +11,7 @@
     "backend/routers/apps.py": "The owner-migration route validates a source-bound Firebase anonymous-token proof before its existing database write and tracked background work, keeping the authorization decision at the HTTP mutation boundary.",
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
-    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
+    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +7 so a refused memory read reports its reason instead of an empty success (#10735): the classification and wire shape live in utils/mcp_memories.mcp_denied_read_payload, leaving only the raise at the two tool branches that own the response contract.",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first. +30 for the disclosed, expiring city-context consent routes and legacy geolocation input boundary; they remain with the authenticated user route owner to prevent invalid coordinates reaching cache/provider paths (SCA-174)."
   },

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -55,7 +55,9 @@ import utils.mcp_action_items as mcp_action_items
 from utils.mcp_memories import (
     collect_filtered_memories,
     list_default_mcp_memories,
+    mcp_denied_read_reason,
     mcp_legacy_read_authorized,
+    mcp_memory_read_denied_detail,
     parse_mcp_bool,
     parse_mcp_datetime,
     parse_mcp_int,
@@ -268,6 +270,18 @@ class SearchedMemory(CleanerMemory):
     relevance_score: float
 
 
+def _raise_if_memory_read_denied(result) -> None:
+    """Surface a denied default-memory read as a 403 carrying its reason.
+
+    Returns without raising only when the decision is a non-serving rollout state rather
+    than a denial, which keeps that caller's existing empty result.
+    """
+    reason = mcp_denied_read_reason(result)
+    if reason is None:
+        return
+    raise HTTPException(status_code=403, detail=mcp_memory_read_denied_detail(reason))
+
+
 @router.get("/v1/mcp/memories/search", tags=["mcp"], response_model=List[SearchedMemory])
 def search_memories(
     query: str,
@@ -301,6 +315,7 @@ def search_memories(
     if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
         return vector_search_results.memories
     if not mcp_legacy_read_authorized(vector_search_results):
+        _raise_if_memory_read_denied(vector_search_results)
         return []
 
     return memory_service.search_mcp(uid, query, limit=limit)
@@ -397,6 +412,7 @@ def get_memories(
     if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
         return memory_list_results.memories
     if not mcp_legacy_read_authorized(memory_list_results):
+        _raise_if_memory_read_denied(memory_list_results)
         return []
 
     result = collect_filtered_memories(

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -55,9 +55,8 @@ import utils.mcp_action_items as mcp_action_items
 from utils.mcp_memories import (
     collect_filtered_memories,
     list_default_mcp_memories,
-    mcp_denied_read_reason,
+    mcp_denied_read_payload,
     mcp_legacy_read_authorized,
-    mcp_memory_read_denied_detail,
     parse_mcp_bool,
     parse_mcp_datetime,
     parse_mcp_int,
@@ -270,18 +269,6 @@ class SearchedMemory(CleanerMemory):
     relevance_score: float
 
 
-def _raise_if_memory_read_denied(result) -> None:
-    """Surface a denied default-memory read as a 403 carrying its reason.
-
-    Returns without raising only when the decision is a non-serving rollout state rather
-    than a denial, which keeps that caller's existing empty result.
-    """
-    reason = mcp_denied_read_reason(result)
-    if reason is None:
-        return
-    raise HTTPException(status_code=403, detail=mcp_memory_read_denied_detail(reason))
-
-
 @router.get("/v1/mcp/memories/search", tags=["mcp"], response_model=List[SearchedMemory])
 def search_memories(
     query: str,
@@ -315,7 +302,9 @@ def search_memories(
     if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
         return vector_search_results.memories
     if not mcp_legacy_read_authorized(vector_search_results):
-        _raise_if_memory_read_denied(vector_search_results)
+        denied = mcp_denied_read_payload(vector_search_results)
+        if denied is not None:
+            raise HTTPException(status_code=403, detail=denied)
         return []
 
     return memory_service.search_mcp(uid, query, limit=limit)
@@ -412,7 +401,9 @@ def get_memories(
     if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
         return memory_list_results.memories
     if not mcp_legacy_read_authorized(memory_list_results):
-        _raise_if_memory_read_denied(memory_list_results)
+        denied = mcp_denied_read_payload(memory_list_results)
+        if denied is not None:
+            raise HTTPException(status_code=403, detail=denied)
         return []
 
     result = collect_filtered_memories(

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -67,9 +67,8 @@ from utils.mcp_memories import (
     build_mcp_default_memory_read_context,
     collect_filtered_memories,
     list_default_mcp_memories,
-    mcp_denied_read_reason,
+    mcp_denied_read_payload,
     mcp_legacy_read_authorized,
-    mcp_memory_read_denied_detail,
     parse_mcp_bool,
     parse_mcp_datetime,
     parse_mcp_int,
@@ -742,18 +741,6 @@ class ToolExecutionError(Exception):
         super().__init__(self.message)
 
 
-def _raise_if_memory_read_denied(result) -> None:
-    """Surface a denied default-memory read as an MCP error carrying its reason.
-
-    Returns without raising only when the decision is a non-serving rollout state rather
-    than a denial, which keeps that caller's existing empty result.
-    """
-    reason = mcp_denied_read_reason(result)
-    if reason is None:
-        return
-    raise ToolExecutionError(str(mcp_memory_read_denied_detail(reason)), code=-32009)
-
-
 def _raise_tool_error_from_http(exc: HTTPException) -> NoReturn:
     if exc.status_code == 404:
         raise ToolExecutionError("Memory not found", code=-32001) from exc
@@ -878,7 +865,9 @@ def execute_tool(
         if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": memory_list_results.memories}
         if not mcp_legacy_read_authorized(memory_list_results):
-            _raise_if_memory_read_denied(memory_list_results)
+            denied = mcp_denied_read_payload(memory_list_results)
+            if denied is not None:
+                raise ToolExecutionError(str(denied), code=-32009)
             return {"memories": []}
 
         result = collect_filtered_memories(
@@ -1107,7 +1096,9 @@ def execute_tool(
         if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": vector_search_results.memories}
         if not mcp_legacy_read_authorized(vector_search_results):
-            _raise_if_memory_read_denied(vector_search_results)
+            denied = mcp_denied_read_payload(vector_search_results)
+            if denied is not None:
+                raise ToolExecutionError(str(denied), code=-32009)
             return {"memories": []}
 
         matches = vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -67,7 +67,9 @@ from utils.mcp_memories import (
     build_mcp_default_memory_read_context,
     collect_filtered_memories,
     list_default_mcp_memories,
+    mcp_denied_read_reason,
     mcp_legacy_read_authorized,
+    mcp_memory_read_denied_detail,
     parse_mcp_bool,
     parse_mcp_datetime,
     parse_mcp_int,
@@ -740,6 +742,18 @@ class ToolExecutionError(Exception):
         super().__init__(self.message)
 
 
+def _raise_if_memory_read_denied(result) -> None:
+    """Surface a denied default-memory read as an MCP error carrying its reason.
+
+    Returns without raising only when the decision is a non-serving rollout state rather
+    than a denial, which keeps that caller's existing empty result.
+    """
+    reason = mcp_denied_read_reason(result)
+    if reason is None:
+        return
+    raise ToolExecutionError(str(mcp_memory_read_denied_detail(reason)), code=-32009)
+
+
 def _raise_tool_error_from_http(exc: HTTPException) -> NoReturn:
     if exc.status_code == 404:
         raise ToolExecutionError("Memory not found", code=-32001) from exc
@@ -864,6 +878,7 @@ def execute_tool(
         if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": memory_list_results.memories}
         if not mcp_legacy_read_authorized(memory_list_results):
+            _raise_if_memory_read_denied(memory_list_results)
             return {"memories": []}
 
         result = collect_filtered_memories(
@@ -1092,6 +1107,7 @@ def execute_tool(
         if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": vector_search_results.memories}
         if not mcp_legacy_read_authorized(vector_search_results):
+            _raise_if_memory_read_denied(vector_search_results)
             return {"memories": []}
 
         matches = vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -607,3 +607,123 @@ class TestToolRegistry:
                     sse.execute_tool(UID, name, {})
                 except sse.ToolExecutionError as e:
                     assert 'Unknown tool' not in e.message
+
+
+# --- denied memory reads are distinguishable from empty accounts (#10735) -----------------
+# A denied default-memory read returned an empty result set with a success status on every
+# MCP surface, so a client could not tell "this key is not authorized" from "you have no
+# memories". That is the failure mode most likely to make a user believe their data was
+# deleted, and support could not separate the two without a per-account Firestore trace.
+#
+# The issue named two sites (mcp_sse get_memories / search_memories). There are four: the
+# REST surface in routers/mcp.py has the identical shape.
+#
+# SHADOW_ONLY deliberately keeps returning empty. It is not an authorization denial - in
+# shadow mode legacy is authoritative - so reporting it as an auth error would be wrong in
+# the other direction. That state is tracked separately.
+
+_DENY_REASONS_REPORTED = [
+    'malformed_rollout_state',
+    'rollout_read_failed',
+    'missing_mcp_default_memory_grant',
+    'uid_mismatch',
+    'unsupported_consumer',
+    'unsupported_rollout_schema',
+    'memory_reads_disabled',
+]
+
+
+def _denied_result(reason, read_decision=None):
+    return SimpleNamespace(
+        read_decision=read_decision or rest.MemoryReadDecision.DENY_MEMORY,
+        memories=[],
+        fallback_reason=reason,
+    )
+
+
+def _shadow_result():
+    return SimpleNamespace(
+        read_decision=rest.MemoryReadDecision.SHADOW_ONLY, memories=[], fallback_reason='shadow_only'
+    )
+
+
+def _rest_legacy_patches(adapter_attr, result):
+    return (
+        patch.object(rest, 'authorize_memory_external_default_memory_read', return_value=SimpleNamespace(allowed=True)),
+        patch.object(rest, 'pin_memory_system', return_value=rest.MemorySystem.LEGACY),
+        patch.object(rest, 'read_default_read_rollout', return_value=SimpleNamespace()),
+        patch.object(rest, adapter_attr, return_value=result),
+    )
+
+
+def _sse_legacy_patches(adapter_attr, result):
+    return (
+        patch.object(sse, 'authorize_memory_external_default_memory_read', return_value=SimpleNamespace(allowed=True)),
+        patch.object(sse, 'pin_memory_system', return_value=sse.MemorySystem.LEGACY),
+        patch.object(sse, 'read_default_read_rollout', return_value=SimpleNamespace()),
+        patch.object(sse, adapter_attr, return_value=result),
+    )
+
+
+def _run_rest_list(result):
+    a, b, c, d = _rest_legacy_patches('list_default_mcp_memories', result)
+    with a, b, c, d:
+        return rest.get_memories(auth_context=SimpleNamespace(uid=UID))
+
+
+def _run_rest_search(result):
+    a, b, c, d = _rest_legacy_patches('search_default_mcp_memories_vector', result)
+    with a, b, c, d:
+        return rest.search_memories(query='espresso', auth_context=SimpleNamespace(uid=UID))
+
+
+def _sse_auth_context():
+    return SimpleNamespace(uid=UID, consumer='mcp', surface='mcp', app_id='app-1', key_id='key-1')
+
+
+def _run_sse_list(result):
+    a, b, c, d = _sse_legacy_patches('list_default_mcp_memories', result)
+    with a, b, c, d:
+        return sse.execute_tool(UID, 'get_memories', {}, auth_context=_sse_auth_context())
+
+
+def _run_sse_search(result):
+    a, b, c, d = _sse_legacy_patches('search_default_mcp_memories_vector', result)
+    with a, b, c, d:
+        return sse.execute_tool(UID, 'search_memories', {'query': 'espresso'}, auth_context=_sse_auth_context())
+
+
+_REST_SURFACES = [pytest.param(_run_rest_list, id='rest_list'), pytest.param(_run_rest_search, id='rest_search')]
+_SSE_SURFACES = [pytest.param(_run_sse_list, id='sse_list'), pytest.param(_run_sse_search, id='sse_search')]
+
+
+@pytest.mark.parametrize('reason', _DENY_REASONS_REPORTED)
+@pytest.mark.parametrize('run_surface', _REST_SURFACES)
+def test_rest_denied_memory_read_raises_with_reason_instead_of_empty_success(run_surface, reason):
+    with pytest.raises(rest.HTTPException) as raised:
+        run_surface(_denied_result(reason))
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail['reason'] == reason
+    assert raised.value.detail['enabled'] is False
+    assert raised.value.detail['consumer'] == 'mcp'
+
+
+@pytest.mark.parametrize('reason', _DENY_REASONS_REPORTED)
+@pytest.mark.parametrize('run_surface', _SSE_SURFACES)
+def test_sse_denied_memory_read_raises_with_reason_instead_of_empty_success(run_surface, reason):
+    with pytest.raises(sse.ToolExecutionError) as raised:
+        run_surface(_denied_result(reason))
+
+    assert raised.value.code == -32009
+    assert reason in raised.value.message
+
+
+@pytest.mark.parametrize('run_surface', _REST_SURFACES)
+def test_rest_shadow_only_still_returns_empty_without_error(run_surface):
+    assert run_surface(_shadow_result()) == []
+
+
+@pytest.mark.parametrize('run_surface', _SSE_SURFACES)
+def test_sse_shadow_only_still_returns_empty_without_error(run_surface):
+    assert run_surface(_shadow_result()) == {"memories": []}

--- a/backend/utils/mcp_memories.py
+++ b/backend/utils/mcp_memories.py
@@ -139,6 +139,32 @@ def mcp_legacy_read_authorized(result: 'McpMemorySearchResult | McpMemoryListRes
     return False
 
 
+MCP_MEMORY_READ_DENIED_FALLBACK_REASON = 'memory_read_denied'
+
+
+def mcp_denied_read_reason(result: 'McpMemorySearchResult | McpMemoryListResult') -> Optional[str]:
+    """The reason a denied MCP memory read must report, or None to serve an empty result.
+
+    Callers reach this only after `mcp_legacy_read_authorized` has refused the legacy
+    surface. Every such state is an authorization or indeterminate-rollout condition the
+    caller cannot see or act on, so it must be reported rather than rendered as an empty
+    account — an empty success is indistinguishable from "you have no memories", which is
+    the reading most likely to make a user believe their data was deleted.
+
+    SHADOW_ONLY is the one exception and returns None. It is not a denial: during shadow
+    mode legacy remains authoritative, so reporting it as an authorization error would be
+    wrong in the other direction. It keeps its existing empty result here.
+    """
+    if result.read_decision == MemoryReadDecision.SHADOW_ONLY:
+        return None
+    return result.fallback_reason or MCP_MEMORY_READ_DENIED_FALLBACK_REASON
+
+
+def mcp_memory_read_denied_detail(reason: str) -> Dict[str, Any]:
+    """Client-visible payload for a denied MCP memory read, mirroring the grant-denial shape."""
+    return {'enabled': False, 'reason': reason, 'consumer': 'mcp'}
+
+
 def _mcp_search_result(result: DefaultReadSearchResult) -> McpMemorySearchResult:
     return McpMemorySearchResult(
         memories=result.items,

--- a/backend/utils/mcp_memories.py
+++ b/backend/utils/mcp_memories.py
@@ -142,26 +142,26 @@ def mcp_legacy_read_authorized(result: 'McpMemorySearchResult | McpMemoryListRes
 MCP_MEMORY_READ_DENIED_FALLBACK_REASON = 'memory_read_denied'
 
 
-def mcp_denied_read_reason(result: 'McpMemorySearchResult | McpMemoryListResult') -> Optional[str]:
-    """The reason a denied MCP memory read must report, or None to serve an empty result.
+def mcp_denied_read_payload(result: 'McpMemorySearchResult | McpMemoryListResult') -> Optional[Dict[str, Any]]:
+    """Client-visible payload for a refused MCP memory read, or None to serve an empty result.
 
     Callers reach this only after `mcp_legacy_read_authorized` has refused the legacy
     surface. Every such state is an authorization or indeterminate-rollout condition the
     caller cannot see or act on, so it must be reported rather than rendered as an empty
     account — an empty success is indistinguishable from "you have no memories", which is
-    the reading most likely to make a user believe their data was deleted.
+    the reading most likely to make a user believe their data was deleted. The payload
+    mirrors the existing grant-denial shape so both refusals read the same to a client.
 
     SHADOW_ONLY is the one exception and returns None. It is not a denial: during shadow
     mode legacy remains authoritative, so reporting it as an authorization error would be
-    wrong in the other direction. It keeps its existing empty result here.
+    wrong in the other direction. It keeps its existing empty result.
+
+    Returning the whole payload rather than a bare reason keeps both the classification and
+    the wire shape here, so each surface adds only its own raise.
     """
     if result.read_decision == MemoryReadDecision.SHADOW_ONLY:
         return None
-    return result.fallback_reason or MCP_MEMORY_READ_DENIED_FALLBACK_REASON
-
-
-def mcp_memory_read_denied_detail(reason: str) -> Dict[str, Any]:
-    """Client-visible payload for a denied MCP memory read, mirroring the grant-denial shape."""
+    reason = result.fallback_reason or MCP_MEMORY_READ_DENIED_FALLBACK_REASON
     return {'enabled': False, 'reason': reason, 'consumer': 'mcp'}
 
 


### PR DESCRIPTION
## Problem

When the memory authorization check denied a hosted-MCP memory read, the handler returned an empty result set with a success status:

```python
if not mcp_legacy_read_authorized(memory_list_results):
    return {"memories": []}
```

The client saw "you have no memories" rather than "this key is not authorized" — the failure mode most likely to make a user believe their data was deleted. An empty success is indistinguishable from a genuinely empty account, so the user had no signal anything was wrong and nothing to report, support could not separate the two without a per-account Firestore trace, and it silently contradicted the memories list screen, which showed the same user's memories fine.

## Scope: the issue named 2 sites, there are 4

`routers/mcp.py` is the REST MCP surface and carries the identical shape. Fixing only the SSE pair would repair the symptom on one surface and leave the same contract violated on the other, so all four are fixed here. **The widened scope is deliberate, not creep.**

| Site | Tool / route | Before |
|---|---|---|
| `routers/mcp_sse.py:866` | `get_memories` | `return {"memories": []}` |
| `routers/mcp_sse.py:1094` | `search_memories` | `return {"memories": []}` |
| `routers/mcp.py:399` | `GET /v1/mcp/memories` | `return []` |
| `routers/mcp.py:303` | `GET /v1/mcp/memories/search` | `return []` |

## Change

One owner for "report this, or serve an empty result": `mcp_denied_read_payload` in `utils/mcp_memories.py` returns the finished client-visible payload for every authorization or indeterminate-rollout state, and `None` for `SHADOW_ONLY`. The payload mirrors the existing grant-denial shape so both refusals read the same to a client.

Each surface then adds only its own raise, keeping its existing error mechanism:

- `routers/mcp.py` → `HTTPException(403, detail={'enabled': False, 'reason': ..., 'consumer': 'mcp'})`
- `routers/mcp_sse.py` → `ToolExecutionError(str(payload), code=-32009)`, the code already used for MCP authorization failures

### Commit order note

The first two commits landed a two-function classifier plus a per-surface raiser helper, which grew the ratchet-frozen `routers/mcp_sse.py` by 16 lines. The third commit collapses that to the single-payload shape above, cutting the frozen file's growth to 7 lines and shrinking `routers/mcp.py` by 9. Those commits are already pushed and this repo does not force-push, so the reshape is a follow-up commit rather than a rewrite; the description above is the shape being merged.

`backend/routers/mcp_sse.py` is frozen by the oversized-product-file ratchet at 1858 lines. Its baseline is raised to the exact new count (1865) with a justification, because the remaining 7 lines are the two raises this fix exists to add and cannot be removed without leaving a surface unrepaired.

## Which reasons are reported

The states the caller cannot see or act on: `malformed_rollout_state`, `rollout_read_failed`, `missing_mcp_default_memory_grant`, `uid_mismatch`, `unsupported_consumer`, `unsupported_rollout_schema`, `memory_reads_disabled`.

### Two corrections to the issue

**1. The stated reason set is wrong, and so is the scale claim.** The issue says the two reasons reaching this branch are `missing_rollout_state` and `missing_app_key_scope_grant`. Neither can reach it:

- `missing_app_key_scope_grant` is refused earlier by `authorize_memory_external_default_memory_read` — `mcp_sse.py:826`/`:1076` raise `ToolExecutionError` code `-32009`, and `mcp.py:277` raises `HTTPException`. It never reaches the empty return.
- `missing_rollout_state` is allowed *through to legacy* by `mcp_legacy_read_authorized` (`utils/mcp_memories.py:130`), so it does not reach the empty return either.

Consequently the issue's evidence — "MCP keys created without scopes have no grant, so every memory read through them returns empty while the account has thousands of memories" — does not hold: those keys already receive an explicit `-32009` error. The bug is real for the reason set above, but the affected population is narrower than the issue implies, and the headline scale claim is unsupported. No live measurement was taken.

**2. `SHADOW_ONLY` is deliberately left returning empty.** It is not an authorization denial. `docs/epics/memory_normative_architecture.md` defines shadow mode as "Legacy authoritative; memory audit artifacts only", so converting it to an error would be wrong in the other direction. It is a separate concern from this fix and is untouched here.

## Tests

Added to `tests/unit/test_mcp_data_endpoints.py`, which already exercises both the REST handlers and MCP tool dispatch. Parametrized over all four sites × the seven reported reasons, asserting both directions:

- every reported reason raises carrying its reason, on all four sites — **28 failed before this change, pass after**
- `SHADOW_ONLY` still returns empty without error, on all four sites — passed before and after, so the change is bounded

## Verification

Backend, aarch64, system `python3.12` + `pytest 9.0.3`.

```
BACKEND_UNIT_TEST_FILE_LIST=<15 files> bash test.sh   ->  275 passed, 0 failed
```

Covering `test_mcp_data_endpoints` (66), `test_mcp_memory_adapter` (27), `test_mcp_search_memories` (20), `test_lock_bypass_fixes` (61), `test_mcp_apps_results` (40), `test_non_active_route_admin_endpoint` (17), `test_dev_api_canonical_grant_ordering` (10), `test_product_memory_router` (8), `test_mcp_conversation_by_id_poison` (7), `test_mcp_conversations_poison` (5), `test_app_client_response_models` (4), `test_mcp_sse_pagination_bounds` (3), `test_mcp_action_item_writes` (3), `test_mcp_profile_contact` (2), `test_mcp_search_conversations_poison` (2).

Local runs used the `python3` fallback documented in `test.sh` because the pinned CPython 3.11.15 has no `linux-aarch64` build, so `scripts/sync-python-deps.sh` cannot create the pinned venv on this machine. CI on the pinned interpreter is the authoritative gate for this PR.

Closes #10735

Invariants: INV-MEM-1
Failure-Class: new
