### PR TITLE
fix(deploy): right-size prod backend-listen requests for pack efficiency

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -393,8 +393,8 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
-    cpu: 1.5
-    memory: 2Gi
+    cpu: 1
+    memory: 1.5Gi
   limits:
     cpu: 2
     memory: 3.5Gi


### PR DESCRIPTION
## Summary

Right-size prod `backend-listen` **requests** so pods pack more densely on `n4-highcpu-4` (2 → **3** pods/node). This is the deployable A1 step for the efficiency/pack failure tracked in #9929. Limits, HPA targets, affinity, PDB, and strategy are unchanged.

Closes #9929
Closes SCA-231

## Problem / root cause

`prod-omi-backend-listen` becomes unschedulable under HPA desire because **request inflation** wastes node pack capacity — not because live util needs 1.5 CPU / 2Gi.

On `n4-highcpu-4` (~3.92 CPU / ~5.8Gi allocatable), requests of **1.5 / 2Gi** hard-pack at **2 pods/node**. Evidence in #9929 (cutoff `2026-07-28T22:42:07Z`): max pod CPU p99 ~0.64 ≪ 1.0; max WSS 7d ~1014Mi < 1.5Gi; CFS throttle ≈0; OOMKilled ≈0. HPA desired spiked to 60 with ~39 Pending.

## Values before → after

File: `backend/charts/backend-listen/prod_omi_backend_listen_values.yaml`

| Field | Before | After |
|---|---|---|
| `resources.requests.cpu` | `1.5` | **`1`** |
| `resources.requests.memory` | `2Gi` | **`1.5Gi`** |
| `resources.limits.cpu` | `2` | unchanged |
| `resources.limits.memory` | `3.5Gi` | unchanged |

Expected pack on `n4-highcpu-4`: **2 → 3** pods/node (CPU and memory together; CPU-only cut would stay mem-bound).

## Product invariants

none (chart values only; `scripts/pr-preflight --suggest`)

Failure-Class: none

Chart request right-size for pack efficiency; no existing FC registry entry. Closing the capacity issue is operational soak after deploy, not a product-invariant instance repair.

## Deliberately not in this PR

- No new env vars / feature flags / config knobs
- HPA `requestsPerPod` / `activeConnectionsPerPod` unchanged
- `scaleDown.stabilizationWindowSeconds` (600) unchanged — post-soak optional polish
- `minReplicas` / `maxReplicas` unchanged
- Affinity, PDB, probes, strategy unchanged
- Dev values unchanged
- Application code unchanged
- **Does not** raise node-pool max (`backend-listen-pool-v2-b` 7 → 15–20) — **manual GKE ops**, optional safety net after merge
- A2 (750m / 1.25Gi) deferred until A1 soak; not required to close #9929’s first deployable scope

## Risk + rollback

- Risk: if a pod’s working set exceeds 1.5Gi under peak, scheduler still places it (limits remain 3.5Gi) but denser packing could increase node memory pressure. Abort on OOM, sustained throttle, or Pending cliff at ≤p95 desire.
- Rollback: revert this chart values change and redeploy via the ordinary Helm/prod listen path.

## Soak signals (observation only)

After deploy, watch (no new metrics pipeline):

1. Pending = 0 at traffic near p95 HPA desire
2. CPU throttle ≈ 0; OOMKilled = 0
3. Deploy Available recovers; no prolonged `MinimumReplicasUnavailable` outside rollouts
4. Privacy-safe STT terminal failure rate vs pre-change baseline (same hours-of-week)

## Verification

- `helm template` with prod values shows requests `cpu: 1` / `memory: 1.5Gi`, limits unchanged
- `make preflight` + `scripts/pr-preflight --pr-body-file` (this body)

## Test plan

- [ ] Reviewers confirm only the two request lines changed in prod listen values
- [ ] After merge/deploy: soak checklist above for ≥24h including one peak hour
- [ ] Optional ops follow-up: raise zone-b pool max (not blocking this PR)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

