### PR TITLE
feat(backend): admin CLI to inspect/reset monthly transcription usage

### DIFF
--- a/backend/docs/runbooks/reset-transcription-usage.md
+++ b/backend/docs/runbooks/reset-transcription-usage.md
@@ -1,0 +1,79 @@
+# Runbook — reset a user's free-tier transcription (listening) minutes
+
+**Use when:** support needs to inspect or goodwill-reset a user's monthly
+transcription minutes after an unexpected burn (e.g. silent open-mic).
+
+**What it touches:** `transcription_seconds` summed from
+`users/{uid}/hourly_usage/{YYYY-MM-DD-HH}` for the current calendar month — the
+exact surface the cap enforces (`utils/subscription.get_remaining_transcription_seconds`).
+This is **not** the fair-use speech-hour system (`/v1/admin/fair-use/...`), which
+already has its own reset.
+
+## Tool
+
+`backend/scripts/admin/reset_transcription_usage.py` (run as a module from the
+backend dir).
+
+## Credentials
+
+Any account with **prod Firestore write** on the Omi GCP project:
+
+- Service account JSON:
+  `GOOGLE_APPLICATION_CREDENTIALS=/path/svc.json`
+- Or operator ADC: `gcloud auth application-default login` (with the prod
+  project's Firestore Writer / Editor role).
+
+`--email` additionally calls Firebase Auth to resolve the uid; `--uid` needs no
+Auth SDK.
+
+## Commands
+
+```bash
+cd backend
+
+# 1) Inspect (read-only) — plan / used / limit / remaining / top buckets:
+python -m scripts.admin.reset_transcription_usage show --uid <UID>
+python -m scripts.admin.reset_transcription_usage show --email user@example.com
+
+# 2) Dry-run reset (default — writes nothing):
+python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
+    --reason "goodwill: silent open-mic burn"
+
+# 3) Apply (zeros current-month transcription_seconds, writes audit record):
+python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
+    --reason "goodwill: silent open-mic burn" --apply --operator "you@"
+```
+
+## Safety
+
+- **Dry-run by default.** `reset-month` prints before/after and exits without
+  writing unless `--apply` is passed.
+- **`--reason` is required** (audited).
+- **Before/after totals printed** on every run.
+- **Audit trail:** on `--apply`, a doc is written to Firestore
+  `admin_audit_log/{auto}` with uid / email / plan / month / reason / operator /
+  before / after / docs-touched / timestamp. Dry-runs print the same record as a
+  JSON line to stdout (not persisted).
+- **No transcript / memory / message data** is read or printed — only the
+  numeric `transcription_seconds` counter and doc ids.
+- **No new IAM.** Reuses the backend's existing credential loader
+  (`database/google_credentials`).
+
+## What is intentionally NOT covered
+
+- **Chat-question quota reset** is deferred. Chat usage lives in
+  `users/{uid}/llm_usage/{YYYY-MM-DD}` across several nested/legacy counter
+  shapes (`desktop_chat.quota_questions`, `backend_chat.quota_questions`,
+  legacy `chat.*.call_count`); zeroing it safely needs integration testing
+  against all those shapes, out of scope for this ops tool. Track separately.
+- **Fair-use reset** already exists at `POST /v1/admin/fair-use/user/{uid}/reset`
+  (`backend/routers/fair_use_admin.py`) — use that for speech-hour state.
+- **Automatic goodwill credits / billing policy** — product decision, out of scope.
+- **Prod runs** are operator-initiated; this repo's CI only unit-tests the pure
+  logic. Never run `--apply` in CI / automated pipelines against real users
+  without an operator decision.
+
+## Tests
+
+`backend/tests/unit/test_reset_transcription_usage.py` — pure logic only
+(month aggregation, reset-plan shape, audit record, dry-run vs apply). No GCP.

--- a/backend/scripts/admin/reset_transcription_usage.py
+++ b/backend/scripts/admin/reset_transcription_usage.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Admin CLI: inspect / reset a user's monthly transcription usage.
+
+Support-ops tool for the free-tier monthly transcription (listening) minutes
+quota. Reads the same surface the cap enforces — ``transcription_seconds``
+summed across ``users/{uid}/hourly_usage/{YYYY-MM-DD-HH}`` for the current
+calendar month (see ``database/user_usage.get_monthly_usage_stats`` and
+``utils/subscription.get_remaining_transcription_seconds``).
+
+Commands
+--------
+``show``       Lookup by --uid (or --email) and print plan / used / limit /
+               remaining for the current month, plus the top hourly buckets.
+               Metadata only — never prints transcripts or memories.
+               (Collapses the issue's ``lookup`` + ``usage show``: a lookup that
+               does not also aggregate has no extra signal, so one command does
+               both.)
+``reset-month``Zero ``transcription_seconds`` on every current-month hourly_usage doc
+               for the user. DRY-RUN by default; requires ``--reason`` and
+               ``--apply`` to write. Prints before/after totals and writes a
+               durable audit record (Firestore ``admin_audit_log`` + a JSON
+               stdout line).
+
+Credentials
+-----------
+Uses the same loader as the backend (``database.google_credentials``): set
+``GOOGLE_APPLICATION_CREDENTIALS`` to a service-account JSON file with Firestore
+write on the prod project, or run ``gcloud auth application-default login`` for
+ADC. ``--email`` additionally initializes firebase_admin to resolve the uid
+(Auth lookup); ``--uid`` needs no Auth SDK.
+
+Examples
+--------
+    # Inspect (read-only):
+    GOOGLE_APPLICATION_CREDENTIALS=svc.json python -m scripts.admin.reset_transcription_usage \
+        show --uid <UID>
+
+    # Dry-run reset (default — writes nothing):
+    python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> --reason "goodwill: silent open-mic"
+
+    # Apply:
+    python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
+        --reason "goodwill: silent open-mic" --apply --operator "david@"
+
+This is an ops tool, not a service: keep heavy backend imports inside the
+command/I-O functions so the pure helpers stay importable without GCP and
+unit-testable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+# Firestore batch write limit.
+_BATCH_LIMIT = 400
+
+# How many top hourly buckets ``show`` prints.
+_TOP_BUCKETS = 5
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — no GCP, unit-testable
+# ---------------------------------------------------------------------------
+
+
+def month_label(now: datetime) -> str:
+    """``YYYY-MM`` label for the calendar month containing ``now`` (UTC)."""
+    return f"{now.year:04d}-{now.month:02d}"
+
+
+@dataclass(frozen=True)
+class HourlyBucket:
+    """One ``hourly_usage`` doc's transcription contribution."""
+
+    doc_id: str
+    seconds: int
+
+    @property
+    def day_hour(self) -> str:
+        # doc_id shape: ``YYYY-MM-DD-HH``
+        return self.doc_id
+
+
+@dataclass(frozen=True)
+class MonthlyUsage:
+    """Aggregated transcription usage for one calendar month."""
+
+    used_seconds: int
+    document_count: int
+    top_buckets: tuple[HourlyBucket, ...]
+
+
+def aggregate_monthly_usage(docs: Iterable[tuple[str, dict[str, Any]]], top_n: int = _TOP_BUCKETS) -> MonthlyUsage:
+    """Sum ``transcription_seconds`` across hourly_usage docs.
+
+    ``docs`` is an iterable of ``(doc_id, data_dict)`` pairs (the Firestore
+    snapshot shape). Missing/zero fields count as zero, matching
+    ``database/user_usage._aggregate_stats_with_count``.
+    """
+    total = 0
+    document_count = 0
+    buckets: list[HourlyBucket] = []
+    for doc_id, data in docs:
+        document_count += 1
+        seconds = int(data.get("transcription_seconds", 0) or 0)
+        total += seconds
+        if seconds > 0:
+            buckets.append(HourlyBucket(doc_id=doc_id, seconds=seconds))
+    buckets.sort(key=lambda b: b.seconds, reverse=True)
+    return MonthlyUsage(
+        used_seconds=total,
+        document_count=document_count,
+        top_buckets=tuple(buckets[:top_n]),
+    )
+
+
+def seconds_to_minutes(seconds: int) -> float:
+    """Seconds → minutes, rounded to one decimal (display only)."""
+    return round(seconds / 60.0, 1)
+
+
+@dataclass(frozen=True)
+class ResetPlan:
+    """What ``reset-month`` will zero, and the before/after monthly totals."""
+
+    doc_ids: tuple[str, ...]  # docs whose transcription_seconds > 0 get zeroed
+    before_total_seconds: int
+    after_total_seconds: int = 0  # zeroing always lands the month at 0
+
+    @property
+    def touches(self) -> int:
+        return len(self.doc_ids)
+
+
+def build_reset_plan(docs: Iterable[tuple[str, dict[str, Any]]]) -> ResetPlan:
+    """Build the zero-out plan for the current month.
+
+    Only docs with ``transcription_seconds > 0`` are touched; empty buckets are
+    skipped so a reset on a fresh user is a no-op write.
+    """
+    to_zero: list[str] = []
+    before_total = 0
+    for doc_id, data in docs:
+        seconds = int(data.get("transcription_seconds", 0) or 0)
+        if seconds > 0:
+            before_total += seconds
+            to_zero.append(doc_id)
+    return ResetPlan(doc_ids=tuple(to_zero), before_total_seconds=before_total)
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    """Durable audit trail for a reset op. Written to Firestore + stdout."""
+
+    uid: str
+    email: Optional[str]
+    plan: str
+    month: str
+    reason: str
+    operator: str
+    applied: bool
+    before_seconds: int
+    after_seconds: int
+    docs_touched: int
+    at: str  # RFC3339 UTC
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uid": self.uid,
+            "email": self.email,
+            "plan": self.plan,
+            "month": self.month,
+            "reason": self.reason,
+            "operator": self.operator,
+            "applied": self.applied,
+            "before_seconds": self.before_seconds,
+            "after_seconds": self.after_seconds,
+            "docs_touched": self.docs_touched,
+            "at": self.at,
+        }
+
+
+def build_audit_record(
+    *,
+    uid: str,
+    email: Optional[str],
+    plan: str,
+    month: str,
+    reason: str,
+    operator: str,
+    applied: bool,
+    before_seconds: int,
+    after_seconds: int,
+    docs_touched: int,
+    now: Optional[datetime] = None,
+) -> AuditRecord:
+    now = now or datetime.now(timezone.utc)
+    return AuditRecord(
+        uid=uid,
+        email=email,
+        plan=plan,
+        month=month,
+        reason=reason,
+        operator=operator,
+        applied=applied,
+        before_seconds=before_seconds,
+        after_seconds=after_seconds,
+        docs_touched=docs_touched,
+        at=now.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# I/O — thin wrappers over Firestore / Auth. Imports are local so the pure
+# helpers above stay importable without the backend runtime.
+# ---------------------------------------------------------------------------
+
+
+def _firestore_client() -> Any:
+    from database._client import db  # lazy: builds on first attr access
+
+    return db
+
+
+def fetch_monthly_hourly_docs(client: Any, uid: str, year: int, month: int) -> list[tuple[str, dict[str, Any]]]:
+    """Return ``(doc_id, data)`` for every hourly_usage doc in the given month.
+
+    Mirrors ``database/user_usage.get_monthly_usage_stats``: filters on the
+    ``year``/``month`` fields the increment path writes alongside each bucket.
+    """
+    from google.cloud.firestore_v1 import FieldFilter
+
+    query = (
+        client.collection("users")
+        .document(uid)
+        .collection("hourly_usage")
+        .where(filter=FieldFilter("year", "==", year))
+        .where(filter=FieldFilter("month", "==", month))
+    )
+    return [(doc.id, (doc.to_dict() or {})) for doc in query.stream()]
+
+
+def resolve_uid(*, uid: Optional[str], email: Optional[str]) -> tuple[str, Optional[str]]:
+    """Resolve a target uid from --uid (preferred) or --email (Firebase Auth)."""
+    if uid:
+        return uid, email
+    if not email:
+        raise SystemExit("error: provide --uid or --email")
+    import firebase_admin
+    from firebase_admin import auth as firebase_auth
+
+    if not firebase_admin._apps:  # type: ignore[attr-defined]
+        # ADC if GOOGLE_APPLICATION_CREDENTIALS unset; matches migration scripts.
+        if os.getenv("SERVICE_ACCOUNT_JSON"):
+            from firebase_admin import credentials
+
+            firebase_admin.initialize_app(credentials.Certificate(json.loads(os.environ["SERVICE_ACCOUNT_JSON"])))
+        else:
+            firebase_admin.initialize_app()
+    user = firebase_auth.get_user_by_email(email)  # raises UserNotFoundError
+    return user.uid, email
+
+
+def resolve_plan_and_limit(uid: str) -> tuple[str, Optional[int]]:
+    """Return ``(plan_name, monthly_seconds_limit_or_None)``.
+
+    ``None`` limit = unlimited plan (operator/architect/unlimited/neo). The
+    transcription cap only bites basic + plus, whose limits come straight from
+    ``utils.subscription.get_plan_limits``.
+    """
+    from database import users as users_db
+    from utils.subscription import get_plan_display_name, get_plan_limits
+
+    subscription = users_db.get_user_subscription(uid)
+    plan = subscription.plan
+    limits = get_plan_limits(plan)
+    limit_seconds = limits.transcription_seconds
+    return get_plan_display_name(plan), (limit_seconds or None)
+
+
+def apply_reset(client: Any, uid: str, plan: ResetPlan) -> None:
+    """Zero ``transcription_seconds`` on every doc in the reset plan (batched).."""
+    if not plan.doc_ids:
+        return
+    hourly = client.collection("users").document(uid).collection("hourly_usage")
+    for chunk_start in range(0, len(plan.doc_ids), _BATCH_LIMIT):
+        batch = client.batch()
+        for doc_id in plan.doc_ids[chunk_start : chunk_start + _BATCH_LIMIT]:
+            batch.set(hourly.document(doc_id), {"transcription_seconds": 0}, merge=True)
+        batch.commit()
+
+
+def write_audit(client: Any, record: AuditRecord) -> str:
+    """Persist the audit record to ``admin_audit_log`` and return its doc id."""
+    doc_ref = client.collection("admin_audit_log").document()
+    doc_ref.set(record.to_dict())
+    return doc_ref.id
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
+def _print_usage(
+    uid: str, email: Optional[str], plan: str, limit_seconds: Optional[int], usage: MonthlyUsage, month: str
+) -> None:
+    used = usage.used_seconds
+    if limit_seconds is None:
+        limit_min_s = "unlimited"
+        remaining_s = "unlimited"
+        pct_s = "n/a"
+    else:
+        limit_min_s = f"{seconds_to_minutes(limit_seconds)} min"
+        remaining = max(0, limit_seconds - used)
+        remaining_s = f"{seconds_to_minutes(remaining)} min ({remaining} s)"
+        pct_s = f"{round(100.0 * used / limit_seconds, 1)}%" if limit_seconds else "n/a"
+    print(f"uid:           {uid}")
+    if email:
+        print(f"email:         {email}")
+    print(f"plan:          {plan}")
+    print(f"month:         {month} (UTC)")
+    print(f"used:          {seconds_to_minutes(used)} min ({used} s) across {usage.document_count} hourly bucket(s)")
+    print(f"limit:         {limit_min_s}")
+    print(f"remaining:     {remaining_s}")
+    print(f"used of limit: {pct_s}")
+    if usage.top_buckets:
+        print("top buckets:")
+        for b in usage.top_buckets:
+            share = f" ({round(100.0 * b.seconds / used, 1)}%)" if used else ""
+            print(f"  {b.doc_id}: {seconds_to_minutes(b.seconds)} min ({b.seconds} s){share}")
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    uid, email = resolve_uid(uid=args.uid, email=args.email)
+    client = _firestore_client()
+    now = datetime.now(timezone.utc)
+    plan, limit_seconds = resolve_plan_and_limit(uid)
+    docs = fetch_monthly_hourly_docs(client, uid, now.year, now.month)
+    usage = aggregate_monthly_usage(docs)
+    _print_usage(uid, email, plan, limit_seconds, usage, month_label(now))
+    return 0
+
+
+def cmd_reset_month(args: argparse.Namespace) -> int:
+    uid, email = resolve_uid(uid=args.uid, email=args.email)
+    client = _firestore_client()
+    now = datetime.now(timezone.utc)
+    plan_name, _limit = resolve_plan_and_limit(uid)
+    docs = fetch_monthly_hourly_docs(client, uid, now.year, now.month)
+    reset_plan = build_reset_plan(docs)
+
+    if not reset_plan.touches:
+        print(f"No transcription_seconds to reset for {uid} in {month_label(now)} (already zero).")
+        return 0
+
+    verb = "APPLY" if args.apply else "DRY-RUN (no writes; pass --apply to commit)"
+    print(f"[{verb}] reset-month for uid={uid} month={month_label(now)}")
+    print(f"  before: {seconds_to_minutes(reset_plan.before_total_seconds)} min ({reset_plan.before_total_seconds} s)")
+    print(f"  docs to zero: {reset_plan.touches}")
+    print("  after:  0.0 min (0 s)")
+    print(f"  reason: {args.reason}")
+    print(f"  operator: {args.operator}")
+
+    record = build_audit_record(
+        uid=uid,
+        email=email,
+        plan=plan_name,
+        month=month_label(now),
+        reason=args.reason,
+        operator=args.operator,
+        applied=args.apply,
+        before_seconds=reset_plan.before_total_seconds,
+        after_seconds=0,
+        docs_touched=reset_plan.touches,
+        now=now,
+    )
+
+    if not args.apply:
+        # Still emit the audit line so dry-run intent is captured in operator logs.
+        print("audit (not persisted): " + json.dumps(record.to_dict(), sort_keys=True))
+        print("Dry-run complete. Re-run with --apply to commit.")
+        return 0
+
+    apply_reset(client, uid, reset_plan)
+    audit_id = write_audit(client, record)
+    print(f"Applied. Audit written: admin_audit_log/{audit_id}")
+    print("audit: " + json.dumps(record.to_dict(), sort_keys=True))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# argparse
+# ---------------------------------------------------------------------------
+
+
+def _add_target_args(p: argparse.ArgumentParser) -> None:
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument("--uid", help="Firebase Auth uid of the target user.")
+    group.add_argument("--email", help="Resolve uid from this email via Firebase Auth.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reset_transcription_usage",
+        description="Inspect / reset a user's monthly free-tier transcription (listening) minutes.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_show = sub.add_parser("show", help="Show plan / used / limit / top buckets for the current month (read-only).")
+    _add_target_args(p_show)
+    p_show.set_defaults(func=cmd_show)
+
+    p_reset = sub.add_parser(
+        "reset-month",
+        help="Zero current-month transcription_seconds. DRY-RUN by default.",
+    )
+    _add_target_args(p_reset)
+    p_reset.add_argument("--reason", required=True, help="Operator reason string (required, audited).")
+    p_reset.add_argument("--apply", action="store_true", help="Commit the reset (default is dry-run).")
+    p_reset.add_argument(
+        "--operator",
+        default=os.getenv("USER", "unknown"),
+        help="Operator identity for the audit record (default: $USER).",
+    )
+    p_reset.set_defaults(func=cmd_reset_month)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/admin/reset_transcription_usage.py
+++ b/backend/scripts/admin/reset_transcription_usage.py
@@ -54,7 +54,7 @@ import json
 import logging
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
@@ -231,9 +231,9 @@ def build_audit_record(
 
 
 def _firestore_client() -> Any:
-    from database._client import db  # lazy: builds on first attr access
+    from database._client import get_firestore_client  # supported getter
 
-    return db
+    return get_firestore_client()
 
 
 def fetch_monthly_hourly_docs(client: Any, uid: str, year: int, month: int) -> list[tuple[str, dict[str, Any]]]:
@@ -278,14 +278,31 @@ def resolve_uid(*, uid: Optional[str], email: Optional[str]) -> tuple[str, Optio
 def resolve_plan_and_limit(uid: str) -> tuple[str, Optional[int]]:
     """Return ``(plan_name, monthly_seconds_limit_or_None)``.
 
+    Uses ``get_user_valid_subscription`` — the same effective subscription the
+    enforcement path (``get_remaining_transcription_seconds``) uses. This is a
+    **non-mutating** read: unlike ``get_user_subscription``, it never creates a
+    default subscription or rewrites legacy ``free`` plans, so ``show`` and
+    dry-run commands stay genuinely read-only.
+
+    For a user whose paid plan has expired, this returns the Basic fallback
+    rather than the stored paid plan — matching what enforcement sees.
+
     ``None`` limit = unlimited plan (operator/architect/unlimited/neo). The
     transcription cap only bites basic + plus, whose limits come straight from
     ``utils.subscription.get_plan_limits``.
     """
     from database import users as users_db
-    from utils.subscription import get_plan_display_name, get_plan_limits
+    from utils.subscription import (
+        get_default_basic_subscription,
+        get_plan_display_name,
+        get_plan_limits,
+    )
 
-    subscription = users_db.get_user_subscription(uid)
+    # get_user_valid_subscription returns None when the stored plan is expired;
+    # enforcement treats that user as Basic, so we do the same here.
+    subscription = users_db.get_user_valid_subscription(uid)
+    if subscription is None:
+        subscription = get_default_basic_subscription()
     plan = subscription.plan
     limits = get_plan_limits(plan)
     limit_seconds = limits.transcription_seconds
@@ -309,6 +326,39 @@ def write_audit(client: Any, record: AuditRecord) -> str:
     doc_ref = client.collection("admin_audit_log").document()
     doc_ref.set(record.to_dict())
     return doc_ref.id
+
+
+def update_audit(client: Any, audit_id: str, record: AuditRecord) -> None:
+    """Update an existing audit record after the mutation outcome is known."""
+    client.collection("admin_audit_log").document(audit_id).set(record.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Audit payload sanitization — stdout/logs get redacted PII; the Firestore
+# record retains the full fields (access-controlled).
+# ---------------------------------------------------------------------------
+
+
+def _sanitized_audit_payload(record: AuditRecord) -> dict[str, Any]:
+    """Return a copy of the audit record with PII redacted for stdout/logs.
+
+    The email and operator-provided reason may contain user-identifiable text;
+    these are masked before serializing to the JSON line printed to stdout,
+    which is intended for operator logs. The full record persists only in the
+    access-controlled ``admin_audit_log`` Firestore collection.
+    """
+    try:
+        from utils.log_sanitizer import sanitize_pii
+    except Exception:
+        # Fallback: don't crash the CLI if the sanitizer can't import.
+        sanitize_pii = lambda v: str(v)  # noqa: E731
+
+    payload = record.to_dict()
+    if payload.get("email") is not None:
+        payload["email"] = sanitize_pii(payload["email"])
+    if payload.get("reason") is not None:
+        payload["reason"] = sanitize_pii(payload["reason"])
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -392,14 +442,34 @@ def cmd_reset_month(args: argparse.Namespace) -> int:
 
     if not args.apply:
         # Still emit the audit line so dry-run intent is captured in operator logs.
-        print("audit (not persisted): " + json.dumps(record.to_dict(), sort_keys=True))
+        print("audit (not persisted): " + json.dumps(_sanitized_audit_payload(record), sort_keys=True))
         print("Dry-run complete. Re-run with --apply to commit.")
         return 0
 
+    # Write a pending audit record BEFORE mutation so a mid-reset failure
+    # (partial batch commit or audit-write error) still leaves a durable trail
+    # describing the intended mutation and the operator who initiated it.
+    pending_record = build_audit_record(
+        uid=uid,
+        email=email,
+        plan=plan_name,
+        month=month_label(now),
+        reason=args.reason,
+        operator=args.operator,
+        applied=False,  # updated to True after mutation completes
+        before_seconds=reset_plan.before_total_seconds,
+        after_seconds=-1,  # sentinel: outcome not yet known
+        docs_touched=reset_plan.touches,
+        now=now,
+    )
+    audit_id = write_audit(client, pending_record)
+
     apply_reset(client, uid, reset_plan)
-    audit_id = write_audit(client, record)
+    # All batched commits succeeded — finalize the audit record.
+    final_record = replace(record, applied=True, after_seconds=0)
+    update_audit(client, audit_id, final_record)
     print(f"Applied. Audit written: admin_audit_log/{audit_id}")
-    print("audit: " + json.dumps(record.to_dict(), sort_keys=True))
+    print("audit: " + json.dumps(_sanitized_audit_payload(final_record), sort_keys=True))
     return 0
 
 

--- a/backend/tests/unit/test_reset_transcription_usage.py
+++ b/backend/tests/unit/test_reset_transcription_usage.py
@@ -21,6 +21,7 @@ from scripts.admin.reset_transcription_usage import (  # noqa: E402
     build_reset_plan,
     month_label,
     seconds_to_minutes,
+    _sanitized_audit_payload,
 )
 
 NOW = datetime(2026, 7, 27, 13, 30, tzinfo=timezone.utc)
@@ -182,3 +183,102 @@ def test_aggregation_trusts_caller_month_filter() -> None:
     usage = aggregate_monthly_usage(cross_month)
 
     assert usage.used_seconds == 1500
+
+
+# ---------------------------------------------------------------------------
+# Audit sanitization (Thread 5)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitized_audit_payload_masks_email() -> None:
+    record = build_audit_record(
+        uid="abc123",
+        email="user@example.com",
+        plan="basic",
+        month="2026-07",
+        reason="goodwill",
+        operator="ops",
+        applied=True,
+        before_seconds=100,
+        after_seconds=0,
+        docs_touched=1,
+        now=NOW,
+    )
+
+    payload = _sanitized_audit_payload(record)
+
+    # Email local part is masked; domain preserved.
+    assert "@" in payload["email"]
+    assert payload["email"] != "user@example.com"
+    assert "example.com" in payload["email"]
+
+
+def test_sanitized_audit_payload_masks_reason_text() -> None:
+    record = build_audit_record(
+        uid="abc123",
+        email=None,
+        plan="basic",
+        month="2026-07",
+        reason="goodwill: user jane@example.com silent open-mic",
+        operator="ops",
+        applied=True,
+        before_seconds=100,
+        after_seconds=0,
+        docs_touched=1,
+        now=NOW,
+    )
+
+    payload = _sanitized_audit_payload(record)
+
+    # The reason contained an email — it must be masked in the sanitized output.
+    assert "jane@example.com" not in payload["reason"]
+
+
+def test_sanitized_audit_payload_preserves_non_pii_fields() -> None:
+    record = build_audit_record(
+        uid="abc123",
+        email=None,
+        plan="basic",
+        month="2026-07",
+        reason="routine",
+        operator="ops",
+        applied=False,
+        before_seconds=10,
+        after_seconds=0,
+        docs_touched=1,
+        now=NOW,
+    )
+
+    payload = _sanitized_audit_payload(record)
+
+    # Non-PII fields pass through unchanged.
+    assert payload["uid"] == "abc123"
+    assert payload["plan"] == "basic"
+    assert payload["before_seconds"] == 10
+    assert payload["applied"] is False
+
+
+# ---------------------------------------------------------------------------
+# Pending audit record uses sentinel before mutation outcome is known (Thread 4)
+# ---------------------------------------------------------------------------
+
+
+def test_pending_audit_record_marks_applied_false_and_sentinel_after() -> None:
+    """A pending audit record is written before mutation with applied=False
+    and a sentinel after_seconds=-1 so partial-failure leaves a recoverable trail."""
+    pending = build_audit_record(
+        uid="abc123",
+        email=None,
+        plan="basic",
+        month="2026-07",
+        reason="goodwill",
+        operator="ops",
+        applied=False,
+        before_seconds=300,
+        after_seconds=-1,  # sentinel: outcome not yet known
+        docs_touched=2,
+        now=NOW,
+    )
+
+    assert pending.applied is False
+    assert pending.after_seconds == -1  # sentinel: not yet finalized

--- a/backend/tests/unit/test_reset_transcription_usage.py
+++ b/backend/tests/unit/test_reset_transcription_usage.py
@@ -1,0 +1,184 @@
+"""Unit tests for the transcription-usage reset admin CLI pure logic.
+
+Covers: month-key labelling, monthly aggregation, reset-plan construction
+(dry-run vs apply shape), audit-record shape. No GCP — the helpers under test
+take plain dicts mirroring the Firestore snapshot shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from scripts.admin.reset_transcription_usage import (  # noqa: E402
+    aggregate_monthly_usage,
+    build_audit_record,
+    build_reset_plan,
+    month_label,
+    seconds_to_minutes,
+)
+
+NOW = datetime(2026, 7, 27, 13, 30, tzinfo=timezone.utc)
+
+
+def _doc(doc_id: str, seconds: int, **extra) -> tuple[str, dict]:
+    """One hourly_usage snapshot shape: (doc_id, data)."""
+    data = {"transcription_seconds": seconds, "year": 2026, "month": 7}
+    data.update(extra)
+    return (doc_id, data)
+
+
+def test_month_label_uses_utc_calendar_month() -> None:
+    assert month_label(NOW) == "2026-07"
+
+
+def test_aggregate_sums_transcription_seconds_and_counts_docs() -> None:
+    docs = [_doc("2026-07-27-10", 120), _doc("2026-07-27-11", 60), _doc("2026-07-27-12", 0)]
+
+    usage = aggregate_monthly_usage(docs)
+
+    assert usage.used_seconds == 180
+    assert usage.document_count == 3
+    # zero-second buckets are dropped from the "top" view
+    assert [b.doc_id for b in usage.top_buckets] == ["2026-07-27-10", "2026-07-27-11"]
+    assert usage.top_buckets[0].seconds == 120
+
+
+def test_aggregate_treats_missing_field_as_zero() -> None:
+    # _aggregate_stats_with_count in database/user_usage does .get(..., 0); mirror it.
+    docs = [("2026-07-27-10", {"year": 2026, "month": 7})]  # no transcription_seconds
+
+    usage = aggregate_monthly_usage(docs)
+
+    assert usage.used_seconds == 0
+    assert usage.top_buckets == ()
+
+
+def test_aggregate_handles_none_value_like_firestore_adapter() -> None:
+    # Firestore snapshots can surface None for a field present-but-null.
+    docs = [("2026-07-27-10", {"transcription_seconds": None})]
+
+    usage = aggregate_monthly_usage(docs)
+
+    assert usage.used_seconds == 0
+
+
+def test_top_buckets_are_sorted_desc_and_capped() -> None:
+    docs = [_doc(f"2026-07-27-{h:02d}", h * 10) for h in range(1, 8)]  # 7 buckets
+
+    usage = aggregate_monthly_usage(docs, top_n=3)
+
+    assert [b.seconds for b in usage.top_buckets] == [70, 60, 50]
+
+
+def test_reset_plan_only_includes_nonzero_buckets_and_sums_before() -> None:
+    docs = [_doc("2026-07-27-10", 120), _doc("2026-07-27-11", 60), _doc("2026-07-27-12", 0)]
+
+    plan = build_reset_plan(docs)
+
+    assert plan.doc_ids == ("2026-07-27-10", "2026-07-27-11")
+    assert plan.before_total_seconds == 180
+    assert plan.after_total_seconds == 0
+    assert plan.touches == 2
+
+
+def test_reset_plan_is_noop_on_fresh_user() -> None:
+    plan = build_reset_plan([_doc("2026-07-27-10", 0), _doc("2026-07-27-11", 0)])
+
+    assert plan.doc_ids == ()
+    assert plan.before_total_seconds == 0
+    assert plan.touches == 0
+
+
+def test_reset_plan_after_total_is_always_zero_regardless_of_input() -> None:
+    # The whole point of reset-month: zeroing lands the month at 0.
+    docs = [_doc("2026-07-27-10", 9999)]
+
+    plan = build_reset_plan(docs)
+
+    assert plan.after_total_seconds == 0
+
+
+def test_dry_run_vs_apply_share_the_same_plan_shape() -> None:
+    # Whether --apply is set or not, the plan computed from the docs is identical;
+    # only the write step differs (exercised in cmd_reset_month, not here).
+    docs = [_doc("2026-07-27-10", 300)]
+
+    plan = build_reset_plan(docs)
+
+    assert plan.doc_ids == ("2026-07-27-10",)
+    assert plan.before_total_seconds == 300
+    # apply path would zero exactly these doc ids — the contract under test.
+    assert plan.touches == 1
+
+
+def test_audit_record_captures_who_when_why_before_after() -> None:
+    record = build_audit_record(
+        uid="abc123",
+        email="user@example.com",
+        plan="basic",
+        month="2026-07",
+        reason="goodwill: silent open-mic burn",
+        operator="david@",
+        applied=True,
+        before_seconds=18000,
+        after_seconds=0,
+        docs_touched=42,
+        now=NOW,
+    )
+
+    d = record.to_dict()
+    assert d["uid"] == "abc123"
+    assert d["email"] == "user@example.com"
+    assert d["plan"] == "basic"
+    assert d["month"] == "2026-07"
+    assert d["reason"] == "goodwill: silent open-mic burn"
+    assert d["operator"] == "david@"
+    assert d["applied"] is True
+    assert d["before_seconds"] == 18000
+    assert d["after_seconds"] == 0
+    assert d["docs_touched"] == 42
+    assert d["at"] == "2026-07-27T13:30:00Z"
+
+
+def test_audit_record_marks_dry_run_as_not_applied() -> None:
+    record = build_audit_record(
+        uid="abc",
+        email=None,
+        plan="basic",
+        month="2026-07",
+        reason="test",
+        operator="ops",
+        applied=False,
+        before_seconds=10,
+        after_seconds=0,
+        docs_touched=1,
+        now=NOW,
+    )
+
+    assert record.applied is False
+    assert record.email is None
+
+
+def test_seconds_to_minutes_rounds_to_one_decimal() -> None:
+    assert seconds_to_minutes(0) == 0.0
+    assert seconds_to_minutes(60) == 1.0
+    assert seconds_to_minutes(90) == 1.5
+    assert seconds_to_minutes(18000) == 300.0  # 300 min cap
+
+
+def test_aggregation_trusts_caller_month_filter() -> None:
+    # The fetch step filters hourly_usage by year/month; the aggregate must not
+    # re-implement that filter. Guard against drift: docs from another month
+    # passed in by mistake still get summed (caller owns the filter).
+    assert month_label(NOW) == "2026-07"
+    cross_month = [_doc("2026-06-30-23", 1000), _doc("2026-07-01-00", 500)]
+
+    usage = aggregate_monthly_usage(cross_month)
+
+    assert usage.used_seconds == 1500


### PR DESCRIPTION
## What

Support-ops tool to **inspect and reset a user's free-tier monthly transcription (listening) minutes**, without hand-editing Firestore or asking engineering for one-off scripts. (SCA-207)

Reads the same surface the cap enforces — `transcription_seconds` summed across `users/{uid}/hourly_usage/{YYYY-MM-DD-HH}` for the current calendar month (`database/user_usage.get_monthly_usage_stats`, `utils/subscription.get_remaining_transcription_seconds`).

This is **not** the fair-use speech-hour system (`/v1/admin/fair-use/...`, which already has its own reset).

## Why

Real support case: a silent open-mic can burn a free user's 300 min/mo cap. Support needs to inspect usage and goodwill-reset the month quickly and safely, with an audit trail.

## Changes

- **`backend/scripts/admin/reset_transcription_usage.py`** — two subcommands:
  - `show` — plan / used / limit / remaining / top hourly buckets (read-only; metadata only, never transcripts/memories). Collapses the issue's `lookup` + `usage show`: a lookup that doesn't also aggregate has no extra signal.
  - `reset-month` — zero current-month `transcription_seconds`. **Dry-run by default**; requires `--reason`; prints before/after; on `--apply` writes a durable audit record to Firestore `admin_audit_log` + a JSON stdout line.
- **`backend/tests/unit/test_reset_transcription_usage.py`** — 13 pure-logic tests (aggregation, reset-plan shape incl. dry-run vs apply, audit record, missing/None field handling). No GCP.
- **`backend/docs/runbooks/reset-transcription-usage.md`** — operator how-to, credentials, safety, explicit deferrals.

## CLI examples

```bash
cd backend

# Inspect (read-only):
python -m scripts.admin.reset_transcription_usage show --uid <UID>
python -m scripts.admin.reset_transcription_usage show --email user@example.com

# Dry-run reset (default — writes nothing):
python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
    --reason "goodwill: silent open-mic burn"

# Apply:
python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
    --reason "goodwill: silent open-mic burn" --apply --operator "you@"
```

## Credentials needed

Any account with **prod Firestore write** on the Omi GCP project:
- `GOOGLE_APPLICATION_CREDENTIALS=/path/svc.json`, or
- `gcloud auth application-default login` (ADC).

`--uid` needs no Auth SDK; `--email` initializes `firebase_admin` for the uid lookup (same pattern as the migration scripts).

## Safety

- Dry-run default; `--apply` to commit.
- `--reason` required (audited).
- Before/after totals printed on every run.
- Audit trail: `admin_audit_log/{auto}` Firestore doc (uid/email/plan/month/reason/operator/before/after/docs-touched/timestamp) on apply; dry-run prints the same record as a JSON line.
- No transcript / memory / message data read or printed.
- No new IAM; reuses the backend's existing credential loader (`database/google_credentials`).

## Intentionally deferred

- **Chat-question quota reset** — chat usage lives in `users/{uid}/llm_usage/{YYYY-MM-DD}` across several nested/legacy counter shapes (`desktop_chat.quota_questions`, `backend_chat.quota_questions`, legacy `chat.*.call_count`); zeroing it safely needs integration testing against all shapes. Out of scope for this ops tool; track separately.
- **Fair-use reset** — already exists at `POST /v1/admin/fair-use/user/{uid}/reset`; use that for speech-hour state.
- **Automatic goodwill credits / billing policy** — product decision.
- No prod `--apply` runs from CI; operator-initiated only.

## Verification

- `backend/tests/unit/test_reset_transcription_usage.py` — **13 passed** (pure logic, no GCP).
- `ruff` (v0.4.4, py39) + `black` (line-length 120) — clean.
- `make preflight` — **10/10 checks green**.
- `reset_transcription_usage --help` / `reset-month --help` — renders correctly.
- Related usage unit tests (`test_billable_transcription_seconds`, `test_high_priority_usage_tracking`) — **29 passed**, no regressions.

No prod mutation performed (side-effect boundary: dev/unit only).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

