### PR TITLE
feat(mcp): support scope-safe Firebase re-consent

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2387,
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2263,
-    "backend/routers/mcp_sse.py": 1865,
+    "backend/routers/mcp_sse.py": 1885,
     "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2076
   },
@@ -11,7 +11,7 @@
     "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract.",
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
-    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +7 so a refused memory read reports its reason instead of an empty success (#10735): the classification and wire shape live in utils/mcp_memories.mcp_denied_read_payload, leaving only the raise at the two tool branches that own the response contract.",
+    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +7 so a refused memory read reports its reason instead of an empty success (#10735): the classification and wire shape live in utils/mcp_memories.mcp_denied_read_payload, leaving only the raise at the two tool branches that own the response contract. +20 keeps Firebase verification on the critical executor and consent validation/grant/code Firestore operations on the database executor, preserving the verified UID before a client-agnostic OAuth grant is minted.",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first. +30 for the disclosed, expiring city-context consent routes and legacy geolocation input boundary; they remain with the authenticated user route owner to prevent invalid coordinates reaching cache/provider paths (SCA-174)."
   },

--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -406,18 +406,26 @@ def create_or_update_grant(uid: str, client_id: str, resource: str, scopes: List
     ref = db.collection("mcp_oauth_grants").document(deterministic_grant_id)
     doc = ref.get()
     existing: Dict[str, Any] = _typed_doc(doc) if doc.exists else {}
+    existing_scopes = sorted(set(existing.get("scopes") or []))
+    granted_scopes = sorted(set(scopes))
     if existing and (existing.get("revoked_at") or existing.get("status") == "revoked"):
         ref = db.collection("mcp_oauth_grants").document(f"{deterministic_grant_id}:{uuid.uuid4()}")
         doc = ref.get()
         existing = {}
-    existing_scopes = set(existing.get("scopes") or [])
-    merged_scopes = sorted(existing_scopes.union(scopes))
+    elif existing and existing_scopes != granted_scopes:
+        # Consent is the complete current authorization for this client/resource.
+        # Rotating the grant on any scope change invalidates already-issued broad
+        # access and refresh tokens before the newly consented scope set is used.
+        ref.update({"revoked_at": now, "status": "revoked", "updated_at": now})
+        ref = db.collection("mcp_oauth_grants").document(f"{deterministic_grant_id}:{uuid.uuid4()}")
+        doc = ref.get()
+        existing = {}
     data: Dict[str, Any] = {
         "id": ref.id,
         "uid": uid,
         "client_id": client_id,
         "resource": resource,
-        "scopes": merged_scopes,
+        "scopes": granted_scopes,
         "updated_at": now,
         "last_used_at": now,
         "revoked_at": None,

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -1598,7 +1598,7 @@ def mcp_authorize(
 
 
 @router.post("/authorize", tags=["mcp"], response_model=McpAuthorizeConsentResponse)
-def mcp_authorize_consent(
+async def mcp_authorize_consent(
     response_type: str = Form(...),
     client_id: str = Form(...),
     redirect_uri: str = Form(...),
@@ -1610,10 +1610,22 @@ def mcp_authorize_consent(
     code_challenge_method: Optional[str] = Form(None),
 ):
     try:
-        _, scopes = _validate_authorize_request(
-            response_type, client_id, redirect_uri, resource, scope, code_challenge, code_challenge_method
+        _, scopes = await run_blocking(
+            db_executor,
+            _validate_authorize_request,
+            response_type,
+            client_id,
+            redirect_uri,
+            resource,
+            scope,
+            code_challenge,
+            code_challenge_method,
         )
-        decoded_token: Dict[str, Any] = firebase_admin.auth.verify_id_token(firebase_id_token)  # type: ignore[reportUnknownMemberType]  # firebase_admin auth untyped
+        decoded_token: Dict[str, Any] = await run_blocking(
+            critical_executor,
+            firebase_admin.auth.verify_id_token,  # type: ignore[reportUnknownMemberType]  # firebase_admin auth untyped
+            firebase_id_token,
+        )
         uid = cast(str, decoded_token["uid"])
     except firebase_admin.auth.InvalidIdTokenError:
         return _oauth_error("access_denied", "Invalid Omi sign-in token", status_code=401)
@@ -1622,9 +1634,17 @@ def mcp_authorize_consent(
             return _oauth_error("invalid_request", str(e))
         return _oauth_error("access_denied", "Could not verify Omi sign-in token", status_code=401)
 
-    grant = mcp_oauth_db.create_or_update_grant(uid, client_id, resource, scopes)
-    code = mcp_oauth_db.issue_authorization_code(
-        uid, grant["id"], client_id, redirect_uri, resource, scopes, cast(str, code_challenge)
+    grant = await run_blocking(db_executor, mcp_oauth_db.create_or_update_grant, uid, client_id, resource, scopes)
+    code = await run_blocking(
+        db_executor,
+        mcp_oauth_db.issue_authorization_code,
+        uid,
+        grant["id"],
+        client_id,
+        redirect_uri,
+        resource,
+        scopes,
+        cast(str, code_challenge),
     )
     return {"redirect_uri": _redirect_with_code(redirect_uri, code, state)}
 

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -246,6 +246,70 @@ async def test_token_request_parser_reads_form_body():
     assert await sse._get_token_request_data(_FormRequest(body)) == body
 
 
+@pytest.mark.asyncio
+async def test_mcp_consent_offloads_firebase_verification_and_uses_verified_uid():
+    calls = []
+
+    async def run_blocking(executor, func, *args, **kwargs):
+        calls.append((executor, func, args, kwargs))
+        return func(*args, **kwargs)
+
+    grant = {'id': 'grant-1'}
+    with (
+        patch.object(sse, '_validate_authorize_request', return_value=({}, ['memories.read'])) as validate_request,
+        patch.object(sse, 'run_blocking', side_effect=run_blocking),
+        patch.object(sse.firebase_admin.auth, 'verify_id_token', return_value={'uid': UID}) as verify_id_token,
+        patch.object(sse.mcp_oauth_db, 'create_or_update_grant', return_value=grant) as create_grant,
+        patch.object(sse.mcp_oauth_db, 'issue_authorization_code', return_value='code-1') as issue_code,
+    ):
+        response = await sse.mcp_authorize_consent(
+            response_type='code',
+            client_id='client-1',
+            redirect_uri='https://client.example/callback',
+            resource=sse.MCP_RESOURCE_URL,
+            firebase_id_token='firebase-token',
+            state=None,
+            scope='memories.read',
+            code_challenge='a' * 64,
+            code_challenge_method='S256',
+        )
+
+    assert response == {'redirect_uri': 'https://client.example/callback?code=code-1'}
+    assert calls == [
+        (
+            sse.db_executor,
+            validate_request,
+            (
+                'code',
+                'client-1',
+                'https://client.example/callback',
+                sse.MCP_RESOURCE_URL,
+                'memories.read',
+                'a' * 64,
+                'S256',
+            ),
+            {},
+        ),
+        (sse.critical_executor, verify_id_token, ('firebase-token',), {}),
+        (sse.db_executor, create_grant, (UID, 'client-1', sse.MCP_RESOURCE_URL, ['memories.read']), {}),
+        (
+            sse.db_executor,
+            issue_code,
+            (
+                UID,
+                'grant-1',
+                'client-1',
+                'https://client.example/callback',
+                sse.MCP_RESOURCE_URL,
+                ['memories.read'],
+                'a' * 64,
+            ),
+            {},
+        ),
+    ]
+    create_grant.assert_called_once_with(UID, 'client-1', sse.MCP_RESOURCE_URL, ['memories.read'])
+
+
 def test_sse_tools_list_filters_by_oauth_scopes():
     auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
     response, session_id = sse.handle_mcp_message(auth_context, {'id': 1, 'method': 'tools/list'})

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -487,6 +487,23 @@ def test_refresh_token_rotates_and_old_refresh_reuse_revokes_grant():
     )
 
 
+def test_reconsent_replaces_grant_scopes_to_allow_downscoping():
+    broad_scopes = ['memories.read', 'memories.write']
+    narrowed_scopes = ['memories.read']
+    grant = mcp_oauth.create_or_update_grant(
+        'user-downscope', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, broad_scopes
+    )
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=broad_scopes)
+
+    updated_grant = mcp_oauth.create_or_update_grant(
+        'user-downscope', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, narrowed_scopes
+    )
+
+    assert updated_grant['id'] != grant['id']
+    assert updated_grant['scopes'] == narrowed_scopes
+    assert mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL) is None
+
+
 def test_revoke_user_grant_invalidates_tokens():
     scopes = ['memories.read']
     grant = mcp_oauth.create_or_update_grant('user-3', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)


### PR DESCRIPTION
## Summary
- run Firebase ID-token verification for MCP OAuth consent through the bounded critical executor
- rotate MCP OAuth grants whenever an account re-consents with a different scope set, immediately invalidating prior access and refresh tokens
- add regressions for Firebase UID handoff and scope downscoping

## Security boundary
Firebase remains the canonical account identity. Firebase ID tokens are accepted only at OAuth consent and are exchanged for separate scoped MCP credentials; the MCP transport never accepts Firebase bearer tokens. The change is client-agnostic for every registered MCP OAuth client.

## Validation
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_mcp_oauth.py backend/tests/unit/test_mcp_data_endpoints.py -q` (87 passed)
- `backend/.venv/bin/python backend/scripts/scan_async_blockers.py --dirs routers utils`
- local production-router authorize-page harness: valid PKCE request returned HTTP 200
- visual computer-use verification blocked: cua-driver session had expired before capture; no credential/consent interaction occurred


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

