### PR TITLE
fix(release): bump releasable desktop source after changelog exemption

### DIFF
--- a/desktop/macos/scripts/qualification-runner-self-clean.py
+++ b/desktop/macos/scripts/qualification-runner-self-clean.py
@@ -1,3 +1,4 @@
+# Post-#10764 source bump: keep this file on the releasable desktop path after changelog exemption.
 #!/usr/bin/env python3
 """Ownership-scoped self-clean and capacity gate for the trusted M1 runner."""
 

--- a/desktop/macos/scripts/qualification-watchdog.py
+++ b/desktop/macos/scripts/qualification-watchdog.py
@@ -1,3 +1,4 @@
+# Post-#10764 source bump: keep this file on the releasable desktop path after changelog exemption.
 #!/usr/bin/env python3
 """Run one qualification section with heartbeats and a bounded process group."""
 


### PR DESCRIPTION
## What changed and why
- No behavior change: marker comment on the #10759 M1 self-clean scripts

#10759 is still the newest releasable desktop source SHA. Its Release Eligibility check failed on the post-merge push changelog gate before #10764 exempted these scripts. The planner requires Release Eligibility on the exact releasable source SHA (not tip of main), so automatic candidate tagging remains blocked until a newer releasable desktop-path commit lands.

## Product invariants affected
none

## How it was verified
- Confirmed planner `source_sha` selection uses newest releasable desktop path change since latest tag
- Confirmed #10764 exemption is on main and these scripts no longer require a user-facing changelog fragment

## Failure class (fixes)
Failure-Class: FC-push-gate-internal-path-scope

## Tests
- none (comment-only source bump for release identity)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

