### PR TITLE
SCA-215: self-clean the M1 qualification runner

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -11,12 +11,12 @@ checks:
     reason: "the hermetic dev-harness stack backs release qualification; the Jul 22 2026 beta qualification outage added a docker/native typesense runtime that must stay behaviorally covered"
   - id: pre-tag-readiness-contract
     command: ["bash", "desktop/macos/tests/test-pre-tag-readiness-contract.sh"]
-    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/tests/test-pre-tag-readiness-contract.sh", ".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test-pre-tag-readiness-contract.sh", ".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "trusted-M1 readiness must retain exact-SHA cache/lease ownership and cannot emit a passing receipt before authenticated cleanup"
   - id: pre-tag-readiness-behavior
     command: ["python3", "desktop/macos/tests/test_pre_tag_readiness_behavior.py"]
-    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/tests/test_pre_tag_readiness_behavior.py", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_pre_tag_readiness_behavior.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "a disposable source and authenticated capability fakes prove the real readiness orchestrator emits its exact-SHA receipt only after ordered cleanup"
   - id: verify-pre-tag-readiness-tests
@@ -594,12 +594,12 @@ checks:
     reason: "#10163 mutation-sensitive Stable retry and default-channel feed fixtures"
   - id: desktop-release-one-path-contract
     command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
-    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
   - id: desktop-qualification-bootstrap-contract
     command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/prepare-qualification-profile.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "Trusted qualification requires an exact-SHA persistent source, isolated named-bundle, unchanged gates, and phase-bound bootstrap contracts"
@@ -617,10 +617,16 @@ checks:
     reason: "Exact-source retries must keep stable absolute SwiftPM paths while rejecting stale provenance, symlinks, collisions, and incomplete entries"
   - id: desktop-qualification-cache-reclaim
     command: ["python3", "desktop/macos/tests/test_qualification_cache_reclaim.py"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test_qualification_cache_reclaim.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-swift-cache.sh", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/tests/test_qualification_cache_reclaim.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
-    reason: "Actions run 30215483845: preserve the 32 GiB M1 gate while reclaiming only old, exact-SHA, provably idle runner cache entries"
+    reason: "Actions runs 30215483845 and 30316131599: preserve the 32 GiB M1 gate while reclaiming exact-SHA, provably idle runner cache entries under capacity pressure"
+  - id: desktop-qualification-runner-self-clean
+    command: ["python3", "desktop/macos/tests/test_qualification_runner_self_clean.py"]
+    triggers: [".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", "desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_qualification_runner_self_clean.py", "scripts/dev-harness/dev_harness/qualification.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "Issue #10749 and Actions run 30316131599 require exact-provenance cleanup of abandoned M1 qualification processes, leases, ports, containers, and run stages without touching production apps"
 
   - id: desktop-beta-qualification-retry
     command: ["python3", ".github/scripts/test_desktop_beta_qualification_retry.py"]

--- a/.github/failure-classes/FC-self-hosted-qualification-residue.json
+++ b/.github/failure-classes/FC-self-hosted-qualification-residue.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "FC-self-hosted-qualification-residue",
+  "violated_contract": "A trusted self-hosted qualification runner must not admit new work while exact-provenance residue from an abandoned run can retain processes, ports, containers, leases, run stages, or required disk capacity.",
+  "canonical_prevention": "Before acquiring a new qualification lease, authenticate and reclaim only repository-owned residue using exact process, process-group, container, path, bundle, and cache provenance; reject ambiguous ownership and production app identities; enforce capacity; and bound long phases with observable watchdogs.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/scripts/qualification-runner-self-clean.py",
+    "desktop/macos/tests/test_qualification_runner_self_clean.py",
+    ".github/workflows/desktop_qualify_beta.yml"
+  ],
+  "evidence_prs": [
+    10759
+  ],
+  "scope_hints": [
+    "desktop/macos/scripts/qualification-*.py",
+    "desktop/macos/scripts/pre-tag-readiness.sh",
+    ".github/workflows/desktop_*qualif*.yml",
+    "scripts/dev-harness/dev_harness/qualification.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ast
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -47,7 +48,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         return subprocess.run(
             ["bash", "-c", self._workflow_script(step_name)],
             cwd=cwd,
-        env=isolated_env,
+            env=isolated_env,
             check=False,
             capture_output=True,
             text=True,
@@ -81,7 +82,15 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
         reclaim_target.parent.mkdir(parents=True)
         reclaim_target.write_bytes(reclaim_source.read_bytes())
         reclaim_target.chmod(0o755)
-        git("add", "candidate.txt", "desktop/macos/scripts/qualification-cache-reclaim.py")
+        for name in ("qualification-runner-self-clean.py", "qualification-watchdog.py"):
+            target = reclaim_target.parent / name
+            target.write_bytes((reclaim_source.parent / name).read_bytes())
+            target.chmod(0o755)
+        shutil.copytree(
+            ROOT / "scripts/dev-harness/dev_harness",
+            source / "scripts/dev-harness/dev_harness",
+        )
+        git("add", "candidate.txt", "desktop/macos/scripts", "scripts/dev-harness/dev_harness")
         git("-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", "candidate")
         candidate_sha = git("rev-parse", "HEAD")
         git("tag", "-a", RELEASE_TAG, "-m", "candidate")
@@ -107,7 +116,8 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             'git rev-parse "$RELEASE_TAG^{commit}"',
             "git rev-parse 'HEAD^{commit}'",
             "check-desktop-auto-beta-candidate.py",
-            "--automatic --github-actions-artifact",
+            "--automatic",
+            "--github-actions-artifact",
             "group: desktop-beta-qualification-m1",
             "cancel-in-progress: false",
         ):
@@ -146,10 +156,12 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "Finalize only this authenticated qualification lease",
             "if: always()",
             "qualification-lease-command.sh\" release",
-            "runner-capacity.json",
-            "--minimum-age-seconds 21600",
-            "--max-entries 8",
-            "--max-reclaim-kib 67108864",
+            "runner-hygiene.json",
+            "qualification-runner-self-clean.py",
+            "qualification-watchdog.py",
+            "--minimum-age-seconds 3600",
+            "--max-entries 16",
+            "--max-reclaim-kib 134217728",
             "33554432",
             "desktop-qualification-evidence-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}",
             "overwrite: false",
@@ -180,6 +192,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             env = {
                 **os.environ,
                 "RUNNER_TEMP": str(runner_temp),
+                "TMPDIR": str(runner_temp),
                 "GITHUB_RUN_ID": run_id,
                 "GITHUB_RUN_ATTEMPT": run_attempt,
                 "QUALIFICATION_STAGE": str(stage),
@@ -246,6 +259,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             env = {
                 **os.environ,
                 "RUNNER_TEMP": str(runner_temp),
+                "TMPDIR": str(runner_temp),
                 "GITHUB_RUN_ID": run_id,
                 "GITHUB_RUN_ATTEMPT": run_attempt,
                 "QUALIFICATION_STAGE": str(stage),
@@ -291,6 +305,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             env = {
                 **os.environ,
                 "RUNNER_TEMP": str(runner_temp),
+                "TMPDIR": str(runner_temp),
                 "GITHUB_RUN_ID": run_id,
                 "GITHUB_RUN_ATTEMPT": run_attempt,
                 "QUALIFICATION_STAGE": str(stage),
@@ -322,17 +337,17 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
                 env=env,
             )
             self.assertNotEqual(capacity_result.returncode, 0)
-            self.assertIn("M1 qualification runner capacity guard refused to start", capacity_result.stdout)
+            self.assertIn("qualification runner self-clean failed", capacity_result.stdout)
             self.assertFalse(
                 (stage / "source/candidate.txt").exists(),
                 "capacity failure must precede expansion of the candidate checkout",
             )
-            capacity = json.loads((stage / "runner-capacity.json").read_text(encoding="utf-8"))
-            self.assertEqual(capacity["status"], "failed")
-            self.assertEqual(capacity["guard"], "runner-capacity-preflight")
-            self.assertNotIn("failure_class", capacity)
-            self.assertIn("insufficient-free-kib", capacity["failure_reasons"])
-            self.assertEqual(capacity["minimum_free_kib"], 2**63 - 1)
+            hygiene = json.loads((stage / "runner-hygiene.json").read_text(encoding="utf-8"))
+            self.assertEqual(hygiene["status"], "failed")
+            self.assertEqual(hygiene["guard"], "qualification-runner-self-clean")
+            self.assertNotIn("failure_class", hygiene)
+            self.assertIn("insufficient-free-kib", hygiene["capacity"]["failure_reasons"])
+            self.assertEqual(hygiene["capacity"]["minimum_free_kib"], 2**63 - 1)
 
             finalize_result = self._run_workflow_script(
                 "Finalize only this authenticated qualification lease",

--- a/.github/scripts/verify-pre-tag-readiness.py
+++ b/.github/scripts/verify-pre-tag-readiness.py
@@ -25,6 +25,7 @@ LANES = frozenset({"local", "ci"})
 REQUIRED_CHECKS = (
     "source_resolved_from_origin",
     "exact_sha_checkout_verified",
+    "runner_self_clean",
     "swift_cache_prepared",
     "self_check",
     "offline_stack_ready",
@@ -130,7 +131,12 @@ def _self_test() -> int:
     expect_fail("malformed sha", {**base, "source_sha": "deadbeef"}, "deadbeef", "40 lowercase hex")
     expect_fail("non-offline provider", {**base, "provider_mode": "production"}, "a" * 40, "offline")
     expect_fail("bad lane", {**base, "lane": "staging"}, "a" * 40, "lane")
-    expect_fail("missing check", {**base, "checks": {n: True for n in REQUIRED_CHECKS if n != "self_check"}}, "a" * 40, "missing")
+    expect_fail(
+        "missing check",
+        {**base, "checks": {n: True for n in REQUIRED_CHECKS if n != "self_check"}},
+        "a" * 40,
+        "missing",
+    )
     expect_fail("failed check", {**base, "checks": {**base["checks"], "self_check": False}}, "a" * 40, "failed")
     expect_fail("forbidden production field", {**base, "is_live": True}, "a" * 40, "production/qualification")
     expect_fail("forbidden qualification field", {**base, "qualified_beta": True}, "a" * 40, "production/qualification")

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -369,14 +369,19 @@ jobs:
 
       - name: Run ownership-scoped M1 pre-tag readiness
         if: steps.final-plan.outputs.should_release == 'true'
+        timeout-minutes: 130
         env:
           OMI_READINESS_LANE: ci
         run: |
           set -euo pipefail
-          desktop/macos/scripts/pre-tag-readiness.sh \
-            --source-repository "$GITHUB_WORKSPACE" \
-            --evidence "$RUNNER_TEMP/desktop-pre-tag-readiness.json" \
-            "${{ steps.identity.outputs.candidate_sha }}"
+          python3 desktop/macos/scripts/qualification-watchdog.py \
+            --label m1-pre-tag-readiness \
+            --heartbeat-seconds 45 \
+            --timeout-seconds 7200 \
+            -- desktop/macos/scripts/pre-tag-readiness.sh \
+              --source-repository "$GITHUB_WORKSPACE" \
+              --evidence "$RUNNER_TEMP/desktop-pre-tag-readiness.json" \
+              "${{ steps.identity.outputs.candidate_sha }}"
 
       - name: Verify M1 readiness receipt
         if: steps.final-plan.outputs.should_release == 'true'
@@ -391,7 +396,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: desktop-pre-tag-readiness-${{ steps.version.outputs.release_tag }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/desktop-pre-tag-readiness.json
+          path: |
+            ${{ runner.temp }}/desktop-pre-tag-readiness.json
+            ${{ runner.temp }}/desktop-pre-tag-runner-hygiene-${{ github.run_id }}-${{ github.run_attempt }}.json
           if-no-files-found: error
           overwrite: false
 

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   qualify-m1-studio:
     runs-on: [self-hosted, macos, omi-desktop-qualification, omi-qual-m1-studio]
+    timeout-minutes: 250
     permissions:
       contents: write
     outputs:
@@ -51,7 +52,11 @@ jobs:
           git init --quiet "$source_dir"
           git -C "$source_dir" remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git -C "$source_dir" sparse-checkout init --no-cone
-          git -C "$source_dir" sparse-checkout set desktop/macos/scripts/qualification-cache-reclaim.py
+          git -C "$source_dir" sparse-checkout set \
+            desktop/macos/scripts/qualification-cache-reclaim.py \
+            desktop/macos/scripts/qualification-runner-self-clean.py \
+            desktop/macos/scripts/qualification-watchdog.py \
+            scripts/dev-harness/dev_harness
           GIT_TERMINAL_PROMPT=0 git -C "$source_dir" fetch --force --depth=1 --filter=blob:none origin "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           git -C "$source_dir" checkout --quiet --detach "refs/tags/$RELEASE_TAG"
           test -x "$source_dir/desktop/macos/scripts/qualification-cache-reclaim.py"
@@ -68,16 +73,24 @@ jobs:
           test -d "$QUALIFICATION_STAGE/source"
           cache_root="${OMI_QUALIFICATION_SWIFT_CACHE_ROOT:-$HOME/Library/Caches/OmiDesktop/qualification-swiftpm-v2}"
           lease_root="${OMI_QUALIFICATION_LEASE_ROOT:-${TMPDIR:-/tmp}/omi-desktop-qualification}"
-          python3 "$QUALIFICATION_STAGE/source/desktop/macos/scripts/qualification-cache-reclaim.py" reclaim \
+          python3 "$QUALIFICATION_STAGE/source/desktop/macos/scripts/qualification-watchdog.py" \
+            --label runner-self-clean \
+            --heartbeat-seconds 45 \
+            --timeout-seconds 1200 \
+            -- python3 "$QUALIFICATION_STAGE/source/desktop/macos/scripts/qualification-runner-self-clean.py" \
+            --repo-root "$QUALIFICATION_STAGE/source" \
             --cache-root "$cache_root" \
             --qualification-lease-root "$lease_root" \
+            --stage-root "$RUNNER_TEMP/desktop-beta-qualification" \
+            --fault-temp-root "${TMPDIR:-$RUNNER_TEMP}" \
             --capacity-path "$RUNNER_TEMP" \
+            --current-run-id "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --minimum-free-kib "${OMI_QUALIFICATION_MINIMUM_FREE_KIB:-33554432}" \
             --minimum-free-inodes "${OMI_QUALIFICATION_MINIMUM_FREE_INODES:-65536}" \
-            --minimum-age-seconds 21600 \
-            --max-entries 8 \
-            --max-reclaim-kib 67108864 \
-            --report "$QUALIFICATION_STAGE/runner-capacity.json"
+            --minimum-age-seconds 3600 \
+            --max-entries 16 \
+            --max-reclaim-kib 134217728 \
+            --report "$QUALIFICATION_STAGE/runner-hygiene.json"
       - name: Expand exact candidate checkout
         working-directory: ${{ runner.temp }}
         env:
@@ -157,6 +170,7 @@ jobs:
           python3 .github/scripts/check-desktop-auto-beta-candidate.py --release-json "$QUALIFICATION_STAGE/release.json" --smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result.json" --beta-smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result-beta.json" --release-tag "$RELEASE_TAG" --latest-tag "$LATEST_TAG" --tag-sha "$TARGET_SHA" --checkout-sha "$TARGET_SHA" --output "$QUALIFICATION_STAGE/candidate-gate.json"
       - name: Qualify exact candidate on the M1 Studio hermetic stack
         id: qualify
+        timeout-minutes: 245
         working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -167,7 +181,16 @@ jobs:
           OMI_QUALIFICATION_FAULT_PREFLIGHT_REPORT: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/fault-listener-preflight.json
         run: |
           set -euo pipefail
-          desktop/macos/scripts/qualify-desktop-beta.sh --automatic --github-actions-artifact --signed-smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result.json" --candidate-gate-result "$QUALIFICATION_STAGE/candidate-gate.json" "$RELEASE_TAG"
+          python3 desktop/macos/scripts/qualification-watchdog.py \
+            --label m1-desktop-qualification \
+            --heartbeat-seconds 45 \
+            --timeout-seconds 14400 \
+            -- desktop/macos/scripts/qualify-desktop-beta.sh \
+              --automatic \
+              --github-actions-artifact \
+              --signed-smoke-result "$QUALIFICATION_STAGE/desktop-smoke-result.json" \
+              --candidate-gate-result "$QUALIFICATION_STAGE/candidate-gate.json" \
+              "$RELEASE_TAG"
       - name: Create immutable qualification evidence
         id: evidence
         working-directory: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/source
@@ -239,7 +262,7 @@ jobs:
         with:
           name: desktop-qualification-cleanup-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/runner-capacity.json
+            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/runner-hygiene.json
             ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/cleanup-evidence.json
             ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/fault-listener-preflight.json
             ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/phase-timings.json

--- a/desktop/macos/docs/qualification-environment.md
+++ b/desktop/macos/docs/qualification-environment.md
@@ -65,27 +65,32 @@ This readiness gate never grants Beta or Stable authority.
 ## Runner capacity preflight
 
 Before expanding the candidate checkout, the M1-only workflow loads the reclaim
-authority from the exact immutable candidate and writes `runner-capacity.json`
-in its run-isolated stage. The guard still requires at least 32 GiB of free
-filesystem blocks plus 65,536 free inodes.
+authority from the exact immutable candidate and runs
+`desktop/macos/scripts/qualification-runner-self-clean.py`. Maintainers can run
+the same entrypoint with `--dry-run --report <path>` for a read-only before/after
+process and capacity report. The workflow writes `runner-hygiene.json` in its
+run-isolated stage. The guard still requires at least 32 GiB of free filesystem
+blocks plus 65,536 free inodes.
 
 When capacity is low, reclaim considers only owner-only
 `qualification-swiftpm-v2/<40-character-SHA>` entries with a valid v2 manifest,
 completion marker, matching Git HEAD, and direct SwiftPM build directory. It
-orders entries by last use and SHA, requires six hours of age, and removes at
-most eight entries or 64 GiB per run, stopping as soon as the unchanged capacity
-threshold passes. The active harness lease, live cache leases, and live process
-references protect their exact worktrees. A malformed entry, symlink, unknown
-lock, ambiguous harness lease, or live qualifier without an authoritative lease
-refuses the entire plan before deletion. Run staging, cleanup artifacts,
-qualification evidence, and release assets are outside the cache root and are
-never reclaim targets.
+orders entries by last use and SHA, removes hour-old idle entries first, then
+admits younger idle entries only while the host is still below the capacity
+gate. It removes at most sixteen entries or 128 GiB per run and stops as soon as
+the threshold passes. Dead cache lease records are retired; the active harness
+lease, live cache leases, and live process references protect their exact
+worktrees. A malformed entry, symlink, unknown lock, ambiguous harness lease,
+or live qualifier without an authoritative lease refuses the entire plan before
+deletion. Run staging, cleanup artifacts, qualification evidence, and release
+assets are outside the cache root and are never reclaim targets.
 
 On a controlled capacity failure, the workflow fails closed before candidate
 assets or the full source checkout are fetched, then its normal finalizer writes
-cleanup evidence and uploads both evidence files. The capacity report records
-the before/after observations and the bounded exact-SHA deletion list; it does
-not attribute a prior incident to a runner or host cause.
+cleanup evidence and uploads both evidence files. The hygiene report records the
+before/after observations, known disposable process counts, abandoned run IDs,
+and bounded exact-SHA deletion list; it does not attribute a prior incident to
+a runner or host cause.
 
 ## Cleanup safety
 
@@ -97,6 +102,15 @@ recorded owner PID is dead and that provenance validates. Unknown listeners and
 unrecorded processes are never killed. `--keep-stack` intentionally leaves the
 recorded lease for later safe reclamation. Retention removes only completed,
 sentinel-proven state and paired logs, never a live/incomplete or foreign root.
+
+If Actions loses communication before the normal finalizer runs, the next
+pre-tag or qualification invocation runs the self-clean entrypoint before
+acquiring new capabilities. It reclaims only the dead authenticated lease,
+listeners that remain in the exact recorded PGID (including fixed 8085/9099),
+an exactly bound `omi-dev-harness-<lease>-typesense` container, token/start-time/
+command-hash-proven `omi-fault-*` apps, and non-current numeric run stages with
+no live path reference. `/Applications/Omi.app`, `Omi Beta.app`, their bundle
+IDs, foreign listeners, and name-only process matches are never cleanup targets.
 
 The automatic fault suite keeps its fault-inject state under the same
 sentinel-protected lease root. Normal harness cleanup stops that token-bearing

--- a/desktop/macos/scripts/pre-tag-readiness.sh
+++ b/desktop/macos/scripts/pre-tag-readiness.sh
@@ -11,6 +11,8 @@ DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$DESKTOP_DIR/../.." && pwd)"
 CACHE_COMMAND="$SCRIPT_DIR/qualification-swift-cache.sh"
 LEASE_COMMAND="$SCRIPT_DIR/qualification-lease-command.sh"
+SELF_CLEAN_COMMAND="$SCRIPT_DIR/qualification-runner-self-clean.py"
+WATCHDOG_COMMAND="$SCRIPT_DIR/qualification-watchdog.py"
 
 EVIDENCE=""
 SOURCE_REPOSITORY="$REPO_ROOT"
@@ -31,6 +33,9 @@ READINESS_COMPLETE=0
 READINESS_CLEANUP_OK=0
 STARTED_AT=""
 START_SEC=0
+CURRENT_RUN_ID="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-attempt}"
+RUNNER_TEMP_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+HYGIENE_EVIDENCE="${OMI_QUALIFICATION_RUNNER_HYGIENE_REPORT:-$RUNNER_TEMP_ROOT/desktop-pre-tag-runner-hygiene-${CURRENT_RUN_ID}.json}"
 
 usage() {
   cat <<'USAGE'
@@ -86,8 +91,8 @@ git -C "$SOURCE_REPOSITORY" rev-parse --git-dir >/dev/null 2>&1 || {
   echo "pre-tag-readiness: --source-repository is not a git repo: $SOURCE_REPOSITORY" >&2
   exit 1
 }
-[[ -x "$CACHE_COMMAND" && -x "$LEASE_COMMAND" ]] || {
-  echo "pre-tag-readiness: cache or authenticated qualification lease command is unavailable" >&2
+[[ -x "$CACHE_COMMAND" && -x "$LEASE_COMMAND" && -x "$SELF_CLEAN_COMMAND" && -x "$WATCHDOG_COMMAND" ]] || {
+  echo "pre-tag-readiness: cache, lease, self-clean, or watchdog authority is unavailable" >&2
   exit 1
 }
 
@@ -96,12 +101,12 @@ START_SEC=$(date +%s)
 
 emit_evidence() {
   local passed="$1" duration_s="$2" err="${3:-}"
-  python3 - "$EVIDENCE" "$passed" "$SOURCE_SHA" "$LANE" "$duration_s" "$STARTED_AT" "$HARNESS_EVIDENCE" "$err" <<'PY'
+  python3 - "$EVIDENCE" "$passed" "$SOURCE_SHA" "$LANE" "$duration_s" "$STARTED_AT" "$HARNESS_EVIDENCE" "$HYGIENE_EVIDENCE" "$err" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-out_path, passed, source_sha, lane, duration_s, started_at, harness_ev, err = sys.argv[1:9]
+out_path, passed, source_sha, lane, duration_s, started_at, harness_ev, hygiene_ev, err = sys.argv[1:10]
 evidence = {
     "kind": "omi-desktop-pre-tag-readiness-v1",
     "passed": passed == "true",
@@ -113,11 +118,13 @@ evidence = {
     "checks": {
         "source_resolved_from_origin": passed == "true",
         "exact_sha_checkout_verified": passed == "true",
+        "runner_self_clean": passed == "true",
         "swift_cache_prepared": passed == "true",
         "self_check": passed == "true",
         "offline_stack_ready": passed == "true",
     },
     "harness_evidence": Path(harness_ev).name if harness_ev else None,
+    "runner_hygiene_evidence": Path(hygiene_ev).name if hygiene_ev else None,
 }
 if err:
     evidence["error"] = err
@@ -129,6 +136,16 @@ if target:
 else:
     print(json.dumps(evidence, indent=2, sort_keys=True))
 PY
+}
+
+run_watchdog() {
+  local label="$1" timeout_seconds="$2"
+  shift 2
+  python3 "$WATCHDOG_COMMAND" \
+    --label "$label" \
+    --heartbeat-seconds "${OMI_QUALIFICATION_HEARTBEAT_SECONDS:-45}" \
+    --timeout-seconds "$timeout_seconds" \
+    -- "$@"
 }
 
 json_capability_field() {
@@ -228,6 +245,25 @@ git -C "$SOURCE_REPOSITORY" merge-base --is-ancestor "$SOURCE_SHA" origin/main |
   exit 1
 }
 
+# The next run is the recovery authority for an abandoned prior run. Cleanup is
+# limited to authenticated qualification state, token-bound fault apps, exact
+# numeric run stages, and idle exact-SHA cache entries. Any ambiguous residue
+# fails before a fresh cache or qualification lease is acquired.
+run_watchdog runner-self-clean 1200 \
+  python3 "$SELF_CLEAN_COMMAND" \
+    --repo-root "$REPO_ROOT" \
+    --cache-root "${OMI_QUALIFICATION_SWIFT_CACHE_ROOT:-$HOME/Library/Caches/OmiDesktop/qualification-swiftpm-v2}" \
+    --qualification-lease-root "$LEASE_ROOT" \
+    --stage-root "$RUNNER_TEMP_ROOT/desktop-beta-qualification" \
+    --capacity-path "$RUNNER_TEMP_ROOT" \
+    --current-run-id "$CURRENT_RUN_ID" \
+    --minimum-free-kib "${OMI_QUALIFICATION_MINIMUM_FREE_KIB:-33554432}" \
+    --minimum-free-inodes "${OMI_QUALIFICATION_MINIMUM_FREE_INODES:-65536}" \
+    --minimum-age-seconds 3600 \
+    --max-entries 16 \
+    --max-reclaim-kib 134217728 \
+    --report "$HYGIENE_EVIDENCE"
+
 # Bound cache and runner ownership to one source/run/pid-derived capability set.
 RUN_SCOPE="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-attempt}-${BASHPID:-$$}"
 RUN_SCOPE="${RUN_SCOPE//[^A-Za-z0-9]/-}"
@@ -241,7 +277,8 @@ PY
 )"
 
 CACHE_JSON="$(
-  "$CACHE_COMMAND" prepare \
+  run_watchdog readiness-cache-prepare 3600 \
+    "$CACHE_COMMAND" prepare \
     "$SOURCE_SHA" "$SOURCE_REPOSITORY" "$CACHE_LEASE_ID" "$$"
 )"
 WORKTREE="$(json_capability_field source "$CACHE_JSON")"
@@ -274,8 +311,9 @@ owned_agent_directory_is_real || exit 1
 }
 (
   cd "$AGENT_DIR"
-  env -u NODE_ENV -u NPM_CONFIG_OMIT -u npm_config_omit -u NPM_CONFIG_PRODUCTION -u npm_config_production \
-    npm ci --include=dev --no-fund --no-audit
+  run_watchdog readiness-agent-dependencies 1800 \
+    env -u NODE_ENV -u NPM_CONFIG_OMIT -u npm_config_omit -u NPM_CONFIG_PRODUCTION -u npm_config_production \
+      npm ci --include=dev --no-fund --no-audit
 )
 [[ -x "$AGENT_DIR/node_modules/.bin/vitest" ]] || {
   echo "pre-tag-readiness: lockfile-pinned agent Vitest dependency is unavailable" >&2
@@ -283,7 +321,8 @@ owned_agent_directory_is_real || exit 1
 }
 (
   cd "$WORKTREE/desktop/macos"
-  OMI_READINESS_LANE="$LANE" ./scripts/desktop-core-harness.sh --readiness
+  run_watchdog readiness-offline-stack 3600 \
+    env OMI_READINESS_LANE="$LANE" ./scripts/desktop-core-harness.sh --readiness
 )
 
 HARNESS_ROOT="$WORKTREE/desktop/macos/.harness/desktop-core"

--- a/desktop/macos/scripts/qualification-cache-reclaim.py
+++ b/desktop/macos/scripts/qualification-cache-reclaim.py
@@ -124,7 +124,15 @@ def _validate_cache_root(cache_root: Path, *, create: bool) -> Path:
         current /= component
         if stat.S_ISLNK(_lstat(current).st_mode):
             raise CacheSafetyError(f"cache path has a symlinked component: {current.name}")
-    _require_owned_directory(root, private=True)
+    root_info = _require_owned_directory(root, private=False)
+    if stat.S_IMODE(root_info.st_mode) & 0o077:
+        if not create:
+            raise CacheSafetyError("cache root is not owner-only")
+        try:
+            root.chmod(0o700)
+        except OSError as error:
+            raise CacheSafetyError("cannot tighten cache root permissions") from error
+        _require_owned_directory(root, private=True)
     return root
 
 
@@ -203,13 +211,12 @@ def _git_head(source: Path) -> str:
     return result.stdout.strip()
 
 
-def _cache_lease_records(entry: Path, source_sha: str) -> tuple[frozenset[int], set[int]]:
+def _cache_lease_payloads(entry: Path, source_sha: str) -> list[tuple[Path, dict[str, object]]]:
     lease_root = entry / ".leases"
     if not lease_root.exists():
-        return frozenset(), set()
+        return []
     _require_owned_directory(lease_root, private=True)
-    owner_pids: set[int] = set()
-    live_pids: set[int] = set()
+    payloads: list[tuple[Path, dict[str, object]]] = []
     for lease_path in sorted(lease_root.iterdir(), key=lambda path: path.name):
         if lease_path.suffix != ".json" or not LEASE_ID_RE.fullmatch(lease_path.stem):
             raise CacheSafetyError(f"unrecognized cache lease record in {source_sha}")
@@ -230,10 +237,37 @@ def _cache_lease_records(entry: Path, source_sha: str) -> tuple[frozenset[int], 
         token = payload.get("token")
         if owner_pid <= 0 or created_at <= 0 or not isinstance(token, str) or len(token) < 32:
             raise CacheSafetyError(f"cache lease is incomplete in {source_sha}")
+        payloads.append((lease_path, payload))
+    return payloads
+
+
+def _cache_lease_records(entry: Path, source_sha: str) -> tuple[frozenset[int], set[int]]:
+    owner_pids: set[int] = set()
+    live_pids: set[int] = set()
+    for _lease_path, payload in _cache_lease_payloads(entry, source_sha):
+        owner_pid = int(payload["owner_pid"])
         owner_pids.add(owner_pid)
         if _process_exists(owner_pid):
             live_pids.add(owner_pid)
     return frozenset(owner_pids), live_pids
+
+
+def _remove_dead_cache_leases(entries: Iterable[CacheEntry]) -> list[dict[str, object]]:
+    removed: list[dict[str, object]] = []
+    for entry in entries:
+        for lease_path, payload in _cache_lease_payloads(entry.path, entry.source_sha):
+            owner_pid = int(payload["owner_pid"])
+            if _process_exists(owner_pid):
+                continue
+            lease_path.unlink()
+            removed.append(
+                {
+                    "source_sha": entry.source_sha,
+                    "lease_id": str(payload["lease_id"]),
+                    "owner_pid": owner_pid,
+                }
+            )
+    return removed
 
 
 def _validate_entry(
@@ -520,6 +554,7 @@ def reclaim(
     observed_at = int(time.time() if now is None else now)
     before = capacity_probe(capacity_path)
     deleted: list[dict[str, object]] = []
+    removed_dead_leases: list[dict[str, object]] = []
     with _ReclaimLock(root):
         entries = _inventory(root)
         harness_shas, harness_owner_pids = _protected_harness_worktree(root, qualification_lease_root)
@@ -530,15 +565,15 @@ def reclaim(
             if entry.live_lease_owner_pids:
                 protected.add(entry.source_sha)
         protected.update(_process_protection(root, entries, represented, process_probe()))
+        removed_dead_leases = _remove_dead_cache_leases(entries)
 
-        eligible = sorted(
-            (
-                entry
-                for entry in entries
-                if entry.source_sha not in protected and observed_at - entry.last_used_at >= minimum_age_seconds
-            ),
+        idle = sorted(
+            (entry for entry in entries if entry.source_sha not in protected),
             key=lambda entry: (entry.last_used_at, entry.source_sha),
         )
+        aged = [entry for entry in idle if observed_at - entry.last_used_at >= minimum_age_seconds]
+        capacity_pressure = [entry for entry in idle if entry not in aged]
+        eligible = [*aged, *capacity_pressure]
         after = before
         reclaimed_kib = 0
         for entry in eligible:
@@ -553,6 +588,11 @@ def reclaim(
                     "source_sha": entry.source_sha,
                     "age_seconds": observed_at - entry.last_used_at,
                     "size_kib": entry.size_kib,
+                    "reason": (
+                        "retention-age"
+                        if observed_at - entry.last_used_at >= minimum_age_seconds
+                        else "capacity-pressure"
+                    ),
                 }
             )
             after = capacity_probe(capacity_path)
@@ -574,11 +614,12 @@ def reclaim(
         "before_reclaim_available_kib": before.available_kib,
         "before_reclaim_available_inodes": before.available_inodes,
         "reclaim": {
-            "policy": "oldest-idle-exact-sha-v1",
+            "policy": "oldest-idle-capacity-first-v2",
             "minimum_age_seconds": minimum_age_seconds,
             "max_entries": max_entries,
             "max_reclaim_kib": max_reclaim_kib,
             "deleted_entries": deleted,
+            "dead_leases_removed": removed_dead_leases,
             "reclaimed_kib": sum(int(item["size_kib"]) for item in deleted),
         },
     }
@@ -687,10 +728,11 @@ def main() -> int:
                 "minimum_free_kib": args.minimum_free_kib,
                 "minimum_free_inodes": args.minimum_free_inodes,
                 "reclaim": {
-                    "policy": "oldest-idle-exact-sha-v1",
+                    "policy": "oldest-idle-capacity-first-v2",
                     "status": "refused",
                     "reason": str(error)[:300],
                     "deleted_entries": [],
+                    "dead_leases_removed": [],
                     "reclaimed_kib": 0,
                 },
             }

--- a/desktop/macos/scripts/qualification-runner-self-clean.py
+++ b/desktop/macos/scripts/qualification-runner-self-clean.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Ownership-scoped self-clean and capacity gate for the trusted M1 runner."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import plistlib
+import re
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+DEV_HARNESS_ROOT = REPO_ROOT / "scripts" / "dev-harness"
+sys.path.insert(0, str(DEV_HARNESS_ROOT))
+
+from dev_harness import qualification, safety  # noqa: E402
+
+RUN_STAGE_RE = re.compile(r"^[0-9]+-[1-9][0-9]*$")
+SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+FAULT_TEMP_RE = re.compile(r"^omi-fault-owned-app\.[A-Za-z0-9]+$")
+FAULT_BUNDLE_RE = re.compile(r"^omi-fault-[a-z0-9][a-z0-9-]{0,79}$")
+RUN_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+FAULT_RECORD = "fault-app.json"
+KNOWN_PROCESS_MARKERS = (
+    "omi-fault-",
+    "desktop-core-harness.sh --fault-suite",
+    "qualify-desktop-beta.sh",
+    "pre-tag-readiness.sh",
+)
+
+
+class HygieneError(RuntimeError):
+    """Runner residue cannot be classified safely."""
+
+
+@dataclass(frozen=True)
+class ProcessRecord:
+    pid: int
+    process_group: int
+    process_start: str
+    command: str
+
+
+@dataclass(frozen=True)
+class FaultAppTarget:
+    record_path: Path
+    pid: int
+    process_start: str
+    command_sha256: str
+    run_token: str
+    bundle: str
+    bundle_id: str
+    app_path: Path
+    executable_path: Path
+    automation_port: int
+
+
+def _load_cache_module() -> ModuleType:
+    path = SCRIPT_DIR / "qualification-cache-reclaim.py"
+    spec = importlib.util.spec_from_file_location("qualification_cache_reclaim_for_runner_hygiene", path)
+    if spec is None or spec.loader is None:
+        raise HygieneError("qualification cache reclaim authority cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CACHE = _load_cache_module()
+
+
+def _owned_directory(path: Path, *, private: bool) -> os.stat_result:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise HygieneError(f"cannot inspect owned directory {path}: {exc}") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise HygieneError(f"runner hygiene root is not a real directory: {path}")
+    if info.st_uid != os.getuid():
+        raise HygieneError(f"runner hygiene root is owned by another user: {path}")
+    if private and stat.S_IMODE(info.st_mode) & 0o077:
+        raise HygieneError(f"runner hygiene root is not owner-only: {path}")
+    return info
+
+
+def _trusted_temp_directory(path: Path) -> os.stat_result:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise HygieneError(f"cannot inspect temporary search root {path}: {exc}") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise HygieneError(f"temporary search root is not a real directory: {path}")
+    if info.st_uid == os.getuid():
+        return info
+    if info.st_uid == 0 and stat.S_IMODE(info.st_mode) & stat.S_ISVTX:
+        return info
+    raise HygieneError(f"temporary search root is neither user-owned nor root-owned sticky: {path}")
+
+
+def _owned_json(path: Path) -> dict[str, object]:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise HygieneError(f"cannot inspect ownership record {path}: {exc}") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid():
+        raise HygieneError(f"ownership record is not an owned regular file: {path}")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise HygieneError(f"ownership record is not owner-only: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HygieneError(f"ownership record is invalid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise HygieneError(f"ownership record is not a JSON object: {path}")
+    return payload
+
+
+def process_snapshot() -> list[ProcessRecord]:
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,pgid=,lstart=,command="],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise HygieneError("cannot inspect runner processes") from exc
+    records: list[ProcessRecord] = []
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(None, 7)
+        if len(fields) != 8 or not fields[0].isdigit() or not fields[1].isdigit():
+            continue
+        records.append(
+            ProcessRecord(
+                pid=int(fields[0]),
+                process_group=int(fields[1]),
+                process_start=" ".join(fields[2:7]),
+                command=fields[7],
+            )
+        )
+    return records
+
+
+def _known_process_count(processes: Iterable[ProcessRecord]) -> int:
+    return sum(
+        1
+        for process in processes
+        if process.pid != os.getpid()
+        and "qualification-runner-self-clean.py" not in process.command
+        and any(marker in process.command for marker in KNOWN_PROCESS_MARKERS)
+    )
+
+
+def _validate_fault_app_target(
+    record_path: Path,
+    processes: dict[int, ProcessRecord],
+) -> tuple[FaultAppTarget, ProcessRecord | None]:
+    payload = _owned_json(record_path)
+    bundle = payload.get("bundle")
+    run_token = payload.get("run_token")
+    bundle_id = payload.get("bundle_id")
+    app_path_value = payload.get("app_path")
+    executable_value = payload.get("executable_path")
+    process_start = payload.get("process_start")
+    command_sha256 = payload.get("command_sha256")
+    try:
+        pid = int(payload.get("launch_pid", -1))
+        automation_port = int(payload.get("automation_port", -1))
+    except (TypeError, ValueError) as exc:
+        raise HygieneError(f"fault app record has invalid numeric provenance: {record_path}") from exc
+    if (
+        payload.get("schema_version") != 2
+        or not isinstance(bundle, str)
+        or not FAULT_BUNDLE_RE.fullmatch(bundle)
+        or not isinstance(run_token, str)
+        or not RUN_TOKEN_RE.fullmatch(run_token)
+        or bundle_id != f"com.omi.{bundle}"
+        or app_path_value != f"/Applications/{bundle}.app"
+        or executable_value != f"/Applications/{bundle}.app/Contents/MacOS/Omi Computer"
+        or not isinstance(process_start, str)
+        or not process_start
+        or not isinstance(command_sha256, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", command_sha256)
+        or pid <= 0
+        or not 1 <= automation_port <= 65535
+        or payload.get("launch_transport") not in {"open", "direct"}
+    ):
+        raise HygieneError(f"fault app record does not prove a disposable bundle: {record_path}")
+    target = FaultAppTarget(
+        record_path=record_path,
+        pid=pid,
+        process_start=process_start,
+        command_sha256=command_sha256,
+        run_token=run_token,
+        bundle=bundle,
+        bundle_id=str(bundle_id),
+        app_path=Path(str(app_path_value)),
+        executable_path=Path(str(executable_value)),
+        automation_port=automation_port,
+    )
+    process = processes.get(pid)
+    if process is None:
+        return target, None
+    token_argument = f"--omi-launch-token={run_token}"
+    if (
+        process.process_start != process_start
+        or str(target.executable_path) not in process.command
+        or token_argument not in process.command
+        or hashlib.sha256(process.command.encode()).hexdigest() != command_sha256
+    ):
+        raise HygieneError(f"fault app PID no longer matches its launch capability: {record_path}")
+    return target, process
+
+
+def _iter_fault_records_under(root: Path, *, max_depth: int) -> Iterable[Path]:
+    if not root.exists():
+        return
+    _owned_directory(root, private=False)
+    root_depth = len(root.parts)
+    for current, directories, files in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        depth = len(current_path.parts) - root_depth
+        safe_directories: list[str] = []
+        for name in directories:
+            candidate = current_path / name
+            try:
+                info = candidate.lstat()
+            except OSError:
+                continue
+            if not stat.S_ISLNK(info.st_mode) and stat.S_ISDIR(info.st_mode) and info.st_uid == os.getuid():
+                safe_directories.append(name)
+        directories[:] = safe_directories if depth < max_depth else []
+        if FAULT_RECORD in files:
+            yield current_path / FAULT_RECORD
+
+
+def discover_fault_records(cache_root: Path, stage_root: Path, fault_temp_root: Path) -> list[Path]:
+    roots: list[Path] = []
+    if cache_root.exists():
+        _owned_directory(cache_root, private=False)
+        for entry in cache_root.iterdir():
+            if SOURCE_SHA_RE.fullmatch(entry.name) and entry.is_dir() and not entry.is_symlink():
+                roots.append(entry / "source" / "desktop" / "macos" / ".harness" / "desktop-core")
+    if stage_root.exists():
+        _owned_directory(stage_root, private=False)
+        for entry in stage_root.iterdir():
+            if RUN_STAGE_RE.fullmatch(entry.name) and entry.is_dir() and not entry.is_symlink():
+                roots.append(entry / "source" / "desktop" / "macos" / ".harness" / "desktop-core")
+    if fault_temp_root.exists():
+        _trusted_temp_directory(fault_temp_root)
+        for entry in fault_temp_root.iterdir():
+            if FAULT_TEMP_RE.fullmatch(entry.name) and entry.is_dir() and not entry.is_symlink():
+                roots.append(entry)
+    records: set[Path] = set()
+    for root in roots:
+        records.update(_iter_fault_records_under(root, max_depth=6))
+    return sorted(records)
+
+
+def _signal_fault_app(
+    target: FaultAppTarget,
+    *,
+    snapshot: Callable[[], list[ProcessRecord]] = process_snapshot,
+) -> None:
+    for sig, timeout_seconds in ((signal.SIGTERM, 5.0), (signal.SIGKILL, 2.0)):
+        processes = {process.pid: process for process in snapshot()}
+        _target, process = _validate_fault_app_target(target.record_path, processes)
+        if process is None:
+            return
+        try:
+            os.kill(target.pid, sig)
+        except (ProcessLookupError, PermissionError) as exc:
+            raise HygieneError(f"cannot signal exact recorded fault app PID {target.pid}: {exc}") from exc
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            processes = {candidate.pid: candidate for candidate in snapshot()}
+            _target, process = _validate_fault_app_target(target.record_path, processes)
+            if process is None:
+                return
+            time.sleep(0.1)
+    raise HygieneError(f"recorded fault app PID {target.pid} did not stop")
+
+
+def _remove_fault_bundle(target: FaultAppTarget, processes: Iterable[ProcessRecord]) -> str:
+    app = target.app_path
+    if not app.exists():
+        return "absent"
+    info = _owned_directory(app, private=False)
+    if info.st_uid != os.getuid() or app.parent != Path("/Applications"):
+        raise HygieneError(f"fault app bundle escaped the disposable Applications boundary: {app}")
+    plist_path = app / "Contents" / "Info.plist"
+    executable = target.executable_path
+    try:
+        with plist_path.open("rb") as handle:
+            plist = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException) as exc:
+        raise HygieneError(f"cannot validate disposable fault app bundle metadata: {app}") from exc
+    if plist.get("CFBundleIdentifier") != target.bundle_id or not executable.is_file():
+        raise HygieneError(f"fault app bundle identity does not match its launch record: {app}")
+    if any(str(app) in process.command for process in processes):
+        return "preserved-live-reference"
+    shutil.rmtree(app)
+    return "removed"
+
+
+def clean_fault_apps(
+    record_paths: Iterable[Path],
+    *,
+    dry_run: bool,
+    snapshot: Callable[[], list[ProcessRecord]] = process_snapshot,
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    seen_pids: dict[int, FaultAppTarget] = {}
+    for record_path in record_paths:
+        processes = {process.pid: process for process in snapshot()}
+        target, process = _validate_fault_app_target(record_path, processes)
+        previous = seen_pids.get(target.pid)
+        if previous is not None and previous != target:
+            raise HygieneError(f"conflicting fault app records claim PID {target.pid}")
+        seen_pids[target.pid] = target
+        action = "already-exited" if process is None else ("would-stop" if dry_run else "stopped")
+        if process is not None and not dry_run:
+            _signal_fault_app(target, snapshot=snapshot)
+        bundle_action = "would-validate" if dry_run else _remove_fault_bundle(target, snapshot())
+        results.append(
+            {
+                "record": str(record_path),
+                "pid": target.pid,
+                "bundle": target.bundle,
+                "process_action": action,
+                "bundle_action": bundle_action,
+            }
+        )
+    return results
+
+
+def clean_stages(
+    stage_root: Path,
+    *,
+    current_run_id: str,
+    processes: Iterable[ProcessRecord],
+    dry_run: bool,
+) -> list[dict[str, str]]:
+    if not stage_root.exists():
+        return []
+    if stage_root.name != "desktop-beta-qualification":
+        raise HygieneError(f"qualification stage root has an unexpected name: {stage_root}")
+    _owned_directory(stage_root, private=False)
+    results: list[dict[str, str]] = []
+    commands = [process.command for process in processes]
+    for entry in sorted(stage_root.iterdir(), key=lambda path: path.name):
+        if not RUN_STAGE_RE.fullmatch(entry.name):
+            continue
+        _owned_directory(entry, private=True)
+        if entry.name == current_run_id:
+            results.append({"run_id": entry.name, "action": "preserved-current"})
+            continue
+        if any(str(entry) in command for command in commands):
+            raise HygieneError(f"abandoned qualification stage still has a live process reference: {entry.name}")
+        if not dry_run:
+            shutil.rmtree(entry)
+        results.append({"run_id": entry.name, "action": "would-remove" if dry_run else "removed"})
+    return results
+
+
+def _capacity_snapshot(path: Path) -> dict[str, int]:
+    capacity = CACHE._capacity(path)
+    return {
+        "available_kib": capacity.available_kib,
+        "available_inodes": capacity.available_inodes,
+    }
+
+
+def _dry_run_capacity(
+    cache_root: Path,
+    capacity_path: Path,
+    *,
+    minimum_free_kib: int,
+    minimum_free_inodes: int,
+    minimum_age_seconds: int,
+    max_entries: int,
+    max_reclaim_kib: int,
+) -> dict[str, object]:
+    cache_root_permissions = "absent"
+    if cache_root.exists():
+        info = _owned_directory(cache_root, private=False)
+        cache_root_permissions = "would-tighten-to-0700" if stat.S_IMODE(info.st_mode) & 0o077 else "owner-only"
+        CACHE._inventory(cache_root.expanduser().absolute())
+    capacity = _capacity_snapshot(capacity_path)
+    failures: list[str] = []
+    if capacity["available_kib"] < minimum_free_kib:
+        failures.append("insufficient-free-kib")
+    if capacity["available_inodes"] < minimum_free_inodes:
+        failures.append("insufficient-free-inodes")
+    return {
+        "schema_version": 2,
+        "guard": "runner-capacity-preflight",
+        "status": "failed" if failures else "passed",
+        "failure_reasons": failures,
+        "minimum_free_kib": minimum_free_kib,
+        "minimum_free_inodes": minimum_free_inodes,
+        **capacity,
+        "before_reclaim_available_kib": capacity["available_kib"],
+        "before_reclaim_available_inodes": capacity["available_inodes"],
+        "reclaim": {
+            "policy": "oldest-idle-capacity-first-v2",
+            "mode": "dry-run",
+            "cache_root_permissions": cache_root_permissions,
+            "minimum_age_seconds": minimum_age_seconds,
+            "max_entries": max_entries,
+            "max_reclaim_kib": max_reclaim_kib,
+            "deleted_entries": [],
+            "dead_leases_removed": [],
+            "reclaimed_kib": 0,
+        },
+    }
+
+
+def _write_report(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    temporary.replace(path)
+
+
+def run(args: argparse.Namespace) -> dict[str, object]:
+    before_processes = process_snapshot()
+    before_capacity = _capacity_snapshot(args.capacity_path)
+    errors: list[str] = []
+    lease_result: dict[str, object] = {"status": "not-run"}
+    fault_results: list[dict[str, object]] = []
+    stage_results: list[dict[str, str]] = []
+    capacity_result: dict[str, object] = {
+        "status": "not-run",
+        "failure_reasons": ["runner-hygiene-aborted"],
+    }
+    try:
+        lease_result = qualification.reclaim_abandoned(
+            lease_root=args.qualification_lease_root,
+            repo_root=args.repo_root,
+            dry_run=args.dry_run,
+        )
+        if lease_result["status"] == "active":
+            raise HygieneError(
+                f"qualification lease {lease_result['lease_id']} still has a live owner; refusing concurrent cleanup"
+            )
+        records = discover_fault_records(args.cache_root, args.stage_root, args.fault_temp_root)
+        fault_results = clean_fault_apps(records, dry_run=args.dry_run)
+        stage_results = clean_stages(
+            args.stage_root,
+            current_run_id=args.current_run_id,
+            processes=process_snapshot(),
+            dry_run=args.dry_run,
+        )
+        if args.dry_run:
+            capacity_result = _dry_run_capacity(
+                args.cache_root,
+                args.capacity_path,
+                minimum_free_kib=args.minimum_free_kib,
+                minimum_free_inodes=args.minimum_free_inodes,
+                minimum_age_seconds=args.minimum_age_seconds,
+                max_entries=args.max_entries,
+                max_reclaim_kib=args.max_reclaim_kib,
+            )
+        else:
+            capacity_result = CACHE.reclaim(
+                args.cache_root,
+                qualification_lease_root=args.qualification_lease_root,
+                capacity_path=args.capacity_path,
+                minimum_free_kib=args.minimum_free_kib,
+                minimum_free_inodes=args.minimum_free_inodes,
+                minimum_age_seconds=args.minimum_age_seconds,
+                max_entries=args.max_entries,
+                max_reclaim_kib=args.max_reclaim_kib,
+                process_probe=lambda: [
+                    process
+                    for process in CACHE._process_snapshot()
+                    if "qualification-runner-self-clean.py" not in process.command
+                    and "qualification-watchdog.py" not in process.command
+                ],
+            )
+        if capacity_result["status"] != "passed":
+            errors.extend(str(reason) for reason in capacity_result.get("failure_reasons", []))
+    except (HygieneError, qualification.QualificationLeaseError, safety.SafetyError, CACHE.CacheSafetyError) as exc:
+        errors.append(str(exc)[:500])
+    after_processes = process_snapshot()
+    after_capacity = _capacity_snapshot(args.capacity_path)
+    report = {
+        "schema_version": 1,
+        "guard": "qualification-runner-self-clean",
+        "mode": "dry-run" if args.dry_run else "clean",
+        "status": "failed" if errors else "passed",
+        "current_run_id": args.current_run_id,
+        "production_bundles_touched": False,
+        "before": {
+            **before_capacity,
+            "known_disposable_process_count": _known_process_count(before_processes),
+        },
+        "after": {
+            **after_capacity,
+            "known_disposable_process_count": _known_process_count(after_processes),
+        },
+        "cleanup": {
+            "abandoned_lease": lease_result,
+            "fault_apps": fault_results,
+            "stages": stage_results,
+        },
+        "capacity": capacity_result,
+        "errors": errors,
+    }
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        default=Path.home() / "Library/Caches/OmiDesktop/qualification-swiftpm-v2",
+    )
+    parser.add_argument(
+        "--qualification-lease-root",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "OMI_QUALIFICATION_LEASE_ROOT", f"{os.environ.get('TMPDIR', '/tmp')}/omi-desktop-qualification"
+            )
+        ),
+    )
+    parser.add_argument(
+        "--stage-root",
+        type=Path,
+        default=Path(os.environ.get("RUNNER_TEMP", os.environ.get("TMPDIR", "/tmp"))) / "desktop-beta-qualification",
+    )
+    parser.add_argument(
+        "--fault-temp-root",
+        type=Path,
+        default=Path(os.environ.get("TMPDIR", "/tmp")),
+    )
+    parser.add_argument(
+        "--capacity-path",
+        type=Path,
+        default=Path(os.environ.get("RUNNER_TEMP", os.environ.get("TMPDIR", "/tmp"))),
+    )
+    parser.add_argument(
+        "--current-run-id",
+        default=f"{os.environ.get('GITHUB_RUN_ID', 'local')}-{os.environ.get('GITHUB_RUN_ATTEMPT', 'attempt')}",
+    )
+    parser.add_argument(
+        "--minimum-free-kib",
+        type=int,
+        default=int(os.environ.get("OMI_QUALIFICATION_MINIMUM_FREE_KIB", "33554432")),
+    )
+    parser.add_argument(
+        "--minimum-free-inodes",
+        type=int,
+        default=int(os.environ.get("OMI_QUALIFICATION_MINIMUM_FREE_INODES", "65536")),
+    )
+    parser.add_argument("--minimum-age-seconds", type=int, default=60 * 60)
+    parser.add_argument("--max-entries", type=int, default=16)
+    parser.add_argument("--max-reclaim-kib", type=int, default=128 * 1024 * 1024)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    report = run(args)
+    _write_report(args.report, report)
+    before = report["before"]
+    after = report["after"]
+    print(
+        "qualification runner self-clean "
+        f"{report['status']} mode={report['mode']} "
+        f"processes={before['known_disposable_process_count']}->{after['known_disposable_process_count']} "
+        f"free_kib={before['available_kib']}->{after['available_kib']} "
+        f"report={args.report}"
+    )
+    if report["status"] != "passed":
+        for error in report["errors"]:
+            print(f"::error::qualification runner self-clean refused: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/macos/scripts/qualification-watchdog.py
+++ b/desktop/macos/scripts/qualification-watchdog.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Run one qualification section with heartbeats and a bounded process group."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+def _stop_group(process: subprocess.Popen[bytes], *, grace_seconds: float) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+        process.wait(timeout=grace_seconds)
+        return
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+    if process.poll() is None:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+        process.wait()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--heartbeat-seconds", type=float, default=45)
+    parser.add_argument("--timeout-seconds", type=float, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("a command is required after --")
+    if args.heartbeat_seconds <= 0 or args.timeout_seconds <= 0:
+        parser.error("heartbeat and timeout must be positive")
+
+    process = subprocess.Popen(
+        command,
+        start_new_session=os.name == "posix",
+    )
+    started = time.monotonic()
+    deadline = started + args.timeout_seconds
+
+    def forward(signum: int, _frame: object) -> None:
+        if process.poll() is None:
+            if os.name == "posix":
+                os.killpg(process.pid, signum)
+            else:
+                process.send_signal(signum)
+
+    for forwarded in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(forwarded, forward)
+
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            elapsed = int(time.monotonic() - started)
+            print(
+                f"::error::qualification watchdog timed out label={args.label} elapsed_seconds={elapsed}",
+                file=sys.stderr,
+                flush=True,
+            )
+            _stop_group(process, grace_seconds=10)
+            return 124
+        try:
+            return process.wait(timeout=min(args.heartbeat_seconds, remaining))
+        except subprocess.TimeoutExpired:
+            elapsed = int(time.monotonic() - started)
+            print(
+                f"qualification heartbeat label={args.label} elapsed_seconds={elapsed}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/macos/tests/test-pre-tag-readiness-contract.sh
+++ b/desktop/macos/tests/test-pre-tag-readiness-contract.sh
@@ -31,6 +31,11 @@ PY
 }
 
 # Cache and qualification leases are independently authenticated capabilities.
+require_text 'qualification-runner-self-clean.py'
+require_text 'qualification-watchdog.py'
+require_text 'run_watchdog runner-self-clean 1200'
+require_text '--current-run-id "$CURRENT_RUN_ID"'
+require_text '--report "$HYGIENE_EVIDENCE"'
 require_text '"$CACHE_COMMAND" prepare'
 require_text '"$SOURCE_SHA" "$SOURCE_REPOSITORY" "$CACHE_LEASE_ID" "$$"'
 require_text '"$LEASE_COMMAND" acquire'
@@ -43,6 +48,9 @@ require_text 'OMI_LOCAL_INSTANCE="$READINESS_LEASE_ID"'
 require_text 'OMI_HARNESS_PORT_OFFSET="$PORT_OFFSET"'
 require_text 'OMI_HARNESS_OWNERSHIP_TOKEN="$READINESS_LEASE_TOKEN"'
 require_text 'desktop-core-harness.sh --readiness'
+require_text 'run_watchdog readiness-cache-prepare 3600'
+require_text 'run_watchdog readiness-agent-dependencies 1800'
+require_text 'run_watchdog readiness-offline-stack 3600'
 
 # A foreign/unproven listener must cause authenticated cleanup to fail closed:
 # no broad process control, no passing receipt, and retained lease evidence.
@@ -50,6 +58,7 @@ require_text 'emit_evidence false'
 require_text 'READINESS_CLEANUP_OK=1'
 require_text 'if [[ "$READINESS_COMPLETE" -eq 1 && "$READINESS_CLEANUP_OK" -ne 1 ]]'
 require_order \
+  'run_watchdog runner-self-clean 1200' \
   '"$LEASE_COMMAND" acquire' \
   'desktop-core-harness.sh --readiness' \
   'READINESS_COMPLETE=1'

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -7,6 +7,8 @@ CORE_HARNESS="$SCRIPT_DIR/../scripts/desktop-core-harness.sh"
 PROFILE_PREP="$SCRIPT_DIR/../scripts/prepare-qualification-profile.sh"
 SWIFT_CACHE="$SCRIPT_DIR/../scripts/qualification-swift-cache.sh"
 LEASE_COMMAND="$SCRIPT_DIR/../scripts/qualification-lease-command.sh"
+SELF_CLEAN="$SCRIPT_DIR/../scripts/qualification-runner-self-clean.py"
+WATCHDOG="$SCRIPT_DIR/../scripts/qualification-watchdog.py"
 APP_CONFIG="$SCRIPT_DIR/../scripts/app-config.sh"
 RUN_SH="$SCRIPT_DIR/../run.sh"
 WORKFLOW="$SCRIPT_DIR/../../../.github/workflows/desktop_qualify_beta.yml"
@@ -81,6 +83,14 @@ require_text 'QUALIFICATION_CACHE_LEASE_ID'
 require_text 'QUALIFICATION_CACHE_LEASE_TOKEN'
 require_text '"$SCRIPT_DIR/qualification-swift-cache.sh" release'
 require_text 'qualification-cache-reclaim.py' "$SWIFT_CACHE"
+require_text 'qualification-runner-self-clean.py' "$WORKFLOW"
+require_text 'qualification-watchdog.py' "$WORKFLOW"
+require_text '--current-run-id "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' "$WORKFLOW"
+require_text '--max-reclaim-kib 134217728' "$WORKFLOW"
+require_text 'runner-hygiene.json' "$WORKFLOW"
+require_text '--label m1-desktop-qualification' "$WORKFLOW"
+require_text '--heartbeat-seconds 45' "$WORKFLOW"
+require_text '--timeout-seconds 14400' "$WORKFLOW"
 require_text 'qualification-lease "$action"' "$LEASE_COMMAND"
 require_text 'acquire)' "$LEASE_COMMAND"
 require_text 'preflight-fault-cleanup)' "$LEASE_COMMAND"
@@ -183,6 +193,10 @@ if [[ ! -x "$SWIFT_CACHE" ]]; then
 fi
 if [[ ! -x "$LEASE_COMMAND" ]]; then
   echo "FAIL: missing executable qualification lease command helper" >&2
+  exit 1
+fi
+if [[ ! -x "$SELF_CLEAN" || ! -x "$WATCHDOG" ]]; then
+  echo "FAIL: missing executable qualification self-clean/watchdog helper" >&2
   exit 1
 fi
 

--- a/desktop/macos/tests/test_pre_tag_readiness_behavior.py
+++ b/desktop/macos/tests/test_pre_tag_readiness_behavior.py
@@ -11,7 +11,6 @@ import unittest
 from unittest.mock import patch
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 REAL_READINESS = REPO_ROOT / "desktop/macos/scripts/pre-tag-readiness.sh"
 INHERITED_GIT_CONTEXT = (
@@ -32,18 +31,22 @@ class PreTagReadinessBehaviorTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         return completed.stdout.strip()
 
-    def run_process(self, args: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    def run_process(
+        self, args: list[str], *, cwd: Path, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
         process_env = dict(os.environ if env is None else env)
         for key in INHERITED_GIT_CONTEXT:
             process_env.pop(key, None)
         for key in tuple(process_env):
             if key.startswith("GIT_CONFIG_"):
                 process_env.pop(key)
-        process_env.update({
-            "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_CONFIG_GLOBAL": "/dev/null",
-            "GIT_TERMINAL_PROMPT": "0",
-        })
+        process_env.update(
+            {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_TERMINAL_PROMPT": "0",
+            }
+        )
         return subprocess.run(args, cwd=cwd, env=process_env, text=True, capture_output=True, check=False)
 
     def write_executable(self, path: Path, text: str) -> None:
@@ -54,7 +57,9 @@ class PreTagReadinessBehaviorTests(unittest.TestCase):
         origin = root / "origin.git"
         source = root / "source"
         self.assertEqual(self.run_process(["git", "init", "--bare", "--quiet", str(origin)], cwd=root).returncode, 0)
-        self.assertEqual(self.run_process(["git", "clone", "--quiet", str(origin), str(source)], cwd=root).returncode, 0)
+        self.assertEqual(
+            self.run_process(["git", "clone", "--quiet", str(origin), str(source)], cwd=root).returncode, 0
+        )
         scripts = source / "desktop/macos/scripts"
         scripts.mkdir(parents=True)
         (source / "backend").mkdir()
@@ -105,6 +110,30 @@ case "$1" in
     ;;
   *) exit 2 ;;
 esac
+""",
+        )
+        self.write_executable(
+            scripts / "qualification-watchdog.py",
+            """#!/usr/bin/env python3
+import os
+import sys
+separator = sys.argv.index("--")
+command = sys.argv[separator + 1:]
+os.execvp(command[0], command)
+""",
+        )
+        self.write_executable(
+            scripts / "qualification-runner-self-clean.py",
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+report = sys.argv[sys.argv.index("--report") + 1]
+with open(os.environ["FAKE_READINESS_LOG"], "a", encoding="utf-8") as handle:
+    handle.write(f"self-clean {report}\\n")
+os.makedirs(os.path.dirname(report), exist_ok=True)
+with open(report, "w", encoding="utf-8") as handle:
+    json.dump({"guard": "qualification-runner-self-clean", "status": "passed"}, handle)
 """,
         )
         self.write_executable(
@@ -161,7 +190,13 @@ exec /bin/rm "$@"
         self.run_git(source, "commit", "--quiet", "-m", "readiness fixture")
         self.run_git(source, "branch", "-M", "main")
         self.run_git(source, "push", "--quiet", "-u", "origin", "main")
-        return source, self.run_git(source, "rev-parse", "HEAD"), fake_bin, scripts / "pre-tag-readiness.sh", foreign_agent
+        return (
+            source,
+            self.run_git(source, "rev-parse", "HEAD"),
+            fake_bin,
+            scripts / "pre-tag-readiness.sh",
+            foreign_agent,
+        )
 
     def run_readiness(
         self, root: Path, *, failed_release: str = "", npm_failure: bool = False
@@ -201,16 +236,26 @@ exec /bin/rm "$@"
         self.assertTrue(receipt["passed"])
         self.assertFalse(dependency_residue_exists)
         self.assertEqual(receipt["source_sha"], sha)
-        self.assertEqual([line.split()[0] for line in operations], [
-            "cache-prepare", "lease-acquire", "agent-deps", "harness", "agent-deps-cleanup", "lease-release", "cache-release",
-        ])
-        cache_prepare = operations[0].split()
-        lease_acquire = operations[1].split()
-        agent_deps = operations[2].split()
-        harness = operations[3].split()
-        agent_cleanup = operations[4].split()
-        lease_release = operations[5].split()
-        cache_release = operations[6].split()
+        self.assertEqual(
+            [line.split()[0] for line in operations],
+            [
+                "self-clean",
+                "cache-prepare",
+                "lease-acquire",
+                "agent-deps",
+                "harness",
+                "agent-deps-cleanup",
+                "lease-release",
+                "cache-release",
+            ],
+        )
+        cache_prepare = operations[1].split()
+        lease_acquire = operations[2].split()
+        agent_deps = operations[3].split()
+        harness = operations[4].split()
+        agent_cleanup = operations[5].split()
+        lease_release = operations[6].split()
+        cache_release = operations[7].split()
         cache_id, readiness_id = cache_prepare[3], lease_acquire[2]
         self.assertNotEqual(cache_id, readiness_id)
         self.assertTrue(cache_id.startswith(f"cache-readiness-{sha[:12]}-"))
@@ -245,9 +290,18 @@ exec /bin/rm "$@"
         self.assertFalse(receipt["passed"])
         self.assertFalse(dependency_residue_exists)
         self.assertNotIn("harness", [line.split()[0] for line in operations])
-        self.assertEqual([line.split()[0] for line in operations], [
-            "cache-prepare", "lease-acquire", "agent-deps", "agent-deps-cleanup", "lease-release", "cache-release",
-        ])
+        self.assertEqual(
+            [line.split()[0] for line in operations],
+            [
+                "self-clean",
+                "cache-prepare",
+                "lease-acquire",
+                "agent-deps",
+                "agent-deps-cleanup",
+                "lease-release",
+                "cache-release",
+            ],
+        )
 
     def test_symlinked_agent_cannot_redirect_dependency_cleanup(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -266,7 +320,9 @@ exec /bin/rm "$@"
             }
             (root / "tmp").mkdir()
             completed = self.run_process(
-                [str(readiness), "--evidence", str(receipt), "--source-repository", str(source), sha], cwd=source, env=env
+                [str(readiness), "--evidence", str(receipt), "--source-repository", str(source), sha],
+                cwd=source,
+                env=env,
             )
 
             self.assertTrue(receipt.is_file(), completed.stderr)
@@ -274,9 +330,16 @@ exec /bin/rm "$@"
             self.assertNotEqual(completed.returncode, 0, completed.stderr)
             self.assertFalse(parsed_receipt["passed"])
             self.assertTrue((foreign_agent / "node_modules/foreign-sentinel").is_file())
-            self.assertEqual([line.split()[0] for line in log.read_text(encoding="utf-8").splitlines()], [
-                "cache-prepare", "lease-acquire", "lease-release", "cache-release",
-            ])
+            self.assertEqual(
+                [line.split()[0] for line in log.read_text(encoding="utf-8").splitlines()],
+                [
+                    "self-clean",
+                    "cache-prepare",
+                    "lease-acquire",
+                    "lease-release",
+                    "cache-release",
+                ],
+            )
 
     def test_inherited_git_config_cannot_redirect_fixture_origin(self) -> None:
         git_config_override = {
@@ -290,9 +353,19 @@ exec /bin/rm "$@"
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertTrue(receipt["passed"])
         self.assertFalse(dependency_residue_exists)
-        self.assertEqual([line.split()[0] for line in operations], [
-            "cache-prepare", "lease-acquire", "agent-deps", "harness", "agent-deps-cleanup", "lease-release", "cache-release",
-        ])
+        self.assertEqual(
+            [line.split()[0] for line in operations],
+            [
+                "self-clean",
+                "cache-prepare",
+                "lease-acquire",
+                "agent-deps",
+                "harness",
+                "agent-deps-cleanup",
+                "lease-release",
+                "cache-release",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/desktop/macos/tests/test_qualification_cache_reclaim.py
+++ b/desktop/macos/tests/test_qualification_cache_reclaim.py
@@ -197,6 +197,58 @@ class QualificationCacheReclaimTests(unittest.TestCase):
         self.assertEqual(report["status"], "passed")
         self.assertFalse(entry.exists())
 
+    def test_dead_cache_lease_is_removed_even_when_capacity_already_passes(self) -> None:
+        source_sha, entry = self._entry("dead-lease", age_seconds=60)
+        lease = reclaim.acquire_cache_lease(
+            self.cache_root,
+            source_sha=source_sha,
+            lease_id="cache-dead",
+            owner_pid=os.getpid(),
+            now=self.now,
+        )
+        lease_path = entry / ".leases/cache-dead.json"
+        payload = json.loads(lease_path.read_text(encoding="utf-8"))
+        payload["owner_pid"] = 999999
+        lease_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        lease_path.chmod(0o600)
+
+        report = self._run(
+            minimum_free_kib=1,
+            capacity_probe=self._capacity_probe({source_sha}),
+        )
+
+        self.assertEqual(report["status"], "passed")
+        self.assertTrue(entry.exists())
+        self.assertFalse(lease_path.exists())
+        self.assertEqual(
+            report["reclaim"]["dead_leases_removed"],
+            [{"source_sha": source_sha, "lease_id": "cache-dead", "owner_pid": 999999}],
+        )
+        self.assertTrue(lease["token"])
+
+    def test_capacity_pressure_reclaims_a_young_idle_exact_sha_cache(self) -> None:
+        source_sha, entry = self._entry("young-pressure", age_seconds=60)
+
+        report = self._run(
+            minimum_free_kib=100,
+            capacity_probe=self._capacity_probe({source_sha}),
+        )
+
+        self.assertEqual(report["status"], "passed")
+        self.assertFalse(entry.exists())
+        self.assertEqual(report["reclaim"]["deleted_entries"][0]["reason"], "capacity-pressure")
+
+    def test_reclaim_tightens_an_owned_cache_root_before_inventory(self) -> None:
+        self.cache_root.chmod(0o755)
+
+        report = self._run(
+            minimum_free_kib=1,
+            capacity_probe=self._capacity_probe(set()),
+        )
+
+        self.assertEqual(report["status"], "passed")
+        self.assertEqual(self.cache_root.stat().st_mode & 0o777, 0o700)
+
     def test_malformed_provenance_refuses_before_deleting_any_valid_entry(self) -> None:
         valid_sha, valid = self._entry("valid", age_seconds=24 * 60 * 60)
         bad_sha, bad = self._entry("bad", age_seconds=48 * 60 * 60)
@@ -271,7 +323,7 @@ class QualificationCacheReclaimTests(unittest.TestCase):
         self.assertEqual(evidence.read_text(encoding="utf-8"), '{"immutable":true}\n')
         self.assertEqual(len(report["reclaim"]["deleted_entries"]), 2)
 
-    def test_young_entry_and_symlinked_entry_are_never_reclaimed(self) -> None:
+    def test_symlinked_entry_refuses_before_any_young_entry_is_reclaimed(self) -> None:
         young_sha, young = self._entry("young", age_seconds=60)
         target = self.root / "foreign-target"
         target.mkdir()

--- a/desktop/macos/tests/test_qualification_runner_self_clean.py
+++ b/desktop/macos/tests/test_qualification_runner_self_clean.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Deterministic contracts for ownership-scoped M1 runner self-clean."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "qualification-runner-self-clean.py"
+SPEC = importlib.util.spec_from_file_location("qualification_runner_self_clean", SCRIPT)
+assert SPEC and SPEC.loader
+self_clean = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = self_clean
+SPEC.loader.exec_module(self_clean)
+
+
+class QualificationRunnerSelfCleanTests(unittest.TestCase):
+    def _fault_record(
+        self,
+        root: Path,
+        *,
+        bundle: str = "omi-fault-owned-contract",
+        token: str = "owned-contract-token-123456789",
+        pid: int = 42424,
+    ) -> tuple[Path, self_clean.ProcessRecord]:
+        executable = f"/Applications/{bundle}.app/Contents/MacOS/Omi Computer"
+        command = f"{executable!r} --omi-launch-token={token}"
+        started = "Mon Jul 27 20:00:00 2026"
+        path = root / "fault-app.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "run_token": token,
+                    "bundle": bundle,
+                    "bundle_id": f"com.omi.{bundle}",
+                    "app_path": f"/Applications/{bundle}.app",
+                    "executable_path": executable,
+                    "automation_port": 47791,
+                    "launch_transport": "open",
+                    "launch_pid": pid,
+                    "process_start": started,
+                    "command_sha256": hashlib.sha256(command.encode()).hexdigest(),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        path.chmod(0o600)
+        return path, self_clean.ProcessRecord(pid, pid, started, command)
+
+    def test_fault_classifier_accepts_only_exact_token_bound_disposable_app(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            record, process = self._fault_record(Path(directory))
+            target, observed = self_clean._validate_fault_app_target(record, {process.pid: process})
+
+            self.assertEqual(target.pid, process.pid)
+            self.assertEqual(target.bundle, "omi-fault-owned-contract")
+            self.assertEqual(observed, process)
+
+            replaced = self_clean.ProcessRecord(
+                process.pid,
+                process.process_group,
+                process.process_start,
+                process.command.replace("owned-contract-token", "foreign-token"),
+            )
+            with self.assertRaisesRegex(self_clean.HygieneError, "no longer matches"):
+                self_clean._validate_fault_app_target(record, {process.pid: replaced})
+
+    def test_fault_classifier_rejects_production_bundle_even_with_self_consistent_record(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            record, process = self._fault_record(Path(directory), bundle="Omi")
+
+            with self.assertRaisesRegex(self_clean.HygieneError, "disposable bundle"):
+                self_clean._validate_fault_app_target(record, {process.pid: process})
+
+    def test_stage_cleanup_removes_only_noncurrent_numeric_owned_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stage_root = Path(directory) / "desktop-beta-qualification"
+            stage_root.mkdir()
+            old = stage_root / "100-1"
+            current = stage_root / "200-2"
+            unrelated = stage_root / "manual-not-a-run"
+            for path in (old, current, unrelated):
+                path.mkdir(mode=0o700)
+                (path / "sentinel").write_text(path.name, encoding="utf-8")
+
+            results = self_clean.clean_stages(
+                stage_root,
+                current_run_id=current.name,
+                processes=[],
+                dry_run=False,
+            )
+
+            self.assertFalse(old.exists())
+            self.assertTrue(current.exists())
+            self.assertTrue(unrelated.exists())
+            self.assertEqual(
+                results,
+                [
+                    {"run_id": "100-1", "action": "removed"},
+                    {"run_id": "200-2", "action": "preserved-current"},
+                ],
+            )
+
+    def test_stage_cleanup_refuses_a_live_exact_path_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stage_root = Path(directory) / "desktop-beta-qualification"
+            stage_root.mkdir()
+            active = stage_root / "300-1"
+            active.mkdir(mode=0o700)
+            process = self_clean.ProcessRecord(
+                51515,
+                51515,
+                "Mon Jul 27 20:00:00 2026",
+                f"python3 {active}/source/desktop/macos/scripts/qualify-desktop-beta.sh",
+            )
+
+            with self.assertRaisesRegex(self_clean.HygieneError, "live process reference"):
+                self_clean.clean_stages(
+                    stage_root,
+                    current_run_id="400-1",
+                    processes=[process],
+                    dry_run=False,
+                )
+
+            self.assertTrue(active.exists())
+
+    def test_dry_run_report_declares_production_bundles_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            args = type(
+                "Args",
+                (),
+                {
+                    "repo_root": Path(__file__).resolve().parents[3],
+                    "cache_root": root / "cache",
+                    "qualification_lease_root": root / "lease",
+                    "stage_root": root / "desktop-beta-qualification",
+                    "fault_temp_root": root,
+                    "capacity_path": root,
+                    "current_run_id": "500-1",
+                    "minimum_free_kib": 1,
+                    "minimum_free_inodes": 1,
+                    "minimum_age_seconds": 3600,
+                    "max_entries": 16,
+                    "max_reclaim_kib": 128 * 1024 * 1024,
+                    "dry_run": True,
+                },
+            )()
+
+            report = self_clean.run(args)
+
+            self.assertEqual(report["status"], "passed")
+            self.assertTrue(report["mode"] == "dry-run")
+            self.assertFalse(report["production_bundles_touched"])
+            self.assertEqual(
+                report["before"]["known_disposable_process_count"], report["after"]["known_disposable_process_count"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -22,7 +22,7 @@ if os.name == "nt":
 else:
     import fcntl
 
-from . import config, safety
+from . import safety
 
 LEASE_SCHEMA_VERSION = 1
 LEASE_OWNER = "omi-desktop-qualification"
@@ -31,6 +31,10 @@ DEFAULT_RETENTION_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
 COMPLETION_FILENAME = "qualification-completed.json"
 QUARANTINE_DIRNAME = "quarantined-lease-pointers"
 FAULT_STATE_DIRNAME = "fault"
+# Docker's official Typesense image listens on this fixed internal port. The
+# harness varies only the loopback host port; keep this dependency-free because
+# runner self-clean imports the lease authority before any venv is provisioned.
+TYPESENSE_CONTAINER_PORT = 8108
 STOP_PHASES: tuple[tuple[signal.Signals, float], ...] = tuple(
     (signal.Signals(value), wait_seconds)
     for name, wait_seconds in (("SIGINT", 8), ("SIGTERM", 5), ("SIGKILL", 2))
@@ -482,7 +486,7 @@ def _is_exact_typesense_docker_proxy(record: dict[str, object], lease_id: str | 
         "--name",
         container,
         "-p",
-        f"127.0.0.1:{port}:{config.TYPESENSE_CONTAINER_PORT}",
+        f"127.0.0.1:{port}:{TYPESENSE_CONTAINER_PORT}",
     ]
     command = record.get("command")
     if not isinstance(command, list) or command[: len(expected_prefix)] != expected_prefix:
@@ -505,17 +509,19 @@ def _is_exact_typesense_docker_proxy(record: dict[str, object], lease_id: str | 
         return False
     network = payload.get("NetworkSettings")
     ports = network.get("Ports") if isinstance(network, dict) else None
-    bindings = ports.get(f"{config.TYPESENSE_CONTAINER_PORT}/tcp") if isinstance(ports, dict) else None
+    bindings = ports.get(f"{TYPESENSE_CONTAINER_PORT}/tcp") if isinstance(ports, dict) else None
     return isinstance(bindings, list) and any(
-        isinstance(binding, dict)
-        and binding.get("HostIp") == "127.0.0.1"
-        and binding.get("HostPort") == str(port)
+        isinstance(binding, dict) and binding.get("HostIp") == "127.0.0.1" and binding.get("HostPort") == str(port)
         for binding in bindings
     )
 
 
 def _validated_signal(
-    record: dict[str, object], process_manifest: Path, port_manifest: Path, sig: signal.Signals, lease_id: str | None = None
+    record: dict[str, object],
+    process_manifest: Path,
+    port_manifest: Path,
+    sig: signal.Signals,
+    lease_id: str | None = None,
 ) -> None:
     """Signal only a current supervisor whose listener children still prove lease lineage."""
 
@@ -527,18 +533,85 @@ def _validated_signal(
     safety.validate_owned_pid(pid, process_manifest=process_manifest, service=service)
     if getpgid(pid) != process_group or process_group != pid:
         raise QualificationLeaseError("Refusing to signal a qualification process group whose ownership changed")
-    safety.validate_port_owner(
-        port, pid=pid, port_manifest=port_manifest, process_manifest=None, service=service
-    )
+    safety.validate_port_owner(port, pid=pid, port_manifest=port_manifest, process_manifest=None, service=service)
     listeners = safety.listening_pids(port)
     if listeners and not _is_exact_typesense_docker_proxy(record, lease_id):
         for listener_pid in listeners:
             if getpgid(listener_pid) != process_group or not safety.is_descendant_of(listener_pid, pid):
-                raise QualificationLeaseError("Refusing to signal a qualification listener whose lease lineage is unproven")
+                raise QualificationLeaseError(
+                    "Refusing to signal a qualification listener whose lease lineage is unproven"
+                )
     try:
         killpg(process_group, sig)
     except (ProcessLookupError, PermissionError) as exc:
         raise QualificationLeaseError(f"Cannot signal recorded qualification process group: {exc}") from exc
+
+
+def _orphaned_record_cleanup_mode(
+    record: dict[str, object],
+    process_manifest: Path,
+    port_manifest: Path,
+    lease_id: str,
+) -> str:
+    """Classify a dead supervisor's surviving listener without name matching.
+
+    A POSIX process group remains authoritative after its leader exits: the PGID
+    cannot be reused while members remain. Docker's host proxy is the one known
+    exception because it lives outside the recorded supervisor group, so it is
+    accepted only after the exact lease container binding is re-proved.
+    """
+
+    pid = int(record["pid"])
+    process_group = int(record["process_group"])
+    port = int(record["port"])
+    service = str(record["service"])
+    if process_group != pid:
+        raise QualificationLeaseError("Qualification process group does not match its recorded leader")
+    safety.validate_port_owner(
+        port,
+        pid=pid,
+        port_manifest=port_manifest,
+        process_manifest=None,
+        service=service,
+    )
+    listeners = safety.listening_pids(port)
+    if not listeners:
+        return "none"
+    if _is_exact_typesense_docker_proxy(record, lease_id):
+        return "docker"
+    getpgid, _killpg = _posix_process_group_api()
+    try:
+        listener_groups = tuple(getpgid(listener_pid) for listener_pid in listeners)
+    except (ProcessLookupError, PermissionError) as exc:
+        raise QualificationLeaseError("Cannot validate an orphaned qualification listener process group") from exc
+    if any(group != process_group for group in listener_groups):
+        raise QualificationLeaseError(
+            "Refusing to signal an orphaned qualification listener whose recorded process group is unproven"
+        )
+    return "process-group"
+
+
+def _stop_exact_typesense_container(record: dict[str, object], lease_id: str, sig: signal.Signals) -> None:
+    if not _is_exact_typesense_docker_proxy(record, lease_id):
+        raise QualificationLeaseError("Refusing to stop a Typesense container whose exact lease binding is unproven")
+    container = f"omi-dev-harness-{lease_id}-typesense"
+    command = ["docker", "kill", container] if sig == signal.SIGKILL else ["docker", "stop", "--time", "10", container]
+    try:
+        stopped = subprocess.run(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise QualificationLeaseError(f"Cannot stop recorded qualification Typesense container: {exc}") from exc
+    if stopped.returncode != 0:
+        detail = stopped.stderr.strip()[:200]
+        raise QualificationLeaseError(
+            f"Cannot stop recorded qualification Typesense container {container}: {detail or stopped.returncode}"
+        )
 
 
 def _open_recorded_ports(records: list[dict[str, object]]) -> list[tuple[str, int, tuple[int, ...]]]:
@@ -553,7 +626,9 @@ def _open_recorded_ports(records: list[dict[str, object]]) -> list[tuple[str, in
     return open_ports
 
 
-def _wait_for_ports_to_close(records: list[dict[str, object]], seconds: float) -> list[tuple[str, int, tuple[int, ...]]]:
+def _wait_for_ports_to_close(
+    records: list[dict[str, object]], seconds: float
+) -> list[tuple[str, int, tuple[int, ...]]]:
     deadline = time.monotonic() + seconds
     open_ports = _open_recorded_ports(records)
     while open_ports and time.monotonic() < deadline:
@@ -570,11 +645,25 @@ def _stop_owned_records(
             pid = int(record["pid"])
             if safety.process_exists(pid):
                 _validated_signal(record, process_manifest, port_manifest, sig, lease_id)
+                continue
+            cleanup_mode = _orphaned_record_cleanup_mode(record, process_manifest, port_manifest, lease_id)
+            if cleanup_mode == "process-group":
+                _getpgid, killpg = _posix_process_group_api()
+                try:
+                    killpg(int(record["process_group"]), sig)
+                except (ProcessLookupError, PermissionError) as exc:
+                    raise QualificationLeaseError(f"Cannot signal orphaned qualification process group: {exc}") from exc
+            elif cleanup_mode == "docker":
+                _stop_exact_typesense_container(record, lease_id, sig)
         open_ports = _wait_for_ports_to_close(records, wait_seconds)
         if not open_ports:
             return
-    details = ", ".join(f"{service}:{port} (listeners {','.join(map(str, pids))})" for service, port, pids in open_ports)
-    raise QualificationLeaseError(f"Qualification port still open after cleanup; retaining incomplete lease state: {details}")
+    details = ", ".join(
+        f"{service}:{port} (listeners {','.join(map(str, pids))})" for service, port, pids in open_ports
+    )
+    raise QualificationLeaseError(
+        f"Qualification port still open after cleanup; retaining incomplete lease state: {details}"
+    )
 
 
 def _safe_remove_state(state_root: Path, repo_root: Path, lease_id: str) -> None:
@@ -652,8 +741,64 @@ def _prune(root: Path, *, keep_lease_ids: set[str], retained_runs: int, retentio
             shutil.rmtree(log_dir)
 
 
+def reclaim_abandoned(*, lease_root: Path, repo_root: Path, dry_run: bool = False) -> dict[str, object]:
+    """Reclaim only the dead active qualification lease at a known runner root.
+
+    Unlike ``acquire``, this runner-hygiene path fails closed on ambiguous
+    provenance instead of quarantining the pointer and admitting new work.
+    """
+
+    root_path = lease_root.expanduser().resolve(strict=False)
+    if not root_path.exists():
+        return {"status": "absent", "lease_id": None, "owned_processes": 0}
+    root = _validate_root(root_path, repo_root)
+    with _locked(root):
+        path = _lease_path(root)
+        lease = _read_lease(path)
+        if lease is None:
+            return {"status": "absent", "lease_id": None, "owned_processes": 0}
+        lease_id, state_root, recorded_repo, owner_pid, token = _lease_provenance(lease, root)
+        if safety.process_exists(owner_pid):
+            return {
+                "status": "active",
+                "lease_id": lease_id,
+                "owner_pid": owner_pid,
+                "owned_processes": 0,
+            }
+        records, process_manifest, port_manifest = _validated_owned_records(state_root, recorded_repo, lease_id, token)
+        fault_record = _validated_fault_record(state_root, token)
+        for record in records:
+            if not safety.process_exists(int(record["pid"])):
+                _orphaned_record_cleanup_mode(record, process_manifest, port_manifest, lease_id)
+        if dry_run:
+            return {
+                "status": "would-reclaim",
+                "lease_id": lease_id,
+                "owner_pid": owner_pid,
+                "owned_processes": len(records) + (1 if fault_record is not None else 0),
+            }
+        _stop_owned_fault_record(fault_record)
+        _stop_owned_records(records, process_manifest, port_manifest, lease_id)
+        _safe_remove_state(state_root, recorded_repo, lease_id)
+        logs = root / "logs" / lease_id
+        if logs.is_dir():
+            shutil.rmtree(logs)
+        path.unlink()
+        return {
+            "status": "reclaimed",
+            "lease_id": lease_id,
+            "owner_pid": owner_pid,
+            "owned_processes": len(records) + (1 if fault_record is not None else 0),
+        }
+
+
 def acquire(
-    *, repo_root: Path, lease_id: str, owner_pid: int, port_offset: int, retained_runs: int = DEFAULT_RETAINED_RUNS,
+    *,
+    repo_root: Path,
+    lease_id: str,
+    owner_pid: int,
+    port_offset: int,
+    retained_runs: int = DEFAULT_RETAINED_RUNS,
     retention_age_seconds: int = DEFAULT_RETENTION_MAX_AGE_SECONDS,
 ) -> dict[str, object]:
     root = _validate_root(lease_root_from_env(), repo_root)
@@ -672,7 +817,9 @@ def acquire(
                     f"Qualification lease {old_id!r} is held by live PID {old_owner}; refusing concurrent stack use"
                 )
             try:
-                records, process_manifest, port_manifest = _validated_owned_records(old_state, old_repo, old_id, old_token)
+                records, process_manifest, port_manifest = _validated_owned_records(
+                    old_state, old_repo, old_id, old_token
+                )
                 fault_record = _validated_fault_record(old_state, old_token)
                 _stop_owned_fault_record(fault_record)
                 _stop_owned_records(records, process_manifest, port_manifest, old_id)
@@ -696,7 +843,9 @@ def acquire(
                 previous_repo = _real(Path(str(sentinel.get("repo_root", ""))))
                 _safe_remove_state(state_root, previous_repo, lease_id)
             except safety.SafetyError as exc:
-                raise QualificationLeaseError(f"Refusing to replace unproven qualification state {state_root}: {exc}") from exc
+                raise QualificationLeaseError(
+                    f"Refusing to replace unproven qualification state {state_root}: {exc}"
+                ) from exc
         safety.create_state_layout(repo_root, lease_id, {"OMI_LOCAL_STATE_ROOT": str(root / "state")})
         log_dir = root / "logs" / lease_id
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -723,7 +872,11 @@ def acquire(
 
 
 def release(
-    *, repo_root: Path, lease_id: str, token: str, retained_runs: int = DEFAULT_RETAINED_RUNS,
+    *,
+    repo_root: Path,
+    lease_id: str,
+    token: str,
+    retained_runs: int = DEFAULT_RETAINED_RUNS,
     retention_age_seconds: int = DEFAULT_RETENTION_MAX_AGE_SECONDS,
 ) -> None:
     root = _validate_root(lease_root_from_env(), repo_root)

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -17,7 +17,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from dev_harness import qualification, safety
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FAULT_INJECTOR = REPO_ROOT / "desktop" / "macos" / "scripts" / "omi-fault-inject.sh"
 
@@ -28,7 +27,13 @@ def _stale_lease(root: Path, lease_id: str, pid: int, port: int) -> None:
     lease = json.loads(lease_path.read_text(encoding="utf-8"))
     marker = f"omi-dev-harness:{lease_id}:backend:{lease['token']}"
     state.joinpath("manifests", "processes.json").write_text(
-        json.dumps({"processes": [{"service": "backend", "pid": pid, "process_group": pid, "port": port, "ownership_marker": marker}]}),
+        json.dumps(
+            {
+                "processes": [
+                    {"service": "backend", "pid": pid, "process_group": pid, "port": port, "ownership_marker": marker}
+                ]
+            }
+        ),
         encoding="utf-8",
     )
     state.joinpath("manifests", "ports.json").write_text(
@@ -111,10 +116,14 @@ def test_qualification_file_lock_serializes_processes(tmp_path: Path) -> None:
 def test_active_lease_serializes_qualification_runs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     root = tmp_path / "qualification"
     monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
-    first = qualification.acquire(repo_root=REPO_ROOT, lease_id="qualification-one", owner_pid=os.getpid(), port_offset=1000)
+    first = qualification.acquire(
+        repo_root=REPO_ROOT, lease_id="qualification-one", owner_pid=os.getpid(), port_offset=1000
+    )
 
     with pytest.raises(qualification.QualificationLeaseError, match="refusing concurrent stack use"):
-        qualification.acquire(repo_root=REPO_ROOT, lease_id="qualification-two", owner_pid=os.getpid(), port_offset=1001)
+        qualification.acquire(
+            repo_root=REPO_ROOT, lease_id="qualification-two", owner_pid=os.getpid(), port_offset=1001
+        )
 
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-one", token=str(first["token"]))
 
@@ -147,7 +156,9 @@ def test_windows_process_manifest_is_retained_without_posix_process_provenance(
     acquired = qualification.acquire(repo_root=REPO_ROOT, lease_id=lease_id, owner_pid=os.getpid(), port_offset=1000)
     _stale_lease(root, lease_id, pid=os.getpid(), port=_free_port())
 
-    with pytest.raises(qualification.QualificationLeaseError, match="process-manifest cleanup requires POSIX process provenance"):
+    with pytest.raises(
+        qualification.QualificationLeaseError, match="process-manifest cleanup requires POSIX process provenance"
+    ):
         qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
 
     assert (root / "qualification-lease.json").is_file()
@@ -278,6 +289,8 @@ def test_fault_listener_preflight_retains_replaced_listener_and_reports_host_pre
         if foreign.poll() is None:
             foreign.terminate()
             foreign.wait(timeout=10)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="fault listener cleanup requires POSIX process groups")
 def test_release_refuses_and_retains_an_unproven_listener_on_the_recorded_fault_port(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -330,7 +343,11 @@ def test_stale_owned_stack_is_reclaimed_without_touching_foreign_listener(
     marker = f"omi-dev-harness:{old_id}:backend:{json.loads((root / 'qualification-lease.json').read_text(encoding='utf-8'))['token']}"
     owned_pid, stopped, signalled = 42424, set(), []
     foreign = subprocess.Popen(
-        [sys.executable, "-c", "import socket,time; s=socket.socket(); s.bind(('127.0.0.1', 49199)); s.listen(); time.sleep(60)"],
+        [
+            sys.executable,
+            "-c",
+            "import socket,time; s=socket.socket(); s.bind(('127.0.0.1', 49199)); s.listen(); time.sleep(60)",
+        ],
         start_new_session=os.name != "nt",
         creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
     )
@@ -386,7 +403,10 @@ def test_dead_lease_with_missing_sentinel_is_quarantined_before_a_fresh_lease_ac
     assert json.loads(quarantined[0].read_text(encoding="utf-8")) == stale_pointer
     assert stale_state.exists()
     assert not (stale_state / safety.HARNESS_SENTINEL_FILENAME).exists()
-    assert json.loads((root / "qualification-lease.json").read_text(encoding="utf-8"))["lease_id"] == "qualification-replacement"
+    assert (
+        json.loads((root / "qualification-lease.json").read_text(encoding="utf-8"))["lease_id"]
+        == "qualification-replacement"
+    )
 
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-replacement", token=str(replacement["token"]))
 
@@ -432,9 +452,7 @@ def test_dead_lease_with_unproven_listener_is_quarantined_without_signalling_it(
                 return pid
             return original_getpgid(pid)
 
-        monkeypatch.setattr(
-            safety, "process_exists", lambda pid: pid == recorded_pid or original_exists(pid)
-        )
+        monkeypatch.setattr(safety, "process_exists", lambda pid: pid == recorded_pid or original_exists(pid))
         monkeypatch.setattr(safety, "command_line_for_pid", lambda pid: marker if pid == recorded_pid else "")
         monkeypatch.setattr(qualification.os, "getpgid", getpgid, raising=False)
         monkeypatch.setattr(
@@ -463,16 +481,22 @@ def test_dead_lease_with_unproven_listener_is_quarantined_without_signalling_it(
             foreign.wait(timeout=10)
 
 
-def test_retention_prunes_only_completed_sentinel_proven_qualification_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_retention_prunes_only_completed_sentinel_proven_qualification_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     root = tmp_path / "qualification"
     monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
-    completed = qualification.acquire(repo_root=REPO_ROOT, lease_id="qualification-completed", owner_pid=os.getpid(), port_offset=1000)
+    completed = qualification.acquire(
+        repo_root=REPO_ROOT, lease_id="qualification-completed", owner_pid=os.getpid(), port_offset=1000
+    )
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-completed", token=str(completed["token"]))
     completion = root / "state" / "qualification-completed" / qualification.COMPLETION_FILENAME
     payload = json.loads(completion.read_text(encoding="utf-8"))
     payload["completed_at"] = 1
     completion.write_text(json.dumps(payload), encoding="utf-8")
-    active = qualification.acquire(repo_root=REPO_ROOT, lease_id="qualification-active", owner_pid=os.getpid(), port_offset=1001)
+    active = qualification.acquire(
+        repo_root=REPO_ROOT, lease_id="qualification-active", owner_pid=os.getpid(), port_offset=1001
+    )
     foreign = root / "state" / "foreign"
     foreign.mkdir(parents=True)
     qualification._prune(root, keep_lease_ids={"qualification-active"}, retained_runs=3, retention_age_seconds=1)
@@ -482,7 +506,7 @@ def test_retention_prunes_only_completed_sentinel_proven_qualification_state(mon
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-active", token=str(active["token"]))
 
 
-def test_supervisor_dead_with_recorded_port_still_open_retains_incomplete_lease(
+def test_supervisor_dead_with_foreign_process_group_retains_incomplete_lease(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     root = tmp_path / "qualification"
@@ -502,13 +526,54 @@ def test_supervisor_dead_with_recorded_port_still_open_retains_incomplete_lease(
     monkeypatch.setattr(safety, "listening_pids", lambda candidate: (os.getpid(),) if candidate == port else ())
     try:
         _stale_lease(root, lease_id, pid=42424, port=port)
-        with pytest.raises(qualification.QualificationLeaseError, match="port.*still open"):
+        with pytest.raises(qualification.QualificationLeaseError, match="process group is unproven"):
             qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
         assert listener.fileno() >= 0
         assert (root / "qualification-lease.json").exists()
         assert not (root / "state" / lease_id / qualification.COMPLETION_FILENAME).exists()
     finally:
         listener.close()
+
+
+def test_supervisor_dead_with_exact_recorded_process_group_reclaims_fixed_port(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "qualification"
+    lease_id = "qualification-orphaned-fixed-port"
+    supervisor_pid, listener_pid, port = 42424, 51515, 9099
+    monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
+    acquired = qualification.acquire(
+        repo_root=REPO_ROOT,
+        lease_id=lease_id,
+        owner_pid=os.getpid(),
+        port_offset=1000,
+    )
+    open_listener = True
+
+    def listening_pids(candidate: int) -> tuple[int, ...]:
+        return (listener_pid,) if candidate == port and open_listener else ()
+
+    def killpg(process_group: int, _sig: signal.Signals) -> None:
+        nonlocal open_listener
+        assert process_group == supervisor_pid
+        open_listener = False
+
+    monkeypatch.setattr(safety, "process_exists", lambda pid: pid == os.getpid())
+    monkeypatch.setattr(safety, "listening_pids", listening_pids)
+    monkeypatch.setattr(
+        qualification.os,
+        "getpgid",
+        lambda pid: supervisor_pid if pid == listener_pid else pid,
+        raising=False,
+    )
+    monkeypatch.setattr(qualification.os, "killpg", killpg, raising=False)
+    _stale_lease(root, lease_id, pid=supervisor_pid, port=port)
+
+    qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+
+    assert not open_listener
+    assert not (root / "qualification-lease.json").exists()
+    assert (root / "state" / lease_id / qualification.COMPLETION_FILENAME).is_file()
 
 
 def test_docker_typesense_proxy_listener_is_reclaimed_only_with_exact_container_binding(
@@ -559,9 +624,7 @@ def test_docker_typesense_proxy_listener_is_reclaimed_only_with_exact_container_
                 {
                     "Name": f"/{container}",
                     "State": {"Running": True},
-                    "NetworkSettings": {
-                        "Ports": {"8108/tcp": [{"HostIp": "127.0.0.1", "HostPort": str(port)}]}
-                    },
+                    "NetworkSettings": {"Ports": {"8108/tcp": [{"HostIp": "127.0.0.1", "HostPort": str(port)}]}},
                 }
             ),
         ),
@@ -616,3 +679,70 @@ def test_external_typesense_listener_without_exact_docker_binding_is_not_signall
         )
 
     assert signalled == []
+
+
+def test_orphaned_typesense_container_is_stopped_only_after_exact_binding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lease_id, supervisor_pid, proxy_pid, port = "qualification-typesense-orphan", 42424, 51515, 49199
+    container = f"omi-dev-harness-{lease_id}-typesense"
+    record = {
+        "service": "typesense",
+        "pid": supervisor_pid,
+        "process_group": supervisor_pid,
+        "port": port,
+        "command": [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            container,
+            "-p",
+            f"127.0.0.1:{port}:8108",
+        ],
+    }
+    running = True
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal running
+        calls.append(command)
+        if command[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(
+                command,
+                0 if running else 1,
+                stdout=(
+                    json.dumps(
+                        {
+                            "Name": f"/{container}",
+                            "State": {"Running": True},
+                            "NetworkSettings": {
+                                "Ports": {"8108/tcp": [{"HostIp": "127.0.0.1", "HostPort": str(port)}]}
+                            },
+                        }
+                    )
+                    if running
+                    else ""
+                ),
+                stderr="",
+            )
+        if command[:2] == ["docker", "stop"]:
+            running = False
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(qualification, "STOP_PHASES", ((signal.SIGTERM, 0),))
+    monkeypatch.setattr(safety, "process_exists", lambda _pid: False)
+    monkeypatch.setattr(safety, "validate_port_owner", lambda *args, **kwargs: None)
+    monkeypatch.setattr(safety, "listening_pids", lambda observed: (proxy_pid,) if observed == port and running else ())
+    monkeypatch.setattr(qualification.subprocess, "run", run)
+
+    qualification._stop_owned_records(
+        [record],
+        tmp_path / "processes.json",
+        tmp_path / "ports.json",
+        lease_id,
+    )
+
+    assert ["docker", "stop", "--time", "10", container] in calls
+    assert not running


### PR DESCRIPTION
## Summary

- self-clean abandoned M1 qualification leases, exact-provenance processes, disposable fault apps, run stages, containers, and cache entries before new work
- reclaim oldest provably idle cache entries under capacity pressure while preserving live entries and enforcing owner-only cache permissions
- wrap long readiness and qualification phases with bounded watchdog heartbeats and exact process-group termination
- emit runner-hygiene evidence and enforce the new behavior through deterministic contracts

## Safety boundary

Cleanup requires exact owner-only qualification records, recorded process identity, start time, command hash, bundle identity, and trusted roots. Production Omi and Omi Beta bundles are explicitly rejected and the report records `production_bundles_touched: false`.

This is qualification-runner-specific because it depends on the repository's lease schema, stage layout, cache provenance, exact fault-app identity, and fixed offline-service ownership. It is not a general process cleanup primitive.

Related incident: #10749 and Actions run [30316131599](https://github.com/BasedHardware/omi/actions/runs/30316131599).

## Verification

- `make setup`
- `python3 desktop/macos/tests/test_qualification_runner_self_clean.py` — 5 passed
- `python3 desktop/macos/tests/test_qualification_cache_reclaim.py` — 11 passed
- `python3 desktop/macos/tests/test_pre_tag_readiness_behavior.py` — 5 passed
- `backend/.venv/bin/pytest -q scripts/dev-harness/tests/test_qualification_lease.py` — 15 passed, 2 skipped
- `bash desktop/macos/tests/test-pre-tag-readiness-contract.sh`
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `python3 .github/scripts/verify-pre-tag-readiness.py self-test`
- `python3 .github/scripts/test_desktop_release_flow_contract.py` — 9 passed
- `actionlint .github/workflows/desktop_auto_release.yml .github/workflows/desktop_qualify_beta.yml`

The final M1 dry run passed with zero disposable processes before and after, no lease/fault-app/stage candidates, 77.5 GiB available, and `production_bundles_touched: false`. It made no cleanup mutations.

## Failure class

Failure-Class: new

New class: `FC-self-hosted-qualification-residue`, with this PR as its first evidence and the runner self-cleaner plus deterministic tests as its canonical prevention artifacts.

Closes SCA-215
