### PR TITLE
fix(desktop): repair onboarding PTT presentation

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2663,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4923,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4918,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2587,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1658

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -1,21 +1,49 @@
 import Foundation
 
+/// Whether a presentation request is allowed to change the user's durable
+/// Floating Bar preference. Onboarding may borrow the real bar for a demo, but
+/// must leave that preference exactly as it found it.
+enum FloatingBarPreferenceMutation: Equatable {
+  case setEnabled(Bool)
+  case preserve
+
+  /// `nil` means the presentation is transient and must not write settings.
+  var persistedEnabledValue: Bool? {
+    switch self {
+    case .setEnabled(let enabled): return enabled
+    case .preserve: return nil
+    }
+  }
+}
+
 /// Shared reveal implementation for persistent settings, temporary snoozes,
 /// and direct Push-to-Talk presentation.
 extension FloatingControlBarManager {
   /// Applies the saved launch preference without overriding a temporary
   /// notification snooze. Push-to-Talk and Settings call `show()` instead.
   func showForLaunch() {
-    present(.background, persistEnabledPreference: false)
+    present(.background, preferenceMutation: .preserve)
+  }
+
+  /// Shows the real Floating Bar for an onboarding voice demo without changing
+  /// the user's saved bar setting.
+  func showForOnboardingDemo() {
+    present(.explicitUserAction, preferenceMutation: .preserve)
+  }
+
+  /// Retracts an onboarding voice demo without changing the user's saved bar
+  /// setting.
+  func hideForOnboardingDemo() {
+    retract(preferenceMutation: .preserve)
   }
 
   func present(
     _ request: FloatingBarPresentationRequest,
-    persistEnabledPreference: Bool
+    preferenceMutation: FloatingBarPreferenceMutation
   ) {
     log("FloatingControlBarManager: show() called, window=\(window != nil), isVisible=\(window?.isVisible ?? false)")
-    if persistEnabledPreference {
-      isEnabled = true
+    if let enabled = preferenceMutation.persistedEnabledValue {
+      isEnabled = enabled
     }
     guard FloatingBarPresentationPolicy.shouldPresent(request: request, isSnoozed: isSnoozed) else {
       return
@@ -41,6 +69,17 @@ extension FloatingControlBarManager {
         DispatchQueue.main.async { [weak window] in
           window?.focusInputField()
         }
+      }
+    }
+  }
+
+  func retract(preferenceMutation: FloatingBarPreferenceMutation) {
+    if let enabled = preferenceMutation.persistedEnabledValue {
+      isEnabled = enabled
+    }
+    if let window {
+      window.retractIntoNotch { [weak window] in
+        window?.orderOut(nil)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -282,9 +282,14 @@ class FloatingControlBarState: NSObject, ObservableObject {
   @MainActor
   final class PTTBarPresenter {
     private weak var barState: FloatingControlBarState?
+    private let resizeForPTT: @MainActor (Bool) -> Void
 
-    init(barState: FloatingControlBarState) {
+    init(
+      barState: FloatingControlBarState,
+      resizeForPTT: @escaping @MainActor (Bool) -> Void
+    ) {
       self.barState = barState
+      self.resizeForPTT = resizeForPTT
     }
 
     func apply(_ projection: VoiceTurnUIProjection) {
@@ -297,11 +302,12 @@ class FloatingControlBarState: NSObject, ObservableObject {
       // compete with the reducer-owned voice presentation.
       barState.dismissNotchHoverForVoicePresentation()
 
+      // Onboarding uses this same renderer. Its PTT demo must receive the
+      // same surface transition as a completed user's first voice turn.
       if shouldExpandForVoice != wasExpandedForVoice,
-        !barState.showingAIConversation,
-        UserDefaults.standard.bool(forKey: .hasCompletedOnboarding)
+        !barState.showingAIConversation
       {
-        FloatingControlBarManager.shared.resizeForPTT(expanded: shouldExpandForVoice)
+        resizeForPTT(shouldExpandForVoice)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3169,17 +3169,12 @@ class FloatingControlBarManager {
 
   /// Show the floating bar and persist the preference.
   func show() {
-    present(.explicitUserAction, persistEnabledPreference: true)
+    present(.explicitUserAction, preferenceMutation: .setEnabled(true))
   }
 
   /// Hide the floating bar and persist the preference.
   func hide() {
-    isEnabled = false
-    if let window {
-      window.retractIntoNotch { [weak window] in
-        window?.orderOut(nil)
-      }
-    }
+    retract(preferenceMutation: .setEnabled(false))
   }
 
   /// Show the floating bar temporarily without changing the user's persisted preference.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
@@ -292,8 +292,15 @@ final class VoiceTurnCoordinator {
     return activeTurn?.activeLease == lease
   }
 
-  func configure(barState: FloatingControlBarState) {
-    presenter = FloatingControlBarState.PTTBarPresenter(barState: barState)
+  func configure(
+    barState: FloatingControlBarState,
+    resizeForPTT: @escaping @MainActor (Bool) -> Void = {
+      FloatingControlBarManager.shared.resizeForPTT(expanded: $0)
+    }
+  ) {
+    presenter = FloatingControlBarState.PTTBarPresenter(
+      barState: barState,
+      resizeForPTT: resizeForPTT)
     presenter?.apply(projection)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -14,7 +14,6 @@ func byokMissingKeysHint(_ keys: [String]) -> String? {
     "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
 }
 
-
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -80,7 +79,6 @@ extension SettingsContentView {
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
   }
-
 
   var byokIncompleteHint: String? {
     byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
@@ -121,6 +121,7 @@ struct OnboardingVoiceDemoView: View {
       if let barState = FloatingControlBarManager.shared.barState {
         PushToTalkManager.shared.setup(barState: barState)
       }
+      FloatingControlBarManager.shared.showForOnboardingDemo()
       // Force live transcription for the demo via a transient, never-persisted
       // override so a quit/crash mid-step can't corrupt the saved PTT mode.
       shortcutSettings.pttTranscriptionModeDemoOverride = .live
@@ -132,6 +133,7 @@ struct OnboardingVoiceDemoView: View {
       shortcutSettings.pttTranscriptionModeDemoOverride = nil
       resetFloatingBarConversation()
       PushToTalkManager.shared.cleanup()
+      FloatingControlBarManager.shared.hideForOnboardingDemo()
     }
     .task {
       await pollOutputReadiness()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
@@ -109,7 +109,7 @@ struct OnboardingVoiceShortcutStepView: View {
       FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
       FloatingControlBarManager.shared.barState?.switchAIDraft(to: .onboardingFloating)
       resetFloatingBarConversation()
-      FloatingControlBarManager.shared.hide()
+      FloatingControlBarManager.shared.hideForOnboardingDemo()
       PushToTalkManager.shared.cleanup()
       installKeyMonitor()
     }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -522,7 +522,7 @@ extension SBOnboardingModel {
     .receive(on: DispatchQueue.main)
     .sink { [weak self] _ in self?.screenDemoDone = true }
     screenDemoPTTReady = true
-    FloatingControlBarManager.shared.show()
+    FloatingControlBarManager.shared.showForOnboardingDemo()
   }
 
   private func resetFloatingBarConversation() {
@@ -545,7 +545,7 @@ extension SBOnboardingModel {
     ShortcutSettings.shared.pttTranscriptionModeDemoOverride = nil
     resetFloatingBarConversation()
     PushToTalkManager.shared.cleanup()
-    FloatingControlBarManager.shared.hide()
+    FloatingControlBarManager.shared.hideForOnboardingDemo()
   }
 
   /// The push-to-talk chord to prompt for the voice demo.

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -594,6 +594,5 @@ final class SBOnboardingModel: ObservableObject {
     pollTasks.removeAll()
     disarmShortcutSummon()
     teardownVoiceDemo()
-    FloatingControlBarManager.shared.hide()
   }
 }

--- a/desktop/macos/Desktop/Tests/FloatingBarLaunchPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarLaunchPolicyTests.swift
@@ -30,6 +30,15 @@ final class FloatingBarLaunchPolicyTests: XCTestCase {
     )
   }
 
+  func testOnboardingDemoPreservesFloatingBarPreference() {
+    XCTAssertNil(FloatingBarPreferenceMutation.preserve.persistedEnabledValue)
+  }
+
+  func testUserVisibilityActionsStillUpdateFloatingBarPreference() {
+    XCTAssertEqual(FloatingBarPreferenceMutation.setEnabled(true).persistedEnabledValue, true)
+    XCTAssertEqual(FloatingBarPreferenceMutation.setEnabled(false).persistedEnabledValue, false)
+  }
+
   func testNormalSignedInLaunchShowsEnabledFloatingBarEvenOnNotchedDisplays() {
     XCTAssertEqual(
       FloatingBarLaunchPolicy.presentation(

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -84,7 +84,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnCoordinatorTests.swift
@@ -179,10 +179,17 @@ import XCTest
 
       let coordinator = VoiceTurnCoordinator(scheduler: ManualVoiceTurnScheduler())
       let barState = FloatingControlBarState()
-      coordinator.configure(barState: barState)
+      var resizeRequests: [Bool] = []
+      coordinator.configure(barState: barState) { expanded in
+        resizeRequests.append(expanded)
+      }
       let turnID = coordinator.begin(intent: .hold)
       XCTAssertTrue(barState.isVoiceListening)
       XCTAssertFalse(barState.isThinking)
+      XCTAssertEqual(
+        resizeRequests,
+        [true],
+        "PTT must expand its surface even while the onboarding demo is active")
 
       coordinator.publish(.selectRoute(turnID: turnID, route: .deepgramBatch))
       coordinator.publish(.finalize(turnID: turnID))

--- a/desktop/macos/changelog/unreleased/20260729-onboarding-ptt-demo.json
+++ b/desktop/macos/changelog/unreleased/20260729-onboarding-ptt-demo.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the onboarding push-to-talk demo waveform and preserved Floating Bar settings after the demo."
+}


### PR DESCRIPTION
## Summary

- Restore the shared Push-to-Talk surface transition during the onboarding demo, so the waveform expands exactly as it does after onboarding.
- Treat onboarding Floating Bar visibility as temporary so the demo cannot overwrite the user's saved Floating Bar setting.

## Testing

- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'VoiceTurnCoordinatorTests/testPresenterDerivesConsistentListeningThinkingAndTerminalUI'`
- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'FloatingBarLaunchPolicyTests'`
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `cd desktop/macos && ./test.sh`
- `cd desktop/macos && OMI_APP_NAME=omi-onboard-wave OMI_ALLOW_ADHOC_SIGN=1 ./run.sh --yolo --fast-only --no-wait`

## Invariants

- INV-CHAT-1
- INV-VOICE-1

## Failure class

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

