### PR TITLE
feat(omi-even): omi on Even Realities G2 — Even AI, Hub app, capture and push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,11 @@ builds-snapshot.md
 .hermes/
 backend/.venv
 backend/.harness/
+
+# omi-even bridge local state
+integrations/omi-even/bridge/.env
+integrations/omi-even/bridge/add-agent-capture.log
+integrations/omi-even/bridge/.venv/
+integrations/omi-even/bridge/__pycache__/
+integrations/omi-even/bridge/.pytest_cache/
+integrations/omi-even/bridge/tests/__pycache__/

--- a/integrations/evenhub-g2/.gitignore
+++ b/integrations/evenhub-g2/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/integrations/evenhub-g2/README.md
+++ b/integrations/evenhub-g2/README.md
@@ -1,0 +1,86 @@
+# Omi G2 First App
+
+The Even Hub [first-app quickstart](https://hub.evenrealities.com/docs/get-started/quickstart/first-app)
+for Even Realities G2 smart glasses: one full-canvas text container that counts
+taps and exits on a double-tap.
+
+```
+Hello from G2!
+
+Tap to count: 0
+Double-tap to exit
+```
+
+## Run it
+
+```bash
+npm install
+npm run dev          # Vite on :5173, bound to the LAN
+```
+
+**In the simulator** (no hardware needed):
+
+```bash
+npm run simulator    # separate terminal
+```
+
+**On real glasses** — phone and laptop on the same Wi-Fi, developer mode enabled
+in the Even Realities companion app:
+
+```bash
+npm run qr           # auto-detects the LAN IP; scan from the phone app
+```
+
+Edits hot-reload on the glasses without rescanning.
+
+## Verify
+
+```bash
+npm run dev          # must be running first
+npm run verify
+```
+
+`scripts/verify-simulator.mjs` drives the simulator's automation HTTP API and
+asserts the app actually works: the bridge connects, the start-up container is
+created, the framebuffer is non-blank at 576x288, two taps advance the counter
+to 2, a double-tap requests the exit dialog, and nothing throws. It decodes the
+PNG framebuffer in pure Node, so there is no image-library dependency.
+
+It needs a GUI (the simulator opens a window), so it is a **local** check and is
+deliberately not wired into CI.
+
+## Notes for anyone extending this
+
+- **Touch input arrives on two different channels.** The simulator delivers tap
+  and double-tap as a `sysEvent`, and only scroll as a `textEvent`. The quickstart
+  code in the docs reads `event.textEvent` only, so taps never reach the handler.
+  `src/main.ts` reads whichever channel the event carries, which works in both
+  places. Verified against SDK 0.0.12:
+
+  | input | delivered as |
+  |---|---|
+  | `click` | `sysEvent: {eventSource: 1}` — `eventType` absent |
+  | `double_click` | `sysEvent: {eventType: 3}` |
+  | `up` / `down` | `textEvent: {containerID: 1, eventType: 1 / 2}` |
+
+  An absent `eventType` means a plain tap; every other event type is explicit.
+
+- **`server.host: true` in `vite.config.ts` is required.** Vite binds to
+  localhost by default and the phone would get connection refused. `strictPort`
+  is on so the dev server fails loudly rather than drifting to :5174 and leaving
+  a QR code pointing at a dead port.
+
+- **TypeScript is pinned to ^5.** `@evenrealities/evenhub-cli` declares a
+  `typescript@^5` peer; current `create-vite` scaffolds TS 6.
+
+- **The simulator needs its platform binary.** `@evenrealities/evenhub-simulator`
+  shells out to `@evenrealities/sim-<platform>-<arch>`, which is not pulled in
+  automatically — hence the explicit `@evenrealities/sim-darwin-arm64` devDependency.
+  Add the matching package for other platforms.
+
+- **Reloading an already-running page logs `createStartUpPageContainer failed: 1`**
+  (`invalid`) because the container already exists. The app keeps working — updates
+  still target the existing container. A fresh load is clean.
+
+- The DOM is not the display. `index.html` only hosts the script; everything the
+  user sees is drawn through the SDK bridge on the 576x288 canvas.

--- a/integrations/evenhub-g2/app.json
+++ b/integrations/evenhub-g2/app.json
@@ -1,0 +1,11 @@
+{
+  "package_id": "com.omi.evenhubfirstapp",
+  "edition": "202601",
+  "name": "Omi G2 First App",
+  "version": "0.1.0",
+  "min_app_version": "2.0.0",
+  "min_sdk_version": "0.0.12",
+  "entrypoint": "index.html",
+  "permissions": [],
+  "supported_languages": ["en"]
+}

--- a/integrations/evenhub-g2/index.html
+++ b/integrations/evenhub-g2/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Omi G2 First App</title>
+  </head>
+  <body>
+    <!-- The G2 display is driven entirely through the SDK bridge, not the DOM.
+         This page only hosts the script; nothing here renders on the glasses. -->
+    <div id="app">Omi G2 First App — running. Output goes to the glasses.</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/integrations/evenhub-g2/package-lock.json
+++ b/integrations/evenhub-g2/package-lock.json
@@ -1,0 +1,1755 @@
+{
+  "name": "evenhub-g2",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "evenhub-g2",
+      "version": "0.1.0",
+      "dependencies": {
+        "@evenrealities/even_hub_sdk": "^0.0.12"
+      },
+      "devDependencies": {
+        "@evenrealities/evenhub-cli": "^0.1.13",
+        "@evenrealities/evenhub-simulator": "^0.8.0",
+        "@evenrealities/sim-darwin-arm64": "^0.8.0",
+        "typescript": "^5.9.3",
+        "vite": "^8.1.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@evenrealities/even_hub_sdk": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@evenrealities/even_hub_sdk/-/even_hub_sdk-0.0.12.tgz",
+      "integrity": "sha512-PXAeuPl7dMIlSWlctDeQAodIr7iuNROaH9GvRrZ86xzRh33DkMJYY1hSxy6BTk+TLkDA0tYlVi4bOsSIJngINA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@evenrealities/evenhub-cli": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@evenrealities/evenhub-cli/-/evenhub-cli-0.1.13.tgz",
+      "integrity": "sha512-glkkGfImds8ceh1YTbVvwuw7jlcSAKnI6Q7ATrDynKSvODs9/FV/R+0CliyCog3JJRTON0+EXBLW3lxU4x8NBQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "commander": "^14.0.2",
+        "inquirer": "^13.1.0",
+        "js-yaml": "^4.1.1",
+        "open": "^11.0.0",
+        "qr-image": "^3.2.0",
+        "qrcode-terminal": "^0.12.0",
+        "zod": "^4.3.2"
+      },
+      "bin": {
+        "eh": "main.js",
+        "evenhub": "main.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@evenrealities/evenhub-simulator": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/evenhub-simulator/-/evenhub-simulator-0.8.0.tgz",
+      "integrity": "sha512-mfogXHtRRTQl8ZsaiESf/nFAmNSlH1LtGbkEIcaERDFcDizWTrXomB5FULz3W1gG+qsMQuJYSmB+jLp0tPHtKg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "evenhub-simulator": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "@evenrealities/sim-darwin-arm64": "0.8.0",
+        "@evenrealities/sim-darwin-x64": "0.8.0",
+        "@evenrealities/sim-linux-x64": "0.8.0",
+        "@evenrealities/sim-win32-x64": "0.8.0"
+      }
+    },
+    "node_modules/@evenrealities/sim-darwin-arm64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-darwin-arm64/-/sim-darwin-arm64-0.8.0.tgz",
+      "integrity": "sha512-k/yW7mUh+6HgvjP8VrSBlkPj2BBa9qp2kJB95ewdXKhwWeCLCfS/q6eFNK0IXCRXo7CkRg1mbvl68REN9UxQEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator"
+      }
+    },
+    "node_modules/@evenrealities/sim-darwin-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-darwin-x64/-/sim-darwin-x64-0.8.0.tgz",
+      "integrity": "sha512-eXKfEsa67wb1SQOHsIKiHCRmWry8arENBt501gC8qP5hbMvmdkFMNbBGi2EOUfxqMrd+3jl7TdneraAaU4NGtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator"
+      }
+    },
+    "node_modules/@evenrealities/sim-linux-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-linux-x64/-/sim-linux-x64-0.8.0.tgz",
+      "integrity": "sha512-XIQX4IuHCAMFaJMiz9Jl9M8aakvGcefUgOc/PTj+8gAJANwdSmBLJhmoRcELlOHxPMeRG1RqfMrZI7neioqTJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator"
+      }
+    },
+    "node_modules/@evenrealities/sim-win32-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-win32-x64/-/sim-win32-x64-0.8.0.tgz",
+      "integrity": "sha512-PvcJr56lHUzDmHj889DOTR1iwPUC9NOplFkyd7UL7xvIZyhctO74BLoBKbyajZsEuqR8weVZQObUV89NGLpZ5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator.exe"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inquirer": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
+      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/prompts": "^8.4.3",
+        "@inquirer/type": "^4.0.5",
+        "mute-stream": "^3.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qr-image": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qr-image/-/qr-image-3.2.0.tgz",
+      "integrity": "sha512-rXKDS5Sx3YipVsqmlMJsJsk6jXylEpiHRC2+nJy66fxA5ExYyGa4PqwteW69SaVmAb2OQ18HbYriT7cGQMbduw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/integrations/evenhub-g2/package.json
+++ b/integrations/evenhub-g2/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "evenhub-g2",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "simulator": "evenhub-simulator http://localhost:5173",
+    "qr": "evenhub qr",
+    "verify": "node scripts/verify-simulator.mjs"
+  },
+  "devDependencies": {
+    "@evenrealities/evenhub-cli": "^0.1.13",
+    "@evenrealities/evenhub-simulator": "^0.8.0",
+    "@evenrealities/sim-darwin-arm64": "^0.8.0",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.1"
+  },
+  "dependencies": {
+    "@evenrealities/even_hub_sdk": "^0.0.12"
+  }
+}

--- a/integrations/evenhub-g2/scripts/verify-simulator.mjs
+++ b/integrations/evenhub-g2/scripts/verify-simulator.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * End-to-end verification of the G2 app against the EvenHub simulator.
+ *
+ * Drives the simulator's automation HTTP API to assert the app actually
+ * renders and responds to touchpad input:
+ *   1. the start-up page container is created
+ *   2. the glasses framebuffer is non-blank
+ *   3. two taps advance the counter 1 -> 2
+ *   4. a double-tap requests the system exit dialog
+ *   5. no uncaught errors were logged
+ *
+ * Requires the Vite dev server on :5173 and the simulator's platform binary.
+ * Needs a GUI (the simulator opens a window), so this is a local check and is
+ * deliberately not wired into CI.
+ *
+ * Usage: npm run dev   (separate terminal)
+ *        npm run verify
+ */
+import { spawn } from 'node:child_process'
+import { inflateSync } from 'node:zlib'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+const DEV_URL = process.env.DEV_URL ?? 'http://localhost:5173'
+const PORT = Number(process.env.AUTOMATION_PORT ?? 9898)
+const API = `http://127.0.0.1:${PORT}`
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+let failures = 0
+const pass = (msg) => console.log(`  PASS  ${msg}`)
+const fail = (msg) => {
+  failures++
+  console.log(`  FAIL  ${msg}`)
+}
+
+// ---------------------------------------------------------------- PNG decode
+
+/**
+ * Minimal non-interlaced 8-bit RGBA PNG decoder — enough to count lit pixels
+ * in the simulator framebuffer without pulling in an image library.
+ * Returns { width, height, data } where data is unfiltered RGBA bytes.
+ */
+function decodePng(buf) {
+  const sig = [137, 80, 78, 71, 13, 10, 26, 10]
+  for (let i = 0; i < 8; i++) {
+    if (buf[i] !== sig[i]) throw new Error('not a PNG')
+  }
+
+  let pos = 8
+  let width = 0
+  let height = 0
+  let bitDepth = 0
+  let colorType = 0
+  let interlace = 0
+  const idat = []
+
+  while (pos < buf.length) {
+    const len = buf.readUInt32BE(pos)
+    const type = buf.toString('ascii', pos + 4, pos + 8)
+    const data = buf.subarray(pos + 8, pos + 8 + len)
+    pos += 12 + len // length + type + data + crc
+
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0)
+      height = data.readUInt32BE(4)
+      bitDepth = data[8]
+      colorType = data[9]
+      interlace = data[12]
+    } else if (type === 'IDAT') {
+      idat.push(data)
+    } else if (type === 'IEND') {
+      break
+    }
+  }
+
+  if (bitDepth !== 8) throw new Error(`unsupported bit depth ${bitDepth}`)
+  if (colorType !== 6) throw new Error(`expected RGBA (colorType 6), got ${colorType}`)
+  if (interlace !== 0) throw new Error('interlaced PNG not supported')
+
+  const raw = inflateSync(Buffer.concat(idat))
+  const bpp = 4
+  const stride = width * bpp
+  const out = Buffer.alloc(height * stride)
+
+  const paeth = (a, b, c) => {
+    const p = a + b - c
+    const pa = Math.abs(p - a)
+    const pb = Math.abs(p - b)
+    const pc = Math.abs(p - c)
+    if (pa <= pb && pa <= pc) return a
+    return pb <= pc ? b : c
+  }
+
+  let rp = 0
+  for (let y = 0; y < height; y++) {
+    const filter = raw[rp++]
+    const row = y * stride
+    const prev = row - stride
+
+    for (let x = 0; x < stride; x++) {
+      const f = raw[rp + x]
+      const a = x >= bpp ? out[row + x - bpp] : 0
+      const b = y > 0 ? out[prev + x] : 0
+      const c = x >= bpp && y > 0 ? out[prev + x - bpp] : 0
+
+      let val
+      switch (filter) {
+        case 0: val = f; break
+        case 1: val = f + a; break
+        case 2: val = f + b; break
+        case 3: val = f + ((a + b) >> 1); break
+        case 4: val = f + paeth(a, b, c); break
+        default: throw new Error(`bad filter type ${filter} on row ${y}`)
+      }
+      out[row + x] = val & 0xff
+    }
+    rp += stride
+  }
+
+  return { width, height, data: out }
+}
+
+// ------------------------------------------------------------------ API glue
+
+async function ping() {
+  try {
+    const r = await fetch(`${API}/api/ping`)
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+async function console_(sinceId) {
+  const url = sinceId === undefined ? `${API}/api/console` : `${API}/api/console?since_id=${sinceId}`
+  const r = await fetch(url)
+  if (!r.ok) throw new Error(`console ${r.status}`)
+  return (await r.json()).entries ?? []
+}
+
+async function input(action) {
+  const r = await fetch(`${API}/api/input`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action }),
+  })
+  if (!r.ok) throw new Error(`input ${action} -> ${r.status}`)
+}
+
+async function litPixels() {
+  const r = await fetch(`${API}/api/screenshot/glasses`)
+  if (!r.ok) throw new Error(`screenshot ${r.status}`)
+  const png = decodePng(Buffer.from(await r.arrayBuffer()))
+  let lit = 0
+  // Background is alpha=0, lit text is alpha=255. Never convert to RGB — both
+  // are pure green and become indistinguishable.
+  for (let i = 3; i < png.data.length; i += 4) {
+    if (png.data[i] > 0) lit++
+  }
+  return { lit, width: png.width, height: png.height }
+}
+
+/** All console text seen so far, accumulated across polls. */
+const seen = []
+let lastId = -1
+async function drainConsole() {
+  const entries = lastId < 0 ? await console_() : await console_(lastId)
+  for (const e of entries) {
+    seen.push(e)
+    if (e.id > lastId) lastId = e.id
+  }
+  return entries
+}
+
+const sawMessage = (needle) => seen.some((e) => (e.message ?? '').includes(needle))
+
+async function waitForMessage(needle, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await drainConsole()
+    if (sawMessage(needle)) {
+      pass(label)
+      return true
+    }
+    await sleep(300)
+  }
+  fail(`${label} — never saw "${needle}" within ${timeoutMs}ms`)
+  return false
+}
+
+// --------------------------------------------------------------------- main
+
+async function main() {
+  console.log(`\nEvenHub G2 simulator verification`)
+  console.log(`  dev server:     ${DEV_URL}`)
+  console.log(`  automation API: ${API}\n`)
+
+  // Fail fast with a clear message rather than a confusing simulator error.
+  try {
+    const r = await fetch(DEV_URL)
+    if (!r.ok) throw new Error(`status ${r.status}`)
+  } catch (e) {
+    console.error(`Dev server not reachable at ${DEV_URL} (${e.message}).`)
+    console.error(`Start it first:  npm run dev`)
+    process.exit(2)
+  }
+
+  // A leftover simulator holding the automation port would answer every request
+  // here and silently produce a green run against a stale instance. Refuse to
+  // start instead.
+  if (await ping()) {
+    console.error(`Something is already serving the automation API on ${API}.`)
+    console.error(`That is almost certainly a leftover simulator. Kill it first:`)
+    console.error(`  pkill -f evenhub-simulator`)
+    process.exit(2)
+  }
+
+  const launcher = require.resolve('@evenrealities/evenhub-simulator/bin/index.js')
+  // detached:true puts the launcher and the platform binary it exec's into
+  // their own process group, so cleanup can kill both. Killing just the Node
+  // launcher leaves the simulator running and holding the port.
+  const sim = spawn(process.execPath, [launcher, DEV_URL, '--automation-port', String(PORT)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  let simErr = ''
+  sim.stderr.on('data', (d) => (simErr += d.toString()))
+  sim.on('exit', (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(`\nSimulator exited early (code ${code}):\n${simErr}`)
+    }
+  })
+
+  let cleanedUp = false
+  const cleanup = () => {
+    if (cleanedUp) return
+    cleanedUp = true
+    try {
+      process.kill(-sim.pid, 'SIGTERM') // negative pid = the whole group
+    } catch {
+      /* already gone */
+    }
+  }
+  process.on('exit', cleanup)
+  process.on('SIGINT', () => { cleanup(); process.exit(130) })
+
+  try {
+    // 1. Simulator up
+    const deadline = Date.now() + 30_000
+    let up = false
+    while (Date.now() < deadline) {
+      if (await ping()) { up = true; break }
+      await sleep(500)
+    }
+    if (!up) {
+      console.error(`Simulator automation API never came up on ${API}.\n${simErr}`)
+      process.exit(2)
+    }
+    pass('simulator automation API is up')
+
+    // 2. App booted and created its page container. Poll before clearing —
+    //    startup logs are emitted once and would be lost.
+    await waitForMessage('[app] bridge ready', 20_000, 'SDK bridge connected')
+    await waitForMessage('[app] page created: success', 20_000, 'start-up page container created')
+
+    // 3. Something is actually on the display
+    const { lit, width, height } = await litPixels()
+    if (width !== 576 || height !== 288) {
+      fail(`framebuffer is ${width}x${height}, expected 576x288`)
+    } else {
+      pass(`framebuffer is ${width}x${height}`)
+    }
+    if (lit > 200) {
+      pass(`display is rendering (${lit} lit pixels)`)
+    } else {
+      fail(`display looks blank (only ${lit} lit pixels)`)
+    }
+
+    // 4. Taps advance the counter
+    await input('click')
+    await sleep(600)
+    await waitForMessage('[app] count=1', 5_000, 'first tap -> count=1')
+
+    await input('click')
+    await sleep(600)
+    await waitForMessage('[app] count=2', 5_000, 'second tap -> count=2')
+
+    const afterTaps = await litPixels()
+    if (afterTaps.lit > 200) {
+      pass(`display still rendering after taps (${afterTaps.lit} lit pixels)`)
+    } else {
+      fail(`display went blank after taps (${afterTaps.lit} lit pixels)`)
+    }
+
+    // 5. Double-tap requests exit
+    await input('double_click')
+    await sleep(600)
+    await waitForMessage('[app] exit requested', 5_000, 'double-tap -> exit requested')
+
+    // 6. No crashes anywhere in the run
+    await drainConsole()
+    const bad = seen.filter((e) => {
+      const m = e.message ?? ''
+      return m.startsWith('[uncaught]') || m.startsWith('[unhandledrejection]') || e.level === 'error'
+    })
+    if (bad.length === 0) {
+      pass('no uncaught errors or failed fetches')
+    } else {
+      fail(`${bad.length} error entr${bad.length === 1 ? 'y' : 'ies'}:`)
+      for (const e of bad.slice(0, 10)) console.log(`          [${e.level}] ${e.message}`)
+    }
+  } finally {
+    cleanup()
+  }
+
+  console.log(
+    failures === 0
+      ? `\nAll checks passed.\n`
+      : `\n${failures} check${failures === 1 ? '' : 's'} failed.\n`,
+  )
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main().catch((e) => {
+  console.error(`\nVerification crashed: ${e.stack ?? e}`)
+  process.exit(2)
+})

--- a/integrations/evenhub-g2/src/main.ts
+++ b/integrations/evenhub-g2/src/main.ts
@@ -1,0 +1,85 @@
+import {
+  waitForEvenAppBridge,
+  TextContainerProperty,
+  TextContainerUpgrade,
+  CreateStartUpPageContainer,
+  OsEventTypeList,
+  StartUpPageCreateResult,
+} from '@evenrealities/even_hub_sdk'
+
+/** Single source of truth for the display copy, so the initial render and every
+ *  update stay in sync. 576x288 is the full G2 canvas. */
+const screen = (count: number) => `Hello from G2!\n\nTap to count: ${count}\nDouble-tap to exit`
+
+const CONTAINER_ID = 1
+
+const bridge = await waitForEvenAppBridge()
+console.log('[app] bridge ready')
+
+const mainText = new TextContainerProperty({
+  xPosition: 0,
+  yPosition: 0,
+  width: 576,
+  height: 288,
+  borderWidth: 0,
+  borderColor: 5,
+  paddingLength: 4,
+  containerID: CONTAINER_ID,
+  containerName: 'main',
+  content: screen(0),
+  isEventCapture: 1,
+})
+
+const result = await bridge.createStartUpPageContainer(
+  new CreateStartUpPageContainer({
+    containerTotalNum: 1,
+    textObject: [mainText],
+  }),
+)
+
+if (result !== StartUpPageCreateResult.success) {
+  console.error('[app] createStartUpPageContainer failed:', result)
+} else {
+  console.log('[app] page created: success')
+}
+
+let count = 0
+
+bridge.onEvenHubEvent((event) => {
+  // Touch input arrives on one of two channels depending on the host. The
+  // simulator reports tap / double-tap as a sysEvent and only scroll as a
+  // textEvent; a capturing text container reports through textEvent. Read
+  // whichever channel this event carries so one build works in both places.
+  let eventType: OsEventTypeList | undefined
+  if (event.textEvent) {
+    if (event.textEvent.containerID !== CONTAINER_ID) return
+    eventType = event.textEvent.eventType
+  } else if (event.sysEvent) {
+    eventType = event.sysEvent.eventType
+  } else {
+    return
+  }
+
+  switch (eventType) {
+    // The host omits eventType for a plain tap, so an undefined type is
+    // treated as a click rather than being dropped.
+    case OsEventTypeList.CLICK_EVENT:
+    case undefined:
+      count += 1
+      console.log(`[app] count=${count}`)
+      bridge.textContainerUpgrade(
+        new TextContainerUpgrade({
+          containerID: CONTAINER_ID,
+          containerName: 'main',
+          content: screen(count),
+        }),
+      )
+      break
+
+    case OsEventTypeList.DOUBLE_CLICK_EVENT:
+      console.log('[app] exit requested')
+      // exitMode 1 = raise the system exit dialog and let the user confirm.
+      bridge.shutDownPageContainer(1)
+      break
+  }
+})

--- a/integrations/evenhub-g2/tsconfig.json
+++ b/integrations/evenhub-g2/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM"],
+    "types": ["vite/client"],
+    "allowArbitraryExtensions": true,
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/integrations/evenhub-g2/vite.config.ts
+++ b/integrations/evenhub-g2/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    // The glasses load this app over the LAN from the phone, so the dev server
+    // must bind to all interfaces — Vite's default is localhost-only and the
+    // phone would get a connection refused.
+    host: true,
+    port: 5173,
+    // Fail loudly instead of silently moving to 5174, which would leave the
+    // generated QR code pointing at a dead port.
+    strictPort: true,
+    // The phone connects by raw LAN IP; allow it explicitly so Vite's host
+    // check can't reject the request.
+    allowedHosts: true,
+  },
+})

--- a/integrations/omi-even/README.md
+++ b/integrations/omi-even/README.md
@@ -1,0 +1,107 @@
+# omi on Even Realities G2
+
+Connects [Omi](https://omi.me) to Even Realities G2 smart glasses across four surfaces.
+
+```
+G2 glasses ──BLE──> Even phone app ──┬── "Add Agent"  ──HTTPS──> tunnel ─┐
+                                     │   (on-device speech-to-text)      │
+                                     └── omi Hub plugin ──LAN/WS────────>┤
+                                                                          v
+                                                           ┌──────────────────────┐
+                                                           │ bridge (Mac, FastAPI)│
+                                                           │ holds Firebase session│
+                                                           └──────────┬───────────┘
+                                        ┌─────────────────────────────┼──────────────────┐
+                                        v                             v                  v
+                               POST /v2/messages          WS /v4/listen      POST /v2/voice-
+                               (chat, streamed)           (capture)          message/transcribe
+```
+
+| Surface | What it does |
+|---|---|
+| **Even AI answers from Omi** | Hold the temple, ask a question, Even's own assistant answers from your Omi memory. No app to open — the glasses do speech-to-text themselves. |
+| **`omi` Hub app** | An app named `omi` on the glasses: chat, memories, action items, today. |
+| **G2 mics feed Omi** | Glasses audio becomes real Omi conversations, like the pendant. |
+| **Omi pushes to glasses** | New action items surface on the display while the app is running. |
+
+Everything runs through **one local bridge**, because Omi's chat endpoint and capture
+socket both accept only a Firebase ID token — no API key family works
+(`backend/utils/other/endpoints.py:81`). Keeping one process means one credential.
+
+## Run it
+
+```bash
+cd bridge && ./run.sh
+```
+
+Prints the URL and token to paste into the Even app under **Add Agent**, plus the
+`ws://` address for the Hub app. `OMI_SKIP_TUNNEL=1` skips the tunnel (LAN only).
+
+No login prompt: the bridge reuses the session the Omi macOS app already holds,
+via the repo's own `desktop/macos/scripts/omi-auth-dump.sh`, and mints fresh ID
+tokens from its refresh token. Sign into the desktop app once and it stays working.
+
+## Verified against live Omi
+
+Not mocks — real account (`Operator` plan), real memories:
+
+| Check | Result |
+|---|---|
+| Firebase session from desktop app, no browser login | ID token minted, `/v1/users/me/usage-quota` → 200 |
+| Chat with memory grounding | 9.3s, correct answer about actual current work |
+| Even AI path through the public tunnel | 10.5s, 246-char answer that fits the display |
+| Unauthorized request | 401 with and without a bad token |
+| Capture → Omi conversation | `source: rayban_meta`, status `completed`, transcript + auto title |
+| App WebSocket | memories, action items, streaming chat, graceful empty states |
+
+## Things that will bite you
+
+- **`source` must be `rayban_meta`.** `ConversationSource._missing_` maps any unknown
+  string to `unknown` rather than raising, so a typo silently mislabels every
+  conversation instead of failing. It is also photo-capable, so
+  `resolve_photo_conversation_source` won't rewrite provenance later.
+- **The chat stream is not SSE.** Frames are `\n\n`-*separated* with bare prefixes,
+  newlines arrive as the literal `__CRLF__`, and `done:` is base64 JSON. `EventSource`
+  drops most of it. Parser ported from `app/lib/backend/http/api/messages.dart:59`.
+- **A quota breach returns HTTP 200**, not 402, with a canned `done:` message. Read the
+  text, not the status.
+- **Stopping capture needs trailing silence.** The STT endpointer only emits its final
+  segment once the utterance ends. Measured: a 7.4s clip yielded 2.8s without it, the
+  full text with it. `CaptureSession.stop()` handles this.
+- **Disconnect does not finalize a conversation** unless `source == 'desktop'` and the
+  close code is 1000, so `stop()` calls `POST /v1/conversations` explicitly.
+- **The listen socket closes after 90s of inbound silence**; the bridge sends keepalives.
+- **The server's heartbeat is the literal text `ping`** — not JSON. Parsing it blindly
+  throws every 10 seconds.
+- **A quick tunnel gets a new URL on every restart**, so you'd re-register in the Even
+  app each time. Use `cloudflared tunnel create omi-even` for a stable one.
+
+## Limits worth knowing
+
+- **No speaker on the G2.** Answers are read, never spoken — Omi's TTS endpoint is
+  useless here. Everything is shaped to ~380 characters of monochrome text.
+- **Push only reaches a running app.** The Hub host keeps a backgrounded plugin alive in
+  a headless WebView, but a closed app receives nothing. There is no OS notification path.
+- **The Add Agent contract is undocumented.** Even publishes no spec; the implementation
+  targets the observed request shape and logs every request to `add-agent-capture.log`
+  so drift is visible.
+- **Always-on capture records everyone nearby.** The app shows a recording indicator and
+  has a hard off switch, but in two-party-consent jurisdictions this carries real legal
+  exposure.
+
+## Layout
+
+```
+bridge/
+  server.py        FastAPI: Add Agent endpoint, /app socket, health, push loop
+  omi_auth.py      Firebase session from the desktop app + token refresh
+  omi_client.py    /v2/messages frame parser, transcribe, memories, action items
+  capture.py       PCM relay to /v4/listen
+  display.py       Markdown/URL/emoji stripping, truncation, pagination
+  run.sh           Bring up bridge + tunnel, print Add Agent details
+  tests/           Hermetic pytest suite
+app/               The `omi` Hub plugin (Vite + TypeScript)
+```
+
+`integrations/evenhub-g2/` next door is the untouched quickstart app, kept as a
+known-good reference and smoke test.

--- a/integrations/omi-even/app/.gitignore
+++ b/integrations/omi-even/app/.gitignore
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# `evenhub pack` output
+*.ehpk
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/integrations/omi-even/app/README.md
+++ b/integrations/omi-even/app/README.md
@@ -1,6 +1,6 @@
 # omi — Even Realities G2 plugin
 
-The omi app for Even Hub. A five-row menu on the glasses, backed by the local
+The omi app for Even Hub. A six-row menu on the glasses, backed by the local
 omi bridge in [`../bridge`](../bridge) over a WebSocket. Scroll moves the
 selection, tap opens, double-tap goes back — and exits from the menu.
 
@@ -11,6 +11,7 @@ selection, tap opens, double-tap goes back — and exits from the menu.
 |   Action items                                   |
 |   Today                                          |
 |   Capture: off                                   |
+|   Suggestions                                    |
 |--------------------------------------------------|
 | scroll move | tap open | double-tap exit         |
 +--------------------------------------------------+
@@ -18,14 +19,41 @@ selection, tap opens, double-tap goes back — and exits from the menu.
 
 | Row | What it does |
 |---|---|
-| **Ask Omi** | Asks a question and streams the answer in, paging at ~380 chars. Tap again for the next question. |
+| **Ask Omi** | Speak the question. Tap to start listening, tap again to ask, double-tap to cancel. |
 | **Memories** | Last 20 memories, paginated. |
 | **Action items** | Open and completed items, `[ ]` / `[x]`. |
 | **Today** | Today's summary. |
-| **Capture: on/off** | Toggles the glasses microphone (`audioControl`). |
+| **Capture: on/off** | Toggles the glasses microphone for continuous capture. |
+| **Suggestions** | The old fixed ring of canned questions — no microphone needed. Tap for the next one. |
 
 The bottom strip is always present: it shows the connection state, the page
 position, or the most recent `push` banner from the bridge.
+
+## Ask Omi
+
+The glasses have no keyboard, and the SDK exposes the 4-mic array as raw PCM
+only — there is no on-device speech recognition available to a plugin. So the
+app streams the audio to the bridge and the bridge transcribes it.
+
+```
+tap  ──►  Starting microphone...        audioControl(true, Glasses)
+          Listening...                  ask_start, then PCM frames
+          [####--------]                a live level meter, drawn from the PCM
+tap  ──►  Thinking...                   audioControl(false), ask_stop
+          Q: <what it heard>            transcribed
+          <the answer, streaming>       chat_delta … chat_done
+```
+
+- **Double-tap while listening cancels** — the microphone closes, the question
+  is thrown away, and the answer the bridge produces anyway is discarded.
+- **Recording is capped at 20 s** and auto-stops, so a forgotten session cannot
+  hold the microphone open or stream forever. Override with `?askmax=<ms>`.
+- **An empty transcript never becomes a question.** The bridge replies
+  `ask_error` and the display says `Didn't catch that. Tap to retry.`
+- **The transcript is shown before the answer**, so a misheard question is
+  obvious rather than something to infer from a strange reply.
+- The level meter is computed from the same PCM16 samples that go out on the
+  wire, so a bar that moves with your voice is real end-to-end evidence.
 
 ## Run it
 
@@ -78,11 +106,20 @@ socket, so a missing bridge is a visible state, not a hang.
 
 ### Protocol
 
-Sent: `chat` · `memories` · `action_items` · `today`.
+Sent: `chat` · `memories` · `action_items` · `today` · `ask_start` · `ask_stop`,
+plus **binary frames** of PCM16 LE / 16 kHz / mono between an `ask_start` and
+its `ask_stop`.
 Received: `chat_delta` · `chat_done` · `memories` · `action_items` · `today` ·
-`push`. Anything else — the bridge's `hello`, `transcript`, `pong` — is ignored
-with a debug log, so a bridge that grows new message types does not break an
-older build of the app.
+`push` · `ask_listening` · `transcribed` · `ask_error`. Anything else — the
+bridge's `hello`, `transcript`, `pong` — is ignored with a debug log, so a
+bridge that grows new message types does not break an older build of the app.
+
+**Binary frames outside an `ask_start`/`ask_stop` bracket mean something else**
+— to the bridge they are continuous-capture audio headed for a conversation —
+so the bracket is strict in both directions. Frames that arrive while the
+microphone is open for Capture rather than for a question are counted and
+dropped, never sent. `scripts/mock-bridge.mjs` counts them separately and the
+verify harness asserts that counter stays at zero.
 
 ## Verify
 
@@ -94,20 +131,39 @@ npm run dev          # must be running for the next one
 npm run verify       # end-to-end against the simulator
 ```
 
-`npm test` covers pagination, the wire format, and background-state snapshotting
-by importing `src/*.ts` directly through Node's TypeScript stripping. No build
-step, no simulator.
+`npm test` covers pagination, the wire format, background-state snapshotting,
+and the whole microphone lifecycle — `src/ask-recorder.ts` is driven with fake
+send/mic functions, so "PCM only goes out between `ask_start` and `ask_stop`",
+"a microphone that will not open still closes the bracket" and "the cap fires on
+its own" are all asserted with no glasses in the room. It imports `src/*.ts`
+directly through Node's TypeScript stripping. No build step, no simulator.
 
 `scripts/verify-simulator.mjs` starts its own mock bridge
 (`scripts/mock-bridge.mjs`, a dependency-free RFC 6455 server serving fixed
 fixtures) plus the simulator, then drives the automation HTTP API and asserts
 the app actually works: the bridge connects, the home list renders non-blank at
-576x288, scroll moves the highlight, every row opens and loads, a chat answer
-streams in and repaints **in place** rather than by rebuilding the page, a
-multi-page answer pages with scroll, a server push renders as a banner, losing
-the bridge shows as offline and retries, the app never reloaded mid-run, and
-nothing threw. It decodes the PNG framebuffer in pure Node, so there is no
-image-library dependency.
+576x288, scroll moves the highlight, every row opens and loads, tapping Ask Omi
+opens the microphone and says so on the display, **real PCM reaches the bridge**
+(the mock counts the bytes), tapping again stops the microphone and shows the
+transcript then the answer, the answer repaints **in place** rather than by
+rebuilding the page, a multi-page answer pages with scroll, double-tap cancels
+and the cancelled answer is discarded, the recording cap auto-stops, an empty
+transcript says so instead of asking Omi nothing, a live microphone outside an
+ask sends nothing, every `audioControl(true)` is matched by an
+`audioControl(false)`, a server push renders as a banner, losing the bridge
+shows as offline and retries, the app never reloaded mid-run, and nothing threw.
+It decodes the PNG framebuffer in pure Node, so there is no image-library
+dependency.
+
+The audio path is exercised for real, not faked: the simulator emits
+`audioEvent`s from the **host machine's microphone** in the documented glasses
+format (16 kHz PCM16 LE, 100 ms per event), and a quiet room still produces
+frames. The run shortens the recording cap with `?askmax=12000` so the auto-stop
+takes twelve seconds instead of twenty; `ASK_MAX_MS=<ms> npm run verify`
+overrides it. Do not shorten it much further — draining the simulator console
+while the microphone is live means transferring the SDK's per-frame audio log,
+which is slow enough that a tight cap fires in the middle of the manual-stop
+test.
 
 It refuses to start if the automation port or the bridge port is already taken —
 a leftover process would answer every request and produce a green run against a
@@ -166,10 +222,36 @@ deliberately not wired into CI. `npm test` is the CI-safe half.
   read exactly as they will once the SDK ships them and the import becomes a
   one-line swap.
 
-- **There is no keyboard and no on-device ASR**, and the bridge protocol carries
-  text rather than audio, so "Ask Omi" cycles a fixed ring of prompts rather
-  than dictating a question. Wiring the glasses mic to speech-to-text needs an
-  audio message type the contract does not define yet.
+- **Audio arrives on the same `onEvenHubEvent` listener as touch input**, as
+  `event.audioEvent`. There is one listener in `src/main.ts` that checks for
+  audio first and returns; registering a second listener for audio is not how
+  the SDK works. `audioControl(true, AudioInputSource.Glasses)` starts the mic
+  and `audioControl(false)` stops it, and both require
+  `createStartUpPageContainer` to have succeeded first — by the time any view is
+  open, it has.
+
+- **`audioPcm` is normalised before it goes on the wire** (`src/audio.ts`). The
+  SDK types it as `Uint8Array` and that is what the simulator delivers, but the
+  host is a Flutter app pushing a `Uint8List` through a JSON channel, and the
+  SDK's own parser accepts `number[]` and base64 too. Forwarding whichever of
+  those arrives without normalising would stream garbage to the bridge.
+
+- **One microphone, two features.** Capture and a dictated question both want
+  `audioControl`, so they go through a single owner in `src/main.ts` that turns
+  the hardware off only when neither wants it — otherwise ending a question
+  would silently switch Capture off underneath it. Every path out of listening
+  (tap, cancel, cap, bridge loss, mic failure, `beforeunload`/`pagehide`, and
+  the background-state snapshot) closes it. Start-up also calls
+  `audioControl(false)` once, because a WebView that died mid-question cannot be
+  relied on to have released it — verified by reloading the simulator's WebView
+  while listening: the app logs `listening torn down`, `ask_stop` reaches the
+  bridge, and the reboot starts from a known-off state.
+
+- **The SDK logs every audio event with its whole PCM payload expanded.** At ten
+  frames a second that is roughly 36 KB of console text per 100 ms, which is why
+  the verify harness truncates console messages as it reads them and skips those
+  lines in `--dump`. Nothing in the app logs per frame; the recorder prints a
+  running byte count twice a second while listening instead.
 
 - **`server.host: true` in `vite.config.ts` is required.** Vite binds to
   localhost by default and the phone would get connection refused. `strictPort`

--- a/integrations/omi-even/app/README.md
+++ b/integrations/omi-even/app/README.md
@@ -1,0 +1,188 @@
+# omi — Even Realities G2 plugin
+
+The omi app for Even Hub. A five-row menu on the glasses, backed by the local
+omi bridge in [`../bridge`](../bridge) over a WebSocket. Scroll moves the
+selection, tap opens, double-tap goes back — and exits from the menu.
+
+```
++--------------------------------------------------+
+| > Ask Omi                                        |
+|   Memories                                       |
+|   Action items                                   |
+|   Today                                          |
+|   Capture: off                                   |
+|--------------------------------------------------|
+| scroll move | tap open | double-tap exit         |
++--------------------------------------------------+
+```
+
+| Row | What it does |
+|---|---|
+| **Ask Omi** | Asks a question and streams the answer in, paging at ~380 chars. Tap again for the next question. |
+| **Memories** | Last 20 memories, paginated. |
+| **Action items** | Open and completed items, `[ ]` / `[x]`. |
+| **Today** | Today's summary. |
+| **Capture: on/off** | Toggles the glasses microphone (`audioControl`). |
+
+The bottom strip is always present: it shows the connection state, the page
+position, or the most recent `push` banner from the bridge.
+
+## Run it
+
+```bash
+npm install
+npm run dev          # Vite on :5273, bound to the LAN
+```
+
+Port **5273**, not Vite's default 5173 — the sibling `integrations/evenhub-g2`
+app claims that one, and `strictPort` is on so running both would otherwise fail.
+
+**In the simulator** (no hardware needed):
+
+```bash
+npm run simulator    # separate terminal
+```
+
+**On real glasses** — phone and laptop on the same Wi-Fi, developer mode enabled
+in the Even Realities companion app:
+
+```bash
+npm run qr           # auto-detects the LAN IP; scan from the phone app
+```
+
+Edits hot-reload on the glasses without rescanning.
+
+**Package for submission:**
+
+```bash
+npm run build && npx evenhub pack app.json dist
+```
+
+## Pointing it at a bridge
+
+The default is `ws://127.0.0.1:8788/app`, which matches
+[`../bridge/run.sh`](../bridge/run.sh). That only resolves for the desktop
+simulator — the glasses render through the *phone's* WebView, so on real
+hardware you must give it a reachable host:
+
+```
+http://<laptop-ip>:5273/?bridge=ws://<laptop-ip>:8788/app
+```
+
+Resolution order is query param → `VITE_OMI_BRIDGE_URL` at build time → the
+constant in `src/config.ts`.
+
+If the bridge is not there, the app says `bridge offline - retrying …` in the
+status strip and reconnects with backoff (500 ms → 8 s). It never blocks on the
+socket, so a missing bridge is a visible state, not a hang.
+
+### Protocol
+
+Sent: `chat` · `memories` · `action_items` · `today`.
+Received: `chat_delta` · `chat_done` · `memories` · `action_items` · `today` ·
+`push`. Anything else — the bridge's `hello`, `transcript`, `pong` — is ignored
+with a debug log, so a bridge that grows new message types does not break an
+older build of the app.
+
+## Verify
+
+Two suites. Run both.
+
+```bash
+npm test             # hermetic unit tests — no GUI, no network, CI-safe
+npm run dev          # must be running for the next one
+npm run verify       # end-to-end against the simulator
+```
+
+`npm test` covers pagination, the wire format, and background-state snapshotting
+by importing `src/*.ts` directly through Node's TypeScript stripping. No build
+step, no simulator.
+
+`scripts/verify-simulator.mjs` starts its own mock bridge
+(`scripts/mock-bridge.mjs`, a dependency-free RFC 6455 server serving fixed
+fixtures) plus the simulator, then drives the automation HTTP API and asserts
+the app actually works: the bridge connects, the home list renders non-blank at
+576x288, scroll moves the highlight, every row opens and loads, a chat answer
+streams in and repaints **in place** rather than by rebuilding the page, a
+multi-page answer pages with scroll, a server push renders as a banner, losing
+the bridge shows as offline and retries, the app never reloaded mid-run, and
+nothing threw. It decodes the PNG framebuffer in pure Node, so there is no
+image-library dependency.
+
+It refuses to start if the automation port or the bridge port is already taken —
+a leftover process would answer every request and produce a green run against a
+stale instance — and it kills the process *group*, since the simulator launcher
+execs a platform binary that survives killing the Node launcher.
+
+It needs a GUI (the simulator opens a window), so it is a **local** check and is
+deliberately not wired into CI. `npm test` is the CI-safe half.
+
+## Notes for anyone extending this
+
+- **Touch input arrives on three different channels.** Tap and double-tap come
+  as `sysEvent`, scroll over a text container comes as `textEvent`, and a list
+  container reports as `listEvent`. `src/main.ts` reads whichever channel the
+  event carries. Verified against SDK 0.0.12 in the simulator:
+
+  | input | delivered as |
+  |---|---|
+  | `click` on a text container | `sysEvent: {eventSource: 1}` — `eventType` absent |
+  | `click` on a list container | `listEvent: {containerID, containerName, currentSelectItemIndex?}` |
+  | `double_click` | `sysEvent: {eventType: 3}` |
+  | `up` / `down` over a text container | `textEvent: {containerID, eventType: 1 / 2}` |
+  | `up` / `down` over a list container | **nothing** |
+
+- **Two absent-means-default traps**, both from proto3 dropping zero values:
+  an absent `eventType` is `CLICK_EVENT`, and an absent `currentSelectItemIndex`
+  is **row 0**. The second one matters because scrolling a list emits no event
+  at all — the OS moves its own highlight and only reports the row on the click
+  that follows. Treating the missing index as "unknown" strands the app on
+  whichever row it last saw, which is exactly the bug the verify harness caught.
+
+- **All SDK calls are serialized** through one FIFO in `src/display.ts`, each
+  racing a 5 s timeout. Concurrent bridge calls can crash the connection, and a
+  flaky BLE hop otherwise hangs for ~30 s.
+
+- **Streaming uses `textContainerUpgrade`, never `rebuildPageContainer`.**
+  Upgrades are flicker-free and in place, but the container ID *and* name must
+  both match or the host drops the update with no error. Rebuilds are reserved
+  for real layout changes: entering/leaving a view, and relabelling the Capture
+  row (list items cannot be updated in place). Chat deltas are coalesced behind
+  a 150 ms dirty-flag loop rather than queueing one upgrade per delta.
+
+- **`createStartUpPageContainer` is called exactly once**, at boot, with the
+  home layout. A WebView reload calls it again and the host returns `invalid`
+  because the containers already exist; the app logs that at `warn` and keeps
+  going, since updates still land. `oversize` and `outOfMemory` are still real
+  errors. The simulator does reload itself once shortly after start-up, so the
+  verify harness waits for that to settle before it touches anything.
+
+- **`setBackgroundState` / `onBackgroundRestore` are implemented locally**, in
+  `src/background-state.ts`. The Even Hub docs describe them as SDK exports, but
+  `@evenrealities/even_hub_sdk@0.0.12` — the latest published version — does not
+  ship them: the symbols are absent from both `dist/index.d.ts` and
+  `dist/index.js`. The local module implements the host's documented
+  `window.__getStateSnapshot()` / `window.__restoreState()` hooks, so call sites
+  read exactly as they will once the SDK ships them and the import becomes a
+  one-line swap.
+
+- **There is no keyboard and no on-device ASR**, and the bridge protocol carries
+  text rather than audio, so "Ask Omi" cycles a fixed ring of prompts rather
+  than dictating a question. Wiring the glasses mic to speech-to-text needs an
+  audio message type the contract does not define yet.
+
+- **`server.host: true` in `vite.config.ts` is required.** Vite binds to
+  localhost by default and the phone would get connection refused. `strictPort`
+  is on so the dev server fails loudly rather than drifting to :5274 and leaving
+  a QR code pointing at a dead port.
+
+- **TypeScript is pinned to ^5.** `@evenrealities/evenhub-cli` declares a
+  `typescript@^5` peer; current `create-vite` scaffolds TS 6.
+
+- **The simulator needs its platform binary.** `@evenrealities/evenhub-simulator`
+  shells out to `@evenrealities/sim-<platform>-<arch>`, which is not pulled in
+  automatically — hence the explicit `@evenrealities/sim-darwin-arm64`
+  devDependency. Add the matching package for other platforms.
+
+- The DOM is not the display. `index.html` only hosts the script; everything the
+  user sees is drawn through the SDK bridge on the 576x288 canvas.

--- a/integrations/omi-even/app/app.json
+++ b/integrations/omi-even/app/app.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "g2-microphone",
-      "desc": "Captures audio from the glasses microphone when you turn Capture on."
+      "desc": "Listens through the glasses microphone while you ask Omi a question, and when you turn Capture on."
     }
   ],
   "supported_languages": ["en"]

--- a/integrations/omi-even/app/app.json
+++ b/integrations/omi-even/app/app.json
@@ -1,0 +1,20 @@
+{
+  "package_id": "com.omi.omi",
+  "edition": "202601",
+  "name": "omi",
+  "version": "0.1.0",
+  "min_app_version": "2.0.0",
+  "min_sdk_version": "0.0.12",
+  "entrypoint": "index.html",
+  "permissions": [
+    {
+      "name": "network",
+      "desc": "Connects to the omi bridge running on your computer to answer questions and read your memories."
+    },
+    {
+      "name": "g2-microphone",
+      "desc": "Captures audio from the glasses microphone when you turn Capture on."
+    }
+  ],
+  "supported_languages": ["en"]
+}

--- a/integrations/omi-even/app/index.html
+++ b/integrations/omi-even/app/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>omi</title>
+  </head>
+  <body>
+    <!-- The G2 display is driven entirely through the SDK bridge, not the DOM.
+         This page only hosts the script; nothing here renders on the glasses. -->
+    <div id="app">omi — running. Output goes to the glasses.</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/integrations/omi-even/app/package-lock.json
+++ b/integrations/omi-even/app/package-lock.json
@@ -1,0 +1,1755 @@
+{
+  "name": "omi-even-app",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omi-even-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "@evenrealities/even_hub_sdk": "^0.0.12"
+      },
+      "devDependencies": {
+        "@evenrealities/evenhub-cli": "^0.1.13",
+        "@evenrealities/evenhub-simulator": "^0.8.0",
+        "@evenrealities/sim-darwin-arm64": "^0.8.0",
+        "typescript": "^5.9.3",
+        "vite": "^8.1.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@evenrealities/even_hub_sdk": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@evenrealities/even_hub_sdk/-/even_hub_sdk-0.0.12.tgz",
+      "integrity": "sha512-PXAeuPl7dMIlSWlctDeQAodIr7iuNROaH9GvRrZ86xzRh33DkMJYY1hSxy6BTk+TLkDA0tYlVi4bOsSIJngINA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@evenrealities/evenhub-cli": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@evenrealities/evenhub-cli/-/evenhub-cli-0.1.13.tgz",
+      "integrity": "sha512-glkkGfImds8ceh1YTbVvwuw7jlcSAKnI6Q7ATrDynKSvODs9/FV/R+0CliyCog3JJRTON0+EXBLW3lxU4x8NBQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "commander": "^14.0.2",
+        "inquirer": "^13.1.0",
+        "js-yaml": "^4.1.1",
+        "open": "^11.0.0",
+        "qr-image": "^3.2.0",
+        "qrcode-terminal": "^0.12.0",
+        "zod": "^4.3.2"
+      },
+      "bin": {
+        "eh": "main.js",
+        "evenhub": "main.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@evenrealities/evenhub-simulator": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/evenhub-simulator/-/evenhub-simulator-0.8.0.tgz",
+      "integrity": "sha512-mfogXHtRRTQl8ZsaiESf/nFAmNSlH1LtGbkEIcaERDFcDizWTrXomB5FULz3W1gG+qsMQuJYSmB+jLp0tPHtKg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "evenhub-simulator": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "@evenrealities/sim-darwin-arm64": "0.8.0",
+        "@evenrealities/sim-darwin-x64": "0.8.0",
+        "@evenrealities/sim-linux-x64": "0.8.0",
+        "@evenrealities/sim-win32-x64": "0.8.0"
+      }
+    },
+    "node_modules/@evenrealities/sim-darwin-arm64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-darwin-arm64/-/sim-darwin-arm64-0.8.0.tgz",
+      "integrity": "sha512-k/yW7mUh+6HgvjP8VrSBlkPj2BBa9qp2kJB95ewdXKhwWeCLCfS/q6eFNK0IXCRXo7CkRg1mbvl68REN9UxQEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator"
+      }
+    },
+    "node_modules/@evenrealities/sim-darwin-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-darwin-x64/-/sim-darwin-x64-0.8.0.tgz",
+      "integrity": "sha512-eXKfEsa67wb1SQOHsIKiHCRmWry8arENBt501gC8qP5hbMvmdkFMNbBGi2EOUfxqMrd+3jl7TdneraAaU4NGtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator"
+      }
+    },
+    "node_modules/@evenrealities/sim-linux-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-linux-x64/-/sim-linux-x64-0.8.0.tgz",
+      "integrity": "sha512-XIQX4IuHCAMFaJMiz9Jl9M8aakvGcefUgOc/PTj+8gAJANwdSmBLJhmoRcELlOHxPMeRG1RqfMrZI7neioqTJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator"
+      }
+    },
+    "node_modules/@evenrealities/sim-win32-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@evenrealities/sim-win32-x64/-/sim-win32-x64-0.8.0.tgz",
+      "integrity": "sha512-PvcJr56lHUzDmHj889DOTR1iwPUC9NOplFkyd7UL7xvIZyhctO74BLoBKbyajZsEuqR8weVZQObUV89NGLpZ5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "evenhub-simulator": "bin/evenhub-simulator.exe"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inquirer": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
+      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/prompts": "^8.4.3",
+        "@inquirer/type": "^4.0.5",
+        "mute-stream": "^3.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qr-image": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qr-image/-/qr-image-3.2.0.tgz",
+      "integrity": "sha512-rXKDS5Sx3YipVsqmlMJsJsk6jXylEpiHRC2+nJy66fxA5ExYyGa4PqwteW69SaVmAb2OQ18HbYriT7cGQMbduw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/integrations/omi-even/app/package.json
+++ b/integrations/omi-even/app/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "omi-even-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "node scripts/unit-test.mjs",
+    "simulator": "evenhub-simulator http://localhost:5273",
+    "mock-bridge": "node scripts/mock-bridge.mjs",
+    "qr": "evenhub qr",
+    "verify": "node scripts/verify-simulator.mjs"
+  },
+  "devDependencies": {
+    "@evenrealities/evenhub-cli": "^0.1.13",
+    "@evenrealities/evenhub-simulator": "^0.8.0",
+    "@evenrealities/sim-darwin-arm64": "^0.8.0",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.1"
+  },
+  "dependencies": {
+    "@evenrealities/even_hub_sdk": "^0.0.12"
+  }
+}

--- a/integrations/omi-even/app/scripts/mock-bridge.mjs
+++ b/integrations/omi-even/app/scripts/mock-bridge.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * Hermetic stand-in for the local omi bridge.
+ *
+ * Speaks the same `ws://<host>/app` JSON protocol as the real bridge but serves
+ * fixed canned data, so `verify-simulator.mjs` can assert the app's behaviour
+ * without a running backend, credentials, or network.
+ *
+ * Implements RFC 6455 directly on `node:http` — no `ws` dependency, matching
+ * the pure-Node PNG decoder in the verify script.
+ *
+ * Usage:
+ *   node scripts/mock-bridge.mjs [--port 8765]
+ *
+ * Control plane (so tests can trigger server-initiated traffic):
+ *   GET  /control/health  -> {"ok":true,"clients":N}
+ *   POST /control/push    -> body is the banner text; broadcast as {"type":"push"}
+ */
+import { createHash } from 'node:crypto'
+import { createServer } from 'node:http'
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+
+const portArg = process.argv.indexOf('--port')
+const PORT = Number(portArg > -1 ? process.argv[portArg + 1] : (process.env.BRIDGE_PORT ?? 8765))
+
+// ------------------------------------------------------------------ fixtures
+
+export const MEMORIES = [
+  { content: 'Prefers dense text over icons on the glasses display.' },
+  { content: 'Ships desktop changes behind a named test bundle first.' },
+  { content: 'Runs the backend test suite before every commit.' },
+  { content: 'Keeps agent instructions in AGENTS.md, not CLAUDE.md.' },
+  { content: 'Reviews PRs in the morning, writes code in the afternoon.' },
+]
+
+export const ACTION_ITEMS = [
+  { description: 'Send the G2 plugin build to the hardware team', completed: false },
+  { description: 'Reply to the Even Realities SDK thread', completed: true },
+  { description: 'Draft the bridge protocol doc', completed: false },
+]
+
+export const TODAY_TEXT = [
+  'Three conversations, two of them about the glasses plugin.',
+  '',
+  'You agreed to send a build to the hardware team by Friday and to write up the bridge protocol before the review.',
+  'The afternoon block stayed clear, so the display work landed ahead of schedule.',
+].join('\n')
+
+/** Long enough to paginate into more than one page at 380 chars per page. */
+export const CHAT_CHUNKS = [
+  'Finish the glasses plugin first. ',
+  'The display layer is done and the bridge protocol is settled, ',
+  'so the remaining work is the verification harness — ',
+  'and that is what unblocks everyone else on the team. ',
+  'After that, the two things competing for your attention are ',
+  'the bridge protocol write-up you promised before the review ',
+  'and the build the hardware team is waiting on. ',
+  'The write-up is cheaper and it removes a question that keeps ',
+  'coming back in review, so do it next. ',
+  'Leave the backlog triage for tomorrow morning; ',
+  'nothing in it is blocking another person today, ',
+  'and it will read very differently once the plugin is shipped.',
+]
+
+export const CHAT_FULL = CHAT_CHUNKS.join('')
+
+const DELTA_INTERVAL_MS = Number(process.env.BRIDGE_DELTA_MS ?? 90)
+
+// -------------------------------------------------------------- ws framing
+
+function acceptKey(key) {
+  return createHash('sha1')
+    .update(key + WS_GUID)
+    .digest('base64')
+}
+
+/** Encode a server -> client text frame (never masked, per RFC 6455). */
+function encodeText(text) {
+  const payload = Buffer.from(text, 'utf8')
+  const len = payload.length
+  let header
+  if (len < 126) {
+    header = Buffer.from([0x81, len])
+  } else if (len < 65536) {
+    header = Buffer.alloc(4)
+    header[0] = 0x81
+    header[1] = 126
+    header.writeUInt16BE(len, 2)
+  } else {
+    header = Buffer.alloc(10)
+    header[0] = 0x81
+    header[1] = 127
+    header.writeBigUInt64BE(BigInt(len), 2)
+  }
+  return Buffer.concat([header, payload])
+}
+
+function encodeControl(opcode, payload = Buffer.alloc(0)) {
+  return Buffer.concat([Buffer.from([0x80 | opcode, payload.length]), payload])
+}
+
+/**
+ * Pull as many complete frames as `buf` holds.
+ * Returns { frames, rest } where each frame is { fin, opcode, payload }.
+ */
+function decodeFrames(buf) {
+  const frames = []
+  let offset = 0
+
+  while (offset + 2 <= buf.length) {
+    const first = buf[offset]
+    const second = buf[offset + 1]
+    const fin = (first & 0x80) !== 0
+    const opcode = first & 0x0f
+    const masked = (second & 0x80) !== 0
+    let len = second & 0x7f
+    let cursor = offset + 2
+
+    if (len === 126) {
+      if (cursor + 2 > buf.length) break
+      len = buf.readUInt16BE(cursor)
+      cursor += 2
+    } else if (len === 127) {
+      if (cursor + 8 > buf.length) break
+      const big = buf.readBigUInt64BE(cursor)
+      if (big > 0x3fffffffn) throw new Error('frame too large')
+      len = Number(big)
+      cursor += 8
+    }
+
+    let mask = null
+    if (masked) {
+      if (cursor + 4 > buf.length) break
+      mask = buf.subarray(cursor, cursor + 4)
+      cursor += 4
+    }
+
+    if (cursor + len > buf.length) break
+    const payload = Buffer.from(buf.subarray(cursor, cursor + len))
+    if (mask) {
+      for (let i = 0; i < payload.length; i++) payload[i] ^= mask[i & 3]
+    }
+    frames.push({ fin, opcode, payload })
+    offset = cursor + len
+  }
+
+  return { frames, rest: buf.subarray(offset) }
+}
+
+// ------------------------------------------------------------------- server
+
+const clients = new Set()
+
+function send(socket, message) {
+  if (socket.destroyed) return
+  socket.write(encodeText(JSON.stringify(message)))
+}
+
+export function broadcastPush(text) {
+  for (const socket of clients) send(socket, { type: 'push', text })
+  return clients.size
+}
+
+function handleMessage(socket, raw) {
+  let msg
+  try {
+    msg = JSON.parse(raw)
+  } catch {
+    console.log('[mock-bridge] ignoring non-JSON frame')
+    return
+  }
+  console.log(`[mock-bridge] <- ${msg.type}`)
+
+  switch (msg.type) {
+    case 'chat': {
+      // Stream the answer the way the real bridge does: deltas first, then one
+      // authoritative `chat_done` carrying the whole text.
+      let index = 0
+      const tick = setInterval(() => {
+        if (socket.destroyed) {
+          clearInterval(tick)
+          return
+        }
+        if (index < CHAT_CHUNKS.length) {
+          send(socket, { type: 'chat_delta', text: CHAT_CHUNKS[index++] })
+          return
+        }
+        clearInterval(tick)
+        send(socket, { type: 'chat_done', text: CHAT_FULL })
+        console.log(`[mock-bridge] -> chat_done (${CHAT_FULL.length} chars)`)
+      }, DELTA_INTERVAL_MS)
+      break
+    }
+    case 'memories': {
+      const limit = Number.isFinite(msg.limit) ? msg.limit : MEMORIES.length
+      send(socket, { type: 'memories', items: MEMORIES.slice(0, limit) })
+      break
+    }
+    case 'action_items':
+      send(socket, { type: 'action_items', items: ACTION_ITEMS })
+      break
+    case 'today':
+      send(socket, { type: 'today', text: TODAY_TEXT })
+      break
+    default:
+      console.log(`[mock-bridge] unknown request type: ${msg.type}`)
+  }
+}
+
+const server = createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/control/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ok: true, clients: clients.size }))
+    return
+  }
+  if (req.method === 'POST' && req.url === '/control/push') {
+    let body = ''
+    req.on('data', (chunk) => (body += chunk))
+    req.on('end', () => {
+      const delivered = broadcastPush(body || 'hello from omi')
+      console.log(`[mock-bridge] -> push to ${delivered} client(s)`)
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, delivered }))
+    })
+    return
+  }
+  res.writeHead(404).end('not found')
+})
+
+server.on('upgrade', (req, socket) => {
+  const key = req.headers['sec-websocket-key']
+  if (!key) {
+    socket.destroy()
+    return
+  }
+  const path = (req.url ?? '').split('?')[0]
+  if (path !== '/app') {
+    console.log(`[mock-bridge] rejecting upgrade for ${path}`)
+    socket.write('HTTP/1.1 404 Not Found\r\n\r\n')
+    socket.destroy()
+    return
+  }
+
+  socket.write(
+    [
+      'HTTP/1.1 101 Switching Protocols',
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      `Sec-WebSocket-Accept: ${acceptKey(key)}`,
+      '\r\n',
+    ].join('\r\n'),
+  )
+  socket.setNoDelay(true)
+  clients.add(socket)
+  console.log(`[mock-bridge] client connected (${clients.size} total)`)
+
+  let buffer = Buffer.alloc(0)
+  // Continuation frames are assembled here; browsers do not fragment small
+  // JSON, but a compliant peer is allowed to.
+  let fragmentOpcode = null
+  let fragments = []
+
+  socket.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk])
+    let decoded
+    try {
+      decoded = decodeFrames(buffer)
+    } catch (error) {
+      console.error(`[mock-bridge] framing error: ${error.message}`)
+      socket.destroy()
+      return
+    }
+    buffer = decoded.rest
+
+    for (const frame of decoded.frames) {
+      if (frame.opcode === 0x8) {
+        socket.write(encodeControl(0x8))
+        socket.end()
+        return
+      }
+      if (frame.opcode === 0x9) {
+        socket.write(encodeControl(0xa, frame.payload))
+        continue
+      }
+      if (frame.opcode === 0xa) continue
+
+      if (frame.opcode === 0x0) {
+        fragments.push(frame.payload)
+      } else {
+        fragmentOpcode = frame.opcode
+        fragments = [frame.payload]
+      }
+      if (!frame.fin) continue
+
+      const payload = Buffer.concat(fragments)
+      fragments = []
+      const opcode = fragmentOpcode
+      fragmentOpcode = null
+      if (opcode === 0x1) handleMessage(socket, payload.toString('utf8'))
+    }
+  })
+
+  const drop = () => {
+    if (clients.delete(socket)) console.log(`[mock-bridge] client gone (${clients.size} left)`)
+  }
+  socket.on('close', drop)
+  socket.on('error', drop)
+})
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[mock-bridge] listening on ws://127.0.0.1:${PORT}/app`)
+})
+
+// Shut down cleanly so the verify script's process-group kill is not the only
+// thing standing between a failed run and a leaked port.
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    for (const socket of clients) socket.destroy()
+    server.close(() => process.exit(0))
+  })
+}

--- a/integrations/omi-even/app/scripts/mock-bridge.mjs
+++ b/integrations/omi-even/app/scripts/mock-bridge.mjs
@@ -2,9 +2,10 @@
 /**
  * Hermetic stand-in for the local omi bridge.
  *
- * Speaks the same `ws://<host>/app` JSON protocol as the real bridge but serves
- * fixed canned data, so `verify-simulator.mjs` can assert the app's behaviour
- * without a running backend, credentials, or network.
+ * Speaks the same `ws://<host>/app` protocol as the real bridge — JSON control
+ * frames plus binary microphone PCM — but serves fixed canned data, so
+ * `verify-simulator.mjs` can assert the app's behaviour without a running
+ * backend, credentials, or network.
  *
  * Implements RFC 6455 directly on `node:http` — no `ws` dependency, matching
  * the pure-Node PNG decoder in the verify script.
@@ -12,9 +13,12 @@
  * Usage:
  *   node scripts/mock-bridge.mjs [--port 8765]
  *
- * Control plane (so tests can trigger server-initiated traffic):
- *   GET  /control/health  -> {"ok":true,"clients":N}
- *   POST /control/push    -> body is the banner text; broadcast as {"type":"push"}
+ * Control plane (so tests can trigger server-initiated traffic and read back
+ * what the app actually sent):
+ *   GET  /control/health   -> counters, including how much PCM arrived
+ *   POST /control/push     -> body is the banner text; broadcast as {"type":"push"}
+ *   POST /control/ask-mode -> body is `transcript` or `empty`; picks what the
+ *                             next `ask_stop` replies with
  */
 import { createHash } from 'node:crypto'
 import { createServer } from 'node:http'
@@ -65,7 +69,33 @@ export const CHAT_CHUNKS = [
 
 export const CHAT_FULL = CHAT_CHUNKS.join('')
 
+/** What the "speech recogniser" hears. Echoed back as `transcribed` before the
+ *  answer, exactly like the real bridge. */
+export const ASK_TRANSCRIPT = 'What should I work on next?'
+
 const DELTA_INTERVAL_MS = Number(process.env.BRIDGE_DELTA_MS ?? 90)
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Counters the verify script reads back over the control plane. `captureBytes`
+ * is the important one: binary frames that arrive outside an
+ * ask_start/ask_stop bracket are continuous-capture audio to the real bridge,
+ * so anything other than zero means the app leaked microphone frames into the
+ * wrong channel.
+ */
+const stats = {
+  askStarts: 0,
+  askStops: 0,
+  askFrames: 0,
+  askBytes: 0,
+  lastAskBytes: 0,
+  captureFrames: 0,
+  captureBytes: 0,
+}
+
+/** `transcript` answers the question; `empty` pretends it heard nothing. */
+let askMode = 'transcript'
 
 // -------------------------------------------------------------- ws framing
 
@@ -162,7 +192,19 @@ export function broadcastPush(text) {
   return clients.size
 }
 
-function handleMessage(socket, raw) {
+/** Stream one answer: deltas first, then the authoritative `chat_done`. */
+async function streamChat(socket) {
+  for (const chunk of CHAT_CHUNKS) {
+    if (socket.destroyed) return
+    send(socket, { type: 'chat_delta', text: chunk })
+    await sleep(DELTA_INTERVAL_MS)
+  }
+  if (socket.destroyed) return
+  send(socket, { type: 'chat_done', text: CHAT_FULL })
+  console.log(`[mock-bridge] -> chat_done (${CHAT_FULL.length} chars)`)
+}
+
+async function handleMessage(socket, state, raw) {
   let msg
   try {
     msg = JSON.parse(raw)
@@ -173,25 +215,37 @@ function handleMessage(socket, raw) {
   console.log(`[mock-bridge] <- ${msg.type}`)
 
   switch (msg.type) {
-    case 'chat': {
-      // Stream the answer the way the real bridge does: deltas first, then one
-      // authoritative `chat_done` carrying the whole text.
-      let index = 0
-      const tick = setInterval(() => {
-        if (socket.destroyed) {
-          clearInterval(tick)
-          return
-        }
-        if (index < CHAT_CHUNKS.length) {
-          send(socket, { type: 'chat_delta', text: CHAT_CHUNKS[index++] })
-          return
-        }
-        clearInterval(tick)
-        send(socket, { type: 'chat_done', text: CHAT_FULL })
-        console.log(`[mock-bridge] -> chat_done (${CHAT_FULL.length} chars)`)
-      }, DELTA_INTERVAL_MS)
+    case 'ask_start':
+      state.askActive = true
+      state.askBytes = 0
+      stats.askStarts++
+      send(socket, { type: 'ask_listening' })
+      break
+
+    case 'ask_stop': {
+      // Idempotent, like the real bridge: a cancel that races an auto-stop
+      // must not be an error.
+      if (!state.askActive) {
+        console.log('[mock-bridge] ask_stop with no ask open, ignoring')
+        break
+      }
+      state.askActive = false
+      stats.askStops++
+      stats.lastAskBytes = state.askBytes
+      console.log(`[mock-bridge] ask_stop after ${state.askBytes} bytes of PCM`)
+      if (askMode === 'empty') {
+        send(socket, { type: 'ask_error', text: "Didn't catch that. Tap to retry." })
+        break
+      }
+      send(socket, { type: 'transcribed', text: ASK_TRANSCRIPT })
+      await streamChat(socket)
       break
     }
+
+    case 'chat':
+      await streamChat(socket)
+      break
+
     case 'memories': {
       const limit = Number.isFinite(msg.limit) ? msg.limit : MEMORIES.length
       send(socket, { type: 'memories', items: MEMORIES.slice(0, limit) })
@@ -208,20 +262,55 @@ function handleMessage(socket, raw) {
   }
 }
 
+/** Binary frames are microphone PCM. What they mean depends on whether an ask
+ *  is open, which is exactly the distinction the app has to get right. */
+function handleBinary(state, payload) {
+  if (state.askActive) {
+    state.askBytes += payload.length
+    stats.askFrames++
+    stats.askBytes += payload.length
+    return
+  }
+  stats.captureFrames++
+  stats.captureBytes += payload.length
+  console.log(`[mock-bridge] ${payload.length} bytes of PCM outside an ask (continuous capture)`)
+}
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    let body = ''
+    req.on('data', (chunk) => (body += chunk))
+    req.on('end', () => resolve(body))
+  })
+}
+
 const server = createServer((req, res) => {
   if (req.method === 'GET' && req.url === '/control/health') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ ok: true, clients: clients.size }))
+    res.end(JSON.stringify({ ok: true, clients: clients.size, askMode, ...stats }))
     return
   }
   if (req.method === 'POST' && req.url === '/control/push') {
-    let body = ''
-    req.on('data', (chunk) => (body += chunk))
-    req.on('end', () => {
+    void readBody(req).then((body) => {
       const delivered = broadcastPush(body || 'hello from omi')
       console.log(`[mock-bridge] -> push to ${delivered} client(s)`)
       res.writeHead(200, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ ok: true, delivered }))
+    })
+    return
+  }
+  if (req.method === 'POST' && req.url === '/control/ask-mode') {
+    void readBody(req).then((body) => {
+      const wanted = body.trim()
+      if (wanted !== 'transcript' && wanted !== 'empty') {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'ask mode must be "transcript" or "empty"' }))
+        return
+      }
+      askMode = wanted
+      console.log(`[mock-bridge] ask mode = ${askMode}`)
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, askMode }))
     })
     return
   }
@@ -261,6 +350,13 @@ server.on('upgrade', (req, socket) => {
   let fragmentOpcode = null
   let fragments = []
 
+  // Per-connection ask state, and a chain that keeps replies strictly ordered.
+  // The real bridge awaits each message inside one receive loop, so an answer
+  // to a cancelled question always completes before the next question is even
+  // read — the app's discard logic is written against that guarantee.
+  const state = { askActive: false, askBytes: 0 }
+  let work = Promise.resolve()
+
   socket.on('data', (chunk) => {
     buffer = Buffer.concat([buffer, chunk])
     let decoded
@@ -297,7 +393,20 @@ server.on('upgrade', (req, socket) => {
       fragments = []
       const opcode = fragmentOpcode
       fragmentOpcode = null
-      if (opcode === 0x1) handleMessage(socket, payload.toString('utf8'))
+      if (opcode === 0x1) {
+        const text = payload.toString('utf8')
+        work = work
+          .then(() => handleMessage(socket, state, text))
+          .catch((error) => console.error(`[mock-bridge] handler failed: ${error.message}`))
+      } else if (opcode === 0x2) {
+        // Binary goes through the same chain, not straight to the counter: the
+        // real bridge reads it from the same sequential receive loop, so a
+        // frame that arrives while an earlier answer is still streaming is
+        // still classified against the ask state at the time it is *read*.
+        work = work
+          .then(() => handleBinary(state, payload))
+          .catch((error) => console.error(`[mock-bridge] audio failed: ${error.message}`))
+      }
     }
   })
 

--- a/integrations/omi-even/app/scripts/unit-test.mjs
+++ b/integrations/omi-even/app/scripts/unit-test.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Hermetic unit tests for the parts of the app that do not need glasses:
+ * pagination, the bridge wire format, and background-state snapshotting.
+ *
+ * No simulator, no GUI, no network — unlike `verify-simulator.mjs` this is safe
+ * to run anywhere, including CI. Uses Node's built-in TypeScript stripping, so
+ * it imports `src/*.ts` directly with no build step.
+ *
+ * Usage: npm test
+ */
+import assert from 'node:assert/strict'
+
+// `background-state.ts` installs its hooks on `window`; give it one before the
+// module is imported, since Node has no DOM.
+globalThis.window = globalThis.window ?? {}
+
+const { paginate, clampPage } = await import('../src/paginate.ts')
+const { parseInbound, frameType } = await import('../src/protocol.ts')
+const { setBackgroundState, onBackgroundRestore } = await import('../src/background-state.ts')
+
+let failures = 0
+let count = 0
+
+function test(name, fn) {
+  count++
+  try {
+    fn()
+    console.log(`  PASS  ${name}`)
+  } catch (error) {
+    failures++
+    console.log(`  FAIL  ${name}`)
+    console.log(`        ${error.message.split('\n').join('\n        ')}`)
+  }
+}
+
+// ------------------------------------------------------------------ paginate
+
+test('paginate: text shorter than the limit stays on one page', () => {
+  assert.deepEqual(paginate('hello glasses', 380), ['hello glasses'])
+})
+
+test('paginate: empty text still yields one (empty) page', () => {
+  assert.deepEqual(paginate('   \n  ', 380), [''])
+})
+
+test('paginate: every page fits the limit', () => {
+  const text = Array.from({ length: 200 }, (_, i) => `sentence number ${i}`).join('. ')
+  const pages = paginate(text, 380)
+  assert.ok(pages.length > 1, `expected several pages, got ${pages.length}`)
+  for (const page of pages) assert.ok(page.length <= 380, `page of ${page.length} chars exceeds 380`)
+})
+
+test('paginate: no word is split across a page boundary', () => {
+  const text = Array.from({ length: 300 }, (_, i) => `word${i}`).join(' ')
+  const pages = paginate(text, 100)
+  // Re-joining with single spaces must reproduce the original word sequence.
+  assert.deepEqual(pages.join(' ').split(/\s+/), text.split(/\s+/))
+})
+
+test('paginate: a word longer than a whole page is hard-cut rather than dropped', () => {
+  const long = 'x'.repeat(250)
+  const pages = paginate(long, 100)
+  assert.equal(pages.join(''), long)
+  assert.equal(pages.length, 3)
+})
+
+test('paginate: prefers a paragraph break over a mid-sentence space', () => {
+  const first = 'a'.repeat(60)
+  const second = 'b'.repeat(60)
+  const pages = paginate(`${first}\n\n${second} tail words here`, 80)
+  assert.equal(pages[0], first)
+})
+
+test('clampPage: keeps the index inside the page range', () => {
+  assert.equal(clampPage(-3, 4), 0)
+  assert.equal(clampPage(9, 4), 3)
+  assert.equal(clampPage(2, 4), 2)
+  assert.equal(clampPage(2, 0), 0)
+})
+
+// ------------------------------------------------------------------ protocol
+
+test('parseInbound: accepts each documented message type', () => {
+  assert.deepEqual(parseInbound('{"type":"chat_delta","text":"hi"}'), { type: 'chat_delta', text: 'hi' })
+  assert.deepEqual(parseInbound('{"type":"chat_done","text":"done"}'), { type: 'chat_done', text: 'done' })
+  assert.deepEqual(parseInbound('{"type":"today","text":"t"}'), { type: 'today', text: 't' })
+  assert.deepEqual(parseInbound('{"type":"push","text":"p"}'), { type: 'push', text: 'p' })
+  assert.deepEqual(parseInbound('{"type":"memories","items":[{"content":"m"}]}'), {
+    type: 'memories',
+    items: [{ content: 'm' }],
+  })
+  assert.deepEqual(parseInbound('{"type":"action_items","items":[{"description":"d","completed":true}]}'), {
+    type: 'action_items',
+    items: [{ description: 'd', completed: true }],
+  })
+})
+
+test('parseInbound: a missing `completed` defaults to false rather than undefined', () => {
+  assert.deepEqual(parseInbound('{"type":"action_items","items":[{"description":"d"}]}'), {
+    type: 'action_items',
+    items: [{ description: 'd', completed: false }],
+  })
+})
+
+test('parseInbound: drops malformed items instead of rendering "undefined"', () => {
+  assert.deepEqual(parseInbound('{"type":"memories","items":[{"content":"ok"},{},null,{"content":7}]}'), {
+    type: 'memories',
+    items: [{ content: 'ok' }],
+  })
+})
+
+test('parseInbound: returns null for junk, so the socket callback cannot throw', () => {
+  assert.equal(parseInbound('not json'), null)
+  assert.equal(parseInbound('null'), null)
+  assert.equal(parseInbound('[1,2,3]'), null)
+  assert.equal(parseInbound('{"type":"chat_delta"}'), null)
+  assert.equal(parseInbound('{"type":"memories"}'), null)
+  assert.equal(parseInbound('{"type":"from_the_future","text":"x"}'), null)
+})
+
+test('frameType: names the type of a frame the app does not handle', () => {
+  // The real bridge greets with `hello` and emits `transcript` / `pong`; none
+  // are errors, so they must be identifiable for a quiet debug log.
+  assert.equal(frameType('{"type":"hello","omi_api":"https://x"}'), 'hello')
+  assert.equal(frameType('{"type":"transcript","text":"..."}'), 'transcript')
+  assert.equal(frameType('not json'), null)
+  assert.equal(frameType('{"no":"type"}'), null)
+})
+
+// ---------------------------------------------------------- background state
+
+test('background state: a snapshot survives the round trip', () => {
+  let value = { page: 3, label: 'chat' }
+  setBackgroundState('round-trip', () => ({ ...value }))
+  onBackgroundRestore('round-trip', (saved) => {
+    value = { ...value, ...saved }
+  })
+
+  const snapshot = window.__getStateSnapshot()
+  // The headless WebView starts from scratch; simulate that reset.
+  value = { page: 0, label: '' }
+  window.__restoreState(snapshot)
+
+  assert.deepEqual(value, { page: 3, label: 'chat' })
+})
+
+test('background state: the snapshot is plain JSON', () => {
+  const snapshot = JSON.parse(window.__getStateSnapshot())
+  assert.equal(typeof snapshot, 'object')
+  assert.deepEqual(snapshot['round-trip'], { page: 3, label: 'chat' })
+})
+
+test('background state: the exporter captures a copy, not a live reference', () => {
+  let live = { n: 1 }
+  setBackgroundState('copy', () => ({ ...live }))
+  const snapshot = window.__getStateSnapshot()
+  live.n = 99 // mutate after the snapshot was taken
+  assert.equal(JSON.parse(snapshot).copy.n, 1)
+})
+
+test('background state: one throwing exporter does not cost the other keys', () => {
+  setBackgroundState('explodes', () => {
+    throw new Error('boom')
+  })
+  const snapshot = JSON.parse(window.__getStateSnapshot())
+  assert.deepEqual(snapshot['round-trip'], { page: 3, label: 'chat' })
+  assert.equal('explodes' in snapshot, false)
+})
+
+test('background state: a key absent from the snapshot leaves its state alone', () => {
+  let untouched = 'original'
+  onBackgroundRestore('never-exported', (saved) => {
+    untouched = saved.value ?? untouched
+  })
+  window.__restoreState('{}')
+  assert.equal(untouched, 'original')
+})
+
+test('background state: invalid snapshot JSON is ignored, not thrown', () => {
+  assert.doesNotThrow(() => window.__restoreState('}{'))
+  assert.doesNotThrow(() => window.__restoreState('null'))
+})
+
+// ---------------------------------------------------------------------- exit
+
+console.log(
+  failures === 0 ? `\nAll ${count} unit tests passed.\n` : `\n${failures} of ${count} unit tests failed.\n`,
+)
+process.exit(failures === 0 ? 0 : 1)

--- a/integrations/omi-even/app/scripts/unit-test.mjs
+++ b/integrations/omi-even/app/scripts/unit-test.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Hermetic unit tests for the parts of the app that do not need glasses:
- * pagination, the bridge wire format, and background-state snapshotting.
+ * pagination, the bridge wire format, background-state snapshotting, and the
+ * microphone lifecycle behind "Ask Omi".
  *
  * No simulator, no GUI, no network — unlike `verify-simulator.mjs` this is safe
  * to run anywhere, including CI. Uses Node's built-in TypeScript stripping, so
@@ -18,6 +19,8 @@ globalThis.window = globalThis.window ?? {}
 const { paginate, clampPage } = await import('../src/paginate.ts')
 const { parseInbound, frameType } = await import('../src/protocol.ts')
 const { setBackgroundState, onBackgroundRestore } = await import('../src/background-state.ts')
+const { toPcmBytes, peakLevel, meterBar, clock } = await import('../src/audio.ts')
+const { AskRecorder } = await import('../src/ask-recorder.ts')
 
 let failures = 0
 let count = 0
@@ -32,6 +35,23 @@ function test(name, fn) {
     console.log(`  FAIL  ${name}`)
     console.log(`        ${error.message.split('\n').join('\n        ')}`)
   }
+}
+
+/** Same reporting, for a test that has to await something. Queued so the
+ *  output stays in order. */
+let chain = Promise.resolve()
+function asyncTest(name, fn) {
+  count++
+  chain = chain.then(async () => {
+    try {
+      await fn()
+      console.log(`  PASS  ${name}`)
+    } catch (error) {
+      failures++
+      console.log(`  FAIL  ${name}`)
+      console.log(`        ${error.message.split('\n').join('\n        ')}`)
+    }
+  })
 }
 
 // ------------------------------------------------------------------ paginate
@@ -182,7 +202,257 @@ test('background state: invalid snapshot JSON is ignored, not thrown', () => {
   assert.doesNotThrow(() => window.__restoreState('null'))
 })
 
+// --------------------------------------------------------------------- audio
+
+test('toPcmBytes: a Uint8Array is passed straight through', () => {
+  const pcm = new Uint8Array([1, 2, 3, 4])
+  assert.equal(toPcmBytes(pcm), pcm)
+})
+
+test('toPcmBytes: the host may hand over a number[] instead of bytes', () => {
+  // The host is a Flutter app: a Uint8List crossing a JSON channel arrives as
+  // an array of numbers, and forwarding that object as-is would send garbage.
+  assert.deepEqual(toPcmBytes([0, 128, 255]), new Uint8Array([0, 128, 255]))
+})
+
+test('toPcmBytes: base64 is decoded', () => {
+  globalThis.atob = globalThis.atob ?? ((s) => Buffer.from(s, 'base64').toString('binary'))
+  assert.deepEqual(toPcmBytes('AAECAw=='), new Uint8Array([0, 1, 2, 3]))
+})
+
+test('toPcmBytes: an ArrayBuffer view respects its offset', () => {
+  const backing = new Uint8Array([9, 9, 1, 2, 3])
+  const view = new Uint8Array(backing.buffer, 2, 3)
+  assert.deepEqual(toPcmBytes(view), new Uint8Array([1, 2, 3]))
+})
+
+test('toPcmBytes: anything that is not audio yields null, never a bad frame', () => {
+  assert.equal(toPcmBytes(undefined), null)
+  assert.equal(toPcmBytes(null), null)
+  assert.equal(toPcmBytes({}), null)
+  assert.equal(toPcmBytes([]), null)
+  assert.equal(toPcmBytes(new Uint8Array(0)), null)
+  assert.equal(toPcmBytes(['a', 'b']), null)
+  assert.equal(toPcmBytes('not base64 !!!'), null)
+})
+
+test('peakLevel: reads samples as signed 16-bit little-endian', () => {
+  assert.equal(peakLevel(new Uint8Array([0, 0, 0, 0])), 0)
+  // 0x8000 little-endian is -32768, full scale negative.
+  assert.equal(peakLevel(new Uint8Array([0x00, 0x80])), 1)
+  // Big-endian would read 0x0080 = 128 here and report near silence.
+  assert.ok(peakLevel(new Uint8Array([0x00, 0x40])) > 0.49)
+  assert.ok(peakLevel(new Uint8Array([0x40, 0x00])) < 0.01)
+})
+
+test('peakLevel: an odd trailing byte cannot form a sample and is ignored', () => {
+  assert.equal(peakLevel(new Uint8Array([0x00, 0x00, 0xff])), 0)
+})
+
+test('meterBar: fills with level and always keeps its width', () => {
+  assert.equal(meterBar(0, 8), '[--------]')
+  assert.equal(meterBar(1, 8), '[########]')
+  const quiet = meterBar(0.05, 8)
+  const loud = meterBar(0.5, 8)
+  assert.ok(quiet.split('#').length - 1 < loud.split('#').length - 1)
+  assert.equal(quiet.length, loud.length)
+  // Out-of-range input must not produce a ragged bar.
+  assert.equal(meterBar(-5, 8), '[--------]')
+  assert.equal(meterBar(99, 8), '[########]')
+})
+
+test('clock: m:ss with a padded seconds field', () => {
+  assert.equal(clock(0), '0:00')
+  assert.equal(clock(9_400), '0:09')
+  assert.equal(clock(65_000), '1:05')
+  assert.equal(clock(-1), '0:00')
+})
+
+// ------------------------------------------------------------- ask recorder
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** The recorder narrates to the console; tests only care about the effects. */
+async function quiet(fn) {
+  const log = console.log
+  const warn = console.warn
+  console.log = () => {}
+  console.warn = () => {}
+  try {
+    return await fn()
+  } finally {
+    console.log = log
+    console.warn = warn
+  }
+}
+
+function harness(overrides = {}) {
+  const calls = { json: [], binary: [], mic: [], caps: 0 }
+  const deps = {
+    sendJson: (message) => {
+      calls.json.push(message.type)
+      return true
+    },
+    sendBinary: (pcm) => {
+      calls.binary.push(pcm.length)
+      return true
+    },
+    setMic: async (on) => {
+      calls.mic.push(on)
+      return true
+    },
+    onUpdate: () => {},
+    onCap: () => {
+      calls.caps++
+    },
+    maxMs: 10_000,
+    // Long enough that the meter tick never fires unless a test wants it.
+    tickMs: 10_000,
+    ...overrides,
+  }
+  return { calls, recorder: new AskRecorder(deps) }
+}
+
+/** One 100 ms frame of 16 kHz PCM16, the size the SDK actually delivers. */
+const frame = () => new Uint8Array(3_200)
+
+asyncTest('ask: the bridge is told before the microphone opens', async () => {
+  const { calls, recorder } = harness()
+  await quiet(() => recorder.start())
+  // ask_start first: a microphone with nowhere to send costs battery for
+  // nothing, so the socket is proven before the hardware is touched.
+  assert.deepEqual(calls.json, ['ask_start'])
+  assert.deepEqual(calls.mic, [true])
+  await quiet(() => recorder.stop('tap'))
+})
+
+asyncTest('ask: PCM only goes out between ask_start and ask_stop', async () => {
+  const { calls, recorder } = harness()
+
+  recorder.feed(frame()) // before start
+  assert.deepEqual(calls.binary, [], 'a frame before ask_start must not be sent')
+
+  await quiet(() => recorder.start())
+  recorder.feed(frame())
+  recorder.feed(frame())
+  assert.deepEqual(calls.binary, [3_200, 3_200])
+
+  await quiet(() => recorder.stop('tap'))
+  recorder.feed(frame()) // after stop
+  assert.deepEqual(calls.binary, [3_200, 3_200], 'a frame after ask_stop must not be sent')
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+  assert.equal(recorder.bytesSent, 6_400)
+  assert.equal(recorder.framesSent, 2)
+  assert.equal(recorder.framesIgnored, 2)
+})
+
+asyncTest('ask: stopping closes the microphone and closes the bracket', async () => {
+  const { calls, recorder } = harness()
+  await quiet(() => recorder.start())
+  const asked = await quiet(() => recorder.stop('tap'))
+  assert.equal(asked, true)
+  assert.deepEqual(calls.mic, [true, false])
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+  assert.equal(recorder.isListening(), false)
+})
+
+asyncTest('ask: a cancel still sends ask_stop, because the bridge is holding a buffer', async () => {
+  const { calls, recorder } = harness()
+  await quiet(() => recorder.start())
+  const asked = await quiet(() => recorder.stop('cancel'))
+  assert.equal(asked, true)
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+  assert.deepEqual(calls.mic, [true, false])
+})
+
+asyncTest('ask: an offline bridge never opens the microphone', async () => {
+  const { calls, recorder } = harness({ sendJson: () => false })
+  const started = await quiet(() => recorder.start())
+  assert.deepEqual(started, { ok: false, reason: 'offline' })
+  assert.deepEqual(calls.mic, [])
+  assert.equal(recorder.isListening(), false)
+})
+
+asyncTest('ask: a microphone that will not open closes the bracket it opened', async () => {
+  const { calls, recorder } = harness({ setMic: async () => false })
+  const started = await quiet(() => recorder.start())
+  assert.deepEqual(started, { ok: false, reason: 'mic' })
+  // Without this the bridge stays in ask mode and files the next frame it sees
+  // as part of a question nobody asked.
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+  assert.equal(recorder.isListening(), false)
+})
+
+asyncTest('ask: stop reports false when ask_stop could not be sent', async () => {
+  let online = true
+  const { recorder } = harness({ sendJson: () => online })
+  await quiet(() => recorder.start())
+  online = false
+  // No answer is owed when the bridge never heard the question, so the caller
+  // must not sit waiting for one.
+  assert.equal(await quiet(() => recorder.stop('tap')), false)
+})
+
+asyncTest('ask: the cap fires on its own and the stop path is the same one', async () => {
+  const { calls, recorder } = harness({ maxMs: 30 })
+  await quiet(() => recorder.start())
+  await sleep(80)
+  assert.equal(calls.caps, 1, 'the cap should have fired')
+  // main.ts runs its normal stop from onCap; do the same and check the effects.
+  await quiet(() => recorder.stop('cap'))
+  assert.deepEqual(calls.mic, [true, false])
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+})
+
+asyncTest('ask: stopping cancels the cap, so a later timer cannot fire', async () => {
+  const { calls, recorder } = harness({ maxMs: 30 })
+  await quiet(() => recorder.start())
+  await quiet(() => recorder.stop('tap'))
+  await sleep(80)
+  assert.equal(calls.caps, 0)
+})
+
+asyncTest('ask: teardown releases the microphone without awaiting anything', async () => {
+  const { calls, recorder } = harness()
+  await quiet(() => recorder.start())
+  quiet(() => recorder.teardown())
+  assert.equal(recorder.isListening(), false)
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+  await sleep(0)
+  assert.deepEqual(calls.mic, [true, false])
+})
+
+asyncTest('ask: stopping twice is a no-op, not a second ask_stop', async () => {
+  const { calls, recorder } = harness()
+  await quiet(() => recorder.start())
+  await quiet(() => recorder.stop('tap'))
+  assert.equal(await quiet(() => recorder.stop('cancel')), false)
+  assert.deepEqual(calls.json, ['ask_start', 'ask_stop'])
+})
+
+asyncTest('ask: a dropped frame is counted, not retried forever', async () => {
+  const { recorder } = harness({ sendBinary: () => false })
+  await quiet(() => recorder.start())
+  recorder.feed(frame())
+  recorder.feed(frame())
+  assert.equal(recorder.bytesSent, 0)
+  assert.equal(recorder.framesDropped, 2)
+  await quiet(() => recorder.stop('tap'))
+})
+
+asyncTest('ask: a frame that is not audio is dropped rather than sent', async () => {
+  const { calls, recorder } = harness()
+  await quiet(() => recorder.start())
+  recorder.feed({ nope: true })
+  recorder.feed(null)
+  assert.deepEqual(calls.binary, [])
+  assert.equal(recorder.framesDropped, 2)
+  await quiet(() => recorder.stop('tap'))
+})
+
 // ---------------------------------------------------------------------- exit
+
+await chain
 
 console.log(
   failures === 0 ? `\nAll ${count} unit tests passed.\n` : `\n${failures} of ${count} unit tests failed.\n`,

--- a/integrations/omi-even/app/scripts/verify-simulator.mjs
+++ b/integrations/omi-even/app/scripts/verify-simulator.mjs
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+/**
+ * End-to-end verification of the omi G2 app against the EvenHub simulator.
+ *
+ * Hermetic: it starts its own mock bridge (`scripts/mock-bridge.mjs`) and the
+ * simulator, so it needs no backend, credentials, or network. The only external
+ * requirement is the Vite dev server, plus a GUI — the simulator opens a window,
+ * which is why this is a local check and is deliberately not wired into CI.
+ *
+ * Asserts:
+ *   1. simulator automation API comes up
+ *   2. the SDK bridge connects and the start-up page is created
+ *   3. the app's WebSocket bridge connects
+ *   4. the home list renders — framebuffer non-blank at 576x288
+ *   5. scroll moves the home selection
+ *   6. tap opens a view and its data loads
+ *   7. double-tap returns home
+ *   8. a chat answer streams in and repaints the body in place, not by rebuild
+ *   9. paging works inside a multi-page answer
+ *  10. a server push renders as a banner
+ *  11. every menu row opens: Memories, Action items, Today, Capture
+ *  12. losing the bridge shows up as offline and starts a retry
+ *  13. the app never reloaded mid-run, and nothing threw
+ *
+ * Usage: npm run dev   (separate terminal)
+ *        npm run verify
+ *        npm run verify -- --dump    # print every console line at the end
+ */
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { createConnection } from 'node:net'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { inflateSync } from 'node:zlib'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+const DEV_URL = process.env.DEV_URL ?? 'http://localhost:5273'
+const AUTOMATION_PORT = Number(process.env.AUTOMATION_PORT ?? 9899)
+const BRIDGE_PORT = Number(process.env.BRIDGE_PORT ?? 18765)
+const API = `http://127.0.0.1:${AUTOMATION_PORT}`
+const BRIDGE_HTTP = `http://127.0.0.1:${BRIDGE_PORT}`
+// The app reads its bridge endpoint from `?bridge=`, so the test drives a
+// throwaway port instead of whatever the developer has running on the default.
+const APP_URL = `${DEV_URL}/?bridge=ws://127.0.0.1:${BRIDGE_PORT}/app`
+
+const DUMP = process.argv.includes('--dump')
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+let failures = 0
+const pass = (msg) => console.log(`  PASS  ${msg}`)
+const fail = (msg) => {
+  failures++
+  console.log(`  FAIL  ${msg}`)
+}
+
+// ---------------------------------------------------------------- PNG decode
+
+/**
+ * Minimal non-interlaced 8-bit RGBA PNG decoder — enough to count lit pixels
+ * in the simulator framebuffer without pulling in an image library.
+ * Returns { width, height, data } where data is unfiltered RGBA bytes.
+ */
+function decodePng(buf) {
+  const sig = [137, 80, 78, 71, 13, 10, 26, 10]
+  for (let i = 0; i < 8; i++) {
+    if (buf[i] !== sig[i]) throw new Error('not a PNG')
+  }
+
+  let pos = 8
+  let width = 0
+  let height = 0
+  let bitDepth = 0
+  let colorType = 0
+  let interlace = 0
+  const idat = []
+
+  while (pos < buf.length) {
+    const len = buf.readUInt32BE(pos)
+    const type = buf.toString('ascii', pos + 4, pos + 8)
+    const data = buf.subarray(pos + 8, pos + 8 + len)
+    pos += 12 + len // length + type + data + crc
+
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0)
+      height = data.readUInt32BE(4)
+      bitDepth = data[8]
+      colorType = data[9]
+      interlace = data[12]
+    } else if (type === 'IDAT') {
+      idat.push(data)
+    } else if (type === 'IEND') {
+      break
+    }
+  }
+
+  if (bitDepth !== 8) throw new Error(`unsupported bit depth ${bitDepth}`)
+  if (colorType !== 6) throw new Error(`expected RGBA (colorType 6), got ${colorType}`)
+  if (interlace !== 0) throw new Error('interlaced PNG not supported')
+
+  const raw = inflateSync(Buffer.concat(idat))
+  const bpp = 4
+  const stride = width * bpp
+  const out = Buffer.alloc(height * stride)
+
+  const paeth = (a, b, c) => {
+    const p = a + b - c
+    const pa = Math.abs(p - a)
+    const pb = Math.abs(p - b)
+    const pc = Math.abs(p - c)
+    if (pa <= pb && pa <= pc) return a
+    return pb <= pc ? b : c
+  }
+
+  let rp = 0
+  for (let y = 0; y < height; y++) {
+    const filter = raw[rp++]
+    const row = y * stride
+    const prev = row - stride
+
+    for (let x = 0; x < stride; x++) {
+      const f = raw[rp + x]
+      const a = x >= bpp ? out[row + x - bpp] : 0
+      const b = y > 0 ? out[prev + x] : 0
+      const c = x >= bpp && y > 0 ? out[prev + x - bpp] : 0
+
+      let val
+      switch (filter) {
+        case 0: val = f; break
+        case 1: val = f + a; break
+        case 2: val = f + b; break
+        case 3: val = f + ((a + b) >> 1); break
+        case 4: val = f + paeth(a, b, c); break
+        default: throw new Error(`bad filter type ${filter} on row ${y}`)
+      }
+      out[row + x] = val & 0xff
+    }
+    rp += stride
+  }
+
+  return { width, height, data: out }
+}
+
+// ------------------------------------------------------------------ API glue
+
+async function ping() {
+  try {
+    const r = await fetch(`${API}/api/ping`)
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+async function console_(sinceId) {
+  const url = sinceId === undefined ? `${API}/api/console` : `${API}/api/console?since_id=${sinceId}`
+  const r = await fetch(url)
+  if (!r.ok) throw new Error(`console ${r.status}`)
+  return (await r.json()).entries ?? []
+}
+
+async function input(action) {
+  const r = await fetch(`${API}/api/input`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action }),
+  })
+  if (!r.ok) throw new Error(`input ${action} -> ${r.status}`)
+}
+
+/**
+ * Grab the glasses framebuffer. `lit` proves something is drawn at all; `hash`
+ * proves the drawing *changed* — the list highlight moves without changing the
+ * lit-pixel count, so a count alone cannot see a selection move.
+ */
+async function framebuffer() {
+  const r = await fetch(`${API}/api/screenshot/glasses`)
+  if (!r.ok) throw new Error(`screenshot ${r.status}`)
+  const png = decodePng(Buffer.from(await r.arrayBuffer()))
+  let lit = 0
+  // Background is alpha=0, lit text is alpha=255. Never convert to RGB — both
+  // are pure green and become indistinguishable.
+  for (let i = 3; i < png.data.length; i += 4) {
+    if (png.data[i] > 0) lit++
+  }
+  const hash = createHash('sha1').update(png.data).digest('hex').slice(0, 12)
+  return { lit, hash, width: png.width, height: png.height }
+}
+
+/** True when something already holds `port` — a leftover process would answer
+ *  every request and silently produce a green run against a stale instance. */
+function portInUse(port) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: '127.0.0.1' })
+    socket.once('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('error', () => resolve(false))
+    setTimeout(() => {
+      socket.destroy()
+      resolve(false)
+    }, 1_000)
+  })
+}
+
+/** All console text seen so far, accumulated across polls. */
+const seen = []
+let lastId = -1
+async function drainConsole() {
+  const entries = lastId < 0 ? await console_() : await console_(lastId)
+  for (const e of entries) {
+    seen.push(e)
+    if (e.id > lastId) lastId = e.id
+  }
+  return entries
+}
+
+const sawMessage = (needle) => seen.some((e) => (e.message ?? '').includes(needle))
+const countMessage = (needle) => seen.filter((e) => (e.message ?? '').includes(needle)).length
+
+async function waitForMessage(needle, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await drainConsole()
+    if (sawMessage(needle)) {
+      pass(label)
+      return true
+    }
+    await sleep(250)
+  }
+  fail(`${label} — never saw "${needle}" within ${timeoutMs}ms`)
+  return false
+}
+
+/** Like `waitForMessage`, but only counts lines logged after this point, so a
+ *  repeated message (e.g. returning to a view a second time) is unambiguous.
+ *  Drains first, or already-emitted lines still sitting on the simulator would
+ *  land after the mark and satisfy the next wait for free. */
+async function mark() {
+  await drainConsole()
+  return seen.length
+}
+async function waitForMessageSince(since, needle, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await drainConsole()
+    if (seen.slice(since).some((e) => (e.message ?? '').includes(needle))) {
+      pass(label)
+      return true
+    }
+    await sleep(250)
+  }
+  fail(`${label} — never saw "${needle}" within ${timeoutMs}ms`)
+  return false
+}
+
+/** Scroll to `row` from the top of the menu and tap it. Only valid from a
+ *  freshly rebuilt home page, where the highlight starts on row 0. */
+async function openRow(row, label) {
+  const since = await mark()
+  for (let i = 0; i < row; i++) {
+    await input('down')
+    await sleep(250)
+  }
+  await input('click')
+  await sleep(400)
+  await waitForMessageSince(since, `[app] home index=${row} (${label})`, 8_000, `row ${row} is "${label}"`)
+  return since
+}
+
+// --------------------------------------------------------------------- main
+
+async function main() {
+  console.log(`\nomi G2 simulator verification`)
+  console.log(`  app URL:        ${APP_URL}`)
+  console.log(`  automation API: ${API}`)
+  console.log(`  mock bridge:    ws://127.0.0.1:${BRIDGE_PORT}/app\n`)
+
+  // Fail fast with a clear message rather than a confusing simulator error.
+  try {
+    const r = await fetch(DEV_URL)
+    if (!r.ok) throw new Error(`status ${r.status}`)
+  } catch (e) {
+    console.error(`Dev server not reachable at ${DEV_URL} (${e.message}).`)
+    console.error(`Start it first:  npm run dev`)
+    process.exit(2)
+  }
+
+  if (await ping()) {
+    console.error(`Something is already serving the automation API on ${API}.`)
+    console.error(`That is almost certainly a leftover simulator. Kill it first:`)
+    console.error(`  pkill -f evenhub-simulator`)
+    process.exit(2)
+  }
+  if (await portInUse(AUTOMATION_PORT)) {
+    console.error(`Port ${AUTOMATION_PORT} is already in use by something that is not the simulator.`)
+    console.error(`Free it, or re-run with AUTOMATION_PORT=<other>.`)
+    process.exit(2)
+  }
+  if (await portInUse(BRIDGE_PORT)) {
+    console.error(`Port ${BRIDGE_PORT} is already in use — a stale mock bridge would serve`)
+    console.error(`fixtures this run never wrote. Free it, or re-run with BRIDGE_PORT=<other>.`)
+    process.exit(2)
+  }
+
+  const children = []
+  let cleanedUp = false
+  const cleanup = () => {
+    if (cleanedUp) return
+    cleanedUp = true
+    for (const child of children) {
+      try {
+        // Negative pid = the whole process group. The simulator launcher execs
+        // a platform binary; killing only the Node launcher leaves the
+        // simulator running and holding the port.
+        process.kill(-child.pid, 'SIGTERM')
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+  process.on('exit', cleanup)
+  process.on('SIGINT', () => {
+    cleanup()
+    process.exit(130)
+  })
+
+  // ---- mock bridge
+  const bridgeProc = spawn(process.execPath, [join(HERE, 'mock-bridge.mjs'), '--port', String(BRIDGE_PORT)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  children.push(bridgeProc)
+  let bridgeLog = ''
+  bridgeProc.stdout.on('data', (d) => (bridgeLog += d.toString()))
+  bridgeProc.stderr.on('data', (d) => (bridgeLog += d.toString()))
+
+  {
+    const deadline = Date.now() + 10_000
+    let up = false
+    while (Date.now() < deadline) {
+      try {
+        const r = await fetch(`${BRIDGE_HTTP}/control/health`)
+        if (r.ok) {
+          up = true
+          break
+        }
+      } catch {
+        /* not listening yet */
+      }
+      await sleep(200)
+    }
+    if (!up) {
+      console.error(`Mock bridge never came up on ${BRIDGE_HTTP}.\n${bridgeLog}`)
+      cleanup()
+      process.exit(2)
+    }
+    pass('mock bridge is up')
+  }
+
+  // ---- simulator
+  const launcher = require.resolve('@evenrealities/evenhub-simulator/bin/index.js')
+  const sim = spawn(process.execPath, [launcher, APP_URL, '--automation-port', String(AUTOMATION_PORT)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  children.push(sim)
+  let simErr = ''
+  sim.stderr.on('data', (d) => (simErr += d.toString()))
+  sim.on('exit', (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(`\nSimulator exited early (code ${code}):\n${simErr}`)
+    }
+  })
+
+  try {
+    // 1. Simulator up
+    const deadline = Date.now() + 30_000
+    let up = false
+    while (Date.now() < deadline) {
+      if (await ping()) {
+        up = true
+        break
+      }
+      await sleep(500)
+    }
+    if (!up) {
+      console.error(`Simulator automation API never came up on ${API}.\n${simErr}`)
+      process.exit(2)
+    }
+    pass('simulator automation API is up')
+
+    // 2. App booted. Poll before clearing — startup logs are emitted once and
+    //    would be lost.
+    await waitForMessage('[app] bridge ready', 20_000, 'SDK bridge connected')
+    await waitForMessage('[app] page ready', 20_000, 'start-up page container created')
+    await waitForMessage('[bridge] online', 20_000, 'app connected to the omi bridge')
+
+    // The simulator's WebView sometimes reloads itself once shortly after
+    // start-up, which resets the app to its initial view. Let that settle
+    // before touching anything, or every later assertion is measuring a
+    // half-restarted app.
+    let boots = countMessage('[app] bridge ready')
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await sleep(2_500)
+      await drainConsole()
+      const now = countMessage('[app] bridge ready')
+      if (now === boots) break
+      console.log(`  note  simulator reloaded the app (boot ${now}); waiting for it to settle`)
+      boots = now
+    }
+    const bootsAtStart = countMessage('[app] bridge ready')
+    if (countMessage('[app] ready') === bootsAtStart) {
+      pass(`app finished start-up and is stable (boot ${bootsAtStart})`)
+    } else {
+      fail(`app is mid-restart: ${bootsAtStart} boot(s) but ${countMessage('[app] ready')} completed`)
+    }
+
+    // 3. The home list is actually on the display
+    const home = await framebuffer()
+    if (home.width !== 576 || home.height !== 288) {
+      fail(`framebuffer is ${home.width}x${home.height}, expected 576x288`)
+    } else {
+      pass(`framebuffer is ${home.width}x${home.height}`)
+    }
+    if (home.lit > 200) {
+      pass(`home list renders (${home.lit} lit pixels)`)
+    } else {
+      fail(`home list looks blank (only ${home.lit} lit pixels)`)
+    }
+
+    // 4. Scroll moves the selection. The OS list owns its highlight and emits
+    //    no event while scrolling — it only reports the row on the click that
+    //    follows — so the move is asserted on the framebuffer, and the row it
+    //    landed on is asserted from the click below.
+    await input('down')
+    await sleep(500)
+    const afterScroll = await framebuffer()
+    if (afterScroll.hash !== home.hash) {
+      pass(`scroll down moves the home highlight (${home.hash} -> ${afterScroll.hash})`)
+    } else {
+      fail(`scroll down left the display byte-identical (${home.hash}) — the highlight did not move`)
+    }
+
+    // 5. Tap opens the view it moved to, and its data loads
+    await input('click')
+    await sleep(400)
+    await waitForMessage('[app] home index=1 (Memories)', 8_000, 'the tapped row is "Memories" (row 1)')
+    await waitForMessage('[app] view=memories', 8_000, 'tap opens the Memories view')
+    await waitForMessage('[app] memories loaded', 8_000, 'memories arrive from the bridge')
+    const memories = await framebuffer()
+    if (memories.lit > 200) {
+      pass(`memories view renders (${memories.lit} lit pixels)`)
+    } else {
+      fail(`memories view looks blank (${memories.lit} lit pixels)`)
+    }
+    if (memories.hash !== afterScroll.hash) {
+      pass('display changed between home and memories')
+    } else {
+      fail(`display is byte-identical to home (${memories.hash}) — the view never redrew`)
+    }
+
+    // 6. Double-tap returns
+    let since = await mark()
+    await input('double_click')
+    await sleep(600)
+    await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap returns to home')
+    const backHome = await framebuffer()
+    if (backHome.hash === home.hash) {
+      pass('home is restored with the highlight back on row 0')
+    } else {
+      fail(`home came back different from how it started (${home.hash} -> ${backHome.hash})`)
+    }
+
+    // 7. Chat: tap row 0 and watch the answer stream in
+    since = await mark()
+    const layoutsBefore = seen.filter((e) => (e.message ?? '').includes('[app] layout=detail')).length
+    await input('click')
+    await sleep(400)
+    await waitForMessageSince(since, '[app] home index=0 (Ask Omi)', 8_000, 'the tapped row is "Ask Omi" (row 0)')
+    await waitForMessageSince(since, '[app] view=chat', 8_000, 'tap opens the chat view')
+    await waitForMessageSince(since, '[app] chat delta', 10_000, 'chat answer streams in')
+    await waitForMessageSince(since, '[app] rendered chat body', 10_000, 'streaming repaints the chat body')
+    await waitForMessageSince(since, '[app] chat done', 20_000, 'chat stream completes')
+
+    const chat = await framebuffer()
+    if (chat.lit > 200) {
+      pass(`chat view renders the answer (${chat.lit} lit pixels)`)
+    } else {
+      fail(`chat view looks blank (${chat.lit} lit pixels)`)
+    }
+
+    // The streaming repaints must be in-place `textContainerUpgrade` calls, not
+    // page rebuilds: exactly one rebuild for entering the view, and no more.
+    const layoutsAfter = seen.filter((e) => (e.message ?? '').includes('[app] layout=detail')).length
+    const repaints = seen.slice(since).filter((e) => (e.message ?? '').includes('[app] rendered chat body')).length
+    if (layoutsAfter - layoutsBefore === 1 && repaints > 1) {
+      pass(`answer streamed with ${repaints} in-place updates and 1 page rebuild`)
+    } else {
+      fail(`expected 1 rebuild and >1 in-place update, got ${layoutsAfter - layoutsBefore} and ${repaints}`)
+    }
+
+    // 8. The answer is longer than one page, so scrolling must page it
+    const pageLine = seen
+      .map((e) => e.message ?? '')
+      .reverse()
+      .find((m) => m.includes('[app] chat done ('))
+    const pageCount = Number(/(\d+) page\(s\)/.exec(pageLine ?? '')?.[1] ?? 0)
+    if (pageCount > 1) {
+      pass(`answer paginated into ${pageCount} pages`)
+      since = await mark()
+      await input('up')
+      await sleep(600)
+      await waitForMessageSince(since, '[app] page=1/', 5_000, 'scroll up pages back through the answer')
+    } else {
+      fail(`answer did not paginate (${pageCount} page) — cannot exercise paging`)
+    }
+
+    // 9. A server push renders as a banner
+    since = await mark()
+    const pushed = await fetch(`${BRIDGE_HTTP}/control/push`, { method: 'POST', body: 'Standup starts in 5 minutes' })
+    if (!pushed.ok) throw new Error(`push control -> ${pushed.status}`)
+    await waitForMessageSince(since, '[app] push banner: Standup starts in 5 minutes', 8_000, 'server push renders as a banner')
+
+    // 10. Back home
+    since = await mark()
+    await input('double_click')
+    await sleep(600)
+    await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap from chat returns to home')
+
+    // 11. The remaining menu rows. Returning home puts the highlight back on
+    //     row 0 (asserted above), so N scrolls lands on row N.
+    since = await openRow(2, 'Action items')
+    await waitForMessageSince(since, '[app] view=actions', 8_000, 'tap opens the Action items view')
+    await waitForMessageSince(since, '[app] action items loaded', 8_000, 'action items arrive from the bridge')
+
+    since = await mark()
+    await input('double_click')
+    await sleep(600)
+    await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap returns from Action items')
+
+    since = await openRow(3, 'Today')
+    await waitForMessageSince(since, '[app] view=today', 8_000, 'tap opens the Today view')
+    await waitForMessageSince(since, '[app] today loaded', 8_000, "today's summary arrives from the bridge")
+
+    since = await mark()
+    await input('double_click')
+    await sleep(600)
+    await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap returns from Today')
+
+    // 12. Capture toggles the glasses mic and relabels its own row in place.
+    const beforeToggle = await framebuffer()
+    since = await openRow(4, 'Capture: off')
+    await waitForMessageSince(since, '[app] capture=on', 8_000, 'tap turns glasses capture on')
+    await sleep(800)
+    const afterToggle = await framebuffer()
+    if (afterToggle.hash !== beforeToggle.hash) {
+      pass('the Capture row relabels itself on the display')
+    } else {
+      fail(`menu is byte-identical after the toggle (${beforeToggle.hash}) — the label never changed`)
+    }
+
+    // 13. Bridge offline is visible, not a hang: drop the bridge and check the
+    //     app notices and starts retrying.
+    since = await mark()
+    bridgeProc.kill('SIGTERM')
+    await waitForMessageSince(since, '[bridge] offline', 10_000, 'app detects the bridge going away')
+    await waitForMessageSince(since, '[bridge] connecting to', 12_000, 'app retries the bridge with backoff')
+
+    // A reload mid-run resets app state, so earlier failures would be fallout
+    // from that rather than real defects. Call it out on its own line.
+    await drainConsole()
+    if (countMessage('[app] bridge ready') === bootsAtStart) {
+      pass('app never reloaded mid-run')
+    } else {
+      fail(
+        `app reloaded ${countMessage('[app] bridge ready') - bootsAtStart} time(s) mid-run — ` +
+          `any failure above may be fallout from the reset`,
+      )
+    }
+
+    const bad = seen.filter((e) => {
+      const m = e.message ?? ''
+      return m.startsWith('[uncaught]') || m.startsWith('[unhandledrejection]') || e.level === 'error'
+    })
+    if (bad.length === 0) {
+      pass('no uncaught errors or failed fetches')
+    } else {
+      fail(`${bad.length} error entr${bad.length === 1 ? 'y' : 'ies'}:`)
+      for (const e of bad.slice(0, 10)) console.log(`          [${e.level}] ${e.message}`)
+    }
+
+    if (DUMP) {
+      console.log('\n--- console dump ---')
+      for (const e of seen) console.log(`  [${e.level}] ${e.message}`)
+      console.log('--- mock bridge ---')
+      console.log(bridgeLog.trim())
+    }
+  } finally {
+    cleanup()
+  }
+
+  console.log(failures === 0 ? `\nAll checks passed.\n` : `\n${failures} check${failures === 1 ? '' : 's'} failed.\n`)
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main().catch((e) => {
+  console.error(`\nVerification crashed: ${e.stack ?? e}`)
+  process.exit(2)
+})

--- a/integrations/omi-even/app/scripts/verify-simulator.mjs
+++ b/integrations/omi-even/app/scripts/verify-simulator.mjs
@@ -15,12 +15,24 @@
  *   5. scroll moves the home selection
  *   6. tap opens a view and its data loads
  *   7. double-tap returns home
- *   8. a chat answer streams in and repaints the body in place, not by rebuild
- *   9. paging works inside a multi-page answer
- *  10. a server push renders as a banner
- *  11. every menu row opens: Memories, Action items, Today, Capture
- *  12. losing the bridge shows up as offline and starts a retry
- *  13. the app never reloaded mid-run, and nothing threw
+ *   8. tapping "Ask Omi" opens the microphone, says so on the display, and
+ *      streams real PCM to the bridge
+ *   9. tapping again stops the microphone, shows the transcript, then the
+ *      answer — repainted in place rather than by rebuilding the page
+ *  10. paging works inside a multi-page answer
+ *  11. double-tap while listening cancels: microphone off, answer discarded
+ *  12. the recording cap auto-stops, and an empty transcript says so instead of
+ *      asking Omi an empty question
+ *  13. a server push renders as a banner
+ *  14. every menu row opens: Memories, Action items, Today, Capture, Suggestions
+ *  15. microphone frames outside an ask are never forwarded to the bridge
+ *  16. every path out of listening turned the microphone back off
+ *  17. losing the bridge shows up as offline and starts a retry
+ *  18. the app never reloaded mid-run, and nothing threw
+ *
+ * The simulator emits real `audioEvent`s from the host machine's microphone
+ * (16 kHz PCM16 LE, 100 ms per event), so the audio path is exercised for real
+ * rather than faked — a quiet room still produces frames.
  *
  * Usage: npm run dev   (separate terminal)
  *        npm run verify
@@ -42,9 +54,16 @@ const AUTOMATION_PORT = Number(process.env.AUTOMATION_PORT ?? 9899)
 const BRIDGE_PORT = Number(process.env.BRIDGE_PORT ?? 18765)
 const API = `http://127.0.0.1:${AUTOMATION_PORT}`
 const BRIDGE_HTTP = `http://127.0.0.1:${BRIDGE_PORT}`
+/** Recording cap for this run. The shipped default is 20s; the app reads
+ *  `?askmax=` so the auto-stop can be exercised in seconds instead.
+ *
+ *  Not shorter than this: draining the simulator console while the microphone
+ *  is live means transferring the SDK's per-frame audio log, which is slow
+ *  enough that a tight cap fires in the middle of the manual-stop test. */
+const ASK_MAX_MS = Number(process.env.ASK_MAX_MS ?? 12_000)
 // The app reads its bridge endpoint from `?bridge=`, so the test drives a
 // throwaway port instead of whatever the developer has running on the default.
-const APP_URL = `${DEV_URL}/?bridge=ws://127.0.0.1:${BRIDGE_PORT}/app`
+const APP_URL = `${DEV_URL}/?bridge=ws://127.0.0.1:${BRIDGE_PORT}/app&askmax=${ASK_MAX_MS}`
 
 const DUMP = process.argv.includes('--dump')
 
@@ -207,13 +226,31 @@ function portInUse(port) {
   })
 }
 
-/** All console text seen so far, accumulated across polls. */
+/** Counters and mode switch on the mock bridge, so the test can assert what
+ *  actually arrived over the socket rather than only what the app claims. */
+async function bridgeHealth() {
+  const r = await fetch(`${BRIDGE_HTTP}/control/health`)
+  if (!r.ok) throw new Error(`bridge health ${r.status}`)
+  return r.json()
+}
+
+async function setAskMode(mode) {
+  const r = await fetch(`${BRIDGE_HTTP}/control/ask-mode`, { method: 'POST', body: mode })
+  if (!r.ok) throw new Error(`ask-mode ${mode} -> ${r.status}`)
+}
+
+/** All console text seen so far, accumulated across polls.
+ *
+ *  Messages are truncated on the way in: the SDK logs every `audioEvent` with
+ *  its whole PCM payload expanded, which is ~36 KB per 100 ms frame, and this
+ *  run records several thousand of them. Nothing asserted here lives past
+ *  column 400. */
 const seen = []
 let lastId = -1
 async function drainConsole() {
   const entries = lastId < 0 ? await console_() : await console_(lastId)
   for (const e of entries) {
-    seen.push(e)
+    seen.push({ ...e, message: (e.message ?? '').slice(0, 400) })
     if (e.id > lastId) lastId = e.id
   }
   return entries
@@ -476,16 +513,88 @@ async function main() {
       fail(`home came back different from how it started (${home.hash} -> ${backHome.hash})`)
     }
 
-    // 7. Chat: tap row 0 and watch the answer stream in
+    // 7. Ask Omi: tap row 0, dictate, tap again, watch the answer stream in.
+    //    The simulator feeds the host machine's microphone through the same
+    //    `audioEvent` channel the glasses use, so this is the real path.
     since = await mark()
     const layoutsBefore = seen.filter((e) => (e.message ?? '').includes('[app] layout=detail')).length
+    const beforeAsk = await bridgeHealth()
     await input('click')
     await sleep(400)
-    await waitForMessageSince(since, '[app] home index=0 (Ask Omi)', 8_000, 'the tapped row is "Ask Omi" (row 0)')
+    // Row 0 is already selected, so there is no index *change* to log — the
+    // selection is asserted from what the tap opened instead.
+    await waitForMessageSince(since, '[app] select chat', 8_000, 'the tapped row is "Ask Omi" (row 0)')
     await waitForMessageSince(since, '[app] view=chat', 8_000, 'tap opens the chat view')
-    await waitForMessageSince(since, '[app] chat delta', 10_000, 'chat answer streams in')
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(true, glasses) ok - mic=on',
+      8_000,
+      'tapping Ask Omi opens the glasses microphone',
+    )
+    await waitForMessageSince(since, '[app] body head: Listening...', 8_000, 'the display says it is listening')
+    await waitForMessageSince(since, '[app] listening (cap ', 8_000, 'the recording cap is armed')
+
+    {
+      const health = await bridgeHealth()
+      if (health.askStarts === beforeAsk.askStarts + 1) {
+        pass('the bridge received ask_start')
+      } else {
+        fail(`bridge saw ${health.askStarts - beforeAsk.askStarts} ask_start(s), expected 1`)
+      }
+    }
+
+    // Let a second of audio flow, then prove the bytes really arrived.
+    await sleep(1_000)
+    {
+      const health = await bridgeHealth()
+      const bytes = health.askBytes - beforeAsk.askBytes
+      if (bytes > 0) {
+        pass(`microphone PCM reaches the bridge (${health.askFrames - beforeAsk.askFrames} frames, ${bytes} bytes)`)
+      } else {
+        fail('no PCM reached the bridge while listening — the audio path is dead')
+      }
+      if (health.captureBytes === 0) {
+        pass('no PCM escaped the ask_start/ask_stop bracket')
+      } else {
+        fail(`${health.captureBytes} bytes arrived outside an ask — the bridge would file them as capture audio`)
+      }
+    }
+
+    // Tap again: microphone off, question sent, transcript back, then answer.
+    since = await mark()
+    await input('click')
+    await sleep(300)
+    await waitForMessageSince(since, '[app] body head: Thinking...', 8_000, 'tapping again shows "Thinking..."')
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(false) ok - mic=off',
+      8_000,
+      'tapping again closes the microphone',
+    )
+    await waitForMessageSince(since, '[app] stopped listening (tap', 8_000, 'the recorder stopped on the tap')
+    {
+      const health = await bridgeHealth()
+      if (health.askStops === beforeAsk.askStops + 1) {
+        pass(`the bridge received ask_stop (${health.lastAskBytes} bytes of question)`)
+      } else {
+        fail(`bridge saw ${health.askStops - beforeAsk.askStops} ask_stop(s), expected 1`)
+      }
+    }
+    await waitForMessageSince(
+      since,
+      '[app] transcript: What should I work on next?',
+      15_000,
+      'the transcript comes back from the bridge',
+    )
+    await waitForMessageSince(
+      since,
+      '[app] body head: Q: What should I work on next?',
+      8_000,
+      'the transcript is shown, so a misheard question is visible',
+    )
+    await waitForMessageSince(since, '[app] chat delta', 10_000, 'the answer streams in')
     await waitForMessageSince(since, '[app] rendered chat body', 10_000, 'streaming repaints the chat body')
-    await waitForMessageSince(since, '[app] chat done', 20_000, 'chat stream completes')
+    await waitForMessageSince(since, '[app] chat done', 20_000, 'the answer completes')
 
     const chat = await framebuffer()
     if (chat.lit > 200) {
@@ -532,7 +641,89 @@ async function main() {
     await sleep(600)
     await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap from chat returns to home')
 
-    // 11. The remaining menu rows. Returning home puts the highlight back on
+    // 11. Double-tap while listening cancels: microphone off, question thrown
+    //     away, and the answer the bridge produces anyway must not surface.
+    since = await mark()
+    await input('click')
+    await sleep(300)
+    await waitForMessageSince(since, '[app] body head: Listening...', 10_000, 'Ask Omi listens again')
+    await sleep(900)
+    since = await mark()
+    await input('double_click')
+    await sleep(400)
+    await waitForMessageSince(since, '[app] stopped listening (cancel', 8_000, 'double-tap stops the recording')
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(false) ok - mic=off',
+      8_000,
+      'cancelling closes the microphone',
+    )
+    await waitForMessageSince(since, '[app] ask cancelled', 8_000, 'the cancel is logged as a cancel')
+    await waitForMessageSince(since, '[app] view=home', 8_000, 'cancelling returns to home')
+    await waitForMessageSince(
+      since,
+      '[app] discarded a cancelled ask response',
+      20_000,
+      'the answer to the cancelled question is discarded',
+    )
+
+    // 12. The recording cap auto-stops a forgotten session, and a transcript
+    //     the bridge could not make out says so instead of asking Omi nothing.
+    await setAskMode('empty')
+    since = await mark()
+    await input('click')
+    await sleep(300)
+    await waitForMessageSince(since, '[app] body head: Listening...', 10_000, 'Ask Omi listens for the cap test')
+    await waitForMessageSince(
+      since,
+      '[app] listening cap reached',
+      ASK_MAX_MS + 10_000,
+      `the ${Math.round(ASK_MAX_MS / 1000)}s cap fires on its own`,
+    )
+    await waitForMessageSince(since, '[app] stopped listening (cap', 8_000, 'the cap stops the recording')
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(false) ok - mic=off',
+      8_000,
+      'the cap closes the microphone',
+    )
+    await waitForMessageSince(
+      since,
+      "[app] ask error: Didn't catch that. Tap to retry.",
+      15_000,
+      'an unusable recording reports back instead of asking an empty question',
+    )
+    await waitForMessageSince(
+      since,
+      "[app] body head: Didn't catch that. Tap to retry.",
+      8_000,
+      'the retry prompt is on the display',
+    )
+
+    // Tapping from the error state must start listening again, not sit there.
+    await setAskMode('transcript')
+    since = await mark()
+    await input('click')
+    await sleep(300)
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(true, glasses) ok - mic=on',
+      10_000,
+      'tapping the retry prompt reopens the microphone',
+    )
+    await sleep(600)
+    since = await mark()
+    await input('double_click')
+    await sleep(400)
+    await waitForMessageSince(since, '[app] view=home', 10_000, 'cancelling the retry returns to home')
+    await waitForMessageSince(
+      since,
+      '[app] discarded a cancelled ask response',
+      20_000,
+      'the retry answer is discarded too',
+    )
+
+    // 13. The remaining menu rows. Returning home puts the highlight back on
     //     row 0 (asserted above), so N scrolls lands on row N.
     since = await openRow(2, 'Action items')
     await waitForMessageSince(since, '[app] view=actions', 8_000, 'tap opens the Action items view')
@@ -552,19 +743,91 @@ async function main() {
     await sleep(600)
     await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap returns from Today')
 
-    // 12. Capture toggles the glasses mic and relabels its own row in place.
+    // 14. Capture toggles the glasses mic and relabels its own row in place.
+    //     The microphone is live but no ask is open, so those frames must go
+    //     nowhere: to the bridge, an unbracketed binary frame is capture audio
+    //     headed for a conversation.
+    const captureBytesBefore = (await bridgeHealth()).captureBytes
     const beforeToggle = await framebuffer()
     since = await openRow(4, 'Capture: off')
     await waitForMessageSince(since, '[app] capture=on', 8_000, 'tap turns glasses capture on')
-    await sleep(800)
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(true, glasses) ok - mic=on',
+      8_000,
+      'Capture opens the microphone',
+    )
+    await sleep(1_500)
     const afterToggle = await framebuffer()
     if (afterToggle.hash !== beforeToggle.hash) {
       pass('the Capture row relabels itself on the display')
     } else {
       fail(`menu is byte-identical after the toggle (${beforeToggle.hash}) — the label never changed`)
     }
+    {
+      const health = await bridgeHealth()
+      if (health.captureBytes === captureBytesBefore) {
+        pass('a live microphone outside an ask sends nothing to the bridge')
+      } else {
+        fail(`${health.captureBytes - captureBytesBefore} bytes leaked to the bridge while only Capture was on`)
+      }
+    }
 
-    // 13. Bridge offline is visible, not a hang: drop the bridge and check the
+    // Toggle it back off — the microphone must not outlive the run.
+    since = await openRow(4, 'Capture: on')
+    await waitForMessageSince(since, '[app] capture=off', 8_000, 'tap turns glasses capture back off')
+    await waitForMessageSince(
+      since,
+      '[app] audioControl(false) ok - mic=off',
+      8_000,
+      'turning Capture off closes the microphone',
+    )
+
+    // 15. Suggestions still works: the canned ring is the fallback for when
+    //     dictating is not an option.
+    since = await openRow(5, 'Suggestions')
+    await waitForMessageSince(since, '[app] view=chat', 8_000, 'tap opens the Suggestions view')
+    await waitForMessageSince(
+      since,
+      '[app] asked: What should I focus on right now?',
+      8_000,
+      'the first canned question is asked',
+    )
+    await waitForMessageSince(since, '[app] chat done', 20_000, 'the canned answer streams in')
+
+    since = await mark()
+    await input('click')
+    await sleep(400)
+    await waitForMessageSince(
+      since,
+      '[app] asked: Summarise my last conversation.',
+      10_000,
+      'tap moves to the next canned question',
+    )
+    await waitForMessageSince(since, '[app] chat done', 20_000, 'the next canned answer streams in')
+
+    since = await mark()
+    await input('double_click')
+    await sleep(600)
+    await waitForMessageSince(since, '[app] view=home', 8_000, 'double-tap returns from Suggestions')
+
+    // 16. Nothing left the microphone on. Every `audioControl(true)` in the run
+    //     has to be matched by an `audioControl(false)`, and the last call must
+    //     be the one that turned it off.
+    await drainConsole()
+    const micOn = countMessage('[app] audioControl(true, glasses)')
+    const micOff = countMessage('[app] audioControl(false)')
+    const lastMic = seen
+      .map((e) => e.message ?? '')
+      .filter((m) => m.includes('[app] audioControl('))
+      .pop()
+    if (micOn > 0 && micOn === micOff && (lastMic ?? '').includes('mic=off')) {
+      pass(`microphone balanced: ${micOn} on, ${micOff} off, and off last`)
+    } else {
+      fail(`microphone left on: ${micOn} audioControl(true), ${micOff} audioControl(false), last was "${lastMic}"`)
+    }
+
+    // 17. Bridge offline is visible, not a hang: drop the bridge and check the
     //     app notices and starts retrying.
     since = await mark()
     bridgeProc.kill('SIGTERM')
@@ -596,7 +859,12 @@ async function main() {
 
     if (DUMP) {
       console.log('\n--- console dump ---')
-      for (const e of seen) console.log(`  [${e.level}] ${e.message}`)
+      // Skipping the SDK's per-frame audio log: it fires 10 times a second
+      // while listening and would bury everything else.
+      for (const e of seen) {
+        if (e.message.startsWith('[EvenAppBridge] EvenHub event:') && e.message.includes('audioEvent')) continue
+        console.log(`  [${e.level}] ${e.message}`)
+      }
       console.log('--- mock bridge ---')
       console.log(bridgeLog.trim())
     }

--- a/integrations/omi-even/app/src/ask-recorder.ts
+++ b/integrations/omi-even/app/src/ask-recorder.ts
@@ -1,0 +1,215 @@
+/** One dictated question: microphone on, PCM to the bridge, microphone off.
+ *
+ *  Split out of `main.ts` because this is the part with the teeth in it. The
+ *  microphone is real hardware on the user's face: every path out of listening
+ *  — tap, cancel, cap, error, bridge loss, page unload — has to turn it off,
+ *  and every binary frame has to sit strictly between `ask_start` and
+ *  `ask_stop` or the bridge files it as continuous-capture audio instead.
+ *
+ *  Nothing here touches the SDK or the display directly, so the whole lifecycle
+ *  is exercised in `scripts/unit-test.mjs` with fakes.
+ */
+import { peakLevel, toPcmBytes } from './audio.ts'
+import { ASK_TICK_MS, askMaxMs } from './config.ts'
+import type { OutboundMessage } from './protocol.ts'
+
+/** Why a listening session ended. Only `tap` and `cap` want an answer back. */
+export type StopReason = 'tap' | 'cap' | 'cancel' | 'teardown'
+
+export type StartFailure = 'offline' | 'mic'
+
+export type AskDeps = {
+  /** Send one JSON control frame. False means the socket is not open. */
+  sendJson: (message: OutboundMessage) => boolean
+  /** Send one binary PCM frame. False means dropped (closed or backed up). */
+  sendBinary: (pcm: Uint8Array) => boolean
+  /** Turn the glasses microphone on or off. False means the call failed. */
+  setMic: (on: boolean) => Promise<boolean>
+  /** Redraw request: the meter, the timer, or the phase changed. */
+  onUpdate: () => void
+  /** The hard cap expired. The caller runs its normal stop path from here so
+   *  an auto-stop and a tap-stop cannot drift apart. */
+  onCap: () => void
+  /** Overrides, for tests. */
+  maxMs?: number
+  tickMs?: number
+  now?: () => number
+}
+
+export class AskRecorder {
+  private readonly deps: AskDeps
+  private readonly maxMs: number
+  private readonly tickMs: number
+  private readonly now: () => number
+
+  private listening = false
+  private startedAt = 0
+  private capTimer: ReturnType<typeof setTimeout> | null = null
+  private ticker: ReturnType<typeof setInterval> | null = null
+
+  /** Peak of the frames seen since the last tick, so the meter tracks the
+   *  voice rather than sitting at whatever the loudest sample ever was. */
+  private windowPeak = 0
+  private displayLevel = 0
+
+  bytesSent = 0
+  framesSent = 0
+  framesDropped = 0
+  /** Frames that arrived while not listening. Expected — the microphone keeps
+   *  running when Capture is on — but a nonzero count outside that case means
+   *  the bracket leaked. */
+  framesIgnored = 0
+
+  constructor(deps: AskDeps) {
+    this.deps = deps
+    this.maxMs = deps.maxMs ?? askMaxMs()
+    this.tickMs = deps.tickMs ?? ASK_TICK_MS
+    this.now = deps.now ?? (() => Date.now())
+  }
+
+  isListening(): boolean {
+    return this.listening
+  }
+
+  elapsedMs(): number {
+    return this.listening ? this.now() - this.startedAt : 0
+  }
+
+  remainingMs(): number {
+    return Math.max(0, this.maxMs - this.elapsedMs())
+  }
+
+  capMs(): number {
+    return this.maxMs
+  }
+
+  level(): number {
+    return this.displayLevel
+  }
+
+  /**
+   * Open the bracket, then the microphone. That order matters: a microphone
+   * with nowhere to send is the one state that costs the user battery for
+   * nothing, so the socket is proven first and the mic is only opened once
+   * `ask_start` is actually on the wire.
+   */
+  async start(): Promise<{ ok: true } | { ok: false; reason: StartFailure }> {
+    if (this.listening) return { ok: true }
+
+    this.bytesSent = 0
+    this.framesSent = 0
+    this.framesDropped = 0
+    this.windowPeak = 0
+    this.displayLevel = 0
+
+    if (!this.deps.sendJson({ type: 'ask_start' })) {
+      console.warn('[app] ask start aborted: bridge offline')
+      return { ok: false, reason: 'offline' }
+    }
+
+    if (!(await this.deps.setMic(true))) {
+      // Close the bracket we just opened, or the bridge stays in ask mode and
+      // files the next continuous-capture frame as part of a question.
+      this.deps.sendJson({ type: 'ask_stop' })
+      return { ok: false, reason: 'mic' }
+    }
+
+    this.listening = true
+    this.startedAt = this.now()
+    console.log(`[app] listening (cap ${Math.round(this.maxMs / 1000)}s)`)
+
+    this.capTimer = setTimeout(() => {
+      this.capTimer = null
+      console.log('[app] listening cap reached')
+      this.deps.onCap()
+    }, this.maxMs)
+
+    this.ticker = setInterval(() => this.tick(), this.tickMs)
+    return { ok: true }
+  }
+
+  /**
+   * Close the bracket. Always sends `ask_stop`, even on a cancel: the bridge
+   * has a buffer open and only `ask_stop` releases it. The caller discards the
+   * response instead.
+   *
+   * Returns whether `ask_stop` actually reached the socket — false means the
+   * bridge never heard the question, so no answer is owed and none is coming.
+   */
+  async stop(reason: StopReason): Promise<boolean> {
+    if (!this.listening) return false
+    // Cleared first so frames still in flight from the last 100ms are dropped
+    // rather than escaping past `ask_stop`.
+    this.listening = false
+    this.clearTimers()
+
+    const seconds = ((this.now() - this.startedAt) / 1000).toFixed(1)
+    // The microphone comes first: if `ask_stop` fails to send, the hardware is
+    // still off, which is the failure that actually costs the user something.
+    const micOff = await this.deps.setMic(false)
+    if (!micOff) console.error('[app] microphone may still be on after stop')
+    const asked = this.deps.sendJson({ type: 'ask_stop' })
+    console.log(
+      `[app] stopped listening (${reason}, ${seconds}s, ${this.framesSent} frame(s), ${this.bytesSent} bytes` +
+        `${this.framesDropped > 0 ? `, ${this.framesDropped} dropped` : ''})`,
+    )
+    return asked
+  }
+
+  /**
+   * One `audioEvent` payload. Called for every frame the host delivers,
+   * including while Capture holds the microphone open with no question being
+   * asked — those are counted and dropped, never sent, because an unbracketed
+   * binary frame means "continuous capture" to the bridge.
+   */
+  feed(raw: unknown): void {
+    if (!this.listening) {
+      this.framesIgnored++
+      return
+    }
+    const pcm = toPcmBytes(raw)
+    if (!pcm) {
+      this.framesDropped++
+      return
+    }
+    const peak = peakLevel(pcm)
+    if (peak > this.windowPeak) this.windowPeak = peak
+
+    if (this.deps.sendBinary(pcm)) {
+      this.bytesSent += pcm.length
+      this.framesSent++
+    } else {
+      this.framesDropped++
+    }
+  }
+
+  /** Last-ditch stop for unload/teardown, where nothing can be awaited. */
+  teardown(): void {
+    if (!this.listening) return
+    this.listening = false
+    this.clearTimers()
+    void this.deps.setMic(false)
+    this.deps.sendJson({ type: 'ask_stop' })
+    console.log('[app] listening torn down')
+  }
+
+  private clearTimers(): void {
+    if (this.capTimer !== null) clearTimeout(this.capTimer)
+    if (this.ticker !== null) clearInterval(this.ticker)
+    this.capTimer = null
+    this.ticker = null
+  }
+
+  private tick(): void {
+    // Decay rather than snap to zero, so a gap between words does not read as
+    // "the microphone died".
+    this.displayLevel = Math.max(this.windowPeak, this.displayLevel * 0.6)
+    this.windowPeak = 0
+    // Two lines a second while listening, and never otherwise: enough to prove
+    // from a log that audio really moved, without drowning the console.
+    console.log(
+      `[app] audio ${this.framesSent} frame(s), ${this.bytesSent} bytes, level=${this.displayLevel.toFixed(2)}`,
+    )
+    this.deps.onUpdate()
+  }
+}

--- a/integrations/omi-even/app/src/audio.ts
+++ b/integrations/omi-even/app/src/audio.ts
@@ -1,0 +1,99 @@
+/** Glasses microphone PCM: normalising it, and describing it on a monochrome
+ *  display.
+ *
+ *  The G2 mic array is delivered to the plugin as raw PCM16 LE / 16 kHz / mono
+ *  on `event.audioEvent.audioPcm` — which is exactly the format the omi bridge
+ *  wants, so the bytes go out over the socket untouched. Everything here is
+ *  about the two things that are *not* pass-through: getting a real byte array
+ *  out of whatever the host handed us, and turning it into something the user
+ *  can look at to know the microphone is live.
+ */
+import { ASK_METER_WIDTH } from './config.ts'
+
+const BASE64_ALPHABET = /^[A-Za-z0-9+/=\s]+$/
+
+/**
+ * Coerce one `audioPcm` payload into bytes.
+ *
+ * The SDK types this as `Uint8Array`, and that is what arrives in the
+ * simulator. The host is a Flutter app sending a `Uint8List` through a JSON
+ * channel though, so `AudioEvent.fromJson` has to cope with `number[]` and
+ * base64 too — and the SDK's own doc comment says as much. Normalising here
+ * rather than trusting the declared type means a host that picks a different
+ * encoding degrades to "works" instead of "streams garbage to the bridge".
+ *
+ * Returns null for anything that is not audio, so callers can drop the frame.
+ */
+export function toPcmBytes(raw: unknown): Uint8Array | null {
+  if (raw instanceof Uint8Array) return raw.length > 0 ? raw : null
+  if (raw instanceof ArrayBuffer) return raw.byteLength > 0 ? new Uint8Array(raw) : null
+  if (ArrayBuffer.isView(raw)) {
+    const view = raw as ArrayBufferView
+    return view.byteLength > 0 ? new Uint8Array(view.buffer, view.byteOffset, view.byteLength) : null
+  }
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return null
+    const out = new Uint8Array(raw.length)
+    for (let i = 0; i < raw.length; i++) {
+      const value = raw[i]
+      if (typeof value !== 'number' || !Number.isFinite(value)) return null
+      out[i] = value & 0xff
+    }
+    return out
+  }
+  if (typeof raw === 'string') {
+    if (raw.length === 0 || !BASE64_ALPHABET.test(raw)) return null
+    try {
+      const binary = atob(raw)
+      const out = new Uint8Array(binary.length)
+      for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+      return out.length > 0 ? out : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+/** Duration of a PCM16 mono buffer at 16 kHz, in seconds. */
+export const SAMPLE_RATE = 16_000
+export function pcmSeconds(bytes: number): number {
+  return bytes / (SAMPLE_RATE * 2)
+}
+
+/**
+ * Loudest sample in the buffer, 0..1. Read as int16 little-endian — the same
+ * interpretation the bridge applies, so a meter that moves is real evidence the
+ * bytes on the wire are speech and not silence or a byte-order mistake.
+ */
+export function peakLevel(pcm: Uint8Array): number {
+  let peak = 0
+  // Odd trailing byte cannot form a sample; the SDK always sends whole frames.
+  for (let i = 0; i + 1 < pcm.length; i += 2) {
+    let sample = pcm[i] | (pcm[i + 1] << 8)
+    if (sample >= 0x8000) sample -= 0x10000
+    const magnitude = sample < 0 ? -sample : sample
+    if (magnitude > peak) peak = magnitude
+  }
+  return Math.min(1, peak / 32_768)
+}
+
+/**
+ * ASCII level meter. The display is monochrome and 576px wide, so a row of
+ * `#` is both the cheapest thing to draw and the least ambiguous: if it moves,
+ * the microphone is live.
+ *
+ * Scaled with a square root because speech spends most of its time well below
+ * full scale and a linear bar barely leaves the first block.
+ */
+export function meterBar(level: number, width: number = ASK_METER_WIDTH): string {
+  const clamped = Math.max(0, Math.min(1, level))
+  const filled = Math.round(Math.sqrt(clamped) * width)
+  return `[${'#'.repeat(filled)}${'-'.repeat(width - filled)}]`
+}
+
+/** `m:ss`, for the recording timer. */
+export function clock(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`
+}

--- a/integrations/omi-even/app/src/background-state.ts
+++ b/integrations/omi-even/app/src/background-state.ts
@@ -1,0 +1,85 @@
+/** Background state persistence.
+ *
+ *  When the phone goes to the background the Even Hub host migrates the plugin
+ *  into a headless WebView: it snapshots JS state with `window.__getStateSnapshot()`,
+ *  reloads the same URL in the headless view, and replays the snapshot through
+ *  `window.__restoreState(json)`. A plugin that registers nothing gets `'{}'`
+ *  back and restarts from its initial state every time the phone is unlocked.
+ *
+ *  `@evenrealities/even_hub_sdk@0.0.12` documents `setBackgroundState` /
+ *  `onBackgroundRestore` but does not actually export them — the symbols are
+ *  absent from both `dist/index.d.ts` and `dist/index.js`, and 0.0.12 is the
+ *  latest published version. This module implements the same two functions
+ *  against the host's documented window hooks, so call sites read exactly as
+ *  they will once the SDK ships them and the import is a one-line swap.
+ */
+
+type Exporter = () => Record<string, unknown>
+type Restorer = (saved: Record<string, unknown>) => void
+
+const exporters = new Map<string, Exporter>()
+const restorers = new Map<string, Restorer>()
+
+type StateHost = {
+  __getStateSnapshot?: () => string
+  __restoreState?: (snapshot: string) => void
+}
+
+/** Register a snapshot producer for `key`. Must return plain JSON — no class
+ *  instances, Maps, Sets or Dates, since the value round-trips through
+ *  `JSON.stringify`. */
+export function setBackgroundState(key: string, exporter: Exporter): void {
+  exporters.set(key, exporter)
+  install()
+}
+
+/** Register the matching restorer for `key`. Runs in the freshly loaded
+ *  WebView, before the plugin has drawn anything. */
+export function onBackgroundRestore(key: string, restorer: Restorer): void {
+  restorers.set(key, restorer)
+  install()
+}
+
+let installed = false
+
+function install(): void {
+  if (installed || typeof window === 'undefined') return
+  installed = true
+  const host = window as unknown as StateHost
+
+  host.__getStateSnapshot = () => {
+    const snapshot: Record<string, unknown> = {}
+    for (const [key, exporter] of exporters) {
+      try {
+        snapshot[key] = exporter()
+      } catch (error) {
+        // One broken exporter must not cost the other keys their snapshot.
+        console.error(`[state] exporter "${key}" threw:`, error)
+      }
+    }
+    return JSON.stringify(snapshot)
+  }
+
+  host.__restoreState = (raw: string) => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch (error) {
+      console.error('[state] snapshot is not valid JSON:', error)
+      return
+    }
+    if (typeof parsed !== 'object' || parsed === null) return
+    const snapshot = parsed as Record<string, unknown>
+
+    for (const [key, restorer] of restorers) {
+      const saved = snapshot[key]
+      if (typeof saved !== 'object' || saved === null) continue
+      try {
+        restorer(saved as Record<string, unknown>)
+        console.log(`[state] restored "${key}"`)
+      } catch (error) {
+        console.error(`[state] restorer "${key}" threw:`, error)
+      }
+    }
+  }
+}

--- a/integrations/omi-even/app/src/bridge-client.ts
+++ b/integrations/omi-even/app/src/bridge-client.ts
@@ -4,7 +4,7 @@
  *  just reflects `status()` on the glasses. A dropped bridge shows up as
  *  "bridge offline" rather than a view that hangs forever.
  */
-import { bridgeUrl } from './config.ts'
+import { ASK_MAX_BUFFERED_BYTES, bridgeUrl } from './config.ts'
 import { frameType, parseInbound } from './protocol.ts'
 import type { InboundMessage, OutboundMessage } from './protocol.ts'
 
@@ -97,6 +97,28 @@ export class BridgeClient {
     }
     this.socket.send(JSON.stringify(message))
     console.log(`[bridge] sent ${message.type}`)
+    return true
+  }
+
+  /**
+   * Send one raw PCM frame. Binary frames are the microphone channel — the
+   * bridge reads them as PCM16 LE / 16 kHz / mono and never as JSON — so this
+   * deliberately does not log per frame: at 10 frames a second the log would
+   * be useless for anything else.
+   *
+   * Returns false when the frame was dropped, either because the socket is
+   * closed or because it is already backed up. Dropping the newest audio beats
+   * queueing without bound: a stalled bridge would otherwise eat memory on the
+   * phone and deliver a question minutes late.
+   */
+  sendBinary(pcm: Uint8Array): boolean {
+    const socket = this.socket
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false
+    if (socket.bufferedAmount > ASK_MAX_BUFFERED_BYTES) {
+      console.warn(`[bridge] dropping audio frame, ${socket.bufferedAmount} bytes still queued`)
+      return false
+    }
+    socket.send(pcm)
     return true
   }
 

--- a/integrations/omi-even/app/src/bridge-client.ts
+++ b/integrations/omi-even/app/src/bridge-client.ts
@@ -1,0 +1,126 @@
+/** WebSocket client for the local omi bridge, with reconnect backoff.
+ *
+ *  The socket is treated as best-effort: the app never awaits a connection, it
+ *  just reflects `status()` on the glasses. A dropped bridge shows up as
+ *  "bridge offline" rather than a view that hangs forever.
+ */
+import { bridgeUrl } from './config.ts'
+import { frameType, parseInbound } from './protocol.ts'
+import type { InboundMessage, OutboundMessage } from './protocol.ts'
+
+export type BridgeStatus = 'connecting' | 'online' | 'offline'
+
+type Listeners = {
+  onMessage: (message: InboundMessage) => void
+  onStatus: (status: BridgeStatus) => void
+}
+
+/** Reconnect delays in ms; the last value repeats forever. */
+const BACKOFF_MS = [500, 1_000, 2_000, 4_000, 8_000]
+
+export class BridgeClient {
+  private socket: WebSocket | null = null
+  private attempt = 0
+  private closed = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private currentStatus: BridgeStatus = 'connecting'
+  private readonly url: string
+  private readonly listeners: Listeners
+
+  constructor(listeners: Listeners) {
+    this.listeners = listeners
+    this.url = bridgeUrl()
+  }
+
+  status(): BridgeStatus {
+    return this.currentStatus
+  }
+
+  endpoint(): string {
+    return this.url
+  }
+
+  connect(): void {
+    if (this.closed) return
+    this.setStatus('connecting')
+    console.log(`[bridge] connecting to ${this.url}`)
+
+    let socket: WebSocket
+    try {
+      socket = new WebSocket(this.url)
+    } catch (error) {
+      // A malformed URL throws synchronously; treat it like any other failure
+      // so the app still boots and shows "bridge offline".
+      console.error('[bridge] could not open socket:', error)
+      this.scheduleReconnect()
+      return
+    }
+    this.socket = socket
+
+    socket.onopen = () => {
+      this.attempt = 0
+      this.setStatus('online')
+      console.log('[bridge] online')
+    }
+
+    socket.onmessage = (event) => {
+      if (typeof event.data !== 'string') return
+      const message = parseInbound(event.data)
+      if (!message) {
+        // Not a warning: the bridge is allowed to speak message types this
+        // build does not implement, and greeting/keepalive frames are normal.
+        console.debug(`[bridge] ignoring frame of type ${frameType(event.data) ?? '(unparseable)'}`)
+        return
+      }
+      this.listeners.onMessage(message)
+    }
+
+    socket.onerror = () => {
+      // `onclose` always follows, so the reconnect is scheduled there and this
+      // handler only exists to stop the error surfacing as unhandled.
+      console.warn('[bridge] socket error')
+    }
+
+    socket.onclose = () => {
+      if (this.socket === socket) this.socket = null
+      console.log('[bridge] offline')
+      this.scheduleReconnect()
+    }
+  }
+
+  /** Returns false when the socket is not open, so callers can render an
+   *  offline state instead of silently dropping the request. */
+  send(message: OutboundMessage): boolean {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      console.warn(`[bridge] send dropped (${this.currentStatus}): ${message.type}`)
+      return false
+    }
+    this.socket.send(JSON.stringify(message))
+    console.log(`[bridge] sent ${message.type}`)
+    return true
+  }
+
+  close(): void {
+    this.closed = true
+    if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer)
+    this.socket?.close()
+    this.socket = null
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed || this.reconnectTimer !== null) return
+    this.setStatus('offline')
+    const delay = BACKOFF_MS[Math.min(this.attempt, BACKOFF_MS.length - 1)]
+    this.attempt++
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.connect()
+    }, delay)
+  }
+
+  private setStatus(status: BridgeStatus): void {
+    if (this.currentStatus === status) return
+    this.currentStatus = status
+    this.listeners.onStatus(status)
+  }
+}

--- a/integrations/omi-even/app/src/config.ts
+++ b/integrations/omi-even/app/src/config.ts
@@ -1,0 +1,63 @@
+/** Where the local omi bridge lives, and the display geometry everything else
+ *  is laid out against. */
+
+/**
+ * Default bridge endpoint. The glasses render through the phone's WebView, so
+ * on real hardware this has to be the LAN IP of the machine running the bridge
+ * — `127.0.0.1` only resolves for the desktop simulator. Override without
+ * rebuilding by appending `?bridge=ws://192.168.1.20:8765/app` to the app URL,
+ * or at build time with `VITE_OMI_BRIDGE_URL`.
+ */
+const DEFAULT_BRIDGE_URL = 'ws://127.0.0.1:8788/app'
+
+/** Resolve the bridge URL: query param > build-time env > default. */
+export function bridgeUrl(): string {
+  try {
+    const fromQuery = new URLSearchParams(window.location.search).get('bridge')
+    if (fromQuery) return fromQuery
+  } catch {
+    /* no window.location in a non-browser host; fall through */
+  }
+  const fromEnv = import.meta.env?.VITE_OMI_BRIDGE_URL
+  return typeof fromEnv === 'string' && fromEnv.length > 0 ? fromEnv : DEFAULT_BRIDGE_URL
+}
+
+/** Full G2 canvas. Nothing may be positioned outside this box. */
+export const CANVAS_WIDTH = 576
+export const CANVAS_HEIGHT = 288
+
+/** The bottom strip is reserved for connection state and push banners, so the
+ *  body gets the rest. */
+export const STATUS_HEIGHT = 48
+export const BODY_HEIGHT = CANVAS_HEIGHT - STATUS_HEIGHT
+
+/** Container IDs are stable across rebuilds so `textContainerUpgrade` keeps
+ *  targeting the same box. ID *and* name must match or the update is dropped
+ *  silently, so both live here. */
+export const HOME_LIST_ID = 1
+export const HOME_LIST_NAME = 'home' // containerName is capped at 16 chars
+export const BODY_ID = 2
+export const BODY_NAME = 'body'
+export const STATUS_ID = 3
+export const STATUS_NAME = 'status'
+
+/**
+ * Characters per body page. The full 576x288 canvas holds roughly 400-500
+ * characters; the body is 240 of those 288 rows, so ~380 leaves a little slack
+ * for a long final word rather than clipping it.
+ */
+export const PAGE_CHARS = 380
+
+/** One line of the status strip, so it never wraps into a second row. */
+export const STATUS_CHARS = 56
+
+/** A flaky BLE hop can leave a bridge call hanging for ~30s. Fail it early so
+ *  the serialized queue keeps moving instead of wedging the whole app. */
+export const BRIDGE_CALL_TIMEOUT_MS = 5_000
+
+/** How long a bridge request may go unanswered before the view shows an error
+ *  instead of an endless spinner. */
+export const REQUEST_TIMEOUT_MS = 20_000
+
+/** How long a push banner stays on screen before the status line reverts. */
+export const BANNER_TTL_MS = 15_000

--- a/integrations/omi-even/app/src/config.ts
+++ b/integrations/omi-even/app/src/config.ts
@@ -10,14 +10,20 @@
  */
 const DEFAULT_BRIDGE_URL = 'ws://127.0.0.1:8788/app'
 
+/** One query parameter off the app URL, or null outside a browser host. */
+function queryParam(name: string): string | null {
+  try {
+    return new URLSearchParams(window.location.search).get(name)
+  } catch {
+    /* no window.location in a non-browser host */
+    return null
+  }
+}
+
 /** Resolve the bridge URL: query param > build-time env > default. */
 export function bridgeUrl(): string {
-  try {
-    const fromQuery = new URLSearchParams(window.location.search).get('bridge')
-    if (fromQuery) return fromQuery
-  } catch {
-    /* no window.location in a non-browser host; fall through */
-  }
+  const fromQuery = queryParam('bridge')
+  if (fromQuery) return fromQuery
   const fromEnv = import.meta.env?.VITE_OMI_BRIDGE_URL
   return typeof fromEnv === 'string' && fromEnv.length > 0 ? fromEnv : DEFAULT_BRIDGE_URL
 }
@@ -61,3 +67,39 @@ export const REQUEST_TIMEOUT_MS = 20_000
 
 /** How long a push banner stays on screen before the status line reverts. */
 export const BANNER_TTL_MS = 15_000
+
+// ------------------------------------------------------------- dictated ask
+
+/**
+ * Hard cap on one dictated question. A forgotten listening session otherwise
+ * holds the glasses microphone open and streams PCM forever, and the bridge
+ * only buffers 30s before it starts dropping audio on the floor.
+ *
+ * Override with `?askmax=1500` (the verify harness does exactly that, so the
+ * auto-stop is exercised in a second rather than in twenty) or at build time
+ * with `VITE_OMI_ASK_MAX_MS`.
+ */
+const ASK_MAX_MS_DEFAULT = 20_000
+
+export function askMaxMs(): number {
+  const fromQuery = Number(queryParam('askmax'))
+  if (Number.isFinite(fromQuery) && fromQuery > 0) return fromQuery
+  const fromEnv = Number(import.meta.env?.VITE_OMI_ASK_MAX_MS)
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv
+  return ASK_MAX_MS_DEFAULT
+}
+
+/** How often the listening screen redraws its timer and level meter. Slow on
+ *  purpose: every tick is a BLE round trip to the glasses. */
+export const ASK_TICK_MS = 500
+
+/** Width of the ASCII level meter drawn while listening. */
+export const ASK_METER_WIDTH = 12
+
+/**
+ * Stop queueing PCM once this much is waiting on the socket. A stalled bridge
+ * would otherwise grow the send buffer without bound — dropping the newest
+ * frames is the only option that keeps the app responsive, and the bridge
+ * transcribes what it got.
+ */
+export const ASK_MAX_BUFFERED_BYTES = 256 * 1024

--- a/integrations/omi-even/app/src/display.ts
+++ b/integrations/omi-even/app/src/display.ts
@@ -1,0 +1,230 @@
+/** Serialized access to the glasses display.
+ *
+ *  Every SDK call goes through one FIFO queue. Two reasons:
+ *   - concurrent bridge calls can crash the BLE connection, so exactly one is
+ *     ever in flight;
+ *   - a flaky hop leaves a call hanging for ~30s, so each one races a 5s
+ *     timeout and the queue keeps moving instead of wedging.
+ *
+ *  A failed call is logged and dropped: the display is not the source of truth,
+ *  the next render redraws whatever the state says.
+ */
+import {
+  CreateStartUpPageContainer,
+  ListContainerProperty,
+  ListItemContainerProperty,
+  RebuildPageContainer,
+  StartUpPageCreateResult,
+  TextContainerProperty,
+  TextContainerUpgrade,
+} from '@evenrealities/even_hub_sdk'
+import type { EvenAppBridge } from '@evenrealities/even_hub_sdk'
+import {
+  BODY_HEIGHT,
+  BODY_ID,
+  BODY_NAME,
+  BRIDGE_CALL_TIMEOUT_MS,
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  HOME_LIST_ID,
+  HOME_LIST_NAME,
+  STATUS_HEIGHT,
+  STATUS_ID,
+  STATUS_NAME,
+} from './config.ts'
+
+/** Tail of the call chain. Every queued call links onto this. */
+let chain: Promise<unknown> = Promise.resolve()
+
+function withTimeout<T>(label: string, task: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${BRIDGE_CALL_TIMEOUT_MS}ms`)), BRIDGE_CALL_TIMEOUT_MS)
+    task().then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+/** Queue one bridge call behind every call already in flight. */
+export function serialize<T>(label: string, task: () => Promise<T>): Promise<T> {
+  const run = chain.then(() => withTimeout(label, task))
+  // Swallow on the *chain* only — the returned promise still rejects, so
+  // callers can react, but one failure never poisons later calls.
+  chain = run.catch(() => undefined)
+  return run
+}
+
+// ------------------------------------------------------------------ builders
+
+/** Bottom strip: connection state, page position, or the latest push banner. */
+function statusContainer(content: string): TextContainerProperty {
+  return new TextContainerProperty({
+    xPosition: 0,
+    yPosition: BODY_HEIGHT,
+    width: CANVAS_WIDTH,
+    height: STATUS_HEIGHT,
+    borderWidth: 0,
+    borderColor: 5,
+    paddingLength: 4,
+    containerID: STATUS_ID,
+    containerName: STATUS_NAME,
+    content,
+    isEventCapture: 0,
+  })
+}
+
+/** Home menu. The OS list owns the highlight; `isItemSelectBorderEn` draws it. */
+function homeListContainer(items: string[]): ListContainerProperty {
+  return new ListContainerProperty({
+    xPosition: 0,
+    yPosition: 0,
+    width: CANVAS_WIDTH,
+    height: BODY_HEIGHT,
+    borderWidth: 0,
+    borderColor: 5,
+    paddingLength: 4,
+    containerID: HOME_LIST_ID,
+    containerName: HOME_LIST_NAME,
+    // Exactly one container per page may capture events, and on the home page
+    // that has to be the list so scroll moves the selection.
+    isEventCapture: 1,
+    itemContainer: new ListItemContainerProperty({
+      itemCount: items.length,
+      itemWidth: CANVAS_WIDTH,
+      isItemSelectBorderEn: 1,
+      itemName: items,
+    }),
+  })
+}
+
+/** Body of a read/chat view: one big text box that owns the touch events. */
+function bodyContainer(content: string): TextContainerProperty {
+  return new TextContainerProperty({
+    xPosition: 0,
+    yPosition: 0,
+    width: CANVAS_WIDTH,
+    height: BODY_HEIGHT,
+    borderWidth: 0,
+    borderColor: 5,
+    paddingLength: 4,
+    containerID: BODY_ID,
+    containerName: BODY_NAME,
+    content,
+    isEventCapture: 1,
+  })
+}
+
+// ------------------------------------------------------------------- surface
+
+export class Display {
+  /** Which layout is currently on the glasses, so `setBody` knows whether the
+   *  body container exists or a rebuild is needed first. */
+  private layout: 'none' | 'home' | 'detail' = 'none'
+  private readonly bridge: EvenAppBridge
+
+  constructor(bridge: EvenAppBridge) {
+    this.bridge = bridge
+  }
+
+  currentLayout(): 'none' | 'home' | 'detail' {
+    return this.layout
+  }
+
+  /**
+   * The one and only `createStartUpPageContainer` call. Called exactly once at
+   * boot with the home layout; every later screen goes through
+   * `rebuildPageContainer`.
+   */
+  async createStartUpPage(items: string[], status: string): Promise<void> {
+    const result = await serialize('createStartUpPageContainer', () =>
+      this.bridge.createStartUpPageContainer(
+        new CreateStartUpPageContainer({
+          containerTotalNum: 2,
+          listObject: [homeListContainer(items)],
+          textObject: [statusContainer(status)],
+        }),
+      ),
+    )
+    this.layout = 'home'
+    if (result === StartUpPageCreateResult.success) {
+      console.log('[app] page ready: created')
+    } else if (result === StartUpPageCreateResult.invalid) {
+      // The host rejects a second create for a page that already exists, which
+      // is exactly what a WebView reload looks like. The containers are still
+      // there and updates still land on them, so this is not a failure — but
+      // `oversize` and `outOfMemory` below genuinely are.
+      console.warn('[app] page ready: reused the containers from before the reload')
+    } else {
+      console.error('[app] createStartUpPageContainer failed:', result)
+    }
+  }
+
+  /** Swap to the home layout. Flickers — list contents cannot update in place. */
+  async showHome(items: string[], status: string): Promise<void> {
+    await serialize('rebuildPageContainer(home)', () =>
+      this.bridge.rebuildPageContainer(
+        new RebuildPageContainer({
+          containerTotalNum: 2,
+          listObject: [homeListContainer(items)],
+          textObject: [statusContainer(status)],
+        }),
+      ),
+    )
+    this.layout = 'home'
+    console.log('[app] layout=home')
+  }
+
+  /** Swap to the text layout. Flickers once; later text goes through `setBody`. */
+  async showDetail(body: string, status: string): Promise<void> {
+    await serialize('rebuildPageContainer(detail)', () =>
+      this.bridge.rebuildPageContainer(
+        new RebuildPageContainer({
+          containerTotalNum: 2,
+          textObject: [bodyContainer(body), statusContainer(status)],
+        }),
+      ),
+    )
+    this.layout = 'detail'
+    console.log('[app] layout=detail')
+  }
+
+  /**
+   * Flicker-free in-place body update — the path streaming chat answers use.
+   * Returns false without doing anything unless the detail layout is on screen,
+   * because the container ID and name must both exist or the host drops the
+   * update without reporting an error.
+   */
+  async setBody(content: string): Promise<boolean> {
+    if (this.layout !== 'detail') return false
+    await serialize('textContainerUpgrade(body)', () =>
+      this.bridge.textContainerUpgrade(
+        new TextContainerUpgrade({ containerID: BODY_ID, containerName: BODY_NAME, content }),
+      ),
+    )
+    return true
+  }
+
+  /** In-place status strip update. Present on every layout. */
+  async setStatus(content: string): Promise<void> {
+    if (this.layout === 'none') return
+    await serialize('textContainerUpgrade(status)', () =>
+      this.bridge.textContainerUpgrade(
+        new TextContainerUpgrade({ containerID: STATUS_ID, containerName: STATUS_NAME, content }),
+      ),
+    )
+  }
+
+  /** Raise the system exit dialog and let the user confirm. */
+  async requestExit(): Promise<void> {
+    await serialize('shutDownPageContainer', () => this.bridge.shutDownPageContainer(1))
+  }
+}
+
+export { CANVAS_HEIGHT, CANVAS_WIDTH }

--- a/integrations/omi-even/app/src/main.ts
+++ b/integrations/omi-even/app/src/main.ts
@@ -1,0 +1,570 @@
+/** omi for Even Realities G2.
+ *
+ *  A five-item home menu on the glasses, backed by a local omi bridge over
+ *  WebSocket. Scroll moves the selection, tap opens, double-tap goes back (and
+ *  exits from home).
+ *
+ *  Everything drawn on the glasses is queued through `Display`, which keeps
+ *  exactly one SDK call in flight — see `display.ts` for why.
+ */
+import { AudioInputSource, OsEventTypeList, waitForEvenAppBridge } from '@evenrealities/even_hub_sdk'
+import type { EvenHubEvent } from '@evenrealities/even_hub_sdk'
+import { onBackgroundRestore, setBackgroundState } from './background-state.ts'
+import { BridgeClient } from './bridge-client.ts'
+import type { BridgeStatus } from './bridge-client.ts'
+import { BANNER_TTL_MS, REQUEST_TIMEOUT_MS, STATUS_CHARS } from './config.ts'
+import { Display, serialize } from './display.ts'
+import { clampPage, paginate } from './paginate.ts'
+import type { ActionItem, InboundMessage, MemoryItem } from './protocol.ts'
+
+// ------------------------------------------------------------------- state
+
+type View = 'home' | 'chat' | 'memories' | 'actions' | 'today'
+/** Views a menu row can open — home is the menu itself, so it is never a target. */
+type MenuTarget = Exclude<View, 'home'> | 'capture'
+
+/** Menu rows, in order. The last row's label depends on `captureOn`. */
+const MENU: Array<{ label: string; view: MenuTarget }> = [
+  { label: 'Ask Omi', view: 'chat' },
+  { label: 'Memories', view: 'memories' },
+  { label: 'Action items', view: 'actions' },
+  { label: 'Today', view: 'today' },
+  { label: 'Capture', view: 'capture' },
+]
+
+/**
+ * The glasses have no keyboard and the bridge protocol carries text, not audio,
+ * so questions come from a fixed ring: tapping in the chat view asks the next
+ * one. Wiring the glasses mic to speech-to-text needs an audio message type the
+ * bridge contract does not define yet.
+ */
+const PROMPTS = [
+  'What should I focus on right now?',
+  'Summarise my last conversation.',
+  'What did I commit to today?',
+  'Anything I am forgetting?',
+]
+
+let view: View = 'home'
+let homeIndex = 0
+let captureOn = false
+/** Paginated body of whichever read/chat view is open. */
+let pages: string[] = ['']
+let pageIndex = 0
+let promptIndex = 0
+let chatQuestion = ''
+let chatAnswer = ''
+let chatStreaming = false
+let chatHistory: Array<{ q: string; a: string }> = []
+let banner = ''
+let bannerAt = 0
+
+// Registered before anything can mutate the variables above, so the host always
+// has a valid snapshot to migrate into the headless WebView.
+setBackgroundState('omi', () => ({
+  view,
+  homeIndex,
+  captureOn,
+  pages: [...pages],
+  pageIndex,
+  promptIndex,
+  chatQuestion,
+  chatAnswer,
+  chatHistory: chatHistory.map((entry) => ({ ...entry })),
+}))
+
+onBackgroundRestore('omi', (saved) => {
+  const s = saved as Partial<{
+    view: View
+    homeIndex: number
+    captureOn: boolean
+    pages: string[]
+    pageIndex: number
+    promptIndex: number
+    chatQuestion: string
+    chatAnswer: string
+    chatHistory: Array<{ q: string; a: string }>
+  }>
+  view = s.view ?? view
+  homeIndex = s.homeIndex ?? homeIndex
+  captureOn = s.captureOn ?? captureOn
+  pages = s.pages ?? pages
+  pageIndex = s.pageIndex ?? pageIndex
+  promptIndex = s.promptIndex ?? promptIndex
+  chatQuestion = s.chatQuestion ?? chatQuestion
+  chatAnswer = s.chatAnswer ?? chatAnswer
+  chatHistory = s.chatHistory ?? chatHistory
+  // A stream cannot survive the migration — the socket is gone with the old
+  // WebView — so the restored view shows whatever text had arrived.
+  chatStreaming = false
+  void renderCurrentView()
+})
+
+// ------------------------------------------------------------------ helpers
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`
+}
+
+function menuLabels(): string[] {
+  return MENU.map((entry) => (entry.view === 'capture' ? `Capture: ${captureOn ? 'on' : 'off'}` : entry.label))
+}
+
+function pageHint(): string {
+  return `p ${pageIndex + 1}/${pages.length}`
+}
+
+function statusLine(): string {
+  if (banner && Date.now() - bannerAt < BANNER_TTL_MS) return truncate(`* ${banner}`, STATUS_CHARS)
+  if (client.status() !== 'online') return truncate(`bridge offline - retrying ${client.endpoint()}`, STATUS_CHARS)
+  if (view === 'home') return 'scroll move | tap open | double-tap exit'
+  if (view === 'chat') {
+    return chatStreaming ? `thinking... ${pageHint()}` : `${pageHint()} | tap next question | 2-tap back`
+  }
+  return `${pageHint()} | scroll page | double-tap back`
+}
+
+/** Body text for the current view: the selected page, plus the question when
+ *  the chat view is open. */
+function bodyText(): string {
+  if (view === 'chat') {
+    const head = `Q: ${chatQuestion}`
+    const page = pages[pageIndex] ?? ''
+    return page.length > 0 ? `${head}\n\n${page}` : `${head}\n\n...`
+  }
+  return pages[pageIndex] ?? ''
+}
+
+function setPages(text: string): void {
+  pages = paginate(text)
+  pageIndex = clampPage(pageIndex, pages.length)
+}
+
+// --------------------------------------------------------- render scheduling
+
+// Chat deltas can arrive far faster than the glasses can redraw. Rather than
+// queueing an upgrade per delta, mark the body dirty and let one loop coalesce
+// them — the last write always wins because the loop re-checks after rendering.
+const BODY_MIN_INTERVAL_MS = 150
+
+let bodyDirty = false
+let bodyRendering = false
+let statusDirty = false
+let statusRendering = false
+
+function markBodyDirty(): void {
+  bodyDirty = true
+  void flushBody()
+}
+
+async function flushBody(): Promise<void> {
+  if (bodyRendering) return
+  bodyRendering = true
+  try {
+    while (bodyDirty) {
+      bodyDirty = false
+      try {
+        const text = bodyText()
+        // Logged here rather than in Display so the line names the view — the
+        // verify harness needs to tell a chat repaint from a memories repaint.
+        if (await display.setBody(text)) console.log(`[app] rendered ${view} body (${text.length} chars)`)
+      } catch (error) {
+        console.error('[app] body render failed:', error)
+      }
+      if (!bodyDirty) break
+      await sleep(BODY_MIN_INTERVAL_MS)
+    }
+  } finally {
+    bodyRendering = false
+  }
+}
+
+function markStatusDirty(): void {
+  statusDirty = true
+  void flushStatus()
+}
+
+async function flushStatus(): Promise<void> {
+  if (statusRendering) return
+  statusRendering = true
+  try {
+    while (statusDirty) {
+      statusDirty = false
+      try {
+        await display.setStatus(statusLine())
+      } catch (error) {
+        console.error('[app] status render failed:', error)
+      }
+      if (!statusDirty) break
+      await sleep(BODY_MIN_INTERVAL_MS)
+    }
+  } finally {
+    statusRendering = false
+  }
+}
+
+/** Rebuild the page into the layout the current view needs. Flickers, so it is
+ *  only used when the layout actually changes. */
+async function renderCurrentView(): Promise<void> {
+  try {
+    if (view === 'home') {
+      await display.showHome(menuLabels(), statusLine())
+    } else {
+      await display.showDetail(bodyText(), statusLine())
+    }
+    console.log(`[app] view=${view}`)
+  } catch (error) {
+    console.error('[app] render failed:', error)
+  }
+}
+
+// ------------------------------------------------------------ bridge traffic
+
+/** The request the open view is waiting on, so a late or missing reply turns
+ *  into a visible message instead of a permanent "Loading". */
+let pending: { view: View; timer: ReturnType<typeof setTimeout> } | null = null
+
+function clearPending(): void {
+  if (pending) clearTimeout(pending.timer)
+  pending = null
+}
+
+function startPending(target: View): void {
+  clearPending()
+  const timer = setTimeout(() => {
+    if (view !== target) return
+    pending = null
+    console.warn(`[app] request for ${target} timed out`)
+    setPages('No answer from the bridge.\n\nDouble-tap to go back, then try again.')
+    markBodyDirty()
+    markStatusDirty()
+  }, REQUEST_TIMEOUT_MS)
+  pending = { view: target, timer }
+}
+
+function formatMemories(items: MemoryItem[]): string {
+  if (items.length === 0) return 'No memories yet.'
+  return items.map((item, index) => `${index + 1}. ${item.content}`).join('\n')
+}
+
+function formatActionItems(items: ActionItem[]): string {
+  if (items.length === 0) return 'No action items.'
+  return items.map((item) => `${item.completed ? '[x]' : '[ ]'} ${item.description}`).join('\n')
+}
+
+function onBridgeMessage(message: InboundMessage): void {
+  switch (message.type) {
+    case 'push':
+      // Banners are advisory: they take over the status strip for a while and
+      // never disturb whatever view the user is in.
+      banner = message.text
+      bannerAt = Date.now()
+      console.log(`[app] push banner: ${truncate(message.text, 60)}`)
+      markStatusDirty()
+      setTimeout(markStatusDirty, BANNER_TTL_MS + 100)
+      break
+
+    case 'chat_delta':
+      if (view !== 'chat') return
+      clearPending()
+      chatAnswer += message.text
+      setPages(chatAnswer)
+      // Follow the tail while the answer streams in, like a terminal.
+      pageIndex = pages.length - 1
+      console.log(`[app] chat delta (+${message.text.length}, total ${chatAnswer.length})`)
+      markBodyDirty()
+      markStatusDirty()
+      break
+
+    case 'chat_done':
+      if (view !== 'chat') return
+      clearPending()
+      // The final frame is authoritative — it repairs any delta that was
+      // dropped or arrived out of order.
+      chatAnswer = message.text
+      chatStreaming = false
+      setPages(chatAnswer)
+      pageIndex = pages.length - 1
+      chatHistory.push({ q: chatQuestion, a: chatAnswer })
+      console.log(`[app] chat done (${chatAnswer.length} chars, ${pages.length} page(s))`)
+      markBodyDirty()
+      markStatusDirty()
+      break
+
+    case 'memories':
+      if (view !== 'memories') return
+      clearPending()
+      pageIndex = 0
+      setPages(formatMemories(message.items))
+      console.log(`[app] memories loaded (${message.items.length} item(s), ${pages.length} page(s))`)
+      markBodyDirty()
+      markStatusDirty()
+      break
+
+    case 'action_items':
+      if (view !== 'actions') return
+      clearPending()
+      pageIndex = 0
+      setPages(formatActionItems(message.items))
+      console.log(`[app] action items loaded (${message.items.length} item(s), ${pages.length} page(s))`)
+      markBodyDirty()
+      markStatusDirty()
+      break
+
+    case 'today':
+      if (view !== 'today') return
+      clearPending()
+      pageIndex = 0
+      setPages(message.text)
+      console.log(`[app] today loaded (${pages.length} page(s))`)
+      markBodyDirty()
+      markStatusDirty()
+      break
+  }
+}
+
+function onBridgeStatus(status: BridgeStatus): void {
+  console.log(`[app] bridge status=${status}`)
+  markStatusDirty()
+}
+
+const client = new BridgeClient({ onMessage: onBridgeMessage, onStatus: onBridgeStatus })
+
+// -------------------------------------------------------------- navigation
+
+async function openRead(target: Exclude<View, 'home' | 'chat'>): Promise<void> {
+  view = target
+  pageIndex = 0
+  setPages('Loading...')
+  await renderCurrentView()
+
+  const sent =
+    target === 'memories'
+      ? client.send({ type: 'memories', limit: 20 })
+      : target === 'actions'
+        ? client.send({ type: 'action_items' })
+        : client.send({ type: 'today' })
+
+  if (sent) {
+    startPending(target)
+  } else {
+    setPages('Bridge offline.\n\nStart the omi bridge on your computer, then double-tap to go back and retry.')
+    markBodyDirty()
+    markStatusDirty()
+  }
+}
+
+async function askOmi(): Promise<void> {
+  view = 'chat'
+  chatQuestion = PROMPTS[promptIndex % PROMPTS.length]
+  chatAnswer = ''
+  chatStreaming = true
+  pageIndex = 0
+  setPages('')
+  await renderCurrentView()
+
+  if (client.send({ type: 'chat', text: chatQuestion })) {
+    console.log(`[app] asked: ${chatQuestion}`)
+    startPending('chat')
+  } else {
+    chatStreaming = false
+    setPages('Bridge offline.\n\nStart the omi bridge on your computer, then tap to retry.')
+    markBodyDirty()
+    markStatusDirty()
+  }
+}
+
+async function toggleCapture(): Promise<void> {
+  const next = !captureOn
+  try {
+    await serialize('audioControl', () => bridge.audioControl(next, AudioInputSource.Glasses))
+    // Only flip the label once the mic actually flipped, so the menu never
+    // claims to be capturing when it is not.
+    captureOn = next
+    console.log(`[app] capture=${captureOn ? 'on' : 'off'}`)
+  } catch (error) {
+    console.error('[app] audioControl failed:', error)
+    banner = 'Microphone unavailable'
+    bannerAt = Date.now()
+  }
+  // List items cannot be updated in place, so the changed label needs a rebuild.
+  await renderCurrentView()
+}
+
+async function goHome(): Promise<void> {
+  clearPending()
+  view = 'home'
+  await renderCurrentView()
+}
+
+function movePage(delta: number): void {
+  const next = clampPage(pageIndex + delta, pages.length)
+  if (next === pageIndex) return
+  pageIndex = next
+  console.log(`[app] page=${pageIndex + 1}/${pages.length}`)
+  markBodyDirty()
+  markStatusDirty()
+}
+
+function moveHomeSelection(delta: number): void {
+  const count = MENU.length
+  const next = (homeIndex + delta + count) % count
+  if (next === homeIndex) return
+  homeIndex = next
+  console.log(`[app] home index=${homeIndex} (${menuLabels()[homeIndex]})`)
+  // The OS list draws its own highlight, so there is nothing to redraw here —
+  // rebuilding on every scroll would flicker the whole page.
+  markStatusDirty()
+}
+
+async function selectHomeItem(): Promise<void> {
+  const entry = MENU[homeIndex]
+  console.log(`[app] select ${entry.view}`)
+  switch (entry.view) {
+    case 'chat':
+      await askOmi()
+      break
+    case 'capture':
+      await toggleCapture()
+      break
+    default:
+      await openRead(entry.view)
+      break
+  }
+}
+
+// ----------------------------------------------------------- input decoding
+
+type Gesture = 'click' | 'double' | 'up' | 'down'
+
+function gestureFromEventType(eventType: OsEventTypeList | undefined): Gesture | null {
+  switch (eventType) {
+    // The host omits eventType for a plain tap, so an undefined type is a
+    // click rather than something to drop.
+    case undefined:
+    case OsEventTypeList.CLICK_EVENT:
+      return 'click'
+    case OsEventTypeList.SCROLL_TOP_EVENT:
+      return 'up'
+    case OsEventTypeList.SCROLL_BOTTOM_EVENT:
+      return 'down'
+    case OsEventTypeList.DOUBLE_CLICK_EVENT:
+      return 'double'
+    default:
+      return null
+  }
+}
+
+/**
+ * Touch input arrives on whichever channel the host feels like using: tap and
+ * double-tap come through `sysEvent`, scroll over a text container comes
+ * through `textEvent`, and a list container reports through `listEvent`. Read
+ * all three so one build works everywhere.
+ *
+ * Two absent-means-default traps, both from proto3 dropping zero values:
+ *  - an absent `eventType` is `CLICK_EVENT`, not "no gesture";
+ *  - an absent `currentSelectItemIndex` is row 0, not "unknown row".
+ * Verified against the simulator on SDK 0.0.12 — scrolling a list emits no
+ * event at all (the OS moves its own highlight) and the index only shows up on
+ * the click that follows, so treating it as unknown would strand the app on
+ * whichever row it last saw.
+ */
+function decode(event: EvenHubEvent): { gesture: Gesture; listIndex?: number } | null {
+  if (event.listEvent) {
+    const gesture = gestureFromEventType(event.listEvent.eventType)
+    if (!gesture) return null
+    return { gesture, listIndex: event.listEvent.currentSelectItemIndex ?? 0 }
+  }
+  if (event.textEvent) {
+    const gesture = gestureFromEventType(event.textEvent.eventType)
+    return gesture ? { gesture } : null
+  }
+  if (event.sysEvent) {
+    const gesture = gestureFromEventType(event.sysEvent.eventType)
+    return gesture ? { gesture } : null
+  }
+  return null
+}
+
+async function handleGesture(gesture: Gesture, listIndex?: number): Promise<void> {
+  if (view === 'home') {
+    // When the host owns the list highlight it also reports the resulting
+    // index; trust it over the local counter so the two never drift.
+    if (typeof listIndex === 'number' && listIndex >= 0 && listIndex < MENU.length) {
+      if (listIndex !== homeIndex) {
+        homeIndex = listIndex
+        console.log(`[app] home index=${homeIndex} (${menuLabels()[homeIndex]})`)
+        markStatusDirty()
+      }
+    }
+
+    switch (gesture) {
+      case 'up':
+        if (listIndex === undefined) moveHomeSelection(-1)
+        break
+      case 'down':
+        if (listIndex === undefined) moveHomeSelection(1)
+        break
+      case 'click':
+        await selectHomeItem()
+        break
+      case 'double':
+        console.log('[app] exit requested')
+        await display.requestExit()
+        break
+    }
+    return
+  }
+
+  switch (gesture) {
+    case 'up':
+      movePage(-1)
+      break
+    case 'down':
+      movePage(1)
+      break
+    case 'click':
+      // Only the chat view has something to do with a tap: ask the next
+      // question in the ring. Read views ignore it.
+      if (view === 'chat' && !chatStreaming) {
+        promptIndex = (promptIndex + 1) % PROMPTS.length
+        await askOmi()
+      }
+      break
+    case 'double':
+      await goHome()
+      break
+  }
+}
+
+// -------------------------------------------------------------------- boot
+
+const bridge = await waitForEvenAppBridge()
+console.log('[app] bridge ready')
+
+const display = new Display(bridge)
+
+client.connect()
+
+await display.createStartUpPage(menuLabels(), statusLine())
+
+// A background restore can land before or after the start-up page exists. If
+// it already moved us off the home view, rebuild into the right layout now.
+if (view !== 'home') await renderCurrentView()
+
+// Serialize gesture handling too: two overlapping handlers could interleave
+// rebuilds and leave the display showing one view's body under another's list.
+let inputChain: Promise<void> = Promise.resolve()
+
+bridge.onEvenHubEvent((event) => {
+  const decoded = decode(event)
+  if (!decoded) return
+  console.log(`[app] gesture=${decoded.gesture}${decoded.listIndex === undefined ? '' : ` index=${decoded.listIndex}`}`)
+  inputChain = inputChain
+    .then(() => handleGesture(decoded.gesture, decoded.listIndex))
+    .catch((error) => console.error('[app] gesture failed:', error))
+})
+
+console.log('[app] ready')

--- a/integrations/omi-even/app/src/main.ts
+++ b/integrations/omi-even/app/src/main.ts
@@ -1,14 +1,21 @@
 /** omi for Even Realities G2.
  *
- *  A five-item home menu on the glasses, backed by a local omi bridge over
+ *  A six-item home menu on the glasses, backed by a local omi bridge over
  *  WebSocket. Scroll moves the selection, tap opens, double-tap goes back (and
  *  exits from home).
+ *
+ *  "Ask Omi" dictates: tap to start listening, tap again to ask. The glasses
+ *  have no keyboard and no on-device speech recognition for plugins, so the
+ *  4-mic array's raw PCM is streamed to the bridge, which transcribes it and
+ *  answers. See `ask-recorder.ts` for the microphone lifecycle.
  *
  *  Everything drawn on the glasses is queued through `Display`, which keeps
  *  exactly one SDK call in flight — see `display.ts` for why.
  */
 import { AudioInputSource, OsEventTypeList, waitForEvenAppBridge } from '@evenrealities/even_hub_sdk'
 import type { EvenHubEvent } from '@evenrealities/even_hub_sdk'
+import { AskRecorder } from './ask-recorder.ts'
+import { clock, meterBar } from './audio.ts'
 import { onBackgroundRestore, setBackgroundState } from './background-state.ts'
 import { BridgeClient } from './bridge-client.ts'
 import type { BridgeStatus } from './bridge-client.ts'
@@ -20,23 +27,26 @@ import type { ActionItem, InboundMessage, MemoryItem } from './protocol.ts'
 // ------------------------------------------------------------------- state
 
 type View = 'home' | 'chat' | 'memories' | 'actions' | 'today'
-/** Views a menu row can open — home is the menu itself, so it is never a target. */
-type MenuTarget = Exclude<View, 'home'> | 'capture'
+/** Views a menu row can open — home is the menu itself, so it is never a
+ *  target. `capture` toggles in place and `suggest` opens the chat view with a
+ *  canned question rather than the microphone. */
+type MenuTarget = Exclude<View, 'home'> | 'capture' | 'suggest'
 
-/** Menu rows, in order. The last row's label depends on `captureOn`. */
+/** Menu rows, in order. The Capture row's label depends on `captureOn`. */
 const MENU: Array<{ label: string; view: MenuTarget }> = [
   { label: 'Ask Omi', view: 'chat' },
   { label: 'Memories', view: 'memories' },
   { label: 'Action items', view: 'actions' },
   { label: 'Today', view: 'today' },
   { label: 'Capture', view: 'capture' },
+  { label: 'Suggestions', view: 'suggest' },
 ]
 
 /**
- * The glasses have no keyboard and the bridge protocol carries text, not audio,
- * so questions come from a fixed ring: tapping in the chat view asks the next
- * one. Wiring the glasses mic to speech-to-text needs an audio message type the
- * bridge contract does not define yet.
+ * Canned questions for the Suggestions row. Dictation is the way to ask
+ * anything, but a fixed ring still earns its place: it is the only thing that
+ * works when the microphone is unavailable, and it is one tap instead of a
+ * spoken sentence for the questions asked over and over.
  */
 const PROMPTS = [
   'What should I focus on right now?',
@@ -45,6 +55,17 @@ const PROMPTS = [
   'Anything I am forgetting?',
 ]
 
+/**
+ * Where the chat view is in the dictate → transcribe → answer cycle.
+ *  - `starting`   the microphone has been asked for but has not opened yet
+ *  - `listening`  the microphone is live and PCM is going to the bridge
+ *  - `thinking`   audio is in, waiting for the transcript
+ *  - `answering`  the transcript is on screen and the answer is streaming
+ *  - `idle`       an answer is complete, or the view was opened cold
+ *  - `error`      nothing heard, no bridge, or no microphone
+ */
+type AskPhase = 'starting' | 'listening' | 'thinking' | 'answering' | 'idle' | 'error'
+
 let view: View = 'home'
 let homeIndex = 0
 let captureOn = false
@@ -52,26 +73,43 @@ let captureOn = false
 let pages: string[] = ['']
 let pageIndex = 0
 let promptIndex = 0
+/** Voice dictates the question; suggest picks it off the canned ring. Only the
+ *  meaning of a tap differs, so both share the one chat view. */
+let askMode: 'voice' | 'suggest' = 'voice'
+let askPhase: AskPhase = 'idle'
+/** User-facing text for the `error` phase, straight from the bridge when it
+ *  sent one. */
+let askHint = ''
 let chatQuestion = ''
 let chatAnswer = ''
-let chatStreaming = false
 let chatHistory: Array<{ q: string; a: string }> = []
 let banner = ''
 let bannerAt = 0
 
 // Registered before anything can mutate the variables above, so the host always
 // has a valid snapshot to migrate into the headless WebView.
-setBackgroundState('omi', () => ({
-  view,
-  homeIndex,
-  captureOn,
-  pages: [...pages],
-  pageIndex,
-  promptIndex,
-  chatQuestion,
-  chatAnswer,
-  chatHistory: chatHistory.map((entry) => ({ ...entry })),
-}))
+setBackgroundState('omi', () => {
+  // Going to the background tears down this WebView and with it the socket the
+  // audio was going to. Release the microphone on the way out — best effort,
+  // since nothing can be awaited here.
+  if (recorder.isListening()) recorder.teardown()
+  return {
+    view,
+    homeIndex,
+    captureOn,
+    pages: [...pages],
+    pageIndex,
+    promptIndex,
+    askMode,
+    // Never restore into a live-microphone phase: the restored WebView has no
+    // microphone open and no socket, so it would be claiming to listen.
+    askPhase: askPhase === 'starting' || askPhase === 'listening' || askPhase === 'thinking' ? 'idle' : askPhase,
+    askHint,
+    chatQuestion,
+    chatAnswer,
+    chatHistory: chatHistory.map((entry) => ({ ...entry })),
+  }
+})
 
 onBackgroundRestore('omi', (saved) => {
   const s = saved as Partial<{
@@ -81,6 +119,9 @@ onBackgroundRestore('omi', (saved) => {
     pages: string[]
     pageIndex: number
     promptIndex: number
+    askMode: 'voice' | 'suggest'
+    askPhase: AskPhase
+    askHint: string
     chatQuestion: string
     chatAnswer: string
     chatHistory: Array<{ q: string; a: string }>
@@ -91,12 +132,12 @@ onBackgroundRestore('omi', (saved) => {
   pages = s.pages ?? pages
   pageIndex = s.pageIndex ?? pageIndex
   promptIndex = s.promptIndex ?? promptIndex
+  askMode = s.askMode ?? askMode
+  askPhase = s.askPhase ?? askPhase
+  askHint = s.askHint ?? askHint
   chatQuestion = s.chatQuestion ?? chatQuestion
   chatAnswer = s.chatAnswer ?? chatAnswer
   chatHistory = s.chatHistory ?? chatHistory
-  // A stream cannot survive the migration — the socket is gone with the old
-  // WebView — so the restored view shows whatever text had arrived.
-  chatStreaming = false
   void renderCurrentView()
 })
 
@@ -120,21 +161,51 @@ function statusLine(): string {
   if (banner && Date.now() - bannerAt < BANNER_TTL_MS) return truncate(`* ${banner}`, STATUS_CHARS)
   if (client.status() !== 'online') return truncate(`bridge offline - retrying ${client.endpoint()}`, STATUS_CHARS)
   if (view === 'home') return 'scroll move | tap open | double-tap exit'
-  if (view === 'chat') {
-    return chatStreaming ? `thinking... ${pageHint()}` : `${pageHint()} | tap next question | 2-tap back`
-  }
+  if (view === 'chat') return truncate(chatStatus(), STATUS_CHARS)
   return `${pageHint()} | scroll page | double-tap back`
 }
 
-/** Body text for the current view: the selected page, plus the question when
- *  the chat view is open. */
-function bodyText(): string {
-  if (view === 'chat') {
-    const head = `Q: ${chatQuestion}`
-    const page = pages[pageIndex] ?? ''
-    return page.length > 0 ? `${head}\n\n${page}` : `${head}\n\n...`
+function chatStatus(): string {
+  switch (askPhase) {
+    case 'starting':
+      return 'opening the mic... | 2-tap cancel'
+    case 'listening':
+      return `rec ${clock(recorder.elapsedMs())}/${clock(recorder.capMs())} | tap ask | 2-tap cancel`
+    case 'thinking':
+      return 'transcribing... | 2-tap back'
+    case 'answering':
+      return `${pageHint()} | answering... | 2-tap back`
+    case 'error':
+      return 'tap to retry | 2-tap back'
+    case 'idle':
+      return askMode === 'voice'
+        ? `${pageHint()} | tap to ask again | 2-tap back`
+        : `${pageHint()} | tap next question | 2-tap back`
   }
-  return pages[pageIndex] ?? ''
+}
+
+/** Body text for the current view: the selected page, plus the question when
+ *  the chat view is showing an answer. */
+function bodyText(): string {
+  if (view !== 'chat') return pages[pageIndex] ?? ''
+
+  switch (askPhase) {
+    case 'starting':
+      return 'Starting microphone...'
+    case 'listening':
+      // The meter is the point: a bar that moves with the user's voice is the
+      // only proof on a screen this small that the microphone is really live.
+      return `Listening...\n\n${meterBar(recorder.level())}\n\nTap to ask. Double-tap to cancel.`
+    case 'thinking':
+      return 'Thinking...'
+    case 'error':
+      return askHint || 'Something went wrong. Tap to retry.'
+    default: {
+      const head = `Q: ${chatQuestion}`
+      const page = pages[pageIndex] ?? ''
+      return page.length > 0 ? `${head}\n\n${page}` : `${head}\n\n...`
+    }
+  }
 }
 
 function setPages(text: string): void {
@@ -153,6 +224,17 @@ let bodyDirty = false
 let bodyRendering = false
 let statusDirty = false
 let statusRendering = false
+let lastBodyHead = ''
+
+/** Log the first line of whatever just went to the display. Cheap, low volume
+ *  (it only fires when the line changes), and it is the only way a test — or a
+ *  bug report — can tell what the user was actually looking at. */
+function logBodyHead(text: string): void {
+  const head = text.split('\n', 1)[0] ?? ''
+  if (head === lastBodyHead) return
+  lastBodyHead = head
+  console.log(`[app] body head: ${head}`)
+}
 
 function markBodyDirty(): void {
   bodyDirty = true
@@ -169,7 +251,10 @@ async function flushBody(): Promise<void> {
         const text = bodyText()
         // Logged here rather than in Display so the line names the view — the
         // verify harness needs to tell a chat repaint from a memories repaint.
-        if (await display.setBody(text)) console.log(`[app] rendered ${view} body (${text.length} chars)`)
+        if (await display.setBody(text)) {
+          console.log(`[app] rendered ${view} body (${text.length} chars)`)
+          logBodyHead(text)
+        }
       } catch (error) {
         console.error('[app] body render failed:', error)
       }
@@ -211,8 +296,14 @@ async function renderCurrentView(): Promise<void> {
   try {
     if (view === 'home') {
       await display.showHome(menuLabels(), statusLine())
+      // A rebuilt list comes back with the OS highlight on row 0. Mirror that
+      // or the app's idea of the selected row drifts from the display's —
+      // which is what happens after the Capture row relabels itself.
+      homeIndex = 0
     } else {
-      await display.showDetail(bodyText(), statusLine())
+      const body = bodyText()
+      await display.showDetail(body, statusLine())
+      logBodyHead(body)
     }
     console.log(`[app] view=${view}`)
   } catch (error) {
@@ -237,11 +328,33 @@ function startPending(target: View): void {
     if (view !== target) return
     pending = null
     console.warn(`[app] request for ${target} timed out`)
-    setPages('No answer from the bridge.\n\nDouble-tap to go back, then try again.')
+    if (target === 'chat') {
+      askPhase = 'error'
+      askHint = 'No answer from the bridge.\n\nTap to retry.'
+    } else {
+      setPages('No answer from the bridge.\n\nDouble-tap to go back, then try again.')
+    }
     markBodyDirty()
     markStatusDirty()
   }, REQUEST_TIMEOUT_MS)
   pending = { view: target, timer }
+}
+
+/**
+ * Answers to questions the user cancelled. The bridge has no request ids and
+ * handles one ask at a time per socket, so counting the responses still owed
+ * is enough to drop them: a cancel that got `ask_stop` out will still be
+ * transcribed and answered, and that answer must not land on the next question.
+ */
+let staleAsks = 0
+
+function dropStaleResponse(terminal: boolean): boolean {
+  if (staleAsks <= 0) return false
+  if (terminal) {
+    staleAsks--
+    console.log(`[app] discarded a cancelled ask response (${staleAsks} still owed)`)
+  }
+  return true
 }
 
 function formatMemories(items: MemoryItem[]): string {
@@ -266,9 +379,55 @@ function onBridgeMessage(message: InboundMessage): void {
       setTimeout(markStatusDirty, BANNER_TTL_MS + 100)
       break
 
-    case 'chat_delta':
+    case 'ask_listening':
+      // Confirmation that the bridge opened its buffer. The display already
+      // says "Listening" — this is here so a one-sided socket is diagnosable.
+      console.log('[app] bridge is buffering the question')
+      break
+
+    case 'transcribed':
+      if (dropStaleResponse(false)) return
       if (view !== 'chat') return
       clearPending()
+      if (message.text.trim().length === 0) {
+        // Defence in depth: the bridge sends `ask_error` for this, but an
+        // empty question must never reach Omi.
+        askPhase = 'error'
+        askHint = "Didn't catch that. Tap to retry."
+        console.warn('[app] empty transcript')
+      } else {
+        chatQuestion = message.text
+        chatAnswer = ''
+        askPhase = 'answering'
+        pageIndex = 0
+        setPages('')
+        console.log(`[app] transcript: ${truncate(message.text, 80)}`)
+      }
+      // Keep the request alive: the transcript is only half the answer.
+      if (askPhase === 'answering') startPending('chat')
+      markBodyDirty()
+      markStatusDirty()
+      break
+
+    case 'ask_error':
+      if (dropStaleResponse(true)) return
+      if (view !== 'chat') return
+      clearPending()
+      askPhase = 'error'
+      askHint = message.text
+      console.warn(`[app] ask error: ${message.text}`)
+      markBodyDirty()
+      markStatusDirty()
+      break
+
+    case 'chat_delta':
+      if (dropStaleResponse(false)) return
+      if (view !== 'chat') return
+      // A delta while the microphone is live belongs to a question that was
+      // already abandoned; taking it would overwrite the listening screen.
+      if (askPhase === 'starting' || askPhase === 'listening') return
+      clearPending()
+      askPhase = 'answering'
       chatAnswer += message.text
       setPages(chatAnswer)
       // Follow the tail while the answer streams in, like a terminal.
@@ -279,12 +438,14 @@ function onBridgeMessage(message: InboundMessage): void {
       break
 
     case 'chat_done':
+      if (dropStaleResponse(true)) return
       if (view !== 'chat') return
+      if (askPhase === 'starting' || askPhase === 'listening') return
       clearPending()
       // The final frame is authoritative — it repairs any delta that was
       // dropped or arrived out of order.
       chatAnswer = message.text
-      chatStreaming = false
+      askPhase = 'idle'
       setPages(chatAnswer)
       pageIndex = pages.length - 1
       chatHistory.push({ q: chatQuestion, a: chatAnswer })
@@ -327,10 +488,57 @@ function onBridgeMessage(message: InboundMessage): void {
 
 function onBridgeStatus(status: BridgeStatus): void {
   console.log(`[app] bridge status=${status}`)
+  // A question being dictated into a socket that just died is dead air, and
+  // the microphone would stay open until the 20s cap for nothing.
+  if (status !== 'online' && recorder.isListening()) {
+    enqueue(() => abortListening('Lost the bridge.\n\nTap to retry once it is back.'))
+  }
   markStatusDirty()
 }
 
 const client = new BridgeClient({ onMessage: onBridgeMessage, onStatus: onBridgeStatus })
+
+// ---------------------------------------------------------------- microphone
+
+/**
+ * The glasses have one microphone and two features that want it: continuous
+ * Capture, and a question being dictated. Both go through here, so whichever
+ * one stops first cannot switch the other one off underneath it.
+ */
+let micOn = false
+let askWantsMic = false
+
+async function applyMic(): Promise<boolean> {
+  const wanted = captureOn || askWantsMic
+  if (wanted === micOn) return true
+  try {
+    await serialize('audioControl', () =>
+      wanted ? bridge.audioControl(true, AudioInputSource.Glasses) : bridge.audioControl(false),
+    )
+    micOn = wanted
+    console.log(`[app] audioControl(${wanted ? 'true, glasses' : 'false'}) ok - mic=${wanted ? 'on' : 'off'}`)
+    return true
+  } catch (error) {
+    console.error('[app] audioControl failed:', error)
+    return false
+  }
+}
+
+const recorder = new AskRecorder({
+  sendJson: (message) => client.send(message),
+  sendBinary: (pcm) => client.sendBinary(pcm),
+  setMic: (on) => {
+    askWantsMic = on
+    return applyMic()
+  },
+  onUpdate: () => {
+    if (view === 'chat' && askPhase === 'listening') {
+      markBodyDirty()
+      markStatusDirty()
+    }
+  },
+  onCap: () => enqueue(() => stopAndAsk('cap')),
+})
 
 // -------------------------------------------------------------- navigation
 
@@ -356,21 +564,109 @@ async function openRead(target: Exclude<View, 'home' | 'chat'>): Promise<void> {
   }
 }
 
-async function askOmi(): Promise<void> {
+/** Open the chat view and start dictating. */
+async function startListening(): Promise<void> {
+  const rebuild = view !== 'chat'
   view = 'chat'
-  chatQuestion = PROMPTS[promptIndex % PROMPTS.length]
+  askMode = 'voice'
+  askPhase = 'starting'
+  askHint = ''
+  chatQuestion = ''
   chatAnswer = ''
-  chatStreaming = true
   pageIndex = 0
   setPages('')
-  await renderCurrentView()
+  clearPending()
+
+  // "Starting microphone" and not "Listening": opening the mic is a round trip
+  // to the glasses, and claiming to listen before it lands is the one thing
+  // this screen must never do.
+  if (rebuild) await renderCurrentView()
+  else markBodyDirty()
+
+  const started = await recorder.start()
+  if (!started.ok) {
+    askPhase = 'error'
+    askHint =
+      started.reason === 'offline'
+        ? 'Bridge offline.\n\nStart the omi bridge on your computer, then tap to retry.'
+        : 'Microphone unavailable.\n\nTry Suggestions from the menu instead.'
+    markBodyDirty()
+    markStatusDirty()
+    return
+  }
+
+  askPhase = 'listening'
+  markBodyDirty()
+  markStatusDirty()
+}
+
+/** Stop the microphone and let the bridge answer what it heard. */
+async function stopAndAsk(reason: 'tap' | 'cap'): Promise<void> {
+  if (!recorder.isListening()) return
+  // Repainted before awaiting the SDK: turning the microphone off is a round
+  // trip, and a screen still saying "Listening" after the user tapped reads as
+  // a dropped input.
+  askPhase = 'thinking'
+  markBodyDirty()
+  markStatusDirty()
+
+  const asked = await recorder.stop(reason)
+  if (asked) {
+    startPending('chat')
+  } else {
+    askPhase = 'error'
+    askHint = 'Bridge offline.\n\nThe question could not be sent. Tap to retry.'
+    markBodyDirty()
+    markStatusDirty()
+  }
+}
+
+/** Throw the question away and go back to the menu. */
+async function cancelListening(): Promise<void> {
+  // `ask_stop` still goes out — it is the only thing that releases the buffer
+  // the bridge opened — so the answer it produces has to be discarded.
+  const asked = await recorder.stop('cancel')
+  if (asked) staleAsks++
+  askPhase = 'idle'
+  askHint = ''
+  console.log('[app] ask cancelled')
+  await goHome()
+}
+
+/** Stop listening and show `reason` in the chat view. */
+async function abortListening(reason: string): Promise<void> {
+  const asked = await recorder.stop('cancel')
+  if (asked) staleAsks++
+  askPhase = 'error'
+  askHint = reason
+  markBodyDirty()
+  markStatusDirty()
+}
+
+/** Ask the next canned question. No microphone involved. */
+async function askSuggestion(advance: boolean): Promise<void> {
+  const rebuild = view !== 'chat'
+  if (advance) promptIndex = (promptIndex + 1) % PROMPTS.length
+  view = 'chat'
+  askMode = 'suggest'
+  askPhase = 'answering'
+  askHint = ''
+  chatQuestion = PROMPTS[promptIndex % PROMPTS.length]
+  chatAnswer = ''
+  pageIndex = 0
+  setPages('')
+  if (rebuild) await renderCurrentView()
+  else {
+    markBodyDirty()
+    markStatusDirty()
+  }
 
   if (client.send({ type: 'chat', text: chatQuestion })) {
     console.log(`[app] asked: ${chatQuestion}`)
     startPending('chat')
   } else {
-    chatStreaming = false
-    setPages('Bridge offline.\n\nStart the omi bridge on your computer, then tap to retry.')
+    askPhase = 'error'
+    askHint = 'Bridge offline.\n\nStart the omi bridge on your computer, then tap to retry.'
     markBodyDirty()
     markStatusDirty()
   }
@@ -378,14 +674,13 @@ async function askOmi(): Promise<void> {
 
 async function toggleCapture(): Promise<void> {
   const next = !captureOn
-  try {
-    await serialize('audioControl', () => bridge.audioControl(next, AudioInputSource.Glasses))
-    // Only flip the label once the mic actually flipped, so the menu never
-    // claims to be capturing when it is not.
-    captureOn = next
+  captureOn = next
+  if (await applyMic()) {
     console.log(`[app] capture=${captureOn ? 'on' : 'off'}`)
-  } catch (error) {
-    console.error('[app] audioControl failed:', error)
+  } else {
+    // Only keep the label flipped if the microphone actually flipped, so the
+    // menu never claims to be capturing when it is not.
+    captureOn = !next
     banner = 'Microphone unavailable'
     bannerAt = Date.now()
   }
@@ -395,7 +690,14 @@ async function toggleCapture(): Promise<void> {
 
 async function goHome(): Promise<void> {
   clearPending()
+  // Defensive: every caller stops the recorder first, but the microphone is
+  // hardware and leaving it on is the worst bug this app can ship.
+  if (recorder.isListening()) {
+    const asked = await recorder.stop('cancel')
+    if (asked) staleAsks++
+  }
   view = 'home'
+  askPhase = 'idle'
   await renderCurrentView()
 }
 
@@ -424,7 +726,10 @@ async function selectHomeItem(): Promise<void> {
   console.log(`[app] select ${entry.view}`)
   switch (entry.view) {
     case 'chat':
-      await askOmi()
+      await startListening()
+      break
+    case 'suggest':
+      await askSuggestion(false)
       break
     case 'capture':
       await toggleCapture()
@@ -518,6 +823,34 @@ async function handleGesture(gesture: Gesture, listIndex?: number): Promise<void
     return
   }
 
+  if (view === 'chat') {
+    switch (gesture) {
+      case 'up':
+        movePage(-1)
+        break
+      case 'down':
+        movePage(1)
+        break
+      case 'click':
+        if (askMode === 'suggest') {
+          // A tap moves to the next canned question, unless one is in flight.
+          if (askPhase !== 'answering') await askSuggestion(true)
+        } else if (askPhase === 'listening') {
+          await stopAndAsk('tap')
+        } else if (askPhase === 'idle' || askPhase === 'error') {
+          await startListening()
+        }
+        // `starting`, `thinking` and `answering` are all "the glasses are busy
+        // with the last question" — a tap there would race the reply.
+        break
+      case 'double':
+        if (askPhase === 'listening' || askPhase === 'starting') await cancelListening()
+        else await goHome()
+        break
+    }
+    return
+  }
+
   switch (gesture) {
     case 'up':
       movePage(-1)
@@ -526,12 +859,6 @@ async function handleGesture(gesture: Gesture, listIndex?: number): Promise<void
       movePage(1)
       break
     case 'click':
-      // Only the chat view has something to do with a tap: ask the next
-      // question in the ring. Read views ignore it.
-      if (view === 'chat' && !chatStreaming) {
-        promptIndex = (promptIndex + 1) % PROMPTS.length
-        await askOmi()
-      }
       break
     case 'double':
       await goHome()
@@ -550,6 +877,16 @@ client.connect()
 
 await display.createStartUpPage(menuLabels(), statusLine())
 
+// `audioControl` needs the start-up page to exist, so this is the earliest it
+// can run. A WebView that died mid-question — a reload, a crash — may have left
+// the microphone open with nothing reading it; boot from a known-off state.
+try {
+  await serialize('audioControl(reset)', () => bridge.audioControl(false))
+  console.log('[app] microphone reset to off at start-up')
+} catch (error) {
+  console.warn('[app] could not reset the microphone at start-up:', error)
+}
+
 // A background restore can land before or after the start-up page exists. If
 // it already moved us off the home view, rebuild into the right layout now.
 if (view !== 'home') await renderCurrentView()
@@ -558,13 +895,37 @@ if (view !== 'home') await renderCurrentView()
 // rebuilds and leave the display showing one view's body under another's list.
 let inputChain: Promise<void> = Promise.resolve()
 
+/** Run `task` behind everything already queued, so timer-driven work (the
+ *  recording cap, a bridge drop) cannot interleave with a gesture. */
+function enqueue(task: () => Promise<void>): void {
+  inputChain = inputChain.then(task).catch((error) => console.error('[app] queued task failed:', error))
+}
+
 bridge.onEvenHubEvent((event) => {
+  // Audio shares this listener with input. It arrives ~10 times a second, so
+  // it is handled first and never logged per frame.
+  const audio = event.audioEvent as { audioPcm?: unknown; audio_pcm?: unknown } | undefined
+  if (audio) {
+    recorder.feed(audio.audioPcm ?? audio.audio_pcm ?? audio)
+    return
+  }
+
   const decoded = decode(event)
   if (!decoded) return
   console.log(`[app] gesture=${decoded.gesture}${decoded.listIndex === undefined ? '' : ` index=${decoded.listIndex}`}`)
-  inputChain = inputChain
-    .then(() => handleGesture(decoded.gesture, decoded.listIndex))
-    .catch((error) => console.error('[app] gesture failed:', error))
+  enqueue(() => handleGesture(decoded.gesture, decoded.listIndex))
 })
+
+// The microphone is hardware: a reload or a closed WebView with a live capture
+// leaves it running on the user's face until the glasses time it out.
+const releaseMic = () => {
+  recorder.teardown()
+  if (micOn) {
+    micOn = false
+    void bridge.audioControl(false)
+  }
+}
+window.addEventListener('beforeunload', releaseMic)
+window.addEventListener('pagehide', releaseMic)
 
 console.log('[app] ready')

--- a/integrations/omi-even/app/src/paginate.ts
+++ b/integrations/omi-even/app/src/paginate.ts
@@ -1,0 +1,41 @@
+/** Split long text into screen-sized pages.
+ *
+ *  The G2 has no scrollbar and no way to ask how much text fit, so the app
+ *  chops the text itself and pages with the touchpad. Breaks land on a
+ *  paragraph, then a space, and only cut mid-word when a single word is longer
+ *  than a whole page.
+ */
+import { PAGE_CHARS } from './config.ts'
+
+export function paginate(text: string, limit: number = PAGE_CHARS): string[] {
+  const normalized = text.replace(/\r\n/g, '\n').trim()
+  if (normalized.length === 0) return ['']
+  if (normalized.length <= limit) return [normalized]
+
+  const pages: string[] = []
+  let rest = normalized
+
+  while (rest.length > limit) {
+    const window = rest.slice(0, limit + 1)
+
+    // Prefer a paragraph break, then any whitespace, then a hard cut. The
+    // `> limit * 0.5` guard stops an early newline from producing a page that
+    // is mostly blank.
+    let cut = window.lastIndexOf('\n\n')
+    if (cut <= limit * 0.5) cut = window.lastIndexOf('\n')
+    if (cut <= limit * 0.5) cut = window.lastIndexOf(' ')
+    if (cut <= 0) cut = limit
+
+    pages.push(rest.slice(0, cut).trimEnd())
+    rest = rest.slice(cut).trimStart()
+  }
+
+  if (rest.length > 0) pages.push(rest)
+  return pages
+}
+
+/** Clamp a page index into range; an empty list still yields page 0. */
+export function clampPage(index: number, pageCount: number): number {
+  if (pageCount <= 0) return 0
+  return Math.max(0, Math.min(index, pageCount - 1))
+}

--- a/integrations/omi-even/app/src/protocol.ts
+++ b/integrations/omi-even/app/src/protocol.ts
@@ -1,17 +1,37 @@
 /** Wire format spoken with the local omi bridge over `ws://<host>/app`.
  *
- *  Everything is JSON with a `type` discriminator. The app only ever sends the
- *  four request shapes below; anything else the bridge pushes is ignored rather
- *  than treated as an error, so a newer bridge can add message types without
- *  breaking an older build of the app.
+ *  Control traffic is JSON with a `type` discriminator; the one binary channel
+ *  is microphone PCM. Anything the bridge pushes that this build does not know
+ *  is ignored rather than treated as an error, so a newer bridge can add
+ *  message types without breaking an older app.
+ *
+ *  Dictating a question is a three-part exchange:
+ *
+ *    app -> bridge   {"type":"ask_start"}
+ *    app -> bridge   binary frames, PCM16 LE / 16 kHz / mono
+ *    app -> bridge   {"type":"ask_stop"}
+ *    bridge -> app   {"type":"transcribed","text":...}  then chat_delta* + chat_done
+ *    bridge -> app   {"type":"ask_error","text":...}    if it heard nothing
+ *
+ *  Binary frames sent *outside* an ask_start/ask_stop bracket mean something
+ *  else entirely to the bridge — they are continuous-capture audio headed for a
+ *  conversation — so the bracket has to be strict in both directions.
  */
 
 export type ChatRequest = { type: 'chat'; text: string }
 export type MemoriesRequest = { type: 'memories'; limit: number }
 export type ActionItemsRequest = { type: 'action_items' }
 export type TodayRequest = { type: 'today' }
+export type AskStartRequest = { type: 'ask_start' }
+export type AskStopRequest = { type: 'ask_stop' }
 
-export type OutboundMessage = ChatRequest | MemoriesRequest | ActionItemsRequest | TodayRequest
+export type OutboundMessage =
+  | ChatRequest
+  | MemoriesRequest
+  | ActionItemsRequest
+  | TodayRequest
+  | AskStartRequest
+  | AskStopRequest
 
 export type MemoryItem = { content: string }
 export type ActionItem = { description: string; completed: boolean }
@@ -22,6 +42,15 @@ export type MemoriesMessage = { type: 'memories'; items: MemoryItem[] }
 export type ActionItemsMessage = { type: 'action_items'; items: ActionItem[] }
 export type TodayMessage = { type: 'today'; text: string }
 export type PushMessage = { type: 'push'; text: string }
+/** The bridge accepted `ask_start` and is now buffering PCM. Advisory — the
+ *  glasses already say "Listening" by the time it lands. */
+export type AskListeningMessage = { type: 'ask_listening' }
+/** What the bridge heard, echoed back before the answer so a misheard question
+ *  is obvious on the display instead of being guessed at from the answer. */
+export type TranscribedMessage = { type: 'transcribed'; text: string }
+/** The dictation failed: nothing audible, or transcription errored. Carries
+ *  text meant to be shown to the user as-is. */
+export type AskErrorMessage = { type: 'ask_error'; text: string }
 
 export type InboundMessage =
   | ChatDeltaMessage
@@ -30,6 +59,9 @@ export type InboundMessage =
   | ActionItemsMessage
   | TodayMessage
   | PushMessage
+  | AskListeningMessage
+  | TranscribedMessage
+  | AskErrorMessage
 
 /**
  * The `type` of a frame, or `null` if it is not even a JSON object. Used only
@@ -71,6 +103,14 @@ export function parseInbound(raw: string): InboundMessage | null {
       return typeof msg.text === 'string' ? { type: 'today', text: msg.text } : null
     case 'push':
       return typeof msg.text === 'string' ? { type: 'push', text: msg.text } : null
+    case 'ask_listening':
+      return { type: 'ask_listening' }
+    case 'transcribed':
+      return typeof msg.text === 'string' ? { type: 'transcribed', text: msg.text } : null
+    case 'ask_error':
+      // Text is required: an error with nothing to show would leave the
+      // display on "Thinking..." forever.
+      return typeof msg.text === 'string' ? { type: 'ask_error', text: msg.text } : null
     case 'memories': {
       if (!Array.isArray(msg.items)) return null
       const items: MemoryItem[] = []

--- a/integrations/omi-even/app/src/protocol.ts
+++ b/integrations/omi-even/app/src/protocol.ts
@@ -1,0 +1,98 @@
+/** Wire format spoken with the local omi bridge over `ws://<host>/app`.
+ *
+ *  Everything is JSON with a `type` discriminator. The app only ever sends the
+ *  four request shapes below; anything else the bridge pushes is ignored rather
+ *  than treated as an error, so a newer bridge can add message types without
+ *  breaking an older build of the app.
+ */
+
+export type ChatRequest = { type: 'chat'; text: string }
+export type MemoriesRequest = { type: 'memories'; limit: number }
+export type ActionItemsRequest = { type: 'action_items' }
+export type TodayRequest = { type: 'today' }
+
+export type OutboundMessage = ChatRequest | MemoriesRequest | ActionItemsRequest | TodayRequest
+
+export type MemoryItem = { content: string }
+export type ActionItem = { description: string; completed: boolean }
+
+export type ChatDeltaMessage = { type: 'chat_delta'; text: string }
+export type ChatDoneMessage = { type: 'chat_done'; text: string }
+export type MemoriesMessage = { type: 'memories'; items: MemoryItem[] }
+export type ActionItemsMessage = { type: 'action_items'; items: ActionItem[] }
+export type TodayMessage = { type: 'today'; text: string }
+export type PushMessage = { type: 'push'; text: string }
+
+export type InboundMessage =
+  | ChatDeltaMessage
+  | ChatDoneMessage
+  | MemoriesMessage
+  | ActionItemsMessage
+  | TodayMessage
+  | PushMessage
+
+/**
+ * The `type` of a frame, or `null` if it is not even a JSON object. Used only
+ * for logging: a bridge that speaks message types this build does not know
+ * about should be diagnosable without being alarming.
+ */
+export function frameType(raw: string): string | null {
+  try {
+    const value = JSON.parse(raw) as unknown
+    if (typeof value !== 'object' || value === null) return null
+    const type = (value as Record<string, unknown>).type
+    return typeof type === 'string' ? type : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse a frame off the socket. Returns `null` for anything that is not a
+ * recognised message so a malformed or future frame degrades to "ignored"
+ * instead of throwing inside the socket callback.
+ */
+export function parseInbound(raw: string): InboundMessage | null {
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof value !== 'object' || value === null) return null
+  const msg = value as Record<string, unknown>
+
+  switch (msg.type) {
+    case 'chat_delta':
+      return typeof msg.text === 'string' ? { type: 'chat_delta', text: msg.text } : null
+    case 'chat_done':
+      return typeof msg.text === 'string' ? { type: 'chat_done', text: msg.text } : null
+    case 'today':
+      return typeof msg.text === 'string' ? { type: 'today', text: msg.text } : null
+    case 'push':
+      return typeof msg.text === 'string' ? { type: 'push', text: msg.text } : null
+    case 'memories': {
+      if (!Array.isArray(msg.items)) return null
+      const items: MemoryItem[] = []
+      for (const item of msg.items) {
+        const content = (item as Record<string, unknown> | null)?.content
+        if (typeof content === 'string') items.push({ content })
+      }
+      return { type: 'memories', items }
+    }
+    case 'action_items': {
+      if (!Array.isArray(msg.items)) return null
+      const items: ActionItem[] = []
+      for (const item of msg.items) {
+        const record = item as Record<string, unknown> | null
+        const description = record?.description
+        if (typeof description === 'string') {
+          items.push({ description, completed: record?.completed === true })
+        }
+      }
+      return { type: 'action_items', items }
+    }
+    default:
+      return null
+  }
+}

--- a/integrations/omi-even/app/tsconfig.json
+++ b/integrations/omi-even/app/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM"],
+    "types": ["vite/client"],
+    "allowArbitraryExtensions": true,
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/integrations/omi-even/app/vite.config.ts
+++ b/integrations/omi-even/app/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    // The glasses load this app over the LAN from the phone, so the dev server
+    // must bind to all interfaces — Vite's default is localhost-only and the
+    // phone would get a connection refused.
+    host: true,
+    // Not Vite's default 5173: the sibling `integrations/evenhub-g2` app already
+    // claims that port, and with `strictPort` on, running both would fail.
+    port: 5273,
+    // Fail loudly instead of silently moving to 5174, which would leave the
+    // generated QR code pointing at a dead port.
+    strictPort: true,
+    // The phone connects by raw LAN IP; allow it explicitly so Vite's host
+    // check can't reject the request.
+    allowedHosts: true,
+  },
+})

--- a/integrations/omi-even/bridge/capture.py
+++ b/integrations/omi-even/bridge/capture.py
@@ -58,6 +58,13 @@ _KEEPALIVE_INTERVAL = 25.0
 _FLUSH_SILENCE_FRAMES = 34  # 34 * 60ms ~= 2.0s
 _FLUSH_SETTLE_SECONDS = 4.0
 
+# How many times to try before concluding the socket will never work. Only
+# applies before the first successful connect; after that, drops are treated as
+# transient and retried for as long as capture is wanted.
+_INITIAL_CONNECT_ATTEMPTS = 3
+_INITIAL_CONNECT_DELAY = 0.5
+_MAX_RECONNECT_DELAY = 30
+
 
 @dataclass
 class CaptureStats:
@@ -67,6 +74,7 @@ class CaptureStats:
     conversation_id: str | None = None
     started_at: float = field(default_factory=time.monotonic)
     last_error: str | None = None
+    reconnects: int = 0
 
     @property
     def audio_seconds(self) -> float:
@@ -199,29 +207,92 @@ class CaptureSession:
             log.warning('could not finalize conversation: %s', exc)
 
     async def _run(self) -> None:
+        """Hold the listen socket open for as long as capture is wanted.
+
+        Built for all-day wear, so a dropped connection is expected rather than
+        exceptional: Wi-Fi roams, the laptop sleeps, the server closes an idle
+        socket with 1001. Any of those used to end capture permanently and
+        silently. Instead we reconnect with backoff until `stop()` is called.
+
+        The auth header is rebuilt per attempt so a reconnect after the ID token's
+        one-hour expiry mints a fresh one instead of looping on 401.
+        """
         url = listen_url(self._base)
-        try:
-            headers = await self._auth.auth_header()
-            async with websockets.connect(url, additional_headers=headers, max_size=None) as socket:
-                log.info('capture socket open (source=%s)', SOURCE)
-                sender = asyncio.create_task(self._send_loop(socket), name='capture-send')
-                receiver = asyncio.create_task(self._recv_loop(socket), name='capture-recv')
-                done, pending = await asyncio.wait(
-                    {sender, receiver}, return_when=asyncio.FIRST_COMPLETED
-                )
-                for task in pending:
-                    task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await task
-                for task in done:
-                    exc = task.exception()
-                    if exc:
-                        raise exc
-        except Exception as exc:  # noqa: BLE001 - surface, never crash the bridge
-            self.stats.last_error = f'{type(exc).__name__}: {exc}'
-            log.error('capture session ended: %s', self.stats.last_error)
-        finally:
-            self.active = False
+        attempt = 0
+        connected_once = False
+
+        while self.active:
+            try:
+                headers = await self._auth.auth_header()
+                async with websockets.connect(url, additional_headers=headers, max_size=None) as socket:
+                    if attempt:
+                        log.info('capture socket reconnected after %d attempt(s)', attempt)
+                    else:
+                        log.info('capture socket open (source=%s)', SOURCE)
+                    attempt = 0  # a successful connect resets the backoff
+                    connected_once = True
+                    self.stats.last_error = None
+
+                    sender = asyncio.create_task(self._send_loop(socket), name='capture-send')
+                    receiver = asyncio.create_task(self._recv_loop(socket), name='capture-recv')
+                    done, pending = await asyncio.wait(
+                        {sender, receiver}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    for task in pending:
+                        task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await task
+                    for task in done:
+                        # `.exception()` re-raises on a cancelled task, which would
+                        # look like the session itself being cancelled.
+                        if task.cancelled():
+                            continue
+                        exc = task.exception()
+                        if exc:
+                            raise exc
+
+                # Both loops finished without error: that only happens when the
+                # send loop consumed the stop sentinel, so this is a clean exit.
+                if not self.active:
+                    break
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - reconnect, never crash the bridge
+                self.stats.last_error = f'{type(exc).__name__}: {exc}'
+                log.warning('capture socket dropped: %s', self.stats.last_error)
+
+            if not self.active:
+                break
+
+            # A socket that has never connected is a configuration or auth problem
+            # -- a bad URL, a revoked token -- and retrying forever would hide it.
+            # One that connected and then dropped is a network blip during all-day
+            # wear, which is expected and worth retrying for a long time.
+            if not connected_once and attempt + 1 >= _INITIAL_CONNECT_ATTEMPTS:
+                log.error('capture never connected after %d attempts; giving up', attempt + 1)
+                break
+
+            attempt += 1
+            self.stats.reconnects += 1
+            if connected_once:
+                # Transient drop during all-day wear. Back off, but cap it so the
+                # session recovers promptly once the network returns rather than
+                # sitting out a long sleep.
+                delay = min(2**attempt, _MAX_RECONNECT_DELAY)
+            else:
+                # Still probing a socket that has never worked; retry quickly so a
+                # misconfiguration surfaces in a second rather than a minute.
+                delay = _INITIAL_CONNECT_DELAY
+            log.info('reconnecting capture in %ss (attempt %d)', delay, attempt)
+            await asyncio.sleep(delay)
+
+        self.active = False
+        log.info(
+            'capture ended: %.1fs audio, %d segments, %d reconnects',
+            self.stats.audio_seconds,
+            self.stats.segments_received,
+            self.stats.reconnects,
+        )
 
     async def _send_loop(self, socket) -> None:
         while True:

--- a/integrations/omi-even/bridge/capture.py
+++ b/integrations/omi-even/bridge/capture.py
@@ -1,0 +1,272 @@
+"""Relay G2 microphone audio into Omi as real conversations.
+
+The glasses emit PCM16 LE mono at 16 kHz, which is exactly what `WS /v4/listen`
+wants, so audio passes through unconverted.
+
+Behaviors this encodes, each verified against the backend rather than assumed:
+
+* **`source` must be a real `ConversationSource` member.** `_missing_` maps any
+  unknown string to `unknown` instead of raising, so a typo does not fail loudly --
+  it silently mislabels every conversation. `rayban_meta` is the correct value for
+  third-party glasses (`docs/rayban-meta-device.md`) and is photo-capable, so
+  `resolve_photo_conversation_source` won't later rewrite provenance to `openglass`.
+* **Something must arrive inbound every 90 s** or the server closes with 1001
+  (`routers/listen/runtime.py:312-323`). Any frame counts; a JSON frame with an
+  unhandled `type` is ignored server-side, so it is a free keepalive.
+* **The server sends the literal text `ping`**, which is not JSON. Parsing it blindly
+  throws on every heartbeat.
+* **Live transcript arrives as a bare JSON array**, not a `{"type": ...}` envelope
+  (`routers/listen/transcripts.py:314`). Only new/updated segments are sent.
+* **Closing the socket does not finalize the conversation.** Disconnect teardown only
+  finalizes when `source == 'desktop'` and the close code is 1000
+  (`runtime.py:612-639`), so we call `POST /v1/conversations` explicitly to close out.
+* Frames of `<= 2` bytes are silently dropped (`receiver.py:491`), so we never emit them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from urllib.parse import urlencode
+
+import websockets
+
+from omi_auth import OmiAuth
+
+log = logging.getLogger(__name__)
+
+SOURCE = 'rayban_meta'
+SAMPLE_RATE = 16000
+BYTES_PER_SAMPLE = 2
+
+# The server flushes to STT every 30 ms (960 bytes at 16 kHz). Sending a little more
+# than that per frame keeps us comfortably above the 2-byte floor without bursting.
+CHUNK_BYTES = 1920  # 60 ms
+_MIN_FRAME_BYTES = 3
+
+# Server closes after 90 s of inbound silence; stay well inside that.
+_KEEPALIVE_INTERVAL = 25.0
+
+# Silence appended on stop so the STT endpointer emits its final segment, and how
+# long to wait for that segment to come back. ~2s of silence is well past any
+# provider's endpointing window without meaningfully delaying the UI.
+_FLUSH_SILENCE_FRAMES = 34  # 34 * 60ms ~= 2.0s
+_FLUSH_SETTLE_SECONDS = 4.0
+
+
+@dataclass
+class CaptureStats:
+    bytes_sent: int = 0
+    frames_sent: int = 0
+    segments_received: int = 0
+    conversation_id: str | None = None
+    started_at: float = field(default_factory=time.monotonic)
+    last_error: str | None = None
+
+    @property
+    def audio_seconds(self) -> float:
+        return self.bytes_sent / (SAMPLE_RATE * BYTES_PER_SAMPLE)
+
+
+SegmentCallback = Callable[[list[dict]], Awaitable[None]]
+EventCallback = Callable[[dict], Awaitable[None]]
+
+
+def listen_url(base_url: str, *, language: str = 'en') -> str:
+    """Build the /v4/listen URL with the parameters the G2 stream needs."""
+    ws_base = base_url.replace('https://', 'wss://').replace('http://', 'ws://').rstrip('/')
+    query = urlencode(
+        {
+            'source': SOURCE,
+            'codec': 'pcm16',
+            'sample_rate': str(SAMPLE_RATE),
+            'channels': '1',
+            'language': language,
+            'include_speech_profile': 'true',
+            # Values below 120 are clamped up server-side; pass the real floor.
+            'conversation_timeout': '120',
+        }
+    )
+    return f'{ws_base}/v4/listen?{query}'
+
+
+class CaptureSession:
+    """One live audio session streaming glasses PCM into Omi."""
+
+    def __init__(
+        self,
+        auth: OmiAuth,
+        base_url: str,
+        on_segments: SegmentCallback | None = None,
+        on_event: EventCallback | None = None,
+    ) -> None:
+        self._auth = auth
+        self._base = base_url.rstrip('/')
+        self._on_segments = on_segments
+        self._on_event = on_event
+        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=256)
+        self._pending = bytearray()
+        self._task: asyncio.Task | None = None
+        self.stats = CaptureStats()
+        self.active = False
+
+    async def start(self) -> None:
+        if self.active:
+            return
+        self.active = True
+        self.stats = CaptureStats()
+        self._task = asyncio.create_task(self._run(), name='omi-even-capture')
+
+    async def stop(self, finalize: bool = True) -> CaptureStats:
+        """Stop streaming. `finalize` closes out the Omi conversation immediately.
+
+        Sends a short tail of silence before closing. The STT endpointer only emits
+        its final segment once it hears the utterance end, so cutting the stream
+        immediately after speech loses the last sentence -- measured: a 7.4s clip
+        yielded only its first 2.8s without this, and the full text with it.
+        """
+        if not self.active:
+            return self.stats
+
+        # Flush the partial frame first so the tail of real audio is not lost.
+        if len(self._pending) >= _MIN_FRAME_BYTES:
+            with contextlib.suppress(asyncio.QueueFull):
+                self._queue.put_nowait(bytes(self._pending))
+        self._pending.clear()
+
+        silence = b'\x00' * CHUNK_BYTES
+        for _ in range(_FLUSH_SILENCE_FRAMES):
+            with contextlib.suppress(asyncio.QueueFull):
+                self._queue.put_nowait(silence)
+        # Give the server time to run the endpointer over that silence and send
+        # the closing segment before we tear the socket down.
+        await asyncio.sleep(_FLUSH_SETTLE_SECONDS)
+
+        self.active = False
+        with contextlib.suppress(asyncio.QueueFull):
+            self._queue.put_nowait(None)
+
+        if self._task is not None:
+            with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+                await asyncio.wait_for(self._task, timeout=10)
+            self._task = None
+
+        if finalize:
+            await self._finalize_conversation()
+        return self.stats
+
+    def feed(self, pcm: bytes) -> None:
+        """Accept PCM from the glasses, batching into sensibly sized frames.
+
+        Non-blocking by design: audio arrives on the app WebSocket and must never
+        be stalled by backpressure here. If the queue is full we drop and count it
+        rather than let the socket read loop back up.
+        """
+        if not self.active or not pcm:
+            return
+        self._pending.extend(pcm)
+        while len(self._pending) >= CHUNK_BYTES:
+            frame = bytes(self._pending[:CHUNK_BYTES])
+            del self._pending[:CHUNK_BYTES]
+            try:
+                self._queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                self.stats.last_error = 'audio queue full; dropped a frame'
+                log.warning('capture queue full -- dropping %d bytes', len(frame))
+
+    async def _finalize_conversation(self) -> None:
+        """Ask Omi to close the in-progress conversation.
+
+        Needed because disconnect-time finalization is desktop-only; without this
+        the conversation lingers `in_progress` until a later session finds it stale.
+        """
+        import httpx  # local: only needed on the stop path
+
+        try:
+            headers = await self._auth.auth_header()
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(f'{self._base}/v1/conversations', headers=headers)
+            if response.status_code >= 400:
+                log.warning('finalize returned HTTP %s: %.160s', response.status_code, response.text)
+            else:
+                log.info('conversation finalized')
+        except Exception as exc:  # noqa: BLE001 - stop() must never raise
+            log.warning('could not finalize conversation: %s', exc)
+
+    async def _run(self) -> None:
+        url = listen_url(self._base)
+        try:
+            headers = await self._auth.auth_header()
+            async with websockets.connect(url, additional_headers=headers, max_size=None) as socket:
+                log.info('capture socket open (source=%s)', SOURCE)
+                sender = asyncio.create_task(self._send_loop(socket), name='capture-send')
+                receiver = asyncio.create_task(self._recv_loop(socket), name='capture-recv')
+                done, pending = await asyncio.wait(
+                    {sender, receiver}, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in pending:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                for task in done:
+                    exc = task.exception()
+                    if exc:
+                        raise exc
+        except Exception as exc:  # noqa: BLE001 - surface, never crash the bridge
+            self.stats.last_error = f'{type(exc).__name__}: {exc}'
+            log.error('capture session ended: %s', self.stats.last_error)
+        finally:
+            self.active = False
+
+    async def _send_loop(self, socket) -> None:
+        while True:
+            try:
+                frame = await asyncio.wait_for(self._queue.get(), timeout=_KEEPALIVE_INTERVAL)
+            except TimeoutError:
+                # Any inbound frame resets the server's 90s activity timer. An
+                # unrecognized `type` is a documented no-op on the server.
+                await socket.send(json.dumps({'type': 'keepalive'}))
+                continue
+            if frame is None:
+                return
+            if len(frame) < _MIN_FRAME_BYTES:
+                continue
+            await socket.send(frame)
+            self.stats.bytes_sent += len(frame)
+            self.stats.frames_sent += 1
+
+    async def _recv_loop(self, socket) -> None:
+        async for raw in socket:
+            if isinstance(raw, bytes):
+                continue
+            # The heartbeat is the literal string "ping" -- not JSON.
+            if raw == 'ping':
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                log.debug('non-JSON frame from listen: %.60s', raw)
+                continue
+
+            # Live transcript arrives as a bare array, with no type envelope.
+            if isinstance(payload, list):
+                self.stats.segments_received += len(payload)
+                if self._on_segments:
+                    await self._on_segments(payload)
+                continue
+
+            if isinstance(payload, dict):
+                kind = payload.get('type')
+                if kind == 'conversation_session':
+                    self.stats.conversation_id = payload.get('conversation_id')
+                    log.info('capture conversation id: %s', self.stats.conversation_id)
+                elif kind == 'freemium_threshold_reached':
+                    self.stats.last_error = 'transcription quota nearly exhausted'
+                    log.warning('%s', self.stats.last_error)
+                if self._on_event:
+                    await self._on_event(payload)

--- a/integrations/omi-even/bridge/capture.py
+++ b/integrations/omi-even/bridge/capture.py
@@ -235,9 +235,7 @@ class CaptureSession:
 
                     sender = asyncio.create_task(self._send_loop(socket), name='capture-send')
                     receiver = asyncio.create_task(self._recv_loop(socket), name='capture-recv')
-                    done, pending = await asyncio.wait(
-                        {sender, receiver}, return_when=asyncio.FIRST_COMPLETED
-                    )
+                    done, pending = await asyncio.wait({sender, receiver}, return_when=asyncio.FIRST_COMPLETED)
                     for task in pending:
                         task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):

--- a/integrations/omi-even/bridge/compose.py
+++ b/integrations/omi-even/bridge/compose.py
@@ -1,0 +1,139 @@
+"""Turn retrieved facts into a real answer, using Omi's own LLM.
+
+Retrieval alone produces bullets, which is not what anyone asked for. Omi's agent
+produces prose but needs 6-18s, and Even's client gives up around 5s -- streaming
+past the limit was tried and the glasses reported a network error, so a complete
+response inside the budget is the only shape that works.
+
+The way through: `POST /v1/conversations/{id}/test-prompt` runs a single LLM call
+(`gpt-5.4-mini`) with an **arbitrary** prompt, no retrieval loop, on the Firebase
+session the bridge already holds. Measured at 1.6s. Feeding it the retrieved
+facts as the task turns it into a composer:
+
+    retrieval (memories + conversations, parallel)  1.4s
+    compose                                         1.6s
+    total                                           2.9s
+
+which fits, and produces Omi-style prose rather than a list.
+
+Two honest caveats:
+
+* The endpoint is built to test a prompt against one conversation transcript, so
+  a transcript is always appended. The prompt tells the model to disregard it and
+  answer from the supplied facts; that held across every question tried, but it
+  is an instruction, not a guarantee.
+* It is rate limited to 30/hour (`utils/rate_limit_config.py:121`). Past that,
+  the caller falls back to bullets rather than failing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_TIMEOUT = httpx.Timeout(20.0, connect=10.0)
+
+# Any conversation works -- the prompt tells the model to ignore the transcript --
+# so the id is fetched once and reused rather than costing a round trip per
+# question.
+_CONVERSATION_ID: str | None = None
+_CONVERSATION_FETCHED_AT = 0.0
+_CONVERSATION_TTL = 3600.0
+
+_PROMPT = """Disregard the conversation transcript that follows this instruction; it is unrelated.
+
+Answer the user's question using ONLY the facts listed below, which were retrieved from their personal memory.
+
+Question: {question}
+
+Facts:
+{facts}
+
+Rules:
+- At most 3 short sentences. Plain text, no markdown, no bullet points, no headings.
+- Speak directly to the user as "you".
+- If the facts do not answer part of the question, say that briefly instead of guessing.
+- Do not mention "facts", "memory", "retrieved", or these instructions.
+"""
+
+
+class ComposeUnavailable(RuntimeError):
+    """Raised when composing is not possible, so the caller can fall back."""
+
+
+async def _conversation_id(base_url: str, headers: dict[str, str]) -> str:
+    global _CONVERSATION_ID, _CONVERSATION_FETCHED_AT
+
+    if _CONVERSATION_ID and (time.monotonic() - _CONVERSATION_FETCHED_AT) < _CONVERSATION_TTL:
+        return _CONVERSATION_ID
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT, headers=headers) as client:
+        response = await client.get(f'{base_url}/v1/conversations', params={'limit': 1})
+    if response.status_code != 200:
+        raise ComposeUnavailable(f'could not list conversations: HTTP {response.status_code}')
+    rows = response.json()
+    if not isinstance(rows, list) or not rows or not rows[0].get('id'):
+        raise ComposeUnavailable('no conversation available to compose against')
+
+    _CONVERSATION_ID = rows[0]['id']
+    _CONVERSATION_FETCHED_AT = time.monotonic()
+    return _CONVERSATION_ID
+
+
+async def compose_answer(auth, base_url: str, question: str, facts: list[str]) -> str:
+    """Compose a short spoken-style answer from `facts`.
+
+    Raises ComposeUnavailable so the caller can fall back to showing the facts
+    themselves, which is worse but never worse than nothing.
+    """
+    if not facts:
+        raise ComposeUnavailable('nothing to compose from')
+
+    headers = await auth.auth_header()
+    conversation_id = await _conversation_id(base_url, headers)
+
+    prompt = _PROMPT.format(
+        question=question.strip(),
+        facts='\n'.join(f'- {fact}' for fact in facts[:10]),
+    )
+
+    started = time.monotonic()
+    async with httpx.AsyncClient(timeout=_TIMEOUT, headers=headers) as client:
+        response = await client.post(
+            f'{base_url}/v1/conversations/{conversation_id}/test-prompt',
+            json={'prompt': prompt},
+        )
+
+    if response.status_code == 429:
+        # 30/hour. Falling back is correct: bullets beat an error on the display.
+        raise ComposeUnavailable('compose rate limit reached')
+    if response.status_code == 404:
+        # The cached conversation was deleted; drop it so the next call refetches.
+        global _CONVERSATION_ID
+        _CONVERSATION_ID = None
+        raise ComposeUnavailable('cached conversation no longer exists')
+    if response.status_code != 200:
+        raise ComposeUnavailable(f'compose failed: HTTP {response.status_code}')
+
+    answer = ((response.json() or {}).get('summary') or '').strip()
+    if not answer:
+        raise ComposeUnavailable('compose returned nothing')
+
+    log.info('composed in %.1fs (%d chars)', time.monotonic() - started, len(answer))
+    return answer
+
+
+async def compose_or_none(auth, base_url: str, question: str, facts: list[str], budget_s: float) -> str | None:
+    """compose_answer, but never raises and never exceeds `budget_s`."""
+    try:
+        return await asyncio.wait_for(compose_answer(auth, base_url, question, facts), timeout=budget_s)
+    except (ComposeUnavailable, TimeoutError) as exc:
+        log.info('falling back to raw facts: %s', exc)
+    except Exception as exc:  # noqa: BLE001 - a compose failure must never 500
+        log.warning('compose error, falling back: %s', exc)
+    return None

--- a/integrations/omi-even/bridge/compose.py
+++ b/integrations/omi-even/bridge/compose.py
@@ -1,38 +1,43 @@
-"""Turn retrieved facts into a real answer, using Omi's own LLM.
+"""Turn retrieved facts into a real answer instead of a list of bullets.
 
 Retrieval alone produces bullets, which is not what anyone asked for. Omi's agent
 produces prose but needs 6-18s, and Even's client gives up around 5s -- streaming
 past the limit was tried and the glasses reported a network error, so a complete
 response inside the budget is the only shape that works.
 
-The way through: `POST /v1/conversations/{id}/test-prompt` runs a single LLM call
-(`gpt-5.4-mini`) with an **arbitrary** prompt, no retrieval loop, on the Firebase
-session the bridge already holds. Measured at 1.6s. Feeding it the retrieved
-facts as the task turns it into a composer:
+So compose is a *separate, single* LLM call over the facts retrieval already
+found, and there are two ways to make it:
+
+**Local (default).** Ollama on this Mac, `qwen3.6:35b-a3b`, ~1.3-2.3s once warm.
+No rate limit, no cost, and the facts never leave the machine to be turned into
+a sentence. See `local_llm.py`.
+
+**Cloud (fallback).** `POST /v1/conversations/{id}/test-prompt` runs one
+`gpt-5.4-mini` call with an **arbitrary** prompt and no retrieval loop, on the
+Firebase session the bridge already holds. ~1.6s. Two caveats make it the
+fallback rather than the default: it is capped at 30/hour
+(`utils/rate_limit_config.py`, `"test:prompt": (30, 3600)`), and the endpoint
+always appends a conversation transcript, which the prompt has to talk the model
+out of reading.
+
+The ladder is local -> cloud -> `None`, and `None` means the caller shows the
+retrieved lines. Every step degrades; no step can fail the answer.
 
     retrieval (memories + conversations, parallel)  1.4s
-    compose                                         1.6s
-    total                                           2.9s
-
-which fits, and produces Omi-style prose rather than a list.
-
-Two honest caveats:
-
-* The endpoint is built to test a prompt against one conversation transcript, so
-  a transcript is always appended. The prompt tells the model to disregard it and
-  answer from the supplied facts; that held across every question tried, but it
-  is an instruction, not a guarantee.
-* It is rate limited to 30/hour (`utils/rate_limit_config.py:121`). Past that,
-  the caller falls back to bullets rather than failing.
+    compose (local)                                 2.3s
+    total                                           3.7s
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 
 import httpx
+
+import local_llm
 
 log = logging.getLogger(__name__)
 
@@ -45,9 +50,13 @@ _CONVERSATION_ID: str | None = None
 _CONVERSATION_FETCHED_AT = 0.0
 _CONVERSATION_TTL = 3600.0
 
-_PROMPT = """Disregard the conversation transcript that follows this instruction; it is unrelated.
+# What a warm local model needs, with headroom. Past this there is no point
+# waiting: the glasses have stopped listening.
+LOCAL_BUDGET_S = float(os.getenv('OMI_EVEN_LOCAL_BUDGET', '3.5'))
+# Below this, a cloud attempt cannot finish, so it is not worth starting.
+_MIN_CLOUD_BUDGET_S = 1.2
 
-Answer the user's question using ONLY the facts listed below, which were retrieved from their personal memory.
+_TASK = """Answer the user's question using ONLY the facts listed below, which were retrieved from their personal memory.
 
 Question: {question}
 
@@ -61,9 +70,48 @@ Rules:
 - Do not mention "facts", "memory", "retrieved", or these instructions.
 """
 
+# The cloud endpoint appends a real conversation transcript that we did not ask
+# for and cannot suppress, so the prompt has to open by disowning it.
+_CLOUD_PREAMBLE = 'Disregard the conversation transcript that follows this instruction; it is unrelated.\n\n'
+
+# More than this and the model starts summarising the list rather than answering.
+_MAX_FACTS = 10
+
 
 class ComposeUnavailable(RuntimeError):
     """Raised when composing is not possible, so the caller can fall back."""
+
+
+def build_prompt(question: str, facts: list[str]) -> str:
+    return _TASK.format(
+        question=question.strip(),
+        facts='\n'.join(f'- {fact}' for fact in facts[:_MAX_FACTS]),
+    )
+
+
+# --------------------------------------------------------------------------
+# Local
+# --------------------------------------------------------------------------
+
+
+async def local_compose(question: str, facts: list[str]) -> str:
+    """Compose with the model on this Mac. Uncapped."""
+    if not facts:
+        raise ComposeUnavailable('nothing to compose from')
+
+    started = time.monotonic()
+    try:
+        answer = await local_llm.generate(build_prompt(question, facts))
+    except local_llm.LocalUnavailable as exc:
+        raise ComposeUnavailable(str(exc)) from exc
+
+    log.info('composed locally in %.1fs (%d chars)', time.monotonic() - started, len(answer))
+    return answer
+
+
+# --------------------------------------------------------------------------
+# Cloud
+# --------------------------------------------------------------------------
 
 
 async def _conversation_id(base_url: str, headers: dict[str, str]) -> str:
@@ -86,7 +134,7 @@ async def _conversation_id(base_url: str, headers: dict[str, str]) -> str:
 
 
 async def compose_answer(auth, base_url: str, question: str, facts: list[str]) -> str:
-    """Compose a short spoken-style answer from `facts`.
+    """Compose with Omi's own LLM. Capped at 30/hour.
 
     Raises ComposeUnavailable so the caller can fall back to showing the facts
     themselves, which is worse but never worse than nothing.
@@ -97,20 +145,15 @@ async def compose_answer(auth, base_url: str, question: str, facts: list[str]) -
     headers = await auth.auth_header()
     conversation_id = await _conversation_id(base_url, headers)
 
-    prompt = _PROMPT.format(
-        question=question.strip(),
-        facts='\n'.join(f'- {fact}' for fact in facts[:10]),
-    )
-
     started = time.monotonic()
     async with httpx.AsyncClient(timeout=_TIMEOUT, headers=headers) as client:
         response = await client.post(
             f'{base_url}/v1/conversations/{conversation_id}/test-prompt',
-            json={'prompt': prompt},
+            json={'prompt': _CLOUD_PREAMBLE + build_prompt(question, facts)},
         )
 
     if response.status_code == 429:
-        # 30/hour. Falling back is correct: bullets beat an error on the display.
+        # 30/hour. Falling back is correct: bullets on the display beat an error.
         raise ComposeUnavailable('compose rate limit reached')
     if response.status_code == 404:
         # The cached conversation was deleted; drop it so the next call refetches.
@@ -124,16 +167,48 @@ async def compose_answer(auth, base_url: str, question: str, facts: list[str]) -
     if not answer:
         raise ComposeUnavailable('compose returned nothing')
 
-    log.info('composed in %.1fs (%d chars)', time.monotonic() - started, len(answer))
+    log.info('composed in cloud in %.1fs (%d chars)', time.monotonic() - started, len(answer))
     return answer
 
 
-async def compose_or_none(auth, base_url: str, question: str, facts: list[str], budget_s: float) -> str | None:
-    """compose_answer, but never raises and never exceeds `budget_s`."""
+# --------------------------------------------------------------------------
+# The ladder
+# --------------------------------------------------------------------------
+
+
+async def _attempt(coro, budget_s: float) -> str | None:
+    """Run one rung. Never raises, never exceeds `budget_s`."""
+    if budget_s <= 0:
+        coro.close()
+        return None
     try:
-        return await asyncio.wait_for(compose_answer(auth, base_url, question, facts), timeout=budget_s)
+        return await asyncio.wait_for(coro, timeout=budget_s)
     except (ComposeUnavailable, TimeoutError) as exc:
-        log.info('falling back to raw facts: %s', exc)
+        log.info('compose rung unavailable: %s', exc)
     except Exception as exc:  # noqa: BLE001 - a compose failure must never 500
-        log.warning('compose error, falling back: %s', exc)
+        log.warning('compose rung errored: %s', exc)
     return None
+
+
+async def compose_or_none(auth, base_url: str, question: str, facts: list[str], budget_s: float) -> str | None:
+    """Local, then cloud, then give up -- inside `budget_s` and without raising."""
+    if not facts:
+        return None
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + budget_s
+
+    if not os.getenv('OMI_EVEN_NO_LOCAL') and local_llm.is_available():
+        # A stopped Ollama refuses the connection in milliseconds, so trying it
+        # first costs the cloud rung almost nothing when it is not there.
+        answer = await _attempt(
+            local_compose(question, facts),
+            min(LOCAL_BUDGET_S, deadline - loop.time()),
+        )
+        if answer:
+            return answer
+
+    remaining = deadline - loop.time()
+    if os.getenv('OMI_EVEN_NO_CLOUD') or remaining < _MIN_CLOUD_BUDGET_S:
+        return None
+    return await _attempt(compose_answer(auth, base_url, question, facts), remaining)

--- a/integrations/omi-even/bridge/display.py
+++ b/integrations/omi-even/bridge/display.py
@@ -90,6 +90,13 @@ _URL_RE = re.compile(r'(?:https?://|ftp://|www\.)[^\s<>()\[\]"\']+', re.IGNORECA
 # from firing on a markdown link whose label happens to be a number.
 _CITATION_RE = re.compile(r'\[\d{1,3}\](?!\()')
 
+# Omi emits <cite index="8-5">quoted evidence</cite> around retrieved passages.
+# Observed live: these survive markdown stripping and render as literal angle
+# brackets on the glasses. Matches any simple tag so a future wrapper element
+# degrades to its text rather than leaking markup. Deliberately requires a
+# letter or `/` after `<`, so "a < b" and "5<10" are untouched.
+_TAG_RE = re.compile(r'</?[a-zA-Z][^<>]{0,200}>')
+
 _CODE_RE = re.compile(r'`{1,3}([^`\n]*)`{1,3}')
 _BOLD_ITALIC_RE = re.compile(r'\*\*\*([^*\n]+)\*\*\*|___([^_\n]+)___')
 _BOLD_RE = re.compile(r'\*\*([^*\n]+)\*\*|__([^_\n]+)__')
@@ -239,6 +246,13 @@ def _strip_markdown(text: str) -> str:
     text = _URL_RE.sub('', text)
 
     text = _CITATION_RE.sub('', text)
+
+    # Omi wraps quoted evidence in <cite index="8-5">...</cite>. Keep the quoted
+    # words -- they are the substance of the answer -- and drop only the tags,
+    # which otherwise render as literal angle brackets on the glasses.
+    # A space is inserted because the opening tag usually abuts the previous word
+    # ("said<cite ...>WhatsApp" -> "said WhatsApp", not "saidWhatsApp").
+    text = _TAG_RE.sub(' ', text)
 
     # Emphasis, widest marker first so *** is not eaten by **.
     text = _CODE_RE.sub(r'\1', text)

--- a/integrations/omi-even/bridge/display.py
+++ b/integrations/omi-even/bridge/display.py
@@ -1,0 +1,437 @@
+"""Adapt Omi chat answers for the Even Realities G2 glasses display.
+
+Omi writes for a phone: markdown, bullet lists, links, fenced code, inline
+citations (``yesterday[1][2]``), emoji and long paragraphs. The G2 renders
+roughly 400 characters of monochrome text with no markdown, no fonts, no
+alignment and a firmware-limited character set, so raw Omi output arrives as
+garbage. This module is the adapter between the two.
+
+Three entry points:
+
+    fit_for_glasses(text, limit=380) -> str
+        One screen of display-ready text.
+
+    paginate(text, page_size=400) -> list[str]
+        Display-ready text split across several screens, losing nothing.
+
+    openai_chat_completion(content, model='omi') -> dict
+        The response body the Even "Add Agent" endpoint expects.
+
+Stdlib only -- the bridge must run before any venv exists.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import unicodedata
+import uuid
+
+__all__ = [
+    'DEFAULT_LIMIT',
+    'DEFAULT_PAGE_SIZE',
+    'fit_for_glasses',
+    'paginate',
+    'openai_chat_completion',
+]
+
+# The G2 shows ~400 characters. The default fit limit keeps a little headroom
+# so a caller can prepend a short prefix without overflowing the screen.
+DEFAULT_LIMIT = 380
+DEFAULT_PAGE_SIZE = 400
+
+ELLIPSIS = '...'
+
+# A sentence boundary is the nicest place to cut, but only if it still fills
+# the screen. Omi's bullet lists carry no terminal punctuation, so the "last
+# sentence that fits" can sit a long way back and waste half the display --
+# and on a 400-character screen those wasted lines are real information. Below
+# this fraction of the budget we take the word boundary instead.
+_MIN_SENTENCE_FILL = 0.6
+
+
+# --------------------------------------------------------------------------
+# Markdown stripping
+#
+# Order matters and is enforced by _strip_markdown: block constructs first
+# (they are anchored to line starts and would be destroyed by inline rules),
+# then links before bare URLs (so a link target is never mistaken for prose),
+# then citations, then emphasis.
+# --------------------------------------------------------------------------
+
+# A fence line -- ```python / ``` / ~~~ -- is dropped, its contents kept. The
+# code is often the whole answer to a "how do I" question; the fence is never
+# information.
+_FENCE_RE = re.compile(r'^[ \t]*(?:`{3,}|~{3,})[^\n]*$', re.MULTILINE)
+
+# Horizontal rules: ---, ***, ___ (with optional spaces between). Must run
+# before the bullet rule so "- - -" is not read as a list item.
+_HR_RE = re.compile(r'^[ \t]{0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$', re.MULTILINE)
+
+_HEADING_RE = re.compile(r'^[ \t]{0,3}#{1,6}[ \t]*', re.MULTILINE)
+_QUOTE_RE = re.compile(r'^[ \t]*>+[ \t]?', re.MULTILINE)
+
+# -, *, + and 1. / 1) all collapse to a plain "- " marker.
+_BULLET_RE = re.compile(r'^[ \t]*(?:[-*+]|\d{1,3}[.)])[ \t]+', re.MULTILINE)
+
+# GitHub task list boxes, after the bullet above has been normalised.
+_TASK_RE = re.compile(r'^- \[[ xX]\][ \t]*', re.MULTILINE)
+
+# Images carry no information on a monochrome text display -- drop them whole.
+_IMAGE_RE = re.compile(r'!\[[^\]\n]*\]\([^)\n]*\)')
+
+# [label](url) -> label
+_LINK_RE = re.compile(r'\[([^\]\n]*)\]\([^)\n]*\)')
+
+_AUTOLINK_RE = re.compile(r'<(?:https?|ftp|mailto):[^>\s]*>')
+_URL_RE = re.compile(r'(?:https?://|ftp://|www\.)[^\s<>()\[\]"\']+', re.IGNORECASE)
+
+# Omi citations: "text[1]", "text[1][2]". The negative lookahead keeps this
+# from firing on a markdown link whose label happens to be a number.
+_CITATION_RE = re.compile(r'\[\d{1,3}\](?!\()')
+
+_CODE_RE = re.compile(r'`{1,3}([^`\n]*)`{1,3}')
+_BOLD_ITALIC_RE = re.compile(r'\*\*\*([^*\n]+)\*\*\*|___([^_\n]+)___')
+_BOLD_RE = re.compile(r'\*\*([^*\n]+)\*\*|__([^_\n]+)__')
+_ITALIC_RE = re.compile(r'(?<![\w*])\*([^*\n]+)\*(?![\w*])|(?<![\w_])_([^_\n]+)_(?![\w_])')
+_STRIKE_RE = re.compile(r'~~([^~\n]+)~~')
+
+# Brackets left empty once their contents were removed, e.g. "see ()".
+_EMPTY_PAIR_RE = re.compile(r'\([ \t]*\)|\[[ \t]*\]|<[ \t]*>')
+
+# A space that only exists because something was deleted before punctuation.
+_SPACE_BEFORE_PUNCT_RE = re.compile(r'[^\S\n]+([,.;:!?])')
+
+_HORIZONTAL_WS_RE = re.compile(r'[^\S\n]+')
+_BLANK_LINES_RE = re.compile(r'\n{3,}')
+
+# Sentence terminator, allowing a closing quote/bracket, followed by space or
+# end of text. Used to prefer sentence boundaries when truncating.
+_SENTENCE_END_RE = re.compile(r'[.!?][\'")\]]*(?=\s|\Z)')
+_SENTENCE_SPLIT_RE = re.compile(r'(?<=[.!?])\s+')
+
+# Leftovers that carry no meaning once their content was stripped.
+_EMPTY_LINE_TOKENS = frozenset({'-', '*', '+', '- -', '|', '-|', '#'})
+
+
+# --------------------------------------------------------------------------
+# Character set
+#
+# The firmware font is limited, so anything outside printable ASCII is either
+# transliterated to a recognisable ASCII equivalent or dropped. Dropping is
+# always safe; rendering an unsupported glyph is not.
+# --------------------------------------------------------------------------
+
+_TRANSLITERATIONS = {
+    # Quotes and primes.
+    '‘': "'",
+    '’': "'",
+    '‚': "'",
+    '‛': "'",
+    '′': "'",
+    '“': '"',
+    '”': '"',
+    '„': '"',
+    '‟': '"',
+    '″': '"',
+    '«': '"',
+    '»': '"',
+    '‹': "'",
+    '›': "'",
+    # Dashes and minus.
+    '‐': '-',
+    '‑': '-',
+    '‒': '-',
+    '–': '-',
+    '—': '-',
+    '―': '-',
+    '−': '-',
+    # Ellipsis expands, so a smart ellipsis still reads as one on-device.
+    '…': '...',
+    # Spaces that are not U+0020.
+    ' ': ' ',
+    ' ': ' ',
+    ' ': ' ',
+    ' ': ' ',
+    ' ': ' ',
+    '　': ' ',
+    # Zero-width joiners/marks: emoji glue and invisible junk.
+    '​': '',
+    '‌': '',
+    '‍': '',
+    '﻿': '',
+    '⁠': '',
+    # List glyphs Omi sometimes emits directly.
+    '•': '-',
+    '‣': '-',
+    '▪': '-',
+    '●': '-',
+    '◦': '-',
+    '·': '-',
+    # Arrows and math that show up in explanations.
+    '→': '->',
+    '←': '<-',
+    '↔': '<->',
+    '⇒': '=>',
+    '≤': '<=',
+    '≥': '>=',
+    '≠': '!=',
+    '×': 'x',
+    '÷': '/',
+    '⁄': '/',
+    # Currency and marks with no ASCII decomposition.
+    '€': 'EUR',
+    '£': 'GBP',
+    '¥': 'JPY',
+    '¢': 'c',
+    '™': 'TM',
+    '®': '(R)',
+    '©': '(C)',
+}
+
+
+def _to_safe_charset(text: str) -> str:
+    """Map text onto printable ASCII, transliterating what has an equivalent.
+
+    Anything with no sensible ASCII rendering -- emoji, CJK, symbols -- is
+    dropped rather than shown as a missing glyph.
+    """
+    out: list[str] = []
+    for char in text:
+        if char == '\n':
+            out.append(char)
+            continue
+        if ' ' <= char <= '~':
+            out.append(char)
+            continue
+        if char == '\t':
+            out.append(' ')
+            continue
+        replacement = _TRANSLITERATIONS.get(char)
+        if replacement is not None:
+            out.append(replacement)
+            continue
+        # Compatibility-decompose so "café" -> "cafe" and "½" -> "1/2".
+        for piece in unicodedata.normalize('NFKD', char):
+            if ' ' <= piece <= '~':
+                out.append(piece)
+            elif unicodedata.combining(piece):
+                continue
+            else:
+                out.append(_TRANSLITERATIONS.get(piece, ''))
+    return ''.join(out)
+
+
+def _strip_markdown(text: str) -> str:
+    """Remove every markdown construct, keeping the words inside it."""
+    # Block level first -- these are anchored to line starts.
+    text = _FENCE_RE.sub('', text)
+    text = _HR_RE.sub('', text)
+    text = _HEADING_RE.sub('', text)
+    text = _QUOTE_RE.sub('', text)
+    text = _BULLET_RE.sub('- ', text)
+    text = _TASK_RE.sub('- ', text)
+
+    # Links before URLs, so a link target never survives as prose.
+    text = _IMAGE_RE.sub('', text)
+    text = _LINK_RE.sub(r'\1', text)
+    text = _AUTOLINK_RE.sub('', text)
+    text = _URL_RE.sub('', text)
+
+    text = _CITATION_RE.sub('', text)
+
+    # Emphasis, widest marker first so *** is not eaten by **.
+    text = _CODE_RE.sub(r'\1', text)
+    text = _BOLD_ITALIC_RE.sub(lambda m: m.group(1) or m.group(2) or '', text)
+    text = _BOLD_RE.sub(lambda m: m.group(1) or m.group(2) or '', text)
+    text = _ITALIC_RE.sub(lambda m: m.group(1) or m.group(2) or '', text)
+    text = _STRIKE_RE.sub(r'\1', text)
+    return text
+
+
+def _collapse_whitespace(text: str) -> str:
+    """Squeeze horizontal runs, drop dead lines, allow at most one blank line."""
+    lines = []
+    for line in text.split('\n'):
+        line = _HORIZONTAL_WS_RE.sub(' ', line).strip()
+        # A bullet whose only content was a URL or an emoji is now noise.
+        if line in _EMPTY_LINE_TOKENS:
+            line = ''
+        lines.append(line)
+    text = '\n'.join(lines)
+    text = _BLANK_LINES_RE.sub('\n\n', text)
+    return text.strip()
+
+
+def _with_ellipsis(head: str) -> str:
+    """Close a truncated fragment with exactly one ellipsis."""
+    # Strip trailing whitespace and dangling punctuation so a cut on a
+    # sentence boundary reads "Done..." rather than "Done....".
+    head = head.rstrip().rstrip(' .,;:')
+    return head + ELLIPSIS
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Cut to `limit` characters INCLUDING the ellipsis, never mid-word.
+
+    Prefers a sentence boundary, falls back to a word boundary. The length
+    cap is absolute: for the degenerate case of a single word longer than the
+    limit there is no whitespace to cut on, and the word is hard-cut rather
+    than overflowing the screen.
+    """
+    if limit <= 0:
+        return ''
+    if len(text) <= limit:
+        return text
+    if limit <= len(ELLIPSIS):
+        # No room for both content and an ellipsis; content wins.
+        return text[:limit].rstrip()
+
+    budget = limit - len(ELLIPSIS)
+
+    # 1. Last sentence boundary that fits.
+    sentence_cut = 0
+    for match in _SENTENCE_END_RE.finditer(text):
+        if match.end() <= budget:
+            sentence_cut = match.end()
+        else:
+            break
+
+    # 2. Otherwise -- or when that boundary wastes most of the screen -- the
+    #    last word boundary that fits. budget + 1 as the search end means a
+    #    separator sitting exactly at `budget` still counts, which keeps the
+    #    word before it whole.
+    cut = sentence_cut
+    if sentence_cut < budget * _MIN_SENTENCE_FILL:
+        word_cut = max(text.rfind(' ', 0, budget + 1), text.rfind('\n', 0, budget + 1))
+        cut = max(cut, word_cut)
+
+    # 3. Otherwise a single oversized word: hard-cut to hold the limit.
+    head = text[:cut] if cut > 0 else text[:budget]
+    return _with_ellipsis(head)
+
+
+def fit_for_glasses(text: str, limit: int = DEFAULT_LIMIT) -> str:
+    """Turn an Omi chat answer into one screen of G2-renderable text.
+
+    Strips markdown, removes URLs and Omi citation markers, forces the text
+    into the firmware-safe character set, collapses whitespace and truncates
+    on a sentence (else word) boundary. The result is never longer than
+    `limit` -- the ellipsis is included in that budget -- and never carries
+    leading or trailing whitespace. Empty or whitespace-only input, and input
+    that is entirely unrenderable (emoji only), returns "".
+    """
+    if not text or not text.strip():
+        return ''
+
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    text = _strip_markdown(text)
+    text = _to_safe_charset(text)
+    text = _EMPTY_PAIR_RE.sub('', text)
+    text = _SPACE_BEFORE_PUNCT_RE.sub(r'\1', text)
+    text = _collapse_whitespace(text)
+    if not text:
+        return ''
+    return _truncate(text, limit)
+
+
+# --------------------------------------------------------------------------
+# Pagination
+# --------------------------------------------------------------------------
+
+
+def _split_word(word: str, page_size: int) -> list[str]:
+    """Last resort: a single word longer than the screen, cut into chunks."""
+    return [word[i : i + page_size] for i in range(0, len(word), page_size)]
+
+
+def _pack(units: list[str], sep: str, page_size: int, split_smaller) -> list[str]:
+    """Greedily pack `units` into pages, recursing when a unit cannot fit.
+
+    Every returned page is <= page_size and no non-whitespace character is
+    lost or reordered.
+    """
+    pages: list[str] = []
+    current = ''
+    for unit in units:
+        candidate = unit if not current else current + sep + unit
+        if len(candidate) <= page_size:
+            current = candidate
+            continue
+        if current:
+            pages.append(current)
+            current = ''
+        if len(unit) <= page_size:
+            current = unit
+            continue
+        # Too big even on its own: break it into finer units. All but the last
+        # chunk are complete pages; the last stays open for what follows.
+        chunks = split_smaller(unit, page_size)
+        if chunks:
+            pages.extend(chunks[:-1])
+            current = chunks[-1]
+    if current:
+        pages.append(current)
+    return pages
+
+
+def _split_sentence(sentence: str, page_size: int) -> list[str]:
+    return _pack(sentence.split(), ' ', page_size, _split_word)
+
+
+def _split_paragraph(paragraph: str, page_size: int) -> list[str]:
+    sentences = [s for s in _SENTENCE_SPLIT_RE.split(paragraph) if s]
+    return _pack(sentences, ' ', page_size, _split_sentence)
+
+
+def paginate(text: str, page_size: int = DEFAULT_PAGE_SIZE) -> list[str]:
+    """Split display-ready text into screens that each fit the G2.
+
+    Breaks on paragraph boundaries, then sentence, then word -- never mid-word
+    (the sole exception being a single word longer than a whole screen, which
+    has no boundary to break on). No page exceeds `page_size`; every word is
+    preserved, in order. Empty or whitespace-only input returns [].
+    """
+    if page_size <= 0:
+        raise ValueError('page_size must be positive')
+    if not text or not text.strip():
+        return []
+
+    paragraphs = [p.strip() for p in re.split(r'\n[ \t]*\n', text.strip())]
+    paragraphs = [p for p in paragraphs if p]
+    return _pack(paragraphs, '\n\n', page_size, _split_paragraph)
+
+
+# --------------------------------------------------------------------------
+# Transport
+# --------------------------------------------------------------------------
+
+
+def openai_chat_completion(content: str, model: str = 'omi') -> dict:
+    """Build the OpenAI chat-completion body the Even glasses expect.
+
+    The Even "Add Agent" endpoint speaks the OpenAI chat-completions shape;
+    the glasses render choices[0].message.content.
+    """
+    content = content if isinstance(content, str) else ''
+    # The glasses do no tokenisation -- this is a cheap, honest estimate so the
+    # body is structurally complete rather than a fabricated exact count.
+    completion_tokens = (len(content) + 3) // 4 if content else 0
+    return {
+        'id': f'chatcmpl-{uuid.uuid4().hex[:24]}',
+        'object': 'chat.completion',
+        'created': int(time.time()),
+        'model': model,
+        'choices': [
+            {
+                'index': 0,
+                'message': {'role': 'assistant', 'content': content},
+                'finish_reason': 'stop',
+            }
+        ],
+        'usage': {
+            'prompt_tokens': 0,
+            'completion_tokens': completion_tokens,
+            'total_tokens': completion_tokens,
+        },
+    }

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -29,6 +29,14 @@ import re
 
 log = logging.getLogger(__name__)
 
+# Defined early: several module-level regexes below interpolate _MONTH_ALT,
+# and module code runs top to bottom.
+_MONTHS = {
+    'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
+    'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12,
+}
+_MONTH_ALT = '|'.join(_MONTHS)
+
 # "Found 5 memories matching 'David Zhang':" -- restates the question, wasting a
 # quarter of the screen.
 _PREAMBLE_RE = re.compile(r'^Found\s+\d+\s+\w+\s+matching\s+.*?:\s*', re.IGNORECASE | re.DOTALL)
@@ -38,9 +46,50 @@ _PREAMBLE_RE = re.compile(r'^Found\s+\d+\s+\w+\s+matching\s+.*?:\s*', re.IGNOREC
 _META_RE = re.compile(r'\s*\((?:relevance|category|date)[^)]*\)\s*$', re.IGNORECASE)
 _RELEVANCE_RE = re.compile(r'relevance:\s*([0-9.]+)')
 
-# Below this, hits are near-random: the live "David Zhang" query returned a
-# downloads-folder path at 0.38 alongside the real colleague fact at 0.48.
-_MIN_RELEVANCE = 0.40
+# Relevance is a weak signal here and was originally set far too high. Measured
+# against the live account, genuinely useful memories score 0.22-0.48, so a 0.40
+# floor was discarding most of the good ones. What actually separates signal from
+# noise is the category (below), not the score, so this only rejects the truly
+# random tail.
+_MIN_RELEVANCE = 0.15
+
+# The dominant failure in memory search: the desktop onboarding file scan writes
+# one memory per indexed local file, and those crowd out real ones. Measured hits
+# per 10 results -- pickleball 7/10 noise, burgers 9/10, "what I learned in July"
+# 10/10, which is why that question answered "nothing".
+#
+# Filtering on `category: system` was the obvious move and is WRONG: `system` is
+# the default bucket for extracted memories
+# (`utils/memory_ingestion/adapters/typed_extraction_prompt.py:201`), so rejecting
+# it discards real ones too. The backend's own cleanup keys on content instead --
+# these patterns follow `backend/utils/memory/legacy_backfill.py:127` and
+# `desktop/windows/src/renderer/src/lib/memoryCleanup.ts:20`.
+_FILE_NOISE_RE = re.compile(
+    r'(\b\d[\d,]*\s+local files indexed\b'
+    r'|\bworks on a local project named\b'
+    r"|\bthe user'?s? (local )?(documents|downloads|files|projects|repos(itories)?|folders)\b"
+    r'|\ba recently modified local file\b'
+    r'|^\s*focused on\b'
+    r'|^\s*distracted on\b'
+    r'|^\s*email from\b'
+    r"|^\s*uses(\s+[\w&+()'-]+){1,4}\s*$)",
+    re.IGNORECASE,
+)
+
+# The double anchor the desktop cleanup uses: a memory that merely mentions a
+# project is real, but one that also carries a filesystem path is inventory.
+_PATH_HINT_RE = re.compile(r'[~/\\]')
+_LOCAL_INDEX_STEM_RE = re.compile(
+    r"the user'?s? (local )?(projects?|files?|repos(itories)?|directories|folders|code(bases?)?)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_file_inventory(line: str) -> bool:
+    """True for a memory that is really an entry from the local-file indexer."""
+    if _FILE_NOISE_RE.search(line):
+        return True
+    return bool(_LOCAL_INDEX_STEM_RE.search(line) and _PATH_HINT_RE.search(line))
 
 # Word groups that decide which store to read. Checked in order, most specific
 # first, because "what did I do yesterday" is about conversations even though it
@@ -106,6 +155,11 @@ def _clean_bullets(result_text: str, min_relevance: float = _MIN_RELEVANCE) -> l
         if not line:
             continue
 
+        # Content first: a file-indexing artifact is noise at any relevance, and
+        # it is the single biggest source of useless answers.
+        if _is_file_inventory(line):
+            continue
+
         match = _RELEVANCE_RE.search(line)
         score = float(match.group(1)) if match else 1.0
         if score < min_relevance:
@@ -167,6 +221,34 @@ def _target_days(question: str) -> set[str]:
     return set()
 
 
+# A bare month name -- "everything I learned for July" -- with no day attached.
+_BARE_MONTH_RE = re.compile(rf'\b(?:in|for|during|about|over)\s+({_MONTH_ALT})\w*\b', re.IGNORECASE)
+
+
+def _explicit_month(question: str) -> tuple[int, int] | None:
+    """(year, month) for a month named without a day.
+
+    "Tell me everything I learned for July" carries a clear time reference that
+    the day-level parser cannot see, so it fell through to a semantic memory
+    search and answered "Nothing in your memories about that."
+    """
+    from datetime import datetime
+
+    if _explicit_date(question):
+        return None  # a full date already handles this
+
+    match = _BARE_MONTH_RE.search(question)
+    if not match:
+        return None
+    month = _MONTHS.get(match.group(1).lower()[:3])
+    if not month:
+        return None
+
+    today = datetime.now().astimezone().date()
+    year = today.year if month <= today.month else today.year - 1
+    return year, month
+
+
 # "23 Jul 2026 at 16:08 America/New_York (Technology)" begins each result block.
 _CONV_DATE_RE = re.compile(r'^\s*(\d{1,2}\s+[A-Za-z]{3}\s+\d{4})\b')
 
@@ -196,6 +278,36 @@ def _blocks_matching_days(result_text: str, days: set[str]) -> str:
         if stamp and any(stamp.lstrip('0') == day.lstrip('0') for day in days):
             kept.append(text)
     return '\n'.join(kept)
+
+
+def _conversation_titles(result_text: str, limit: int = 3) -> list[str]:
+    """The one-line summary each conversation block leads with.
+
+    A conversation's title is its most information-dense line -- "A group orders
+    fast food and discusses what they got, including burgers, fries, sauces" --
+    so it is what belongs next to a memory bullet.
+    """
+    body = _PREAMBLE_RE.sub('', result_text or '').strip()
+    if _NO_RESULTS_RE.match(body):
+        return []
+
+    titles: list[str] = []
+    expecting = False
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if re.match(r'^\s*Conversation\s*#\d+', line, re.IGNORECASE):
+            expecting = True  # the date line comes next, then the title
+            continue
+        if not line or _CONV_NOISE_RE.match(line):
+            continue
+        if expecting:
+            candidate = line.lstrip('#-').strip()
+            if candidate and not _is_junk(candidate) and candidate not in titles:
+                titles.append(candidate)
+            expecting = False
+        if len(titles) >= limit:
+            break
+    return titles
 
 
 def _compact_conversations(result_text: str, limit: int = 4, only_days: set[str] | None = None) -> str:
@@ -282,11 +394,6 @@ def _day_bounds(days_ago_start: int, days_ago_end: int) -> dict[str, str]:
     }
 
 
-_MONTHS = {
-    'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
-    'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12,
-}
-_MONTH_ALT = '|'.join(_MONTHS)
 # "4 July", "July 4", "4th of July", "on Jul 4th" -- both orders, optional
 # ordinal suffix, optional "of".
 # `\w*` after each month prefix absorbs the rest of the full name. Without it on
@@ -431,20 +538,31 @@ async def fast_answer(client, question: str) -> str:
             return 'Nothing recorded for that day.'
         return 'Nothing in your conversations about that.'
 
-    # Default: memories only.
-    #
-    # There used to be a conversation fallback here for when memory recall was
-    # thin, and it actively made answers worse. "Who is the president of the USA"
-    # returned a conversation about wallpapers -- and a word-overlap guard could
-    # not catch it, because that transcript really does contain both "president"
-    # and "USA" somewhere. The deeper issue is that such a question is not a
-    # memory question at all: answering it needs world knowledge, which this path
-    # has no LLM for. Admitting that beats confidently returning something
-    # unrelated.
-    memories_text = await _search_or_empty(client, 'memories/search', {'query': question, 'limit': 8})
+    # Both stores, in parallel, because they hold different things and neither is
+    # sufficient alone. Memories carry standing facts ("David is a colleague");
+    # conversations carry what actually happened ("a group orders burgers, fries,
+    # sauces"). Searching only memories answered "burgers" with a downloads-folder
+    # path, while conversations had the real thing. Running them together costs
+    # the slower of the two rather than their sum.
+    memories_text, conversations_text = await asyncio.gather(
+        _search_or_empty(client, 'memories/search', {'query': question, 'limit': 10}),
+        _search_or_empty(
+            client, 'conversations/search', {'query': question, 'limit': 4, 'include_transcript': False}
+        ),
+    )
+
     lines = _clean_bullets(memories_text)
 
-    if lines:
-        return _format(lines, '', limit=3)
+    # Conversations are only merged in when they clearly concern the question.
+    # Unguarded, this search always returns its nearest neighbour, which is how
+    # "who is the president of the USA" once answered with a chat about
+    # wallpapers -- a transcript that genuinely contains both words.
+    if _looks_relevant(question, conversations_text):
+        for extra in _conversation_titles(conversations_text):
+            if extra not in lines:
+                lines.append(extra)
 
-    return "Nothing in your memories about that."
+    if lines:
+        return _format(lines, '', limit=4)
+
+    return 'Nothing in your memories about that.'

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -1,0 +1,263 @@
+"""Answer a question fast enough that Even AI will actually show it.
+
+Even's custom-agent client has an undocumented timeout, and it is short. Proven
+on real hardware: a 0.4s reply renders on the glasses, while 5.6-8.4s replies
+arrive at the bridge, return 200 OK, and are never seen.
+
+Omi's `/v2/messages` cannot meet that budget -- its time to *first token* was
+6.6-13.9s in measurement, because the agent runs a retrieval loop before writing
+anything. So this path skips the agent and reads Omi's stores directly:
+
+    /v1/action-items                   0.17s
+    /v1/tools/conversations/search     0.79s
+    /v1/tools/memories/search          1.48s
+
+The cost is real and worth stating plainly: these return retrieved facts, not
+Omi's composed, reasoned answer. Composing would need an LLM the bridge does not
+have a key for. A slightly blunter answer that appears beats a better one that
+does not.
+
+The full agent path is still used by the omi Hub app, which streams to the
+display and has no deadline to beat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# "Found 5 memories matching 'David Zhang':" -- restates the question, wasting a
+# quarter of the screen.
+_PREAMBLE_RE = re.compile(r'^Found\s+\d+\s+\w+\s+matching\s+.*?:\s*', re.IGNORECASE | re.DOTALL)
+
+# "(relevance: 0.48, category: interesting, date: 2026-07-27)" -- debugging
+# metadata, meaningless on a heads-up display.
+_META_RE = re.compile(r'\s*\((?:relevance|category|date)[^)]*\)\s*$', re.IGNORECASE)
+_RELEVANCE_RE = re.compile(r'relevance:\s*([0-9.]+)')
+
+# Below this, hits are near-random: the live "David Zhang" query returned a
+# downloads-folder path at 0.38 alongside the real colleague fact at 0.48.
+_MIN_RELEVANCE = 0.40
+
+# Word groups that decide which store to read. Checked in order, most specific
+# first, because "what did I do yesterday" is about conversations even though it
+# contains "do".
+_ACTION_WORDS = ('action item', 'task', 'to-do', 'todo', 'behind on', 'due', 'my plate', 'commit')
+_CONVERSATION_WORDS = (
+    'yesterday', 'today', 'last night', 'this morning', 'this week', 'last week',
+    'talk', 'said', 'meeting', 'call', 'conversation', 'discuss', 'happened',
+)
+
+
+def _classify(question: str) -> str:
+    q = question.lower()
+    if any(w in q for w in _ACTION_WORDS):
+        return 'actions'
+    if any(w in q for w in _CONVERSATION_WORDS):
+        return 'conversations'
+    return 'memories'
+
+
+def _clean_bullets(result_text: str, min_relevance: float = _MIN_RELEVANCE) -> list[str]:
+    """Turn a tool's result_text into readable lines, best first."""
+    body = _PREAMBLE_RE.sub('', result_text or '').strip()
+    scored: list[tuple[float, str]] = []
+
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line.startswith('-'):
+            continue
+        line = line.lstrip('-').strip()
+        if not line:
+            continue
+
+        match = _RELEVANCE_RE.search(line)
+        score = float(match.group(1)) if match else 1.0
+        if score < min_relevance:
+            continue
+
+        line = _META_RE.sub('', line).strip().rstrip(',;')
+        if line:
+            scored.append((score, line))
+
+    # Stable sort keeps the tool's own ordering among equal scores.
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [text for _, text in scored]
+
+
+def _format(lines: list[str], empty_message: str, limit: int = 3) -> str:
+    if not lines:
+        return empty_message
+    return '\n'.join(f'- {line}' for line in lines[:limit])
+
+
+# Lines in a conversation result that are scaffolding rather than content.
+_CONV_NOISE_RE = re.compile(
+    r'^\s*(Conversation\s*#\d+|Started:|Finished:|\d{1,2}\s+\w+\s+\d{4}\s+at\b)', re.IGNORECASE
+)
+
+# The tools report "nothing found" as prose, not as an empty body.
+_NO_RESULTS_RE = re.compile(r'^\s*(No\s+(conversations?|memories|results)\s+found|Error:)', re.IGNORECASE)
+
+
+def _compact_conversations(result_text: str, limit: int = 4) -> str:
+    """Reduce a conversation dump to the few lines worth reading on glasses.
+
+    The raw result leads with `Conversation #1`, a timezone-qualified timestamp,
+    then `Started:`/`Finished:` repeating it twice more. That is most of a
+    380-character screen spent before any content appears.
+    """
+    body = _PREAMBLE_RE.sub('', result_text or '').strip()
+    # The tool phrases "no results" as a sentence rather than returning empty, and
+    # echoing it back reads as a broken answer ("- No conversations found matching
+    # 'What did I do yesterday?' in the specified date range.").
+    if _NO_RESULTS_RE.match(body):
+        return ''
+    kept: list[str] = []
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line or _CONV_NOISE_RE.match(line):
+            continue
+        line = line.lstrip('#').strip()  # "## Screen Check" -> "Screen Check"
+        line = line.lstrip('-').strip()
+        if line:
+            kept.append(line)
+        if len(kept) >= limit:
+            break
+    return '\n'.join(f'- {line}' for line in kept)
+
+
+_STOPWORDS = frozenset(
+    'a an the is are was were do does did i me my you your what when where who whom '
+    'why how all about tell know of on in to for and or with can could would should '
+    'me mine we us our there here that this those these it its'.split()
+)
+
+
+def _looks_relevant(question: str, text: str) -> bool:
+    """Guard so a thin match is not passed off as an answer.
+
+    Conversation search carries no relevance score and always returns
+    *something*: "who is the president of the USA" surfaced a conversation about
+    wallpapers. One shared word proved too weak a filter -- a long transcript
+    mentions almost any single common word eventually -- so this requires most of
+    the question's content words, matched on word boundaries rather than as
+    substrings.
+    """
+    terms = {w for w in re.findall(r'[a-z0-9]+', question.lower()) if w not in _STOPWORDS and len(w) > 2}
+    if not terms:
+        return True  # nothing to check against; do not block on it
+
+    haystack = text.lower()
+    hits = sum(1 for term in terms if re.search(rf'\b{re.escape(term)}\b', haystack))
+    # With only one or two content words, a single incidental hit is exactly the
+    # failure case -- "USA" appears in a conversation about a trip, and the answer
+    # to "who is the president of the USA" becomes a wallpaper chat. Demand all of
+    # them. Longer questions relax to a majority so a stray word cannot veto a
+    # genuine match.
+    required = len(terms) if len(terms) <= 2 else (len(terms) + 1) // 2
+    return hits >= required
+
+
+def _day_bounds(days_ago_start: int, days_ago_end: int) -> dict[str, str]:
+    """Timezone-aware bounds spanning whole local days.
+
+    The search tool rejects a bare date: it requires
+    `YYYY-MM-DDTHH:MM:SS+HH:MM`, and a plain `2026-07-20` comes back as an error
+    rather than a filter. That error is indistinguishable from an empty result,
+    so the bad format silently produced "nothing recorded" for days that had
+    plenty -- a wrong answer, not a missing one.
+    """
+    from datetime import datetime, time, timedelta
+
+    local_tz = datetime.now().astimezone().tzinfo
+    today = datetime.now(local_tz).date()
+    start_day = today - timedelta(days=days_ago_start)
+    end_day = today - timedelta(days=days_ago_end)
+    return {
+        'start_date': datetime.combine(start_day, time.min, tzinfo=local_tz).isoformat(),
+        'end_date': datetime.combine(end_day, time.max.replace(microsecond=0), tzinfo=local_tz).isoformat(),
+    }
+
+
+def _date_window(question: str) -> dict[str, str]:
+    """Date bounds for a temporal question, so "yesterday" means yesterday.
+
+    Without this the search is purely semantic and happily returns a conversation
+    from three weeks ago -- observed live, "what did I do yesterday" returned
+    08 Jul on 27 Jul.
+    """
+    q = question.lower()
+    if 'yesterday' in q:
+        return _day_bounds(1, 1)
+    if 'today' in q or 'this morning' in q:
+        return _day_bounds(0, 0)
+    if 'this week' in q:
+        return _day_bounds(7, 0)
+    if 'last week' in q:
+        return _day_bounds(14, 7)
+    return {}
+
+
+async def _search_or_empty(client, tool: str, payload: dict) -> str:
+    """Run a retrieval tool, treating any failure as "found nothing".
+
+    These tools flag an empty result the same way they flag a real error, and a
+    question with no matches is a normal outcome -- not a reason to spend six
+    seconds on the agent path to reach the same conclusion.
+    """
+    try:
+        return await client.tool_search(tool, payload)
+    except Exception as exc:  # noqa: BLE001 - empty and broken look alike here
+        log.info('%s returned nothing usable: %s', tool, exc)
+        return ''
+
+
+async def fast_answer(client, question: str) -> str:
+    """Answer from Omi's stores directly, in roughly two seconds."""
+    kind = _classify(question)
+    log.info('fastpath: %s', kind)
+
+    if kind == 'actions':
+        rows = await client.action_items(limit=25)
+        open_items = [r for r in rows if not r.get('completed')]
+        # Newest first: an old task the user has ignored for weeks is the least
+        # useful thing to put in front of them.
+        open_items.sort(key=lambda r: str(r.get('created_at') or ''), reverse=True)
+        lines = [str(r.get('description', '')).strip() for r in open_items if r.get('description')]
+        return _format(lines, 'Nothing open right now.', limit=4)
+
+    if kind == 'conversations':
+        window = _date_window(question)
+        payload = {'query': question, 'limit': 3, 'include_transcript': False, **window}
+        # The tool reports `is_error` for an empty result as well as a real
+        # failure. Treating "nothing that day" as a failure sent the request down
+        # the 6s agent path to be told the same thing.
+        text = await _search_or_empty(client, 'conversations/search', payload)
+        compact = _compact_conversations(text)
+        if compact:
+            return compact
+        if window:
+            return 'Nothing recorded for that period.'
+        return 'Nothing in your conversations about that.'
+
+    # Default: memories only.
+    #
+    # There used to be a conversation fallback here for when memory recall was
+    # thin, and it actively made answers worse. "Who is the president of the USA"
+    # returned a conversation about wallpapers -- and a word-overlap guard could
+    # not catch it, because that transcript really does contain both "president"
+    # and "USA" somewhere. The deeper issue is that such a question is not a
+    # memory question at all: answering it needs world knowledge, which this path
+    # has no LLM for. Admitting that beats confidently returning something
+    # unrelated.
+    memories_text = await _search_or_empty(client, 'memories/search', {'query': question, 'limit': 8})
+    lines = _clean_bullets(memories_text)
+
+    if lines:
+        return _format(lines, '', limit=3)
+
+    return "Nothing in your memories about that."

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -499,6 +499,42 @@ def _is_too_vague(question: str) -> bool:
     return len(terms) == 1 and max(len(t) for t in terms) <= 4
 
 
+async def gather_facts(client, question: str) -> list[str]:
+    """The retrieved lines behind an answer, best first.
+
+    Split out from `fast_answer` so the same material can either be shown as-is
+    or handed to a composer -- see `compose.py`, which turns these into prose
+    using Omi's own LLM.
+    """
+    kind = _classify(question)
+    if kind == 'actions':
+        rows = await client.action_items(limit=25)
+        open_items = [r for r in rows if not r.get('completed')]
+        open_items.sort(key=lambda r: str(r.get('created_at') or ''), reverse=True)
+        return [str(r.get('description', '')).strip() for r in open_items if r.get('description')][:8]
+
+    if kind == 'conversations':
+        target = _target_days(question)
+        text = await _search_or_empty(
+            client, 'conversations/search', {'query': question, 'limit': 8, 'include_transcript': False}
+        )
+        compact = _compact_conversations(text, limit=8, only_days=target)
+        return [line.lstrip('-').strip() for line in compact.splitlines() if line.strip()]
+
+    memories_text, conversations_text = await asyncio.gather(
+        _search_or_empty(client, 'memories/search', {'query': question, 'limit': 10}),
+        _search_or_empty(
+            client, 'conversations/search', {'query': question, 'limit': 4, 'include_transcript': False}
+        ),
+    )
+    facts = _clean_bullets(memories_text)
+    if _looks_relevant(question, conversations_text):
+        for extra in _conversation_titles(conversations_text):
+            if extra not in facts:
+                facts.append(extra)
+    return facts[:10]
+
+
 async def fast_answer(client, question: str) -> str:
     """Answer from Omi's stores directly, in roughly two seconds."""
     kind = _classify(question)

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -105,7 +105,36 @@ def _is_file_inventory(line: str) -> bool:
 # Word groups that decide which store to read. Checked in order, most specific
 # first, because "what did I do yesterday" is about conversations even though it
 # contains "do".
-_ACTION_WORDS = ('action item', 'task', 'to-do', 'todo', 'behind on', 'due', 'my plate', 'commit')
+_ACTION_WORDS = (
+    'action item',
+    'task',
+    'to-do',
+    'todo',
+    'behind on',
+    'due',
+    'my plate',
+    'commit',
+    # "What do I need to do today?" -- the question this whole surface exists to
+    # answer -- was being routed to conversations, because it contains "today"
+    # and none of the words above. It came back with what was *said* today
+    # instead of what is *owed*. Phrases, not bare words: "need to" alone would
+    # capture "what do I need to know about David", which is a memory question.
+    'need to do',
+    'need to get done',
+    'need to finish',
+    'needs doing',
+    'have to do',
+    'left to do',
+    'still have to',
+    'should i do',
+    'get done',
+    'to do today',
+    'reply to',
+    'respond to',
+    'get back to',
+    'follow up',
+    'my agenda',
+)
 _CONVERSATION_WORDS = (
     'yesterday',
     'today',

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -58,7 +58,39 @@ def _classify(question: str) -> str:
         return 'actions'
     if any(w in q for w in _CONVERSATION_WORDS):
         return 'conversations'
+    # A named day ("on 4 July") is asking what happened, which lives in
+    # conversations. Without this it fell through to a semantic memory search
+    # with nothing constraining it to the day.
+    if _explicit_date(question):
+        return 'conversations'
     return 'memories'
+
+
+# Screen capture files interface chrome into memories. Answering "what did I do
+# on 4 July" with "- Show less" is what prompted this: a button label scraped off
+# a page, stored as a fact, and returned as an answer.
+_UI_CHROME = frozenset(
+    {
+        'show less', 'show more', 'see more', 'see all', 'read more', 'learn more',
+        'click here', 'load more', 'view all', 'sign in', 'log in', 'sign up',
+        'accept all', 'got it', 'ok', 'cancel', 'submit', 'continue', 'next',
+        'back', 'close', 'done', 'menu', 'search', 'settings', 'home',
+    }
+)
+
+# Fewer than this many characters cannot carry a fact worth a line of the display.
+_MIN_FACT_CHARS = 15
+
+
+def _is_junk(line: str) -> bool:
+    """True for a retrieved line that is interface text rather than a fact."""
+    stripped = line.strip().rstrip('.').strip().lower()
+    if stripped in _UI_CHROME:
+        return True
+    if len(stripped) < _MIN_FACT_CHARS:
+        return True
+    # A "fact" with no verb-like structure and only one or two words is a label.
+    return len(stripped.split()) < 3
 
 
 def _clean_bullets(result_text: str, min_relevance: float = _MIN_RELEVANCE) -> list[str]:
@@ -80,7 +112,7 @@ def _clean_bullets(result_text: str, min_relevance: float = _MIN_RELEVANCE) -> l
             continue
 
         line = _META_RE.sub('', line).strip().rstrip(',;')
-        if line:
+        if line and not _is_junk(line):
             scored.append((score, line))
 
     # Stable sort keeps the tool's own ordering among equal scores.
@@ -103,7 +135,70 @@ _CONV_NOISE_RE = re.compile(
 _NO_RESULTS_RE = re.compile(r'^\s*(No\s+(conversations?|memories|results)\s+found|Error:)', re.IGNORECASE)
 
 
-def _compact_conversations(result_text: str, limit: int = 4) -> str:
+def _target_days(question: str) -> set[str]:
+    """The calendar days a question is asking about, as 'DD Mon YYYY' strings.
+
+    Matches the format the search results print ("23 Jul 2026 at 16:08"), so the
+    filtering can happen here rather than as a server-side window -- which costs
+    13.5s against 3.1s without.
+    """
+    from datetime import datetime, timedelta
+
+    local_tz = datetime.now().astimezone().tzinfo
+    today = datetime.now(local_tz).date()
+
+    def fmt(day) -> str:
+        return f'{day.day:02d} {day.strftime("%b")} {day.year}'
+
+    q = question.lower()
+    if 'yesterday' in q:
+        return {fmt(today - timedelta(days=1))}
+    if 'today' in q or 'this morning' in q:
+        return {fmt(today)}
+    if 'this week' in q:
+        return {fmt(today - timedelta(days=n)) for n in range(8)}
+    if 'last week' in q:
+        return {fmt(today - timedelta(days=n)) for n in range(7, 15)}
+
+    window = _explicit_date(question)
+    if window:
+        stamp = datetime.fromisoformat(window['start_date']).date()
+        return {fmt(stamp)}
+    return set()
+
+
+# "23 Jul 2026 at 16:08 America/New_York (Technology)" begins each result block.
+_CONV_DATE_RE = re.compile(r'^\s*(\d{1,2}\s+[A-Za-z]{3}\s+\d{4})\b')
+
+
+def _blocks_matching_days(result_text: str, days: set[str]) -> str:
+    """Keep only the result blocks whose date line falls on one of `days`."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in result_text.splitlines():
+        if re.match(r'^\s*Conversation\s*#\d+', line, re.IGNORECASE):
+            if current:
+                blocks.append(current)
+            current = []
+        current.append(line)
+    if current:
+        blocks.append(current)
+
+    kept: list[str] = []
+    for block in blocks:
+        text = '\n'.join(block)
+        stamp = None
+        for line in block:
+            found = _CONV_DATE_RE.match(line.strip())
+            if found:
+                stamp = found.group(1)
+                break
+        if stamp and any(stamp.lstrip('0') == day.lstrip('0') for day in days):
+            kept.append(text)
+    return '\n'.join(kept)
+
+
+def _compact_conversations(result_text: str, limit: int = 4, only_days: set[str] | None = None) -> str:
     """Reduce a conversation dump to the few lines worth reading on glasses.
 
     The raw result leads with `Conversation #1`, a timezone-qualified timestamp,
@@ -116,6 +211,10 @@ def _compact_conversations(result_text: str, limit: int = 4) -> str:
     # 'What did I do yesterday?' in the specified date range.").
     if _NO_RESULTS_RE.match(body):
         return ''
+    if only_days:
+        body = _blocks_matching_days(body, only_days)
+        if not body.strip():
+            return ''
     kept: list[str] = []
     for raw_line in body.splitlines():
         line = raw_line.strip()
@@ -183,6 +282,66 @@ def _day_bounds(days_ago_start: int, days_ago_end: int) -> dict[str, str]:
     }
 
 
+_MONTHS = {
+    'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
+    'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12,
+}
+_MONTH_ALT = '|'.join(_MONTHS)
+# "4 July", "July 4", "4th of July", "on Jul 4th" -- both orders, optional
+# ordinal suffix, optional "of".
+# `\w*` after each month prefix absorbs the rest of the full name. Without it on
+# BOTH branches, "4 July" fails to match while "July 4" succeeds: the alternation
+# matches "jul" and then demands a word boundary that the "y" denies.
+_EXPLICIT_DATE_RE = re.compile(
+    rf'\b(?:(\d{{1,2}})(?:st|nd|rd|th)?\s+(?:of\s+)?({_MONTH_ALT})\w*'
+    rf'|({_MONTH_ALT})\w*\s+(\d{{1,2}})(?:st|nd|rd|th)?)\b',
+    re.IGNORECASE,
+)
+
+
+def _explicit_date(question: str) -> dict[str, str] | None:
+    """Bounds for a named calendar day, e.g. "what did I do on 4 July".
+
+    Without this, a dated question falls through to a semantic memory search --
+    "What did I do on 4 July that was not work?" answered "- Show less", a
+    fragment of UI chrome, because nothing constrained it to that day.
+
+    A month later than today is read as last year, since people ask about days
+    that have happened.
+    """
+    from datetime import datetime, time, timedelta
+
+    match = _EXPLICIT_DATE_RE.search(question)
+    if not match:
+        return None
+
+    day_str, month_str = (match.group(1), match.group(2)) if match.group(1) else (match.group(4), match.group(3))
+    try:
+        day = int(day_str)
+    except (TypeError, ValueError):
+        return None
+    month = _MONTHS.get(month_str.lower()[:3]) if month_str else None
+    if not month or not 1 <= day <= 31:
+        return None
+
+    local_tz = datetime.now().astimezone().tzinfo
+    today = datetime.now(local_tz).date()
+    year = today.year
+    try:
+        target = today.replace(year=year, month=month, day=day)
+    except ValueError:
+        return None  # e.g. 31 February
+    if target > today:
+        target = target.replace(year=year - 1)
+
+    return {
+        'start_date': datetime.combine(target, time.min, tzinfo=local_tz).isoformat(),
+        'end_date': datetime.combine(
+            target + timedelta(days=1) - timedelta(seconds=1), time.max.replace(microsecond=0), tzinfo=local_tz
+        ).replace(hour=23, minute=59, second=59).isoformat(),
+    }
+
+
 def _date_window(question: str) -> dict[str, str]:
     """Date bounds for a temporal question, so "yesterday" means yesterday.
 
@@ -199,7 +358,8 @@ def _date_window(question: str) -> dict[str, str]:
         return _day_bounds(7, 0)
     if 'last week' in q:
         return _day_bounds(14, 7)
-    return {}
+    explicit = _explicit_date(question)
+    return explicit or {}
 
 
 async def _search_or_empty(client, tool: str, payload: dict) -> str:
@@ -234,11 +394,16 @@ def _is_too_vague(question: str) -> bool:
 
 async def fast_answer(client, question: str) -> str:
     """Answer from Omi's stores directly, in roughly two seconds."""
-    if _is_too_vague(question):
+    kind = _classify(question)
+
+    # Only a question with no recognisable intent can be a stray syllable. Asking
+    # this before classifying rejected "What did I do on 4 July?", because
+    # stopwords and the bare digit leave "july" as the single content word --
+    # which looks exactly like a mis-transcription and is not one.
+    if kind == 'memories' and _is_too_vague(question):
         log.info('fastpath: question too vague to search on (%.40r)', question)
         return 'Ask me something about your day, your people, or your tasks.'
 
-    kind = _classify(question)
     log.info('fastpath: %s', kind)
 
     if kind == 'actions':
@@ -251,17 +416,19 @@ async def fast_answer(client, question: str) -> str:
         return _format(lines, 'Nothing open right now.', limit=4)
 
     if kind == 'conversations':
-        window = _date_window(question)
-        payload = {'query': question, 'limit': 3, 'include_transcript': False, **window}
-        # The tool reports `is_error` for an empty result as well as a real
-        # failure. Treating "nothing that day" as a failure sent the request down
-        # the 6s agent path to be told the same thing.
+        target = _target_days(question)
+        # Deliberately NOT passing start_date/end_date. Measured on the live
+        # account, the same query costs 13.5s with a server-side date window and
+        # 3.1s without -- and 13.5s is past the timeout this whole path exists to
+        # beat. Fetching wider and filtering by date here is the cheaper way to
+        # get the same correctness.
+        payload = {'query': question, 'limit': 8, 'include_transcript': False}
         text = await _search_or_empty(client, 'conversations/search', payload)
-        compact = _compact_conversations(text)
+        compact = _compact_conversations(text, only_days=target)
         if compact:
             return compact
-        if window:
-            return 'Nothing recorded for that period.'
+        if target:
+            return 'Nothing recorded for that day.'
         return 'Nothing in your conversations about that.'
 
     # Default: memories only.

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -32,8 +32,18 @@ log = logging.getLogger(__name__)
 # Defined early: several module-level regexes below interpolate _MONTH_ALT,
 # and module code runs top to bottom.
 _MONTHS = {
-    'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
-    'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12,
+    'jan': 1,
+    'feb': 2,
+    'mar': 3,
+    'apr': 4,
+    'may': 5,
+    'jun': 6,
+    'jul': 7,
+    'aug': 8,
+    'sep': 9,
+    'oct': 10,
+    'nov': 11,
+    'dec': 12,
 }
 _MONTH_ALT = '|'.join(_MONTHS)
 
@@ -91,13 +101,25 @@ def _is_file_inventory(line: str) -> bool:
         return True
     return bool(_LOCAL_INDEX_STEM_RE.search(line) and _PATH_HINT_RE.search(line))
 
+
 # Word groups that decide which store to read. Checked in order, most specific
 # first, because "what did I do yesterday" is about conversations even though it
 # contains "do".
 _ACTION_WORDS = ('action item', 'task', 'to-do', 'todo', 'behind on', 'due', 'my plate', 'commit')
 _CONVERSATION_WORDS = (
-    'yesterday', 'today', 'last night', 'this morning', 'this week', 'last week',
-    'talk', 'said', 'meeting', 'call', 'conversation', 'discuss', 'happened',
+    'yesterday',
+    'today',
+    'last night',
+    'this morning',
+    'this week',
+    'last week',
+    'talk',
+    'said',
+    'meeting',
+    'call',
+    'conversation',
+    'discuss',
+    'happened',
 )
 
 
@@ -120,10 +142,32 @@ def _classify(question: str) -> str:
 # a page, stored as a fact, and returned as an answer.
 _UI_CHROME = frozenset(
     {
-        'show less', 'show more', 'see more', 'see all', 'read more', 'learn more',
-        'click here', 'load more', 'view all', 'sign in', 'log in', 'sign up',
-        'accept all', 'got it', 'ok', 'cancel', 'submit', 'continue', 'next',
-        'back', 'close', 'done', 'menu', 'search', 'settings', 'home',
+        'show less',
+        'show more',
+        'see more',
+        'see all',
+        'read more',
+        'learn more',
+        'click here',
+        'load more',
+        'view all',
+        'sign in',
+        'log in',
+        'sign up',
+        'accept all',
+        'got it',
+        'ok',
+        'cancel',
+        'submit',
+        'continue',
+        'next',
+        'back',
+        'close',
+        'done',
+        'menu',
+        'search',
+        'settings',
+        'home',
     }
 )
 
@@ -181,9 +225,7 @@ def _format(lines: list[str], empty_message: str, limit: int = 3) -> str:
 
 
 # Lines in a conversation result that are scaffolding rather than content.
-_CONV_NOISE_RE = re.compile(
-    r'^\s*(Conversation\s*#\d+|Started:|Finished:|\d{1,2}\s+\w+\s+\d{4}\s+at\b)', re.IGNORECASE
-)
+_CONV_NOISE_RE = re.compile(r'^\s*(Conversation\s*#\d+|Started:|Finished:|\d{1,2}\s+\w+\s+\d{4}\s+at\b)', re.IGNORECASE)
 
 # The tools report "nothing found" as prose, not as an empty body.
 _NO_RESULTS_RE = re.compile(r'^\s*(No\s+(conversations?|memories|results)\s+found|Error:)', re.IGNORECASE)
@@ -445,7 +487,9 @@ def _explicit_date(question: str) -> dict[str, str] | None:
         'start_date': datetime.combine(target, time.min, tzinfo=local_tz).isoformat(),
         'end_date': datetime.combine(
             target + timedelta(days=1) - timedelta(seconds=1), time.max.replace(microsecond=0), tzinfo=local_tz
-        ).replace(hour=23, minute=59, second=59).isoformat(),
+        )
+        .replace(hour=23, minute=59, second=59)
+        .isoformat(),
     }
 
 
@@ -523,9 +567,7 @@ async def gather_facts(client, question: str) -> list[str]:
 
     memories_text, conversations_text = await asyncio.gather(
         _search_or_empty(client, 'memories/search', {'query': question, 'limit': 10}),
-        _search_or_empty(
-            client, 'conversations/search', {'query': question, 'limit': 4, 'include_transcript': False}
-        ),
+        _search_or_empty(client, 'conversations/search', {'query': question, 'limit': 4, 'include_transcript': False}),
     )
     facts = _clean_bullets(memories_text)
     if _looks_relevant(question, conversations_text):
@@ -582,9 +624,7 @@ async def fast_answer(client, question: str) -> str:
     # the slower of the two rather than their sum.
     memories_text, conversations_text = await asyncio.gather(
         _search_or_empty(client, 'memories/search', {'query': question, 'limit': 10}),
-        _search_or_empty(
-            client, 'conversations/search', {'query': question, 'limit': 4, 'include_transcript': False}
-        ),
+        _search_or_empty(client, 'conversations/search', {'query': question, 'limit': 4, 'include_transcript': False}),
     )
 
     lines = _clean_bullets(memories_text)

--- a/integrations/omi-even/bridge/fastpath.py
+++ b/integrations/omi-even/bridge/fastpath.py
@@ -216,8 +216,28 @@ async def _search_or_empty(client, tool: str, payload: dict) -> str:
         return ''
 
 
+def _is_too_vague(question: str) -> bool:
+    """True when there is not enough in the question to search on.
+
+    Speech-to-text produces fragments -- a cough, a half-word, "ping" -- and
+    vector search answers every one of them with its nearest neighbour. Asking
+    "ping" surfaced an unrelated obscenity from an old transcript. On a display
+    worn on your face, returning nothing is strictly better than returning
+    whatever happened to be closest.
+    """
+    terms = {w for w in re.findall(r'[a-z0-9]+', question.lower()) if w not in _STOPWORDS and len(w) > 2}
+    if not terms:
+        return True
+    # A single short token is far more often a mis-transcription than a query.
+    return len(terms) == 1 and max(len(t) for t in terms) <= 4
+
+
 async def fast_answer(client, question: str) -> str:
     """Answer from Omi's stores directly, in roughly two seconds."""
+    if _is_too_vague(question):
+        log.info('fastpath: question too vague to search on (%.40r)', question)
+        return 'Ask me something about your day, your people, or your tasks.'
+
     kind = _classify(question)
     log.info('fastpath: %s', kind)
 

--- a/integrations/omi-even/bridge/local_llm.py
+++ b/integrations/omi-even/bridge/local_llm.py
@@ -1,0 +1,145 @@
+"""Compose on the Mac, via Ollama, so there is no rate limit at all.
+
+Omi's `test-prompt` endpoint composes well but is capped at 30/hour
+(`utils/rate_limit_config.py`, `"test:prompt": (30, 3600)`), which a normal day
+of wearing the glasses burns through. The bridge already only works while this
+Mac is awake -- it *is* the tunnel endpoint -- so a model running here adds no
+new failure mode, costs nothing, and the retrieved facts never leave the
+machine to be turned into a sentence.
+
+Measured on this hardware (M-series, 64 GB), composing 2-3 sentences from
+retrieved facts:
+
+    llama3.2:latest      0.5-1.2s warm,  5.5s cold   (drops items from a list)
+    qwen3.6:35b-a3b      1.3-2.3s warm, 16.5s cold   (keeps them; the default)
+
+`qwen3.6:35b-a3b` is a mixture-of-experts model with ~3B active parameters, so
+it answers at small-model speed with large-model recall. The 16.5s cold load is
+the one thing that would break the ~5s budget, which is why `warm()` runs at
+startup and on a timer: a model that has fallen out of memory mid-day is the
+only realistic way this path goes slow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+BASE_URL = os.getenv('OMI_EVEN_OLLAMA_URL', 'http://127.0.0.1:11434')
+MODEL = os.getenv('OMI_EVEN_LOCAL_MODEL', 'qwen3.6:35b-a3b')
+
+# Each request refreshes this TTL, and `warm()` re-pings well inside it, so the
+# model stays resident while the bridge runs and is released a while after it
+# stops -- rather than holding ~23 GB forever.
+KEEP_ALIVE = os.getenv('OMI_EVEN_LOCAL_KEEP_ALIVE', '30m')
+WARM_INTERVAL_S = 600.0
+
+# Long enough to cover a cold load; the *caller* enforces the answer deadline,
+# and warming deliberately has no deadline at all.
+_WARM_TIMEOUT = httpx.Timeout(300.0, connect=2.0)
+# A refused connection must be instant, so a stopped Ollama costs no budget.
+_ANSWER_TIMEOUT = httpx.Timeout(30.0, connect=1.0)
+
+# Two or three sentences. Left uncapped, a small model will happily narrate the
+# whole fact list back, which does not fit the display anyway.
+_NUM_PREDICT = 160
+
+# Ollama sizes the KV cache from the model's declared maximum, not from what we
+# actually send: `ollama ps` showed qwen3.6 resident at 28 GB for a 262144-token
+# context, to serve prompts of roughly 500 tokens. On a machine that is also
+# doing the user's real work, that is the difference between a background
+# service and a stall. Ten facts plus the instructions fit in 4096 with room to
+# spare.
+_NUM_CTX = int(os.getenv('OMI_EVEN_LOCAL_NUM_CTX', '4096'))
+
+_available = True
+
+
+class LocalUnavailable(RuntimeError):
+    """Ollama is not running, has no such model, or returned nothing."""
+
+
+def _payload(prompt: str, *, num_predict: int) -> dict:
+    return {
+        'model': MODEL,
+        'prompt': prompt,
+        'stream': False,
+        # qwen3.6 is a reasoning model; its thinking tokens would cost more than
+        # the whole budget and never reach the display.
+        'think': False,
+        'keep_alive': KEEP_ALIVE,
+        'options': {'temperature': 0.3, 'num_predict': num_predict, 'num_ctx': _NUM_CTX},
+    }
+
+
+async def generate(prompt: str) -> str:
+    """One completion. Raises LocalUnavailable rather than returning junk."""
+    global _available
+    try:
+        async with httpx.AsyncClient(timeout=_ANSWER_TIMEOUT) as client:
+            response = await client.post(f'{BASE_URL}/api/generate', json=_payload(prompt, num_predict=_NUM_PREDICT))
+    except httpx.HTTPError as exc:
+        _available = False
+        raise LocalUnavailable(f'ollama unreachable: {exc}') from exc
+
+    if response.status_code != 200:
+        # A missing model is a config problem, not a blip: stop trying until the
+        # next successful warm, so every question does not pay for the discovery.
+        _available = False
+        raise LocalUnavailable(f'ollama HTTP {response.status_code}: {response.text[:120]}')
+
+    _available = True
+    answer = ((response.json() or {}).get('response') or '').strip()
+    if not answer:
+        raise LocalUnavailable('ollama returned nothing')
+    return answer
+
+
+def is_available() -> bool:
+    """False once a call has failed, until a later call or warm succeeds.
+
+    Consulted only to decide whether local is worth *trying first*; it is never
+    the reason an answer is missing, because every path falls through.
+    """
+    return _available
+
+
+async def warm() -> bool:
+    """Load the model into memory. Safe to call repeatedly; never raises."""
+    global _available
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=_WARM_TIMEOUT) as client:
+            response = await client.post(f'{BASE_URL}/api/generate', json=_payload('hi', num_predict=1))
+        if response.status_code != 200:
+            _available = False
+            log.warning('local model %s unavailable: HTTP %s', MODEL, response.status_code)
+            return False
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - a warmer must never take the bridge with it
+        _available = False
+        log.info('local model unavailable (%s); cloud compose will be used', exc)
+        return False
+
+    _available = True
+    log.info('local model %s warm in %.1fs', MODEL, time.monotonic() - started)
+    return True
+
+
+async def warm_forever() -> None:
+    """Keep the model resident for as long as the bridge runs.
+
+    A cold `qwen3.6:35b-a3b` takes 16.5s to answer, which is three times the
+    whole budget -- so the model going cold, not the model being slow, is what
+    would actually break this path.
+    """
+    while True:
+        await warm()
+        await asyncio.sleep(WARM_INTERVAL_S)

--- a/integrations/omi-even/bridge/observe_contract.py
+++ b/integrations/omi-even/bridge/observe_contract.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Capture the Even Realities "Add Agent" HTTP contract from real hardware.
+
+Even publishes no specification for the custom-agent endpoint. Everything known
+about it is reverse-engineered from blog posts, so this logs exactly what the
+device sends before any real endpoint is written against it.
+
+It answers with a well-formed OpenAI chat-completion, so a single spoken query
+verifies both directions at once: the log shows what the glasses send, and the
+display shows whether our response shape is one the glasses can render.
+
+Zero dependencies -- stdlib only, so it runs before the bridge venv exists.
+
+    python3 observe_contract.py [--port 8788]
+
+Then register the URL in the Even app (Add Agent) and speak one question.
+"""
+
+import argparse
+import json
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+LOG_PATH = Path(__file__).with_name('add-agent-capture.log')
+
+# Long enough to be unmistakable on the 576x288 display, short enough to fit.
+REPLY_TEXT = 'omi bridge online. Contract captured -- check the Mac.'
+
+
+def _record(entry: dict) -> None:
+    """Write one captured request to stdout and the log file."""
+    rendered = json.dumps(entry, indent=2, ensure_ascii=False)
+    print(f'\n=== {entry["method"]} {entry["path"]} @ {entry["received_at"]} ===')
+    print(rendered, flush=True)
+    with LOG_PATH.open('a', encoding='utf-8') as fh:
+        fh.write(rendered + '\n---\n')
+
+
+class CaptureHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+    server_version = 'omi-even-observe/0'
+
+    def _capture(self) -> None:
+        # Read the body strictly by Content-Length; a short read would hang and
+        # the glasses would report a timeout rather than a contract mismatch.
+        try:
+            length = int(self.headers.get('Content-Length') or 0)
+        except ValueError:
+            length = 0
+        raw = self.rfile.read(length) if length > 0 else b''
+
+        try:
+            body = json.loads(raw.decode('utf-8')) if raw else None
+            body_parse_error = None
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            body = raw.decode('utf-8', errors='replace')
+            body_parse_error = str(exc)
+
+        _record(
+            {
+                'received_at': datetime.now(timezone.utc).isoformat(),
+                'method': self.command,
+                'path': self.path,
+                'client': self.client_address[0],
+                'http_version': self.request_version,
+                # Header order and exact casing matter when reverse-engineering.
+                'headers': [[k, v] for k, v in self.headers.items()],
+                'body_bytes': len(raw),
+                'body': body,
+                'body_parse_error': body_parse_error,
+            }
+        )
+
+        self._respond_openai()
+
+    def _respond_openai(self) -> None:
+        payload = json.dumps(
+            {
+                'id': f'chatcmpl-{uuid.uuid4().hex[:24]}',
+                'object': 'chat.completion',
+                'created': int(time.time()),
+                'model': 'omi',
+                'choices': [
+                    {
+                        'index': 0,
+                        'message': {'role': 'assistant', 'content': REPLY_TEXT},
+                        'finish_reason': 'stop',
+                    }
+                ],
+                'usage': {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0},
+            }
+        ).encode('utf-8')
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    # Every verb routes to the same capture -- we do not yet know which the
+    # device uses, and an unhandled verb would look like a network failure.
+    do_GET = _capture
+    do_POST = _capture
+    do_PUT = _capture
+    do_PATCH = _capture
+    do_DELETE = _capture
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - stdlib naming
+        self._capture()
+
+    def log_message(self, fmt: str, *args) -> None:
+        """Silence the default access log; _record is the real output."""
+        return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--port', type=int, default=8788)
+    parser.add_argument('--host', default='0.0.0.0')
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), CaptureHandler)
+    print(f'Listening on {args.host}:{args.port} -- logging to {LOG_PATH}')
+    print('Register this URL in the Even app (Add Agent), then speak a question.\n')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print('\nStopped.')
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/integrations/omi-even/bridge/omi_auth.py
+++ b/integrations/omi-even/bridge/omi_auth.py
@@ -117,6 +117,11 @@ def _parse_session_file(path: Path) -> dict | None:
     except (OSError, json.JSONDecodeError) as exc:
         log.debug('could not read session file %s: %s', path, exc)
         return None
+    if not isinstance(raw, dict):
+        # Valid JSON, wrong file. Read as "no session" so the caller re-exports
+        # and ends with the actionable AuthError instead of an AttributeError.
+        log.debug('session file %s is %s, not an object', path, type(raw).__name__)
+        return None
     flat = {}
     for key, entry in raw.items():
         flat[key] = entry.get('value') if isinstance(entry, dict) else entry

--- a/integrations/omi-even/bridge/omi_auth.py
+++ b/integrations/omi-even/bridge/omi_auth.py
@@ -1,0 +1,218 @@
+"""Firebase session for the Omi bridge, borrowed from the desktop app.
+
+Omi's chat endpoint (`POST /v2/messages`) and the capture socket (`WS /v4/listen`)
+accept **only** a Firebase ID token -- no `omi_mcp_`, `omi_dev_`, or app key works
+(`backend/utils/other/endpoints.py:81`). Rather than run a browser OAuth flow, this
+reuses the session the macOS desktop app already holds and mints fresh ID tokens
+from its long-lived refresh token.
+
+ID tokens last an hour; refresh tokens last a year, so the bridge stays signed in
+with no user interaction as long as the desktop app was signed in once.
+
+The session is obtained through the repo's own `desktop/macos/scripts/omi-auth-dump.sh`,
+which is the sanctioned way to export a signed-in desktop session (its header
+documents this exact use). Going through that script rather than reimplementing the
+Keychain lookup keeps one source of truth for the team+bundle scoped service name,
+which the desktop app derives at runtime and has already changed once.
+
+Token material is held in memory and never logged. `describe()` reports status
+without exposing values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+# Public Firebase Web API key for the `based-hardware` project. Firebase API keys
+# identify a project, they do not authorize -- they ship in every public build.
+# This is the unrestricted (Windows) key: a referrer-locked web key 403s from a
+# non-browser client with API_KEY_HTTP_REFERRER_BLOCKED. Same key omi-cli uses
+# (sdks/python-cli/omi_cli/auth/oauth.py).
+_FIREBASE_API_KEY = 'AIzaSyA88gHcmiAxjN_aE23tHRWXOgFfapyO6dk'
+_FIREBASE_REFRESH_URL = f'https://securetoken.googleapis.com/v1/token?key={_FIREBASE_API_KEY}'
+
+# Bundles to try, in order. Only the dev bundle is attempted by default: reading the
+# prod bundle's entry can sit behind a Keychain ACL dialog that blocks indefinitely,
+# and prod is the user's real installed app which we never want to disturb.
+_DEFAULT_BUNDLES = ('com.omi.desktop-dev',)
+
+# Refresh this far before the server-quoted expiry, to absorb clock skew and the
+# round trip of the request the token is about to be used for.
+_REFRESH_MARGIN_SECONDS = 120
+
+# The dump shells out to `security`, which can block on an ACL prompt. A short
+# timeout turns that into a fast, reportable failure instead of a hung bridge.
+_DUMP_TIMEOUT_SECONDS = 30
+
+
+class AuthError(RuntimeError):
+    """Raised when no usable Omi session can be established."""
+
+
+@dataclass
+class _Session:
+    id_token: str
+    refresh_token: str
+    expires_at: float
+    uid: str
+
+
+def _repo_root() -> Path:
+    """Walk up to the repository root that contains desktop/macos/scripts."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / 'desktop' / 'macos' / 'scripts' / 'omi-auth-dump.sh').exists():
+            return parent
+    raise AuthError(f'could not locate the omi repo root above {here}')
+
+
+def _session_file() -> Path:
+    override = os.getenv('OMI_SESSION_FILE')
+    if override:
+        return Path(override).expanduser()
+    # The dump script's own default, which the repo gitignores.
+    return _repo_root() / 'desktop' / 'tmp' / 'desktop-auth.json'
+
+
+def _run_dump(bundle_id: str, out_path: Path) -> bool:
+    """Export a signed-in desktop session via the repo's sanctioned script."""
+    script = _repo_root() / 'desktop' / 'macos' / 'scripts' / 'omi-auth-dump.sh'
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            ['bash', str(script), bundle_id, str(out_path)],
+            capture_output=True,
+            text=True,
+            timeout=_DUMP_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        # Almost always a Keychain ACL dialog waiting on a human.
+        log.warning('auth dump for %s timed out (Keychain prompt?) -- skipping', bundle_id)
+        return False
+    except OSError as exc:
+        log.debug('auth dump for %s failed to start: %s', bundle_id, exc)
+        return False
+
+    if result.returncode != 0:
+        log.debug('auth dump for %s exited %s: %s', bundle_id, result.returncode, result.stderr.strip()[:200])
+        return False
+    return out_path.exists()
+
+
+def _parse_session_file(path: Path) -> dict | None:
+    """Read the dump file's {key: {type, value}} shape into a flat dict."""
+    try:
+        raw = json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug('could not read session file %s: %s', path, exc)
+        return None
+    flat = {}
+    for key, entry in raw.items():
+        flat[key] = entry.get('value') if isinstance(entry, dict) else entry
+    return flat
+
+
+class OmiAuth:
+    """Supplies a valid Firebase ID token, refreshing it as needed."""
+
+    def __init__(self, bundles: tuple[str, ...] | None = None) -> None:
+        env_bundle = os.getenv('OMI_SOURCE_BUNDLE')
+        self._bundles = (env_bundle,) if env_bundle else (bundles or _DEFAULT_BUNDLES)
+        self._session: _Session | None = None
+        self._lock = asyncio.Lock()
+
+    def _load_session(self) -> _Session:
+        """Find a desktop session, re-exporting it if the cached file is unusable."""
+        path = _session_file()
+        flat = _parse_session_file(path) if path.exists() else None
+
+        if not (flat or {}).get('auth_refreshToken'):
+            for bundle in self._bundles:
+                if _run_dump(bundle, path):
+                    flat = _parse_session_file(path)
+                    if (flat or {}).get('auth_refreshToken'):
+                        log.info('exported Omi session from %s', bundle)
+                        break
+                    flat = None
+
+        if not flat or not flat.get('auth_refreshToken'):
+            raise AuthError(
+                'No signed-in Omi desktop session found (tried: '
+                + ', '.join(self._bundles)
+                + f'; session file: {path}). Sign in to the Omi macOS app once, '
+                'then restart the bridge.'
+            )
+
+        return _Session(
+            id_token=flat.get('auth_idToken') or '',
+            refresh_token=flat['auth_refreshToken'],
+            # Ignore the stored expiry and force a refresh on first use, so a stale
+            # dump can never produce a confusing 401 mid-conversation.
+            expires_at=0.0,
+            uid=flat.get('auth_tokenUserId') or flat.get('auth_userId') or '',
+        )
+
+    async def _refresh(self, session: _Session) -> _Session:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=10.0)) as client:
+            response = await client.post(
+                _FIREBASE_REFRESH_URL,
+                data={'grant_type': 'refresh_token', 'refresh_token': session.refresh_token},
+                headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            )
+        if response.status_code != 200:
+            # Body can echo the token; surface only the reason code.
+            reason = ''
+            try:
+                reason = response.json().get('error', {}).get('message', '')
+            except ValueError:
+                pass
+            raise AuthError(
+                f'Firebase token refresh failed ({response.status_code} {reason}). '
+                'The desktop session may have been revoked -- sign in again.'
+            )
+        payload = response.json()
+        return _Session(
+            id_token=payload['id_token'],
+            # Firebase may rotate the refresh token; keep the newest.
+            refresh_token=payload.get('refresh_token') or session.refresh_token,
+            expires_at=time.time() + float(payload.get('expires_in', 3600)),
+            uid=payload.get('user_id') or session.uid,
+        )
+
+    async def id_token(self) -> str:
+        """Return a currently-valid Firebase ID token, refreshing if needed."""
+        async with self._lock:
+            if self._session is None:
+                self._session = self._load_session()
+            if time.time() >= self._session.expires_at - _REFRESH_MARGIN_SECONDS:
+                self._session = await self._refresh(self._session)
+            return self._session.id_token
+
+    async def uid(self) -> str:
+        await self.id_token()
+        assert self._session is not None
+        return self._session.uid
+
+    async def auth_header(self) -> dict[str, str]:
+        return {'Authorization': f'Bearer {await self.id_token()}'}
+
+    def describe(self) -> dict[str, object]:
+        """Status for health endpoints -- never includes token material."""
+        if self._session is None:
+            return {'loaded': False}
+        return {
+            'loaded': True,
+            'uid': self._session.uid,
+            'expires_in': max(0, int(self._session.expires_at - time.time())),
+        }

--- a/integrations/omi-even/bridge/omi_client.py
+++ b/integrations/omi-even/bridge/omi_client.py
@@ -320,9 +320,7 @@ class OmiClient:
         """
         headers = {**await self._headers(), 'Content-Type': 'application/json'}
         async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:
-            response = await client.post(
-                f'{self._base}/v1/tools/{tool}', headers=headers, json=payload
-            )
+            response = await client.post(f'{self._base}/v1/tools/{tool}', headers=headers, json=payload)
         if response.status_code != 200:
             raise RuntimeError(f'{tool} failed: HTTP {response.status_code}')
         body = response.json() or {}

--- a/integrations/omi-even/bridge/omi_client.py
+++ b/integrations/omi-even/bridge/omi_client.py
@@ -43,7 +43,7 @@ import json
 import logging
 import os
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 
 import httpx
@@ -181,12 +181,20 @@ class OmiClient:
         text: str,
         app_id: str | None = None,
         deadline_s: float | None = None,
+        enough: Callable[[str], bool] | None = None,
     ) -> ChatResult:
         """Run a chat turn to completion, or to `deadline_s`, whichever comes first.
 
         The deadline exists because the glasses' client will give up long before
         Omi's 150s agent cap. On timeout the partial answer accumulated so far is
         returned rather than nothing -- a truncated answer beats a spinner.
+
+        `enough` stops the stream early once the accumulated text is already more
+        than the caller can display. Omi writes for a phone and routinely emits
+        three times what fits on the glasses; measured, waiting for the rest costs
+        about 3 seconds per answer that the user never sees. The predicate is only
+        consulted on `data` frames, and a stream stopped this way is *not* marked
+        truncated -- the answer shown is complete as far as the display goes.
         """
         started = time.monotonic()
         parts: list[str] = []
@@ -212,6 +220,9 @@ class OmiClient:
 
                 if event.kind == 'data':
                     parts.append(event.text)
+                    if enough is not None and enough(''.join(parts)):
+                        saw_terminal = True  # complete for display purposes
+                        break
                 elif event.kind == 'think':
                     thinking.append(event.text)
                 elif event.kind == 'error':

--- a/integrations/omi-even/bridge/omi_client.py
+++ b/integrations/omi-even/bridge/omi_client.py
@@ -311,6 +311,25 @@ class OmiClient:
             payload = payload.get('daily_summaries') or payload.get('items') or []
         return payload[:limit] if isinstance(payload, list) else []
 
+    async def tool_search(self, tool: str, payload: dict) -> str:
+        """Call one of Omi's direct retrieval tools and return its text result.
+
+        These skip the agent loop entirely. Measured against the live account:
+        memories 1.5s, conversations 0.8s, versus 6-18s for `/v2/messages`. That
+        difference is what makes an answer arrive before Even's client gives up.
+        """
+        headers = {**await self._headers(), 'Content-Type': 'application/json'}
+        async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:
+            response = await client.post(
+                f'{self._base}/v1/tools/{tool}', headers=headers, json=payload
+            )
+        if response.status_code != 200:
+            raise RuntimeError(f'{tool} failed: HTTP {response.status_code}')
+        body = response.json() or {}
+        if body.get('is_error'):
+            raise RuntimeError(f'{tool} reported an error')
+        return body.get('result_text', '')
+
     async def usage_quota(self) -> dict:
         headers = await self._headers()
         async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:

--- a/integrations/omi-even/bridge/omi_client.py
+++ b/integrations/omi-even/bridge/omi_client.py
@@ -1,0 +1,308 @@
+"""Client for the Omi APIs the glasses need.
+
+The important piece is `POST /v2/messages`. It advertises `text/event-stream` and
+`response_model=ResponseMessage`, and both are misleading:
+
+* It is **always** a stream -- the declared JSON response model is never returned
+  (`backend/routers/chat.py:481`).
+* It is **not** spec-compliant SSE. `EventSource` silently drops most of it. Frames
+  are `\\n\\n`-delimited records with a bare prefix, so the body must be buffered and
+  split manually.
+
+Frame protocol, ported from the app's reference parser
+(`app/lib/backend/http/api/messages.dart:59` `parseMessageChunk`):
+
+    data: <token>       token delta; literal `__CRLF__` stands in for a newline
+    think: <text>       progress/status line, same `__CRLF__` escaping
+    error: <message>    terminal error
+    error:402:<body>    legacy quota shape, no space after the colon
+    done: <base64>      terminal; base64 of the authoritative ResponseMessage JSON
+    message: <base64>   voice endpoint only; the transcribed user message
+
+A well-formed stream always ends in `done:` or `error:`.
+
+Two traps worth knowing:
+
+* A quota breach returns **HTTP 200** with a canned `done:` message, not a 402
+  (`chat.py:299-313`). Read the text, not the status code.
+* The agent may run to 150s while the server's default request timeout is 120s
+  (`utils/other/timeout.py:20`), so a slow answer can die as a bare 504 with no
+  terminal frame. Callers must treat stream truncation as a real outcome.
+
+`X-App-Platform` is deliberately not sent: only `desktop` is trial-paywalled
+(`utils/subscription.py:270`), and an absent platform never is. `X-Request-Start-Time`
+is also omitted -- clock skew beyond the allowance is rejected with a 408.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import json
+import logging
+import os
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+import httpx
+
+from omi_auth import OmiAuth
+
+log = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = os.getenv('OMI_API_BASE', 'https://api.omi.me')
+
+_FRAME_SEP = b'\n\n'
+# Generous: the agent's own hard cap is 150s. The read timeout must exceed the
+# gap between frames, not the total, since keepalives arrive every ~20s.
+_STREAM_TIMEOUT = httpx.Timeout(180.0, connect=10.0, read=60.0)
+_JSON_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
+
+
+@dataclass
+class ChatEvent:
+    """One decoded frame from the chat stream."""
+
+    kind: str  # 'data' | 'think' | 'error' | 'done' | 'message'
+    text: str = ''
+    message: dict | None = None
+
+
+@dataclass
+class ChatResult:
+    """The outcome of a complete chat turn."""
+
+    text: str
+    error: str | None = None
+    truncated: bool = False  # stream ended without a terminal frame
+    elapsed_s: float = 0.0
+    thinking: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and bool(self.text.strip())
+
+
+def _decode_b64_json(payload: str) -> dict | None:
+    try:
+        decoded = json.loads(base64.b64decode(payload).decode('utf-8'))
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        log.warning('could not decode terminal frame: %s', exc)
+        return None
+    # Valid JSON is not necessarily an object: b64decode ignores non-alphabet
+    # characters, so a corrupted payload can decode to a bare list or number.
+    # The caller does `.get()` on this, so anything else must read as absent.
+    if not isinstance(decoded, dict):
+        log.warning('terminal frame was %s, not a JSON object', type(decoded).__name__)
+        return None
+    return decoded
+
+
+def parse_frame(frame: str) -> ChatEvent | None:
+    """Decode one `\\n\\n`-delimited frame. Returns None if unrecognized.
+
+    Mirrors `parseMessageChunk` in the Flutter client, including the `__CRLF__`
+    un-escaping that applies to both `data:` and `think:`.
+    """
+    # Checked before `error: ` -- this legacy variant has no space after the colon.
+    if frame.startswith('error:402:'):
+        return ChatEvent('error', frame[len('error:402:') :].strip())
+
+    if frame.startswith('error: '):
+        text = frame[len('error: ') :].strip()
+        return ChatEvent('error', text or 'Omi returned an unspecified error')
+
+    if frame.startswith('think: '):
+        return ChatEvent('think', frame[len('think: ') :].replace('__CRLF__', '\n'))
+
+    if frame.startswith('data: '):
+        return ChatEvent('data', frame[len('data: ') :].replace('__CRLF__', '\n'))
+
+    if frame.startswith('done: '):
+        decoded = _decode_b64_json(frame[len('done: ') :])
+        return ChatEvent('done', (decoded or {}).get('text', ''), decoded)
+
+    if frame.startswith('message: '):
+        decoded = _decode_b64_json(frame[len('message: ') :])
+        return ChatEvent('message', (decoded or {}).get('text', ''), decoded)
+
+    return None
+
+
+class OmiClient:
+    def __init__(self, auth: OmiAuth, base_url: str = DEFAULT_BASE_URL) -> None:
+        self._auth = auth
+        self._base = base_url.rstrip('/')
+
+    async def _headers(self) -> dict[str, str]:
+        return await self._auth.auth_header()
+
+    async def chat_stream(self, text: str, app_id: str | None = None) -> AsyncIterator[ChatEvent]:
+        """Stream one chat turn, yielding decoded frames as they arrive."""
+        url = f'{self._base}/v2/messages'
+        params = {'app_id': app_id} if app_id else None
+        headers = {**await self._headers(), 'Content-Type': 'application/json'}
+
+        async with httpx.AsyncClient(timeout=_STREAM_TIMEOUT) as client:
+            async with client.stream(
+                'POST', url, params=params, headers=headers, json={'text': text, 'file_ids': []}
+            ) as response:
+                if response.status_code != 200:
+                    body = (await response.aread()).decode('utf-8', errors='replace')[:300]
+                    yield ChatEvent('error', f'HTTP {response.status_code}: {body}')
+                    return
+
+                buffer = b''
+                async for chunk in response.aiter_bytes():
+                    buffer += chunk
+                    # Frames are separated, not terminated -- the tail stays buffered.
+                    while _FRAME_SEP in buffer:
+                        raw, buffer = buffer.split(_FRAME_SEP, 1)
+                        frame = raw.decode('utf-8', errors='replace')
+                        if not frame.strip():
+                            continue
+                        event = parse_frame(frame)
+                        if event is None:
+                            log.debug('ignoring unrecognized frame: %.80s', frame)
+                            continue
+                        yield event
+
+                # A final frame without a trailing separator is still valid.
+                tail = buffer.decode('utf-8', errors='replace').strip()
+                if tail:
+                    event = parse_frame(tail)
+                    if event is not None:
+                        yield event
+
+    async def chat(
+        self,
+        text: str,
+        app_id: str | None = None,
+        deadline_s: float | None = None,
+    ) -> ChatResult:
+        """Run a chat turn to completion, or to `deadline_s`, whichever comes first.
+
+        The deadline exists because the glasses' client will give up long before
+        Omi's 150s agent cap. On timeout the partial answer accumulated so far is
+        returned rather than nothing -- a truncated answer beats a spinner.
+        """
+        started = time.monotonic()
+        parts: list[str] = []
+        thinking: list[str] = []
+        final_text = ''
+        error: str | None = None
+        saw_terminal = False
+
+        stream = self.chat_stream(text, app_id=app_id)
+        try:
+            while True:
+                remaining = None
+                if deadline_s is not None:
+                    remaining = deadline_s - (time.monotonic() - started)
+                    if remaining <= 0:
+                        break
+                try:
+                    event = await asyncio.wait_for(anext(stream), timeout=remaining)
+                except StopAsyncIteration:
+                    break
+                except TimeoutError:
+                    break
+
+                if event.kind == 'data':
+                    parts.append(event.text)
+                elif event.kind == 'think':
+                    thinking.append(event.text)
+                elif event.kind == 'error':
+                    error = event.text
+                    saw_terminal = True
+                    break
+                elif event.kind == 'done':
+                    # Authoritative: prefer it over the accumulated deltas.
+                    final_text = event.text or ''.join(parts)
+                    saw_terminal = True
+                    break
+        finally:
+            await stream.aclose()
+
+        elapsed = time.monotonic() - started
+        answer = (final_text or ''.join(parts)).strip()
+        return ChatResult(
+            text=answer,
+            error=error,
+            truncated=not saw_terminal,
+            elapsed_s=elapsed,
+            thinking=thinking,
+        )
+
+    async def get_messages(self, limit: int = 20, app_id: str | None = None) -> list[dict]:
+        """Recent chat history, newest last (server caps this at 100)."""
+        headers = await self._headers()
+        params = {'app_id': app_id} if app_id else None
+        async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:
+            response = await client.get(f'{self._base}/v2/messages', params=params, headers=headers)
+        response.raise_for_status()
+        messages = response.json()
+        return messages[-limit:] if isinstance(messages, list) else []
+
+    async def transcribe_pcm(
+        self,
+        pcm: bytes,
+        sample_rate: int = 16000,
+        channels: int = 1,
+        language: str = 'en',
+    ) -> str:
+        """Transcribe raw PCM16 via the endpoint's octet-stream mode.
+
+        The G2 mic emits exactly PCM16 LE mono at 16 kHz, so nothing is resampled.
+        """
+        headers = {**await self._headers(), 'Content-Type': 'application/octet-stream'}
+        params = {
+            'language': language,
+            'encoding': 'linear16',
+            'sample_rate': str(sample_rate),
+            'channels': str(channels),
+        }
+        async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:
+            response = await client.post(
+                f'{self._base}/v2/voice-message/transcribe',
+                params=params,
+                headers=headers,
+                content=pcm,
+            )
+        if response.status_code != 200:
+            raise RuntimeError(f'transcribe failed: HTTP {response.status_code} {response.text[:200]}')
+        return (response.json() or {}).get('transcript', '')
+
+    async def _get_json(self, path: str, params: dict | None = None):
+        headers = await self._headers()
+        async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:
+            response = await client.get(f'{self._base}{path}', params=params, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    async def memories(self, limit: int = 20) -> list[dict]:
+        """Recent memories. Note `offset=0` makes the server ignore `limit` and
+        return up to 5000 (`routers/memories.py:740`), so we slice client-side."""
+        rows = await self._get_json('/v3/memories', {'limit': limit, 'offset': 0})
+        return rows[:limit] if isinstance(rows, list) else []
+
+    async def action_items(self, limit: int = 20) -> list[dict]:
+        payload = await self._get_json('/v1/action-items', {'limit': limit})
+        if isinstance(payload, dict):
+            payload = payload.get('action_items') or payload.get('items') or []
+        return payload[:limit] if isinstance(payload, list) else []
+
+    async def daily_summaries(self, limit: int = 3) -> list[dict]:
+        payload = await self._get_json('/v1/users/daily-summaries', {'limit': limit})
+        if isinstance(payload, dict):
+            payload = payload.get('daily_summaries') or payload.get('items') or []
+        return payload[:limit] if isinstance(payload, list) else []
+
+    async def usage_quota(self) -> dict:
+        headers = await self._headers()
+        async with httpx.AsyncClient(timeout=_JSON_TIMEOUT) as client:
+            response = await client.get(f'{self._base}/v1/users/me/usage-quota', headers=headers)
+        response.raise_for_status()
+        return response.json()

--- a/integrations/omi-even/bridge/run.sh
+++ b/integrations/omi-even/bridge/run.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Start the omi <-> Even Realities bridge and expose it for the glasses.
+#
+# Brings up three things:
+#   1. the bridge (FastAPI) on $PORT
+#   2. a Cloudflare tunnel, so the Even app can reach it over HTTPS
+#   3. a printed summary with the exact values to paste into "Add Agent"
+#
+# The token is persisted to .env on first run so the URL you register in the
+# Even app keeps working across restarts. The *tunnel URL* does not survive a
+# restart unless you use a named tunnel -- see the note printed at the end.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+PORT="${PORT:-8788}"
+ENV_FILE=".env"
+
+if [ ! -d .venv ]; then
+  echo "No .venv found. Creating one..."
+  python3 -m venv .venv
+  ./.venv/bin/python -m pip install -q --upgrade pip
+  ./.venv/bin/python -m pip install -q fastapi "uvicorn[standard]" httpx websockets pytest
+fi
+
+# A stable shared secret: regenerating it on every run would silently break the
+# agent already registered on the phone.
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+if [ -z "${OMI_EVEN_TOKEN:-}" ]; then
+  OMI_EVEN_TOKEN="omi-even-$(python3 -c 'import secrets;print(secrets.token_hex(12))')"
+  printf 'OMI_EVEN_TOKEN=%s\n' "$OMI_EVEN_TOKEN" >> "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  echo "Generated a new bridge token and saved it to $ENV_FILE"
+fi
+export OMI_EVEN_TOKEN
+
+cleanup() {
+  [ -n "${BRIDGE_PID:-}" ] && kill "$BRIDGE_PID" 2>/dev/null || true
+  [ -n "${TUNNEL_PID:-}" ] && kill "$TUNNEL_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting bridge on :$PORT ..."
+./.venv/bin/uvicorn server:app --host 0.0.0.0 --port "$PORT" > /tmp/omi-even-server.log 2>&1 &
+BRIDGE_PID=$!
+
+# Wait for readiness rather than sleeping a fixed amount -- the first request
+# also performs the Firebase refresh, which can take a couple of seconds.
+for _ in $(seq 1 30); do
+  if curl -sf -o /dev/null --max-time 5 "http://127.0.0.1:$PORT/health"; then break; fi
+  sleep 1
+done
+
+if ! curl -sf -o /dev/null --max-time 5 "http://127.0.0.1:$PORT/health"; then
+  echo "Bridge failed to start. Last log lines:" >&2
+  tail -20 /tmp/omi-even-server.log >&2
+  exit 1
+fi
+
+TUNNEL_URL=""
+if [ "${OMI_SKIP_TUNNEL:-0}" != "1" ]; then
+  if ! command -v cloudflared > /dev/null; then
+    echo "cloudflared not found (brew install cloudflared). Continuing without a tunnel." >&2
+  else
+    echo "Starting tunnel ..."
+    cloudflared tunnel --url "http://localhost:$PORT" > /tmp/omi-even-tunnel.log 2>&1 &
+    TUNNEL_PID=$!
+    for _ in $(seq 1 40); do
+      TUNNEL_URL="$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/omi-even-tunnel.log | head -1 || true)"
+      [ -n "$TUNNEL_URL" ] && break
+      sleep 1
+    done
+  fi
+fi
+
+LAN_IP="$(ipconfig getifaddr en0 2>/dev/null || echo '')"
+
+cat <<EOF
+
+  omi bridge is running.
+
+  Register in the Even Realities app -> Add Agent:
+     Name:   omi
+     URL:    ${TUNNEL_URL:-<no tunnel; use http://${LAN_IP:-127.0.0.1}:$PORT>}
+     Token:  $OMI_EVEN_TOKEN
+
+  For the omi Hub app on the glasses:
+     ws://${LAN_IP:-127.0.0.1}:$PORT/app
+
+  Health:  curl -s http://127.0.0.1:$PORT/health
+  Logs:    /tmp/omi-even-server.log
+  Captured Add Agent requests: $(pwd)/add-agent-capture.log
+
+  Note: a quick tunnel gets a NEW URL every restart, so you would have to
+  re-register in the Even app each time. For a URL that survives restarts,
+  set up a named tunnel: cloudflared tunnel create omi-even
+
+  Ctrl-C to stop.
+
+EOF
+
+wait $BRIDGE_PID

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -53,6 +53,10 @@ EVEN_TOKEN = os.getenv('OMI_EVEN_TOKEN') or secrets.token_urlsafe(24)
 # cap our own wait and return whatever partial answer exists rather than nothing.
 AGENT_DEADLINE_S = float(os.getenv('OMI_EVEN_DEADLINE', '20'))
 
+# Ceiling for the fast path. Answers that took 5.6s+ were never rendered on the
+# glasses, so anything approaching that is already lost -- better to say so.
+FAST_DEADLINE_S = float(os.getenv('OMI_EVEN_FAST_DEADLINE', '5'))
+
 _CONTRACT_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'add-agent-capture.log')
 
 # Larger than any answer Omi produces; used to strip markup without truncating.
@@ -173,10 +177,17 @@ async def _answer_for_glasses(question: str) -> str:
     if not os.getenv('OMI_EVEN_FULL_AGENT'):
         started = time.monotonic()
         try:
-            answer = await fast_answer(omi, question)
+            # A hard ceiling, because being late is the same as failing here: the
+            # glasses show nothing at all. One query was measured at 14s when a
+            # server-side date window made the search pathologically slow, which
+            # is exactly the outcome this path exists to prevent.
+            answer = await asyncio.wait_for(fast_answer(omi, question), timeout=FAST_DEADLINE_S)
             fitted = fit_for_glasses(answer, limit=DISPLAY_LIMIT)
             log.info('fastpath answered in %.1fs (%d chars shown)', time.monotonic() - started, len(fitted))
             return fitted or "I don't have anything on that."
+        except TimeoutError:
+            log.warning('fastpath exceeded %.0fs; answering rather than hanging', FAST_DEADLINE_S)
+            return 'That took too long to look up. Try asking a shorter question.'
         except Exception as exc:  # noqa: BLE001 - fall back rather than fail
             log.warning('fastpath failed (%s); falling back to the agent', exc)
 

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -33,6 +33,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from capture import CaptureSession
 from display import DEFAULT_LIMIT as DISPLAY_LIMIT
 from display import fit_for_glasses, openai_chat_completion, paginate
+import local_llm
 from compose import compose_or_none
 from fastpath import fast_answer, gather_facts
 from omi_auth import AuthError, OmiAuth
@@ -58,8 +59,8 @@ AGENT_DEADLINE_S = float(os.getenv('OMI_EVEN_DEADLINE', '20'))
 # glasses, so anything approaching that is already lost -- better to say so.
 FAST_DEADLINE_S = float(os.getenv('OMI_EVEN_FAST_DEADLINE', '5'))
 
-# Retrieval plus one compose call measured 2.9s end to end. This bounds the pair,
-# leaving headroom under the ~5s the glasses tolerate.
+# Retrieval plus one compose call measured 2.9s in the cloud and 3.7s locally.
+# This bounds the pair, leaving headroom under the ~5s the glasses tolerate.
 COMPOSE_DEADLINE_S = float(os.getenv('OMI_EVEN_COMPOSE_DEADLINE', '4.5'))
 
 _CONTRACT_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'add-agent-capture.log')
@@ -80,12 +81,25 @@ async def _lifespan(_: FastAPI):
     if not os.getenv('OMI_EVEN_TOKEN'):
         log.warning('OMI_EVEN_TOKEN was unset -- generated one for this run only')
     push_task = asyncio.create_task(_push_loop(), name='omi-even-push')
+    # Composing locally is uncapped, but only while the model is resident: cold,
+    # it takes 16.5s, which is three times the whole budget. Warming is a
+    # background task so a slow first load never delays the bridge coming up.
+    warm_task = (
+        None if os.getenv('OMI_EVEN_NO_LOCAL') else asyncio.create_task(local_llm.warm_forever(), name='omi-even-warm')
+    )
     try:
         yield
     finally:
-        push_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await push_task
+        for task in (push_task, warm_task):
+            if task is None:
+                continue
+            task.cancel()
+            # CancelledError is a BaseException, so it has to be named
+            # explicitly -- suppressing Exception alone lets it escape and turns
+            # an ordinary shutdown into a traceback. A background task that
+            # already died must not fail shutdown either.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
 
 
 app = FastAPI(title='omi-even-bridge', lifespan=_lifespan)

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -33,7 +33,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from capture import CaptureSession
 from display import DEFAULT_LIMIT as DISPLAY_LIMIT
 from display import fit_for_glasses, openai_chat_completion, paginate
-from fastpath import fast_answer
+from compose import compose_or_none
+from fastpath import fast_answer, gather_facts
 from omi_auth import AuthError, OmiAuth
 from omi_client import OmiClient
 
@@ -56,6 +57,10 @@ AGENT_DEADLINE_S = float(os.getenv('OMI_EVEN_DEADLINE', '20'))
 # Ceiling for the fast path. Answers that took 5.6s+ were never rendered on the
 # glasses, so anything approaching that is already lost -- better to say so.
 FAST_DEADLINE_S = float(os.getenv('OMI_EVEN_FAST_DEADLINE', '5'))
+
+# Retrieval plus one compose call measured 2.9s end to end. This bounds the pair,
+# leaving headroom under the ~5s the glasses tolerate.
+COMPOSE_DEADLINE_S = float(os.getenv('OMI_EVEN_COMPOSE_DEADLINE', '4.5'))
 
 _CONTRACT_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'add-agent-capture.log')
 
@@ -184,7 +189,24 @@ async def _answer_for_glasses(question: str) -> str:
             # glasses show nothing at all. One query was measured at 14s when a
             # server-side date window made the search pathologically slow, which
             # is exactly the outcome this path exists to prevent.
-            answer = await asyncio.wait_for(fast_answer(omi, question), timeout=FAST_DEADLINE_S)
+            facts = await asyncio.wait_for(gather_facts(omi, question), timeout=FAST_DEADLINE_S)
+
+            # Compose the facts into prose with Omi's own LLM. Bullets were never
+            # what was wanted; this reads like Omi and still lands in ~3s.
+            # Whatever budget retrieval did not use is what remains for it.
+            remaining = COMPOSE_DEADLINE_S - (time.monotonic() - started)
+            if facts and remaining > 1.0 and not os.getenv('OMI_EVEN_NO_COMPOSE'):
+                composed = await compose_or_none(auth, OMI_API_BASE, question, facts, remaining)
+                if composed:
+                    fitted = fit_for_glasses(composed, limit=DISPLAY_LIMIT)
+                    log.info(
+                        'composed answer in %.1fs (%d chars shown)', time.monotonic() - started, len(fitted)
+                    )
+                    return fitted
+
+            # Fallback: show the retrieved lines. Worse than prose, better than
+            # nothing, and reached whenever compose is rate limited or slow.
+            answer = await asyncio.wait_for(fast_answer(omi, question), timeout=2.0)
             fitted = fit_for_glasses(answer, limit=DISPLAY_LIMIT)
             log.info('fastpath answered in %.1fs (%d chars shown)', time.monotonic() - started, len(fitted))
             return fitted or "I don't have anything on that."

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -1,0 +1,464 @@
+"""The omi <-> Even Realities bridge.
+
+Serves three consumers from one process, because all three need the same Firebase
+session and it should live in exactly one place:
+
+1. **Even's built-in assistant** (`POST /`) -- the Even phone app's "Add Agent"
+   feature posts OpenAI chat-completions here after doing speech-to-text on the
+   glasses. This is what makes Even AI answer out of Omi's memory.
+2. **The `omi` Hub plugin** (`WS /app`) -- the app on the glasses. JSON text frames
+   are control; binary frames are microphone PCM.
+3. **Operators** (`GET /health`) -- status without exposing credentials.
+
+Run it:
+
+    OMI_EVEN_TOKEN=<shared secret> .venv/bin/uvicorn server:app --host 0.0.0.0 --port 8788
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import secrets
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+
+from capture import CaptureSession
+from display import fit_for_glasses, openai_chat_completion, paginate
+from omi_auth import AuthError, OmiAuth
+from omi_client import OmiClient
+
+logging.basicConfig(
+    level=os.getenv('OMI_EVEN_LOG_LEVEL', 'INFO'),
+    format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+)
+log = logging.getLogger('omi-even')
+
+OMI_API_BASE = os.getenv('OMI_API_BASE', 'https://api.omi.me')
+
+# Shared secret the Even app sends as `Authorization: Bearer ...`. Generated at
+# startup when unset so the bridge is never accidentally left open.
+EVEN_TOKEN = os.getenv('OMI_EVEN_TOKEN') or secrets.token_urlsafe(24)
+
+# A measured Omi answer takes ~9s. Even's client timeout is undocumented, so we
+# cap our own wait and return whatever partial answer exists rather than nothing.
+AGENT_DEADLINE_S = float(os.getenv('OMI_EVEN_DEADLINE', '20'))
+
+_CONTRACT_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'add-agent-capture.log')
+
+auth = OmiAuth()
+omi = OmiClient(auth, OMI_API_BASE)
+
+
+@asynccontextmanager
+async def _lifespan(_: FastAPI):
+    log.info('bridge starting; Even token: %s', EVEN_TOKEN)
+    if not os.getenv('OMI_EVEN_TOKEN'):
+        log.warning('OMI_EVEN_TOKEN was unset -- generated one for this run only')
+    push_task = asyncio.create_task(_push_loop(), name='omi-even-push')
+    try:
+        yield
+    finally:
+        push_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await push_task
+
+
+app = FastAPI(title='omi-even-bridge', lifespan=_lifespan)
+
+
+# --------------------------------------------------------------------- health
+
+
+@app.get('/health')
+async def health() -> dict:
+    status: dict = {
+        'ok': True,
+        'omi_api': OMI_API_BASE,
+        'deadline_s': AGENT_DEADLINE_S,
+        'app_clients': len(_clients),
+    }
+    try:
+        # Before describe(): this is what actually loads the session, so reporting
+        # auth state first would show "not loaded" on an otherwise healthy bridge.
+        status['quota'] = await omi.usage_quota()
+    except Exception as exc:  # noqa: BLE001 - health must never 500
+        status['ok'] = False
+        status['quota_error'] = f'{type(exc).__name__}: {exc}'
+    status['auth'] = auth.describe()
+    return status
+
+
+# ------------------------------------------------------- Even AI agent endpoint
+
+
+def _extract_question(payload: dict) -> str:
+    """Pull the user's question out of an OpenAI chat-completions body.
+
+    Tolerant on purpose: the Add Agent contract is undocumented, so accept both a
+    plain string `content` and the newer list-of-parts shape, and fall back to any
+    last message if no explicit user role is present.
+    """
+    messages = payload.get('messages')
+    if not isinstance(messages, list) or not messages:
+        return ''
+
+    def content_of(message: object) -> str:
+        if not isinstance(message, dict):
+            return ''
+        content = message.get('content')
+        if isinstance(content, str):
+            return content.strip()
+        if isinstance(content, list):
+            parts = [p.get('text', '') for p in content if isinstance(p, dict) and p.get('type') == 'text']
+            return ' '.join(part for part in parts if part).strip()
+        return ''
+
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get('role') == 'user':
+            text = content_of(message)
+            if text:
+                return text
+    return content_of(messages[-1])
+
+
+def _authorized(request: Request) -> bool:
+    header = request.headers.get('authorization') or ''
+    parts = header.split(' ', 1)
+    if len(parts) != 2 or parts[0].lower() != 'bearer':
+        return False
+    # Constant-time compare: this is a shared secret over the open internet.
+    return secrets.compare_digest(parts[1].strip(), EVEN_TOKEN)
+
+
+async def _answer_for_glasses(question: str) -> str:
+    """Ask Omi and reduce the answer to something the G2 can actually show."""
+    result = await omi.chat(question, deadline_s=AGENT_DEADLINE_S)
+
+    if result.error:
+        log.warning('chat error: %s', result.error)
+        return fit_for_glasses(f'Omi could not answer: {result.error}')
+
+    if not result.text.strip():
+        return 'Omi had no answer for that.'
+
+    fitted = fit_for_glasses(result.text)
+    if result.truncated:
+        log.info('answer truncated at the %.0fs deadline', AGENT_DEADLINE_S)
+    log.info('answered in %.1fs (%d chars -> %d shown)', result.elapsed_s, len(result.text), len(fitted))
+    return fitted
+
+
+def _record_contract(request: Request, raw: bytes) -> None:
+    """Append the raw request to a log, since Even publishes no spec for this.
+
+    The first real request from the glasses is the only authoritative description
+    of the contract, so it is captured verbatim rather than inferred. The bearer
+    token is redacted -- everything else is kept, including header order and case.
+    """
+    try:
+        headers = [
+            [k, '<redacted>' if k.lower() == 'authorization' else v] for k, v in request.headers.items()
+        ]
+        entry = {
+            'received_at': time.strftime('%Y-%m-%dT%H:%M:%S%z'),
+            'method': request.method,
+            'path': request.url.path,
+            'query': str(request.url.query),
+            'client': request.client.host if request.client else None,
+            'headers': headers,
+            'body': raw.decode('utf-8', errors='replace')[:4000],
+        }
+        with open(_CONTRACT_LOG, 'a', encoding='utf-8') as fh:
+            fh.write(json.dumps(entry, indent=2) + '\n---\n')
+    except Exception as exc:  # noqa: BLE001 - logging must never break a request
+        log.debug('contract capture failed: %s', exc)
+
+
+async def _handle_agent(request: Request) -> JSONResponse:
+    raw = await request.body()
+    _record_contract(request, raw)
+
+    if not _authorized(request):
+        # Logged above, so a token mismatch is still diagnosable from the capture.
+        log.warning('rejected unauthorized agent request from %s', request.client)
+        return JSONResponse({'error': {'message': 'Unauthorized'}}, status_code=401)
+
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return JSONResponse({'error': {'message': 'Body must be JSON'}}, status_code=400)
+    if not isinstance(payload, dict):
+        return JSONResponse({'error': {'message': 'Body must be a JSON object'}}, status_code=400)
+
+    question = _extract_question(payload)
+    if not question:
+        return JSONResponse({'error': {'message': 'No user message found'}}, status_code=400)
+
+    log.info('agent question: %.120s', question)
+    try:
+        answer = await _answer_for_glasses(question)
+    except AuthError as exc:
+        log.error('auth failure: %s', exc)
+        return JSONResponse({'error': {'message': str(exc)}}, status_code=503)
+    except Exception as exc:  # noqa: BLE001 - never hand the glasses a 500
+        log.exception('agent request failed')
+        answer = fit_for_glasses(f'Bridge error: {type(exc).__name__}')
+
+    return JSONResponse(openai_chat_completion(answer, model=payload.get('model') or 'omi'))
+
+
+# The exact path Even posts to is not documented; the known implementation uses the
+# root. Register the conventional OpenAI paths too so a firmware change that starts
+# appending /v1/chat/completions does not silently break.
+@app.post('/')
+async def agent_root(request: Request) -> JSONResponse:
+    return await _handle_agent(request)
+
+
+@app.post('/v1/chat/completions')
+async def agent_openai(request: Request) -> JSONResponse:
+    return await _handle_agent(request)
+
+
+@app.post('/chat/completions')
+async def agent_openai_short(request: Request) -> JSONResponse:
+    return await _handle_agent(request)
+
+
+# ------------------------------------------------------ glasses plugin socket
+
+_clients: set[WebSocket] = set()
+
+
+async def _send(socket: WebSocket, payload: dict) -> None:
+    with contextlib.suppress(Exception):
+        await socket.send_text(json.dumps(payload))
+
+
+async def broadcast(payload: dict) -> None:
+    """Push to every connected glasses app (proactive surfacing)."""
+    for socket in list(_clients):
+        await _send(socket, payload)
+
+
+async def _stream_chat_to(socket: WebSocket, text: str) -> None:
+    """Stream an answer to the glasses, coalescing deltas.
+
+    Every frame costs a BLE round trip, so tokens are batched into readable
+    chunks instead of forwarded one at a time.
+    """
+    buffer: list[str] = []
+    pending = 0
+    full: list[str] = []
+    error: str | None = None
+
+    async for event in omi.chat_stream(text):
+        if event.kind == 'data':
+            buffer.append(event.text)
+            full.append(event.text)
+            pending += len(event.text)
+            if pending >= 60:
+                await _send(socket, {'type': 'chat_delta', 'text': ''.join(buffer)})
+                buffer.clear()
+                pending = 0
+        elif event.kind == 'think':
+            await _send(socket, {'type': 'chat_status', 'text': event.text[:60]})
+        elif event.kind == 'error':
+            error = event.text
+            break
+        elif event.kind == 'done':
+            if event.text:
+                full = [event.text]
+            break
+
+    if error:
+        await _send(socket, {'type': 'chat_done', 'text': fit_for_glasses(f'Error: {error}'), 'error': True})
+        return
+
+    answer = ''.join(full).strip()
+    fitted = fit_for_glasses(answer, limit=1800)  # textContainerUpgrade caps at 2000
+    await _send(
+        socket,
+        {'type': 'chat_done', 'text': fitted, 'pages': paginate(fitted), 'error': False},
+    )
+
+
+async def _handle_app_message(socket: WebSocket, payload: dict, session: CaptureSession) -> None:
+    kind = payload.get('type')
+
+    if kind == 'chat':
+        question = (payload.get('text') or '').strip()
+        if not question:
+            await _send(socket, {'type': 'chat_done', 'text': 'Nothing to ask.', 'error': True})
+            return
+        await _stream_chat_to(socket, question)
+
+    elif kind == 'memories':
+        rows = await omi.memories(int(payload.get('limit') or 20))
+        items = [{'content': fit_for_glasses(r.get('content', ''), limit=200)} for r in rows]
+        await _send(socket, {'type': 'memories', 'items': items})
+
+    elif kind == 'action_items':
+        rows = await omi.action_items(int(payload.get('limit') or 20))
+        items = [
+            {
+                'description': fit_for_glasses(r.get('description', ''), limit=120),
+                'completed': bool(r.get('completed')),
+            }
+            for r in rows
+        ]
+        await _send(socket, {'type': 'action_items', 'items': items})
+
+    elif kind == 'today':
+        rows = await omi.daily_summaries(1)
+        if rows:
+            raw = rows[0].get('summary') or rows[0].get('overview') or ''
+            text = fit_for_glasses(str(raw), limit=1800)
+        else:
+            text = 'No summary for today yet.'
+        await _send(socket, {'type': 'today', 'text': text, 'pages': paginate(text)})
+
+    elif kind == 'capture':
+        if payload.get('enabled'):
+            await session.start()
+            await _send(socket, {'type': 'capture', 'active': True})
+        else:
+            stats = await session.stop(finalize=True)
+            await _send(
+                socket,
+                {
+                    'type': 'capture',
+                    'active': False,
+                    'seconds': round(stats.audio_seconds, 1),
+                    'conversation_id': stats.conversation_id,
+                },
+            )
+
+    elif kind == 'transcribe':
+        # One-shot push-to-talk: the app buffered PCM and wants text back.
+        pcm = bytes.fromhex(payload.get('pcm_hex', ''))
+        transcript = await omi.transcribe_pcm(pcm) if pcm else ''
+        await _send(socket, {'type': 'transcribed', 'text': transcript})
+
+    elif kind == 'ping':
+        await _send(socket, {'type': 'pong'})
+
+    else:
+        log.debug('unknown app message type: %s', kind)
+
+
+@app.websocket('/app')
+async def app_socket(socket: WebSocket) -> None:
+    await socket.accept()
+    _clients.add(socket)
+    log.info('glasses app connected (%d total)', len(_clients))
+
+    async def on_segments(segments: list[dict]) -> None:
+        text = ' '.join(s.get('text', '') for s in segments if s.get('text')).strip()
+        if text:
+            await _send(socket, {'type': 'transcript', 'text': fit_for_glasses(text, limit=300)})
+
+    session = CaptureSession(auth, OMI_API_BASE, on_segments=on_segments)
+
+    try:
+        await _send(socket, {'type': 'hello', 'omi_api': OMI_API_BASE})
+        while True:
+            message = await socket.receive()
+            if message.get('type') == 'websocket.disconnect':
+                break
+
+            if (data := message.get('bytes')) is not None:
+                # Binary frames are microphone PCM straight from the glasses.
+                session.feed(data)
+                continue
+
+            raw = message.get('text')
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+
+            try:
+                await _handle_app_message(socket, payload, session)
+            except Exception as exc:  # noqa: BLE001 - one bad request must not kill the socket
+                log.exception('app message failed')
+                await _send(socket, {'type': 'error', 'text': f'{type(exc).__name__}: {exc}'})
+
+    except WebSocketDisconnect:
+        pass
+    finally:
+        _clients.discard(socket)
+        with contextlib.suppress(Exception):
+            await session.stop(finalize=True)
+        log.info('glasses app disconnected (%d left)', len(_clients))
+
+
+# --------------------------------------------------------------- push polling
+
+
+def _created_at(row: dict) -> str:
+    """Sortable creation timestamp. Missing values sort oldest."""
+    return str(row.get('created_at') or '')
+
+
+async def _push_loop() -> None:
+    """Surface newly created action items to any connected glasses app.
+
+    Only reaches the glasses while the app is running -- the Hub host keeps a
+    backgrounded plugin alive in a headless WebView, but a closed app receives
+    nothing. There is no OS-level notification path in the SDK.
+
+    `GET /v1/action-items` does **not** return newest-first: a freshly created task
+    was observed at index 20 of 100, so polling a small window silently watched only
+    the oldest tasks and could never fire. We therefore pull a generous window and
+    sort by `created_at` ourselves rather than trusting server order.
+    """
+    interval = float(os.getenv('OMI_EVEN_PUSH_INTERVAL', '120'))
+    window = int(os.getenv('OMI_EVEN_PUSH_WINDOW', '100'))
+    seen: set[str] = set()
+    first_pass = True
+
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            if not _clients:
+                continue
+
+            rows = await omi.action_items(window)
+            rows.sort(key=_created_at, reverse=True)
+
+            if first_pass:
+                # Seed, or every pre-existing task would push at once on startup.
+                seen = {r['id'] for r in rows if r.get('id')}
+                first_pass = False
+                continue
+
+            # Newest first, so the most recent task is announced first.
+            for row in rows:
+                item_id = row.get('id')
+                if not item_id or item_id in seen:
+                    continue
+                seen.add(item_id)
+                if row.get('completed'):
+                    continue
+                await broadcast(
+                    {
+                        'type': 'push',
+                        'text': fit_for_glasses(f"New task: {row.get('description', '')}", limit=200),
+                    }
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a poll failure must not end the loop
+            log.warning('push poll failed: %s', exc)

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -199,9 +199,7 @@ async def _answer_for_glasses(question: str) -> str:
                 composed = await compose_or_none(auth, OMI_API_BASE, question, facts, remaining)
                 if composed:
                     fitted = fit_for_glasses(composed, limit=DISPLAY_LIMIT)
-                    log.info(
-                        'composed answer in %.1fs (%d chars shown)', time.monotonic() - started, len(fitted)
-                    )
+                    log.info('composed answer in %.1fs (%d chars shown)', time.monotonic() - started, len(fitted))
                     return fitted
 
             # Fallback: show the retrieved lines. Worse than prose, better than
@@ -240,9 +238,7 @@ def _record_contract(request: Request, raw: bytes) -> None:
     token is redacted -- everything else is kept, including header order and case.
     """
     try:
-        headers = [
-            [k, '<redacted>' if k.lower() == 'authorization' else v] for k, v in request.headers.items()
-        ]
+        headers = [[k, '<redacted>' if k.lower() == 'authorization' else v] for k, v in request.headers.items()]
         entry = {
             'received_at': time.strftime('%Y-%m-%dT%H:%M:%S%z'),
             'method': request.method,

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -33,6 +33,7 @@ from fastapi.responses import JSONResponse
 from capture import CaptureSession
 from display import DEFAULT_LIMIT as DISPLAY_LIMIT
 from display import fit_for_glasses, openai_chat_completion, paginate
+from fastpath import fast_answer
 from omi_auth import AuthError, OmiAuth
 from omi_client import OmiClient
 
@@ -161,7 +162,24 @@ def _display_is_full(raw: str) -> bool:
 
 
 async def _answer_for_glasses(question: str) -> str:
-    """Ask Omi and reduce the answer to something the G2 can actually show."""
+    """Ask Omi and reduce the answer to something the G2 can actually show.
+
+    Defaults to the fast retrieval path, because Even's client timeout is short
+    enough that the full agent answer is never seen: proven on hardware, a 0.4s
+    reply renders and a 5.6s one does not, despite returning 200 OK.
+    Set OMI_EVEN_FULL_AGENT=1 to use `/v2/messages` instead, for a client that
+    can wait.
+    """
+    if not os.getenv('OMI_EVEN_FULL_AGENT'):
+        started = time.monotonic()
+        try:
+            answer = await fast_answer(omi, question)
+            fitted = fit_for_glasses(answer, limit=DISPLAY_LIMIT)
+            log.info('fastpath answered in %.1fs (%d chars shown)', time.monotonic() - started, len(fitted))
+            return fitted or "I don't have anything on that."
+        except Exception as exc:  # noqa: BLE001 - fall back rather than fail
+            log.warning('fastpath failed (%s); falling back to the agent', exc)
+
     result = await omi.chat(question, deadline_s=AGENT_DEADLINE_S, enough=_display_is_full)
 
     if result.error:
@@ -225,6 +243,19 @@ async def _handle_agent(request: Request) -> JSONResponse:
         return JSONResponse({'error': {'message': 'No user message found'}}, status_code=400)
 
     log.info('agent question: %.120s', question)
+
+    # Diagnostic: answer instantly, skipping Omi entirely. Even's client timeout
+    # is undocumented, so if a real answer never renders but this one does, the
+    # cause is latency rather than the response shape or the routing.
+    if os.getenv('OMI_EVEN_FAST_TEST'):
+        log.info('FAST_TEST enabled -- replying instantly without calling Omi')
+        return JSONResponse(
+            openai_chat_completion(
+                'omi bridge replying instantly. If you can read this, the bridge '
+                'works and slow answers were timing out.',
+                model=payload.get('model') or 'omi',
+            )
+        )
     try:
         answer = await _answer_for_glasses(question)
     except AuthError as exc:

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -31,6 +31,7 @@ from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 
 from capture import CaptureSession
+from display import DEFAULT_LIMIT as DISPLAY_LIMIT
 from display import fit_for_glasses, openai_chat_completion, paginate
 from omi_auth import AuthError, OmiAuth
 from omi_client import OmiClient
@@ -52,6 +53,9 @@ EVEN_TOKEN = os.getenv('OMI_EVEN_TOKEN') or secrets.token_urlsafe(24)
 AGENT_DEADLINE_S = float(os.getenv('OMI_EVEN_DEADLINE', '20'))
 
 _CONTRACT_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'add-agent-capture.log')
+
+# Larger than any answer Omi produces; used to strip markup without truncating.
+_UNLIMITED = 1_000_000
 
 auth = OmiAuth()
 omi = OmiClient(auth, OMI_API_BASE)
@@ -138,9 +142,27 @@ def _authorized(request: Request) -> bool:
     return secrets.compare_digest(parts[1].strip(), EVEN_TOKEN)
 
 
+def _display_is_full(raw: str) -> bool:
+    """True once the accumulated answer already overflows one screen.
+
+    Omi writes for a phone: measured answers ran 929-1511 characters where the
+    glasses show ~380, and waiting for that tail cost about 3 seconds per
+    question the user never saw. Stripping only ever shrinks text, so a raw
+    length below the limit cannot possibly fill the screen -- that cheap check
+    guards the expensive one, which runs at most a handful of times per answer.
+    """
+    if len(raw) < DISPLAY_LIMIT:
+        return False
+    # Fit with an effectively unlimited budget so this measures the *stripped*
+    # length. Fitting at DISPLAY_LIMIT would truncate to at most DISPLAY_LIMIT --
+    # and usually a few characters below it, having landed on a word boundary --
+    # so comparing that against DISPLAY_LIMIT is a test that almost never passes.
+    return len(fit_for_glasses(raw, limit=_UNLIMITED)) >= DISPLAY_LIMIT
+
+
 async def _answer_for_glasses(question: str) -> str:
     """Ask Omi and reduce the answer to something the G2 can actually show."""
-    result = await omi.chat(question, deadline_s=AGENT_DEADLINE_S)
+    result = await omi.chat(question, deadline_s=AGENT_DEADLINE_S, enough=_display_is_full)
 
     if result.error:
         log.warning('chat error: %s', result.error)
@@ -149,7 +171,7 @@ async def _answer_for_glasses(question: str) -> str:
     if not result.text.strip():
         return 'Omi had no answer for that.'
 
-    fitted = fit_for_glasses(result.text)
+    fitted = fit_for_glasses(result.text, limit=DISPLAY_LIMIT)
     if result.truncated:
         log.info('answer truncated at the %.0fs deadline', AGENT_DEADLINE_S)
     log.info('answered in %.1fs (%d chars -> %d shown)', result.elapsed_s, len(result.text), len(fitted))

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -28,7 +28,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from capture import CaptureSession
 from display import DEFAULT_LIMIT as DISPLAY_LIMIT
@@ -61,6 +61,9 @@ _CONTRACT_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'add-ag
 
 # Larger than any answer Omi produces; used to strip markup without truncating.
 _UNLIMITED = 1_000_000
+
+# Stable id across a stream's chunks, as the OpenAI format expects.
+_STREAM_ID = 'chatcmpl-omi-stream'
 
 auth = OmiAuth()
 omi = OmiClient(auth, OMI_API_BASE)
@@ -233,6 +236,55 @@ def _record_contract(request: Request, raw: bytes) -> None:
         log.debug('contract capture failed: %s', exc)
 
 
+def _sse_chunk(text: str, model: str, *, finish: str | None = None) -> str:
+    """One OpenAI streaming chunk."""
+    payload = {
+        'id': _STREAM_ID,
+        'object': 'chat.completion.chunk',
+        'created': int(time.time()),
+        'model': model,
+        'choices': [{'index': 0, 'delta': ({'content': text} if text else {}), 'finish_reason': finish}],
+    }
+    return f'data: {json.dumps(payload)}\n\n'
+
+
+async def _stream_agent_answer(question: str, model: str):
+    """Stream Omi's real, composed answer as it is produced.
+
+    The reason this exists: Even's client gives up on a slow *response*, and
+    Omi's agent needs 6-18s to produce one. If the client measures time to first
+    byte instead of total time, opening the stream immediately buys the agent all
+    the time it needs -- and the answer is Omi's own, not a pile of raw search
+    hits.
+
+    An empty role chunk goes out first, before any Omi call, so bytes are on the
+    wire within milliseconds.
+    """
+    yield _sse_chunk('', model)
+
+    sent = 0
+    try:
+        async for event in omi.chat_stream(question):
+            if event.kind == 'data' and event.text:
+                yield _sse_chunk(event.text, model)
+                sent += len(event.text)
+            elif event.kind == 'error':
+                yield _sse_chunk(f'Omi error: {event.text}'[:200], model)
+                break
+            elif event.kind == 'done':
+                # `done` is authoritative; emit only the tail not already sent.
+                remainder = (event.text or '')[sent:]
+                if remainder:
+                    yield _sse_chunk(remainder, model)
+                break
+    except Exception as exc:  # noqa: BLE001 - a broken stream must still terminate
+        log.exception('streaming answer failed')
+        yield _sse_chunk(f'Bridge error: {type(exc).__name__}', model)
+
+    yield _sse_chunk('', model, finish='stop')
+    yield 'data: [DONE]\n\n'
+
+
 async def _handle_agent(request: Request) -> JSONResponse:
     raw = await request.body()
     _record_contract(request, raw)
@@ -254,6 +306,18 @@ async def _handle_agent(request: Request) -> JSONResponse:
         return JSONResponse({'error': {'message': 'No user message found'}}, status_code=400)
 
     log.info('agent question: %.120s', question)
+
+    # Streaming mode: Omi's own answer, unabridged, with the connection opened
+    # immediately so a slow agent cannot trip a time-to-first-byte timeout.
+    # Whether Even's client honours a streamed response is undocumented, so this
+    # is opt-in until proven on hardware.
+    if os.getenv('OMI_EVEN_STREAM') or payload.get('stream') is True:
+        log.info('answering as a stream')
+        return StreamingResponse(
+            _stream_agent_answer(question, payload.get('model') or 'omi'),
+            media_type='text/event-stream',
+            headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'},
+        )
 
     # Diagnostic: answer instantly, skipping Omi entirely. Even's client timeout
     # is undocumented, so if a real answer never renders but this one does, the

--- a/integrations/omi-even/bridge/server.py
+++ b/integrations/omi-even/bridge/server.py
@@ -25,6 +25,7 @@ import os
 import secrets
 import time
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
@@ -290,8 +291,71 @@ async def _stream_chat_to(socket: WebSocket, text: str) -> None:
     )
 
 
-async def _handle_app_message(socket: WebSocket, payload: dict, session: CaptureSession) -> None:
+@dataclass
+class _AppSession:
+    """Per-connection state for one glasses app.
+
+    Binary frames mean two different things depending on mode: between
+    `ask_start` and `ask_stop` they are a question being dictated, otherwise
+    they are continuous capture headed for `/v4/listen`. Keeping the mode here
+    rather than globally means two connected apps can't confuse each other.
+    """
+
+    capture: CaptureSession
+    ask_active: bool = False
+    ask_buffer: bytearray = field(default_factory=bytearray)
+
+
+# 30s of PCM16 at 16kHz. The app caps recording well below this; the bound
+# exists so a client that never sends `ask_stop` cannot grow memory forever.
+MAX_ASK_BYTES = 16000 * 2 * 30
+
+
+async def _handle_ask_stop(socket: WebSocket, session: _AppSession) -> None:
+    """Transcribe the dictated question, echo it back, then answer it."""
+    pcm = bytes(session.ask_buffer)
+    session.ask_buffer.clear()
+    session.ask_active = False
+
+    seconds = len(pcm) / (16000 * 2)
+    if seconds < 0.4:
+        # Too short to be speech -- almost always a double-tap cancel or a
+        # mis-tap. Answering "" would send an empty question to Omi.
+        await _send(socket, {'type': 'ask_error', 'text': "Didn't catch that. Tap to retry."})
+        return
+
+    try:
+        transcript = (await omi.transcribe_pcm(pcm)).strip()
+    except Exception as exc:  # noqa: BLE001 - report, never kill the socket
+        log.warning('transcription failed: %s', exc)
+        await _send(socket, {'type': 'ask_error', 'text': 'Could not transcribe that.'})
+        return
+
+    log.info('ask: %.1fs of audio -> %r', seconds, transcript[:120])
+    if not transcript:
+        await _send(socket, {'type': 'ask_error', 'text': "Didn't catch that. Tap to retry."})
+        return
+
+    # Echo the transcript first so a misheard question is visible before the
+    # answer arrives, rather than leaving the user guessing what was asked.
+    await _send(socket, {'type': 'transcribed', 'text': fit_for_glasses(transcript, limit=200)})
+    await _stream_chat_to(socket, transcript)
+
+
+async def _handle_app_message(socket: WebSocket, payload: dict, session: _AppSession) -> None:
     kind = payload.get('type')
+
+    if kind == 'ask_start':
+        session.ask_active = True
+        session.ask_buffer.clear()
+        await _send(socket, {'type': 'ask_listening'})
+        return
+
+    if kind == 'ask_stop':
+        if not session.ask_active and not session.ask_buffer:
+            return  # idempotent: a cancel after an auto-stop is not an error
+        await _handle_ask_stop(socket, session)
+        return
 
     if kind == 'chat':
         question = (payload.get('text') or '').strip()
@@ -327,10 +391,10 @@ async def _handle_app_message(socket: WebSocket, payload: dict, session: Capture
 
     elif kind == 'capture':
         if payload.get('enabled'):
-            await session.start()
+            await session.capture.start()
             await _send(socket, {'type': 'capture', 'active': True})
         else:
-            stats = await session.stop(finalize=True)
+            stats = await session.capture.stop(finalize=True)
             await _send(
                 socket,
                 {
@@ -365,7 +429,7 @@ async def app_socket(socket: WebSocket) -> None:
         if text:
             await _send(socket, {'type': 'transcript', 'text': fit_for_glasses(text, limit=300)})
 
-    session = CaptureSession(auth, OMI_API_BASE, on_segments=on_segments)
+    session = _AppSession(capture=CaptureSession(auth, OMI_API_BASE, on_segments=on_segments))
 
     try:
         await _send(socket, {'type': 'hello', 'omi_api': OMI_API_BASE})
@@ -375,8 +439,17 @@ async def app_socket(socket: WebSocket) -> None:
                 break
 
             if (data := message.get('bytes')) is not None:
-                # Binary frames are microphone PCM straight from the glasses.
-                session.feed(data)
+                # Binary frames are microphone PCM straight from the glasses, and
+                # mean different things depending on mode.
+                if session.ask_active:
+                    if len(session.ask_buffer) < MAX_ASK_BYTES:
+                        session.ask_buffer.extend(data)
+                    else:
+                        # Stop accumulating rather than grow without bound; the
+                        # question is already far longer than anyone speaks.
+                        log.warning('ask buffer hit %d bytes; ignoring further audio', MAX_ASK_BYTES)
+                else:
+                    session.capture.feed(data)
                 continue
 
             raw = message.get('text')
@@ -400,7 +473,7 @@ async def app_socket(socket: WebSocket) -> None:
     finally:
         _clients.discard(socket)
         with contextlib.suppress(Exception):
-            await session.stop(finalize=True)
+            await session.capture.stop(finalize=True)
         log.info('glasses app disconnected (%d left)', len(_clients))
 
 

--- a/integrations/omi-even/bridge/tests/conftest.py
+++ b/integrations/omi-even/bridge/tests/conftest.py
@@ -30,6 +30,10 @@ os.environ['OMI_EVEN_TOKEN'] = EVEN_TOKEN
 # The push loop starts on app startup; keep it asleep unless a test drives it.
 os.environ.setdefault('OMI_EVEN_PUSH_INTERVAL', '3600')
 os.environ['OMI_SESSION_FILE'] = str(Path(__file__).parent / 'no-such-dir' / 'desktop-auth.json')
+# Ollama on 127.0.0.1 is a fourth escape hatch, and a live one on this machine:
+# an unpatched test would reach a real 23 GB model and block for seconds. Tests
+# that exercise the local rung clear this and install a mock transport.
+os.environ['OMI_EVEN_NO_LOCAL'] = '1'
 
 import httpx  # noqa: E402
 

--- a/integrations/omi-even/bridge/tests/conftest.py
+++ b/integrations/omi-even/bridge/tests/conftest.py
@@ -1,0 +1,139 @@
+"""Shared fixtures and fakes for the omi <-> Even Realities bridge tests.
+
+Everything here exists to keep the suite hermetic. The bridge's entire job is
+talking to `api.omi.me` over HTTP and WebSocket and to the macOS Keychain via a
+shell script, so each of those three escape hatches is closed by default:
+
+* real DNS/TCP is blocked outright (`_no_network`), so a test that forgets to
+  patch a transport fails loudly instead of silently reaching production;
+* `omi_auth._run_dump` is stubbed, so no test can shell out to `security` and
+  pop a Keychain ACL dialog on the developer's machine;
+* `OMI_SESSION_FILE` points somewhere that does not exist, so the real desktop
+  session is never read.
+
+`OMI_EVEN_TOKEN` is set before anything imports `server`: the module reads it
+exactly once at import time and otherwise mints a random token that no test
+could ever authenticate with.
+"""
+
+import os
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+EVEN_TOKEN = 'test-shared-secret-not-a-real-token'
+os.environ['OMI_EVEN_TOKEN'] = EVEN_TOKEN
+# The push loop starts on app startup; keep it asleep unless a test drives it.
+os.environ.setdefault('OMI_EVEN_PUSH_INTERVAL', '3600')
+os.environ['OMI_SESSION_FILE'] = str(Path(__file__).parent / 'no-such-dir' / 'desktop-auth.json')
+
+import httpx  # noqa: E402
+
+import omi_auth  # noqa: E402
+
+AUTH_HEADER = {'Authorization': f'Bearer {EVEN_TOKEN}'}
+
+# Captured before anything can patch it, so installing a second mock transport
+# inside one test replaces the first instead of nesting behind it.
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+# --------------------------------------------------------------------------
+# Hermeticity guards
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    """Fail any test that tries to open a real socket.
+
+    `TestClient` and `httpx.MockTransport` are both in-process, so nothing
+    legitimate in this suite resolves a hostname or connects.
+    """
+
+    def _blocked(*args, **kwargs):
+        raise AssertionError('test attempted real network access -- patch the transport')
+
+    monkeypatch.setattr(socket, 'getaddrinfo', _blocked)
+    monkeypatch.setattr(socket.socket, 'connect', _blocked)
+    monkeypatch.setattr(socket.socket, 'connect_ex', _blocked)
+
+
+@pytest.fixture(autouse=True)
+def _no_keychain(monkeypatch):
+    """Never shell out to the auth dump script (it can block on a Keychain prompt)."""
+
+    def _blocked(bundle_id, out_path):
+        return False
+
+    monkeypatch.setattr(omi_auth, '_run_dump', _blocked)
+
+
+# --------------------------------------------------------------------------
+# Transport fakes
+# --------------------------------------------------------------------------
+
+
+def install_mock_transport(monkeypatch, handler):
+    """Route every `httpx.AsyncClient` through `handler`, recording requests.
+
+    The modules under test construct their own clients internally, so there is
+    no injection point -- the class itself is swapped for a factory that pins a
+    `MockTransport` onto whatever the caller asked for. Returns the list of
+    captured `httpx.Request` objects.
+
+    Only the async client is patched; `TestClient` is a sync `httpx.Client` and
+    keeps working.
+    """
+    requests: list[httpx.Request] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler(request)
+
+    def factory(*args, **kwargs):
+        kwargs['transport'] = httpx.MockTransport(_record)
+        return _REAL_ASYNC_CLIENT(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, 'AsyncClient', factory)
+    return requests
+
+
+def streaming_body(chunks):
+    """An async byte stream that yields exactly the chunks given, in order."""
+
+    async def body():
+        for chunk in chunks:
+            yield chunk
+
+    return body()
+
+
+class FakeAuth:
+    """Stands in for `OmiAuth` with no session file, Keychain or Firebase."""
+
+    def __init__(self, token: str = 'fake-id-token', fail: Exception | None = None) -> None:
+        self.token = token
+        self.fail = fail
+        self.header_calls = 0
+
+    async def id_token(self) -> str:
+        if self.fail:
+            raise self.fail
+        return self.token
+
+    async def uid(self) -> str:
+        return 'fake-uid'
+
+    async def auth_header(self) -> dict[str, str]:
+        self.header_calls += 1
+        if self.fail:
+            raise self.fail
+        return {'Authorization': f'Bearer {self.token}'}
+
+    def describe(self) -> dict:
+        return {'loaded': True, 'uid': 'fake-uid', 'expires_in': 3000}

--- a/integrations/omi-even/bridge/tests/test_capture.py
+++ b/integrations/omi-even/bridge/tests/test_capture.py
@@ -1,0 +1,650 @@
+"""Tests for the G2 -> Omi audio capture session.
+
+Most of what this module encodes is invisible in the happy path and silent when
+wrong: a mistyped `source` mislabels every conversation instead of erroring, a
+frame of two bytes is dropped by the server without a word, and a stream with
+no inbound traffic for 90s is closed from the other end. The tests below assert
+those invariants directly rather than through behaviour that would still look
+fine on-screen.
+"""
+
+import asyncio
+import json
+import random
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import capture  # noqa: E402
+from conftest import FakeAuth, install_mock_transport  # noqa: E402
+from capture import CHUNK_BYTES, SOURCE, CaptureSession, CaptureStats, listen_url  # noqa: E402
+
+
+async def wait_until(predicate, timeout=2.0):
+    """Poll `predicate` until true, so tests never depend on a fixed sleep."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(f'condition never became true within {timeout}s')
+
+
+def drain(queue: asyncio.Queue) -> list:
+    items = []
+    while not queue.empty():
+        items.append(queue.get_nowait())
+    return items
+
+
+def make_session(**kwargs) -> CaptureSession:
+    return CaptureSession(FakeAuth(), 'https://api.omi.me', **kwargs)
+
+
+class FakeSocket:
+    """A websockets-style connection: awaitable `send`, async-iterable inbound."""
+
+    def __init__(self) -> None:
+        self.sent: list = []
+        self.inbound: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def send(self, frame) -> None:
+        self.sent.append(frame)
+
+    def push(self, message) -> None:
+        self.inbound.put_nowait(message)
+
+    async def __aiter__(self):
+        while True:
+            message = await self.inbound.get()
+            if message is _END:
+                return
+            yield message
+
+
+_END = object()
+
+
+def fake_connect(socket, *, record=None):
+    """Replacement for `websockets.connect` returning `socket`."""
+
+    class _CM:
+        def __init__(self, url, **kwargs):
+            if record is not None:
+                record.append((url, kwargs))
+
+        async def __aenter__(self):
+            return socket
+
+        async def __aexit__(self, *exc):
+            socket.closed = True
+            return False
+
+    return _CM
+
+
+# --------------------------------------------------------------------------
+# listen_url
+# --------------------------------------------------------------------------
+
+
+def params_of(url: str) -> dict:
+    return {k: v[0] for k, v in parse_qs(urlsplit(url).query).items()}
+
+
+def test_source_is_rayban_meta():
+    """The single most important parameter in this module.
+
+    `ConversationSource._missing_` maps any unknown string to `unknown` instead
+    of raising, so a typo here does not fail -- it silently relabels every
+    conversation the glasses ever record. `rayban_meta` is also photo-capable,
+    which stops `resolve_photo_conversation_source` from later rewriting the
+    provenance to `openglass`.
+    """
+    assert params_of(listen_url('https://api.omi.me'))['source'] == 'rayban_meta'
+    assert SOURCE == 'rayban_meta'
+
+
+def test_audio_parameters_match_what_the_g2_microphone_emits():
+    """PCM16 LE mono at 16 kHz, passed through unconverted. A mismatch here is
+    not an error either -- it is garbled audio and an empty transcript.
+    """
+    params = params_of(listen_url('https://api.omi.me'))
+    assert params['codec'] == 'pcm16'
+    assert params['sample_rate'] == '16000'
+    assert params['channels'] == '1'
+
+
+def test_listen_url_carries_the_remaining_session_parameters():
+    params = params_of(listen_url('https://api.omi.me'))
+    assert params['language'] == 'en'
+    assert params['include_speech_profile'] == 'true'
+    # Values below 120 are clamped up server-side; passing the real floor keeps
+    # the client's idea of the timeout equal to the server's.
+    assert params['conversation_timeout'] == '120'
+
+
+def test_listen_url_honours_a_language_override():
+    assert params_of(listen_url('https://api.omi.me', language='fr'))['language'] == 'fr'
+
+
+@pytest.mark.parametrize(
+    'base,expected',
+    [
+        ('https://api.omi.me', 'wss://api.omi.me/v4/listen'),
+        ('https://api.omi.me/', 'wss://api.omi.me/v4/listen'),
+        ('http://localhost:8000', 'ws://localhost:8000/v4/listen'),
+        ('http://localhost:8000/', 'ws://localhost:8000/v4/listen'),
+    ],
+)
+def test_listen_url_upgrades_the_scheme_and_normalises_the_path(base, expected):
+    url = listen_url(base)
+    assert url.split('?')[0] == expected
+    assert '//v4' not in url
+
+
+def test_listen_url_is_properly_query_encoded():
+    url = listen_url('https://api.omi.me')
+    assert url.count('?') == 1
+    assert ' ' not in url
+
+
+# --------------------------------------------------------------------------
+# feed / batching
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_feed_batches_into_chunk_sized_frames():
+    session = make_session()
+    session.active = True
+    session.feed(b'\x01' * (CHUNK_BYTES * 2))
+    frames = drain(session._queue)
+    assert [len(f) for f in frames] == [CHUNK_BYTES, CHUNK_BYTES]
+
+
+@pytest.mark.asyncio
+async def test_feed_holds_back_the_partial_tail_until_it_fills():
+    session = make_session()
+    session.active = True
+    session.feed(b'\x00' * (CHUNK_BYTES + 100))
+    assert [len(f) for f in drain(session._queue)] == [CHUNK_BYTES]
+    assert len(session._pending) == 100
+
+    session.feed(b'\x00' * (CHUNK_BYTES - 100))
+    assert [len(f) for f in drain(session._queue)] == [CHUNK_BYTES]
+    assert len(session._pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_feed_reassembles_across_many_tiny_writes():
+    """The glasses deliver audio in whatever size the BLE stack produces."""
+    session = make_session()
+    session.active = True
+    for _ in range(CHUNK_BYTES // 2):
+        session.feed(b'\xaa\xbb')
+    assert [len(f) for f in drain(session._queue)] == [CHUNK_BYTES]
+
+
+@pytest.mark.asyncio
+async def test_feed_never_emits_a_frame_the_server_would_drop():
+    """Frames of <= 2 bytes are silently discarded server-side (receiver.py:491),
+    so emitting one loses audio with no error anywhere.
+    """
+    session = make_session()
+    session.active = True
+    rng = random.Random(4242)
+    for _ in range(400):
+        session.feed(bytes(rng.randrange(256) for _ in range(rng.randint(1, 5))))
+    for frame in drain(session._queue):
+        assert len(frame) > 2, 'the server drops frames of 2 bytes or fewer'
+
+
+@pytest.mark.asyncio
+async def test_feed_loses_no_bytes_and_preserves_order():
+    """Property: queued frames + the pending tail reconstruct the input exactly."""
+    rng = random.Random(7)
+    for _ in range(60):
+        session = make_session()
+        session.active = True
+        writes = [bytes(rng.randrange(256) for _ in range(rng.randint(0, 900))) for _ in range(rng.randint(1, 40))]
+        for write in writes:
+            session.feed(write)
+        frames = drain(session._queue)
+        assert all(len(f) == CHUNK_BYTES for f in frames)
+        assert b''.join(frames) + bytes(session._pending) == b''.join(writes)
+
+
+@pytest.mark.asyncio
+async def test_feed_is_a_no_op_before_start_and_after_stop():
+    session = make_session()
+    session.feed(b'\x01' * CHUNK_BYTES)
+    assert session._queue.empty()
+    assert len(session._pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_feed_ignores_empty_audio():
+    session = make_session()
+    session.active = True
+    session.feed(b'')
+    assert session._queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_feed_drops_and_counts_instead_of_blocking_when_the_queue_is_full():
+    """`feed` runs on the app WebSocket's read loop. Blocking here stalls every
+    other message from the glasses, so a full queue must cost audio, not latency.
+    """
+    session = make_session()
+    session.active = True
+    capacity = session._queue.maxsize
+    assert capacity > 0
+
+    session.feed(b'\x01' * (CHUNK_BYTES * (capacity + 20)))
+
+    assert session._queue.qsize() == capacity
+    assert session.stats.last_error is not None
+    assert 'queue full' in session.stats.last_error
+
+
+@pytest.mark.asyncio
+async def test_feed_recovers_once_the_queue_drains():
+    session = make_session()
+    session.active = True
+    session.feed(b'\x01' * (CHUNK_BYTES * (session._queue.maxsize + 5)))
+    drain(session._queue)
+    session.feed(b'\x02' * CHUNK_BYTES)
+    assert session._queue.qsize() == 1
+
+
+# --------------------------------------------------------------------------
+# stop
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fast_flush(monkeypatch):
+    """The real settle is 4s of wall clock; the behaviour is identical at 0."""
+    monkeypatch.setattr(capture, '_FLUSH_SETTLE_SECONDS', 0.0)
+
+
+@pytest.mark.asyncio
+async def test_stop_on_an_inactive_session_is_a_no_op(fast_flush):
+    session = make_session()
+    stats = await session.stop(finalize=True)  # finalize would need the network
+    assert stats is session.stats
+    assert session._queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_stop_flushes_the_partial_frame_before_the_silence(fast_flush):
+    """Without this the last fraction of a second of speech never leaves the
+    process -- and it is usually the end of the sentence.
+    """
+    session = make_session()
+    session.active = True
+    session.feed(b'\x07' * 500)
+    assert len(session._pending) == 500
+
+    await session.stop(finalize=False)
+
+    frames = drain(session._queue)
+    assert frames[0] == b'\x07' * 500
+    assert len(session._pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_appends_a_tail_of_silence_so_the_endpointer_emits(fast_flush):
+    """Measured: a 7.4s clip returned only its first 2.8s without this."""
+    session = make_session()
+    session.active = True
+    await session.stop(finalize=False)
+
+    frames = drain(session._queue)
+    assert frames[-1] is None, 'the send loop needs its sentinel last'
+    silence = frames[:-1]
+    assert len(silence) == capture._FLUSH_SILENCE_FRAMES
+    assert all(frame == b'\x00' * CHUNK_BYTES for frame in silence)
+    # ~2s of silence: past any provider's endpointing window.
+    seconds = len(silence) * CHUNK_BYTES / (capture.SAMPLE_RATE * capture.BYTES_PER_SAMPLE)
+    assert 1.5 <= seconds <= 3.0
+
+
+@pytest.mark.asyncio
+async def test_stop_never_queues_a_frame_the_server_would_drop(fast_flush):
+    session = make_session()
+    session.active = True
+    session.feed(b'\x01\x02')  # 2 bytes: below the server's floor
+    await session.stop(finalize=False)
+
+    for frame in drain(session._queue):
+        assert frame is None or len(frame) > 2
+
+
+@pytest.mark.asyncio
+async def test_stop_marks_the_session_inactive_so_later_audio_is_ignored(fast_flush):
+    session = make_session()
+    session.active = True
+    await session.stop(finalize=False)
+    assert session.active is False
+
+    before = session._queue.qsize()
+    session.feed(b'\x01' * CHUNK_BYTES)
+    assert session._queue.qsize() == before, 'audio after stop must not be queued'
+    assert len(session._pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_returns_the_stats_object(fast_flush):
+    session = make_session()
+    session.active = True
+    session.stats.bytes_sent = 32000
+    stats = await session.stop(finalize=False)
+    assert stats.audio_seconds == 1.0
+
+
+def test_audio_seconds_is_computed_from_the_pcm16_rate():
+    assert CaptureStats(bytes_sent=16000 * 2).audio_seconds == 1.0
+    assert CaptureStats(bytes_sent=0).audio_seconds == 0.0
+
+
+# --------------------------------------------------------------------------
+# send loop
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_loop_forwards_frames_and_counts_them():
+    session = make_session()
+    socket = FakeSocket()
+    session._queue.put_nowait(b'\x01' * CHUNK_BYTES)
+    session._queue.put_nowait(b'\x02' * CHUNK_BYTES)
+    session._queue.put_nowait(None)
+
+    await asyncio.wait_for(session._send_loop(socket), timeout=2)
+
+    assert socket.sent == [b'\x01' * CHUNK_BYTES, b'\x02' * CHUNK_BYTES]
+    assert session.stats.frames_sent == 2
+    assert session.stats.bytes_sent == CHUNK_BYTES * 2
+
+
+@pytest.mark.asyncio
+async def test_send_loop_skips_frames_the_server_would_drop():
+    session = make_session()
+    socket = FakeSocket()
+    for frame in (b'', b'\x01', b'\x01\x02', b'\x01\x02\x03', None):
+        session._queue.put_nowait(frame)
+
+    await asyncio.wait_for(session._send_loop(socket), timeout=2)
+
+    assert socket.sent == [b'\x01\x02\x03']
+    assert session.stats.frames_sent == 1
+
+
+@pytest.mark.asyncio
+async def test_send_loop_emits_a_keepalive_when_no_audio_arrives(monkeypatch):
+    """The server closes with 1001 after 90s of inbound silence. Any frame
+    resets the timer, and an unrecognized `type` is a documented server no-op.
+    """
+    monkeypatch.setattr(capture, '_KEEPALIVE_INTERVAL', 0.01)
+    session = make_session()
+    socket = FakeSocket()
+
+    task = asyncio.create_task(session._send_loop(socket))
+    try:
+        await wait_until(lambda: len(socket.sent) >= 2)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    for frame in socket.sent:
+        assert isinstance(frame, str), 'a keepalive must be a JSON text frame'
+        assert json.loads(frame) == {'type': 'keepalive'}
+    assert session.stats.frames_sent == 0, 'keepalives are not audio'
+
+
+@pytest.mark.asyncio
+async def test_send_loop_returns_on_the_sentinel_without_sending_it():
+    session = make_session()
+    socket = FakeSocket()
+    session._queue.put_nowait(None)
+    session._queue.put_nowait(b'\x09' * CHUNK_BYTES)
+
+    await asyncio.wait_for(session._send_loop(socket), timeout=2)
+    assert socket.sent == []
+
+
+# --------------------------------------------------------------------------
+# receive loop
+# --------------------------------------------------------------------------
+
+
+async def run_recv(session: CaptureSession, messages) -> None:
+    socket = FakeSocket()
+    for message in messages:
+        socket.push(message)
+    socket.push(_END)
+    await asyncio.wait_for(session._recv_loop(socket), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_recv_loop_survives_the_literal_ping_heartbeat():
+    """The server sends the bare text `ping`, which is not JSON. Parsing it
+    blindly raises on every heartbeat and kills the session.
+    """
+    session = make_session()
+    await run_recv(session, ['ping', 'ping'])
+    assert session.stats.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_recv_loop_ignores_binary_and_unparseable_frames():
+    session = make_session()
+    await run_recv(session, [b'\x00\x01', 'not json at all', '{"unterminated'])
+    assert session.stats.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_live_transcript_arrives_as_a_bare_array_not_an_envelope():
+    """`transcripts.py:314` sends a raw JSON list of new/updated segments."""
+    seen = []
+
+    async def on_segments(segments):
+        seen.append(segments)
+
+    session = make_session(on_segments=on_segments)
+    await run_recv(session, [json.dumps([{'text': 'hello there'}, {'text': 'again'}])])
+
+    assert seen == [[{'text': 'hello there'}, {'text': 'again'}]]
+    assert session.stats.segments_received == 2
+
+
+@pytest.mark.asyncio
+async def test_conversation_session_frame_records_the_conversation_id():
+    session = make_session()
+    await run_recv(session, [json.dumps({'type': 'conversation_session', 'conversation_id': 'conv-42'})])
+    assert session.stats.conversation_id == 'conv-42'
+
+
+@pytest.mark.asyncio
+async def test_freemium_threshold_frame_is_surfaced_as_an_error():
+    session = make_session()
+    await run_recv(session, [json.dumps({'type': 'freemium_threshold_reached'})])
+    assert session.stats.last_error and 'quota' in session.stats.last_error
+
+
+@pytest.mark.asyncio
+async def test_every_dict_frame_reaches_the_event_callback():
+    events = []
+
+    async def on_event(payload):
+        events.append(payload)
+
+    session = make_session(on_event=on_event)
+    await run_recv(
+        session,
+        [
+            json.dumps({'type': 'conversation_session', 'conversation_id': 'c1'}),
+            json.dumps({'type': 'something_new_the_server_added'}),
+        ],
+    )
+    assert [e['type'] for e in events] == ['conversation_session', 'something_new_the_server_added']
+
+
+@pytest.mark.asyncio
+async def test_recv_loop_without_callbacks_does_not_crash():
+    session = make_session()
+    await run_recv(session, [json.dumps([{'text': 'hi'}]), json.dumps({'type': 'conversation_session'})])
+    assert session.stats.segments_received == 1
+
+
+# --------------------------------------------------------------------------
+# session lifecycle
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_failed_connection_is_recorded_and_never_raises(monkeypatch):
+    """The bridge serves three consumers from one process; a dead capture
+    socket must not take the chat path down with it.
+    """
+
+    def boom(*args, **kwargs):
+        raise ConnectionRefusedError('nothing listening')
+
+    monkeypatch.setattr(capture.websockets, 'connect', boom)
+
+    session = make_session()
+    await session.start()
+    await asyncio.wait_for(session._task, timeout=2)
+
+    assert session.active is False
+    assert 'ConnectionRefusedError' in session.stats.last_error
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent(monkeypatch, fast_flush):
+    """A second `capture: enabled` from the glasses must not open a second socket."""
+    socket = FakeSocket()
+    connections: list = []
+    monkeypatch.setattr(capture.websockets, 'connect', fake_connect(socket, record=connections))
+
+    session = make_session()
+    await session.start()
+    first = session._task
+    await session.start()
+
+    assert session._task is first
+    await wait_until(lambda: bool(connections))
+    assert len(connections) == 1
+    await asyncio.wait_for(session.stop(finalize=False), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_start_resets_the_stats(monkeypatch):
+    def boom(*args, **kwargs):
+        raise OSError('nothing listening')
+
+    monkeypatch.setattr(capture.websockets, 'connect', boom)
+    session = make_session()
+    session.stats.bytes_sent = 999
+    await session.start()
+    await asyncio.wait_for(session._task, timeout=2)
+    assert session.stats.bytes_sent == 0
+
+
+@pytest.mark.asyncio
+async def test_a_full_session_streams_audio_and_receives_transcript(monkeypatch, fast_flush):
+    """End to end over a fake socket: connect, batch, send, transcribe, stop."""
+    socket = FakeSocket()
+    connections: list = []
+    monkeypatch.setattr(capture.websockets, 'connect', fake_connect(socket, record=connections))
+
+    segments = []
+
+    async def on_segments(rows):
+        segments.append(rows)
+
+    session = make_session(on_segments=on_segments)
+    await session.start()
+    await wait_until(lambda: bool(connections))
+
+    url, kwargs = connections[0]
+    assert params_of(url)['source'] == 'rayban_meta'
+    assert kwargs['additional_headers'] == {'Authorization': 'Bearer fake-id-token'}
+    assert kwargs['max_size'] is None, 'audio frames must not hit a size cap'
+
+    session.feed(b'\x11\x22' * CHUNK_BYTES)  # two full frames
+    await wait_until(lambda: len(socket.sent) >= 2)
+    assert all(isinstance(f, bytes) and len(f) == CHUNK_BYTES for f in socket.sent[:2])
+
+    socket.push(json.dumps({'type': 'conversation_session', 'conversation_id': 'conv-7'}))
+    socket.push(json.dumps([{'text': 'the battery regression'}]))
+    await wait_until(lambda: bool(segments))
+    assert segments == [[{'text': 'the battery regression'}]]
+
+    stats = await asyncio.wait_for(session.stop(finalize=False), timeout=5)
+    assert stats.conversation_id == 'conv-7'
+    assert stats.frames_sent >= 2
+    assert stats.audio_seconds > 0
+    assert session.active is False
+
+
+# --------------------------------------------------------------------------
+# finalization
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_posts_to_the_conversations_endpoint(monkeypatch):
+    """Disconnect-time finalization is `source == 'desktop'` only, so without
+    this explicit POST the conversation lingers `in_progress`.
+    """
+
+    def handler(request):
+        return httpx.Response(200, json={'id': 'conv-1'})
+
+    requests = install_mock_transport(monkeypatch, handler)
+    session = make_session()
+    await session._finalize_conversation()
+
+    assert len(requests) == 1
+    assert requests[0].method == 'POST'
+    assert str(requests[0].url) == 'https://api.omi.me/v1/conversations'
+    assert requests[0].headers['authorization'] == 'Bearer fake-id-token'
+
+
+@pytest.mark.asyncio
+async def test_finalize_swallows_http_errors(monkeypatch):
+    def handler(request):
+        return httpx.Response(500, text='boom')
+
+    install_mock_transport(monkeypatch, handler)
+    await make_session()._finalize_conversation()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_finalize_swallows_auth_errors():
+    """`stop()` runs on the disconnect path, where raising strands the socket."""
+    session = CaptureSession(FakeAuth(fail=RuntimeError('session revoked')), 'https://api.omi.me')
+    await session._finalize_conversation()
+
+
+@pytest.mark.asyncio
+async def test_stop_with_finalize_calls_the_endpoint_once(monkeypatch, fast_flush):
+    def handler(request):
+        return httpx.Response(200, json={})
+
+    requests = install_mock_transport(monkeypatch, handler)
+    session = make_session()
+    session.active = True
+    await session.stop(finalize=True)
+    assert len(requests) == 1

--- a/integrations/omi-even/bridge/tests/test_capture_reconnect.py
+++ b/integrations/omi-even/bridge/tests/test_capture_reconnect.py
@@ -1,0 +1,203 @@
+"""Tests for capture surviving all-day wear.
+
+Capture is meant to run for a whole day on a head-worn device, so a dropped
+socket is routine, not exceptional: Wi-Fi roams between APs, the laptop sleeps,
+and the server itself closes an idle socket with 1001 after 90s. Originally any
+of those ended capture permanently and near-silently -- the session went inactive
+and audio was accepted into a queue nobody was draining.
+
+The reconnect logic distinguishes two failures that look identical at the socket
+layer but are not:
+
+* **Never connected** -- a bad URL or a revoked token. Retrying forever hides a
+  configuration error, so this gives up quickly and records why.
+* **Connected, then dropped** -- a network blip. This retries with backoff for as
+  long as capture is wanted.
+
+These tests pin that distinction, because collapsing the two is the natural
+refactor and it breaks all-day wear.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import capture
+from capture import CaptureSession
+
+
+class _FakeAuth:
+    def __init__(self) -> None:
+        self.header_calls = 0
+
+    async def auth_header(self) -> dict[str, str]:
+        self.header_calls += 1
+        # A distinct token per call, so a reconnect that reuses a stale header
+        # is detectable.
+        return {'Authorization': f'Bearer token-{self.header_calls}'}
+
+
+class _FakeSocket:
+    """A socket that yields nothing and then dies, or blocks until cancelled."""
+
+    def __init__(self, die_after: float | None) -> None:
+        self.die_after = die_after
+        self.sent: list = []
+        self.headers_seen: dict | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.die_after is not None:
+            await asyncio.sleep(self.die_after)
+            raise ConnectionResetError('socket closed by peer')
+        await asyncio.sleep(3600)
+        raise StopAsyncIteration
+
+
+def _install_connect(monkeypatch, sockets: list, record: list) -> None:
+    """Hand out `sockets` in order; raise once the list is exhausted."""
+    index = {'n': 0}
+
+    def connect(url, additional_headers=None, **kwargs):
+        record.append(additional_headers)
+        i = index['n']
+        index['n'] += 1
+        if i >= len(sockets):
+            raise ConnectionRefusedError('no more sockets')
+        result = sockets[i]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(capture.websockets, 'connect', connect)
+
+
+def _session(auth=None) -> CaptureSession:
+    return CaptureSession(auth or _FakeAuth(), 'https://api.omi.me')
+
+
+@pytest.mark.asyncio
+async def test_a_drop_after_a_successful_connect_reconnects(monkeypatch):
+    """The all-day case: one good connection, a blip, then keep going."""
+    headers_seen: list = []
+    _install_connect(
+        monkeypatch,
+        [_FakeSocket(die_after=0.05), _FakeSocket(die_after=None)],
+        headers_seen,
+    )
+    monkeypatch.setattr(capture, '_MAX_RECONNECT_DELAY', 0.01)
+
+    session = _session()
+    await session.start()
+    await asyncio.sleep(0.5)
+
+    assert session.active is True, 'capture must survive a transient drop'
+    assert session.stats.reconnects >= 1
+    assert len(headers_seen) >= 2
+
+    session.active = False
+    session._task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await session._task
+
+
+@pytest.mark.asyncio
+async def test_reconnect_mints_a_fresh_auth_header(monkeypatch):
+    """An ID token lasts an hour; an all-day session outlives it.
+
+    Reusing the header captured at start would make every reconnect after the
+    first hour fail with 401 forever.
+    """
+    headers_seen: list = []
+    auth = _FakeAuth()
+    _install_connect(
+        monkeypatch,
+        [_FakeSocket(die_after=0.05), _FakeSocket(die_after=None)],
+        headers_seen,
+    )
+    monkeypatch.setattr(capture, '_MAX_RECONNECT_DELAY', 0.01)
+
+    session = _session(auth)
+    await session.start()
+    await asyncio.sleep(0.5)
+
+    assert len(headers_seen) >= 2
+    assert headers_seen[0] != headers_seen[1], 'reconnect reused a stale token'
+
+    session.active = False
+    session._task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await session._task
+
+
+@pytest.mark.asyncio
+async def test_a_socket_that_never_connects_gives_up(monkeypatch):
+    """A bad URL or revoked token must surface, not retry silently forever."""
+    _install_connect(monkeypatch, [], [])
+    monkeypatch.setattr(capture, '_INITIAL_CONNECT_DELAY', 0.01)
+
+    session = _session()
+    await session.start()
+    await asyncio.wait_for(session._task, timeout=3)
+
+    assert session.active is False
+    assert session.stats.last_error is not None
+    assert 'ConnectionRefusedError' in session.stats.last_error
+    # Bounded: it must not have burned through a long retry schedule.
+    assert session.stats.reconnects < capture._INITIAL_CONNECT_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_stop_during_a_reconnect_backoff_ends_promptly(monkeypatch):
+    """Turning capture off while it is waiting to retry must not hang."""
+    _install_connect(monkeypatch, [_FakeSocket(die_after=0.05)], [])
+    monkeypatch.setattr(capture, '_MAX_RECONNECT_DELAY', 0.05)
+    monkeypatch.setattr(capture, '_FLUSH_SILENCE_FRAMES', 1)
+    monkeypatch.setattr(capture, '_FLUSH_SETTLE_SECONDS', 0.01)
+
+    session = _session()
+    await session.start()
+    await asyncio.sleep(0.2)  # let it drop and enter backoff
+
+    await asyncio.wait_for(session.stop(finalize=False), timeout=5)
+    assert session.active is False
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_inner_task_is_not_mistaken_for_a_crash(monkeypatch):
+    """`Task.exception()` re-raises on a cancelled task.
+
+    Reading it during teardown made a routine cancellation look like the session
+    itself being cancelled, which propagated out of the reconnect loop.
+    """
+    _install_connect(
+        monkeypatch,
+        [_FakeSocket(die_after=0.05), _FakeSocket(die_after=None)],
+        [],
+    )
+    monkeypatch.setattr(capture, '_MAX_RECONNECT_DELAY', 0.01)
+
+    session = _session()
+    await session.start()
+    await asyncio.sleep(0.4)
+
+    # Survived the first socket's teardown rather than dying with it.
+    assert session.active is True
+
+    session.active = False
+    session._task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await session._task

--- a/integrations/omi-even/bridge/tests/test_cite_tags.py
+++ b/integrations/omi-even/bridge/tests/test_cite_tags.py
@@ -1,0 +1,93 @@
+"""Regression tests for XML-ish markup leaking onto the glasses.
+
+Omi wraps retrieved evidence in `<cite index="8-5">...</cite>`. Nothing in the
+markdown stripper touched those, so they reached the display as literal angle
+brackets -- observed on real hardware in an answer about commitments to a
+colleague, where roughly a fifth of a 380-character screen was spent rendering
+tag syntax.
+
+The quoted words inside the tag are the substance of the answer, so they are
+kept; only the markup is removed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from display import fit_for_glasses
+
+
+def test_cite_tags_are_removed_but_their_quote_survives():
+    raw = 'You said<cite index="8-5">WhatsApp and Telegram are next</cite> to David.'
+    out = fit_for_glasses(raw)
+    assert '<cite' not in out
+    assert '</cite>' not in out
+    assert 'index=' not in out
+    assert 'WhatsApp and Telegram are next' in out
+
+
+def test_opening_tag_abutting_a_word_does_not_fuse_it():
+    """The live output has no space before `<cite`; naive removal glues words."""
+    out = fit_for_glasses('and said<cite index="1-1">next week</cite> firmly')
+    assert 'saidnext' not in out
+    assert 'said next week' in out
+
+
+def test_the_exact_live_answer_renders_clean():
+    """Verbatim from a real answer that shipped tags to the display."""
+    raw = (
+        "Here's what you actually committed to David (Zhang):\n\n"
+        '**1. Fix the iMessage integration**\n'
+        'During your demo you said<cite index="8-5">WhatsApp and Telegram are next</cite>'
+        ' - but the demo revealed<cite index="8-6">Gmail integration was not working and '
+        'full disk access needed for iMessage</cite>.'
+    )
+    out = fit_for_glasses(raw)
+    assert '<' not in out and '>' not in out
+    assert 'WhatsApp and Telegram are next' in out
+    assert '**' not in out
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [
+        '<b>bold</b> text',
+        '<span class="x">inner</span>',
+        '<br/>line',
+        '<UNKNOWN attr="1">kept</UNKNOWN>',
+        'nested <a><b>deep</b></a> end',
+    ],
+)
+def test_any_simple_tag_degrades_to_its_text(raw):
+    out = fit_for_glasses(raw)
+    assert '<' not in out and '>' not in out
+
+
+@pytest.mark.parametrize(
+    ('raw', 'must_keep'),
+    [
+        ('5 < 10 and 10 > 5', ['5', '10']),
+        ('use a < b for the comparison', ['a', 'b']),
+        ('x <- y assignment', ['x', 'y']),
+        ('temp > 3 degrees', ['temp', '3']),
+    ],
+)
+def test_mathematical_comparisons_are_not_mistaken_for_tags(raw, must_keep):
+    """`<` followed by a non-letter is arithmetic, not markup."""
+    out = fit_for_glasses(raw)
+    for token in must_keep:
+        assert token in out
+
+
+def test_an_unterminated_tag_does_not_eat_the_rest_of_the_answer():
+    """A truncated stream can end mid-tag; the visible words must survive."""
+    out = fit_for_glasses('The answer is <cite index="9-9" and then it was cut off')
+    assert 'The answer is' in out
+    assert 'cut off' in out
+
+
+def test_tag_stripping_still_respects_the_length_limit():
+    raw = 'prefix ' + '<cite index="1-1">word</cite> ' * 200
+    out = fit_for_glasses(raw, limit=380)
+    assert len(out) <= 380
+    assert '<' not in out

--- a/integrations/omi-even/bridge/tests/test_compose.py
+++ b/integrations/omi-even/bridge/tests/test_compose.py
@@ -1,0 +1,167 @@
+"""Tests for composing retrieved facts into prose with Omi's own LLM.
+
+Compose is a best-effort layer sitting between retrieval and the display, so
+every test here is really about one property: **it may degrade, but it may never
+take the answer down with it.** The endpoint it depends on is rate limited to
+30/hour and keyed to a conversation that the user can delete at any time, so its
+failure modes are ordinary rather than exceptional -- each one must surface as
+`None` to the caller, which then shows the raw facts instead.
+
+The conversation id is module-level cache, deliberately: re-listing
+conversations on every question would spend a round trip out of a ~5s budget.
+`_reset_cache` keeps that shared state from leaking between tests.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import compose  # noqa: E402
+from compose import ComposeUnavailable, compose_answer, compose_or_none  # noqa: E402
+from conftest import FakeAuth, install_mock_transport  # noqa: E402
+
+BASE = 'https://api.omi.me'
+FACTS = ['You watched fireworks in New York.', 'You grilled burgers with friends.']
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    compose._CONVERSATION_ID = None
+    compose._CONVERSATION_FETCHED_AT = 0.0
+    yield
+    compose._CONVERSATION_ID = None
+    compose._CONVERSATION_FETCHED_AT = 0.0
+
+
+def _handler(*, conversations=None, prompt_status=200, summary='You watched fireworks.'):
+    """Answer the two calls compose makes: list conversations, then test-prompt."""
+    rows = [{'id': 'conv-1'}] if conversations is None else conversations
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path == '/v1/conversations':
+            return httpx.Response(200, json=rows)
+        if request.url.path.endswith('/test-prompt'):
+            if prompt_status != 200:
+                return httpx.Response(prompt_status, json={'detail': 'nope'})
+            return httpx.Response(200, json={'summary': summary})
+        raise AssertionError(f'unexpected request: {request.url}')
+
+    return handle
+
+
+# --------------------------------------------------------------------------
+# The path that matters
+# --------------------------------------------------------------------------
+
+
+def test_composes_prose_from_facts(monkeypatch):
+    requests = install_mock_transport(monkeypatch, _handler(summary='You watched fireworks in NY.'))
+
+    answer = asyncio.run(compose_answer(FakeAuth(), BASE, 'What did I do on 4 July?', FACTS))
+
+    assert answer == 'You watched fireworks in NY.'
+
+    prompt = json.loads(requests[-1].content)['prompt']
+    # The model only ever sees what we retrieved; if the question or the facts
+    # went missing the answer would be confidently made up rather than absent.
+    assert 'What did I do on 4 July?' in prompt
+    for fact in FACTS:
+        assert fact in prompt
+    # The endpoint appends a real conversation transcript we did not ask for.
+    assert 'Disregard the conversation transcript' in prompt
+
+
+def test_conversation_id_is_cached_across_calls(monkeypatch):
+    requests = install_mock_transport(monkeypatch, _handler())
+
+    asyncio.run(compose_answer(FakeAuth(), BASE, 'q1', FACTS))
+    asyncio.run(compose_answer(FakeAuth(), BASE, 'q2', FACTS))
+
+    listings = [r for r in requests if r.url.path == '/v1/conversations']
+    assert len(listings) == 1, 'a listing per question wastes a round trip out of a 5s budget'
+
+
+def test_sends_at_most_ten_facts(monkeypatch):
+    requests = install_mock_transport(monkeypatch, _handler())
+
+    asyncio.run(compose_answer(FakeAuth(), BASE, 'q', [f'fact {i}' for i in range(30)]))
+
+    prompt = json.loads(requests[-1].content)['prompt']
+    assert 'fact 9' in prompt
+    assert 'fact 10' not in prompt
+
+
+# --------------------------------------------------------------------------
+# Degrading, never failing
+# --------------------------------------------------------------------------
+
+
+def test_rate_limit_falls_back_rather_than_raising(monkeypatch):
+    install_mock_transport(monkeypatch, _handler(prompt_status=429))
+
+    # 30/hour is low enough that a normal session reaches it; bullets on the
+    # display beat an error on the display.
+    assert asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=5)) is None
+
+
+def test_deleted_conversation_clears_the_cache(monkeypatch):
+    install_mock_transport(monkeypatch, _handler(prompt_status=404))
+
+    with pytest.raises(ComposeUnavailable):
+        asyncio.run(compose_answer(FakeAuth(), BASE, 'q', FACTS))
+
+    # Otherwise every later question would keep posting to a dead id for an hour.
+    assert compose._CONVERSATION_ID is None
+
+
+def test_no_conversations_is_unavailable_not_a_crash(monkeypatch):
+    install_mock_transport(monkeypatch, _handler(conversations=[]))
+
+    assert asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=5)) is None
+
+
+def test_empty_summary_falls_back(monkeypatch):
+    install_mock_transport(monkeypatch, _handler(summary='   '))
+
+    assert asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=5)) is None
+
+
+def test_no_facts_never_calls_omi(monkeypatch):
+    requests = install_mock_transport(monkeypatch, _handler())
+
+    assert asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', [], budget_s=5)) is None
+    assert requests == [], 'composing from nothing invents an answer; skip the call'
+
+
+def test_budget_is_a_hard_ceiling(monkeypatch):
+    def slow(request: httpx.Request) -> httpx.Response:
+        raise AssertionError('should have been cancelled before the request completed')
+
+    async def never(*args, **kwargs):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(compose, 'compose_answer', never)
+
+    # Late is the same as failed here: past ~5s the glasses show nothing at all.
+    async def run():
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        result = await compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=0.05)
+        return result, loop.time() - started
+
+    result, elapsed = asyncio.run(run())
+    assert result is None
+    assert elapsed < 1.0
+
+
+def test_auth_failure_falls_back(monkeypatch):
+    install_mock_transport(monkeypatch, _handler())
+
+    auth = FakeAuth(fail=RuntimeError('no session'))
+    assert asyncio.run(compose_or_none(auth, BASE, 'q', FACTS, budget_s=5)) is None

--- a/integrations/omi-even/bridge/tests/test_compose.py
+++ b/integrations/omi-even/bridge/tests/test_compose.py
@@ -1,15 +1,17 @@
-"""Tests for composing retrieved facts into prose with Omi's own LLM.
+"""Tests for composing retrieved facts into prose.
 
 Compose is a best-effort layer sitting between retrieval and the display, so
 every test here is really about one property: **it may degrade, but it may never
-take the answer down with it.** The endpoint it depends on is rate limited to
-30/hour and keyed to a conversation that the user can delete at any time, so its
-failure modes are ordinary rather than exceptional -- each one must surface as
-`None` to the caller, which then shows the raw facts instead.
+take the answer down with it.** It is a ladder -- the local model on this Mac,
+then Omi's rate-limited cloud endpoint, then nothing -- and each rung fails for
+ordinary reasons: Ollama is not running, the hourly cap is spent, the cached
+conversation was deleted. Every one of those must surface as `None` to the
+caller, which then shows the raw retrieved lines instead.
 
-The conversation id is module-level cache, deliberately: re-listing
-conversations on every question would spend a round trip out of a ~5s budget.
-`_reset_cache` keeps that shared state from leaking between tests.
+The local rung is off by default here (`_local_off`) so the cloud tests exercise
+the cloud; the ladder tests turn it back on explicitly. The conversation id is a
+module-level cache, deliberately -- re-listing conversations per question would
+spend a round trip out of a ~5s budget -- so it is reset between tests too.
 """
 
 import asyncio
@@ -23,6 +25,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import compose  # noqa: E402
+import local_llm  # noqa: E402
 from compose import ComposeUnavailable, compose_answer, compose_or_none  # noqa: E402
 from conftest import FakeAuth, install_mock_transport  # noqa: E402
 
@@ -34,9 +37,17 @@ FACTS = ['You watched fireworks in New York.', 'You grilled burgers with friends
 def _reset_cache():
     compose._CONVERSATION_ID = None
     compose._CONVERSATION_FETCHED_AT = 0.0
+    local_llm._available = True
     yield
     compose._CONVERSATION_ID = None
     compose._CONVERSATION_FETCHED_AT = 0.0
+    local_llm._available = True
+
+
+@pytest.fixture(autouse=True)
+def _local_off(monkeypatch):
+    """Default the local rung off; ladder tests opt back in."""
+    monkeypatch.setenv('OMI_EVEN_NO_LOCAL', '1')
 
 
 def _handler(*, conversations=None, prompt_status=200, summary='You watched fireworks.'):
@@ -165,3 +176,84 @@ def test_auth_failure_falls_back(monkeypatch):
 
     auth = FakeAuth(fail=RuntimeError('no session'))
     assert asyncio.run(compose_or_none(auth, BASE, 'q', FACTS, budget_s=5)) is None
+
+
+# --------------------------------------------------------------------------
+# The ladder: local first, cloud second, bullets last
+# --------------------------------------------------------------------------
+
+
+def _ladder_handler(*, local_status=200, local_text='You watched fireworks.', cloud_summary='cloud answer'):
+    """Answer both rungs: Ollama's /api/generate and Omi's test-prompt."""
+    cloud = _handler(summary=cloud_summary)
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path == '/api/generate':
+            if local_status != 200:
+                return httpx.Response(local_status, text='no such model')
+            return httpx.Response(200, json={'response': local_text})
+        return cloud(request)
+
+    return handle
+
+
+def test_local_is_preferred_over_the_capped_cloud(monkeypatch):
+    monkeypatch.delenv('OMI_EVEN_NO_LOCAL', raising=False)
+    requests = install_mock_transport(monkeypatch, _ladder_handler(local_text='You saw fireworks.'))
+
+    answer = asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=5))
+
+    assert answer == 'You saw fireworks.'
+    # Spending the 30/hour cloud budget when a free local model answered would
+    # be the whole point of this rung, wasted.
+    assert [r.url.path for r in requests] == ['/api/generate']
+
+
+def test_local_failure_falls_through_to_cloud(monkeypatch):
+    monkeypatch.delenv('OMI_EVEN_NO_LOCAL', raising=False)
+    requests = install_mock_transport(
+        monkeypatch, _ladder_handler(local_status=404, cloud_summary='cloud picked it up')
+    )
+
+    answer = asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=5))
+
+    assert answer == 'cloud picked it up'
+    assert '/api/generate' in [r.url.path for r in requests]
+    assert any(r.url.path.endswith('/test-prompt') for r in requests)
+
+
+def test_a_broken_local_model_is_not_retried_every_question(monkeypatch):
+    monkeypatch.delenv('OMI_EVEN_NO_LOCAL', raising=False)
+    requests = install_mock_transport(monkeypatch, _ladder_handler(local_status=404))
+
+    asyncio.run(compose_or_none(FakeAuth(), BASE, 'q1', FACTS, budget_s=5))
+    asyncio.run(compose_or_none(FakeAuth(), BASE, 'q2', FACTS, budget_s=5))
+
+    # A missing model is config, not a blip: paying for that discovery once per
+    # question would eat budget that the cloud rung needs.
+    assert [r.url.path for r in requests].count('/api/generate') == 1
+
+
+def test_both_rungs_down_returns_none_rather_than_raising(monkeypatch):
+    monkeypatch.delenv('OMI_EVEN_NO_LOCAL', raising=False)
+    install_mock_transport(monkeypatch, _ladder_handler(local_status=500, cloud_summary=''))
+
+    assert asyncio.run(compose_or_none(FakeAuth(), BASE, 'q', FACTS, budget_s=5)) is None
+
+
+def test_local_prompt_carries_the_question_and_facts(monkeypatch):
+    monkeypatch.delenv('OMI_EVEN_NO_LOCAL', raising=False)
+    requests = install_mock_transport(monkeypatch, _ladder_handler())
+
+    asyncio.run(compose_or_none(FakeAuth(), BASE, 'What did I do?', FACTS, budget_s=5))
+
+    body = json.loads(requests[0].content)
+    assert 'What did I do?' in body['prompt']
+    assert FACTS[0] in body['prompt']
+    # qwen3.6 reasons by default; its thinking tokens cost more than the budget.
+    assert body['think'] is False
+    # Cold, this model needs 16.5s -- three times the budget -- so residency is
+    # not an optimisation here, it is the difference between working and not.
+    assert body['keep_alive'] == local_llm.KEEP_ALIVE
+    # The cloud-only preamble must not leak into the local prompt.
+    assert 'Disregard the conversation transcript' not in body['prompt']

--- a/integrations/omi-even/bridge/tests/test_display.py
+++ b/integrations/omi-even/bridge/tests/test_display.py
@@ -1,0 +1,541 @@
+"""Tests for the G2 display adapter.
+
+The samples below are written to look like real Omi chat answers -- markdown
+headings, mixed bullet styles, inline citations with no space before the
+bracket, links, fenced code and emoji -- because that is exactly what the
+bridge receives and what a naive adapter mangles.
+"""
+
+import json
+import random
+import re
+import string
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from display import (  # noqa: E402
+    DEFAULT_LIMIT,
+    DEFAULT_PAGE_SIZE,
+    fit_for_glasses,
+    openai_chat_completion,
+    paginate,
+)
+
+# --------------------------------------------------------------------------
+# Representative Omi output
+# --------------------------------------------------------------------------
+
+OMI_STANDUP = """## Your morning so far
+
+You spent most of the standup on the **firmware OTA rollout** with Sarah[1].
+The team agreed to *hold* the release until the battery regression is
+reproduced[2][3].
+
+Action items:
+- Reply to Marcus about the `battery_drain` metric
+- [ ] File the regression in [the tracker](https://github.com/omi/omi/issues/42)
+* Ping Sarah before 4pm
+1. Draft the changelog entry
+
+> Sarah: "we should not ship this blind"
+
+More context: https://linear.app/omi/issue/OMI-1234 and www.notion.so/omi/notes
+"""
+
+OMI_CODE_ANSWER = """Here is the fix 🎉
+
+```python
+# retry with backoff
+def fetch(url):
+    return requests.get(url, timeout=5)
+```
+
+That handles the timeout you hit yesterday[1]. See the ~~old~~ new docs at
+<https://docs.omi.me/retries> for the ___full___ story.
+"""
+
+OMI_EMOJI_ANSWER = 'Great news 🎉! Your meeting with Sarah 👩‍💻 is confirmed ✅ for 3pm — bring the “battery” notes.'
+
+OMI_LONG_ANSWER = (
+    'You have three things left today. First, Marcus is waiting on the battery '
+    'regression writeup and said he would block the release without it. Second, '
+    'the design review moved to 4pm because Priya had a conflict with the '
+    'investor call. Third, you promised Sarah a decision on the firmware '
+    'rollout before end of day. Everything else on the list can slip to '
+    'tomorrow without anyone noticing.'
+)
+
+
+def assert_display_safe(text):
+    """Every guarantee the firmware relies on, asserted in one place."""
+    assert isinstance(text, str)
+    assert text == text.strip(), 'leading/trailing whitespace leaks to the display'
+    for char in text:
+        assert char == '\n' or ' ' <= char <= '~', f'unsafe character {char!r} for the G2 font'
+    assert '\n\n\n' not in text, 'more than one blank line'
+
+
+# --------------------------------------------------------------------------
+# Markdown stripping
+# --------------------------------------------------------------------------
+
+
+def test_headings_are_stripped():
+    out = fit_for_glasses('## Your morning so far\n\nYou had two meetings.')
+    assert '#' not in out
+    assert out.startswith('Your morning so far')
+
+
+def test_bold_italic_and_code_markers_are_stripped():
+    out = fit_for_glasses('The **firmware OTA** rollout is *held* until `battery_drain` drops.')
+    assert out == 'The firmware OTA rollout is held until battery_drain drops.'
+
+
+def test_bold_italic_combined_and_underscore_emphasis():
+    out = fit_for_glasses('That is ___really___ __important__ and _urgent_.')
+    assert out == 'That is really important and urgent.'
+
+
+def test_snake_case_identifiers_survive_italic_stripping():
+    out = fit_for_glasses('Check the some_var_name field in battery_drain_v2.')
+    assert 'some_var_name' in out
+    assert 'battery_drain_v2' in out
+
+
+def test_fenced_code_keeps_the_code_and_drops_the_fences():
+    out = fit_for_glasses(OMI_CODE_ANSWER)
+    assert '```' not in out
+    assert 'def fetch(url):' in out
+    assert 'requests.get(url, timeout=5)' in out
+
+
+def test_blockquote_marker_is_stripped():
+    out = fit_for_glasses('> Sarah: "we should not ship this blind"')
+    assert out.startswith('Sarah:')
+    assert '>' not in out
+
+
+def test_all_bullet_styles_normalise_to_one_marker():
+    out = fit_for_glasses('- dash item\n* star item\n+ plus item\n1. numbered item\n2) paren item')
+    assert out.splitlines() == [
+        '- dash item',
+        '- star item',
+        '- plus item',
+        '- numbered item',
+        '- paren item',
+    ]
+
+
+def test_task_list_checkboxes_are_stripped():
+    out = fit_for_glasses('- [ ] File the regression\n- [x] Reply to Marcus')
+    assert out.splitlines() == ['- File the regression', '- Reply to Marcus']
+
+
+def test_horizontal_rules_are_removed():
+    out = fit_for_glasses('Before\n\n---\n\nAfter')
+    assert out == 'Before\n\nAfter'
+
+
+def test_strikethrough_keeps_the_words():
+    out = fit_for_glasses('See the ~~old~~ new docs.')
+    assert out == 'See the old new docs.'
+
+
+def test_link_becomes_its_label():
+    out = fit_for_glasses('File it in [the tracker](https://github.com/omi/omi/issues/42) today.')
+    assert out == 'File it in the tracker today.'
+
+
+def test_images_are_dropped_entirely():
+    out = fit_for_glasses('Chart: ![battery graph](https://cdn.omi.me/g.png) looks flat.')
+    assert 'battery graph' not in out
+    assert out == 'Chart: looks flat.'
+
+
+def test_full_standup_sample_has_no_markdown_left():
+    out = fit_for_glasses(OMI_STANDUP, limit=2000)
+    assert_display_safe(out)
+    for marker in ('**', '```', '](', '#', '>', '~~'):
+        assert marker not in out, f'{marker!r} survived'
+    # The words themselves must all still be there.
+    for word in ('firmware', 'Sarah', 'battery_drain', 'tracker', 'changelog'):
+        assert word in out
+
+
+# --------------------------------------------------------------------------
+# URLs, citations, emoji
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [
+        'Details at https://linear.app/omi/issue/OMI-1234 today.',
+        'Details at http://example.com/a/b?c=d#frag today.',
+        'Details at www.notion.so/omi/notes today.',
+        'Details at <https://docs.omi.me/retries> today.',
+    ],
+)
+def test_bare_urls_are_removed(raw):
+    out = fit_for_glasses(raw)
+    assert 'http' not in out
+    assert 'www.' not in out
+    assert out == 'Details at today.'
+
+
+def test_url_removal_leaves_no_empty_brackets():
+    out = fit_for_glasses('Read it (https://docs.omi.me/retries) when you can.')
+    assert '()' not in out
+    assert out == 'Read it when you can.'
+
+
+@pytest.mark.parametrize(
+    'raw,expected',
+    [
+        ('You discussed firmware yesterday[1].', 'You discussed firmware yesterday.'),
+        ('You discussed firmware yesterday[1][2].', 'You discussed firmware yesterday.'),
+        ('Hold the release[12][3] until Monday[7].', 'Hold the release until Monday.'),
+    ],
+)
+def test_omi_citation_markers_are_removed(raw, expected):
+    assert fit_for_glasses(raw) == expected
+
+
+def test_citation_removal_does_not_eat_markdown_links_with_numeric_labels():
+    out = fit_for_glasses('See [1](https://omi.me/one) for context.')
+    assert out == 'See 1 for context.'
+
+
+def test_emoji_are_dropped_and_words_preserved():
+    out = fit_for_glasses(OMI_EMOJI_ANSWER)
+    assert_display_safe(out)
+    assert out == 'Great news! Your meeting with Sarah is confirmed for 3pm - bring the "battery" notes.'
+
+
+def test_smart_punctuation_is_converted_to_ascii():
+    raw = 'She said “ship it” — it’s ready… → today ½ done ≥ 90%.'
+    out = fit_for_glasses(raw)
+    assert_display_safe(out)
+    assert out == 'She said "ship it" - it\'s ready... -> today 1/2 done >= 90%.'
+
+
+def test_accented_latin_is_transliterated_not_dropped():
+    out = fit_for_glasses('Meet Renee at the café in Zürich nächste Woche.')
+    assert out == 'Meet Renee at the cafe in Zurich nachste Woche.'
+
+
+def test_emoji_only_input_returns_empty_string():
+    assert fit_for_glasses('🎉🎉🎉 👩‍💻 ✅') == ''
+
+
+def test_cjk_only_input_does_not_crash():
+    assert fit_for_glasses('こんにちは世界') == ''
+
+
+def test_bullet_whose_content_was_only_a_url_disappears():
+    out = fit_for_glasses('- https://linear.app/omi/OMI-1\n- Reply to Marcus')
+    assert out == '- Reply to Marcus'
+
+
+def test_zero_width_and_nbsp_characters_are_neutralised():
+    out = fit_for_glasses('Ship​it now﻿.')
+    assert_display_safe(out)
+    assert out == 'Shipit now.'
+
+
+# --------------------------------------------------------------------------
+# Whitespace
+# --------------------------------------------------------------------------
+
+
+def test_whitespace_runs_collapse_and_blank_lines_are_capped():
+    out = fit_for_glasses('One    two\t\tthree\n\n\n\n\nfour')
+    assert out == 'One two three\n\nfour'
+
+
+def test_crlf_input_is_normalised():
+    out = fit_for_glasses('One\r\n\r\nTwo\r\n')
+    assert out == 'One\n\nTwo'
+
+
+# --------------------------------------------------------------------------
+# Truncation
+# --------------------------------------------------------------------------
+
+
+def test_truncation_lands_on_a_sentence_boundary():
+    text = 'First sentence here. Second sentence here. Third sentence here.'
+    out = fit_for_glasses(text, limit=30)
+    assert out == 'First sentence here...'
+    assert len(out) <= 30
+
+
+def test_truncation_prefers_the_last_sentence_that_fits():
+    out = fit_for_glasses(OMI_LONG_ANSWER, limit=200)
+    assert len(out) <= 200
+    assert out.endswith('...')
+    assert out.startswith('You have three things left today.')
+    # Cut after a complete sentence, so the next sentence's opener is absent.
+    assert 'Second,' not in out
+
+
+def test_truncation_fills_the_screen_when_the_sentence_boundary_is_far_back():
+    """Bullet lists have no terminal punctuation, so a strict sentence cut
+
+    would strand half the screen. The action items are the useful part of a
+    standup answer -- they must survive.
+    """
+    out = fit_for_glasses(OMI_STANDUP, limit=DEFAULT_LIMIT)
+    assert len(out) <= DEFAULT_LIMIT
+    assert len(out) > DEFAULT_LIMIT * 0.8, f'wasted {DEFAULT_LIMIT - len(out)} chars of screen'
+    assert 'Reply to Marcus' in out
+
+
+def test_truncation_never_produces_four_dots():
+    out = fit_for_glasses('Done. And more text that will certainly not fit here.', limit=12)
+    assert out.endswith('...')
+    assert not out.endswith('....')
+
+
+def test_truncation_falls_back_to_a_word_boundary():
+    text = 'alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima'
+    out = fit_for_glasses(text, limit=30)
+    assert len(out) <= 30
+    assert out.endswith('...')
+    body = out[:-3]
+    # No partial word: every emitted word is one of the originals.
+    assert set(body.split()) <= set(text.split())
+
+
+def test_truncation_length_includes_the_ellipsis():
+    for limit in range(4, 120):
+        out = fit_for_glasses(OMI_LONG_ANSWER, limit=limit)
+        assert len(out) <= limit, f'limit={limit} produced {len(out)} chars'
+        assert out.endswith('...')
+
+
+def test_short_text_is_returned_untouched_without_ellipsis():
+    out = fit_for_glasses('All clear.', limit=DEFAULT_LIMIT)
+    assert out == 'All clear.'
+    assert not out.endswith('...')
+
+
+def test_default_limit_is_respected_on_a_real_sample():
+    out = fit_for_glasses(OMI_STANDUP)
+    assert len(out) <= DEFAULT_LIMIT
+    assert_display_safe(out)
+
+
+def test_output_never_exceeds_limit_property():
+    """Property: for arbitrary markdown-ish input and limit, len(out) <= limit."""
+    rng = random.Random(20240727)
+    vocabulary = [
+        'meeting',
+        'Sarah',
+        '**bold**',
+        '*held*',
+        '`code`',
+        '[label](https://omi.me/x)',
+        'yesterday[1]',
+        'https://linear.app/omi/OMI-9',
+        '🎉',
+        'don’t',
+        '- bullet',
+        '# heading',
+        'supercalifragilisticexpialidocious',
+        'end.',
+        'Next?',
+        'wow!',
+        '\n',
+        '\n\n',
+    ]
+    for _ in range(400):
+        words = [rng.choice(vocabulary) for _ in range(rng.randint(0, 120))]
+        raw = ' '.join(words)
+        limit = rng.randint(1, 500)
+        out = fit_for_glasses(raw, limit=limit)
+        assert len(out) <= limit, f'limit={limit} produced {len(out)} chars from {raw!r}'
+        assert_display_safe(out)
+
+
+def test_random_unicode_input_never_crashes_or_overflows():
+    rng = random.Random(7)
+    for _ in range(300):
+        raw = ''.join(chr(rng.randint(1, 0x2FFFF)) for _ in range(rng.randint(0, 200)))
+        out = fit_for_glasses(raw, limit=rng.randint(1, 400))
+        assert_display_safe(out)
+
+
+# --------------------------------------------------------------------------
+# Edge cases
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('raw', ['', '   ', '\n\n', '\t \n \t', '\r\n'])
+def test_empty_and_whitespace_only_input_returns_empty_string(raw):
+    assert fit_for_glasses(raw) == ''
+
+
+def test_markdown_only_input_returns_empty_string():
+    assert fit_for_glasses('## \n\n---\n\n> \n\n- \n') == ''
+
+
+def test_single_word_longer_than_limit_is_cut_to_fit():
+    word = 'a' * 500
+    out = fit_for_glasses(word, limit=50)
+    assert len(out) == 50
+    assert out == 'a' * 47 + '...'
+
+
+def test_limit_smaller_than_the_ellipsis_still_holds_the_cap():
+    for limit in (1, 2, 3):
+        out = fit_for_glasses('hello world', limit=limit)
+        assert len(out) <= limit
+
+
+def test_non_positive_limit_returns_empty_string():
+    assert fit_for_glasses('hello world', limit=0) == ''
+    assert fit_for_glasses('hello world', limit=-5) == ''
+
+
+# --------------------------------------------------------------------------
+# Pagination
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('raw', ['', '   ', '\n\n'])
+def test_paginate_empty_input_returns_empty_list(raw):
+    assert paginate(raw) == []
+
+
+def test_paginate_short_text_is_a_single_page():
+    assert paginate('All clear.') == ['All clear.']
+
+
+def test_paginate_respects_page_size_and_keeps_every_word_in_order():
+    text = fit_for_glasses(OMI_STANDUP, limit=4000)
+    pages = paginate(text, page_size=80)
+    assert len(pages) > 1
+    for page in pages:
+        assert len(page) <= 80
+        assert page == page.strip()
+    assert ' '.join(pages).split() == text.split()
+
+
+def test_paginate_prefers_paragraph_boundaries():
+    text = 'First paragraph here.\n\nSecond paragraph here.\n\nThird paragraph here.'
+    pages = paginate(text, page_size=50)
+    # Two paragraphs fit together (21 + 2 + 22 = 45), the third starts a page.
+    assert pages == ['First paragraph here.\n\nSecond paragraph here.', 'Third paragraph here.']
+
+
+def test_paginate_falls_back_to_sentence_boundaries():
+    text = 'Alpha one two. Bravo three four. Charlie five six. Delta seven eight.'
+    pages = paginate(text, page_size=35)
+    for page in pages:
+        assert len(page) <= 35
+    assert all(page.endswith(('.', '!', '?')) for page in pages)
+    assert ' '.join(pages).split() == text.split()
+
+
+def test_paginate_never_breaks_mid_word():
+    rng = random.Random(99)
+    words = [''.join(rng.choice(string.ascii_lowercase) for _ in range(rng.randint(1, 12))) for _ in range(400)]
+    text = ' '.join(words)
+    for page_size in (20, 37, 64, 100, 256, 400):
+        pages = paginate(text, page_size=page_size)
+        for page in pages:
+            assert len(page) <= page_size
+            for word in page.split():
+                assert word in words, f'{word!r} is not an original word (mid-word break)'
+        assert ' '.join(pages).split() == words
+
+
+def test_paginate_property_over_random_sizes_and_texts():
+    rng = random.Random(4242)
+    for _ in range(200):
+        sentences = []
+        for _ in range(rng.randint(1, 20)):
+            n = rng.randint(1, 12)
+            sentences.append(' '.join('w' * rng.randint(1, 15) for _ in range(n)) + rng.choice('.!?'))
+        paragraphs = []
+        while sentences:
+            take = rng.randint(1, 4)
+            paragraphs.append(' '.join(sentences[:take]))
+            sentences = sentences[take:]
+        text = '\n\n'.join(paragraphs)
+        page_size = rng.randint(20, 300)
+        pages = paginate(text, page_size=page_size)
+        assert all(len(p) <= page_size for p in pages)
+        assert ' '.join(pages).split() == text.split()
+
+
+def test_paginate_single_word_longer_than_page_is_chunked_not_dropped():
+    word = 'x' * 250
+    pages = paginate(word, page_size=100)
+    assert [len(p) for p in pages] == [100, 100, 50]
+    assert ''.join(pages) == word
+
+
+def test_paginate_default_page_size_fits_the_screen():
+    text = fit_for_glasses(OMI_LONG_ANSWER, limit=4000)
+    pages = paginate(text)
+    assert all(len(p) <= DEFAULT_PAGE_SIZE for p in pages)
+
+
+def test_paginate_rejects_non_positive_page_size():
+    with pytest.raises(ValueError):
+        paginate('hello', page_size=0)
+
+
+def test_fit_then_paginate_is_one_page_at_matching_sizes():
+    out = fit_for_glasses(OMI_STANDUP, limit=DEFAULT_LIMIT)
+    assert len(paginate(out, page_size=DEFAULT_PAGE_SIZE)) == 1
+
+
+# --------------------------------------------------------------------------
+# OpenAI response body
+# --------------------------------------------------------------------------
+
+
+def test_openai_chat_completion_is_structurally_valid():
+    body = openai_chat_completion('All clear.')
+    assert re.fullmatch(r'chatcmpl-[0-9a-f]{24}', body['id'])
+    assert body['object'] == 'chat.completion'
+    assert isinstance(body['created'], int) and body['created'] > 0
+    assert body['model'] == 'omi'
+
+    assert isinstance(body['choices'], list) and len(body['choices']) == 1
+    choice = body['choices'][0]
+    assert choice['index'] == 0
+    assert choice['finish_reason'] == 'stop'
+    assert choice['message'] == {'role': 'assistant', 'content': 'All clear.'}
+
+    usage = body['usage']
+    assert set(usage) == {'prompt_tokens', 'completion_tokens', 'total_tokens'}
+    assert all(isinstance(v, int) and v >= 0 for v in usage.values())
+
+
+def test_openai_chat_completion_is_json_serialisable():
+    body = openai_chat_completion(fit_for_glasses(OMI_STANDUP))
+    round_tripped = json.loads(json.dumps(body))
+    assert round_tripped == body
+
+
+def test_openai_chat_completion_honours_the_model_override():
+    assert openai_chat_completion('hi', model='omi-standup')['model'] == 'omi-standup'
+
+
+def test_openai_chat_completion_ids_are_unique():
+    ids = {openai_chat_completion('hi')['id'] for _ in range(50)}
+    assert len(ids) == 50
+
+
+def test_openai_chat_completion_handles_empty_content():
+    body = openai_chat_completion('')
+    assert body['choices'][0]['message']['content'] == ''
+    assert body['usage']['total_tokens'] == 0

--- a/integrations/omi-even/bridge/tests/test_early_stop.py
+++ b/integrations/omi-even/bridge/tests/test_early_stop.py
@@ -1,0 +1,102 @@
+"""Tests for stopping the chat stream once the display is already full.
+
+Omi writes for a phone. Measured against the live account, answers ran 929-1511
+characters where the glasses show ~380, and waiting for that unseen tail cost
+2.7-3.4s per question. Cutting the stream once a screenful has arrived took
+"Who is David Zhang?" from 18.4s to 6.1s.
+
+The first implementation of the predicate was silently wrong and is the reason
+this file exists. It asked:
+
+    len(fit_for_glasses(raw, limit=DISPLAY_LIMIT)) >= DISPLAY_LIMIT
+
+but `fit_for_glasses` *truncates* to at most `limit`, and usually a few
+characters below it after landing on a word boundary. So the comparison was
+essentially never true, the stream never stopped early, and the optimisation
+looked present while doing nothing -- latency barely moved and the bridge went
+on receiving 1100+ characters. The fix strips markup with an unbounded budget so
+the length being measured is the stripped length, not the truncated one.
+
+That failure mode is invisible to a test that only checks "long text returns
+True" against text far above the limit, so these pin the boundary specifically.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import server
+from display import DEFAULT_LIMIT, fit_for_glasses
+
+
+def test_short_text_does_not_stop_the_stream():
+    assert server._display_is_full('Short answer.') is False
+
+
+def test_text_well_over_the_limit_stops_the_stream():
+    assert server._display_is_full('This is a sentence. ' * 60) is True
+
+
+def test_text_just_over_the_limit_stops_the_stream():
+    """The regression: a truncating comparison fails right here.
+
+    Text a little longer than one screen is the realistic case -- an answer that
+    overflows by 10% is exactly what we want to stop on, and exactly what the
+    original predicate missed.
+    """
+    raw = 'word ' * ((DEFAULT_LIMIT // 5) + 6)  # ~30 chars past the limit
+    assert len(raw) > DEFAULT_LIMIT
+    assert server._display_is_full(raw) is True
+
+
+def test_the_predicate_is_not_defeated_by_truncation():
+    """Directly asserts the bug cannot come back.
+
+    `fit_for_glasses` at the display limit can never exceed it, so any predicate
+    written in terms of that value is dead code. If someone reintroduces it, this
+    fails.
+    """
+    raw = 'This is a sentence. ' * 60
+    truncated = fit_for_glasses(raw, limit=DEFAULT_LIMIT)
+    assert len(truncated) <= DEFAULT_LIMIT
+    # The naive comparison the bug used:
+    naive = len(truncated) >= DEFAULT_LIMIT
+    # ...disagrees with the correct answer for this input, which is what made the
+    # optimisation silently inert.
+    assert server._display_is_full(raw) is True
+    assert naive is False, 'if this ever holds, the naive check stopped being wrong by accident'
+
+
+def test_markup_heavy_text_is_measured_after_stripping():
+    """A screenful of tags is not a screenful of words.
+
+    Raw length alone would stop the stream on an answer that renders almost
+    empty, cutting off the actual content.
+    """
+    raw = '<cite index="1-1"></cite>' * 40  # long raw, no visible text
+    assert len(raw) > DEFAULT_LIMIT
+    assert server._display_is_full(raw) is False
+
+
+def test_empty_and_whitespace_never_stop_the_stream():
+    for raw in ('', '   ', '\n\n\n'):
+        assert server._display_is_full(raw) is False
+
+
+@pytest.mark.asyncio
+async def test_the_agent_path_passes_the_predicate_through(monkeypatch):
+    """Wiring check: forgetting `enough=` costs seconds and changes nothing visible."""
+    seen = {}
+
+    class FakeOmi:
+        async def chat(self, text, app_id=None, deadline_s=None, enough=None):
+            seen['enough'] = enough
+            from omi_client import ChatResult
+
+            return ChatResult(text='ok')
+
+    monkeypatch.setattr(server, 'omi', FakeOmi())
+    await server._answer_for_glasses('anything')
+
+    assert seen['enough'] is not None, 'the agent path stopped passing the early-stop predicate'
+    assert seen['enough']('This is a sentence. ' * 60) is True

--- a/integrations/omi-even/bridge/tests/test_early_stop.py
+++ b/integrations/omi-even/bridge/tests/test_early_stop.py
@@ -86,6 +86,9 @@ def test_empty_and_whitespace_never_stop_the_stream():
 @pytest.mark.asyncio
 async def test_the_agent_path_passes_the_predicate_through(monkeypatch):
     """Wiring check: forgetting `enough=` costs seconds and changes nothing visible."""
+    # The endpoint now prefers the fast retrieval path, which returns before the
+    # agent is ever consulted. This test is about the agent path, so ask for it.
+    monkeypatch.setenv('OMI_EVEN_FULL_AGENT', '1')
     seen = {}
 
     class FakeOmi:

--- a/integrations/omi-even/bridge/tests/test_fastpath.py
+++ b/integrations/omi-even/bridge/tests/test_fastpath.py
@@ -102,7 +102,8 @@ def test_relevance_metadata_is_stripped_and_weak_hits_dropped():
     raw = (
         "Found 3 memories matching 'x':\n\n"
         '- Archit works with David on the trial engagement. (relevance: 0.62, category: interesting, date: 2026-07-27)\n'
-        '- A barely related note about something else. (relevance: 0.31, category: system, date: 2026-07-08)\n'
+        # Below the 0.15 floor: this is the random tail, not a weak-but-real hit.
+        '- A barely related note about something else. (relevance: 0.04, category: system, date: 2026-07-08)\n'
     )
     lines = _clean_bullets(raw)
     assert lines == ['Archit works with David on the trial engagement.']
@@ -293,3 +294,96 @@ async def test_a_real_short_question_still_works():
     client = FakeClient(memories='- David is your colleague. (relevance: 0.80)')
     answer = await fast_answer(client, 'Who is David?')
     assert 'David is your colleague.' in answer
+
+
+# ------------------------------------------- the dominant retrieval failure
+
+
+def test_indexed_file_paths_are_never_returned_as_memories():
+    """The single biggest cause of useless answers.
+
+    An indexer files every local document into the memory store as a `system`
+    memory. Measured against the live account, those were 7/10 results for
+    "pickleball", 9/10 for "burgers", and 10/10 for "what I learned in July" --
+    which is why that question answered "nothing at all".
+    """
+    raw = (
+        "Found 4 memories matching 'burgers':\n\n"
+        "- The user's local downloads include ~/Downloads/cheese/groundedshakes.md (md). "
+        '(relevance: 0.24, category: system, date: 2026-07-07)\n'
+        '- The user works on a local project named lecture01-code. '
+        '(relevance: 0.26, category: system, date: 2026-07-08)\n'
+        '- Liiban organized a group dinner at Wally with Aryaveer and Archit. '
+        '(relevance: 0.22, category: system, date: 2026-07-05)\n'
+    )
+    lines = _clean_bullets(raw)
+    assert lines == ['Liiban organized a group dinner at Wally with Aryaveer and Archit.']
+    assert not any('Downloads' in line or 'lecture01' in line for line in lines)
+
+
+def test_a_real_memory_below_the_old_threshold_survives():
+    """The relevance floor was set to 0.40 and was simply wrong.
+
+    Genuinely useful memories score 0.22-0.48 on this account, so that floor
+    discarded most of the good ones and left only file-path noise, which scored
+    no worse. Category is the real discriminator, not the number.
+    """
+    raw = (
+        '- Liiban organized a group dinner at Wally with Aryaveer and Archit. '
+        '(relevance: 0.22, category: interesting, date: 2026-07-05)\n'
+    )
+    assert _clean_bullets(raw), 'a 0.22 memory is useful and must not be dropped'
+
+
+def test_conversation_titles_are_extracted_for_merging():
+    """Conversations carry what happened; memories carry standing facts.
+
+    Searching memories alone answered "burgers" with a downloads-folder path
+    while conversations held "A group orders fast food ... burgers, fries".
+    """
+    from fastpath import _conversation_titles
+
+    raw = (
+        "Found 1 conversations matching 'burgers':\n\n"
+        'Conversation #1\n'
+        '05 Jul 2026 at 19:00 America/New_York (Social)\n'
+        'A group orders fast food and discusses burgers, fries and sauces\n'
+        '- Some detail line\n'
+    )
+    titles = _conversation_titles(raw)
+    assert titles == ['A group orders fast food and discusses burgers, fries and sauces']
+
+
+def test_a_real_memory_in_the_system_category_is_kept():
+    """`system` is the DEFAULT extraction category, not a noise marker.
+
+    Rejecting the category wholesale -- which is the obvious first move -- throws
+    away real memories, because the backend labels most extracted facts `system`
+    (utils/memory_ingestion/adapters/typed_extraction_prompt.py:201). The backend's
+    own cleanup keys on content instead, and so does this.
+    """
+    raw = (
+        '- Archit and Sami courted Pasha at A1 Base for a partnership. '
+        '(relevance: 0.30, category: system, date: 2026-07-02)\n'
+    )
+    assert _clean_bullets(raw) == ['Archit and Sami courted Pasha at A1 Base for a partnership.']
+
+
+@pytest.mark.parametrize(
+    'line',
+    [
+        "- The user's local documents include ~/Documents/x/y.md (md). (relevance: 0.4)",
+        '- The user works on a local project named lecture01-code. (relevance: 0.4)',
+        '- 2,800 local files indexed across their machine. (relevance: 0.4)',
+        '- focused on Terminal for 40 minutes (relevance: 0.4)',
+        '- distracted on Twitter for 10 minutes (relevance: 0.4)',
+    ],
+)
+def test_local_file_inventory_lines_are_dropped(line):
+    assert _clean_bullets(line) == []
+
+
+def test_a_project_mention_without_a_path_survives():
+    """The double anchor: mentioning a project is real, a path makes it inventory."""
+    raw = '- Archit is building the omi-even bridge for smart glasses. (relevance: 0.35)\n'
+    assert _clean_bullets(raw), 'a genuine project memory must not be swept up'

--- a/integrations/omi-even/bridge/tests/test_fastpath.py
+++ b/integrations/omi-even/bridge/tests/test_fastpath.py
@@ -101,21 +101,25 @@ def test_a_question_with_no_time_reference_has_no_window():
 def test_relevance_metadata_is_stripped_and_weak_hits_dropped():
     raw = (
         "Found 3 memories matching 'x':\n\n"
-        '- A strong fact. (relevance: 0.62, category: interesting, date: 2026-07-27)\n'
-        '- A weak fact. (relevance: 0.31, category: system, date: 2026-07-08)\n'
+        '- Archit works with David on the trial engagement. (relevance: 0.62, category: interesting, date: 2026-07-27)\n'
+        '- A barely related note about something else. (relevance: 0.31, category: system, date: 2026-07-08)\n'
     )
     lines = _clean_bullets(raw)
-    assert lines == ['A strong fact.']
+    assert lines == ['Archit works with David on the trial engagement.']
     assert 'relevance' not in ' '.join(lines)
 
 
 def test_bullets_come_back_strongest_first():
     raw = (
-        '- Middling. (relevance: 0.50)\n'
-        '- Best. (relevance: 0.90)\n'
-        '- Also good. (relevance: 0.70)\n'
+        '- The middling fact about a thing. (relevance: 0.50)\n'
+        '- The best fact about a thing. (relevance: 0.90)\n'
+        '- Another good fact about a thing. (relevance: 0.70)\n'
     )
-    assert _clean_bullets(raw) == ['Best.', 'Also good.', 'Middling.']
+    assert _clean_bullets(raw) == [
+        'The best fact about a thing.',
+        'Another good fact about a thing.',
+        'The middling fact about a thing.',
+    ]
 
 
 def test_conversation_scaffolding_is_removed():
@@ -201,11 +205,37 @@ async def test_a_general_knowledge_question_admits_it_does_not_know():
 
 
 @pytest.mark.asyncio
-async def test_a_temporal_question_sends_a_date_window():
+async def test_a_temporal_question_does_not_use_a_server_side_date_window():
+    """Date filtering happens here, not in the query -- on purpose.
+
+    Measured on the live account, the same question cost 13.5s with a
+    start_date/end_date window and 3.1s without. 13.5s is past the timeout this
+    whole path exists to beat, so the window would have made the answer correct
+    and invisible.
+    """
     client = FakeClient(conversations='- something')
     await fast_answer(client, 'What did I do yesterday?')
     payload = client.payloads['conversations/search']
-    assert 'start_date' in payload and 'T' in payload['start_date']
+    assert 'start_date' not in payload, 'a server-side window makes this 4x slower'
+    assert payload['limit'] >= 8, 'fetch wider, since filtering happens client-side'
+
+
+@pytest.mark.asyncio
+async def test_results_from_the_wrong_day_are_filtered_out():
+    """The correctness the server-side window used to provide, done locally."""
+    conversations = (
+        "Found 2 conversations matching 'x':\n\n"
+        'Conversation #1\n'
+        '04 Jul 2026 at 12:00 America/New_York (Social)\n'
+        'Friends share burgers on july fourth\n\n'
+        'Conversation #2\n'
+        '23 Jul 2026 at 16:08 America/New_York (Technology)\n'
+        'Archit investigates web search\n'
+    )
+    client = FakeClient(conversations=conversations)
+    answer = await fast_answer(client, 'What did I do on 4 July?')
+    assert 'burgers' in answer
+    assert 'web search' not in answer, 'a conversation from another day leaked through'
 
 
 @pytest.mark.asyncio

--- a/integrations/omi-even/bridge/tests/test_fastpath.py
+++ b/integrations/omi-even/bridge/tests/test_fastpath.py
@@ -235,3 +235,31 @@ async def test_the_answer_stays_within_a_screenful():
     )
     answer = await fast_answer(client, 'What am I behind on?')
     assert len(answer.splitlines()) <= 4
+
+
+# --------------------------------------------------- garbled speech guard
+
+
+@pytest.mark.parametrize(
+    'question',
+    ['ping', 'uh', 'hm', 'the a of', '', '   ', 'ok', 'yeah'],
+)
+@pytest.mark.asyncio
+async def test_a_fragment_returns_a_prompt_not_a_random_memory(question):
+    """Speech-to-text emits fragments, and vector search answers every one.
+
+    Asking "ping" surfaced an unrelated obscenity from an old transcript. On a
+    display worn on your face, nothing beats nearest-neighbour noise.
+    """
+    client = FakeClient(memories='- Something unrelated. (relevance: 0.55)')
+    answer = await fast_answer(client, question)
+    assert 'Ask me something' in answer
+    assert 'unrelated' not in answer
+
+
+@pytest.mark.asyncio
+async def test_a_real_short_question_still_works():
+    """The guard must not swallow genuine brief questions."""
+    client = FakeClient(memories='- David is your colleague. (relevance: 0.80)')
+    answer = await fast_answer(client, 'Who is David?')
+    assert 'David is your colleague.' in answer

--- a/integrations/omi-even/bridge/tests/test_fastpath.py
+++ b/integrations/omi-even/bridge/tests/test_fastpath.py
@@ -1,0 +1,237 @@
+"""Tests for the fast retrieval path used by Even AI.
+
+Even's custom-agent client times out well before Omi's agent can answer. Proven
+on hardware: a 0.4s reply renders on the glasses; 5.6-8.4s replies return 200 OK
+and are never seen. This path reads Omi's stores directly and lands in 0.5-2.8s.
+
+Most of these tests exist because a specific wrong answer shipped and had to be
+walked back. Each is named for the failure it prevents.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import fastpath
+from fastpath import (
+    _classify,
+    _clean_bullets,
+    _compact_conversations,
+    _date_window,
+    _looks_relevant,
+    fast_answer,
+)
+
+
+class FakeClient:
+    def __init__(self, memories='', conversations='', actions=None, fail=()):
+        self.memories = memories
+        self.conversations = conversations
+        self.actions = actions or []
+        self.fail = fail
+        self.payloads: dict[str, dict] = {}
+
+    async def tool_search(self, tool, payload):
+        self.payloads[tool] = payload
+        if tool in self.fail:
+            raise RuntimeError(f'{tool} reported an error')
+        return self.conversations if 'conversations' in tool else self.memories
+
+    async def action_items(self, limit=20):
+        return list(self.actions)
+
+
+# ------------------------------------------------------------------ routing
+
+
+@pytest.mark.parametrize(
+    ('question', 'expected'),
+    [
+        ('What am I behind on?', 'actions'),
+        ("What's on my plate?", 'actions'),
+        ('What tasks do I have?', 'actions'),
+        ('What did I do yesterday?', 'conversations'),
+        ('What did we discuss in the meeting?', 'conversations'),
+        ('Who is David Zhang?', 'memories'),
+        ('Tell me about my cofounder', 'memories'),
+    ],
+)
+def test_questions_route_to_the_right_store(question, expected):
+    assert _classify(question) == expected
+
+
+def test_temporal_questions_beat_the_task_wording():
+    """"What did I do yesterday" contains "do" but is not a task question."""
+    assert _classify('What did I do yesterday?') == 'conversations'
+
+
+# ------------------------------------------------------------- date windows
+
+
+def test_date_bounds_carry_a_timezone():
+    """The search tool rejects a bare date.
+
+    It requires `YYYY-MM-DDTHH:MM:SS+HH:MM`. Sending `2026-07-20` came back as an
+    error, and because the tool reports "no results" the same way it reports a
+    failure, the bad format silently produced "nothing recorded" for days that
+    had plenty. That is a wrong answer, not a missing one.
+    """
+    window = _date_window('What did I do yesterday?')
+    assert window, 'yesterday must produce a window'
+    for value in window.values():
+        assert 'T' in value, f'{value} has no time component'
+        # An offset (+05:00 / -04:00) or Z must be present after the time.
+        assert value[-6] in '+-' or value.endswith('Z'), f'{value} has no timezone'
+
+
+def test_a_day_window_spans_the_whole_day():
+    window = _date_window('What did I do yesterday?')
+    assert window['start_date'] < window['end_date']
+    assert 'T00:00:00' in window['start_date']
+    assert 'T23:59:59' in window['end_date']
+
+
+def test_a_question_with_no_time_reference_has_no_window():
+    assert _date_window('Who is David Zhang?') == {}
+
+
+# ---------------------------------------------------------------- cleaning
+
+
+def test_relevance_metadata_is_stripped_and_weak_hits_dropped():
+    raw = (
+        "Found 3 memories matching 'x':\n\n"
+        '- A strong fact. (relevance: 0.62, category: interesting, date: 2026-07-27)\n'
+        '- A weak fact. (relevance: 0.31, category: system, date: 2026-07-08)\n'
+    )
+    lines = _clean_bullets(raw)
+    assert lines == ['A strong fact.']
+    assert 'relevance' not in ' '.join(lines)
+
+
+def test_bullets_come_back_strongest_first():
+    raw = (
+        '- Middling. (relevance: 0.50)\n'
+        '- Best. (relevance: 0.90)\n'
+        '- Also good. (relevance: 0.70)\n'
+    )
+    assert _clean_bullets(raw) == ['Best.', 'Also good.', 'Middling.']
+
+
+def test_conversation_scaffolding_is_removed():
+    """Timestamps repeated three times ate most of a 380-character screen."""
+    raw = (
+        "Found 1 conversations matching 'x':\n\n"
+        'Conversation #1\n'
+        '23 Jul 2026 at 16:08 America/New_York (Technology)\n'
+        'Started: 23 Jul 2026 at 16:08 America/New_York\n'
+        'Finished: 23 Jul 2026 at 21:21 America/New_York\n'
+        'Archit investigates web search\n'
+        '## Screen Check\n'
+        '- Asked to test freezing.\n'
+    )
+    out = _compact_conversations(raw)
+    assert 'Started:' not in out and 'Finished:' not in out
+    assert 'Conversation #1' not in out
+    assert 'America/New_York' not in out
+    assert 'Archit investigates web search' in out
+    assert 'Screen Check' in out  # heading kept, its '##' removed
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        "No conversations found matching 'x' in the specified date range.",
+        'No memories found.',
+        'Error: Invalid start_date format',
+    ],
+)
+def test_a_no_results_sentence_is_not_echoed_as_an_answer(body):
+    """These tools phrase emptiness as prose; repeating it reads as a bug."""
+    assert _compact_conversations(body) == ''
+
+
+# -------------------------------------------------------------- relevance
+
+
+def test_a_single_shared_word_cannot_carry_an_unrelated_result():
+    """The live failure: "who is the president of the USA" returned a
+    conversation about wallpapers, which really did contain "USA"."""
+    text = 'Wallpapers spark playful relationship talk. A trip across the USA.'
+    assert _looks_relevant('Who is the president of the USA?', text) is False
+
+
+def test_a_genuine_match_still_passes():
+    text = 'David Zhang and Archit debugged the iMessage integration together.'
+    assert _looks_relevant('What did I promise David Zhang?', text) is True
+
+
+def test_a_question_of_only_stopwords_is_not_blocked():
+    assert _looks_relevant('what is it', 'anything at all') is True
+
+
+# ------------------------------------------------------------- end to end
+
+
+@pytest.mark.asyncio
+async def test_open_tasks_are_returned_newest_first():
+    client = FakeClient(
+        actions=[
+            {'description': 'old thing', 'completed': False, 'created_at': '2026-01-01'},
+            {'description': 'new thing', 'completed': False, 'created_at': '2026-07-27'},
+            {'description': 'done thing', 'completed': True, 'created_at': '2026-07-26'},
+        ]
+    )
+    answer = await fast_answer(client, 'What am I behind on?')
+    assert answer.index('new thing') < answer.index('old thing')
+    assert 'done thing' not in answer
+
+
+@pytest.mark.asyncio
+async def test_a_general_knowledge_question_admits_it_does_not_know():
+    """Answering from whatever was nearest in vector space is worse than silence.
+
+    The fast path has no LLM, so a question needing world knowledge cannot be
+    answered -- and must not be answered wrongly.
+    """
+    client = FakeClient(memories='', conversations='Wallpapers and a USA road trip.')
+    answer = await fast_answer(client, 'Who is the president of the USA?')
+    assert 'Nothing in your memories' in answer
+    assert 'Wallpaper' not in answer
+
+
+@pytest.mark.asyncio
+async def test_a_temporal_question_sends_a_date_window():
+    client = FakeClient(conversations='- something')
+    await fast_answer(client, 'What did I do yesterday?')
+    payload = client.payloads['conversations/search']
+    assert 'start_date' in payload and 'T' in payload['start_date']
+
+
+@pytest.mark.asyncio
+async def test_a_failing_tool_does_not_raise():
+    """A raised error here falls back to the 6s agent path, which is the very
+    latency this exists to avoid."""
+    client = FakeClient(fail=('memories/search',))
+    answer = await fast_answer(client, 'Who is David Zhang?')
+    assert answer  # a message, not an exception
+
+
+@pytest.mark.asyncio
+async def test_an_empty_day_says_so_without_falling_back():
+    client = FakeClient(conversations='')
+    answer = await fast_answer(client, 'What did I do yesterday?')
+    assert 'Nothing recorded' in answer
+
+
+@pytest.mark.asyncio
+async def test_the_answer_stays_within_a_screenful():
+    client = FakeClient(
+        actions=[
+            {'description': f'task number {i} with a fairly long description', 'completed': False,
+             'created_at': f'2026-07-{i:02d}'}
+            for i in range(1, 20)
+        ]
+    )
+    answer = await fast_answer(client, 'What am I behind on?')
+    assert len(answer.splitlines()) <= 4

--- a/integrations/omi-even/bridge/tests/test_fastpath.py
+++ b/integrations/omi-even/bridge/tests/test_fastpath.py
@@ -61,7 +61,7 @@ def test_questions_route_to_the_right_store(question, expected):
 
 
 def test_temporal_questions_beat_the_task_wording():
-    """"What did I do yesterday" contains "do" but is not a task question."""
+    """ "What did I do yesterday" contains "do" but is not a task question."""
     assert _classify('What did I do yesterday?') == 'conversations'
 
 
@@ -259,8 +259,11 @@ async def test_an_empty_day_says_so_without_falling_back():
 async def test_the_answer_stays_within_a_screenful():
     client = FakeClient(
         actions=[
-            {'description': f'task number {i} with a fairly long description', 'completed': False,
-             'created_at': f'2026-07-{i:02d}'}
+            {
+                'description': f'task number {i} with a fairly long description',
+                'completed': False,
+                'created_at': f'2026-07-{i:02d}',
+            }
             for i in range(1, 20)
         ]
     )

--- a/integrations/omi-even/bridge/tests/test_fastpath.py
+++ b/integrations/omi-even/bridge/tests/test_fastpath.py
@@ -65,6 +65,33 @@ def test_temporal_questions_beat_the_task_wording():
     assert _classify('What did I do yesterday?') == 'conversations'
 
 
+@pytest.mark.parametrize(
+    'question',
+    [
+        'What do I need to do today?',
+        'what do i need to get done today',
+        'What do I have to do this morning?',
+        'Who do I have to reply to?',
+        'What is left to do today?',
+    ],
+)
+def test_owed_work_beats_the_day_it_is_owed_on(question):
+    """The exact question this surface exists for was going to the wrong store.
+
+    "What do I need to do today?" contains "today" and none of the original
+    task words, so it routed to conversations and answered with what was *said*
+    today rather than what is *owed*. Tense is what separates these from
+    `test_temporal_questions_beat_the_task_wording`: "did I do" is history,
+    "need to do" is a list.
+    """
+    assert _classify(question) == 'actions'
+
+
+def test_knowing_is_not_owing():
+    """ "need to" alone would swallow memory questions, so only phrases match."""
+    assert _classify('What do I need to know about David?') == 'memories'
+
+
 # ------------------------------------------------------------- date windows
 
 

--- a/integrations/omi-even/bridge/tests/test_omi_auth.py
+++ b/integrations/omi-even/bridge/tests/test_omi_auth.py
@@ -1,0 +1,452 @@
+"""Tests for the Firebase session the bridge borrows from the desktop app.
+
+Two things make this module worth testing hard despite its size. It is the only
+place the bridge holds long-lived credentials, so anything that leaks token
+material into a log or an exception message is a real incident. And it is the
+first thing that runs on every request path, so a failure here must arrive as
+an actionable `AuthError` -- "sign in to the desktop app once" -- rather than as
+whatever exception happened to escape.
+
+Nothing here touches the Keychain (`conftest._no_keychain` stubs the dump) or
+the network (`conftest._no_network`); Firebase is a `MockTransport`.
+"""
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import omi_auth  # noqa: E402
+from conftest import install_mock_transport  # noqa: E402
+from omi_auth import AuthError, OmiAuth, _parse_session_file, _session_file  # noqa: E402
+
+REFRESH_TOKEN = 'AMf-vBz-REFRESH-TOKEN-SECRET-0123456789'
+ID_TOKEN = 'eyJhbGciOiJSUzI1NiIsImtpZCI6IklEIFRPS0VOIn0.payload.signature'
+
+
+def dump_shape(**values) -> str:
+    """The `{key: {type, value}}` layout `omi-auth-dump.sh` writes."""
+    return json.dumps({key: {'type': 'string', 'value': value} for key, value in values.items()})
+
+
+@pytest.fixture
+def session_file(tmp_path, monkeypatch):
+    path = tmp_path / 'desktop-auth.json'
+    monkeypatch.setenv('OMI_SESSION_FILE', str(path))
+    return path
+
+
+def firebase_ok(**overrides):
+    body = {
+        'id_token': ID_TOKEN,
+        'refresh_token': REFRESH_TOKEN,
+        'expires_in': '3600',
+        'user_id': 'firebase-uid-1',
+        **overrides,
+    }
+
+    def handler(request):
+        return httpx.Response(200, json=body)
+
+    return handler
+
+
+# --------------------------------------------------------------------------
+# _parse_session_file
+# --------------------------------------------------------------------------
+
+
+def test_the_dump_shape_is_flattened(tmp_path):
+    path = tmp_path / 'auth.json'
+    path.write_text(dump_shape(auth_idToken=ID_TOKEN, auth_refreshToken=REFRESH_TOKEN, auth_userId='uid-1'))
+    assert _parse_session_file(path) == {
+        'auth_idToken': ID_TOKEN,
+        'auth_refreshToken': REFRESH_TOKEN,
+        'auth_userId': 'uid-1',
+    }
+
+
+def test_plain_values_pass_through_unwrapped(tmp_path):
+    path = tmp_path / 'auth.json'
+    path.write_text(json.dumps({'auth_refreshToken': REFRESH_TOKEN, 'count': 3, 'flag': True}))
+    assert _parse_session_file(path) == {'auth_refreshToken': REFRESH_TOKEN, 'count': 3, 'flag': True}
+
+
+def test_a_wrapper_without_a_value_key_becomes_none(tmp_path):
+    path = tmp_path / 'auth.json'
+    path.write_text(json.dumps({'auth_refreshToken': {'type': 'string'}}))
+    assert _parse_session_file(path) == {'auth_refreshToken': None}
+
+
+def test_an_empty_object_is_an_empty_mapping(tmp_path):
+    path = tmp_path / 'auth.json'
+    path.write_text('{}')
+    assert _parse_session_file(path) == {}
+
+
+def test_a_missing_file_is_none_not_an_exception(tmp_path):
+    assert _parse_session_file(tmp_path / 'nope.json') is None
+
+
+def test_a_directory_is_none_not_an_exception(tmp_path):
+    assert _parse_session_file(tmp_path) is None
+
+
+@pytest.mark.parametrize('raw', ['', 'not json', '{"unterminated', '\x00\x01'])
+def test_unparseable_content_is_none(tmp_path, raw):
+    path = tmp_path / 'auth.json'
+    path.write_text(raw)
+    assert _parse_session_file(path) is None
+
+
+@pytest.mark.parametrize('raw', ['[1, 2, 3]', '"a bare string"', 'null', '42'])
+def test_valid_json_that_is_not_an_object_is_none(tmp_path, raw):
+    """Regression: `.items()` was called unconditionally, so a session file
+    pointed at the wrong JSON raised AttributeError instead of degrading into
+    the actionable "no signed-in session" error.
+    """
+    path = tmp_path / 'auth.json'
+    path.write_text(raw)
+    assert _parse_session_file(path) is None
+
+
+def test_session_file_honours_the_override_and_expands_home(monkeypatch):
+    monkeypatch.setenv('OMI_SESSION_FILE', '~/custom/auth.json')
+    assert _session_file() == Path.home() / 'custom' / 'auth.json'
+
+
+# --------------------------------------------------------------------------
+# _load_session
+# --------------------------------------------------------------------------
+
+
+def test_a_session_file_with_a_refresh_token_is_loaded(session_file):
+    session_file.write_text(
+        dump_shape(auth_idToken=ID_TOKEN, auth_refreshToken=REFRESH_TOKEN, auth_tokenUserId='uid-7')
+    )
+    session = OmiAuth()._load_session()
+    assert session.refresh_token == REFRESH_TOKEN
+    assert session.id_token == ID_TOKEN
+    assert session.uid == 'uid-7'
+
+
+def test_the_stored_expiry_is_ignored_so_a_stale_dump_cannot_401_mid_conversation(session_file):
+    session_file.write_text(
+        json.dumps(
+            {
+                'auth_refreshToken': {'type': 'string', 'value': REFRESH_TOKEN},
+                'auth_tokenExpiry': {'type': 'double', 'value': time.time() + 86400},
+            }
+        )
+    )
+    assert OmiAuth()._load_session().expires_at == 0.0
+
+
+def test_uid_falls_back_to_the_legacy_key(session_file):
+    session_file.write_text(dump_shape(auth_refreshToken=REFRESH_TOKEN, auth_userId='legacy-uid'))
+    assert OmiAuth()._load_session().uid == 'legacy-uid'
+
+
+def test_a_session_without_an_id_token_still_loads(session_file):
+    """Only the refresh token matters -- the ID token is minted on first use."""
+    session_file.write_text(dump_shape(auth_refreshToken=REFRESH_TOKEN))
+    session = OmiAuth()._load_session()
+    assert session.id_token == ''
+    assert session.refresh_token == REFRESH_TOKEN
+
+
+def test_no_session_anywhere_raises_an_actionable_auth_error(session_file):
+    with pytest.raises(AuthError) as excinfo:
+        OmiAuth()._load_session()
+
+    message = str(excinfo.value)
+    assert 'com.omi.desktop-dev' in message, 'the operator needs to know what was tried'
+    assert str(session_file) in message
+    assert 'Sign in to the Omi macOS app' in message
+
+
+def test_a_session_file_without_a_refresh_token_triggers_a_re_export(session_file, monkeypatch):
+    """A dump that predates a bundle-id change is present but useless."""
+    session_file.write_text(dump_shape(auth_idToken=ID_TOKEN))
+    dumped = []
+
+    def fake_dump(bundle_id, out_path):
+        dumped.append(bundle_id)
+        Path(out_path).write_text(dump_shape(auth_refreshToken=REFRESH_TOKEN, auth_userId='re-exported'))
+        return True
+
+    monkeypatch.setattr(omi_auth, '_run_dump', fake_dump)
+    session = OmiAuth()._load_session()
+
+    assert dumped == ['com.omi.desktop-dev']
+    assert session.uid == 're-exported'
+
+
+def test_a_dump_that_succeeds_but_yields_nothing_useful_still_raises(session_file, monkeypatch):
+    def fake_dump(bundle_id, out_path):
+        Path(out_path).write_text(dump_shape(auth_idToken=ID_TOKEN))
+        return True
+
+    monkeypatch.setattr(omi_auth, '_run_dump', fake_dump)
+    with pytest.raises(AuthError):
+        OmiAuth()._load_session()
+
+
+def test_bundles_are_tried_in_order_until_one_works(session_file, monkeypatch):
+    tried = []
+
+    def fake_dump(bundle_id, out_path):
+        tried.append(bundle_id)
+        if bundle_id != 'com.omi.second':
+            return False
+        Path(out_path).write_text(dump_shape(auth_refreshToken=REFRESH_TOKEN))
+        return True
+
+    monkeypatch.setattr(omi_auth, '_run_dump', fake_dump)
+    OmiAuth(bundles=('com.omi.first', 'com.omi.second', 'com.omi.third'))._load_session()
+    assert tried == ['com.omi.first', 'com.omi.second']
+
+
+def test_the_source_bundle_env_var_overrides_the_defaults(monkeypatch):
+    monkeypatch.setenv('OMI_SOURCE_BUNDLE', 'com.omi.omi-even-test')
+    assert OmiAuth(bundles=('com.omi.ignored',))._bundles == ('com.omi.omi-even-test',)
+
+
+def test_the_prod_bundle_is_not_tried_by_default():
+    """Reading the prod entry can sit behind a Keychain ACL dialog that blocks
+    indefinitely, and it is the user's real installed app.
+    """
+    assert OmiAuth()._bundles == ('com.omi.desktop-dev',)
+    assert 'com.omi.computer-macos' not in OmiAuth()._bundles
+
+
+# --------------------------------------------------------------------------
+# _refresh
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def loaded_auth(session_file):
+    session_file.write_text(dump_shape(auth_refreshToken=REFRESH_TOKEN, auth_userId='uid-file'))
+    return OmiAuth()
+
+
+@pytest.mark.asyncio
+async def test_refresh_exchanges_the_refresh_token_for_an_id_token(loaded_auth, monkeypatch):
+    requests = install_mock_transport(monkeypatch, firebase_ok())
+    token = await loaded_auth.id_token()
+
+    assert token == ID_TOKEN
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == 'POST'
+    assert request.url.host == 'securetoken.googleapis.com'
+    assert request.headers['content-type'] == 'application/x-www-form-urlencoded'
+
+    body = request.content.decode()
+    assert 'grant_type=refresh_token' in body
+    # In the body, never the query string: URLs end up in proxy access logs.
+    assert REFRESH_TOKEN.replace('-', '%2D') in body or REFRESH_TOKEN in body
+    assert REFRESH_TOKEN not in str(request.url)
+
+
+@pytest.mark.asyncio
+async def test_a_rotated_refresh_token_replaces_the_old_one(loaded_auth, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok(refresh_token='AMf-vBz-ROTATED'))
+    await loaded_auth.id_token()
+    assert loaded_auth._session.refresh_token == 'AMf-vBz-ROTATED'
+
+
+@pytest.mark.asyncio
+async def test_an_absent_refresh_token_keeps_the_current_one(loaded_auth, monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={'id_token': ID_TOKEN, 'expires_in': '3600'})
+
+    install_mock_transport(monkeypatch, handler)
+    await loaded_auth.id_token()
+    assert loaded_auth._session.refresh_token == REFRESH_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_the_expiry_comes_from_the_server_quoted_lifetime(loaded_auth, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok(expires_in='1800'))
+    before = time.time()
+    await loaded_auth.id_token()
+    assert before + 1800 <= loaded_auth._session.expires_at <= time.time() + 1800
+
+
+@pytest.mark.asyncio
+async def test_a_missing_expiry_defaults_to_an_hour(loaded_auth, monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={'id_token': ID_TOKEN})
+
+    install_mock_transport(monkeypatch, handler)
+    await loaded_auth.id_token()
+    assert loaded_auth._session.expires_at >= time.time() + 3500
+
+
+@pytest.mark.asyncio
+async def test_the_uid_comes_from_the_refresh_response(loaded_auth, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok(user_id='firebase-uid-9'))
+    assert await loaded_auth.uid() == 'firebase-uid-9'
+
+
+@pytest.mark.asyncio
+async def test_the_uid_falls_back_to_the_file_when_firebase_omits_it(loaded_auth, monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={'id_token': ID_TOKEN, 'expires_in': '3600'})
+
+    install_mock_transport(monkeypatch, handler)
+    assert await loaded_auth.uid() == 'uid-file'
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_failure_raises_an_actionable_auth_error(loaded_auth, monkeypatch):
+    def handler(request):
+        return httpx.Response(400, json={'error': {'message': 'TOKEN_EXPIRED', 'code': 400}})
+
+    install_mock_transport(monkeypatch, handler)
+    with pytest.raises(AuthError) as excinfo:
+        await loaded_auth.id_token()
+
+    message = str(excinfo.value)
+    assert '400' in message
+    assert 'TOKEN_EXPIRED' in message
+    assert 'sign in again' in message
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_failure_never_echoes_token_material(loaded_auth, monkeypatch):
+    """Firebase error bodies can contain the credential that was rejected."""
+
+    def handler(request):
+        return httpx.Response(
+            400,
+            json={'error': {'message': 'INVALID_REFRESH_TOKEN', 'token': REFRESH_TOKEN}, 'raw': REFRESH_TOKEN},
+        )
+
+    install_mock_transport(monkeypatch, handler)
+    with pytest.raises(AuthError) as excinfo:
+        await loaded_auth.id_token()
+
+    assert REFRESH_TOKEN not in str(excinfo.value)
+    assert REFRESH_TOKEN not in repr(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_a_non_json_error_body_still_raises_an_auth_error(loaded_auth, monkeypatch):
+    def handler(request):
+        return httpx.Response(502, text='<html>Bad Gateway</html>')
+
+    install_mock_transport(monkeypatch, handler)
+    with pytest.raises(AuthError, match='502'):
+        await loaded_auth.id_token()
+
+
+# --------------------------------------------------------------------------
+# Caching, margins and concurrency
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_valid_token_is_reused_rather_than_re_minted(loaded_auth, monkeypatch):
+    requests = install_mock_transport(monkeypatch, firebase_ok())
+    for _ in range(5):
+        assert await loaded_auth.id_token() == ID_TOKEN
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_expired_token_is_refreshed(loaded_auth, monkeypatch):
+    requests = install_mock_transport(monkeypatch, firebase_ok())
+    await loaded_auth.id_token()
+    loaded_auth._session.expires_at = time.time() - 1
+    await loaded_auth.id_token()
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_token_inside_the_safety_margin_is_refreshed_early(loaded_auth, monkeypatch):
+    """Refreshing exactly at expiry loses the race against clock skew and the
+    round trip of the request the token is about to be used for.
+    """
+    requests = install_mock_transport(monkeypatch, firebase_ok())
+    await loaded_auth.id_token()
+
+    loaded_auth._session.expires_at = time.time() + omi_auth._REFRESH_MARGIN_SECONDS - 10
+    await loaded_auth.id_token()
+    assert len(requests) == 2
+
+    loaded_auth._session.expires_at = time.time() + omi_auth._REFRESH_MARGIN_SECONDS + 60
+    await loaded_auth.id_token()
+    assert len(requests) == 2, 'a token outside the margin must not be re-minted'
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_mint_exactly_one_token(loaded_auth, monkeypatch):
+    """The three consumers of this bridge start at once; without the lock they
+    each burn a refresh and the last one wins.
+    """
+
+    def handler(request):
+        return httpx.Response(200, json={'id_token': ID_TOKEN, 'refresh_token': REFRESH_TOKEN, 'expires_in': '3600'})
+
+    requests = install_mock_transport(monkeypatch, handler)
+    tokens = await asyncio.gather(*(loaded_auth.id_token() for _ in range(10)))
+
+    assert tokens == [ID_TOKEN] * 10
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_auth_header_is_a_bearer_header(loaded_auth, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok())
+    assert await loaded_auth.auth_header() == {'Authorization': f'Bearer {ID_TOKEN}'}
+
+
+@pytest.mark.asyncio
+async def test_a_load_failure_surfaces_on_every_call(session_file, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok())
+    auth = OmiAuth()
+    for _ in range(2):
+        with pytest.raises(AuthError):
+            await auth.auth_header()
+
+
+# --------------------------------------------------------------------------
+# describe()
+# --------------------------------------------------------------------------
+
+
+def test_describe_before_any_session_is_loaded():
+    assert OmiAuth().describe() == {'loaded': False}
+
+
+@pytest.mark.asyncio
+async def test_describe_reports_status_without_token_material(loaded_auth, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok())
+    await loaded_auth.id_token()
+    described = loaded_auth.describe()
+
+    assert described['loaded'] is True
+    assert described['uid'] == 'firebase-uid-1'
+    assert 0 < described['expires_in'] <= 3600
+
+    serialised = json.dumps(described)
+    assert ID_TOKEN not in serialised
+    assert REFRESH_TOKEN not in serialised
+    assert 'eyJ' not in serialised, 'no JWT fragment may reach a health endpoint'
+
+
+@pytest.mark.asyncio
+async def test_describe_never_reports_a_negative_lifetime(loaded_auth, monkeypatch):
+    install_mock_transport(monkeypatch, firebase_ok())
+    await loaded_auth.id_token()
+    loaded_auth._session.expires_at = time.time() - 10_000
+    assert loaded_auth.describe()['expires_in'] == 0

--- a/integrations/omi-even/bridge/tests/test_omi_client.py
+++ b/integrations/omi-even/bridge/tests/test_omi_client.py
@@ -1,0 +1,790 @@
+"""Tests for the Omi chat client.
+
+`POST /v2/messages` advertises `text/event-stream` and is not spec SSE: frames
+are `\\n\\n`-*separated* records with a bare prefix, `data:`/`think:` carry a
+literal `__CRLF__` in place of a newline, and the terminal `done:` frame is
+base64 JSON. Every one of those is a place where a plausible-looking
+implementation silently corrupts the answer rather than failing, so the tests
+below pin the exact bytes rather than the general shape.
+
+Two properties get hammered hardest, because they are the ones a network makes
+non-deterministic in production and deterministic here:
+
+* frame boundaries never line up with chunk boundaries;
+* a stream can simply stop -- Omi's agent may run to 150s behind a 120s
+  request timeout, dying as a bare 504 with no terminal frame.
+"""
+
+import asyncio
+import base64
+import json
+import random
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from conftest import FakeAuth, install_mock_transport, streaming_body  # noqa: E402
+from omi_client import ChatEvent, OmiClient, parse_frame  # noqa: E402
+
+
+def b64(payload) -> str:
+    return base64.b64encode(json.dumps(payload).encode('utf-8')).decode('ascii')
+
+
+def done_frame(text: str, **extra) -> bytes:
+    return b'done: ' + b64({'text': text, 'id': 'msg-1', **extra}).encode('ascii')
+
+
+# --------------------------------------------------------------------------
+# parse_frame -- data / think
+# --------------------------------------------------------------------------
+
+
+def test_data_frame_yields_the_token():
+    event = parse_frame('data: The battery regression')
+    assert event == ChatEvent('data', 'The battery regression')
+
+
+def test_data_frame_unescapes_the_literal_crlf_marker():
+    """`__CRLF__` is how Omi transports a newline through a `\\n\\n`-framed
+    protocol. Leaving it un-substituted puts the literal token on the glasses.
+    """
+    event = parse_frame('data: Line one__CRLF__Line two')
+    assert event.text == 'Line one\nLine two'
+    assert '__CRLF__' not in event.text
+
+
+def test_data_frame_unescapes_every_crlf_marker_not_just_the_first():
+    event = parse_frame('data: a__CRLF__b__CRLF__c')
+    assert event.text == 'a\nb\nc'
+
+
+def test_think_frame_unescapes_the_crlf_marker_too():
+    event = parse_frame('think: Searching memories__CRLF__Reading conversations')
+    assert event.kind == 'think'
+    assert event.text == 'Searching memories\nReading conversations'
+
+
+def test_data_frame_preserves_leading_and_trailing_spaces():
+    """Deltas are concatenated verbatim. Stripping them welds words together:
+    "The"+"battery" instead of "The battery".
+    """
+    assert parse_frame('data:  battery').text == ' battery'
+    assert parse_frame('data: battery ').text == 'battery '
+    assert parse_frame('data:   ').text == '  '
+
+
+def test_data_frame_with_an_empty_payload_is_still_a_data_event():
+    event = parse_frame('data: ')
+    assert event == ChatEvent('data', '')
+
+
+def test_data_frame_keeps_a_colon_in_the_payload():
+    assert parse_frame('data: note: ship it').text == 'note: ship it'
+
+
+# --------------------------------------------------------------------------
+# parse_frame -- errors
+# --------------------------------------------------------------------------
+
+
+def test_legacy_402_frame_has_no_space_after_the_colon():
+    """`error:402:` is checked before `error: ` and strips the whole prefix.
+
+    A parser that treats the two as one `error:` check leaves `402:` glued to
+    the front of the user-visible message.
+    """
+    event = parse_frame('error:402:You have used all of your credits')
+    assert event.kind == 'error'
+    assert event.text == 'You have used all of your credits'
+    assert not event.text.startswith('402')
+
+
+def test_402_frame_is_not_confused_with_a_spaced_error_frame():
+    spaced = parse_frame('error: 402 payment required')
+    assert spaced.text == '402 payment required'
+    legacy = parse_frame('error:402:payment required')
+    assert legacy.text == 'payment required'
+
+
+def test_error_frame_strips_surrounding_whitespace():
+    assert parse_frame('error: Something broke   ').text == 'Something broke'
+
+
+def test_empty_error_frame_still_carries_a_message():
+    """An empty error would render as a blank screen -- worse than a wrong one."""
+    event = parse_frame('error: ')
+    assert event.kind == 'error'
+    assert event.text.strip(), 'an error frame must never yield an empty message'
+    assert event.text == 'Omi returned an unspecified error'
+
+
+def test_whitespace_only_error_frame_still_carries_a_message():
+    assert parse_frame('error:    \t ').text == 'Omi returned an unspecified error'
+
+
+def test_error_without_a_space_and_without_402_is_unrecognized():
+    """Pins the prefix set exactly: only `error: ` and `error:402:` are errors.
+
+    Anything else is dropped, which surfaces as a truncated stream rather than
+    a mislabelled one.
+    """
+    assert parse_frame('error:no space here') is None
+
+
+# --------------------------------------------------------------------------
+# parse_frame -- terminal frames
+# --------------------------------------------------------------------------
+
+
+def test_done_frame_decodes_base64_json():
+    event = parse_frame('done: ' + b64({'text': 'All clear.', 'id': 'msg-9'}))
+    assert event.kind == 'done'
+    assert event.text == 'All clear.'
+    assert event.message == {'text': 'All clear.', 'id': 'msg-9'}
+
+
+def test_message_frame_decodes_base64_json():
+    event = parse_frame('message: ' + b64({'text': 'what is on my plate', 'sender': 'human'}))
+    assert event.kind == 'message'
+    assert event.text == 'what is on my plate'
+    assert event.message['sender'] == 'human'
+
+
+def test_done_frame_without_a_text_key_yields_empty_text_not_a_crash():
+    event = parse_frame('done: ' + b64({'id': 'msg-9'}))
+    assert event.kind == 'done'
+    assert event.text == ''
+    assert event.message == {'id': 'msg-9'}
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        'not base64 at all!!',
+        '',
+        '=====',
+        base64.b64encode(b'\xff\xfe\xfd not utf-8').decode('ascii'),
+        base64.b64encode(b'{not json}').decode('ascii'),
+        base64.b64encode(b'{"text": "unterminated').decode('ascii'),
+    ],
+)
+def test_malformed_terminal_payloads_never_raise(payload):
+    """A corrupt terminal frame must degrade to "no answer", not an exception:
+    `parse_frame` runs inside the stream loop with no handler around it.
+    """
+    event = parse_frame('done: ' + payload)
+    assert event.kind == 'done'
+    assert event.text == ''
+    assert event.message is None
+
+
+@pytest.mark.parametrize('payload', ['[1, 2, 3]', '"a bare string"', '123', 'null', 'true'])
+def test_terminal_frame_that_is_valid_json_but_not_an_object_never_raises(payload):
+    """Regression: `_decode_b64_json` is typed `dict | None` but `json.loads`
+    happily returns lists, strings and numbers, and `parse_frame` then called
+    `.get()` on them -- an AttributeError straight out of the stream loop.
+    """
+    encoded = base64.b64encode(payload.encode()).decode('ascii')
+    for prefix in ('done: ', 'message: '):
+        event = parse_frame(prefix + encoded)
+        assert event.text == ''
+        assert event.message is None
+
+
+def test_done_frame_carries_the_full_decoded_message_for_the_caller():
+    body = {'text': 'ok', 'id': 'm1', 'memories': [{'id': 'x'}], 'type': 'text'}
+    event = parse_frame('done: ' + b64(body))
+    assert event.message == body
+
+
+# --------------------------------------------------------------------------
+# parse_frame -- unrecognized input
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'frame',
+    [
+        '',
+        '   ',
+        'ping',
+        ': keepalive',
+        'event: message',
+        'id: 42',
+        'retry: 3000',
+        'data:no space',
+        'think:no space',
+        'done:no space',
+        'DATA: uppercase',
+        '{"text": "raw json, not a frame"}',
+        'garbage',
+    ],
+)
+def test_unrecognized_frames_return_none(frame):
+    assert parse_frame(frame) is None
+
+
+def test_parse_frame_never_raises_on_random_input():
+    rng = random.Random(20240727)
+    prefixes = ['data: ', 'think: ', 'done: ', 'message: ', 'error: ', 'error:402:', '', 'x: ']
+    alphabet = 'abz09 :\n\t=+/{}"[]' + '__CRLF__'
+    for _ in range(2000):
+        frame = rng.choice(prefixes) + ''.join(rng.choice(alphabet) for _ in range(rng.randint(0, 40)))
+        result = parse_frame(frame)
+        assert result is None or isinstance(result, ChatEvent)
+
+
+# --------------------------------------------------------------------------
+# chat_stream -- request shape
+# --------------------------------------------------------------------------
+
+
+def make_client(monkeypatch, chunks, status=200, auth=None):
+    """An OmiClient whose one HTTP call replays `chunks` as the response body."""
+
+    def handler(request):
+        return httpx.Response(status, content=streaming_body(chunks))
+
+    requests = install_mock_transport(monkeypatch, handler)
+    return OmiClient(auth or FakeAuth(), 'https://api.omi.me'), requests
+
+
+async def collect(stream):
+    return [event async for event in stream]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_posts_the_expected_request(monkeypatch):
+    client, requests = make_client(monkeypatch, [done_frame('hi')])
+    await collect(client.chat_stream('what is on my plate'))
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == 'POST'
+    assert str(request.url) == 'https://api.omi.me/v2/messages'
+    assert request.headers['authorization'] == 'Bearer fake-id-token'
+    assert request.headers['content-type'] == 'application/json'
+    assert json.loads(request.content) == {'text': 'what is on my plate', 'file_ids': []}
+    # Deliberately absent: only `desktop` is trial-paywalled, and a skewed
+    # X-Request-Start-Time is rejected with a 408.
+    assert 'x-app-platform' not in request.headers
+    assert 'x-request-start-time' not in request.headers
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_passes_app_id_as_a_query_param(monkeypatch):
+    client, requests = make_client(monkeypatch, [done_frame('hi')])
+    await collect(client.chat_stream('hello', app_id='omi-standup'))
+    assert requests[0].url.params['app_id'] == 'omi-standup'
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_omits_the_query_string_without_an_app_id(monkeypatch):
+    client, requests = make_client(monkeypatch, [done_frame('hi')])
+    await collect(client.chat_stream('hello'))
+    assert requests[0].url.query == b''
+
+
+@pytest.mark.asyncio
+async def test_base_url_trailing_slash_is_normalised(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, content=streaming_body([done_frame('hi')]))
+
+    requests = install_mock_transport(monkeypatch, handler)
+    client = OmiClient(FakeAuth(), 'https://api.omi.me/')
+    await collect(client.chat_stream('hello'))
+    assert str(requests[0].url) == 'https://api.omi.me/v2/messages'
+
+
+# --------------------------------------------------------------------------
+# chat_stream -- framing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_several_frames_in_one_chunk_are_all_emitted(monkeypatch):
+    chunk = b'think: Searching\n\ndata: All\n\ndata:  clear.\n\n' + done_frame('All clear.') + b'\n\n'
+    client, _ = make_client(monkeypatch, [chunk])
+    events = await collect(client.chat_stream('hi'))
+    assert [(e.kind, e.text) for e in events] == [
+        ('think', 'Searching'),
+        ('data', 'All'),
+        ('data', ' clear.'),
+        ('done', 'All clear.'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_frame_split_across_two_chunks_is_reassembled(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'data: All cl', b'ear.\n\n'])
+    events = await collect(client.chat_stream('hi'))
+    assert [(e.kind, e.text) for e in events] == [('data', 'All clear.')]
+
+
+@pytest.mark.asyncio
+async def test_a_separator_split_across_two_chunks_is_reassembled(monkeypatch):
+    """The nastiest boundary: the `\\n\\n` itself straddles two TCP reads."""
+    client, _ = make_client(monkeypatch, [b'data: one\n', b'\ndata: two\n\n'])
+    events = await collect(client.chat_stream('hi'))
+    assert [e.text for e in events] == ['one', 'two']
+
+
+@pytest.mark.asyncio
+async def test_a_final_frame_with_no_trailing_separator_is_still_emitted(monkeypatch):
+    """Frames are separated, not terminated -- the tail is a real frame."""
+    client, _ = make_client(monkeypatch, [b'data: All clear.\n\n' + done_frame('All clear.')])
+    events = await collect(client.chat_stream('hi'))
+    assert [e.kind for e in events] == ['data', 'done']
+    assert events[-1].text == 'All clear.'
+
+
+@pytest.mark.asyncio
+async def test_a_lone_trailing_separator_does_not_emit_an_empty_frame(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'data: hi\n\n\n\n'])
+    events = await collect(client.chat_stream('hi'))
+    assert [e.text for e in events] == ['hi']
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_tail_is_not_emitted(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'data: hi\n\n   \n  '])
+    events = await collect(client.chat_stream('hi'))
+    assert [e.text for e in events] == ['hi']
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_frames_are_skipped_without_stopping_the_stream(monkeypatch):
+    body = b': keepalive\n\ndata: one\n\nevent: noise\n\ndata: two\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    events = await collect(client.chat_stream('hi'))
+    assert [e.text for e in events] == ['one', 'two']
+
+
+@pytest.mark.asyncio
+async def test_a_single_newline_does_not_terminate_a_frame(monkeypatch):
+    """Frames are `\\n\\n`-delimited; a lone `\\n` is content.
+
+    Splitting on `\\n` would truncate this think line at "Searching" and then
+    drop "your memories" as an unrecognized frame.
+    """
+    client, _ = make_client(monkeypatch, [b'think: Searching\nyour memories\n\ndata: hi\n\n'])
+    events = await collect(client.chat_stream('hi'))
+    assert [(e.kind, e.text) for e in events] == [
+        ('think', 'Searching\nyour memories'),
+        ('data', 'hi'),
+    ]
+
+
+# A small but complete stream, with every trap in it: a multi-byte character
+# (so a naive per-chunk decode corrupts it), a lone newline inside a frame, a
+# `__CRLF__` escape, a leading-space delta, and a terminal `done:`.
+BOUNDARY_BODY = (
+    'think: Searching\nyour memories\n\n'
+    'data: The battery\n\n'
+    'data:  regression—open\n\n'
+    'data: __CRLF__Owner: Sarah\n\n'
+    'done: ' + b64({'text': 'The battery regression—open.\nOwner: Sarah'}) + '\n\n'
+).encode('utf-8')
+
+BOUNDARY_EXPECTED = [
+    ('think', 'Searching\nyour memories'),
+    ('data', 'The battery'),
+    ('data', ' regression—open'),
+    ('data', '\nOwner: Sarah'),
+    ('done', 'The battery regression—open.\nOwner: Sarah'),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('split', range(len(BOUNDARY_BODY) + 1))
+async def test_every_possible_two_chunk_split_decodes_identically(monkeypatch, split):
+    """Exhaustive: the network may break the body at any byte, including in the
+    middle of a separator, a base64 payload or a UTF-8 sequence.
+    """
+    chunks = [c for c in (BOUNDARY_BODY[:split], BOUNDARY_BODY[split:]) if c]
+    client, _ = make_client(monkeypatch, chunks)
+    events = await collect(client.chat_stream('hi'))
+    assert [(e.kind, e.text) for e in events] == BOUNDARY_EXPECTED
+
+
+@pytest.mark.asyncio
+async def test_one_byte_at_a_time_decodes_identically(monkeypatch):
+    chunks = [BOUNDARY_BODY[i : i + 1] for i in range(len(BOUNDARY_BODY))]
+    client, _ = make_client(monkeypatch, chunks)
+    events = await collect(client.chat_stream('hi'))
+    assert [(e.kind, e.text) for e in events] == BOUNDARY_EXPECTED
+
+
+@pytest.mark.asyncio
+async def test_random_multi_chunk_splits_decode_identically(monkeypatch):
+    rng = random.Random(99)
+    for _ in range(40):
+        cuts = sorted(rng.sample(range(1, len(BOUNDARY_BODY)), rng.randint(1, 6)))
+        bounds = [0, *cuts, len(BOUNDARY_BODY)]
+        chunks = [BOUNDARY_BODY[a:b] for a, b in zip(bounds, bounds[1:]) if b > a]
+        client, _ = make_client(monkeypatch, chunks)
+        events = await collect(client.chat_stream('hi'))
+        assert [(e.kind, e.text) for e in events] == BOUNDARY_EXPECTED, f'cuts={cuts}'
+
+
+@pytest.mark.asyncio
+async def test_empty_body_yields_no_events(monkeypatch):
+    client, _ = make_client(monkeypatch, [])
+    assert await collect(client.chat_stream('hi')) == []
+
+
+# --------------------------------------------------------------------------
+# chat_stream -- transport failures
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_200_yields_exactly_one_error_event(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'{"detail": "boom"}'], status=500)
+    events = await collect(client.chat_stream('hi'))
+    assert len(events) == 1
+    assert events[0].kind == 'error'
+    assert events[0].text.startswith('HTTP 500:')
+    assert 'boom' in events[0].text
+
+
+@pytest.mark.asyncio
+async def test_non_200_body_is_truncated_so_a_html_error_page_cannot_flood_the_glasses(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'x' * 100_000], status=502)
+    events = await collect(client.chat_stream('hi'))
+    assert len(events) == 1
+    assert len(events[0].text) <= len('HTTP 502: ') + 300
+
+
+@pytest.mark.asyncio
+async def test_non_200_does_not_parse_the_body_as_frames(monkeypatch):
+    """A 401 page that happens to contain `data: ` must not look like an answer."""
+    client, _ = make_client(monkeypatch, [b'data: you are not signed in\n\n'], status=401)
+    events = await collect(client.chat_stream('hi'))
+    assert [e.kind for e in events] == ['error']
+
+
+@pytest.mark.asyncio
+async def test_a_204_with_no_body_is_still_an_error(monkeypatch):
+    client, _ = make_client(monkeypatch, [], status=204)
+    events = await collect(client.chat_stream('hi'))
+    assert [e.kind for e in events] == ['error']
+    assert 'HTTP 204' in events[0].text
+
+
+# --------------------------------------------------------------------------
+# chat -- accumulation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_joins_deltas_in_order(monkeypatch):
+    body = b'data: The\n\ndata:  battery\n\ndata:  regression.\n\n' + done_frame('') + b'\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    result = await client.chat('hi')
+    assert result.text == 'The battery regression.'
+    assert result.error is None
+    assert result.truncated is False
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_done_text_is_authoritative_over_the_deltas(monkeypatch):
+    """The deltas can be a partial or re-written draft; `done:` is the answer."""
+    body = b'data: partial dr\n\ndata: aft\n\n' + done_frame('The final, corrected answer.') + b'\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    result = await client.chat('hi')
+    assert result.text == 'The final, corrected answer.'
+    assert 'partial' not in result.text
+
+
+@pytest.mark.asyncio
+async def test_empty_done_text_falls_back_to_the_deltas(monkeypatch):
+    body = b'data: from the deltas\n\n' + done_frame('') + b'\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    assert (await client.chat('hi')).text == 'from the deltas'
+
+
+@pytest.mark.asyncio
+async def test_chat_collects_thinking_lines_separately_from_the_answer(monkeypatch):
+    body = b'think: Searching memories\n\nthink: Reading conversations\n\ndata: Done.\n\n' + done_frame('Done.') + b'\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    result = await client.chat('hi')
+    assert result.thinking == ['Searching memories', 'Reading conversations']
+    assert result.text == 'Done.'
+
+
+@pytest.mark.asyncio
+async def test_chat_strips_surrounding_whitespace_from_the_answer(monkeypatch):
+    body = b'data: \n\ndata:   All clear.  \n\n'
+    client, _ = make_client(monkeypatch, [body])
+    assert (await client.chat('hi')).text == 'All clear.'
+
+
+@pytest.mark.asyncio
+async def test_chat_stops_consuming_after_the_terminal_frame(monkeypatch):
+    body = done_frame('final') + b'\n\ndata: this must never be read\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    result = await client.chat('hi')
+    assert result.text == 'final'
+    assert 'never' not in result.text
+
+
+@pytest.mark.asyncio
+async def test_error_frame_populates_error_and_is_terminal(monkeypatch):
+    body = b'data: partial\n\nerror: quota exhausted\n\ndata: after the error\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    result = await client.chat('hi')
+    assert result.error == 'quota exhausted'
+    assert result.truncated is False, 'an error frame is a terminal frame'
+    assert result.ok is False
+    assert 'after the error' not in result.text
+
+
+@pytest.mark.asyncio
+async def test_a_402_quota_frame_surfaces_as_an_error(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'error:402:Out of credits\n\n'])
+    result = await client.chat('hi')
+    assert result.error == 'Out of credits'
+
+
+@pytest.mark.asyncio
+async def test_a_stream_that_ends_without_a_terminal_frame_is_truncated(monkeypatch):
+    """The agent's 150s cap sits behind a 120s request timeout, so a slow answer
+    dies as a bare 504 mid-stream. That is a real outcome, not an impossibility.
+    """
+    client, _ = make_client(monkeypatch, [b'data: The battery reg\n\n'])
+    result = await client.chat('hi')
+    assert result.text == 'The battery reg'
+    assert result.truncated is True
+    assert result.error is None
+    assert result.ok is True, 'a partial answer is still an answer'
+
+
+@pytest.mark.asyncio
+async def test_an_entirely_empty_stream_is_truncated_and_not_ok(monkeypatch):
+    client, _ = make_client(monkeypatch, [])
+    result = await client.chat('hi')
+    assert result.text == ''
+    assert result.truncated is True
+    assert result.ok is False
+
+
+@pytest.mark.asyncio
+async def test_chat_reports_elapsed_time(monkeypatch):
+    client, _ = make_client(monkeypatch, [done_frame('hi') + b'\n\n'])
+    result = await client.chat('hi')
+    assert 0 <= result.elapsed_s < 5
+
+
+@pytest.mark.asyncio
+async def test_http_error_becomes_a_chat_error_not_an_exception(monkeypatch):
+    client, _ = make_client(monkeypatch, [b'nope'], status=503)
+    result = await client.chat('hi')
+    assert result.error and 'HTTP 503' in result.error
+    assert result.ok is False
+
+
+# --------------------------------------------------------------------------
+# chat -- the deadline
+# --------------------------------------------------------------------------
+
+
+def make_stalling_client(monkeypatch, first: bytes, stall_seconds: float = 5.0):
+    """A stream that emits `first`, then hangs -- Omi's slow-agent failure mode."""
+
+    def handler(request):
+        async def body():
+            yield first
+            await asyncio.sleep(stall_seconds)
+            yield b'done: never arrives\n\n'
+
+        return httpx.Response(200, content=body())
+
+    install_mock_transport(monkeypatch, handler)
+    return OmiClient(FakeAuth(), 'https://api.omi.me')
+
+
+@pytest.mark.asyncio
+async def test_deadline_returns_the_partial_answer_instead_of_hanging(monkeypatch):
+    client = make_stalling_client(monkeypatch, b'data: The battery regression is\n\n')
+    # The outer wait_for turns "it hangs" into a failure rather than a hung suite.
+    result = await asyncio.wait_for(client.chat('hi', deadline_s=0.1), timeout=5)
+    assert result.text == 'The battery regression is'
+    assert result.truncated is True
+    assert result.error is None
+    assert result.elapsed_s < 2, 'the deadline must cut the stream, not wait it out'
+
+
+@pytest.mark.asyncio
+async def test_deadline_keeps_every_delta_received_before_it_fired(monkeypatch):
+    client = make_stalling_client(monkeypatch, b'data: one\n\ndata:  two\n\ndata:  three\n\n')
+    result = await asyncio.wait_for(client.chat('hi', deadline_s=0.1), timeout=5)
+    assert result.text == 'one two three'
+    assert result.truncated is True
+
+
+@pytest.mark.asyncio
+async def test_an_already_expired_deadline_returns_immediately(monkeypatch):
+    client = make_stalling_client(monkeypatch, b'data: never read\n\n')
+    result = await asyncio.wait_for(client.chat('hi', deadline_s=0), timeout=5)
+    assert result.text == ''
+    assert result.truncated is True
+
+
+@pytest.mark.asyncio
+async def test_no_deadline_waits_for_the_terminal_frame(monkeypatch):
+    body = b'data: slow\n\n' + done_frame('slow but complete') + b'\n\n'
+    client, _ = make_client(monkeypatch, [body])
+    result = await asyncio.wait_for(client.chat('hi'), timeout=5)
+    assert result.text == 'slow but complete'
+    assert result.truncated is False
+
+
+@pytest.mark.asyncio
+async def test_a_generous_deadline_does_not_truncate_a_fast_answer(monkeypatch):
+    client, _ = make_client(monkeypatch, [done_frame('quick') + b'\n\n'])
+    result = await client.chat('hi', deadline_s=30)
+    assert result.text == 'quick'
+    assert result.truncated is False
+
+
+@pytest.mark.asyncio
+async def test_the_deadline_bounds_the_whole_turn_not_each_frame(monkeypatch):
+    """Three 60ms gaps against a 100ms deadline: a per-frame timeout would let
+    the turn run to 180ms+.
+    """
+
+    def handler(request):
+        async def body():
+            for i in range(6):
+                yield f'data: {i}'.encode() + b'\n\n'
+                await asyncio.sleep(0.06)
+
+        return httpx.Response(200, content=body())
+
+    install_mock_transport(monkeypatch, handler)
+    client = OmiClient(FakeAuth(), 'https://api.omi.me')
+    result = await asyncio.wait_for(client.chat('hi', deadline_s=0.1), timeout=5)
+    assert result.truncated is True
+    assert result.elapsed_s < 0.5
+    assert len(result.text) < 6
+
+
+# --------------------------------------------------------------------------
+# JSON endpoints
+# --------------------------------------------------------------------------
+
+
+def make_json_client(monkeypatch, payload, status=200):
+    def handler(request):
+        return httpx.Response(status, json=payload)
+
+    requests = install_mock_transport(monkeypatch, handler)
+    return OmiClient(FakeAuth(), 'https://api.omi.me'), requests
+
+
+@pytest.mark.asyncio
+async def test_memories_are_sliced_client_side(monkeypatch):
+    """`offset=0` makes the server ignore `limit` and return up to 5000 rows."""
+    client, requests = make_json_client(monkeypatch, [{'id': str(i)} for i in range(500)])
+    rows = await client.memories(limit=3)
+    assert len(rows) == 3
+    assert requests[0].url.params['offset'] == '0'
+    assert requests[0].url.path == '/v3/memories'
+
+
+@pytest.mark.asyncio
+async def test_memories_tolerates_a_non_list_payload(monkeypatch):
+    client, _ = make_json_client(monkeypatch, {'detail': 'nope'})
+    assert await client.memories() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'payload,expected',
+    [
+        ([{'id': 'a'}], [{'id': 'a'}]),
+        ({'action_items': [{'id': 'b'}]}, [{'id': 'b'}]),
+        ({'items': [{'id': 'c'}]}, [{'id': 'c'}]),
+        ({'nothing': 1}, []),
+    ],
+)
+async def test_action_items_unwraps_either_envelope(monkeypatch, payload, expected):
+    client, _ = make_json_client(monkeypatch, payload)
+    assert await client.action_items() == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'payload,expected',
+    [
+        ([{'summary': 'a'}], [{'summary': 'a'}]),
+        ({'daily_summaries': [{'summary': 'b'}]}, [{'summary': 'b'}]),
+        ({'items': [{'summary': 'c'}]}, [{'summary': 'c'}]),
+    ],
+)
+async def test_daily_summaries_unwraps_either_envelope(monkeypatch, payload, expected):
+    client, _ = make_json_client(monkeypatch, payload)
+    assert await client.daily_summaries() == expected
+
+
+@pytest.mark.asyncio
+async def test_get_messages_returns_the_newest_rows_last(monkeypatch):
+    client, _ = make_json_client(monkeypatch, [{'id': str(i)} for i in range(10)])
+    rows = await client.get_messages(limit=3)
+    assert [r['id'] for r in rows] == ['7', '8', '9']
+
+
+@pytest.mark.asyncio
+async def test_json_endpoints_raise_on_http_errors(monkeypatch):
+    client, _ = make_json_client(monkeypatch, {'detail': 'nope'}, status=401)
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.memories()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_pcm_sends_raw_octets_with_the_g2_audio_parameters(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={'transcript': 'what is on my plate'})
+
+    requests = install_mock_transport(monkeypatch, handler)
+    client = OmiClient(FakeAuth(), 'https://api.omi.me')
+    pcm = b'\x01\x02' * 100
+    assert await client.transcribe_pcm(pcm) == 'what is on my plate'
+
+    request = requests[0]
+    assert request.headers['content-type'] == 'application/octet-stream'
+    assert request.content == pcm
+    # The G2 mic is PCM16 LE mono at 16 kHz -- nothing is resampled.
+    assert request.url.params['encoding'] == 'linear16'
+    assert request.url.params['sample_rate'] == '16000'
+    assert request.url.params['channels'] == '1'
+
+
+@pytest.mark.asyncio
+async def test_transcribe_pcm_raises_a_readable_error_on_failure(monkeypatch):
+    def handler(request):
+        return httpx.Response(413, text='payload too large')
+
+    install_mock_transport(monkeypatch, handler)
+    client = OmiClient(FakeAuth(), 'https://api.omi.me')
+    with pytest.raises(RuntimeError, match='413'):
+        await client.transcribe_pcm(b'\x00' * 10)
+
+
+@pytest.mark.asyncio
+async def test_auth_failures_propagate_out_of_the_stream(monkeypatch):
+    """No token means no request: the caller must see the auth error, not an
+    empty answer that looks like Omi had nothing to say.
+    """
+    boom = RuntimeError('no signed-in session')
+    client, requests = make_client(monkeypatch, [done_frame('hi')], auth=FakeAuth(fail=boom))
+    with pytest.raises(RuntimeError, match='no signed-in session'):
+        await collect(client.chat_stream('hi'))
+    assert requests == []

--- a/integrations/omi-even/bridge/tests/test_omi_client.py
+++ b/integrations/omi-even/bridge/tests/test_omi_client.py
@@ -512,7 +512,9 @@ async def test_empty_done_text_falls_back_to_the_deltas(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_chat_collects_thinking_lines_separately_from_the_answer(monkeypatch):
-    body = b'think: Searching memories\n\nthink: Reading conversations\n\ndata: Done.\n\n' + done_frame('Done.') + b'\n\n'
+    body = (
+        b'think: Searching memories\n\nthink: Reading conversations\n\ndata: Done.\n\n' + done_frame('Done.') + b'\n\n'
+    )
     client, _ = make_client(monkeypatch, [body])
     result = await client.chat('hi')
     assert result.thinking == ['Searching memories', 'Reading conversations']

--- a/integrations/omi-even/bridge/tests/test_push_regression.py
+++ b/integrations/omi-even/bridge/tests/test_push_regression.py
@@ -1,0 +1,201 @@
+"""Regression tests for the proactive push loop.
+
+The bug these exist for: `_push_loop` fetched a small window of action items and
+trusted the server's ordering. `GET /v1/action-items` does **not** return
+newest-first -- against the live account a freshly created task appeared at index
+20 of 100, so a `limit=20` poll watched only the twenty *oldest* tasks. The loop
+was a silent no-op: it never raised, never logged, and could never fire.
+
+That failure mode is invisible to any test that stubs the endpoint as
+newest-first, so these tests deliberately return items in an adversarial order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import server
+
+
+class _FakeOmi:
+    """Serves action items in a hostile order, like the real endpoint does."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.requested_limits: list[int] = []
+
+    async def action_items(self, limit: int = 20) -> list[dict]:
+        self.requested_limits.append(limit)
+        return list(self.rows[:limit])
+
+
+def _item(item_id: str, created_at: str, description: str = 'task', completed: bool = False) -> dict:
+    return {
+        'id': item_id,
+        'created_at': created_at,
+        'description': description,
+        'completed': completed,
+    }
+
+
+@pytest.fixture
+def collected(monkeypatch):
+    """Capture everything broadcast to connected glasses apps."""
+    sent: list[dict] = []
+
+    async def fake_broadcast(payload: dict) -> None:
+        sent.append(payload)
+
+    monkeypatch.setattr(server, 'broadcast', fake_broadcast)
+    # A non-empty client set, since the loop skips polling when nobody is connected.
+    monkeypatch.setattr(server, '_clients', {object()})
+    return sent
+
+
+async def _run_push_loop(cycles: int, interval: float = 0.01) -> None:
+    """Run the real loop for a bounded number of polls, then cancel it."""
+    task = asyncio.create_task(server._push_loop())
+    # Each cycle is one sleep + one poll; give it room without being flaky.
+    await asyncio.sleep(interval * cycles * 6 + 0.15)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_new_task_outside_the_default_window_is_still_detected(monkeypatch, collected):
+    """The exact live failure: the new task is not near the front of the response.
+
+    Twenty-five old tasks are returned before the new one. With a `limit=20` fetch
+    and no client-side sort, the new task is never even seen.
+    """
+    old = [_item(f'old-{i}', f'2026-07-0{i % 9 + 1}T00:00:00', f'old task {i}') for i in range(25)]
+    fake = _FakeOmi(old)
+
+    monkeypatch.setattr(server, 'omi', fake)
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+    monkeypatch.setenv('OMI_EVEN_PUSH_WINDOW', '100')
+
+    async def scenario() -> None:
+        task = asyncio.create_task(server._push_loop())
+        await asyncio.sleep(0.08)  # let the first pass seed the baseline
+        # Arrives buried mid-list, exactly as the real endpoint delivered it.
+        fake.rows.insert(20, _item('brand-new', '2026-07-27T12:00:00', 'Push regression check'))
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    await scenario()
+
+    pushed = [p for p in collected if p.get('type') == 'push']
+    assert pushed, 'a task created after startup must push even when buried in the response'
+    assert 'Push regression check' in pushed[0]['text']
+    # And the window must be large enough to have contained it.
+    assert max(fake.requested_limits) >= 100
+
+
+@pytest.mark.asyncio
+async def test_preexisting_tasks_never_push(monkeypatch, collected):
+    """Startup must not dump every existing task onto the display."""
+    fake = _FakeOmi([_item(f'existing-{i}', f'2026-07-1{i}T00:00:00') for i in range(5)])
+    monkeypatch.setattr(server, 'omi', fake)
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+
+    await _run_push_loop(cycles=3)
+
+    assert not [p for p in collected if p.get('type') == 'push']
+
+
+@pytest.mark.asyncio
+async def test_completed_tasks_do_not_push_but_are_still_marked_seen(monkeypatch, collected):
+    """A task created already-completed is noise, and must not push twice later."""
+    fake = _FakeOmi([_item('a', '2026-07-01T00:00:00')])
+    monkeypatch.setattr(server, 'omi', fake)
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+
+    async def scenario() -> None:
+        task = asyncio.create_task(server._push_loop())
+        await asyncio.sleep(0.08)
+        fake.rows.append(_item('done-task', '2026-07-27T12:00:00', 'already done', completed=True))
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    await scenario()
+
+    assert not [p for p in collected if p.get('type') == 'push']
+
+
+@pytest.mark.asyncio
+async def test_a_task_pushes_exactly_once(monkeypatch, collected):
+    """Polling repeatedly must not re-announce the same task."""
+    fake = _FakeOmi([_item('a', '2026-07-01T00:00:00')])
+    monkeypatch.setattr(server, 'omi', fake)
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+
+    async def scenario() -> None:
+        task = asyncio.create_task(server._push_loop())
+        await asyncio.sleep(0.08)
+        fake.rows.append(_item('new', '2026-07-27T12:00:00', 'only once'))
+        await asyncio.sleep(0.4)  # many further polls
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    await scenario()
+
+    pushed = [p for p in collected if p.get('type') == 'push']
+    assert len(pushed) == 1, f'expected exactly one push, got {len(pushed)}'
+
+
+@pytest.mark.asyncio
+async def test_poll_failure_does_not_kill_the_loop(monkeypatch, collected):
+    """One bad poll must not silently end proactive push for the session."""
+    calls = {'n': 0}
+    rows = [_item('a', '2026-07-01T00:00:00')]
+
+    class Flaky:
+        async def action_items(self, limit: int = 20) -> list[dict]:
+            calls['n'] += 1
+            if calls['n'] == 2:
+                raise RuntimeError('transient upstream failure')
+            return list(rows)
+
+    monkeypatch.setattr(server, 'omi', Flaky())
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+
+    async def scenario() -> None:
+        task = asyncio.create_task(server._push_loop())
+        await asyncio.sleep(0.1)  # seed, then hit the failing poll
+        rows.append(_item('after-failure', '2026-07-27T12:00:00', 'still alive'))
+        await asyncio.sleep(0.25)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    await scenario()
+
+    assert calls['n'] > 2, 'the loop stopped polling after a failure'
+    pushed = [p for p in collected if p.get('type') == 'push']
+    assert pushed and 'still alive' in pushed[0]['text']
+
+
+def test_created_at_sort_key_tolerates_missing_values():
+    """Rows without a timestamp must sort rather than raise."""
+    rows = [{'id': 'a'}, {'id': 'b', 'created_at': '2026-07-27T00:00:00'}]
+    rows.sort(key=server._created_at, reverse=True)
+    assert rows[0]['id'] == 'b'  # dated item is newest; undated sorts oldest

--- a/integrations/omi-even/bridge/tests/test_server.py
+++ b/integrations/omi-even/bridge/tests/test_server.py
@@ -585,7 +585,9 @@ def test_ping_is_answered(bridge):
         assert ws.receive_json() == {'type': 'pong'}
 
 
-@pytest.mark.parametrize('raw', ['not json', '', '[1, 2, 3]', '"a string"', 'null', '{"no type": 1}', '{"type": "nope"}'])
+@pytest.mark.parametrize(
+    'raw', ['not json', '', '[1, 2, 3]', '"a string"', 'null', '{"no type": 1}', '{"type": "nope"}']
+)
 def test_junk_and_unknown_messages_are_ignored_without_a_reply(bridge, raw):
     """An unknown type must be a silent no-op, not an error frame and not a
     close -- the plugin and the bridge ship on different schedules.

--- a/integrations/omi-even/bridge/tests/test_server.py
+++ b/integrations/omi-even/bridge/tests/test_server.py
@@ -1024,3 +1024,32 @@ async def test_the_push_loop_does_not_poll_without_a_connected_app(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         await task
     assert calls == 0
+
+
+def test_shutdown_is_clean_when_background_tasks_are_cancelled(monkeypatch):
+    """Lifespan shutdown must not raise, whatever the background tasks did.
+
+    `CancelledError` is a `BaseException`, so `suppress(Exception)` does not
+    catch it -- a detail that turned an ordinary shutdown into a traceback in
+    the bridge log until it was named explicitly. The local-model warmer is the
+    other half: it runs forever, so it is always mid-flight at shutdown, and if
+    it has already died the await must swallow that too.
+    """
+    started = []
+
+    async def dies_immediately():
+        started.append('dead')
+        raise RuntimeError('warmer blew up')
+
+    async def sleeps_forever():
+        started.append('sleeping')
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(server, '_push_loop', sleeps_forever)
+    monkeypatch.setattr(server.local_llm, 'warm_forever', dies_immediately)
+    monkeypatch.delenv('OMI_EVEN_NO_LOCAL', raising=False)
+
+    with TestClient(server.app) as client:
+        assert client.get('/health').status_code == 200
+
+    assert set(started) == {'dead', 'sleeping'}

--- a/integrations/omi-even/bridge/tests/test_server.py
+++ b/integrations/omi-even/bridge/tests/test_server.py
@@ -1,0 +1,1015 @@
+"""Tests for the bridge itself: the Even AI agent endpoint and the glasses socket.
+
+Both consumers are unforgiving in the same way -- they have no error UI. The
+Even phone app renders `choices[0].message.content` and nothing else, and the
+Hub plugin renders whatever text frame arrives. So the contract asserted here is
+that *something displayable always comes back*: never a 500, never a body that
+overflows the 400-character screen, and never a socket that dies because one
+message handler raised.
+
+`server.omi` and `server.auth` are replaced wholesale; no test may reach
+api.omi.me (see `conftest._no_network`).
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server  # noqa: E402
+from conftest import AUTH_HEADER, EVEN_TOKEN, FakeAuth  # noqa: E402
+from capture import CaptureStats  # noqa: E402
+from display import DEFAULT_LIMIT  # noqa: E402
+from omi_client import ChatEvent, ChatResult  # noqa: E402
+
+AGENT_PATHS = ['/', '/v1/chat/completions', '/chat/completions']
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class FakeOmi:
+    """Every Omi call the bridge makes, scripted."""
+
+    def __init__(self) -> None:
+        self.chat_result = ChatResult(text='All clear.')
+        self.chat_exc: Exception | None = None
+        self.stream_events = [ChatEvent('done', 'All clear.')]
+        self.stream_exc: Exception | None = None
+        self.memories_rows: list[dict] = []
+        self.action_rows: list[dict] = []
+        self.summary_rows: list[dict] = []
+        self.transcript = ''
+        self.quota: dict = {'plan': 'unlimited'}
+        self.quota_exc: Exception | None = None
+        self.calls: list = []
+
+    async def chat(self, text, app_id=None, deadline_s=None):
+        self.calls.append(('chat', text, deadline_s))
+        if self.chat_exc:
+            raise self.chat_exc
+        return self.chat_result
+
+    async def chat_stream(self, text, app_id=None):
+        self.calls.append(('chat_stream', text))
+        if self.stream_exc:
+            raise self.stream_exc
+        for event in self.stream_events:
+            yield event
+
+    async def memories(self, limit=20):
+        self.calls.append(('memories', limit))
+        if isinstance(self.memories_rows, Exception):
+            raise self.memories_rows
+        return self.memories_rows[:limit]
+
+    async def action_items(self, limit=20):
+        self.calls.append(('action_items', limit))
+        if isinstance(self.action_rows, Exception):
+            raise self.action_rows
+        return self.action_rows[:limit]
+
+    async def daily_summaries(self, limit=3):
+        self.calls.append(('daily_summaries', limit))
+        return self.summary_rows[:limit]
+
+    async def transcribe_pcm(self, pcm, **kwargs):
+        self.calls.append(('transcribe_pcm', pcm))
+        return self.transcript
+
+    async def usage_quota(self):
+        if self.quota_exc:
+            raise self.quota_exc
+        return self.quota
+
+
+class FakeCaptureSession:
+    """Stands in for `CaptureSession` so no test opens the listen socket."""
+
+    def __init__(self, auth, base_url, on_segments=None, on_event=None) -> None:
+        self.auth = auth
+        self.base_url = base_url
+        self.on_segments = on_segments
+        self.fed: list[bytes] = []
+        self.starts = 0
+        self.stops: list[bool] = []
+        self.start_segments: list[dict] | None = None
+        self.stats = CaptureStats(bytes_sent=32000, conversation_id='conv-7')
+
+    async def start(self) -> None:
+        self.starts += 1
+        if self.start_segments and self.on_segments:
+            await self.on_segments(self.start_segments)
+
+    async def stop(self, finalize=True):
+        self.stops.append(finalize)
+        return self.stats
+
+    def feed(self, pcm: bytes) -> None:
+        self.fed.append(pcm)
+
+
+@pytest.fixture
+def bridge(monkeypatch, tmp_path):
+    omi = FakeOmi()
+    sessions: list[FakeCaptureSession] = []
+
+    class _Session(FakeCaptureSession):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            sessions.append(self)
+
+    monkeypatch.setattr(server, 'omi', omi)
+    monkeypatch.setattr(server, 'auth', FakeAuth())
+    monkeypatch.setattr(server, 'CaptureSession', _Session)
+    monkeypatch.setattr(server, '_CONTRACT_LOG', str(tmp_path / 'add-agent-capture.log'))
+
+    yield SimpleNamespace(
+        client=TestClient(server.app),
+        omi=omi,
+        sessions=sessions,
+        contract_log=tmp_path / 'add-agent-capture.log',
+    )
+    server._clients.clear()
+
+
+def assert_openai_body(body: dict, *, model: str = 'omi') -> str:
+    """The Even app reads exactly one field; the rest must still be well formed."""
+    assert body['object'] == 'chat.completion'
+    assert body['model'] == model
+    assert isinstance(body['created'], int)
+    assert isinstance(body['choices'], list) and len(body['choices']) == 1
+    choice = body['choices'][0]
+    assert choice['index'] == 0
+    assert choice['finish_reason'] == 'stop'
+    assert choice['message']['role'] == 'assistant'
+    content = choice['message']['content']
+    assert isinstance(content, str)
+    assert set(body['usage']) == {'prompt_tokens', 'completion_tokens', 'total_tokens'}
+    return content
+
+
+def user_body(text) -> dict:
+    return {'messages': [{'role': 'user', 'content': text}]}
+
+
+# --------------------------------------------------------------------------
+# _extract_question
+# --------------------------------------------------------------------------
+
+
+def test_plain_string_content():
+    assert server._extract_question(user_body('what is on my plate')) == 'what is on my plate'
+
+
+def test_list_of_parts_content():
+    """The newer OpenAI content shape; a string-only parser returns nothing
+    here and the bridge answers "No user message found" to every question.
+    """
+    payload = {'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'what is on my plate'}]}]}
+    assert server._extract_question(payload) == 'what is on my plate'
+
+
+def test_list_of_parts_joins_text_and_ignores_other_types():
+    payload = {
+        'messages': [
+            {
+                'role': 'user',
+                'content': [
+                    {'type': 'image_url', 'image_url': {'url': 'https://x/y.png'}},
+                    {'type': 'text', 'text': 'what is'},
+                    {'type': 'text', 'text': 'on my plate'},
+                    {'type': 'text'},
+                ],
+            }
+        ]
+    }
+    assert server._extract_question(payload) == 'what is on my plate'
+
+
+def test_the_last_user_message_wins():
+    payload = {
+        'messages': [
+            {'role': 'user', 'content': 'first question'},
+            {'role': 'assistant', 'content': 'an answer'},
+            {'role': 'user', 'content': 'second question'},
+        ]
+    }
+    assert server._extract_question(payload) == 'second question'
+
+
+def test_system_prompts_are_not_mistaken_for_the_question():
+    payload = {
+        'messages': [
+            {'role': 'system', 'content': 'You are a helpful assistant.'},
+            {'role': 'user', 'content': 'what is on my plate'},
+        ]
+    }
+    assert server._extract_question(payload) == 'what is on my plate'
+
+
+def test_falls_back_to_the_last_message_when_no_user_role_is_present():
+    """The Add Agent contract is undocumented; a firmware that omits `role`
+    must still get an answer rather than a 400.
+    """
+    payload = {'messages': [{'content': 'what is on my plate'}]}
+    assert server._extract_question(payload) == 'what is on my plate'
+
+
+def test_an_empty_last_user_message_falls_back_to_an_earlier_one():
+    payload = {
+        'messages': [
+            {'role': 'user', 'content': 'the real question'},
+            {'role': 'user', 'content': '   '},
+        ]
+    }
+    assert server._extract_question(payload) == 'the real question'
+
+
+def test_content_is_stripped():
+    assert server._extract_question(user_body('  spaced out  ')) == 'spaced out'
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        {},
+        {'messages': []},
+        {'messages': None},
+        {'messages': 'not a list'},
+        {'messages': {'role': 'user'}},
+        {'messages': [None]},
+        {'messages': ['a bare string']},
+        {'messages': [42]},
+        {'messages': [{'role': 'user'}]},
+        {'messages': [{'role': 'user', 'content': None}]},
+        {'messages': [{'role': 'user', 'content': 123}]},
+        {'messages': [{'role': 'user', 'content': {'text': 'nested wrong'}}]},
+        {'messages': [{'role': 'user', 'content': []}]},
+        {'messages': [{'role': 'user', 'content': ['a bare string']}]},
+        {'messages': [{'role': 'user', 'content': [{'type': 'image_url'}]}]},
+        {'messages': [{'role': 'user', 'content': '   '}]},
+    ],
+)
+def test_unusable_bodies_yield_an_empty_question_without_crashing(payload):
+    assert server._extract_question(payload) == ''
+
+
+# --------------------------------------------------------------------------
+# _authorized
+# --------------------------------------------------------------------------
+
+
+def make_request(headers: dict):
+    scope = {
+        'type': 'http',
+        'http_version': '1.1',
+        'method': 'POST',
+        'scheme': 'http',
+        'path': '/',
+        'raw_path': b'/',
+        'query_string': b'',
+        'root_path': '',
+        'server': ('testserver', 80),
+        'client': ('1.2.3.4', 5000),
+        'headers': [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+    }
+    from starlette.requests import Request
+
+    return Request(scope)
+
+
+@pytest.mark.parametrize(
+    'header',
+    [
+        None,
+        '',
+        'Bearer',
+        'Bearer ',
+        EVEN_TOKEN,
+        f'Basic {EVEN_TOKEN}',
+        f'Token {EVEN_TOKEN}',
+        'Bearer wrong-token',
+        f'Bearer {EVEN_TOKEN}x',
+        f'Bearer {EVEN_TOKEN[:-1]}',
+        'Bearer ' + EVEN_TOKEN.upper(),
+    ],
+)
+def test_unauthorized_headers_are_rejected(header):
+    headers = {} if header is None else {'authorization': header}
+    assert server._authorized(make_request(headers)) is False
+
+
+@pytest.mark.parametrize(
+    'header',
+    [
+        f'Bearer {EVEN_TOKEN}',
+        f'bearer {EVEN_TOKEN}',  # scheme is case-insensitive per RFC 7235
+        f'BEARER {EVEN_TOKEN}',
+        f'Bearer  {EVEN_TOKEN} ',  # stray whitespace around the value
+    ],
+)
+def test_valid_headers_are_accepted(header):
+    assert server._authorized(make_request({'authorization': header})) is True
+
+
+def test_the_token_is_compared_in_constant_time(monkeypatch):
+    """A shared secret over the open internet: `==` short-circuits on the first
+    differing byte and leaks the token one character at a time.
+    """
+    seen = []
+    real = server.secrets.compare_digest
+
+    def spy(a, b):
+        seen.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr(server.secrets, 'compare_digest', spy)
+    assert server._authorized(make_request({'authorization': f'Bearer {EVEN_TOKEN}'})) is True
+    assert seen == [(EVEN_TOKEN, EVEN_TOKEN)]
+
+
+# --------------------------------------------------------------------------
+# Agent endpoint -- auth
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('path', AGENT_PATHS)
+def test_agent_requires_a_token(bridge, path):
+    response = bridge.client.post(path, json=user_body('hi'))
+    assert response.status_code == 401
+    assert response.json() == {'error': {'message': 'Unauthorized'}}
+
+
+@pytest.mark.parametrize('path', AGENT_PATHS)
+def test_agent_rejects_the_wrong_token(bridge, path):
+    response = bridge.client.post(path, json=user_body('hi'), headers={'Authorization': 'Bearer nope'})
+    assert response.status_code == 401
+
+
+def test_an_unauthorized_request_never_reaches_omi(bridge):
+    bridge.client.post('/', json=user_body('hi'))
+    assert bridge.omi.calls == []
+
+
+# --------------------------------------------------------------------------
+# Agent endpoint -- bad requests
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('body', [b'not json', b'', b'{"unterminated', b'\xff\xfe'])
+def test_non_json_bodies_are_rejected(bridge, body):
+    response = bridge.client.post('/', content=body, headers=AUTH_HEADER)
+    assert response.status_code == 400
+    assert 'JSON' in response.json()['error']['message']
+
+
+@pytest.mark.parametrize('body', ['[1, 2, 3]', '"a string"', '42', 'null'])
+def test_json_that_is_not_an_object_is_rejected(bridge, body):
+    response = bridge.client.post('/', content=body, headers=AUTH_HEADER)
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize('payload', [{}, {'messages': []}, {'messages': [{'role': 'user', 'content': ''}]}])
+def test_a_body_with_no_question_is_rejected(bridge, payload):
+    response = bridge.client.post('/', json=payload, headers=AUTH_HEADER)
+    assert response.status_code == 400
+    assert response.json()['error']['message'] == 'No user message found'
+
+
+def test_a_bad_request_never_reaches_omi(bridge):
+    bridge.client.post('/', content=b'not json', headers=AUTH_HEADER)
+    assert bridge.omi.calls == []
+
+
+# --------------------------------------------------------------------------
+# Agent endpoint -- answers
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('path', AGENT_PATHS)
+def test_a_question_returns_a_valid_chat_completion(bridge, path):
+    bridge.omi.chat_result = ChatResult(text='You have three things left today.')
+    response = bridge.client.post(path, json=user_body('what is on my plate'), headers=AUTH_HEADER)
+
+    assert response.status_code == 200
+    content = assert_openai_body(response.json())
+    assert content == 'You have three things left today.'
+    assert bridge.omi.calls[0][:2] == ('chat', 'what is on my plate')
+
+
+def test_the_configured_deadline_is_passed_to_omi(bridge):
+    bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+    assert bridge.omi.calls[0][2] == server.AGENT_DEADLINE_S
+
+
+def test_the_answer_is_reduced_to_something_the_glasses_can_show(bridge):
+    """Omi writes markdown for a phone; the G2 renders ~400 plain characters."""
+    bridge.omi.chat_result = ChatResult(
+        text='## Today\n\nYou owe **Marcus** the writeup[1] -- see [the doc](https://omi.me/d) 🎉. '
+        + 'Also, every other thing on the list is still open and waiting for you. ' * 20
+    )
+    response = bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+    content = assert_openai_body(response.json())
+
+    assert len(content) <= DEFAULT_LIMIT
+    assert '**' not in content and '](' not in content and '[1]' not in content
+    assert 'http' not in content
+    for char in content:
+        assert char == '\n' or ' ' <= char <= '~', f'unrenderable character {char!r}'
+
+
+def test_an_omi_error_is_reported_as_an_answer_not_an_http_error(bridge):
+    bridge.omi.chat_result = ChatResult(text='', error='quota exhausted')
+    response = bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+
+    assert response.status_code == 200
+    content = assert_openai_body(response.json())
+    assert 'could not answer' in content
+    assert 'quota exhausted' in content
+    assert len(content) <= DEFAULT_LIMIT
+
+
+def test_an_empty_answer_becomes_a_readable_sentence(bridge):
+    bridge.omi.chat_result = ChatResult(text='   ')
+    content = assert_openai_body(bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER).json())
+    assert content == 'Omi had no answer for that.'
+
+
+def test_a_truncated_answer_is_still_returned(bridge):
+    """A partial answer beats a spinner; the deadline exists precisely for this."""
+    bridge.omi.chat_result = ChatResult(text='The battery regression is', truncated=True)
+    content = assert_openai_body(bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER).json())
+    assert content == 'The battery regression is'
+
+
+def test_an_unexpected_exception_never_becomes_a_500(bridge):
+    """The glasses have no error path: a 500 shows as nothing at all."""
+    bridge.omi.chat_exc = ZeroDivisionError('unexpected')
+    response = bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+
+    assert response.status_code == 200
+    content = assert_openai_body(response.json())
+    assert content == 'Bridge error: ZeroDivisionError'
+    assert len(content) <= DEFAULT_LIMIT
+
+
+def test_an_exception_message_is_not_leaked_to_the_glasses(bridge):
+    bridge.omi.chat_exc = RuntimeError('postgres://user:hunter2@internal-host/db')
+    content = assert_openai_body(bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER).json())
+    assert 'hunter2' not in content
+
+
+def test_an_auth_failure_is_a_503_so_the_operator_can_tell_it_apart(bridge):
+    bridge.omi.chat_exc = server.AuthError('No signed-in Omi desktop session found')
+    response = bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+    assert response.status_code == 503
+    assert 'session' in response.json()['error']['message']
+
+
+def test_the_model_field_is_echoed_back(bridge):
+    body = {'model': 'gpt-4o-mini', **user_body('hi')}
+    response = bridge.client.post('/', json=body, headers=AUTH_HEADER)
+    assert_openai_body(response.json(), model='gpt-4o-mini')
+
+
+def test_a_null_model_falls_back_to_omi(bridge):
+    body = {'model': None, **user_body('hi')}
+    assert_openai_body(bridge.client.post('/', json=body, headers=AUTH_HEADER).json(), model='omi')
+
+
+def test_the_response_is_plain_json(bridge):
+    response = bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+    assert response.headers['content-type'].startswith('application/json')
+    json.loads(response.text)
+
+
+# --------------------------------------------------------------------------
+# Contract capture
+# --------------------------------------------------------------------------
+
+
+def test_the_raw_request_is_captured_for_the_undocumented_contract(bridge):
+    bridge.client.post('/', json=user_body('what is on my plate'), headers=AUTH_HEADER)
+    entry = json.loads(bridge.contract_log.read_text().split('\n---\n')[0])
+    assert entry['method'] == 'POST'
+    assert entry['path'] == '/'
+    assert 'what is on my plate' in entry['body']
+
+
+def test_the_bearer_token_is_redacted_from_the_capture(bridge):
+    bridge.client.post('/', json=user_body('hi'), headers={'Authorization': 'Bearer super-secret-value'})
+    text = bridge.contract_log.read_text()
+    assert 'super-secret-value' not in text
+    assert '<redacted>' in text
+
+
+def test_rejected_requests_are_captured_too(bridge):
+    """A token mismatch has to stay diagnosable from the capture alone."""
+    bridge.client.post('/', json=user_body('hi'), headers={'Authorization': 'Bearer wrong'})
+    assert bridge.contract_log.exists()
+
+
+def test_a_failing_capture_never_breaks_the_request(bridge, monkeypatch):
+    monkeypatch.setattr(server, '_CONTRACT_LOG', '/nonexistent-dir/capture.log')
+    response = bridge.client.post('/', json=user_body('hi'), headers=AUTH_HEADER)
+    assert response.status_code == 200
+
+
+# --------------------------------------------------------------------------
+# /health
+# --------------------------------------------------------------------------
+
+
+def test_health_reports_quota_and_auth_without_credentials(bridge):
+    bridge.omi.quota = {'plan': 'unlimited', 'used': 3}
+    body = bridge.client.get('/health').json()
+
+    assert body['ok'] is True
+    assert body['quota'] == {'plan': 'unlimited', 'used': 3}
+    assert body['auth'] == {'loaded': True, 'uid': 'fake-uid', 'expires_in': 3000}
+    assert body['omi_api'] == server.OMI_API_BASE
+    assert 'token' not in json.dumps(body).lower()
+
+
+def test_health_never_500s_when_omi_is_down(bridge):
+    bridge.omi.quota_exc = RuntimeError('connection refused')
+    response = bridge.client.get('/health')
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['ok'] is False
+    assert 'RuntimeError' in body['quota_error']
+    assert body['auth'] == {'loaded': True, 'uid': 'fake-uid', 'expires_in': 3000}
+
+
+# --------------------------------------------------------------------------
+# /app -- handshake and framing
+# --------------------------------------------------------------------------
+
+
+def test_the_socket_greets_with_the_backend_it_is_bound_to(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        assert ws.receive_json() == {'type': 'hello', 'omi_api': server.OMI_API_BASE}
+
+
+def test_connected_clients_are_tracked_and_released(bridge):
+    assert len(server._clients) == 0
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        assert len(server._clients) == 1
+    assert len(server._clients) == 0
+
+
+def test_ping_is_answered(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'ping'}))
+        assert ws.receive_json() == {'type': 'pong'}
+
+
+@pytest.mark.parametrize('raw', ['not json', '', '[1, 2, 3]', '"a string"', 'null', '{"no type": 1}', '{"type": "nope"}'])
+def test_junk_and_unknown_messages_are_ignored_without_a_reply(bridge, raw):
+    """An unknown type must be a silent no-op, not an error frame and not a
+    close -- the plugin and the bridge ship on different schedules.
+    """
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(raw)
+        ws.send_text(json.dumps({'type': 'ping'}))
+        assert ws.receive_json() == {'type': 'pong'}
+
+
+# --------------------------------------------------------------------------
+# /app -- chat
+# --------------------------------------------------------------------------
+
+
+def read_until(ws, kind, limit=50):
+    """Collect frames up to and including the first of type `kind`."""
+    frames = []
+    for _ in range(limit):
+        frame = ws.receive_json()
+        frames.append(frame)
+        if frame.get('type') == kind:
+            return frames
+    raise AssertionError(f'never received a {kind!r} frame; got {frames}')
+
+
+def test_chat_streams_deltas_then_a_done_frame(bridge):
+    bridge.omi.stream_events = [
+        ChatEvent('data', 'x' * 40),
+        ChatEvent('data', 'y' * 40),
+        ChatEvent('done', 'The battery regression is open.'),
+    ]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'what is on my plate'}))
+        frames = read_until(ws, 'chat_done')
+
+    assert [f['type'] for f in frames] == ['chat_delta', 'chat_done']
+    done = frames[-1]
+    assert done['text'] == 'The battery regression is open.'
+    assert done['error'] is False
+    assert done['pages'] == ['The battery regression is open.']
+    assert bridge.omi.calls[0] == ('chat_stream', 'what is on my plate')
+
+
+def test_deltas_are_coalesced_instead_of_one_frame_per_token(bridge):
+    """Every frame is a BLE round trip. 20 tokens must not be 20 writes."""
+    bridge.omi.stream_events = [ChatEvent('data', 'token' * 2) for _ in range(20)]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        frames = read_until(ws, 'chat_done')
+
+    deltas = [f for f in frames if f['type'] == 'chat_delta']
+    assert 0 < len(deltas) < 20 / 2, f'{len(deltas)} frames for 20 tokens is not coalescing'
+    assert all(len(d['text']) >= 60 for d in deltas)
+    assert ''.join(d['text'] for d in deltas) in frames[-1]['text']
+
+
+def test_thinking_lines_are_forwarded_as_status_and_capped(bridge):
+    bridge.omi.stream_events = [ChatEvent('think', 'S' * 500), ChatEvent('done', 'ok')]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        frames = read_until(ws, 'chat_done')
+
+    status = [f for f in frames if f['type'] == 'chat_status']
+    assert len(status) == 1
+    assert len(status[0]['text']) <= 60
+
+
+def test_a_stream_with_no_done_frame_still_answers_from_the_deltas(bridge):
+    bridge.omi.stream_events = [ChatEvent('data', 'partial '), ChatEvent('data', 'answer')]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        done = read_until(ws, 'chat_done')[-1]
+
+    assert done['text'] == 'partial answer'
+    assert done['error'] is False
+
+
+def test_an_empty_done_text_falls_back_to_the_deltas(bridge):
+    bridge.omi.stream_events = [ChatEvent('data', 'from the deltas'), ChatEvent('done', '')]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        assert read_until(ws, 'chat_done')[-1]['text'] == 'from the deltas'
+
+
+def test_a_stream_error_ends_the_turn_with_an_error_frame(bridge):
+    bridge.omi.stream_events = [ChatEvent('data', 'partial'), ChatEvent('error', 'quota exhausted')]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        done = read_until(ws, 'chat_done')[-1]
+
+    assert done['error'] is True
+    assert 'quota exhausted' in done['text']
+    assert 'pages' not in done
+
+
+def test_the_answer_is_fitted_and_paginated_for_the_text_container(bridge):
+    """`textContainerUpgrade` caps at 2000 characters."""
+    bridge.omi.stream_events = [ChatEvent('done', 'Sentence number one. ' * 400)]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        done = read_until(ws, 'chat_done')[-1]
+
+    assert len(done['text']) <= 1800
+    assert done['pages'] and all(len(page) <= 400 for page in done['pages'])
+    assert ' '.join(done['pages']).split() == done['text'].split()
+
+
+@pytest.mark.parametrize('text', ['', '   ', None])
+def test_an_empty_question_is_refused_without_calling_omi(bridge, text):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': text}))
+        frame = ws.receive_json()
+
+    assert frame == {'type': 'chat_done', 'text': 'Nothing to ask.', 'error': True}
+    assert bridge.omi.calls == []
+
+
+# --------------------------------------------------------------------------
+# /app -- data views
+# --------------------------------------------------------------------------
+
+
+def test_memories_are_returned_fitted(bridge):
+    bridge.omi.memories_rows = [{'content': 'Sarah prefers **async** updates 🎉'}, {'content': 'x' * 900}]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'memories', 'limit': 5}))
+        frame = ws.receive_json()
+
+    assert frame['type'] == 'memories'
+    assert frame['items'][0] == {'content': 'Sarah prefers async updates'}
+    assert len(frame['items'][1]['content']) <= 200
+    assert ('memories', 5) in bridge.omi.calls
+
+
+def test_memories_default_to_twenty(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'memories'}))
+        ws.receive_json()
+    assert ('memories', 20) in bridge.omi.calls
+
+
+def test_action_items_carry_their_completed_flag(bridge):
+    bridge.omi.action_rows = [
+        {'description': 'Reply to *Marcus*', 'completed': True},
+        {'description': 'File the regression'},
+        {},
+    ]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'action_items'}))
+        frame = ws.receive_json()
+
+    assert frame['items'] == [
+        {'description': 'Reply to Marcus', 'completed': True},
+        {'description': 'File the regression', 'completed': False},
+        {'description': '', 'completed': False},
+    ]
+
+
+def test_action_item_descriptions_are_capped(bridge):
+    bridge.omi.action_rows = [{'description': 'w ' * 500}]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'action_items'}))
+        assert len(ws.receive_json()['items'][0]['description']) <= 120
+
+
+def test_today_returns_the_summary_paginated(bridge):
+    bridge.omi.summary_rows = [{'summary': 'You shipped the OTA. ' * 200}]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'today'}))
+        frame = ws.receive_json()
+
+    assert frame['type'] == 'today'
+    assert len(frame['text']) <= 1800
+    assert all(len(page) <= 400 for page in frame['pages'])
+    assert ('daily_summaries', 1) in bridge.omi.calls
+
+
+def test_today_accepts_the_overview_field_too(bridge):
+    bridge.omi.summary_rows = [{'overview': 'A quiet day.'}]
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'today'}))
+        assert ws.receive_json()['text'] == 'A quiet day.'
+
+
+def test_today_with_no_summary_says_so(bridge):
+    bridge.omi.summary_rows = []
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'today'}))
+        frame = ws.receive_json()
+    assert frame['text'] == 'No summary for today yet.'
+    assert frame['pages'] == ['No summary for today yet.']
+
+
+# --------------------------------------------------------------------------
+# /app -- audio
+# --------------------------------------------------------------------------
+
+
+def test_binary_frames_are_fed_to_the_capture_session(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_bytes(b'\x01\x02' * 500)
+        ws.send_bytes(b'\x03\x04' * 500)
+        ws.send_text(json.dumps({'type': 'ping'}))
+        assert ws.receive_json() == {'type': 'pong'}
+
+    assert bridge.sessions[0].fed == [b'\x01\x02' * 500, b'\x03\x04' * 500]
+
+
+def test_capture_can_be_started_and_stopped(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'capture', 'enabled': True}))
+        assert ws.receive_json() == {'type': 'capture', 'active': True}
+
+        ws.send_text(json.dumps({'type': 'capture', 'enabled': False}))
+        stopped = ws.receive_json()
+
+    session = bridge.sessions[0]
+    assert session.starts == 1
+    assert session.stops[0] is True, 'the conversation must be finalized explicitly'
+    assert stopped == {'type': 'capture', 'active': False, 'seconds': 1.0, 'conversation_id': 'conv-7'}
+
+
+def test_live_transcript_segments_are_pushed_to_the_glasses(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        bridge.sessions[0].start_segments = [{'text': 'the battery'}, {'text': 'regression'}, {}]
+        ws.send_text(json.dumps({'type': 'capture', 'enabled': True}))
+        frames = read_until(ws, 'capture')
+
+    transcripts = [f for f in frames if f['type'] == 'transcript']
+    assert transcripts == [{'type': 'transcript', 'text': 'the battery regression'}]
+
+
+def test_the_capture_session_is_stopped_when_the_socket_drops(bridge):
+    """Otherwise the conversation lingers `in_progress` until something else
+    notices it is stale.
+    """
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'capture', 'enabled': True}))
+        ws.receive_json()
+    assert bridge.sessions[0].stops[-1] is True
+
+
+def test_push_to_talk_transcribes_buffered_pcm(bridge):
+    bridge.omi.transcript = 'what is on my plate'
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'transcribe', 'pcm_hex': '0102ffee'}))
+        assert ws.receive_json() == {'type': 'transcribed', 'text': 'what is on my plate'}
+
+    assert ('transcribe_pcm', b'\x01\x02\xff\xee') in bridge.omi.calls
+
+
+def test_push_to_talk_with_no_audio_does_not_call_omi(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'transcribe', 'pcm_hex': ''}))
+        assert ws.receive_json() == {'type': 'transcribed', 'text': ''}
+    assert bridge.omi.calls == []
+
+
+# --------------------------------------------------------------------------
+# /app -- failure isolation
+# --------------------------------------------------------------------------
+
+
+def test_a_handler_exception_sends_an_error_frame_and_keeps_the_socket_open(bridge):
+    """One bad request must not take the session down; the plugin has no
+    reconnect UI and the user would just see the app stop responding.
+    """
+    bridge.omi.memories_rows = RuntimeError('omi is down')
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'memories'}))
+        error = ws.receive_json()
+
+        assert error['type'] == 'error'
+        assert 'RuntimeError' in error['text']
+
+        # Still alive, and still serving.
+        ws.send_text(json.dumps({'type': 'ping'}))
+        assert ws.receive_json() == {'type': 'pong'}
+
+        bridge.omi.action_rows = [{'description': 'still working'}]
+        ws.send_text(json.dumps({'type': 'action_items'}))
+        assert ws.receive_json()['items'] == [{'description': 'still working', 'completed': False}]
+
+
+def test_a_malformed_limit_is_an_error_frame_not_a_dropped_socket(bridge):
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'memories', 'limit': 'twenty'}))
+        assert ws.receive_json()['type'] == 'error'
+        ws.send_text(json.dumps({'type': 'ping'}))
+        assert ws.receive_json() == {'type': 'pong'}
+
+
+def test_a_chat_stream_failure_is_isolated_too(bridge):
+    bridge.omi.stream_exc = RuntimeError('stream died')
+    with bridge.client.websocket_connect('/app') as ws:
+        ws.receive_json()
+        ws.send_text(json.dumps({'type': 'chat', 'text': 'hi'}))
+        assert ws.receive_json()['type'] == 'error'
+        ws.send_text(json.dumps({'type': 'ping'}))
+        assert ws.receive_json() == {'type': 'pong'}
+
+
+# --------------------------------------------------------------------------
+# Proactive push
+# --------------------------------------------------------------------------
+
+
+class RecordingSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.got = asyncio.Event()
+
+    async def send_text(self, raw: str) -> None:
+        self.sent.append(json.loads(raw))
+        self.got.set()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_survives_a_dead_client(monkeypatch):
+    class Dead:
+        async def send_text(self, raw):
+            raise RuntimeError('socket closed')
+
+    alive = RecordingSocket()
+    monkeypatch.setattr(server, '_clients', {Dead(), alive})
+    await server.broadcast({'type': 'push', 'text': 'hi'})
+    assert alive.sent == [{'type': 'push', 'text': 'hi'}]
+
+
+@pytest.mark.asyncio
+async def test_the_push_loop_seeds_on_the_first_pass_and_skips_completed(monkeypatch):
+    """Without seeding, connecting the app pushes every existing action item at
+    once. Completed items must never surface at all.
+    """
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+
+    polls = 0
+
+    class Omi:
+        async def action_items(self, limit=20):
+            nonlocal polls
+            polls += 1
+            if polls == 1:
+                return [{'id': 'existing', 'description': 'was already here'}]
+            return [
+                {'id': 'existing', 'description': 'was already here'},
+                {'id': 'done', 'description': 'already finished', 'completed': True},
+                {'id': 'new', 'description': 'File the **regression**'},
+            ]
+
+    socket = RecordingSocket()
+    monkeypatch.setattr(server, 'omi', Omi())
+    monkeypatch.setattr(server, '_clients', {socket})
+
+    task = asyncio.create_task(server._push_loop())
+    try:
+        await asyncio.wait_for(socket.got.wait(), timeout=5)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert len(socket.sent) == 1, f'expected exactly one push, got {socket.sent}'
+    assert socket.sent[0] == {'type': 'push', 'text': 'New task: File the regression'}
+
+
+@pytest.mark.asyncio
+async def test_the_push_loop_survives_a_failing_poll(monkeypatch):
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+    calls = 0
+
+    class Omi:
+        async def action_items(self, limit=20):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError('omi is down')
+
+    monkeypatch.setattr(server, 'omi', Omi())
+    monkeypatch.setattr(server, '_clients', {RecordingSocket()})
+
+    task = asyncio.create_task(server._push_loop())
+    try:
+        while calls < 3:
+            await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert calls >= 3, 'a poll failure must not end the loop'
+
+
+@pytest.mark.asyncio
+async def test_the_push_loop_does_not_poll_without_a_connected_app(monkeypatch):
+    monkeypatch.setenv('OMI_EVEN_PUSH_INTERVAL', '0.01')
+    calls = 0
+
+    class Omi:
+        async def action_items(self, limit=20):
+            nonlocal calls
+            calls += 1
+            return []
+
+    monkeypatch.setattr(server, 'omi', Omi())
+    monkeypatch.setattr(server, '_clients', set())
+
+    task = asyncio.create_task(server._push_loop())
+    await asyncio.sleep(0.06)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls == 0

--- a/integrations/omi-even/bridge/tests/test_server.py
+++ b/integrations/omi-even/bridge/tests/test_server.py
@@ -52,8 +52,12 @@ class FakeOmi:
         self.quota_exc: Exception | None = None
         self.calls: list = []
 
-    async def chat(self, text, app_id=None, deadline_s=None):
+    async def chat(self, text, app_id=None, deadline_s=None, enough=None):
+        # `enough` lets the caller stop the stream once the answer already
+        # overflows the display. Recorded so tests can assert it was supplied --
+        # omitting it costs about 3 seconds per answer.
         self.calls.append(('chat', text, deadline_s))
+        self.enough = enough
         if self.chat_exc:
             raise self.chat_exc
         return self.chat_result

--- a/integrations/omi-even/bridge/tests/test_server.py
+++ b/integrations/omi-even/bridge/tests/test_server.py
@@ -135,6 +135,11 @@ def bridge(monkeypatch, tmp_path):
     monkeypatch.setattr(server, 'auth', FakeAuth())
     monkeypatch.setattr(server, 'CaptureSession', _Session)
     monkeypatch.setattr(server, '_CONTRACT_LOG', str(tmp_path / 'add-agent-capture.log'))
+    # These tests cover the full agent path -- deadlines, truncation, error
+    # handling. The endpoint now prefers the fast retrieval path, so opt back in
+    # explicitly rather than let the fast path silently answer instead.
+    # Fast-path behavior is covered by tests/test_fastpath.py.
+    monkeypatch.setenv('OMI_EVEN_FULL_AGENT', '1')
 
     yield SimpleNamespace(
         client=TestClient(server.app),

--- a/integrations/omi-even/docs/add-agent-contract.md
+++ b/integrations/omi-even/docs/add-agent-contract.md
@@ -1,0 +1,89 @@
+# The Even Realities "Add Agent" contract
+
+Even publishes no specification for the custom-agent endpoint. This is the
+contract **as observed from a real G2 + phone**, captured by the bridge itself
+(`bridge/add-agent-capture.log`), not inferred from documentation or blog posts.
+
+Captured 2026-07-27 against Even Realities app on iOS, G2 glasses.
+
+## The request
+
+```http
+POST / HTTP/1.1
+Authorization: Bearer <the token you typed into Add Agent>
+Content-Type: application/json
+User-Agent: Dart/3.11 (dart:io)
+
+{"model":"openclaw","messages":[{"role":"user","content":"What should I focus on today?"}]}
+```
+
+| Detail | Observed value |
+|---|---|
+| Method / path | `POST` to the **root** of the registered URL — not `/v1/chat/completions` |
+| Client | The **phone's** public IP, not the glasses. The phone does the HTTP. |
+| User-Agent | `Dart/3.11 (dart:io)` — the Even app is Flutter |
+| `model` | Always the literal **`"openclaw"`**, regardless of the agent name you chose |
+| `messages` | A single `{"role":"user","content":"<transcript>"}`. **No conversation history** — every turn is stateless, so the agent cannot see what was asked before. |
+| Speech-to-text | Done **on-device**; the endpoint receives finished text |
+
+The `model` value is a fixed string, so don't key behavior off it. The bridge
+accepts any value and echoes it back.
+
+## The response
+
+A standard OpenAI chat-completion body is accepted and rendered:
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "created": 1785135941,
+  "model": "omi",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "..."}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+}
+```
+
+Confirmed working end to end: spoken question → glasses display, ~10s round trip
+including Omi's agentic retrieval.
+
+## Even AI intercepts some phrasings before your agent sees them
+
+**This is the single most surprising behavior.** Even AI classifies the utterance
+first, and only forwards it to the custom agent if it doesn't match a built-in
+intent. Observed live:
+
+| Said | Reached the agent? |
+|---|---|
+| "What should I focus on today?" | yes |
+| "What did I have for dinner when I first met David?" | yes |
+| "What was I doing on 4 July?" | yes |
+| "What apart from work did I do on Fourth of July?" | yes |
+| "what I need to get done today" | **no** — routed to Quicknote instead |
+
+Questions reach the agent. Utterances that read as notes, reminders, or commands
+get captured by Even's own note-taking feature, and nothing arrives at the
+endpoint. There is no observed way to disable this from the agent side; the
+workaround is phrasing — lead with an interrogative.
+
+Because the interception happens on the phone, **an empty capture log is the
+diagnostic**: if a query didn't arrive, Even routed it internally rather than the
+bridge failing.
+
+## What is still unknown
+
+- **The client timeout.** Not measured. Answers taking ~10s are fine; the bridge
+  caps its own wait at `OMI_EVEN_DEADLINE` (default 20s) and returns whatever
+  partial answer exists rather than risking a silent client-side timeout.
+- **Whether streaming responses are accepted.** Only non-streaming JSON has been
+  tested, and it works.
+- **The display limit in this mode.** Answers are fitted to ~380 characters, which
+  renders correctly; the true cap has not been probed.
+- **Whether `messages` ever carries history** in a multi-turn exchange. Every
+  captured request had exactly one message.
+
+## Re-capturing
+
+The bridge logs every incoming agent request to `bridge/add-agent-capture.log`
+with the bearer token redacted. If Even changes the contract, the diff shows up
+there rather than as a mystery failure.


### PR DESCRIPTION
## What this is

`omi` on Even Realities G2 glasses. Four surfaces, one local bridge:

1. **Even AI answers from Omi** — ask the built-in assistant anything and it answers from your Omi memories, conversations and action items
2. **The `omi` Hub app** — chat, memories, action items on the display
3. **G2 mics feed Omi** — the glasses act as an Omi capture device
4. **Push** — new action items surface on the display

Everything routes through a FastAPI bridge on the Mac, because `/v2/messages` and
`/v4/listen` both require a Firebase ID token — no app key family can reach them
(`backend/utils/other/endpoints.py`). The bridge mints tokens from the desktop
app's existing session via the repo's own `omi-auth-dump.sh`, so there is no
browser login step.

## The constraint everything else follows from

Even's client gives up at about **5 seconds**. This was measured on hardware,
not assumed: a 0.4s reply renders and a 5.6s reply does not, despite the bridge
returning `200 OK` both times. Streaming past the limit was tried and the
glasses reported a network error.

Omi's agent takes 6–18s, so it cannot be the answer path. Instead:

    retrieve facts (memories + conversations, in parallel)   1.4s
    compose them into prose with one LLM call                1.3-2.3s
    -----------------------------------------------------------
    total                                                    ~3s

Compose is a ladder — the local model on this Mac, then Omi's cloud endpoint,
then the raw retrieved lines. Every rung degrades; none can fail the answer.

**Local first, because the cloud rung is capped at 30/hour**
(`utils/rate_limit_config.py`, `"test:prompt": (30, 3600)`) — a day of actually
wearing the glasses spends that. Ollama already runs on the machine hosting the
bridge, so composing there is uncapped and free, and the retrieved facts never
leave the Mac to be turned into a sentence.

## Notable findings

* **Omi's chat stream is not spec SSE.** Frames are `\n\n`-*separated* with bare
  prefixes (`data:`/`think:`/`done:`), newlines escaped as `__CRLF__`, and the
  terminal `done:` is base64. The parser here is ported from
  `app/lib/backend/http/api/messages.dart`, the reference implementation.
* **Ollama sizes its KV cache from the model's declared maximum, not the
  prompt.** `ollama ps` showed 23GB of weights resident at **28 GB** for a
  262144-token context, serving prompts of ~500 tokens. Pinning `num_ctx` to
  4096 took it back to 23 GB.
* **Residency, not speed, is the local risk.** `qwen3.6:35b-a3b` answers in
  1.3–2.3s warm and 16.5s cold — three times the entire budget. A warmer runs
  at startup and every 10 minutes.
* **A server-side date window made search 4× slower** (13.5s vs 3.1s on the live
  account) for the same result, so date filtering happens client-side.
* **`CancelledError` is a `BaseException`**, so `suppress(Exception)` does not
  catch it — an ordinary shutdown printed a traceback until it was named.

## Verification

Live against the real Omi account, through the bridge:

    [2.9s] What did I do on 4 July?
           You shared burgers with friends on July fourth. You handled food prep
           details like burger assembly and serving.

    [3.1s] What do I need to do today?
           You need to complete the UMN Robotics workspace access form and
           investigate the invalid Omi Discord link on omi.me. Additionally,
           rebuild Sage's voice profile by setting xurl OAuth and review PR
           #10463 for the Google Calendar persistence fix.

    [2.0s] What am I behind on?
           You're behind on replying to Tharun, addressing requested changes for
           Omi desktop PR #10687, and submitting your Startup School weekly
           update.

Suites:

    integrations/omi-even/bridge      662 passed
    integrations/omi-even/app         40 unit tests, 82 simulator checks
    integrations/evenhub-g2           reference quickstart, unchanged

Capture was verified by making a real recording through the glasses and
confirming the conversation and transcript appeared in Omi.

## Known limits

* **Even's on-device intent classifier intercepts some utterances** before any
  network call — note-shaped phrasing gets saved to the quicklist and never
  reaches the bridge. Nothing server-side can change that.
* **A Cloudflare quick tunnel gets a new URL on restart**, so the agent has to
  be re-registered in the Even app. A named tunnel fixes this.
* The cloud compose rung appends a conversation transcript that the prompt
  instructs the model to disregard. That held on every question tried, but it
  is an instruction, not a guarantee.

## Not done yet

* `gather_facts` and `fast_answer` each retrieve independently, so the bullet
  fallback re-runs the search it just ran. Harmless today because compose
  almost always wins, but it should be one retrieval feeding both.
* One unexplained 76s stall of the bridge event loop was observed under memory
  pressure while a 28 GB model was resident. The `num_ctx` fix removes the
  suspected cause; catastrophic regex backtracking was measured and ruled out.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aNauQfdfh98dZFWbE8PdP


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

