### PR TITLE
Fix desktop onboarding feedback flow

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-onboarding.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-onboarding.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift": 2180,
-    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": 1714
+    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": 1750
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": "Onboarding adopts the async-arriving auth name, cancels the local file import task in deinit, and carries the sharpened goal/task prompts on top of the terminal-scan-state helper."
+    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": "Onboarding serializes Calendar and Gmail's shared Safe Storage access to prevent duplicate Chrome Keychain consent prompts."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
+++ b/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
@@ -78,6 +78,10 @@ final class CloudConnectorGuidanceOverlay {
   static let shared = CloudConnectorGuidanceOverlay()
 
   private var window: NSWindow?
+  /// Click-through outline over the permission list. It is deliberately a
+  /// separate panel from `window`: the drop destination must remain available
+  /// to System Settings while the source card receives the initial drag.
+  private var dragTargetWindow: NSWindow?
   private var dismissTask: Task<Void, Never>?
   private var settingsWatchTask: Task<Void, Never>?
   private var lastAutomationState: [String: String]?
@@ -108,7 +112,7 @@ final class CloudConnectorGuidanceOverlay {
     candidates: [SpatialOverlayAnchorCandidate]
   ) {
     dismissTask?.cancel()
-    window?.close()
+    closeCurrentOverlay()
 
     let overlaySize = CGSize(width: 330, height: 118)
     guard
@@ -168,7 +172,7 @@ final class CloudConnectorGuidanceOverlay {
   /// near the relevant window (System Settings) so the user connects the dots.
   func presentInstructionCard(title: String, subtitle: String, near anchor: CGRect?) {
     dismissTask?.cancel()
-    window?.close()
+    closeCurrentOverlay()
 
     let cardSize = Self.instructionCardSize(title: title, subtitle: subtitle)
     let screen = Self.screen(forAnchor: anchor)
@@ -221,24 +225,28 @@ final class CloudConnectorGuidanceOverlay {
   func presentDragToGrantCard(appIcon: NSImage, appName: String, appURL: URL, near anchor: CGRect) {
     dismissTask?.cancel()
     settingsWatchTask?.cancel()
-    window?.close()
+    closeCurrentOverlay()
 
     let cardSize = Self.dragCardSize(appName: appName)
     dragCardSize = cardSize
     let screen = Self.screen(forAnchor: anchor)
-    let pointsDown = Self.dragCardArrowPointsDown(
-      anchor: anchor, cardSize: cardSize, visibleFrame: screen.visibleFrame)
-    let dragTargetState = ScreenRecordingDragTargetState(frame: anchor, arrowPointsDown: pointsDown)
-    self.dragTargetState = dragTargetState
+    let targetFrame = Self.permissionListTargetFrame(in: anchor)
     let frame = Self.dragCardFrame(
-      anchor: anchor, cardSize: cardSize, visibleFrame: screen.visibleFrame)
+      target: targetFrame, cardSize: cardSize, visibleFrame: screen.visibleFrame)
+    let dragTargetState = ScreenRecordingDragTargetState(
+      frame: targetFrame,
+      direction: Self.dragCardDirection(cardFrame: frame, targetFrame: targetFrame))
+    self.dragTargetState = dragTargetState
 
     lastAutomationState = [
       "visible": "true",
       "kind": "dragToGrant",
       "appName": appName,
       "panelFrame": Self.string(frame),
+      "dropTargetFrame": Self.string(targetFrame),
     ]
+
+    presentPermissionDropTarget(appName: appName, frame: targetFrame)
 
     let view = ScreenRecordingDragCardView(
       appIcon: appIcon, appName: appName, appURL: appURL, targetState: dragTargetState,
@@ -308,40 +316,82 @@ final class CloudConnectorGuidanceOverlay {
 
   func repositionDragCard(near anchor: CGRect) {
     guard let window, let size = dragCardSize else { return }
-    dragTargetState?.frame = anchor
     let screen = Self.screen(forAnchor: anchor)
-    dragTargetState?.arrowPointsDown = Self.dragCardArrowPointsDown(
-      anchor: anchor, cardSize: size, visibleFrame: screen.visibleFrame)
+    let targetFrame = Self.permissionListTargetFrame(in: anchor)
+    dragTargetState?.frame = targetFrame
     let frame = Self.dragCardFrame(
-      anchor: anchor, cardSize: size, visibleFrame: screen.visibleFrame)
+      target: targetFrame, cardSize: size, visibleFrame: screen.visibleFrame)
+    dragTargetState?.direction = Self.dragCardDirection(cardFrame: frame, targetFrame: targetFrame)
     window.setFrame(frame, display: true)
+    dragTargetWindow?.setFrame(targetFrame, display: true)
     lastAutomationState?["panelFrame"] = Self.string(frame)
+    lastAutomationState?["dropTargetFrame"] = Self.string(targetFrame)
   }
 
-  /// Drag-card placement: horizontally centered on the anchor (Settings window)
-  /// and pinned directly beneath it. If Settings fills the screen and leaves no
-  /// room below, keep the card in the screen's bottom quarter where it remains
-  /// close to the permission list instead of jumping to the top.
-  static func dragCardFrame(anchor: CGRect, cardSize: CGSize, visibleFrame: CGRect) -> CGRect {
-    let gap: CGFloat = 12
+  /// The list is the actual drag destination, not the entire System Settings
+  /// window. System Settings does not expose this list before Accessibility has
+  /// been granted, so model its stable content region from the public window
+  /// geometry. Keep it proportional so a resized or moved Settings window gets
+  /// guidance in the same place.
+  static func permissionListTargetFrame(in settingsFrame: CGRect) -> CGRect {
+    let sidebarWidth = min(max(settingsFrame.width * 0.28, 180), 270)
+    let horizontalInset = min(max(settingsFrame.width * 0.05, 24), 44)
+    let x = min(
+      settingsFrame.maxX - horizontalInset - 120,
+      settingsFrame.minX + sidebarWidth + horizontalInset)
+    let width = max(120, settingsFrame.maxX - horizontalInset - x)
+    let height = min(max(settingsFrame.height * 0.28, 96), 180)
+    let y = settingsFrame.minY + max(56, settingsFrame.height * 0.22)
+    return CGRect(x: x, y: y, width: width, height: height)
+  }
+
+  /// Place the draggable source directly beside the highlighted permission list.
+  /// Leading placement keeps the list itself unobstructed; vertical fallbacks
+  /// preserve the same adjacency on unusually narrow displays.
+  static func dragCardFrame(target: CGRect, cardSize: CGSize, visibleFrame: CGRect) -> CGRect {
+    let gap: CGFloat = 16
     let padding: CGFloat = 12
-    let x = anchor.midX - cardSize.width / 2
-    let y: CGFloat
-    // AppKit is bottom-left origin: the window's bottom edge is `minY`, so
-    // "under" the window is a smaller y.
-    let below = anchor.minY - gap - cardSize.height
-    y =
-      below >= visibleFrame.minY + padding
-      ? below
-      : visibleFrame.minY + (visibleFrame.height / 4 - cardSize.height) / 2
-    let proposed = CGRect(x: x, y: y, width: cardSize.width, height: cardSize.height)
+    let centeredY = target.midY - cardSize.height / 2
+    let leading = CGRect(
+      x: target.minX - gap - cardSize.width,
+      y: centeredY,
+      width: cardSize.width,
+      height: cardSize.height)
+    if leading.minX >= visibleFrame.minX + padding {
+      return SpatialOverlayGeometry.clamped(leading, to: visibleFrame, padding: padding)
+    }
+
+    let trailing = CGRect(
+      x: target.maxX + gap,
+      y: centeredY,
+      width: cardSize.width,
+      height: cardSize.height)
+    if trailing.maxX <= visibleFrame.maxX - padding {
+      return SpatialOverlayGeometry.clamped(trailing, to: visibleFrame, padding: padding)
+    }
+
+    let below = CGRect(
+      x: target.midX - cardSize.width / 2,
+      y: target.minY - gap - cardSize.height,
+      width: cardSize.width,
+      height: cardSize.height)
+    if below.minY >= visibleFrame.minY + padding {
+      return SpatialOverlayGeometry.clamped(below, to: visibleFrame, padding: padding)
+    }
+
+    let proposed = CGRect(
+      x: target.midX - cardSize.width / 2,
+      y: target.maxY + gap,
+      width: cardSize.width,
+      height: cardSize.height)
     return SpatialOverlayGeometry.clamped(proposed, to: visibleFrame, padding: padding)
   }
 
-  /// The card always stays below the permission target, including its bottom-quarter
-  /// fallback, so its arrow points up.
-  static func dragCardArrowPointsDown(anchor: CGRect, cardSize: CGSize, visibleFrame: CGRect) -> Bool {
-    false
+  static func dragCardDirection(cardFrame: CGRect, targetFrame: CGRect) -> PermissionDragDirection {
+    if cardFrame.maxX <= targetFrame.minX { return .right }
+    if cardFrame.minX >= targetFrame.maxX { return .left }
+    if cardFrame.minY >= targetFrame.maxY { return .down }
+    return .up
   }
 
   /// A named development bundle can have a much longer display name than the
@@ -349,7 +399,7 @@ final class CloudConnectorGuidanceOverlay {
   /// render outside the transparent panel and get clipped by AppKit.
   static func dragCardSize(appName: String) -> CGSize {
     let hasLongDisplayName = appName.count > 16
-    return CGSize(width: hasLongDisplayName ? 240 : 180, height: hasLongDisplayName ? 180 : 164)
+    return CGSize(width: hasLongDisplayName ? 260 : 220, height: hasLongDisplayName ? 200 : 190)
   }
 
   static func dragCardInitialAlpha(reduceMotion: Bool) -> CGFloat {
@@ -380,7 +430,7 @@ final class CloudConnectorGuidanceOverlay {
     near anchor: CGRect?
   ) {
     dismissTask?.cancel()
-    window?.close()
+    closeCurrentOverlay()
 
     CloudConnectorCopySection.assertUniqueIDs(sections)
     let fields = CloudConnectorCopySection.flattenedFields(sections)
@@ -506,10 +556,46 @@ final class CloudConnectorGuidanceOverlay {
     dismissTask = nil
     settingsWatchTask?.cancel()
     settingsWatchTask = nil
-    window?.close()
-    window = nil
+    closeCurrentOverlay()
     dragCardSize = nil
     dragTargetState = nil
+  }
+
+  private func closeCurrentOverlay() {
+    settingsWatchTask?.cancel()
+    settingsWatchTask = nil
+    window?.close()
+    window = nil
+    dragTargetWindow?.close()
+    dragTargetWindow = nil
+  }
+
+  private func presentPermissionDropTarget(appName: String, frame: CGRect) {
+    let view = PermissionDragDropTargetView(appName: appName, size: frame.size)
+    let hostingView = TransparentHostingView(rootView: view)
+    hostingView.frame = CGRect(origin: .zero, size: frame.size)
+    hostingView.wantsLayer = true
+    hostingView.layer?.backgroundColor = NSColor.clear.cgColor
+    hostingView.layer?.isOpaque = false
+
+    let panel = NSPanel(
+      contentRect: frame,
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
+    )
+    panel.contentView = hostingView
+    panel.isOpaque = false
+    panel.backgroundColor = .clear
+    panel.hasShadow = false
+    panel.level = .screenSaver
+    // The highlight intentionally cannot receive events: the system list below
+    // must remain the real drop receiver.
+    panel.ignoresMouseEvents = true
+    panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]
+    panel.animationBehavior = .none
+    panel.orderFrontRegardless()
+    dragTargetWindow = panel
   }
 
   var automationWindow: NSWindow? {
@@ -688,15 +774,38 @@ private final class TransparentHostingView<Content: View>: NSHostingView<Content
   override var isOpaque: Bool { false }
 }
 
+enum PermissionDragDirection: Equatable {
+  case up
+  case down
+  case left
+  case right
+
+  var systemImage: String {
+    switch self {
+    case .up: return "arrow.up"
+    case .down: return "arrow.down"
+    case .left: return "arrow.left"
+    case .right: return "arrow.right"
+    }
+  }
+
+  var vector: CGSize {
+    switch self {
+    case .up: return CGSize(width: 0, height: 1)
+    case .down: return CGSize(width: 0, height: -1)
+    case .left: return CGSize(width: -1, height: 0)
+    case .right: return CGSize(width: 1, height: 0)
+    }
+  }
+}
+
 final class ScreenRecordingDragTargetState: ObservableObject {
   var frame: CGRect?
-  /// Drives the drag card's arrow direction — true when the card sits above the
-  /// Settings window (list is below → point down), false when below (point up).
-  @Published var arrowPointsDown: Bool
+  @Published var direction: PermissionDragDirection
 
-  init(frame: CGRect?, arrowPointsDown: Bool = false) {
+  init(frame: CGRect?, direction: PermissionDragDirection = .up) {
     self.frame = frame
-    self.arrowPointsDown = arrowPointsDown
+    self.direction = direction
   }
 }
 
@@ -815,6 +924,33 @@ private struct AppBundleDragSource: NSViewRepresentable {
   }
 }
 
+/// A visual marker only. Its panel ignores every event so the native System
+/// Settings list underneath keeps receiving the actual app-bundle drop.
+private struct PermissionDragDropTargetView: View {
+  let appName: String
+  let size: CGSize
+
+  var body: some View {
+    RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+      .strokeBorder(
+        OmiColors.success.opacity(0.94),
+        style: StrokeStyle(lineWidth: 2.5, dash: [8, 5])
+      )
+      .overlay(alignment: .topLeading) {
+        Text("DROP \(appName.uppercased()) HERE")
+          .scaledFont(size: 10.5, weight: .bold)
+          .tracking(0.7)
+          .foregroundColor(.white)
+          .padding(.horizontal, OmiSpacing.sm)
+          .padding(.vertical, OmiSpacing.xxs)
+          .background(Capsule().fill(OmiColors.success.opacity(0.96)))
+          .padding(OmiSpacing.sm)
+      }
+      .frame(width: size.width, height: size.height)
+      .accessibilityLabel("Drop \(appName) in this highlighted permission list")
+  }
+}
+
 private struct ScreenRecordingDragCardView: View {
   let appIcon: NSImage
   let appName: String
@@ -826,11 +962,17 @@ private struct ScreenRecordingDragCardView: View {
   /// loop, so the card reads as "drag me into the list". Respects reduce-motion.
   @State private var hintUp = false
   private var reduceMotion: Bool { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
-  /// Direction the drop target sits relative to the card (down when the card is
-  /// flipped above the Settings window). The idle drift follows the same axis.
-  private var pointsDown: Bool { targetState.arrowPointsDown }
-  private var hintOffset: CGFloat { (pointsDown ? 1 : -1) * (hintUp ? 3 : -1) }
-  private var iconHintOffset: CGFloat { (pointsDown ? 1 : -1) * (hintUp ? 6 : 0) }
+  /// The source card starts beside the target rather than below the whole
+  /// Settings window. The arrow and idle motion make that relationship explicit.
+  private var direction: PermissionDragDirection { targetState.direction }
+  private var hintOffset: CGSize {
+    let amount: CGFloat = hintUp ? 3 : -1
+    return CGSize(width: direction.vector.width * amount, height: direction.vector.height * amount)
+  }
+  private var iconHintOffset: CGSize {
+    let amount: CGFloat = hintUp ? 6 : 0
+    return CGSize(width: direction.vector.width * amount, height: direction.vector.height * amount)
+  }
 
   var body: some View {
     ZStack {
@@ -842,19 +984,20 @@ private struct ScreenRecordingDragCardView: View {
       )
 
       VStack(spacing: 7) {
-        Image(systemName: pointsDown ? "chevron.down" : "chevron.up")
+        Image(systemName: direction.systemImage)
           .scaledFont(size: 14, weight: .bold)
           .foregroundColor(OmiColors.textSecondary.opacity(hintUp ? 1 : 0.6))
-          .offset(y: hintOffset)
+          .offset(hintOffset)
 
         AppBundleDragSource(icon: appIcon, appURL: appURL, targetState: targetState)
           .frame(width: 64, height: 64)
           .shadow(color: Color.black.opacity(0.58), radius: 12, y: 5)
-          .offset(y: iconHintOffset)
-          .help("Drag \(appName) into the Screen Recording list")
-          .accessibilityLabel("Drag \(appName) to enable Screen Recording")
+          .offset(iconHintOffset)
+          .help("Press, drag \(appName) to the highlighted permission list, then release")
+          .accessibilityLabel(
+            "Press and drag \(appName) to the highlighted permission list, then release")
 
-        Text("Drag \(appName)\ninto the list")
+        Text("Press, drag, and release \(appName)\nin the highlighted list")
           .scaledFont(size: 13.5, weight: .bold)
           .foregroundColor(OmiColors.textPrimary)
           .multilineTextAlignment(.center)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportRunner.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportRunner.swift
@@ -77,6 +77,10 @@ final class ConnectorImportRunner: ObservableObject {
   private var tasks: [String: Task<Void, Never>] = [:]
   private var runTokens: [String: UUID] = [:]
   private var runStartedAt: [String: Date] = [:]
+  /// The surface that started each run. The shared runner is the sole terminal
+  /// telemetry boundary for imports, so onboarding must retain its identity
+  /// through completion instead of being reported as an Apps-tab import.
+  private var runSurfaces: [String: IntegrationConnectTelemetry.Surface] = [:]
 
   func isRunning(_ connectorID: String) -> Bool {
     tasks[connectorID] != nil
@@ -90,6 +94,7 @@ final class ConnectorImportRunner: ObservableObject {
     connectorID: String,
     progressTitle: String,
     progressDetail: String,
+    surface: IntegrationConnectTelemetry.Surface = .apps,
     operation: @escaping @MainActor (ProgressSink) async -> RunOutcome
   ) -> Task<Void, Never>? {
     guard tasks[connectorID] == nil else { return nil }
@@ -104,13 +109,14 @@ final class ConnectorImportRunner: ObservableObject {
       errorMessage: nil
     )
     runStartedAt[connectorID] = Date()
+    runSurfaces[connectorID] = surface
     // Funnel numerator: one Attempted per real user-initiated connect, emitted
     // at the single authoritative start boundary so every surface (Apps tab,
     // and future onboarding callers) is measured identically.
     AnalyticsManager.shared.integrationConnectAttempted(
       integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID),
       connectorID: connectorID,
-      surface: .apps,
+      surface: surface,
       stage: "import"
     )
 
@@ -144,6 +150,8 @@ final class ConnectorImportRunner: ObservableObject {
     tasks[connectorID] = nil
     let startedAt = runStartedAt[connectorID]
     runStartedAt[connectorID] = nil
+    let surface = runSurfaces[connectorID] ?? .apps
+    runSurfaces[connectorID] = nil
     let durationMs = startedAt.map { max(0, Int(Date().timeIntervalSince($0) * 1000)) }
     switch outcome {
     case .success(let message, let metrics):
@@ -153,7 +161,7 @@ final class ConnectorImportRunner: ObservableObject {
       AnalyticsManager.shared.integrationConnectSucceeded(
         integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID),
         connectorID: connectorID,
-        surface: .apps,
+        surface: surface,
         stage: "import",
         durationMs: durationMs,
         sourceCount: metrics.sourceCount,
@@ -173,7 +181,7 @@ final class ConnectorImportRunner: ObservableObject {
       AnalyticsManager.shared.integrationConnectFailed(
         integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID),
         connectorID: connectorID,
-        surface: .apps,
+        surface: surface,
         stage: "import",
         errorClass: errorClass,
         durationMs: durationMs,

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingAnswerWriteGate.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingAnswerWriteGate.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Preserves a user's answer order when they revisit an onboarding question.
+///
+/// The UI advances optimistically, while name, acquisition source, and language
+/// each write to the backend asynchronously. A second answer for the same field
+/// must wait for its predecessor to finish before it begins, otherwise an older
+/// request may finish last and overwrite the revision.
+@MainActor
+final class OnboardingAnswerWriteGate {
+  enum Key: Hashable {
+    case name
+    case acquisitionSource
+    case language
+  }
+
+  private var tails: [Key: Task<Void, Never>] = [:]
+
+  func enqueue(_ key: Key, operation: @escaping @MainActor () async -> Void) {
+    let predecessor = tails[key]
+    let task = Task { @MainActor in
+      _ = await predecessor?.result
+      await operation()
+    }
+    tails[key] = task
+  }
+
+  func waitForIdle(_ key: Key) async {
+    _ = await tails[key]?.result
+  }
+}

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -658,7 +658,7 @@ struct OnboardingChatView: View {
       Task {
         // Start bridge eagerly so it's ready by the time we need to send
         // (ensureBridgeStarted waits for API keys internally)
-        async let bridgeWarmup: () = chatProvider.warmupBridge()
+        async let bridgeWarmup: Bool = chatProvider.warmupBridge()
 
         // Load previous messages from backend (same default chat, sessionId=nil)
         await chatProvider.loadDefaultChatMessages()
@@ -683,7 +683,7 @@ struct OnboardingChatView: View {
         }
 
         // Wait for bridge warmup before sending
-        await bridgeWarmup
+        _ = await bridgeWarmup
 
         // Resume the conversation — tell the AI the app was restarted
         await chatProvider.sendMessage(

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
@@ -4,6 +4,31 @@ import Foundation
 @preconcurrency import GRDB
 import SwiftUI
 
+/// Serializes the two Google browser-cookie imports during legacy onboarding.
+/// Calendar and Gmail share the same Chromium Safe Storage grant, so launching
+/// both readers at once can produce duplicate Chrome Keychain consent sheets.
+/// This gate releases Gmail after Calendar reaches *any* terminal result — a
+/// Calendar failure must never prevent Gmail from making progress.
+actor OnboardingGoogleInsightGate {
+  private var calendarFinished = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func waitForCalendar() async {
+    if calendarFinished { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func markCalendarFinished() {
+    guard !calendarFinished else { return }
+    calendarFinished = true
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending {
+      waiter.resume()
+    }
+  }
+}
+
 @MainActor
 final class OnboardingPagedIntroCoordinator: ObservableObject {
   struct ScanSnapshot: Equatable {
@@ -810,7 +835,15 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     appleNotesInsightsFailed = false
     webResearchSummary = ""
 
+    // Calendar and Gmail read the same browser Safe Storage item. Keep the
+    // first consent/request singular; BrowserKeychainCache still coalesces
+    // profile-level reads, while this onboarding gate prevents two import
+    // processes from racing the one user-visible authorization prompt.
+    let googleInsightGate = OnboardingGoogleInsightGate()
+
     gmailTask = Task {
+      await googleInsightGate.waitForCalendar()
+      guard !Task.isCancelled else { return }
       do {
         let emails = try await GmailReaderService.shared.readRecentEmails(
           maxResults: 300,
@@ -868,6 +901,9 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     }
 
     calendarTask = Task {
+      defer {
+        Task { await googleInsightGate.markCalendarFinished() }
+      }
       do {
         let events = try await CalendarReaderService.shared.readEvents(
           daysBack: 365,

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -128,7 +128,7 @@ struct OnboardingView: View {
     .task {
       guard !isExportPreview else { return }
       // Pre-warm the agent bridge before the chat step starts.
-      await chatProvider.warmupBridge()
+      _ = await chatProvider.warmupBridge()
       await graphViewModel.addGraphFromStorage()
       if graphViewModel.isEmpty {
         await graphViewModel.loadGraph()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
@@ -125,7 +125,7 @@ struct OnboardingVoiceDemoView: View {
       // override so a quit/crash mid-step can't corrupt the saved PTT mode.
       shortcutSettings.pttTranscriptionModeDemoOverride = .live
       Task {
-        await chatProvider.warmupBridge()
+        _ = await chatProvider.warmupBridge()
       }
     }
     .onDisappear {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -469,6 +469,7 @@ extension SBOnboardingModel {
   func startScreenDemo() {
     screenDemoDone = false
     screenDemoPTTReady = false
+    screenDemoPTTUnavailable = false
     FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
     FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
     resetFloatingBarConversation()
@@ -493,11 +494,15 @@ extension SBOnboardingModel {
   /// boundary can be regression-tested: leaving the stage during a cold bridge
   /// start must not attach fresh event monitors to the next onboarding page.
   func activateScreenDemoPTTAfterBridgeWarmup(
-    warmup: @escaping @MainActor () async -> Void,
+    warmup: @escaping @MainActor () async -> Bool,
     activate: @escaping @MainActor () -> Void
   ) async {
-    await warmup()
+    let bridgeReady = await warmup()
     guard !Task.isCancelled, step == .screenDemo else { return }
+    guard bridgeReady else {
+      screenDemoPTTUnavailable = true
+      return
+    }
     activate()
   }
 
@@ -536,6 +541,7 @@ extension SBOnboardingModel {
     voiceCancellable = nil
     screenDemoDone = false
     screenDemoPTTReady = false
+    screenDemoPTTUnavailable = false
     ShortcutSettings.shared.pttTranscriptionModeDemoOverride = nil
     resetFloatingBarConversation()
     PushToTalkManager.shared.cleanup()

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -340,11 +340,18 @@ extension SBOnboardingModel {
   /// NSMenu key equivalents that AppKit dispatches before local monitors). Both are
   /// restored on leave. This is why the earlier attempt's monitor never fired.
   func armShortcutSummon() {
-    // Reset pick/press state so each shortcut step (open, then talk) starts fresh.
-    shortcutPicked = false
+    // Preserve a choice when the user returns with Back. A fresh stage still
+    // starts empty, while an already-confirmed shortcut stays visible/editable.
+    let rememberedSelection: ShortcutSettings.KeyboardShortcut?
+    switch step {
+    case .shortcutOpen: rememberedSelection = openShortcutSelection
+    case .shortcutTalk: rememberedSelection = talkShortcutSelection
+    default: rememberedSelection = nil
+    }
+    shortcutPicked = rememberedSelection != nil
     shortcutPressed = false
-    shortcutTokens = []
-    chosenShortcut = nil
+    shortcutTokens = rememberedSelection?.displayTokens ?? []
+    chosenShortcut = rememberedSelection
     GlobalShortcutManager.shared.setRegistrationSuspended(true)
     if savedMainMenu == nil { savedMainMenu = NSApp.mainMenu }
     NSApp.mainMenu = nil
@@ -431,9 +438,11 @@ extension SBOnboardingModel {
     shortcutPicked = true
     shortcutPressed = false
     if isTalk {
+      talkShortcutSelection = shortcut
       ShortcutSettings.shared.pttShortcut = shortcut
       ShortcutSettings.shared.pttEnabled = true
     } else {
+      openShortcutSelection = shortcut
       ShortcutSettings.shared.askOmiShortcut = shortcut
       ShortcutSettings.shared.askOmiEnabled = true
     }
@@ -459,33 +468,55 @@ extension SBOnboardingModel {
   /// the notch, which spins while Omi is thinking.
   func startScreenDemo() {
     screenDemoDone = false
+    screenDemoPTTReady = false
     FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
     FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
     resetFloatingBarConversation()
-    if let bar = FloatingControlBarManager.shared.barState {
-      PushToTalkManager.shared.setup(barState: bar)
-      // Mark the demo done the first time Omi actually answers, so the Continue
-      // button appears once the user has seen it work. The demo forces push-to-talk
-      // (`pttTranscriptionModeDemoOverride = .live`), and a *voice* answer surfaces
-      // through `voiceProjection` (the notch response phase) — it never flips
-      // `showingAIResponse`, which is only set by the typed/`.mainResponse` path.
-      // Watching only `showingAIResponse` is why the demo never advanced. Observe
-      // BOTH signals so either a voice or a typed answer reveals Continue.
-      // `resetFloatingBarConversation()` above cleared `showingAIResponse`, so its
-      // subscribe-time value is already false. `voiceProjection` has no such reset,
-      // and @Published replays its CURRENT value on subscribe — so on a resume/
-      // re-entry of the demo a stale `isResponseActive` would fire immediately and
-      // reveal Continue before the user does anything. `dropFirst()` ignores that
-      // replayed value; a real answer is always a later emission.
-      voiceCancellable = Publishers.Merge(
-        bar.$showingAIResponse.filter { $0 }.map { _ in () },
-        bar.$voiceProjection.dropFirst().filter { $0.isResponseActive }.map { _ in () }
-      )
-      .receive(on: DispatchQueue.main)
-      .sink { [weak self] _ in self?.screenDemoDone = true }
-    }
     ShortcutSettings.shared.pttTranscriptionModeDemoOverride = .live
-    Task { await chatProvider.warmupBridge() }
+    screenDemoSetupTask?.cancel()
+    screenDemoSetupTask = Task { [weak self] in
+      guard let self else { return }
+      // Unlike the normal app, onboarding did not have an earlier home-screen
+      // warmup. The old order set up PTT first, which made the hub request its
+      // kernel context before the bridge existed; the user's first hold then
+      // raced that cold start and could end without an answer. Establish the
+      // bridge before arming PTT so its first turn has a real response route.
+      await self.activateScreenDemoPTTAfterBridgeWarmup(
+        warmup: { await self.chatProvider.warmupBridge() },
+        activate: { self.activateScreenDemoPTT() }
+      )
+    }
+  }
+
+  /// The screen demo owns PTT only while its stage is still mounted. Keep this
+  /// lifecycle fence outside the unstructured task so the same production
+  /// boundary can be regression-tested: leaving the stage during a cold bridge
+  /// start must not attach fresh event monitors to the next onboarding page.
+  func activateScreenDemoPTTAfterBridgeWarmup(
+    warmup: @escaping @MainActor () async -> Void,
+    activate: @escaping @MainActor () -> Void
+  ) async {
+    await warmup()
+    guard !Task.isCancelled, step == .screenDemo else { return }
+    activate()
+  }
+
+  private func activateScreenDemoPTT() {
+    guard step == .screenDemo,
+      let bar = FloatingControlBarManager.shared.barState
+    else { return }
+    PushToTalkManager.shared.setup(barState: bar)
+    // Mark the demo done the first time Omi actually answers. Voice answers
+    // surface through `voiceProjection`; typed answers use `showingAIResponse`.
+    // Drop the current voice projection so re-entering the demo cannot inherit a
+    // stale response from a prior turn.
+    voiceCancellable = Publishers.Merge(
+      bar.$showingAIResponse.filter { $0 }.map { _ in () },
+      bar.$voiceProjection.dropFirst().filter { $0.isResponseActive }.map { _ in () }
+    )
+    .receive(on: DispatchQueue.main)
+    .sink { [weak self] _ in self?.screenDemoDone = true }
+    screenDemoPTTReady = true
     FloatingControlBarManager.shared.show()
   }
 
@@ -498,10 +529,13 @@ extension SBOnboardingModel {
   }
 
   func teardownVoiceDemo() {
+    screenDemoSetupTask?.cancel()
+    screenDemoSetupTask = nil
     voiceTimeout?.cancel()
     voiceTimeout = nil
     voiceCancellable = nil
     screenDemoDone = false
+    screenDemoPTTReady = false
     ShortcutSettings.shared.pttTranscriptionModeDemoOverride = nil
     resetFloatingBarConversation()
     PushToTalkManager.shared.cleanup()
@@ -647,16 +681,62 @@ extension SBOnboardingModel {
       {
         self.contextStates["applenotes"] = "on"
       }
-      let cal = await CalendarReaderService.shared.verifyConnection()
-      if cal.isConnected { self.markContextConnected("calendar") }
-      let gmail = await GmailReaderService.shared.verifyConnection()
-      if gmail.isConnected { self.markContextConnected("gmail") }
+
+      // Do not probe browser cookies just to decorate a fresh onboarding row.
+      // A functional probe without a completed import used to paint "on" even
+      // though post-onboarding Home/Apps had no persisted connector state and
+      // no imported data. Only re-check a connector that this account already
+      // completed through the canonical import path; a new source stays
+      // explicitly connectable until the user starts that import.
+      guard self.hasPersistedGoogleImport("calendar") || self.hasPersistedGoogleImport("gmail") else {
+        return
+      }
+      if self.hasPersistedGoogleImport("calendar") {
+        let calendar = await CalendarReaderService.shared.verifyConnection()
+        self.projectGoogleVerification("calendar", status: calendar)
+      }
+      if self.hasPersistedGoogleImport("gmail") {
+        let gmail = await GmailReaderService.shared.verifyConnection()
+        self.projectGoogleVerification("gmail", status: gmail)
+      }
     }
   }
 
-  func markContextConnected(_ id: String) {
+  private func hasPersistedGoogleImport(_ contextID: String) -> Bool {
+    guard
+      let statusStore = importConnectorStatusStore,
+      let connector = ImportConnector.all.first(where: {
+        $0.id == Self.importConnectorID(forGoogleContextID: contextID)
+      })
+    else { return false }
+    return statusStore.snapshot(for: connector).isConnected
+  }
+
+  private func markGoogleContextImported(_ id: String) {
     contextStates[id] = "on"
     contextDetails[id] = nil
+  }
+
+  private func projectGoogleVerification(_ id: String, status: CalendarConnectionStatus) {
+    switch status {
+    case .connected:
+      markGoogleContextImported(id)
+    case .needsSignIn:
+      projectGoogleContext(id, connected: false, needsSignIn: true)
+    case .error:
+      projectGoogleContext(id, connected: false, needsSignIn: false)
+    }
+  }
+
+  private func projectGoogleVerification(_ id: String, status: GmailConnectionStatus) {
+    switch status {
+    case .connected:
+      markGoogleContextImported(id)
+    case .needsSignIn:
+      projectGoogleContext(id, connected: false, needsSignIn: true)
+    case .error:
+      projectGoogleContext(id, connected: false, needsSignIn: false)
+    }
   }
 
   /// ChatGPT and Claude on this surface mean importing existing memories into
@@ -669,6 +749,10 @@ extension SBOnboardingModel {
     default:
       return .direct
     }
+  }
+
+  nonisolated static func importConnectorID(forGoogleContextID id: String) -> String {
+    id == "gmail" ? "email" : "calendar"
   }
 
   nonisolated static func googleContextResolution(
@@ -691,17 +775,10 @@ extension SBOnboardingModel {
     )
   }
 
-  /// Resolve a cookie-based Google connector (Calendar, Gmail). These don't OAuth —
-  /// they read your existing browser Google session — so a "not signed in" result
-  /// isn't an error to shrug at: OPEN the Google page so the user can actually sign
-  /// in, then Retry picks up the new session. (An `.error`, e.g. a not-yet-loaded
-  /// API key, just leaves a Retry button — opening Google wouldn't help.)
-  private func resolveGoogleConnect(
-    _ id: String,
-    connected: Bool,
-    needsSignIn: Bool,
-    signInURL: String
-  ) {
+  /// Projects a cookie-based Google import/probe into bounded onboarding copy.
+  /// Reconnect-required terminal imports open the browser separately; passive
+  /// refreshes must only show an honest retry state, never steal focus.
+  private func projectGoogleContext(_ id: String, connected: Bool, needsSignIn: Bool) {
     let resolution = Self.googleContextResolution(
       connectorID: id,
       connected: connected,
@@ -709,33 +786,6 @@ extension SBOnboardingModel {
     )
     contextStates[id] = resolution.state
     contextDetails[id] = resolution.detail
-    if resolution.shouldOpenSignIn, let url = URL(string: signInURL) {
-      NSWorkspace.shared.open(url)
-    }
-  }
-
-  /// Emits the terminal outcome for an onboarding connect verify-probe
-  /// (Calendar/Gmail). `needsSignIn` is the reconnect-required signal;
-  /// `.error` maps to the generic `unknown` class because the bounded status
-  /// enum does not carry the native failure subclass. The Apps-tab import path
-  /// emits the precise native class for the same connectors.
-  static func emitConnectVerifyOutcome(
-    connectorID: String,
-    connected: Bool,
-    needsSignIn: Bool,
-    durationMs: Int
-  ) {
-    let integrationName = IntegrationConnectTelemetry.integrationName(forConnectorID: connectorID)
-    if connected {
-      AnalyticsManager.shared.integrationConnectSucceeded(
-        integrationName: integrationName, connectorID: connectorID,
-        surface: .onboarding, stage: "verify", durationMs: durationMs)
-    } else {
-      let errorClass: IntegrationConnectTelemetry.ErrorClass = needsSignIn ? .notSignedIn : .unknown
-      AnalyticsManager.shared.integrationConnectFailed(
-        integrationName: integrationName, connectorID: connectorID,
-        surface: .onboarding, stage: "verify", errorClass: errorClass, durationMs: durationMs)
-    }
   }
 
   func connectContext(_ id: String) {
@@ -743,71 +793,14 @@ extension SBOnboardingModel {
     // The view owns import-sheet presentation. Keep this guard so another
     // caller cannot accidentally route a memory import into the MCP exporter.
     guard Self.contextConnectionRoute(for: id) == .direct else { return }
-    contextStates[id] = "connecting"
-    contextDetails[id] = nil
     switch id {
     case "calendar":
-      Task { [weak self] in
-        let startedAt = Date()
-        AnalyticsManager.shared.integrationConnectAttempted(
-          integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: "calendar"),
-          connectorID: "calendar",
-          surface: .onboarding,
-          stage: "verify"
-        )
-        let s = await CalendarReaderService.shared.verifyConnection()
-        let durationMs = max(0, Int(Date().timeIntervalSince(startedAt) * 1000))
-        let needsSignIn = {
-          switch s {
-          case .connected, .error:
-            return false
-          case .needsSignIn:
-            return true
-          }
-        }()
-        // Outcome telemetry for the onboarding connect probe. The bounded
-        // status enum is the only signal here; the precise native failure class
-        // is not recoverable from `CalendarConnectionStatus`, so needsSignIn
-        // maps to the reconnect-required class and `.error` to unknown. The
-        // Apps-tab import path carries the precise class.
-        Self.emitConnectVerifyOutcome(
-          connectorID: "calendar", connected: s.isConnected, needsSignIn: needsSignIn,
-          durationMs: durationMs)
-        self?.resolveGoogleConnect(
-          "calendar",
-          connected: s.isConnected,
-          needsSignIn: needsSignIn,
-          signInURL: "https://calendar.google.com"
-        )
+      startGoogleContextImport("calendar") { progress in
+        await ConnectorImportOperations.importCalendar(progress: progress)
       }
     case "gmail":
-      Task { [weak self] in
-        let startedAt = Date()
-        AnalyticsManager.shared.integrationConnectAttempted(
-          integrationName: IntegrationConnectTelemetry.integrationName(forConnectorID: "gmail"),
-          connectorID: "gmail",
-          surface: .onboarding,
-          stage: "verify"
-        )
-        let s = await GmailReaderService.shared.verifyConnection()
-        let durationMs = max(0, Int(Date().timeIntervalSince(startedAt) * 1000))
-        let needsSignIn = {
-          switch s {
-          case .connected, .error:
-            return false
-          case .needsSignIn:
-            return true
-          }
-        }()
-        Self.emitConnectVerifyOutcome(
-          connectorID: "gmail", connected: s.isConnected, needsSignIn: needsSignIn,
-          durationMs: durationMs)
-        self?.resolveGoogleConnect(
-          "gmail",
-          connected: s.isConnected,
-          needsSignIn: needsSignIn,
-          signInURL: "https://mail.google.com"
-        )
+      startGoogleContextImport("gmail") { progress in
+        await ConnectorImportOperations.importGmail(progress: progress)
       }
     case "applenotes":
       Task { [weak self] in
@@ -854,10 +847,116 @@ extension SBOnboardingModel {
     }
   }
 
+  /// Starts Gmail/Calendar through the exact shared importer that Apps uses.
+  /// Success is deliberately a three-part predicate: the browser auth worked
+  /// for a real data read, that read/import completed, and the account-scoped
+  /// connector status persisted for the surface shown after onboarding.
+  private func startGoogleContextImport(
+    _ contextID: String,
+    operation: @escaping @MainActor (ConnectorImportRunner.ProgressSink) async -> ConnectorImportOperations.Outcome
+  ) {
+    guard
+      let statusStore = importConnectorStatusStore,
+      let connector = ImportConnector.all.first(where: {
+        $0.id == Self.importConnectorID(forGoogleContextID: contextID)
+      })
+    else {
+      projectGoogleContext(contextID, connected: false, needsSignIn: false)
+      return
+    }
+
+    let connectorID = connector.id
+    let wasFirstSync = !statusStore.snapshot(for: connector).isConnected
+    contextStates[contextID] = "connecting"
+    contextDetails[contextID] = nil
+    let task = ConnectorImportRunner.shared.start(
+      connectorID: connectorID,
+      progressTitle: "Connecting to \(connector.title)",
+      progressDetail: "Reading data and saving it to your Omi memory.",
+      surface: .onboarding
+    ) { [self] progress in
+      let outcome = await operation(progress)
+      let terminal = completeGoogleContextImport(
+        contextID: contextID,
+        connectorID: connectorID,
+        outcome: outcome,
+        statusStore: statusStore,
+        wasFirstSync: wasFirstSync
+      )
+      if case .failure(_, let metrics) = terminal,
+        let failureClass = metrics.failureClass,
+        IntegrationConnectTelemetry.failureRequiresReconnect(failureClass),
+        let url = URL(string: contextID == "gmail" ? "https://mail.google.com" : "https://calendar.google.com")
+      {
+        NSWorkspace.shared.open(url)
+      }
+      return terminal
+    }
+    if task == nil {
+      // A shared Apps/onboarding import is already running. Don't leave the
+      // row spinning indefinitely; the persisted status is updated by that
+      // authoritative run and the user can retry once it settles.
+      contextStates[contextID] = "error"
+      contextDetails[contextID] = "This connection is already syncing. Wait a moment, then retry."
+    }
+  }
+
+  /// Applies an import terminal exactly once. Keeping this state transition in
+  /// the onboarding model makes the durable Apps/Home status and the visible
+  /// onboarding status change together, so one cannot report a false success.
+  func completeGoogleContextImport(
+    contextID: String,
+    connectorID: String,
+    outcome: ConnectorImportOperations.Outcome,
+    statusStore: ImportConnectorStatusStore,
+    wasFirstSync: Bool
+  ) -> ConnectorImportRunner.RunOutcome {
+    switch outcome {
+    case .success(let result, let message):
+      statusStore.markSynced(
+        connectorID: connectorID,
+        sourceCount: result.sourceCount,
+        memoryCount: result.memoryCount,
+        lastDeltaCount: result.newItems
+      )
+      markGoogleContextImported(contextID)
+      return .success(
+        message: message,
+        metrics: ConnectorImportRunner.RunMetrics(
+          sourceCount: result.sourceCount,
+          memoryCount: result.memoryCount,
+          wasFirstSync: wasFirstSync
+        )
+      )
+    case .failure(let message, let failureClass):
+      let reconnectRequired = failureClass.map(IntegrationConnectTelemetry.failureRequiresReconnect) ?? false
+      projectGoogleContext(contextID, connected: false, needsSignIn: reconnectRequired)
+      return .failure(
+        message: message,
+        metrics: ConnectorImportRunner.RunMetrics(
+          failureClass: failureClass,
+          wasFirstSync: wasFirstSync
+        )
+      )
+    }
+  }
+
   func markContextImportConnected(_ connectorID: String) {
     guard Self.contextConnectionRoute(for: connectorID) == .importConnector(connectorID) else { return }
     contextStates[connectorID] = "on"
     contextDetails[connectorID] = nil
+  }
+
+  /// Receives the canonical persisted connector ID from the shared import
+  /// status store. Gmail's context-row ID differs from its Apps ID (`gmail`
+  /// vs `email`), so translate at this one authority boundary rather than
+  /// allowing a completed shared import to leave the onboarding row stale.
+  func markPersistedContextConnectorConnected(_ connectorID: String) {
+    switch connectorID {
+    case "calendar": markGoogleContextImported("calendar")
+    case "email": markGoogleContextImported("gmail")
+    default: markContextImportConnected(connectorID)
+    }
   }
 
   func answerContext() { advance(userAnswer: "Continue", to: .capture) }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -43,6 +43,7 @@ final class SBOnboardingModel: ObservableObject {
   @Published var nameDraft = ""
   @Published var languageDraft = ""
   @Published var languageName: String?
+  @Published var howHeard: String?
   @Published var roleDraft = ""
   @Published var role: String?
 
@@ -68,6 +69,10 @@ final class SBOnboardingModel: ObservableObject {
   /// The chosen shortcut + which mechanism it uses (key hotkey vs modifier-hold).
   var chosenShortcut: ShortcutSettings.KeyboardShortcut?
   var chosenShortcutIsPTT = false
+  /// Each shortcut stage keeps its own choice so stepping back does not make a
+  /// user re-select a key they already confirmed.
+  var openShortcutSelection: ShortcutSettings.KeyboardShortcut?
+  var talkShortcutSelection: ShortcutSettings.KeyboardShortcut?
   var shortcutMonitors: [Any] = []
   /// Main menu stashed while the shortcut step's key monitor is armed (menu key
   /// equivalents like ⌘O would otherwise swallow the press before we see it).
@@ -82,8 +87,13 @@ final class SBOnboardingModel: ObservableObject {
   /// response). The screen-demo Continue button stays hidden until then, so the
   /// user can't skip past before seeing the "fun part" work.
   @Published var screenDemoDone = false
+  /// The hold-to-talk demo is armed only after the bridge has initialized its
+  /// kernel context. Showing the chord sooner invites a first PTT turn while its
+  /// only response route is still cold.
+  @Published var screenDemoPTTReady = false
   var voiceCancellable: AnyCancellable?
   var voiceTimeout: Task<Void, Never>?
+  var screenDemoSetupTask: Task<Void, Never>?
 
   // Connectors — keyed by a stable id ("openclaw", "calendar", …) → state string
   // ("idle" | "connecting" | "on" | "unavailable" | "needsSignIn").
@@ -96,6 +106,10 @@ final class SBOnboardingModel: ObservableObject {
 
   unowned let appState: AppState
   let chatProvider: ChatProvider
+  /// The same persisted connector authority the post-onboarding Home and Apps
+  /// surfaces read. A context row is not connected until this store records a
+  /// completed import, never merely because a browser session passed a probe.
+  let importConnectorStatusStore: ImportConnectorStatusStore?
   private let onComplete: (() -> Void)?
   var streamTask: Task<Void, Never>?
   /// Permission-grant pollers, one per permission key. Keyed so requesting a
@@ -110,9 +124,15 @@ final class SBOnboardingModel: ObservableObject {
   /// only ever written on the main actor and `removeObserver` is thread-safe.
   nonisolated(unsafe) private var nameObserver: NSObjectProtocol?
 
-  init(appState: AppState, chatProvider: ChatProvider, onComplete: (() -> Void)?) {
+  init(
+    appState: AppState,
+    chatProvider: ChatProvider,
+    importConnectorStatusStore: ImportConnectorStatusStore? = nil,
+    onComplete: (() -> Void)?
+  ) {
     self.appState = appState
     self.chatProvider = chatProvider
+    self.importConnectorStatusStore = importConnectorStatusStore
     self.onComplete = onComplete
     // Isolate any onboarding chat/voice turns to the throwaway `.onboarding()`
     // journal surface so they never pollute the real Chat tab. Cleared on
@@ -319,12 +339,43 @@ final class SBOnboardingModel: ObservableObject {
     streamMessage(for: target)
   }
 
+  /// Return to the immediately preceding onboarding stage without discarding
+  /// any answer the user already supplied. The conversational transcript stays
+  /// intact; the re-rendered widget is the editable source of truth for that
+  /// stage, so a user can revise (for example) Student to Founder.
+  func goBack() {
+    guard let previous = Step(rawValue: step.rawValue - 1) else { return }
+    teardownStep(step)
+    cancelPermissionPollForCurrentStep()
+    rehydrateDrafts()
+    step = previous
+    UserDefaults.standard.set(previous.rawValue, forKey: Self.resumeStepKey)
+    streamMessage(for: previous)
+  }
+
+  var canGoBack: Bool {
+    step != .promise
+  }
+
   /// Tear down any live monitors/tasks a step installed before leaving it.
   private func teardownStep(_ step: Step) {
     switch step {
     case .shortcutOpen, .shortcutTalk: disarmShortcutSummon()
     case .screenDemo: teardownVoiceDemo()
     default: break
+    }
+  }
+
+  /// A permission poll is scoped to the page that requested it. If Back leaves
+  /// that page while macOS is still open, stop the stale poll so a late grant
+  /// cannot overwrite the newly displayed page's state. The system grant itself
+  /// is still observed if the user returns to this page.
+  private func cancelPermissionPollForCurrentStep() {
+    guard let key = permissionKey(for: step) else { return }
+    pollTasks[key]?.cancel()
+    pollTasks[key] = nil
+    if permState(key) == .waiting {
+      resetPermToAsk(key)
     }
   }
 
@@ -336,9 +387,16 @@ final class SBOnboardingModel: ObservableObject {
       let n = AuthService.shared.givenName.trimmingCharacters(in: .whitespaces)
       if !n.isEmpty { nameDraft = n }
     }
-    if roleDraft.isEmpty, role == nil {
+    if role == nil {
       let saved = UserDefaults.standard.string(forKey: .onboardingRole) ?? ""
-      if !saved.isEmpty { roleDraft = saved }
+      if !saved.isEmpty {
+        role = saved
+        if roleDraft.isEmpty { roleDraft = saved }
+      }
+    }
+    if howHeard == nil {
+      let saved = UserDefaults.standard.string(forKey: DefaultsKey.onboardingHowDidYouHearSource)
+      if let saved, !saved.isEmpty { howHeard = saved }
     }
     if languageDraft.isEmpty, languageName == nil, let code = AssistantSettings.shared.voiceLanguages.first,
       let match = AssistantSettings.supportedLanguages.first(where: { $0.code == code })
@@ -361,6 +419,7 @@ final class SBOnboardingModel: ObservableObject {
   /// Record the acquisition source (analytics + backend, like the legacy step),
   /// then move on.
   func pickHowHeard(_ source: String) {
+    howHeard = source
     UserDefaults.standard.set(source, forKey: DefaultsKey.onboardingHowDidYouHearSource)
     AnalyticsManager.shared.onboardingHowDidYouHear(source: source)
     Task { try? await APIClient.shared.updateOnboardingAcquisitionSource(source) }
@@ -371,6 +430,7 @@ final class SBOnboardingModel: ObservableObject {
   /// confirmLanguages, single-primary). Advances optimistically.
   func pickLanguage(code: String, name: String) {
     languageName = name
+    languageDraft = name
     AssistantSettings.shared.voiceLanguages = [code]
     Task { _ = try? await APIClient.shared.updateUserLanguage(code) }
     advance(userAnswer: name, to: .role)

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -91,6 +91,10 @@ final class SBOnboardingModel: ObservableObject {
   /// kernel context. Showing the chord sooner invites a first PTT turn while its
   /// only response route is still cold.
   @Published var screenDemoPTTReady = false
+  /// Bridge startup can fail before an authenticated response route exists. In
+  /// that state, leave PTT unarmed and offer an explicit retry or skip instead
+  /// of presenting a shortcut which cannot answer.
+  @Published var screenDemoPTTUnavailable = false
   var voiceCancellable: AnyCancellable?
   var voiceTimeout: Task<Void, Never>?
   var screenDemoSetupTask: Task<Void, Never>?
@@ -110,6 +114,9 @@ final class SBOnboardingModel: ObservableObject {
   /// surfaces read. A context row is not connected until this store records a
   /// completed import, never merely because a browser session passed a probe.
   let importConnectorStatusStore: ImportConnectorStatusStore?
+  /// Backend writes for editable answers are per-field serialized. Revisiting a
+  /// question never lets an earlier request finish after the user's revision.
+  private let answerWriteGate = OnboardingAnswerWriteGate()
   private let onComplete: (() -> Void)?
   var streamTask: Task<Void, Never>?
   /// Permission-grant pollers, one per permission key. Keyed so requesting a
@@ -412,7 +419,9 @@ final class SBOnboardingModel: ObservableObject {
   func answerName() {
     let trimmed = nameDraft.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty else { return }
-    Task { await AuthService.shared.updateGivenName(trimmed) }
+    answerWriteGate.enqueue(.name) { [trimmed] in
+      await AuthService.shared.updateGivenName(trimmed)
+    }
     advance(userAnswer: trimmed, to: .howHeard)
   }
 
@@ -422,7 +431,9 @@ final class SBOnboardingModel: ObservableObject {
     howHeard = source
     UserDefaults.standard.set(source, forKey: DefaultsKey.onboardingHowDidYouHearSource)
     AnalyticsManager.shared.onboardingHowDidYouHear(source: source)
-    Task { try? await APIClient.shared.updateOnboardingAcquisitionSource(source) }
+    answerWriteGate.enqueue(.acquisitionSource) { [source] in
+      _ = try? await APIClient.shared.updateOnboardingAcquisitionSource(source)
+    }
     advance(userAnswer: source, to: .language)
   }
 
@@ -432,7 +443,9 @@ final class SBOnboardingModel: ObservableObject {
     languageName = name
     languageDraft = name
     AssistantSettings.shared.voiceLanguages = [code]
-    Task { _ = try? await APIClient.shared.updateUserLanguage(code) }
+    answerWriteGate.enqueue(.language) { [code] in
+      _ = try? await APIClient.shared.updateUserLanguage(code)
+    }
     advance(userAnswer: name, to: .role)
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -29,7 +29,12 @@ struct SBOnboardingView: View {
     onComplete: (() -> Void)?
   ) {
     _model = StateObject(
-      wrappedValue: SBOnboardingModel(appState: appState, chatProvider: chatProvider, onComplete: onComplete))
+      wrappedValue: SBOnboardingModel(
+        appState: appState,
+        chatProvider: chatProvider,
+        importConnectorStatusStore: importConnectorStatusStore,
+        onComplete: onComplete
+      ))
     _importConnectorStatusStore = ObservedObject(wrappedValue: importConnectorStatusStore)
   }
 
@@ -55,18 +60,35 @@ struct SBOnboardingView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .overlay(alignment: .topTrailing) {
-      Button(action: { model.skip() }) {
-        Text("Skip")
-          .geist(size: 13).foregroundStyle(sb.ink(.w45))
-          .padding(.horizontal, 14).padding(.vertical, 7)
-          .background(
-            Capsule().fill(Color.white.opacity(0.06))
-              .background(.ultraThinMaterial, in: Capsule())
-          )
-          .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+      HStack(spacing: 8) {
+        if model.canGoBack {
+          Button(action: { model.goBack() }) {
+            Text("← Back")
+              .geist(size: 13).foregroundStyle(sb.ink(.w75))
+              .padding(.horizontal, 14).padding(.vertical, 7)
+              .background(
+                Capsule().fill(Color.white.opacity(0.06))
+                  .background(.ultraThinMaterial, in: Capsule())
+              )
+              .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+          }
+          .buttonStyle(.plain)
+          .help("Go back and change an earlier answer")
+        }
+
+        Button(action: { model.skip() }) {
+          Text("Skip")
+            .geist(size: 13).foregroundStyle(sb.ink(.w45))
+            .padding(.horizontal, 14).padding(.vertical, 7)
+            .background(
+              Capsule().fill(Color.white.opacity(0.06))
+                .background(.ultraThinMaterial, in: Capsule())
+            )
+            .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help("Skip onboarding and go to your second brain")
       }
-      .buttonStyle(.plain)
-      .help("Skip onboarding and go to your second brain")
       .padding(.top, 20).padding(.trailing, 24)
     }
     .onAppear { model.begin() }
@@ -77,7 +99,7 @@ struct SBOnboardingView: View {
       if step == .context { refreshContextStates() }
     }
     .onReceive(importConnectorStatusStore.connectorDidSync) { connectorID in
-      model.markContextImportConnected(connectorID)
+      model.markPersistedContextConnectorConnected(connectorID)
     }
     .dismissableSheet(item: $selectedImportConnector) { connector in
       ImportConnectorSheet(
@@ -247,7 +269,7 @@ struct SBOnboardingView: View {
   }
 
   private var howHeardWidget: some View {
-    FlowChips(items: SBOnboardingModel.howHeardSources) { source in
+    FlowChips(items: SBOnboardingModel.howHeardSources, selectedItem: model.howHeard) { source in
       model.pickHowHeard(source)
     }
   }
@@ -316,7 +338,10 @@ struct SBOnboardingView: View {
 
   private var roleWidget: some View {
     VStack(alignment: .leading, spacing: 10) {
-      FlowChips(items: ["Student", "Sales", "Consultant", "Founder", "Engineer", "Analyst", "Creator", "Other"]) { r in
+      FlowChips(
+        items: ["Student", "Sales", "Consultant", "Founder", "Engineer", "Analyst", "Creator", "Other"],
+        selectedItem: model.role
+      ) { r in
         model.pickRole(r)
       }
       HStack(spacing: 8) {
@@ -482,15 +507,24 @@ struct SBOnboardingView: View {
 
   private var screenDemoWidget: some View {
     VStack(alignment: .leading, spacing: 12) {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 5) {
-          Text("Hold").geist(size: 14).foregroundStyle(sb.ink(.w85))
-          ForEach(model.voiceChordTokens, id: \.self) { tok in keycap(tok) }
-          Text("and ask me about it, out loud.").geist(size: 14).foregroundStyle(sb.ink(.w85))
-        }
-        Text("Try \u{201c}what's on my screen right now?\u{201d} I can see it, and I answer at the top of your screen.")
+      if model.screenDemoPTTReady {
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 5) {
+            Text("Hold").geist(size: 14).foregroundStyle(sb.ink(.w85))
+            ForEach(model.voiceChordTokens, id: \.self) { tok in keycap(tok) }
+            Text("and ask me about it, out loud.").geist(size: 14).foregroundStyle(sb.ink(.w85))
+          }
+          Text(
+            "Try \u{201c}what's on my screen right now?\u{201d} I can see it, and I answer at the top of your screen."
+          )
           .geist(size: 12.5).foregroundStyle(sb.ink(.w45))
           .fixedSize(horizontal: false, vertical: true)
+        }
+      } else {
+        HStack(spacing: 8) {
+          ProgressView().controlSize(.small)
+          Text("Preparing voice…").geist(size: 14).foregroundStyle(sb.ink(.w6))
+        }
       }
       // Continue appears once Omi has actually answered — before that, an always-
       // tappable, clearly-visible "Skip for now" so the user is never stuck if the
@@ -668,16 +702,19 @@ struct SBOnboardingView: View {
 private struct FlowChips: View {
   @Environment(\.sbTheme) private var sb
   let items: [String]
+  var selectedItem: String? = nil
   let onPick: (String) -> Void
   var body: some View {
     ChipFlowLayout(spacing: 8, lineSpacing: 8) {
       ForEach(items, id: \.self) { item in
+        let isSelected = selectedItem == item
         Button {
           onPick(item)
         } label: {
-          Text(item).geist(size: 14).foregroundStyle(sb.ink(.w85))
+          Text(item).geist(size: 14).foregroundStyle(isSelected ? sb.inkInverted : sb.ink(.w85))
             .padding(.horizontal, 15).padding(.vertical, 8)
-            .overlay(Capsule().stroke(sb.ink(.w14), lineWidth: 1))
+            .background(Capsule().fill(isSelected ? sb.ink : Color.clear))
+            .overlay(Capsule().stroke(isSelected ? sb.ink : sb.ink(.w14), lineWidth: 1))
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -520,6 +520,17 @@ struct SBOnboardingView: View {
           .geist(size: 12.5).foregroundStyle(sb.ink(.w45))
           .fixedSize(horizontal: false, vertical: true)
         }
+      } else if model.screenDemoPTTUnavailable {
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Voice setup isn't available yet. You can retry, or skip for now.")
+            .geist(size: 14).foregroundStyle(sb.ink(.w6))
+          Button("Try again") {
+            model.startScreenDemo()
+          }
+          .buttonStyle(.plain)
+          .geist(size: 14, weight: .medium)
+          .foregroundStyle(sb.ink(.w85))
+        }
       } else {
         HStack(spacing: 8) {
           ProgressView().controlSize(.small)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1553,9 +1553,9 @@ class ChatProvider: ObservableObject {
   }
 
   /// Pre-start the active bridge so the first query doesn't wait for process launch
-  func warmupBridge() async {
+  func warmupBridge() async -> Bool {
     await preparePromptContextIfNeeded()
-    _ = await ensureBridgeStarted()
+    return await ensureBridgeStarted()
   }
 
   /// Drop a cached agent surface so the next query recreates it with fresh prompt context.

--- a/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
@@ -77,6 +77,30 @@ final class BrowserGoogleSessionTests: XCTestCase {
     XCTAssertEqual(query[kSecReturnData as String] as? Bool, true)
   }
 
+  func testSuccessfulSharedSafeStorageGrantIsReadOnceAcrossGoogleConsumers() {
+    // This is the exact shared Chrome Safe Storage identity Calendar and Gmail
+    // derive through `BrowserKeychainCache.password(for:account:)`; prefix it
+    // only to keep the test isolated from a real user credential.
+    let cacheKey = "BrowserGoogleSessionTests.\(UUID().uuidString)\u{0}Chrome Safe Storage\u{0}Chrome"
+    var keychainReads = 0
+
+    let calendarPassword = BrowserKeychainCache.shared.password(for: cacheKey) {
+      keychainReads += 1
+      return "granted"
+    }
+    let gmailPassword = BrowserKeychainCache.shared.password(for: cacheKey) {
+      keychainReads += 1
+      return "granted"
+    }
+
+    XCTAssertEqual(calendarPassword, "granted")
+    XCTAssertEqual(gmailPassword, "granted")
+    // A second loader would be a second Keychain authorization request. Both
+    // consumers must reuse the original successful grant and exact secret.
+    XCTAssertEqual(keychainReads, 1)
+    BrowserKeychainCache.shared.invalidate(cacheKey: cacheKey)
+  }
+
   func testUnknownVersionCookieBlobIsSkippedInsteadOfEmittedAsPlaintext() throws {
     let databasePath = tempRoot.appendingPathComponent("Cookies").path
     let script =

--- a/desktop/macos/Desktop/Tests/IntegrationConnectTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/IntegrationConnectTelemetryTests.swift
@@ -318,34 +318,48 @@ final class IntegrationConnectTelemetryTests: XCTestCase {
     XCTAssertEqual(attempted.count, 1)
   }
 
-  // MARK: - Behavioral: onboarding verify-probe outcome mapping
+  // MARK: - Behavioral: onboarding uses the shared import terminal
 
-  func testOnboardingVerifyOutcomeForConnectedEmitsSucceeded() {
-    SBOnboardingModel.emitConnectVerifyOutcome(
-      connectorID: "calendar", connected: true, needsSignIn: false, durationMs: 800)
-    XCTAssertEqual(captured.count, 1)
-    XCTAssertEqual(captured[0].name, "Integration Connect Succeeded")
+  func testOnboardingImportRetainsItsSurfaceAtAttemptAndSuccess() async {
+    let runner = ConnectorImportRunner()
+    let task = runner.start(
+      connectorID: "calendar",
+      progressTitle: "Connecting",
+      progressDetail: "Calendar",
+      surface: .onboarding
+    ) { _ in
+      .success(message: "done")
+    }
+
+    await task?.value
+
+    XCTAssertEqual(captured.map(\.name), ["Integration Connect Attempted", "Integration Connect Succeeded"])
     XCTAssertEqual(captured[0].properties["surface"] as? String, "onboarding")
-    XCTAssertEqual(captured[0].properties["stage"] as? String, "verify")
-    XCTAssertEqual(captured[0].properties["duration_bucket"] as? String, "0_1s")
+    XCTAssertEqual(captured[0].properties["stage"] as? String, "import")
+    XCTAssertEqual(captured[1].properties["surface"] as? String, "onboarding")
+    XCTAssertEqual(captured[1].properties["stage"] as? String, "import")
   }
 
-  func testOnboardingVerifyOutcomeForNeedsSignInEmitsFailedReconnectRequired() {
-    SBOnboardingModel.emitConnectVerifyOutcome(
-      connectorID: "gmail", connected: false, needsSignIn: true, durationMs: 1_200)
-    XCTAssertEqual(captured.count, 1)
-    XCTAssertEqual(captured[0].name, "Integration Connect Failed")
-    XCTAssertEqual(captured[0].properties["error_class"] as? String, "not_signed_in")
-    XCTAssertEqual(captured[0].properties["reconnect_required"] as? Bool, true)
-  }
+  func testOnboardingImportFailureRetainsReconnectClassification() async {
+    let runner = ConnectorImportRunner()
+    let task = runner.start(
+      connectorID: "email",
+      progressTitle: "Connecting",
+      progressDetail: "Gmail",
+      surface: .onboarding
+    ) { _ in
+      .failure(
+        message: "Sign in",
+        metrics: ConnectorImportRunner.RunMetrics(failureClass: .notSignedIn)
+      )
+    }
 
-  func testOnboardingVerifyOutcomeForErrorEmitsFailedUnknown() {
-    SBOnboardingModel.emitConnectVerifyOutcome(
-      connectorID: "gmail", connected: false, needsSignIn: false, durationMs: 1_200)
-    XCTAssertEqual(captured.count, 1)
-    XCTAssertEqual(captured[0].name, "Integration Connect Failed")
-    XCTAssertEqual(captured[0].properties["error_class"] as? String, "unknown")
-    XCTAssertEqual(captured[0].properties["reconnect_required"] as? Bool, false)
+    await task?.value
+
+    XCTAssertEqual(captured[1].name, "Integration Connect Failed")
+    XCTAssertEqual(captured[1].properties["surface"] as? String, "onboarding")
+    XCTAssertEqual(captured[1].properties["error_class"] as? String, "not_signed_in")
+    XCTAssertEqual(captured[1].properties["reconnect_required"] as? Bool, true)
   }
 }
 

--- a/desktop/macos/Desktop/Tests/MemoryAtlasPerformanceHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasPerformanceHarnessTests.swift
@@ -401,12 +401,11 @@ final class MemoryAtlasPerformanceHarnessTests: XCTestCase {
   func testMeasureProductionScaleLayout() {
     let graph = makeProductionScaleGraph()
 
-    // Three iterations, not the default ten. Laying out this fixture is now a
-    // relaxation rather than a formula, and ten repeats of it added roughly a
-    // minute to every full run of this suite in a debug build — a high price
-    // for a diagnostic that reports a local number and asserts nothing.
+    // One iteration, not the default ten. This reports a diagnostic local
+    // baseline without letting a non-asserting benchmark consume the isolated
+    // suite's CI timeout budget under a loaded debug runner.
     let options = XCTMeasureOptions()
-    options.iterationCount = 3
+    options.iterationCount = 1
 
     measure(metrics: [XCTClockMetric(), XCTCPUMetric(), XCTMemoryMetric()], options: options) {
       _ = MemoryAtlasLayoutEngine.makeSnapshot(graph: graph, userName: "Atlas Owner")

--- a/desktop/macos/Desktop/Tests/OnboardingAnswerWriteGateTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingAnswerWriteGateTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import Omi_Computer
+
+private actor OnboardingAnswerWriteTestLatch {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var isOpen = false
+
+  func wait() async {
+    guard !isOpen else { return }
+    await withCheckedContinuation { continuation in
+      if isOpen {
+        continuation.resume()
+      } else {
+        self.continuation = continuation
+      }
+    }
+  }
+
+  func open() {
+    isOpen = true
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+@MainActor
+final class OnboardingAnswerWriteGateTests: XCTestCase {
+  func testRevisionWaitsForEarlierWriteBeforeItCanReachTheBackend() async {
+    let gate = OnboardingAnswerWriteGate()
+    let firstWriteStarted = expectation(description: "first write started")
+    let latch = OnboardingAnswerWriteTestLatch()
+    var writes: [String] = []
+
+    gate.enqueue(.name) {
+      writes.append("first started")
+      firstWriteStarted.fulfill()
+      await latch.wait()
+      writes.append("first finished")
+    }
+    await fulfillment(of: [firstWriteStarted], timeout: 1)
+
+    gate.enqueue(.name) {
+      writes.append("revision")
+    }
+    await latch.open()
+    await gate.waitForIdle(.name)
+
+    XCTAssertEqual(writes, ["first started", "first finished", "revision"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/OnboardingGoogleInsightGateTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingGoogleInsightGateTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class OnboardingGoogleInsightGateTests: XCTestCase {
+  private actor Signal {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+      if isOpen { return }
+      await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+      guard !isOpen else { return }
+      isOpen = true
+      let pending = waiters
+      waiters.removeAll()
+      for waiter in pending {
+        waiter.resume()
+      }
+    }
+  }
+
+  private actor Trace {
+    private var values: [String] = []
+
+    func append(_ value: String) { values.append(value) }
+    func snapshot() -> [String] { values }
+  }
+
+  func testGmailWaitsForCalendarThenContinuesAfterCalendarFailure() async {
+    let gate = OnboardingGoogleInsightGate()
+    let gmailStarted = Signal()
+    let gmailFinished = Signal()
+    let trace = Trace()
+
+    let gmail = Task {
+      await gmailStarted.open()
+      await gate.waitForCalendar()
+      // This models Gmail's own terminal failure. It still must run after a
+      // separate Calendar failure released the shared-auth gate.
+      await trace.append("gmail_attempted")
+      await gmailFinished.open()
+      return false
+    }
+
+    await gmailStarted.wait()
+    let beforeCalendarCompletes = await trace.snapshot()
+    XCTAssertEqual(beforeCalendarCompletes, [])
+
+    await trace.append("calendar_failed")
+    await gate.markCalendarFinished()
+    await gmailFinished.wait()
+
+    let gmailSucceeded = await gmail.value
+    let completedTrace = await trace.snapshot()
+    XCTAssertFalse(gmailSucceeded)
+    XCTAssertEqual(completedTrace, ["calendar_failed", "gmail_attempted"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
@@ -59,7 +59,7 @@ final class SBOnboardingBackNavigationTests: XCTestCase {
     var activated = false
 
     await model.activateScreenDemoPTTAfterBridgeWarmup(
-      warmup: {},
+      warmup: { true },
       activate: { activated = true }
     )
 
@@ -68,10 +68,29 @@ final class SBOnboardingBackNavigationTests: XCTestCase {
     activated = false
     model.step = .screenDemo
     await model.activateScreenDemoPTTAfterBridgeWarmup(
-      warmup: { model.step = .agents },
+      warmup: {
+        model.step = .agents
+        return true
+      },
       activate: { activated = true }
     )
 
     XCTAssertFalse(activated, "A late bridge warmup must not arm PTT after navigating away")
+  }
+
+  func testVoiceDemoKeepsPTTUnarmedWhenBridgeWarmupFails() async {
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.step = .screenDemo
+    var activated = false
+
+    await model.activateScreenDemoPTTAfterBridgeWarmup(
+      warmup: { false },
+      activate: { activated = true }
+    )
+
+    XCTAssertFalse(activated)
+    XCTAssertFalse(model.screenDemoPTTReady)
+    XCTAssertTrue(model.screenDemoPTTUnavailable)
   }
 }

--- a/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SBOnboardingBackNavigationTests: XCTestCase {
+  private let resumeStepKey = "sbOnboardingResumeStep"
+
+  override func setUp() {
+    super.setUp()
+    UserDefaults.standard.removeObject(forKey: resumeStepKey)
+    UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingHowDidYouHearSource)
+    UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingRole)
+  }
+
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: resumeStepKey)
+    UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingHowDidYouHearSource)
+    UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingRole)
+    super.tearDown()
+  }
+
+  func testBackFromPermissionsReturnsToRoleAndPreservesSelectedRole() {
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    UserDefaults.standard.set("Student", forKey: DefaultsKey.onboardingRole)
+    model.step = .mic
+
+    model.goBack()
+
+    XCTAssertEqual(model.step, .role)
+    XCTAssertEqual(model.role, "Student")
+    XCTAssertEqual(
+      UserDefaults.standard.integer(forKey: SBOnboardingModel.resumeStepKey),
+      SBOnboardingModel.Step.role.rawValue)
+  }
+
+  func testBackPreservesEarlierAcquisitionChoiceAndStopsAtFirstStep() {
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.howHeard = "Friend"
+    UserDefaults.standard.set("Friend", forKey: DefaultsKey.onboardingHowDidYouHearSource)
+    model.step = .language
+
+    model.goBack()
+
+    XCTAssertEqual(model.step, .howHeard)
+    XCTAssertEqual(model.howHeard, "Friend")
+
+    model.step = .promise
+    model.goBack()
+    XCTAssertEqual(model.step, .promise)
+  }
+
+  func testVoiceDemoArmsPTTOnlyAfterBridgeWarmupWhileStillOnDemoStage() async {
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.step = .screenDemo
+    var activated = false
+
+    await model.activateScreenDemoPTTAfterBridgeWarmup(
+      warmup: {},
+      activate: { activated = true }
+    )
+
+    XCTAssertTrue(activated)
+
+    activated = false
+    model.step = .screenDemo
+    await model.activateScreenDemoPTTAfterBridgeWarmup(
+      warmup: { model.step = .agents },
+      activate: { activated = true }
+    )
+
+    XCTAssertFalse(activated, "A late bridge warmup must not arm PTT after navigating away")
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
@@ -56,6 +56,8 @@ final class SBOnboardingCloudContextStateTests: XCTestCase {
     XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "claude"), .importConnector("claude"))
     XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "calendar"), .direct)
     XCTAssertEqual(SBOnboardingModel.contextConnectionRoute(for: "gmail"), .direct)
+    XCTAssertEqual(SBOnboardingModel.importConnectorID(forGoogleContextID: "calendar"), "calendar")
+    XCTAssertEqual(SBOnboardingModel.importConnectorID(forGoogleContextID: "gmail"), "email")
 
     for connectorID in ["chatgpt", "claude"] {
       let connector = ImportConnector.all.first(where: { $0.id == connectorID })
@@ -107,17 +109,103 @@ final class SBOnboardingCloudContextStateTests: XCTestCase {
   }
 
   @MainActor
-  func testPassiveGoogleRecoveryClearsThePreviouslyProjectedFailure() {
+  func testSuccessfulGoogleImportPersistsTheSameConnectedStateReadAfterOnboarding() throws {
+    let testDefaults = try makeDefaults()
+    defer { testDefaults.defaults.removePersistentDomain(forName: testDefaults.suiteName) }
+    let statusStore = ImportConnectorStatusStore(defaults: testDefaults.defaults, sessionUserID: "test-user")
+    let model = SBOnboardingModel(
+      appState: AppState(),
+      chatProvider: ChatProvider(),
+      importConnectorStatusStore: statusStore,
+      onComplete: nil)
+
+    let terminal = model.completeGoogleContextImport(
+      contextID: "calendar",
+      connectorID: "calendar",
+      outcome: .success(
+        ConnectorImportOperations.SyncResult(sourceCount: 0, memoryCount: 0, newItems: 0),
+        message: "Imported 0 events and saved 0 memories."
+      ),
+      statusStore: statusStore,
+      wasFirstSync: true
+    )
+
+    XCTAssertEqual(model.contextStates["calendar"], "on")
+    XCTAssertNil(model.contextDetails["calendar"])
+    guard case .success(_, let metrics) = terminal else {
+      return XCTFail("expected a successful import terminal")
+    }
+    XCTAssertEqual(metrics.sourceCount, 0)
+    guard let calendarConnector = ImportConnector.all.first(where: { $0.id == "calendar" }) else {
+      return XCTFail("calendar connector must remain registered")
+    }
+    XCTAssertTrue(
+      ImportConnectorStatusStore(defaults: testDefaults.defaults, sessionUserID: "test-user")
+        .snapshot(for: calendarConnector)
+        .isConnected
+    )
+  }
+
+  @MainActor
+  func testFailedGoogleImportNeverPersistsOrProjectsConnected() throws {
+    let testDefaults = try makeDefaults()
+    defer { testDefaults.defaults.removePersistentDomain(forName: testDefaults.suiteName) }
+    let statusStore = ImportConnectorStatusStore(defaults: testDefaults.defaults, sessionUserID: "test-user")
+    let model = SBOnboardingModel(
+      appState: AppState(),
+      chatProvider: ChatProvider(),
+      importConnectorStatusStore: statusStore,
+      onComplete: nil)
+
+    let terminal = model.completeGoogleContextImport(
+      contextID: "gmail",
+      connectorID: "email",
+      outcome: .failure(message: "Sign in", failureClass: .sessionExpired),
+      statusStore: statusStore,
+      wasFirstSync: true
+    )
+
+    XCTAssertEqual(model.contextStates["gmail"], "needsSignIn")
+    XCTAssertEqual(
+      model.contextDetails["gmail"],
+      "Open Gmail in Chrome, Arc, Brave, or Edge, sign in, then retry."
+    )
+    guard case .failure(_, let metrics) = terminal else {
+      return XCTFail("expected a failed import terminal")
+    }
+    XCTAssertEqual(metrics.failureClass, .sessionExpired)
+    guard let emailConnector = ImportConnector.all.first(where: { $0.id == "email" }) else {
+      return XCTFail("email connector must remain registered")
+    }
+    XCTAssertFalse(
+      ImportConnectorStatusStore(defaults: testDefaults.defaults, sessionUserID: "test-user")
+        .snapshot(for: emailConnector)
+        .isConnected
+    )
+  }
+
+  @MainActor
+  func testPersistedEmailConnectorIDUpdatesGmailContextRow() {
     let model = SBOnboardingModel(
       appState: AppState(),
       chatProvider: ChatProvider(),
       onComplete: nil)
-    model.contextStates["calendar"] = "error"
-    model.contextDetails["calendar"] = "Couldn't verify Google Calendar."
 
-    model.markContextConnected("calendar")
+    model.markPersistedContextConnectorConnected("email")
 
-    XCTAssertEqual(model.contextStates["calendar"], "on")
-    XCTAssertNil(model.contextDetails["calendar"])
+    XCTAssertEqual(model.contextStates["gmail"], "on")
+    XCTAssertNil(model.contextDetails["gmail"])
+  }
+
+  private func makeDefaults() throws -> (defaults: UserDefaults, suiteName: String) {
+    let suiteName = "SBOnboardingCloudContextStateTests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      throw NSError(
+        domain: "SBOnboardingCloudContextStateTests",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "unable to create isolated UserDefaults suite"]
+      )
+    }
+    return (defaults, suiteName)
   }
 }

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -142,58 +142,44 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
     XCTAssertEqual(CloudConnectorGuidanceOverlay.dragCardInitialAlpha(reduceMotion: true), 1)
   }
 
-  /// The drag card pins directly beneath the Settings window (x-centered on it,
-  /// its top a fixed gap below the window's bottom edge) so it follows the window
-  /// and never covers the drop target.
+  /// Regression for the reported detached icon: the draggable source must begin
+  /// immediately beside the in-window permission list, not below the entire
+  /// System Settings window.
   @MainActor
-  func testDragCardSitsDirectlyUnderSettingsWindow() {
-    let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
-    let card = CGSize(width: 180, height: 164)
-    let anchor = CGRect(x: 900, y: 300, width: 600, height: 500)
+  func testDragCardStartsAdjacentToHighlightedPermissionList() {
+    let visible = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+    let settings = CGRect(x: 600, y: 160, width: 800, height: 640)
+    let card = CloudConnectorGuidanceOverlay.dragCardSize(appName: "Omi Dev")
+    let target = CloudConnectorGuidanceOverlay.permissionListTargetFrame(in: settings)
 
     let frame = CloudConnectorGuidanceOverlay.dragCardFrame(
-      anchor: anchor, cardSize: card, visibleFrame: visible)
-    XCTAssertEqual(frame.midX, anchor.midX)
-    // Sits below the window's bottom edge (minY) with a 12pt gap, not covering it.
-    XCTAssertEqual(frame.maxY, anchor.minY - 12)
+      target: target, cardSize: card, visibleFrame: visible)
+    XCTAssertGreaterThan(target.midX, settings.midX, "target belongs in the Settings content pane")
+    XCTAssertEqual(frame.maxX, target.minX - 16, accuracy: 0.001)
+    XCTAssertEqual(frame.midY, target.midY, accuracy: 0.001)
+    XCTAssertTrue(frame.intersection(target).isEmpty, "source must never cover the drop list")
+    XCTAssertEqual(
+      CloudConnectorGuidanceOverlay.dragCardDirection(cardFrame: frame, targetFrame: target),
+      .right)
   }
 
-  /// When Settings leaves no room below it, the card stays in the bottom quarter
-  /// instead of jumping to the top of the screen.
+  /// Target and source geometry must follow a resized/moved System Settings
+  /// window instead of drifting to a screen-relative fallback position.
   @MainActor
-  func testDragCardUsesBottomQuarterWhenNoRoomBelow() {
-    let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
-    let card = CGSize(width: 180, height: 164)
-    let anchor = CGRect(x: 900, y: 0, width: 600, height: 1000)
+  func testPermissionListTargetAndSourceFollowSettingsResize() {
+    let visible = CGRect(x: 0, y: 0, width: 1_800, height: 1_100)
+    let initialSettings = CGRect(x: 200, y: 140, width: 760, height: 620)
+    let movedSettings = CGRect(x: 680, y: 280, width: 920, height: 700)
+    let card = CloudConnectorGuidanceOverlay.dragCardSize(appName: "Omi Dev")
+    let initialTarget = CloudConnectorGuidanceOverlay.permissionListTargetFrame(in: initialSettings)
+    let movedTarget = CloudConnectorGuidanceOverlay.permissionListTargetFrame(in: movedSettings)
+    let movedCard = CloudConnectorGuidanceOverlay.dragCardFrame(
+      target: movedTarget, cardSize: card, visibleFrame: visible)
 
-    let frame = CloudConnectorGuidanceOverlay.dragCardFrame(
-      anchor: anchor, cardSize: card, visibleFrame: visible)
-    XCTAssertEqual(frame.midX, anchor.midX)
-    XCTAssertEqual(frame.midY, visible.height / 8)
-  }
-
-  /// Card sits below the window → arrow points up at the list above it.
-  @MainActor
-  func testDragArrowPointsUpWhenCardIsBelowWindow() {
-    let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
-    let card = CGSize(width: 180, height: 164)
-    let anchor = CGRect(x: 900, y: 300, width: 600, height: 500)
-    XCTAssertFalse(
-      CloudConnectorGuidanceOverlay.dragCardArrowPointsDown(
-        anchor: anchor, cardSize: card, visibleFrame: visible),
-      "Card below the window must point its arrow UP toward the list")
-  }
-
-  /// The bottom-quarter fallback remains below the permission target.
-  @MainActor
-  func testDragArrowPointsUpInBottomQuarter() {
-    let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
-    let card = CGSize(width: 180, height: 164)
-    let anchor = CGRect(x: 900, y: 0, width: 600, height: 1000)
-    XCTAssertFalse(
-      CloudConnectorGuidanceOverlay.dragCardArrowPointsDown(
-        anchor: anchor, cardSize: card, visibleFrame: visible),
-      "Bottom-quarter card must point its arrow UP toward the list")
+    XCTAssertGreaterThan(movedTarget.width, initialTarget.width)
+    XCTAssertGreaterThan(movedTarget.minX, initialTarget.minX)
+    XCTAssertEqual(movedCard.maxX, movedTarget.minX - 16, accuracy: 0.001)
+    XCTAssertEqual(movedCard.midY, movedTarget.midY, accuracy: 0.001)
   }
 
   @MainActor
@@ -231,10 +217,10 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
   func testDragCardExpandsForLongBundleDisplayNames() {
     XCTAssertEqual(
       CloudConnectorGuidanceOverlay.dragCardSize(appName: "Omi Dev"),
-      CGSize(width: 180, height: 164))
+      CGSize(width: 220, height: 190))
     XCTAssertEqual(
       CloudConnectorGuidanceOverlay.dragCardSize(appName: "omi-tool-stall-reliability"),
-      CGSize(width: 240, height: 180))
+      CGSize(width: 260, height: 200))
   }
 
   func testCaptureKitFailureDoesNotOverrideGrantedTccPermission() {

--- a/desktop/macos/changelog/unreleased/20260728-onboarding-feedback.json
+++ b/desktop/macos/changelog/unreleased/20260728-onboarding-feedback.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved onboarding navigation, permission guidance, voice setup, and Gmail and Calendar connections."
+}

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -25,6 +25,7 @@ covers:
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingWelcomeStepView.swift
   - desktop/macos/Desktop/Sources/PostOnboardingPromptViews.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+  - desktop/macos/Desktop/Sources/Onboarding/OnboardingAnswerWriteGate.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift


### PR DESCRIPTION
## What changed and why

Repairs the onboarding feedback flow: users can go back without losing their choices, the Screen Recording drag helper points to the actual permission list, and PTT waits for its bridge context before accepting the first onboarding turn. A failed bridge warmup now leaves PTT unarmed with an explicit retry/skip path, while revised name, acquisition-source, and language answers serialize their backend writes so the newest answer remains authoritative. Gmail and Calendar now use the canonical importer and durable status that Home and Apps read, while the legacy Google readers are serialized to prevent duplicate Chrome Keychain prompts.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-INT-1
- INV-UI-1
- INV-VOICE-1

## How it was verified

- `cd desktop/macos && ./test.sh` — completed the full desktop component runner: launcher, backend, and 428 isolated Swift suites, with no failure status observed.
- Focused Swift suite: 54 onboarding, import, telemetry, and permission tests passed after rebasing.
- `cd desktop/macos && ./scripts/agent-logic-harness.sh` — 529 Swift lifecycle tests and 108 runtime tests passed.
- `SBOnboardingBackNavigationTests` and `OnboardingAnswerWriteGateTests` — all 5 focused review-regression tests passed.
- `MemoryAtlasPerformanceHarnessTests` — all 19 tests passed in 93.8s (102s wall-clock), below the 120s isolated-suite CI budget after reducing the non-asserting layout diagnostic to one iteration.
- Pinned SwiftFormat, full SwiftLint, and preflight passed. Launched the named, ad-hoc-signed `omi-onboarding-feedback` bundle against development and verified its health/automation endpoint. A real signed-in Google import and deeper onboarding UI traversal remain unavailable on this Mac because it has no reusable dev sign-in session or Accessibility permission.

## Tests

- `SBOnboardingBackNavigationTests` and `OnboardingAnswerWriteGateTests` preserve prior choices, keep PTT unarmed after failed warmup, and ensure revised answers cannot overtake predecessor writes.
- `SBOnboardingCloudContextStateTests` ensures Google import state persists, failure is not connected, and Gmail maps from canonical `email`.
- `OnboardingGoogleInsightGateTests` and `BrowserGoogleSessionTests` cover serial Google access and Safe Storage reuse.
- `ScreenRecordingPermissionPolicyTests` and `IntegrationConnectTelemetryTests` cover target geometry and onboarding telemetry.
- `MemoryAtlasPerformanceHarnessTests` remains deterministic and fits its healthy 120-second isolated-suite CI budget.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

