### PR TITLE
feat(desktop): default onboarding recording to meetings

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -14,7 +14,6 @@ func byokMissingKeysHint(_ keys: [String]) -> String? {
     "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
 }
 
-
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -80,7 +79,6 @@ extension SettingsContentView {
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
   }
-
 
   var byokIncompleteHint: String? {
     byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -13,6 +13,24 @@ import Foundation
 /// `SBOnboardingModel+Steps.swift`.
 @MainActor
 final class SBOnboardingModel: ObservableObject {
+  enum CaptureSelection: Equatable {
+    case onlyDuringMeetings
+    case continuous
+
+    var systemAudioCaptureMode: AssistantSettings.SystemAudioCaptureMode {
+      switch self {
+      case .onlyDuringMeetings: .onlyDuringMeetings
+      case .continuous: .always
+      }
+    }
+
+    var startsListeningImmediately: Bool {
+      self == .continuous
+    }
+  }
+
+  static let defaultCaptureSelection: CaptureSelection = .onlyDuringMeetings
+
   enum Step: Int, CaseIterable {
     case promise, name, howHeard, language, role
     case mic, systemAudio, screen, files, accessibility, automation
@@ -210,8 +228,6 @@ final class SBOnboardingModel: ObservableObject {
     case .context:
       return "The more I can see, the more I can help. Connect anything you want me to know:"
     case .capture:
-      // The shortcut chord is rendered as keycap chips in `captureWidget` (a
-      // streamed Text can't host inline keycap views), so it's omitted here.
       return
         "You're all set, \(name). One last thing: should I listen all the time, or only during your meetings?"
     }
@@ -224,10 +240,6 @@ final class SBOnboardingModel: ObservableObject {
     if !stored.isEmpty { return stored }
     return "friend"
   }
-
-  /// The chosen open-Omi chord as individual tokens, rendered as keycap chips in
-  /// `captureWidget` (e.g. ⌘ + O) rather than plain glyphs in the message copy.
-  var summonTokens: [String] { ShortcutSettings.shared.askOmiShortcut.displayTokens }
 
   // MARK: lifecycle
 
@@ -482,14 +494,9 @@ final class SBOnboardingModel: ObservableObject {
 
   // MARK: capture choice → completes onboarding
 
-  func captureContinuous() {
-    AssistantSettings.shared.systemAudioCaptureMode = .always
-    complete(startListening: true)
-  }
-
-  func captureMeetingsOnly() {
-    AssistantSettings.shared.systemAudioCaptureMode = .onlyDuringMeetings
-    complete(startListening: false)
+  func capture(_ selection: CaptureSelection) {
+    AssistantSettings.shared.systemAudioCaptureMode = selection.systemAudioCaptureMode
+    complete(startListening: selection.startsListeningImmediately)
   }
 
   /// Skip the rest of onboarding: mark it complete and drop straight to the Chat

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -674,33 +674,24 @@ struct SBOnboardingView: View {
 
   private var captureWidget: some View {
     VStack(spacing: 8) {
-      // The chosen open-Omi chord as keycap chips (e.g. ⌘ O), matching the ⌥ keycap
-      // on the demo step — instead of plain "⌘O" glyphs buried in the message copy.
-      if !model.summonTokens.isEmpty {
-        HStack(spacing: 5) {
-          ForEach(model.summonTokens, id: \.self) { tok in keycap(tok) }
-          Text("reaches me anytime").geist(size: 14).foregroundStyle(sb.ink(.w85))
-          Spacer(minLength: 0)
-        }
-        .padding(.bottom, 2)
-      }
       Button {
-        model.captureContinuous()
-      } label: {
-        Text("● Start listening — continuously").geist(size: 14, weight: .semibold).foregroundStyle(sb.inkInverted)
-          .frame(maxWidth: .infinity).padding(.vertical, 11)
-          .background(RoundedRectangle(cornerRadius: 11).fill(sb.ink))
-      }
-      .buttonStyle(.plain)
-      Button {
-        model.captureMeetingsOnly()
+        model.capture(SBOnboardingModel.defaultCaptureSelection)
       } label: {
         HStack(spacing: 4) {
-          Text("Only during meetings").geist(size: 14).foregroundStyle(sb.ink(.w85))
-          Text("· from my calendar").geist(size: 12).foregroundStyle(sb.ink(.w4))
+          Text("● Only during meetings").geist(size: 14, weight: .semibold).foregroundStyle(sb.inkInverted)
+          Text("· from my calendar").geist(size: 12).foregroundStyle(sb.inkInverted.opacity(0.7))
         }
         .frame(maxWidth: .infinity).padding(.vertical, 11)
-        .overlay(RoundedRectangle(cornerRadius: 11).stroke(sb.ink(.w18), lineWidth: 1))
+        .background(RoundedRectangle(cornerRadius: 11).fill(sb.ink))
+      }
+      .buttonStyle(.plain)
+      .keyboardShortcut(.defaultAction)
+      Button {
+        model.capture(.continuous)
+      } label: {
+        Text("Start listening — continuously").geist(size: 14).foregroundStyle(sb.ink(.w85))
+          .frame(maxWidth: .infinity).padding(.vertical, 11)
+          .overlay(RoundedRectangle(cornerRadius: 11).stroke(sb.ink(.w18), lineWidth: 1))
       }
       .buttonStyle(.plain)
     }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -437,7 +437,8 @@ final class OnboardingFlowTests: XCTestCase {
       continuousChoice.lowerBound,
       "Meeting-only recording must be the first capture choice")
     XCTAssertTrue(
-      secondBrainSource[defaultChoice.lowerBound...].prefix(500).contains(".keyboardShortcut(.defaultAction)"),
+      secondBrainSource[defaultChoice.lowerBound..<continuousChoice.lowerBound]
+        .contains(".keyboardShortcut(.defaultAction)"),
       "Return must choose the meeting-only capture default")
     XCTAssertFalse(secondBrainSource.contains("reaches me anytime"))
   }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -425,6 +425,23 @@ final class OnboardingFlowTests: XCTestCase {
       "SBInkButton must wire opted-in proceed actions to Return")
   }
 
+  func testSecondBrainCaptureDefaultsToMeetingsWithoutShortcutReminder() throws {
+    // omi-test-quality: source-inspection -- static contract: verifies the SwiftUI capture-choice hierarchy and copy
+    let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
+    let defaultChoice = try XCTUnwrap(
+      secondBrainSource.range(of: "model.capture(SBOnboardingModel.defaultCaptureSelection)"))
+    let continuousChoice = try XCTUnwrap(secondBrainSource.range(of: "model.capture(.continuous)"))
+
+    XCTAssertLessThan(
+      defaultChoice.lowerBound,
+      continuousChoice.lowerBound,
+      "Meeting-only recording must be the first capture choice")
+    XCTAssertTrue(
+      secondBrainSource[defaultChoice.lowerBound...].prefix(500).contains(".keyboardShortcut(.defaultAction)"),
+      "Return must choose the meeting-only capture default")
+    XCTAssertFalse(secondBrainSource.contains("reaches me anytime"))
+  }
+
   // Regression: arrow navigation must be computed from persisted step state and
   // applied by the mounted view — the NSEvent monitor's captured view copy drops
   // @AppStorage writes on some macOS versions. These cover the extracted

--- a/desktop/macos/Desktop/Tests/SBOnboardingCaptureSelectionTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCaptureSelectionTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SBOnboardingCaptureSelectionTests: XCTestCase {
+  func testDefaultCaptureSelectionRecordsOnlyDuringMeetings() {
+    let selection = SBOnboardingModel.defaultCaptureSelection
+
+    XCTAssertEqual(selection.systemAudioCaptureMode, .onlyDuringMeetings)
+    XCTAssertFalse(selection.startsListeningImmediately)
+  }
+
+  func testContinuousCaptureSelectionStartsListeningImmediately() {
+    let selection = SBOnboardingModel.CaptureSelection.continuous
+
+    XCTAssertEqual(selection.systemAudioCaptureMode, .always)
+    XCTAssertTrue(selection.startsListeningImmediately)
+  }
+}

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -84,7 +84,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/changelog/unreleased/20260729-meeting-recording-onboarding.json
+++ b/desktop/macos/changelog/unreleased/20260729-meeting-recording-onboarding.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made meeting-only recording the default onboarding choice and clarified the capture options"
+}


### PR DESCRIPTION
## Summary

- Make "Only during meetings" the first, primary, Return-key default capture choice in Second Brain onboarding.
- Keep continuous recording available as the secondary outlined option.
- Remove the redundant ⌘O shortcut reminder from this capture decision.

## Verification

- Passed: `xcrun swiftc -frontend -parse` for all edited Swift sources and tests.
- Passed: `git diff --check` and changelog JSON validation.
- Passed: pinned swift-format `lint-scope` (all first-party Swift files clean).
- Passed: `Desktop Swift Static & Test Contracts` CI check (format lint + OnboardingFlowTests + SBOnboardingCaptureSelectionTests).
- Blocked: focused local `xcrun swift test` — SwiftPM ran out of disk space extracting binary artifacts.

Failure-Class: none

## Product invariants

None affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
