### PR TITLE
fix(backend): declare the conversation-scoped action-item due-range Firestore indexes (#10780)

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -186,6 +186,18 @@ INDEX_ONLY_REQUIREMENTS = (
         (_asc('completed'), _asc('due_at'), _asc('__name__')),
     ),
     FirestoreIndexRequirement(
+        'action_items_conversation_due',
+        'action_items',
+        'COLLECTION',
+        (_asc('conversation_id'), _asc('due_at'), _asc('__name__')),
+    ),
+    FirestoreIndexRequirement(
+        'action_items_completed_conversation_due',
+        'action_items',
+        'COLLECTION',
+        (_asc('completed'), _asc('conversation_id'), _asc('due_at'), _asc('__name__')),
+    ),
+    FirestoreIndexRequirement(
         'candidate_integration_outbox_generation_status',
         'candidate_integration_outbox',
         'COLLECTION',

--- a/backend/tests/unit/test_action_items_due_range_index_contract.py
+++ b/backend/tests/unit/test_action_items_due_range_index_contract.py
@@ -1,17 +1,18 @@
-"""The due-range action-item read must be served by a declared Firestore index.
+"""Every due-range action-item read must be served by a declared Firestore index.
 
-``get_action_items`` filters ``completed`` for equality and orders ``due_at`` ascending
-whenever a due-date range is requested, so Firestore needs a composite index on
-(completed ASC, due_at ASC). Prod only had (completed ASC, due_at DESC), which serves the
-reverse ordering and not this one, so every due-range read -- the chat ``get_action_items``
-tool and GET /v1/action-items with due filters -- failed with
-``FailedPrecondition: 400 The query requires an index``.
+``get_action_items`` orders ``due_at`` ascending whenever a due-date range is requested and
+combines that order with whichever equality filters the caller asked for: ``completed``,
+``conversation_id``, or both. Each combination is a distinct Firestore composite. Prod only
+had (completed ASC, due_at DESC), which serves the reverse ordering and not this one, so every
+due-range read -- the chat ``get_action_items`` tool and GET /v1/action-items with due filters --
+failed with ``FailedPrecondition: 400 The query requires an index``; the ``conversation_id``
+chains kept failing after (completed ASC, due_at ASC) was declared.
 
-The query shape is discovered by running the production function through the sanctioned
-``monkeypatch.setattr(action_items, 'db', ...)`` seam and is then converted to the Firestore
-index signature (equality fields, then the ordered field, then ``__name__``). Changing the
-order direction or adding an equality filter without declaring the matching index fails here
-instead of in prod.
+The query shapes are discovered by running the production function through the sanctioned
+``monkeypatch.setattr(action_items, 'db', ...)`` seam and are then converted to Firestore index
+signatures (equality fields, then the ordered field, then ``__name__``). Firestore orders the
+equality prefix itself, so equality fields are compared as a set. Adding an equality filter or
+changing the order direction without declaring the matching index fails here instead of in prod.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -25,12 +26,21 @@ BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
 class _RecordingQuery:
-    """Firestore query stand-in that records the composite the caller builds."""
+    """Firestore query stand-in that records every composite the caller builds.
 
-    def __init__(self, recorder):
-        self._recorder = recorder
+    ``get_action_items`` can build more than one query per call (the completed bucket and the
+    bounded legacy scan), each starting from ``db.collection('users')``; that call opens a new
+    recording.
+    """
 
-    def collection(self, _name):
+    def __init__(self):
+        self.queries: list[list[tuple]] = []
+        self._current: list[tuple] = []
+
+    def collection(self, name):
+        if name == 'users':
+            self._current = []
+            self.queries.append(self._current)
         return self
 
     def document(self, _name):
@@ -38,11 +48,11 @@ class _RecordingQuery:
 
     def where(self, *_args, **kwargs):
         filt = kwargs.get('filter')
-        self._recorder.append(('where', getattr(filt, 'field_path', None), getattr(filt, 'op_string', None)))
+        self._current.append(('where', getattr(filt, 'field_path', None), getattr(filt, 'op_string', None)))
         return self
 
     def order_by(self, field, direction=None):
-        self._recorder.append(('order_by', field, direction))
+        self._current.append(('order_by', field, direction))
         return self
 
     def offset(self, _n):
@@ -56,40 +66,66 @@ class _RecordingQuery:
 
 
 def _declared_action_item_signatures():
-    return {
-        tuple((field['fieldPath'], field['order']) for field in index['fields'])
-        for index in firebase_index_manifest()['indexes']
-        if index['collectionGroup'] == 'action_items' and index['queryScope'] == 'COLLECTION'
-    }
+    signatures = set()
+    for index in firebase_index_manifest()['indexes']:
+        if index['collectionGroup'] != 'action_items' or index['queryScope'] != 'COLLECTION':
+            continue
+        fields = [(field['fieldPath'], field['order']) for field in index['fields']]
+        signatures.add((frozenset(fields[:-2]), fields[-2], fields[-1]))
+    return signatures
 
 
 def _index_signature(recorded):
     """Firestore composite order: equality fields, then the ordered field, then __name__."""
-    equalities = [field for kind, field, op in recorded if kind == 'where' and op == '==']
+    equalities = [(field, 'ASCENDING') for kind, field, op in recorded if kind == 'where' and op == '==']
     orders = [(field, direction) for kind, field, direction in recorded if kind == 'order_by']
     assert orders, 'due-range reads must order explicitly so a bounded prefix matches product sort'
-    last_direction = orders[-1][1]
-    return tuple([(field, 'ASCENDING') for field in equalities] + orders + [('__name__', last_direction)])
+    ordered = orders[-1]
+    return (frozenset(equalities), ordered, ('__name__', ordered[1]))
 
 
-@pytest.fixture
-def recorded_due_range_query(monkeypatch):
-    recorder = []
-    monkeypatch.setattr(action_items, 'db', _RecordingQuery(recorder))
+def _record_due_range_queries(monkeypatch, **filters):
+    recorder = _RecordingQuery()
+    monkeypatch.setattr(action_items, 'db', recorder)
     action_items.get_action_items(
         'uid-under-test',
-        completed=False,
         due_start_date=BASE,
         due_end_date=BASE + timedelta(days=7),
         limit=50,
+        **filters,
     )
-    return recorder
+    return recorder.queries
 
 
-def test_due_range_read_filters_completed_and_orders_due_at_ascending(recorded_due_range_query):
-    assert ('where', 'completed', '==') in recorded_due_range_query
-    assert ('order_by', 'due_at', action_items.firestore.Query.ASCENDING) in recorded_due_range_query
+# Every filter combination GET /v1/action-items and the chat get_action_items tool accept
+# alongside a due-date range.
+DUE_RANGE_CALLS = [
+    pytest.param({'completed': False}, id='completed'),
+    pytest.param({'conversation_id': 'conv-under-test'}, id='conversation'),
+    pytest.param({'conversation_id': 'conv-under-test', 'completed': False}, id='conversation+completed'),
+    pytest.param({}, id='unfiltered'),
+]
 
 
-def test_due_range_composite_is_declared_in_the_firestore_index_manifest(recorded_due_range_query):
-    assert _index_signature(recorded_due_range_query) in _declared_action_item_signatures()
+def test_due_range_read_filters_completed_and_orders_due_at_ascending(monkeypatch):
+    (recorded,) = _record_due_range_queries(monkeypatch, completed=False)
+    assert ('where', 'completed', '==') in recorded
+    assert ('order_by', 'due_at', action_items.firestore.Query.ASCENDING) in recorded
+
+
+def test_conversation_due_range_read_keeps_the_conversation_equality(monkeypatch):
+    recorded = _record_due_range_queries(monkeypatch, conversation_id='conv-under-test')
+    assert recorded, 'a conversation-scoped due-range read must issue at least one query'
+    for query in recorded:
+        assert ('where', 'conversation_id', '==') in query
+
+
+@pytest.mark.parametrize('filters', DUE_RANGE_CALLS)
+def test_due_range_composites_are_declared_in_the_firestore_index_manifest(monkeypatch, filters):
+    declared = _declared_action_item_signatures()
+    for query in _record_due_range_queries(monkeypatch, **filters):
+        signature = _index_signature(query)
+        if not signature[0]:
+            # No equality filter: Firestore's automatic single-field index serves it.
+            continue
+        assert signature in declared, f'undeclared Firestore composite for {filters}: {signature}'

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -245,6 +245,46 @@
       ]
     },
     {
+      "collectionGroup": "action_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "conversation_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "due_at",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "action_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "completed",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "conversation_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "due_at",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "candidate_integration_outbox",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Bug

`GET /v1/action-items` and the chat `get_action_items` tool accept `conversation_id`
alongside `due_start_date`/`due_end_date`. Every such read 500'd with
`FailedPrecondition: 400 The query requires an index`. Issue #10780.

## Root cause

`_apply_action_item_date_filters` orders a due range ascending, and `get_action_items`
adds `conversation_id ==` (and, for the completed bucket, `completed ==`) on top. That
needs two composites — `(conversation_id ASC, due_at ASC)` and
`(completed ASC, conversation_id ASC, due_at ASC)` — neither declared in
`backend/database/firestore_index_registry.py` nor deployed. #10777/#10778 declared only
the `(completed ASC, due_at ASC)` chain, so the conversation-scoped reads kept failing.

## Fix

- Declare both composites in the index registry and regenerate `firestore.indexes.json`.
- Widen `test_action_items_due_range_index_contract.py` to every filter combination the
  endpoint accepts. The recorder now captures *every* query `get_action_items` builds (the
  completed bucket and the bounded legacy scan each start their own from
  `db.collection('users')`), and equality fields are compared as a set because Firestore
  orders the equality prefix itself.
- Both indexes are already created and READY in `based-hardware-dev` and `based-hardware`,
  so the deploy-time reconcile check-only gate stays green.

## Verified

- Prod Firestore probe (read-only, non-existent uid) **before** the indexes existed:
  `conversation_id + due range` and `conversation_id + completed + due range` both raised
  `FailedPrecondition`; `completed + due range` was OK (control).
- After creating the composites, re-probed `based-hardware-dev` once READY: both
  conversation_id chains return with no error.
- `backend/test.sh` over the index registry, manifest, reconcile and query-contract tests:
  46 pass.
- Removing the two registry entries fails the new parametrizations `[conversation]` and
  `[conversation+completed]`; restoring them passes.

Closes #10780

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

