### PR TITLE
test(ci): keep candidate probe fixtures Windows-safe

### DIFF
--- a/.github/scripts/test_desktop_backend_candidate_probe.py
+++ b/.github/scripts/test_desktop_backend_candidate_probe.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -183,6 +184,10 @@ class CandidateProbeTests(unittest.TestCase):
             path = Path(directory) / "token"
             path.write_text("abc.def.ghi", encoding="utf-8")
             path.chmod(0o600)
+            if os.name == "nt":
+                with self.assertRaisesRegex(PROBE.ProbeError, "mode-0600"):
+                    PROBE._valid_token(path)
+                return
             self.assertEqual(PROBE._valid_token(path), "abc.def.ghi")
             path.chmod(0o644)
             with self.assertRaisesRegex(PROBE.ProbeError, "mode-0600"):
@@ -210,10 +215,15 @@ class CandidateProbeTests(unittest.TestCase):
             ]
             with mock.patch.object(sys, "argv", argv), mock.patch.object(
                 PROBE,
+                "_valid_token",
+                return_value="abc.def.ghi",
+            ) as valid_token, mock.patch.object(
+                PROBE,
                 "probe_candidate",
                 return_value={"status": "passed"},
             ) as candidate:
                 self.assertEqual(PROBE.main(), 0)
+            valid_token.assert_called_once_with(token)
             self.assertEqual(candidate.call_args.kwargs["expected_revision"], "desktop-backend-abc")
             self.assertEqual(candidate.call_args.kwargs["workflow_run_id"], "123")
 


### PR DESCRIPTION
## What changed and why

Keep the desktop-backend candidate-probe fixtures faithful to the production security boundary on native Windows.

The token helper intentionally requires a regular POSIX mode-`0600` file. Windows cannot represent or prove that mode through `st_mode`, so the permission test now asserts the existing fail-closed result there instead of expecting `chmod(0o600)` to create POSIX semantics.

The full CLI provenance test now mocks the token-validation boundary and asserts that it receives the requested path. That test remains focused on forwarding candidate revision, image, tag, and workflow provenance instead of depending on host filesystem permission semantics.

## Product invariants affected

none

## How it was verified

- Before the fix on native Windows: 12 tests passed, one failed, and one errored.
- After the fix: all 14 candidate-probe tests passed.
- Ruff 0.4.4 passed.
- Pyright 1.1.403 passed with 0 errors and 0 warnings.
- `py_compile` and `git diff --check` passed.

## Tests

The mode test still exercises successful mode-`0600` reads and rejection of mode `0644` on POSIX. On Windows it verifies that the production reader fails closed. The CLI test independently verifies the token path and all candidate provenance forwarded to the probe.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

