### PR TITLE
fix(backend): surface denied hosted-MCP memory reads as errors (#10735)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2373,
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2263,
-    "backend/routers/mcp_sse.py": 1858,
+    "backend/routers/mcp_sse.py": 1873,
     "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2076
   },
@@ -11,7 +11,7 @@
     "backend/routers/apps.py": "The owner-migration route validates a source-bound Firebase anonymous-token proof before its existing database write and tracked background work, keeping the authorization decision at the HTTP mutation boundary.",
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
-    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line.",
+    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +15 for the shared _raise_memory_read_denied helper both memory reads call, so a denial surfaces as an authorization error instead of an empty result the client reports as 'you have no memories' (#10735).",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first. +30 for the disclosed, expiring city-context consent routes and legacy geolocation input boundary; they remain with the authenticated user route owner to prevent invalid coordinates reaching cache/provider paths (SCA-174)."
   },

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -750,6 +750,21 @@ def _raise_tool_error_from_http(exc: HTTPException) -> NoReturn:
     raise ToolExecutionError(str(exc.detail)) from exc
 
 
+def _raise_memory_read_denied(fallback_reason: Optional[str]) -> NoReturn:
+    """Surface a denied memory read as an error instead of an empty result (#10735).
+
+    Every reason that reaches here is a server-side authorization state the caller
+    cannot see or act on (missing app-key grant, unreadable rollout state,
+    shadow-only). Returning `{"memories": []}` for those is indistinguishable from
+    an account that genuinely has no memories, so the client reports the user's
+    data as gone rather than as withheld.
+    """
+    raise ToolExecutionError(
+        f"Memory read is not authorized for this key (reason: {fallback_reason or 'denied'})",
+        code=-32009,
+    )
+
+
 def _raise_screen_activity_index_error(exc: FailedPrecondition) -> NoReturn:
     """Turn a missing-Firestore-index failure into a typed, actionable tool error.
 
@@ -864,7 +879,7 @@ def execute_tool(
         if memory_list_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": memory_list_results.memories}
         if not mcp_legacy_read_authorized(memory_list_results):
-            return {"memories": []}
+            _raise_memory_read_denied(memory_list_results.fallback_reason)
 
         result = collect_filtered_memories(
             lambda batch_offset, batch_limit: memories_db.get_memories(
@@ -1092,7 +1107,7 @@ def execute_tool(
         if vector_search_results.read_decision == MemoryReadDecision.USE_MEMORY:
             return {"memories": vector_search_results.memories}
         if not mcp_legacy_read_authorized(vector_search_results):
-            return {"memories": []}
+            _raise_memory_read_denied(vector_search_results.fallback_reason)
 
         matches = vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)
         if not matches:

--- a/backend/tests/unit/test_mcp_sse_denied_memory_read_errors.py
+++ b/backend/tests/unit/test_mcp_sse_denied_memory_read_errors.py
@@ -1,0 +1,128 @@
+"""#10735: a denied hosted-MCP memory read must be an error, not an empty 200.
+
+The denial reasons that reach the fail-closed branch (missing app-key grant,
+unreadable rollout state, shadow-only) are server-side authorization states the
+caller cannot see. Returning ``{"memories": []}`` made them indistinguishable
+from an account with no memories, so the client told the user their data was
+gone instead of that it was withheld.
+
+These drive the real client-facing seam -- ``handle_mcp_message('tools/call')``,
+the same entry the hosted SSE transport calls -- with only the rollout adapters
+stubbed, and assert on the JSON-RPC envelope the MCP client actually receives.
+"""
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from routers import mcp_sse as sse
+from utils.mcp_memories import McpMemoryListResult, McpMemorySearchResult
+from utils.memory.default_read_rollout import MemoryReadDecision
+from utils.memory.memory_system import MemorySystem
+
+UID = "mcp-user"
+MEMORY_SCOPES = ["memories.read", "memories.write"]
+
+
+def _auth_context():
+    return sse.MCPAuthContext(
+        uid=UID,
+        auth_type="api_key",
+        scopes=MEMORY_SCOPES,
+        memory_context=SimpleNamespace(uid=UID, app_id="app-1", key_id="key-1"),
+    )
+
+
+def _tools_call(tool_name, arguments):
+    response, _ = sse.handle_mcp_message(
+        _auth_context(),
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},
+    )
+    return response
+
+
+def _legacy_rollout_patches(list_result, search_result):
+    return (
+        patch.object(sse, "pin_memory_system", return_value=MemorySystem.LEGACY),
+        patch.object(sse, "authorize_memory_external_default_memory_read", return_value=SimpleNamespace(allowed=True)),
+        patch.object(sse, "read_default_read_rollout", return_value=SimpleNamespace()),
+        patch.object(sse, "list_default_mcp_memories", return_value=list_result),
+        patch.object(sse, "search_default_mcp_memories_vector", return_value=search_result),
+    )
+
+
+def _enter(*managers):
+    """Enter a set of patches together and close them all on exit."""
+    stack = ExitStack()
+    for manager in managers:
+        stack.enter_context(manager)
+    return stack
+
+
+def _denied(reason='missing_mcp_default_memory_grant', decision=MemoryReadDecision.DENY_MEMORY):
+    return (
+        McpMemoryListResult(memories=[], read_decision=decision, fallback_reason=reason),
+        McpMemorySearchResult(memories=[], read_decision=decision, fallback_reason=reason),
+    )
+
+
+@pytest.mark.parametrize(
+    "decision,reason",
+    [
+        (MemoryReadDecision.DENY_MEMORY, 'missing_mcp_default_memory_grant'),
+        (MemoryReadDecision.DENY_MEMORY, 'rollout_read_failed'),
+        (MemoryReadDecision.SHADOW_ONLY, 'shadow_only'),
+    ],
+)
+def test_denied_get_memories_returns_jsonrpc_error_not_empty_result(decision, reason):
+    list_result, search_result = _denied(reason, decision)
+    with _enter(*_legacy_rollout_patches(list_result, search_result)):
+        response = _tools_call("get_memories", {})
+
+    assert "result" not in response
+    assert response["error"]["code"] == -32009
+    assert reason in response["error"]["message"]
+
+
+def test_denied_search_memories_returns_jsonrpc_error_not_empty_result():
+    list_result, search_result = _denied()
+    with _enter(*_legacy_rollout_patches(list_result, search_result)):
+        response = _tools_call("search_memories", {"query": "anything"})
+
+    assert "result" not in response
+    assert response["error"]["code"] == -32009
+    assert 'missing_mcp_default_memory_grant' in response["error"]["message"]
+
+
+def test_authorized_legacy_read_still_serves_memories():
+    """The un-enrolled cohort (absent rollout state doc) must keep reading legacy memories."""
+    list_result, search_result = _denied('missing_rollout_state')
+    legacy_memory = {"id": "m1", "content": "legacy memory", "category": "core"}
+    with _enter(
+        *_legacy_rollout_patches(list_result, search_result),
+        patch.object(sse.memories_db, "get_memories", return_value=[legacy_memory]),
+    ):
+        response = _tools_call("get_memories", {})
+
+    assert "error" not in response
+    assert "legacy memory" in response["result"]["content"][0]["text"]
+
+
+def test_enabled_memory_read_still_serves_memories():
+    """A USE_MEMORY decision returns before the denial branch and is unaffected."""
+    memory = {"id": "m2", "content": "canonical memory"}
+    list_result = McpMemoryListResult(
+        memories=[memory], read_decision=MemoryReadDecision.USE_MEMORY, fallback_reason=None
+    )
+    search_result = McpMemorySearchResult(
+        memories=[memory], read_decision=MemoryReadDecision.USE_MEMORY, fallback_reason=None
+    )
+    with _enter(*_legacy_rollout_patches(list_result, search_result)):
+        get_response = _tools_call("get_memories", {})
+        search_response = _tools_call("search_memories", {"query": "anything"})
+
+    for response in (get_response, search_response):
+        assert "error" not in response
+        assert "canonical memory" in response["result"]["content"][0]["text"]


### PR DESCRIPTION
Fixes #10735.

## Bug

A hosted-MCP memory read that the authorization check **denies** came back as a successful JSON-RPC result carrying `{"memories": []}`. The client reports "you have no memories" for an account whose memories are simply withheld — the failure mode most likely to make a user believe their data was deleted. Support cannot separate it from a genuinely empty account without a per-account Firestore trace, and it contradicts the memories screen, which lists the same user's memories fine.

## Root cause

`backend/routers/mcp_sse.py`, the two legacy-cohort memory reads (`get_memories` :866, `search_memories` :1094):

```python
if not mcp_legacy_read_authorized(memory_list_results):
    return {"memories": []}
```

Every reason that reaches this fail-closed branch is a server-side authorization state the caller cannot see or act on — `missing_mcp_default_memory_grant` (see #10734 for the grant-seeding gap), `malformed_rollout_state`, `rollout_read_failed`, `shadow_only`. Returning an empty list makes the denial indistinguishable from an empty account.

## Fix

Both sites now raise `ToolExecutionError(..., code=-32009)` carrying the denial reason, mirroring the app-key grant check a few lines above in the same handler. `handle_mcp_message` already converts that into a JSON-RPC error, so the client gets an explicit failure instead of a false empty.

Authorized paths are untouched: `USE_MEMORY` still returns memories, `USE_LEGACY_SAFE` and the un-enrolled cohort (`missing_rollout_state`, #9892) still fall through to the legacy read. Nothing that previously returned data returns less, and no data is exposed that was not exposed before.

The line-count ratchet baseline for `mcp_sse.py` is raised by the 15 lines of the shared helper, with its justification.

## What I tested

Drove `handle_mcp_message('tools/call')` — the exact seam the hosted SSE transport calls — with a denied decision, and read the envelope the MCP client receives.

Before:
```
get_memories    -> {"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text","text":"{\n  \"memories\": []\n}"}]}}
search_memories -> {"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text","text":"{\n  \"memories\": []\n}"}]}}
```

After:
```
get_memories    -> {"jsonrpc":"2.0","id":7,"error":{"code":-32009,"message":"Memory read is not authorized for this key (reason: missing_mcp_default_memory_grant)"}}
search_memories -> {"jsonrpc":"2.0","id":7,"error":{"code":-32009,"message":"Memory read is not authorized for this key (reason: missing_mcp_default_memory_grant)"}}
```

- New regression test `backend/tests/unit/test_mcp_sse_denied_memory_read_errors.py` (6 tests) drives the same client seam: 3 denial reasons on `get_memories`, one on `search_memories`, plus two that assert the authorized paths still serve memories. **4 of the 6 fail on the pre-fix code** (`git checkout routers/mcp_sse.py` → `4 failed, 2 passed`) and all 6 pass on the fix.
- `pytest tests/unit/test_mcp_memory_adapter.py tests/unit/test_mcp_data_endpoints.py tests/unit/test_mcp_sse_pagination_bounds.py tests/unit/test_mcp_auth_context_static.py tests/unit/test_mcp_action_item_writes.py tests/unit/test_mcp_conversations_pagination_clamp.py tests/unit/test_memory_api_egress_contract.py` → **118 passed**.
- `check_module_stub_pollution.py` / `scan_import_time_side_effects.py` → 0 violations. `make preflight` green.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

