### PR TITLE
fix(desktop-windows): recover muted Rewind capture tracks

### DIFF
--- a/.github/failure-classes/FC-media-track-output-liveness.json
+++ b/.github/failure-classes/FC-media-track-output-liveness.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-media-track-output-liveness",
+  "violated_contract": "A long-lived capture loop must treat every browser-declared media-output unavailable state, including a muted live track and an ended track, as non-capturable and recover before persisting another frame.",
+  "canonical_prevention": "Centralize track usability as live and not muted, route ended, mute, and initially unusable tracks through one generation-fenced restart path, and behaviorally assert that no frame is saved until a replacement stream is usable.",
+  "canonical_prevention_artifact": [
+    "desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx"
+  ],
+  "evidence_prs": [10549],
+  "scope_hints": [
+    "desktop/windows/src/renderer/src/components/rewind/**"
+  ],
+  "status": "open"
+}

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.test.tsx
@@ -4,6 +4,8 @@
 // The host opens ONE persistent desktop stream; when that track dies (display
 // sleep, GPU/driver reset, session change) nothing noticed — the sampler kept
 // drawing a dead <video> and saving frames from it, and capture never recovered.
+// #10737 recurred after that fix because a source can become muted while its
+// track remains live; that state must use the same no-save + reopen path.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, cleanup, act } from '@testing-library/react'
 import { RewindCaptureHost } from './RewindCaptureHost'
@@ -13,6 +15,7 @@ const RESTART_DELAY_MS = 2000
 
 class FakeTrack extends EventTarget {
   readyState: 'live' | 'ended' = 'live'
+  muted = false
   stop(): void {
     this.readyState = 'ended'
   }
@@ -91,7 +94,7 @@ async function tick(ms: number): Promise<void> {
   })
 }
 
-describe('RewindCaptureHost — dead capture track', () => {
+describe('RewindCaptureHost — unavailable capture track', () => {
   it('stops saving frames and reopens the stream when the capture track dies', async () => {
     render(<RewindCaptureHost />)
     await settle()
@@ -118,6 +121,50 @@ describe('RewindCaptureHost — dead capture track', () => {
     saveFrame.mockClear()
     await tick(INTERVAL_MS)
     expect(saveFrame).toHaveBeenCalled()
+  })
+
+  it('stops saving frames and reopens the stream when a live track becomes muted', async () => {
+    render(<RewindCaptureHost />)
+    await settle()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+
+    saveFrame.mockClear()
+    await act(async () => {
+      tracks[0].muted = true
+      expect(tracks[0].readyState).toBe('live')
+      tracks[0].dispatchEvent(new Event('mute'))
+    })
+
+    await tick(INTERVAL_MS)
+    expect(saveFrame).not.toHaveBeenCalled()
+
+    await tick(RESTART_DELAY_MS)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    saveFrame.mockClear()
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('reopens a stream that is already muted when getUserMedia resolves', async () => {
+    getUserMedia.mockImplementationOnce(async () => {
+      const track = new FakeTrack()
+      track.muted = true
+      tracks.push(track)
+      return fakeStream(track)
+    })
+
+    render(<RewindCaptureHost />)
+    await settle()
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+    expect(saveFrame).not.toHaveBeenCalled()
+
+    await tick(RESTART_DELAY_MS)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    await tick(INTERVAL_MS)
+    expect(saveFrame).toHaveBeenCalledTimes(1)
   })
 
   it('keeps a single sampling loop when the track dies mid-save', async () => {

--- a/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindCaptureHost.tsx
@@ -94,17 +94,18 @@ export function RewindCaptureHost(): React.JSX.Element {
       if (videoRef.current) videoRef.current.srcObject = null
     }
 
-    const isLive = (): boolean =>
-      streamRef.current?.getVideoTracks().some((t) => t.readyState === 'live') ?? false
+    const hasUsableVideoTrack = (stream = streamRef.current): boolean =>
+      stream?.getVideoTracks().some((t) => t.readyState === 'live' && !t.muted) ?? false
 
-    // A desktop-capture track can die while the app keeps running (display sleep,
-    // GPU/driver reset, resolution or session change). Nothing used to notice: the
-    // sampler kept drawing a dead <video>, so the timeline filled with blank frames
-    // and capture never came back. Re-open the stream instead. Our own teardown
-    // uses track.stop(), which does not fire 'ended', so this can't self-trigger.
-    const onTrackEnded = (): void => {
-      if (cancelled) return
-      console.warn('[rewind] capture track ended — reopening stream')
+    // #10504/#10737: a desktop-capture track can end or stay "live" while
+    // muted (temporarily unable to provide media) after display sleep, a
+    // GPU/driver reset, or a session change. Both states otherwise leave the
+    // sampler drawing blank frames indefinitely. Re-open the stream through one
+    // bounded recovery path.
+    // Our own track.stop() does not fire these events, so this cannot self-trigger.
+    const onTrackUnavailable = (): void => {
+      if (cancelled || hasUsableVideoTrack()) return
+      console.warn('[rewind] capture track unavailable — reopening stream')
       stop()
       timerRef.current = setTimeout(() => void start(), RESTART_DELAY_MS)
     }
@@ -115,7 +116,7 @@ export function RewindCaptureHost(): React.JSX.Element {
       if (cancelled || gen !== generation) return
       try {
         const v = videoRef.current
-        if (v && isLive() && v.videoWidth && v.videoHeight && !savingRef.current) {
+        if (v && hasUsableVideoTrack() && v.videoWidth && v.videoHeight && !savingRef.current) {
           const scale = Math.min(1, tier.maxEdge / Math.max(v.videoWidth, v.videoHeight))
           const w = Math.round(v.videoWidth * scale)
           const h = Math.round(v.videoHeight * scale)
@@ -178,13 +179,22 @@ export function RewindCaptureHost(): React.JSX.Element {
           return
         }
         streamRef.current = stream
-        stream.getVideoTracks().forEach((t) => t.addEventListener('ended', onTrackEnded))
-        const gen = generation
+        stream.getVideoTracks().forEach((t) => {
+          t.addEventListener('ended', onTrackUnavailable)
+          t.addEventListener('mute', onTrackUnavailable)
+        })
         const v = videoRef.current
         if (v) {
           v.srcObject = stream
           await v.play().catch(() => undefined)
         }
+        // A mute event may have recovered the stream while play() was pending.
+        if (streamRef.current !== stream) return
+        if (!hasUsableVideoTrack(stream)) {
+          onTrackUnavailable()
+          return
+        }
+        const gen = generation
         timerRef.current = setTimeout(() => void grabAndSchedule(gen), intervalMs)
       } catch (e) {
         console.error('[rewind] failed to start capture:', (e as Error).message)


### PR DESCRIPTION
## What changed and why

Addresses #10737's recurrence after #10549.

#10549 made Rewind recover when a desktop-capture track reaches `readyState === "ended"`. A browser can also report that the source is unable to provide media by setting `MediaStreamTrack.muted` while leaving `readyState === "live"`. The existing `isLive()` check accepted that state, so the hidden capture video could keep producing and saving blank frames without taking the recovery path.

This change defines one usable-track predicate (`live && !muted`), listens for both `mute` and `ended`, and routes both states through the existing generation-fenced two-second restart. It also checks the initial track after `video.play()` and avoids duplicate recovery if a lifecycle event fired while `play()` was pending.

This deliberately does not add pixel-based black-frame heuristics, which would misclassify legitimate dark screens. It closes the remaining browser-declared unavailable-track state; a post-merge recurrence would need runtime health telemetry for a different source of blank pixels.

## Product invariants affected

none

## How it was verified

- Before the implementation change, the new live-but-muted regression failed because `rewindSaveFrame` was called once after the `mute` event.
- `RewindCaptureHost.test.tsx`: 10/10 passed, including runtime mute and initially-muted stream recovery.
- All Rewind component tests: 20/20 passed.
- Full Windows desktop Vitest suite: 5,070 passed, 18 skipped across 532 test files.
- Node and renderer TypeScript checks passed.
- Focused ESLint and Prettier checks passed.
- Failure-class CLI tests: 17/17 passed.
- The Windows manifest preflight passed all 11 selected checks; the isolated verification worktree included #10825's pending path-portability fix because current `main` still contains #10824.

## Tests

- A live track becomes muted without ending: no frame is saved, the stream reopens, and the replacement resumes capture.
- `getUserMedia` resolves an already-muted stream: no sample is scheduled before the replacement stream is usable.
- Existing ended-track, mid-save generation, quality, and unmount coverage remains green.

## Failure class (fixes)

Failure-Class: new

Registers `FC-media-track-output-liveness`: a long-lived capture loop must treat every browser-declared media-output unavailable state as non-capturable and recover before persisting another frame. #10549 is the historical evidence PR, and `RewindCaptureHost.test.tsx` is the canonical prevention artifact.

## New guards (only when adding a check or ratchet)

The behavioral regression lives with `RewindCaptureHost` because that component is the sole owner of the Windows desktop `MediaStreamTrack`, sampling timer, and generation fence. There is no second media-track capture owner to justify a shared repository primitive; the single usable-track predicate is reused by event recovery, initial admission, and every sample.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

