### PR TITLE
fix(backend): stop 500ing app enable on a non-object setup_completed body

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/routers/apps.py": 2373,
+    "backend/routers/apps.py": 2387,
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2263,
     "backend/routers/mcp_sse.py": 1865,
@@ -8,7 +8,7 @@
     "backend/routers/users.py": 2076
   },
   "raise_justifications": {
-    "backend/routers/apps.py": "The owner-migration route validates a source-bound Firebase anonymous-token proof before its existing database write and tracked background work, keeping the authorization decision at the HTTP mutation boundary.",
+    "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract.",
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +7 so a refused memory read reports its reason instead of an empty success (#10735): the classification and wire shape live in utils/mcp_memories.mcp_denied_read_payload, leaving only the raise at the two tool branches that own the response contract.",

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -2079,6 +2079,20 @@ async def refresh_mcp_tools(app_id: str, uid: str = Depends(auth.get_current_use
 # ******************************************************
 
 
+def _setup_completed_from_response(res: httpx.Response) -> bool:
+    """Read `is_setup_completed` from a third-party setup_completed_url response.
+
+    The body is developer-controlled, so it may be non-JSON or a JSON scalar/array
+    rather than the documented object. Anything that is not an object carrying a
+    truthy `is_setup_completed` means setup is not completed.
+    """
+    try:
+        payload: object = res.json()
+    except ValueError:
+        return False
+    return isinstance(payload, dict) and bool(payload.get('is_setup_completed', False))
+
+
 @router.post('/v1/apps/enable', response_model=AppMutationResponse)
 async def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     app = await run_blocking(db_executor, get_available_app_by_id, app_id, uid)
@@ -2097,7 +2111,7 @@ async def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_u
         client = get_webhook_client()
         res = await client.get(app.external_integration.setup_completed_url + f'?uid={uid}')
         logger.info(f'enable_app_endpoint {res.status_code} {res.content}')
-        if res.status_code != 200 or not res.json().get('is_setup_completed', False):
+        if res.status_code != 200 or not _setup_completed_from_response(res):
             raise HTTPException(status_code=400, detail='App setup is not completed')
 
     # Check payment status

--- a/backend/tests/unit/test_apps_enable_setup_completed_response.py
+++ b/backend/tests/unit/test_apps_enable_setup_completed_response.py
@@ -1,0 +1,49 @@
+"""Regression: POST /v1/apps/enable must not 500 on a malformed setup_completed_url body.
+
+The body of an app's `setup_completed_url` is developer-controlled. When it answered with a
+bare JSON scalar (e.g. `true`) the endpoint ran `res.json().get(...)` and raised
+AttributeError: 'bool' object has no attribute 'get', turning the intended 400
+"App setup is not completed" into an unhandled 500 (~46 prod occurrences 2026-07-21..28).
+Non-JSON bodies raised json.JSONDecodeError the same way. No live services.
+"""
+
+import os
+
+import httpx
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+from routers.apps import _setup_completed_from_response  # noqa: E402
+
+
+def _response(content: bytes, content_type: str = "application/json") -> httpx.Response:
+    return httpx.Response(200, content=content, headers={"Content-Type": content_type})
+
+
+def test_object_with_true_flag_is_completed():
+    assert _setup_completed_from_response(_response(b'{"is_setup_completed": true}')) is True
+
+
+def test_object_with_false_or_missing_flag_is_not_completed():
+    assert _setup_completed_from_response(_response(b'{"is_setup_completed": false}')) is False
+    assert _setup_completed_from_response(_response(b'{}')) is False
+
+
+def test_bare_json_scalar_is_not_completed():
+    # The prod crasher: `res.json()` returns a bool, which has no .get
+    assert _setup_completed_from_response(_response(b'true')) is False
+    assert _setup_completed_from_response(_response(b'false')) is False
+    assert _setup_completed_from_response(_response(b'"ok"')) is False
+    assert _setup_completed_from_response(_response(b'null')) is False
+
+
+def test_json_array_is_not_completed():
+    assert _setup_completed_from_response(_response(b'[{"is_setup_completed": true}]')) is False
+
+
+def test_non_json_body_is_not_completed():
+    assert _setup_completed_from_response(_response(b'<html>OK</html>', "text/html")) is False
+    assert _setup_completed_from_response(_response(b'', "text/plain")) is False


### PR DESCRIPTION
## Bug

`POST /v1/apps/enable` returns an unhandled **500** instead of the intended `400 "App setup is not completed"` whenever an app's `setup_completed_url` answers with a body that is not a JSON object. Prod logged **46** of these between 2026-07-21 and 2026-07-28, still recurring today (`based-hardware` / Cloud Run `backend`):

```
File "/app/routers/apps.py", line 2100, in enable_app_endpoint
  if res.status_code != 200 or not res.json().get('is_setup_completed', False):
AttributeError: 'bool' object has no attribute 'get'
```

User impact: installing one of those third-party apps fails with a generic server error rather than the setup prompt that tells the user what to do.

## Root cause

That response body is developer-controlled, but the route read it as if the documented `{"is_setup_completed": bool}` object were guaranteed:

- bare JSON scalar (`true`, `false`, `null`, `"ok"`) → `AttributeError: 'bool' object has no attribute 'get'`
- JSON array → `AttributeError: 'list' object has no attribute 'get'`
- non-JSON body (HTML error page, empty) → `json.JSONDecodeError`

## Fix

Read the flag through `_setup_completed_from_response`, mirroring the `isinstance`-guarded parse already used for the other developer-supplied document on this surface (`utils.apps.fetch_app_chat_tools_from_manifest`): anything that is not a JSON object carrying a truthy `is_setup_completed` means setup is not completed. Happy path and the legitimate not-completed path are unchanged.

`.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json` raises `backend/routers/apps.py` 2373 → 2389 with a justification; the guard belongs in the route that owns the enable response contract.

## What I tested

Drove the **real `enable_app_endpoint` body** against a stubbed `setup_completed_url` (before = current `main`, after = this branch):

| response body | before | after |
|---|---|---|
| `true` (the prod crasher) | `AttributeError: 'bool' object has no attribute 'get'` | `400 App setup is not completed` |
| `false` | `AttributeError` | `400 App setup is not completed` |
| `<html>ok</html>` | `JSONDecodeError` | `400 App setup is not completed` |
| `[{"is_setup_completed": true}]` | `AttributeError: 'list' object has no attribute 'get'` | `400 App setup is not completed` |
| `{"is_setup_completed": true}` | `{'status': 'ok'}` | `{'status': 'ok'}` (unchanged) |
| `{"is_setup_completed": false}` | `400 App setup is not completed` | `400` (unchanged) |

- New regression test `backend/tests/unit/test_apps_enable_setup_completed_response.py` — **5 passed** via `BACKEND_UNIT_TEST_FILE_LIST=... bash backend/test.sh`.
- All seven existing `*apps*` backend suites — **44 passed**, no failures.
- `make preflight` — passed.

## Failure Class

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

