### PR TITLE
fix(backend): regenerate titles when reprocessing conversations

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "backend/utils/apps.py": 1652,
-    "backend/utils/conversations/process_conversation.py": 1898,
+    "backend/utils/conversations/process_conversation.py": 1896,
     "backend/utils/memory/canonical_consolidation.py": 1935,
     "backend/utils/memory/canonical_memory_adapter.py": 2012,
     "backend/utils/memory/legacy_backfill.py": 1723,

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -287,10 +287,23 @@ class TestStructureFunctionsTimezone:
             started_at=datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc),
             language_code="en",
             tz="Pacific/Honolulu",
-            title="Lunch",
         )
         assert result["invoke"]["started_at"] == "2025-01-01T13:48:00"
         assert result["invoke"]["tz"] == "Pacific/Honolulu"
+
+    def test_reprocess_regenerates_title_and_emoji_from_current_content(self):
+        result = _capture_structure(
+            conv_proc.get_reprocess_transcript_structure,
+            transcript="The corrected transcript is about a product launch",
+            started_at=datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
+            language_code="en",
+            tz="UTC",
+        )
+
+        assert "generate a concise title from the current content" in result["system_text"]
+        assert "select a single emoji" in result["system_text"]
+        assert "For the title, use" not in result["system_text"]
+        assert "title" not in result["invoke"]
 
     def test_both_prompts_state_local_and_drop_convert_instruction(self):
         # The semantic core of the fix is the prompt wording; pin it so a revert can't pass silently.
@@ -301,7 +314,7 @@ class TestStructureFunctionsTimezone:
             ),
             (
                 conv_proc.get_reprocess_transcript_structure,
-                dict(transcript="x", language_code="en", tz="Pacific/Honolulu", title="t"),
+                dict(transcript="x", language_code="en", tz="Pacific/Honolulu"),
             ),
         ]:
             result = _capture_structure(fn, started_at=datetime(2025, 1, 1, 23, 48, tzinfo=timezone.utc), **kwargs)

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -263,7 +263,6 @@ def _get_structured(
         # For re-processing, we don't discard, just re-structure.
         if force_process:
             conv_started_at = cast(datetime, main_conv.started_at)
-            structured_conv = cast(Conversation, main_conv)
             # reprocess endpoint
             with track_usage(uid, Features.CONVERSATION_STRUCTURE):
                 structured = get_reprocess_transcript_structure(
@@ -271,7 +270,6 @@ def _get_structured(
                     conv_started_at,
                     language_code,
                     tz_str,
-                    structured_conv.structured.title,
                     photos=main_conv.photos,
                     output_language_code=user_language,
                 )

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1184,7 +1184,6 @@ def get_reprocess_transcript_structure(
     started_at: datetime,
     language_code: str,
     tz: str,
-    title: str,
     photos: Optional[List[ConversationPhoto]] = None,
     output_language_code: Optional[str] = None,
 ) -> Structured:
@@ -1206,7 +1205,7 @@ def get_reprocess_transcript_structure(
     prompt_text = '''You are an expert content analyzer. Your task is to analyze the provided content (which could be a transcript, a series of photo descriptions from a wearable camera, or both) and provide structure and clarity.
     The content language is {language_code}. You MUST respond entirely in {response_language}.
 
-    For the title, use ```{title}```, if it is empty, use the main topic of the content.
+    For the title, generate a concise title from the current content. Do not reuse a previous title.
     For the overview, condense the content into a summary with the main topics discussed or scenes observed, making sure to capture the key points and important details.
     For the emoji, select a single emoji that vividly reflects the core subject, mood, or outcome of the content. Strive for an emoji that is specific and evocative, rather than generic (e.g., prefer 🎉 for a celebration over 👍 for general agreement, or 💡 for a new idea over 🧠 for general thought).
 
@@ -1254,7 +1253,6 @@ def get_reprocess_transcript_structure(
         chain.invoke(
             {
                 'full_context': full_context,
-                'title': title,
                 'format_instructions': parser.get_format_instructions(),
                 'language_code': language_code,
                 'response_language': response_language,


### PR DESCRIPTION
## Summary

- Regenerate a conversation title from the current transcript and photos when the user reprocesses it, instead of forcing the previous title into the LLM prompt.
- Keep emoji selection tied to the same current-content regeneration pass.
- Add prompt-contract coverage proving the old title is absent from both the template and invocation payload.

Closes #5075

## Product invariants affected

none

Failure-Class: none

## Validation

- `backend/.venv/Scripts/python.exe -m pytest backend/tests/unit/test_conversation_structure_timezone.py -q` (14 passed)
- Individually ran `test_process_conversation_usage_context.py`, `test_conversation_discard_revival.py`, and `test_reprocess_tombstone_guard.py` (35 passed)
- `backend/.venv/Scripts/pyright.exe utils/conversations/process_conversation.py utils/llm/conversation_processing.py` (0 errors)
- `backend/.venv/Scripts/python.exe .github/scripts/check_product_file_line_count_ratchet.py --changed-files ... --base origin/main` (passed after ratcheting `backend-utils.json` down to the new source line count)
- `backend/.venv/Scripts/python.exe .github/scripts/test_check_product_file_line_count_ratchet.py` (10 passed)
- The repository changed-files backend lane completed environment preflight and full Pyright, then selected the broad 798-file backend suite. Its change-related tests passed; four existing Windows failures in `test_auto_dev_backend_scope.py` remain because `subprocess.run(["bash", ...])` resolves the Windows System32 WSL launcher before PATH and receives its UTF-16 error output instead of running Git Bash.
- A live reprocess request was not sent because it requires private conversation data and a real LLM call; the production prompt chain was exercised through its existing mocked-provider seam.
