### PR TITLE
fix(desktop): surface the notifications gate that silences proactive insights (#10731)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-insight-notifications-gate.json
+++ b/desktop/windows/changelog/unreleased/2026-07-insight-notifications-gate.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Settings → Rewind now tells you when proactive insights can't run because notifications are off, instead of showing the feature as on while it stays silent."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.insightGate.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.insightGate.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+// Regression for #10731: "Proactive insights" read as on (and its test
+// notification worked) while the pipeline never ran, because InsightAssistant
+// additionally requires a deliverable notification — master on AND frequency
+// above Off — and frequency ships at 0. The row now says so instead of claiming
+// the feature is running.
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen, configure } from '@testing-library/react'
+import { RewindTab } from './RewindTab'
+import { SettingsSearchProvider } from '../SettingsSearchProvider'
+import type { AssistantSettingsView, InsightSettings } from '../../../../../shared/types'
+
+vi.setConfig({ testTimeout: 15000 })
+configure({ asyncUtilTimeout: 5000 })
+
+const SILENCED_NOTE = /Notifications are off, so insights never run/
+
+const INSIGHT: InsightSettings = {
+  enabled: true,
+  intervalMin: 15,
+  notificationStyle: 'omi',
+  denylist: [],
+  lastRunAt: null
+}
+
+const ASSISTANTS: AssistantSettingsView = {
+  notificationsEnabled: true,
+  notificationFrequency: 0, // Off — the shipped default
+  focusNotificationsEnabled: true,
+  memoryEnabled: false,
+  glowOverlayEnabled: true,
+  screenAnalysisEnabled: true
+}
+
+function mockBridge(
+  insight: Partial<InsightSettings>,
+  assistants: Partial<AssistantSettingsView>
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).omi = {
+    rewindGetSettings: vi.fn(async () => ({
+      captureEnabled: true,
+      intervalMs: 1000,
+      retentionDays: 30,
+      excludedApps: [],
+      captureQuality: 'balanced'
+    })),
+    rewindSetSettings: vi.fn(async (s: unknown) => s),
+    screenSynthGetState: vi.fn(async () => ({
+      enabled: false,
+      watermarkTs: 0,
+      lastRunAt: null,
+      lastCount: 0,
+      denylist: []
+    })),
+    insightGetSettings: vi.fn(async () => ({ ...INSIGHT, ...insight })),
+    insightSetSettings: vi.fn(async (p: Partial<InsightSettings>) => ({
+      ...INSIGHT,
+      ...insight,
+      ...p
+    })),
+    goalsGetAutoGeneration: vi.fn(async () => false),
+    assistantsGetSettings: vi.fn(async () => ({ ...ASSISTANTS, ...assistants })),
+    onAssistantSettingsChanged: vi.fn(() => () => {})
+  }
+}
+
+const renderTab = (): void => {
+  render(
+    <SettingsSearchProvider>
+      <RewindTab />
+    </SettingsSearchProvider>
+  )
+}
+
+afterEach(cleanup)
+
+describe('RewindTab — proactive insights notification gate', () => {
+  it('warns that insights never run when the frequency is Off', async () => {
+    mockBridge({ enabled: true }, { notificationFrequency: 0 })
+    renderTab()
+    expect(await screen.findByText(SILENCED_NOTE)).toBeTruthy()
+  })
+
+  it('warns when the notifications master toggle is off', async () => {
+    mockBridge({ enabled: true }, { notificationsEnabled: false, notificationFrequency: 3 })
+    renderTab()
+    expect(await screen.findByText(SILENCED_NOTE)).toBeTruthy()
+  })
+
+  it('stays quiet once notifications are on and the frequency is above Off', async () => {
+    mockBridge({ enabled: true }, { notificationsEnabled: true, notificationFrequency: 3 })
+    renderTab()
+    await screen.findByText('Proactive insights')
+    expect(screen.queryByText(SILENCED_NOTE)).toBeNull()
+  })
+
+  it('stays quiet when the user turned insights off themselves', async () => {
+    mockBridge({ enabled: false }, { notificationFrequency: 0 })
+    renderTab()
+    await screen.findByText('Proactive insights')
+    expect(screen.queryByText(SILENCED_NOTE)).toBeNull()
+  })
+})

--- a/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
@@ -21,7 +21,8 @@ import type {
   RewindSettings,
   RewindCaptureQuality,
   ScreenSynthState,
-  InsightSettings
+  InsightSettings,
+  AssistantSettingsView
 } from '../../../../../shared/types'
 
 // Preset cadences offered for proactive insights (minutes). Each run is a Gemini
@@ -32,6 +33,12 @@ export function RewindTab(): React.JSX.Element {
   const [rewind, setRewind] = useState<RewindSettings | null>(null)
   const [screenSynth, setScreenSynth] = useState<ScreenSynthState | null>(null)
   const [insight, setInsight] = useState<InsightSettings | null>(null)
+  // Insight's OTHER gate. `InsightAssistant.isEnabled()` (main/assistants/insight)
+  // also requires a notification to be deliverable — master on AND frequency above
+  // Off — because Insight has no glow, so a run that can't notify is pure wasted
+  // spend. Frequency ships at 0 (Off), so out of the box this row reads "on" while
+  // the pipeline never runs. Read the same flags here to say so.
+  const [assistants, setAssistants] = useState<AssistantSettingsView | null>(null)
   // "Automatically suggest goals" (Wave C). null until the main-process value loads.
   const [goalAutoGen, setGoalAutoGen] = useState<boolean | null>(null)
   const [newExcluded, setNewExcluded] = useState('')
@@ -56,6 +63,14 @@ export function RewindTab(): React.JSX.Element {
     void window.omi.screenSynthGetState().then(setScreenSynth)
     void window.omi.insightGetSettings().then(setInsight)
     void window.omi.goalsGetAutoGeneration().then(setGoalAutoGen)
+  }, [])
+
+  // Separate effect: the notifications gate is broadcast (tray checkbox, the
+  // Notifications tab, a future backend sync), so this row has to stay in
+  // lock-step rather than read once on mount.
+  useEffect(() => {
+    void window.omi?.assistantsGetSettings?.().then(setAssistants)
+    return window.omi?.onAssistantSettingsChanged?.(setAssistants)
   }, [])
 
   const toggleGoalAutoGen = (on: boolean): void => {
@@ -88,6 +103,14 @@ export function RewindTab(): React.JSX.Element {
   const patchInsight = async (patch: Partial<InsightSettings>): Promise<void> => {
     setInsight(await window.omi.insightSetSettings(patch))
   }
+
+  // Mirrors notify.ts `notificationsActive`: master on AND frequency above Off.
+  // Null while the settings are still loading — no claim either way until then.
+  const insightsDeliverable =
+    assistants === null
+      ? null
+      : assistants.notificationsEnabled && assistants.notificationFrequency > 0
+  const insightsSilenced = !!insight?.enabled && insightsDeliverable === false
 
   // Snap any legacy / out-of-range interval (e.g. an old 1- or 10-min value) to a
   // valid preset, so the picker (15/20/30/60) and the engine stay in agreement.
@@ -333,10 +356,19 @@ export function RewindTab(): React.JSX.Element {
 
       <SettingRow
         icon={Lightbulb}
-        dot={insight?.enabled ? 'on' : 'off'}
+        dot={insight?.enabled ? (insightsSilenced ? 'warn' : 'on') : 'off'}
         title="Proactive insights"
-        subtitle="Periodically reviews recent screen activity and surfaces a single useful insight (choose the style below). On by default — requires screen capture to be on."
-        keywords="notifications toast gemini suggestion"
+        subtitle="Periodically reviews recent screen activity and surfaces a single useful insight (choose the style below). Requires screen capture, and Notifications turned on with a frequency above Off."
+        keywords="notifications toast gemini suggestion frequency off silenced"
+        note={
+          insightsSilenced ? (
+            <span className="text-xs text-amber-400/90">
+              Notifications are off, so insights never run — a test notification still shows because
+              it bypasses this. Turn Notifications on and raise the frequency above Off in Settings
+              → Notifications.
+            </span>
+          ) : undefined
+        }
         control={
           <Toggle
             on={!!insight?.enabled}


### PR DESCRIPTION
Fixes #10731.

## Bug

On Windows, Settings → Rewind shows **Proactive insights** as on, with a "Check every 15 minutes" picker, a notification-style picker, and a **Send a test notification** button that works — yet no real insight ever fires. The working test notification points users away from the actual cause.

## Root cause

Insight has two gates, on two different tabs, and only one of them is visible where the feature is configured.

- `InsightAssistant.isEnabled()` (`desktop/windows/src/main/assistants/insight/insightAssistant.ts:53`) returns `getInsightSettings().enabled && notificationsActive(id)`.
- `notificationsActive` (`assistants/core/notify.ts:134`) additionally requires the master notifications toggle to be on **and** `notificationFrequency` to be above Off. This is deliberate: Insight has no glow, so a run whose toast can't be delivered is pure wasted Gemini spend.
- `notificationFrequency` ships at `0` (Off) — `appSettings.ts:61` — and is only reachable from Settings → **Notifications**.

So out of the box the Rewind row reads "on" while the pipeline never runs, forever, with no indication. And `ipc/insight.ts:49` (`insight:test`) calls `deliverInsight` directly, bypassing the throttle entirely — which is why the test notification keeps working and reads as "notifications are fine".

## Fix

The Rewind row now reads the same two flags through the existing scoped assistant bridge (`assistantsGetSettings` + the change broadcast, same as the Notifications tab and the General screen-analysis row) and, when they silence Insight:

- shows an amber note naming the one action that turns it on, and calling out that the test notification bypasses this gate;
- flips the row's status dot to `warn` instead of `on`;
- drops the subtitle's claim that screen capture is the only requirement.

No default is changed — the cost policy behind frequency = Off stays exactly as it is. This makes the silent gate visible instead of the UI claiming a feature that cannot run.

## Verification

Ran in `desktop/windows`:

- `npx vitest run src/renderer/src/components/settings/tabs/RewindTab.insightGate.test.tsx` — 4/4 pass. New regression suite; **2 of the 4 fail on the pre-fix `RewindTab.tsx`** (verified by stashing the component change), the 2 negative cases pass either way.
- `npx vitest run src/main/assistants` — all pass (coordinator, notify, insightAssistant included).
- `npx vitest run src/renderer/src/components/settings/tabs` — 6 passed / 4 failed; the 4 failures are pre-existing and identical on a stashed tree (`localStorage.clear()` is unavailable under this machine's Node 26; the repo pins Node 22).
- `npx tsc --noEmit -p tsconfig.web.json --composite false` — clean. `npx eslint` on both changed files — clean after `prettier --write`.
- **Rendered the real component in Chromium** (temporary vite harness + Playwright, not committed) with the shipped defaults: at `notificationFrequency = 0` the amber warning and warn dot appear; at `3` the row is unchanged from before. Screenshots inspected for both states.

Not run: a packaged Windows build — this is a renderer-only copy/state change and no Windows machine was available.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

