### PR TITLE
fix(desktop): move planner source past orphan gitmodules removal

### DIFF
--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -890,7 +890,7 @@ if [[ "$AUTOMATIC" -eq 1 ]]; then
 fi
 
 # After signed-artifact + static + Tier-2 + fault gates pass, runner-hygiene
-# cleanup is best-effort. (tip-bump for planner source after 143 changelog) A green behavioral run must not be fenced solely by
+# cleanup is best-effort. (tip-bump after gitmodules fix so source tree has no orphan submodule) A green behavioral run must not be fenced solely by
 # lease-lineage cleanup failures (incident #10779 / v0.12.142). Still attempt
 # cleanup and record phase status; residual leases are reclaimed on next acquire.
 phase_begin "final-cleanup" "runner-hygiene-cleanup"


### PR DESCRIPTION
## Summary
Tag-release checks out exact planner `source_sha`. That SHA still had the orphan `.gitmodules` from before #10791, so M1 `actions/checkout` hung on `git submodule foreach` again.

This tip-bump makes releasable desktop source a commit **after** the gitmodules removal.

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

