### PR TITLE
fix(release): bind Desktop Swift source after changelog exemption

### DIFF
--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 
+// Keep Desktop/Tests in the releasable path set so ordinary macOS Beta planning can bind a post-exemption source SHA after internal qualification infra merges.
 @testable import Omi_Computer
 
 // MARK: - Request-capturing protocol for routing verification


### PR DESCRIPTION
## What changed and why
- One-line comment in an exempt `Desktop/Tests` file so ordinary release planning can select a post-#10764 source SHA
- Unblocks Desktop Swift + Release Eligibility on a SHA that includes the M1 self-clean changelog exemption

## Product invariants affected
none

## How it was verified
- Path is under `EXEMPT_DESKTOP_PATH_PREFIXES` (`desktop/macos/Desktop/Tests/`)
- `pre_push_ci_prediction` selects desktop-swift-tests + desktop-swift-release-compile on push

## Failure class (fixes)
Failure-Class: FC-push-gate-internal-path-scope

## Tests
- Relies on existing APIClientRoutingTests (comment-only)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

