### PR TITLE
fix(release): do not clobber existing desktop changelog versions

### DIFF
--- a/.github/scripts/desktop-changelog.py
+++ b/.github/scripts/desktop-changelog.py
@@ -154,6 +154,29 @@ def format_changes(changes: list[str], output_format: str) -> str:
 
 
 def consolidate(version: str, release_date: str, *, write: bool) -> dict[str, object]:
+    """Fold unreleased fragments into releases/<version>.json.
+
+    If that version file already exists and there are no unreleased fragments,
+    leave it untouched. Retries after a partial tag-release must not clobber a
+    previously consolidated 0.12.N entry with the generic fallback string.
+    """
+
+    release_path = RELEASES_DIR / f"{version}.json"
+    fragments = unreleased_fragment_paths()
+    if release_path.is_file() and not fragments:
+        existing = read_json(release_path)
+        if not isinstance(existing, dict):
+            raise ChangelogError(f"{release_path} must contain a JSON object")
+        normalized = {
+            "version": str(existing.get("version", version)).strip() or version,
+            "date": str(existing.get("date", release_date)).strip() or release_date,
+            "changes": normalize_changes(existing.get("changes", []), release_path),
+        }
+        if write:
+            # Keep legacy CHANGELOG.json aligned without rewriting the release file.
+            write_json(LEGACY_CHANGELOG_PATH, legacy_changelog())
+        return normalized
+
     changes = unreleased_changes() or ["Bug fixes and improvements"]
     release = {
         "version": version,
@@ -162,8 +185,8 @@ def consolidate(version: str, release_date: str, *, write: bool) -> dict[str, ob
     }
 
     if write:
-        write_json(RELEASES_DIR / f"{version}.json", release)
-        for path in unreleased_fragment_paths():
+        write_json(release_path, release)
+        for path in fragments:
             path.unlink()
         write_json(LEGACY_CHANGELOG_PATH, legacy_changelog())
 

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -890,7 +890,7 @@ if [[ "$AUTOMATIC" -eq 1 ]]; then
 fi
 
 # After signed-artifact + static + Tier-2 + fault gates pass, runner-hygiene
-# cleanup is best-effort. (tip-bump after libopus gitlink removal so M1 checkout cannot hang) A green behavioral run must not be fenced solely by
+# cleanup is best-effort. (tip-bump with changelog consolidate noclobber so retries do not rewrite v0.12.143) A green behavioral run must not be fenced solely by
 # lease-lineage cleanup failures (incident #10779 / v0.12.142). Still attempt
 # cleanup and record phase status; residual leases are reclaimed on next acquire.
 phase_begin "final-cleanup" "runner-hygiene-cleanup"


### PR DESCRIPTION
## Summary
Tag-release retries never reached Codemagic: `desktop-changelog.py consolidate --write` re-ran for already-published **0.12.143** notes and clobbered them to "Bug fixes and improvements", leaving a dirty tree / failed changelog branch step.

**Fix:** if `releases/<version>.json` exists and unreleased fragments are empty, do not rewrite it. Desktop tip-bump so planner `source_sha` includes the helper.

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

