### PR TITLE
fix(ci): parse SwiftLint baseline URIs independent of host

### DIFF
--- a/desktop/macos/scripts/prepare-swiftlint-baseline.py
+++ b/desktop/macos/scripts/prepare-swiftlint-baseline.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.parse import unquote, urlparse
 
 
@@ -26,7 +26,8 @@ def _current_file_url(file_url: str, desktop_dir: Path) -> str:
     if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
         raise ValueError(f"baseline location is not a local file URL: {file_url!r}")
 
-    source_path = Path(unquote(parsed.path))
+    # SwiftLint emits baseline URLs on macOS, even when CI validates them elsewhere.
+    source_path = PurePosixPath(unquote(parsed.path))
     if not source_path.is_absolute():
         raise ValueError(f"baseline location is not an absolute path: {file_url!r}")
 


### PR DESCRIPTION
## What changed and why

SwiftLint baseline entries contain macOS `file://` URLs even when repository checks run on another host. Parse those source URLs with `PurePosixPath` before rebasing their Desktop-relative suffix onto the current checkout, so Windows no longer rejects `/Users/...` as a non-absolute path.

## Product invariants affected

none

## How it was verified

- Reproduced the failure from `origin/main` on Windows: a macOS baseline URL is rejected as `not an absolute path`.
- Ran the two focused baseline-preparer tests on Windows: 2 passed.
- Ran Ruff, Black, `py_compile`, and `git diff --check` on the changed file.

## Tests

The existing `test_baseline_preparer_rebases_file_urls_to_the_current_checkout` and `test_baseline_preparer_rejects_a_location_outside_desktop` tests are the regression coverage: they fail against the old implementation on Windows and pass with this change. No test file change is needed because the cross-host contract was already encoded.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

