### PR TITLE
fix(desktop-backend): cache GCP tokens for the lifetime the issuer granted

### DIFF
--- a/.github/failure-classes/FC-assumed-credential-lifetime.json
+++ b/.github/failure-classes/FC-assumed-credential-lifetime.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-assumed-credential-lifetime",
+  "violated_contract": "A credential's lifetime belongs to its issuer. A client that caches an access token must key expiry off the lifetime the token endpoint reported (`expires_in`), never off a locally assumed constant \u2014 assuming a longer life keeps an already-expired credential in service and every downstream call fails UNAUTHENTICATED until the local cache happens to lapse.",
+  "canonical_prevention": "Carry the issuer-reported lifetime alongside the token through the fetch path and compute the cache expiry from it, with a regression test that drives the real token-acquisition path against a token endpoint returning a short lifetime and asserts the client re-mints instead of reusing.",
+  "evidence_prs": [
+    10797
+  ],
+  "scope_hints": [
+    "desktop/macos/Backend-Rust/src/services/firestore.rs"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Backend-Rust/src/services/firestore.rs
+++ b/desktop/macos/Backend-Rust/src/services/firestore.rs
@@ -47,6 +47,23 @@ struct CachedToken {
     expires_at: i64,
 }
 
+/// A freshly minted access token plus the lifetime its issuer reported.
+struct FetchedToken {
+    token: String,
+    /// Seconds of remaining life, as reported by the token endpoint.
+    expires_in: Option<i64>,
+}
+
+/// Lifetime assumed when a token endpoint omits `expires_in`.
+const DEFAULT_TOKEN_LIFETIME_SECS: i64 = 3600;
+
+/// GCE metadata server token endpoint. The server hands back a *shared* token
+/// whose remaining life is frequently far below an hour, so its `expires_in`
+/// is the only correct cache lifetime — assuming a full hour serves an expired
+/// token until the local cache happens to lapse.
+const METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
 /// Firestore collection paths
 /// Copied from Python database.py
 const USERS_COLLECTION: &str = "users";
@@ -71,6 +88,7 @@ pub(crate) struct FirestoreService {
     project_id: String,
     credentials: Option<ServiceAccountCredentials>,
     cached_token: Arc<RwLock<Option<CachedToken>>>,
+    metadata_token_url: String,
 }
 
 impl FirestoreService {
@@ -88,6 +106,7 @@ impl FirestoreService {
             project_id,
             credentials,
             cached_token: Arc::new(RwLock::new(None)),
+            metadata_token_url: METADATA_TOKEN_URL.to_string(),
         };
 
         // Pre-fetch an access token
@@ -146,24 +165,26 @@ impl FirestoreService {
         }
 
         // Need to refresh token
-        let token = self.fetch_new_access_token().await?;
+        let fetched = self.fetch_new_access_token().await?;
 
-        // Cache it (tokens are valid for 1 hour, we'll refresh after 55 minutes)
+        // Cache it until the issuer's own expiry; the read path above keeps a
+        // 60s safety margin. Never assume a lifetime the issuer did not grant.
         {
             let mut cache = self.cached_token.write().await;
             *cache = Some(CachedToken {
-                token: token.clone(),
-                expires_at: Utc::now().timestamp() + 3300, // 55 minutes
+                token: fetched.token.clone(),
+                expires_at: Utc::now().timestamp()
+                    + fetched.expires_in.unwrap_or(DEFAULT_TOKEN_LIFETIME_SECS),
             });
         }
 
-        Ok(token)
+        Ok(fetched.token)
     }
 
     /// Fetch a new access token from Google OAuth
     async fn fetch_new_access_token(
         &self,
-    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<FetchedToken, Box<dyn std::error::Error + Send + Sync>> {
         // Use service account credentials first (has full permissions)
         if let Some(creds) = &self.credentials {
             let token = self.get_token_from_service_account(creds).await?;
@@ -183,13 +204,10 @@ impl FirestoreService {
     /// Try to get token from GCP metadata server
     async fn try_metadata_server(
         &self,
-    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let metadata_url =
-            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
-
+    ) -> Result<FetchedToken, Box<dyn std::error::Error + Send + Sync>> {
         let response = self
             .client
-            .get(metadata_url)
+            .get(&self.metadata_token_url)
             .header("Metadata-Flavor", "Google")
             .timeout(std::time::Duration::from_secs(2))
             .send()
@@ -199,9 +217,13 @@ impl FirestoreService {
             #[derive(Deserialize)]
             struct TokenResponse {
                 access_token: String,
+                expires_in: Option<i64>,
             }
             let token: TokenResponse = response.json().await?;
-            return Ok(token.access_token);
+            return Ok(FetchedToken {
+                token: token.access_token,
+                expires_in: token.expires_in,
+            });
         }
 
         Err("Metadata server not available".into())
@@ -211,7 +233,7 @@ impl FirestoreService {
     async fn get_token_from_service_account(
         &self,
         creds: &ServiceAccountCredentials,
-    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<FetchedToken, Box<dyn std::error::Error + Send + Sync>> {
         let now = Utc::now().timestamp();
         let token_uri = creds
             .token_uri
@@ -254,6 +276,7 @@ impl FirestoreService {
         #[derive(Deserialize)]
         struct TokenResponse {
             access_token: String,
+            expires_in: Option<i64>,
         }
 
         let token_response: TokenResponse = response
@@ -261,7 +284,10 @@ impl FirestoreService {
             .await
             .map_err(|e| format!("Failed to parse token response: {}", e))?;
 
-        Ok(token_response.access_token)
+        Ok(FetchedToken {
+            token: token_response.access_token,
+            expires_in: token_response.expires_in,
+        })
     }
 
     /// Build Firestore REST API base URL
@@ -402,7 +428,80 @@ fn parse_effective_plan_from_doc(doc: &Value) -> String {
 
 #[cfg(test)]
 mod tests {
+    // Tests may unwrap: the crate-level unwrap_used deny targets production
+    // code; a test failing on unwrap is the test doing its job.
+    #![allow(clippy::unwrap_used)]
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Serve the metadata-server token shape with a caller-chosen lifetime and
+    /// count how many times a token was minted.
+    async fn spawn_token_server(expires_in: i64) -> (String, Arc<AtomicUsize>) {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let served = hits.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let app = axum::Router::new().route(
+            "/token",
+            axum::routing::get(move || {
+                let served = served.clone();
+                async move {
+                    let minted = served.fetch_add(1, Ordering::SeqCst);
+                    axum::Json(serde_json::json!({
+                        "access_token": format!("token-{}", minted),
+                        "expires_in": expires_in,
+                        "token_type": "Bearer",
+                    }))
+                }
+            }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{}/token", address), hits)
+    }
+
+    fn service_with_metadata_url(metadata_token_url: String) -> FirestoreService {
+        FirestoreService {
+            client: Client::builder().no_proxy().build().unwrap(),
+            project_id: "test-project".to_string(),
+            credentials: None,
+            cached_token: Arc::new(RwLock::new(None)),
+            metadata_token_url,
+        }
+    }
+
+    /// The metadata server hands back a shared token that is often minutes from
+    /// expiry. Caching it for a hardcoded 55 minutes kept an already-expired
+    /// token in use — every Firestore call then failed UNAUTHENTICATED
+    /// (ACCESS_TOKEN_EXPIRED) until the local cache lapsed. The issuer's
+    /// `expires_in` has to win.
+    #[tokio::test]
+    async fn short_lived_metadata_token_is_not_cached_past_its_expiry() {
+        let (url, hits) = spawn_token_server(30).await;
+        let service = service_with_metadata_url(url);
+
+        let first = service.get_access_token().await.unwrap();
+        let second = service.get_access_token().await.unwrap();
+
+        // 30s of life is inside the 60s freshness margin, so the second call
+        // must mint a new token instead of serving the stale one.
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+        assert_eq!(first, "token-0");
+        assert_eq!(second, "token-1");
+    }
+
+    #[tokio::test]
+    async fn long_lived_metadata_token_is_reused_from_cache() {
+        let (url, hits) = spawn_token_server(3600).await;
+        let service = service_with_metadata_url(url);
+
+        let first = service.get_access_token().await.unwrap();
+        let second = service.get_access_token().await.unwrap();
+
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(first, second);
+    }
 
     #[test]
     fn test_document_id_from_seed() {


### PR DESCRIPTION
## Bug (live in prod)

`desktop-backend` has failed **every** Firestore call with `401 UNAUTHENTICATED / reason: ACCESS_TOKEN_EXPIRED` since the 2026-07-27T18:53Z Cloud Run revision went live — first errors at 19:24Z (~31 min later), and still >1k log lines/hour.

Symptoms in prod right now:
- `byok: failed to fetch BYOK state for uid=…: Failed to get user document: 401 … ACCESS_TOKEN_EXPIRED, failing open (not cached)` on essentially every request
- `POST /v1/screen-activity/sync` → 500
- `POST /v2/agent/provision`, `GET /v2/agent/status` → 500

## Root cause

The prod deploy strips the service-account file from the service (`desktop_backend_prod.yml` → `--remove-env-vars=GOOGLE_APPLICATION_CREDENTIALS,…`), so **prod is the only environment that takes the GCE metadata-server token path** — dev still mounts `/secrets/firebase/service-account.json` (`desktop_backend_auto_dev.yml`), which is why this never showed up before the 07-27 prod deploy (the previous revision, from 07-12, still had the env var).

That path threw away the metadata server's `expires_in` and cached every token for a hardcoded `3300` seconds:

```rust
expires_at: Utc::now().timestamp() + 3300, // 55 minutes
```

The metadata server returns a *shared* token whose remaining life is routinely far under an hour, so the client kept presenting an already-expired token for up to 55 minutes at a stretch.

## Fix

Carry the issuer-reported lifetime through the fetch path (`FetchedToken`) and cache to it. The read path's existing 60s freshness margin is unchanged, and the service-account path now honours its own `expires_in` too; `3600` remains only as the fallback when an endpoint omits the field. One file.

## What I tested

- New regression test drives the **real** `get_access_token()` against a local token endpoint returning `expires_in: 30` and asserts the second call re-mints. On the pre-fix code it fails (`left: 1, right: 2` — the expired token was reused); it passes here.
- Companion test pins that a long-lived (`expires_in: 3600`) token is still served from cache — the fix does not turn every call into a token fetch.
- `cargo test` → **400 passed, 0 failed**; `cargo clippy --all-targets` clean; `cargo fmt --check` clean.

## Deploy note

Merging does **not** fix prod: `desktop_backend_prod.yml` is `workflow_dispatch`-only. Prod stays broken until someone deploys this SHA (or, as an immediate stopgap, restores `GOOGLE_APPLICATION_CREDENTIALS` on the running service).

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged
