### PR TITLE
SCA-209: wire Personas to the internal LLM gateway

### DIFF
--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -785,7 +785,9 @@ jobs:
         self.assertEqual(personas.deployment.runtime_secrets["LINKEDIN_API_KEY"], "NEXT_PUBLIC_LINKEDIN_API_KEY:latest")
         self.assertEqual(
             personas.deployment.runtime_env_vars,
-            {"LINKEDIN_RAPIDAPI_HOST": "linkedin-api8.p.rapidapi.com"},
+            {
+                "LINKEDIN_RAPIDAPI_HOST": "linkedin-api8.p.rapidapi.com",
+            },
         )
         self.assertEqual(
             personas.deployment.preserve_runtime_secrets,
@@ -877,6 +879,15 @@ jobs:
         readme = (ROOT / "web/personas-open-source/README.md").read_text(encoding="utf-8")
         self.assertIn("/rockapis-rockapis-default/api/linkedin-api8", readme)
         self.assertIn("LINKEDIN_RAPIDAPI_HOST=linkedin-api8.p.rapidapi.com", readme)
+
+        personas_workflow = (ROOT / ".github/workflows/gcp_personas.yml").read_text(encoding="utf-8")
+        self.assertIn("network: ${{ vars.CLOUD_RUN_VPC_NETWORK }}", personas_workflow)
+        self.assertIn("subnet: ${{ vars.CLOUD_RUN_VPC_SUBNET }}", personas_workflow)
+        self.assertIn(
+            "runtime_env_vars: OMI_LLM_GATEWAY_URL=${{ vars.OMI_LLM_GATEWAY_URL }}",
+            personas_workflow,
+        )
+        self.assertIn("require_gateway_url: true", personas_workflow)
 
     def test_rejects_a_required_value_missing_from_reviewed_source(self) -> None:
         contract = STATIC.load_contract(self.root / "config/public-build-contract.json")

--- a/backend/tests/unit/test_llm_gateway_allowed_callers_contract.py
+++ b/backend/tests/unit/test_llm_gateway_allowed_callers_contract.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import yaml
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_CALLERS = ['backend', 'omi-web', 'omi-admin-dashboard']
+
+
+def _allowed_callers(environment: str) -> list[str]:
+    values_path = BACKEND_ROOT / 'charts' / 'llm-gateway' / f'{environment}_omi_llm_gateway_values.yaml'
+    values = yaml.safe_load(values_path.read_text(encoding='utf-8'))
+    return next(entry['value'].split(',') for entry in values['env'] if entry['name'] == 'LLM_GATEWAY_ALLOWED_CALLERS')
+
+
+def test_llm_gateway_allows_personas_from_dev_and_prod_charts():
+    for environment in ('dev', 'prod'):
+        assert _allowed_callers(environment) == EXPECTED_CALLERS

--- a/config/public-build-contract.json
+++ b/config/public-build-contract.json
@@ -3,7 +3,10 @@
   "configuration": {
     "source": "repository_config",
     "path": "config/public-build-values.json",
-    "environments": ["development", "prod"]
+    "environments": [
+      "development",
+      "prod"
+    ]
   },
   "targets": {
     "admin": {
@@ -13,8 +16,14 @@
       "deployment": {
         "region": "us-central1",
         "build_context": "web/admin",
-        "platforms": ["linux/amd64"],
-        "flags": ["--memory=2Gi", "--cpu=1", "--timeout=3600"],
+        "platforms": [
+          "linux/amd64"
+        ],
+        "flags": [
+          "--memory=2Gi",
+          "--cpu=1",
+          "--timeout=3600"
+        ],
         "runtime_secrets": {
           "FIREBASE_PROJECT_ID": "WEB_ADMIN_FIREBASE_PROJECT_ID:latest",
           "FIREBASE_CLIENT_EMAIL": "WEB_ADMIN_FIREBASE_CLIENT_EMAIL:latest",
@@ -39,22 +48,97 @@
           "GOAFFPRO_ACCESS_TOKEN": "GOAFFPRO_ACCESS_TOKEN:latest",
           "CRON_SECRET": "WEB_ADMIN_CRON_SECRET:latest"
         },
-        "remove_runtime_secrets": ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"]
+        "remove_runtime_secrets": [
+          "ANTHROPIC_API_KEY",
+          "CLAUDE_API_KEY",
+          "OPENAI_API_KEY",
+          "OPENROUTER_API_KEY"
+        ]
       },
       "canary_component": "web/admin/components/public-build-canary.tsx",
       "inputs": [
-        {"name": "NEXT_PUBLIC_FIREBASE_API_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_APP_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_VAPID_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_PLUGINS_APP_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_OMI_API_URL", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]}
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_API_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_APP_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_VAPID_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_PLUGINS_APP_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_OMI_API_URL",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        }
       ],
       "candidate_acceptance": {
-        "command": ["python3", ".github/scripts/smoke_public_build_browser.py", "--target", "admin", "--base-url", "{base_url}"],
+        "command": [
+          "python3",
+          ".github/scripts/smoke_public_build_browser.py",
+          "--target",
+          "admin",
+          "--base-url",
+          "{base_url}"
+        ],
         "marker": "admin:ready"
       },
       "traffic_promotion": "candidate_after_browser_acceptance"
@@ -66,24 +150,96 @@
       "deployment": {
         "region": "us-central1",
         "build_context": ".",
-        "platforms": ["linux/amd64"],
+        "platforms": [
+          "linux/amd64"
+        ],
         "flags": [],
         "runtime_secrets": {}
       },
       "canary_component": "web/app/src/components/public-build-canary.tsx",
       "inputs": [
-        {"name": "NEXT_PUBLIC_API_BASE_URL", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_API_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_APP_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_VAPID_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]}
+        {
+          "name": "NEXT_PUBLIC_API_BASE_URL",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_API_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_APP_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_VAPID_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        }
       ],
       "candidate_acceptance": {
-        "command": ["python3", ".github/scripts/smoke_public_build_browser.py", "--target", "app", "--base-url", "{base_url}"],
+        "command": [
+          "python3",
+          ".github/scripts/smoke_public_build_browser.py",
+          "--target",
+          "app",
+          "--base-url",
+          "{base_url}"
+        ],
         "marker": "app:ready"
       },
       "traffic_promotion": "candidate_after_browser_acceptance"
@@ -95,26 +251,95 @@
       "deployment": {
         "region": "us-central1",
         "build_context": ".",
-        "platforms": ["linux/amd64"],
-        "flags": ["--ingress=internal-and-cloud-load-balancing"],
+        "platforms": [
+          "linux/amd64"
+        ],
+        "flags": [
+          "--ingress=internal-and-cloud-load-balancing"
+        ],
         "runtime_secrets": {
           "PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY": "PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY:latest"
         },
-        "remove_runtime_secrets": ["OPENAI_API_KEY"]
+        "remove_runtime_secrets": [
+          "OPENAI_API_KEY"
+        ]
       },
       "canary_component": "web/frontend/src/components/public-build-canary.tsx",
       "inputs": [
-        {"name": "NEXT_PUBLIC_FIREBASE_API_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_APP_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "API_URL", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]}
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_API_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_APP_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "API_URL",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        }
       ],
       "candidate_acceptance": {
-        "command": ["python3", ".github/scripts/smoke_public_build_browser.py", "--target", "frontend", "--base-url", "{base_url}"],
+        "command": [
+          "python3",
+          ".github/scripts/smoke_public_build_browser.py",
+          "--target",
+          "frontend",
+          "--base-url",
+          "{base_url}"
+        ],
         "marker": "frontend:ready"
       },
       "traffic_promotion": "candidate_after_browser_acceptance"
@@ -127,7 +352,9 @@
       "deployment": {
         "region": "us-central1",
         "build_context": ".",
-        "platforms": ["linux/amd64"],
+        "platforms": [
+          "linux/amd64"
+        ],
         "flags": [],
         "runtime_secrets": {
           "RAPIDAPI_KEY": "NEXT_PUBLIC_RAPIDAPI_KEY:latest",
@@ -168,18 +395,88 @@
       },
       "canary_component": "web/personas-open-source/src/components/public-build-canary.tsx",
       "inputs": [
-        {"name": "NEXT_PUBLIC_FIREBASE_API_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_APP_ID", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_FIREBASE_VAPID_KEY", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_MIXPANEL_TOKEN", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]},
-        {"name": "NEXT_PUBLIC_EXTRA_PROMPT_RULES", "required": true, "source": "repository_config", "allowed_scopes": ["repository"]}
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_API_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_APP_ID",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_FIREBASE_VAPID_KEY",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_MIXPANEL_TOKEN",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        },
+        {
+          "name": "NEXT_PUBLIC_EXTRA_PROMPT_RULES",
+          "required": true,
+          "source": "repository_config",
+          "allowed_scopes": [
+            "repository"
+          ]
+        }
       ],
       "candidate_acceptance": {
-        "command": ["python3", ".github/scripts/smoke_public_build_browser.py", "--target", "personas", "--base-url", "{base_url}"],
+        "command": [
+          "python3",
+          ".github/scripts/smoke_public_build_browser.py",
+          "--target",
+          "personas",
+          "--base-url",
+          "{base_url}"
+        ],
         "marker": "personas:ready"
       },
       "traffic_promotion": "candidate_after_browser_acceptance"

--- a/web/personas-open-source/src/lib/server/persona-chat-gateway.test.mjs
+++ b/web/personas-open-source/src/lib/server/persona-chat-gateway.test.mjs
@@ -105,3 +105,26 @@ test('gateway failure never invokes a provider fallback', async () => {
   );
   assert.equal(calls, 1);
 });
+
+test('missing gateway URL or service token fails closed before a request is sent', async () => {
+  for (const { gatewayUrl, gatewayToken } of [
+    { gatewayUrl: '', gatewayToken: 'service-token' },
+    { gatewayUrl: 'http://gateway.internal', gatewayToken: '  ' },
+  ]) {
+    let calls = 0;
+    await assert.rejects(
+      requestPersonaChatStream({
+        identity: null,
+        messages: [{ role: 'user', content: 'hello' }],
+        gatewayUrl,
+        gatewayToken,
+        fetchImpl: async () => {
+          calls += 1;
+          return okStreamResponse();
+        },
+      }),
+      PersonaGatewayUnavailableError,
+    );
+    assert.equal(calls, 0);
+  }
+});


### PR DESCRIPTION
## Summary
Resolve SCA-209 onto current main after #10754.

- Per-env `OMI_LLM_GATEWAY_URL` from GitHub vars + `require_gateway_url` fail-closed (no shared prod ILB hardcode)
- Remove stale `NEXT_PUBLIC_LINKEDIN_API_HOST`
- Allowlist contract for `omi-web`
- Personas gateway missing URL/token tests

## Failure-Class
Failure-Class: FC-runtime-binding-contract

## Verification
- public-build contract tests OK
- allowlist unit test OK
- persona-chat-gateway node tests 6/6
