### PR TITLE
feat(desktop): standardize settings controls

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -4,6 +4,15 @@ import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
 
+enum SubscriptionPlanPresentation {
+  static func selectionLabel(planTitle: String, startingPrice: String?) -> String {
+    guard let startingPrice, !startingPrice.isEmpty else {
+      return "Select \(planTitle)"
+    }
+    return "Select \(planTitle) · \(startingPrice)"
+  }
+}
+
 extension SettingsContentView {
   var hasPaidSubscription: Bool {
     guard let subscription = userSubscription?.subscription else { return false }
@@ -140,6 +149,13 @@ extension SettingsContentView {
 
   func planSummaryText(for plan: SubscriptionPlanOption) -> String {
     preferredStartingPrice(for: plan)?.priceString ?? ""
+  }
+
+  func planSelectionLabel(for plan: SubscriptionPlanOption) -> String {
+    SubscriptionPlanPresentation.selectionLabel(
+      planTitle: plan.title,
+      startingPrice: preferredStartingPrice(for: plan)?.priceString
+    )
   }
 
   func preferredStartingPrice(for plan: SubscriptionPlanOption) -> SubscriptionPriceOption? {
@@ -431,16 +447,13 @@ extension SettingsContentView {
                         .scaledFont(size: OmiType.caption, weight: .bold)
                       Text(price.priceString)
                         .scaledFont(size: OmiType.caption)
-                        .foregroundColor(OmiColors.backgroundPrimary.opacity(0.92))
+                        .foregroundColor(OmiColors.textSecondary)
                     }
-                    .foregroundColor(OmiColors.backgroundPrimary)
                     .frame(maxWidth: .infinity)
                   }
                 }
-                .padding(.vertical, OmiSpacing.sm)
               }
-              .buttonStyle(.borderedProminent)
-              .tint(accent)
+              .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
               .disabled(activeCheckoutPriceId != nil)
             }
           }
@@ -460,17 +473,15 @@ extension SettingsContentView {
           selectedPlanIdForCheckout = plan.id
         }) {
           HStack {
-            Text("Select \(plan.title)")
+            Text(planSelectionLabel(for: plan))
               .scaledFont(size: OmiType.caption, weight: .bold)
             Spacer()
             Image(systemName: "arrow.right")
               .scaledFont(size: OmiType.caption, weight: .bold)
           }
-          .foregroundColor(OmiColors.backgroundPrimary)
-          .padding(.vertical, OmiSpacing.sm)
+          .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderedProminent)
-        .tint(accent)
+        .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
       }
     }
     .padding(OmiSpacing.xxl)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
@@ -69,8 +69,7 @@ extension SettingsContentView {
                   .scaledFont(size: OmiType.body, weight: .semibold)
               }
             }
-            .buttonStyle(.borderedProminent)
-            .tint(OmiColors.error)
+            .buttonStyle(OmiButtonStyle(.destructive, size: .compact))
             .disabled(isDeletingAccount)
           }
 
@@ -348,11 +347,8 @@ extension SettingsContentView {
             }) {
               Text("Try Operator")
                 .scaledFont(size: OmiType.body, weight: .semibold)
-                .padding(.horizontal, OmiSpacing.lg)
-                .padding(.vertical, OmiSpacing.sm)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(OmiColors.success)
+            .buttonStyle(OmiButtonStyle(.primary, size: .compact))
           }
         }
       }
@@ -360,16 +356,6 @@ extension SettingsContentView {
       if shouldShowPlanPurchaseOptions {
         settingsCard(settingId: "planusage.purchase") {
           VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-            VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-              Text("Choose a plan")
-                .scaledFont(size: OmiType.subheading, weight: .semibold)
-                .foregroundColor(OmiColors.textPrimary)
-
-              Text("Pick one plan first. Billing options appear only after the card is selected.")
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(OmiColors.textTertiary)
-            }
-
             // All plan cards share the row width — no horizontal scrolling.
             HStack(alignment: .top, spacing: OmiSpacing.lg) {
               ForEach(subscriptionPlansForDisplay) { plan in

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -153,25 +153,9 @@ extension SettingsContentView {
               .scaledFont(size: OmiType.subheading)
               .foregroundColor(OmiColors.textTertiary)
 
-            VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
-              Text("AI Provider")
-                .scaledFont(size: OmiType.body)
-                .foregroundColor(OmiColors.textSecondary)
-
-              if let provider = AIProvider.from(bridgeMode: chatBridgeMode) {
-                if let url = provider.attributionURL {
-                  Link(destination: url) {
-                    Text("\(provider.tagline) · \(url.host ?? "")")
-                      .scaledFont(size: OmiType.caption)
-                      .foregroundColor(OmiColors.textTertiary)
-                  }
-                } else {
-                  Text(provider.tagline)
-                    .scaledFont(size: OmiType.caption)
-                    .foregroundColor(OmiColors.textTertiary)
-                }
-              }
-            }
+            Text("AI Provider")
+              .scaledFont(size: OmiType.subheading, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
 
             Spacer()
 
@@ -186,6 +170,20 @@ extension SettingsContentView {
                   await chatProvider?.switchBridgeMode(to: mode)
                 }
               }
+            }
+          }
+
+          if let provider = AIProvider.from(bridgeMode: chatBridgeMode) {
+            if let url = provider.attributionURL {
+              Link(destination: url) {
+                Text("\(provider.tagline) · \(url.host ?? "")")
+                  .scaledFont(size: OmiType.caption)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            } else {
+              Text(provider.tagline)
+                .scaledFont(size: OmiType.caption)
+                .foregroundColor(OmiColors.textTertiary)
             }
           }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -14,7 +14,6 @@ func byokMissingKeysHint(_ keys: [String]) -> String? {
     "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
 }
 
-
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -80,7 +79,6 @@ extension SettingsContentView {
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
   }
-
 
   var byokIncompleteHint: String? {
     byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])

--- a/desktop/macos/Desktop/Sources/Theme/OmiButtonStyle.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiButtonStyle.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
 /// The app's single button primitive. Primary: accent (white) fill with ink
-/// content; secondary: dark fill with a subtle border. Use this instead of
-/// per-view ButtonStyle structs so CTAs look and press the same everywhere.
+/// content; secondary: dark fill with a subtle border; destructive: error fill
+/// with white content. Use this instead of per-view ButtonStyle structs so CTAs
+/// look and press the same everywhere.
 package struct OmiButtonStyle: ButtonStyle {
   package enum Kind {
     case primary
     case secondary
+    case destructive
   }
 
   package enum Size {
@@ -38,15 +40,63 @@ package struct OmiButtonStyle: ButtonStyle {
     size == .regular ? OmiChrome.chipRadius : OmiChrome.smallControlRadius
   }
 
+  private var foregroundColor: Color {
+    switch kind {
+    case .primary:
+      OmiColors.backgroundPrimary
+    case .secondary, .destructive:
+      OmiColors.textPrimary
+    }
+  }
+
+  private var backgroundColor: Color {
+    switch kind {
+    case .primary:
+      OmiColors.accent
+    case .secondary:
+      OmiColors.backgroundTertiary
+    case .destructive:
+      OmiColors.error
+    }
+  }
+
   package func makeBody(configuration: Configuration) -> some View {
+    OmiButtonContent(
+      configuration: configuration,
+      kind: kind,
+      fontSize: fontSize,
+      foregroundColor: foregroundColor,
+      backgroundColor: backgroundColor,
+      horizontalPadding: horizontalPadding,
+      verticalPadding: verticalPadding,
+      radius: radius
+    )
+  }
+}
+
+/// Extracted body so it can read `@Environment(\.isEnabled)` — `ButtonStyle`
+/// configurations do not expose enabled state directly.
+private struct OmiButtonContent: View {
+  let configuration: ButtonStyle.Configuration
+  let kind: OmiButtonStyle.Kind
+  let fontSize: CGFloat
+  let foregroundColor: Color
+  let backgroundColor: Color
+  let horizontalPadding: CGFloat
+  let verticalPadding: CGFloat
+  let radius: CGFloat
+
+  @Environment(\.isEnabled) private var isEnabled
+
+  var body: some View {
     configuration.label
       .scaledFont(size: fontSize, weight: .semibold)
-      .foregroundColor(kind == .primary ? OmiColors.backgroundPrimary : OmiColors.textPrimary)
+      .foregroundColor(foregroundColor)
       .padding(.horizontal, horizontalPadding)
       .padding(.vertical, verticalPadding)
       .background(
         RoundedRectangle(cornerRadius: radius, style: .continuous)
-          .fill(kind == .primary ? OmiColors.accent : OmiColors.backgroundTertiary)
+          .fill(backgroundColor)
       )
       .overlay {
         if kind == .secondary {
@@ -54,7 +104,7 @@ package struct OmiButtonStyle: ButtonStyle {
             .stroke(Color.white.opacity(0.08), lineWidth: 1)
         }
       }
-      .opacity(configuration.isPressed ? 0.92 : 1)
+      .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.45)
       .scaleEffect(configuration.isPressed ? 0.985 : 1)
       .omiAnimation(.easeOut(duration: 0.12), value: configuration.isPressed)
   }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -84,7 +84,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/Desktop/Tests/SubscriptionPlanPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionPlanPresentationTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SubscriptionPlanPresentationTests: XCTestCase {
+  func testSelectionLabelIncludesTheStartingPrice() {
+    XCTAssertEqual(
+      SubscriptionPlanPresentation.selectionLabel(
+        planTitle: "Operator", startingPrice: "$49.00/month"),
+      "Select Operator · $49.00/month"
+    )
+  }
+
+  func testSelectionLabelOmitsTheSeparatorWhenNoPriceIsAvailable() {
+    XCTAssertEqual(
+      SubscriptionPlanPresentation.selectionLabel(planTitle: "Operator", startingPrice: nil),
+      "Select Operator"
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260729-settings-style-consistency.json
+++ b/desktop/macos/changelog/unreleased/20260729-settings-style-consistency.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS settings controls with consistent provider, account, and plan selection styling"
+}

--- a/desktop/macos/e2e/flows/delete-account.yaml
+++ b/desktop/macos/e2e/flows/delete-account.yaml
@@ -5,6 +5,7 @@ description: Delete Account confirmation sheet only — never confirm deletion (
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiButtonStyle.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
 preconditions:
   - auth_ready


### PR DESCRIPTION
## Summary

- Align the Advanced AI Provider row with the surrounding setting controls.
- Standardize destructive, plan, and trial actions; plan selection now uses white text and includes the starting price.
- Remove redundant plan-picker copy and cover the shared destructive button with the Delete Account flow.

## Testing

- `xcrun swift test --package-path Desktop --filter SubscriptionPlanPresentationTests`
- `./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `OMI_APP_NAME="omi-settings-style" OMI_SIGN_IDENTITY="-" OMI_ALLOW_ADHOC_SIGN=1 ./run.sh --yolo`
- `make preflight` (all change-specific checks pass; the repository-wide Swift-format scope reports existing drift in untouched files)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

