### PR TITLE
SCA-224: wire dev parity pack capture

### DIFF
--- a/backend/routers/listen/parity_capture.py
+++ b/backend/routers/listen/parity_capture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from copy import deepcopy
 from hashlib import sha256
 import logging
 import os
@@ -14,6 +15,10 @@ from testing.parity_pack_v0.schema import CassetteIdentity
 from testing.parity_pack_v0.whitelist import CaptureWhitelist
 
 logger = logging.getLogger(__name__)
+
+# Cassettes are a local diagnostic aid, never an unbounded in-memory recording.
+MAX_CAPTURE_EVENTS = 1_000
+MAX_CAPTURE_AUDIO_BYTES = 8 * 1024 * 1024
 
 
 def _anonymous_id(*parts: str) -> str:
@@ -46,6 +51,9 @@ class ListenParityCapture:
 
     def __init__(self, invocation: CaptureInvocation | None) -> None:
         self._invocation = invocation
+        self._event_count = 0
+        self._audio_bytes = 0
+        self._limit_reached = False
 
     @classmethod
     def from_environ(
@@ -70,8 +78,15 @@ class ListenParityCapture:
             retry_attempt=0,
             parent_event_anon=_anonymous_id(session_id, "listen-stt"),
         )
-        invocation = CaptureTap(root, CaptureWhitelist.from_environ(dict(env))).start(principal_id, identity, request)
-        return cls(invocation)
+        try:
+            invocation = CaptureTap(root, CaptureWhitelist.from_environ(dict(env))).start(
+                principal_id, identity, request
+            )
+            return cls(invocation)
+        except Exception as error:
+            # Capture must never make an otherwise valid listen session unavailable.
+            logger.warning("Parity pack capture initialization failed error_type=%s", type(error).__name__)
+            return cls(None)
 
     @property
     def enabled(self) -> bool:
@@ -84,12 +99,36 @@ class ListenParityCapture:
         self._observe_audio("outbound", audio)
 
     def observe_inbound_stt(self, segments: list[dict[str, Any]]) -> None:
-        if self._invocation is not None:
-            self._invocation.observe("inbound", {"type": "transcript", "segments": segments})
+        # Transcript processing annotates these dictionaries later; preserve the provider
+        # callback as it arrived instead of retaining a mutable reference.
+        if not self._can_observe():
+            return
+        self._observe("inbound", {"type": "transcript", "segments": deepcopy(segments)})
 
     def _observe_audio(self, direction: str, audio: bytes) -> None:
-        if self._invocation is not None:
-            self._invocation.observe(direction, {"type": "audio", "audio_b64": base64.b64encode(audio).decode("ascii")})
+        # Check the raw input before allocating its base64 representation.
+        if not self._can_observe(len(audio)):
+            return
+        self._observe(direction, {"type": "audio", "audio_b64": base64.b64encode(audio).decode("ascii")}, len(audio))
+
+    def _can_observe(self, audio_bytes: int = 0) -> bool:
+        if self._invocation is None or self._limit_reached:
+            return False
+        if self._event_count >= MAX_CAPTURE_EVENTS or self._audio_bytes + audio_bytes > MAX_CAPTURE_AUDIO_BYTES:
+            self._limit_reached = True
+            logger.warning("Parity pack capture limit reached; dropping subsequent events")
+            return False
+        return True
+
+    def _observe(self, direction: str, payload: Mapping[str, Any], audio_bytes: int = 0) -> None:
+        if not self._can_observe(audio_bytes):
+            return
+        try:
+            self._invocation.observe(direction, payload)
+            self._event_count += 1
+            self._audio_bytes += audio_bytes
+        except Exception as error:
+            logger.warning("Parity pack capture observe failed error_type=%s", type(error).__name__)
 
     def persist(self) -> None:
         if self._invocation is None:

--- a/backend/routers/listen/parity_capture.py
+++ b/backend/routers/listen/parity_capture.py
@@ -123,8 +123,11 @@ class ListenParityCapture:
     def _observe(self, direction: str, payload: Mapping[str, Any], audio_bytes: int = 0) -> None:
         if not self._can_observe(audio_bytes):
             return
+        invocation = self._invocation
+        if invocation is None:
+            return
         try:
-            self._invocation.observe(direction, payload)
+            invocation.observe(direction, payload)
             self._event_count += 1
             self._audio_bytes += audio_bytes
         except Exception as error:

--- a/backend/routers/listen/parity_capture.py
+++ b/backend/routers/listen/parity_capture.py
@@ -1,0 +1,100 @@
+"""Fail-closed dev-only parity-pack capture for the live listen STT seam."""
+
+from __future__ import annotations
+
+import base64
+from hashlib import sha256
+import logging
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from testing.parity_pack_v0.capture import CaptureInvocation, CaptureTap
+from testing.parity_pack_v0.schema import CassetteIdentity
+from testing.parity_pack_v0.whitelist import CaptureWhitelist
+
+logger = logging.getLogger(__name__)
+
+
+def _anonymous_id(*parts: str) -> str:
+    """Create an opaque stable-in-session identifier without retaining a UID."""
+    return sha256("\0".join(parts).encode("utf-8")).hexdigest()[:32]
+
+
+def _capture_root(environ: Mapping[str, str]) -> Path | None:
+    value = environ.get("OMI_PARITY_PACK_ROOT", "").strip()
+    if not value:
+        return None
+    root = Path(value).expanduser()
+    if not root.is_absolute():
+        return None
+    repository_root = Path(__file__).resolve().parents[3]
+    try:
+        root.resolve().relative_to(repository_root)
+    except ValueError:
+        return root
+    return None
+
+
+class ListenParityCapture:
+    """Small listener-side adapter around the pack's generic ``CaptureTap``.
+
+    The adapter has no effect unless the existing whitelist allows the Firebase
+    UID and a restricted absolute root has been supplied. Event bodies are only
+    serialized into that local root; logs contain no principal or payload data.
+    """
+
+    def __init__(self, invocation: CaptureInvocation | None) -> None:
+        self._invocation = invocation
+
+    @classmethod
+    def from_environ(
+        cls,
+        *,
+        principal_id: str,
+        session_id: str,
+        provider: str,
+        model: str,
+        request: Mapping[str, Any],
+        environ: Mapping[str, str] | None = None,
+    ) -> "ListenParityCapture":
+        env = os.environ if environ is None else environ
+        root = _capture_root(env)
+        if root is None:
+            return cls(None)
+        identity = CassetteIdentity(
+            anon_session=_anonymous_id(principal_id, session_id),
+            provider_lane="stt",
+            route_or_model=model or provider or "live",
+            call_ordinal=0,
+            retry_attempt=0,
+            parent_event_anon=_anonymous_id(session_id, "listen-stt"),
+        )
+        invocation = CaptureTap(root, CaptureWhitelist.from_environ(dict(env))).start(principal_id, identity, request)
+        return cls(invocation)
+
+    @property
+    def enabled(self) -> bool:
+        return self._invocation is not None
+
+    def observe_client_audio(self, audio: bytes) -> None:
+        self._observe_audio("client", audio)
+
+    def observe_outbound_stt(self, audio: bytes) -> None:
+        self._observe_audio("outbound", audio)
+
+    def observe_inbound_stt(self, segments: list[dict[str, Any]]) -> None:
+        if self._invocation is not None:
+            self._invocation.observe("inbound", {"type": "transcript", "segments": segments})
+
+    def _observe_audio(self, direction: str, audio: bytes) -> None:
+        if self._invocation is not None:
+            self._invocation.observe(direction, {"type": "audio", "audio_b64": base64.b64encode(audio).decode("ascii")})
+
+    def persist(self) -> None:
+        if self._invocation is None:
+            return
+        try:
+            self._invocation.persist()
+        except Exception as error:
+            logger.warning("Parity pack capture persist failed error_type=%s", type(error).__name__)

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -117,6 +117,16 @@ class ListenReceiver:
         self.image_chunks: OrderedDict[str, Dict[str, Any]] = OrderedDict()
         self.last_image_chunk_cleanup = 0.0
 
+    def _capture(self, method: str, *args: Any) -> None:
+        """Keep optional dev capture out of the production audio failure domain."""
+        capture = getattr(self.host, method, None)
+        if not callable(capture):
+            return
+        try:
+            capture(*args)
+        except Exception as error:
+            logger.warning('Listen parity capture failed method=%s type=%s', method, type(error).__name__)
+
     def initialize_decoders(self) -> None:
         request = self.host.request
         if self.host.is_multi_channel:
@@ -206,7 +216,7 @@ class ListenReceiver:
                 for index, config in enumerate(self.channel_configs):
 
                     def callback(segments: List[Dict[str, Any]], channel: ChannelConfig = config) -> None:
-                        self.host.capture_inbound_stt(segments)
+                        self._capture('capture_inbound_stt', segments)
                         for segment in segments:
                             segment['is_user'] = channel.is_user
                             segment['speaker'] = channel.speaker_label
@@ -238,7 +248,7 @@ class ListenReceiver:
                     logger.exception('VAD gate initialization failed; continuing without it')
 
             def capture_and_enqueue(segments: List[Dict[str, Any]]) -> None:
-                self.host.capture_inbound_stt(segments)
+                self._capture('capture_inbound_stt', segments)
                 self.host.transcripts.enqueue(segments)
 
             parakeet_callback = make_stream_callback(capture_and_enqueue, self.vad_gate, False)
@@ -374,7 +384,7 @@ class ListenReceiver:
             platform=self.host.client_device_context.platform,
         )
         if sent:
-            self.host.capture_outbound_stt(outbound_audio)
+            self._capture('capture_outbound_stt', outbound_audio)
             self.host.state.dg_usage_ms_pending += decision.dg_usage_ms
 
     async def _handle_multi_channel_audio(self, data: bytes) -> None:
@@ -398,6 +408,7 @@ class ListenReceiver:
             if not audio:
                 return
         pcm = resample_pcm(bytes(audio), request.sample_rate, TARGET_SAMPLE_RATE)
+        self._capture('capture_client_audio', pcm)
         # Custom-STT clients own transcript production.  Their channel sockets are intentionally
         # absent, but captured audio still proceeds to the pusher mix path.
         if not self.host.use_custom_stt:
@@ -417,7 +428,7 @@ class ListenReceiver:
                     platform=self.host.client_device_context.platform,
                 )
                 if sent:
-                    self.host.capture_outbound_stt(pcm)
+                    self._capture('capture_outbound_stt', pcm)
                     self.host.state.dg_usage_ms_pending += dg_usage_ms
         # Only accumulate channel audio for the pusher mix when an audio-bytes consumer is attached.
         # decide_multi_channel_mix and the teardown flush both gate on this same condition, so
@@ -544,7 +555,7 @@ class ListenReceiver:
                         continue
                     if not decoded:
                         continue
-                    self.host.capture_client_audio(decoded)
+                    self._capture('capture_client_audio', decoded)
                     if self.host.state.audio_ring_buffer is not None:
                         self.host.state.audio_ring_buffer.write(decoded, now)
                     if not self.host.use_custom_stt:

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -206,6 +206,7 @@ class ListenReceiver:
                 for index, config in enumerate(self.channel_configs):
 
                     def callback(segments: List[Dict[str, Any]], channel: ChannelConfig = config) -> None:
+                        self.host.capture_inbound_stt(segments)
                         for segment in segments:
                             segment['is_user'] = channel.is_user
                             segment['speaker'] = channel.speaker_label
@@ -235,8 +236,13 @@ class ListenReceiver:
                     )
                 except Exception:
                     logger.exception('VAD gate initialization failed; continuing without it')
-            parakeet_callback = make_stream_callback(self.host.transcripts.enqueue, self.vad_gate, False)
-            modulate_callback = make_stream_callback(self.host.transcripts.enqueue, self.vad_gate, True)
+
+            def capture_and_enqueue(segments: List[Dict[str, Any]]) -> None:
+                self.host.capture_inbound_stt(segments)
+                self.host.transcripts.enqueue(segments)
+
+            parakeet_callback = make_stream_callback(capture_and_enqueue, self.vad_gate, False)
+            modulate_callback = make_stream_callback(capture_and_enqueue, self.vad_gate, True)
             raw = await self._create_stt_socket(
                 parakeet_callback,
                 request.sample_rate,
@@ -358,6 +364,7 @@ class ListenReceiver:
         if self.host.state.fair_use_dg_budget_exhausted:
             buffer.clear()
             return
+        outbound_audio = bytes(buffer)
         sent = await flush_live_stt_buffer(
             request.websocket,
             self.host.state,
@@ -367,6 +374,7 @@ class ListenReceiver:
             platform=self.host.client_device_context.platform,
         )
         if sent:
+            self.host.capture_outbound_stt(outbound_audio)
             self.host.state.dg_usage_ms_pending += decision.dg_usage_ms
 
     async def _handle_multi_channel_audio(self, data: bytes) -> None:
@@ -409,6 +417,7 @@ class ListenReceiver:
                     platform=self.host.client_device_context.platform,
                 )
                 if sent:
+                    self.host.capture_outbound_stt(pcm)
                     self.host.state.dg_usage_ms_pending += dg_usage_ms
         # Only accumulate channel audio for the pusher mix when an audio-bytes consumer is attached.
         # decide_multi_channel_mix and the teardown flush both gate on this same condition, so
@@ -535,6 +544,7 @@ class ListenReceiver:
                         continue
                     if not decoded:
                         continue
+                    self.host.capture_client_audio(decoded)
                     if self.host.state.audio_ring_buffer is not None:
                         self.host.state.audio_ring_buffer.write(decoded, now)
                     if not self.host.use_custom_stt:

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -195,13 +195,22 @@ class ListenSessionRuntime:
             )
 
     def capture_client_audio(self, audio: bytes) -> None:
-        self.parity_capture.observe_client_audio(audio)
+        try:
+            self.parity_capture.observe_client_audio(audio)
+        except Exception as error:
+            logger.warning('Listen parity capture client event failed type=%s', type(error).__name__)
 
     def capture_outbound_stt(self, audio: bytes) -> None:
-        self.parity_capture.observe_outbound_stt(audio)
+        try:
+            self.parity_capture.observe_outbound_stt(audio)
+        except Exception as error:
+            logger.warning('Listen parity capture outbound event failed type=%s', type(error).__name__)
 
     def capture_inbound_stt(self, segments: List[Dict[str, Any]]) -> None:
-        self.parity_capture.observe_inbound_stt(segments)
+        try:
+            self.parity_capture.observe_inbound_stt(segments)
+        except Exception as error:
+            logger.warning('Listen parity capture inbound event failed type=%s', type(error).__name__)
 
     def complete_live_transcription(self) -> None:
         """Record the first nonempty transcript successfully delivered to the client."""
@@ -671,7 +680,10 @@ class ListenSessionRuntime:
         if self.onboarding_handler:
             self.onboarding_handler.cleanup()
         await self.task_supervisor.drain_all(timeout=5.0, cancel=True)
-        self.parity_capture.persist()
+        try:
+            self.parity_capture.persist()
+        except Exception as error:
+            logger.warning('Listen parity capture teardown failed type=%s', type(error).__name__)
         self.receiver.clear()
         self.transcripts.clear()
         self.speakers.clear()

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -68,6 +68,7 @@ from utils.transcribe_decisions import USER_SELF_PERSON_ID, person_id_for_client
 from .contracts import ListenLimits, ListenRequest, ListenSessionState
 from .conversations import LiveConversationController
 from .persistence import ListenPersistence
+from .parity_capture import ListenParityCapture
 from .receiver import ListenReceiver
 from .speakers import SpeakerMatcher
 from .transcripts import TranscriptProcessor
@@ -133,6 +134,7 @@ class ListenSessionRuntime:
         self.speakers: Any = None
         self.transcripts: Any = None
         self.conversations: Any = None
+        self.parity_capture = ListenParityCapture(None)
 
     def _build_components(self) -> None:
         channels = build_channel_config(self.request.source or 'phone_call') if self.is_multi_channel else []
@@ -192,6 +194,15 @@ class ListenSessionRuntime:
                 platform=self.client_device_context.platform,
             )
 
+    def capture_client_audio(self, audio: bytes) -> None:
+        self.parity_capture.observe_client_audio(audio)
+
+    def capture_outbound_stt(self, audio: bytes) -> None:
+        self.parity_capture.observe_outbound_stt(audio)
+
+    def capture_inbound_stt(self, segments: List[Dict[str, Any]]) -> None:
+        self.parity_capture.observe_inbound_stt(segments)
+
     def complete_live_transcription(self) -> None:
         """Record the first nonempty transcript successfully delivered to the client."""
         if self.state.live_transcription_attempt is not None:
@@ -243,6 +254,20 @@ class ListenSessionRuntime:
             self.language,
             multi_lang_enabled=not single_language_mode,
             preferred_service=request.stt_service,
+        )
+        self.parity_capture = ListenParityCapture.from_environ(
+            principal_id=request.uid,
+            session_id=getattr(self, 'session_id', ''),
+            provider=getattr(self.stt_service, 'value', self.stt_service),
+            model=self.stt_model or '',
+            request={
+                'codec': request.codec,
+                'sample_rate': request.sample_rate,
+                'channels': request.channels,
+                'language': self.stt_language,
+                'provider': getattr(self.stt_service, 'value', self.stt_service),
+                'model': self.stt_model,
+            },
         )
         if not self.stt_service or not self.stt_language:
             await request.websocket.close(code=1008, reason=f'The language is not supported, {self.language}')
@@ -646,6 +671,7 @@ class ListenSessionRuntime:
         if self.onboarding_handler:
             self.onboarding_handler.cleanup()
         await self.task_supervisor.drain_all(timeout=5.0, cancel=True)
+        self.parity_capture.persist()
         self.receiver.clear()
         self.transcripts.clear()
         self.speakers.clear()

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -26,6 +26,28 @@ manifests, reports, or Git.
 wire observations using relative milliseconds. A whitelist miss writes no
 cassette bytes and retains only bounded lane/reason metadata.
 
+## Live listen wiring
+
+The `/v4/listen` runtime creates `routers.listen.parity_capture.ListenParityCapture`
+only after Firebase WebSocket authentication and STT provider selection. It uses
+the Firebase UID solely for the exact `CaptureWhitelist` comparison, derives
+anonymous session/event identifiers before cassette creation, and records decoded
+client audio, the successful STT socket send, and provider transcript callbacks.
+The capture persists during normal listen-session teardown.
+
+Set a fourth, required operator-only variable to an absolute path outside the
+repository:
+
+```bash
+OMI_PARITY_PACK_ROOT=/absolute/restricted/local/parity-pack
+```
+
+There is no default root. A missing, relative, or repository-contained root is
+disabled; `OMI_ENV_STAGE` other than `dev`, a missing `OMI_PARITY_PACK_CAPTURE=1`,
+or an allowlist miss is also disabled. No Helm or production default enables this
+path. The local cassette may include restricted audio/transcript event payloads,
+so keep its root outside Git and never attach it to a PR.
+
 ## Replay players
 
 `STTCassettePlayer` and `LLMCassettePlayer` are callback-oriented loopback

--- a/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
+++ b/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
@@ -64,3 +64,14 @@ def test_multichannel_mix_still_drains_with_audio_bytes_consumer():
     asyncio.run(_feed(recv, [(0, pcm), (1, pcm)]))
     assert sent, "expected a mixed frame delivered to the audio-bytes consumer"
     assert sum(len(b) for b in recv.channel_mix_buffers) == 0
+
+
+def test_multichannel_client_pcm_reaches_optional_parity_capture():
+    captured = []
+    recv = _make_receiver(audio_bytes_send=None)
+    recv.host.capture_client_audio = captured.append
+    pcm = b'\x01\x02' * 160
+
+    asyncio.run(_feed(recv, [(0, pcm)]))
+
+    assert captured == [pcm]

--- a/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
+++ b/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
@@ -15,7 +15,7 @@ flows to the mix path).
 """
 
 import asyncio
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import routers.listen.receiver as receiver
 
@@ -23,7 +23,7 @@ TARGET_SAMPLE_RATE = receiver.TARGET_SAMPLE_RATE
 
 
 def _make_receiver(audio_bytes_send):
-    return SimpleNamespace(
+    recv = SimpleNamespace(
         host=SimpleNamespace(
             request=SimpleNamespace(codec='pcm', sample_rate=TARGET_SAMPLE_RATE, websocket=None),
             use_custom_stt=True,
@@ -35,6 +35,9 @@ def _make_receiver(audio_bytes_send):
         stt_sockets_multi=[None, None],
         channel_mix_buffers=[bytearray(), bytearray()],
     )
+    # Bind the real _capture so the mock exercises actual capture delegation.
+    recv._capture = MethodType(receiver.ListenReceiver._capture, recv)
+    return recv
 
 
 def _frame(channel_id, payload):

--- a/backend/tests/unit/test_listen_parity_capture.py
+++ b/backend/tests/unit/test_listen_parity_capture.py
@@ -1,0 +1,93 @@
+"""Focused coverage for the dev-only live listen parity-pack seam."""
+
+import json
+
+from routers.listen.parity_capture import ListenParityCapture
+
+
+def _capture_env(root):
+    return {
+        'OMI_ENV_STAGE': 'dev',
+        'OMI_PARITY_PACK_CAPTURE': '1',
+        'OMI_PARITY_PACK_ALLOWED_PRINCIPALS': 'allowed-firebase-uid',
+        'OMI_PARITY_PACK_ROOT': str(root),
+    }
+
+
+def _request():
+    return {
+        'codec': 'pcm8',
+        'sample_rate': 8000,
+        'channels': 1,
+        'language': 'en',
+        'provider': 'parakeet',
+        'model': 'parakeet_streaming',
+    }
+
+
+def test_listen_capture_persists_client_provider_and_inbound_events_for_allowed_uid(tmp_path):
+    capture = ListenParityCapture.from_environ(
+        principal_id='allowed-firebase-uid',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=_capture_env(tmp_path),
+    )
+
+    capture.observe_client_audio(b'client-audio')
+    capture.observe_outbound_stt(b'provider-request')
+    capture.observe_inbound_stt([{'text': 'synthetic transcript'}])
+    capture.persist()
+
+    cassette_files = list((tmp_path / 'cassettes').glob('*.json'))
+    assert len(cassette_files) == 1
+    cassette = json.loads(cassette_files[0].read_text())
+    assert [event['direction'] for event in cassette['events']] == ['client', 'outbound', 'inbound']
+    assert cassette['identity']['anon_session'] != 'allowed-firebase-uid'
+    assert 'allowed-firebase-uid' not in cassette_files[0].read_text()
+    assert cassette['request_fingerprint']['algorithm'] == 'sha256-canonical-redacted-v1'
+
+
+def test_listen_capture_whitelist_miss_writes_no_cassette_bytes(tmp_path):
+    capture = ListenParityCapture.from_environ(
+        principal_id='not-allowlisted',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=_capture_env(tmp_path),
+    )
+
+    assert not capture.enabled
+    capture.observe_client_audio(b'must-not-persist')
+    capture.observe_outbound_stt(b'must-not-persist')
+    capture.observe_inbound_stt([{'text': 'must-not-persist'}])
+    capture.persist()
+    assert not (tmp_path / 'cassettes').exists()
+
+
+def test_listen_capture_requires_a_restricted_absolute_root(tmp_path):
+    relative_env = _capture_env(tmp_path)
+    relative_env['OMI_PARITY_PACK_ROOT'] = 'parity-pack'
+    relative = ListenParityCapture.from_environ(
+        principal_id='allowed-firebase-uid',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=relative_env,
+    )
+    assert not relative.enabled
+
+    not_dev_env = _capture_env(tmp_path)
+    not_dev_env['OMI_ENV_STAGE'] = 'prod'
+    not_dev = ListenParityCapture.from_environ(
+        principal_id='allowed-firebase-uid',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=not_dev_env,
+    )
+    assert not not_dev.enabled

--- a/backend/tests/unit/test_listen_parity_capture.py
+++ b/backend/tests/unit/test_listen_parity_capture.py
@@ -91,3 +91,25 @@ def test_listen_capture_requires_a_restricted_absolute_root(tmp_path):
         environ=not_dev_env,
     )
     assert not not_dev.enabled
+
+
+def test_listen_capture_bounds_audio_and_snapshots_transcript_segments(tmp_path):
+    capture = ListenParityCapture.from_environ(
+        principal_id='allowed-firebase-uid',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=_capture_env(tmp_path),
+    )
+    segments = [{'text': 'provider callback', 'speaker': 'unknown'}]
+    capture.observe_inbound_stt(segments)
+    segments[0]['speaker'] = 'backend-enriched'
+    capture.observe_client_audio(b'x' * (8 * 1024 * 1024 + 1))
+    capture.observe_outbound_stt(b'must-be-dropped-after-limit')
+    capture.persist()
+
+    cassette = json.loads(next((tmp_path / 'cassettes').glob('*.json')).read_text())
+    assert len(cassette['events']) == 1
+    assert cassette['events'][0]['direction'] == 'inbound'
+    assert cassette['events'][0]['payload']['segments'][0]['speaker'] == 'unknown'

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -139,6 +139,23 @@ user IDs, model revisions, or other high-cardinality request data. Custom-STT
 sessions are excluded because the backend does not own their provider socket or
 provider attempt lifecycle.
 
+### Dev-only parity-pack capture
+
+For local conformance debugging only, the listen runtime may write a restricted
+local cassette. It starts after listen has selected its STT service and accepts
+only an exact Firebase UID from `OMI_PARITY_PACK_ALLOWED_PRINCIPALS`. Capture is
+off unless all of `OMI_ENV_STAGE=dev`, `OMI_PARITY_PACK_CAPTURE=1`, and an
+absolute, outside-repository `OMI_PARITY_PACK_ROOT` are present. No Helm or
+production setting enables it.
+
+When enabled, the receiver records decoded client PCM (including each
+multi-channel PCM stream), successfully forwarded STT audio, and provider
+transcript callbacks. The runtime persists the anonymous cassette during
+teardown. Events and raw audio retained in memory are bounded (1,000 events or
+8 MiB of audio); once either limit is reached, remaining capture events are
+dropped. Capture initialization, observation, and persistence errors are
+isolated from the listen path.
+
 ### Terminal STT provider failure
 
 Provider initialization failure, a latched dead provider socket, or an audio


### PR DESCRIPTION
## Summary

Wires Parity Pack v0 capture into the accepted `/v4/listen` live-STT session.
The adapter starts only after Firebase WebSocket authentication and provider
selection, captures decoded client audio, successful STT sends, and transcript
callbacks, and persists on normal session teardown.

## Safety gate and non-goals

Capture remains fail-closed. It requires `OMI_ENV_STAGE=dev`,
`OMI_PARITY_PACK_CAPTURE=1`, an exact `OMI_PARITY_PACK_ALLOWED_PRINCIPALS`
match against the Firebase UID, and an absolute `OMI_PARITY_PACK_ROOT` outside
the repository. Identities are anonymous hashes and requests have only redacted
fingerprints. This change does not add Helm defaults, production enablement,
real-data collection, or committed cassettes.

## Verification

- `.venv/bin/pytest tests/unit/test_listen_runtime_regressions.py tests/unit/test_listen_parity_capture.py tests/unit/test_parity_pack_v0.py -q` — 29 passed
- `npm run test:parity-pack-v0` — 16 passed

Failure-Class: none

Closes SCA-224


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

