### PR TITLE
fix(ci): guard Agent VM build step against missing AGENT_GCS_BUCKET

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -183,9 +183,13 @@ jobs:
       - name: Build and publish Agent VM image
         env:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          AGENT_GCS_BUCKET: ${{ vars.AGENT_GCS_BUCKET }}
         run: |
           set -euo pipefail
-          test -n "$AGENT_GCS_BUCKET"
+          if [[ -z "$AGENT_GCS_BUCKET" ]]; then
+            echo "::warning::AGENT_GCS_BUCKET is not set — skipping Agent VM image build"
+            exit 0
+          fi
           agent_image="gcr.io/$PROJECT_ID/agent-vm:${{ steps.candidate-identity.outputs.image_tag }}"
           docker build --tag "$agent_image" --file backend/agent_vm/Dockerfile .
           python3 backend/scripts/runtime_image_contracts.py smoke \


### PR DESCRIPTION
## Summary

- Guard the `Build and publish Agent VM image` step against missing `AGENT_GCS_BUCKET` repo variable
- When `AGENT_GCS_BUCKET` is unset/empty, the step now logs a warning and exits 0 (skip) instead of hard-failing with `test -n ""`
- Moves `AGENT_GCS_BUCKET` from top-level env (where it was empty string) into step-level env so the guard can read it

## Context

The auto-dev workflow was recently updated to include an Agent VM image build step that requires `${{ vars.AGENT_GCS_BUCKET }}`. This GitHub repo variable was never created, causing **every** desktop-backend auto-deploy run to fail at this step — blocking all dev deployments including the Python backend migration.

The variable needs to be created separately (likely by infra). This change unblocks deploys in the meantime by gracefully skipping the Agent VM build when the bucket isn't configured.

## Verification

- YAML syntax validates cleanly
- Guard uses standard `if [[ -z ... ]]` pattern consistent with other conditional steps in the workflow
- `exit 0` on skip is safe: downstream steps don't depend on the Agent VM artifact

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

