### PR TITLE
fix(ci): resolve PR Metadata Preflight base live instead of the stale event-payload SHA

### DIFF
--- a/.github/failure-classes/FC-stale-event-payload-diff-base.json
+++ b/.github/failure-classes/FC-stale-event-payload-diff-base.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-stale-event-payload-diff-base",
+  "violated_contract": "A CI check that diffs a PR against a base ref must resolve that ref live from the checkout it is running against, not from a value captured in a GitHub event payload; a payload field is only as fresh as the last event that populated it, and a trigger type that fires without a new commit (edited/labeled/unlabeled) does not refresh it even as the base branch keeps advancing.",
+  "canonical_prevention": "Resolve the diff base as origin/<base-branch> (or an equivalent live git ref) against a fetch-depth:0 checkout performed in the same job, the way the changes/detect-changes job in repo-checks.yml already does; never pass github.event.pull_request.base.sha (or any other event-payload SHA) as the diff base for a check that can run on a metadata-only re-trigger.",
+  "canonical_prevention_artifact": [
+    ".github/workflows/repo-checks.yml",
+    ".github/scripts/test_pr_preflight.py"
+  ],
+  "evidence_prs": [10758],
+  "scope_hints": [
+    ".github/workflows/",
+    ".github/scripts/pr_preflight.py",
+    ".github/actions/detect-changes/"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -353,7 +353,13 @@ class SelectionTests(unittest.TestCase):
             self.assertIn(event, changes_job)
             self.assertIn(event, hygiene_job)
         self.assertIn("scripts/pr-preflight", metadata_job)
-        self.assertIn("github.event.pull_request.base.sha", metadata_job)
+        # base.sha is frozen at whatever PR event last delivered it, so a
+        # metadata-only edited/labeled/unlabeled event days after the last push
+        # can diff against a base main has long since moved past (false invariant
+        # hits on files the PR never touched). origin/<base_ref> is resolved live
+        # against the fetch-depth:0 checkout instead, matching the `changes` job.
+        self.assertNotIn("github.event.pull_request.base.sha", metadata_job)
+        self.assertIn('--base "origin/${{ github.base_ref }}"', metadata_job)
         self.assertIn("astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84", metadata_job)
         self.assertLess(metadata_job.index("Set up uv"), metadata_job.index("Run current PR metadata preflight"))
         self.assertIn("github.event_name != 'pull_request'", changes_job)

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -179,6 +179,72 @@ class SelectionTests(unittest.TestCase):
             "base...head",
         )
 
+    def test_stale_event_payload_base_widens_diff_scope_past_the_live_base(self) -> None:
+        """Behavioral regression for FC-stale-event-payload-diff-base (#10758).
+
+        Exercises the real changed_files() git seam end to end: a base SHA
+        captured once (standing in for github.event.pull_request.base.sha) and
+        never refreshed goes stale as the target branch keeps advancing, so a
+        downstream merge-ref diff against it silently picks up unrelated
+        commits. A live-resolved base ref does not.
+        """
+        # Disposable repo must not inherit the caller's git context: under a
+        # pre-commit/pre-push hook, GIT_DIR points at the real checkout and its
+        # commit-msg hook would reject these throwaway messages.
+        git_isolation = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+
+        def run(*args: str, cwd: Path) -> None:
+            subprocess.run(["git", *git_isolation, *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+        def rev_parse(cwd: Path, ref: str = "HEAD") -> str:
+            result = subprocess.run(
+                ["git", *git_isolation, "rev-parse", ref], cwd=cwd, check=True, capture_output=True, text=True
+            )
+            return result.stdout.strip()
+
+        def commit(cwd: Path, path: str, content: str, message: str) -> str:
+            (cwd / path).write_text(content, encoding="utf-8")
+            run("add", path, cwd=cwd)
+            run("commit", "-q", "-m", message, cwd=cwd)
+            return rev_parse(cwd)
+
+        with patch.dict(os.environ):
+            for key in list(os.environ):
+                if key.startswith("GIT_"):
+                    del os.environ[key]
+
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                run("init", "-q", "-b", "main", cwd=root)
+                run("config", "user.email", "test@example.com", cwd=root)
+                run("config", "user.name", "Test", cwd=root)
+
+                # The SHA a PR event payload would have captured at PR-open time.
+                stale_base_sha = commit(root, "root.txt", "root", "root commit")
+
+                run("checkout", "-q", "-b", "pr", cwd=root)
+                commit(root, "pr_file.txt", "pr change", "touch pr_file.txt")
+                run("checkout", "-q", "main", cwd=root)
+
+                # main keeps moving after the PR branched. This is what makes
+                # stale_base_sha stale: no event ever refreshes it past here.
+                commit(root, "unrelated_file.txt", "v1", "unrelated main commit 1")
+                commit(root, "unrelated_file.txt", "v2", "unrelated main commit 2")
+
+                # GitHub's refs/pull/N/merge: the PR branch merged onto main's
+                # *current* tip, on its own ref — main itself does not move.
+                run("checkout", "-q", "-b", "merge_ref", "main", cwd=root)
+                run("merge", "--no-ff", "-q", "-m", "merge pr into main", "pr", cwd=root)
+                merge_sha = rev_parse(root)
+
+                stale_diff = changed_files(root, stale_base_sha, merge_sha)
+                # "main" stands in for a freshly fetched origin/<base_ref>: a
+                # live ref, not a value captured once and carried across events.
+                live_diff = changed_files(root, "main", merge_sha)
+
+                self.assertEqual(sorted(live_diff), ["pr_file.txt"])
+                self.assertEqual(sorted(stale_diff), ["pr_file.txt", "unrelated_file.txt"])
+
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
         result = subprocess.run(
             ["make", "-n", "preflight"],
@@ -353,11 +419,11 @@ class SelectionTests(unittest.TestCase):
             self.assertIn(event, changes_job)
             self.assertIn(event, hygiene_job)
         self.assertIn("scripts/pr-preflight", metadata_job)
-        # base.sha is frozen at whatever PR event last delivered it, so a
-        # metadata-only edited/labeled/unlabeled event days after the last push
-        # can diff against a base main has long since moved past (false invariant
-        # hits on files the PR never touched). origin/<base_ref> is resolved live
-        # against the fetch-depth:0 checkout instead, matching the `changes` job.
+        # Static tripwire only: confirms the workflow text wires --base to the
+        # live ref rather than the stale event-payload SHA. It does not exercise
+        # changed_files() itself — see
+        # test_stale_event_payload_base_widens_diff_scope_past_the_live_base for
+        # the behavioral regression backing FC-stale-event-payload-diff-base.
         self.assertNotIn("github.event.pull_request.base.sha", metadata_job)
         self.assertIn('--base "origin/${{ github.base_ref }}"', metadata_job)
         self.assertIn("astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84", metadata_job)

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -56,8 +56,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          # The PR event payload's base-branch SHA field is frozen at whatever PR
+          # event last delivered it; a metadata-only edited/labeled/unlabeled event
+          # days later can carry a value main has long since moved past. actions/checkout
+          # already fetched origin/${{ github.base_ref }} live (fetch-depth: 0
+          # above), so diff against that instead of the stale payload field.
           scripts/pr-preflight \
-            --base "${{ github.event.pull_request.base.sha }}" \
+            --base "origin/${{ github.base_ref }}" \
             --repository "${{ github.repository }}" \
             --pr-number "${{ github.event.pull_request.number }}"
 


### PR DESCRIPTION
## Summary

`PR Metadata Preflight` (repo-checks.yml `metadata-preflight` job) diffed against `github.event.pull_request.base.sha` — a value frozen at whatever PR event last delivered it. That job only runs on metadata-only `edited`/`labeled`/`unlabeled` events, which fire with no new commit and don't refresh that field. On PR #10758, `main` had advanced 37 commits (including a change to `backend/routers/memories.py` in an unrelated PR) since the last time an event refreshed `base.sha`, so the diff scope silently ballooned to include those unrelated commits and the job failed on a false `INV-MEM-1` citation requirement for files the PR never touched.

The sibling `changes` job in the same workflow already avoids this: it resolves `origin/${{ github.base_ref }}` live against the job's own `fetch-depth: 0` checkout instead of trusting a payload field. This PR points `metadata-preflight` at the same thing.

## Fix

- `.github/workflows/repo-checks.yml`: `metadata-preflight`'s `scripts/pr-preflight --base` now uses `origin/${{ github.base_ref }}` instead of `github.event.pull_request.base.sha`.
- `.github/scripts/test_pr_preflight.py`: updated the workflow-content regression test to assert the live-resolved base and guard against reintroducing the stale payload field.

No behavior changes for the `changes`/`hygiene` (code) lane — it already used the correct pattern.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

Registered `FC-stale-event-payload-diff-base`: a check that diffs a PR against a base ref must resolve that ref live from the checkout, not from a value captured in an event payload that isn't refreshed by every trigger type that can run the check. No existing registered class covers event-payload staleness driving an incorrect diff scope. `evidence_prs` points at #10758, where this exact failure surfaced. Guard artifact: `test_repo_checks_routes_metadata_events_to_the_narrow_preflight` now asserts the live-resolved base and would fail if the stale field were reintroduced.

## Verification

- `python3 .github/scripts/test_pr_preflight.py` — 26/26 pass (updated regression test covers this exact case).
- `scripts/pr-preflight --pr-body-file <this file>` — passes locally with `files=2` against `origin/main`.
- Live-reproduced the bug on PR #10758 before this fix: confirmed the branch was 37 commits behind `main`, confirmed the exact upstream commit (#10750) that touched the flagged memory files, and confirmed `git diff origin/main...HEAD` (fresh, correct base) shows 27 files with no memory files touched — matching what `metadata-preflight` should have reported.

## Related

Filed a follow-up issue: the same `github.event.pull_request.base.sha` pattern also appears in `backend-unit-tests.yml`, `desktop-swift-ci.yml`, `backend-hermetic-e2e.yml`, and `desktop-backend-image-checks.yml`. Those jobs trigger on code-changing events (`synchronize`/`opened`) where the payload field is refreshed by the same event that needs it, so the staleness window is much narrower — but not zero under queued/delayed runs. Left out of this PR to keep the fix scoped and verifiable; tracked separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

