### PR TITLE
SCA-219: Parity Pack v0 (SCA-220 foundation)

### DIFF
--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -5,8 +5,8 @@ are restricted local/dev artifacts and must never be committed.
 
 ## Dev capture gate
 
-Future capture callers must instantiate `CaptureWhitelist.from_environ()` and
-call `allows(principal_id)` before serializing any cassette bytes. It defaults to
+`CaptureTap` uses `CaptureWhitelist.from_environ()` and calls
+`allows(principal_id)` before serializing any cassette bytes. It defaults to
 deny. A capture is permitted only with all three settings:
 
 ```bash
@@ -20,6 +20,21 @@ fingerprints are SHA-256 digests of canonical redacted request structure; auth,
 cookies, keys, signed URL parameters, and best-effort email/phone strings are
 removed or masked before the digest is generated. Do not put raw request data in
 manifests, reports, or Git.
+
+`CaptureTap.start()` creates one invocation under that anonymous identity. Its
+`observe()` boundary records client, outbound provider, and inbound provider
+wire observations using relative milliseconds. A whitelist miss writes no
+cassette bytes and retains only bounded lane/reason metadata.
+
+## Replay players
+
+`STTCassettePlayer` and `LLMCassettePlayer` are callback-oriented loopback
+adapters for the wire-oracle fakes. Give both the shared ordered
+`InvocationTopology`; `play()` verifies complete identity and canonical
+redacted request fingerprint, then yields recorded events and relative
+`dt_ms`. `assert_complete()` fails unused cassettes; a mismatch, wrong order,
+or an extra call fails immediately. Cassettes remain restricted local/dev
+inputs and must not be committed.
 
 ## Layout
 

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -10,7 +10,7 @@ are restricted local/dev artifacts and must never be committed.
 deny. A capture is permitted only with all three settings:
 
 ```bash
-OMI_ENV=dev
+OMI_ENV_STAGE=dev
 OMI_PARITY_PACK_CAPTURE=1
 OMI_PARITY_PACK_ALLOWED_PRINCIPALS='synthetic-user-1,synthetic-device-2'
 ```
@@ -45,9 +45,10 @@ inputs and must not be committed.
   cassettes/<identity-key>.json # referenced by cassette_refs
 ```
 
-`manifest.json` records the schema version, artifact hashes, input/cassette
-references, expected outcomes, and invariant IDs. Run the foundation checks with
-`npm run test:parity-pack-v0`.
+`manifest.json` records the schema version, `pack_id`, artifact hashes, and one
+entry per case: input/cassette references, expected outcomes, invariant IDs, the
+anonymous cassette identity, and the redacted request fingerprint (digest only).
+Run the foundation checks with `npm run test:parity-pack-v0`.
 
 ## Gold, drift, and rewrite slot
 

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -1,12 +1,12 @@
-# Parity Pack v0 foundation
+# Parity Pack v0
 
 This is a local replay-pack contract, not a production capture path. Pack payloads
 are restricted local/dev artifacts and must never be committed.
 
 ## Dev capture gate
 
-`CaptureTap` uses `CaptureWhitelist.from_environ()` and calls
-`allows(principal_id)` before serializing any cassette bytes. It defaults to
+Future capture callers must instantiate `CaptureWhitelist.from_environ()` and
+call `allows(principal_id)` before serializing any cassette bytes. It defaults to
 deny. A capture is permitted only with all three settings:
 
 ```bash
@@ -21,21 +21,6 @@ cookies, keys, signed URL parameters, and best-effort email/phone strings are
 removed or masked before the digest is generated. Do not put raw request data in
 manifests, reports, or Git.
 
-`CaptureTap.start()` creates one invocation under that anonymous identity. Its
-`observe()` boundary records client, outbound provider, and inbound provider
-wire observations using relative milliseconds. A whitelist miss writes no
-cassette bytes and retains only bounded lane/reason metadata.
-
-## Replay players
-
-`STTCassettePlayer` and `LLMCassettePlayer` are callback-oriented loopback
-adapters for the wire-oracle fakes. Give both the shared ordered
-`InvocationTopology`; `play()` verifies complete identity and canonical
-redacted request fingerprint, then yields recorded events and relative
-`dt_ms`. `assert_complete()` fails unused cassettes; a mismatch, wrong order,
-or an extra call fails immediately. Cassettes remain restricted local/dev
-inputs and must not be committed.
-
 ## Layout
 
 ```text
@@ -48,3 +33,30 @@ inputs and must not be committed.
 `manifest.json` records the schema version, artifact hashes, input/cassette
 references, expected outcomes, and invariant IDs. Run the foundation checks with
 `npm run test:parity-pack-v0`.
+
+## Gold, drift, and rewrite slot
+
+`double_run_gold()` runs every case twice before a gold update. It rejects a
+nondeterministic result; `write_gold=True` is the only way it changes
+`expected_outcomes`. Ordinary replay produces a digest-only, **warn-only**
+drift report, so drift never masks a result or blocks a developer investigation.
+
+`rewrite_launch_descriptor()` is the explicit integration slot for a future
+rewrite binary. The descriptor is intentionally unavailable in this repository:
+operators must install and invoke the approved binary themselves rather than
+having replay download or execute one.
+
+The synthetic v0 matrix names six overlays: `baseline`, `duplicate_delivery`,
+`provider_timeout`, `provider_error`, `out_of_order_events`, and
+`redacted_capture`. They contain no captured payloads.
+
+## Operator workflow (dev only)
+
+1. Keep the local pack outside this repository. Never commit cassettes, inputs,
+   payloads, or a whitelist.
+2. Set `OMI_ENV_STAGE=dev`, `OMI_PARITY_PACK_CAPTURE=1`, and an explicit
+   `OMI_PARITY_PACK_ALLOWED_PRINCIPALS` allowlist. Any other stage or a missing
+   allowlist is deny-by-default and persists no cassette bytes.
+3. Run the application path with the opted-in synthetic/dev principal, then run
+   `npm run test:parity-pack-v0` to replay hermetically. The tests deny egress
+   and require fake-hit accounting; no provider or production service is used.

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -1,0 +1,35 @@
+# Parity Pack v0 foundation
+
+This is a local replay-pack contract, not a production capture path. Pack payloads
+are restricted local/dev artifacts and must never be committed.
+
+## Dev capture gate
+
+Future capture callers must instantiate `CaptureWhitelist.from_environ()` and
+call `allows(principal_id)` before serializing any cassette bytes. It defaults to
+deny. A capture is permitted only with all three settings:
+
+```bash
+OMI_ENV=dev
+OMI_PARITY_PACK_CAPTURE=1
+OMI_PARITY_PACK_ALLOWED_PRINCIPALS='synthetic-user-1,synthetic-device-2'
+```
+
+Use anonymous session/event identifiers in `CassetteIdentity`. Request
+fingerprints are SHA-256 digests of canonical redacted request structure; auth,
+cookies, keys, signed URL parameters, and best-effort email/phone strings are
+removed or masked before the digest is generated. Do not put raw request data in
+manifests, reports, or Git.
+
+## Layout
+
+```text
+<restricted-local-pack>/
+  manifest.json                 # hashes + case descriptors only
+  inputs/<case>.json            # referenced by inputs_ref
+  cassettes/<identity-key>.json # referenced by cassette_refs
+```
+
+`manifest.json` records the schema version, artifact hashes, input/cassette
+references, expected outcomes, and invariant IDs. Run the foundation checks with
+`npm run test:parity-pack-v0`.

--- a/backend/testing/parity_pack_v0/__init__.py
+++ b/backend/testing/parity_pack_v0/__init__.py
@@ -1,0 +1,10 @@
+"""Local-only foundations for the Parity Pack v0 replay harness.
+
+This package deliberately contains no production capture hook.  Capture wiring
+is added by a later stage and must use :mod:`whitelist` before it writes a pack.
+"""
+
+from .schema import CassetteIdentity, RequestFingerprint
+from .whitelist import CaptureWhitelist
+
+__all__ = ("CassetteIdentity", "RequestFingerprint", "CaptureWhitelist")

--- a/backend/testing/parity_pack_v0/capture.py
+++ b/backend/testing/parity_pack_v0/capture.py
@@ -1,0 +1,66 @@
+"""Dev-only capture boundary for local parity-pack cassettes."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import time
+from typing import Any, Callable, Mapping
+
+from .schema import CassetteIdentity, RequestFingerprint
+from .whitelist import CaptureWhitelist
+
+
+@dataclass(frozen=True)
+class CassetteEvent:
+    direction: str
+    dt_ms: int
+    payload: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if self.direction not in {"client", "outbound", "inbound"}:
+            raise ValueError("direction must be client, outbound, or inbound")
+        if self.dt_ms < 0:
+            raise ValueError("dt_ms must be non-negative")
+
+
+class CaptureTap:
+    """Persists restricted local cassettes only after the dev whitelist allows it."""
+
+    def __init__(self, root: Path, whitelist: CaptureWhitelist, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self.root, self.whitelist, self._clock = root, whitelist, clock
+        self.denied_metadata: list[dict[str, str]] = []
+
+    def start(
+        self, principal_id: str | None, identity: CassetteIdentity, request: Mapping[str, Any]
+    ) -> "CaptureInvocation | None":
+        if not self.whitelist.allows(principal_id):
+            self.denied_metadata.append({"provider_lane": identity.provider_lane, "reason": "whitelist_miss"})
+            del self.denied_metadata[:-100]
+            return None
+        return CaptureInvocation(self.root, identity, RequestFingerprint.from_request(request), self._clock)
+
+
+class CaptureInvocation:
+    def __init__(
+        self, root: Path, identity: CassetteIdentity, fingerprint: RequestFingerprint, clock: Callable[[], float]
+    ) -> None:
+        self.root, self.identity, self.fingerprint, self._clock = root, identity, fingerprint, clock
+        self._started_at = clock()
+        self._events: list[CassetteEvent] = []
+
+    def observe(self, direction: str, payload: Mapping[str, Any]) -> None:
+        self._events.append(CassetteEvent(direction, round((self._clock() - self._started_at) * 1000), dict(payload)))
+
+    def persist(self) -> Path:
+        path = self.root / "cassettes" / f"{self.identity.key()}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        document = {
+            "schema_version": 1,
+            "identity": self.identity.as_dict(),
+            "request_fingerprint": self.fingerprint.as_dict(),
+            "events": [asdict(event) for event in self._events],
+        }
+        path.write_text(json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+        return path

--- a/backend/testing/parity_pack_v0/gold.py
+++ b/backend/testing/parity_pack_v0/gold.py
@@ -1,0 +1,65 @@
+"""Deterministic gold-freeze and warn-only drift helpers for parity packs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False)
+
+
+@dataclass(frozen=True)
+class Drift:
+    case_id: str
+    expected_digest: str
+    actual_digest: str
+
+
+def result_digest(result: Mapping[str, Any]) -> str:
+    """Return a stable digest without retaining result payloads in reports."""
+    return sha256(_canonical(dict(result)).encode()).hexdigest()
+
+
+def double_run_gold(
+    manifest_path: Path,
+    run_case: Callable[[Mapping[str, Any]], Mapping[str, Any]],
+    *,
+    write_gold: bool = False,
+) -> tuple[Drift, ...]:
+    """Run every manifest case twice, reject nondeterminism, optionally freeze gold.
+
+    ``write_gold`` is deliberately explicit: ordinary replay only reports drift;
+    it never changes a local pack's expected outcomes as a side effect.
+    """
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    drifts: list[Drift] = []
+    for case in manifest["cases"]:
+        first = dict(run_case(case))
+        second = dict(run_case(case))
+        first_digest, second_digest = result_digest(first), result_digest(second)
+        if first_digest != second_digest:
+            raise AssertionError(f"non-deterministic replay for {case['case_id']}")
+        expected = dict(case.get("expected_outcomes", {}))
+        expected_digest = result_digest(expected)
+        if expected_digest != first_digest:
+            drifts.append(Drift(case["case_id"], expected_digest, first_digest))
+            if write_gold:
+                case["expected_outcomes"] = first
+    if write_gold:
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return tuple(drifts)
+
+
+def drift_report(drifts: tuple[Drift, ...]) -> dict[str, Any]:
+    """A payload-free, warn-only report suitable for local operator output."""
+    return {
+        "status": "warn" if drifts else "ok",
+        "drift_count": len(drifts),
+        "drifts": [drift.__dict__ for drift in drifts],
+        "enforcement": "warn-only",
+    }

--- a/backend/testing/parity_pack_v0/manifest.py
+++ b/backend/testing/parity_pack_v0/manifest.py
@@ -1,0 +1,57 @@
+"""On-disk manifest contract for a restricted local parity pack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .schema import CassetteIdentity, RequestFingerprint
+
+
+def sha256_file(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class PackCase:
+    case_id: str
+    inputs_ref: str
+    cassette_refs: tuple[str, ...]
+    expected_outcomes: Mapping[str, Any]
+    invariant_ids: tuple[str, ...]
+    identity: CassetteIdentity
+    request_fingerprint: RequestFingerprint
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "inputs_ref": self.inputs_ref,
+            "cassette_refs": list(self.cassette_refs),
+            "expected_outcomes": dict(self.expected_outcomes),
+            "invariant_ids": list(self.invariant_ids),
+            "identity": self.identity.as_dict(),
+            "request_fingerprint": self.request_fingerprint.as_dict(),
+        }
+
+
+def build_manifest(*, pack_id: str, cases: Sequence[PackCase], artifact_hashes: Mapping[str, str]) -> dict[str, Any]:
+    if not pack_id or not cases:
+        raise ValueError("pack_id and at least one case are required")
+    return {
+        "schema_version": 1,
+        "pack_id": pack_id,
+        "cases": [case.as_dict() for case in cases],
+        "artifact_hashes": dict(sorted(artifact_hashes.items())),
+    }
+
+
+def write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/backend/testing/parity_pack_v0/matrix.py
+++ b/backend/testing/parity_pack_v0/matrix.py
@@ -4,12 +4,23 @@ from __future__ import annotations
 
 from typing import Final
 
-
 SYNTHETIC_MATRIX: Final[dict[str, dict[str, str]]] = {
     "baseline": {"delivery": "single", "provider": "recorded", "expected": "finalized"},
-    "duplicate_delivery": {"delivery": "duplicate", "provider": "recorded", "expected": "idempotent"},
+    "duplicate_delivery": {
+        "delivery": "duplicate",
+        "provider": "recorded",
+        "expected": "idempotent",
+    },
     "provider_timeout": {"delivery": "single", "provider": "timeout", "expected": "recoverable"},
     "provider_error": {"delivery": "single", "provider": "error", "expected": "failed-safe"},
-    "out_of_order_events": {"delivery": "reordered", "provider": "recorded", "expected": "rejected"},
-    "redacted_capture": {"delivery": "single", "provider": "recorded", "expected": "no-sensitive-payload"},
+    "out_of_order_events": {
+        "delivery": "reordered",
+        "provider": "recorded",
+        "expected": "rejected",
+    },
+    "redacted_capture": {
+        "delivery": "single",
+        "provider": "recorded",
+        "expected": "no-sensitive-payload",
+    },
 }

--- a/backend/testing/parity_pack_v0/matrix.py
+++ b/backend/testing/parity_pack_v0/matrix.py
@@ -1,0 +1,15 @@
+"""Named synthetic overlays for the initial replay conformance matrix."""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+SYNTHETIC_MATRIX: Final[dict[str, dict[str, str]]] = {
+    "baseline": {"delivery": "single", "provider": "recorded", "expected": "finalized"},
+    "duplicate_delivery": {"delivery": "duplicate", "provider": "recorded", "expected": "idempotent"},
+    "provider_timeout": {"delivery": "single", "provider": "timeout", "expected": "recoverable"},
+    "provider_error": {"delivery": "single", "provider": "error", "expected": "failed-safe"},
+    "out_of_order_events": {"delivery": "reordered", "provider": "recorded", "expected": "rejected"},
+    "redacted_capture": {"delivery": "single", "provider": "recorded", "expected": "no-sensitive-payload"},
+}

--- a/backend/testing/parity_pack_v0/players.py
+++ b/backend/testing/parity_pack_v0/players.py
@@ -1,0 +1,78 @@
+"""Cassette-backed STT/LLM loopback adapters with strict invocation accounting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .schema import CassetteIdentity, RequestFingerprint
+
+
+class CassetteTopologyError(AssertionError):
+    pass
+
+
+@dataclass(frozen=True)
+class PlayedEvent:
+    direction: str
+    dt_ms: int
+    payload: Mapping[str, Any]
+
+
+class InvocationTopology:
+    """Consumes an ordered cassette plan and rejects every topology mismatch."""
+
+    def __init__(self, paths: tuple[Path, ...]) -> None:
+        self._documents = tuple(_read(path) for path in paths)
+        self._position = 0
+
+    def consume(self, identity: CassetteIdentity, request: Mapping[str, Any]) -> tuple[PlayedEvent, ...]:
+        if self._position == len(self._documents):
+            raise CassetteTopologyError(f"extra invocation: {identity.key()}")
+        document = self._documents[self._position]
+        if document["identity"] != identity.as_dict():
+            raise CassetteTopologyError(
+                f"out-of-order cassette: expected={document['identity']}, actual={identity.as_dict()}"
+            )
+        if document["request_fingerprint"] != RequestFingerprint.from_request(request).as_dict():
+            raise CassetteTopologyError("cassette request fingerprint mismatch")
+        self._position += 1
+        return tuple(PlayedEvent(**event) for event in document["events"])
+
+    def assert_complete(self) -> None:
+        if self._position != len(self._documents):
+            raise CassetteTopologyError(f"unused cassettes: {len(self._documents) - self._position}")
+
+
+class _CassettePlayer:
+    lane: str
+
+    def __init__(self, topology: InvocationTopology) -> None:
+        self._topology = topology
+
+    def play(self, identity: CassetteIdentity, request: Mapping[str, Any], emit: Callable[[PlayedEvent], None]) -> None:
+        if identity.provider_lane != self.lane:
+            raise CassetteTopologyError(f"{self.lane} player cannot play {identity.provider_lane}")
+        for event in self._topology.consume(identity, request):
+            emit(event)
+
+
+class STTCassettePlayer(_CassettePlayer):
+    """Drop-in loopback callback adapter for streaming STT fake observations."""
+
+    lane = "stt"
+
+
+class LLMCassettePlayer(_CassettePlayer):
+    """Drop-in loopback callback adapter for outbound LLM fake observations."""
+
+    lane = "llm"
+
+
+def _read(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if document.get("schema_version") != 1:
+        raise ValueError(f"unsupported cassette schema: {path}")
+    return document

--- a/backend/testing/parity_pack_v0/redaction.py
+++ b/backend/testing/parity_pack_v0/redaction.py
@@ -7,7 +7,10 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 SENSITIVE_KEY = re.compile(
-    r"(?:^|[_-])(?:authorization|auth|cookie|token|secret|api[_-]?key|password|signature|signed)(?:$|[_-])", re.I
+    r"(?:^|[_-])(?:authorization|auths?|cookies?|tokens?|secrets?|api[_-]?keys?|"
+    r"passwords?|passwd|pwd|signatures?|signed|private[_-]?keys?|access[_-]?keys?|"
+    r"credentials?|bearer|jwts?)(?:$|[_-])",
+    re.I,
 )
 EMAIL = re.compile(r"(?<![\w.+-])[\w.+-]+@[\w-]+(?:\.[\w-]+)+(?![\w.+-])")
 PHONE = re.compile(r"(?<!\w)(?:\+?\d[\d(). -]{6,}\d)(?!\w)")

--- a/backend/testing/parity_pack_v0/redaction.py
+++ b/backend/testing/parity_pack_v0/redaction.py
@@ -26,6 +26,17 @@ def redact_text(value: str) -> str:
     return PHONE.sub("[REDACTED_PHONE]", value)
 
 
+def _is_sensitive_key(key_text: str) -> bool:
+    """True when a mapping key names a credential-like field.
+
+    Handles snake_case, kebab-case, and camelCase so keys like
+    ``accessToken`` and ``clientSecret`` are caught alongside
+    ``access_token`` and ``access-token``.
+    """
+    normalized = re.sub(r"(?<=[a-z])(?=[A-Z])", "_", key_text)
+    return bool(SENSITIVE_KEY.search(normalized))
+
+
 def redact_value(value: Any, *, drop_sensitive: bool = False) -> Any:
     """Return a structurally equivalent, safe-to-log representation.
 
@@ -36,7 +47,7 @@ def redact_value(value: Any, *, drop_sensitive: bool = False) -> Any:
         result: dict[str, Any] = {}
         for key, item in value.items():
             key_text = str(key)
-            if SENSITIVE_KEY.search(key_text):
+            if _is_sensitive_key(key_text):
                 if not drop_sensitive:
                     result[key_text] = "[REDACTED]"
             else:

--- a/backend/testing/parity_pack_v0/redaction.py
+++ b/backend/testing/parity_pack_v0/redaction.py
@@ -1,0 +1,49 @@
+"""Conservative redaction for cassette metadata, fingerprints, and reports."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+SENSITIVE_KEY = re.compile(
+    r"(?:^|[_-])(?:authorization|auth|cookie|token|secret|api[_-]?key|password|signature|signed)(?:$|[_-])", re.I
+)
+EMAIL = re.compile(r"(?<![\w.+-])[\w.+-]+@[\w-]+(?:\.[\w-]+)+(?![\w.+-])")
+PHONE = re.compile(r"(?<!\w)(?:\+?\d[\d(). -]{6,}\d)(?!\w)")
+URL = re.compile(r"https?://[^\s\"']+", re.I)
+
+
+def redact_text(value: str) -> str:
+    """Strip URL query/fragment and mask common direct identifiers."""
+
+    def clean_url(match: re.Match[str]) -> str:
+        parsed = urlsplit(match.group(0))
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", "")) + "[REDACTED_URL_PARAMS]"
+
+    value = URL.sub(clean_url, value)
+    value = EMAIL.sub("[REDACTED_EMAIL]", value)
+    return PHONE.sub("[REDACTED_PHONE]", value)
+
+
+def redact_value(value: Any, *, drop_sensitive: bool = False) -> Any:
+    """Return a structurally equivalent, safe-to-log representation.
+
+    Sensitive mapping values are omitted when ``drop_sensitive`` is true (for
+    fingerprints), otherwise replaced with a stable marker (for reports).
+    """
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if SENSITIVE_KEY.search(key_text):
+                if not drop_sensitive:
+                    result[key_text] = "[REDACTED]"
+            else:
+                result[key_text] = redact_value(item, drop_sensitive=drop_sensitive)
+        return result
+    if isinstance(value, (list, tuple)):
+        return [redact_value(item, drop_sensitive=drop_sensitive) for item in value]
+    if isinstance(value, str):
+        return redact_text(value)
+    return value

--- a/backend/testing/parity_pack_v0/rewrite.py
+++ b/backend/testing/parity_pack_v0/rewrite.py
@@ -14,7 +14,9 @@ class RewriteLaunchDescriptor:
     available: bool
 
 
-def rewrite_launch_descriptor(input_manifest: Path, output_manifest: Path, binary: str = "omi-replay-rewrite") -> RewriteLaunchDescriptor:
+def rewrite_launch_descriptor(
+    input_manifest: Path, output_manifest: Path, binary: str = "omi-replay-rewrite"
+) -> RewriteLaunchDescriptor:
     """Describe, but never silently invoke, the optional rewrite integration."""
     return RewriteLaunchDescriptor(
         command=(binary, "--manifest", str(input_manifest), "--output", str(output_manifest)),

--- a/backend/testing/parity_pack_v0/rewrite.py
+++ b/backend/testing/parity_pack_v0/rewrite.py
@@ -1,0 +1,24 @@
+"""Descriptor-only slot for an optional external cassette rewrite binary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RewriteLaunchDescriptor:
+    command: tuple[str, ...]
+    input_manifest: Path
+    output_manifest: Path
+    available: bool
+
+
+def rewrite_launch_descriptor(input_manifest: Path, output_manifest: Path, binary: str = "omi-replay-rewrite") -> RewriteLaunchDescriptor:
+    """Describe, but never silently invoke, the optional rewrite integration."""
+    return RewriteLaunchDescriptor(
+        command=(binary, "--manifest", str(input_manifest), "--output", str(output_manifest)),
+        input_manifest=input_manifest,
+        output_manifest=output_manifest,
+        available=False,
+    )

--- a/backend/testing/parity_pack_v0/run.sh
+++ b/backend/testing/parity_pack_v0/run.sh
@@ -6,4 +6,4 @@ python_bin="${PYTHON:-$repo_root/backend/.venv/bin/python}"
 if [[ ! -x "$python_bin" ]]; then
   python_bin="python3"
 fi
-PYTHONPATH=backend "$python_bin" -m pytest backend/tests/unit/test_parity_pack_v0.py "$@"
+PYTHONPATH=backend "$python_bin" -m pytest backend/tests/unit/test_parity_pack_v0.py backend/tests/unit/test_parity_pack_v0_stage3.py "$@"

--- a/backend/testing/parity_pack_v0/run.sh
+++ b/backend/testing/parity_pack_v0/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$repo_root"
+python_bin="${PYTHON:-$repo_root/backend/.venv/bin/python}"
+if [[ ! -x "$python_bin" ]]; then
+  python_bin="python3"
+fi
+PYTHONPATH=backend "$python_bin" -m pytest backend/tests/unit/test_parity_pack_v0.py "$@"

--- a/backend/testing/parity_pack_v0/runner.py
+++ b/backend/testing/parity_pack_v0/runner.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-import socket
 from collections.abc import Callable, Iterator
+
+from testing.hermetic_network import BlockedNetworkError, block_outbound_network
 
 
 class UnexpectedEgress(AssertionError):
@@ -30,17 +31,17 @@ class FakeHitRegistry:
 
 @contextmanager
 def deny_network() -> Iterator[None]:
-    """Deny TCP socket creation during a unit replay; always restore on cleanup."""
-    original = socket.create_connection
+    """Deny outbound network during a unit replay; always restore on cleanup.
 
-    def denied(*_args: object, **_kwargs: object) -> socket.socket:
-        raise UnexpectedEgress("parity-pack runner denied network egress")
-
-    socket.create_connection = denied
+    Delegates to the repository's validated :func:`block_outbound_network`
+    guard so that low-level ``socket.connect``, ``connect_ex``, and DNS
+    resolution are also blocked — not just ``socket.create_connection``.
+    """
     try:
-        yield
-    finally:
-        socket.create_connection = original
+        with block_outbound_network():
+            yield
+    except BlockedNetworkError as exc:
+        raise UnexpectedEgress(str(exc)) from exc
 
 
 @contextmanager

--- a/backend/testing/parity_pack_v0/runner.py
+++ b/backend/testing/parity_pack_v0/runner.py
@@ -46,11 +46,27 @@ def deny_network() -> Iterator[None]:
 
 @contextmanager
 def hermetic_run(*, cleanup: tuple[Callable[[], None], ...] = ()) -> Iterator[FakeHitRegistry]:
-    """Run with egress denied and deterministic reverse-order cleanup hooks."""
+    """Run with egress denied and deterministic reverse-order cleanup hooks.
+
+    Each hook is isolated so a failing hook cannot prevent later hooks from
+    running.  A body exception is always preserved over a cleanup-hook error.
+    """
     registry = FakeHitRegistry()
+    body_error: BaseException | None = None
     try:
         with deny_network():
             yield registry
+    except BaseException as exc:  # noqa: BLE001 - capture to preserve over cleanup failures
+        body_error = exc
     finally:
+        cleanup_error: BaseException | None = None
         for hook in reversed(cleanup):
-            hook()
+            try:
+                hook()
+            except BaseException as exc:  # noqa: BLE001 - cleanup must not abort siblings
+                if cleanup_error is None:
+                    cleanup_error = exc
+    if body_error is not None:
+        raise body_error
+    if cleanup_error is not None:
+        raise cleanup_error

--- a/backend/testing/parity_pack_v0/runner.py
+++ b/backend/testing/parity_pack_v0/runner.py
@@ -1,0 +1,55 @@
+"""Small hermetic runner primitives for parity-pack replay tests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import socket
+from collections.abc import Callable, Iterator
+
+
+class UnexpectedEgress(AssertionError):
+    pass
+
+
+class FakeHitRegistry:
+    def __init__(self) -> None:
+        self._hits: dict[str, int] = {}
+
+    def hit(self, fake_name: str) -> None:
+        self._hits[fake_name] = self._hits.get(fake_name, 0) + 1
+
+    def require(self, **expected: int) -> None:
+        actual = {key: self._hits.get(key, 0) for key in expected}
+        if actual != expected:
+            raise AssertionError(f"fake hits mismatch: expected={expected}, actual={actual}")
+
+    @property
+    def hits(self) -> dict[str, int]:
+        return dict(self._hits)
+
+
+@contextmanager
+def deny_network() -> Iterator[None]:
+    """Deny TCP socket creation during a unit replay; always restore on cleanup."""
+    original = socket.create_connection
+
+    def denied(*_args: object, **_kwargs: object) -> socket.socket:
+        raise UnexpectedEgress("parity-pack runner denied network egress")
+
+    socket.create_connection = denied
+    try:
+        yield
+    finally:
+        socket.create_connection = original
+
+
+@contextmanager
+def hermetic_run(*, cleanup: tuple[Callable[[], None], ...] = ()) -> Iterator[FakeHitRegistry]:
+    """Run with egress denied and deterministic reverse-order cleanup hooks."""
+    registry = FakeHitRegistry()
+    try:
+        with deny_network():
+            yield registry
+    finally:
+        for hook in reversed(cleanup):
+            hook()

--- a/backend/testing/parity_pack_v0/schema.py
+++ b/backend/testing/parity_pack_v0/schema.py
@@ -1,0 +1,68 @@
+"""Versioned, privacy-safe cassette identity and request fingerprints."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
+from typing import Any, Mapping
+
+from .redaction import redact_value
+
+SCHEMA_VERSION = 1
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False)
+
+
+def _canonical_request(value: Any) -> Any:
+    """Canonicalize a request after recursively removing/redacting sensitive data.
+
+    The resulting representation is only used transiently to calculate a
+    one-way digest.  It is never written into a manifest or report.
+    """
+    return redact_value(value, drop_sensitive=True)
+
+
+@dataclass(frozen=True)
+class CassetteIdentity:
+    """Identity tuple for an individual provider call.
+
+    ``anon_session`` and ``parent_event_anon`` must already be anonymous,
+    stable identifiers; raw user, device, and event IDs are not accepted here.
+    """
+
+    anon_session: str
+    provider_lane: str
+    route_or_model: str
+    call_ordinal: int
+    retry_attempt: int
+    parent_event_anon: str
+
+    def __post_init__(self) -> None:
+        if not self.anon_session or not self.provider_lane or not self.route_or_model or not self.parent_event_anon:
+            raise ValueError("cassette identity fields must be non-empty")
+        if self.call_ordinal < 0 or self.retry_attempt < 0:
+            raise ValueError("call_ordinal and retry_attempt must be non-negative")
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def key(self) -> str:
+        """Stable filesystem-safe key; does not include request content."""
+        return sha256(_canonical_json(self.as_dict()).encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class RequestFingerprint:
+    algorithm: str
+    digest: str
+
+    @classmethod
+    def from_request(cls, request: Mapping[str, Any] | Any) -> "RequestFingerprint":
+        canonical = _canonical_json(_canonical_request(request))
+        return cls(algorithm="sha256-canonical-redacted-v1", digest=sha256(canonical.encode()).hexdigest())
+
+    def as_dict(self) -> dict[str, str]:
+        return {"algorithm": self.algorithm, "digest": self.digest}

--- a/backend/testing/parity_pack_v0/schema.py
+++ b/backend/testing/parity_pack_v0/schema.py
@@ -41,8 +41,14 @@ class CassetteIdentity:
     parent_event_anon: str
 
     def __post_init__(self) -> None:
-        if not self.anon_session or not self.provider_lane or not self.route_or_model or not self.parent_event_anon:
-            raise ValueError("cassette identity fields must be non-empty")
+        text_fields = (
+            self.anon_session,
+            self.provider_lane,
+            self.route_or_model,
+            self.parent_event_anon,
+        )
+        if any(not isinstance(value, str) or not value.strip() for value in text_fields):
+            raise ValueError("cassette identity fields must be non-empty strings")
         if self.call_ordinal < 0 or self.retry_attempt < 0:
             raise ValueError("call_ordinal and retry_attempt must be non-negative")
 

--- a/backend/testing/parity_pack_v0/whitelist.py
+++ b/backend/testing/parity_pack_v0/whitelist.py
@@ -1,0 +1,29 @@
+"""Dev-only, explicit principal gate for future capture hooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass(frozen=True)
+class CaptureWhitelist:
+    enabled: bool
+    environment: str
+    principal_ids: frozenset[str]
+
+    @classmethod
+    def from_environ(cls, environ: dict[str, str] | None = None) -> "CaptureWhitelist":
+        env = os.environ if environ is None else environ
+        principals = frozenset(
+            item.strip() for item in env.get("OMI_PARITY_PACK_ALLOWED_PRINCIPALS", "").split(",") if item.strip()
+        )
+        return cls(
+            enabled=env.get("OMI_PARITY_PACK_CAPTURE", "").strip().lower() in {"1", "true", "yes"},
+            environment=env.get("OMI_ENV", "").strip().lower(),
+            principal_ids=principals,
+        )
+
+    def allows(self, principal_id: str | None) -> bool:
+        """Default deny: only explicit dev enablement plus an exact allow-list hit."""
+        return bool(self.enabled and self.environment == "dev" and principal_id and principal_id in self.principal_ids)

--- a/backend/testing/parity_pack_v0/whitelist.py
+++ b/backend/testing/parity_pack_v0/whitelist.py
@@ -20,7 +20,7 @@ class CaptureWhitelist:
         )
         return cls(
             enabled=env.get("OMI_PARITY_PACK_CAPTURE", "").strip().lower() in {"1", "true", "yes"},
-            environment=env.get("OMI_ENV", "").strip().lower(),
+            environment=env.get("OMI_ENV_STAGE", "").strip().lower(),
             principal_ids=principals,
         )
 

--- a/backend/tests/unit/test_parity_pack_v0.py
+++ b/backend/tests/unit/test_parity_pack_v0.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from testing.parity_pack_v0.manifest import PackCase, build_manifest
+from testing.parity_pack_v0.redaction import redact_value
+from testing.parity_pack_v0.runner import UnexpectedEgress, hermetic_run
+from testing.parity_pack_v0.schema import CassetteIdentity, RequestFingerprint
+from testing.parity_pack_v0.whitelist import CaptureWhitelist
+
+
+def test_identity_tuple_is_stable_and_complete() -> None:
+    identity = CassetteIdentity("session-a", "llm", "gpt-test", 2, 1, "event-a")
+    assert identity.as_dict() == {
+        "anon_session": "session-a",
+        "provider_lane": "llm",
+        "route_or_model": "gpt-test",
+        "call_ordinal": 2,
+        "retry_attempt": 1,
+        "parent_event_anon": "event-a",
+    }
+    assert len(identity.key()) == 64
+
+
+def test_fingerprint_is_canonical_and_never_contains_sensitive_values() -> None:
+    first = {"model": "a", "authorization": "Bearer secret", "body": "hello jane@example.com"}
+    second = {"body": "hello jane@example.com", "model": "a", "authorization": "another"}
+    assert RequestFingerprint.from_request(first) == RequestFingerprint.from_request(second)
+    safe = redact_value({"url": "https://x.test/a?sig=topsecret", "phone": "+1 212 555 0110"})
+    assert "topsecret" not in str(safe) and "555 0110" not in str(safe)
+
+
+def test_manifest_has_references_hashes_outcomes_and_invariants() -> None:
+    identity = CassetteIdentity("s", "stt", "model", 0, 0, "e")
+    case = PackCase(
+        "synthetic-1",
+        "inputs/synthetic-1.json",
+        ("cassettes/a.json",),
+        {"status": "ok"},
+        ("finalizes",),
+        identity,
+        RequestFingerprint.from_request({"x": 1}),
+    )
+    manifest = build_manifest(
+        pack_id="local-pack", cases=(case,), artifact_hashes={"inputs/synthetic-1.json": "a" * 64}
+    )
+    assert manifest["cases"][0]["invariant_ids"] == ["finalizes"]
+    assert manifest["artifact_hashes"]["inputs/synthetic-1.json"] == "a" * 64
+
+
+def test_capture_whitelist_is_default_deny_and_dev_only() -> None:
+    config = CaptureWhitelist.from_environ(
+        {"OMI_ENV": "dev", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+    )
+    assert config.allows("u1") and not config.allows("u2")
+    assert not CaptureWhitelist.from_environ(
+        {"OMI_ENV": "prod", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+    ).allows("u1")
+    assert not CaptureWhitelist.from_environ({}).allows("u1")
+
+
+def test_hermetic_runner_denies_egress_counts_fakes_and_runs_cleanup() -> None:
+    cleanup: list[str] = []
+    with pytest.raises(UnexpectedEgress), hermetic_run(
+        cleanup=(lambda: cleanup.append("first"), lambda: cleanup.append("second"))
+    ) as fakes:
+        fakes.hit("llm")
+        fakes.hit("llm")
+        fakes.require(llm=2)
+        socket.create_connection(("example.com", 443))
+    assert cleanup == ["second", "first"]

--- a/backend/tests/unit/test_parity_pack_v0.py
+++ b/backend/tests/unit/test_parity_pack_v0.py
@@ -52,13 +52,34 @@ def test_manifest_has_references_hashes_outcomes_and_invariants() -> None:
 
 def test_capture_whitelist_is_default_deny_and_dev_only() -> None:
     config = CaptureWhitelist.from_environ(
-        {"OMI_ENV": "dev", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+        {"OMI_ENV_STAGE": "dev", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
     )
     assert config.allows("u1") and not config.allows("u2")
     assert not CaptureWhitelist.from_environ(
-        {"OMI_ENV": "prod", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+        {"OMI_ENV_STAGE": "prod", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
     ).allows("u1")
     assert not CaptureWhitelist.from_environ({}).allows("u1")
+
+
+def test_capture_whitelist_ignores_non_canonical_env_var() -> None:
+    """OMI_ENV is not the canonical runtime-stage variable; only OMI_ENV_STAGE gates dev capture."""
+    config = CaptureWhitelist.from_environ(
+        {"OMI_ENV": "dev", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+    )
+    assert not config.allows("u1")
+
+
+def test_redaction_catches_camelcase_credential_keys() -> None:
+    """camelCase credential keys like accessToken/clientSecret must be redacted."""
+    raw = {"accessToken": "Bearer abc123", "clientSecret": "shh", "model": "gpt-test"}
+    safe = redact_value(raw)
+    assert safe["accessToken"] == "[REDACTED]"
+    assert safe["clientSecret"] == "[REDACTED]"
+    assert safe["model"] == "gpt-test"
+    # drop_sensitive path (fingerprints) must also catch camelCase
+    dropped = redact_value(raw, drop_sensitive=True)
+    assert "accessToken" not in dropped
+    assert "clientSecret" not in dropped
 
 
 def test_hermetic_runner_denies_egress_counts_fakes_and_runs_cleanup() -> None:
@@ -71,3 +92,16 @@ def test_hermetic_runner_denies_egress_counts_fakes_and_runs_cleanup() -> None:
         fakes.require(llm=2)
         socket.create_connection(("example.com", 443))
     assert cleanup == ["second", "first"]
+
+
+def test_hermetic_runner_denies_low_level_socket_connect() -> None:
+    """The egress-deny guard must block socket.connect, not just create_connection."""
+    with pytest.raises(UnexpectedEgress), hermetic_run():
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(("example.com", 443))
+
+
+def test_hermetic_runner_denies_dns_resolution() -> None:
+    """The egress-deny guard must block DNS resolution."""
+    with pytest.raises(UnexpectedEgress), hermetic_run():
+        socket.getaddrinfo("example.com", 443)

--- a/backend/tests/unit/test_parity_pack_v0.py
+++ b/backend/tests/unit/test_parity_pack_v0.py
@@ -90,6 +90,40 @@ def test_redaction_catches_camelcase_credential_keys() -> None:
     assert "clientSecret" not in dropped
 
 
+def test_redaction_catches_plural_and_synonym_credential_keys() -> None:
+    """Plurals (cookies/tokens/passwords) and synonyms (passwd/private_key/access_key/bearer/jwt) redact."""
+    raw = {
+        "cookies": "session=abc",
+        "accessTokens": ["t1"],
+        "passwords": "p",
+        "passwd": "p",
+        "private_key": "-----BEGIN-----",
+        "access_key": "AKIA...",
+        "credentials": "blob",
+        "bearer": "xyz",
+        "jwt": "eyJ...",
+        "model": "gpt-test",
+    }
+    masked = redact_value(raw)
+    for key, original in raw.items():
+        if key == "model":
+            assert masked[key] == original
+        else:
+            assert masked[key] == "[REDACTED]", key
+    dropped = redact_value(raw, drop_sensitive=True)
+    assert dropped["model"] == "gpt-test"
+    for key in raw:
+        if key != "model":
+            assert key not in dropped, key
+
+
+def test_identity_rejects_whitespace_only_fields() -> None:
+    with pytest.raises(ValueError):
+        CassetteIdentity("   ", "llm", "model", 0, 0, "event")
+    with pytest.raises(ValueError):
+        CassetteIdentity("session", "llm", "model", 0, 0, "")
+
+
 def test_hermetic_runner_denies_egress_counts_fakes_and_runs_cleanup() -> None:
     cleanup: list[str] = []
     with pytest.raises(UnexpectedEgress), hermetic_run(

--- a/backend/tests/unit/test_parity_pack_v0.py
+++ b/backend/tests/unit/test_parity_pack_v0.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import socket
+from pathlib import Path
 
 import pytest
 
 from testing.parity_pack_v0.manifest import PackCase, build_manifest
+from testing.parity_pack_v0.capture import CaptureTap
+from testing.parity_pack_v0.players import (
+    CassetteTopologyError,
+    InvocationTopology,
+    LLMCassettePlayer,
+    STTCassettePlayer,
+)
 from testing.parity_pack_v0.redaction import redact_value
 from testing.parity_pack_v0.runner import UnexpectedEgress, hermetic_run
 from testing.parity_pack_v0.schema import CassetteIdentity, RequestFingerprint
@@ -105,3 +113,49 @@ def test_hermetic_runner_denies_dns_resolution() -> None:
     """The egress-deny guard must block DNS resolution."""
     with pytest.raises(UnexpectedEgress), hermetic_run():
         socket.getaddrinfo("example.com", 443)
+
+
+def test_capture_tap_gates_before_persistence_and_records_wire_events(tmp_path: Path) -> None:
+    identity = CassetteIdentity("anon-capture", "stt", "parakeet", 0, 0, "anon-event")
+    denied = CaptureTap(tmp_path, CaptureWhitelist.from_environ({}))
+    assert denied.start("u1", identity, {"audio": "not-written"}) is None
+    assert not (tmp_path / "cassettes").exists()
+    assert denied.denied_metadata == [{"provider_lane": "stt", "reason": "whitelist_miss"}]
+
+    ticks = iter((1.0, 1.025, 1.070, 1.100))
+    allowed = CaptureWhitelist.from_environ(
+        {"OMI_ENV_STAGE": "dev", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+    )
+    tap = CaptureTap(tmp_path, allowed, clock=lambda: next(ticks))
+    invocation = tap.start("u1", identity, {"token": "secret", "audio": "synthetic"})
+    assert invocation is not None
+    invocation.observe("client", {"type": "audio", "bytes": 4})
+    invocation.observe("outbound", {"type": "stt_send"})
+    invocation.observe("inbound", {"type": "transcript", "text": "synthetic"})
+    cassette = invocation.persist()
+    topology = InvocationTopology((cassette,))
+    seen = []
+    STTCassettePlayer(topology).play(identity, {"audio": "synthetic", "token": "different"}, seen.append)
+    assert [(event.direction, event.dt_ms) for event in seen] == [("client", 25), ("outbound", 70), ("inbound", 100)]
+    topology.assert_complete()
+
+
+def test_players_fail_on_extra_out_of_order_and_unused_cassettes(tmp_path: Path) -> None:
+    whitelist = CaptureWhitelist.from_environ(
+        {"OMI_ENV_STAGE": "dev", "OMI_PARITY_PACK_CAPTURE": "1", "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "u1"}
+    )
+    stt = CassetteIdentity("s", "stt", "model", 0, 0, "e")
+    llm = CassetteIdentity("s", "llm", "model", 1, 0, "e")
+    tap = CaptureTap(tmp_path, whitelist)
+    stt_invocation = tap.start("u1", stt, {"x": 1})
+    llm_invocation = tap.start("u1", llm, {"x": 2})
+    assert stt_invocation is not None and llm_invocation is not None
+    topology = InvocationTopology((stt_invocation.persist(), llm_invocation.persist()))
+    with pytest.raises(CassetteTopologyError, match="out-of-order"):
+        LLMCassettePlayer(topology).play(llm, {"x": 2}, lambda _: None)
+    with pytest.raises(CassetteTopologyError, match="unused"):
+        topology.assert_complete()
+    STTCassettePlayer(topology).play(stt, {"x": 1}, lambda _: None)
+    LLMCassettePlayer(topology).play(llm, {"x": 2}, lambda _: None)
+    with pytest.raises(CassetteTopologyError, match="extra"):
+        STTCassettePlayer(topology).play(stt, {"x": 1}, lambda _: None)

--- a/backend/tests/unit/test_parity_pack_v0_stage3.py
+++ b/backend/tests/unit/test_parity_pack_v0_stage3.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from testing.parity_pack_v0.gold import double_run_gold, drift_report
+from testing.parity_pack_v0.matrix import SYNTHETIC_MATRIX
+from testing.parity_pack_v0.rewrite import rewrite_launch_descriptor
+from testing.parity_pack_v0.runner import hermetic_run
+
+
+def test_double_run_requires_determinism_and_only_writes_gold_explicitly(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"cases": [{"case_id": "c1", "expected_outcomes": {"status": "old"}}]}))
+    drifts = double_run_gold(manifest, lambda _: {"status": "new"})
+    assert drift_report(drifts)["status"] == "warn"
+    assert json.loads(manifest.read_text())["cases"][0]["expected_outcomes"] == {"status": "old"}
+    double_run_gold(manifest, lambda _: {"status": "new"}, write_gold=True)
+    assert json.loads(manifest.read_text())["cases"][0]["expected_outcomes"] == {"status": "new"}
+
+
+def test_double_run_rejects_nondeterminism(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"cases": [{"case_id": "c1", "expected_outcomes": {}}]}))
+    responses = iter(({"status": "one"}, {"status": "two"}))
+    with pytest.raises(AssertionError, match="non-deterministic"):
+        double_run_gold(manifest, lambda _: next(responses))
+
+
+def test_matrix_rewrite_slot_and_hermetic_canary_are_explicit() -> None:
+    assert len(SYNTHETIC_MATRIX) == 6
+    descriptor = rewrite_launch_descriptor(Path("in.json"), Path("out.json"))
+    assert not descriptor.available and descriptor.command[0] == "omi-replay-rewrite"
+    with hermetic_run() as fakes:
+        fakes.hit("stt")
+        fakes.hit("llm")
+        fakes.require(stt=1, llm=1)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:replay-lc3-frame-timing": "backend/testing/replay_harness_lc3_frame_timing/run.sh",
     "test:replay-llm-fake-upstream": "backend/testing/replay_harness_llm_gateway_fake_upstream/run.sh",
     "test:replay-llm-streaming-wire-fidelity": "backend/testing/replay_harness_llm_streaming_wire_fidelity/run.sh",
+    "test:parity-pack-v0": "backend/testing/parity_pack_v0/run.sh",
     "test:memory-vector-repair-outbox:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_emulator_test.py\"",
     "test:memory-vector-repair-outbox-rules:emulator": "firebase emulators:exec --only firestore --project demo-memory \"node backend/scripts/firestore_rules_emulator_test.mjs\"",
     "test:memory-vector-repair-outbox-lease:emulator": "firebase emulators:exec --only firestore --project demo-memory \"python3 backend/scripts/vector_repair_outbox_lease_emulator_test.py\"",


### PR DESCRIPTION
## Summary

Delivers Parity Pack v0 as a local/dev-only behavior-replay harness:

- Versioned cassette identity, safe manifest contract, canonical redacted request fingerprints, and restricted pack layout.
- Default-deny dev capture whitelist enforced before cassette serialization or persistence.
- Client/STT/LLM capture observations, cassette players, and strict missing/extra/unused/out-of-order topology accounting.
- Hermetic egress denial, fake-hit accounting, cleanup isolation, and canary coverage.
- Deterministic Python double-run gold freezing, digest-only warn drift reports, and an explicit rewrite-launch descriptor slot.
- Six named synthetic overlays: baseline, duplicate delivery, provider timeout/error, out-of-order events, and redacted capture.
- Operator documentation for dev capture, replay, and the prohibition on committing payloads.

This PR does not enable production capture, authorize real-data collection, or commit cassette payloads.

## Dev-only operator workflow

Keep the pack outside the repository, then explicitly opt in a synthetic/dev principal:

```bash
export OMI_ENV_STAGE=dev
export OMI_PARITY_PACK_CAPTURE=1
export OMI_PARITY_PACK_ALLOWED_PRINCIPALS='synthetic-user-1,synthetic-device-2'
```

Run the application path using an allowlisted principal, then replay with:

```bash
npm run test:parity-pack-v0
```

A missing/incorrect stage, disabled capture flag, or whitelist miss denies capture before cassette bytes are persisted. Never commit cassettes, inputs, payloads, or a whitelist.

## Verification

- `npm run test:parity-pack-v0` — 16 passed after the GLM review/fix wave.
- Black formatting — clean.
- GitHub formatting, hygiene, runtime image contracts, OpenAPI contract, hermetic E2E, replay feasibility, listen/sync gauntlets, and backend hermetic merge gate — green on the final head.
- Remaining repository-wide CI jobs are tracked by GitHub on the PR head.

## Adversarial review

OMP GLM 5.2 completed a five-lane adversarial review covering whitelist safety, hermetic egress, cassette topology, runner behavior, and docs-vs-code. It found no fail-closed gate violation and pushed focused fixes on this same PR.

Residual risks accepted for v0: completion assertion remains caller-invoked; redaction is best-effort; `CaptureInvocation` is a public API; a pre-existing bytes-host IDNA edge case remains in the shared hermetic network utility; NaN/Inf inputs fail closed by raising; and there is no in-repo generated-pack gitignore guard. Packs remain restricted local/dev artifacts.

Closes SCA-219

Failure-Class: none
