### PR TITLE
fix(ci): exempt M1 self-clean scripts from changelog gate

### DIFF
--- a/.github/failure-classes/FC-push-gate-internal-path-scope.json
+++ b/.github/failure-classes/FC-push-gate-internal-path-scope.json
@@ -2,8 +2,18 @@
   "schema_version": 1,
   "id": "FC-push-gate-internal-path-scope",
   "violated_contract": "A CI gate that also runs on the post-merge push lane must scope its 'user-facing change' trigger to exclude internal, non-user-facing paths (generated code, tests, release infrastructure); otherwise a legitimate change to those paths reddens main on the push run with no author able to satisfy the gate.",
-  "canonical_prevention": "Keep the gate's exemption set (e.g. EXEMPT_DESKTOP_PATH_PREFIXES) covering every never-user-facing path class, and add a path to it — with a test — rather than relying on a PR-only label that the post-merge push run cannot honor.",
-  "evidence_prs": [10387, 10481],
-  "scope_hints": [".github/scripts/check-desktop-changelog.py", ".github/scripts/"],
+  "canonical_prevention": "Keep the gate's exemption set (e.g. EXEMPT_DESKTOP_PATH_PREFIXES) covering every never-user-facing path class, and add a path to it \u2014 with a test \u2014 rather than relying on a PR-only label that the post-merge push run cannot honor.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check-desktop-changelog.py",
+    ".github/scripts/test_desktop_changelog.py"
+  ],
+  "evidence_prs": [
+    10387,
+    10481
+  ],
+  "scope_hints": [
+    ".github/scripts/check-desktop-changelog.py",
+    ".github/scripts/"
+  ],
   "status": "open"
 }

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -19,6 +19,11 @@ EXEMPT_DESKTOP_PATHS = {
     "desktop/macos/scripts/qualify-desktop-beta.sh",
     # Capacity/lease authority for the same internal qualification runner.
     "desktop/macos/scripts/qualification-cache-reclaim.py",
+    # M1 self-clean / lost-communication recovery for the qualification runner
+    # (#10759). Internal release infrastructure; post-merge push must not demand
+    # a user-facing changelog fragment (FC-push-gate-internal-path-scope).
+    "desktop/macos/scripts/qualification-runner-self-clean.py",
+    "desktop/macos/scripts/qualification-watchdog.py",
     # Sibling qualification-runner helper to qualify-desktop-beta.sh: internal
     # release infrastructure with no user-facing app surface.
     "desktop/macos/scripts/qualification-swift-cache.sh",

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -72,6 +72,9 @@ class ChangelogRequirementTests(unittest.TestCase):
             "desktop/macos/docs/qualification-environment.md",
             "desktop/macos/scripts/qualify-desktop-beta.sh",
             "desktop/macos/scripts/qualification-cache-reclaim.py",
+            # #10759 M1 self-clean/watchdog helpers (EXEMPT_DESKTOP_PATHS).
+            "desktop/macos/scripts/qualification-runner-self-clean.py",
+            "desktop/macos/scripts/qualification-watchdog.py",
             # Sibling qualification-runner helper (EXEMPT_DESKTOP_PATHS).
             "desktop/macos/scripts/qualification-swift-cache.sh",
             "desktop/macos/scripts/qualification-lease-command.sh",


### PR DESCRIPTION
Fixes Release Eligibility blocked after #10759.

## What changed and why
- Exempt `qualification-runner-self-clean.py` and `qualification-watchdog.py` from the desktop changelog gate
- Cover both paths in `ChangelogRequirementTests`

These scripts are M1 qualification runner infrastructure from #10759. The PR lane could skip via `no-changelog-needed`, but the post-merge push/Release Eligibility lane cannot, so main stayed red and `desktop_auto_release` refused to tag (`should_release=false`).

## Product invariants affected
none

## How it was verified
- `python3 .github/scripts/test_desktop_changelog.py`

## Failure class (fixes)
Failure-Class: FC-push-gate-internal-path-scope

## Tests
- `ChangelogRequirementTests` includes the two new script paths