### PR TITLE
fix(desktop/windows): align memories paging with backend 500 cap

### DIFF
--- a/desktop/windows/src/main/agentKernel/productToolExecutors.ts
+++ b/desktop/windows/src/main/agentKernel/productToolExecutors.ts
@@ -595,7 +595,7 @@ export function createGetMemoriesExecutor(caller?: BackendToolCaller): ProductTo
       method: 'GET',
       path: '/v1/tools/memories',
       query: {
-        limit: clampInt(input.limit, 50, 1, 5000),
+        limit: clampInt(input.limit, 50, 1, 500),
         offset: clampInt(input.offset, 0, 0, 1_000_000),
         start_date: start.value,
         end_date: end.value

--- a/desktop/windows/src/renderer/src/hooks/useMemories.test.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.test.ts
@@ -39,17 +39,14 @@ beforeEach(() => {
   omiApiDelete.mockReset().mockResolvedValue({ data: { status: 'ok' } })
 })
 
-// Fakes the REAL GET /v3/memories pagination contract: offset===0 FORCES the
-// server to return min(total, 5000) items regardless of the requested limit;
-// only a non-zero offset honors the caller's limit. `header` rides on the
-// response so the hook can read the canonical-lifecycle capability flag.
+// Fakes GET /v3/memories pagination: hard page cap 500, no first-page expansion.
 function fakeBackend(total: number, header?: string) {
   return async (
     _path: string,
     config: { params: { limit: number; offset: number } }
   ): Promise<{ data: Partial<Memory>[]; headers?: Record<string, string> }> => {
     const { limit, offset } = config.params
-    const effectiveLimit = offset === 0 ? Math.min(total, 5000) : limit
+    const effectiveLimit = Math.min(limit, 500)
     const end = Math.min(offset + effectiveLimit, total)
     const data = (
       offset >= total
@@ -124,25 +121,19 @@ describe('useMemories — edit/visibility query-param contract (C9)', () => {
 })
 
 describe('useMemories — pagination, capability header, delete', () => {
-  it('pages past the forced 5000-item first page instead of stopping at it', async () => {
-    // Regression: fetchMemories used to do a single GET limit=500&offset=0.
-    // The backend forces limit=5000 at offset 0, so that one call returned the
-    // first ~5000 rows and NEVER requested a second page — an account with more
-    // than 5000 memories silently lost the tail on the Memories page. It must
-    // now page through the whole set.
-    omiApiGet.mockImplementation(fakeBackend(5200))
+  it('pages past the first server page instead of stopping at it', async () => {
+    // Backend hard-caps pages at 500. Display path must page the whole set.
+    omiApiGet.mockImplementation(fakeBackend(1200))
     const { result } = renderHook(() => useMemories())
 
     await act(async () => {
       await result.current.refresh()
     })
 
-    expect(result.current.memories).toHaveLength(5200)
-    expect(result.current.memories.some((m) => m.id === 'm5199')).toBe(true)
-    // Proves a second page was requested at the real resume offset (5000), not
-    // a naive offset=500 that would sit inside the already-collected first page.
+    expect(result.current.memories).toHaveLength(1200)
+    expect(result.current.memories.some((m) => m.id === 'm1199')).toBe(true)
     expect(omiApiGet).toHaveBeenCalledWith('/v3/memories', {
-      params: { limit: 5000, offset: 5000 }
+      params: { limit: 500, offset: 500 }
     })
   })
 

--- a/desktop/windows/src/renderer/src/hooks/useMemories.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.ts
@@ -38,17 +38,9 @@ const CANONICAL_LIFECYCLE_HEADER = 'x-omi-memory-canonical-lifecycle-exposed'
 // reassign it, so UI coloring must not depend on it.
 export type CreateMemoryExtra = { category?: string; tags?: string[] }
 
-// Fetch EVERY memory for the page, not just the first server page. The backend
-// forces limit=5000 whenever offset is 0, so the old single
-// `GET /v3/memories?limit=500&offset=0` call silently capped the page at the
-// server's first ~5000 rows and never requested a second page — an account with
-// more than 5000 memories would never see the tail (while bulk export/purge,
-// which already paged via fetchAllMemories, reached all of them). Reuse the one
-// shared pager so display and bulk paths can't drift, and read the
-// canonical-lifecycle capability header off the first response to gate the
-// tier/device filters. Then sort newest-first: the server doesn't return
-// memories in created_at order, so freshly created/imported ones would
-// otherwise land mid-list and look "missing".
+// Fetch EVERY memory for the page via the shared pager (server page cap 500).
+// Read canonical-lifecycle capability header off the first response; sort
+// newest-first because the server does not guarantee created_at order.
 async function fetchMemories(): Promise<Memory[]> {
   const list = await fetchAllMemoriesPaged((r) => {
     const header = r.headers?.[CANONICAL_LIFECYCLE_HEADER]


### PR DESCRIPTION
## Summary

Fix-forward for main after #10750: Desktop Windows CI `Typecheck · Lint · Test` failed because two client paths still assumed the old first-page `limit=5000` contract.

## Changes

- `createGetMemoriesExecutor` clamps max limit to **500** (matches backend hard page cap).
- `useMemories` tests/comments updated for 500-row paging (no forced first-page 5000).

## Product invariants affected

- INV-CHAT-1

## Failure-Class

Failure-Class: none

## Verification

- Targeted Windows vitest files: `useMemories.test.ts`, `memoriesBulk.test.ts`, `productToolExecutorsTierB.test.ts` (run in CI Desktop Windows lane).

## Non-goals

No backend changes; no deploy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

