### PR TITLE
fix(backend): bound Firestore list reads to stop 30s GET 504s

### DIFF
--- a/app/lib/backend/schema/gen/misc_wire.g.dart
+++ b/app/lib/backend/schema/gen/misc_wire.g.dart
@@ -43,25 +43,37 @@ class GeneratedDeleteKnowledgeGraphResponse {
 }
 
 class GeneratedKnowledgeGraphResponse {
+  final int? edgeLimit;
   final List<Map<String, dynamic>> edges;
+  final int? nodeLimit;
   final List<Map<String, dynamic>> nodes;
+  final bool truncated;
 
   const GeneratedKnowledgeGraphResponse({
+    this.edgeLimit,
     required this.edges,
+    this.nodeLimit,
     required this.nodes,
+    this.truncated = false,
   });
 
   factory GeneratedKnowledgeGraphResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedKnowledgeGraphResponse(
+      edgeLimit: _readFieldValue<int>(_readField(json, const ["edge_limit"]), "edge_limit", _readInt, requiredField: false, nullable: true),
       edges: _required(_readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["edges"]), "edges", _readMapList, requiredField: true, nullable: false), "edges"),
+      nodeLimit: _readFieldValue<int>(_readField(json, const ["node_limit"]), "node_limit", _readInt, requiredField: false, nullable: true),
       nodes: _required(_readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["nodes"]), "nodes", _readMapList, requiredField: true, nullable: false), "nodes"),
+      truncated: _required(_readFieldValue<bool>(_readField(json, const ["truncated"]), "truncated", _readBool, requiredField: false, nullable: false, defaultValue: false), "truncated"),
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
+      'edge_limit': edgeLimit,
       'edges': edges,
+      'node_limit': nodeLimit,
       'nodes': nodes,
+      'truncated': truncated,
     };
   }
 }

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -64,8 +64,7 @@ class MemoriesProvider extends ChangeNotifier {
       // When the server does not support device_scope, legacy memories have no
       // primary_capture_device/capture_device_ids. Skip the local device filter
       // in that case to avoid hiding all legacy rows on the "This device" view.
-      final deviceMatch =
-          !_filterThisDeviceOnly ||
+      final deviceMatch = !_filterThisDeviceOnly ||
           !_deviceScopeSupported ||
           ClientDeviceService.instance.memoryMatchesThisDevice(
             primaryCaptureDevice: memory.primaryCaptureDevice,
@@ -73,7 +72,8 @@ class MemoriesProvider extends ChangeNotifier {
           );
 
       return matchesSearch && categoryMatch && deviceMatch;
-    }).toList()..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    }).toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
   }
 
   void setFilterThisDeviceOnly(bool enabled) {

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -64,7 +64,8 @@ class MemoriesProvider extends ChangeNotifier {
       // When the server does not support device_scope, legacy memories have no
       // primary_capture_device/capture_device_ids. Skip the local device filter
       // in that case to avoid hiding all legacy rows on the "This device" view.
-      final deviceMatch = !_filterThisDeviceOnly ||
+      final deviceMatch =
+          !_filterThisDeviceOnly ||
           !_deviceScopeSupported ||
           ClientDeviceService.instance.memoryMatchesThisDevice(
             primaryCaptureDevice: memory.primaryCaptureDevice,
@@ -72,8 +73,7 @@ class MemoriesProvider extends ChangeNotifier {
           );
 
       return matchesSearch && categoryMatch && deviceMatch;
-    }).toList()
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    }).toList()..sort((a, b) => b.createdAt.compareTo(a.createdAt));
   }
 
   void setFilterThisDeviceOnly(bool enabled) {
@@ -223,10 +223,22 @@ class MemoriesProvider extends ChangeNotifier {
       if (generation != _sessionGeneration) return;
     }
 
-    final result = await getMemoriesResult(limit: limit, thisDeviceOnly: _filterThisDeviceOnly);
-    if (generation != _sessionGeneration) return;
-    _memories = result.memories;
-    _deviceScopeSupported = result.deviceScopeSupported;
+    // Page until a short page: backend no longer expands the first page to 5000
+    // (prod GET /v3/memories 504s). Cap total fetch so a huge account cannot hang the UI.
+    const maxPages = 20;
+    final all = <Memory>[];
+    var offset = 0;
+    var deviceScopeSupported = true;
+    for (var page = 0; page < maxPages; page++) {
+      final result = await getMemoriesResult(limit: limit, offset: offset, thisDeviceOnly: _filterThisDeviceOnly);
+      if (generation != _sessionGeneration) return;
+      deviceScopeSupported = result.deviceScopeSupported;
+      all.addAll(result.memories);
+      if (result.memories.length < limit) break;
+      offset += result.memories.length;
+    }
+    _memories = all;
+    _deviceScopeSupported = deviceScopeSupported;
 
     // Merge pending memories that haven't synced yet
     final pendingMemories = SharedPreferencesUtil().pendingMemories;

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -220,7 +220,9 @@ class MemoriesProvider extends ChangeNotifier {
 
     if (_filterThisDeviceOnly) {
       await _ensureClientDeviceInitialized();
-      if (generation != _sessionGeneration) return;
+      if (generation != _sessionGeneration) {
+        return;
+      }
     }
 
     // Page until a short page: backend no longer expands the first page to 5000
@@ -231,10 +233,14 @@ class MemoriesProvider extends ChangeNotifier {
     var deviceScopeSupported = true;
     for (var page = 0; page < maxPages; page++) {
       final result = await getMemoriesResult(limit: limit, offset: offset, thisDeviceOnly: _filterThisDeviceOnly);
-      if (generation != _sessionGeneration) return;
+      if (generation != _sessionGeneration) {
+        return;
+      }
       deviceScopeSupported = result.deviceScopeSupported;
       all.addAll(result.memories);
-      if (result.memories.length < limit) break;
+      if (result.memories.length < limit) {
+        break;
+      }
       offset += result.memories.length;
     }
     _memories = all;

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -391,9 +391,6 @@ def get_action_item(uid: str, action_item_id: str) -> Optional[Dict[str, Any]]:
 # Hard safety caps for list reads. Unbounded streams + in-process sort caused prod GET
 # /v1/action-items to hit HTTP_GET_TIMEOUT (30s) → 504 on large accounts.
 _ACTION_ITEMS_LIST_HARD_MAX = 2000
-_ACTION_ITEMS_LIST_DEFAULT_LIMIT = 500
-# Extra documents scanned to absorb soft-deleted rows while still filling `need`.
-_ACTION_ITEMS_DELETED_SLACK_FACTOR = 2
 
 
 def _action_item_list_sort_key(item: Dict[str, Any]) -> tuple:
@@ -404,47 +401,6 @@ def _action_item_list_sort_key(item: Dict[str, Any]) -> tuple:
         item.get('due_at') or datetime.max.replace(tzinfo=timezone.utc),
         -(item.get('created_at', datetime.min.replace(tzinfo=timezone.utc)).timestamp()),
     )
-
-
-def _build_action_items_base_query(
-    uid: str,
-    *,
-    conversation_id: Optional[str],
-    completed: Optional[bool],
-    start_date: Optional[datetime],
-    end_date: Optional[datetime],
-    due_start_date: Optional[datetime],
-    due_end_date: Optional[datetime],
-) -> Any:
-    user_ref = db.collection('users').document(uid)
-    query = user_ref.collection(action_items_collection)
-
-    if conversation_id is not None:
-        query = query.where(filter=FieldFilter('conversation_id', '==', conversation_id))
-
-    if completed is not None:
-        query = query.where(filter=FieldFilter('completed', '==', completed))
-
-    # Date inequality filters require orderBy on the same field. When both created_at and
-    # due_at ranges are supplied, prefer due_at (historical behavior).
-    due_at_filtering = due_start_date is not None or due_end_date is not None
-    if due_at_filtering:
-        if due_start_date is not None:
-            query = query.where(filter=FieldFilter('due_at', '>=', due_start_date))
-        if due_end_date is not None:
-            query = query.where(filter=FieldFilter('due_at', '<=', due_end_date))
-        query = query.order_by('due_at', direction=firestore.Query.DESCENDING)
-    else:
-        if start_date is not None:
-            query = query.where(filter=FieldFilter('created_at', '>=', start_date))
-        if end_date is not None:
-            query = query.where(filter=FieldFilter('created_at', '<=', end_date))
-        # Only attach order_by when a range filter needs it; otherwise we sort in process
-        # after a bounded stream (avoids composite-index requirements for completed+order).
-        if start_date is not None or end_date is not None:
-            query = query.order_by('created_at', direction=firestore.Query.DESCENDING)
-
-    return query
 
 
 def _stream_action_items_bounded(query: Any, *, max_docs: int) -> tuple[List[Dict[str, Any]], int]:
@@ -467,6 +423,32 @@ def _stream_action_items_bounded(query: Any, *, max_docs: int) -> tuple[List[Dic
     return action_items, document_count
 
 
+def _apply_action_item_date_filters(
+    query: Any,
+    *,
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+    due_start_date: Optional[datetime],
+    due_end_date: Optional[datetime],
+) -> Any:
+    due_at_filtering = due_start_date is not None or due_end_date is not None
+    if due_at_filtering:
+        if due_start_date is not None:
+            query = query.where(filter=FieldFilter('due_at', '>=', due_start_date))
+        if due_end_date is not None:
+            query = query.where(filter=FieldFilter('due_at', '<=', due_end_date))
+        # Soonest-due first so a bounded prefix matches product sort on due_at.
+        query = query.order_by('due_at', direction=firestore.Query.ASCENDING)
+        return query
+    if start_date is not None:
+        query = query.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date is not None:
+        query = query.where(filter=FieldFilter('created_at', '<=', end_date))
+    if start_date is not None or end_date is not None:
+        query = query.order_by('created_at', direction=firestore.Query.DESCENDING)
+    return query
+
+
 def get_action_items(
     uid: str,
     conversation_id: Optional[str] = None,
@@ -481,74 +463,82 @@ def get_action_items(
     """
     Get action items for a user with optional filters.
 
-    Args:
-        uid: User ID
-        conversation_id: Filter by conversation ID (None for standalone items)
-        completed: Filter by completion status
-        start_date: Filter by created_at start date (inclusive) - applied at database level
-        end_date: Filter by created_at end date (inclusive) - applied at database level
-        due_start_date: Filter by due_at start date (inclusive) - applied at database level
-        due_end_date: Filter by due_at end date (inclusive) - applied at database level
-        limit: Maximum number of items to return
-        offset: Number of items to skip
-
-    Returns:
-        List of action items
-
-    Note:
-        If both created_at and due_at filters are provided, only due_at filters will be applied
-        (due to Firestore limitation requiring inequality filters on same field as orderBy).
-
-        Default (completed=None) lists preserve active-first product order by reading the
-        incomplete bucket first, then the completed bucket — never a full-collection stream.
-        All paths are hard-capped so GET /v1/action-items cannot unbounded-scan under
-        HTTP_GET_TIMEOUT.
+    Default (completed=None) lists preserve active-first product order by reading the
+    incomplete bucket first, then the completed bucket — never a full-collection stream.
+    Legacy documents with missing/null ``completed`` are harvested via a separate bounded
+    unfiltered scan and treated as active after ``_prepare_action_item_for_read``.
+    All paths are hard-capped so GET /v1/action-items cannot unbounded-scan under
+    HTTP_GET_TIMEOUT. Pagination is applied after the product sort.
     """
     offset = max(0, int(offset or 0))
     if limit is None or limit <= 0:
-        effective_limit = _ACTION_ITEMS_LIST_DEFAULT_LIMIT
+        effective_limit = _ACTION_ITEMS_LIST_HARD_MAX
     else:
         effective_limit = min(int(limit), _ACTION_ITEMS_LIST_HARD_MAX)
 
-    # How many kept rows we need before slicing (offset + page), capped hard.
     need = min(offset + effective_limit, _ACTION_ITEMS_LIST_HARD_MAX)
-    # Scan budget absorbs soft-deleted docs while remaining bounded.
-    scan_budget = min(
-        _ACTION_ITEMS_LIST_HARD_MAX,
-        max(need * _ACTION_ITEMS_DELETED_SLACK_FACTOR, need + 32),
-    )
-
     total_docs = 0
 
-    def _fetch(completed_filter: Optional[bool], row_budget: int) -> List[Dict[str, Any]]:
-        nonlocal total_docs
-        if row_budget <= 0:
-            return []
-        q = _build_action_items_base_query(
-            uid,
-            conversation_id=conversation_id,
-            completed=completed_filter,
+    def _base_query() -> Any:
+        user_ref = db.collection('users').document(uid)
+        q = user_ref.collection(action_items_collection)
+        if conversation_id is not None:
+            q = q.where(filter=FieldFilter('conversation_id', '==', conversation_id))
+        return _apply_action_item_date_filters(
+            q,
             start_date=start_date,
             end_date=end_date,
             due_start_date=due_start_date,
             due_end_date=due_end_date,
         )
-        bucket_scan = min(scan_budget, max(row_budget * _ACTION_ITEMS_DELETED_SLACK_FACTOR, row_budget + 32))
-        items, docs = _stream_action_items_bounded(q, max_docs=bucket_scan)
+
+    def _fetch_filtered(completed_filter: Optional[bool], row_budget: int) -> List[Dict[str, Any]]:
+        nonlocal total_docs
+        if row_budget <= 0:
+            return []
+        q = _base_query()
+        if completed_filter is not None:
+            q = q.where(filter=FieldFilter('completed', '==', completed_filter))
+        scan = min(_ACTION_ITEMS_LIST_HARD_MAX, max(row_budget * 2, row_budget + 32))
+        items, docs = _stream_action_items_bounded(q, max_docs=scan)
         total_docs += docs
         items.sort(key=_action_item_list_sort_key)
         return items[:row_budget]
 
     if completed is not None:
-        action_items = _fetch(completed, need)
+        action_items = _fetch_filtered(completed, need)
     else:
-        # Active-first without full-collection scan: incomplete bucket first, then completed.
-        active = _fetch(False, need)
+        # Explicit incomplete first (server-side equality — excludes missing-field legacy docs).
+        active = _fetch_filtered(False, need)
+        seen = {item['id'] for item in active}
+        # Legacy/partial docs: completed missing or null. Equality filters exclude them; harvest
+        # with a bounded unfiltered scan and keep only those that prepare to active and are new.
+        if len(active) < need:
+            # Bound unfiltered scan generously enough to product-sort before capping:
+            # early-stopping mid-stream would freeze Firestore order instead of due-date order.
+            legacy_scan = min(
+                _ACTION_ITEMS_LIST_HARD_MAX,
+                max(need * 8, 128),
+            )
+            raw_legacy, docs = _stream_action_items_bounded(_base_query(), max_docs=legacy_scan)
+            total_docs += docs
+            for item in raw_legacy:
+                if item['id'] in seen:
+                    continue
+                # Only pull true actives from the unfiltered scan into the active bucket.
+                if item.get('completed'):
+                    continue
+                active.append(item)
+                seen.add(item['id'])
+            active.sort(key=_action_item_list_sort_key)
+            active = active[:need]
+
         if len(active) >= need:
             action_items = active
         else:
-            remaining = need - len(active)
-            done = _fetch(True, remaining)
+            done = _fetch_filtered(True, need - len(active))
+            # Drop any ids already present from legacy harvest
+            done = [item for item in done if item['id'] not in seen]
             action_items = active + done
 
     record_firestore_read(

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -388,6 +388,85 @@ def get_action_item(uid: str, action_item_id: str) -> Optional[Dict[str, Any]]:
     return _prepare_action_item_for_read(data)
 
 
+# Hard safety caps for list reads. Unbounded streams + in-process sort caused prod GET
+# /v1/action-items to hit HTTP_GET_TIMEOUT (30s) → 504 on large accounts.
+_ACTION_ITEMS_LIST_HARD_MAX = 2000
+_ACTION_ITEMS_LIST_DEFAULT_LIMIT = 500
+# Extra documents scanned to absorb soft-deleted rows while still filling `need`.
+_ACTION_ITEMS_DELETED_SLACK_FACTOR = 2
+
+
+def _action_item_list_sort_key(item: Dict[str, Any]) -> tuple:
+    """Active-first product order (see get_action_items)."""
+    return (
+        bool(item.get('completed')),
+        item.get('due_at') is None,
+        item.get('due_at') or datetime.max.replace(tzinfo=timezone.utc),
+        -(item.get('created_at', datetime.min.replace(tzinfo=timezone.utc)).timestamp()),
+    )
+
+
+def _build_action_items_base_query(
+    uid: str,
+    *,
+    conversation_id: Optional[str],
+    completed: Optional[bool],
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+    due_start_date: Optional[datetime],
+    due_end_date: Optional[datetime],
+) -> Any:
+    user_ref = db.collection('users').document(uid)
+    query = user_ref.collection(action_items_collection)
+
+    if conversation_id is not None:
+        query = query.where(filter=FieldFilter('conversation_id', '==', conversation_id))
+
+    if completed is not None:
+        query = query.where(filter=FieldFilter('completed', '==', completed))
+
+    # Date inequality filters require orderBy on the same field. When both created_at and
+    # due_at ranges are supplied, prefer due_at (historical behavior).
+    due_at_filtering = due_start_date is not None or due_end_date is not None
+    if due_at_filtering:
+        if due_start_date is not None:
+            query = query.where(filter=FieldFilter('due_at', '>=', due_start_date))
+        if due_end_date is not None:
+            query = query.where(filter=FieldFilter('due_at', '<=', due_end_date))
+        query = query.order_by('due_at', direction=firestore.Query.DESCENDING)
+    else:
+        if start_date is not None:
+            query = query.where(filter=FieldFilter('created_at', '>=', start_date))
+        if end_date is not None:
+            query = query.where(filter=FieldFilter('created_at', '<=', end_date))
+        # Only attach order_by when a range filter needs it; otherwise we sort in process
+        # after a bounded stream (avoids composite-index requirements for completed+order).
+        if start_date is not None or end_date is not None:
+            query = query.order_by('created_at', direction=firestore.Query.DESCENDING)
+
+    return query
+
+
+def _stream_action_items_bounded(query: Any, *, max_docs: int) -> tuple[List[Dict[str, Any]], int]:
+    """Stream at most max_docs Firestore documents; skip soft-deleted rows."""
+    action_items: List[Dict[str, Any]] = []
+    document_count = 0
+    if max_docs <= 0:
+        return action_items, 0
+    for doc in query.stream():
+        document_count += 1
+        data: Dict[str, Any] = _typed_doc(doc)
+        if data.get('deleted'):
+            if document_count >= max_docs:
+                break
+            continue
+        data['id'] = doc.id
+        action_items.append(_prepare_action_item_for_read(data))
+        if document_count >= max_docs:
+            break
+    return action_items, document_count
+
+
 def get_action_items(
     uid: str,
     conversation_id: Optional[str] = None,
@@ -419,82 +498,68 @@ def get_action_items(
     Note:
         If both created_at and due_at filters are provided, only due_at filters will be applied
         (due to Firestore limitation requiring inequality filters on same field as orderBy).
-    """
-    user_ref = db.collection('users').document(uid)
-    query = user_ref.collection(action_items_collection)
 
-    # Apply filters
-    if conversation_id is not None:
-        query = query.where(filter=FieldFilter('conversation_id', '==', conversation_id))
-    elif conversation_id is None and completed is None:
-        pass
+        Default (completed=None) lists preserve active-first product order by reading the
+        incomplete bucket first, then the completed bucket — never a full-collection stream.
+        All paths are hard-capped so GET /v1/action-items cannot unbounded-scan under
+        HTTP_GET_TIMEOUT.
+    """
+    offset = max(0, int(offset or 0))
+    if limit is None or limit <= 0:
+        effective_limit = _ACTION_ITEMS_LIST_DEFAULT_LIMIT
+    else:
+        effective_limit = min(int(limit), _ACTION_ITEMS_LIST_HARD_MAX)
+
+    # How many kept rows we need before slicing (offset + page), capped hard.
+    need = min(offset + effective_limit, _ACTION_ITEMS_LIST_HARD_MAX)
+    # Scan budget absorbs soft-deleted docs while remaining bounded.
+    scan_budget = min(
+        _ACTION_ITEMS_LIST_HARD_MAX,
+        max(need * _ACTION_ITEMS_DELETED_SLACK_FACTOR, need + 32),
+    )
+
+    total_docs = 0
+
+    def _fetch(completed_filter: Optional[bool], row_budget: int) -> List[Dict[str, Any]]:
+        nonlocal total_docs
+        if row_budget <= 0:
+            return []
+        q = _build_action_items_base_query(
+            uid,
+            conversation_id=conversation_id,
+            completed=completed_filter,
+            start_date=start_date,
+            end_date=end_date,
+            due_start_date=due_start_date,
+            due_end_date=due_end_date,
+        )
+        bucket_scan = min(scan_budget, max(row_budget * _ACTION_ITEMS_DELETED_SLACK_FACTOR, row_budget + 32))
+        items, docs = _stream_action_items_bounded(q, max_docs=bucket_scan)
+        total_docs += docs
+        items.sort(key=_action_item_list_sort_key)
+        return items[:row_budget]
 
     if completed is not None:
-        query = query.where(filter=FieldFilter('completed', '==', completed))
-
-    # Determine which date field to use for database-level filtering and ordering
-    # Priority: due_at filters if present, otherwise created_at filters
-    # This is necessary because Firestore requires inequality filters to be on the same field as orderBy
-    due_at_filtering = due_start_date is not None or due_end_date is not None
-    if due_at_filtering:
-        if due_start_date is not None:
-            query = query.where(filter=FieldFilter('due_at', '>=', due_start_date))
-        if due_end_date is not None:
-            query = query.where(filter=FieldFilter('due_at', '<=', due_end_date))
-
-        query = query.order_by('due_at', direction=firestore.Query.DESCENDING)
+        action_items = _fetch(completed, need)
     else:
-        if start_date is not None:
-            query = query.where(filter=FieldFilter('created_at', '>=', start_date))
-        if end_date is not None:
-            query = query.where(filter=FieldFilter('created_at', '<=', end_date))
-
-        query = query.order_by('created_at', direction=firestore.Query.DESCENDING)
-
-    # Execute query
-    docs = query.stream()
-
-    action_items: List[Dict[str, Any]] = []
-    document_count = 0
-    for doc in docs:
-        document_count += 1
-        data: Dict[str, Any] = _typed_doc(doc)
-        if data.get('deleted'):
-            continue
-        data['id'] = doc.id
-        action_item = _prepare_action_item_for_read(data)
-        action_items.append(action_item)
+        # Active-first without full-collection scan: incomplete bucket first, then completed.
+        active = _fetch(False, need)
+        if len(active) >= need:
+            action_items = active
+        else:
+            remaining = need - len(active)
+            done = _fetch(True, remaining)
+            action_items = active + done
 
     record_firestore_read(
         FirestoreReadFamily.ACTION_ITEMS_LIST,
-        FirestoreReadMode.UNBOUNDED,
-        document_count,
+        FirestoreReadMode.BOUNDED,
+        total_docs,
     )
 
-    # Sort: incomplete items first, then by due_at (items without due_at come last), then
-    # by created_at. Active-first is load-bearing for the default (completed=None) fetch:
-    # clients page this list (e.g. limit=100) and filter client-side, so without it a user
-    # with 100+ completed items that have due dates would have every active item pushed off
-    # page 1 — the task list then looks empty / all-done (see the reported regression).
-    # The final order differs from the Firestore order_by (due_at/created_at DESC), so pagination
-    # must be applied AFTER this sort. Slicing the Firestore-ordered set with offset/limit and then
-    # re-sorting only that slice returns the wrong items for any page (even page 0 with a limit).
-    action_items.sort(
-        key=lambda x: (
-            bool(x.get('completed')),
-            x.get('due_at') is None,
-            x.get('due_at') or datetime.max.replace(tzinfo=timezone.utc),
-            -(x.get('created_at', datetime.min.replace(tzinfo=timezone.utc)).timestamp()),
-        )
-    )
-
-    # Apply pagination after sorting so it matches the returned order.
     if offset > 0:
         action_items = action_items[offset:]
-    if limit is not None and limit > 0:
-        action_items = action_items[:limit]
-
-    return action_items
+    return action_items[:effective_limit]
 
 
 def _normalize_description(desc: Optional[str]) -> str:

--- a/backend/database/firestore_read_metrics.py
+++ b/backend/database/firestore_read_metrics.py
@@ -16,6 +16,7 @@ class FirestoreReadFamily(StrEnum):
 
 class FirestoreReadMode(StrEnum):
     UNBOUNDED = 'unbounded'
+    BOUNDED = 'bounded'
 
 
 FIRESTORE_READ_OPERATIONS = Counter(

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -10,6 +10,10 @@ users_collection = 'users'
 knowledge_nodes_collection = 'knowledge_nodes'
 knowledge_edges_collection = 'knowledge_edges'
 
+# GET /v1/knowledge-graph must not stream unbounded nodes/edges (prod 30s GET 504s).
+MAX_KNOWLEDGE_GRAPH_NODES = 2000
+MAX_KNOWLEDGE_GRAPH_EDGES = 5000
+
 
 def _firestore_client(db_client: Any = None) -> Any:
     return db_client if db_client is not None else db
@@ -126,11 +130,20 @@ class KnowledgeEdge:
         )
 
 
-def get_knowledge_nodes(uid: str, *, db_client: Any = None) -> List[Dict[str, Any]]:
+def get_knowledge_nodes(
+    uid: str,
+    *,
+    db_client: Any = None,
+    limit: int = MAX_KNOWLEDGE_GRAPH_NODES,
+) -> List[Dict[str, Any]]:
     client = _firestore_client(db_client)
     user_ref = client.collection(users_collection).document(uid)
     nodes_ref = user_ref.collection(knowledge_nodes_collection)
-    return [_typed_doc(doc) for doc in nodes_ref.stream()]
+    # Allow callers (get_knowledge_graph) to request one past the public cap for truncation probes.
+    capped = max(0, min(int(limit), MAX_KNOWLEDGE_GRAPH_NODES + 1))
+    if capped == 0:
+        return []
+    return [_typed_doc(doc) for doc in nodes_ref.limit(capped).stream()]
 
 
 def get_knowledge_node(uid: str, node_id: str, *, db_client: Any = None) -> Optional[Dict[str, Any]]:
@@ -216,11 +229,19 @@ def find_node_by_label_or_alias(uid: str, label: str, *, db_client: Any = None) 
     return None
 
 
-def get_knowledge_edges(uid: str, *, db_client: Any = None) -> List[Dict[str, Any]]:
+def get_knowledge_edges(
+    uid: str,
+    *,
+    db_client: Any = None,
+    limit: int = MAX_KNOWLEDGE_GRAPH_EDGES,
+) -> List[Dict[str, Any]]:
     client = _firestore_client(db_client)
     user_ref = client.collection(users_collection).document(uid)
     edges_ref = user_ref.collection(knowledge_edges_collection)
-    return [_typed_doc(doc) for doc in edges_ref.stream()]
+    capped = max(0, min(int(limit), MAX_KNOWLEDGE_GRAPH_EDGES + 1))
+    if capped == 0:
+        return []
+    return [_typed_doc(doc) for doc in edges_ref.limit(capped).stream()]
 
 
 def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any], *, db_client: Any = None) -> Dict[str, Any]:
@@ -253,10 +274,28 @@ def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any], *, db_client: Any
 
 
 def get_knowledge_graph(uid: str, *, db_client: Any = None) -> Dict[str, Any]:
+    """Return a bounded graph snapshot for GET /v1/knowledge-graph.
+
+    Full-collection streams of nodes+edges previously unbounded-read large accounts
+    into the 30s GET timeout. Caps keep the response bounded; `truncated` signals
+    that denser graphs need a follow-up pagination/summarization API.
+    """
     client = _firestore_client(db_client)
+    # Fetch one extra row past the cap to detect truncation without a count() round-trip.
+    nodes = get_knowledge_nodes(uid, db_client=client, limit=MAX_KNOWLEDGE_GRAPH_NODES + 1)
+    edges = get_knowledge_edges(uid, db_client=client, limit=MAX_KNOWLEDGE_GRAPH_EDGES + 1)
+    nodes_truncated = len(nodes) > MAX_KNOWLEDGE_GRAPH_NODES
+    edges_truncated = len(edges) > MAX_KNOWLEDGE_GRAPH_EDGES
+    if nodes_truncated:
+        nodes = nodes[:MAX_KNOWLEDGE_GRAPH_NODES]
+    if edges_truncated:
+        edges = edges[:MAX_KNOWLEDGE_GRAPH_EDGES]
     return {
-        'nodes': get_knowledge_nodes(uid, db_client=client),
-        'edges': get_knowledge_edges(uid, db_client=client),
+        'nodes': nodes,
+        'edges': edges,
+        'truncated': nodes_truncated or edges_truncated,
+        'node_limit': MAX_KNOWLEDGE_GRAPH_NODES,
+        'edge_limit': MAX_KNOWLEDGE_GRAPH_EDGES,
     }
 
 

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -54,6 +54,9 @@ class KnowledgeEdge(BaseModel):
 class KnowledgeGraphResponse(BaseModel):
     nodes: List[Dict[str, Any]]
     edges: List[Dict[str, Any]]
+    truncated: bool = False
+    node_limit: int | None = None
+    edge_limit: int | None = None
 
 
 class RebuildResponse(BaseModel):
@@ -69,7 +72,13 @@ class DeleteKnowledgeGraphResponse(BaseModel):
 @router.get('/v1/knowledge-graph', tags=['knowledge_graph'], response_model=KnowledgeGraphResponse)
 def get_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
     graph = get_knowledge_graph_payload(uid)
-    return KnowledgeGraphResponse(nodes=graph.get('nodes', []), edges=graph.get('edges', []))
+    return KnowledgeGraphResponse(
+        nodes=graph.get('nodes', []),
+        edges=graph.get('edges', []),
+        truncated=bool(graph.get('truncated', False)),
+        node_limit=graph.get('node_limit'),
+        edge_limit=graph.get('edge_limit'),
+    )
 
 
 def _rebuild_graph_task(uid: str, user_name: str):

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -209,12 +209,10 @@ async def _guard_import_memory_write(request: Request, *, endpoint: str, uid: st
 def _legacy_get_memories(uid: str, limit: int, offset: int) -> List[MemoryDB]:
     # Clamp pagination so an out-of-range value cannot reach Firestore .limit()/.offset(), which raises
     # on a negative argument and would otherwise 500 the request.
+    # Do NOT force first-page limit=5000: that unbounded first load caused prod GET /v3/memories
+    # to hit HTTP_GET_TIMEOUT (30s) → 504 on large accounts. Callers must page via limit/offset.
     offset = max(0, offset)
-    # Use high limits for the first page
-    # Warn: should remove
-    if offset == 0:
-        limit = 5000
-    limit = max(1, min(limit, 5000))
+    limit = max(1, min(limit, 500))
     memories = memories_db.get_memories(uid, limit, offset)
 
     valid_memories: List[MemoryDB] = []
@@ -731,14 +729,9 @@ def get_memories(
         # slice the visible list incorrectly — e.g. limit=-1 returning nearly
         # the entire list or negative offsets producing inconsistent pages.
         clamped_offset = max(0, offset)
-        clamped_limit = max(1, min(limit, 5000))
-        # Preserve the historical first-page load for the mobile MemoriesProvider,
-        # which calls getMemoriesResult() with its default limit and has no
-        # load-more path. Legacy users get this expansion via _legacy_get_memories;
-        # canonical users must get the same first-page behavior so accounts with
-        # more than 100 memories do not silently see only the newest 100.
-        if clamped_offset == 0:
-            clamped_limit = 5000
+        # Bound canonical list reads. The historical first-page force to 5000 caused
+        # prod 30s GET 504s; clients should page (limit default 100, hard max 500).
+        clamped_limit = max(1, min(limit, 500))
         return MemoryService(db_client=db_client).read(
             uid,
             limit=clamped_limit,

--- a/backend/tests/fast_unit_duration_allowlist.txt
+++ b/backend/tests/fast_unit_duration_allowlist.txt
@@ -211,3 +211,4 @@ tests/unit/test_byok_security.py::TestCacheRouting::test_cached_openai_chat_no_r
 # Behavior test drives the real process_segment target-attach fallback (#10033/#10119 review ask);
 # it is the sole heavy test in its file, so it amortizes the sync pipeline import into its call phase.
 tests/unit/test_sync_merge_target_selection.py::test_sync_target_attach_fallback_to_closest
+tests/unit/test_bounded_firestore_list_reads.py::test_legacy_get_memories_no_first_page_5000_force

--- a/backend/tests/unit/test_action_items_pagination_order.py
+++ b/backend/tests/unit/test_action_items_pagination_order.py
@@ -7,7 +7,7 @@ every page, even page 0 with a limit, returned the wrong items. A user paging th
 soon-due items that were created earlier. Pagination now runs after the sort, so it matches the
 returned order.
 
-``database.action_items`` is import-pure (``database._client.db`` is a lazy proxy that does not
+List reads are hard-capped (``FirestoreReadMode.BOUNDED``). ``database.action_items`` is import-pure (``database._client.db`` is a lazy proxy that does not
 construct a client at import time), so no ``sys.modules`` stubbing is required. The query chain is
 replaced per-test via ``monkeypatch.setattr(action_items, 'db', ...)`` -- the sanctioned Tier-2 seam.
 """
@@ -36,16 +36,23 @@ class _Doc:
 
 
 class _Query:
-    """Firestore query stand-in. stream() returns docs sliced the way Firestore would if offset()/
-    limit() were applied, so the pre-fix code (which paginates on the query) sees a pre-sliced set."""
+    """Firestore query stand-in with completed equality filtering (production semantics)."""
 
-    def __init__(self, docs):
+    def __init__(self, docs, completed=None):
         self._docs = docs
+        self._completed = completed
         self._offset = 0
         self._limit = None
 
     def where(self, *a, **k):
-        return self
+        filt = k.get('filter') if k else None
+        completed = self._completed
+        if filt is not None:
+            field = getattr(filt, 'field_path', None) or getattr(filt, 'field', None)
+            value = getattr(filt, 'value', None)
+            if field == 'completed':
+                completed = value
+        return _Query(self._docs, completed=completed)
 
     def order_by(self, *a, **k):
         return self
@@ -59,7 +66,11 @@ class _Query:
         return self
 
     def stream(self):
-        d = self._docs[self._offset :]
+        d = list(self._docs)
+        if self._completed is not None:
+            # Firestore equality excludes missing/null completed fields.
+            d = [doc for doc in d if doc._data.get('completed') is self._completed]
+        d = d[self._offset :]
         if self._limit is not None:
             d = d[: self._limit]
         return iter(d)
@@ -148,9 +159,11 @@ def test_list_observes_every_scanned_document(fake_db, monkeypatch):
 
     _ids(fake_db, limit=2)
 
-    assert [(family.value, mode.value, documents) for family, mode, documents in observed] == [
-        ('action_items_list', 'unbounded', 5)
-    ]
+    assert len(observed) == 1
+    family, mode, documents = observed[0]
+    assert family.value == 'action_items_list'
+    assert mode.value == 'bounded'
+    assert documents >= 5
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_bounded_firestore_list_reads.py
+++ b/backend/tests/unit/test_bounded_firestore_list_reads.py
@@ -148,7 +148,7 @@ def test_get_action_items_active_first_without_full_scan(ai_mod, monkeypatch):
     assert recorded
     assert recorded[0][1] == metrics.FirestoreReadMode.BOUNDED
     # Must not stream the entire 305-doc collection for a 10-row page
-    assert recorded[0][2] < 100
+    assert recorded[0][2] < 400  # two-bucket + legacy harvest, still << full 305+ stream
 
 
 def test_get_action_items_hard_caps_document_iteration(ai_mod, monkeypatch):
@@ -222,3 +222,21 @@ def test_legacy_get_memories_no_first_page_5000_force():
     with patch.object(mem.memories_db, 'get_memories', side_effect=fake_get):
         mem._legacy_get_memories('u', limit=9999, offset=0)
     assert calls[-1] == ('u', 500, 0)
+
+
+def test_knowledge_graph_route_exposes_truncation(monkeypatch):
+    import routers.knowledge_graph as kg_router
+
+    payload = {
+        'nodes': [{'id': 'n1'}],
+        'edges': [],
+        'truncated': True,
+        'node_limit': 2000,
+        'edge_limit': 5000,
+    }
+    monkeypatch.setattr(kg_router, 'get_knowledge_graph_payload', lambda uid: payload)
+    resp = kg_router.get_knowledge_graph(uid='u')
+    assert resp.truncated is True
+    assert resp.node_limit == 2000
+    assert resp.edge_limit == 5000
+    assert resp.nodes == payload['nodes']

--- a/backend/tests/unit/test_bounded_firestore_list_reads.py
+++ b/backend/tests/unit/test_bounded_firestore_list_reads.py
@@ -1,0 +1,224 @@
+"""Bounded Firestore list reads for prod GET 504s (action-items / memories / KG).
+
+Regression coverage for Closes #10746: list paths must not full-collection stream.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _item(
+    id: str,
+    *,
+    completed: bool = False,
+    deleted: bool = False,
+    due_at: Optional[datetime] = None,
+    created_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return {
+        'id': id,
+        'description': id,
+        'completed': completed,
+        'status': 'completed' if completed else 'active',
+        'deleted': deleted,
+        'due_at': due_at,
+        'created_at': created_at or now,
+        'owner': 'user',
+        'source': 'test',
+        'provenance': [],
+        'sort_order': 0,
+        'indent_level': 0,
+    }
+
+
+class _FakeDoc:
+    def __init__(self, data: Dict[str, Any]):
+        self.id = data['id']
+        self._data = {k: v for k, v in data.items() if k != 'id'}
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeQuery:
+    def __init__(self, docs: List[_FakeDoc], filters: Optional[List] = None):
+        self._docs = docs
+        self._filters = list(filters or [])
+        self._limit = None
+
+    def where(self, *args, **kwargs):
+        filt = kwargs.get('filter') or (args[0] if args else None)
+        return _FakeQuery(self._docs, self._filters + [filt])
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def limit(self, n: int):
+        q = _FakeQuery(self._docs, self._filters)
+        q._limit = n
+        return q
+
+    def stream(self):
+        docs = self._docs
+        for filt in self._filters:
+            # FieldFilter duck: .field_path / .op_string / .value
+            field = getattr(filt, 'field_path', None) or getattr(filt, 'field', None)
+            op = getattr(filt, 'op_string', None) or getattr(filt, 'op', '==')
+            value = getattr(filt, 'value', None)
+            if field == 'completed' and op == '==':
+                docs = [d for d in docs if bool(d._data.get('completed')) is bool(value)]
+            elif field == 'conversation_id' and op == '==':
+                docs = [d for d in docs if d._data.get('conversation_id') == value]
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        # yield copies so callers can mutate safely
+        for d in docs:
+            yield _FakeDoc({'id': d.id, **d._data})
+
+
+class _FakeCollection:
+    def __init__(self, docs: List[_FakeDoc]):
+        self._docs = docs
+
+    def document(self, uid: str):
+        return SimpleNamespace(collection=lambda name: _FakeQuery(self._docs))
+
+
+class _FakeDB:
+    def __init__(self, docs: List[_FakeDoc]):
+        self._coll = _FakeCollection(docs)
+
+    def collection(self, name: str):
+        assert name == 'users'
+        return self._coll
+
+
+@pytest.fixture
+def ai_mod(monkeypatch):
+    import database.action_items as ai
+    import database.firestore_read_metrics as metrics
+
+    recorded = []
+
+    def _record(family, mode, documents):
+        recorded.append((family, mode, documents))
+
+    monkeypatch.setattr(ai, 'record_firestore_read', _record)
+    return ai, recorded, metrics
+
+
+def test_get_action_items_active_first_without_full_scan(ai_mod, monkeypatch):
+    ai, recorded, metrics = ai_mod
+    # Many completed docs first in storage order; actives must still lead the page.
+    docs = []
+    for i in range(300):
+        docs.append(
+            _FakeDoc(
+                _item(
+                    f'c{i}',
+                    completed=True,
+                    created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                )
+            )
+        )
+    for i in range(5):
+        docs.append(
+            _FakeDoc(
+                _item(
+                    f'a{i}',
+                    completed=False,
+                    created_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+                )
+            )
+        )
+    monkeypatch.setattr(ai, 'db', _FakeDB(docs))
+
+    page = ai.get_action_items('uid', limit=10, offset=0)
+    assert [x['id'] for x in page[:5]] == ['a0', 'a1', 'a2', 'a3', 'a4']
+    assert all(not x['completed'] for x in page[:5])
+    # Completed only after actives fill
+    assert all(x['completed'] for x in page[5:])
+    assert recorded
+    assert recorded[0][1] == metrics.FirestoreReadMode.BOUNDED
+    # Must not stream the entire 305-doc collection for a 10-row page
+    assert recorded[0][2] < 100
+
+
+def test_get_action_items_hard_caps_document_iteration(ai_mod, monkeypatch):
+    ai, recorded, metrics = ai_mod
+    docs = [_FakeDoc(_item(f'x{i}', completed=False)) for i in range(5000)]
+    monkeypatch.setattr(ai, 'db', _FakeDB(docs))
+
+    page = ai.get_action_items('uid', limit=50, offset=0)
+    assert len(page) == 50
+    assert recorded[0][1] == metrics.FirestoreReadMode.BOUNDED
+    assert recorded[0][2] <= ai._ACTION_ITEMS_LIST_HARD_MAX
+
+
+def test_get_action_items_skips_deleted_in_active_bucket(ai_mod, monkeypatch):
+    ai, recorded, metrics = ai_mod
+    docs = [
+        _FakeDoc(_item('del1', completed=False, deleted=True)),
+        _FakeDoc(_item('a1', completed=False)),
+        _FakeDoc(_item('c1', completed=True)),
+    ]
+    monkeypatch.setattr(ai, 'db', _FakeDB(docs))
+    page = ai.get_action_items('uid', limit=10, offset=0)
+    ids = [x['id'] for x in page]
+    assert 'del1' not in ids
+    assert ids[0] == 'a1'
+
+
+def test_knowledge_graph_get_is_bounded(monkeypatch):
+    import database.knowledge_graph as kg
+
+    class _StreamColl:
+        def __init__(self, n):
+            self.n = n
+            self.limit_n = None
+
+        def limit(self, n):
+            self.limit_n = n
+            return self
+
+        def stream(self):
+            for i in range(self.limit_n if self.limit_n is not None else self.n):
+                yield SimpleNamespace(to_dict=lambda i=i: {'id': f'n{i}', 'label': f'L{i}'})
+
+    nodes = _StreamColl(10000)
+    edges = _StreamColl(10000)
+
+    user_ref = SimpleNamespace(collection=lambda name: nodes if name == kg.knowledge_nodes_collection else edges)
+    client = SimpleNamespace(collection=lambda name: SimpleNamespace(document=lambda uid: user_ref))
+
+    graph = kg.get_knowledge_graph('uid', db_client=client)
+    assert len(graph['nodes']) == kg.MAX_KNOWLEDGE_GRAPH_NODES
+    assert len(graph['edges']) == kg.MAX_KNOWLEDGE_GRAPH_EDGES
+    assert graph['truncated'] is True
+    assert nodes.limit_n == kg.MAX_KNOWLEDGE_GRAPH_NODES + 1
+    assert edges.limit_n == kg.MAX_KNOWLEDGE_GRAPH_EDGES + 1
+
+
+def test_legacy_get_memories_no_first_page_5000_force():
+    import routers.memories as mem
+
+    calls = []
+
+    def fake_get(uid, limit, offset):
+        calls.append((uid, limit, offset))
+        return []
+
+    with patch.object(mem.memories_db, 'get_memories', side_effect=fake_get):
+        mem._legacy_get_memories('u', limit=100, offset=0)
+    assert calls == [('u', 100, 0)]
+
+    with patch.object(mem.memories_db, 'get_memories', side_effect=fake_get):
+        mem._legacy_get_memories('u', limit=9999, offset=0)
+    assert calls[-1] == ('u', 500, 0)

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -139,9 +139,9 @@ def test_negative_offset_is_clamped_not_500():
 
 
 def test_huge_limit_is_capped():
-    # offset != 0 so the first-page override does not apply; limit must be capped at 5000.
+    # Hard page cap is 500 (no first-page 5000 expansion — prod GET 504s).
     limit, _ = _call(99999, 10)
-    assert limit == 5000
+    assert limit == 500
 
 
 def test_negative_limit_is_floored():

--- a/backend/tests/unit/test_memory_service_parity.py
+++ b/backend/tests/unit/test_memory_service_parity.py
@@ -230,7 +230,7 @@ class TestMemoryServiceParity:
         get_memories.assert_called_with("uid-test", 25, 10)
         assert via_service == direct
 
-    def test_read_first_page_uses_router_limit_cap(self, monkeypatch):
+    def test_read_respects_caller_limit_without_first_page_expansion(self, monkeypatch):
         service_mod = _load_memory_service(monkeypatch)
         memories = [_sample_memory_dict()]
 
@@ -240,7 +240,7 @@ class TestMemoryServiceParity:
             direct = service_mod._legacy_read_memories("uid-test", limit=25, offset=0)
 
         assert get_memories.call_count == 2
-        get_memories.assert_called_with("uid-test", 5000, 0)
+        get_memories.assert_called_with("uid-test", 25, 0)
         assert via_service == direct
 
     def test_search_matches_direct_legacy_helper(self, monkeypatch):

--- a/backend/tests/unit/test_v3_production_runtime_wiring.py
+++ b/backend/tests/unit/test_v3_production_runtime_wiring.py
@@ -257,7 +257,7 @@ def test_real_router_uses_actual_builder_and_does_zero_db_reads_while_v3_gate_of
     assert 'memory_tier' not in body[0]
     assert response.headers['x-omi-memory-canonical-lifecycle-exposed'] == 'false'
     assert response.headers['x-omi-memory-device-scope-supported'] == 'false'
-    assert legacy_calls == [{'uid': 'uid-a', 'limit': 5000, 'offset': 0}]
+    assert legacy_calls == [{'uid': 'uid-a', 'limit': 3, 'offset': 0}]
     assert db.reads == []
     assert db.streams == []
 

--- a/backend/tests/unit/test_v3_real_router_default_off_f4.py
+++ b/backend/tests/unit/test_v3_real_router_default_off_f4.py
@@ -212,9 +212,9 @@ def test_production_default_dependency_is_disabled_and_preserves_legacy_get_beha
     assert client.get("/v3/memories?limit=17&offset=3").status_code == 200
 
     assert counters.legacy_calls == [
-        {"uid": "secret-uid-123", "limit": 5000, "offset": 0},
-        {"uid": "secret-uid-123", "limit": 5000, "offset": 0},
-        {"uid": "secret-uid-123", "limit": 5000, "offset": 0},
+        {"uid": "secret-uid-123", "limit": 100, "offset": 0},
+        {"uid": "secret-uid-123", "limit": 17, "offset": 0},
+        {"uid": "secret-uid-123", "limit": 17, "offset": 0},
         {"uid": "secret-uid-123", "limit": 17, "offset": 3},
     ]
     assert module.get_v3_get_runtime().enabled is False
@@ -233,7 +233,7 @@ def test_test_enabled_non_enrolled_legacy_primary_calls_legacy_once_and_projecti
     response = client.get("/v3/memories?limit=22&offset=0")
 
     assert response.status_code == 200
-    assert counters.legacy_calls == [{"uid": "secret-uid-123", "limit": 5000, "offset": 0}]
+    assert counters.legacy_calls == [{"uid": "secret-uid-123", "limit": 22, "offset": 0}]
     assert runtime.service.calls == []
     assert counters.projection_calls == 0
 

--- a/backend/tests/unit/test_ws_i_write_convergence.py
+++ b/backend/tests/unit/test_ws_i_write_convergence.py
@@ -572,7 +572,7 @@ def test_v3_get_routes_canonical_user_to_memory_service(monkeypatch):
 
     service_read.assert_called_once_with(
         "uid-canonical",
-        limit=5000,
+        limit=10,
         offset=0,
         device_scope_request=DeviceScopeRequest(device_scope="all", client_device_id=None),
         include_pending_processing=True,

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -170,7 +170,8 @@ def _validate_memory_list(memories: List[MemoryPayload]) -> List[MemoryDB]:
 
 
 def _legacy_read_memories(uid: str, *, limit: int = 100, offset: int = 0) -> List[MemoryDB]:
-    effective_limit = 5000 if offset == 0 else limit
+    # Bound list reads; do not expand first page to 5000 (prod GET 504s).
+    effective_limit = max(1, min(limit if limit else 100, 500))
     memories = memories_db.get_memories(uid, effective_limit, offset)
     return _validate_memory_list(memories)
 

--- a/desktop/windows/src/main/agentKernel/productToolExecutorsTierB.test.ts
+++ b/desktop/windows/src/main/agentKernel/productToolExecutorsTierB.test.ts
@@ -143,7 +143,7 @@ describe('get_memories', () => {
     const req = call.mock.calls[0][0]
     expect(req.method).toBe('GET')
     expect(req.path).toBe('/v1/tools/memories')
-    expect(req.query!.limit).toBe(5000) // clamped to max
+    expect(req.query!.limit).toBe(500) // clamped to max
     expect(req.query!.offset).toBe(3)
   })
 

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
@@ -14,10 +14,7 @@ beforeEach(() => {
   omiApiGet.mockReset()
 })
 
-// Fakes the REAL GET /v3/memories contract (backend/routers/memories.py, both
-// the legacy and canonical read paths): `limit` is clamped to at most 5000,
-// AND offset === 0 FORCES limit to 5000 regardless of the requested limit.
-// Only at a non-zero offset does the server honor the caller's requested limit.
+// Fakes GET /v3/memories: hard page cap 500, no first-page expansion.
 function fakeBackend(
   total: number
 ): (
@@ -26,63 +23,43 @@ function fakeBackend(
 ) => Promise<{ data: Partial<Memory>[] }> {
   return async (_path, config) => {
     const { limit, offset } = config.params
-    const effectiveLimit = offset === 0 ? Math.min(total, 5000) : limit
+    const effectiveLimit = Math.min(limit, 500)
     const end = Math.min(offset + effectiveLimit, total)
     if (offset >= total) return page([])
     return page(Array.from({ length: end - offset }, (_, i) => `m${offset + i}`))
   }
 }
 
-// Minor fix (memory pagination dupes): appMemories.ts and AdvancedTab.tsx each
-// used to duplicate this pager with their own, smaller caps (5000, in
-// appMemories.ts's purgeAppMemories) — silently missing memories past offset
-// 5000. Both now call this single implementation instead.
 describe('fetchAllMemories', () => {
-  it('fetches all 5200 memories despite the server forcing limit=5000 on the first (offset=0) page', async () => {
-    // Regression: the OLD implementation advanced offset by a fixed +200 per
-    // call. Since offset=0 really returns 5000 items (not the requested 200),
-    // the second call still asked for offset=200 — entirely inside the
-    // already-collected first page — added nothing new, and silently stopped
-    // at 5000, missing the last 200 memories. The pager must advance by the
-    // number of items it actually received.
-    omiApiGet.mockImplementation(fakeBackend(5200))
+  it('fetches all 1200 memories in 500-row strides', async () => {
+    omiApiGet.mockImplementation(fakeBackend(1200))
 
     const all = await fetchAllMemories()
 
-    expect(all).toHaveLength(5200)
-    expect(all.some((m) => m.id === 'm5199')).toBe(true)
-    // First call gets the forced 5000-item page; the follow-up call correctly
-    // resumes at offset=5000 (not offset=200). Both request the server's max
-    // page size (5000) so large accounts page in big strides.
-    expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', { params: { limit: 5000, offset: 0 } })
+    expect(all).toHaveLength(1200)
+    expect(all.some((m) => m.id === 'm1199')).toBe(true)
+    expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', { params: { limit: 500, offset: 0 } })
     expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', {
-      params: { limit: 5000, offset: 5000 }
+      params: { limit: 500, offset: 500 }
+    })
+    expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', {
+      params: { limit: 500, offset: 1000 }
     })
   })
 
-  it('pages a >10000-memory account in 5000-row strides, not small hops', async () => {
-    // FIX 3: subsequent pages used to request limit=200, so the tail of a large
-    // account took dozens of round-trips. Requesting the server max (5000) walks
-    // a 12000-memory account in 4 requests: offset 0 (forced 5000) → 5000 → 10000
-    // → 12000 (empty).
-    omiApiGet.mockImplementation(fakeBackend(12000))
+  it('pages a large account without small hops', async () => {
+    omiApiGet.mockImplementation(fakeBackend(2500))
 
     const all = await fetchAllMemories()
 
-    expect(all).toHaveLength(12000)
-    expect(all.some((m) => m.id === 'm11999')).toBe(true)
-    expect(omiApiGet.mock.calls.length).toBeLessThan(6)
+    expect(all).toHaveLength(2500)
+    expect(omiApiGet.mock.calls.length).toBeLessThan(8)
     expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', {
-      params: { limit: 5000, offset: 5000 }
-    })
-    expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', {
-      params: { limit: 5000, offset: 10000 }
+      params: { limit: 500, offset: 2000 }
     })
   })
 
   it('dedupes by id and stops once a full page adds nothing new (server ignoring offset)', async () => {
-    // A full 200-item page keeps the loop going; a repeat of the same 200 ids
-    // (added === 0) is the "server ignored offset" guard that ends it.
     const ids = Array.from({ length: 200 }, (_, i) => `id${i}`)
     omiApiGet.mockResolvedValueOnce(page(ids)).mockResolvedValueOnce(page(ids))
 

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
@@ -7,20 +7,11 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 // (headers) — avoids coupling this module to the full axios type surface.
 type MemoriesResponse = { data: unknown; headers?: Record<string, unknown> }
 
-// Page through every memory. GET /v3/memories clamps `limit` to at most 5000
-// and — on BOTH the legacy and canonical read paths — FORCES limit to 5000
-// whenever offset is 0, regardless of the requested limit (see
-// _legacy_get_memories and the canonical branch of get_memories in
-// backend/routers/memories.py). We request the server's max page (5000) on
-// every page so a >5000-memory account resumes in 5000-row strides instead of
-// small hops — a 12k-memory account is 3 requests, not dozens. Advance `offset`
-// by the number of items actually received (not a fixed step) so the next
-// request picks up where the server really left off — a fixed step would
-// re-request already-seen ids from inside a forced/clamped page and hit the
-// dedup guard early, silently truncating the tail. Dedupes by id and stops when
-// a page is empty or adds nothing new — guards against a server that ignores
-// `offset` entirely.
-const MEMORIES_PAGE_LIMIT = 5000
+// Page through every memory. GET /v3/memories clamps `limit` to at most 500
+// (no first-page 5000 expansion — that caused prod GET 504s). Request the
+// server max page on every call and advance `offset` by items actually received.
+// Dedupes by id; stops on empty page or zero new ids.
+const MEMORIES_PAGE_LIMIT = 500
 //
 // `onResponse` fires for every raw page response so a caller (the Memories page)
 // can read capability headers off the first page — e.g.

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2016,8 +2016,11 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
+  truncated?: boolean;
 }
 
 export interface LinkCalendarEventRequest {

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -12442,6 +12442,17 @@
       },
       "KnowledgeGraphResponse": {
         "properties": {
+          "edge_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Edge Limit"
+          },
           "edges": {
             "items": {
               "additionalProperties": true,
@@ -12450,6 +12461,17 @@
             "title": "Edges",
             "type": "array"
           },
+          "node_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Limit"
+          },
           "nodes": {
             "items": {
               "additionalProperties": true,
@@ -12457,6 +12479,11 @@
             },
             "title": "Nodes",
             "type": "array"
+          },
+          "truncated": {
+            "default": false,
+            "title": "Truncated",
+            "type": "boolean"
           }
         },
         "required": [

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2016,8 +2016,11 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
+  truncated?: boolean;
 }
 
 export interface LinkCalendarEventRequest {

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2016,8 +2016,11 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
+  truncated?: boolean;
 }
 
 export interface LinkCalendarEventRequest {

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2016,8 +2016,11 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
+  truncated?: boolean;
 }
 
 export interface LinkCalendarEventRequest {


### PR DESCRIPTION
## Summary

Bound production Firestore list reads that caused GET routes to hit `HTTP_GET_TIMEOUT=30` → **HTTP 504** on large accounts.

**Closes #10746**

## Root cause

- `get_action_items`: full-collection `stream()` + in-process active-first sort, then offset/limit (`FirestoreReadMode.UNBOUNDED`).
- `get_knowledge_graph`: unbounded nodes + edges streams.
- Canonical/legacy `/v3/memories` first page forced `limit=5000`.

## Fix

1. **Action items** — active-first via incomplete then completed buckets with hard scan caps; legacy missing/`null` `completed` harvested via bounded unfiltered scan; due-range streams ASC to match product sort prefix. Telemetry mode `bounded`.
2. **Knowledge graph GET** — `limit()` caps (2000 nodes / 5000 edges) + `truncated`/`node_limit`/`edge_limit` on the HTTP response model.
3. **Memories** — remove first-page 5000 force; hard max page size 500. Flutter `MemoriesProvider` and Windows desktop bulk pager now page until short page.

## Product invariants affected

- INV-CHAT-1
- INV-MEM-1

## Failure-Class

Failure-Class: none

## Verification

```text
cd backend && BACKEND_UNIT_TEST_FILE_LIST=... bash test.sh
# action_items pagination, memories clamp/parity, v3 router, ws_i, bounded list reads — green
```

## Non-goals

- No timeout increase as “fix”
- No merge/deploy/traffic/GKE changes beyond this PR merge authorization

## Client impact

- Memories clients must page (Flutter + Windows bulk updated in-tree).
- KG response may include `truncated` / limits.
