### PR TITLE
ci: stop automatic desktop version tags on every merge

### DIFF
--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -469,13 +469,16 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
 
     def test_workflow_has_no_input_manual_trigger_and_tags_only_the_merged_main_source(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        # workflow_dispatch stays bare (no manual inputs). Continuous deployment:
-        # auto-release fires on macOS-affecting merges to main (push); the schedule
-        # remains a backstop. No `inputs:` may appear in the trigger block.
+        # Manual candidate publication only. Automatic push/schedule tagging was
+        # retired so merges no longer mint a new macOS version tag per CI run.
+        # workflow_dispatch stays bare (no manual inputs). No `inputs:` may appear
+        # in the trigger block.
         self.assertIn("  workflow_dispatch:\n", workflow)
         self.assertNotIn("inputs:", workflow.split("\njobs:", 1)[0])
-        self.assertIn("  push:\n    branches: [main]", workflow)
-        self.assertIn("- cron: '*/15 * * * *'", workflow)
+        trigger = workflow.split("\njobs:", 1)[0]
+        self.assertNotIn("\n  push:", trigger)
+        self.assertNotIn("schedule:", trigger)
+        self.assertNotIn("cron:", trigger)
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
@@ -517,25 +520,16 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertIn("if: always()", tag_release)
         self.assertIn("desktop-pre-tag-readiness", tag_release)
 
-    def test_push_paths_cover_releasable_desktop_paths(self) -> None:
-        # Continuous deployment: every releasable desktop input the planner
-        # recognizes must also be in the workflow's push filter, or a merge
-        # touching only that input would be releasable yet never get the immediate
-        # push trigger (only the schedule backstop would catch it). A directory
-        # entry maps to '<dir>/**'.
-        #
-        # Parse the push filter without PyYAML: this check runs in the `local` and
-        # `ci` lanes across environments that do not all ship PyYAML.
-        branches, push_paths = _parse_push_filter(WORKFLOW.read_text(encoding="utf-8"))
-        self.assertEqual(branches, ["main"])
-        for path in planner.DESKTOP_RELEASE_PATHS:
-            expected = f"{path}/**" if (ROOT / path).is_dir() else path
-            self.assertIn(
-                expected,
-                push_paths,
-                f"releasable desktop path {path!r} (expected push filter {expected!r}) "
-                "is missing from desktop_auto_release.yml push.paths",
-            )
+    def test_auto_release_is_manual_only(self) -> None:
+        # Candidate tags must not fire on push/schedule. The planner may still
+        # gate a manual run; continuous path filters are intentionally gone.
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        trigger = workflow.split("\njobs:", 1)[0]
+        self.assertIn("workflow_dispatch:", trigger)
+        self.assertNotIn("\n  push:", trigger)
+        self.assertNotIn("schedule:", trigger)
+        with self.assertRaises(AssertionError):
+            _parse_push_filter(workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -1,40 +1,11 @@
 name: Build Desktop Release Candidate
 
 on:
+  # Manual only: automatic push/schedule tagging was cutting a new macOS candidate
+  # tag on nearly every desktop-affecting main merge and every 15 minutes. Plan and
+  # publish a candidate deliberately via workflow_dispatch; qualification/promotion
+  # workflows remain unchanged once a tag exists.
   workflow_dispatch:
-  # Continuous deployment: plan a beta candidate on every macOS-affecting merge to
-  # main. The candidate flows through the two-machine qualification pipeline
-  # (desktop_qualify_beta.yml: Codemagic primary lane + self-hosted qualify-m1-studio
-  # and qualify-m4-mini fallbacks); on qualification success desktop_promote_beta.yml
-  # advances the beta channel to the Codemagic-built, notarized, Sparkle-signed
-  # artifact. The push filter is intentionally coarse (the planner does the precise
-  # releasable-change check, excluding CHANGELOG/AGENTS/changelog); the
-  # quiet-window, exact-SHA, and one-active-release fences still admit at most one
-  # candidate at a time, so bursts collapse to the newest SHA. Keep these paths in
-  # lockstep with DESKTOP_RELEASE_PATHS in plan-desktop-release.py; the alignment is
-  # enforced by test_push_paths_cover_releasable_desktop_paths.
-  push:
-    branches: [main]
-    paths:
-      - 'desktop/macos/**'
-      - 'codemagic.yaml'
-      - 'scripts/dev-harness/dev_harness/qualification.py'
-      - '.github/scripts/plan-desktop-release.py'
-      - '.github/scripts/desktop-release-source-identity.py'
-      - '.github/scripts/publish-desktop-candidate-tag.py'
-      - '.github/scripts/verify-pre-tag-readiness.py'
-      - '.github/workflows/desktop_auto_release.yml'
-      - '.github/workflows/desktop_qualify_beta.yml'
-      - '.github/workflows/desktop-swift-ci.yml'
-  schedule:
-    # Poll every 15 min. The push trigger fires immediately on merge, but at that
-    # instant the change is inside the quiet window AND its required CI checks
-    # (Build & Tests / Release Compile / Release Eligibility, ~10-20 min) are not
-    # yet green, so the planner fail-closes. This frequent backstop re-evaluates
-    # shortly after those checks settle and the active-release fence clears, so a
-    # candidate reliably cuts without waiting for the next hour. Builds stay
-    # serialized by the one-active-release fence, so this cannot pile up builds.
-    - cron: '*/15 * * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -1,10 +1,14 @@
 name: Auto Release Desktop (Windows) on Main
 
-# Windows counterpart to desktop_auto_release.yml (macOS). Same SHAPE:
-#   merge to main touching the desktop app -> bump the patch version, tag it,
-#   build the installer, publish it to a prerelease (beta) GitHub Release.
+# Windows counterpart to desktop_auto_release.yml (macOS). Manual release only:
+#   workflow_dispatch -> bump the patch version, tag it, build the installer,
+#   publish it to a prerelease (beta) GitHub Release.
 #
-# Difference from macOS: macOS only tags here and hands the build to Codemagic.
+# Automatic push-to-main tagging was retired: every desktop/windows merge was
+# minting a new v*-windows tag and opening a sync PR. Cut Windows releases
+# deliberately via workflow_dispatch (release_now / force_release / next_version).
+#
+# Difference from macOS: macOS only tags and hands the build to Codemagic.
 # Windows has no external CI, so this workflow ALSO builds + publishes, on a
 # windows-latest runner, using electron-builder (NSIS) + gh.
 #
@@ -20,19 +24,8 @@ name: Auto Release Desktop (Windows) on Main
 # pi-mono asarUnpack closure at pack time. Dropping the flag would silently ship an
 # installer missing that closure and break the coding agent. `pnpm build:win`
 # already carries the flag; the signed path passes it by hand.
-#
-# Loop prevention (the bump must not re-trigger this workflow):
-#   1. Every git write here uses GITHUB_TOKEN, and GitHub does not start new
-#      workflow runs for pushes made with GITHUB_TOKEN. This alone breaks the loop.
-#   2. Belt-and-suspenders: the plan job skips commits whose message is a release
-#      bump, and skips when there is no releasable desktop/windows change since
-#      the latest tag (so an empty/no-op push never cuts a release).
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - 'desktop/windows/**'
   workflow_dispatch:
     inputs:
       release_mode:


### PR DESCRIPTION
## What

Stop GitHub Actions from minting a new desktop version tag on every relevant main merge / CI cadence.

## Why

`Build Desktop Release Candidate` was firing on:
- every push to `main` that touched macOS desktop paths, and
- a `*/15` cron backstop

`Auto Release Desktop (Windows) on Main` was firing on every `desktop/windows/**` merge, creating `v*-windows` tags and sync PRs.

That produced a steady stream of version tags and changelog/sync noise unrelated to intentional releases.

## Change

| Workflow | Before | After |
|---|---|---|
| `desktop_auto_release.yml` (macOS) | `push` + `schedule` + `workflow_dispatch` | **`workflow_dispatch` only** |
| `desktop_windows_release.yml` | `push` + `workflow_dispatch` | **`workflow_dispatch` only** |

Tag/publish/build logic is unchanged once manually triggered. Qualification/promotion after a tag still works as before.

## Tests

- `python3 .github/scripts/test_plan_desktop_release.py`
- `python3 .github/scripts/test_publish_desktop_candidate_tag.py`
- `python3 .github/scripts/test_check_codemagic_tag_intake.py`

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

