### PR TITLE
fix(dev-harness): keep qualification cleanup portable on Windows

### DIFF
--- a/scripts/dev-harness/dev_harness/qualification.py
+++ b/scripts/dev-harness/dev_harness/qualification.py
@@ -606,7 +606,7 @@ def _stop_exact_typesense_container(record: dict[str, object], lease_id: str, si
     if not _is_exact_typesense_docker_proxy(record, lease_id):
         raise QualificationLeaseError("Refusing to stop a Typesense container whose exact lease binding is unproven")
     container = f"omi-dev-harness-{lease_id}-typesense"
-    command = ["docker", "kill", container] if sig == signal.SIGKILL else ["docker", "stop", "--time", "10", container]
+    command = ["docker", "kill", container] if sig.name == "SIGKILL" else ["docker", "stop", "--time", "10", container]
     try:
         stopped = subprocess.run(
             command,

--- a/scripts/dev-harness/tests/test_qualification_lease.py
+++ b/scripts/dev-harness/tests/test_qualification_lease.py
@@ -128,8 +128,8 @@ def test_active_lease_serializes_qualification_runs(monkeypatch: pytest.MonkeyPa
     qualification.release(repo_root=REPO_ROOT, lease_id="qualification-one", token=str(first["token"]))
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows-specific fail-closed behavior")
-def test_windows_fault_state_is_retained_without_posix_process_provenance(
+@pytest.mark.skipif(os.name != "nt", reason="Windows-specific non-POSIX cleanup behavior")
+def test_windows_release_retires_lease_pointer_while_retaining_fault_state(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     root = tmp_path / "qualification"
@@ -139,11 +139,11 @@ def test_windows_fault_state_is_retained_without_posix_process_provenance(
     fault_state = root / "state" / lease_id / qualification.FAULT_STATE_DIRNAME
     fault_state.mkdir()
 
-    with pytest.raises(qualification.QualificationLeaseError, match="requires POSIX process provenance"):
-        qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
+    qualification.release(repo_root=REPO_ROOT, lease_id=lease_id, token=str(acquired["token"]))
 
-    assert (root / "qualification-lease.json").is_file()
+    assert not (root / "qualification-lease.json").exists()
     assert fault_state.is_dir()
+    assert (root / "state" / lease_id / qualification.COMPLETION_FILENAME).is_file()
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows-specific fail-closed behavior")


### PR DESCRIPTION
## What changed and why

Keep qualification cleanup portable when the dev-harness suite runs on Windows. Select Docker's force-stop command from the signal enum name instead of reading the unavailable Windows `signal.SIGKILL` attribute, and update the Windows fault-state regression to match the current non-gating release contract: retire the admission lease, preserve unproven state, and write the completion marker.

## Product invariants affected

none

## How it was verified

- Reproduced the Windows suite failures on `origin/main`: 2 failed, 70 passed, 5 skipped.
- Ran the two focused qualification cleanup regressions: 2 passed.
- Ran the full dev-harness suite on Windows: 72 passed, 5 skipped.
- Ran Ruff, Black, `py_compile`, and `git diff --check` on the changed files.

## Tests

`test_orphaned_typesense_container_is_stopped_only_after_exact_binding` covers the missing-`SIGKILL` failure through the normal `SIGTERM` cleanup path. `test_windows_release_retires_lease_pointer_while_retaining_fault_state` now verifies the post-#10779 release contract on Windows without weakening the state-retention safety assertion.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

