### PR TITLE
fix(desktop-backend): add gcc to Dockerfile for webrtcvad C extension build

### DIFF
--- a/backend/Dockerfile.desktop_backend
+++ b/backend/Dockerfile.desktop_backend
@@ -8,7 +8,7 @@ ARG UV_VERSION
 RUN python -m venv /opt/venv
 RUN python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"
 # pyogg is locked from a Git source, so uv needs git available while syncing.
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git gcc && rm -rf /var/lib/apt/lists/*
 COPY backend/pylock.runtime.toml /tmp/pylock.runtime.toml
 RUN uv pip sync /tmp/pylock.runtime.toml --python /opt/venv/bin/python --compile-bytecode
 


### PR DESCRIPTION
## Summary

- Add `gcc` to `backend/Dockerfile.desktop_backend` apt-get install line
- Unblocks `webrtcvad==2.0.10` C extension build during `uv pip sync`

## Context

Follow-up to #10686 (replace Rust cloud backend with Python) and #10807 (add git for pyogg VCS source).

The dev deployment has failed on every post-merge run since #10686 landed. The error:

```
webrtcvad==2.0.10 → gcc: No such file or directory
error: command 'gcc' failed: No such file or directory
```

`webrtcvad` compiles a C extension (`_webrtcvad`) and needs a C compiler in the builder image. The slim Python base image ships no compiler toolchain.

## Verification

- Confirmed `pylock.runtime.toml` locks `webrtcvad==2.0.10` which requires C compilation
- Diff adds only `gcc` to the existing apt-get line (no other changes)
- CI auto-dev workflow will exercise the full Docker build on next push

Failure-Class: none
