### PR TITLE
fix(desktop): recover all silent microphone routes

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1526
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1533
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds the session-owned silent-microphone recovery cap so recreated CoreAudio services cannot loop indefinitely while transcription remains visibly active."
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds shared-capture silent-mic recovery telemetry so non-Bluetooth CoreAudio rebuild attempts are visible to release-health alongside the existing Bluetooth fallback."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,0 +1,9 @@
+{
+  "files": {
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1526
+  },
+  "raise_justifications": {
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds the session-owned silent-microphone recovery cap so recreated CoreAudio services cannot loop indefinitely while transcription remains visibly active."
+  },
+  "threshold": 1500
+}

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -3,12 +3,14 @@
     "desktop/macos/Desktop/Sources/AuthService.swift": 2812,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4447,
+    "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1515,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1519,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1562
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls.",
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "present_onboarding_opener QA action renders the real post-onboarding opener in-process for verification; merged with main's capture_main_window_png sheet-surface capture support, plus the Canonical Memory Atlas open/scrub/viewport QA actions this bridge exposes for the atlas e2e flow. Adds memory_graph_rebuild so the Brain Map's rebuild control can be exercised without a cursor; the rest of that surface is only reachable by clicking. Also exposes the QA actions backing clickable Brain Map connections and cited-memory navigation (commit 97a24cd2cf). Adds memory_atlas_enter_region and a label form of memory_atlas_select so going into a Brain Map island, and picking an entity inside it, are reachable without a cursor; both are otherwise only doable by clicking a painted canvas, which no headless check can do.",
+    "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": "Adds the bounded shared-capture silent-microphone terminal incident so a persistent zero-sample CoreAudio route is queryable without recording sensitive content.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Adds cloudOAuthGrantClientIDs so ChatGPT directory grants (always omi-chatgpt-prod) verify on dev/Beta builds, fixing the connector chip never flipping to connected.",
     "desktop/macos/Desktop/Sources/OmiApp.swift": "Extracts onboarding journal lifecycle and removes startup maintenance while retaining newer main additions; also wires AgentCompletionVoiceDelivery.shared.start() at the app-launch site so completed background-agent runs reach a live voice session."
   },

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -354,6 +354,10 @@ class AppState: ObservableObject {
   var captureGateInFlight = false
   var captureReconcilePending = false
   var pendingCoreAudioCaptureRecoveryReason: String?
+  /// Counts CoreAudio rebuilds caused by a zero-sample microphone during one
+  /// transcription session. This lives above `AudioCaptureService` because each
+  /// rebuild creates a fresh service (and therefore a fresh service-local watchdog).
+  var silentMicRecoveryAttempts = 0
   var meetingEndFinalizationInProgress = false
   @Published var isAwaitingMeeting = false
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -672,6 +672,13 @@ extension AppState {
     switch SharedCaptureSilentMicRecoveryPolicy.action(for: silentMicRecoveryAttempts) {
     case .rebuild:
       log("Transcription: silent microphone detected — rebuilding CoreAudio capture stack")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "silent_mic",
+        from: "stalled_route",
+        to: "rebuilt_capture",
+        reason: "local_heal",
+        outcome: .degraded,
+        extra: ["recovery_attempts": silentMicRecoveryAttempts, "user_visible": false])
       await rebuildCoreAudioCaptureStack(reason: reason)
     case .stopAndSurfaceError:
       log("Transcription: stopping after repeated silent microphone recovery failures")

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -18,6 +18,7 @@ extension AppState {
   func startTranscription(source: AudioSource? = nil) {
     guard !isTranscribing else { return }
     sttSession.prepareForStart()
+    silentMicRecoveryAttempts = 0
     meetingEndFinalizationInProgress = false
 
     // Paywall hard-stop: every code path that enables the mic + WS streaming
@@ -322,16 +323,17 @@ extension AppState {
   func startMicrophoneAudioCapture() async {
     guard let audioCaptureService = audioCaptureService else { return }
 
-    // Silent-mic watchdog: on A2DP profile conflict the Bluetooth input device returns zero
-    // samples even though CoreAudio reports healthy capture. Fall back to built-in mic for
-    // Bluetooth, and rebuild the full CoreAudio capture stack for stale-route wedges.
+    // Silent-mic watchdog: CoreAudio can report a healthy IOProc while a Bluetooth, USB, or
+    // built-in input returns only zeros. Listen/manual/Quick Note all flow through here, so
+    // they must opt into all-transport detection just as PTT does.
+    SharedCaptureSilentMicRecoveryPolicy.configure(audioCaptureService)
     audioCaptureService.onSilentMicDetected = { [weak self] detection in
       Task { @MainActor in
         switch detection.suggestedAction {
         case .fallbackToBuiltIn:
           self?.handleSilentMicFallback()
         case .rebuildCoreAudioStack:
-          await self?.rebuildCoreAudioCaptureStack(reason: detection.reason)
+          await self?.handleSharedCaptureSilentMicDetection(reason: detection.reason)
         }
       }
     }
@@ -657,6 +659,30 @@ extension AppState {
 
     recordingInputDeviceName = AudioCaptureService.getCurrentMicrophoneName() ?? recordingInputDeviceName
     await startMicrophoneAudioCapture()
+  }
+
+  /// A fresh `AudioCaptureService` resets its own watchdog cap. Keep the terminal policy at
+  /// the session owner so an unrecoverable USB/built-in route cannot loop forever while the
+  /// UI continues to claim it is recording.
+  @MainActor
+  func handleSharedCaptureSilentMicDetection(reason: String) async {
+    guard isTranscribing else { return }
+    silentMicRecoveryAttempts += 1
+
+    switch SharedCaptureSilentMicRecoveryPolicy.action(for: silentMicRecoveryAttempts) {
+    case .rebuild:
+      log("Transcription: silent microphone detected — rebuilding CoreAudio capture stack")
+      await rebuildCoreAudioCaptureStack(reason: reason)
+    case .stopAndSurfaceError:
+      log("Transcription: stopping after repeated silent microphone recovery failures")
+      DesktopDiagnosticsManager.shared.recordTranscriptionSilentCaptureExhausted(
+        recoveryAttempts: silentMicRecoveryAttempts)
+      stopTranscription()
+      showAlert(
+        title: "Microphone Isn't Capturing Audio",
+        message:
+          "Omi stopped recording because your microphone returned no audio. Check your input device and try again.")
+    }
   }
 
   /// Start BLE device audio capture
@@ -1153,6 +1179,7 @@ extension AppState {
     captureGateInFlight = false
     captureReconcilePending = false
     pendingCoreAudioCaptureRecoveryReason = nil
+    silentMicRecoveryAttempts = 0
     isAwaitingMeeting = false
     meetingEndFinalizationInProgress = false
 

--- a/desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
@@ -1,0 +1,22 @@
+/// Terminal policy for the shared microphone capture path used by listening,
+/// manual recording, and Quick Note. `AudioCaptureService` is deliberately
+/// recreated during recovery, so the cross-rebuild cap belongs here.
+enum SharedCaptureSilentMicRecoveryPolicy {
+  enum Action: Equatable {
+    case rebuild
+    case stopAndSurfaceError
+  }
+
+  static let maximumRecoveryAttempts = 3
+
+  /// Shared capture must treat a zero-sample CoreAudio stream as a failure for
+  /// every input transport, not only Bluetooth. This configuration is intentionally
+  /// testable without a physical audio route.
+  static func configure(_ capture: AudioCaptureService) {
+    capture.detectSilentMicOnAnyTransport = true
+  }
+
+  static func action(for recoveryAttempt: Int) -> Action {
+    recoveryAttempt >= maximumRecoveryAttempts ? .stopAndSurfaceError : .rebuild
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -437,6 +437,22 @@ final class DesktopDiagnosticsManager {
       ],
       trackRemotely: false)
   }
+
+  /// Terminal shared-capture failure for listen, manual recording, and Quick Note.
+  /// The event intentionally carries only a bounded retry count; the incident attachment is
+  /// produced by the common privacy-redacted Sentry path.
+  func recordTranscriptionSilentCaptureExhausted(recoveryAttempts: Int) {
+    recordUserVisibleIssue(
+      area: "transcription",
+      failureClass: "silent_capture",
+      phase: "audio_capture",
+      extra: [
+        "capture_path": "shared",
+        "recovery_attempts": recoveryAttempts,
+        "recovery_action": "stop_and_surface_error",
+        "recovery_result": "exhausted",
+      ])
+  }
   /// Record one bounded PTT attempt lifecycle snapshot (see
   /// `PTTAttemptLifecycleRecorder`). Routes through the shared ring buffer + Sentry
   /// attachment path. Emitted remotely (PostHog) for EVERY terminal disposition —
@@ -1345,7 +1361,7 @@ final class DesktopDiagnosticsManager {
 
   private func safeIncidentArea(_ area: String) -> String {
     switch area {
-    case "ptt", "chat", "realtime", "crash", "startup": return area
+    case "ptt", "chat", "realtime", "crash", "startup", "transcription": return area
     default: return "other"
     }
   }
@@ -1371,7 +1387,8 @@ final class DesktopDiagnosticsManager {
     "source", "mode", "hub_active",
     "turn_audio_seconds", "voiced_audio_seconds",
     "peak", "rms", "is_near_zero", "watchdog_eligible", "consecutive_silent_turns",
-    "tcc_microphone_granted", "input_device_class", "recovery_action", "recovery_result",
+    "tcc_microphone_granted", "input_device_class", "capture_path", "recovery_attempts",
+    "recovery_action", "recovery_result",
     "osstatus", "keycode", "modifiers",
   ]
 

--- a/desktop/macos/Desktop/Tests/SharedCaptureSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/SharedCaptureSilentMicRecoveryPolicyTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SharedCaptureSilentMicRecoveryPolicyTests: XCTestCase {
+  func testConfiguresNonBluetoothInputsForSilentCaptureDetection() {
+    let capture = AudioCaptureService()
+    SharedCaptureSilentMicRecoveryPolicy.configure(capture)
+
+    XCTAssertNil(capture.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 0))
+    XCTAssertNotNil(capture.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 1))
+  }
+
+  func testRebuildsBeforeTheBoundedRecoveryLimit() {
+    XCTAssertEqual(SharedCaptureSilentMicRecoveryPolicy.action(for: 1), .rebuild)
+    XCTAssertEqual(SharedCaptureSilentMicRecoveryPolicy.action(for: 2), .rebuild)
+  }
+
+  func testStopsAndSurfacesErrorAtTheRecoveryLimit() {
+    XCTAssertEqual(
+      SharedCaptureSilentMicRecoveryPolicy.action(for: 3),
+      .stopAndSurfaceError)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260728-recover-silent-microphone.json
+++ b/desktop/macos/changelog/unreleased/20260728-recover-silent-microphone.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop recordings that could stay active while USB or built-in microphones delivered no audio."
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -5,6 +5,7 @@ description: Hermetic capture lifecycle via capture_test_transcript seam (no mic
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+  - desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
   - desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
   - desktop/macos/Desktop/Sources/LocalTranscriptionService.swift


### PR DESCRIPTION
## Summary

Closes #10798.

The shared desktop transcription path (Listening, manual recording, and Quick Note) installed the silent-mic watchdog without enabling its non-Bluetooth route. A CoreAudio IOProc that started successfully but returned only zero samples on USB or built-in microphones could therefore leave the UI recording indefinitely.

This change enables all-transport watchdog detection for the shared path, rebuilds the CoreAudio stack for the first two silent-capture detections, and stops with a clear user error on the third. The terminal case emits the existing privacy-redacted `desktop_health_event` and a Sentry incident (`diagnostic_area=transcription`, `failure_class=silent_capture`) with only bounded fields: `capture_path=shared`, `recovery_attempts`, and recovery outcome.

## Verification

- `xcrun swift test --package-path Desktop --filter SharedCaptureSilentMicRecoveryPolicyTests`
  - Passed: 3 tests, 0 failures after a clean full Swift package build.
- `git diff --check`
  - Passed.

## Dogfood notes / residual risk

The unit seam covers USB/built-in detection and the bounded terminal policy. A physical macOS 26.5 route reproduction was not available in this environment, so this PR does not claim to prove the underlying OS-level trigger; it repairs the observed zero-sample failure class and makes any persistent recurrence visible in Sentry/PostHog without sending audio, device names, transcripts, titles, paths, or prompts.

## Failure Class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

