### PR TITLE
fix(desktop): adapt layouts for compact windows

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1869,
-    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1636,
+    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1634,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3626,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4459,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3516,

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -31,8 +31,6 @@ private protocol HostingSizingConfigurable: AnyObject {
 extension NSHostingView: HostingSizingConfigurable {}
 
 struct DesktopHomeView: View {
-  private let minimumWindowWidth: CGFloat = 1200
-  private let minimumWindowHeight: CGFloat = 680
   private static let pageNavigationAnimation = Animation.easeOut(duration: 0.08)
 
   @EnvironmentObject private var appState: AppState
@@ -411,7 +409,7 @@ struct DesktopHomeView: View {
       }
     }
     .background(OmiColors.backgroundPrimary)
-    .frame(minWidth: minimumWindowWidth, minHeight: minimumWindowHeight)
+    .frame(minWidth: DesktopWindowLayoutPolicy.width, minHeight: DesktopWindowLayoutPolicy.height)
     .preferredColorScheme(.dark)
     .tint(OmiColors.accent)
     .onAppear {
@@ -500,7 +498,7 @@ struct DesktopHomeView: View {
   }
 
   private func enforceMainWindowMinimumSize() {
-    let minimumContentSize = NSSize(width: minimumWindowWidth, height: minimumWindowHeight)
+    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
     DispatchQueue.main.async {
       for window in NSApp.windows where window.title.lowercased().hasPrefix("omi") {
         window.appearance = NSAppearance(named: .darkAqua)
@@ -534,7 +532,7 @@ struct DesktopHomeView: View {
   private func installMinimumSizeGuardIfNeeded() {
     guard !Self.minimumSizeGuardInstalled else { return }
     Self.minimumSizeGuardInstalled = true
-    let minimumContentSize = NSSize(width: minimumWindowWidth, height: minimumWindowHeight)
+    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
     NotificationCenter.default.addObserver(
       forName: NSWindow.didResizeNotification, object: nil, queue: .main
     ) { notification in

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -341,10 +341,22 @@ private struct TopNavigationBarRowLayout: Layout {
     let settingsX = bounds.maxX
     let controlsX = settingsX - sizes.settings.width - Self.controlsToSettingsSpacing
 
+    // Cap navigation to the space available before the persistent controls so
+    // that an enlarged font scale (where even the compact fallback overflows)
+    // constrains navigation instead of overlapping capture/settings controls.
+    let availableNavigationWidth = max(
+      0,
+      controlsX - Self.navigationToControlsSpacing - bounds.minX
+    )
+    let navigationProposal = CGSize(
+      width: min(sizes.navigation.width, availableNavigationWidth),
+      height: sizes.navigation.height
+    )
+
     subviews[0].place(
       at: CGPoint(x: bounds.minX, y: bounds.midY),
       anchor: .leading,
-      proposal: ProposedViewSize(sizes.navigation)
+      proposal: ProposedViewSize(navigationProposal)
     )
     subviews[1].place(
       at: CGPoint(x: controlsX, y: bounds.midY),

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -19,21 +19,7 @@ struct DesktopTopBar: View {
   @State private var memoryDropdownTask: Task<Void, Never>?
   @State private var isMemoryButtonHovered = false
 
-  private struct NavItem: Identifiable {
-    let index: Int
-    let title: String
-    let icon: String
-    var id: Int { index }
-  }
-
-  private var navItems: [NavItem] {
-    [
-      NavItem(index: SidebarNavItem.dashboard.rawValue, title: "Home", icon: "house.fill"),
-      NavItem(index: SidebarNavItem.conversations.rawValue, title: "Memory", icon: "brain"),
-      NavItem(index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist"),
-      NavItem(index: SidebarNavItem.apps.rawValue, title: "Apps", icon: "puzzlepiece.fill"),
-    ]
-  }
+  private var navItems: [TopNavigationItem] { TopNavigationRoutes.primaryItems }
 
   private var newConversations: Int {
     appState.conversations.filter { $0.createdAt > sinceDate && $0.deleted != true }.count
@@ -46,17 +32,61 @@ struct DesktopTopBar: View {
   }
 
   var body: some View {
-    HStack(spacing: OmiSpacing.md) {
-      navPills
-      Spacer(minLength: OmiSpacing.md)
-      CaptureListeningControls(appState: appState, onRewind: onRewind)
-      settingsButton
-    }
+    TopNavigationBarLayout(
+      expandedNavigation: { navPills },
+      compactNavigation: { compactNavigationMenu },
+      persistentControls: { CaptureListeningControls(appState: appState, onRewind: onRewind) },
+      settings: { settingsButton }
+    )
+    .frame(maxWidth: .infinity)
     .frame(height: 44)
     .padding(.horizontal, OmiSpacing.lg)
     .padding(.vertical, OmiSpacing.sm)
     .onDisappear {
       memoryDropdownTask?.cancel()
+    }
+  }
+
+  /// The complete primary navigation remains available when the full set of
+  /// fixed-width pills will not fit beside the persistent status controls.
+  private var compactNavigationMenu: some View {
+    Menu {
+      ForEach(navItems) { item in
+        compactNavigationItem(item)
+      }
+    } label: {
+      Label("Navigate", systemImage: "sidebar.left")
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .frame(height: 32)
+    }
+    .help("Navigate")
+    .accessibilityLabel("Navigate")
+    .accessibilityIdentifier("compact-navigation-menu")
+  }
+
+  @ViewBuilder
+  private func compactNavigationItem(_ item: TopNavigationItem) -> some View {
+    if item.index == SidebarNavItem.conversations.rawValue {
+      Menu {
+        ForEach(TopNavigationRoutes.memoryDestinations) { destination in
+          Button {
+            selectMemoryDestination(destination)
+          } label: {
+            Label(destination.title, systemImage: destination.icon)
+          }
+        }
+      } label: {
+        Label(item.title, systemImage: item.icon)
+      }
+    } else {
+      Button {
+        dismissMemoryDropdown()
+        OmiMotion.withGated(.easeOut(duration: 0.08)) {
+          selectedIndex = item.index
+        }
+      } label: {
+        Label(item.title, systemImage: item.icon)
+      }
     }
   }
 
@@ -121,7 +151,7 @@ struct DesktopTopBar: View {
     }
   }
 
-  private func memoryNavigationItem(_ item: NavItem) -> some View {
+  private func memoryNavigationItem(_ item: TopNavigationItem) -> some View {
     let isSelected =
       selectedIndex == item.index && memoryDestination == .memories
     let badgeCount = newCount(for: item)
@@ -227,13 +257,134 @@ struct DesktopTopBar: View {
   /// New-item count to badge on a nav button (since Omi was last in front).
   /// The Memory hub holds both memories and conversations, so its badge sums
   /// them; Tasks badges new tasks. Home/Apps have no counter.
-  private func newCount(for item: NavItem) -> Int {
+  private func newCount(for item: TopNavigationItem) -> Int {
     switch item.index {
     case SidebarNavItem.conversations.rawValue: return newMemories + newConversations
     case SidebarNavItem.tasks.rawValue: return newTasks
     default: return 0
     }
   }
+}
+
+/// Keeps the persistent capture and settings controls visible while replacing
+/// only primary navigation with its compact menu when a whole top-bar row no
+/// longer fits. Keeping the alternatives at this level means SwiftUI measures
+/// the complete row instead of an unconstrained child of an `HStack`.
+struct TopNavigationBarLayout<
+  ExpandedNavigation: View,
+  CompactNavigation: View,
+  PersistentControls: View,
+  Settings: View
+>: View {
+  let expandedNavigation: ExpandedNavigation
+  let compactNavigation: CompactNavigation
+  let persistentControls: PersistentControls
+  let settings: Settings
+
+  init(
+    @ViewBuilder expandedNavigation: () -> ExpandedNavigation,
+    @ViewBuilder compactNavigation: () -> CompactNavigation,
+    @ViewBuilder persistentControls: () -> PersistentControls,
+    @ViewBuilder settings: () -> Settings
+  ) {
+    self.expandedNavigation = expandedNavigation()
+    self.compactNavigation = compactNavigation()
+    self.persistentControls = persistentControls()
+    self.settings = settings()
+  }
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      TopNavigationBarRowLayout {
+        expandedNavigation
+        persistentControls
+        settings
+      }
+      TopNavigationBarRowLayout {
+        compactNavigation
+        persistentControls
+        settings
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+}
+
+/// Measures a top-bar row at its no-overflow width, then pins its persistent
+/// controls to the trailing edge once `ViewThatFits` has selected it.
+private struct TopNavigationBarRowLayout: Layout {
+  private static let navigationToControlsSpacing = OmiSpacing.md * 3
+  private static let controlsToSettingsSpacing = OmiSpacing.md
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    let sizes = sizes(for: subviews)
+    return CGSize(
+      width: sizes.navigation.width + Self.navigationToControlsSpacing + sizes.controls.width
+        + Self.controlsToSettingsSpacing + sizes.settings.width,
+      height: max(sizes.navigation.height, sizes.controls.height, sizes.settings.height)
+    )
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    let sizes = sizes(for: subviews)
+    guard subviews.count == 3 else { return }
+
+    let settingsX = bounds.maxX
+    let controlsX = settingsX - sizes.settings.width - Self.controlsToSettingsSpacing
+
+    subviews[0].place(
+      at: CGPoint(x: bounds.minX, y: bounds.midY),
+      anchor: .leading,
+      proposal: ProposedViewSize(sizes.navigation)
+    )
+    subviews[1].place(
+      at: CGPoint(x: controlsX, y: bounds.midY),
+      anchor: .trailing,
+      proposal: ProposedViewSize(sizes.controls)
+    )
+    subviews[2].place(
+      at: CGPoint(x: settingsX, y: bounds.midY),
+      anchor: .trailing,
+      proposal: ProposedViewSize(sizes.settings)
+    )
+  }
+
+  private func sizes(for subviews: Subviews) -> (navigation: CGSize, controls: CGSize, settings: CGSize) {
+    guard subviews.count == 3 else { return (.zero, .zero, .zero) }
+    return (
+      subviews[0].sizeThatFits(.unspecified),
+      subviews[1].sizeThatFits(.unspecified),
+      subviews[2].sizeThatFits(.unspecified)
+    )
+  }
+}
+
+struct TopNavigationItem: Identifiable, Equatable {
+  let index: Int
+  let title: String
+  let icon: String
+
+  var id: Int { index }
+}
+
+enum TopNavigationRoutes {
+  static let primaryItems = [
+    TopNavigationItem(index: SidebarNavItem.dashboard.rawValue, title: "Home", icon: "house.fill"),
+    TopNavigationItem(index: SidebarNavItem.conversations.rawValue, title: "Memory", icon: "brain"),
+    TopNavigationItem(index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist"),
+    TopNavigationItem(index: SidebarNavItem.apps.rawValue, title: "Apps", icon: "puzzlepiece.fill"),
+  ]
+
+  static let memoryDestinations = MemoryHubDestination.allCases
 }
 
 enum TopNavigationPillMetrics {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+/// The full desktop experience must fit on a 1024pt-wide display. Individual
+/// rows choose compact layouts below their preferred width; this is only the
+/// floor that keeps AppKit from restoring a window wider than the display.
+enum DesktopWindowLayoutPolicy {
+  static let width: CGFloat = 800
+  static let height: CGFloat = 680
+  static let minimumContentSize = NSSize(width: width, height: height)
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 enum AppsHeaderMetrics {
   static let searchFieldMaxWidth: CGFloat = 360
+  static let searchFieldMinWidth: CGFloat = 200
   static let controlIconSize: CGFloat = 16
   static let controlHeight: CGFloat = 44
 }
@@ -31,7 +32,10 @@ struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: 
     ViewThatFits(in: .horizontal) {
       HStack(spacing: OmiSpacing.md) {
         search
-          .frame(maxWidth: AppsHeaderMetrics.searchFieldMaxWidth)
+          .frame(
+            minWidth: AppsHeaderMetrics.searchFieldMinWidth,
+            maxWidth: AppsHeaderMetrics.searchFieldMaxWidth
+          )
         filters
           .fixedSize(horizontal: true, vertical: false)
         create
@@ -40,7 +44,7 @@ struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: 
 
       VStack(alignment: .leading, spacing: OmiSpacing.sm) {
         HStack(spacing: OmiSpacing.sm) {
-          search
+          search.frame(minWidth: AppsHeaderMetrics.searchFieldMinWidth)
           dismiss
         }
 
@@ -49,6 +53,20 @@ struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: 
             .fixedSize(horizontal: true, vertical: false)
           create
         }
+      }
+
+      // The real filter controls have a fixed minimum width. Once they no
+      // longer fit with Create App, give each control group its own row.
+      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+        HStack(spacing: OmiSpacing.sm) {
+          search
+          dismiss
+        }
+
+        filters
+          .fixedSize(horizontal: true, vertical: false)
+
+        create
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -14,7 +14,6 @@ func byokMissingKeysHint(_ keys: [String]) -> String? {
     "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
 }
 
-
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -80,7 +79,6 @@ extension SettingsContentView {
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
   }
-
 
   var byokIncompleteHint: String? {
     byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -319,6 +319,12 @@ struct SettingsSearchItem: Identifiable {
   ]
 }
 
+enum SettingsSidebarMetrics {
+  static let expandedWidth: CGFloat = 260
+  static let horizontalInset: CGFloat = OmiSpacing.sm
+  static let itemAvailableWidth = expandedWidth - 2 * horizontalInset
+}
+
 /// Settings sidebar that replaces the main sidebar when in settings
 struct SettingsSidebar: View {
   @Binding var selectedSection: SettingsContentView.SettingsSection
@@ -329,7 +335,6 @@ struct SettingsSidebar: View {
   @State private var searchQuery = ""
   @FocusState private var isSearchFocused: Bool
 
-  private let expandedWidth: CGFloat = 260
   private let iconWidth: CGFloat = 20
   // Merged nav: `.account` hosts Account & Plan (renders `.planUsage` content
   // too) and `.notifications` hosts Notifications & Privacy (renders `.privacy`
@@ -411,7 +416,7 @@ struct SettingsSidebar: View {
 
       Spacer()
     }
-    .frame(width: expandedWidth)
+    .frame(width: SettingsSidebarMetrics.expandedWidth)
     .background(OmiColors.backgroundPrimary)
   }
 
@@ -548,6 +553,9 @@ struct SettingsSidebarItem: View {
             Text(section.displayTitle)
               .scaledFont(size: OmiType.body, weight: isSelected ? .medium : .regular)
               .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
+              .lineLimit(1)
+              .fixedSize(horizontal: true, vertical: false)
+              .layoutPriority(1)
 
             Spacer()
           }

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -554,7 +554,7 @@ struct SettingsSidebarItem: View {
               .scaledFont(size: OmiType.body, weight: isSelected ? .medium : .regular)
               .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
               .lineLimit(1)
-              .fixedSize(horizontal: true, vertical: false)
+              .truncationMode(.tail)
               .layoutPriority(1)
 
             Spacer()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
@@ -49,83 +49,82 @@ struct OnboardingFloatingBarDemoView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
-
-      // Content
-      VStack(spacing: OmiSpacing.xxl) {
-        VStack(spacing: OmiSpacing.md) {
-          if !barActivated {
-            Text("Omi sees your screen and gives you hyper-personalized responses")
-              .font(.system(size: 20, weight: .bold))
-              .foregroundColor(OmiColors.textPrimary)
-              .multilineTextAlignment(.center)
-              .frame(maxWidth: 560)
-
-            Text("Press this shortcut to try it.")
-              .font(.system(size: 18, weight: .medium))
-              .foregroundColor(OmiColors.textSecondary)
-              .multilineTextAlignment(.center)
-          } else {
-            Text("Omi is answering 'Which computer should I buy?' in the floating bar")
-              .font(.system(size: 24, weight: .bold))
-              .foregroundColor(OmiColors.textPrimary)
-              .lineLimit(1)
-              .fixedSize()
-          }
-        }
-
-        if !barActivated {
+      // Keep the header/progress chrome fixed. The interactive content is
+      // centered when it fits and becomes vertically scrollable when a compact
+      // display or expanded response would otherwise clip the action row.
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
           VStack(spacing: OmiSpacing.md) {
-            HStack(spacing: OmiSpacing.xs) {
-              ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) {
-                index, symbol in
-                if index > 0 {
-                  Text("+")
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(OmiColors.textTertiary)
-                }
-                keyCap(symbol, isPressed: pressedTokens.contains(symbol))
-              }
+            if !barActivated {
+              Text("Omi sees your screen and gives you hyper-personalized responses")
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(OmiColors.textPrimary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 560)
+
+              Text("Press this shortcut to try it.")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(OmiColors.textSecondary)
+                .multilineTextAlignment(.center)
+            } else {
+              Text("Omi is answering 'Which computer should I buy?' in the floating bar")
+                .font(.system(size: 24, weight: .bold))
+                .foregroundColor(OmiColors.textPrimary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
             }
-
-            Text("Omi answers in the floating bar at the top of your screen.")
-              .font(.system(size: 13))
-              .foregroundColor(OmiColors.textTertiary)
           }
-          .padding(.top, OmiSpacing.xxs)
-          .transition(.opacity)
-        } else {
-          MacLineupPreview()
-            .frame(maxWidth: 980)
-            .transition(.opacity.combined(with: .move(edge: .bottom)))
-        }
 
-      }
-      .padding(.top, 88)
-      .padding(.horizontal, OmiSpacing.page)
+          if !barActivated {
+            VStack(spacing: OmiSpacing.md) {
+              HStack(spacing: OmiSpacing.xs) {
+                ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) {
+                  index, symbol in
+                  if index > 0 {
+                    Text("+")
+                      .font(.system(size: 15, weight: .medium))
+                      .foregroundColor(OmiColors.textTertiary)
+                  }
+                  keyCap(symbol, isPressed: pressedTokens.contains(symbol))
+                }
+              }
 
-      Spacer()
-
-      // Bottom row — back is always available; Continue appears after the AI responds
-      HStack(spacing: OmiSpacing.md) {
-        OnboardingBackButton()
-
-        if showContinue {
-          Button(action: onComplete) {
-            Text("Continue")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundColor(.black)
-              .frame(maxWidth: 280)
-              .padding(.vertical, OmiSpacing.md)
-              .background(Color.white)
-              .cornerRadius(OmiChrome.smallControlRadius)
+              Text("Omi answers in the floating bar at the top of your screen.")
+                .font(.system(size: 13))
+                .foregroundColor(OmiColors.textTertiary)
+            }
+            .padding(.top, OmiSpacing.xxs)
+            .transition(.opacity)
+          } else {
+            MacLineupPreview()
+              .frame(maxWidth: 980)
+              .transition(.opacity.combined(with: .move(edge: .bottom)))
           }
-          .buttonStyle(.plain)
-          .keyboardShortcut(.defaultAction)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+
         }
+        .frame(maxWidth: 980)
+      } actions: {
+        // Back/Continue stays visible while the response preview scrolls.
+        HStack(spacing: OmiSpacing.md) {
+          OnboardingBackButton()
+
+          if showContinue {
+            Button(action: onComplete) {
+              Text("Continue")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.black)
+                .frame(maxWidth: 280)
+                .padding(.vertical, OmiSpacing.md)
+                .background(Color.white)
+                .cornerRadius(OmiChrome.smallControlRadius)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+          }
+        }
+        .frame(maxWidth: 980)
       }
-      .padding(.bottom, OmiSpacing.section)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarShortcutStepView.swift
@@ -52,39 +52,45 @@ struct OnboardingFloatingBarShortcutStepView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
+          Text("Let's set the \"Open Omi\" shortcut.\nPress this shortcut. Do the buttons light up?")
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundColor(OmiColors.textPrimary)
+            .multilineTextAlignment(.center)
 
-      VStack(spacing: OmiSpacing.xxl) {
-        Text("Let's set the \"Open Omi\" shortcut.\nPress this shortcut. Do the buttons light up?")
-          .font(.system(size: 22, weight: .semibold))
-          .foregroundColor(OmiColors.textPrimary)
-          .multilineTextAlignment(.center)
-
-        RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
-          .fill(OmiColors.backgroundSecondary)
-          .frame(height: 152)
-          .frame(maxWidth: 480)
-          .overlay {
-            shortcutKeyPreview
-          }
-
-        VStack(spacing: OmiSpacing.md) {
-          Text("Choose a different shortcut:")
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-
-          HStack(spacing: OmiSpacing.sm) {
-            ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
-              shortcutChoiceButton(shortcut)
+          RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+            .frame(height: 152)
+            .frame(maxWidth: 480)
+            .overlay {
+              shortcutKeyPreview
             }
-            customShortcutButton
+
+          VStack(spacing: OmiSpacing.md) {
+            Text("Choose a different shortcut:")
+              .font(.system(size: 14, weight: .medium))
+              .foregroundColor(OmiColors.textSecondary)
+
+            LazyVGrid(
+              columns: [GridItem(.adaptive(minimum: 92), spacing: OmiSpacing.sm)],
+              alignment: .center,
+              spacing: OmiSpacing.sm
+            ) {
+              ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
+                shortcutChoiceButton(shortcut)
+              }
+              customShortcutButton
+            }
+
+            if isRecordingCustomShortcut || shortcutSettings.askOmiUsesCustomShortcut || captureError != nil {
+              customShortcutRecorder
+            }
           }
 
-          if isRecordingCustomShortcut || shortcutSettings.askOmiUsesCustomShortcut || captureError != nil {
-            customShortcutRecorder
-          }
         }
-
+        .frame(maxWidth: 480)
+      } actions: {
         HStack(spacing: OmiSpacing.md) {
           OnboardingBackButton()
 
@@ -105,9 +111,8 @@ struct OnboardingFloatingBarShortcutStepView: View {
             .transition(.move(edge: .bottom).combined(with: .opacity))
           }
         }
+        .frame(maxWidth: 480)
       }
-
-      Spacer()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingStepScaffold.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingStepScaffold.swift
@@ -52,6 +52,58 @@ enum OnboardingLayoutMode {
   case centered
 }
 
+/// Keeps the onboarding chrome visible while allowing a step's content to
+/// scroll only when a compact window cannot contain it. The minimum-height
+/// frame preserves the existing centered composition at ordinary sizes.
+struct OnboardingCenteredContentRegion<Content: View>: View {
+  let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      ScrollView(showsIndicators: false) {
+        content
+          .frame(maxWidth: .infinity)
+          .frame(minHeight: geometry.size.height, alignment: .center)
+          .padding(.horizontal, OmiSpacing.page)
+          .padding(.vertical, OmiSpacing.section)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+    }
+  }
+}
+
+/// Splits an onboarding step into scrollable content and persistent navigation
+/// actions. Keeping the footer outside the scroll view ensures users can
+/// always go back or continue, even while a compact-height window scrolls the
+/// larger instructional content.
+struct OnboardingContentWithPinnedActions<Content: View, Actions: View>: View {
+  let content: Content
+  let actions: Actions
+
+  init(
+    @ViewBuilder content: () -> Content,
+    @ViewBuilder actions: () -> Actions
+  ) {
+    self.content = content()
+    self.actions = actions()
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      OnboardingCenteredContentRegion { content }
+        .frame(maxHeight: .infinity)
+
+      actions
+        .padding(.horizontal, OmiSpacing.page)
+        .padding(.bottom, OmiSpacing.section)
+    }
+  }
+}
+
 struct OnboardingStepScaffold<Content: View>: View {
   @ObservedObject private var graphViewModel: MemoryGraphViewModel
   @Environment(\.onboardingJumpTo) private var onboardingJumpTo

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
@@ -45,71 +45,70 @@ struct OnboardingVoiceDemoView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
-
-      VStack(spacing: OmiSpacing.xxl) {
-        VStack(spacing: OmiSpacing.md) {
-          Text("Hold \(shortcutSettings.pttShortcut.displayLabel) and Ask")
-            .font(.system(size: 24, weight: .bold))
-            .foregroundColor(OmiColors.textPrimary)
-
-          Text("Try asking: What's on my screen?")
-            .font(.system(size: 18, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-            .multilineTextAlignment(.center)
-        }
-
-        if outputReadiness.shouldAskUserToTurnUpVolume {
-          volumeWarning
-            .transition(.opacity)
-        } else if !observedShortcutPress {
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
           VStack(spacing: OmiSpacing.md) {
-            Text("Hold the shortcut, speak, then release")
-              .font(.system(size: 13))
-              .foregroundColor(OmiColors.textTertiary)
+            Text("Hold \(shortcutSettings.pttShortcut.displayLabel) and Ask")
+              .font(.system(size: 24, weight: .bold))
+              .foregroundColor(OmiColors.textPrimary)
 
-            HStack(spacing: OmiSpacing.xs) {
-              ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
-                keyCap(token)
-              }
-              Text("hold")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(OmiColors.textTertiary)
-            }
+            Text("Try asking: What's on my screen?")
+              .font(.system(size: 18, weight: .medium))
+              .foregroundColor(OmiColors.textSecondary)
+              .multilineTextAlignment(.center)
           }
-          .padding(.top, OmiSpacing.xxs)
-          .transition(.opacity)
-        } else if !showContinue {
-          Text(waitingForResponse ? "Waiting for omi to respond..." : "Listening... release when done")
-            .font(.system(size: 13))
-            .foregroundColor(OmiColors.textTertiary)
+
+          if outputReadiness.shouldAskUserToTurnUpVolume {
+            volumeWarning
+              .transition(.opacity)
+          } else if !observedShortcutPress {
+            VStack(spacing: OmiSpacing.md) {
+              Text("Hold the shortcut, speak, then release")
+                .font(.system(size: 13))
+                .foregroundColor(OmiColors.textTertiary)
+
+              HStack(spacing: OmiSpacing.xs) {
+                ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                  keyCap(token)
+                }
+                Text("hold")
+                  .font(.system(size: 13, weight: .medium))
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            }
             .padding(.top, OmiSpacing.xxs)
             .transition(.opacity)
-        }
-      }
-      .padding(.horizontal, OmiSpacing.page)
-
-      Spacer()
-
-      HStack(spacing: OmiSpacing.md) {
-        OnboardingBackButton()
-
-        if showContinue {
-          Button(action: onComplete) {
-            Text("Continue")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundColor(.black)
-              .frame(maxWidth: 280)
-              .padding(.vertical, OmiSpacing.md)
-              .background(Color.white)
-              .cornerRadius(OmiChrome.smallControlRadius)
+          } else if !showContinue {
+            Text(waitingForResponse ? "Waiting for omi to respond..." : "Listening... release when done")
+              .font(.system(size: 13))
+              .foregroundColor(OmiColors.textTertiary)
+              .padding(.top, OmiSpacing.xxs)
+              .transition(.opacity)
           }
-          .buttonStyle(.plain)
-          .keyboardShortcut(.defaultAction)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+
         }
+        .frame(maxWidth: 420)
+      } actions: {
+        HStack(spacing: OmiSpacing.md) {
+          OnboardingBackButton()
+
+          if showContinue {
+            Button(action: onComplete) {
+              Text("Continue")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.black)
+                .frame(maxWidth: 280)
+                .padding(.vertical, OmiSpacing.md)
+                .background(Color.white)
+                .cornerRadius(OmiChrome.smallControlRadius)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+          }
+        }
+        .frame(maxWidth: 420)
       }
-      .padding(.bottom, OmiSpacing.section)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
@@ -46,39 +46,45 @@ struct OnboardingVoiceShortcutStepView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
+          Text("Let's set \"Audio ask a question\" shortcut.\nPress and hold to test. Does the button light up?")
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundColor(OmiColors.textPrimary)
+            .multilineTextAlignment(.center)
 
-      VStack(spacing: OmiSpacing.xxl) {
-        Text("Let's set \"Audio ask a question\" shortcut.\nPress and hold to test. Does the button light up?")
-          .font(.system(size: 22, weight: .semibold))
-          .foregroundColor(OmiColors.textPrimary)
-          .multilineTextAlignment(.center)
-
-        RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
-          .fill(OmiColors.backgroundSecondary)
-          .frame(height: 128)
-          .frame(maxWidth: 420)
-          .overlay {
-            shortcutKeyPreview
-          }
-
-        VStack(spacing: OmiSpacing.md) {
-          Text("Try another shortcut if it doesn't react:")
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-
-          HStack(spacing: OmiSpacing.sm) {
-            ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
-              shortcutChoiceButton(shortcut)
+          RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+            .frame(height: 128)
+            .frame(maxWidth: 420)
+            .overlay {
+              shortcutKeyPreview
             }
-            customShortcutButton
+
+          VStack(spacing: OmiSpacing.md) {
+            Text("Try another shortcut if it doesn't react:")
+              .font(.system(size: 14, weight: .medium))
+              .foregroundColor(OmiColors.textSecondary)
+
+            LazyVGrid(
+              columns: [GridItem(.adaptive(minimum: 92), spacing: OmiSpacing.sm)],
+              alignment: .center,
+              spacing: OmiSpacing.sm
+            ) {
+              ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
+                shortcutChoiceButton(shortcut)
+              }
+              customShortcutButton
+            }
+
+            if isRecordingCustomShortcut || shortcutSettings.pttUsesCustomShortcut || captureError != nil {
+              customShortcutRecorder
+            }
           }
 
-          if isRecordingCustomShortcut || shortcutSettings.pttUsesCustomShortcut || captureError != nil {
-            customShortcutRecorder
-          }
         }
-
+        .frame(maxWidth: 420)
+      } actions: {
         HStack(spacing: OmiSpacing.md) {
           OnboardingBackButton()
 
@@ -99,9 +105,8 @@ struct OnboardingVoiceShortcutStepView: View {
             .transition(.move(edge: .trailing).combined(with: .opacity))
           }
         }
+        .frame(maxWidth: 420)
       }
-
-      Spacer()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -6,6 +6,19 @@ enum SBOnboardingRepository {
   static let url = URL(string: "https://github.com/BasedHardware/omi")!
 }
 
+enum SBOnboardingPanelLayout {
+  static let maximumSize = CGSize(width: 540, height: 640)
+  static let horizontalInset: CGFloat = 24
+  static let verticalInset: CGFloat = 20
+
+  static func size(in availableSize: CGSize) -> CGSize {
+    CGSize(
+      width: min(maximumSize.width, max(0, availableSize.width - horizontalInset * 2)),
+      height: min(maximumSize.height, max(0, availableSize.height - verticalInset * 2))
+    )
+  }
+}
+
 /// The Second Brain conversational onboarding — a chat with Omi that streams
 /// word-by-word and performs real side-effects. Replaces the legacy wizard.
 struct SBOnboardingView: View {
@@ -55,39 +68,23 @@ struct SBOnboardingView: View {
       } else {
         SBWallpaper()
       }
-      panel
-        .frame(width: 540, height: min(640, 900))
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      GeometryReader { geometry in
+        let panelSize = SBOnboardingPanelLayout.size(in: geometry.size)
+        panel
+          .frame(width: panelSize.width, height: panelSize.height)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
     }
     .overlay(alignment: .topTrailing) {
-      HStack(spacing: 8) {
-        if model.canGoBack {
-          Button(action: { model.goBack() }) {
-            Text("← Back")
-              .geist(size: 13).foregroundStyle(sb.ink(.w75))
-              .padding(.horizontal, 14).padding(.vertical, 7)
-              .background(
-                Capsule().fill(Color.white.opacity(0.06))
-                  .background(.ultraThinMaterial, in: Capsule())
-              )
-              .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
-          }
-          .buttonStyle(.plain)
-          .help("Go back and change an earlier answer")
+      ViewThatFits(in: .horizontal) {
+        HStack(spacing: 8) {
+          backButton
+          skipButton
         }
-
-        Button(action: { model.skip() }) {
-          Text("Skip")
-            .geist(size: 13).foregroundStyle(sb.ink(.w45))
-            .padding(.horizontal, 14).padding(.vertical, 7)
-            .background(
-              Capsule().fill(Color.white.opacity(0.06))
-                .background(.ultraThinMaterial, in: Capsule())
-            )
-            .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+        VStack(alignment: .trailing, spacing: 8) {
+          backButton
+          skipButton
         }
-        .buttonStyle(.plain)
-        .help("Skip onboarding and go to your second brain")
       }
       .padding(.top, 20).padding(.trailing, 24)
     }
@@ -158,6 +155,38 @@ struct SBOnboardingView: View {
     )
     .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(Color.white.opacity(0.12), lineWidth: 1))
     .shadow(color: .black.opacity(0.5), radius: 60, y: 30)
+  }
+
+  @ViewBuilder private var backButton: some View {
+    if model.canGoBack {
+      Button(action: { model.goBack() }) {
+        Text("← Back")
+          .geist(size: 13).foregroundStyle(sb.ink(.w75))
+          .padding(.horizontal, 14).padding(.vertical, 7)
+          .background(
+            Capsule().fill(Color.white.opacity(0.06))
+              .background(.ultraThinMaterial, in: Capsule())
+          )
+          .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+      }
+      .buttonStyle(.plain)
+      .help("Go back and change an earlier answer")
+    }
+  }
+
+  private var skipButton: some View {
+    Button(action: { model.skip() }) {
+      Text("Skip")
+        .geist(size: 13).foregroundStyle(sb.ink(.w45))
+        .padding(.horizontal, 14).padding(.vertical, 7)
+        .background(
+          Capsule().fill(Color.white.opacity(0.06))
+            .background(.ultraThinMaterial, in: Capsule())
+        )
+        .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+    .help("Skip onboarding and go to your second brain")
   }
 
   private func scrollDown(_ proxy: ScrollViewProxy) {

--- a/desktop/macos/Desktop/Sources/SignInView.swift
+++ b/desktop/macos/Desktop/Sources/SignInView.swift
@@ -91,7 +91,11 @@ struct SignInView: View {
                 leading: { GoogleLogo().frame(width: 15, height: 15) },
                 action: { signIn(apple: false) })
             }
-            .frame(width: 320)
+            // This used to be a fixed 320pt column. When the window was
+            // narrower (or its usable width was reduced by window chrome),
+            // both sign-in actions extended past the visible content area.
+            .frame(maxWidth: 320)
+            .frame(maxWidth: .infinity)
             .padding(.top, 34)
 
             if authState.isLoading {
@@ -110,7 +114,8 @@ struct SignInView: View {
               Text(UserFacingErrorPresentation.message(from: error, while: .signIn))
                 .geist(size: 12.5).foregroundStyle(sb.ink(.w6))
                 .multilineTextAlignment(.center)
-                .frame(width: 320)
+                .frame(maxWidth: 320)
+                .frame(maxWidth: .infinity)
                 .padding(.top, 12)
             }
 
@@ -123,6 +128,7 @@ struct SignInView: View {
         }
       }
       .frame(maxWidth: 460)
+      .padding(.horizontal, 24)
       .animation(.easeOut(duration: 0.5), value: introRevealed)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/desktop/macos/Desktop/Tests/AppsHeaderRowLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsHeaderRowLayoutTests.swift
@@ -32,6 +32,30 @@ final class AppsHeaderRowLayoutTests: XCTestCase {
     }
   }
 
+  func testCreateControlMovesBelowFiltersWhenTheCompactRowWouldOverflow() {
+    let recorder = AppsHeaderLayoutRecorder()
+    let width: CGFloat = 380
+    layOut(
+      width: width,
+      recorder: recorder,
+      filters: Color.clear.frame(width: 280, height: AppsHeaderMetrics.controlHeight)
+    )
+
+    guard let filters = recorder.frame(of: .filters),
+      let create = recorder.frame(of: .create)
+    else {
+      return XCTFail("the compact header controls never laid out")
+    }
+
+    XCTAssertLessThanOrEqual(filters.maxX, width + 0.5)
+    XCTAssertLessThanOrEqual(create.maxX, width + 0.5)
+    XCTAssertGreaterThanOrEqual(
+      create.minY,
+      filters.maxY - 0.5,
+      "Create App should move below filters instead of extending the compact row"
+    )
+  }
+
   func testAppsToolbarControlsShareTheSearchFieldHeight() {
     let recorder = AppsHeaderLayoutRecorder()
     let host = NSHostingView(
@@ -77,6 +101,14 @@ final class AppsHeaderRowLayoutTests: XCTestCase {
   }
 
   private func layOut(width: CGFloat, recorder: AppsHeaderLayoutRecorder) {
+    layOut(width: width, recorder: recorder, filters: AppsHeaderFilterFixture())
+  }
+
+  private func layOut<Filters: View>(
+    width: CGFloat,
+    recorder: AppsHeaderLayoutRecorder,
+    filters: Filters
+  ) {
     let host = NSHostingView(
       rootView: AppsHeaderRow(
         search: {
@@ -86,10 +118,14 @@ final class AppsHeaderRowLayoutTests: XCTestCase {
         },
         filters: {
           AppsHeaderLayoutProbe(recorder: recorder, slot: .filters) {
-            AppsHeaderFilterFixture()
+            filters
           }
         },
-        create: { Color.clear.frame(width: 100, height: AppsHeaderMetrics.controlHeight) },
+        create: {
+          AppsHeaderLayoutProbe(recorder: recorder, slot: .create) {
+            Color.clear.frame(width: 100, height: AppsHeaderMetrics.controlHeight)
+          }
+        },
         dismiss: { EmptyView() }
       )
       .frame(width: width)

--- a/desktop/macos/Desktop/Tests/DesktopWindowLayoutPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopWindowLayoutPolicyTests.swift
@@ -1,0 +1,15 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopWindowLayoutPolicyTests: XCTestCase {
+  func testMainWindowMinimumFitsA1024PointWideDisplay() {
+    XCTAssertLessThanOrEqual(
+      DesktopWindowLayoutPolicy.minimumContentSize.width,
+      1024,
+      "The responsive main window must fit common compact desktop displays."
+    )
+    XCTAssertEqual(DesktopWindowLayoutPolicy.minimumContentSize.height, 680)
+  }
+}

--- a/desktop/macos/Desktop/Tests/OnboardingPinnedActionsLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPinnedActionsLayoutTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class OnboardingPinnedActionsLayoutTests: XCTestCase {
+  func testActionsStayInsideCompactViewportWhenContentOverflows() {
+    let recorder = OnboardingActionLayoutRecorder()
+    let host = NSHostingView(
+      rootView: OnboardingContentWithPinnedActions {
+        Color.clear.frame(width: 280, height: 600)
+      } actions: {
+        OnboardingActionLayoutProbe(recorder: recorder) {
+          Color.clear.frame(width: 160, height: 40)
+        }
+      }
+      .frame(width: 320, height: 180)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+    host.layoutSubtreeIfNeeded()
+
+    guard let actionFrame = recorder.frame else {
+      return XCTFail("the pinned action row was never placed")
+    }
+    XCTAssertGreaterThanOrEqual(actionFrame.minY, -0.5)
+    XCTAssertLessThanOrEqual(actionFrame.maxY, 180.5)
+  }
+}
+
+private final class OnboardingActionLayoutRecorder: @unchecked Sendable {
+  private(set) var frame: CGRect?
+
+  func record(_ frame: CGRect) {
+    self.frame = frame
+  }
+}
+
+private struct OnboardingActionLayoutProbe: Layout {
+  let recorder: OnboardingActionLayoutRecorder
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    subviews.first?.sizeThatFits(proposal) ?? .zero
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    recorder.record(bounds)
+    for subview in subviews {
+      subview.place(at: bounds.origin, proposal: ProposedViewSize(bounds.size))
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingLayoutTests.swift
@@ -1,0 +1,23 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+final class SBOnboardingLayoutTests: XCTestCase {
+  func testPanelKeepsItsDesignedSizeWhenThereIsRoom() {
+    XCTAssertEqual(
+      SBOnboardingPanelLayout.size(in: CGSize(width: 1_200, height: 680)),
+      SBOnboardingPanelLayout.maximumSize
+    )
+  }
+
+  func testPanelStaysInsideCompactWindowContent() {
+    let availableSize = CGSize(width: 480, height: 420)
+    let panelSize = SBOnboardingPanelLayout.size(in: availableSize)
+
+    XCTAssertEqual(panelSize.width, 432)
+    XCTAssertEqual(panelSize.height, 380)
+    XCTAssertLessThanOrEqual(panelSize.width + SBOnboardingPanelLayout.horizontalInset * 2, availableSize.width)
+    XCTAssertLessThanOrEqual(panelSize.height + SBOnboardingPanelLayout.verticalInset * 2, availableSize.height)
+  }
+}

--- a/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
@@ -37,6 +37,30 @@ final class SettingsSidebarItemLayoutTests: XCTestCase {
     )
   }
 
+  func testNotificationsLabelTruncatesGracefullyAtConstrainedWidth() {
+    // At a narrower-than-default width the label must not overflow the row —
+    // it should truncate with an ellipsis rather than being clipped or wrapped.
+    let narrowWidth: CGFloat = 120
+    let host = NSHostingView(
+      rootView: SettingsSidebarItem(
+        section: .notifications,
+        isSelected: true,
+        iconWidth: 20,
+        onTap: {}
+      )
+      .frame(width: narrowWidth)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: narrowWidth, height: 100)
+    host.layoutSubtreeIfNeeded()
+
+    // The item should remain a single line (no wrapping) even when truncated.
+    XCTAssertLessThan(
+      host.fittingSize.height,
+      60,
+      "constrained sidebar label should stay on one line (truncate, not wrap)"
+    )
+  }
+
   private func itemHeight(isSelected: Bool) -> CGFloat {
     let host = NSHostingView(
       rootView: SettingsSidebarItem(

--- a/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SettingsSidebarItemLayoutTests: XCTestCase {
+  func testMergedNotificationsAndPrivacyLabelStaysOnOneLineWhenSelected() {
+    let labelWidth = NSHostingView(
+      rootView: Text(SettingsContentView.SettingsSection.notifications.displayTitle)
+        .scaledFont(size: OmiType.body, weight: .medium)
+        .fixedSize()
+    ).fittingSize.width
+    let requiredWidth = labelWidth + 20 + OmiSpacing.md + 2 * OmiSpacing.md
+
+    XCTAssertLessThanOrEqual(
+      requiredWidth,
+      SettingsSidebarMetrics.itemAvailableWidth,
+      "the merged label must fit in the fixed settings-sidebar row"
+    )
+
+    let unselectedHeight = itemHeight(isSelected: false)
+    let selectedHeight = itemHeight(isSelected: true)
+
+    XCTAssertEqual(
+      selectedHeight,
+      unselectedHeight,
+      accuracy: 0.5,
+      "selection styling must not make the merged navigation label wrap"
+    )
+    XCTAssertLessThan(
+      selectedHeight,
+      60,
+      "the merged navigation label should retain the row's single-line height"
+    )
+  }
+
+  private func itemHeight(isSelected: Bool) -> CGFloat {
+    let host = NSHostingView(
+      rootView: SettingsSidebarItem(
+        section: .notifications,
+        isSelected: isSelected,
+        iconWidth: 20,
+        onTap: {}
+      )
+      .frame(width: SettingsSidebarMetrics.itemAvailableWidth)
+    )
+    host.frame = NSRect(
+      x: 0,
+      y: 0,
+      width: SettingsSidebarMetrics.itemAvailableWidth,
+      height: 100
+    )
+    host.layoutSubtreeIfNeeded()
+    return host.fittingSize.height
+  }
+}

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -84,7 +84,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -53,6 +53,53 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertLessThanOrEqual(settings.maxX, 300.5)
   }
 
+  func testNavigationIsClippedRatherThanOverlappingPersistentControlsWhenCompactRowOverflows() {
+    // Expanded = 500pt nav, compact = 200pt nav, controls = 200pt, settings = 32pt.
+    // At a 300pt host the compact row (200 + spacing*3 + 200 + spacing + 32 ≈ 642)
+    // still overflows. Verify navigation does not overlap the persistent controls.
+    let recorder = TopNavigationLayoutRecorder()
+    let host = NSHostingView(
+      rootView: TopNavigationBarLayout(
+        expandedNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .expanded) {
+            Color.clear.frame(width: 500, height: 32)
+          }
+        },
+        compactNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .compact) {
+            Color.clear.frame(width: 200, height: 32)
+          }
+        },
+        persistentControls: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .persistentControls) {
+            Color.clear.frame(width: 200, height: 32)
+          }
+        },
+        settings: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .settings) {
+            Color.clear.frame(width: 32, height: 32)
+          }
+        }
+      )
+      .frame(width: 300, height: 44)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 300, height: 44)
+    host.layoutSubtreeIfNeeded()
+
+    guard
+      let navigation = recorder.frame(of: .compact),
+      let controls = recorder.frame(of: .persistentControls)
+    else {
+      return XCTFail("expected compact navigation and persistent controls to be placed")
+    }
+    // Navigation's proposed width must not cause it to overlap the controls.
+    XCTAssertLessThanOrEqual(
+      navigation.maxX,
+      controls.minX,
+      "compact navigation must not overlap persistent controls even when the row overflows"
+    )
+  }
+
   func testCompactNavigationRetainsEveryPrimaryRouteAndMemoryDestination() {
     XCTAssertEqual(
       TopNavigationRoutes.primaryItems.map(\.index),

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class TopNavigationBarLayoutTests: XCTestCase {
+  func testCompactNavigationIsPlacedWhenTheFullTopBarWouldOverflow() {
+    let recorder = TopNavigationLayoutRecorder()
+    let host = NSHostingView(
+      rootView: TopNavigationBarLayout(
+        expandedNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .expanded) {
+            Color.clear.frame(width: 420, height: 32)
+          }
+        },
+        compactNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .compact) {
+            Color.clear.frame(width: 68, height: 32)
+          }
+        },
+        persistentControls: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .persistentControls) {
+            Color.clear.frame(width: 150, height: 32)
+          }
+        },
+        settings: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .settings) {
+            Color.clear.frame(width: 32, height: 32)
+          }
+        }
+      )
+      .frame(width: 300, height: 44)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 300, height: 44)
+    host.layoutSubtreeIfNeeded()
+
+    XCTAssertNil(recorder.frame(of: .expanded))
+    guard let compact = recorder.frame(of: .compact) else {
+      return XCTFail("the compact navigation was never placed")
+    }
+    XCTAssertLessThanOrEqual(compact.maxX, 300.5)
+
+    guard
+      let persistentControls = recorder.frame(of: .persistentControls),
+      let settings = recorder.frame(of: .settings)
+    else {
+      return XCTFail("the persistent controls were never placed")
+    }
+    XCTAssertGreaterThan(persistentControls.minX, compact.maxX)
+    XCTAssertGreaterThanOrEqual(settings.maxX, 299)
+    XCTAssertLessThanOrEqual(settings.maxX, 300.5)
+  }
+
+  func testCompactNavigationRetainsEveryPrimaryRouteAndMemoryDestination() {
+    XCTAssertEqual(
+      TopNavigationRoutes.primaryItems.map(\.index),
+      [
+        SidebarNavItem.dashboard.rawValue,
+        SidebarNavItem.conversations.rawValue,
+        SidebarNavItem.tasks.rawValue,
+        SidebarNavItem.apps.rawValue,
+      ]
+    )
+    XCTAssertEqual(TopNavigationRoutes.memoryDestinations, [.memories, .conversations, .brainMap])
+  }
+}
+
+private enum TopNavigationLayoutSlot: Hashable {
+  case expanded
+  case compact
+  case persistentControls
+  case settings
+}
+
+private final class TopNavigationLayoutRecorder: @unchecked Sendable {
+  private var frames: [TopNavigationLayoutSlot: CGRect] = [:]
+
+  func record(_ slot: TopNavigationLayoutSlot, _ frame: CGRect) {
+    frames[slot] = frame
+  }
+
+  func frame(of slot: TopNavigationLayoutSlot) -> CGRect? {
+    frames[slot]
+  }
+}
+
+private struct TopNavigationLayoutProbe: Layout {
+  let recorder: TopNavigationLayoutRecorder
+  let slot: TopNavigationLayoutSlot
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    subviews.first?.sizeThatFits(proposal) ?? .zero
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    recorder.record(slot, bounds)
+    for subview in subviews {
+      subview.place(at: bounds.origin, proposal: ProposedViewSize(bounds.size))
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260729-responsive-layouts.json
+++ b/desktop/macos/changelog/unreleased/20260729-responsive-layouts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop navigation, settings, and onboarding layouts so controls stay usable on compact screens."
+}

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -6,6 +6,7 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+  - desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/FocusPage.swift
 preconditions:
   - auth_ready


### PR DESCRIPTION
## Summary

- Make the desktop window's minimum content width fit a compact 1024pt display.
- Replace overflowing top-navigation pills with a compact navigation menu while keeping Capture and Settings pinned to the trailing edge.
- Prevent selected “Notifications & Privacy” from wrapping; stack Apps, sign-in, and onboarding controls when their rows no longer fit.

## Root cause

The desktop shell enforced a 1200pt content minimum and several fixed-width SwiftUI rows had no compact layout. In the top bar, that allowed primary navigation to be clipped by persistent controls; in Settings, selected type made the merged row exceed its available width.

## Verification

- `xcrun swift test --package-path Desktop --skip-build --filter 'DesktopWindowLayoutPolicyTests|TopNavigationBarLayoutTests|OnboardingPinnedActionsLayoutTests|SBOnboardingLayoutTests|AppsHeaderRowLayoutTests|SettingsSidebarItemLayoutTests'` (11 passed)
- `xcrun swift build -c debug --package-path Desktop`
- `python3 scripts/check_desktop_test_quality.py`
- `make preflight` (20 selected checks passed)
- Built and launched the isolated `omi-responsive-layout` named bundle; its health bridge confirmed bundle id `com.omi.omi-responsive-layout` and the development backend. Direct visual control was unavailable because local Accessibility/Screen Recording permission is pending and the named bundle had no seeded sign-in session.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

