### PR TITLE
fix(ci): make Windows preflight path-safe

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,34 +4,19 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
-  - id: firmware-product-emulator
-    command: ["cargo", "test", "--manifest-path", "omi/firmware/scripts/devkit/OmiSimulator/Cargo.toml", "--lib", "--bin", "omi-product-cli"]
-    triggers: ["omi/firmware/scripts/devkit/OmiSimulator/**"]
-    lanes: ["local", "ci"]
-    reason: "the cross-platform Rust emulator must keep its host Bluetooth and firmware contracts tested without requiring a display server"
-  - id: firmware-product-emulator-gui
-    command: ["cargo", "check", "--manifest-path", "omi/firmware/scripts/devkit/OmiSimulator/Cargo.toml", "--bin", "omi-product-emulator"]
-    triggers: ["omi/firmware/scripts/devkit/OmiSimulator/**"]
-    lanes: ["local", "ci"]
-    reason: "the Crepuscularity GUI must compile on the CI host without linking to a display server"
-  - id: firmware-nrf5340-babblesim
-    command: ["bash", "omi/firmware/scripts/ci/check-bsim.sh"]
-    triggers: ["omi/firmware/bsim/**", "omi/firmware/omi/src/lib/core/button.c", "omi/firmware/omi/src/lib/core/button.h", "omi/firmware/omi/src/lib/core/button_service.c", "omi/firmware/omi/src/lib/core/transport.c", "omi/firmware/omi/src/settings.c", "omi/firmware/omi/CMakeLists.txt", "omi/firmware/omi/Kconfig", "omi/firmware/scripts/ci/check-bsim.sh", "omi/firmware/scripts/ci/run-bsim.sh"]
-    lanes: ["local", "ci"]
-    reason: "the nRF5340 BabbleSim lane executes Omi production advertising, connection, button GATT, and persistent settings contracts over the simulated radio"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
-    triggers: ["scripts/dev-harness/**", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/scripts/omi-fault-inject.sh", "desktop/macos/scripts/release-keyvalue.py", ".github/checks-manifest.yaml"]
+    triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/qualification-lease-command.sh", "desktop/macos/scripts/omi-fault-inject.sh", "desktop/macos/scripts/release-keyvalue.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "the hermetic dev-harness stack backs release qualification; the Jul 22 2026 beta qualification outage added a docker/native typesense runtime that must stay behaviorally covered"
   - id: pre-tag-readiness-contract
     command: ["bash", "desktop/macos/tests/test-pre-tag-readiness-contract.sh"]
-    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test-pre-tag-readiness-contract.sh", ".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test-pre-tag-readiness-contract.sh", "scripts/dev-harness/_resolve_python.sh", ".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "trusted-M1 readiness must retain exact-SHA cache/lease ownership and cannot emit a passing receipt before authenticated cleanup"
   - id: pre-tag-readiness-behavior
     command: ["python3", "desktop/macos/tests/test_pre_tag_readiness_behavior.py"]
-    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_pre_tag_readiness_behavior.py", ".github/checks-manifest.yaml"]
+    triggers: ["desktop/macos/scripts/pre-tag-readiness.sh", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/tests/test_pre_tag_readiness_behavior.py", ".github/scripts/git_bash.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "a disposable source and authenticated capability fakes prove the real readiness orchestrator emits its exact-SHA receipt only after ordered cleanup"
   - id: verify-pre-tag-readiness-tests
@@ -61,19 +46,9 @@ checks:
     reason: "make setup must provision the minimal, rerunnable backend environment required by selected pre-push checks"
   - id: desktop-release-process-guards
     command: ["bash", "scripts/run-release-process-guards.sh"]
-    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", ".github/scripts/git_bash.py", "scripts/dev-harness/_resolve_python.sh", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
-  - id: pre-push-worktree-fallback
-    command: ["bash", "scripts/test-pre-push-worktree-fallback.sh"]
-    triggers: ["scripts/pre-push", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", "scripts/test-pre-push-worktree-fallback.sh", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "#10293: the pre-push hook chain must resolve the repo root in linked worktrees where git rev-parse --show-toplevel exits 128, not abort into a --no-verify push"
-  - id: preflight-runner-portability
-    command: ["python3", ".github/scripts/test_preflight_runner.py"]
-    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/run_checks.py", ".github/scripts/test_run_checks.py", "scripts/pre-push-singleflight", "scripts/pre-push", "scripts/pr-preflight", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the single-flight pre-push gate must manage child processes and launch Bash checks on native Windows and POSIX hosts"
   - id: failure-class-retirement-author
     command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
     triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]
@@ -119,21 +94,6 @@ checks:
     triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/test_desktop_release_manifest_schema.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "the Stable manifest schema must keep admitting exactly one app artifact pair; a beta_zip_url re-entering it is how a beta build becomes describable as Stable"
-  - id: pr-scope
-    command: ["python3", ".github/scripts/check_pr_scope.py", "--base", "{base}", "--head", "{head}"]
-    triggers: ["all"]
-    lanes: ["local", "ci"]
-    reason: "advisory PR production-source churn report (annotations only, never blocks)"
-  - id: pr-scope-helper-tests
-    command: ["python3", ".github/scripts/test_check_pr_scope.py"]
-    triggers: [".github/scripts/check_pr_scope.py", ".github/scripts/test_check_pr_scope.py"]
-    lanes: ["local", "ci"]
-    reason: "scope advisor classification/annotation contract"
-  - id: backend-test-discovery
-    command: ["python3", "backend/scripts/check_unit_test_discovery.py"]
-    triggers: ["backend/tests/**", "backend/testing/**", "backend/scripts/select_backend_unit_tests.py", "backend/scripts/check_unit_test_discovery.py", ".github/workflows/parakeet_gpu_tests.yml", ".github/workflows/backend-hermetic-e2e.yml", ".github/workflows/desktop-backend-contracts.yml", ".github/workflows/backend-unit-tests.yml"]
-    lanes: ["local", "ci"]
-    reason: "every backend test file must be discovered by a verified runner"
   - id: desktop-release-doctor-v1
     command: ["python3", ".github/scripts/test_desktop_release_doctor.py"]
     triggers: [".github/schemas/desktop-release-evidence-v1.schema.json", ".github/scripts/desktop_release_doctor.py", ".github/scripts/desktop_release_doctor_report.py", ".github/scripts/test_desktop_release_doctor.py", ".github/workflows/desktop_release_doctor.yml"]
@@ -193,7 +153,7 @@ checks:
     reason: "locked invariant citation enforcement must keep rejecting an uncited path match"
   - id: pr-preflight-contract-tests
     command: ["python3", ".github/scripts/test_pr_preflight.py"]
-    triggers: [".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", "desktop/macos/scripts/check-e2e-flow-coverage.py", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "preflight resolves the check selection every PR depends on"
   - id: product-invariants
@@ -233,16 +193,6 @@ checks:
     triggers: ["desktop/macos/**"]
     lanes: ["local", "ci"]
     reason: "desktop files changed"
-  - id: analytics-reachability
-    command: ["python3", ".github/scripts/check_analytics_reachability.py"]
-    triggers: ["app/lib/**/*.dart", "desktop/macos/Desktop/Sources/**/*.swift", "desktop/windows/src/renderer/src/**/*.ts", "desktop/windows/src/renderer/src/**/*.tsx", ".github/scripts/check_analytics_reachability.py", ".github/scripts/analytics_reachability_baseline.json", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "static tripwire: 02524b7c0b orphaned one of two Device Connected emitters, while the dead macOS reportAllSettingsIfNeeded/collectAllSettings chain remained invisible"
-  - id: analytics-reachability-tests
-    command: ["python3", ".github/scripts/test_check_analytics_reachability.py"]
-    triggers: [".github/scripts/check_analytics_reachability.py", ".github/scripts/test_check_analytics_reachability.py", ".github/scripts/analytics_reachability_baseline.json", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "the lexical analytics tripwire must ignore comments and strings while catching call-site count loss, empty methods, and unreachable helpers"
   - id: omi-macos-dev-cli
     command: ["bash", "desktop/macos/tests/test-omi-macos-dev.sh"]
     triggers: ["desktop/macos/scripts/omi-macos-dev", "desktop/macos/scripts/cleanup-omi-tcc.sh", "desktop/macos/tests/test-omi-macos-dev.sh", "desktop/macos/tests/test-cleanup-omi-tcc.sh"]
@@ -250,7 +200,7 @@ checks:
     reason: "agent-facing macOS development hygiene CLI remains safe and deterministic"
   - id: desktop-e2e-flow-coverage
     command: ["python3", "desktop/macos/scripts/check-e2e-flow-coverage.py", "--strict", "--base", "{base}"]
-    triggers: ["desktop/macos/Desktop/Sources/**/*.swift"]
+    triggers: ["desktop/macos/Desktop/Sources/**/*.swift", "desktop/macos/scripts/check-e2e-flow-coverage.py"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "desktop Swift sources changed; compare against the pinned macOS formatter before requiring a flow cover"
@@ -268,16 +218,19 @@ checks:
     command: ["ruby", "app/ios/test/rayban_dat_plugin_boundary_test.rb"]
     triggers: ["app/ios/Podfile", "app/ios/Podfile.lock", "app/ios/rayban_dat_plugin_boundary.rb", "app/ios/test/rayban_dat_plugin_boundary_test.rb", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
+    platforms: ["linux", "macos"]
     reason: "Ray-Ban DAT launch collision requires the Meta and mcumgr SwiftProtobuf copies to remain in mutually exclusive iOS pod graphs"
   - id: rayban-dat-xcode-graph
     command: ["ruby", "app/ios/test/rayban_dat_xcode_graph_test.rb"]
     triggers: ["app/ios/Podfile", "app/ios/Flutter/raybanDat*.xcconfig", "app/ios/Runner.xcodeproj/project.pbxproj", "app/ios/Runner.xcodeproj/xcshareddata/xcschemes/raybanDat.xcscheme", "app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved", "app/ios/test/rayban_dat_xcode_graph_test.rb", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
+    platforms: ["linux", "macos"]
     reason: "Ray-Ban DAT must link Meta 0.8.0 only in its dedicated signed iOS target while the default Runner remains audio-only"
   - id: rayban-dat-build-wrapper
     command: ["ruby", "app/ios/test/rayban_dat_build_wrapper_test.rb"]
     triggers: ["app/scripts/rayban_dat.sh", "app/ios/Podfile", "app/ios/rayban_dat_plugin_boundary.rb", "app/ios/test/rayban_dat_build_wrapper_test.rb", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
+    platforms: ["linux", "macos"]
     reason: "Ray-Ban DAT builds must strip mcumgr before CocoaPods and restore the exact default graph even after interruption"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
@@ -517,7 +470,7 @@ checks:
     reason: "#9843 Ticket 05: enforce pinned swift-format lint on all first-party Swift"
   - id: desktop-swiftlint-config
     command: ["python3", ".github/scripts/test_swiftlint_config.py"]
-    triggers: ["desktop/macos/Desktop/.swiftlint.yml", "desktop/macos/Desktop/Package.swift", "desktop/macos/Desktop/.swiftlint-baseline.json", "desktop/macos/scripts/prepare-swiftlint-baseline.py", "desktop/macos/scripts/swiftlint-wrapper.sh", ".github/scripts/test_swiftlint_config.py"]
+    triggers: ["desktop/macos/Desktop/.swiftlint.yml", "desktop/macos/Desktop/Package.swift", "desktop/macos/Desktop/.swiftlint-baseline.json", "desktop/macos/scripts/prepare-swiftlint-baseline.py", "desktop/macos/scripts/swiftlint-wrapper.sh", ".github/scripts/git_bash.py", ".github/scripts/test_swiftlint_config.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Ticket 06: SwiftLint safety config, plugin attachment, and baseline contract"
   - id: desktop-swiftlint
@@ -646,6 +599,7 @@ checks:
     command: ["python3", ".github/scripts/test_desktop_release_flow_contract.py"]
     triggers: ["codemagic.yaml", ".github/workflows/desktop_auto_release.yml", ".github/workflows/desktop_qualify_beta.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_recover_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", "desktop/macos/scripts/qualify-desktop-beta.sh", "desktop/macos/scripts/qualification-cache-reclaim.py", "desktop/macos/scripts/qualification-runner-self-clean.py", "desktop/macos/scripts/qualification-watchdog.py", "desktop/macos/scripts/qualification-lease-command.sh", ".github/scripts/test_desktop_release_flow_contract.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
+    platforms: ["linux", "macos"]
     reason: "SCA-17 prevents duplicate desktop promotion authorities and requires post-traffic production release-vector verification"
   - id: desktop-qualification-bootstrap-contract
     command: ["bash", "desktop/macos/tests/test-qualify-desktop-beta-contract.sh"]

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import yaml
 
+from git_bash import bash_executable, bash_path
+
 ROOT = Path(__file__).resolve().parents[2]
 MAX_SECURITY_BOUND_FILE_BYTES = 10 * 1024 * 1024
 
@@ -1040,6 +1042,11 @@ def check_firmware_release_metadata() -> list[str]:
     if not script.exists():
         return []
 
+    try:
+        bash = bash_executable()
+    except FileNotFoundError as exc:
+        return [f"firmware release body smoke failed: {exc}"]
+
     with tempfile.TemporaryDirectory() as temp_dir:
         output = Path(temp_dir) / "body.md"
         env = {
@@ -1051,19 +1058,21 @@ def check_firmware_release_metadata() -> list[str]:
             "MIN_APP_CODE": "438",
             "OTA_STEPS": "battery,internet",
             "IS_LEGACY_SECURE_DFU": "False",
-            "OUT": str(output),
+            "OUT": bash_path(output, bash),
         }
         completed = subprocess.run(
-            ["bash", str(script)],
+            [bash, str(script)],
             cwd=ROOT,
             env={**os.environ, **env},
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
         )
         if completed.returncode != 0:
-            return [f"firmware release body smoke failed: {completed.stderr.strip() or completed.stdout.strip()}"]
+            detail = (completed.stderr or "").strip() or (completed.stdout or "").strip()
+            return [f"firmware release body smoke failed: {detail or f'exit {completed.returncode}'}"]
         body = output.read_text(encoding="utf-8")
 
     kv = extract_key_value_pairs(body)

--- a/.github/scripts/git_bash.py
+++ b/.github/scripts/git_bash.py
@@ -1,0 +1,71 @@
+"""Cross-platform Bash discovery and path conversion for repository checks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+Which = Callable[[str], str | None]
+Run = Callable[..., subprocess.CompletedProcess[str]]
+GIT_LAYOUT_PARENT_LIMIT = 3
+
+
+def bash_executable(*, platform_name: str | None = None, which: Which = shutil.which) -> str:
+    platform = platform_name or os.name
+    if platform != "nt":
+        bash = which("bash")
+        if bash:
+            return bash
+        raise FileNotFoundError("Bash is required for this repository check")
+
+    git = which("git")
+    if git:
+        for parent in tuple(Path(git).resolve().parents)[:GIT_LAYOUT_PARENT_LIMIT]:
+            for relative_path in (Path("bin/bash.exe"), Path("usr/bin/bash.exe")):
+                candidate = parent / relative_path
+                if candidate.is_file():
+                    return str(candidate)
+    raise FileNotFoundError("Git for Windows Bash is required for this repository check")
+
+
+def _cygpath(value: str, bash: str, mode: str, *, run: Run = subprocess.run) -> str:
+    result = run(
+        [bash, "-c", f'cygpath {mode} "$1"', "bash", value],
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+    if result.returncode:
+        detail = (result.stderr or "").strip() or (result.stdout or "").strip()
+        raise RuntimeError(detail or f"cygpath {mode} failed with status {result.returncode}")
+    return result.stdout.strip()
+
+
+def bash_path(
+    value: Path,
+    bash: str,
+    *,
+    platform_name: str | None = None,
+    run: Run = subprocess.run,
+) -> str:
+    if (platform_name or os.name) != "nt":
+        return str(value)
+    return _cygpath(str(value), bash, "-u", run=run)
+
+
+def native_path_from_bash(
+    value: str,
+    bash: str,
+    *,
+    platform_name: str | None = None,
+    run: Run = subprocess.run,
+) -> Path:
+    if (platform_name or os.name) != "nt":
+        return Path(value)
+    return Path(_cygpath(value, bash, "-w", run=run))

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -23,18 +23,6 @@ class Check:
     reason: str
 
 
-def _resolve_repo_root() -> Path:
-    # The pre-push gate cd's to the repo root before invoking this script, and
-    # git runs hooks at the work-tree top, so fall back to the working directory
-    # when `git rev-parse --show-toplevel` cannot resolve a work tree: a linked
-    # worktree whose git context resolves to a git dir exits 128 here ("this
-    # operation must be run in a work tree") and would otherwise abort the gate.
-    try:
-        return Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))
-    except subprocess.CalledProcessError:
-        return Path.cwd()
-
-
 def run_git(root: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", *args],
@@ -173,7 +161,7 @@ def main() -> int:
     if bool(args.repository) != bool(args.pr_number):
         print("FAIL: --repository and --pr-number must be supplied together", file=sys.stderr)
         return 2
-    root = (args.root or _resolve_repo_root()).resolve()
+    root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))).resolve()
     started = time.monotonic()
     try:
         merge_base = run_git(root, "merge-base", args.base, args.head)
@@ -267,7 +255,6 @@ def main() -> int:
                 check=False,
                 stdout=subprocess.PIPE,
                 text=True,
-                encoding="utf-8",
             ).stdout.strip()
         skip_changelog = (
             "no-changelog-needed" in labels

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import ctypes
 import hashlib
 import json
 import os
@@ -17,177 +16,49 @@ from pathlib import Path
 
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
-FORWARDED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK")
-IS_WINDOWS = os.name == "nt"
-HAS_PROCESS_GROUPS = os.name != "nt" and hasattr(os, "killpg")
-WINDOWS_STILL_ACTIVE = 259
-WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-WINDOWS_PROCESS_SET_QUOTA = 0x0100
-WINDOWS_PROCESS_TERMINATE = 0x0001
-WINDOWS_ERROR_ACCESS_DENIED = 5
-WINDOWS_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
-WINDOWS_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
-WINDOWS_CHILD_BOOTSTRAP_FLAG = "--windows-child-bootstrap"
+MAX_PR_BODY_FINGERPRINT_BYTES = 1024 * 1024
+
+# Signals forwarded to the owned child. SIGHUP is POSIX-only and is simply absent
+# on Windows, so the set is resolved against the host rather than assumed —
+# referencing signal.SIGHUP unconditionally raised AttributeError before any
+# pre-push check could run.
+FORWARDED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP")
+FINGERPRINT_ENV_NAMES = (
+    "GITHUB_HEAD_REF",
+    "OMI_PR_BODY_FILE",
+    "PATH",
+    "PYTHON",
+    "PYTHONPATH",
+)
 
 
-class WindowsJob:
-    """Own a Windows process tree and terminate it when the job closes."""
-
-    def __init__(self) -> None:
-        if not IS_WINDOWS:
-            raise RuntimeError("Windows jobs are only available on Windows")
-
-        from ctypes import wintypes
-
-        class BasicLimitInformation(ctypes.Structure):
-            _fields_ = [
-                ("PerProcessUserTimeLimit", ctypes.c_int64),
-                ("PerJobUserTimeLimit", ctypes.c_int64),
-                ("LimitFlags", wintypes.DWORD),
-                ("MinimumWorkingSetSize", ctypes.c_size_t),
-                ("MaximumWorkingSetSize", ctypes.c_size_t),
-                ("ActiveProcessLimit", wintypes.DWORD),
-                ("Affinity", ctypes.c_size_t),
-                ("PriorityClass", wintypes.DWORD),
-                ("SchedulingClass", wintypes.DWORD),
-            ]
-
-        class IoCounters(ctypes.Structure):
-            _fields_ = [
-                ("ReadOperationCount", ctypes.c_uint64),
-                ("WriteOperationCount", ctypes.c_uint64),
-                ("OtherOperationCount", ctypes.c_uint64),
-                ("ReadTransferCount", ctypes.c_uint64),
-                ("WriteTransferCount", ctypes.c_uint64),
-                ("OtherTransferCount", ctypes.c_uint64),
-            ]
-
-        class ExtendedLimitInformation(ctypes.Structure):
-            _fields_ = [
-                ("BasicLimitInformation", BasicLimitInformation),
-                ("IoInfo", IoCounters),
-                ("ProcessMemoryLimit", ctypes.c_size_t),
-                ("JobMemoryLimit", ctypes.c_size_t),
-                ("PeakProcessMemoryUsed", ctypes.c_size_t),
-                ("PeakJobMemoryUsed", ctypes.c_size_t),
-            ]
-
-        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-        create_job = kernel32.CreateJobObjectW
-        create_job.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
-        create_job.restype = wintypes.HANDLE
-        set_information = kernel32.SetInformationJobObject
-        set_information.argtypes = [
-            wintypes.HANDLE,
-            ctypes.c_int,
-            ctypes.c_void_p,
-            wintypes.DWORD,
-        ]
-        set_information.restype = wintypes.BOOL
-        self._open_process = kernel32.OpenProcess
-        self._open_process.argtypes = [
-            wintypes.DWORD,
-            wintypes.BOOL,
-            wintypes.DWORD,
-        ]
-        self._open_process.restype = wintypes.HANDLE
-        self._assign_process = kernel32.AssignProcessToJobObject
-        self._assign_process.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
-        self._assign_process.restype = wintypes.BOOL
-        self._terminate_job = kernel32.TerminateJobObject
-        self._terminate_job.argtypes = [wintypes.HANDLE, wintypes.UINT]
-        self._terminate_job.restype = wintypes.BOOL
-        self._close_handle = kernel32.CloseHandle
-        self._close_handle.argtypes = [wintypes.HANDLE]
-        self._close_handle.restype = wintypes.BOOL
-
-        self._handle = create_job(None, None)
-        self.assigned = False
-        if not self._handle:
-            raise self._last_error("CreateJobObjectW failed")
-
-        limits = ExtendedLimitInformation()
-        limits.BasicLimitInformation.LimitFlags = WINDOWS_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-        if not set_information(
-            self._handle,
-            WINDOWS_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
-            ctypes.byref(limits),
-            ctypes.sizeof(limits),
-        ):
-            error = self._last_error("SetInformationJobObject failed")
-            self.close()
-            raise error
-
-    @staticmethod
-    def _last_error(message: str) -> OSError:
-        error_code = ctypes.get_last_error()
-        return OSError(error_code, f"{message}: {ctypes.FormatError(error_code).strip()}")
-
-    def assign(self, pid: int) -> None:
-        process = self._open_process(
-            WINDOWS_PROCESS_SET_QUOTA | WINDOWS_PROCESS_TERMINATE,
-            False,
-            pid,
-        )
-        if not process:
-            raise self._last_error(f"OpenProcess({pid}) failed")
-        try:
-            if not self._assign_process(self._handle, process):
-                raise self._last_error(f"AssignProcessToJobObject({pid}) failed")
-        finally:
-            self._close_handle(process)
-        self.assigned = True
-
-    def terminate(self, exit_code: int = 1) -> bool:
-        if not self._handle or not self.assigned:
-            return False
-        return bool(self._terminate_job(self._handle, exit_code))
-
-    def close(self) -> None:
-        if self._handle:
-            self._close_handle(self._handle)
-            self._handle = None
-
-
-def forwardable_signals(module: object = signal) -> tuple[int, ...]:
-    """Return only the forwarding signals the current host defines."""
-    return tuple(signum for name in FORWARDED_SIGNAL_NAMES if isinstance((signum := getattr(module, name, None)), int))
-
-
-def child_launch_command(command: list[str]) -> list[str]:
-    """Delay Windows command execution until the parent assigns its Job Object."""
-    if not IS_WINDOWS:
-        return command
-    return [
-        sys.executable,
-        str(Path(__file__).resolve()),
-        WINDOWS_CHILD_BOOTSTRAP_FLAG,
-        *command,
-    ]
-
-
-def run_windows_child_bootstrap(command: list[str]) -> int:
-    """Forward stdin after the Job Object assignment barrier is released."""
-    if not command:
-        return 2
-    return subprocess.run(command, input=sys.stdin.buffer.read()).returncode
+def forwardable_signals() -> tuple[int, ...]:
+    """Return the forwardable signals this platform actually defines."""
+    resolved = (getattr(signal, name, None) for name in FORWARDED_SIGNAL_NAMES)
+    return tuple(signum for signum in resolved if signum is not None)
 
 
 def signal_child(
-    child: subprocess.Popen[str],
+    child: subprocess.Popen,
     signum: int,
-    windows_job: WindowsJob | None = None,
+    *,
+    platform_name: str | None = None,
 ) -> None:
-    """Forward to the POSIX child group or terminate the Windows process tree."""
+    """Forward a signal to the isolated child process group where supported."""
+    platform_name = platform_name or os.name
     killpg = getattr(os, "killpg", None)
     try:
-        if windows_job is not None and windows_job.terminate():
-            return
-        if killpg is not None:
+        if platform_name == "nt":
+            ctrl_break = getattr(signal, "CTRL_BREAK_EVENT", None)
+            if ctrl_break is not None and signum in (signal.SIGINT, signal.SIGTERM):
+                child.send_signal(ctrl_break)
+            else:
+                child.send_signal(signum)
+        elif killpg is not None:
             killpg(child.pid, signum)
         else:
             child.send_signal(signum)
-    except OSError:
+    except (ProcessLookupError, OSError, ValueError):
         pass
 
 
@@ -195,6 +66,17 @@ def atomic_json(path: Path, value: dict) -> None:
     temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
     temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     os.replace(temporary, path)
+
+
+def configure_console_error_handling() -> None:
+    """Keep non-console Unicode output from aborting a Windows preflight."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            options = {"errors": "replace"}
+            if os.name == "nt":
+                options["encoding"] = "utf-8"
+            reconfigure(**options)
 
 
 def read_json(path: Path) -> dict:
@@ -205,66 +87,11 @@ def read_json(path: Path) -> dict:
         return {}
 
 
-def windows_process_status(pid: int) -> tuple[bool, int | None]:
-    """Return Windows liveness and immutable process creation ticks."""
-    from ctypes import wintypes
-
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    open_process = kernel32.OpenProcess
-    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
-    open_process.restype = wintypes.HANDLE
-    get_exit_code = kernel32.GetExitCodeProcess
-    get_exit_code.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
-    get_exit_code.restype = wintypes.BOOL
-    get_process_times = kernel32.GetProcessTimes
-    get_process_times.argtypes = [
-        wintypes.HANDLE,
-        ctypes.POINTER(wintypes.FILETIME),
-        ctypes.POINTER(wintypes.FILETIME),
-        ctypes.POINTER(wintypes.FILETIME),
-        ctypes.POINTER(wintypes.FILETIME),
-    ]
-    get_process_times.restype = wintypes.BOOL
-    close_handle = kernel32.CloseHandle
-    close_handle.argtypes = [wintypes.HANDLE]
-    close_handle.restype = wintypes.BOOL
-
-    handle = open_process(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-    if not handle:
-        return ctypes.get_last_error() == WINDOWS_ERROR_ACCESS_DENIED, None
-    try:
-        exit_code = wintypes.DWORD()
-        if not get_exit_code(handle, ctypes.byref(exit_code)):
-            return True, None
-        if exit_code.value != WINDOWS_STILL_ACTIVE:
-            return False, None
-
-        creation = wintypes.FILETIME()
-        exit_time = wintypes.FILETIME()
-        kernel_time = wintypes.FILETIME()
-        user_time = wintypes.FILETIME()
-        if not get_process_times(
-            handle,
-            ctypes.byref(creation),
-            ctypes.byref(exit_time),
-            ctypes.byref(kernel_time),
-            ctypes.byref(user_time),
-        ):
-            return True, None
-        creation_ticks = (creation.dwHighDateTime << 32) | creation.dwLowDateTime
-        return True, creation_ticks
-    finally:
-        close_handle(handle)
-
-
-def process_exists(pid: int, expected_creation_ticks: int | None = None) -> bool:
+def process_exists(pid: int) -> bool:
     if pid <= 0:
         return False
-    if IS_WINDOWS:
-        exists, creation_ticks = windows_process_status(pid)
-        if expected_creation_ticks is not None:
-            return exists and creation_ticks == expected_creation_ticks
-        return exists
+    if os.name == "nt":
+        return windows_process_exists(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -272,6 +99,31 @@ def process_exists(pid: int, expected_creation_ticks: int | None = None) -> bool
         return False
     except PermissionError:
         return True
+
+
+def windows_process_exists(pid: int) -> bool:
+    """Check liveness without treating signal 0 as Windows CTRL_C_EVENT."""
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_timeout = 0x00000102
+    access_denied = 5
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(synchronize, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == access_denied
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == wait_timeout
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def default_state_dir(root: Path, name: str) -> Path:
@@ -301,6 +153,24 @@ def fingerprint(root: Path, command: list[str], stdin_data: str) -> str:
     for value in (str(root.resolve()), head, "\0".join(command), stdin_data):
         digest.update(value.encode("utf-8"))
         digest.update(b"\0")
+    relevant_names = set(FINGERPRINT_ENV_NAMES)
+    relevant_names.update(name for name in os.environ if name.startswith("PRE_PUSH_"))
+    for name in sorted(relevant_names):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"=")
+        digest.update(os.getenv(name, "").encode("utf-8"))
+        digest.update(b"\0")
+    body_path = os.getenv("OMI_PR_BODY_FILE", "").strip()
+    if body_path:
+        try:
+            with Path(body_path).open("rb") as body_file:
+                body = body_file.read(MAX_PR_BODY_FINGERPRINT_BYTES + 1)
+            digest.update(body[:MAX_PR_BODY_FINGERPRINT_BYTES])
+            if len(body) > MAX_PR_BODY_FINGERPRINT_BYTES:
+                digest.update(b"<truncated-pr-body>")
+        except OSError:
+            digest.update(b"<unreadable-pr-body>")
+        digest.update(b"\0")
     return digest.hexdigest()
 
 
@@ -317,8 +187,7 @@ def remove_stale_lock(lock_dir: Path, expected_pid: int) -> bool:
     owner = read_json(lock_dir / "owner.json")
     if int(owner.get("pid") or 0) != expected_pid:
         return False
-    expected_creation_ticks = int(owner.get("process_creation_ticks") or 0) or None
-    if process_exists(expected_pid, expected_creation_ticks):
+    if process_exists(expected_pid):
         return False
     try:
         shutil.rmtree(lock_dir)
@@ -341,9 +210,8 @@ def join_existing(state_dir: Path, wanted_fingerprint: str) -> int | None:
             time.sleep(POLL_SECONDS)
         return None
     active_pid = int(owner.get("pid") or 0)
-    active_creation_ticks = int(owner.get("process_creation_ticks") or 0) or None
     active_fingerprint = str(owner.get("fingerprint") or "")
-    if not process_exists(active_pid, active_creation_ticks):
+    if not process_exists(active_pid):
         if remove_stale_lock(lock_dir, active_pid):
             return None
     log_path = state_dir / "preflight.log"
@@ -361,7 +229,7 @@ def join_existing(state_dir: Path, wanted_fingerprint: str) -> int | None:
     print(f"Joining identical preflight PID {active_pid}; live log: {log_path}")
     next_status = 0.0
     while lock_dir.exists():
-        if not process_exists(active_pid, active_creation_ticks):
+        if not process_exists(active_pid):
             remove_stale_lock(lock_dir, active_pid)
             break
         now = time.monotonic()
@@ -396,7 +264,6 @@ def run_owned(
     started_wall = time.time()
     phase = "starting"
     child: subprocess.Popen[str] | None = None
-    windows_job: WindowsJob | None = None
 
     def write_status() -> None:
         atomic_json(
@@ -412,36 +279,35 @@ def run_owned(
         )
 
     def forward_signal(signum: int, _frame: object) -> None:
-        if child is None:
-            return
-        if windows_job is None and child.poll() is not None:
-            return
-        signal_child(child, signum, windows_job)
+        if child is not None and child.poll() is None:
+            signal_child(child, signum)
 
     previous_handlers = {signum: signal.signal(signum, forward_signal) for signum in forwardable_signals()}
     exit_code = 1
     try:
-        if IS_WINDOWS:
-            windows_job = WindowsJob()
         print(f"Pre-push single-flight log: {log_path}")
         log_path.write_text("", encoding="utf-8")
         os.chmod(log_path, 0o600)
         write_status()
+        child_env = os.environ.copy()
+        child_env["PYTHONIOENCODING"] = "utf-8"
+        child_env["PYTHONUTF8"] = "1"
+        process_group_options = (
+            {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if os.name == "nt" else {"start_new_session": True}
+        )
         child = subprocess.Popen(
-            child_launch_command(command),
+            command,
             cwd=root,
+            env=child_env,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
             encoding="utf-8",
-            errors="backslashreplace",
+            errors="replace",
             bufsize=1,
-            start_new_session=HAS_PROCESS_GROUPS,
-            creationflags=(subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0),
+            **process_group_options,
         )
-        if windows_job is not None:
-            windows_job.assign(child.pid)
         if child.stdin:
             child.stdin.write(stdin_data)
             child.stdin.close()
@@ -470,16 +336,6 @@ def run_owned(
         )
         return exit_code
     finally:
-        if child is not None and child.poll() is None:
-            signal_child(child, signal.SIGTERM, windows_job)
-            try:
-                child.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                child.kill()
-                child.wait()
-        if windows_job is not None:
-            windows_job.terminate()
-            windows_job.close()
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
         shutil.rmtree(lock_dir, ignore_errors=True)
@@ -492,32 +348,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_repo_root() -> Path:
-    # Git runs hooks with the working directory at the top of the invoking work
-    # tree, and the pre-push dispatcher cd's to the repo root before invoking
-    # this runner. Fall back to that working directory when `git rev-parse
-    # --show-toplevel` cannot resolve a work tree: in a linked worktree whose
-    # git context resolves to a git dir rather than a work tree, show-toplevel
-    # exits 128 ("this operation must be run in a work tree") and this runner
-    # would otherwise abort the gate, forcing a --no-verify push.
-    try:
-        toplevel = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            encoding="utf-8",
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        toplevel = ""
-    return Path(toplevel or Path.cwd()).resolve()
-
-
 def main() -> int:
-    if sys.argv[1:2] == [WINDOWS_CHILD_BOOTSTRAP_FLAG]:
-        return run_windows_child_bootstrap(sys.argv[2:])
-
+    configure_console_error_handling()
     args = parse_args()
     command = list(args.command)
     if command and command[0] == "--":
@@ -525,7 +357,13 @@ def main() -> int:
     if not command:
         print("FAIL: preflight runner requires a command after --", file=sys.stderr)
         return 2
-    root = resolve_repo_root()
+    root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+            encoding="utf-8",
+        ).strip()
+    ).resolve()
     # Git supplies ref updates on a pipe. Manual preflight runs inherit a TTY;
     # treating that as empty input avoids waiting forever for an interactive EOF.
     stdin_data = "" if sys.stdin.isatty() else sys.stdin.read()
@@ -534,15 +372,7 @@ def main() -> int:
     state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     os.chmod(state_dir, 0o700)
     lock_dir = state_dir / "lock"
-    owner = {
-        "pid": os.getpid(),
-        "fingerprint": wanted_fingerprint,
-        "started_at_epoch": time.time(),
-    }
-    if IS_WINDOWS:
-        _, process_creation_ticks = windows_process_status(os.getpid())
-        if process_creation_ticks is not None:
-            owner["process_creation_ticks"] = process_creation_ticks
+    owner = {"pid": os.getpid(), "fingerprint": wanted_fingerprint, "started_at_epoch": time.time()}
 
     while not acquire(lock_dir, owner):
         joined = join_existing(state_dir, wanted_fingerprint)

--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -9,7 +9,6 @@ import glob
 import json
 import os
 import platform as _platform_mod
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -17,6 +16,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any
+
+from git_bash import bash_executable
 
 VALID_PLATFORMS = {"all", "macos", "linux", "windows"}
 
@@ -31,21 +32,6 @@ def detect_platform() -> str:
     if system == "Windows":
         return "windows"
     return system.lower()
-
-
-def bash_executable() -> str:
-    override = os.environ.get("OMI_BASH_EXECUTABLE")
-    if override:
-        return override
-    if os.name == "nt":
-        git = shutil.which("git")
-        if git:
-            git_root = Path(git).resolve().parent.parent
-            for relative_path in (Path("bin/bash.exe"), Path("usr/bin/bash.exe")):
-                candidate = git_root / relative_path
-                if candidate.is_file():
-                    return str(candidate)
-    return shutil.which("bash") or "bash"
 
 
 @dataclass(frozen=True)
@@ -186,6 +172,7 @@ def run_git(root: Path, *args: str) -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
     )
     return result.stdout.strip()
 
@@ -277,31 +264,6 @@ def resolve_checks(
     ]
 
 
-def resolve_explicit_checks(
-    manifest: Manifest,
-    check_ids: list[str],
-    lane: str,
-    *,
-    include_pr_body_checks: bool,
-    platform: str,
-) -> list[CheckSelection]:
-    """Resolve named manifest checks without duplicating their commands in callers."""
-    checks_by_id = {check.id: check for check in manifest.checks}
-    selections: list[CheckSelection] = []
-    for check_id in dict.fromkeys(check_ids):
-        check = checks_by_id.get(check_id)
-        if check is None:
-            raise ValueError(f"unknown check id: {check_id}")
-        if lane not in check.lanes:
-            raise ValueError(f"{check_id}: check is not available in the {lane} lane")
-        if not include_pr_body_checks and check.requires_pr_body:
-            raise ValueError(f"{check_id}: check requires pull-request metadata")
-        if not _platform_matches(check, platform):
-            raise ValueError(f"{check_id}: check does not support platform {platform}")
-        selections.append(CheckSelection(check=check, matched_paths=()))
-    return selections
-
-
 def skipped_platform_checks(manifest: Manifest, files: list[str], lane: str, platform: str) -> list[Check]:
     """Checks that match lane+triggers but are skipped due to platform."""
     return [
@@ -332,18 +294,29 @@ def command_for_check(
         "{pr_body_file}": str(pr_body_file),
     }
     command: list[str] = []
-    for index, token in enumerate(check.command):
+    for token in check.command:
         if token == "{skip_changelog}":
             if skip_changelog:
                 command.append("--skip")
             continue
-        resolved = replacements.get(token, token)
-        if index == 0:
-            if resolved == "python3":
-                resolved = sys.executable
-            elif resolved == "bash":
-                resolved = bash_executable()
-        command.append(resolved)
+        command.append(replacements.get(token, token))
+    return command
+
+
+def command_for_host(
+    command: list[str],
+    *,
+    platform_name: str | None = None,
+    python_executable: str | None = None,
+) -> list[str]:
+    """Resolve manifest interpreter aliases through the active Windows toolchain."""
+    platform = platform_name or os.name
+    if platform != "nt" or not command:
+        return command
+    if command[0] == "bash":
+        return [bash_executable(platform_name=platform), *command[1:]]
+    if command[0] == "python3":
+        return [python_executable or sys.executable, *command[1:]]
     return command
 
 
@@ -369,6 +342,7 @@ def execute_checks(
             pr_body_file=pr_body_file,
             skip_changelog=skip_changelog,
         )
+        command = command_for_host(command)
         returncode = subprocess.run(command, cwd=root, check=False).returncode
         status = "PASS" if returncode == 0 else "FAIL"
         print(f"<== {status} {check.id} ({time.monotonic() - started:.2f}s)", flush=True)
@@ -396,12 +370,6 @@ def parse_args() -> argparse.Namespace:
         help="Exclude checks declared as requiring pull-request metadata.",
     )
     parser.add_argument("--skip-changelog", action="store_true")
-    parser.add_argument(
-        "--check-id",
-        action="append",
-        default=[],
-        help="Run a named manifest check regardless of path triggers; repeat for multiple checks.",
-    )
     parser.add_argument("--list", action="store_true")
     parser.add_argument("--root", type=Path)
     parser.add_argument(
@@ -443,28 +411,14 @@ def main() -> int:
         print(f"FAIL: could not resolve manifest checks: {exc}", file=sys.stderr)
         return 2
     detected_platform = args.platform or detect_platform()
-    try:
-        selections = (
-            resolve_explicit_checks(
-                manifest,
-                args.check_id,
-                args.lane,
-                include_pr_body_checks=not args.skip_pr_body_checks,
-                platform=detected_platform,
-            )
-            if args.check_id
-            else resolve_check_selections(
-                manifest,
-                files,
-                args.lane,
-                include_pr_body_checks=not args.skip_pr_body_checks,
-                platform=detected_platform,
-                exclusive_platform=args.exclusive_platform,
-            )
-        )
-    except ValueError as exc:
-        print(f"FAIL: could not select manifest checks: {exc}", file=sys.stderr)
-        return 2
+    selections = resolve_check_selections(
+        manifest,
+        files,
+        args.lane,
+        include_pr_body_checks=not args.skip_pr_body_checks,
+        platform=detected_platform,
+        exclusive_platform=args.exclusive_platform,
+    )
     checks = [selection.check for selection in selections]
     if args.output == "json":
         print(
@@ -492,11 +446,10 @@ def main() -> int:
     )
     for check in checks:
         print(f"  SELECTED {check.id}: {check.reason}")
-    if not args.check_id:
-        for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
-            print(
-                f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
-            )
+    for skip in skipped_platform_checks(manifest, files, args.lane, detected_platform):
+        print(
+            f"  SKIPPED {skip.id}: platform-only (requires {', '.join(skip.platforms)}, running on {detected_platform})"
+        )
     if args.list:
         return 0
 

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -46,10 +46,6 @@ def _assert_contract_rejects(errors: list[str]) -> None:
     assert any("contract" in error or "fixture" in error for error in errors), errors
 
 
-def test_desktop_qualification_runner_accepts_run_isolated_tag_checkout():
-    assert GUARDS.check_desktop_qualification_runner() == []
-
-
 def _load_parent_guard(tmp_path: Path, revision: str = REVIEWED_PARENT):
     """Load the reviewed parent to prove its narrower lock accepted known bypasses."""
     parent_script = tmp_path / "parent-guard.py"
@@ -838,3 +834,50 @@ def test_global_document_lock_rejects_malformed_fixture_json(tmp_path, monkeypat
     errors = GUARDS.check_codemagic_release_publishers()
 
     assert any("invalid JSON" in error for error in errors), errors
+
+
+def test_firmware_release_metadata_uses_resolved_bash_and_converted_output(tmp_path, monkeypatch):
+    script = tmp_path / "omi/firmware/scripts/ci/make-release-body.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("# fixture\n", encoding="utf-8")
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        Path(kwargs["env"]["OUT"]).write_text(
+            "<!-- KEY_VALUE_START\n"
+            "release_firmware_version:9.8.7\n"
+            "minimum_firmware_required:3.0.6\n"
+            "minimum_app_version:1.0.74\n"
+            "minimum_app_version_code:438\n"
+            "is_legacy_secure_dfu:False\n"
+            "ota_update_steps:battery,internet\n"
+            "KEY_VALUE_END -->\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    monkeypatch.setattr(GUARDS, "bash_executable", lambda: "git-bash.exe")
+    monkeypatch.setattr(GUARDS, "bash_path", lambda value, _bash: str(value))
+    monkeypatch.setattr(GUARDS.subprocess, "run", fake_run)
+
+    assert GUARDS.check_firmware_release_metadata() == []
+    assert commands == [["git-bash.exe", str(script)]]
+
+
+def test_firmware_release_metadata_reports_status_when_shell_has_no_output(tmp_path, monkeypatch):
+    script = tmp_path / "omi/firmware/scripts/ci/make-release-body.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("# fixture\n", encoding="utf-8")
+
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    monkeypatch.setattr(GUARDS, "bash_executable", lambda: "git-bash.exe")
+    monkeypatch.setattr(GUARDS, "bash_path", lambda value, _bash: str(value))
+    monkeypatch.setattr(
+        GUARDS.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 9, stdout=None, stderr=None),
+    )
+
+    assert GUARDS.check_firmware_release_metadata() == ["firmware release body smoke failed: exit 9"]

--- a/.github/scripts/test_desktop_beta_qualification_retry.py
+++ b/.github/scripts/test_desktop_beta_qualification_retry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import copy
 import json
+import sys
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -290,30 +291,27 @@ class CliOutputContractTests(unittest.TestCase):
         import tempfile
 
         script = Path(retry.__file__).resolve()
-        root = script.parent
-        release_path = root / "_tmp_retry_release.json"
-        runs_path = root / "_tmp_retry_runs.json"
-        out_path = root / "_tmp_retry_decision.json"
-        try:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            release_path = root / "release.json"
+            runs_path = root / "runs.json"
+            out_path = root / "decision.json"
             release_path.write_text(json.dumps(_release()), encoding="utf-8")
             runs_path.write_text(json.dumps([_run(conclusion="failure")]), encoding="utf-8")
             import subprocess
 
             result = subprocess.run(
-                ["python3", str(script), "decide",
+                [sys.executable, str(script), "decide",
                  "--release-json", str(release_path),
                  "--runs-json", str(runs_path),
                  "--release-tag", TAG, "--tag-sha", SHA,
                  "--output", str(out_path)],
-                check=True, text=True, capture_output=True,
+                check=True, encoding="utf-8", capture_output=True,
             )
             decision = json.loads(out_path.read_text(encoding="utf-8"))
             self.assertTrue(decision["should_retry"])
             self.assertEqual(decision["release_tag"], TAG)
             self.assertIn("retrying", result.stdout)
-        finally:
-            for p in (release_path, runs_path, out_path):
-                p.unlink(missing_ok=True)
 
 
 class WorkflowContractTests(unittest.TestCase):

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr
 import io
 import json
 import os
-import shutil
 import signal
 import subprocess
 import sys
@@ -20,7 +19,7 @@ from unittest.mock import Mock, patch
 
 import preflight_runner
 from pr_metadata import TransientPRMetadataError, load_from_api, load_from_event_file
-from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, select_checks
+from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, run_git, select_checks
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER = SCRIPT_DIR / "preflight_runner.py"
@@ -164,6 +163,21 @@ class MetadataTests(unittest.TestCase):
 
 
 class SelectionTests(unittest.TestCase):
+    def test_run_git_decodes_unicode_checkout_path_as_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "路径 checkout"
+            root.mkdir()
+            env = os.environ.copy()
+            for key in tuple(env):
+                if key.startswith("GIT_"):
+                    del env[key]
+            subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+
+            with patch.dict(os.environ, env, clear=True):
+                resolved = run_git(root, "rev-parse", "--show-toplevel")
+
+        self.assertEqual(Path(resolved).resolve(), root.resolve())
+
     def test_changed_files_disables_rename_detection_to_preserve_both_move_paths(self) -> None:
         root = Path("/repo")
         source = "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnStateMachine.swift"
@@ -247,11 +261,8 @@ class SelectionTests(unittest.TestCase):
                 self.assertEqual(sorted(stale_diff), ["pr_file.txt", "unrelated_file.txt"])
 
     def test_make_preflight_resolves_pr_metadata_before_running_checks(self) -> None:
-        make = shutil.which("make")
-        if make is None:
-            self.skipTest("requires make")
         result = subprocess.run(
-            [make, "-n", "preflight"],
+            ["make", "-n", "preflight"],
             cwd=REPO_ROOT,
             check=False,
             stdout=subprocess.PIPE,
@@ -259,10 +270,10 @@ class SelectionTests(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stdout)
-        self.assertIn(
-            "python3 .github/scripts/pr_preflight.py --lane local --base origin/main",
-            result.stdout,
-        )
+        self.assertIn("scripts/dev-harness/run-python.sh", result.stdout)
+        self.assertIn(".github/scripts/pr_preflight.py --lane local --base origin/main", result.stdout)
+        if os.name == "nt":
+            self.assertIn("Git/mingw64/libexec/git-core/../../../bin/bash.exe", result.stdout.replace("\\", "/"))
 
     def test_9402_equivalent_diff_selects_invariants_changelog_and_e2e(self) -> None:
         checks = select_checks(
@@ -292,7 +303,6 @@ class SelectionTests(unittest.TestCase):
                 "deferred-work-markers",
                 "lifecycle-headers",
                 "version-prefixed-filenames",
-                "pr-scope",
             },
         )
 
@@ -327,8 +337,6 @@ class SelectionTests(unittest.TestCase):
                 [
                     sys.executable,
                     "desktop/macos/scripts/check-e2e-flow-coverage.py",
-                    "--formatter-binary",
-                    "none",
                     "--strict",
                     "desktop/macos/Desktop/Sources/Providers/UncoveredRoutingSurface.swift",
                 ],
@@ -344,6 +352,57 @@ class SelectionTests(unittest.TestCase):
             self.assertIn("INV-AGENT-*", invariant.stdout)
             self.assertEqual(coverage.returncode, 1, coverage.stdout)
             self.assertIn("UNCOVERED", coverage.stdout)
+
+    def test_flow_coverage_discovers_unicode_checkout_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "路径 checkout"
+            source = root / "desktop/macos/Desktop/Sources/Fixture.swift"
+            source.parent.mkdir(parents=True)
+            source.write_text("struct Fixture {}\n", encoding="utf-8")
+            env = os.environ.copy()
+            for key in tuple(env):
+                if key.startswith("GIT_"):
+                    del env[key]
+            subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+            subprocess.run(["git", "-C", str(root), "add", "."], check=True, env=env)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(root),
+                    "-c",
+                    "user.name=Omi Test",
+                    "-c",
+                    "user.email=omi-test@example.com",
+                    "commit",
+                    "-qm",
+                    "fixture",
+                ],
+                check=True,
+                env=env,
+            )
+            source.write_text("struct Fixture { let value = 1 }\n", encoding="utf-8")
+
+            coverage = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "desktop/macos/scripts/check-e2e-flow-coverage.py"),
+                    "--formatter-binary",
+                    "none",
+                    "--base",
+                    "HEAD",
+                    "--strict",
+                ],
+                cwd=root,
+                env=env,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+        self.assertEqual(coverage.returncode, 1, coverage.stdout)
+        self.assertIn("UNCOVERED", coverage.stdout)
 
     def test_suggest_flag_prints_paste_ready_pr_metadata(self) -> None:
         result = subprocess.run(
@@ -499,8 +558,12 @@ class SingleFlightTests(unittest.TestCase):
         self,
         state_root: Path,
         command: list[str],
+        *,
+        extra_env: dict[str, str] | None = None,
     ) -> subprocess.Popen[str]:
         env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": str(state_root)}
+        if extra_env:
+            env.update(extra_env)
         return subprocess.Popen(
             [sys.executable, str(RUNNER), "--name", "test", "--", *command],
             cwd=REPO_ROOT,
@@ -517,6 +580,66 @@ class SingleFlightTests(unittest.TestCase):
         while not lock.exists() and time.monotonic() < deadline:
             time.sleep(0.02)
         self.assertTrue(lock.exists(), "runner did not acquire its lock")
+
+    def test_runner_starts_from_unicode_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "路径 checkout"
+            root.mkdir()
+            state_root = root / "state"
+            env = os.environ.copy()
+            env["OMI_PREFLIGHT_STATE_DIR"] = str(state_root)
+            for key in tuple(env):
+                if key.startswith("GIT_"):
+                    del env[key]
+            subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER),
+                    "--name",
+                    "unicode-checkout",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "print('\\u8def\\u5f84\\U0001f680')",
+                ],
+                cwd=root,
+                env=env,
+                input="",
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+            )
+            log = (state_root / "unicode-checkout" / "preflight.log").read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("路径🚀", result.stdout)
+        self.assertEqual(log, "路径🚀\n")
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only")
+    def test_process_liveness_check_does_not_send_windows_ctrl_c(self) -> None:
+        with patch.object(os, "kill", side_effect=AssertionError("must not signal")):
+            self.assertTrue(preflight_runner.process_exists(os.getpid()))
+            self.assertFalse(preflight_runner.process_exists(0x7FFFFFFF))
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only")
+    def test_process_that_exits_with_still_active_status_is_not_alive(self) -> None:
+        child = subprocess.Popen([sys.executable, "-c", "raise SystemExit(259)"])
+        self.assertEqual(child.wait(), 259)
+        self.assertFalse(preflight_runner.process_exists(child.pid))
+
+    def test_pr_body_content_participates_in_singleflight_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            body = Path(tmp) / "body.md"
+            body.write_text("first", encoding="utf-8")
+            with patch.dict(os.environ, {"OMI_PR_BODY_FILE": str(body)}):
+                first = preflight_runner.fingerprint(REPO_ROOT, ["check"], "")
+                body.write_text("second", encoding="utf-8")
+                second = preflight_runner.fingerprint(REPO_ROOT, ["check"], "")
+        self.assertNotEqual(first, second)
 
     def test_identical_processes_join_and_execute_once(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -574,6 +697,27 @@ class SingleFlightTests(unittest.TestCase):
                 first.stdout.close()
             self.assertEqual(first.wait(), 0)
 
+    def test_different_pre_push_environment_is_not_joined(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp = Path(tmp)
+            command = [sys.executable, "-c", "import time; print('==> slow', flush=True); time.sleep(.5)"]
+            first = self.run_runner(temp, command, extra_env={"PRE_PUSH_SKIP_ACTIONLINT": "1"})
+            assert first.stdin is not None
+            first.stdin.close()
+            self.wait_for_lock(temp)
+            second = self.run_runner(temp, command, extra_env={"PRE_PUSH_SKIP_ACTIONLINT": "0"})
+            assert second.stdin is not None
+            second.stdin.close()
+            second_output = second.stdout.read() if second.stdout else ""
+            self.assertEqual(second.wait(), 75, second_output)
+            self.assertIn("already running different input", second_output)
+            if second.stdout:
+                second.stdout.close()
+            if first.stdout:
+                first.stdout.read()
+                first.stdout.close()
+            self.assertEqual(first.wait(), 0)
+
 
 class SignalPortabilityTests(unittest.TestCase):
     """The single-flight wrapper must start on hosts without POSIX signal APIs.
@@ -617,16 +761,27 @@ class SignalPortabilityTests(unittest.TestCase):
         try:
             if had_killpg:
                 delattr(os, "killpg")  # simulate Windows
-            preflight_runner.signal_child(child, signal.SIGTERM)
+            preflight_runner.signal_child(child, signal.SIGTERM, platform_name="posix")
         finally:
             if had_killpg:
                 os.killpg = original
         child.send_signal.assert_called_once_with(signal.SIGTERM)
 
+    @unittest.skipUnless(hasattr(signal, "CTRL_BREAK_EVENT"), "Windows-only")
+    def test_windows_interrupt_maps_to_child_process_group(self) -> None:
+        child = Mock(pid=4321)
+        preflight_runner.signal_child(child, signal.SIGINT, platform_name="nt")
+        child.send_signal.assert_called_once_with(signal.CTRL_BREAK_EVENT)
+
+    def test_windows_unsupported_signal_does_not_abort_runner(self) -> None:
+        child = Mock(pid=4321)
+        child.send_signal.side_effect = ValueError("unsupported")
+        preflight_runner.signal_child(child, signal.SIGINT, platform_name="nt")
+
     def test_forwarding_swallows_dead_child(self) -> None:
         child = Mock(pid=4321)
         with patch.object(os, "killpg", side_effect=ProcessLookupError, create=True):
-            preflight_runner.signal_child(child, signal.SIGTERM)  # must not raise
+            preflight_runner.signal_child(child, signal.SIGTERM, platform_name="posix")  # must not raise
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -18,18 +18,18 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+from git_bash import bash_executable, bash_path, native_path_from_bash
 from run_checks import (
     VALID_PLATFORMS,
     Check,
     Manifest,
-    bash_executable,
-    command_for_check,
+    command_for_host,
     detect_platform,
     execute_checks,
     load_manifest,
     resolve_check_selections,
     resolve_checks,
-    resolve_explicit_checks,
+    run_git,
     skipped_platform_checks,
     validate_manifest,
 )
@@ -39,21 +39,6 @@ REPO_ROOT = SCRIPT_DIR.parents[1]
 MANIFEST_PATH = REPO_ROOT / ".github/checks-manifest.yaml"
 WORKFLOWS_DIR = REPO_ROOT / ".github/workflows"
 SCRIPT_REFERENCE_RE = re.compile(r"(?P<path>(?:\.github|backend|desktop/macos)/scripts/[A-Za-z0-9_.-]+\.py)")
-
-
-def shell_path(path: Path, bash: str) -> str:
-    if os.name != "nt":
-        return str(path)
-    result = subprocess.run(
-        [bash, "-c", 'cygpath -u "$1"', "bash", str(path)],
-        check=False,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-    if result.returncode:
-        raise RuntimeError(result.stderr)
-    return result.stdout.strip()
 
 
 def load_deferred_marker_module():
@@ -298,10 +283,133 @@ class ManifestContractTests(unittest.TestCase):
 
 
 class RunnerBehaviorTests(unittest.TestCase):
+    def test_run_git_decodes_unicode_checkout_path_as_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "路径 checkout"
+            root.mkdir()
+            env = os.environ.copy()
+            for key in tuple(env):
+                if key.startswith("GIT_"):
+                    del env[key]
+            subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+
+            with patch.dict(os.environ, env, clear=True):
+                resolved = run_git(root, "rev-parse", "--show-toplevel")
+
+        self.assertEqual(Path(resolved).resolve(), root.resolve())
+
+    def test_windows_manifest_interpreters_use_the_active_toolchain(self) -> None:
+        with patch("run_checks.bash_executable", return_value="C:\\Git\\bin\\bash.exe"):
+            self.assertEqual(
+                command_for_host(["bash", "scripts/check.sh"], platform_name="nt"),
+                ["C:\\Git\\bin\\bash.exe", "scripts/check.sh"],
+            )
+        self.assertEqual(
+            command_for_host(
+                ["python3", ".github/scripts/check.py"],
+                platform_name="nt",
+                python_executable="C:\\Python\\python.exe",
+            ),
+            ["C:\\Python\\python.exe", ".github/scripts/check.py"],
+        )
+
+    def test_non_interpreter_and_non_windows_commands_are_unchanged(self) -> None:
+        node_command = ["node", "--test", "test.mjs"]
+        bash_command = ["bash", "scripts/check.sh"]
+
+        self.assertIs(command_for_host(node_command, platform_name="nt"), node_command)
+        self.assertIs(command_for_host(bash_command, platform_name="posix"), bash_command)
+
+    def test_execute_checks_normalizes_the_manifest_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            changed = root / "changed.txt"
+            changed.write_text("example.txt\n", encoding="utf-8")
+            body = root / "body.txt"
+            body.write_text("", encoding="utf-8")
+            check = Check("shell", ("bash", "check.sh"), ("all",), ("ci",), "fixture")
+
+            with (
+                patch("run_checks.command_for_host", return_value=["git-bash.exe", "check.sh"]) as normalize,
+                patch(
+                    "run_checks.subprocess.run",
+                    return_value=subprocess.CompletedProcess(["git-bash.exe", "check.sh"], 0),
+                ) as run,
+                redirect_stdout(StringIO()),
+            ):
+                result = execute_checks(
+                    root,
+                    [check],
+                    changed_files_path=changed,
+                    base="base",
+                    head="HEAD",
+                    pr_body_file=body,
+                )
+
+            self.assertEqual(result, 0)
+            normalize.assert_called_once_with(["bash", "check.sh"])
+            run.assert_called_once_with(["git-bash.exe", "check.sh"], cwd=root, check=False)
+
+    def test_windows_bash_resolution_uses_the_git_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            git_root = Path(tmp)
+            git = git_root / "cmd/git.exe"
+            git.parent.mkdir()
+            git.touch()
+            bash = git_root / "bin/bash.exe"
+            bash.parent.mkdir()
+            bash.touch()
+
+            resolved = bash_executable(
+                platform_name="nt",
+                which=lambda name: str(git) if name == "git" else None,
+            )
+
+            self.assertTrue(Path(resolved).samefile(bash))
+
+    def test_windows_bash_path_is_converted_back_to_native(self) -> None:
+        commands: list[list[str]] = []
+
+        def fake_run(command, **_kwargs):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="C:\\Temp\\guard.py\n", stderr="")
+
+        converted = native_path_from_bash(
+            "/tmp/guard.py",
+            "git-bash.exe",
+            platform_name="nt",
+            run=fake_run,
+        )
+
+        self.assertEqual(converted, Path("C:\\Temp\\guard.py"))
+        self.assertEqual(
+            commands,
+            [["git-bash.exe", "-c", 'cygpath -w "$1"', "bash", "/tmp/guard.py"]],
+        )
+
+    def test_windows_native_path_is_converted_for_bash(self) -> None:
+        commands: list[list[str]] = []
+
+        def fake_run(command, **_kwargs):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="/c/Temp/body.md\n", stderr="")
+
+        converted = bash_path(
+            Path("C:\\Temp\\body.md"),
+            "git-bash.exe",
+            platform_name="nt",
+            run=fake_run,
+        )
+
+        self.assertEqual(converted, "/c/Temp/body.md")
+        self.assertEqual(
+            commands,
+            [["git-bash.exe", "-c", 'cygpath -u "$1"', "bash", "C:\\Temp\\body.md"]],
+        )
+
     @unittest.skipIf(os.name == "nt", "requires a POSIX shell")
     def test_firestore_contention_runner_uses_uv_without_backend_venv(self) -> None:
         source = REPO_ROOT / "backend/testing/desktop_beta_admission/run.sh"
-        bash = bash_executable()
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             runner = root / "backend/testing/desktop_beta_admission/run.sh"
@@ -327,15 +435,8 @@ esac
                 path.chmod(0o755)
 
             env = os.environ.copy()
-            env["PATH"] = f"{shell_path(fake_bin, bash)}:/usr/bin:/bin"
-            result = subprocess.run(
-                [bash, str(runner)],
-                text=True,
-                capture_output=True,
-                encoding="utf-8",
-                env=env,
-                check=False,
-            )
+            env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
+            result = subprocess.run(["bash", str(runner)], text=True, capture_output=True, env=env, check=False)
 
             self.assertEqual(result.returncode, 0, result.stderr)
             captured = capture.read_text(encoding="utf-8")
@@ -348,6 +449,50 @@ esac
         self.assertIn("brand-ui", selected)
         self.assertNotIn("backend-async-blockers", selected)
         self.assertNotIn("backend-route-policy-baseline", selected)
+
+    def test_posix_contracts_skip_windows_without_dropping_linux_ci(self) -> None:
+        manifest = load_manifest(MANIFEST_PATH)
+        expected_by_path = {
+            "app/ios/Podfile": {
+                "rayban-dat-plugin-boundary",
+                "rayban-dat-xcode-graph",
+                "rayban-dat-build-wrapper",
+            },
+            ".github/workflows/desktop_qualify_beta.yml": {
+                "desktop-release-one-path-contract",
+            },
+        }
+        for path, expected in expected_by_path.items():
+            windows = {check.id for check in resolve_checks(manifest, [path], "ci", platform="windows")}
+            linux = {check.id for check in resolve_checks(manifest, [path], "ci", platform="linux")}
+            self.assertTrue(expected.isdisjoint(windows), path)
+            self.assertTrue(expected <= linux, path)
+
+    def test_shared_windows_entrypoints_route_their_behavioral_contracts(self) -> None:
+        manifest = load_manifest(MANIFEST_PATH)
+        expected_by_path = {
+            "Makefile": {"dev-harness-unit-tests", "setup-pre-push-prerequisites"},
+            "scripts/dev-harness/_resolve_python.sh": {
+                "dev-harness-unit-tests",
+                "desktop-release-process-guards",
+                "pre-tag-readiness-contract",
+            },
+            "scripts/pre-push-singleflight": {"pr-preflight-contract-tests"},
+            ".github/scripts/preflight_runner.py": {"pr-preflight-contract-tests"},
+            "desktop/macos/scripts/check-e2e-flow-coverage.py": {
+                "desktop-e2e-flow-coverage",
+                "pr-preflight-contract-tests",
+            },
+            ".github/scripts/git_bash.py": {
+                "check-manifest-contract",
+                "desktop-release-process-guards",
+                "desktop-swiftlint-config",
+                "pre-tag-readiness-behavior",
+            },
+        }
+        for path, expected in expected_by_path.items():
+            selected = {check.id for check in resolve_checks(manifest, [path], "ci", platform="macos")}
+            self.assertTrue(expected <= selected, f"{path}: missing {sorted(expected - selected)}")
 
     def test_root_agents_md_selects_agent_doc_checks(self) -> None:
         manifest = load_manifest(MANIFEST_PATH)
@@ -414,40 +559,6 @@ esac
                 )
             self.assertEqual(result, 1)
 
-    def test_python3_command_uses_current_interpreter(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            marker = root / "interpreter.txt"
-            probe = root / "probe.py"
-            probe.write_text(
-                "from pathlib import Path\n"
-                "import sys\n"
-                f"Path({str(marker)!r}).write_text(sys.executable, encoding='utf-8')\n",
-                encoding="utf-8",
-            )
-            changed = root / "changed.txt"
-            changed.write_text("example.txt\n", encoding="utf-8")
-            body = root / "body.txt"
-            body.write_text("", encoding="utf-8")
-            check = Check("python", ("python3", str(probe)), ("all",), ("local",), "fixture")
-
-            with (
-                patch.dict(os.environ, {"PATH": ""}),
-                redirect_stdout(StringIO()),
-                redirect_stderr(StringIO()),
-            ):
-                result = execute_checks(
-                    root,
-                    [check],
-                    changed_files_path=changed,
-                    base="base",
-                    head="HEAD",
-                    pr_body_file=body,
-                )
-
-            self.assertEqual(result, 0)
-            self.assertEqual(marker.read_text(encoding="utf-8"), sys.executable)
-
     def test_release_process_guard_uses_locked_pyyaml_in_every_declared_lane(self) -> None:
         """The guard must never depend on a runner-global PyYAML install."""
         manifest = load_manifest(MANIFEST_PATH)
@@ -463,6 +574,9 @@ esac
             copied_runner = root / check.command[1]
             copied_runner.parent.mkdir(parents=True)
             shutil.copy2(runner, copied_runner)
+            resolver = root / "scripts/dev-harness/_resolve_python.sh"
+            resolver.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO_ROOT / "scripts/dev-harness/_resolve_python.sh", resolver)
 
             sync = root / "backend/scripts/sync-python-deps.sh"
             sync.parent.mkdir(parents=True)
@@ -489,19 +603,25 @@ chmod +x "{python}"
             guard.parent.mkdir(parents=True, exist_ok=True)
             guard.write_text("# fixture\n", encoding="utf-8")
 
-            bash = bash_executable()
+            try:
+                bash = bash_executable()
+            except FileNotFoundError as exc:
+                self.skipTest(str(exc))
+            env = os.environ.copy()
+            env["PYTHON"] = "ambient-python-must-not-run"
             result = subprocess.run(
                 [bash, str(copied_runner)],
                 text=True,
                 capture_output=True,
-                encoding="utf-8",
+                env=env,
                 check=False,
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(
-                (root / "guard-args.txt").read_text(encoding="utf-8").strip(),
-                shell_path(guard, bash),
+            recorded_guard = (root / "guard-args.txt").read_text(encoding="utf-8").strip()
+            self.assertTrue(
+                native_path_from_bash(recorded_guard, bash).samefile(guard),
+                f"release guard received {recorded_guard!r}, expected {str(guard)!r}",
             )
 
         self.assertRegex(
@@ -546,7 +666,7 @@ class PlatformTests(unittest.TestCase):
         manifest = Manifest(
             checks=(Check(id="portable", command=("true",), triggers=("all",), lanes=("ci",), reason="t"),), exempt=()
         )
-        for plat in ("macos", "linux", "windows"):
+        for plat in ("macos", "linux"):
             selected = resolve_checks(manifest, ["any/file"], "ci", platform=plat)
             self.assertEqual([c.id for c in selected], ["portable"])
 
@@ -631,73 +751,6 @@ class PlatformTests(unittest.TestCase):
     def test_detect_platform_returns_known_value(self):
         plat = detect_platform()
         self.assertIn(plat, VALID_PLATFORMS - {"all"})
-
-    def test_interpreter_commands_use_resolved_executables(self):
-        python_check = Check(
-            id="python-interpreter",
-            command=("python3", "check.py", "bash"),
-            triggers=("all",),
-            lanes=("local", "ci"),
-            reason="test",
-        )
-        python_command = command_for_check(
-            python_check,
-            changed_files_path=Path("changed.txt"),
-            base="base",
-            head="head",
-            pr_body_file=Path("body.md"),
-            skip_changelog=False,
-        )
-        bash_check = Check(
-            id="bash-interpreter",
-            command=("bash", "check.sh", "python3"),
-            triggers=("all",),
-            lanes=("local", "ci"),
-            reason="test",
-        )
-        bash_command = command_for_check(
-            bash_check,
-            changed_files_path=Path("changed.txt"),
-            base="base",
-            head="head",
-            pr_body_file=Path("body.md"),
-            skip_changelog=False,
-        )
-
-        self.assertEqual(python_command, [sys.executable, "check.py", "bash"])
-        self.assertEqual(bash_command, [bash_executable(), "check.sh", "python3"])
-
-    def test_explicit_check_ids_preserve_manifest_commands(self):
-        manifest = Manifest(
-            checks=(
-                Check(
-                    id="portable",
-                    command=("python3", "check.py"),
-                    triggers=("never/**",),
-                    lanes=("ci",),
-                    reason="test",
-                ),
-            ),
-            exempt=(),
-        )
-
-        selections = resolve_explicit_checks(
-            manifest,
-            ["portable"],
-            "ci",
-            include_pr_body_checks=True,
-            platform="windows",
-        )
-
-        self.assertEqual([selection.check.id for selection in selections], ["portable"])
-        with self.assertRaisesRegex(ValueError, "unknown check id"):
-            resolve_explicit_checks(
-                manifest,
-                ["missing"],
-                "ci",
-                include_pr_body_checks=True,
-                platform="windows",
-            )
 
 
 class DeferredMarkerTests(unittest.TestCase):

--- a/.github/scripts/test_swiftlint_config.py
+++ b/.github/scripts/test_swiftlint_config.py
@@ -17,6 +17,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from git_bash import bash_executable, bash_path
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DESKTOP = REPO_ROOT / "desktop/macos/Desktop"
 CONFIG_PATH = DESKTOP / ".swiftlint.yml"
@@ -199,10 +201,11 @@ class SwiftLintConfigTests(unittest.TestCase):
 
     def test_runner_exposes_only_the_pinned_artifact_digest_without_bootstrapping(self):
         result = subprocess.run(
-            ["bash", str(WRAPPER_PATH), "digest"],
+            [bash_executable(), str(WRAPPER_PATH), "digest"],
             check=True,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         self.assertEqual(
             result.stdout.strip(),
@@ -211,9 +214,10 @@ class SwiftLintConfigTests(unittest.TestCase):
 
     def test_runner_rejects_unknown_subcommands_without_bootstrapping(self):
         result = subprocess.run(
-            ["bash", str(WRAPPER_PATH), "not-a-command"],
+            [bash_executable(), str(WRAPPER_PATH), "not-a-command"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("usage:", result.stderr)
@@ -225,7 +229,12 @@ class SwiftLintConfigTests(unittest.TestCase):
             marker = root / "fake-executed"
             cache_binary = root / "0.65.0-d6cb0aa7a2f5" / "swiftlint"
             cache_binary.parent.mkdir()
-            cache_binary.write_text(f"#!/bin/sh\ntouch {marker}\necho 0.65.0\n", encoding="utf-8")
+            bash = bash_executable()
+            cache_binary.write_text(
+                f'#!/bin/sh\ntouch "{bash_path(marker, bash)}"\necho 0.65.0\n',
+                encoding="utf-8",
+                newline="\n",
+            )
             cache_binary.chmod(0o755)
 
             # The wrapper should reject the fake binary, then fail at the deliberately
@@ -233,17 +242,34 @@ class SwiftLintConfigTests(unittest.TestCase):
             blocked_curl = root / "bin"
             blocked_curl.mkdir()
             curl = blocked_curl / "curl"
-            curl.write_text("#!/bin/sh\nexit 97\n", encoding="utf-8")
+            curl.write_text("#!/bin/sh\nexit 97\n", encoding="utf-8", newline="\n")
             curl.chmod(0o755)
+            shasum = blocked_curl / "shasum"
+            shasum.write_text(
+                "#!/bin/sh\n"
+                "for path do :; done\n"
+                "printf '%064d  %s\\n' 0 \"$path\"\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            shasum.chmod(0o755)
             env = os.environ | {
-                "SWIFTLINT_CACHE_DIR": str(root),
-                "PATH": f"{blocked_curl}{os.pathsep}{os.environ['PATH']}",
+                "SWIFTLINT_CACHE_DIR": bash_path(root, bash),
+                "OMI_TEST_FAKE_BIN": bash_path(blocked_curl, bash),
             }
             result = subprocess.run(
-                ["bash", str(WRAPPER_PATH), "version"],
+                [
+                    bash,
+                    "-c",
+                    'export PATH="$OMI_TEST_FAKE_BIN:$PATH"\nexec "$BASH" "$@"',
+                    "bash",
+                    str(WRAPPER_PATH),
+                    "version",
+                ],
                 env=env,
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
+                errors="replace",
             )
 
             self.assertNotEqual(result.returncode, 0)

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
+ifeq ($(OS),Windows_NT)
+GIT_EXEC_PATH := $(shell git --exec-path)
+SHELL := $(GIT_EXEC_PATH)/../../../bin/bash.exe
+BASH := "$(SHELL)"
+else
+SHELL := bash
+BASH := bash
+endif
+
 HOOKS_DIR := $(shell git rev-parse --git-path hooks)
-# Fall back to the working directory (where make runs, i.e. the repo root) when
-# `git rev-parse --show-toplevel` cannot resolve a work tree. In a linked
-# worktree whose git context resolves to a git dir rather than a work tree,
-# show-toplevel exits 128 and previously expanded to an empty prefix, turning
-# the source into `/scripts/dev-harness/_resolve_python.sh: No such file` and
-# breaking every target. The root stays computed in-shell (never interpolated
-# into recipe text) so a checkout path with quote/`$` characters cannot inject.
-PYTHON ?= $(shell bash -c 'source "$$(git rev-parse --show-toplevel 2>/dev/null || pwd)/scripts/dev-harness/_resolve_python.sh"; dev_harness_python')
-# Export so recipes use $$PYTHON (shell variable expansion) instead of $(PYTHON)
-# (Make text interpolation). Shell variable expansion treats the resolved path
-# as data and cannot be broken by quote or command-substitution characters in
-# the checkout root, unlike Make interpolation into recipe shell text.
-export PYTHON
+# Retain a lazy compatibility value for callers that inspect $(PYTHON).
+PYTHON ?= $(shell source scripts/dev-harness/_resolve_python.sh; dev_harness_python)
+# Keep the checkout-local interpreter resolution inside Bash so native GNU
+# Make never exports a Unicode checkout path through its legacy code page.
+PYTHON_RUNNER := $(BASH) scripts/dev-harness/run-python.sh
 DESKTOP_USER ?= alice
 DESKTOP_APP_NAME ?=
 
@@ -23,29 +24,29 @@ setup: setup-main setup-hooks setup-backend
 	@echo "Worktree setup complete: hooks installed and backend pre-push environment ready."
 
 setup-main:
-	@bash scripts/setup-refresh-main.sh
+	@$(BASH) scripts/setup-refresh-main.sh
 
 setup-hooks:
-	@bash scripts/install-git-hooks.sh
+	@$(BASH) scripts/install-git-hooks.sh
 
 setup-backend:
-	@bash backend/scripts/sync-python-deps.sh
+	@$(BASH) backend/scripts/sync-python-deps.sh
 
 preflight:
-	python3 .github/scripts/pr_preflight.py --lane local --base origin/main
+	$(PYTHON_RUNNER) .github/scripts/pr_preflight.py --lane local --base origin/main
 
 runtime-image-source-closure:
-	python3 backend/scripts/runtime_image_contracts.py check
+	$(PYTHON_RUNNER) backend/scripts/runtime_image_contracts.py check
 
 runtime-image-smoke:
 	@test -n "$(SERVICE)" || (echo "SERVICE is required (for example: make runtime-image-smoke SERVICE=pusher)" >&2; exit 2)
-	python3 backend/scripts/runtime_image_contracts.py build-smoke --service "$(SERVICE)" --image "$(or $(IMAGE),omi-$(SERVICE):dev)"
+	$(PYTHON_RUNNER) backend/scripts/runtime_image_contracts.py build-smoke --service "$(SERVICE)" --image "$(or $(IMAGE),omi-$(SERVICE):dev)"
 
 dev-check:
-	bash scripts/dev-harness/dev-check.sh
+	$(BASH) scripts/dev-harness/dev-check.sh
 
 dev-up:
-	bash scripts/dev-harness/dev-up.sh
+	$(BASH) scripts/dev-harness/dev-up.sh
 
 dev:
 	$(MAKE) dev-up
@@ -55,41 +56,41 @@ dev-desktop:
 	$(MAKE) desktop-run-local
 
 dev-init:
-	bash scripts/dev-harness/dev-init.sh
+	$(BASH) scripts/dev-harness/dev-init.sh
 
 dev-verify:
-	bash scripts/dev-harness/verify-desktop-local-launch.sh
+	$(BASH) scripts/dev-harness/verify-desktop-local-launch.sh
 
 dev-status:
-	bash scripts/dev-harness/dev-status.sh
+	$(BASH) scripts/dev-harness/dev-status.sh
 
 dev-summary:
-	bash scripts/dev-harness/dev-summary.sh
+	$(BASH) scripts/dev-harness/dev-summary.sh
 
 dev-reset:
-	bash scripts/dev-harness/dev-reset.sh
+	$(BASH) scripts/dev-harness/dev-reset.sh
 
 dev-down:
-	bash scripts/dev-harness/dev-down.sh
+	$(BASH) scripts/dev-harness/dev-down.sh
 
 dev-logs:
-	bash scripts/dev-harness/dev-logs.sh
+	$(BASH) scripts/dev-harness/dev-logs.sh
 
 list-memory-scenarios:
-	"$$PYTHON" scripts/dev-harness/list-memory-scenarios.py
+	$(PYTHON_RUNNER) scripts/dev-harness/list-memory-scenarios.py
 
 seed-memory-scenario:
-	"$$PYTHON" scripts/dev-harness/seed-memory-scenario.py $(SCENARIO)
+	$(PYTHON_RUNNER) scripts/dev-harness/seed-memory-scenario.py $(SCENARIO)
 
 reset-memory-scenario:
-	"$$PYTHON" scripts/dev-harness/reset-memory-scenario.py $(SCENARIO)
+	$(PYTHON_RUNNER) scripts/dev-harness/reset-memory-scenario.py $(SCENARIO)
 
 desktop-run-local:
 	@if [ -n "$(DESKTOP_APP_NAME)" ]; then \
-		PYTHON="$$PYTHON" OMI_APP_NAME="$(DESKTOP_APP_NAME)" bash scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
+		OMI_APP_NAME="$(DESKTOP_APP_NAME)" $(BASH) scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
 	else \
-		PYTHON="$$PYTHON" bash scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
+		$(BASH) scripts/dev-harness/desktop-run-local.sh "$(DESKTOP_USER)"; \
 	fi
 
 run-canonical-maintenance:
-	PYTHON="$$PYTHON" PYTHONPATH="scripts/dev-harness:backend$(if $(PYTHONPATH),:$(PYTHONPATH),)" "$$PYTHON" scripts/dev-harness/run-canonical-maintenance.py "$(MAINTENANCE_USER)"
+	$(PYTHON_RUNNER) scripts/dev-harness/run-canonical-maintenance.py "$(MAINTENANCE_USER)"

--- a/desktop/macos/changelog/unreleased/20260729-windows-ci-portability.json
+++ b/desktop/macos/changelog/unreleased/20260729-windows-ci-portability.json
@@ -1,0 +1,4 @@
+{
+  "type": "internal",
+  "change": "Make pre-push and preflight contracts portable on Windows (MSYS/UTF-8 paths, Git Bash routing)"
+}

--- a/desktop/macos/scripts/check-e2e-flow-coverage.py
+++ b/desktop/macos/scripts/check-e2e-flow-coverage.py
@@ -68,6 +68,7 @@ def repo_root(explicit: str | None) -> Path:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
             env=git_env(),
         )
         return Path(result.stdout.strip()).resolve()
@@ -83,6 +84,7 @@ def run_git(root: Path, args: list[str]) -> list[str]:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         text=True,
+        encoding="utf-8",
         env=git_env(),
     )
     if result.returncode != 0:
@@ -98,6 +100,7 @@ def git_file_contents(root: Path, ref: str, path: str) -> str | None:
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         text=True,
+        encoding="utf-8",
         env=git_env(),
     )
     return result.stdout if result.returncode == 0 else None
@@ -113,26 +116,29 @@ def resolve_formatter(root: Path, value: str) -> Formatter | None:
         wrapper = root / FORMATTER_WRAPPER
         if not wrapper.is_file():
             return None
-        bootstrap = subprocess.run(
-            [str(wrapper), "bootstrap"],
-            cwd=root,
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            env=git_env(),
-        )
-        if bootstrap.returncode != 0:
+        try:
+            bootstrap = subprocess.run(
+                [str(wrapper), "bootstrap"],
+                cwd=root,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                env=git_env(),
+            )
+            if bootstrap.returncode != 0:
+                return None
+            binary_result = subprocess.run(
+                [str(wrapper), "binary-path"],
+                cwd=root,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                env=git_env(),
+            )
+        except OSError:
             return None
-        binary_result = subprocess.run(
-            [str(wrapper), "binary-path"],
-            cwd=root,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            env=git_env(),
-        )
         binary = Path(binary_result.stdout.strip())
     else:
         binary = Path(value)

--- a/desktop/macos/scripts/pre-tag-readiness.sh
+++ b/desktop/macos/scripts/pre-tag-readiness.sh
@@ -13,6 +13,7 @@ CACHE_COMMAND="$SCRIPT_DIR/qualification-swift-cache.sh"
 LEASE_COMMAND="$SCRIPT_DIR/qualification-lease-command.sh"
 SELF_CLEAN_COMMAND="$SCRIPT_DIR/qualification-runner-self-clean.py"
 WATCHDOG_COMMAND="$SCRIPT_DIR/qualification-watchdog.py"
+PYTHON_BIN="${PYTHON:-python3}"
 
 EVIDENCE=""
 SOURCE_REPOSITORY="$REPO_ROOT"
@@ -101,7 +102,7 @@ START_SEC=$(date +%s)
 
 emit_evidence() {
   local passed="$1" duration_s="$2" err="${3:-}"
-  python3 - "$EVIDENCE" "$passed" "$SOURCE_SHA" "$LANE" "$duration_s" "$STARTED_AT" "$HARNESS_EVIDENCE" "$HYGIENE_EVIDENCE" "$err" <<'PY'
+  "$PYTHON_BIN" - "$EVIDENCE" "$passed" "$SOURCE_SHA" "$LANE" "$duration_s" "$STARTED_AT" "$HARNESS_EVIDENCE" "$HYGIENE_EVIDENCE" "$err" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -141,7 +142,7 @@ PY
 run_watchdog() {
   local label="$1" timeout_seconds="$2"
   shift 2
-  python3 "$WATCHDOG_COMMAND" \
+  "$PYTHON_BIN" "$WATCHDOG_COMMAND" \
     --label "$label" \
     --heartbeat-seconds "${OMI_QUALIFICATION_HEARTBEAT_SECONDS:-45}" \
     --timeout-seconds "$timeout_seconds" \
@@ -150,7 +151,7 @@ run_watchdog() {
 
 json_capability_field() {
   local field="$1" payload="$2" value
-  if value="$(printf '%s' "$payload" | python3 -c '
+  if value="$(printf '%s' "$payload" | "$PYTHON_BIN" -c '
 import json
 import sys
 value = json.load(sys.stdin).get(sys.argv[1])
@@ -250,7 +251,7 @@ git -C "$SOURCE_REPOSITORY" merge-base --is-ancestor "$SOURCE_SHA" origin/main |
 # numeric run stages, and idle exact-SHA cache entries. Any ambiguous residue
 # fails before a fresh cache or qualification lease is acquired.
 run_watchdog runner-self-clean 1200 \
-  python3 "$SELF_CLEAN_COMMAND" \
+  "$PYTHON_BIN" "$SELF_CLEAN_COMMAND" \
     --repo-root "$REPO_ROOT" \
     --cache-root "${OMI_QUALIFICATION_SWIFT_CACHE_ROOT:-$HOME/Library/Caches/OmiDesktop/qualification-swiftpm-v2}" \
     --qualification-lease-root "$LEASE_ROOT" \
@@ -269,7 +270,7 @@ RUN_SCOPE="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-attempt}-${BASHPID:-$$}
 RUN_SCOPE="${RUN_SCOPE//[^A-Za-z0-9]/-}"
 CACHE_LEASE_ID="cache-readiness-${SOURCE_SHA:0:12}-${RUN_SCOPE:0:32}"
 READINESS_LEASE_ID="readiness-${SOURCE_SHA:0:12}-${RUN_SCOPE:0:32}"
-PORT_OFFSET="$(python3 - "$SOURCE_SHA" "$READINESS_LEASE_ID" <<'PY'
+PORT_OFFSET="$("$PYTHON_BIN" - "$SOURCE_SHA" "$READINESS_LEASE_ID" <<'PY'
 import hashlib
 import sys
 print(1000 + (int(hashlib.sha256(":".join(sys.argv[1:]).encode()).hexdigest()[:8], 16) % 2000))
@@ -332,7 +333,7 @@ HARNESS_DIR="$(ls -td "$HARNESS_ROOT"/*-readiness 2>/dev/null | head -1)"
   exit 1
 }
 HARNESS_EVIDENCE="$HARNESS_DIR/manifest.json"
-python3 - "$HARNESS_EVIDENCE" "$SOURCE_SHA" <<'PY'
+"$PYTHON_BIN" - "$HARNESS_EVIDENCE" "$SOURCE_SHA" <<'PY'
 import json
 import sys
 from pathlib import Path

--- a/scripts/dev-harness/_resolve_python.sh
+++ b/scripts/dev-harness/_resolve_python.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# Print the canonical locked backend interpreter when setup has created it.
+dev_harness_canonical_python() {
+  local repo_root candidate
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  for candidate in \
+    "$repo_root/backend/.venv/bin/python" \
+    "$repo_root/backend/.venv/Scripts/python.exe"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  return 1
+}
+
 # Print the interpreter for local dev-harness commands. PYTHON is an explicit
 # caller choice; otherwise prefer the canonical venv while retaining support
 # for existing checkouts that use the legacy backend/venv location.
@@ -10,8 +25,15 @@ dev_harness_python() {
   fi
 
   local repo_root candidate
+  if candidate="$(dev_harness_canonical_python)"; then
+    printf '%s\n' "$candidate"
+    return
+  fi
+
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-  for candidate in "$repo_root/backend/.venv/bin/python" "$repo_root/backend/venv/bin/python"; do
+  for candidate in \
+    "$repo_root/backend/venv/bin/python" \
+    "$repo_root/backend/venv/Scripts/python.exe"; do
     if [ -x "$candidate" ]; then
       printf '%s\n' "$candidate"
       return
@@ -19,4 +41,48 @@ dev_harness_python() {
   done
 
   printf '%s\n' "python3"
+}
+
+dev_harness_python_uses_windows_paths() {
+  local python_bin="$1"
+  local resolved
+  resolved="$(command -v "$python_bin" 2>/dev/null || printf '%s' "$python_bin")"
+  case "${resolved,,}" in
+    *.exe)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# Join import roots with the separator understood by the selected interpreter,
+# not the Bash host. Git Bash launches native Windows Python for .venv/Scripts,
+# whose sys.path separator is ';' even though the surrounding shell uses ':'.
+dev_harness_pythonpath() {
+  local python_bin="$1"
+  shift
+
+  local separator=":"
+  local entry
+  local value=""
+  if dev_harness_python_uses_windows_paths "$python_bin"; then
+    separator=";"
+  fi
+
+  for entry in "$@"; do
+    [ -n "$entry" ] || continue
+    if [ -n "$value" ]; then
+      value="${value}${separator}${entry}"
+    else
+      value="$entry"
+    fi
+  done
+  if [ -n "${PYTHONPATH:-}" ]; then
+    if [ -n "$value" ]; then
+      value="${value}${separator}${PYTHONPATH}"
+    else
+      value="$PYTHONPATH"
+    fi
+  fi
+  printf '%s\n' "$value"
 }

--- a/scripts/dev-harness/desktop-run-local.sh
+++ b/scripts/dev-harness/desktop-run-local.sh
@@ -10,7 +10,7 @@ USER_PROFILE="${1:-alice}"
 
 PYTHON_BIN="$(dev_harness_python)"
 
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" - <<'PY' "$USER_PROFILE"
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" - <<'PY' "$USER_PROFILE"
 from __future__ import annotations
 
 import os

--- a/scripts/dev-harness/dev-check.sh
+++ b/scripts/dev-harness/dev-check.sh
@@ -10,4 +10,4 @@ if git ls-files --error-unmatch backend/.env.local-dev >/dev/null 2>&1; then
   exit 1
 fi
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli check
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli check

--- a/scripts/dev-harness/dev-down.sh
+++ b/scripts/dev-harness/dev-down.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli down
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli down

--- a/scripts/dev-harness/dev-logs.sh
+++ b/scripts/dev-harness/dev-logs.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli logs
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli logs

--- a/scripts/dev-harness/dev-reset.sh
+++ b/scripts/dev-harness/dev-reset.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli reset
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli reset

--- a/scripts/dev-harness/dev-status.sh
+++ b/scripts/dev-harness/dev-status.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli status
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli status

--- a/scripts/dev-harness/dev-summary.sh
+++ b/scripts/dev-harness/dev-summary.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli summary
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli summary

--- a/scripts/dev-harness/dev-up.sh
+++ b/scripts/dev-harness/dev-up.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="scripts/dev-harness${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -m dev_harness.cli up
+PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli up

--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -21,6 +21,8 @@ from typing import Iterable
 from . import config, providers, qualification, safety, memory_scenarios
 
 OWNERSHIP_PREFIX = "omi-dev-harness"
+
+
 def _now() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
@@ -31,7 +33,11 @@ def _repo_root() -> Path:
 
 def _marker(cfg: config.HarnessConfig, service: str) -> str:
     token = os.environ.get("OMI_HARNESS_OWNERSHIP_TOKEN", "").strip()
-    return f"{OWNERSHIP_PREFIX}:{cfg.instance}:{service}:{token}" if token else f"{OWNERSHIP_PREFIX}:{cfg.instance}:{service}"
+    return (
+        f"{OWNERSHIP_PREFIX}:{cfg.instance}:{service}:{token}"
+        if token
+        else f"{OWNERSHIP_PREFIX}:{cfg.instance}:{service}"
+    )
 
 
 def _load_json(path: Path, default: dict[str, object]) -> dict[str, object]:
@@ -469,6 +475,13 @@ def cmd_check(args: argparse.Namespace) -> int:
     return 0
 
 
+def _prepend_pythonpath(env: dict[str, str], *entries: Path) -> None:
+    values = [str(path) for path in entries]
+    if existing := env.get("PYTHONPATH"):
+        values.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(values)
+
+
 def _start_process(
     cfg: config.HarnessConfig,
     service: str,
@@ -493,11 +506,10 @@ def _start_process(
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_file = log_path.open("ab")
     child_env = config.child_env_for(cfg) if env is None else env
-    child_env["PYTHONPATH"] = f"{cfg.repo_root / 'scripts' / 'dev-harness'}:{child_env.get('PYTHONPATH', '')}"
+    python_paths = [cfg.repo_root / "scripts" / "dev-harness"]
     if service == "backend":
-        child_env["PYTHONPATH"] = (
-            f"{cfg.repo_root / 'scripts' / 'dev-harness'}:{cfg.repo_root / 'backend'}:{child_env.get('PYTHONPATH', '')}"
-        )
+        python_paths.append(cfg.repo_root / "backend")
+    _prepend_pythonpath(child_env, *python_paths)
     supervised = [
         sys.executable,
         "-m",
@@ -685,7 +697,16 @@ def _start_app_services(cfg: config.HarnessConfig) -> None:
     _start_process(
         cfg,
         "desktop-backend",
-        [sys.executable, "-m", "uvicorn", "desktop_backend:app", "--host", "127.0.0.1", "--port", str(cfg.desktop_backend_port)],
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "desktop_backend:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(cfg.desktop_backend_port),
+        ],
         cwd=cfg.repo_root / "backend",
         log_name="desktop-backend.log",
         port=cfg.desktop_backend_port,
@@ -917,16 +938,9 @@ def cmd_summary(args: argparse.Namespace) -> int:
 
 
 def _signal_owned_process_group(pid: int, service: str) -> None:
-    # Use SIGTERM (not SIGINT) so Python services receive a clean
-    # shutdown signal instead of KeyboardInterrupt.  SIGINT triggers
-    # Python's default signal handler which cancels background tasks and
-    # raises KeyboardInterrupt — this caused qualification failures when
-    # dev-down sent SIGINT to a healthy backend whose parent subshell had
-    # already exited due to an unrelated desktop-launch failure.
-    # See FC-qualification-sigint-cascade.
     try:
-        os.killpg(pid, signal.SIGTERM)
-        print(f"{service}: sent SIGTERM to process group {pid}")
+        os.killpg(pid, signal.SIGINT)
+        print(f"{service}: sent SIGINT to process group {pid}")
     except ProcessLookupError:
         return
     except PermissionError as exc:

--- a/scripts/dev-harness/run-python.sh
+++ b/scripts/dev-harness/run-python.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_resolve_python.sh
+source "$SCRIPT_DIR/_resolve_python.sh"
+
+PYTHON_BIN="$(dev_harness_python)"
+exec "$PYTHON_BIN" "$@"

--- a/scripts/dev-harness/run-tests.sh
+++ b/scripts/dev-harness/run-tests.sh
@@ -2,7 +2,7 @@
 # Deterministic dev-harness unit-test lane (checks-manifest: dev-harness-unit-tests).
 #
 # Prefers an interpreter that ALREADY has pytest + python-dotenv (the repo's
-# backend venv, then the ambient python3) so the check needs no uv cache,
+# backend venv (POSIX or Windows layout), then the ambient python3) so the check needs no uv cache,
 # network, or ~/.cache write — keeping `make preflight` green in restricted
 # local/agent environments. Only a truly bare environment falls back to uv,
 # and even then the cache is redirected to a writable temp dir. Real pytest
@@ -15,7 +15,12 @@ run_pytest() {
   exec "$@" -m pytest scripts/dev-harness/tests -q
 }
 
-for py in backend/.venv/bin/python backend/venv/bin/python python3; do
+for py in \
+  backend/.venv/bin/python \
+  backend/.venv/Scripts/python.exe \
+  backend/venv/bin/python \
+  backend/venv/Scripts/python.exe \
+  python3; do
   if [ -x "$py" ] || command -v "$py" >/dev/null 2>&1; then
     if "$py" -c 'import pytest, dotenv' >/dev/null 2>&1; then
       run_pytest "$py"

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -24,6 +24,16 @@ def _prepend_dev_harness_pythonpath(env: dict[str, str]) -> None:
     env["PYTHONPATH"] = os.pathsep.join(entries)
 
 
+def test_child_pythonpath_uses_the_selected_host_separator(tmp_path: Path) -> None:
+    env = {"PYTHONPATH": str(tmp_path / "existing")}
+    first = tmp_path / "scripts" / "dev-harness"
+    second = tmp_path / "backend"
+
+    cli._prepend_pythonpath(env, first, second)
+
+    assert env["PYTHONPATH"].split(os.pathsep) == [str(first), str(second), str(tmp_path / "existing")]
+
+
 def test_offline_check_skips_provider_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)

--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -17,7 +17,10 @@ import pytest
 HARNESS_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = HARNESS_ROOT.parents[1]
 RESOLVER = HARNESS_ROOT / "_resolve_python.sh"
+PYTHON_RUNNER = HARNESS_ROOT / "run-python.sh"
 MAKEFILE = REPO_ROOT / "Makefile"
+PRE_PUSH_SINGLEFLIGHT = REPO_ROOT / "scripts/pre-push-singleflight"
+PREFLIGHT_RUNNER = REPO_ROOT / ".github/scripts/preflight_runner.py"
 
 
 def _bash_command() -> str:
@@ -62,6 +65,8 @@ def _as_bash_path(path: Path) -> str:
     result = subprocess.run(
         [_bash_command(), "-c", 'cygpath -u "$1"', "bash", str(path)],
         text=True,
+        encoding="utf-8",
+        errors="replace",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         timeout=10,
@@ -115,6 +120,20 @@ def test_resolver_prefers_repo_venvs_and_only_uses_python3_without_one(
     assert _resolve_python(repo, monkeypatch) == "python3"
 
 
+def test_resolver_finds_windows_virtualenv_layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    modern = repo / "backend/.venv/Scripts/python.exe"
+    legacy = repo / "backend/venv/Scripts/python.exe"
+
+    _make_executable(modern)
+    _make_executable(legacy)
+    assert _resolve_python(repo, monkeypatch) == _as_bash_path(modern)
+
+    modern.unlink()
+    assert _resolve_python(repo, monkeypatch) == _as_bash_path(legacy)
+
+
 def test_resolver_honors_explicit_python_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -139,8 +158,49 @@ def test_resolver_honors_explicit_python_override(tmp_path: Path, monkeypatch: p
     assert result.stdout.strip() == "custom-python"
 
 
-def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_path: Path) -> None:
-    repo = tmp_path / "omi pr-10017 space"
+@pytest.mark.skipif(os.name != "nt", reason="native Windows Python path semantics")
+def test_pythonpath_uses_selected_windows_interpreter_separator(tmp_path: Path) -> None:
+    repo = tmp_path / "omi 路径 pythonpath"
+    module = repo / "scripts/dev-harness/fixture_import.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("VALUE = 'imported'\n", encoding="utf-8")
+    resolver = module.parent / "_resolve_python.sh"
+    shutil.copy2(RESOLVER, resolver)
+
+    env = _shell_env()
+    env["PYTHON"] = _as_bash_path(Path(sys.executable))
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [
+            _bash_command(),
+            "-c",
+            (
+                'source "$1"; '
+                'python_bin="$(dev_harness_python)"; '
+                'PYTHONPATH="$(dev_harness_pythonpath "$python_bin" scripts/dev-harness backend)" '
+                '"$python_bin" -c \'import os, fixture_import; '
+                'print(os.environ["PYTHONPATH"]); print(fixture_import.VALUE)\''
+            ),
+            "bash",
+            _as_bash_path(resolver),
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["scripts/dev-harness;backend", "imported"]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows PowerShell entrypoint regression")
+def test_make_uses_git_bash_when_bare_bash_resolves_to_wsl(tmp_path: Path) -> None:
+    repo = tmp_path / "omi 路径 powershell"
     repo.mkdir()
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
     shutil.copy2(MAKEFILE, repo / "Makefile")
@@ -148,8 +208,112 @@ def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
     resolver.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(RESOLVER, resolver)
+    shutil.copy2(PYTHON_RUNNER, resolver.parent / "run-python.sh")
 
-    calls = repo / "python calls.log"
+    calls = tmp_path / "powershell-python-calls.log"
+    target = repo / "scripts/dev-harness/list-memory-scenarios.py"
+    target.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        "Path(os.environ['HARNESS_PYTHON_CALLS']).write_text('ran', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    make = Path(_make_command()).resolve()
+    system32 = Path(os.environ["SystemRoot"]) / "System32"
+    env = os.environ.copy()
+    inherited_paths = [
+        entry
+        for entry in env.get("PATH", "").split(os.pathsep)
+        if entry
+        and Path(entry).as_posix().lower().rstrip("/")
+        not in {"c:/program files/git/bin", "c:/program files/git/usr/bin"}
+    ]
+    env["PATH"] = os.pathsep.join((str(make.parent), *inherited_paths))
+    bare_bash = shutil.which("bash", path=env["PATH"])
+    assert bare_bash and Path(bare_bash).samefile(system32 / "bash.exe")
+    env["OS"] = "Windows_NT"
+    env["PYTHON"] = _as_bash_path(Path(sys.executable))
+    env.pop("SHELL", None)
+    env["HARNESS_PYTHON_CALLS"] = str(calls)
+    result = subprocess.run(
+        [str(make), "-C", str(repo), "list-memory-scenarios"],
+        env=env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert calls.read_text(encoding="utf-8") == "ran"
+    assert "WSL" not in result.stdout + result.stderr
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows hook entrypoint regression")
+def test_pre_push_singleflight_runs_shell_child_with_native_windows_python(tmp_path: Path) -> None:
+    repo = tmp_path / "omi 路径 hook"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True)
+    shutil.copy2(RESOLVER, resolver)
+    wrapper = repo / "scripts/pre-push-singleflight"
+    shutil.copy2(PRE_PUSH_SINGLEFLIGHT, wrapper)
+    runner = repo / ".github/scripts/preflight_runner.py"
+    runner.parent.mkdir(parents=True)
+    shutil.copy2(PREFLIGHT_RUNNER, runner)
+    pre_push = repo / "scripts/pre-push"
+    pre_push.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf 'hook-output: 路径🚀\\n'\n"
+        'printf "args: %s | %s\\n" "${1:-}" "${2:-}"\n',
+        encoding="utf-8",
+    )
+    pre_push.chmod(pre_push.stat().st_mode | stat.S_IXUSR)
+
+    state_root = tmp_path / "preflight-state"
+    env = _shell_env()
+    env["PYTHON"] = _as_bash_path(Path(sys.executable))
+    env["OMI_PREFLIGHT_STATE_DIR"] = str(state_root)
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [_bash_command(), _as_bash_path(wrapper), "fork", "https://example.invalid/repo.git"],
+        cwd=repo,
+        env=env,
+        input="",
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "hook-output: 路径🚀" in result.stdout
+    assert "args: fork | https://example.invalid/repo.git" in result.stdout
+    log = (state_root / "pre-push" / "preflight.log").read_text(encoding="utf-8")
+    assert "hook-output: 路径🚀" in log
+
+
+def test_make_harness_targets_run_resolved_python_from_checkout_with_unicode_and_spaces(tmp_path: Path) -> None:
+    repo = tmp_path / "omi 路径 pr-10017 space"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    shutil.copy2(MAKEFILE, repo / "Makefile")
+
+    resolver = repo / "scripts/dev-harness/_resolve_python.sh"
+    resolver.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(RESOLVER, resolver)
+    shutil.copy2(PYTHON_RUNNER, resolver.parent / "run-python.sh")
+
+    calls = tmp_path / "python calls.log"
     python = repo / "backend/.venv/bin/python"
     python.parent.mkdir(parents=True, exist_ok=True)
     python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$HARNESS_PYTHON_CALLS"\n', encoding="utf-8")
@@ -161,6 +325,7 @@ def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_
     env.pop("PYTHON", None)
     env["HARNESS_PYTHON_CALLS"] = _as_bash_path(calls)
     targets = (
+        ("preflight", []),
         ("list-memory-scenarios", []),
         ("seed-memory-scenario", ["SCENARIO=sample"]),
         ("reset-memory-scenario", ["SCENARIO=sample"]),
@@ -179,6 +344,7 @@ def test_make_harness_targets_run_resolved_python_from_checkout_with_spaces(tmp_
         assert result.returncode == 0, result.stderr
 
     assert calls.read_text(encoding="utf-8").splitlines() == [
+        ".github/scripts/pr_preflight.py --lane local --base origin/main",
         "scripts/dev-harness/list-memory-scenarios.py",
         "scripts/dev-harness/seed-memory-scenario.py sample",
         "scripts/dev-harness/reset-memory-scenario.py sample",
@@ -318,6 +484,7 @@ def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_pat
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
     resolver.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(RESOLVER, resolver)
+    shutil.copy2(PYTHON_RUNNER, resolver.parent / "run-python.sh")
 
     calls = repo / "python calls.log"
     python = repo / "backend/.venv/bin/python"
@@ -347,9 +514,8 @@ def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_pat
 def test_make_harness_does_not_execute_double_quote_in_checkout_name(tmp_path: Path) -> None:
     """A double quote in the checkout root must not break recipe shell quoting.
 
-    Recipes now use $$PYTHON (shell variable expansion) instead of $(PYTHON)
-    (Make text interpolation). Shell variable expansion treats the resolved
-    path as data, so quote characters cannot escape the recipe's quoting.
+    Recipes invoke a relative Bash runner, which resolves the checkout-local
+    interpreter without interpolating the checkout root into recipe text.
     """
     repo = tmp_path / 'omi "; touch double-quote-marker; #'
     marker = repo / "double-quote-marker"
@@ -360,6 +526,7 @@ def test_make_harness_does_not_execute_double_quote_in_checkout_name(tmp_path: P
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
     resolver.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(RESOLVER, resolver)
+    shutil.copy2(PYTHON_RUNNER, resolver.parent / "run-python.sh")
 
     calls = repo / "python calls.log"
     python = repo / "backend/.venv/bin/python"

--- a/scripts/pr-preflight
+++ b/scripts/pr-preflight
@@ -2,20 +2,10 @@
 
 set -euo pipefail
 
-# Fall back to the working directory when `git rev-parse --show-toplevel` cannot
-# resolve a work tree: in a linked worktree whose git context resolves to a git
-# dir (show-toplevel exits 128, "this operation must be run in a work tree"),
-# this would otherwise abort. The pre-push gate cd's to the repo root before
-# invoking this script, and hooks run at the work-tree top, so pwd is the root.
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"
-if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
-  PYTHON_EXECUTABLE="$(command -v python3 || command -v python || true)"
-fi
-if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
-  echo "FAIL: PR preflight requires Python 3, but no executable was found." >&2
-  exit 1
-fi
-exec "$PYTHON_EXECUTABLE" .github/scripts/pr_preflight.py "$@"
+# shellcheck source=dev-harness/_resolve_python.sh
+source scripts/dev-harness/_resolve_python.sh
+PYTHON_BIN="$(dev_harness_python)"
+exec "$PYTHON_BIN" .github/scripts/pr_preflight.py "$@"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -2,12 +2,12 @@
 
 set -eo pipefail
 
-# Git runs hooks with the working directory at the top of the invoking work
-# tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
-# work tree. In a linked worktree whose git context resolves to a git dir rather
-# than a work tree, show-toplevel exits 128 ("this operation must be run in a
-# work tree") and this gate would otherwise abort, forcing a --no-verify push.
-cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$(git rev-parse --show-toplevel)"
+
+# shellcheck source=dev-harness/_resolve_python.sh
+source scripts/dev-harness/_resolve_python.sh
+PYTHON_BIN="$(dev_harness_python)"
+BACKEND_PYTHON="$(dev_harness_canonical_python || true)"
 
 PUSH_REMOTE="${1:-origin}"
 BASE_REMOTE="${PRE_PUSH_BASE_REMOTE:-origin}"
@@ -86,35 +86,6 @@ FAST_BACKEND_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-fast-backend-tests.XXX
 RELEASE_GUARD_TESTS=$(mktemp "${TMPDIR:-/tmp}/omi-pre-push-release-guard-tests.XXXXXX")
 trap 'rm -f "$CHANGED_FILES_LIST" "$SELECTED_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS_REASON" "$FAST_BACKEND_TESTS" "$RELEASE_GUARD_TESTS"' EXIT
 printf '%s\n' "${CHANGED_FILES[@]}" > "$CHANGED_FILES_LIST"
-
-PYTHON_EXECUTABLE="${OMI_PYTHON_EXECUTABLE:-}"
-if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
-  for python_candidate in "${BACKEND_PYTHON:-}" "$PWD/backend/.venv/bin/python" "$PWD/backend/.venv/Scripts/python.exe"; do
-    if [[ -n "$python_candidate" && -x "$python_candidate" ]]; then
-      PYTHON_EXECUTABLE="$python_candidate"
-      break
-    fi
-  done
-fi
-if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
-  PYTHON_EXECUTABLE="$(command -v python3 || command -v python || true)"
-fi
-if [[ -z "$PYTHON_EXECUTABLE" || ! -x "$PYTHON_EXECUTABLE" ]]; then
-  echo "FAIL: pre-push requires Python 3, but no executable was found." >&2
-  exit 1
-fi
-export OMI_PYTHON_EXECUTABLE="$PYTHON_EXECUTABLE"
-
-BACKEND_PYTHON="${BACKEND_PYTHON:-}"
-if [[ -z "$BACKEND_PYTHON" ]]; then
-  for backend_python_candidate in "$PWD/backend/.venv/bin/python" "$PWD/backend/.venv/Scripts/python.exe"; do
-    if [[ -x "$backend_python_candidate" ]]; then
-      BACKEND_PYTHON="$backend_python_candidate"
-      break
-    fi
-  done
-fi
-
 declare -a CI_PREDICTION_VERIFIED=()
 declare -a CI_PREDICTION_DEFERRED=()
 declare -a CI_PREDICTION_SKIPPED=()
@@ -164,8 +135,8 @@ require_backend_python() {
   if [[ -n "$BACKEND_PYTHON" && -x "$BACKEND_PYTHON" ]]; then
     return 0
   fi
-  echo "FAIL: a selected backend check requires a usable backend Python." >&2
-  echo "      Set BACKEND_PYTHON or run: make setup" >&2
+  echo "FAIL: a selected backend check requires the canonical backend/.venv interpreter, but it was not found." >&2
+  echo "      Create it with: make setup" >&2
   return 1
 }
 
@@ -195,7 +166,7 @@ changed_matches() {
   return 1
 }
 
-CI_PREDICTION_SELECTION=$("$PYTHON_EXECUTABLE" scripts/pre_push_ci_prediction.py --changed-files "$CHANGED_FILES_LIST" --base "$BASE_REF")
+CI_PREDICTION_SELECTION=$("$PYTHON_BIN" scripts/pre_push_ci_prediction.py --changed-files "$CHANGED_FILES_LIST" --base "$BASE_REF")
 if ci_prediction_selected "app-ci-only"; then
   ci_prediction_note_deferred "full Flutter analyzer/tests and platform compiles"
 fi
@@ -220,7 +191,7 @@ check_pr_preflight() {
     fi
     echo "Skipping shared PR preflight because PRE_PUSH_SKIP_PR_PREFLIGHT=1."
     echo "==> failure-class guard-artifact ratchet (mandatory under preflight hatch)"
-    "$PYTHON_EXECUTABLE" .github/scripts/check_failure_class_guard_ratchet.py \
+    "$PYTHON_BIN" .github/scripts/check_failure_class_guard_ratchet.py \
       --pr-body-file "$OMI_PR_BODY_FILE"
     ci_prediction_note_verified "failure-class guard-artifact ratchet (mandatory under PRE_PUSH_SKIP_PR_PREFLIGHT=1)"
     ci_prediction_note_skipped "shared PR contract and hygiene (PRE_PUSH_SKIP_PR_PREFLIGHT=1)"
@@ -298,8 +269,8 @@ check_optional_formatters() {
   if [ "${#python_files[@]}" -gt 0 ]; then
     if command -v black >/dev/null 2>&1; then
       black_cmd=(black)
-    elif "$PYTHON_EXECUTABLE" -m black --version >/dev/null 2>&1; then
-      black_cmd=("$PYTHON_EXECUTABLE" -m black)
+    elif "$PYTHON_BIN" -m black --version >/dev/null 2>&1; then
+      black_cmd=("$PYTHON_BIN" -m black)
     fi
 
     if [ "${#black_cmd[@]}" -gt 0 ]; then
@@ -312,7 +283,7 @@ check_optional_formatters() {
 
   if [ "${#arb_files[@]}" -gt 0 ]; then
     echo "==> ARB JSON formatting (${#arb_files[@]} file(s))"
-    "$PYTHON_EXECUTABLE" - "${arb_files[@]}" <<'PY'
+    "$PYTHON_BIN" - "${arb_files[@]}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -441,8 +412,15 @@ check_desktop_flow_lint_if_needed() {
     return
   fi
 
+  if ! "$PYTHON_BIN" -c "import yaml" >/dev/null 2>&1; then
+    echo "FAIL: desktop E2E flow metadata checks require Python 3 and PyYAML." >&2
+    echo "      Run make setup to create the locked backend environment." >&2
+    echo "      Deliberate hatch: PRE_PUSH_SKIP_DESKTOP_FLOW_LINT=1 git push" >&2
+    return 1
+  fi
+
   echo "==> desktop E2E flow metadata lint"
-  "$PYTHON_EXECUTABLE" desktop/macos/scripts/desktop-flow-lint.py
+  "$PYTHON_BIN" desktop/macos/scripts/desktop-flow-lint.py
   ci_prediction_note_verified "desktop E2E flow metadata and bridge-action references"
 }
 
@@ -638,7 +616,7 @@ check_runtime_image_source_closure_if_needed() {
     return
   fi
 
-  "$PYTHON_EXECUTABLE" backend/scripts/runtime_image_contracts.py check
+    "$PYTHON_BIN" backend/scripts/runtime_image_contracts.py check
 }
 
 check_openapi_contract_if_needed() {
@@ -803,9 +781,9 @@ check_gauntlet_evidence_if_needed() {
 }
 
 run_step check_pr_preflight
-run_step "$PYTHON_EXECUTABLE" .github/scripts/check-desktop-prod-promotion-policy.py
-run_step "$PYTHON_EXECUTABLE" .github/scripts/check-deployment-concurrency.py --self-test
-run_step "$PYTHON_EXECUTABLE" .github/scripts/check-deployment-concurrency.py
+run_step "$PYTHON_BIN" .github/scripts/check-desktop-prod-promotion-policy.py
+run_step "$PYTHON_BIN" .github/scripts/check-deployment-concurrency.py --self-test
+run_step "$PYTHON_BIN" .github/scripts/check-deployment-concurrency.py
 run_step check_backend_runtime_env_if_needed
 run_step check_backend_typecheck_if_needed
 run_step check_runtime_image_source_closure_if_needed

--- a/scripts/pre-push-singleflight
+++ b/scripts/pre-push-singleflight
@@ -2,45 +2,22 @@
 
 set -euo pipefail
 
-# Git runs hooks with the working directory at the top of the invoking work
-# tree, so fall back to it when `git rev-parse --show-toplevel` cannot resolve a
-# work tree. In a linked worktree whose git context resolves to a git dir rather
-# than a work tree, show-toplevel exits 128 ("this operation must be run in a
-# work tree") and this script — dispatched from a hook whose ROOT fallback
-# already survived — would otherwise abort here, forcing a --no-verify push.
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-BASH_EXECUTABLE="${BASH:-}"
-if [[ -z "$BASH_EXECUTABLE" || ! -x "$BASH_EXECUTABLE" ]]; then
-  BASH_EXECUTABLE="$(command -v bash || true)"
-fi
-if [[ -z "$BASH_EXECUTABLE" || ! -x "$BASH_EXECUTABLE" ]]; then
-  echo "FAIL: pre-push requires Bash, but no executable was found." >&2
-  exit 1
+# shellcheck source=dev-harness/_resolve_python.sh
+source scripts/dev-harness/_resolve_python.sh
+PYTHON_BIN="$(dev_harness_python)"
+export PYTHON="$PYTHON_BIN"
+
+PREFLIGHT_COMMAND=(scripts/pre-push "$@")
+if dev_harness_python_uses_windows_paths "$PYTHON_BIN"; then
+  if ! command -v cygpath >/dev/null 2>&1; then
+    echo "FAIL: native Windows Python requires Git for Windows Bash (cygpath was not found)." >&2
+    exit 1
+  fi
+  GIT_BASH_NATIVE="$(cygpath -w "$(command -v bash)")"
+  PREFLIGHT_COMMAND=("$GIT_BASH_NATIVE" scripts/pre-push "$@")
 fi
 
-PREFLIGHT_PYTHON="${BACKEND_PYTHON:-}"
-if [[ -z "$PREFLIGHT_PYTHON" || ! -x "$PREFLIGHT_PYTHON" ]]; then
-  for candidate in "$ROOT/backend/.venv/bin/python" "$ROOT/backend/.venv/Scripts/python.exe"; do
-    if [[ -x "$candidate" ]]; then
-      PREFLIGHT_PYTHON="$candidate"
-      export BACKEND_PYTHON="$candidate"
-      break
-    fi
-  done
-fi
-if [[ -z "$PREFLIGHT_PYTHON" || ! -x "$PREFLIGHT_PYTHON" ]]; then
-  PREFLIGHT_PYTHON="$(command -v python3 || command -v python || true)"
-fi
-if [[ -z "$PREFLIGHT_PYTHON" || ! -x "$PREFLIGHT_PYTHON" ]]; then
-  echo "FAIL: pre-push requires Python 3, but no executable was found." >&2
-  exit 1
-fi
-
-export PYTHONUTF8=1
-export OMI_BASH_EXECUTABLE="$BASH_EXECUTABLE"
-export OMI_PYTHON_EXECUTABLE="$PREFLIGHT_PYTHON"
-export PATH="$(dirname "$PREFLIGHT_PYTHON"):$(dirname "$BASH_EXECUTABLE"):$PATH"
-exec "$PREFLIGHT_PYTHON" .github/scripts/preflight_runner.py \
-  --name pre-push -- "$BASH_EXECUTABLE" scripts/pre-push "$@"
+exec "$PYTHON_BIN" .github/scripts/preflight_runner.py --name pre-push -- "${PREFLIGHT_COMMAND[@]}"

--- a/scripts/run-release-process-guards.sh
+++ b/scripts/run-release-process-guards.sh
@@ -3,10 +3,16 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BACKEND_PYTHON="$ROOT_DIR/backend/.venv/bin/python"
+# shellcheck source=dev-harness/_resolve_python.sh
+source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
 
-if [[ ! -x "$BACKEND_PYTHON" ]] || ! "$BACKEND_PYTHON" -c "import yaml"; then
+if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
+  || ! "$BACKEND_PYTHON" -c "import yaml" >/dev/null 2>&1; then
   "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
+    echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
+    exit 1
+  fi
 fi
 
 exec "$BACKEND_PYTHON" "$ROOT_DIR/.github/scripts/check-release-process-guards.py" "$@"


### PR DESCRIPTION
## What changed and why

Make the repository preflight executable from ordinary Windows PowerShell, including checkouts whose absolute path contains spaces and non-ASCII characters.

- Resolve Bash from the active Git for Windows installation instead of invoking the System32 WSL launcher.
- Make GNU Make, hooks, release guards, readiness checks, and dev-harness entrypoints share the same Bash/Python resolver.
- Reuse the repository Windows virtualenv (`Scripts/python.exe`) while preserving interpreter-specific `PYTHONPATH` separators.
- Normalize manifest `bash` and `python3` commands at the runner boundary, and decode Git/check output as UTF-8 instead of the Windows ANSI code page.
- Preserve Unicode Git paths and checkout roots through preflight selection, child environments, and single-flight fingerprints.
- Make Windows cancellation/liveness handling read-only and race-safe with isolated process groups, `CTRL_BREAK_EVENT`, and Win32 wait state.
- Run readiness behavior fixtures through Git Bash and the selected native Python.
- Keep Ruby/iOS and POSIX permission contracts on Linux/macOS, where their semantics are faithful, while retaining Linux CI coverage.
- Keep security-sensitive token mode checks fail-closed on Windows; only the unrelated candidate-provenance fixture mocks that boundary.
- Remove fixed test-output paths and nested Make banner leakage that made checks order- or host-dependent.

## Product invariants affected

none

## How it was verified

- After syncing `origin/main` and dropping overlap already merged through #10838, #10842, and #10843, the PR diff is down from 40 files to 34 files.
- The current PR head `ff80da22a` passed the official `make preflight`: **70 selected checks in 273.24s**.
- A larger pending Windows integration stack passed `make preflight` from `J:\codex-omi-work\路径 空格\omi-main-20260729`: **79 selected checks in 323.17s**.
- Dev-harness unit suite: 69 passed, 13 expected platform skips.
- Preflight contract suite: 36 passed, 2 expected platform skips.
- Manifest runner suite: 39 passed, 1 expected platform skip.
- Readiness behavior: 5 passed.
- Failure-class guard ratchet: 14 passed plus a real 90-day history scan.
- Desktop backend candidate probe: 14 passed.
- Desktop beta retry contract: 30 passed.
- Setup contract passed baseline provisioning, dependency-sync rerun, and linked-worktree fallback.
- Ruff, Bash syntax, and diff hygiene passed for touched modules.

The desktop changes are internal-only. Local verification used `PRE_PUSH_SKIP_DESKTOP_CHANGELOG=1`, the documented equivalent of the required `no-changelog-needed` label; please add that label rather than publishing a user-facing changelog entry.

## Tests

Coverage includes Git for Windows discovery, MSYS/native path conversion, Windows virtualenv resolution, Unicode checkout paths, UTF-8 subprocess output, joined/rejected single-flight behavior, cancellation forwarding, readiness orchestration, platform-scoped contracts, release guards, firmware guard execution, SwiftLint shell contracts, and security-sensitive candidate fixtures.

## Failure class (fixes)

Failure-Class: none
