### PR TITLE
fix(web): return 404 instead of 500 for unknown marketplace app ids

### DIFF
--- a/web/frontend/src/__tests__/app-detail-not-found.test.mjs
+++ b/web/frontend/src/__tests__/app-detail-not-found.test.mjs
@@ -1,0 +1,27 @@
+/**
+ * STATIC CHECKER (not behavioral coverage) for the public app detail page.
+ * Run: npm test  (from web/frontend)
+ *
+ * The page is a Next.js server component, so it cannot be imported by node:test.
+ * This asserts the source-level contract that produced the regression: an unknown
+ * app id must signal a 404 via notFound(), never throw a bare Error (which Next
+ * renders as HTTP 500). Behavioral proof lives in the PR: a running server
+ * returned 500 before the fix and 404 after, for the same missing app id.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const PAGE = new URL('../app/apps/[id]/page.tsx', import.meta.url);
+const source = readFileSync(PAGE, 'utf8');
+
+describe('apps/[id] missing app handling (static checker)', () => {
+  it('signals a 404 through notFound()', () => {
+    assert.match(source, /from 'next\/navigation'/);
+    assert.match(source, /notFound\(\)/);
+  });
+
+  it('never throws a bare Error for a missing app', () => {
+    assert.doesNotMatch(source, /throw new Error\('App not found'\)/);
+  });
+});

--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -5,6 +5,7 @@ import { CategoryBreadcrumb } from '../components/category-breadcrumb';
 import { AppActionButton } from '../components/app-action-button';
 import { Calendar, User, FolderOpen, Puzzle } from 'lucide-react';
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import { ProductBanner } from '@/src/app/components/product-banner';
 import { getAppById, getAppsByCategory } from '@/src/lib/api/apps';
@@ -176,7 +177,7 @@ export default async function PluginDetailView(props: {
   const plugin = await getAppById(params.id);
 
   if (!plugin) {
-    throw new Error('App not found');
+    notFound();
   }
 
   const userAgent = (await headers()).get('user-agent') || '';


### PR DESCRIPTION
## Bug

Every request to a marketplace app page whose id is not in the approved-apps list returns **HTTP 500** instead of 404.

Live prod (Cloud Run `frontend`, last 6h): **92** `Error: App not found` 500s at `/app/.next/server/app/apps/[id]/page.js`, across ~20 distinct delisted/removed app ids — including inbound affiliate traffic (`/apps/prepmate-01JDXSGWCE4NKKHC8D309582DW?ref=aiu_121495`).

```
$ curl -o /dev/null -w '%{http_code}' https://h.omi.me/apps/01JQ8VRYGM8K198ZMM7B1TA9KR   # 500
$ curl -o /dev/null -w '%{http_code}' https://h.omi.me/apps/does-not-exist-xyz            # 500
```

Users following a stale link or a removed app's share URL get a crash page, and crawlers see a server fault instead of a not-found — so dead app URLs never drop out of the index.

## Root cause

`web/frontend/src/app/apps/[id]/page.tsx` threw a bare `Error('App not found')` when `getAppById()` returned `undefined`. Next.js renders a thrown Error through the error boundary with a 500 status; only `notFound()` produces a 404.

The page already treated this as a not-found case everywhere else — `generateMetadata` returns an `App Not Found | Omi` title for the same null plugin. Only the render path disagreed.

## Fix

Replace the throw with `notFound()` from `next/navigation` — the idiom already used by every other dynamic public page in this app (`tasks/[token]`, `chat/[token]`, `recaps/[id]`, `case/[ref]`, `memories/[id]`).

2-line change plus a regression check.

## What I tested

Ran the real Next server (`next dev`, `API_URL=https://api.omi.me`) and exercised the user-facing path, toggling only this change on the same running server:

| Request | Before | After |
| --- | --- | --- |
| `GET /apps/01JQ8VRYGM8K198ZMM7B1TA9KR` (delisted, 500s in prod) | 500 | **404** |
| `GET /apps/does-not-exist-xyz` (garbage id) | 500 | **404** |
| `GET /apps/01JE2Q73KAMPCRNK920F92EASA` (live app) | 200 | **200**, page renders (title + body content intact) |

Also, in `web/frontend`:
- `npm test` → 47 pass / 0 fail (includes the 2 new checks)
- `npm run lint` → clean
- `npm run lint:format -- --check` → clean
- `make preflight` → pass

The added test is labelled a **static checker**, not behavioral coverage: the page is a server component and cannot be imported by `node:test`, so it asserts the source-level contract (`notFound()` present, bare `throw new Error('App not found')` absent). The behavioral proof is the before/after table above. Note `web/frontend`'s `npm test` is not currently wired into `web-checks.yml` (only `web/admin` and `web/personas-open-source` run theirs); the check runs locally via `npm test`.

## Product invariants

None affected (`scripts/pr-preflight`: "no locked invariants require naming for these changes").

Failure-Class: none

One-off route slip, not a class: this app already has five dynamic public pages that call `notFound()` correctly, and this page's own `generateMetadata` handled the null case. A single route disagreed with the established idiom. No existing registry class covers it and minting one for a two-line divergence would be paperwork without a guard surface, so this declares `none`.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

