### PR TITLE
SCA-235: install git for desktop backend runtime lock

### DIFF
--- a/backend/Dockerfile.desktop_backend
+++ b/backend/Dockerfile.desktop_backend
@@ -7,6 +7,8 @@ ARG UV_VERSION
 
 RUN python -m venv /opt/venv
 RUN python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"
+# pyogg is locked from a Git source, so uv needs git available while syncing.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 COPY backend/pylock.runtime.toml /tmp/pylock.runtime.toml
 RUN uv pip sync /tmp/pylock.runtime.toml --python /opt/venv/bin/python --compile-bytecode
 


### PR DESCRIPTION
## Summary

- install `git` in the desktop-backend builder before syncing the runtime lock
- unblock the Git-sourced `pyogg` dependency introduced by #10686

## Context

Follow-up to #10686. The dev deployment failed during its image build: https://github.com/BasedHardware/omi/actions/runs/30405177980

The slim Python builder ran `uv pip sync` without Git, while `pyogg` is locked from `git+https://github.com/TeamPyOgg/PyOgg`. The agent-VM lock has no Git-sourced dependency, so its Dockerfile is unchanged.

## Verification

- `make setup`
- `make preflight`
- `docker build -f backend/Dockerfile.desktop_backend .` (blocked before build layers because the local Docker daemon lacks authentication to pull `gcr.io/based-hardware-dev/python:3.11-slim-forky`; GCR returned 403)
- confirmed `pylock.runtime.toml` retains the Git VCS entry for `pyogg`, and the Dockerfile installs Git before `uv pip sync`

## Residual risk

The full image build remains to be exercised by authenticated CI. This change deliberately adds only Git, not compilers or unrelated build tooling.

Failure-Class: none

Closes SCA-235


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

