### PR TITLE
fix(desktop-backend): use build-essential for webrtcvad C extension

### DIFF
--- a/backend/Dockerfile.desktop_backend
+++ b/backend/Dockerfile.desktop_backend
@@ -8,7 +8,7 @@ ARG UV_VERSION
 RUN python -m venv /opt/venv
 RUN python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"
 # pyogg is locked from a Git source, so uv needs git available while syncing.
-RUN apt-get update && apt-get install -y --no-install-recommends git gcc && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git build-essential && rm -rf /var/lib/apt/lists/*
 COPY backend/pylock.runtime.toml /tmp/pylock.runtime.toml
 RUN uv pip sync /tmp/pylock.runtime.toml --python /opt/venv/bin/python --compile-bytecode
 


### PR DESCRIPTION
## Summary

- Replace `gcc` with `build-essential` in `backend/Dockerfile.desktop_backend`
- `build-essential` provides gcc **plus** libc headers (stdlib.h etc.) needed by webrtcvad C extension

## Context

PR #10816 added `gcc` but auto-dev still failed: `fatal error: stdlib.h: No such file or directory`. The slim Python base image lacks C standard library headers. `build-essential` is the canonical Debian/Ubuntu metapackage that includes gcc, make, and all required libc dev headers.

## Verification

- Diff only changes `gcc` → `build-essential` (superset)
- CI auto-dev will exercise full Docker build on push-to-main

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

