### PR TITLE
fix(backend): declare the action-items due-range Firestore index (#10777)

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -180,6 +180,12 @@ INDEX_ONLY_REQUIREMENTS = (
         (_asc('status'), _asc('account_generation'), _desc('created_at'), _desc('__name__')),
     ),
     FirestoreIndexRequirement(
+        'action_items_completed_due',
+        'action_items',
+        'COLLECTION',
+        (_asc('completed'), _asc('due_at'), _asc('__name__')),
+    ),
+    FirestoreIndexRequirement(
         'candidate_integration_outbox_generation_status',
         'candidate_integration_outbox',
         'COLLECTION',

--- a/backend/tests/unit/test_action_items_due_range_index_contract.py
+++ b/backend/tests/unit/test_action_items_due_range_index_contract.py
@@ -1,0 +1,95 @@
+"""The due-range action-item read must be served by a declared Firestore index.
+
+``get_action_items`` filters ``completed`` for equality and orders ``due_at`` ascending
+whenever a due-date range is requested, so Firestore needs a composite index on
+(completed ASC, due_at ASC). Prod only had (completed ASC, due_at DESC), which serves the
+reverse ordering and not this one, so every due-range read -- the chat ``get_action_items``
+tool and GET /v1/action-items with due filters -- failed with
+``FailedPrecondition: 400 The query requires an index``.
+
+The query shape is discovered by running the production function through the sanctioned
+``monkeypatch.setattr(action_items, 'db', ...)`` seam and is then converted to the Firestore
+index signature (equality fields, then the ordered field, then ``__name__``). Changing the
+order direction or adding an equality filter without declaring the matching index fails here
+instead of in prod.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import database.action_items as action_items
+from database.firestore_index_registry import firebase_index_manifest
+
+BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class _RecordingQuery:
+    """Firestore query stand-in that records the composite the caller builds."""
+
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def collection(self, _name):
+        return self
+
+    def document(self, _name):
+        return self
+
+    def where(self, *_args, **kwargs):
+        filt = kwargs.get('filter')
+        self._recorder.append(('where', getattr(filt, 'field_path', None), getattr(filt, 'op_string', None)))
+        return self
+
+    def order_by(self, field, direction=None):
+        self._recorder.append(('order_by', field, direction))
+        return self
+
+    def offset(self, _n):
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def stream(self):
+        return iter(())
+
+
+def _declared_action_item_signatures():
+    return {
+        tuple((field['fieldPath'], field['order']) for field in index['fields'])
+        for index in firebase_index_manifest()['indexes']
+        if index['collectionGroup'] == 'action_items' and index['queryScope'] == 'COLLECTION'
+    }
+
+
+def _index_signature(recorded):
+    """Firestore composite order: equality fields, then the ordered field, then __name__."""
+    equalities = [field for kind, field, op in recorded if kind == 'where' and op == '==']
+    orders = [(field, direction) for kind, field, direction in recorded if kind == 'order_by']
+    assert orders, 'due-range reads must order explicitly so a bounded prefix matches product sort'
+    last_direction = orders[-1][1]
+    return tuple([(field, 'ASCENDING') for field in equalities] + orders + [('__name__', last_direction)])
+
+
+@pytest.fixture
+def recorded_due_range_query(monkeypatch):
+    recorder = []
+    monkeypatch.setattr(action_items, 'db', _RecordingQuery(recorder))
+    action_items.get_action_items(
+        'uid-under-test',
+        completed=False,
+        due_start_date=BASE,
+        due_end_date=BASE + timedelta(days=7),
+        limit=50,
+    )
+    return recorder
+
+
+def test_due_range_read_filters_completed_and_orders_due_at_ascending(recorded_due_range_query):
+    assert ('where', 'completed', '==') in recorded_due_range_query
+    assert ('order_by', 'due_at', action_items.firestore.Query.ASCENDING) in recorded_due_range_query
+
+
+def test_due_range_composite_is_declared_in_the_firestore_index_manifest(recorded_due_range_query):
+    assert _index_signature(recorded_due_range_query) in _declared_action_item_signatures()

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -227,6 +227,24 @@
       ]
     },
     {
+      "collectionGroup": "action_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "completed",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "due_at",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "candidate_integration_outbox",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Bug

Every due-date-filtered action-item read fails in prod with
`google.api_core.exceptions.FailedPrecondition: 400 The query requires an index`.

- Chat's `get_action_items` tool returns `Error retrieving action items` (traceback from
  `utils/retrieval/tools/action_item_tools.py` → `database/action_items.py:_stream_action_items_bounded`).
- `GET /v1/action-items` with `due_start_date`/`due_end_date` hits the same path.
- Prod Cloud Run `backend`: 55 occurrences in the 7 days to 2026-07-28, 50 of them in the last 24h.

## Root cause

`_apply_action_item_date_filters` orders `due_at` **ascending** whenever a due range is
requested (a bounded prefix must match the soonest-due-first product sort), and
`get_action_items` then adds the `completed ==` equality filter. That composite needs a
Firestore index on `(completed ASC, due_at ASC)`.

The only deployed `action_items` composite was `(completed ASC, due_at DESC)`, which serves
the reverse ordering and not this query. The index was never declared in
`firestore_index_registry.py`, so nothing caught the gap — `firestore.indexes.json` had no
`action_items` entry at all.

## Fix

Declare `(completed ASC, due_at ASC, __name__ ASC)` for `action_items` (COLLECTION scope) in
the registry and regenerate `firestore.indexes.json`.

The index is already created and READY in `based-hardware` and `based-hardware-dev`, so the
deploy-time `reconcile_firestore_indexes.py --check-only` gate stays green on merge; this PR
adds no serving-schema mutation of its own.

## Tested

- **Reproduced against prod Firestore** before the index existed: the exact production query
  (`completed == False`, `due_at` range, `order_by due_at ASC`) raised
  `FailedPrecondition: 400 The query requires an index`.
- **Same query after index creation: returns rows, no error** — the failing path now works.
- `backend/test.sh` over the index + action-item read files
  (`test_action_items_due_range_index_contract.py`, `test_firestore_indexes.py`,
  `test_firestore_query_contract.py`, `test_action_items_pagination_order.py`,
  `test_reconcile_firestore_indexes.py`, `test_bounded_firestore_list_reads.py`): 6 files pass.
- The new regression test builds the query through the production `get_action_items` seam,
  derives the Firestore index signature from it, and asserts the manifest declares it. It
  **fails** when the registry entry is removed (verified) — so flipping the order direction
  without declaring the matching index breaks here, not in prod.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged

Closes #10777


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

