### PR TITLE
fix(ci): make backend shell contracts Windows-safe

### DIFF
--- a/backend/scripts/needs-typecheck.sh
+++ b/backend/scripts/needs-typecheck.sh
@@ -15,8 +15,8 @@ input="${1:--}"
 if [ "$input" != "-" ] && [ ! -f "$input" ]; then
   usage
 fi
-if [ "$input" = "-" ]; then
-  input=/dev/stdin
+if [ "$input" != "-" ]; then
+  exec < "$input"
 fi
 
 while IFS= read -r path || [ -n "$path" ]; do
@@ -25,6 +25,6 @@ while IFS= read -r path || [ -n "$path" ]; do
       exit 0
       ;;
   esac
-done < "$input"
+done
 
 exit 1

--- a/backend/testing/shell.py
+++ b/backend/testing/shell.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+from typing import TypeAlias
+
+ShellArgument: TypeAlias = str | os.PathLike[str]
+GIT_LAYOUT_PARENT_LIMIT = 3
+
+
+def find_git_bash(git_exec_path: Path) -> Path:
+    """Find bash.exe in the Git for Windows installation that owns git."""
+    for parent in tuple(git_exec_path.parents)[:GIT_LAYOUT_PARENT_LIMIT]:
+        for relative_path in ('bin/bash.exe', 'usr/bin/bash.exe'):
+            candidate = parent / relative_path
+            if candidate.is_file():
+                return candidate
+    raise FileNotFoundError(f'Git Bash was not found above {git_exec_path}')
+
+
+def bash_executable(
+    *,
+    cwd: Path | None = None,
+    platform_name: str | None = None,
+    git_exec_path: Path | None = None,
+) -> str:
+    if (platform_name or os.name) != 'nt':
+        return 'bash'
+
+    if git_exec_path is None:
+        environment = os.environ.copy()
+        environment.pop('GIT_EXEC_PATH', None)
+        git_exec_path = Path(
+            subprocess.check_output(
+                ['git', '--exec-path'],
+                cwd=cwd,
+                env=environment,
+                text=True,
+            ).strip()
+        )
+    return str(find_git_bash(git_exec_path))
+
+
+def bash_command(
+    *args: ShellArgument,
+    cwd: Path | None = None,
+    platform_name: str | None = None,
+    git_exec_path: Path | None = None,
+) -> list[str]:
+    return [
+        bash_executable(cwd=cwd, platform_name=platform_name, git_exec_path=git_exec_path),
+        *(os.fspath(arg) for arg in args),
+    ]
+
+
+def bash_path(path: Path, *, cwd: Path | None = None) -> str:
+    if os.name != 'nt':
+        return str(path)
+    return subprocess.check_output(
+        bash_command('-c', 'cygpath -u "$1"', 'bash', path, cwd=cwd),
+        cwd=cwd,
+        text=True,
+    ).strip()

--- a/backend/tests/test_replay_harness_lc3_frame_timing.py
+++ b/backend/tests/test_replay_harness_lc3_frame_timing.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 import subprocess
 
+from testing.shell import bash_command, bash_path
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS_DIR = REPO_ROOT / "backend" / "testing" / "replay_harness_lc3_frame_timing"
 RUNNER = HARNESS_DIR / "run.sh"
@@ -26,6 +28,7 @@ def _unsupported_uname(tmp_path: Path) -> Path:
         "  exit 64\n"
         "fi\n",
         encoding="utf-8",
+        newline="\n",
     )
     uname.chmod(0o755)
     return tmp_path
@@ -33,10 +36,16 @@ def _unsupported_uname(tmp_path: Path) -> Path:
 
 def test_lc3_replay_runner_fails_closed_on_an_unsupported_host(tmp_path: Path) -> None:
     environment = os.environ.copy()
-    environment["PATH"] = f"{_unsupported_uname(tmp_path)}:{environment['PATH']}"
+    environment["OMI_TEST_FAKE_BIN"] = bash_path(_unsupported_uname(tmp_path), cwd=REPO_ROOT)
 
     completed = subprocess.run(
-        ["bash", str(RUNNER)],
+        bash_command(
+            "-c",
+            'export PATH="$OMI_TEST_FAKE_BIN:$PATH"\nexec "$BASH" "$@"',
+            "bash",
+            RUNNER,
+            cwd=REPO_ROOT,
+        ),
         cwd=REPO_ROOT,
         env=environment,
         capture_output=True,

--- a/backend/tests/unit/test_agent_vm_reaper.py
+++ b/backend/tests/unit/test_agent_vm_reaper.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from testing.shell import bash_command
+
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "backend" / "scripts" / "agent_vm_reaper.py"
 APPLY = ROOT / "backend" / "scripts" / "apply-agent-vm-reaper.sh"
@@ -232,7 +234,7 @@ def test_apply_script_refuses_without_gate():
     env = os.environ.copy()
     env.pop("AGENT_VM_REAPER_APPLY", None)
     proc = subprocess.run(
-        ["bash", str(APPLY)],
+        bash_command(APPLY, cwd=ROOT),
         cwd=ROOT,
         env=env,
         capture_output=True,

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from testing.shell import bash_command, bash_path
+
 ROOT = Path(__file__).resolve().parents[2]
 STARTUP = ROOT / "agent_vm" / "startup.sh"
 
@@ -22,11 +24,21 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
     environment = {
         **os.environ,
         "AGENT_VM_IMAGE": "gcr.io/project/agent-vm:abcdef0",
-        "AGENT_VM_DATA_DIR": str(tmp_path / "data"),
-        "COMMAND_LOG": str(log),
-        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "AGENT_VM_DATA_DIR": bash_path(tmp_path / "data", cwd=ROOT),
+        "COMMAND_LOG": bash_path(log, cwd=ROOT),
+        "OMI_TEST_FAKE_BIN": bash_path(bin_dir, cwd=ROOT),
     }
-    subprocess.run(["bash", str(STARTUP)], check=True, env=environment)
+    subprocess.run(
+        bash_command(
+            "-c",
+            'export PATH="$OMI_TEST_FAKE_BIN:$PATH"\nexec "$BASH" "$@"',
+            "bash",
+            STARTUP,
+            cwd=ROOT,
+        ),
+        check=True,
+        env=environment,
+    )
 
     commands = log.read_text(encoding="utf-8")
     assert "gcloud secrets versions access latest --secret=DESKTOP_ANTHROPIC_API_KEY" in commands

--- a/backend/tests/unit/test_auto_dev_backend_scope.py
+++ b/backend/tests/unit/test_auto_dev_backend_scope.py
@@ -11,6 +11,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = ROOT / '.github/workflows/gcp_backend_auto_dev.yml'
+GIT_LAYOUT_PARENT_LIMIT = 3
 
 
 def _load_admission_script():
@@ -30,6 +31,30 @@ def _scope_job() -> dict:
 
 def _git(repo: Path, *args: str) -> str:
     return subprocess.check_output(['git', *args], cwd=repo, text=True).strip()
+
+
+def _find_git_bash(git_exec_path: Path) -> Path:
+    for parent in tuple(git_exec_path.parents)[:GIT_LAYOUT_PARENT_LIMIT]:
+        for relative_path in ('bin/bash.exe', 'usr/bin/bash.exe'):
+            candidate = parent / relative_path
+            if candidate.is_file():
+                return candidate
+    raise FileNotFoundError(f'Git Bash was not found above {git_exec_path}')
+
+
+def _bash(*, platform_name: str | None = None, git_exec_path: Path | None = None) -> str:
+    if (platform_name or os.name) != 'nt':
+        return 'bash'
+    return str(_find_git_bash(git_exec_path or Path(_git(ROOT, '--exec-path'))))
+
+
+def _bash_path(path: Path) -> str:
+    if os.name != 'nt':
+        return str(path)
+    return subprocess.check_output(
+        [_bash(), '-c', 'cygpath -u "$1"', 'bash', path],
+        text=True,
+    ).strip()
 
 
 def _commit(repo: Path, relative_path: str) -> str:
@@ -74,15 +99,39 @@ printf '200'
         encoding='utf-8',
     )
     curl.chmod(0o755)
+    if os.name == 'nt':
+        # Git for Windows does not ship jq, so model the two exact API
+        # identities while Linux continues to exercise the real jq filters.
+        jq = fake_bin / 'jq'
+        jq.write_text(
+            '''#!/usr/bin/env bash
+set -euo pipefail
+payload="$(<"${!#}")"
+status=identical
+[[ "$RELEASE_SHA" != "$MOCK_MAIN_SHA" ]] && status=behind
+expected_ref='{"ref":"refs/heads/main","object":{"type":"commit","sha":"'"$MOCK_MAIN_SHA"'"}}'
+expected_compare='{"base_commit":{"sha":"'"$RELEASE_SHA"'"},"head_commit":{"sha":"'"$MOCK_MAIN_SHA"'"},"status":"'"$status"'"}'
+if [[ "$payload" == "$expected_ref" ]]; then
+  printf '%s\\n' "$MOCK_MAIN_SHA"
+elif [[ "$payload" == "$expected_compare" ]]; then
+  printf '%s\\n' "$status"
+else
+  exit 1
+fi
+''',
+            encoding='utf-8',
+        )
+        jq.chmod(0o755)
     scope_step = next(step for step in _scope_job()['steps'] if step.get('id') == 'scope')
+    scope_script = f'export PATH="$OMI_TEST_FAKE_BIN:$PATH"\n{scope_step["run"]}'
     result = subprocess.run(
-        ['bash', '-c', scope_step['run']],
+        [_bash(), '-c', scope_script],
         cwd=repo,
         check=False,
         capture_output=True,
         env={
             **os.environ,
-            'PATH': f'{fake_bin}:{os.environ["PATH"]}',
+            'OMI_TEST_FAKE_BIN': _bash_path(fake_bin),
             'GH_TOKEN': 'test-token',
             'GITHUB_REPOSITORY': 'BasedHardware/omi',
             'RELEASE_SHA': sha,
@@ -104,6 +153,17 @@ def git_repo(tmp_path: Path) -> Path:
     _git(tmp_path, 'config', 'user.name', 'Scope Test')
     _commit(tmp_path, 'README.md')
     return tmp_path
+
+
+def test_windows_bash_resolution_uses_the_active_git_installation(tmp_path: Path) -> None:
+    git_root = tmp_path / 'Git'
+    git_exec_path = git_root / 'mingw64/libexec/git-core'
+    git_exec_path.mkdir(parents=True)
+    git_bash = git_root / 'bin/bash.exe'
+    git_bash.parent.mkdir()
+    git_bash.touch()
+
+    assert _bash(platform_name='nt', git_exec_path=git_exec_path) == str(git_bash)
 
 
 def test_unrelated_desktop_change_exits_as_a_green_no_op(git_repo: Path) -> None:

--- a/backend/tests/unit/test_auto_dev_backend_scope.py
+++ b/backend/tests/unit/test_auto_dev_backend_scope.py
@@ -9,9 +9,10 @@ import sys
 import pytest
 import yaml
 
+from testing.shell import bash_command, bash_executable, bash_path
+
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = ROOT / '.github/workflows/gcp_backend_auto_dev.yml'
-GIT_LAYOUT_PARENT_LIMIT = 3
 
 
 def _load_admission_script():
@@ -31,30 +32,6 @@ def _scope_job() -> dict:
 
 def _git(repo: Path, *args: str) -> str:
     return subprocess.check_output(['git', *args], cwd=repo, text=True).strip()
-
-
-def _find_git_bash(git_exec_path: Path) -> Path:
-    for parent in tuple(git_exec_path.parents)[:GIT_LAYOUT_PARENT_LIMIT]:
-        for relative_path in ('bin/bash.exe', 'usr/bin/bash.exe'):
-            candidate = parent / relative_path
-            if candidate.is_file():
-                return candidate
-    raise FileNotFoundError(f'Git Bash was not found above {git_exec_path}')
-
-
-def _bash(*, platform_name: str | None = None, git_exec_path: Path | None = None) -> str:
-    if (platform_name or os.name) != 'nt':
-        return 'bash'
-    return str(_find_git_bash(git_exec_path or Path(_git(ROOT, '--exec-path'))))
-
-
-def _bash_path(path: Path) -> str:
-    if os.name != 'nt':
-        return str(path)
-    return subprocess.check_output(
-        [_bash(), '-c', 'cygpath -u "$1"', 'bash', path],
-        text=True,
-    ).strip()
 
 
 def _commit(repo: Path, relative_path: str) -> str:
@@ -125,13 +102,13 @@ fi
     scope_step = next(step for step in _scope_job()['steps'] if step.get('id') == 'scope')
     scope_script = f'export PATH="$OMI_TEST_FAKE_BIN:$PATH"\n{scope_step["run"]}'
     result = subprocess.run(
-        [_bash(), '-c', scope_script],
+        bash_command('-c', scope_script, cwd=ROOT),
         cwd=repo,
         check=False,
         capture_output=True,
         env={
             **os.environ,
-            'OMI_TEST_FAKE_BIN': _bash_path(fake_bin),
+            'OMI_TEST_FAKE_BIN': bash_path(fake_bin, cwd=ROOT),
             'GH_TOKEN': 'test-token',
             'GITHUB_REPOSITORY': 'BasedHardware/omi',
             'RELEASE_SHA': sha,
@@ -163,7 +140,7 @@ def test_windows_bash_resolution_uses_the_active_git_installation(tmp_path: Path
     git_bash.parent.mkdir()
     git_bash.touch()
 
-    assert _bash(platform_name='nt', git_exec_path=git_exec_path) == str(git_bash)
+    assert bash_executable(cwd=ROOT, platform_name='nt', git_exec_path=git_exec_path) == str(git_bash)
 
 
 def test_unrelated_desktop_change_exits_as_a_green_no_op(git_repo: Path) -> None:

--- a/backend/tests/unit/test_backend_test_runner.py
+++ b/backend/tests/unit/test_backend_test_runner.py
@@ -5,32 +5,38 @@ import stat
 import subprocess
 from pathlib import Path
 
+from testing.shell import bash_command, bash_path
+
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 TEST_RUNNER = BACKEND_DIR / "test.sh"
 
 
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8", newline="\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
 def test_file_isolation_failure_prints_exact_rerun_guidance(tmp_path):
     selected_tests = tmp_path / "selected-tests.txt"
-    selected_tests.write_text("tests/unit/test_example_failure.py\n", encoding="utf-8")
+    selected_tests.write_text("tests/unit/test_example_failure.py\n", encoding="utf-8", newline="\n")
 
     fake_python = tmp_path / "fake-python"
-    fake_python.write_text(
+    _write_executable(
+        fake_python,
         "#!/usr/bin/env bash\n"
         "if [[ \"$1\" == \"-m\" && \"$2\" == \"pytest\" ]]; then\n"
         "  exit 1\n"
         "fi\n"
         "exit 0\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
 
     environment = os.environ | {
-        "PYTHON": str(fake_python),
-        "BACKEND_UNIT_TEST_FILE_LIST": str(selected_tests),
+        "PYTHON": bash_path(fake_python, cwd=BACKEND_DIR),
+        "BACKEND_UNIT_TEST_FILE_LIST": bash_path(selected_tests, cwd=BACKEND_DIR),
         "BACKEND_PYTEST_WORKERS": "1",
     }
     result = subprocess.run(
-        ["bash", str(TEST_RUNNER)],
+        bash_command(TEST_RUNNER, cwd=BACKEND_DIR),
         cwd=BACKEND_DIR,
         env=environment,
         text=True,
@@ -49,27 +55,27 @@ def test_file_isolation_failure_prints_exact_rerun_guidance(tmp_path):
 
 def test_file_isolation_caps_native_pools_and_scrubs_hook_git_environment(tmp_path):
     selected_tests = tmp_path / "selected-tests.txt"
-    selected_tests.write_text("tests/unit/test_example_success.py\n", encoding="utf-8")
+    selected_tests.write_text("tests/unit/test_example_success.py\n", encoding="utf-8", newline="\n")
     captured_environment = tmp_path / "native-thread-environment.txt"
 
     fake_python = tmp_path / "fake-python"
-    fake_python.write_text(
+    _write_executable(
+        fake_python,
         "#!/usr/bin/env bash\n"
         "if [[ \"$1\" == \"-m\" && \"$2\" == \"pytest\" ]]; then\n"
-        f"  printf '%s\\n' \"$OMP_NUM_THREADS\" \"$OPENBLAS_NUM_THREADS\" \"$MKL_NUM_THREADS\" "
-        f"\"$VECLIB_MAXIMUM_THREADS\" \"$NUMEXPR_NUM_THREADS\" \"$BLIS_NUM_THREADS\" "
-        f"\"${{GIT_DIR-unset}}\" \"${{GIT_WORK_TREE-unset}}\" \"${{GIT_INDEX_FILE-unset}}\" "
-        f"> {captured_environment}\n"
+        "  printf '%s\\n' \"$OMP_NUM_THREADS\" \"$OPENBLAS_NUM_THREADS\" \"$MKL_NUM_THREADS\" "
+        "\"$VECLIB_MAXIMUM_THREADS\" \"$NUMEXPR_NUM_THREADS\" \"$BLIS_NUM_THREADS\" "
+        "\"${GIT_DIR-unset}\" \"${GIT_WORK_TREE-unset}\" \"${GIT_INDEX_FILE-unset}\" "
+        "> \"$CAPTURED_ENVIRONMENT\"\n"
         "fi\n"
         "exit 0\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
 
     environment = os.environ | {
-        "PYTHON": str(fake_python),
-        "BACKEND_UNIT_TEST_FILE_LIST": str(selected_tests),
+        "PYTHON": bash_path(fake_python, cwd=BACKEND_DIR),
+        "BACKEND_UNIT_TEST_FILE_LIST": bash_path(selected_tests, cwd=BACKEND_DIR),
         "BACKEND_PYTEST_WORKERS": "1",
+        "CAPTURED_ENVIRONMENT": bash_path(captured_environment, cwd=BACKEND_DIR),
         "GIT_DIR": subprocess.check_output(["git", "rev-parse", "--git-dir"], cwd=BACKEND_DIR, text=True).strip(),
         "GIT_WORK_TREE": str(BACKEND_DIR.parent),
         "GIT_INDEX_FILE": str(tmp_path / "outer-index"),
@@ -85,7 +91,7 @@ def test_file_isolation_caps_native_pools_and_scrubs_hook_git_environment(tmp_pa
         environment.pop(variable, None)
 
     result = subprocess.run(
-        ["bash", str(TEST_RUNNER)],
+        bash_command(TEST_RUNNER, cwd=BACKEND_DIR),
         cwd=BACKEND_DIR,
         env=environment,
         text=True,
@@ -105,7 +111,7 @@ def test_file_isolation_caps_native_pools_and_scrubs_hook_git_environment(tmp_pa
         "BLIS_NUM_THREADS": "7",
     }
     override_result = subprocess.run(
-        ["bash", str(TEST_RUNNER)],
+        bash_command(TEST_RUNNER, cwd=BACKEND_DIR),
         cwd=BACKEND_DIR,
         env=environment | overrides,
         text=True,
@@ -129,15 +135,17 @@ def test_file_isolation_reuses_first_worker_that_finishes(tmp_path):
     selected_tests.write_text(
         "tests/unit/test_slow.py\ntests/unit/test_fast.py\ntests/unit/test_releases_slow.py\n",
         encoding="utf-8",
+        newline="\n",
     )
     control_dir = tmp_path / "control"
     control_dir.mkdir()
 
     fake_python = tmp_path / "fake-python"
-    fake_python.write_text(
+    _write_executable(
+        fake_python,
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
-        f"control_dir={control_dir!s}\n"
+        'control_dir="$CONTROL_DIR"\n'
         'test_path="${!#}"\n'
         'case "$test_path" in\n'
         "  tests/unit/test_slow.py)\n"
@@ -158,18 +166,17 @@ def test_file_isolation_reuses_first_worker_that_finishes(tmp_path):
         '    touch "$control_dir/release-slow"\n'
         "    ;;\n"
         "esac\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
 
     result = subprocess.run(
-        ["bash", str(TEST_RUNNER)],
+        bash_command(TEST_RUNNER, cwd=BACKEND_DIR),
         cwd=BACKEND_DIR,
         env=os.environ
         | {
-            "PYTHON": str(fake_python),
-            "BACKEND_UNIT_TEST_FILE_LIST": str(selected_tests),
+            "PYTHON": bash_path(fake_python, cwd=BACKEND_DIR),
+            "BACKEND_UNIT_TEST_FILE_LIST": bash_path(selected_tests, cwd=BACKEND_DIR),
             "BACKEND_PYTEST_WORKERS": "2",
+            "CONTROL_DIR": bash_path(control_dir, cwd=BACKEND_DIR),
         },
         text=True,
         capture_output=True,
@@ -195,10 +202,12 @@ def test_file_isolation_reaps_worker_that_dies_before_status(tmp_path):
     selected_tests.write_text(
         "tests/unit/test_crash.py\ntests/unit/test_ok.py\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     fake_python = tmp_path / "fake-python"
-    fake_python.write_text(
+    _write_executable(
+        fake_python,
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         'test_path="${!#}"\n'
@@ -213,17 +222,15 @@ def test_file_isolation_reaps_worker_that_dies_before_status(tmp_path):
         "    exit 0\n"
         "    ;;\n"
         "esac\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
 
     result = subprocess.run(
-        ["bash", str(TEST_RUNNER)],
+        bash_command(TEST_RUNNER, cwd=BACKEND_DIR),
         cwd=BACKEND_DIR,
         env=os.environ
         | {
-            "PYTHON": str(fake_python),
-            "BACKEND_UNIT_TEST_FILE_LIST": str(selected_tests),
+            "PYTHON": bash_path(fake_python, cwd=BACKEND_DIR),
+            "BACKEND_UNIT_TEST_FILE_LIST": bash_path(selected_tests, cwd=BACKEND_DIR),
             "BACKEND_PYTEST_WORKERS": "1",
         },
         text=True,

--- a/backend/tests/unit/test_backend_typecheck_predicate.py
+++ b/backend/tests/unit/test_backend_typecheck_predicate.py
@@ -3,18 +3,21 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 
-PREDICATE = Path(__file__).resolve().parents[2] / 'scripts' / 'needs-typecheck.sh'
+from testing.shell import bash_command
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY_ROOT = BACKEND_ROOT.parent
+PREDICATE = BACKEND_ROOT / 'scripts' / 'needs-typecheck.sh'
 
 
 def _needs_typecheck(paths: list[str]) -> bool:
     result = subprocess.run(
-        ['bash', str(PREDICATE)],
-        input=''.join(f'{path}\n' for path in paths),
-        text=True,
+        bash_command(PREDICATE, cwd=REPOSITORY_ROOT),
+        input=''.join(f'{path}\n' for path in paths).encode(),
         check=False,
         capture_output=True,
     )
-    assert result.returncode in {0, 1}, result.stderr
+    assert result.returncode in {0, 1}, result.stderr.decode(errors='replace')
     return result.returncode == 0
 
 

--- a/backend/tests/unit/test_backend_unit_ci_runner.py
+++ b/backend/tests/unit/test_backend_unit_ci_runner.py
@@ -6,6 +6,8 @@ import shutil
 import subprocess
 import sys
 
+from testing.shell import bash_command, bash_path
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RUNNER_SOURCE = REPO_ROOT / 'backend' / 'scripts' / 'run-unit-ci.sh'
 TYPECHECK_PREDICATE_SOURCE = REPO_ROOT / 'backend' / 'scripts' / 'needs-typecheck.sh'
@@ -30,7 +32,7 @@ def test_runner_executes_the_same_selected_contract_as_ci(tmp_path):
 
     log_path = tmp_path / 'runner.log'
     changed_files = tmp_path / 'changed-files.txt'
-    changed_files.write_text('backend/routers/example.py\n', encoding='utf-8')
+    changed_files.write_text('backend/routers/example.py\n', encoding='utf-8', newline='\n')
 
     _write_executable(
         scripts / 'select_backend_unit_tests.py',
@@ -57,7 +59,7 @@ with open(os.environ['RUNNER_LOG'], 'a', encoding='utf-8') as log:
         '''
 #!/usr/bin/env bash
 set -euo pipefail
-echo "preflight:$PYTHON" >> "$RUNNER_LOG"
+echo "preflight:$PYTHON" >> "$RUNNER_SHELL_LOG"
 '''.lstrip(),
     )
     _write_executable(
@@ -65,7 +67,7 @@ echo "preflight:$PYTHON" >> "$RUNNER_LOG"
         '''
 #!/usr/bin/env bash
 set -euo pipefail
-echo "typecheck:$PYTHON" >> "$RUNNER_LOG"
+echo "typecheck:$PYTHON" >> "$RUNNER_SHELL_LOG"
 '''.lstrip(),
     )
     _write_executable(
@@ -80,13 +82,18 @@ printf 'test:%s:%s:%s:%s:%s:%s\\n' \\
   "$BACKEND_PYTEST_FILE_ISOLATION" \\
   "$BACKEND_PYTEST_MARK_EXPR" \\
   "$BACKEND_PYTEST_XDIST" \\
-  "$BACKEND_PYTEST_WORKERS" >> "$RUNNER_LOG"
+  "$BACKEND_PYTEST_WORKERS" >> "$RUNNER_SHELL_LOG"
 '''.lstrip(),
     )
 
-    environment = os.environ | {'PYTHON': sys.executable, 'RUNNER_LOG': str(log_path)}
+    shell_python = bash_path(Path(sys.executable), cwd=REPO_ROOT)
+    environment = os.environ | {
+        'PYTHON': shell_python,
+        'RUNNER_LOG': str(log_path),
+        'RUNNER_SHELL_LOG': bash_path(log_path, cwd=REPO_ROOT),
+    }
     result = subprocess.run(
-        ['bash', str(runner), '--changed-files', str(changed_files)],
+        bash_command(runner, '--changed-files', changed_files, cwd=REPO_ROOT),
         cwd=backend,
         env=environment,
         check=False,
@@ -98,7 +105,7 @@ printf 'test:%s:%s:%s:%s:%s:%s\\n' \\
     assert 'Selected 1 backend unit test file(s): fixture selection' in result.stdout
 
     all_result = subprocess.run(
-        ['bash', str(runner), '--all'],
+        bash_command(runner, '--all', cwd=REPO_ROOT),
         cwd=backend,
         env=environment,
         check=False,
@@ -109,11 +116,11 @@ printf 'test:%s:%s:%s:%s:%s:%s\\n' \\
     assert all_result.returncode == 0, all_result.stderr
     assert log_path.read_text(encoding='utf-8').splitlines() == [
         'select',
-        f'preflight:{sys.executable}',
-        f'typecheck:{sys.executable}',
+        f'preflight:{shell_python}',
+        f'typecheck:{shell_python}',
         'test:0.1:1.0:1:not integration and not slow:auto:auto',
         'select',
-        f'preflight:{sys.executable}',
-        f'typecheck:{sys.executable}',
+        f'preflight:{shell_python}',
+        f'typecheck:{shell_python}',
         'test:0.1:1.0:1:not integration and not slow:auto:auto',
     ]

--- a/backend/tests/unit/test_changed_files_script.py
+++ b/backend/tests/unit/test_changed_files_script.py
@@ -1,6 +1,7 @@
-import os
 from pathlib import Path
 import subprocess
+
+from testing.shell import bash_command
 
 ROOT = Path(__file__).resolve().parents[3]
 CHANGED_FILES = ROOT / 'scripts/changed-files'
@@ -8,21 +9,6 @@ CHANGED_FILES = ROOT / 'scripts/changed-files'
 
 def _git(repo: Path, *args: str) -> str:
     return subprocess.check_output(['git', *args], cwd=repo, text=True).strip()
-
-
-def _find_git_bash(git_exec_path: Path) -> Path:
-    for parent in git_exec_path.parents:
-        for relative_path in ('bin/bash.exe', 'usr/bin/bash.exe'):
-            candidate = parent / relative_path
-            if candidate.is_file():
-                return candidate
-    raise FileNotFoundError(f'Git Bash was not found above {git_exec_path}')
-
-
-def _bash() -> str:
-    if os.name != 'nt':
-        return 'bash'
-    return str(_find_git_bash(Path(_git(ROOT, '--exec-path'))))
 
 
 def _commit(repo: Path, message: str) -> str:
@@ -56,7 +42,13 @@ def test_changed_files_reports_delete_rename_and_file_type_change(tmp_path):
     changed_type.symlink_to('target.py')
     head = _commit(repo, 'move delete and change type')
 
-    changed = set(subprocess.check_output([_bash(), str(CHANGED_FILES), base, head], cwd=repo, text=True).splitlines())
+    changed = set(
+        subprocess.check_output(
+            bash_command(CHANGED_FILES, base, head, cwd=ROOT),
+            cwd=repo,
+            text=True,
+        ).splitlines()
+    )
 
     assert changed == {
         'backend/routers/deleted.py',
@@ -74,14 +66,3 @@ def test_changed_files_helper_is_not_hidden_by_repository_ignore_rules():
     )
 
     assert result.returncode == 1
-
-
-def test_git_bash_resolution_uses_the_git_installation(tmp_path):
-    git_root = tmp_path / 'Git'
-    git_exec_path = git_root / 'mingw64/libexec/git-core'
-    git_exec_path.mkdir(parents=True)
-    git_bash = git_root / 'bin/bash.exe'
-    git_bash.parent.mkdir()
-    git_bash.touch()
-
-    assert _find_git_bash(git_exec_path) == git_bash

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -8,6 +8,8 @@ from typing import Any, cast
 
 import yaml
 
+from testing.shell import bash_command, bash_path
+
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 REPOSITORY_ROOT = BACKEND_ROOT.parent
 GATEWAY_DEPLOY_WORKFLOWS = (
@@ -307,7 +309,6 @@ def test_gateway_deploy_workflows_bind_identity_and_gate_serving_static_contract
 
 def test_gateway_vpc_probe_workflows_execute_the_production_parser(tmp_path):
     """Exercise each rendered workflow caller through the real probe parser with fake gcloud."""
-    probe = BACKEND_ROOT / 'scripts' / 'probe-llm-gateway-from-cloud-run.sh'
     calls = tmp_path / 'gcloud-calls.txt'
     fake_gcloud = tmp_path / 'gcloud'
     fake_gcloud.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$FAKE_GCLOUD_CALLS"\n', encoding='utf-8')
@@ -318,16 +319,17 @@ def test_gateway_vpc_probe_workflows_execute_the_production_parser(tmp_path):
         step = _workflow_step_with_run(workflow, 'probe-llm-gateway-from-cloud-run.sh')
         environment = {
             **os.environ,
-            'FAKE_GCLOUD_CALLS': str(calls),
+            'FAKE_GCLOUD_CALLS': bash_path(calls, cwd=REPOSITORY_ROOT),
             'GITHUB_RUN_ATTEMPT': '1',
             'GITHUB_RUN_ID': '42',
             'GITHUB_SHA': 'abcdef0123456789',
-            'DEPLOY_CONTROL_SCRIPTS': str(BACKEND_ROOT / 'scripts'),
-            'PATH': f'{tmp_path}{os.pathsep}{os.environ["PATH"]}',
+            'DEPLOY_CONTROL_SCRIPTS': bash_path(BACKEND_ROOT / 'scripts', cwd=REPOSITORY_ROOT),
+            'OMI_TEST_FAKE_BIN': bash_path(tmp_path, cwd=REPOSITORY_ROOT),
         }
+        run = f'export PATH="$OMI_TEST_FAKE_BIN:$PATH"\n{_render_probe_workflow_run(str(step["run"]))}'
 
         result = subprocess.run(
-            ['bash', '-c', _render_probe_workflow_run(str(step['run']))],
+            bash_command('-c', run, cwd=REPOSITORY_ROOT),
             cwd=REPOSITORY_ROOT,
             check=False,
             capture_output=True,
@@ -345,11 +347,11 @@ def test_gateway_vpc_probe_workflows_execute_the_production_parser(tmp_path):
 
 def test_gateway_vpc_probe_rejects_equals_style_arguments():
     result = subprocess.run(
-        [
-            'bash',
+        bash_command(
             str(BACKEND_ROOT / 'scripts' / 'probe-llm-gateway-from-cloud-run.sh'),
             '--project=test-project',
-        ],
+            cwd=REPOSITORY_ROOT,
+        ),
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## What changed and why

Resolve shell subprocesses through the active Git for Windows installation instead of invoking a bare `bash`, which Windows process lookup can resolve to the System32 WSL launcher. A shared `testing.shell` helper now discovers Git Bash from `git --exec-path`, converts native paths with `cygpath`, and keeps command arguments separate from shell source.

Migrate every direct Bash subprocess in the backend test tree to that helper. Tests that inject fake tools now prepend their POSIX path inside Git Bash, and shell-consumed temporary scripts and path lists use LF explicitly. This covers workflow scope rendering, VM startup and reaper contracts, backend test runners, changed-files, gateway deploy probes, and the LC3 replay harness.

Make `backend/scripts/needs-typecheck.sh` consume inherited stdin directly instead of redirecting `/dev/stdin`, which Git for Windows does not provide in this environment. This preserves file-list behavior while preventing the Windows pre-push hook from silently skipping backend type checking.

## Product invariants affected

none

## How it was verified

- Ordinary PowerShell: `backend/.venv/Scripts/python.exe -m pytest` across the 9 affected test modules (`41 passed`)
- Python AST audit of `backend/tests/**/*.py`: zero subprocess commands whose executable is a literal `bash`, `/bin/bash`, or `/usr/bin/bash`
- `black --check` across the 10 affected Python files
- `ruff 0.4.4 check` across the 10 affected Python files
- Targeted Pyright with the backend venv (`0 errors`; existing warnings remain in older untyped tests)
- `C:\Program Files\Git\bin\bash.exe -n backend/scripts/needs-typecheck.sh`
- `git diff --check`
- The full local PR preflight still stops in `check-manifest-contract` at the existing main-branch Windows Bash/Python command-resolution boundary; #10825 fixes that independent release-guard test issue and is green.

## Tests

The focused suites were first run from ordinary PowerShell before the fixes and reproduced the WSL launcher failures, UTF-16/GBK decode warnings, fake-PATH misses, and `/dev/stdin` failure. The same combined suite now passes through Git Bash selected from the active Git installation. `test_windows_bash_resolution_uses_the_active_git_installation` also covers discovery without relying on the host installation layout.

## Failure class (fixes)

Failure-Class: none
