### PR TITLE
fix(desktop): non-gating qual cleanup after green T2+fault

### DIFF
--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -232,6 +232,7 @@ jobs:
           echo "qualified=true" >> "$GITHUB_OUTPUT"
       - name: Finalize only this authenticated qualification lease
         if: always()
+        continue-on-error: true
         working-directory: ${{ runner.temp }}
         env:
           QUALIFICATION_STAGE: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}
@@ -251,9 +252,24 @@ jobs:
             cache_owner_pid=$(jq -r .cache_owner_pid "$context"); cache_token=$(jq -r .cache_token "$context")
             echo "::add-mask::$token"
             echo "::add-mask::$cache_token"
-            OMI_HARNESS_OWNERSHIP_TOKEN="$token" "$worktree/desktop/macos/scripts/qualification-lease-command.sh" release "$worktree" "$lease_id" "$token" "$retained" "$age"
-            "$worktree/desktop/macos/scripts/qualification-swift-cache.sh" release "$cache_sha" "$cache_lease_id" "$cache_owner_pid" "$cache_token"
-            jq -n --arg lease_id "$lease_id" '{lease_id: $lease_id, cleanup_status: "released"}' > "$cleanup"
+            # Best-effort: authenticated release now skips unproven listeners rather
+            # than failing the job after green behavioral qualification (#10779).
+            if OMI_HARNESS_OWNERSHIP_TOKEN="$token" "$worktree/desktop/macos/scripts/qualification-lease-command.sh" release "$worktree" "$lease_id" "$token" "$retained" "$age"; then
+              release_status=released
+            else
+              release_status=release-failed
+              echo "lease finalize release failed (non-gating): status=$release_status" >&2
+            fi
+            if "$worktree/desktop/macos/scripts/qualification-swift-cache.sh" release "$cache_sha" "$cache_lease_id" "$cache_owner_pid" "$cache_token"; then
+              :
+            else
+              echo "cache finalize release failed (non-gating)" >&2
+              if [ "$release_status" = released ]; then
+                release_status=cache-release-failed
+              fi
+            fi
+            jq -n --arg lease_id "$lease_id" --arg cleanup_status "$release_status" \
+              '{lease_id: $lease_id, cleanup_status: $cleanup_status}' > "$cleanup"
           else
             printf '%s\n' '{"cleanup_status":"no-lease-acquired"}' > "$cleanup"
           fi

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -711,8 +711,17 @@ cleanup() {
     phase_begin "final-cleanup" "runner-hygiene-cleanup"
     if ! run_qualification_cleanup; then
       phase_end failed
-      echo "qualification cleanup failed; preserving qualification lease and preventing success evidence" >&2
-      [[ "$exit_code" -ne 0 ]] || exit_code=1
+      # Only fail closed on cleanup when behavioral success was not yet reached.
+      # QUALIFICATION_SUCCESS is set after evidence handoff; before that, a mid-run
+      # abort still treats cleanup failure as fatal so leases are not silently lost
+      # without a reported error. After behavioral gates, main-path cleanup is
+      # non-gating; EXIT-only leftovers must not rewrite a green exit code.
+      if [[ "$QUALIFICATION_SUCCESS" -eq 0 && "$exit_code" -eq 0 ]]; then
+        echo "qualification cleanup failed before success evidence; failing closed" >&2
+        exit_code=1
+      else
+        echo "qualification cleanup failed (non-gating on EXIT); preserving residual lease for later reclaim" >&2
+      fi
     else
       phase_end passed
     fi
@@ -880,15 +889,17 @@ if [[ "$AUTOMATIC" -eq 1 ]]; then
   phase_end passed
 fi
 
-# Cleanup is a qualification gate, not best-effort EXIT housekeeping. Do this
-# before any trusted workflow artifact or release evidence can claim success.
+# After signed-artifact + static + Tier-2 + fault gates pass, runner-hygiene
+# cleanup is best-effort. A green behavioral run must not be fenced solely by
+# lease-lineage cleanup failures (incident #10779 / v0.12.142). Still attempt
+# cleanup and record phase status; residual leases are reclaimed on next acquire.
 phase_begin "final-cleanup" "runner-hygiene-cleanup"
 if ! run_qualification_cleanup; then
   phase_end failed
-  echo "qualification cleanup failed; preserving qualification lease and preventing success evidence" >&2
-  exit 1
+  echo "qualification cleanup failed (non-gating after behavioral pass); continuing to evidence registration" >&2
+else
+  phase_end passed
 fi
-phase_end passed
 
 if [[ "$GITHUB_ACTIONS_ARTIFACT" -eq 1 ]]; then
   QUALIFICATION_SUCCESS=1

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -66,7 +66,8 @@ require_text 'lsof -nP -iTCP:"$AUTOMATION_PORT" -sTCP:LISTEN'
 require_text 'qualification automation port remains bound after owned app cleanup'
 require_text 'kill -KILL "$pid"'
 require_text 'refusing unproven qualification app cleanup'
-require_text 'cleanup failed; preserving qualification lease and preventing success evidence'
+require_text 'cleanup failed (non-gating after behavioral pass); continuing to evidence registration'
+require_text 'cleanup failed (non-gating on EXIT); preserving residual lease for later reclaim'
 if grep -Eq 'osascript|pkill|kill_process_tree|quit app id' "$QUALIFIER"; then
   echo "FAIL: qualification cleanup must not use broad app-name or bundle-id termination" >&2
   exit 1
@@ -108,6 +109,9 @@ require_text "--format='%(refname:strip=2)' 'refs/tags/v*-macos'"
 
 # Acceleration changes bootstrap only. The signed-artifact, static self-check,
 # Tier-2, fault-suite, evidence, and newest-candidate gates remain mandatory.
+# Runner-hygiene final-cleanup is best-effort after those behavioral gates
+# (must not fence a green T2+fault solely on lease-lineage cleanup).
+require_text 'non-gating after behavioral pass'
 require_text 'python3 "$KEYVALUE_PY" preflight-release'
 require_text './scripts/desktop-core-harness.sh --self-check --skip-backend-contracts'
 require_text './scripts/desktop-core-harness.sh --tier 2 --bundle "$BUNDLE" --port "$AUTOMATION_PORT" --keep-stack'

--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -522,8 +522,16 @@ def _validated_signal(
     port_manifest: Path,
     sig: signal.Signals,
     lease_id: str | None = None,
-) -> None:
-    """Signal only a current supervisor whose listener children still prove lease lineage."""
+    *,
+    allow_unproven_listener_skip: bool = False,
+) -> bool:
+    """Signal only a current supervisor whose listener children still prove lease lineage.
+
+    Returns True when a signal was sent. When ``allow_unproven_listener_skip`` is
+    set and a live listener cannot prove process-group descent, returns False
+    without signaling so callers can retire the lease pointer without killing
+    unknown processes (release path after green behavioral gates).
+    """
 
     pid = int(record["pid"])
     service = str(record["service"])
@@ -538,6 +546,8 @@ def _validated_signal(
     if listeners and not _is_exact_typesense_docker_proxy(record, lease_id):
         for listener_pid in listeners:
             if getpgid(listener_pid) != process_group or not safety.is_descendant_of(listener_pid, pid):
+                if allow_unproven_listener_skip:
+                    return False
                 raise QualificationLeaseError(
                     "Refusing to signal a qualification listener whose lease lineage is unproven"
                 )
@@ -545,6 +555,7 @@ def _validated_signal(
         killpg(process_group, sig)
     except (ProcessLookupError, PermissionError) as exc:
         raise QualificationLeaseError(f"Cannot signal recorded qualification process group: {exc}") from exc
+    return True
 
 
 def _orphaned_record_cleanup_mode(
@@ -638,15 +649,36 @@ def _wait_for_ports_to_close(
 
 
 def _stop_owned_records(
-    records: list[dict[str, object]], process_manifest: Path, port_manifest: Path, lease_id: str
+    records: list[dict[str, object]],
+    process_manifest: Path,
+    port_manifest: Path,
+    lease_id: str,
+    *,
+    allow_unproven_listener_skip: bool = False,
 ) -> None:
+    skipped_unproven = False
     for sig, wait_seconds in STOP_PHASES:
         for record in records:
             pid = int(record["pid"])
             if safety.process_exists(pid):
-                _validated_signal(record, process_manifest, port_manifest, sig, lease_id)
+                signaled = _validated_signal(
+                    record,
+                    process_manifest,
+                    port_manifest,
+                    sig,
+                    lease_id,
+                    allow_unproven_listener_skip=allow_unproven_listener_skip,
+                )
+                if not signaled:
+                    skipped_unproven = True
                 continue
-            cleanup_mode = _orphaned_record_cleanup_mode(record, process_manifest, port_manifest, lease_id)
+            try:
+                cleanup_mode = _orphaned_record_cleanup_mode(record, process_manifest, port_manifest, lease_id)
+            except QualificationLeaseError:
+                if allow_unproven_listener_skip:
+                    skipped_unproven = True
+                    continue
+                raise
             if cleanup_mode == "process-group":
                 _getpgid, killpg = _posix_process_group_api()
                 try:
@@ -657,6 +689,9 @@ def _stop_owned_records(
                 _stop_exact_typesense_container(record, lease_id, sig)
         open_ports = _wait_for_ports_to_close(records, wait_seconds)
         if not open_ports:
+            return
+        if allow_unproven_listener_skip and skipped_unproven:
+            # Leave residual listeners; release still retires the admission pointer.
             return
     details = ", ".join(
         f"{service}:{port} (listeners {','.join(map(str, pids))})" for service, port, pids in open_ports
@@ -893,9 +928,22 @@ def release(
         records, process_manifest, port_manifest = _validated_owned_records(
             state_root, recorded_repo, recorded_id, recorded_token
         )
-        fault_record = _validated_fault_record(state_root, recorded_token)
-        _stop_owned_fault_record(fault_record)
-        _stop_owned_records(records, process_manifest, port_manifest, recorded_id)
+        # Authenticated release after a completed run must retire the admission
+        # pointer even when a residual listener fails lineage proof. Never kill
+        # unproven processes; skip them and leave residual ports for next acquire
+        # quarantine/reclaim. This is the 142 final-cleanup failure class.
+        try:
+            fault_record = _validated_fault_record(state_root, recorded_token)
+            _stop_owned_fault_record(fault_record)
+        except QualificationLeaseError:
+            fault_record = None
+        _stop_owned_records(
+            records,
+            process_manifest,
+            port_manifest,
+            recorded_id,
+            allow_unproven_listener_skip=True,
+        )
         path.unlink(missing_ok=True)
         _mark_completed(state_root, recorded_repo, recorded_id, recorded_token)
         _prune(

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -292,9 +292,15 @@ def test_fault_listener_preflight_retains_replaced_listener_and_reports_host_pre
 
 
 @pytest.mark.skipif(os.name == "nt", reason="fault listener cleanup requires POSIX process groups")
-def test_release_refuses_and_retains_an_unproven_listener_on_the_recorded_fault_port(
+def test_release_skips_unproven_listener_and_retires_lease_pointer(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Authenticated release must not fence a finished run on unproven listeners.
+
+    Residual foreign listeners stay alive (never kill unknown PIDs); the lease
+    admission pointer is retired so the next acquire can proceed.
+    """
+
     root = tmp_path / "qualification"
     lease_id = "qualification-foreign-fault"
     monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
@@ -321,12 +327,10 @@ def test_release_refuses_and_retains_an_unproven_listener_on_the_recorded_fault_
         deadline = time.monotonic() + 5
         while foreign.pid not in safety.listening_pids(port) and time.monotonic() < deadline:
             time.sleep(0.05)
-        with pytest.raises(qualification.QualificationLeaseError, match="lease lineage is unproven"):
-            qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+        qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
         assert foreign.poll() is None
-        assert (root / "qualification-lease.json").is_file()
-        assert (state / "meta").is_file()
-        assert not (root / "state" / lease_id / qualification.COMPLETION_FILENAME).exists()
+        assert not (root / "qualification-lease.json").exists()
+        assert (root / "state" / lease_id / qualification.COMPLETION_FILENAME).is_file()
     finally:
         if foreign.poll() is None:
             foreign.terminate()
@@ -506,9 +510,11 @@ def test_retention_prunes_only_completed_sentinel_proven_qualification_state(
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-active", token=str(active["token"]))
 
 
-def test_supervisor_dead_with_foreign_process_group_retains_incomplete_lease(
+def test_supervisor_dead_with_foreign_process_group_still_retires_lease_pointer(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Release skips unproven orphaned listeners and still retires the pointer."""
+
     root = tmp_path / "qualification"
     monkeypatch.setenv("OMI_QUALIFICATION_LEASE_ROOT", str(root))
     lease_id = "qualification-port-still-open"
@@ -526,11 +532,10 @@ def test_supervisor_dead_with_foreign_process_group_retains_incomplete_lease(
     monkeypatch.setattr(safety, "listening_pids", lambda candidate: (os.getpid(),) if candidate == port else ())
     try:
         _stale_lease(root, lease_id, pid=42424, port=port)
-        with pytest.raises(qualification.QualificationLeaseError, match="process group is unproven"):
-            qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+        qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
         assert listener.fileno() >= 0
-        assert (root / "qualification-lease.json").exists()
-        assert not (root / "state" / lease_id / qualification.COMPLETION_FILENAME).exists()
+        assert not (root / "qualification-lease.json").exists()
+        assert (root / "state" / lease_id / qualification.COMPLETION_FILENAME).is_file()
     finally:
         listener.close()
 


### PR DESCRIPTION
## Summary
v0.12.142 ordinary M1 qualification failed after **Tier-2 and fault suite both passed**, solely on final-cleanup lease-lineage (`Refusing to signal a qualification listener whose lease lineage is unproven`). That permanently fenced the tag.

This change keeps behavioral gates mandatory and loosens **runner-hygiene cleanup** so the next candidate can qualify when user-visible suites are green.

## Changes
- `qualify-desktop-beta.sh`: final-cleanup is **non-gating after behavioral pass**; EXIT trap does not rewrite a green exit solely for residual lease cleanup.
- `qualification.release`: authenticated release **retires the lease pointer** even when residual listeners fail lineage proof; never kills unproven PIDs.
- `desktop_qualify_beta.yml` finalize step: `continue-on-error` + records cleanup status (non-gating).
- Contract + lease tests updated for the new release semantics.
- Preflight fault cleanup remains fail-closed (still blocks before expensive build on unproven listeners).

## Failure-Class
Failure-Class: none

## Verification
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh` ✅
- `bash desktop/macos/tests/test-qualification-lease-command.sh` ✅
- `python3 -m pytest scripts/dev-harness/tests/test_qualification_lease.py -q` → 15 passed, 2 skipped ✅

## Related
- Incident: https://github.com/BasedHardware/omi/issues/10779
- Break-glass Beta 142 (audited, not normally qualified): https://github.com/BasedHardware/omi/actions/runs/30372217165


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

