### PR TITLE
fix(ci): remove orphan omiGlass libopus gitmodules entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-# PlatformIO materializes this dependency under .pio; keep the gitlink mapped so
-# GitHub checkout cleanup can resolve it without treating generated files as an unknown submodule.
-[submodule "omiGlass/firmware/.pio/libdeps/seeed_xiao_esp32s3/libopus"]
-	path = omiGlass/firmware/.pio/libdeps/seeed_xiao_esp32s3/libopus
-	url = https://github.com/pschatzmann/arduino-libopus.git


### PR DESCRIPTION
## Summary
M1 `desktop_auto_release` tag-release repeatedly hung/failed in `actions/checkout` on `git submodule foreach` because `.gitmodules` listed `omiGlass/firmware/.pio/libdeps/seeed_xiao_esp32s3/libopus` without a corresponding gitlink. That blocked publishing v0.12.143.

## Failure-Class
Failure-Class: none

## Verification
Locally, `git submodule foreach` no longer hangs after removing the orphan entry. Unblocks tag-release checkout on m1-mac-studio-qualification.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

