### PR TITLE
fix(ci): remove orphan libopus gitlink blocking M1 tag-release

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -532,6 +532,16 @@ checks:
     triggers: ["desktop/macos/agent/src/runtime/agent-spawn-journal.ts", "desktop/macos/agent/fixtures/spawn-receipt/**", "desktop/macos/agent/tests/spawn-receipt-fixtures.test.ts", "desktop/macos/scripts/check-spawn-receipt-fixtures.sh", "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeSpawnReceipt.swift", "desktop/macos/Desktop/Tests/RealtimeHubSpawnAgentTests.swift"]
     lanes: ["local", "ci"]
     reason: "cross-language realtime spawn receipt producer/consumer contract"
+  - id: orphan-gitlinks
+    command: ["python3", ".github/scripts/check_orphan_gitlinks.py"]
+    triggers: ["omiGlass/**", ".github/scripts/check_orphan_gitlinks.py", ".github/scripts/test_check_orphan_gitlinks.py", ".github/checks-manifest.yaml", ".github/workflows/desktop_auto_release.yml"]
+    lanes: ["local", "ci"]
+    reason: "orphan mode-160000 gitlinks without .gitmodules hang/fail M1 actions/checkout during desktop tag-release"
+  - id: orphan-gitlinks-fixtures
+    command: ["python3", ".github/scripts/test_check_orphan_gitlinks.py"]
+    triggers: [".github/scripts/check_orphan_gitlinks.py", ".github/scripts/test_check_orphan_gitlinks.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "fixture coverage for clean trees and unmapped gitlinks"
   - id: release-eligibility-contract
     command: ["python3", ".github/scripts/check_release_eligibility.py"]
     triggers: [".github/workflows/release-eligibility.yml", ".github/actions/release-eligibility/**", ".github/scripts/verify_release_eligibility.py", ".github/scripts/check_release_eligibility.py", ".github/scripts/test_check_release_eligibility.py", ".github/checks-manifest.yaml"]

--- a/.github/scripts/check_orphan_gitlinks.py
+++ b/.github/scripts/check_orphan_gitlinks.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Fail closed when the tree has gitlinks (mode 160000) without .gitmodules maps.
+
+actions/checkout post-steps run `git submodule foreach` whenever a gitlink is
+present. An unmapped gitlink yields:
+
+  no submodule mapping found in .gitmodules for path '...'
+
+and can hang or fail M1 tag-release checkout cleanup. Static checker.
+"""
+from __future__ import annotations
+
+import configparser
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _gitlinks(repo: Path) -> list[str]:
+    out = subprocess.check_output(
+        ["git", "-C", str(repo), "ls-files", "-s"],
+        text=True,
+    )
+    paths: list[str] = []
+    for line in out.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        meta, path = parts
+        mode = meta.split()[0]
+        if mode == "160000":
+            paths.append(path)
+    return paths
+
+
+def _mapped_paths(repo: Path) -> set[str]:
+    gm = repo / ".gitmodules"
+    if not gm.is_file():
+        return set()
+    parser = configparser.ConfigParser()
+    parser.read(gm)
+    mapped: set[str] = set()
+    for section in parser.sections():
+        path = parser.get(section, "path", fallback="").strip()
+        if path:
+            mapped.add(path)
+    return mapped
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[2]
+    links = _gitlinks(repo)
+    if not links:
+        print("check_orphan_gitlinks: no gitlinks")
+        return 0
+    mapped = _mapped_paths(repo)
+    orphans = sorted(p for p in links if p not in mapped)
+    if orphans:
+        print("Orphan gitlink(s) without .gitmodules path mapping:", file=sys.stderr)
+        for path in orphans:
+            print(f"  - {path}", file=sys.stderr)
+        print(
+            "Remove the gitlink (`git rm`) or add a matching .gitmodules entry.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"check_orphan_gitlinks: {len(links)} gitlink(s) mapped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_orphan_gitlinks.py
+++ b/.github/scripts/test_check_orphan_gitlinks.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_SRC = Path(__file__).resolve().with_name("check_orphan_gitlinks.py")
+
+
+def clean_git_environment(env: dict[str, str]) -> dict[str, str]:
+    """Keep hook-local Git state out of isolated fixtures."""
+    cleaned = {k: v for k, v in env.items() if not k.startswith("GIT_")}
+    cleaned.setdefault("GIT_AUTHOR_NAME", "test")
+    cleaned.setdefault("GIT_AUTHOR_EMAIL", "test@example.com")
+    cleaned.setdefault("GIT_COMMITTER_NAME", "test")
+    cleaned.setdefault("GIT_COMMITTER_EMAIL", "test@example.com")
+    return cleaned
+
+
+def _run(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+        env=clean_git_environment(dict(os.environ)),
+    )
+
+
+def _git(cwd: Path, *args: str) -> None:
+    _run(cwd, "git", *args)
+
+
+class CheckOrphanGitlinksTests(unittest.TestCase):
+    def _layout(self, repo: Path) -> Path:
+        tools = repo / ".github" / "scripts"
+        tools.mkdir(parents=True)
+        target = tools / "check_orphan_gitlinks.py"
+        target.write_text(SCRIPT_SRC.read_text(encoding="utf-8"), encoding="utf-8")
+        return target
+
+    def _init_repo(self, repo: Path) -> None:
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "test")
+        (repo / "README").write_text("x\n", encoding="utf-8")
+        _git(repo, "add", "README")
+        _git(repo, "commit", "-m", "init")
+
+    def test_clean_tree_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            script = self._layout(repo)
+            proc = _run(repo, "python3", str(script), check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
+    def test_orphan_gitlink_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            nested = repo / "_nested"
+            nested.mkdir()
+            _git(nested, "init")
+            _git(nested, "config", "user.email", "test@example.com")
+            _git(nested, "config", "user.name", "test")
+            (nested / "f").write_text("y\n", encoding="utf-8")
+            _git(nested, "add", "f")
+            _git(nested, "commit", "-m", "nested")
+            oid = _run(nested, "git", "rev-parse", "HEAD").stdout.strip()
+            _run(
+                repo,
+                "git",
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"160000,{oid},vendor/dep",
+            )
+            _git(repo, "commit", "-m", "add orphan gitlink")
+            script = self._layout(repo)
+            proc = _run(repo, "python3", str(script), check=False)
+            self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+            self.assertIn("Orphan gitlink", proc.stderr)
+
+    def test_mapped_gitlink_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            nested = repo / "_nested"
+            nested.mkdir()
+            _git(nested, "init")
+            _git(nested, "config", "user.email", "test@example.com")
+            _git(nested, "config", "user.name", "test")
+            (nested / "f").write_text("y\n", encoding="utf-8")
+            _git(nested, "add", "f")
+            _git(nested, "commit", "-m", "nested")
+            oid = _run(nested, "git", "rev-parse", "HEAD").stdout.strip()
+            _run(
+                repo,
+                "git",
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"160000,{oid},vendor/dep",
+            )
+            (repo / ".gitmodules").write_text(
+                '[submodule "vendor/dep"]\n\tpath = vendor/dep\n'
+                "\turl = https://example.com/dep.git\n",
+                encoding="utf-8",
+            )
+            _git(repo, "add", ".gitmodules")
+            _git(repo, "commit", "-m", "mapped gitlink")
+            script = self._layout(repo)
+            proc = _run(repo, "python3", str(script), check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -55,6 +55,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Never recurse submodules: an orphan gitlink (no .gitmodules map)
+          # hangs/fails actions/checkout post-cleanup on the M1 shared workspace.
+          submodules: false
 
       - name: Generate Omi Bot token
         id: app-token
@@ -103,6 +106,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          submodules: false
 
       - name: Recheck desktop release queue before tagging
         id: recheck
@@ -126,6 +130,7 @@ jobs:
           ref: ${{ steps.recheck.outputs.source_sha }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          submodules: false
 
       - name: Compute next version and consolidate changelog
         if: steps.recheck.outputs.should_release == 'true'

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -890,7 +890,7 @@ if [[ "$AUTOMATIC" -eq 1 ]]; then
 fi
 
 # After signed-artifact + static + Tier-2 + fault gates pass, runner-hygiene
-# cleanup is best-effort. (tip-bump after gitmodules fix so source tree has no orphan submodule) A green behavioral run must not be fenced solely by
+# cleanup is best-effort. (tip-bump: drop libopus gitlink + submodules:false on auto-release) A green behavioral run must not be fenced solely by
 # lease-lineage cleanup failures (incident #10779 / v0.12.142). Still attempt
 # cleanup and record phase status; residual leases are reclaimed on next acquire.
 phase_begin "final-cleanup" "runner-hygiene-cleanup"


### PR DESCRIPTION
## Summary
#10791 deleted `.gitmodules` but left the mode-`160000` gitlink at
`omiGlass/firmware/.pio/libdeps/seeed_xiao_esp32s3/libopus`. Worker log on
tag-release run 30394660315:

`no submodule mapping found in .gitmodules for path '…/libopus'`

That cancelled `Checkout exact releasable desktop source` and hung Post Checkout
on the M1, blocking v0.12.143 publish.

This PR:
1. Removes the orphan gitlink
2. Sets `submodules: false` on all `desktop_auto_release.yml` checkouts
3. Adds static guard + fixtures so unmapped gitlinks fail CI
4. Tip-bumps releasable desktop source past the partial 143 changelog state

## Failure-Class
Failure-Class: none

## Verification
- `python3 .github/scripts/check_orphan_gitlinks.py` → no gitlinks
- `python3 .github/scripts/test_check_orphan_gitlinks.py` → 3 passed
- Local `git ls-files -s` has no `160000` after removal


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

