### PR TITLE
feat(macOS): enable drag selection for completed chat messages

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -207,7 +207,7 @@ struct ChatBubble: View {
         if let backgroundAgentSummary {
           BackgroundAgentSummaryCard(summary: backgroundAgentSummary, onOpenAgent: onOpenAgent)
         } else if !message.text.isEmpty {
-          OmiMarkdown(text: displayText, sender: message.sender)
+          OmiMarkdown(text: displayText, sender: message.sender, isStreaming: message.isStreaming)
             .padding(.horizontal, OmiSpacing.md)
             .padding(.vertical, OmiSpacing.sm)
             .background(
@@ -274,7 +274,7 @@ struct ChatBubble: View {
         return AnyView(EmptyView())
       }
       return AnyView(
-        OmiMarkdown(text: text, sender: .ai)
+        OmiMarkdown(text: text, sender: .ai, isStreaming: message.isStreaming)
           .padding(.horizontal, OmiSpacing.md)
           .padding(.vertical, OmiSpacing.sm)
           .background(OmiColors.backgroundTertiary.opacity(0.42))

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
@@ -11,11 +11,10 @@ import OmiTheme
 /// - Tables use an Omi-owned `Grid` with fixed decoration. They deliberately
 ///   avoid geometry preferences.
 ///
-/// Chat Markdown deliberately disables SwiftUI text selection. On macOS,
-/// `textSelection(.enabled)` installs AppKit-backed `SelectionOverlay` views
-/// that can form a non-converging setFont → intrinsic-size → AttributeGraph
-/// loop when a long transcript scrolls. Chat bubbles already provide a
-/// whole-message copy action; code blocks add a focused copy action.
+/// Text selection is opt-in. On macOS, `textSelection(.enabled)` installs
+/// AppKit-backed `SelectionOverlay` views, so callers must enable it only for
+/// settled message bodies—not the transcript container or streaming content.
+/// Code blocks retain their focused copy action.
 struct OmiMarkdown: View {
   enum Style: Equatable {
     case assistant
@@ -25,22 +24,40 @@ struct OmiMarkdown: View {
 
   let text: String
   let style: Style
+  let textSelectionEnabled: Bool
   @Environment(\.fontScale) private var fontScale
 
-  init(text: String, sender: ChatSender) {
+  init(text: String, sender: ChatSender, textSelectionEnabled: Bool = false) {
     self.text = text
     self.style = sender == .user ? .user : .assistant
+    self.textSelectionEnabled = textSelectionEnabled
   }
 
-  init(text: String, style: Style) {
+  init(text: String, sender: ChatSender, isStreaming: Bool) {
+    self.text = text
+    self.style = sender == .user ? .user : .assistant
+    self.textSelectionEnabled = !isStreaming
+  }
+
+  init(text: String, style: Style, textSelectionEnabled: Bool = false) {
     self.text = text
     self.style = style
+    self.textSelectionEnabled = textSelectionEnabled
   }
 
   var body: some View {
+    if textSelectionEnabled {
+      renderedContent
+        .textSelection(.enabled)
+    } else {
+      renderedContent
+        .textSelection(.disabled)
+    }
+  }
+
+  private var renderedContent: some View {
     OmiMarkdownContent(text: text, style: style, fontScale: fontScale)
       .equatable()
-      .textSelection(.disabled)
   }
 
   static func containsGFMTable(_ content: String) -> Bool {
@@ -52,9 +69,8 @@ struct OmiMarkdown: View {
 }
 
 /// Keeps parent-only UI feedback (copy checkmarks, hover chrome, ratings) from
-/// rebuilding unchanged message content. Combined with the selection-free
-/// render boundary above, this prevents AppKit font invalidations from
-/// re-entering AttributeGraph while the transcript scrolls.
+/// rebuilding unchanged message content. The selection boundary remains scoped
+/// above this value renderer so those feedback updates do not re-enter it.
 struct OmiMarkdownContent: View, Equatable {
   let text: String
   let style: OmiMarkdown.Style

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -14,7 +14,6 @@ func byokMissingKeysHint(_ keys: [String]) -> String? {
     "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
 }
 
-
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -80,7 +79,6 @@ extension SettingsContentView {
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
   }
-
 
   var byokIncompleteHint: String? {
     byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1685,8 +1685,11 @@ import XCTest
     XCTAssertFalse(tableRendererSource.contains("ScrollView"))
     XCTAssertFalse(rendererSource.contains("@State private var document"))
     XCTAssertFalse(rendererSource.contains("attrCache"))
-    XCTAssertFalse(rendererSource.contains(".textSelection(.enabled)"))
-    XCTAssertTrue(rendererSource.contains(".textSelection(.disabled)"))
+    XCTAssertTrue(
+      rendererSource.contains("if textSelectionEnabled {")
+        && rendererSource.contains(".textSelection(.enabled)")
+    )
+    XCTAssertTrue(tableRendererSource.contains(".textSelection(.disabled)"))
     XCTAssertFalse(rendererSource.contains("MarkdownTableCopyButton"))
     XCTAssertFalse(rendererSource.contains("Copy table"))
     XCTAssertFalse(chatBubbleSource.contains(".markdownTableBorderStyle"))

--- a/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
@@ -1295,11 +1295,12 @@ final class ChatTimelineContinuityTests: XCTestCase {
     )
   }
 
-  func testChatSelectionDoesNotWrapStackChromeInSelectionOverlay() throws {
+  func testChatSelectionIsLimitedToSettledMessageBodies() throws {
     // Mechanical guard for the omi-chat-continuity main-thread freeze:
     // ChatMessagesView used to apply `.textSelection(.enabled)` on the LazyVStack,
     // wrapping every agent-card header Text in SelectionOverlay and thrashing
-    // GraphHost via setFont → invalidateIntrinsicContentSize.
+    // GraphHost via setFont → invalidateIntrinsicContentSize. Settled message
+    // bodies may opt in; streaming content and stack chrome must not.
     let root = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
@@ -1321,13 +1322,16 @@ final class ChatTimelineContinuityTests: XCTestCase {
       messagesSource.contains(".textSelection(.enabled)"),
       "chat message stack must not enable selection on chrome Text views"
     )
-    XCTAssertFalse(
-      markdownSource.contains(".textSelection(.enabled)"),
-      "chat Markdown must not create SelectionOverlay views that can loop while scrolling"
+    XCTAssertTrue(
+      markdownSource.contains("if textSelectionEnabled {")
+        && markdownSource.contains(".textSelection(.enabled)")
+        && markdownSource.contains(".textSelection(.disabled)"),
+      "the markdown boundary must make body selection an explicit opt-in"
     )
     XCTAssertTrue(
-      markdownSource.contains(".textSelection(.disabled)"),
-      "the OmiMarkdown boundary must explicitly suppress inherited text selection"
+      bubbleSource.contains("isStreaming: message.isStreaming")
+        && markdownSource.contains("self.textSelectionEnabled = !isStreaming"),
+      "main-chat message bodies must enable native selection only after streaming finishes"
     )
     XCTAssertTrue(
       bubbleSource.contains(".textSelection(.disabled)"),

--- a/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import SwiftUI
 import XCTest
 
 @testable import Omi_Computer
@@ -1337,6 +1339,54 @@ final class ChatTimelineContinuityTests: XCTestCase {
       bubbleSource.contains(".textSelection(.disabled)"),
       "agent card headers must disable SelectionOverlay on truncated snippets"
     )
+  }
+
+  func testSettledMessageBodyEnablesSelectionWhileStreamingBodyDoesNot() {
+    // Behavioral coverage for the production selection branch. The source
+    // inspection tripwire above guards the forbidden patterns; this test
+    // exercises the API the chat surface uses and verifies that settled
+    // messages opt into selection while streaming messages do not.
+    let settled = OmiMarkdown(text: "Completed response", sender: .ai, isStreaming: false)
+    XCTAssertTrue(
+      settled.textSelectionEnabled,
+      "settled message bodies must enable native selection"
+    )
+
+    let streaming = OmiMarkdown(text: "Partial…", sender: .ai, isStreaming: true)
+    XCTAssertFalse(
+      streaming.textSelectionEnabled,
+      "streaming message bodies must not create SelectionOverlay views"
+    )
+  }
+
+  func testSelectableMarkdownRendersWithStableLayout() {
+    // Render a settled (selectable) message body in a real hosting view and
+    // verify the SelectionOverlay-backed content produces a finite, stable size
+    // across layout passes — the regression proxy for the prior layout loop.
+    let body = """
+      This is a completed assistant response with **bold**, `code`, and a list:
+
+      - First point
+      - Second point
+
+      It must remain selectable without reintroducing the scroll layout loop.
+      """
+    let host = NSHostingView(
+      rootView: OmiMarkdown(text: body, sender: .ai, isStreaming: false)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 480, height: 400)
+    host.layoutSubtreeIfNeeded()
+
+    let size = host.fittingSize
+    XCTAssertTrue(size.width.isFinite, "selectable body width must be finite")
+    XCTAssertTrue(size.height.isFinite, "selectable body height must be finite")
+    XCTAssertGreaterThan(size.height, 0, "selectable body must produce visible content")
+
+    // Second pass — size must not diverge (the original SelectionOverlay loop
+    // thrashed setFont → invalidateIntrinsicContentSize on every layout pass).
+    host.layoutSubtreeIfNeeded()
+    let sizeAfterRelayout = host.fittingSize
+    XCTAssertEqual(size, sizeAfterRelayout, "selectable body layout must converge")
   }
 
   func testCanonicalSurfacesBindSharedProviderMessages() throws {

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -84,7 +84,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/changelog/unreleased/20260729-selectable-chat-messages.json
+++ b/desktop/macos/changelog/unreleased/20260729-selectable-chat-messages.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added standard mouse drag selection for completed chat messages"
+}


### PR DESCRIPTION
## Summary

- Enable regular native mouse-drag selection for settled main-chat message bodies.
- Keep streaming content and transcript chrome unselectable to avoid the historical selection-overlay layout loop.
- Include the two existing formatter-only desktop Swift changes required by the repository-wide formatter gate.

## Validation

- `desktop/macos/scripts/swift-format-wrapper.sh format -i desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift`
- `xcrun swift test --package-path Desktop --filter ChatTimelineContinuityTests`
- `xcrun swift test --package-path Desktop --filter AgentPillLifecycleTests`
- Built and launched the isolated `omi-chat-select` named bundle against the offline local harness; sent a synthetic settled chat message and captured the rendered chat surface.
- `OMI_PR_BODY_FILE=/tmp/omi-chat-selection-pr.md make preflight`

## Product invariants

- INV-CHAT-1

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

