### PR TITLE
fix(deploy): treat Cannot find service as first-create preflight

### DIFF
--- a/.github/scripts/preflight_public_build_runtime.py
+++ b/.github/scripts/preflight_public_build_runtime.py
@@ -166,6 +166,8 @@ def _gcloud_json(arguments: Sequence[str]) -> Mapping[str, Any]:
         if (
             "not found" in raw_message
             or "could not be found" in raw_message
+            # gcloud run services describe: "Cannot find service [name]"
+            or "cannot find" in raw_message
             or "does not exist" in raw_message
             or "not_found" in raw_message
         ):

--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -736,6 +736,21 @@ jobs:
         finally:
             RUNTIME_PREFLIGHT.subprocess.run = original_run
 
+    def test_runtime_preflight_classifies_cloud_run_cannot_find_service_as_first_create(self) -> None:
+        # Live gcloud run wording (2026-07): "Cannot find service [omi-web]"
+        original_run = RUNTIME_PREFLIGHT.subprocess.run
+        RUNTIME_PREFLIGHT.subprocess.run = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RUNTIME_PREFLIGHT.subprocess.CalledProcessError(
+                1,
+                "gcloud",
+                stderr="ERROR: (gcloud.run.services.describe) Cannot find service [omi-web]",
+            )
+        )
+        try:
+            self.assertIsNone(RUNTIME_PREFLIGHT.load_current_service(target=self.target(), project_id="fake-project"))
+        finally:
+            RUNTIME_PREFLIGHT.subprocess.run = original_run
+
     def test_runtime_preflight_rejects_secret_where_reviewed_runtime_config_will_be_applied(self) -> None:
         contract = fixture_contract()
         contract["targets"]["fake"]["deployment"]["runtime_env_vars"] = {"FAKE_RUNTIME_CONFIG": "reviewed.example"}


### PR DESCRIPTION
## Summary
Treat Cloud Run `Cannot find service [...]` as a first-create (missing service) in public-build runtime preflight so greenfield Personas/app deploys to development do not fail closed incorrectly.

## Failure-Class
Failure-Class: none

## Verification
- `python3 .github/scripts/test_check_public_build_contract.py` (36 tests OK)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

