### PR TITLE
fix(desktop): tip-bump planner source after v0.12.143 changelog

### DIFF
--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -890,7 +890,7 @@ if [[ "$AUTOMATIC" -eq 1 ]]; then
 fi
 
 # After signed-artifact + static + Tier-2 + fault gates pass, runner-hygiene
-# cleanup is best-effort. A green behavioral run must not be fenced solely by
+# cleanup is best-effort. (tip-bump for planner source after 143 changelog) A green behavioral run must not be fenced solely by
 # lease-lineage cleanup failures (incident #10779 / v0.12.142). Still attempt
 # cleanup and record phase status; residual leases are reclaimed on next acquire.
 phase_begin "final-cleanup" "runner-hygiene-cleanup"


### PR DESCRIPTION
## Summary
Ordinary tag-release keeps selecting pre-changelog source `caed431` and failing changelog re-commit / M1 workspace checkout. Changelog for 0.12.143 is already on main (#10787). This tip-bump makes planner `source_sha` the live tip so tag can bind current main.

## Failure-Class
Failure-Class: none

## Verification
Comment-only tip bump on exempt qualification script path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

