### PR TITLE
fix(ios): clarify Bluetooth purpose strings for App Review 5.1.1(ii)

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -130,9 +130,9 @@
 		<true/>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Bluetooth permission is required to connect with your Omi.</string>
+	<string>Omi uses Bluetooth to connect to your Omi wearable and stream its microphone audio to your phone — for example, to transcribe your meetings into notes and check the device's battery.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>Bluetooth permission is required to connect with your Omi.</string>
+	<string>Omi uses Bluetooth to connect to your Omi wearable and stream its microphone audio to your phone — for example, to transcribe your meetings into notes and check the device's battery.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Access most functions for calendar viewing and editing.</string>
 	<key>NSCalendarsUsageDescription</key>

--- a/app/ios/Runner/ja.lproj/InfoPlist.strings
+++ b/app/ios/Runner/ja.lproj/InfoPlist.strings
@@ -1,7 +1,7 @@
 /* Localized versions of Info.plist keys (Japanese) */
 
-"NSBluetoothAlwaysUsageDescription" = "Omi デバイスと接続するために Bluetooth の利用許可が必要です。";
-"NSBluetoothPeripheralUsageDescription" = "Omi デバイスと接続するために Bluetooth の利用許可が必要です。";
+"NSBluetoothAlwaysUsageDescription" = "Omi は Bluetooth で Omi デバイスと接続し、マイクの音声を端末に送信します。例えば会議の音声を文字起こししてメモにしたり、デバイスの電池残量を確認したりします。";
+"NSBluetoothPeripheralUsageDescription" = "Omi は Bluetooth で Omi デバイスと接続し、マイクの音声を端末に送信します。例えば会議の音声を文字起こししてメモにしたり、デバイスの電池残量を確認したりします。";
 
 "NSCalendarsUsageDescription" = "予定の閲覧と編集など、カレンダー機能の大部分にアクセスします。";
 "NSCalendarsFullAccessUsageDescription" = "予定の閲覧と編集など、カレンダー機能の大部分にアクセスします。";


### PR DESCRIPTION
## Summary

Apple rejected the iOS build under **Guideline 5.1.1(ii) — Privacy / Data Collection and Storage**: the Bluetooth purpose string did not sufficiently explain how the data is used and gave no concrete example.

This rewrites the Bluetooth usage descriptions to state *how* Bluetooth is used and give a *specific example*, while staying short enough to render fully in the iOS system permission dialog.

## Changes

- `app/ios/Runner/Info.plist` — `NSBluetoothAlwaysUsageDescription` and `NSBluetoothPeripheralUsageDescription`
- `app/ios/Runner/ja.lproj/InfoPlist.strings` — matching Japanese localization

**Before**
> Bluetooth permission is required to connect with your Omi.

**After**
> Omi uses Bluetooth to connect to your Omi wearable and stream its microphone audio to your phone — for example, to transcribe your meetings into notes and check the device's battery.

## Why this satisfies 5.1.1(ii)

- **Says how** the resource is used — connect to the wearable and stream microphone audio.
- **Gives a concrete example** — transcribing meetings into notes (plus a battery check).
- **Stays short** (~180 chars) so it is not truncated in the iOS permission alert.

## Verification

- Reviewed both rendered strings for length; each is ~180 chars, within the iOS system alert display limit.
- Copy-only change to Info.plist / localized strings; no code paths changed, no runtime behavior affected.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

