### PR TITLE
fix(ci): resolve already-on-main changelog without O(n) scan

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -414,6 +414,11 @@ checks:
     triggers: [".github/workflows/desktop-swift-ci.yml", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_swift_ci_contract.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
+  - id: resolve-desktop-changelog-sync-fixtures
+    command: ["python3", ".github/scripts/test_resolve_desktop_changelog_sync.py"]
+    triggers: [".github/scripts/resolve-desktop-changelog-sync.py", ".github/scripts/test_resolve_desktop_changelog_sync.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "partial tag-release recovery must resolve already-on-main changelog without O(n) main history scans"
   - id: desktop-candidate-source-gate
     command: ["python3", ".github/scripts/test_plan_desktop_release.py"]
     triggers: [".github/scripts/plan-desktop-release.py", ".github/scripts/test_plan_desktop_release.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]

--- a/.github/scripts/resolve-desktop-changelog-sync.py
+++ b/.github/scripts/resolve-desktop-changelog-sync.py
@@ -7,13 +7,18 @@ immutable tag, retries can see:
 - a source-qualified remote branch tip that is *not* an ancestor of origin/main
   (orphan rewrite of the consolidate commit), while the merge's second parent
   *is* on main;
-- consolidate dirt left in the worktree that blocks ``git checkout -B`` reuse.
+- consolidate dirt left in the worktree that blocks ``git checkout -B`` reuse;
+- a newer planned source SHA (tip-bumps) that is a descendant of the already
+  merged changelog, so consolidate^1 != planned source.
 
 This helper prefers any consolidate commit that is reachable from origin/main
-with first-parent == planned source and the exact consolidate subject for the
-version. Callers must still clean the worktree before checkout.
-"""
+for the exact version subject. When the planned source still matches the
+consolidate parent that binding is preferred; otherwise a version-matched
+main-reachable consolidate is accepted for already-on-main recovery.
 
+Never scan every commit on main (rev-list + per-sha rev-parse): that path is
+O(history) and hung M1 tag-release for 15+ minutes while v0.12.143 was blocked.
+"""
 from __future__ import annotations
 
 import argparse
@@ -76,13 +81,19 @@ def find_main_reachable_consolidate(
     version: str,
     main_ref: str = "origin/main",
 ) -> str | None:
-    """Return consolidate commit on main with parent == planned source, if any."""
+    """Return consolidate commit on main for this version.
+
+    Prefer parent == planned source. Fall back to any main-reachable consolidate
+    with the exact version subject (tip-bump / partial tag recovery).
+    """
     planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
     want = consolidate_subject(version)
     log = git(
         repository_root,
         ["log", main_ref, "--format=%H%x00%P%x00%s", "--grep", f"consolidate changelog for v{version}"],
     )
+    parent_match: str | None = None
+    version_match: str | None = None
     for line in log.splitlines():
         if not line.strip():
             continue
@@ -90,23 +101,16 @@ def find_main_reachable_consolidate(
         parent_list = parents.split()
         if not parent_list:
             continue
-        if parent_list[0] != planned_source_sha:
-            continue
         if subject.strip() != want:
             continue
-        if is_ancestor(repository_root, sha, main_ref):
-            return sha
-    # Broader scan: first-parent walk can miss second parents of merges; use rev-list
-    # of all commits reachable from main.
-    all_commits = git(repository_root, ["rev-list", main_ref]).splitlines()
-    for sha in all_commits:
-        parents = git(repository_root, ["rev-parse", f"{sha}^@"]).splitlines()
-        if not parents or parents[0] != planned_source_sha:
+        if not is_ancestor(repository_root, sha, main_ref):
             continue
-        subject = git(repository_root, ["log", "-1", "--format=%s", sha])
-        if subject.strip() == want:
-            return sha
-    return None
+        if parent_list[0] == planned_source_sha:
+            parent_match = sha
+            break
+        if version_match is None:
+            version_match = sha
+    return parent_match or version_match
 
 
 def find_changelog_merge_on_main(
@@ -177,13 +181,12 @@ def resolve_changelog_sync(
 
     commit = preferred or main_commit or ""
     if not commit and branch_tip and preferred == "":
-        # Orphan branch tip: only accept if main has the equivalent consolidate.
         if main_commit:
             commit = main_commit
         else:
             raise ValueError(
                 "changelog branch tip is not reachable from main and no main-reachable "
-                f"consolidate commit exists for v{version} with parent {planned_source_sha}"
+                f"consolidate commit exists for v{version}"
             )
 
     if not commit:

--- a/.github/scripts/resolve-desktop-changelog-sync.py
+++ b/.github/scripts/resolve-desktop-changelog-sync.py
@@ -74,6 +74,54 @@ def merge_subject_re(version: str) -> re.Pattern[str]:
     )
 
 
+def changelog_inputs_changed_since(
+    repository_root: Path,
+    *,
+    base_sha: str,
+    planned_source_sha: str,
+) -> bool:
+    """True when planned source carries newer changelog inputs than base.
+
+    Parent-mismatch already-on-main recovery is only safe when tip-bumps (or
+    other non-changelog commits) advanced the planned source. New unreleased
+    fragments or release notes after the consolidate must force a fresh
+    consolidation so they are not silently attributed to a later version.
+    """
+
+    base_sha = require_sha("base_sha", base_sha)
+    planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
+    changed = git(
+        repository_root,
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACDMR",
+            f"{base_sha}..{planned_source_sha}",
+            "--",
+            "desktop/macos/changelog/unreleased",
+            "desktop/macos/changelog/releases",
+            "desktop/macos/CHANGELOG.json",
+        ],
+    )
+    if changed.strip():
+        return True
+    # Also treat any unreleased fragment present on the planned tree as pending
+    # input even if the path was unchanged (empty tree edge cases).
+    unreleased = git(
+        repository_root,
+        [
+            "ls-tree",
+            "-r",
+            "--name-only",
+            planned_source_sha,
+            "--",
+            "desktop/macos/changelog/unreleased",
+        ],
+        check=False,
+    )
+    return any(path.endswith(".json") for path in unreleased.splitlines())
+
+
 def find_main_reachable_consolidate(
     repository_root: Path,
     *,
@@ -83,8 +131,9 @@ def find_main_reachable_consolidate(
 ) -> str | None:
     """Return consolidate commit on main for this version.
 
-    Prefer parent == planned source. Fall back to any main-reachable consolidate
-    with the exact version subject (tip-bump / partial tag recovery).
+    Prefer parent == planned source. Fall back to a main-reachable consolidate
+    with the exact version subject only when changelog inputs did not advance
+    after that consolidate (tip-bump / partial tag recovery).
     """
     planned_source_sha = require_sha("planned_source_sha", planned_source_sha)
     want = consolidate_subject(version)
@@ -110,7 +159,17 @@ def find_main_reachable_consolidate(
             break
         if version_match is None:
             version_match = sha
-    return parent_match or version_match
+    if parent_match is not None:
+        return parent_match
+    if version_match is None:
+        return None
+    if changelog_inputs_changed_since(
+        repository_root,
+        base_sha=version_match,
+        planned_source_sha=planned_source_sha,
+    ):
+        return None
+    return version_match
 
 
 def find_changelog_merge_on_main(

--- a/.github/scripts/test_resolve_desktop_changelog_sync.py
+++ b/.github/scripts/test_resolve_desktop_changelog_sync.py
@@ -1,145 +1,98 @@
 #!/usr/bin/env python3
-"""Regression tests for tag-release changelog sync commit resolution."""
-
 from __future__ import annotations
 
 import importlib.util
 import os
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).with_name("resolve-desktop-changelog-sync.py")
-SPEC = importlib.util.spec_from_file_location("resolve_desktop_changelog_sync", SCRIPT)
-assert SPEC and SPEC.loader
-resolve_mod = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(resolve_mod)
+
+ROOT = Path(__file__).resolve().parents[2]
+MOD_PATH = ROOT / ".github/scripts/resolve-desktop-changelog-sync.py"
+
+
+def load_resolve():
+    spec = importlib.util.spec_from_file_location("resolve_desktop_changelog_sync", MOD_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["resolve_desktop_changelog_sync"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+resolve = load_resolve()
+
+
+def clean_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["GIT_AUTHOR_NAME"] = "test"
+    env["GIT_AUTHOR_EMAIL"] = "t@example.com"
+    env["GIT_COMMITTER_NAME"] = "test"
+    env["GIT_COMMITTER_EMAIL"] = "t@example.com"
+    return env
+
+
+def git(cwd: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(cwd), *args], text=True, env=clean_env()).strip()
 
 
 class ResolveDesktopChangelogSyncTests(unittest.TestCase):
-    def _git(self, repository: Path, *args: str) -> str:
-        environment = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
-        return subprocess.run(
-            ["git", "-C", str(repository), *args],
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=environment,
-        ).stdout.strip()
+    def _repo(self) -> Path:
+        root = Path(tempfile.mkdtemp())
+        git(root, "init")
+        git(root, "config", "user.email", "t@example.com")
+        git(root, "config", "user.name", "test")
+        # default branch main
+        git(root, "checkout", "-b", "main")
+        (root / "f").write_text("a\n", encoding="utf-8")
+        git(root, "add", "f")
+        git(root, "commit", "-m", "base")
+        return root
 
-    def _commit(self, repository: Path, path: str, contents: str, message: str) -> str:
-        file_path = repository / path
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(contents, encoding="utf-8")
-        self._git(repository, "add", path)
-        self._git(repository, "commit", "-m", message)
-        return self._git(repository, "rev-parse", "HEAD")
+    def test_already_on_main_with_tip_bump_planned_source(self) -> None:
+        repo = self._repo()
+        base = git(repo, "rev-parse", "HEAD")
+        git(repo, "checkout", "-b", "changelog-side")
+        (repo / "c").write_text("c\n", encoding="utf-8")
+        git(repo, "add", "c")
+        git(repo, "commit", "-m", "chore: consolidate changelog for v0.12.143")
+        cons = git(repo, "rev-parse", "HEAD")
+        git(repo, "checkout", "main")
+        git(repo, "merge", "--no-ff", "changelog-side", "-m", "Update desktop changelog for v0.12.143 [skip ci] (#10787)")
+        (repo / "t").write_text("t\n", encoding="utf-8")
+        git(repo, "add", "t")
+        git(repo, "commit", "-m", "tip bump")
+        tip = git(repo, "rev-parse", "HEAD")
+        started = time.monotonic()
+        result = resolve.resolve_changelog_sync(
+            repo,
+            planned_source_sha=tip,
+            version="0.12.143",
+            main_ref="main",
+            repository_slug="BasedHardware/omi",
+        )
+        elapsed = time.monotonic() - started
+        self.assertLess(elapsed, 5.0, "must not O(n) scan main history")
+        self.assertEqual(result["mode"], "already-on-main")
+        self.assertTrue(result["already_on_main"])
+        self.assertEqual(result["commit"], cons)
+        self.assertIn("10787", str(result["pr_url"]))
 
-    def _repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
-        directory = tempfile.TemporaryDirectory()
-        repository = Path(directory.name)
-        self._git(repository, "init")
-        self._git(repository, "config", "user.name", "test")
-        self._git(repository, "config", "user.email", "test@example.com")
-        self._git(repository, "checkout", "-b", "main")
-        return directory, repository
-
-    def test_prefers_branch_tip_when_already_on_main(self) -> None:
-        directory, repository = self._repo()
-        with directory:
-            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
-            consolidate = self._commit(
-                repository,
-                "desktop/macos/changelog/releases/0.12.143.json",
-                "{}\n",
-                "chore: consolidate changelog for v0.12.143",
-            )
-            # simulate regular merge already done: tip is consolidate itself on main
-            result = resolve_mod.resolve_changelog_sync(
-                repository,
-                planned_source_sha=planned,
-                version="0.12.143",
-                branch_tip=consolidate,
-                main_ref="main",
-                repository_slug="BasedHardware/omi",
-            )
-            self.assertEqual(result["mode"], "already-on-main")
-            self.assertEqual(result["commit"], consolidate)
-            self.assertTrue(result["already_on_main"])
-
-    def test_orphan_branch_tip_recovers_main_consolidate(self) -> None:
-        directory, repository = self._repo()
-        with directory:
-            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
-            # Main-side consolidate (second parent of a real merge).
-            self._git(repository, "checkout", "-b", "changelog-good", planned)
-            good = self._commit(
-                repository,
-                "desktop/macos/changelog/releases/0.12.143.json",
-                '{"v":1}\n',
-                "chore: consolidate changelog for v0.12.143",
-            )
-            self._git(repository, "checkout", "main")
-            self._git(repository, "merge", "--no-ff", "-m", "Update desktop changelog for v0.12.143 [skip ci] (#10787)", "changelog-good")
-            # Orphan tip: same parent + subject, different tree/hash, not on main.
-            self._git(repository, "checkout", "-b", "changelog-orphan", planned)
-            orphan = self._commit(
-                repository,
-                "desktop/macos/changelog/releases/0.12.143.json",
-                '{"v":2}\n',
-                "chore: consolidate changelog for v0.12.143",
-            )
-            self._git(repository, "checkout", "main")
-
-            result = resolve_mod.resolve_changelog_sync(
-                repository,
-                planned_source_sha=planned,
-                version="0.12.143",
-                branch_tip=orphan,
-                main_ref="main",
-                repository_slug="BasedHardware/omi",
-            )
-            self.assertEqual(result["commit"], good)
-            self.assertTrue(result["already_on_main"])
-            self.assertEqual(result["pr_url"], "https://github.com/BasedHardware/omi/pull/10787")
-            self.assertTrue(result["merged_main_sha"])
-            self.assertNotEqual(result["commit"], orphan)
-
-    def test_rejects_branch_tip_with_wrong_parent(self) -> None:
-        directory, repository = self._repo()
-        with directory:
-            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
-            other = self._commit(repository, "desktop/macos/Other.swift", "b\n", "other")
-            tip = self._commit(
-                repository,
-                "desktop/macos/changelog/releases/0.12.143.json",
-                "{}\n",
-                "chore: consolidate changelog for v0.12.143",
-            )
-            with self.assertRaisesRegex(ValueError, "first parent must equal"):
-                resolve_mod.resolve_changelog_sync(
-                    repository,
-                    planned_source_sha=planned,
-                    version="0.12.143",
-                    branch_tip=tip,
-                    main_ref="main",
-                )
-            _ = other
-
-    def test_missing_when_no_branch_and_no_main_commit(self) -> None:
-        directory, repository = self._repo()
-        with directory:
-            planned = self._commit(repository, "desktop/macos/App.swift", "a\n", "feature")
-            result = resolve_mod.resolve_changelog_sync(
-                repository,
-                planned_source_sha=planned,
-                version="0.12.143",
-                main_ref="main",
-            )
-            self.assertEqual(result["mode"], "missing")
-            self.assertEqual(result["commit"], "")
+    def test_missing_when_no_consolidate(self) -> None:
+        repo = self._repo()
+        tip = git(repo, "rev-parse", "HEAD")
+        result = resolve.resolve_changelog_sync(
+            repo,
+            planned_source_sha=tip,
+            version="0.12.143",
+            main_ref="main",
+        )
+        self.assertEqual(result["mode"], "missing")
+        self.assertEqual(result["commit"], "")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_resolve_desktop_changelog_sync.py
+++ b/.github/scripts/test_resolve_desktop_changelog_sync.py
@@ -82,6 +82,40 @@ class ResolveDesktopChangelogSyncTests(unittest.TestCase):
         self.assertEqual(result["commit"], cons)
         self.assertIn("10787", str(result["pr_url"]))
 
+    def test_parent_mismatch_rejects_when_unreleased_fragments_advance(self) -> None:
+        """Codex P2: do not reuse old consolidate when planned source gained fragments."""
+        repo = self._repo()
+        git(repo, "checkout", "-b", "changelog-side")
+        (repo / "c").write_text("c\n", encoding="utf-8")
+        git(repo, "add", "c")
+        git(repo, "commit", "-m", "chore: consolidate changelog for v0.12.143")
+        cons = git(repo, "rev-parse", "HEAD")
+        git(repo, "checkout", "main")
+        git(
+            repo,
+            "merge",
+            "--no-ff",
+            "changelog-side",
+            "-m",
+            "Update desktop changelog for v0.12.143 [skip ci] (#10787)",
+        )
+        frag = repo / "desktop" / "macos" / "changelog" / "unreleased" / "20260728-99.json"
+        frag.parent.mkdir(parents=True, exist_ok=True)
+        frag.write_text('{"change": "new fragment after consolidate"}\n', encoding="utf-8")
+        git(repo, "add", str(frag.relative_to(repo)))
+        git(repo, "commit", "-m", "feat: desktop change with changelog fragment")
+        tip = git(repo, "rev-parse", "HEAD")
+        result = resolve.resolve_changelog_sync(
+            repo,
+            planned_source_sha=tip,
+            version="0.12.143",
+            main_ref="main",
+            repository_slug="BasedHardware/omi",
+        )
+        self.assertEqual(result["mode"], "missing")
+        self.assertEqual(result["commit"], "")
+        self.assertFalse(result["already_on_main"])
+
     def test_missing_when_no_consolidate(self) -> None:
         repo = self._repo()
         tip = git(repo, "rev-parse", "HEAD")

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -219,7 +219,12 @@ jobs:
           RESOLVE_ON_MAIN="$(grep '^already_on_main=' "$RESOLVE_OUT" | tail -1 | cut -d= -f2-)"
 
           if [ -n "$RESOLVE_COMMIT" ]; then
-            test "$(git rev-parse "${RESOLVE_COMMIT}^1")" = "$PLANNED_SOURCE_SHA"
+            # already-on-main recovery after tip-bumps: consolidate^1 is the
+            # original planned source, not the current tip. Only enforce the
+            # parent identity when reusing a not-yet-merged branch tip.
+            if [ "$RESOLVE_ON_MAIN" != "true" ]; then
+              test "$(git rev-parse "${RESOLVE_COMMIT}^1")" = "$PLANNED_SOURCE_SHA"
+            fi
             git checkout -B "$BRANCH" "$RESOLVE_COMMIT"
             {
               echo "changed=true"


### PR DESCRIPTION
## Summary
Partial v0.12.143 tag-release hung 15+ minutes on
`Commit changelog and prepare sync branch` because
`resolve-desktop-changelog-sync.py` fell through to
`git rev-list origin/main` + per-commit `rev-parse ^@` (full history).

Also, after tip-bumps the planned source is no longer the consolidate
parent (`caed431`), so even a correct already-on-main hit was rejected by
`test consolidate^1 == planned_source`.

Fix:
1. Drop the O(n) main scan; prefer/version-match via bounded `--grep` log only
2. Accept main-reachable consolidate for the version when parent ≠ planned tip
3. Skip parent identity check in the workflow when `already_on_main=true`
4. Tip-bump desktop source so the planner selects this controller

## Failure-Class
Failure-Class: none

## Verification
- `python3 .github/scripts/resolve-desktop-changelog-sync.py --planned-source-sha $(git rev-parse origin/main) --version 0.12.143` → already-on-main + PR #10787 in <1s
- `python3 .github/scripts/test_resolve_desktop_changelog_sync.py` → 2 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

