### PR TITLE
fix(backend): keep a closed client socket from killing the listen transcript loop

### DIFF
--- a/.github/failure-classes/FC-peer-close-aborts-owed-write.json
+++ b/.github/failure-classes/FC-peer-close-aborts-owed-write.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-peer-close-aborts-owed-write",
+  "violated_contract": "A peer that has already closed its connection is an expected condition, not a fault of the task delivering to it: a send refused because the socket is closed must end delivery to that peer and leave the session's own owed work intact, never abort a loop before the durable write it still has to perform.",
+  "canonical_prevention": "Deliver to a client connection through one seam that classifies peer-gone conditions (disconnect and the ASGI post-close RuntimeError alike) as end-of-delivery: mark the connection inactive, return the delivery outcome to the caller so success-only bookkeeping stays truthful, and let the owning loop run to its final flush. Cover it with a regression test that drives the real loop against a socket that refuses the send.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_listen_runtime_regressions.py"
+  ],
+  "evidence_prs": [
+    10840
+  ],
+  "scope_hints": [
+    "backend/routers/listen/**",
+    "backend/utils/async_tasks.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -162,6 +162,11 @@ class ListenSessionRuntime:
             return True
         except WebSocketDisconnect:
             self.state.active = False
+        except RuntimeError as error:
+            # The ASGI server refuses a send after close: the socket is gone, so stop
+            # queueing events for it instead of failing once per remaining event.
+            self.state.active = False
+            logger.warning('Listen event delivery after close type=%s', type(error).__name__)
         except Exception as error:
             logger.error('Listen event delivery failed type=%s', type(error).__name__)
         return False

--- a/backend/routers/listen/transcripts.py
+++ b/backend/routers/listen/transcripts.py
@@ -10,6 +10,8 @@ from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, cast
 
+from fastapi.websockets import WebSocketDisconnect
+
 from models.conversation import Conversation
 from models.conversation_enums import ConversationSource
 from models.conversation_photo import ConversationPhoto
@@ -243,6 +245,23 @@ class TranscriptProcessor:
         if self.translation_coordinator:
             await self.translation_coordinator.observe(segments, removed, conversation_id)
 
+    async def _deliver_segments(self, client_segments: List[Dict[str, Any]]) -> bool:
+        """Push live segments to the client without letting a gone client kill the loop.
+
+        A disconnect is normal, and the ASGI server answers a send after close with a
+        RuntimeError. Either way the socket is finished, not this loop: `process_loop`
+        still owes the session its final speaker-assignment flush.
+        """
+        try:
+            await self.host.request.websocket.send_json(client_segments)
+            return True
+        except WebSocketDisconnect:
+            self.host.state.active = False
+        except RuntimeError as error:
+            self.host.state.active = False
+            logger.warning('Listen segment delivery after close type=%s', type(error).__name__)
+        return False
+
     async def process_loop(self) -> None:
         while self.host.state.active or self.segment_buffer or self.photo_buffer:
             if await self.host.wait(0.6) and not (self.segment_buffer or self.photo_buffer):
@@ -312,8 +331,8 @@ class TranscriptProcessor:
             if not transcript_segments:
                 continue
             client_segments = [segment.model_dump() for segment in updated]
-            await self.host.request.websocket.send_json(client_segments)
-            if client_segments:
+            delivered = await self._deliver_segments(client_segments)
+            if delivered and client_segments:
                 self.host.complete_live_transcription()
             if self.host.transcript_send is not None and self.host.user_has_credits:
                 self.host.transcript_send([segment.model_dump() for segment in transcript_segments])

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -303,7 +303,29 @@ def test_live_transcription_teardown_classifies_unsent_attempts_once(
 
 
 @pytest.mark.anyio
-async def test_transcript_delivery_marks_live_transcription_success_only_after_a_nonempty_client_send(monkeypatch):
+async def test_event_delivery_after_close_stops_queueing_events_for_a_gone_socket():
+    """A post-close RuntimeError means the client is gone, same as a disconnect."""
+    attempts = []
+
+    async def send_json(payload):
+        attempts.append(payload)
+        raise RuntimeError("Unexpected ASGI message 'websocket.send', after sending 'websocket.close'.")
+
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.state = SimpleNamespace(active=True)
+    runtime.request = SimpleNamespace(websocket=SimpleNamespace(send_json=send_json))
+
+    event = SimpleNamespace(to_json=lambda: {'type': 'ping'})
+    assert await runtime.asend_event(event) is False
+    assert runtime.state.active is False
+
+    # Now inactive, so the next event is not even attempted.
+    assert await runtime.asend_event(event) is False
+    assert attempts == [{'type': 'ping'}]
+
+
+def _transcript_processor_for_delivery(monkeypatch, websocket):
+    """One buffered segment ready to deliver, with the loop ending after that pass."""
     import routers.listen.transcripts as transcripts_module
 
     class Segment:
@@ -322,13 +344,6 @@ async def test_transcript_delivery_marks_live_transcription_success_only_after_a
         def combine_segments(_existing, new_segments):
             return new_segments, [], []
 
-    class WebSocket:
-        def __init__(self):
-            self.sent = []
-
-        async def send_json(self, payload):
-            self.sent.append(payload)
-
     state = SimpleNamespace(
         active=True,
         first_audio_byte_timestamp=100.0,
@@ -338,8 +353,8 @@ async def test_transcript_delivery_marks_live_transcription_success_only_after_a
         speaker_id_done=asyncio.Event(),
     )
     state.speaker_id_done.set()
-    websocket = WebSocket()
     delivered = []
+    flushed = []
 
     async def wait(_seconds):
         state.active = False
@@ -353,6 +368,9 @@ async def test_transcript_delivery_marks_live_transcription_success_only_after_a
 
     async def no_op(*_args, **_kwargs):
         return None
+
+    async def flush_speaker_assignments(conversation_id):
+        flushed.append(conversation_id)
 
     host = SimpleNamespace(
         state=state,
@@ -375,15 +393,63 @@ async def test_transcript_delivery_marks_live_transcription_success_only_after_a
     processor._update_live_conversation = update
     processor._translate = no_op
     processor._speaker_detection = no_op
-    processor.flush_speaker_assignments = no_op
+    processor.flush_speaker_assignments = flush_speaker_assignments
 
     monkeypatch.setattr(transcripts_module, 'TranscriptSegment', Segment)
     monkeypatch.setattr(transcripts_module, 'deserialize_conversation', lambda _data: SimpleNamespace())
+
+    return processor, delivered, flushed
+
+
+@pytest.mark.anyio
+async def test_transcript_delivery_marks_live_transcription_success_only_after_a_nonempty_client_send(monkeypatch):
+    class WebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send_json(self, payload):
+            self.sent.append(payload)
+
+    websocket = WebSocket()
+    processor, delivered, flushed = _transcript_processor_for_delivery(monkeypatch, websocket)
 
     await processor.process_loop()
 
     assert websocket.sent == [[{'id': 'segment-1', 'text': 'Hello'}]]
     assert delivered == [True]
+    assert flushed == ['conversation-1']
+
+
+@pytest.mark.anyio
+async def test_transcript_loop_still_flushes_speaker_assignments_when_the_client_socket_is_closed(monkeypatch):
+    """A send after close must not kill the loop before its final speaker flush.
+
+    Starlette answers a send on a closed socket with RuntimeError. That escaped the
+    lifetime task, so the tail of `process_loop` never ran and the session's
+    speaker -> person assignments were never written to the conversation.
+    """
+
+    class ClosedWebSocket:
+        def __init__(self):
+            self.attempts = 0
+
+        async def send_json(self, _payload):
+            self.attempts += 1
+            raise RuntimeError(
+                "Unexpected ASGI message 'websocket.send', after sending 'websocket.close' "
+                'or response already completed.'
+            )
+
+    websocket = ClosedWebSocket()
+    processor, delivered, flushed = _transcript_processor_for_delivery(monkeypatch, websocket)
+
+    await processor.process_loop()
+
+    assert websocket.attempts == 1
+    assert flushed == ['conversation-1']
+    # Nothing reached the client, so the live-transcription attempt is not a success.
+    assert delivered == []
+    assert processor.host.state.active is False
 
 
 async def _async_result(value):


### PR DESCRIPTION
## Bug

`backend-listen` crashed its `stream_transcript` lifetime task **201 times in the 24h to 2026-07-29T07:40Z** in prod:

```
ERROR:utils.async_tasks:Unhandled exception in WebSocket task ws:<uid>:stream_transcript [listen]:
RuntimeError("Unexpected ASGI message 'websocket.send', after sending 'websocket.close' or response already completed.")
```

Each crash is a conversation that silently lost its speaker labels.

## Root cause

`TranscriptProcessor.process_loop` delivered live segments with a raw `await self.host.request.websocket.send_json(...)`. When the client is already gone the ASGI server answers a send with `RuntimeError`, and nothing caught it, so the coroutine died mid-loop — skipping the tail of `process_loop`, which owes the session its final `flush_speaker_assignments(current_conversation_id)`. The speaker → person assignments computed during the session were therefore never written to the conversation's segments.

Separately, `ListenSessionRuntime.asend_event` logged the same post-close `RuntimeError` at ERROR but left `state.active` True, so every remaining event of the session was still queued for a dead socket and failed again — `Listen event delivery failed type=RuntimeError`, 6+/hour in prod.

## Fix

- `TranscriptProcessor._deliver_segments`: deliver through one seam that treats a `WebSocketDisconnect` and a post-close `RuntimeError` alike — the socket is finished, the loop is not. `complete_live_transcription()` now fires only when the segments actually reached the client, which is what it documents.
- `asend_event`: mark the socket gone on a post-close `RuntimeError`, as the disconnect branch already does.

No behaviour change on the healthy path: a successful send still delivers, still completes the live-transcription attempt, and still feeds the pusher/integration lanes.

## Tested

`backend/test.sh` on `tests/unit/test_listen_runtime_regressions.py` → **15 passed** (4.82s).

Both new regression tests fail on `origin/main`'s behaviour and pass with the fix (verified by stashing only the two source files and re-running):

- `test_transcript_loop_still_flushes_speaker_assignments_when_the_client_socket_is_closed` — pre-fix the RuntimeError propagates out of `process_loop`; post-fix the loop completes, `flush_speaker_assignments` runs with the live conversation id, and the attempt is not marked delivered.
- `test_event_delivery_after_close_stops_queueing_events_for_a_gone_socket` — pre-fix `state.active` stays True and the next event is attempted again; post-fix the session is marked inactive after one failure.

Not exercised against a live `/v4/listen` socket: forcing a real send-after-close race needs a client disconnecting inside a specific 0.6s window. The regression tests drive the production `process_loop`/`asend_event` code with the exact Starlette error text seen in prod.

## Product invariants

`scripts/pr-preflight --suggest`: none affected.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

