### PR TITLE
fix(setup): repair mistaken core.bare on primary checkout

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -41,7 +41,7 @@ checks:
     reason: "make setup provisions no app toolchain while .github/checks-manifest.yaml is a ROUTING_INPUTS entry that wakes the Flutter codegen lane, so a docs-only PR hit 'run flutter pub get' with no mention of PRE_PUSH_SKIP_FLUTTER_GENERATED; actionlint's branch had the same omission, and a hatch nobody can find is not a hatch"
   - id: setup-pre-push-prerequisites
     command: ["bash", "scripts/test-make-setup.sh"]
-    triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
+    triggers: ["Makefile", "backend/scripts/sync-python-deps.sh", "scripts/pre-push", "scripts/repair-git-primary-worktree.sh", "scripts/setup-refresh-main.sh", "scripts/test-make-setup.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
   - id: desktop-release-process-guards

--- a/scripts/repair-git-primary-worktree.sh
+++ b/scripts/repair-git-primary-worktree.sh
@@ -12,7 +12,9 @@ if [ ! -d "$TARGET/.git" ] || [ -f "$TARGET/.git" ]; then
   exit 0
 fi
 
-if [ "$(git -C "$TARGET" config --get core.bare 2>/dev/null || echo false)" != "true" ]; then
+# Use --bool so any valid true spelling (yes, on, 1, TRUE, …) canonicalises
+# to "true"; a plain --get returns the raw value and would miss these.
+if [ "$(git -C "$TARGET" config --bool --get core.bare 2>/dev/null || echo false)" != "true" ]; then
   exit 0
 fi
 

--- a/scripts/repair-git-primary-worktree.sh
+++ b/scripts/repair-git-primary-worktree.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-$ROOT}"
+
+# Primary checkout: repo-root `.git` is a directory. A mistaken `core.bare=true` makes
+# Git treat this path as a bare repo: `git status` and `show-toplevel` fail here,
+# and `git worktree list` labels the main path "(bare)" even though the tree exists.
+if [ ! -d "$TARGET/.git" ] || [ -f "$TARGET/.git" ]; then
+  exit 0
+fi
+
+if [ "$(git -C "$TARGET" config --get core.bare 2>/dev/null || echo false)" != "true" ]; then
+  exit 0
+fi
+
+echo "Repairing mistaken core.bare=true on primary checkout at $TARGET" >&2
+git -C "$TARGET" config core.bare false

--- a/scripts/setup-refresh-main.sh
+++ b/scripts/setup-refresh-main.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+bash "$(dirname "${BASH_SOURCE[0]}")/repair-git-primary-worktree.sh"
+
 REMOTE="${SETUP_REMOTE:-origin}"
 BRANCH="${SETUP_MAIN_BRANCH:-main}"
 REMOTE_BRANCH="${REMOTE}/${BRANCH}"

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -159,3 +159,19 @@ if [ "$(git -C "$MISBARE_ROOT" rev-parse --is-inside-work-tree)" != "true" ]; th
   exit 1
 fi
 echo "repair-git-primary-worktree test passed."
+
+# Regression: git accepts many true spellings (yes, on, 1, TRUE …). The repair
+# must canonicalise via --bool, not compare the raw value to "true".
+for spelling in yes on 1 TRUE; do
+  git -C "$MISBARE_ROOT" config core.bare "$spelling"
+  if [ "$(git -C "$MISBARE_ROOT" rev-parse --is-inside-work-tree)" = "true" ]; then
+    echo "FAIL: misbare fixture should not report inside-work-tree for spelling '$spelling'." >&2
+    exit 1
+  fi
+  bash "$ROOT/scripts/repair-git-primary-worktree.sh" "$MISBARE_ROOT"
+  if [ "$(git -C "$MISBARE_ROOT" config --get core.bare)" != "false" ]; then
+    echo "FAIL: repair did not clear core.bare spelling '$spelling'." >&2
+    exit 1
+  fi
+done
+echo "repair-git-primary-worktree boolean-spelling test passed."

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -139,3 +139,23 @@ if [ "$out" != "$expected" ]; then
   exit 1
 fi
 echo "linked-worktree repo-root fallback test passed."
+
+# Regression: mistaken core.bare=true on a primary checkout (directory .git) breaks
+# git status and worktree spawning from the main path.
+MISBARE_ROOT="$TMPDIR/misbare"
+git init -q --initial-branch=main "$MISBARE_ROOT"
+git -C "$MISBARE_ROOT" config core.bare true
+if [ "$(git -C "$MISBARE_ROOT" rev-parse --is-inside-work-tree)" = "true" ]; then
+  echo "FAIL: misbare fixture should not report inside-work-tree before repair." >&2
+  exit 1
+fi
+bash "$ROOT/scripts/repair-git-primary-worktree.sh" "$MISBARE_ROOT"
+if [ "$(git -C "$MISBARE_ROOT" config --get core.bare)" != "false" ]; then
+  echo "FAIL: repair-git-primary-worktree.sh did not clear core.bare." >&2
+  exit 1
+fi
+if [ "$(git -C "$MISBARE_ROOT" rev-parse --is-inside-work-tree)" != "true" ]; then
+  echo "FAIL: primary checkout still not a work tree after core.bare repair." >&2
+  exit 1
+fi
+echo "repair-git-primary-worktree test passed."


### PR DESCRIPTION
## Summary

- Add `scripts/repair-git-primary-worktree.sh` to clear mistaken `core.bare=true` on a primary clone (directory `.git`), which breaks `git status`, `show-toplevel`, and Cursor worktree spawning.
- Run the repair at the start of `make setup` (`setup-refresh-main.sh`).
- Regression coverage in `scripts/test-make-setup.sh`; manifest triggers updated.

## Test plan

- [x] `env -u TMPDIR bash scripts/test-make-setup.sh`
- [x] Local push with `OMI_PR_BODY_FILE` + `PRE_PUSH_SKIP_FLUTTER_GENERATED=1` (scripts-only diff; no app toolchain on this machine)

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

