### PR TITLE
feat(backend): add the Developer API key memory-grant backfill (dry-run only)

### DIFF
--- a/backend/scripts/backfill_developer_api_key_memory_grants.py
+++ b/backend/scripts/backfill_developer_api_key_memory_grants.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Seed missing app/key memory grants for Developer API keys created before seeding landed.
+
+Developer API keys created before commit 8e03144a (2026-06-27) have no entry under
+``users/{uid}/memory_control/app_key_memory_grants``. The grant gate
+(``authorize_memory_external_default_memory_read``) fails closed when no grant document is
+found, so those keys receive a permanent 403 from ``GET /v1/dev/user/memories`` regardless
+of the scopes on the key, while ``/conversations`` and ``/action-items`` keep working.
+
+This grants nothing new. It materialises the grant each key's own scopes already imply, by
+making exactly the call the create path in ``database/dev_api_key.py`` makes:
+
+    grant_default_read = has_scope(scopes, Scopes.MEMORIES_READ)
+    grant_write = has_scope(scopes, Scopes.MEMORIES_WRITE)
+    if grant_default_read or grant_write:
+        seed_developer_api_key_memory_grant(...)
+
+Scope resolution deliberately goes through ``utils.scopes.has_scope``, the same authority
+the request path uses, rather than a literal membership test. That matters for one legacy
+shape: ``has_scope(None, ...)`` treats a key with no stored ``scopes`` field as read-only,
+which includes ``memories:read``. Such a key can already read memories at the request
+layer, so it needs the grant too, and a literal ``'memories:read' in scopes`` test would
+skip it. Write is never inferred that way — ``memories:write`` is not a read-only scope.
+
+Keys that already hold a grant for the same app/key are left untouched, so re-running is
+safe. Dry run is the default and performs no writes.
+
+Usage:
+    python scripts/backfill_developer_api_key_memory_grants.py              # dry run
+    python scripts/backfill_developer_api_key_memory_grants.py --limit 200  # bounded dry run
+    python scripts/backfill_developer_api_key_memory_grants.py --apply      # write grants
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+from typing import Any, Optional, cast
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_DIR))
+
+from database._client import get_firestore_client
+from database.memory_app_key_grants import (
+    DEVELOPER_API_CONSUMER,
+    DEVELOPER_API_DEFAULT_APP_ID,
+    read_app_key_memory_grants_state,
+    seed_developer_api_key_memory_grant,
+)
+from utils.scopes import Scopes, has_scope
+
+# Developer API keys created before this instant predate the create-path grant seeding
+# (commit 8e03144a, 2026-06-27 22:54:46 +0700). Keys created after it are seeded on create.
+SEEDING_LANDED_AT = datetime(2026, 6, 27, 15, 54, 46, tzinfo=timezone.utc)
+
+
+def _stored_scopes(value: Any) -> Optional[list[str]]:
+    """The key's stored scopes, or None when the field is absent/unusable.
+
+    None is meaningful, not an error: `has_scope` treats it as the legacy read-only
+    default, so it must be preserved rather than coerced to an empty list.
+    """
+    if not isinstance(value, list):
+        return None
+    items = cast(list[Any], value)
+    return [scope for scope in items if isinstance(scope, str) and scope]
+
+
+def _created_before_seeding(created_at: Any) -> Optional[bool]:
+    """Whether the key predates grant seeding, or None when the timestamp is unusable."""
+    if not isinstance(created_at, datetime):
+        return None
+    # Firestore returns tz-aware datetimes; treat a naive value as UTC rather than crashing
+    # on the comparison, so one malformed row cannot abort the scan.
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    return created_at < SEEDING_LANDED_AT
+
+
+def _has_grant(db: Any, uid: str, key_id: str, grant_cache: dict[str, Any]) -> bool:
+    """Whether this uid already holds any grant entry for this Developer API key."""
+    if uid not in grant_cache:
+        state = read_app_key_memory_grants_state(uid, db_client=db)
+        grant_cache[uid] = state.state if state.present and not state.malformed else {}
+    return (
+        cast(dict[str, Any], grant_cache[uid])
+        .get("grants", {})
+        .get(DEVELOPER_API_CONSUMER, {})
+        .get("apps", {})
+        .get(DEVELOPER_API_DEFAULT_APP_ID, {})
+        .get("keys", {})
+        .get(key_id)
+        is not None
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Inventory and backfill app/key memory grants for pre-seeding Developer API keys."
+    )
+    parser.add_argument("--apply", action="store_true", help="Write grants. Default is dry-run inventory only.")
+    parser.add_argument("--limit", type=int, default=0, help="Optional max number of Developer API keys to inspect.")
+    args = parser.parse_args()
+
+    db: Any = get_firestore_client()
+    counts: defaultdict[str, int] = defaultdict(int)
+    grant_cache: dict[str, Any] = {}
+    would_seed_uids: set[str] = set()
+
+    query = db.collection("dev_api_keys").select(["id", "user_id", "scopes", "created_at"])
+    if args.limit:
+        query = query.limit(args.limit)
+
+    for doc in query.stream():
+        data = cast(dict[str, Any], doc.to_dict() or {})
+        counts["total_dev_key_docs"] += 1
+
+        key_id = str(data.get("id") or doc.id)
+        uid = data.get("user_id")
+        if not uid or not isinstance(uid, str):
+            counts["skipped_missing_user_id"] += 1
+            continue
+
+        created_before = _created_before_seeding(data.get("created_at"))
+        if created_before is None:
+            # Cannot prove the key predates seeding, so leave it alone rather than guess.
+            counts["skipped_unusable_created_at"] += 1
+            continue
+        if not created_before:
+            counts["skipped_created_after_seeding"] += 1
+            continue
+
+        scopes = _stored_scopes(data.get("scopes"))
+        if scopes is None:
+            counts["absent_scopes_treated_as_read_only"] += 1
+        grant_default_read = has_scope(scopes, Scopes.MEMORIES_READ)
+        grant_write = has_scope(scopes, Scopes.MEMORIES_WRITE)
+        if not (grant_default_read or grant_write):
+            counts["skipped_no_memory_scope"] += 1
+            continue
+
+        counts["pre_seeding_keys_with_memory_scope"] += 1
+        if _has_grant(db, uid, key_id, grant_cache):
+            counts["already_granted"] += 1
+            continue
+
+        counts["keys_needing_backfill"] += 1
+        counts["grant_default_read" if grant_default_read else "grant_write_only"] += 1
+        would_seed_uids.add(uid)
+
+        if args.apply:
+            seed_developer_api_key_memory_grant(
+                uid,
+                key_id,
+                default_read=grant_default_read,
+                write=grant_write,
+                db_client=db,
+            )
+            counts["grants_written"] += 1
+            # This uid's cached grant document is now stale; drop it so a second key for the
+            # same uid is checked against the written state instead of the pre-write copy.
+            grant_cache.pop(uid, None)
+
+    counts["distinct_users_needing_backfill"] = len(would_seed_uids)
+    counts["unique_users_read_for_grants"] = len(grant_cache)
+    counts["dry_run"] = not args.apply
+    print(dict(counts))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_backfill_developer_api_key_memory_grants.py
+++ b/backend/tests/unit/test_backfill_developer_api_key_memory_grants.py
@@ -1,0 +1,276 @@
+"""The Developer API key memory-grant backfill grants only what a key's own scopes imply (#10734).
+
+Developer API keys created before the create-path grant seeding landed (commit 8e03144a,
+2026-06-27) have no entry under ``users/{uid}/memory_control/app_key_memory_grants``. The
+grant gate fails closed on a missing grant, so those keys get a permanent 403 from
+``GET /v1/dev/user/memories`` while their other endpoints keep working, and nothing
+backfills them.
+
+These tests pin the two properties that make the script safe to run against production:
+dry run writes nothing, and applying grants exactly the capability the key already has —
+never more.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import scripts.backfill_developer_api_key_memory_grants as backfill
+from database.memory_app_key_grants import (
+    APP_KEY_MEMORY_GRANT_DOC_ID,
+    APP_KEY_MEMORY_GRANTS_COLLECTION,
+    DEVELOPER_API_CONSUMER,
+    DEVELOPER_API_DEFAULT_APP_ID,
+)
+
+BEFORE = backfill.SEEDING_LANDED_AT - timedelta(days=30)
+AFTER = backfill.SEEDING_LANDED_AT + timedelta(days=1)
+
+
+def _deep_merge(target, patch):
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = value
+
+
+class _Snapshot:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self):
+        return dict(self._data) if self._data is not None else None
+
+
+class _DocRef:
+    def __init__(self, db, path):
+        self._db = db
+        self._path = path
+
+    def get(self):
+        return _Snapshot(self._path.rsplit('/', 1)[-1], self._db.docs.get(self._path))
+
+    def set(self, data, merge=False):
+        self._db.writes.append(self._path)
+        if merge:
+            _deep_merge(self._db.docs.setdefault(self._path, {}), dict(data))
+        else:
+            self._db.docs[self._path] = dict(data)
+
+
+class _Query:
+    def __init__(self, db, prefix):
+        self._db = db
+        self._prefix = prefix
+        self._limit = None
+
+    def select(self, _fields):
+        # The script projects fields; the fake ignores projection and returns whole docs.
+        return self
+
+    def document(self, doc_id):
+        # The grant reader addresses a doc as collection('users/{uid}/memory_control').document(id).
+        return _DocRef(self._db, f'{self._prefix}/{doc_id}')
+
+    def limit(self, limit):
+        self._limit = limit
+        return self
+
+    def stream(self):
+        rows = [
+            _Snapshot(path.rsplit('/', 1)[-1], data)
+            for path, data in self._db.docs.items()
+            if path.startswith(f'{self._prefix}/') and path.count('/') == self._prefix.count('/') + 1
+        ]
+        return rows[: self._limit] if self._limit is not None else rows
+
+
+class _FirestoreFake:
+    """Path-keyed document store: collection()/document() and document(path) hit the same map."""
+
+    def __init__(self):
+        self.docs = {}
+        self.writes = []
+
+    def collection(self, name):
+        return _Query(self, name)
+
+    def document(self, path):
+        return _DocRef(self, path)
+
+    # -- test helpers ------------------------------------------------------------------
+    def add_key(self, key_id, uid, scopes, created_at):
+        doc = {'id': key_id, 'user_id': uid, 'created_at': created_at}
+        if scopes is not _ABSENT:
+            doc['scopes'] = scopes
+        self.docs[f'dev_api_keys/{key_id}'] = doc
+
+    def grant_path(self, uid):
+        return f'users/{uid}/{APP_KEY_MEMORY_GRANTS_COLLECTION}/{APP_KEY_MEMORY_GRANT_DOC_ID}'
+
+    def add_grant(self, uid, key_id):
+        self.docs[self.grant_path(uid)] = {
+            'grants': {
+                DEVELOPER_API_CONSUMER: {'apps': {DEVELOPER_API_DEFAULT_APP_ID: {'keys': {key_id: {'enabled': True}}}}}
+            }
+        }
+
+    def grant_for(self, uid, key_id):
+        doc = self.docs.get(self.grant_path(uid)) or {}
+        keys = (
+            doc.get('grants', {})
+            .get(DEVELOPER_API_CONSUMER, {})
+            .get('apps', {})
+            .get(DEVELOPER_API_DEFAULT_APP_ID, {})
+            .get('keys', {})
+        )
+        return keys.get(key_id)
+
+
+_ABSENT = object()
+
+
+def _run(db, monkeypatch, capsys, argv):
+    monkeypatch.setattr(backfill, 'get_firestore_client', lambda: db)
+    monkeypatch.setattr('sys.argv', ['backfill_developer_api_key_memory_grants.py', *argv])
+    backfill.main()
+    return eval(capsys.readouterr().out.strip())  # the script prints a dict literal
+
+
+@pytest.fixture
+def db():
+    return _FirestoreFake()
+
+
+def test_dry_run_reports_the_cohort_and_writes_nothing(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:read'], BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, [])
+
+    assert counts['keys_needing_backfill'] == 1
+    assert counts['distinct_users_needing_backfill'] == 1
+    assert counts['dry_run'] is True
+    assert db.writes == [], 'dry run must not write'
+    assert db.grant_for('u1', 'k1') is None
+
+
+def test_apply_seeds_read_only_grant_for_a_read_scoped_key(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:read', 'conversations:read'], BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['grants_written'] == 1
+    grant = db.grant_for('u1', 'k1')
+    assert grant['default_read'] is True
+    assert grant['write'] is False, 'a read-scoped key must not gain write'
+    assert grant['archive_read'] is False
+    assert grant['scopes'] == ['memories.read']
+
+
+def test_apply_seeds_write_for_a_write_scoped_key_without_inventing_read(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:write'], BEFORE)
+
+    _run(db, monkeypatch, capsys, ['--apply'])
+
+    grant = db.grant_for('u1', 'k1')
+    assert grant['write'] is True
+    assert grant['default_read'] is False
+    assert grant['scopes'] == ['memories.write']
+
+
+def test_key_without_a_memory_scope_is_left_alone(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['conversations:read'], BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['skipped_no_memory_scope'] == 1
+    assert counts.get('keys_needing_backfill', 0) == 0
+    assert db.writes == []
+
+
+def test_key_created_after_seeding_is_left_alone(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:read'], AFTER)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['skipped_created_after_seeding'] == 1
+    assert db.writes == []
+
+
+def test_absent_scopes_field_is_treated_as_read_only_like_the_request_path(db, monkeypatch, capsys):
+    # has_scope(None, ...) resolves a scope-less legacy key to the read-only set, which
+    # includes memories:read — such a key can already read memories, so it needs the grant.
+    db.add_key('k1', 'u1', _ABSENT, BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['absent_scopes_treated_as_read_only'] == 1
+    grant = db.grant_for('u1', 'k1')
+    assert grant['default_read'] is True
+    assert grant['write'] is False, 'write is never inferred from an absent scopes field'
+
+
+def test_existing_grant_is_not_rewritten_so_reruns_are_safe(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:read'], BEFORE)
+    db.add_grant('u1', 'k1')
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['already_granted'] == 1
+    assert counts.get('keys_needing_backfill', 0) == 0
+    assert db.writes == []
+
+
+def test_unusable_created_at_is_skipped_rather_than_guessed(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:read'], None)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['skipped_unusable_created_at'] == 1
+    assert db.writes == []
+
+
+def test_naive_created_at_is_read_as_utc_instead_of_crashing_the_scan(db, monkeypatch, capsys):
+    db.add_key('k1', 'u1', ['memories:read'], BEFORE.replace(tzinfo=None))
+    db.add_key('k2', 'u2', ['memories:read'], BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['keys_needing_backfill'] == 2
+    assert counts.get('skipped_unusable_created_at', 0) == 0
+
+
+def test_second_key_for_the_same_user_is_seeded_against_written_state(db, monkeypatch, capsys):
+    # The grant document is cached per uid; after a write that cache is stale, so a second
+    # key for the same user must still be evaluated and seeded.
+    db.add_key('k1', 'u1', ['memories:read'], BEFORE)
+    db.add_key('k2', 'u1', ['memories:write'], BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['grants_written'] == 2
+    assert counts['distinct_users_needing_backfill'] == 1
+    assert db.grant_for('u1', 'k1')['default_read'] is True
+    assert db.grant_for('u1', 'k2')['write'] is True
+
+
+def test_limit_bounds_the_scan(db, monkeypatch, capsys):
+    for i in range(5):
+        db.add_key(f'k{i}', f'u{i}', ['memories:read'], BEFORE)
+
+    counts = _run(db, monkeypatch, capsys, ['--limit', '2'])
+
+    assert counts['total_dev_key_docs'] == 2
+    assert db.writes == []
+
+
+def test_key_without_user_id_is_skipped(db, monkeypatch, capsys):
+    db.docs['dev_api_keys/k1'] = {'id': 'k1', 'scopes': ['memories:read'], 'created_at': BEFORE}
+
+    counts = _run(db, monkeypatch, capsys, ['--apply'])
+
+    assert counts['skipped_missing_user_id'] == 1
+    assert db.writes == []


### PR DESCRIPTION
## Problem

Developer API keys created before the create-path grant seeding landed (`8e03144a`, 2026-06-27 22:54:46 +0700) have no entry under `users/{uid}/memory_control/app_key_memory_grants`. `authorize_memory_external_default_memory_read` fails closed when no grant document is found, so those keys receive a permanent `403` from `GET /v1/dev/user/memories` regardless of the scopes on the key:

```
{"detail":{"enabled":false,"reason":"missing_app_key_scope_grant","consumer":"developer_api"}}
```

`/v1/dev/user/conversations` and `/v1/dev/user/action-items` return `200` on the same key, so it reads to the developer as "the memories endpoint is broken" rather than "my key is missing a grant". Nothing backfills them, so the state is unrecoverable without creating a new key.

This is a second, independent gate from the rollout gate fixed by #10094. The create-path defect itself is already fixed; what remains is the residual data.

## What this PR delivers

**The script and its dry-run mode only. It has not been run against production.** Applying it touches roughly 1,417 accounts, which is the maintainer's call to make, not this PR's.

`backend/scripts/backfill_developer_api_key_memory_grants.py`, modelled on the existing `backfill_mcp_key_full_access.py`:

```
python scripts/backfill_developer_api_key_memory_grants.py              # dry run (default)
python scripts/backfill_developer_api_key_memory_grants.py --limit 200  # bounded dry run
python scripts/backfill_developer_api_key_memory_grants.py --apply      # write grants
```

It walks `dev_api_keys`, selects keys created before the seeding instant that carry a memories capability, and seeds the grant with exactly the call the create path makes:

```python
grant_default_read = has_scope(scopes, Scopes.MEMORIES_READ)
grant_write = has_scope(scopes, Scopes.MEMORIES_WRITE)
if grant_default_read or grant_write:
    seed_developer_api_key_memory_grant(uid, key_id, default_read=..., write=..., db_client=db)
```

Dry run prints the same counts as an apply run without writing, so the cohort can be measured before anyone commits to a write.

## Grants nothing new

The whole safety argument is that no key gains a capability it did not already have:

- `default_read` comes only from `memories:read`, `write` only from `memories:write`; `archive_read` is always `False`.
- A key with neither memory scope is skipped entirely.
- A key that already holds a grant for the same app/key is skipped, so re-running is safe.
- A key whose `created_at` cannot be read is skipped rather than guessed.

### One deviation from the issue's proposed filter

The issue says to select keys that "carry `memories:read`/`memories:write`". Taken literally as a membership test, that misses a legacy shape. Scope resolution here goes through `utils.scopes.has_scope`, the same authority the request path uses:

```python
def has_scope(user_scopes, required_scope):
    """Check if user has required scope. None scopes are treated as read-only."""
    if user_scopes is None:
        return required_scope in READ_ONLY_SCOPES
    return required_scope in user_scopes
```

`READ_ONLY_SCOPES` includes `Scopes.MEMORIES_READ`, so a key with **no stored `scopes` field can already read memories at the request layer** — and therefore also 403s on this gate and needs the grant. A literal `'memories:read' in scopes` test would silently leave that population broken. Write is never inferred this way, because `memories:write` is not a read-only scope.

That means the affected cohort may be slightly larger than the issue's measured 1,763 keys / 1,417 accounts, which counted explicit scopes. The dry run reports `absent_scopes_treated_as_read_only` separately so the difference is visible before applying.

## Tests

`backend/tests/unit/test_backfill_developer_api_key_memory_grants.py` — 12 cases against a path-keyed Firestore fake, pinning the two properties that make the script safe to run:

- **dry run writes nothing at all** (asserted on the fake's write log, not just the printed counts)
- **applying grants exactly the key's own capability**: a read-scoped key gets `default_read` without `write`; a write-scoped key gets `write` without `default_read`; an absent `scopes` field resolves to read-only; a key with no memory scope, or created after seeding, is left untouched

Plus: an existing grant is never rewritten (safe re-run), a second key for the same user is still seeded after the per-uid grant cache is invalidated by the first write, an unusable `created_at` is skipped rather than guessed, a naive `created_at` is read as UTC instead of aborting the scan, `--limit` bounds the scan, and a key with no `user_id` is skipped.

## Verification

Backend, aarch64, system `python3.12` + `pytest 9.0.3`.

```
BACKEND_UNIT_TEST_FILE_LIST=tests/unit/test_backfill_developer_api_key_memory_grants.py bash test.sh
  ->  12 passed, 0 failed
```

Local runs used the `python3` fallback documented in `test.sh` because the pinned CPython 3.11.15 has no `linux-aarch64` build, so `scripts/sync-python-deps.sh` cannot create the pinned venv on this machine. CI on the pinned interpreter is the authoritative gate for this PR.

No production run was performed, and the script was not executed against any live Firestore project. Its behavior is exercised only through the fake in the test above.

Closes #10734


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

