### PR TITLE
test(setup): make linked-worktree fixture Windows-safe

### DIFF
--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -136,7 +136,9 @@ print-resolved-python:
 	@printf 'PYTHON=%s\n' "$(PYTHON)"
 EOF
 git init -q --bare "$TMPDIR/fallback-bare.git"
-out="$(cd "$FB_ROOT" && env -u PYTHON GIT_DIR="$TMPDIR/fallback-bare.git" make print-resolved-python 2>/dev/null)"
+# This contract also runs beneath `make preflight`; suppress nested Make's
+# directory banner so stdout remains the resolver value under both entrypoints.
+out="$(cd "$FB_ROOT" && env -u PYTHON GIT_DIR="$TMPDIR/fallback-bare.git" make --no-print-directory print-resolved-python 2>/dev/null)"
 # Resolve the physical path because Git Bash exposes /tmp as a logical mount
 # while BASH_SOURCE resolves the same directory through its Windows path.
 expected="PYTHON=$(cd "$FB_ROOT" && pwd -P)/backend/.venv/bin/python"

--- a/scripts/test-make-setup.sh
+++ b/scripts/test-make-setup.sh
@@ -123,7 +123,12 @@ dev_harness_python() {
   printf '%s\n' python3
 }
 EOF
-: >"$FB_ROOT/backend/.venv/bin/python"
+# Git for Windows derives extensionless-file executability from a shebang;
+# chmod alone leaves an empty fixture non-executable on NTFS.
+cat >"$FB_ROOT/backend/.venv/bin/python" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
 chmod +x "$FB_ROOT/backend/.venv/bin/python"
 cat >>"$FB_ROOT/Makefile" <<'EOF'
 
@@ -132,7 +137,9 @@ print-resolved-python:
 EOF
 git init -q --bare "$TMPDIR/fallback-bare.git"
 out="$(cd "$FB_ROOT" && env -u PYTHON GIT_DIR="$TMPDIR/fallback-bare.git" make print-resolved-python 2>/dev/null)"
-expected="PYTHON=$(cd "$FB_ROOT" && pwd)/backend/.venv/bin/python"
+# Resolve the physical path because Git Bash exposes /tmp as a logical mount
+# while BASH_SOURCE resolves the same directory through its Windows path.
+expected="PYTHON=$(cd "$FB_ROOT" && pwd -P)/backend/.venv/bin/python"
 if [ "$out" != "$expected" ]; then
   echo "FAIL: Makefile repo-root resolution collapsed when show-toplevel could not resolve a work tree." >&2
   printf 'Expected: %s\nGot:      %s\n' "$expected" "$out" >&2


### PR DESCRIPTION
## Summary

- Give the linked-worktree Python fixture a real shebang so Git for Windows treats the extensionless file as executable on NTFS.
- Compare the fixture's physical path so Git Bash's logical `/tmp` mount and the `BASH_SOURCE`-derived Windows path resolve to the same location.
- Let the existing `setup-pre-push-prerequisites` regression run through its linked-worktree fallback assertions on Windows instead of failing in fixture setup.
- Suppress nested Make directory banners so the strict stdout contract is stable when this script runs beneath `make preflight`.

## Verification

- Before this change, native Git for Windows failed with `Got: PYTHON=python3` before reaching the linked-worktree assertion.
- `PATH=/d/codex-omi-work/.tools/make-shim:$PATH env -u TMPDIR bash scripts/test-make-setup.sh` now passes all three sections.
- The same full script passes when launched as a recipe beneath a parent GNU Make process.
- `bash -n scripts/test-make-setup.sh`
- `git diff --check`


## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

