### PR TITLE
ci(release): recover tag-release when changelog already on main

### DIFF
--- a/.github/failure-classes/FC-tag-release-partial-changelog-retry.json
+++ b/.github/failure-classes/FC-tag-release-partial-changelog-retry.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-tag-release-partial-changelog-retry",
+  "violated_contract": "After a desktop tag-release merges the versioned changelog to main but fails before publishing the immutable v*-macos tag, a sole retry must recover a main-reachable consolidate commit (not an orphan source-qualified branch tip) and must not fail closed on consolidate dirt left in the worktree before branch checkout.",
+  "canonical_prevention": "Resolve changelog sync commits with a pure helper that prefers main-reachable consolidate commits for the planned source and version, clean the worktree before reuse checkout, and skip opening a second changelog PR when merge evidence is already on main.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/resolve-desktop-changelog-sync.py",
+    ".github/scripts/test_resolve_desktop_changelog_sync.py",
+    ".github/workflows/desktop_auto_release.yml"
+  ],
+  "evidence_prs": [10787],
+  "scope_hints": [
+    ".github/workflows/desktop_auto_release.yml",
+    ".github/scripts/resolve-desktop-changelog-sync.py",
+    ".github/scripts/desktop-release-source-identity.py",
+    ".github/scripts/plan-desktop-release.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/resolve-desktop-changelog-sync.py
+++ b/.github/scripts/resolve-desktop-changelog-sync.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Resolve a main-reachable desktop changelog consolidate commit for tag-release.
+
+When a prior tag-release merged the changelog PR but failed before publishing the
+immutable tag, retries can see:
+
+- a source-qualified remote branch tip that is *not* an ancestor of origin/main
+  (orphan rewrite of the consolidate commit), while the merge's second parent
+  *is* on main;
+- consolidate dirt left in the worktree that blocks ``git checkout -B`` reuse.
+
+This helper prefers any consolidate commit that is reachable from origin/main
+with first-parent == planned source and the exact consolidate subject for the
+version. Callers must still clean the worktree before checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def require_sha(name: str, value: str) -> str:
+    if not SHA_RE.fullmatch(value):
+        raise ValueError(f"{name} must be a 40-character lowercase SHA")
+    return value
+
+
+def git(repository_root: Path, args: list[str], *, check: bool = True) -> str:
+    environment = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
+    result = subprocess.run(
+        ["git", "-C", str(repository_root), *args],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+    return result.stdout.strip()
+
+
+def is_ancestor(repository_root: Path, maybe_ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repository_root), "merge-base", "--is-ancestor", maybe_ancestor, descendant],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={name: value for name, value in os.environ.items() if not name.startswith("GIT_")},
+    )
+    return result.returncode == 0
+
+
+def consolidate_subject(version: str) -> str:
+    return f"chore: consolidate changelog for v{version}"
+
+
+def merge_subject_re(version: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"^Update desktop changelog for v{re.escape(version)}\b.*\(#([1-9][0-9]*)\)\s*$"
+    )
+
+
+def find_main_reachable_consolidate(
+    repository_root: Path,
+    *,
+    planned_source_sha: str,
+    version: str,
+    main_ref: str = "origin/main",
+) -> str | None:
+    """Return consolidate commit on main with parent == planned source, if any."""
+    planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
+    want = consolidate_subject(version)
+    log = git(
+        repository_root,
+        ["log", main_ref, "--format=%H%x00%P%x00%s", "--grep", f"consolidate changelog for v{version}"],
+    )
+    for line in log.splitlines():
+        if not line.strip():
+            continue
+        sha, parents, subject = line.split("\x00", 2)
+        parent_list = parents.split()
+        if not parent_list:
+            continue
+        if parent_list[0] != planned_source_sha:
+            continue
+        if subject.strip() != want:
+            continue
+        if is_ancestor(repository_root, sha, main_ref):
+            return sha
+    # Broader scan: first-parent walk can miss second parents of merges; use rev-list
+    # of all commits reachable from main.
+    all_commits = git(repository_root, ["rev-list", main_ref]).splitlines()
+    for sha in all_commits:
+        parents = git(repository_root, ["rev-parse", f"{sha}^@"]).splitlines()
+        if not parents or parents[0] != planned_source_sha:
+            continue
+        subject = git(repository_root, ["log", "-1", "--format=%s", sha])
+        if subject.strip() == want:
+            return sha
+    return None
+
+
+def find_changelog_merge_on_main(
+    repository_root: Path,
+    *,
+    version: str,
+    consolidate_commit: str,
+    main_ref: str = "origin/main",
+    repository_slug: str = "",
+) -> tuple[str, str] | None:
+    """Return (merge_commit_sha, pr_url) for the changelog merge on main."""
+    consolidate_commit = require_sha("consolidate_commit", consolidate_commit)
+    pattern = merge_subject_re(version)
+    log = git(
+        repository_root,
+        ["log", main_ref, "--merges", "--format=%H%x00%s", f"--grep=Update desktop changelog for v{version}"],
+    )
+    for line in log.splitlines():
+        if not line.strip():
+            continue
+        sha, subject = line.split("\x00", 1)
+        match = pattern.match(subject.strip())
+        if not match:
+            continue
+        parents = git(repository_root, ["rev-parse", f"{sha}^@"]).splitlines()
+        if consolidate_commit not in parents and not is_ancestor(repository_root, consolidate_commit, sha):
+            continue
+        pr_number = match.group(1)
+        if repository_slug:
+            pr_url = f"https://github.com/{repository_slug}/pull/{pr_number}"
+        else:
+            pr_url = f"pull/{pr_number}"
+        return sha, pr_url
+    return None
+
+
+def resolve_changelog_sync(
+    repository_root: Path,
+    *,
+    planned_source_sha: str,
+    version: str,
+    branch_tip: str = "",
+    main_ref: str = "origin/main",
+    repository_slug: str = "",
+) -> dict[str, object]:
+    """Resolve commit + optional PR evidence for tag-release changelog sync."""
+    planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
+    main_tip = git(repository_root, ["rev-parse", f"{main_ref}^{{commit}}"])
+
+    preferred = ""
+    if branch_tip:
+        branch_tip = require_sha("branch_tip", branch_tip)
+        parent = git(repository_root, ["rev-parse", f"{branch_tip}^1"])
+        if parent != planned_source_sha:
+            raise ValueError(
+                "changelog branch tip first parent must equal the planned source SHA "
+                f"(got {parent}, want {planned_source_sha})"
+            )
+        if is_ancestor(repository_root, branch_tip, main_ref):
+            preferred = branch_tip
+
+    main_commit = find_main_reachable_consolidate(
+        repository_root,
+        planned_source_sha=planned_source_sha,
+        version=version,
+        main_ref=main_ref,
+    )
+
+    commit = preferred or main_commit or ""
+    if not commit and branch_tip and preferred == "":
+        # Orphan branch tip: only accept if main has the equivalent consolidate.
+        if main_commit:
+            commit = main_commit
+        else:
+            raise ValueError(
+                "changelog branch tip is not reachable from main and no main-reachable "
+                f"consolidate commit exists for v{version} with parent {planned_source_sha}"
+            )
+
+    if not commit:
+        return {
+            "mode": "missing",
+            "commit": "",
+            "pr_url": "",
+            "merged_main_sha": "",
+            "already_on_main": False,
+            "main_tip": main_tip,
+        }
+
+    already_on_main = is_ancestor(repository_root, commit, main_ref)
+    pr_url = ""
+    merged_main_sha = ""
+    if already_on_main:
+        found = find_changelog_merge_on_main(
+            repository_root,
+            version=version,
+            consolidate_commit=commit,
+            main_ref=main_ref,
+            repository_slug=repository_slug,
+        )
+        if found:
+            merged_main_sha, pr_url = found
+        mode = "already-on-main"
+    else:
+        mode = "branch-tip"
+
+    return {
+        "mode": mode,
+        "commit": commit,
+        "pr_url": pr_url,
+        "merged_main_sha": merged_main_sha,
+        "already_on_main": already_on_main,
+        "main_tip": main_tip,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository-root", type=Path, default=Path("."))
+    parser.add_argument("--planned-source-sha", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--branch-tip", default="")
+    parser.add_argument("--main-ref", default="origin/main")
+    parser.add_argument("--repository", default="")
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--github-output", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        result = resolve_changelog_sync(
+            args.repository_root.resolve(),
+            planned_source_sha=args.planned_source_sha.lower(),
+            version=args.version,
+            branch_tip=args.branch_tip.lower() if args.branch_tip else "",
+            main_ref=args.main_ref,
+            repository_slug=args.repository,
+        )
+    except ValueError as error:
+        print(f"resolve-desktop-changelog-sync.py: error: {error}", file=sys.stderr)
+        return 2
+
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output_json:
+        args.output_json.write_text(payload, encoding="utf-8")
+    if args.github_output:
+        gh_out = os.environ.get("GITHUB_OUTPUT")
+        if not gh_out:
+            print("GITHUB_OUTPUT is not set", file=sys.stderr)
+            return 2
+        with open(gh_out, "a", encoding="utf-8") as handle:
+            for key in ("mode", "commit", "pr_url", "merged_main_sha"):
+                handle.write(f"{key}={result[key]}\n")
+            handle.write(f"already_on_main={'true' if result['already_on_main'] else 'false'}\n")
+    if not args.output_json and not args.github_output:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_resolve_desktop_changelog_sync.py
+++ b/.github/scripts/test_resolve_desktop_changelog_sync.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Regression tests for tag-release changelog sync commit resolution."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("resolve-desktop-changelog-sync.py")
+SPEC = importlib.util.spec_from_file_location("resolve_desktop_changelog_sync", SCRIPT)
+assert SPEC and SPEC.loader
+resolve_mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(resolve_mod)
+
+
+class ResolveDesktopChangelogSyncTests(unittest.TestCase):
+    def _git(self, repository: Path, *args: str) -> str:
+        environment = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
+        return subprocess.run(
+            ["git", "-C", str(repository), *args],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+        ).stdout.strip()
+
+    def _commit(self, repository: Path, path: str, contents: str, message: str) -> str:
+        file_path = repository / path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(contents, encoding="utf-8")
+        self._git(repository, "add", path)
+        self._git(repository, "commit", "-m", message)
+        return self._git(repository, "rev-parse", "HEAD")
+
+    def _repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+        directory = tempfile.TemporaryDirectory()
+        repository = Path(directory.name)
+        self._git(repository, "init")
+        self._git(repository, "config", "user.name", "test")
+        self._git(repository, "config", "user.email", "test@example.com")
+        self._git(repository, "checkout", "-b", "main")
+        return directory, repository
+
+    def test_prefers_branch_tip_when_already_on_main(self) -> None:
+        directory, repository = self._repo()
+        with directory:
+            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
+            consolidate = self._commit(
+                repository,
+                "desktop/macos/changelog/releases/0.12.143.json",
+                "{}\n",
+                "chore: consolidate changelog for v0.12.143",
+            )
+            # simulate regular merge already done: tip is consolidate itself on main
+            result = resolve_mod.resolve_changelog_sync(
+                repository,
+                planned_source_sha=planned,
+                version="0.12.143",
+                branch_tip=consolidate,
+                main_ref="main",
+                repository_slug="BasedHardware/omi",
+            )
+            self.assertEqual(result["mode"], "already-on-main")
+            self.assertEqual(result["commit"], consolidate)
+            self.assertTrue(result["already_on_main"])
+
+    def test_orphan_branch_tip_recovers_main_consolidate(self) -> None:
+        directory, repository = self._repo()
+        with directory:
+            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
+            # Main-side consolidate (second parent of a real merge).
+            self._git(repository, "checkout", "-b", "changelog-good", planned)
+            good = self._commit(
+                repository,
+                "desktop/macos/changelog/releases/0.12.143.json",
+                '{"v":1}\n',
+                "chore: consolidate changelog for v0.12.143",
+            )
+            self._git(repository, "checkout", "main")
+            self._git(repository, "merge", "--no-ff", "-m", "Update desktop changelog for v0.12.143 [skip ci] (#10787)", "changelog-good")
+            # Orphan tip: same parent + subject, different tree/hash, not on main.
+            self._git(repository, "checkout", "-b", "changelog-orphan", planned)
+            orphan = self._commit(
+                repository,
+                "desktop/macos/changelog/releases/0.12.143.json",
+                '{"v":2}\n',
+                "chore: consolidate changelog for v0.12.143",
+            )
+            self._git(repository, "checkout", "main")
+
+            result = resolve_mod.resolve_changelog_sync(
+                repository,
+                planned_source_sha=planned,
+                version="0.12.143",
+                branch_tip=orphan,
+                main_ref="main",
+                repository_slug="BasedHardware/omi",
+            )
+            self.assertEqual(result["commit"], good)
+            self.assertTrue(result["already_on_main"])
+            self.assertEqual(result["pr_url"], "https://github.com/BasedHardware/omi/pull/10787")
+            self.assertTrue(result["merged_main_sha"])
+            self.assertNotEqual(result["commit"], orphan)
+
+    def test_rejects_branch_tip_with_wrong_parent(self) -> None:
+        directory, repository = self._repo()
+        with directory:
+            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
+            other = self._commit(repository, "desktop/macos/Other.swift", "b\n", "other")
+            tip = self._commit(
+                repository,
+                "desktop/macos/changelog/releases/0.12.143.json",
+                "{}\n",
+                "chore: consolidate changelog for v0.12.143",
+            )
+            with self.assertRaisesRegex(ValueError, "first parent must equal"):
+                resolve_mod.resolve_changelog_sync(
+                    repository,
+                    planned_source_sha=planned,
+                    version="0.12.143",
+                    branch_tip=tip,
+                    main_ref="main",
+                )
+            _ = other
+
+    def test_missing_when_no_branch_and_no_main_commit(self) -> None:
+        directory, repository = self._repo()
+        with directory:
+            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
+            result = resolve_mod.resolve_changelog_sync(
+                repository,
+                planned_source_sha=planned,
+                version="0.12.143",
+                main_ref="main",
+            )
+            self.assertEqual(result["mode"], "missing")
+            self.assertEqual(result["commit"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -167,6 +167,8 @@ jobs:
       - name: Commit changelog and prepare sync branch
         if: steps.recheck.outputs.should_release == 'true'
         id: changelog
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
@@ -180,27 +182,69 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # A rerun for the same source must reuse its immutable branch commit.
-          # The source-qualified branch name intentionally ignores stale legacy
-          # `changelog/v<version>` branches from an older planner source.
+          # Partial tag-release recovery: changelog may already be on main while
+          # the source-qualified branch tip is an orphan rewrite. Prefer a
+          # main-reachable consolidate commit. Always drop consolidate dirt
+          # before any branch checkout so reuse cannot fail on a dirty tree.
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git reset --hard HEAD
+          git clean -fd -- desktop/macos/CHANGELOG.json desktop/macos/changelog || true
+
+          BRANCH_TIP=""
           if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null; then
             git fetch --no-tags origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
-            CHANGELOG_COMMIT="$(git rev-parse "origin/$BRANCH^{commit}")"
-            test "$(git rev-parse "${CHANGELOG_COMMIT}^1")" = "$PLANNED_SOURCE_SHA"
-            git checkout -B "$BRANCH" "$CHANGELOG_COMMIT"
+            BRANCH_TIP="$(git rev-parse "origin/$BRANCH^{commit}")"
+          fi
+
+          RESOLVE_ARGS=(
+            python3 .github/scripts/resolve-desktop-changelog-sync.py
+            --repository-root .
+            --planned-source-sha "$PLANNED_SOURCE_SHA"
+            --version "$VERSION"
+            --main-ref origin/main
+            --repository "${{ github.repository }}"
+            --github-output
+          )
+          if [ -n "$BRANCH_TIP" ]; then
+            RESOLVE_ARGS+=(--branch-tip "$BRANCH_TIP")
+          fi
+          # Capture resolve into step outputs via GITHUB_OUTPUT.
+          RESOLVE_OUT="$RUNNER_TEMP/desktop-changelog-resolve-outputs.txt"
+          : > "$RESOLVE_OUT"
+          GITHUB_OUTPUT="$RESOLVE_OUT" "${RESOLVE_ARGS[@]}"
+          RESOLVE_MODE="$(grep '^mode=' "$RESOLVE_OUT" | tail -1 | cut -d= -f2-)"
+          RESOLVE_COMMIT="$(grep '^commit=' "$RESOLVE_OUT" | tail -1 | cut -d= -f2-)"
+          RESOLVE_PR_URL="$(grep '^pr_url=' "$RESOLVE_OUT" | tail -1 | cut -d= -f2-)"
+          RESOLVE_MERGED_MAIN="$(grep '^merged_main_sha=' "$RESOLVE_OUT" | tail -1 | cut -d= -f2-)"
+          RESOLVE_ON_MAIN="$(grep '^already_on_main=' "$RESOLVE_OUT" | tail -1 | cut -d= -f2-)"
+
+          if [ -n "$RESOLVE_COMMIT" ]; then
+            test "$(git rev-parse "${RESOLVE_COMMIT}^1")" = "$PLANNED_SOURCE_SHA"
+            git checkout -B "$BRANCH" "$RESOLVE_COMMIT"
             {
               echo "changed=true"
-              echo "commit=$CHANGELOG_COMMIT"
+              echo "commit=$RESOLVE_COMMIT"
               echo "reused=true"
+              echo "already_on_main=$RESOLVE_ON_MAIN"
+              echo "pr_url=$RESOLVE_PR_URL"
+              echo "merged_main_sha=$RESOLVE_MERGED_MAIN"
+              echo "resolve_mode=$RESOLVE_MODE"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # Fresh consolidate path: rebuild from the planned source tree.
+          git checkout --detach "$PLANNED_SOURCE_SHA"
+          TODAY=$(date -u +%Y-%m-%d)
+          python3 .github/scripts/desktop-changelog.py consolidate \
+            --version "$VERSION" \
+            --date "$TODAY" \
+            --write
           git add desktop/macos/CHANGELOG.json desktop/macos/changelog
           if git diff --cached --quiet; then
-            # Nothing needed to move through a PR. The direct tag path below
-            # still requires the planner SHA to be the fresh main tip.
+            # Nothing to PR. Direct tag path admits later non-desktop main commits.
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "already_on_main=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -212,6 +256,10 @@ jobs:
             echo "changed=true"
             echo "commit=$CHANGELOG_COMMIT"
             echo "reused=false"
+            echo "already_on_main=false"
+            echo "pr_url="
+            echo "merged_main_sha="
+            echo "resolve_mode=created"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create and regular-merge PR to sync changelog back to main
@@ -229,6 +277,26 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           PLANNED_SOURCE_SHA="${{ steps.recheck.outputs.source_sha }}"
           BRANCH="changelog/v${VERSION}-${PLANNED_SOURCE_SHA:0:12}"
+          CHANGELOG_COMMIT="${{ steps.changelog.outputs.commit }}"
+
+          # Changelog already on main from a partial prior tag-release: do not
+          # open a second PR. Reuse the merge commit + PR URL from resolve.
+          if [ "${{ steps.changelog.outputs.already_on_main }}" = "true" ]; then
+            PR_URL="${{ steps.changelog.outputs.pr_url }}"
+            MERGED_MAIN_SHA="${{ steps.changelog.outputs.merged_main_sha }}"
+            if [ -z "$PR_URL" ] || [ -z "$MERGED_MAIN_SHA" ]; then
+              echo "Changelog commit is on main but merge PR evidence is missing."
+              exit 1
+            fi
+            test "$(git merge-base --is-ancestor "$CHANGELOG_COMMIT" origin/main && echo ok)" = "ok"
+            PR_NUMBER=$(echo "$PR_URL" | awk -F/ '{print $NF}')
+            {
+              echo "number=$PR_NUMBER"
+              echo "url=$PR_URL"
+              echo "merged_main_sha=$MERGED_MAIN_SHA"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           PR_NUMBER=$(gh pr list \
             --head "$BRANCH" \


### PR DESCRIPTION
## Summary
Unblocks ordinary macOS Beta tagging after a **partial** `tag-release`: changelog for the next version is already on `main`, but no `v*-macos` tag was published.

Retries were fail-closing on:
1. Orphan `changelog/vX.Y.Z-<source12>` tip not reachable from `main` (bind identity)
2. Dirty worktree after consolidate blocking `git checkout -B` reuse

## Fix
- Register `FC-tag-release-partial-changelog-retry`
- Add `resolve-desktop-changelog-sync.py` (main-reachable consolidate preference)
- Clean changelog paths before reuse checkout
- When already on main, skip a second changelog PR and reuse merge PR evidence
- Unit tests for orphan-tip recovery

## Verification
```bash
python3 .github/scripts/test_resolve_desktop_changelog_sync.py -v
python3 .github/scripts/resolve-desktop-changelog-sync.py \
  --planned-source-sha caed431bf50d247d4f5e125bffa79b2d05d78173 \
  --version 0.12.143 \
  --branch-tip 07f64fa87682698ebdf12f3b3fc881e8d3df69bc \
  --main-ref origin/main \
  --repository BasedHardware/omi
# -> commit 3c4ab8093f…, pr #10787, already_on_main true
```

## Failure-Class
Failure-Class: none

## Product invariants affected
none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

