### PR TITLE
fix(backend): install a C toolchain in the desktop-backend builder

### DIFF
--- a/backend/Dockerfile.desktop_backend
+++ b/backend/Dockerfile.desktop_backend
@@ -7,8 +7,9 @@ ARG UV_VERSION
 
 RUN python -m venv /opt/venv
 RUN python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"
-# pyogg is locked from a Git source, so uv needs git available while syncing.
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+# pyogg is locked from a Git source, so uv needs git available while syncing;
+# webrtcvad ships only an sdist, so the sync also compiles a C extension.
+RUN apt-get update && apt-get install -y --no-install-recommends git gcc libc6-dev && rm -rf /var/lib/apt/lists/*
 COPY backend/pylock.runtime.toml /tmp/pylock.runtime.toml
 RUN uv pip sync /tmp/pylock.runtime.toml --python /opt/venv/bin/python --compile-bytecode
 


### PR DESCRIPTION
## Summary

- install `gcc` + `libc6-dev` in the desktop-backend builder stage so `uv pip sync` can compile the sdist-only `webrtcvad`
- unblocks every desktop-backend deploy, which has failed at image build since #10686

## Context

`Auto Deploy Desktop Backend to Development` has failed on every push to `main` since 2026-07-28 22:36 (last green: run 30400702765 at 21:26). #10807 fixed the first half — `uv pip sync` needed `git` for the Git-sourced `pyogg` — and deliberately added only Git, not compilers. The sync now gets one step further and dies on the next missing tool:

```
building '_webrtcvad' extension
gcc -Wsign-compare -DNDEBUG ... -c cbits/pywebrtcvad.c
error: command 'gcc' failed: No such file or directory
```

`webrtcvad` 2.0.10 is sdist-only in `backend/pylock.runtime.toml`, so the sync must build a C extension, and `python:3.11-slim-forky` ships no compiler. `backend/Dockerfile` (the main backend) already installs `gcc`; this brings the desktop-backend builder to parity with the smallest possible addition.

Builder stage only — the runtime stage still copies just `/opt/venv`, so the shipped image is unchanged in size and contents.

## Verification

Local, `linux/amd64`, against the real base image `gcr.io/based-hardware-dev/python:3.11-slim-forky`:

- **Reproduced CI exactly** on unmodified `main`: `docker build --platform linux/amd64 --target builder -f backend/Dockerfile.desktop_backend .` → `error: command 'gcc' failed: No such file or directory`, identical to run 30417276330.
- **With the fix** the builder stage completes: `+ webrtcvad==2.0.10` and the Git-sourced `pyogg` both install.
- **Full image builds** (`docker build --platform linux/amd64 -f backend/Dockerfile.desktop_backend .`).
- **Ran the built image** and exercised the real entrypoint: `uvicorn desktop_backend:app` reaches `Application startup complete`, `GET /health` → 200, `GET /` → 200.
- `make preflight` — 13 checks pass.

Note that the green `image-smoke (desktop-backend)` on this PR is **not** evidence for the fix; see below.

## Why CI did not catch either break

`image-smoke (desktop-backend)` is the lane that would have caught this — `backend/runtime_images.json` sets `pull_request_smoke: true`, and `make runtime-image-smoke` really does `docker build` this Dockerfile. But every step in that job is gated on `env.GCP_CREDENTIALS_AVAILABLE == 'true'`, and `GCP_CREDENTIALS` is not exposed to these pull-request runs, so the job logs `Skipping desktop-backend image smoke because GCP_CREDENTIALS is not available to this run.` and reports **pass** without building anything (run 30418561267 on this branch; it passed the same way on #10807). A gate that reports green while doing nothing is why two consecutive builder-dependency breaks were both discovered by a failed deploy. Worth a follow-up — either publish a credential-free base for the smoke lane or make the skip a neutral/failed state rather than a pass — but out of scope here.

## Follow-up (not in this PR)

`webrtcvad` has no importer anywhere in `backend/` (`grep -rn webrtcvad backend --include="*.py"` is empty), and it cannot even be imported in the runtime image (`webrtcvad.py` does `import pkg_resources`, and setuptools is not installed there). Dropping it from `pylock.runtime.toml` would remove the compile step entirely, but that lock is shared with the main backend image, so it belongs in its own change.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged
