### PR TITLE
fix(chat): serve legacy memories when a legacy-cohort account has no rollout state (#10736)

### DIFF
--- a/backend/tests/unit/test_chat_memory_adapter.py
+++ b/backend/tests/unit/test_chat_memory_adapter.py
@@ -50,7 +50,9 @@ def test_chat_memory_tool_wires_memory_adapter_before_legacy_vector_search():
     assert legacy_call in contents
     assert contents.index(rollout_call) < contents.index(legacy_call)
     assert 'if default_memories is not None:' not in contents
-    assert 'MemoryReadDecision.USE_LEGACY_SAFE' in contents
+    # The legacy-fallback decision is centralized in chat_legacy_read_authorized (#10736),
+    # which allows USE_LEGACY_SAFE plus the un-enrolled missing_rollout_state cohort.
+    assert 'if not chat_legacy_read_authorized(default_memories):' in contents
 
 
 def test_chat_rollout_reader_supports_omi_chat_grant_without_reading_memory_items():

--- a/backend/tests/unit/test_chat_memory_missing_rollout_fallback.py
+++ b/backend/tests/unit/test_chat_memory_missing_rollout_fallback.py
@@ -1,0 +1,179 @@
+"""Chat memory reads recover the un-enrolled legacy cohort (issue #10736).
+
+An account with no `users/{uid}/memory_control/state` doc resolves to
+DENY_MEMORY / `missing_rollout_state`, which is the expected state for the legacy
+cohort. The Developer API (#10094) and MCP (#10095) already read the legacy
+`memories` collection for that signal; the chat retrieval tools used to return
+"No memories available for this request." instead, so chat answered as though the
+user had no memories while the memories screen showed them normally.
+
+These exercise the tools themselves through the adapter seam, not source text.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key-not-real")
+
+# Imported at module scope so the retrieval-tool import graph is paid at collection time
+# rather than inside a test's call phase (backend fast-unit duration guard).
+import database.memories as memory_db  # noqa: E402
+import database.notifications as notification_db  # noqa: E402
+import database.vector_db as vector_db  # noqa: E402
+import utils.retrieval.tool_services.memories as memory_service_tools  # noqa: E402
+import utils.retrieval.tools.memory_tools as memory_tools  # noqa: E402
+from utils.memory.chat_memory_adapter import (  # noqa: E402
+    ChatMemorySearchResult,
+    chat_legacy_read_authorized,
+)
+from utils.memory.default_read_rollout import MemoryReadDecision  # noqa: E402
+from utils.memory.memory_system import MemorySystem  # noqa: E402
+
+
+def _denied(reason: str) -> ChatMemorySearchResult:
+    return ChatMemorySearchResult(
+        text="No memories available for this request.",
+        read_decision=MemoryReadDecision.DENY_MEMORY,
+        fallback_reason=reason,
+    )
+
+
+def _legacy_memory(memory_id: str = 'mem-1', content: str = 'LEGACY_COHORT_MEMORY') -> dict:
+    return {
+        'id': memory_id,
+        'uid': 'u1',
+        'content': content,
+        'category': 'core',
+        'created_at': '2026-07-27T00:00:00+00:00',
+        'updated_at': '2026-07-27T00:00:00+00:00',
+    }
+
+
+class TestChatLegacyReadAuthorized:
+    def test_missing_rollout_state_is_authorized(self):
+        assert chat_legacy_read_authorized(_denied('missing_rollout_state')) is True
+
+    def test_explicit_legacy_safe_is_authorized(self):
+        legacy_safe = ChatMemorySearchResult(
+            text=None, read_decision=MemoryReadDecision.USE_LEGACY_SAFE, fallback_reason='chat_legacy_safe'
+        )
+        assert chat_legacy_read_authorized(legacy_safe) is True
+
+    @pytest.mark.parametrize(
+        'reason',
+        ['missing_chat_default_memory_grant', 'malformed_rollout_state', 'uid_mismatch', 'shadow_only'],
+    )
+    def test_other_deny_reasons_stay_fail_closed(self, reason):
+        assert chat_legacy_read_authorized(_denied(reason)) is False
+
+
+class TestChatToolsFallBackToLegacy:
+    def test_get_memories_tool_serves_legacy_on_missing_rollout_state(self):
+        with (
+            patch.object(memory_tools, 'pin_memory_system', return_value=MemorySystem.LEGACY),
+            patch.object(
+                memory_tools,
+                'list_default_chat_memories_decision_text',
+                return_value=_denied('missing_rollout_state'),
+            ),
+            patch.object(memory_db, 'get_memories', return_value=[_legacy_memory()]),
+        ):
+            result = memory_tools.get_memories_tool.invoke(
+                {'limit': 10, 'offset': 0}, config={'configurable': {'user_id': 'u1'}}
+            )
+
+        assert 'LEGACY_COHORT_MEMORY' in result
+        assert 'No memories available for this request.' not in result
+
+    def test_get_memories_tool_still_denies_other_reasons(self):
+        with (
+            patch.object(memory_tools, 'pin_memory_system', return_value=MemorySystem.LEGACY),
+            patch.object(
+                memory_tools,
+                'list_default_chat_memories_decision_text',
+                return_value=_denied('missing_chat_default_memory_grant'),
+            ),
+            patch.object(memory_db, 'get_memories', return_value=[_legacy_memory()]) as legacy_read,
+        ):
+            result = memory_tools.get_memories_tool.invoke(
+                {'limit': 10, 'offset': 0}, config={'configurable': {'user_id': 'u1'}}
+            )
+
+        assert result == 'No memories available for this request.'
+        legacy_read.assert_not_called()
+
+    def test_search_memories_tool_serves_legacy_on_missing_rollout_state(self):
+        with (
+            patch.object(memory_tools, 'pin_memory_system', return_value=MemorySystem.LEGACY),
+            patch.object(
+                memory_tools,
+                'search_memory_default_chat_memories_vector_decision_text',
+                return_value=_denied('missing_rollout_state'),
+            ),
+            patch.object(notification_db, 'get_user_time_zone', return_value='UTC'),
+            patch.object(vector_db, 'find_similar_memories', return_value=[{'memory_id': 'mem-1', 'score': 0.9}]),
+            patch.object(memory_db, 'get_memories_by_ids', return_value=[_legacy_memory()]),
+        ):
+            result = memory_tools.search_memories_tool.invoke(
+                {'query': 'coffee'}, config={'configurable': {'user_id': 'u1'}}
+            )
+
+        assert 'LEGACY_COHORT_MEMORY' in result
+        assert 'No memories available for this request.' not in result
+
+    def test_search_memories_tool_still_denies_other_reasons(self):
+        with (
+            patch.object(memory_tools, 'pin_memory_system', return_value=MemorySystem.LEGACY),
+            patch.object(
+                memory_tools,
+                'search_memory_default_chat_memories_vector_decision_text',
+                return_value=_denied('missing_chat_default_memory_grant'),
+            ),
+            patch.object(notification_db, 'get_user_time_zone', return_value='UTC'),
+            patch.object(vector_db, 'find_similar_memories', return_value=[]) as vector_read,
+        ):
+            result = memory_tools.search_memories_tool.invoke(
+                {'query': 'coffee'}, config={'configurable': {'user_id': 'u1'}}
+            )
+
+        assert result == 'No memories available for this request.'
+        vector_read.assert_not_called()
+
+
+class TestToolServicesFallBackToLegacy:
+    """The REST tool services (desktop/web chat) share the same guard."""
+
+    def test_get_memories_text_serves_legacy_on_missing_rollout_state(self):
+        with (
+            patch.object(memory_service_tools, 'pin_memory_system', return_value=MemorySystem.LEGACY),
+            patch.object(
+                memory_service_tools,
+                'list_default_chat_memories_decision_text',
+                return_value=_denied('missing_rollout_state'),
+            ),
+            patch.object(memory_db, 'get_memories', return_value=[_legacy_memory()]),
+        ):
+            result = memory_service_tools.get_memories_text(uid='u1', limit=10, offset=0)
+
+        assert 'LEGACY_COHORT_MEMORY' in result
+
+    def test_get_memories_text_still_denies_other_reasons(self):
+        with (
+            patch.object(memory_service_tools, 'pin_memory_system', return_value=MemorySystem.LEGACY),
+            patch.object(
+                memory_service_tools,
+                'list_default_chat_memories_decision_text',
+                return_value=_denied('missing_chat_default_memory_grant'),
+            ),
+            patch.object(memory_db, 'get_memories', return_value=[_legacy_memory()]) as legacy_read,
+        ):
+            result = memory_service_tools.get_memories_text(uid='u1', limit=10, offset=0)
+
+        assert result == 'No memories available for this request.'
+        legacy_read.assert_not_called()

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -213,10 +213,15 @@ memory_adapter_stub.list_default_chat_memories_decision_text = MagicMock(
 memory_adapter_stub.search_memory_default_chat_memories_vector_decision_text = MagicMock(
     return_value=types.SimpleNamespace(read_decision="use_legacy_safe", text="", fallback_reason="test")
 )
+memory_adapter_stub.chat_legacy_read_authorized = MagicMock(
+    side_effect=lambda result: result.read_decision == "use_legacy_safe"
+    or (result.read_decision == "deny_memory" and result.fallback_reason == "missing_rollout_state")
+)
 read_rollout_stub = _stub_module("utils.memory.default_read_rollout")
 read_rollout_stub.MemoryReadDecision = types.SimpleNamespace(
     USE_MEMORY="use_memory",
     USE_LEGACY_SAFE="use_legacy_safe",
+    DENY_MEMORY="deny_memory",
 )
 
 memory_system_stub = _stub_module("utils.memory.memory_system")

--- a/backend/utils/memory/chat_memory_adapter.py
+++ b/backend/utils/memory/chat_memory_adapter.py
@@ -20,6 +20,7 @@ from utils.memory.default_read_surface import (
     parse_optional_default_read_datetime,
 )
 from utils.memory.product_memory_read_service import fetch_default_product_memory_search
+from utils.observability import record_fallback
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,30 @@ class ChatMemorySearchResult:
     @property
     def should_use_legacy_fallback(self) -> bool:
         return self.read_decision == MemoryReadDecision.USE_LEGACY_SAFE
+
+
+def chat_legacy_read_authorized(result: ChatMemorySearchResult) -> bool:
+    """Whether an Omi chat memory read may serve the legacy `memories` surface.
+
+    True for an explicit legacy-safe decision, and for a legacy-cohort account whose
+    `memory_control/state` doc was never created (#10736): callers reach this only on
+    the non-canonical branch after `pin_memory_system`, where the absent doc is the
+    expected un-enrolled state and legacy reads are authoritative. Mirrors
+    `mcp_legacy_read_authorized` (#10095) and the Developer API guard (#10094); every
+    other deny reason stays fail-closed.
+    """
+    if result.read_decision == MemoryReadDecision.USE_LEGACY_SAFE:
+        return True
+    if result.read_decision == MemoryReadDecision.DENY_MEMORY and result.fallback_reason == 'missing_rollout_state':
+        record_fallback(
+            component='other',
+            from_mode='memory_default_read',
+            to_mode='legacy_memories',
+            reason='policy',
+            outcome='recovered',
+        )
+        return True
+    return False
 
 
 CHAT_MEMORY_CONTENT_MAX_CHARS = 280

--- a/backend/utils/retrieval/tool_services/memories.py
+++ b/backend/utils/retrieval/tool_services/memories.py
@@ -16,6 +16,7 @@ from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.surface_routing import pin_memory_system
 from utils.memory.chat_memory_adapter import (
+    chat_legacy_read_authorized,
     list_default_chat_memories_decision_text,
     search_memory_default_chat_memories_vector_decision_text,
 )
@@ -81,7 +82,7 @@ def get_memories_text(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("get_memories_text - using memory default chat memory list results")
         return default_memories.text or "No memory default memories found."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not chat_legacy_read_authorized(default_memories):
         logger.info(
             "get_memories_text - memory default memory list denied without legacy fallback: "
             f"{default_memories.fallback_reason}"
@@ -170,7 +171,7 @@ def search_memories_text(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("search_memories_text - using memory default chat vector memory results")
         return default_memories.text or f"No memory vector memories found matching '{query}'."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not chat_legacy_read_authorized(default_memories):
         logger.info(
             "search_memories_text - memory default memory vector search denied without legacy fallback: "
             f"{default_memories.fallback_reason}"

--- a/backend/utils/retrieval/tools/memory_tools.py
+++ b/backend/utils/retrieval/tools/memory_tools.py
@@ -18,6 +18,7 @@ from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.surface_routing import pin_memory_system
 from utils.memory.chat_memory_adapter import (
+    chat_legacy_read_authorized,
     list_default_chat_memories_decision_text,
     search_memory_default_chat_memories_vector_decision_text,
 )
@@ -217,7 +218,7 @@ def get_memories_tool(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("✅ get_memories_tool - using memory default chat memory list results")
         return default_memories.text or "No memory default memories found."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not chat_legacy_read_authorized(default_memories):
         logger.info(
             "🛑 get_memories_tool - memory chat memory list denied without legacy fallback: "
             f"{default_memories.fallback_reason}"
@@ -378,7 +379,7 @@ def search_memories_tool(
     if default_memories.read_decision == MemoryReadDecision.USE_MEMORY:
         logger.info("✅ search_memories_tool - using memory default chat memory results")
         return default_memories.text or f"No memory vector memories found matching '{query}'."
-    if default_memories.read_decision != MemoryReadDecision.USE_LEGACY_SAFE:
+    if not chat_legacy_read_authorized(default_memories):
         logger.info(
             "🛑 search_memories_tool - memory chat memory denied without legacy fallback: "
             f"{default_memories.fallback_reason}"


### PR DESCRIPTION
# Summary

Omi chat's memory tools (`get_memories_tool`, `search_memories_tool`, and the REST tool services behind `/v1/tools/*`) no longer return "No memories available for this request." for accounts that were never enrolled in the canonical-memory rollout: they now serve the authoritative legacy `memories` surface.

All four sites route the decision through one shared helper, `chat_legacy_read_authorized`, instead of four copies of the `!= USE_LEGACY_SAFE` comparison. Every other deny reason (malformed state, read failure, missing grant, shadow-only) stays fail-closed. The mode change is recorded through the shared `record_fallback` helper — no new one-off counter.

Chat-surface counterpart of #10094 / #10485 (Developer API) and #10095 (MCP), same root cause. This is the cross-surface unification #10485 explicitly deferred. Fixes #10736.

# Root cause

`pin_memory_system` resolves every account outside the canonical whitelist to `MemorySystem.LEGACY`, where `users/{uid}/memory_control/state` is *expected* to be absent — but `read_default_read_rollout` reports the absent doc as `DENY_MEMORY` / `missing_rollout_state`. The chat sites reach that branch only after the cohort pin already said LEGACY, then refused to read the collection the selector had just declared authoritative. It is silent from the user's side: chat answers as though the user has no memories, so it reads as the assistant forgetting rather than as an error. Prod logs show 23 of these denials on 2026-07-27 alone.

# Failure class

Failure-Class: none

Same call as #10094 / #10095: no registered class covers a reader failing closed on state whose absence the authoritative cohort selector defines as normal.

# Durable guard

- One shared decision owner: the four chat call sites can no longer drift apart — the narrow un-enrolled exception and its telemetry live in `chat_legacy_read_authorized`, whose docstring names the contract.
- The fallback is narrow: only `missing_rollout_state` (doc absent = never enrolled) qualifies; `malformed_rollout_state`, `uid_mismatch`, and `rollout_read_failed` stay fail-closed because there the doc exists or its state is unknown.
- The behavioral regression test drives the real tools through the adapter seam (not source text) and covers both directions of the decision table.

# Validation

- New `tests/unit/test_chat_memory_missing_rollout_fallback.py` — 12 passed. It invokes `get_memories_tool`, `search_memories_tool`, and `get_memories_text` with the adapter denying on `missing_rollout_state` and asserts the legacy memory reaches the result, plus the mirror cases asserting a `missing_chat_default_memory_grant` denial still returns the safe string and never calls the legacy read. These cannot pass on pre-fix code.
- 81 memory/retrieval-related test files via the repo runner (`BACKEND_UNIT_TEST_FILE_LIST=... bash test.sh`) → exit 0, including `test_chat_memory_adapter.py`, `test_tools_router.py`, `test_mcp_memory_adapter.py`, `test_lock_bypass_fixes.py`.
- `black --line-length 120 --skip-string-normalization` clean on all changed files.
- Not exercised live: a production chat turn for a real un-enrolled account (no such credentials here). The fix point is the shared server-side decision helper the tests drive directly.

# Product invariants affected

- **INV-MEM-1** (path-matched via `backend/utils/memory/chat_memory_adapter.py`): no tier vocabulary change — the helper only decides legacy-vs-deny routing for chat reads; tier semantics and the guard test are untouched.
- INV-MEM-3 note: the new fallback runs only on the non-canonical branch (the cohort pin already resolved LEGACY); canonical selection still never falls back to legacy.

# Out of scope, named

- `should_use_legacy_fallback` on `ChatMemorySearchResult` stays for API compatibility; the call sites now use the shared helper.
- #10735 (hosted MCP returning an empty 200 instead of an error on a denial) and #10734 (Developer API keys with no memory grant) are separate surfaces and are not touched here.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

