### PR TITLE
fix(desktop): restore onboarding permission and file discovery

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-onboarding.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-onboarding.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift": 2180,
-    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": 1750
+    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": 1804
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift": "Pinned swift-format normalizes line layout without changing this source's runtime behavior.",
-    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": "Onboarding serializes Calendar and Gmail's shared Safe Storage access to prevent duplicate Chrome Keychain consent prompts."
+    "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift": "Onboarding serializes Calendar and Gmail's shared Safe Storage access and binds local-file import writes to the active owner."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6269,
-    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2913
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2929
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ACP authentication terminalizes the active turn with an explicit disposition instead of awaiting OAuth, and failed bridge starts consume typed runtime diagnostics at the sole user-facing error surface to avoid a duplicate Sentry event; a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "update_action_item accepts the realtime `id` alias and backend task writes refresh TasksStore so agent-created tasks appear immediately; already-granted permissions still gate their Settings/drag-card opens behind the granted result. Swift 6: explicit @preconcurrency import ApplicationServices for AX APIs used by tool execution path."
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "update_action_item accepts the realtime `id` alias and backend task writes refresh TasksStore so agent-created tasks appear immediately; permission opens and local-file scans both stay bound to their authorized owner. Swift 6: explicit @preconcurrency import ApplicationServices for AX APIs used by tool execution path."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -67,7 +67,9 @@ actor FileIndexerService {
     guard activeScanOperations == 0 else { return }
     let waiters = scanCompletionWaiters
     scanCompletionWaiters.removeAll()
-    waiters.forEach { $0.resume() }
+    for waiter in waiters {
+      waiter.resume()
+    }
   }
 
   /// Returns the total number of indexed files in the database
@@ -163,9 +165,14 @@ actor FileIndexerService {
   /// Scan folders and store file metadata in indexed_files table
   /// Returns total number of files indexed
   @discardableResult
-  func scanFolders(_ folders: [URL], incremental: Bool = false) async -> Int {
+  func scanFolders(
+    _ folders: [URL],
+    incremental: Bool = false,
+    shouldContinue: @escaping @Sendable () -> Bool = { !Task.isCancelled }
+  ) async -> Int {
     activeScanOperations += 1
     defer { finishScanOperation() }
+    guard shouldContinue() else { return 0 }
     let db: DatabasePool
     do {
       db = try await ensureDB()
@@ -198,6 +205,7 @@ actor FileIndexerService {
     ]
 
     for folder in folders {
+      guard shouldContinue() else { return 0 }
       guard fm.fileExists(atPath: folder.path) else { continue }
 
       let folderName = folder.lastPathComponent
@@ -215,17 +223,19 @@ actor FileIndexerService {
         db: db,
         existingIndex: existingIndex,
         scannedPaths: &scannedPaths,
-        failedDirectories: &failedDirectories
+        failedDirectories: &failedDirectories,
+        shouldContinue: shouldContinue
       )
+      guard shouldContinue() else { return 0 }
     }
 
     // Flush remaining batch
-    if !batch.isEmpty {
+    if !batch.isEmpty, shouldContinue() {
       insertBatch(batch, into: db)
     }
 
     // For incremental scans, remove files that no longer exist on disk
-    if incremental && !existingIndex.isEmpty {
+    if incremental && !existingIndex.isEmpty, shouldContinue() {
       deleteRemovedFiles(
         scannedPaths: scannedPaths,
         existingPaths: Set(existingIndex.keys),
@@ -249,8 +259,10 @@ actor FileIndexerService {
     db: DatabasePool,
     existingIndex: [String: Date?],
     scannedPaths: inout Set<String>,
-    failedDirectories: inout Set<String>
+    failedDirectories: inout Set<String>,
+    shouldContinue: @escaping @Sendable () -> Bool
   ) {
+    guard shouldContinue() else { return }
     guard scanPolicy.shouldScanDirectory(atDepth: depth) else { return }
 
     let contents: [URL]
@@ -270,6 +282,7 @@ actor FileIndexerService {
     }
 
     for item in contents {
+      guard shouldContinue() else { return }
       // Check directory
       let resourceValues = try? item.resourceValues(forKeys: Set(resourceKeys))
       if resourceValues == nil {
@@ -332,7 +345,8 @@ actor FileIndexerService {
             db: db,
             existingIndex: existingIndex,
             scannedPaths: &scannedPaths,
-            failedDirectories: &failedDirectories
+            failedDirectories: &failedDirectories,
+            shouldContinue: shouldContinue
           )
           continue
         }

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingImportEvidenceService.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingImportEvidenceService.swift
@@ -2,10 +2,36 @@ import Foundation
 
 protocol ImportEvidenceBatchCreating {
   func createMemoryImportBatch(_ batch: ImportEvidenceBatch) async throws -> ImportEvidenceBatchResponse
+  func createMemoryImportBatch(
+    _ batch: ImportEvidenceBatch,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> ImportEvidenceBatchResponse
 }
 
 protocol MemoryBatchCreating {
   func createMemoriesBatch(_ memories: [MemoryBatchItem]) async throws -> BatchMemoriesResponse
+  func createMemoriesBatch(
+    _ memories: [MemoryBatchItem],
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> BatchMemoriesResponse
+}
+
+extension ImportEvidenceBatchCreating {
+  func createMemoryImportBatch(
+    _ batch: ImportEvidenceBatch,
+    authorizationSnapshot _: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> ImportEvidenceBatchResponse {
+    try await createMemoryImportBatch(batch)
+  }
+}
+
+extension MemoryBatchCreating {
+  func createMemoriesBatch(
+    _ memories: [MemoryBatchItem],
+    authorizationSnapshot _: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> BatchMemoriesResponse {
+    try await createMemoriesBatch(memories)
+  }
 }
 
 extension APIClient: ImportEvidenceBatchCreating {}
@@ -21,11 +47,12 @@ enum OnboardingImportEvidenceService {
     importRunId: String? = nil,
     sourceAccountHash: String? = nil,
     legacyMemories: [MemoryBatchItem]? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
     apiClient: ImportEvidenceBatchCreating = APIClient.shared,
     legacyApiClient: MemoryBatchCreating = APIClient.shared,
     sleep: @escaping (UInt64) async -> Void = sleepSeconds
   ) async -> (saved: Int, failed: Int) {
-    guard !artifacts.isEmpty else { return (0, 0) }
+    guard !artifacts.isEmpty, isAuthorized(authorizationSnapshot) else { return (0, 0) }
 
     let importRunId = importRunId ?? Self.newImportRunId(sourceType: sourceType)
     let artifacts = withClientDeviceProvenance(artifacts)
@@ -34,6 +61,7 @@ enum OnboardingImportEvidenceService {
     var failed = 0
 
     for chunk in chunks {
+      guard isAuthorized(authorizationSnapshot) else { return (saved, failed) }
       do {
         let response = try await createChunkWithRetry(
           chunk,
@@ -42,8 +70,10 @@ enum OnboardingImportEvidenceService {
           sourceAccountHash: sourceAccountHash,
           logPrefix: logPrefix,
           apiClient: apiClient,
+          authorizationSnapshot: authorizationSnapshot,
           sleep: sleep
         )
+        guard isAuthorized(authorizationSnapshot) else { return (saved, failed) }
         saved += response.artifactsCreated + response.artifactsDeduped
         failed += max(0, chunk.count - response.artifactsReceived)
       } catch {
@@ -52,6 +82,7 @@ enum OnboardingImportEvidenceService {
           return await OnboardingMemoryBatchImportService.save(
             legacyMemories,
             logPrefix: logPrefix,
+            authorizationSnapshot: authorizationSnapshot,
             apiClient: legacyApiClient,
             sleep: sleep
           )
@@ -88,19 +119,22 @@ enum OnboardingImportEvidenceService {
     sourceAccountHash: String?,
     logPrefix: String,
     apiClient: ImportEvidenceBatchCreating,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?,
     sleep: @escaping (UInt64) async -> Void
   ) async throws -> ImportEvidenceBatchResponse {
     var lastError: Error?
 
     for attempt in 0...retryBackoffSeconds.count {
       do {
+        guard isAuthorized(authorizationSnapshot) else { throw AuthError.userChangedDuringRequest }
         return try await apiClient.createMemoryImportBatch(
           ImportEvidenceBatch(
             sourceType: sourceType,
             importRunId: importRunId,
             sourceAccountHash: sourceAccountHash,
             items: chunk
-          )
+          ),
+          authorizationSnapshot: authorizationSnapshot
         )
       } catch {
         lastError = error
@@ -142,6 +176,11 @@ enum OnboardingImportEvidenceService {
     try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
   }
 
+  private static func isAuthorized(_ authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?) -> Bool {
+    !Task.isCancelled
+      && (authorizationSnapshot.map(RuntimeOwnerIdentity.isAuthorizationCurrent) ?? true)
+  }
+
   private static func isLegacyMemorySystemError(_ error: Error) -> Bool {
     guard case APIError.httpError(let statusCode, let detail) = error else { return false }
     if statusCode == 403 && detail == "memory_import_requires_canonical" { return true }
@@ -166,23 +205,27 @@ enum OnboardingMemoryBatchImportService {
   static func save(
     _ memories: [MemoryBatchItem],
     logPrefix: String,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
     apiClient: MemoryBatchCreating = APIClient.shared,
     sleep: @escaping (UInt64) async -> Void = sleepSeconds
   ) async -> (saved: Int, failed: Int) {
-    guard !memories.isEmpty else { return (0, 0) }
+    guard !memories.isEmpty, isAuthorized(authorizationSnapshot) else { return (0, 0) }
 
     let chunks = memories.chunked(maxSize: APIClient.memoriesBatchMaxSize)
     var saved = 0
     var failed = 0
 
     for chunk in chunks {
+      guard isAuthorized(authorizationSnapshot) else { return (saved, failed) }
       do {
         let response = try await createChunkWithRetry(
           chunk,
           logPrefix: logPrefix,
           apiClient: apiClient,
+          authorizationSnapshot: authorizationSnapshot,
           sleep: sleep
         )
+        guard isAuthorized(authorizationSnapshot) else { return (saved, failed) }
         saved += response.createdCount
         failed += max(0, chunk.count - response.createdCount)
       } catch {
@@ -198,13 +241,17 @@ enum OnboardingMemoryBatchImportService {
     _ chunk: [MemoryBatchItem],
     logPrefix: String,
     apiClient: MemoryBatchCreating,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?,
     sleep: @escaping (UInt64) async -> Void
   ) async throws -> BatchMemoriesResponse {
     var lastError: Error?
 
     for attempt in 0...retryBackoffSeconds.count {
       do {
-        return try await apiClient.createMemoriesBatch(chunk)
+        guard isAuthorized(authorizationSnapshot) else { throw AuthError.userChangedDuringRequest }
+        return try await apiClient.createMemoriesBatch(
+          chunk,
+          authorizationSnapshot: authorizationSnapshot)
       } catch {
         lastError = error
         guard shouldRetry(error), attempt < retryBackoffSeconds.count else {
@@ -243,6 +290,11 @@ enum OnboardingMemoryBatchImportService {
 
   private static func sleepSeconds(_ seconds: UInt64) async {
     try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+  }
+
+  private static func isAuthorized(_ authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?) -> Bool {
+    !Task.isCancelled
+      && (authorizationSnapshot.map(RuntimeOwnerIdentity.isAuthorizationCurrent) ?? true)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
@@ -644,7 +644,20 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     scanStatusText = "Your workspace is mapped."
   }
 
-  func refreshSnapshotIfAvailable() async {
+  func refreshSnapshotIfAvailable(
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async {
+    func isAuthorized() -> Bool {
+      guard !Task.isCancelled else { return false }
+      if let authorizationSnapshot {
+        return authorizationSnapshot.ownerID == expectedOwnerID
+          && RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot)
+      }
+      return ChatToolExecutor.isExpectedOwnerCurrent(expectedOwnerID)
+    }
+
+    guard isAuthorized() else { return }
     guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
 
     do {
@@ -777,12 +790,12 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         )
       }
 
-      guard let snapshot else { return }
+      guard isAuthorized(), let snapshot else { return }
       let previousSnapshot = scanSnapshot
       scanSnapshot = snapshot
       suggestedGoals = buildSuggestedGoals(from: snapshot)
 
-      guard previousSnapshot != snapshot else { return }
+      guard isAuthorized(), previousSnapshot != snapshot else { return }
 
       var nodes: [[String: Any]] = []
       var edges: [[String: Any]] = []
@@ -811,11 +824,19 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         edges.append(["source_id": "user", "target_id": id, "label": "stores_work_in"])
       }
 
-      if !nodes.isEmpty {
-        await saveGraph(nodes: nodes, edges: edges)
+      if !nodes.isEmpty, isAuthorized() {
+        await saveGraph(
+          nodes: nodes,
+          edges: edges,
+          expectedOwnerID: expectedOwnerID,
+          authorizationSnapshot: authorizationSnapshot)
       }
 
-      localFileMemoriesSaved = await importLocalFileMemories(from: snapshot)
+      guard isAuthorized() else { return }
+      localFileMemoriesSaved = await importLocalFileMemories(
+        from: snapshot,
+        expectedOwnerID: expectedOwnerID,
+        authorizationSnapshot: authorizationSnapshot)
     } catch {
       logError("OnboardingPagedIntroCoordinator: Failed to load scan snapshot", error: error)
     }
@@ -1487,22 +1508,50 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     return Array(NSOrderedSet(array: suggestions).array as? [String] ?? suggestions)
   }
 
-  private func executeTool(name: String, arguments: [String: Any]) async -> String {
+  private func executeTool(
+    name: String,
+    arguments: [String: Any],
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async -> String {
     await ChatToolExecutor.execute(
       ToolCall(name: name, arguments: arguments, thoughtSignature: nil),
-      isOnboardingSurface: true
+      isOnboardingSurface: true,
+      expectedOwnerID: expectedOwnerID,
+      authorizationSnapshot: authorizationSnapshot
     )
   }
 
-  private func saveGraph(nodes: [[String: Any]], edges: [[String: Any]]) async {
+  private func saveGraph(
+    nodes: [[String: Any]],
+    edges: [[String: Any]],
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async {
     guard !nodes.isEmpty else { return }
     _ = await executeTool(
       name: "save_knowledge_graph",
-      arguments: ["nodes": nodes, "edges": edges]
+      arguments: ["nodes": nodes, "edges": edges],
+      expectedOwnerID: expectedOwnerID,
+      authorizationSnapshot: authorizationSnapshot
     )
   }
 
-  private func importLocalFileMemories(from snapshot: ScanSnapshot) async -> Int {
+  private func importLocalFileMemories(
+    from snapshot: ScanSnapshot,
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async -> Int {
+    func isAuthorized() -> Bool {
+      guard !Task.isCancelled else { return false }
+      if let authorizationSnapshot {
+        return authorizationSnapshot.ownerID == expectedOwnerID
+          && RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot)
+      }
+      return ChatToolExecutor.isExpectedOwnerCurrent(expectedOwnerID)
+    }
+
+    guard isAuthorized() else { return 0 }
     if localFileMemoriesSaved > 0 {
       return localFileMemoriesSaved
     }
@@ -1512,8 +1561,9 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     }
 
     let task = Task<Int, Never> {
+      guard isAuthorized() else { return 0 }
       let drafts = await buildLocalFileMemoryDrafts(from: snapshot)
-      guard !drafts.isEmpty else { return 0 }
+      guard isAuthorized(), !drafts.isEmpty else { return 0 }
 
       // Batch the drafts through the import evidence ingress. The previous
       // implementation fanned out 12 concurrent POST /v3/memories calls
@@ -1548,15 +1598,19 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         artifacts,
         sourceType: "local_files",
         logPrefix: "OnboardingPagedIntroCoordinator",
-        legacyMemories: legacyMemories
+        legacyMemories: legacyMemories,
+        authorizationSnapshot: authorizationSnapshot
       )
+      guard isAuthorized() else { return 0 }
       let savedCount = result.saved
       log("OnboardingPagedIntroCoordinator: Saved \(savedCount) local file import evidence artifacts")
       return savedCount
     }
 
     localFileMemoryImportTask = task
-    let saved = await task.value
+    let saved = await withTaskCancellationHandler(
+      operation: { await task.value },
+      onCancel: { task.cancel() })
     localFileMemoryImportTask = nil
     return saved
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -7,6 +7,15 @@ import Foundation
 
 extension SBOnboardingModel {
   func requestPerm(_ key: String) {
+    // The user may have changed a grant in System Settings while this step was
+    // onscreen. Re-check it before opening another pane or asking macOS again.
+    refreshPermCheck(key)
+    if isGranted(key) {
+      setPermOn(key)
+      autoAdvanceIfCurrent(key)
+      return
+    }
+
     switch key {
     case "microphone":
       micState = .waiting
@@ -115,26 +124,30 @@ extension SBOnboardingModel {
     pollTasks["system_audio"]?.cancel()
     pollTasks["system_audio"] = Task { [weak self] in
       for _ in 0..<40 {  // ~20s
-        try? await Task.sleep(nanoseconds: 500_000_000)
         guard let self, !Task.isCancelled else { return }
         // Skipping this step is an explicit choice not to surface its consent.
         // Never let a late Screen Recording grant trigger the modal elsewhere.
         guard self.step == .systemAudio else { return }
         self.appState.checkScreenRecordingPermission()
-        guard self.appState.hasScreenRecordingPermission else { continue }
+        if self.appState.hasScreenRecordingPermission {
+          // A real process-tap attempt is the only truthful preflight for
+          // system audio. It completes without another prompt when consent was
+          // already granted, so reconcile it before asking the user again.
+          let granted = await self.appState.primeSystemAudioPermission()
+          guard !Task.isCancelled else { return }
+          guard granted else {
+            self.resetPermToAsk("system_audio")
+            return
+          }
 
-        let granted = await self.appState.primeSystemAudioPermission()
-        guard !Task.isCancelled else { return }
-        guard granted else {
-          self.resetPermToAsk("system_audio")
+          self.setPermOn("system_audio")
+          try? await Task.sleep(nanoseconds: 600_000_000)
+          guard !Task.isCancelled else { return }
+          self.autoAdvanceIfCurrent("system_audio")
           return
         }
 
-        self.setPermOn("system_audio")
-        try? await Task.sleep(nanoseconds: 600_000_000)
-        guard !Task.isCancelled else { return }
-        self.autoAdvanceIfCurrent("system_audio")
-        return
+        try? await Task.sleep(nanoseconds: 500_000_000)
       }
 
       guard let self, !Task.isCancelled else { return }
@@ -260,7 +273,53 @@ extension SBOnboardingModel {
   func answerMic() { advance(userAnswer: micState == .on ? "Allowed" : "Skip", to: .systemAudio) }
   func answerSystemAudio() { advance(userAnswer: sysState == .on ? "Allowed" : "Skip", to: .screen) }
   func answerScreen() { advance(userAnswer: scrState == .on ? "Allowed" : "Skip", to: .files) }
-  func answerFiles() { advance(userAnswer: fdaState == .on ? "Allowed" : "Skip", to: .accessibility) }
+  /// Restores the legacy Files-stage contract: scan what is readable after the
+  /// Full Disk Access choice, then form the aggregate local-file memories
+  /// before moving on. A skipped FDA grant still scans folders macOS permits.
+  func answerFiles() {
+    switch localFileProfileState {
+    case .idle:
+      thread.append(Msg(isOmi: false, text: fdaState == .on ? "Allowed" : "Skip"))
+      startLocalFileScan()
+    case .scanning:
+      break
+    case .complete, .failed:
+      finishFilesStep()
+    }
+  }
+
+  func startLocalFileScan() {
+    guard case .idle = localFileProfileState, localFileScanTask == nil else { return }
+    localFileProfileState = .scanning
+    let taskID = UUID()
+    localFileScanID = taskID
+    localFileScanTask = Task { [weak self] in
+      guard let self else { return }
+      defer {
+        if self.localFileScanID == taskID {
+          self.localFileScanTask = nil
+          self.localFileScanID = nil
+        }
+      }
+      let result = await self.fileScanRunner(self.appState)
+      guard !Task.isCancelled, self.step == .files, self.localFileScanID == taskID else { return }
+      self.localFileProfileState = result
+      if case .complete = result {
+        UserDefaults.standard.set(true, forKey: DefaultsKey.hasCompletedFileIndexing.rawValue)
+      }
+    }
+  }
+
+  func retryLocalFileScan() {
+    guard case .failed = localFileProfileState else { return }
+    localFileProfileState = .idle
+    startLocalFileScan()
+  }
+
+  func finishFilesStep() {
+    guard localFileProfileState.isTerminal else { return }
+    advance(userAnswer: nil, to: .accessibility)
+  }
   func answerAccessibility() { advance(userAnswer: accState == .on ? "Allowed" : "Skip", to: .automation) }
   func answerAutomation() { advance(userAnswer: autoState == .on ? "Allowed" : "Skip", to: .shortcutOpen) }
 
@@ -302,6 +361,12 @@ extension SBOnboardingModel {
     var step = target
     while let key = permissionKey(for: step) {
       refreshPermCheck(key)
+      // A pre-granted FDA permission must still visit Files once so this flow
+      // performs the required scan and aggregate-memory formation.
+      if step == .files, isGranted(key), !localFileProfileState.isTerminal {
+        setPermOn(key)
+        break
+      }
       guard isGranted(key), let next = Step(rawValue: step.rawValue + 1) else { break }
       setPermOn(key)
       step = next

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -306,6 +306,10 @@ extension SBOnboardingModel {
       self.localFileProfileState = result
       if case .complete = result {
         UserDefaults.standard.set(true, forKey: DefaultsKey.hasCompletedFileIndexing.rawValue)
+        // If the app closes before the user taps Continue, resuming at Files
+        // would otherwise run the scan and import a second time. The scan is
+        // complete, so resume at the next stage instead.
+        UserDefaults.standard.set(Step.accessibility.rawValue, forKey: Self.resumeStepKey)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -50,6 +50,22 @@ final class SBOnboardingModel: ObservableObject {
 
   enum PermState: Equatable { case ask, waiting, on }
 
+  enum LocalFileProfileState: Equatable {
+    case idle
+    case scanning
+    case complete(fileCount: Int, memoryCount: Int, deniedFolders: [String])
+    case failed(message: String)
+
+    var isTerminal: Bool {
+      switch self {
+      case .complete, .failed: true
+      case .idle, .scanning: false
+      }
+    }
+  }
+
+  typealias FileScanRunner = @MainActor (AppState) async -> LocalFileProfileState
+
   @Published var step: Step = .promise
   @Published var thread: [Msg] = []
   /// The current Omi message streaming in (nil once committed).
@@ -72,6 +88,7 @@ final class SBOnboardingModel: ObservableObject {
   @Published var fdaState: PermState = .ask  // full disk access (files)
   @Published var accState: PermState = .ask  // accessibility
   @Published var autoState: PermState = .ask  // automation / Apple Events
+  @Published var localFileProfileState: LocalFileProfileState = .idle
 
   var launchAtLogin: Bool = LaunchAtLoginManager.shared.isEnabled
 
@@ -135,8 +152,11 @@ final class SBOnboardingModel: ObservableObject {
   /// Backend writes for editable answers are per-field serialized. Revisiting a
   /// question never lets an earlier request finish after the user's revision.
   private let answerWriteGate = OnboardingAnswerWriteGate()
+  let fileScanRunner: FileScanRunner
   private let onComplete: (() -> Void)?
   var streamTask: Task<Void, Never>?
+  var localFileScanTask: Task<Void, Never>?
+  var localFileScanID: UUID?
   /// Permission-grant pollers, one per permission key. Keyed so requesting a
   /// second permission (the meetings "both" mic+system-audio step) never cancels
   /// a still-running poll for the first and strands it on "macOS…".
@@ -153,11 +173,33 @@ final class SBOnboardingModel: ObservableObject {
     appState: AppState,
     chatProvider: ChatProvider,
     importConnectorStatusStore: ImportConnectorStatusStore? = nil,
+    fileScanRunner: @escaping FileScanRunner = { appState in
+      ChatToolExecutor.onboardingAppState = appState
+      let outcome = await ChatToolExecutor.scanLocalFiles()
+      guard outcome.didCompleteSuccessfully, outcome.hasReadableUserFileTarget else {
+        return .failed(message: ConnectorImportOperations.localFilesFailureLine(for: outcome))
+      }
+
+      // Preserve the legacy post-scan owner: it derives the indexed-file
+      // snapshot, writes aggregate local-file profile evidence, and updates the
+      // knowledge graph. The conversational flow merely presents its outcome.
+      let coordinator = OnboardingPagedIntroCoordinator()
+      await coordinator.refreshSnapshotIfAvailable()
+      let fileCount = coordinator.scanSnapshot?.fileCount ?? outcome.indexedFileCount
+      if fileCount > 0, coordinator.localFileMemoriesSaved == 0 {
+        return .failed(message: "Your files were indexed, but Omi couldn't save your profile memories. Try again.")
+      }
+      return .complete(
+        fileCount: fileCount,
+        memoryCount: coordinator.localFileMemoriesSaved,
+        deniedFolders: outcome.deniedUserFolders)
+    },
     onComplete: (() -> Void)?
   ) {
     self.appState = appState
     self.chatProvider = chatProvider
     self.importConnectorStatusStore = importConnectorStatusStore
+    self.fileScanRunner = fileScanRunner
     self.onComplete = onComplete
     // Isolate any onboarding chat/voice turns to the throwaway `.onboarding()`
     // journal surface so they never pollute the real Chat tab. Cleared on
@@ -379,6 +421,13 @@ final class SBOnboardingModel: ObservableObject {
   /// Tear down any live monitors/tasks a step installed before leaving it.
   private func teardownStep(_ step: Step) {
     switch step {
+    case .files:
+      localFileScanTask?.cancel()
+      localFileScanTask = nil
+      localFileScanID = nil
+      if case .scanning = localFileProfileState {
+        localFileProfileState = .idle
+      }
     case .shortcutOpen, .shortcutTalk: disarmShortcutSummon()
     case .screenDemo: teardownVoiceDemo()
     default: break
@@ -595,6 +644,9 @@ final class SBOnboardingModel: ObservableObject {
   /// Cancel every live task/monitor this model owns. Safe to call repeatedly.
   private func teardownAll() {
     streamTask?.cancel()
+    localFileScanTask?.cancel()
+    localFileScanTask = nil
+    localFileScanID = nil
     for pollTask in pollTasks.values {
       pollTask.cancel()
     }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -175,7 +175,15 @@ final class SBOnboardingModel: ObservableObject {
     importConnectorStatusStore: ImportConnectorStatusStore? = nil,
     fileScanRunner: @escaping FileScanRunner = { appState in
       ChatToolExecutor.onboardingAppState = appState
-      let outcome = await ChatToolExecutor.scanLocalFiles()
+      guard let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
+        return .failed(message: "Please sign in again before building your local profile.")
+      }
+      let outcome = await ChatToolExecutor.scanLocalFiles(
+        expectedOwnerID: authorization.ownerID,
+        authorizationSnapshot: authorization)
+      guard !Task.isCancelled, RuntimeOwnerIdentity.isAuthorizationCurrent(authorization) else {
+        return .failed(message: "Your account changed before Omi could save your local profile.")
+      }
       guard outcome.didCompleteSuccessfully, outcome.hasReadableUserFileTarget else {
         return .failed(message: ConnectorImportOperations.localFilesFailureLine(for: outcome))
       }
@@ -184,7 +192,12 @@ final class SBOnboardingModel: ObservableObject {
       // snapshot, writes aggregate local-file profile evidence, and updates the
       // knowledge graph. The conversational flow merely presents its outcome.
       let coordinator = OnboardingPagedIntroCoordinator()
-      await coordinator.refreshSnapshotIfAvailable()
+      await coordinator.refreshSnapshotIfAvailable(
+        expectedOwnerID: authorization.ownerID,
+        authorizationSnapshot: authorization)
+      guard !Task.isCancelled, RuntimeOwnerIdentity.isAuthorizationCurrent(authorization) else {
+        return .failed(message: "Your account changed before Omi could save your local profile.")
+      }
       let fileCount = coordinator.scanSnapshot?.fileCount ?? outcome.indexedFileCount
       if fileCount > 0, coordinator.localFileMemoriesSaved == 0 {
         return .failed(message: "Your files were indexed, but Omi couldn't save your profile memories. Try again.")
@@ -423,8 +436,6 @@ final class SBOnboardingModel: ObservableObject {
     switch step {
     case .files:
       localFileScanTask?.cancel()
-      localFileScanTask = nil
-      localFileScanID = nil
       if case .scanning = localFileProfileState {
         localFileProfileState = .idle
       }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -232,10 +232,7 @@ struct SBOnboardingView: View {
       permStepWidget("screen_recording", "Screen Recording", "so I can see what you're looking at") {
         model.answerScreen()
       }
-    case .files:
-      permStepWidget("full_disk_access", "Full Disk Access", "cite your files · read-only, stays on this Mac") {
-        model.answerFiles()
-      }
+    case .files: filesWidget
     case .accessibility:
       permStepWidget("accessibility", "Accessibility", "catch your shortcut + click/type for you") {
         model.answerAccessibility()
@@ -435,6 +432,49 @@ struct SBOnboardingView: View {
       }
     }
     .frame(maxWidth: 380, alignment: .leading)
+  }
+
+  @ViewBuilder private var filesWidget: some View {
+    switch model.localFileProfileState {
+    case .idle:
+      permStepWidget("full_disk_access", "Full Disk Access", "cite your files · read-only, stays on this Mac") {
+        model.answerFiles()
+      }
+    case .scanning:
+      VStack(alignment: .leading, spacing: 10) {
+        Text("Building your local profile").geist(size: 14, weight: .medium).foregroundStyle(sb.ink)
+        HStack(spacing: 8) {
+          ProgressView().controlSize(.small)
+          Text("Scanning your projects and recent files…").geist(size: 13).foregroundStyle(sb.ink(.w45))
+        }
+      }
+      .frame(maxWidth: 380, alignment: .leading)
+    case .complete(let fileCount, let memoryCount, let deniedFolders):
+      VStack(alignment: .leading, spacing: 10) {
+        Text("Your local profile is ready").geist(size: 14, weight: .medium).foregroundStyle(sb.ink)
+        Text("\(fileCount.formatted()) files indexed · \(memoryCount) profile memories saved")
+          .geist(size: 13).foregroundStyle(sb.ink(.w45))
+        if !deniedFolders.isEmpty {
+          Text("Some folders need access later: \(deniedFolders.joined(separator: ", "))")
+            .geist(size: 12.5).foregroundStyle(sb.ink(.w45))
+        }
+        SBInkButton(title: "Continue", isDefaultAction: true) { model.finishFilesStep() }
+      }
+      .frame(maxWidth: 380, alignment: .leading)
+    case .failed(let message):
+      VStack(alignment: .leading, spacing: 10) {
+        Text("I couldn't finish scanning your files").geist(size: 14, weight: .medium).foregroundStyle(sb.ink)
+        Text(message).geist(size: 13).foregroundStyle(sb.ink(.w45))
+        HStack(spacing: 10) {
+          SBInkButton(title: "Retry") { model.retryLocalFileScan() }
+          Button("Continue without a scan") { model.finishFilesStep() }
+            .buttonStyle(.plain)
+            .geist(size: 13, weight: .medium)
+            .foregroundStyle(sb.ink(.w6))
+        }
+      }
+      .frame(maxWidth: 380, alignment: .leading)
+    }
   }
 
   /// A physical-looking keycap (symbol + key name for modifiers, centered glyph

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -458,6 +458,15 @@ struct SBOnboardingView: View {
           Text("Some folders need access later: \(deniedFolders.joined(separator: ", "))")
             .geist(size: 12.5).foregroundStyle(sb.ink(.w45))
         }
+        if model.fdaState != .on {
+          Button(model.fdaState == .waiting ? "Waiting for Full Disk Access…" : "Allow Full Disk Access") {
+            if model.fdaState == .ask { model.requestPerm("full_disk_access") }
+          }
+          .buttonStyle(.plain)
+          .disabled(model.fdaState == .waiting)
+          .geist(size: 13, weight: .medium)
+          .foregroundStyle(sb.ink(.w6))
+        }
         SBInkButton(title: "Continue", isDefaultAction: true) { model.finishFilesStep() }
       }
       .frame(maxWidth: 380, alignment: .leading)

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -2200,7 +2200,10 @@ class ChatToolExecutor {
     return outcome.summaryText
   }
 
-  static func scanLocalFiles(expectedOwnerID: String? = nil) async -> LocalFileScanOutcome {
+  static func scanLocalFiles(
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async -> LocalFileScanOutcome {
     func ownerChangedOutcome() -> LocalFileScanOutcome {
       LocalFileScanOutcome(
         hasReadableUserFileTarget: false,
@@ -2209,7 +2212,12 @@ class ChatToolExecutor {
         deniedUserFolders: [],
         summaryText: authorizedOwnerChangedResult())
     }
-    guard isExpectedOwnerCurrent(expectedOwnerID) else { return ownerChangedOutcome() }
+    func isAuthorized() -> Bool {
+      !Task.isCancelled
+        && isExpectedOwnerCurrent(expectedOwnerID, authorizationSnapshot: authorizationSnapshot)
+    }
+
+    guard isAuthorized() else { return ownerChangedOutcome() }
     let fm = FileManager.default
     let homeDir = fm.homeDirectoryForCurrentUser
     let scanTargets: [(label: String, pathForUser: String, url: URL, countsAsUserFileAccess: Bool)] = {
@@ -2256,7 +2264,7 @@ class ChatToolExecutor {
     var accessibleFolders: [URL] = []
     var readableUserFileTargetCount = 0
     for target in scanTargets {
-      guard isExpectedOwnerCurrent(expectedOwnerID) else { return ownerChangedOutcome() }
+      guard isAuthorized() else { return ownerChangedOutcome() }
       do {
         _ = try fm.contentsOfDirectory(
           at: target.url,
@@ -2283,9 +2291,17 @@ class ChatToolExecutor {
     }
 
     // Actually scan accessible folders (blocking)
-    guard isExpectedOwnerCurrent(expectedOwnerID) else { return ownerChangedOutcome() }
-    let count = await FileIndexerService.shared.scanFolders(accessibleFolders)
-    guard isExpectedOwnerCurrent(expectedOwnerID) else { return ownerChangedOutcome() }
+    guard isAuthorized() else { return ownerChangedOutcome() }
+    let shouldContinue: @Sendable () -> Bool = {
+      !Task.isCancelled
+        && ChatToolExecutor.isExpectedOwnerCurrent(
+          expectedOwnerID,
+          authorizationSnapshot: authorizationSnapshot)
+    }
+    let count = await FileIndexerService.shared.scanFolders(
+      accessibleFolders,
+      shouldContinue: shouldContinue)
+    guard isAuthorized() else { return ownerChangedOutcome() }
     log(
       "Onboarding file scan completed: \(count) files indexed, \(deniedFolders.count) folders denied"
     )
@@ -2295,7 +2311,7 @@ class ChatToolExecutor {
     var out: String
     do {
       out = try await getFileScanResultsFromDB(expectedOwnerID: expectedOwnerID)
-      guard isExpectedOwnerCurrent(expectedOwnerID) else { return ownerChangedOutcome() }
+      guard isAuthorized() else { return ownerChangedOutcome() }
     } catch {
       didCompleteSuccessfully = false
       out = "Error: \(error.localizedDescription)"

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
@@ -431,19 +431,26 @@ extension APIClient {
   struct UploadSegment: Encodable {
     let text: String
     let speaker: String
+    // swift-format-ignore
     let speaker_id: Int?
+    // swift-format-ignore
     let is_user: Bool
+    // swift-format-ignore
     let person_id: String?
     let start: Double
     let end: Double
   }
 
   struct CreateConversationFromSegmentsRequest: Encodable {
+    // swift-format-ignore
     let transcript_segments: [UploadSegment]
     let source: String
+    // swift-format-ignore
     let started_at: String?  // ISO8601
+    // swift-format-ignore
     let finished_at: String?  // ISO8601
     let language: String
+    // swift-format-ignore
     let client_conversation_id: String?
   }
 
@@ -631,6 +638,13 @@ extension APIClient {
   /// Caller is responsible for chunking input into groups of at most
   /// `memoriesBatchMaxSize`. Returns the created count from the server.
   func createMemoriesBatch(_ memories: [MemoryBatchItem]) async throws -> BatchMemoriesResponse {
+    try await createMemoriesBatch(memories, authorizationSnapshot: nil)
+  }
+
+  func createMemoriesBatch(
+    _ memories: [MemoryBatchItem],
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> BatchMemoriesResponse {
     precondition(
       memories.count <= Self.memoriesBatchMaxSize,
       "createMemoriesBatch received \(memories.count) memories, max is \(Self.memoriesBatchMaxSize)"
@@ -639,15 +653,26 @@ extension APIClient {
       let memories: [MemoryBatchItem]
     }
     let body = BatchRequest(memories: memories)
-    return try await post("v3/memories/batch", body: body)
+    return try await post("v3/memories/batch", body: body, authorizationSnapshot: authorizationSnapshot)
   }
 
   func createMemoryImportBatch(_ batch: ImportEvidenceBatch) async throws -> ImportEvidenceBatchResponse {
+    try await createMemoryImportBatch(batch, authorizationSnapshot: nil)
+  }
+
+  func createMemoryImportBatch(
+    _ batch: ImportEvidenceBatch,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> ImportEvidenceBatchResponse {
     precondition(
       batch.items.count <= Self.memoryImportBatchMaxSize,
       "createMemoryImportBatch received \(batch.items.count) artifacts, max is \(Self.memoryImportBatchMaxSize)"
     )
-    return try await post("v3/memory-imports/batch", body: batch, includeBYOK: false)
+    return try await post(
+      "v3/memory-imports/batch",
+      body: batch,
+      includeBYOK: false,
+      authorizationSnapshot: authorizationSnapshot)
   }
 
   /// Deletes a memory by ID

--- a/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
@@ -102,6 +102,20 @@ final class FileIndexerServiceTests: XCTestCase {
     XCTAssertEqual(records.first { $0.filename == "new.csv" }?.fileType, FileTypeCategory.spreadsheet.rawValue)
   }
 
+  func testScanFoldersStopsBeforeWritingAfterCancellation() async throws {
+    let root = temporaryRoot.appendingPathComponent("Documents", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    _ = try writeFile("do not index", at: root.appendingPathComponent("private.md"))
+
+    let service = FileIndexerService(databasePool: databasePool, batchSize: 1)
+    let gate = ScanContinuationGate(allowedChecks: 3)
+
+    let count = await service.scanFolders([root], shouldContinue: { gate.shouldContinue() })
+
+    XCTAssertEqual(count, 0)
+    XCTAssertTrue(try fetchIndexedRecords().isEmpty)
+  }
+
   private func writeFile(_ contents: String, at url: URL) throws -> URL {
     try FileManager.default.createDirectory(
       at: url.deletingLastPathComponent(),
@@ -116,6 +130,23 @@ final class FileIndexerServiceTests: XCTestCase {
       try IndexedFileRecord
         .order(IndexedFileRecord.Columns.path)
         .fetchAll(db)
+    }
+  }
+}
+
+private final class ScanContinuationGate: @unchecked Sendable {
+  private let lock = NSLock()
+  private var remainingChecks: Int
+
+  init(allowedChecks: Int) {
+    remainingChecks = allowedChecks
+  }
+
+  func shouldContinue() -> Bool {
+    lock.withLock {
+      guard remainingChecks > 0 else { return false }
+      remainingChecks -= 1
+      return true
     }
   }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -412,7 +412,7 @@ final class OnboardingFlowTests: XCTestCase {
     }
     XCTAssertEqual(
       secondBrainSource.components(separatedBy: "isDefaultAction: true").count - 1,
-      6,
+      7,
       "every visible second-brain proceed action must register Return")
     XCTAssertTrue(
       secondBrainSource.contains("Text(\"Continue →\")")

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -3,6 +3,18 @@ import XCTest
 @testable import Omi_Computer
 
 final class OnboardingPermissionToolTests: XCTestCase {
+  private let hasCompletedFileIndexingKey = "hasCompletedFileIndexing"
+
+  override func setUp() {
+    super.setUp()
+    UserDefaults.standard.removeObject(forKey: hasCompletedFileIndexingKey)
+  }
+
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: hasCompletedFileIndexingKey)
+    super.tearDown()
+  }
+
   func testPermissionStatusPayloadIncludesEveryPermissionAdvertisedToOnboardingAgent() {
     let statuses = ChatToolExecutor.onboardingPermissionStatusPayload(
       screenRecording: false,
@@ -73,5 +85,90 @@ final class OnboardingPermissionToolTests: XCTestCase {
 
     XCTAssertTrue(first.isCancelled)
     XCTAssertFalse(second.isCancelled)
+  }
+
+  @MainActor
+  func testFilesStageScansAndFormsProfileBeforeAdvancing() async {
+    var scanCalls = 0
+    let appState = AppState()
+    let chatProvider = ChatProvider()
+    let model = SBOnboardingModel(
+      appState: appState,
+      chatProvider: chatProvider,
+      fileScanRunner: { _ in
+        scanCalls += 1
+        return .complete(fileCount: 42, memoryCount: 3, deniedFolders: [])
+      },
+      onComplete: nil)
+    model.step = .files
+    model.fdaState = .on
+
+    model.answerFiles()
+    await model.localFileScanTask?.value
+
+    XCTAssertEqual(scanCalls, 1)
+    XCTAssertEqual(model.step, .files, "Files must wait for local profile formation")
+    XCTAssertEqual(model.localFileProfileState, .complete(fileCount: 42, memoryCount: 3, deniedFolders: []))
+    XCTAssertTrue(UserDefaults.standard.bool(forKey: hasCompletedFileIndexingKey))
+
+    model.finishFilesStep()
+
+    XCTAssertEqual(model.step, .accessibility)
+  }
+
+  @MainActor
+  func testFilesStageCanContinueAfterScanFailure() async {
+    let appState = AppState()
+    let chatProvider = ChatProvider()
+    let model = SBOnboardingModel(
+      appState: appState,
+      chatProvider: chatProvider,
+      fileScanRunner: { _ in .failed(message: "No readable folders") },
+      onComplete: nil)
+    model.step = .files
+
+    model.answerFiles()
+    await model.localFileScanTask?.value
+    model.finishFilesStep()
+
+    XCTAssertEqual(model.step, .accessibility)
+    XCTAssertFalse(UserDefaults.standard.bool(forKey: hasCompletedFileIndexingKey))
+  }
+
+  @MainActor
+  func testLeavingFilesCancelsTheScanAndAllowsARetryOnReturn() async {
+    let firstScanStarted = expectation(description: "first scan started")
+    let releaseFirstScan = expectation(description: "release first scan")
+    var scanCalls = 0
+    let appState = AppState()
+    let chatProvider = ChatProvider()
+    let model = SBOnboardingModel(
+      appState: appState,
+      chatProvider: chatProvider,
+      fileScanRunner: { _ in
+        scanCalls += 1
+        if scanCalls == 1 {
+          firstScanStarted.fulfill()
+          await self.fulfillment(of: [releaseFirstScan], timeout: 1)
+        }
+        return .complete(fileCount: 1, memoryCount: 1, deniedFolders: [])
+      },
+      onComplete: nil)
+    model.step = .files
+
+    model.answerFiles()
+    await fulfillment(of: [firstScanStarted], timeout: 1)
+    model.goBack()
+
+    XCTAssertEqual(model.localFileProfileState, .idle)
+    XCTAssertNil(model.localFileScanTask)
+
+    releaseFirstScan.fulfill()
+    model.step = .files
+    model.answerFiles()
+    await model.localFileScanTask?.value
+
+    XCTAssertEqual(scanCalls, 2)
+    XCTAssertEqual(model.localFileProfileState, .complete(fileCount: 1, memoryCount: 1, deniedFolders: []))
   }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -4,14 +4,17 @@ import XCTest
 
 final class OnboardingPermissionToolTests: XCTestCase {
   private let hasCompletedFileIndexingKey = "hasCompletedFileIndexing"
+  private let resumeStepKey = "sbOnboardingResumeStep"
 
   override func setUp() {
     super.setUp()
     UserDefaults.standard.removeObject(forKey: hasCompletedFileIndexingKey)
+    UserDefaults.standard.removeObject(forKey: resumeStepKey)
   }
 
   override func tearDown() {
     UserDefaults.standard.removeObject(forKey: hasCompletedFileIndexingKey)
+    UserDefaults.standard.removeObject(forKey: resumeStepKey)
     super.tearDown()
   }
 
@@ -110,10 +113,14 @@ final class OnboardingPermissionToolTests: XCTestCase {
     XCTAssertEqual(model.step, .files, "Files must wait for local profile formation")
     XCTAssertEqual(model.localFileProfileState, .complete(fileCount: 42, memoryCount: 3, deniedFolders: []))
     XCTAssertTrue(UserDefaults.standard.bool(forKey: hasCompletedFileIndexingKey))
+    XCTAssertEqual(
+      UserDefaults.standard.integer(forKey: SBOnboardingModel.resumeStepKey),
+      SBOnboardingModel.Step.accessibility.rawValue,
+      "a completed scan must not repeat after a relaunch before Continue")
 
     model.finishFilesStep()
 
-    XCTAssertEqual(model.step, .accessibility)
+    XCTAssertNotEqual(model.step, .files, "Files must advance even when the test host already has later TCC grants")
   }
 
   @MainActor
@@ -131,7 +138,7 @@ final class OnboardingPermissionToolTests: XCTestCase {
     await model.localFileScanTask?.value
     model.finishFilesStep()
 
-    XCTAssertEqual(model.step, .accessibility)
+    XCTAssertNotEqual(model.step, .files, "Files must advance even when the test host already has later TCC grants")
     XCTAssertFalse(UserDefaults.standard.bool(forKey: hasCompletedFileIndexingKey))
   }
 
@@ -161,9 +168,10 @@ final class OnboardingPermissionToolTests: XCTestCase {
     model.goBack()
 
     XCTAssertEqual(model.localFileProfileState, .idle)
-    XCTAssertNil(model.localFileScanTask)
+    XCTAssertNotNil(model.localFileScanTask, "a cancelled scan must finish before another scan can start")
 
     releaseFirstScan.fulfill()
+    await model.localFileScanTask?.value
     model.step = .files
     model.answerFiles()
     await model.localFileScanTask?.value

--- a/desktop/macos/changelog/unreleased/20260729-onboarding-permissions-and-local-files.json
+++ b/desktop/macos/changelog/unreleased/20260729-onboarding-permissions-and-local-files.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding permission detection and restored local file scanning and profile memories"
+}

--- a/desktop/macos/e2e/flows/connector-import.yaml
+++ b/desktop/macos/e2e/flows/connector-import.yaml
@@ -5,8 +5,10 @@ description: Typed wrap of memory_log_import_probe connector import seam
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
+  - desktop/macos/Desktop/Sources/Onboarding/OnboardingImportEvidenceService.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
   - desktop/macos/Desktop/Sources/PipeProcessRunner.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
 preconditions:
   - automation_bridge_ready
 


### PR DESCRIPTION
## Summary

- Refresh macOS permission state before re-prompting and immediately reconcile an already granted system-audio permission.
- Restore the legacy Files-stage scan and aggregate local-file memory formation, with visible progress, retry, and safe continuation after a failure.
- Bind file scanning, profile-memory import, and knowledge-graph writes to the captured signed-in owner; cancellation stops the indexer before it persists a batch or starts profile import.
- Persist completed scanning at the next step to prevent re-import after relaunch, and let users request Full Disk Access when returning to a completed Files stage.

## Validation

- `xcrun swift test --package-path Desktop --filter OnboardingPermissionToolTests --filter OnboardingFlowTests --filter FileIndexerServiceTests --filter APIClientMemoryBulkSafetyTests` (45 tests)
- `./scripts/agent-logic-harness.sh --swift-only` (529 tests)
- `python3 scripts/check_desktop_test_quality.py`
- Pinned `swift-format` and SwiftLint on every changed Swift file.
- `make preflight` with this PR body.

## Manual verification limitation

The named bundle launched, but its Omi Dev auth seed was signed out and Terminal lacks Accessibility permission, so the live signed-in onboarding/Full Disk Access path could not be exercised on this machine. The Files-stage behavior is covered by the focused production-model tests above.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->