### PR TITLE
fix(desktop): fall back Swift cache clone when Actions promisor fails

### DIFF
--- a/.github/failure-classes/FC-qualification-swift-cache-promisor-clone.json
+++ b/.github/failure-classes/FC-qualification-swift-cache-promisor-clone.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-qualification-swift-cache-promisor-clone",
+  "violated_contract": "Trusted qualification must materialize an exact candidate-SHA source tree for the Swift cache even when the Actions/worktree checkout is a partial or promisor clone whose local no-hardlinks clone cannot fetch missing objects.",
+  "canonical_prevention": "Prefer local no-hardlinks clone of the source repository; on materialization failure, fetch the exact candidate SHA from the source's origin URL into a fresh checkout and verify HEAD matches the candidate before publishing the cache entry.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/scripts/qualification-swift-cache.sh",
+    "desktop/macos/tests/test-qualification-swift-cache.sh"
+  ],
+  "evidence_prs": [
+    10811
+  ],
+  "scope_hints": [
+    "desktop/macos/scripts/qualification-swift-cache.sh",
+    "desktop/macos/scripts/qualify-desktop-beta.sh",
+    ".github/workflows/desktop_qualify_beta.yml"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/scripts/qualification-swift-cache.sh
+++ b/desktop/macos/scripts/qualification-swift-cache.sh
@@ -179,17 +179,87 @@ if [[ -e "$CACHE_DIR" && ! -d "$CACHE_DIR" ]]; then
   exit 1
 fi
 
+# Materialize an exact-SHA detached checkout into $1.
+# Prefer a local no-hardlinks clone of the Actions/worktree source (fast, offline).
+# Trusted M1 Actions checkouts are often partial/promisor clones; cloning them
+# locally inherits the promisor and fails checkout with:
+#   could not fetch … from promisor remote / possible repository corruption (exit 128)
+# Fall back to fetching the exact SHA from the source's origin URL when local
+# materialization fails and origin is configured (incident #10809 / v0.12.143).
+materialize_exact_source_checkout() {
+  local dest="$1"
+  local err_log="$TEMP_DIR/materialize-exact-source.err"
+  local origin_url=""
+  local force_origin=0
+
+  case "${OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE:-auto}" in
+    origin) force_origin=1 ;;
+    local | auto) ;;
+    *)
+      echo "qualification Swift cache: invalid OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE=${OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE}" >&2
+      return 2
+      ;;
+  esac
+
+  rm -rf "$dest"
+  : >"$err_log"
+
+  try_local_clone() {
+    rm -rf "$dest"
+    git clone --quiet --no-hardlinks --no-checkout "$SOURCE_REPOSITORY" "$dest" 2>>"$err_log" \
+      && git -C "$dest" checkout --quiet --detach "$SOURCE_SHA" 2>>"$err_log" \
+      && [[ "$(git -C "$dest" rev-parse HEAD 2>/dev/null || true)" == "$SOURCE_SHA" ]]
+  }
+
+  try_origin_fetch() {
+    origin_url="$(git -C "$SOURCE_REPOSITORY" remote get-url origin 2>/dev/null || true)"
+    if [[ -z "$origin_url" ]]; then
+      echo "qualification Swift cache: cannot fall back to origin fetch; source has no origin remote" >&2
+      return 1
+    fi
+    echo "qualification Swift cache: materializing exact source via origin fetch" >&2
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    git -C "$dest" init -q
+    git -C "$dest" remote add origin "$origin_url"
+    # Prefer a single-SHA fetch; widen only if the host rejects depth on that ref.
+    if ! git -C "$dest" fetch --quiet --depth=1 origin "$SOURCE_SHA" 2>>"$err_log"; then
+      git -C "$dest" fetch --quiet origin "$SOURCE_SHA" 2>>"$err_log" || return 1
+    fi
+    git -C "$dest" checkout --quiet --detach "$SOURCE_SHA" 2>>"$err_log" || return 1
+    [[ "$(git -C "$dest" rev-parse HEAD 2>/dev/null || true)" == "$SOURCE_SHA" ]]
+  }
+
+  if [[ "$force_origin" -eq 1 ]]; then
+    try_origin_fetch || {
+      echo "qualification Swift cache: origin exact-source materialization failed for $SOURCE_SHA" >&2
+      cat "$err_log" >&2 || true
+      return 1
+    }
+  elif try_local_clone; then
+    :
+  else
+    echo "qualification Swift cache: local exact-source clone failed; trying origin fetch fallback" >&2
+    cat "$err_log" >&2 || true
+    : >"$err_log"
+    try_origin_fetch || {
+      echo "qualification Swift cache: exact-source materialization failed for $SOURCE_SHA" >&2
+      cat "$err_log" >&2 || true
+      return 1
+    }
+  fi
+
+  [[ "$(git -C "$dest" rev-parse HEAD)" == "$SOURCE_SHA" ]] || {
+    echo "qualification Swift cache: cloned source SHA does not match candidate $SOURCE_SHA" >&2
+    return 1
+  }
+}
+
 CACHE_STATE="HIT"
 if [[ ! -e "$CACHE_DIR" ]]; then
   CACHE_STATE="MISS"
   TEMP_DIR="$(mktemp -d "$CACHE_ROOT/.${SOURCE_SHA}.prepare.XXXXXX")"
-  mkdir "$TEMP_DIR/source"
-  git clone --quiet --no-hardlinks --no-checkout "$SOURCE_REPOSITORY" "$TEMP_DIR/source"
-  git -C "$TEMP_DIR/source" checkout --quiet --detach "$SOURCE_SHA"
-  [[ "$(git -C "$TEMP_DIR/source" rev-parse HEAD)" == "$SOURCE_SHA" ]] || {
-    echo "qualification Swift cache: cloned source SHA does not match candidate $SOURCE_SHA" >&2
-    exit 1
-  }
+  materialize_exact_source_checkout "$TEMP_DIR/source" || exit 1
   mkdir -p "$TEMP_DIR/source/desktop/macos/Desktop/.build"
   CACHE_DIR="$TEMP_DIR"
   PERSISTENT_SOURCE="$CACHE_DIR/source"

--- a/desktop/macos/scripts/qualification-swift-cache.sh
+++ b/desktop/macos/scripts/qualification-swift-cache.sh
@@ -204,11 +204,32 @@ materialize_exact_source_checkout() {
   rm -rf "$dest"
   : >"$err_log"
 
+  # A blobless/promisor source can make `git checkout` report success and set HEAD
+  # while tracked blobs are still missing (worktree paths deleted / invalid objects).
+  # Reject that incomplete materialization so auto mode can fall back to origin.
+  local_checkout_is_complete() {
+    local tree="$1"
+    [[ "$(git -C "$tree" rev-parse HEAD 2>/dev/null || true)" == "$SOURCE_SHA" ]] || return 1
+    # Worktree must match HEAD (missing blobs often surface as deleted paths).
+    git -C "$tree" diff-index --quiet HEAD -- 2>>"$err_log" || return 1
+    # Critical package identity must resolve as a real blob + regular file.
+    git -C "$tree" cat-file -e "HEAD:desktop/macos/Desktop/Package.swift" 2>>"$err_log" || return 1
+    [[ -f "$tree/desktop/macos/Desktop/Package.swift" ]] || return 1
+    if git -C "$SOURCE_REPOSITORY" cat-file -e "$SOURCE_SHA:desktop/macos/Desktop/Package.resolved" 2>/dev/null; then
+      git -C "$tree" cat-file -e "HEAD:desktop/macos/Desktop/Package.resolved" 2>>"$err_log" || return 1
+      [[ -f "$tree/desktop/macos/Desktop/Package.resolved" ]] || return 1
+    fi
+    return 0
+  }
+
   try_local_clone() {
     rm -rf "$dest"
-    git clone --quiet --no-hardlinks --no-checkout "$SOURCE_REPOSITORY" "$dest" 2>>"$err_log" \
-      && git -C "$dest" checkout --quiet --detach "$SOURCE_SHA" 2>>"$err_log" \
-      && [[ "$(git -C "$dest" rev-parse HEAD 2>/dev/null || true)" == "$SOURCE_SHA" ]]
+    git clone --quiet --no-hardlinks --no-checkout "$SOURCE_REPOSITORY" "$dest" 2>>"$err_log" || return 1
+    # Reject checkout failures explicitly (do not treat partial success as OK).
+    if ! git -C "$dest" checkout --quiet --detach "$SOURCE_SHA" 2>>"$err_log"; then
+      return 1
+    fi
+    local_checkout_is_complete "$dest"
   }
 
   try_origin_fetch() {
@@ -227,7 +248,7 @@ materialize_exact_source_checkout() {
       git -C "$dest" fetch --quiet origin "$SOURCE_SHA" 2>>"$err_log" || return 1
     fi
     git -C "$dest" checkout --quiet --detach "$SOURCE_SHA" 2>>"$err_log" || return 1
-    [[ "$(git -C "$dest" rev-parse HEAD 2>/dev/null || true)" == "$SOURCE_SHA" ]]
+    local_checkout_is_complete "$dest"
   }
 
   if [[ "$force_origin" -eq 1 ]]; then

--- a/desktop/macos/tests/test-qualification-swift-cache.sh
+++ b/desktop/macos/tests/test-qualification-swift-cache.sh
@@ -193,17 +193,63 @@ expect_rejected collision "exact-SHA cache destination collision" \
   "$CACHE_HELPER" prepare "$SHA_C" "$REPO_A" cache-collision "$$"
 
 # Origin-fetch path (Actions partial/promisor clone fallback; incident #10809).
+# Reproduce a real incomplete local materialization: blobless/promisor source where
+# checkout can set HEAD to the candidate SHA while package blobs stay missing
+# (worktree paths deleted). Auto mode must reject that and fall back to origin.
 ORIGIN_UPSTREAM="$TMP_ROOT/origin-upstream"
 ORIGIN_BARE="$TMP_ROOT/origin-upstream.git"
-ORIGIN_CLIENT="$TMP_ROOT/origin-client"
+PROMISOR_CLIENT="$TMP_ROOT/promisor-client"
 make_repo "$ORIGIN_UPSTREAM"
 git -C "$ORIGIN_UPSTREAM" clone --quiet --bare "$ORIGIN_UPSTREAM" "$ORIGIN_BARE"
-git -C "$ORIGIN_UPSTREAM" remote remove origin 2>/dev/null || true
+git -C "$ORIGIN_BARE" config uploadpack.allowFilter true
+git -C "$ORIGIN_BARE" config uploadpack.allowAnySHA1InWant true
+ORIGIN_SHA="$(git -C "$ORIGIN_UPSTREAM" rev-parse HEAD)"
+
+rm -rf "$PROMISOR_CLIENT"
+git clone --quiet --filter=blob:none --no-checkout "file://$ORIGIN_BARE" "$PROMISOR_CLIENT"
+git -C "$PROMISOR_CLIENT" fetch --quiet --filter=blob:none origin "$ORIGIN_SHA"
+# Checkout without a working promisor so blobs are not filled — HEAD can still move.
+git -C "$PROMISOR_CLIENT" remote set-url origin "file://$TMP_ROOT/missing-promisor.git"
+git -C "$PROMISOR_CLIENT" checkout --quiet --detach "$ORIGIN_SHA" 2>/dev/null || true
+# Restore origin to the full object store for the prepare() fallback path.
+git -C "$PROMISOR_CLIENT" remote set-url origin "file://$ORIGIN_BARE"
+
+# Sanity: naive local clone+checkout of this promisor source is incomplete.
+PROBE="$TMP_ROOT/promisor-local-probe"
+rm -rf "$PROBE"
+git clone --quiet --no-hardlinks --no-checkout "$PROMISOR_CLIENT" "$PROBE"
+git -C "$PROBE" checkout --quiet --detach "$ORIGIN_SHA" 2>/dev/null || true
+if [[ -f "$PROBE/desktop/macos/Desktop/Package.swift" ]] \
+  && git -C "$PROBE" diff-index --quiet HEAD -- 2>/dev/null \
+  && git -C "$PROBE" cat-file -e HEAD:desktop/macos/Desktop/Package.swift 2>/dev/null; then
+  fail "test fixture did not reproduce incomplete promisor materialization"
+fi
+
+PROMISOR_CACHE="$TMP_ROOT/promisor-cache"
+promisor_source="$(
+  env OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$PROMISOR_CACHE" \
+    OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE=auto \
+    "$CACHE_HELPER" prepare "$ORIGIN_SHA" "$PROMISOR_CLIENT" cache-promisor-auto "$$" \
+    2>"$TMP_ROOT/promisor-auto.err" | source_from_json
+)"
+grep -Fq 'local exact-source clone failed; trying origin fetch fallback' "$TMP_ROOT/promisor-auto.err" \
+  || fail "auto mode did not fall back after incomplete local clone: $(cat "$TMP_ROOT/promisor-auto.err")"
+grep -Fq 'materializing exact source via origin fetch' "$TMP_ROOT/promisor-auto.err" \
+  || fail "auto mode did not materialize via origin fetch: $(cat "$TMP_ROOT/promisor-auto.err")"
+[[ "$(git -C "$promisor_source" rev-parse HEAD)" == "$ORIGIN_SHA" ]] \
+  || fail "promisor auto fallback did not detach at exact SHA"
+[[ -f "$promisor_source/desktop/macos/Desktop/Package.swift" ]] \
+  || fail "promisor auto fallback missing package identity files"
+git -C "$promisor_source" diff-index --quiet HEAD -- \
+  || fail "promisor auto fallback left a dirty/incomplete worktree"
+git -C "$promisor_source" cat-file -e HEAD:desktop/macos/Desktop/Package.swift \
+  || fail "promisor auto fallback missing Package.swift blob"
+
+# Forced origin mode still works against a full client with origin set.
+ORIGIN_CLIENT="$TMP_ROOT/origin-client"
 rm -rf "$ORIGIN_CLIENT"
 git clone --quiet "$ORIGIN_BARE" "$ORIGIN_CLIENT"
-# Point client origin at the bare full object store (file:// avoids local hardlink tricks).
 git -C "$ORIGIN_CLIENT" remote set-url origin "file://$ORIGIN_BARE"
-ORIGIN_SHA="$(git -C "$ORIGIN_CLIENT" rev-parse HEAD)"
 ORIGIN_CACHE="$TMP_ROOT/origin-cache"
 origin_source="$(
   env OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$ORIGIN_CACHE" \

--- a/desktop/macos/tests/test-qualification-swift-cache.sh
+++ b/desktop/macos/tests/test-qualification-swift-cache.sh
@@ -192,4 +192,41 @@ printf collision > "$OMI_QUALIFICATION_SWIFT_CACHE_ROOT/$SHA_C"
 expect_rejected collision "exact-SHA cache destination collision" \
   "$CACHE_HELPER" prepare "$SHA_C" "$REPO_A" cache-collision "$$"
 
+# Origin-fetch path (Actions partial/promisor clone fallback; incident #10809).
+ORIGIN_UPSTREAM="$TMP_ROOT/origin-upstream"
+ORIGIN_BARE="$TMP_ROOT/origin-upstream.git"
+ORIGIN_CLIENT="$TMP_ROOT/origin-client"
+make_repo "$ORIGIN_UPSTREAM"
+git -C "$ORIGIN_UPSTREAM" clone --quiet --bare "$ORIGIN_UPSTREAM" "$ORIGIN_BARE"
+git -C "$ORIGIN_UPSTREAM" remote remove origin 2>/dev/null || true
+rm -rf "$ORIGIN_CLIENT"
+git clone --quiet "$ORIGIN_BARE" "$ORIGIN_CLIENT"
+# Point client origin at the bare full object store (file:// avoids local hardlink tricks).
+git -C "$ORIGIN_CLIENT" remote set-url origin "file://$ORIGIN_BARE"
+ORIGIN_SHA="$(git -C "$ORIGIN_CLIENT" rev-parse HEAD)"
+ORIGIN_CACHE="$TMP_ROOT/origin-cache"
+origin_source="$(
+  env OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$ORIGIN_CACHE" \
+    OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE=origin \
+    "$CACHE_HELPER" prepare "$ORIGIN_SHA" "$ORIGIN_CLIENT" cache-origin-mode "$$" \
+    2>"$TMP_ROOT/origin-mode.err" | source_from_json
+)"
+grep -Fq 'materializing exact source via origin fetch' "$TMP_ROOT/origin-mode.err" \
+  || fail "origin clone mode did not use origin fetch: $(cat "$TMP_ROOT/origin-mode.err")"
+[[ "$(git -C "$origin_source" rev-parse HEAD)" == "$ORIGIN_SHA" ]] \
+  || fail "origin clone mode did not detach at exact SHA"
+[[ -f "$origin_source/desktop/macos/Desktop/Package.swift" ]] \
+  || fail "origin clone mode missing package identity files"
+
+# Forced local mode must still work against a full local object store.
+LOCAL_ONLY_CACHE="$TMP_ROOT/local-only-cache"
+local_source="$(
+  env OMI_QUALIFICATION_SWIFT_CACHE_ROOT="$LOCAL_ONLY_CACHE" \
+    OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE=local \
+    "$CACHE_HELPER" prepare "$SHA_A" "$REPO_A" cache-local-mode "$$" \
+    2>"$TMP_ROOT/local-mode.err" | source_from_json
+)"
+[[ "$(git -C "$local_source" rev-parse HEAD)" == "$SHA_A" ]] \
+  || fail "local clone mode failed on full object store"
+
 echo "qualification Swift cache tests passed"


### PR DESCRIPTION
## Summary

Trusted M1 qualification for `v0.12.143+12143-macos` failed closed in `candidate-and-lease-preflight` while preparing the exact-SHA Swift cache:

- `git clone --no-hardlinks` of the Actions checkout inherits partial/promisor state
- checkout then dies with `could not fetch … from promisor remote` / exit 128
- product suites never ran; ordinary path fenced the immutable tag

## Fix

`qualification-swift-cache.sh` still prefers a local no-hardlinks clone, but on materialization failure (or `OMI_QUALIFICATION_SWIFT_CACHE_CLONE_MODE=origin`) fetches the **exact candidate SHA** from the source repository's `origin` URL into a fresh checkout.

## Test plan

- [x] `bash desktop/macos/tests/test-qualification-swift-cache.sh` (existing cases + origin-mode / local-mode regression)
- [x] `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`

## Failure-Class
Failure-Class: new

## Related

- Incident: https://github.com/BasedHardware/omi/issues/10809
- Does not unfence `v0.12.143+12143-macos` (already audited Beta-only break-glass)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

