### PR TITLE
test(desktop-windows): keep full-suite fixtures within timeout

### DIFF
--- a/desktop/windows/src/main/ipc/dbRecovery.test.ts
+++ b/desktop/windows/src/main/ipc/dbRecovery.test.ts
@@ -193,8 +193,10 @@ describe('archiving the corrupt database', () => {
   it('keeps only the 5 newest backups', () => {
     const made: string[] = []
     for (let i = 0; i < 8; i++) {
-      // A fresh database each time (the archive MOVES it), one minute apart.
-      buildDb(dbFile)
+      // Retention only needs a real file to move. Distinct sentinel bytes keep
+      // this contract fast under worker contention; the next test proves that a
+      // complete SQLite database is preserved byte-for-byte.
+      writeFileSync(dbFile, `corrupt-${i}`)
       made.push(archiveCorruptDb(dbFile, backupsDir, new Date(2026, 0, 1, 12, i, 0)))
     }
     const kept = backupNames()
@@ -209,6 +211,7 @@ describe('archiving the corrupt database', () => {
     ])
     expect(existsSync(made[0])).toBe(false)
     expect(existsSync(made[7])).toBe(true)
+    expect(readFileSync(made[7], 'utf8')).toBe('corrupt-7')
   })
 
   // THE GUARDRAIL: a copy that fails halfway followed by a delete loses everything.

--- a/desktop/windows/src/renderer/src/pages/Apps.errorToast.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Apps.errorToast.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, cleanup, waitFor, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { Apps } from './Apps'
 
 // PR1 (error surfacing): the app-enable/disable toggle used to swallow EVERY failure
 // (backend 400 "setup not completed", 403 paid/private, network) into a console.error,
@@ -9,9 +10,11 @@ import { MemoryRouter } from 'react-router-dom'
 // a failed enable/disable raises a real error toast, the row reverts to its prior
 // state, and the button is never left stuck busy/disabled.
 
-const getMock = vi.fn()
-const postMock = vi.fn()
-const toastMock = vi.fn()
+const { getMock, postMock, toastMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  postMock: vi.fn(),
+  toastMock: vi.fn()
+}))
 vi.mock('../lib/apiClient', () => ({
   omiApi: {
     get: (...a: unknown[]) => getMock(...a),
@@ -58,11 +61,9 @@ beforeEach(() => {
 })
 afterEach(() => {
   cleanup()
-  vi.resetModules()
 })
 
-async function renderApps(): Promise<void> {
-  const { Apps } = await import('./Apps')
+function renderApps(): void {
   render(
     <MemoryRouter>
       <Apps />
@@ -79,7 +80,7 @@ describe('Apps — enable/disable error surfacing (PR1)', () => {
   it('shows an error toast, reverts the row, and does not leave the button stuck busy when enable fails', async () => {
     seedGrid()
     postMock.mockRejectedValue(httpError(403, 'You are not authorized to enable this app'))
-    await renderApps()
+    renderApps()
 
     // Exact name 'Install' targets the card button, not the "Installed" tab (which
     // a /install/i regex would also match, making the query ambiguous).
@@ -114,7 +115,7 @@ describe('Apps — enable/disable error surfacing (PR1)', () => {
     postMock.mockRejectedValue(
       httpError(400, 'This app is currently unavailable. Please try again later.')
     )
-    await renderApps()
+    renderApps()
 
     const btn = await screen.findByRole('button', { name: 'Install' })
     fireEvent.click(btn)


### PR DESCRIPTION
## What changed and why

Keep two Windows desktop tests below Vitest's 5-second per-test timeout under full-suite worker contention. The database-retention case now uses small sentinel files because it only exercises move/prune behavior, while the Apps error-toast suite imports the component once with hoisted mocks instead of transforming the module inside each test.

## Product invariants affected

none

## How it was verified

On clean `main`, a native Windows full-suite run first timed out in `keeps only the 5 newest backups`. After optimizing that fixture, the next full run exposed the same 5-second timeout in `shows an error toast...`. With both changes applied, a third full run completed with 5,090 tests: 5,072 passed, 18 skipped, and 0 failed.

- `node node_modules/vitest/vitest.mjs run src/main/ipc/dbRecovery.test.ts src/renderer/src/pages/Apps.errorToast.test.tsx --reporter=verbose` (Node 22.23.1): 45 passed
- `pnpm run typecheck`: passed
- `pnpm exec eslint src/main/ipc/dbRecovery.test.ts src/renderer/src/pages/Apps.errorToast.test.tsx`: passed
- `pnpm exec prettier --check src/main/ipc/dbRecovery.test.ts src/renderer/src/pages/Apps.errorToast.test.tsx`: passed
- `git diff --check`: passed

## Tests

The existing retention test still verifies that exactly the five newest files remain, the oldest file is removed, and the newest file's bytes survive the move. The adjacent full-SQLite test continues to verify byte-for-byte database preservation. The Apps tests retain their install-failure, toast, optimistic-revert, and busy-state assertions.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

