### PR TITLE
fix(backend): allow gemini-2.5-flash-lite, the model desktop live suggestions actually use

### DIFF
--- a/.github/failure-classes/FC-client-model-outside-proxy-allowlist.json
+++ b/.github/failure-classes/FC-client-model-outside-proxy-allowlist.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-client-model-outside-proxy-allowlist",
+  "violated_contract": "A shipped client and the server gate that admits its requests share one capability list: whenever a client is retargeted at a model, provider or action, the allowlist that admits it must be widened in the same change, because a gate that does not know a value rejects it silently instead of degrading.",
+  "canonical_prevention": "Derive the gate's admitted set from the client's own declaration, or hold the two in sync with a check that reads the client's model table and fails when it names a value the gate would reject - so a tier or cost change cannot ship a 403 that only production logs reveal.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_desktop_proxy.py"
+  ],
+  "evidence_prs": [
+    10847
+  ],
+  "scope_hints": [
+    "backend/routers/desktop_proxy.py",
+    "desktop/macos/Desktop/Sources/ModelQoS.swift"
+  ],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-client-model-outside-proxy-allowlist.json
+++ b/.github/failure-classes/FC-client-model-outside-proxy-allowlist.json
@@ -7,7 +7,7 @@
     "backend/tests/unit/test_desktop_proxy.py"
   ],
   "evidence_prs": [
-    10847
+    10848
   ],
   "scope_hints": [
     "backend/routers/desktop_proxy.py",

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -18,8 +18,8 @@ from utils.subscription import is_trial_paywalled
 router = APIRouter()
 
 _ALLOWED_ACTIONS = frozenset({"generateContent", "streamGenerateContent", "embedContent", "batchEmbedContents"})
-_ALLOWED_MODELS = frozenset({"gemini-2.5-flash", "gemini-2.5-pro", "gemini-embedding-001"})
-_VERTEX_MODELS = frozenset({"gemini-2.5-flash", "gemini-2.5-pro", "gemini-embedding-001"})
+_ALLOWED_MODELS = frozenset({"gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-embedding-001"})
+_VERTEX_MODELS = frozenset({"gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-embedding-001"})
 _MAX_BODY_BYTES = 5 * 1024 * 1024
 _MAX_OUTPUT_TOKENS = 8192
 _DEFAULT_THINKING_BUDGET = 1024

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -43,6 +44,35 @@ def test_sanitize_rejects_multiple_candidates_and_path_is_allowlisted():
     )
     with pytest.raises(HTTPException):
         desktop_proxy._path_parts("models/gemini-2.5-pro:deleteModel")
+
+
+def test_desktop_live_suggestions_model_is_allowed_and_vertex_routed(monkeypatch):
+    """Desktop live suggestions run on Flash-Lite (ModelQoS.suggestions), so the proxy must forward it."""
+    assert desktop_proxy._path_parts("models/gemini-2.5-flash-lite:generateContent") == (
+        "models/gemini-2.5-flash-lite:generateContent",
+        "gemini-2.5-flash-lite",
+        "generateContent",
+    )
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "omi-test")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+    assert desktop_proxy._vertex_url("gemini-2.5-flash-lite", "generateContent") == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/omi-test/locations/us-central1"
+        "/publishers/google/models/gemini-2.5-flash-lite:generateContent"
+    )
+
+
+def test_every_model_the_desktop_client_ships_is_proxy_allowlisted():
+    """Static checker: ModelQoS.swift picks the models the desktop sends to this proxy.
+
+    Not behavioral coverage — it reads the client's model table so a tier change there
+    cannot ship a model the proxy answers with 403.
+    """
+    qos = BACKEND_DIR.parent / "desktop/macos/Desktop/Sources/ModelQoS.swift"
+    if not qos.exists():  # partial checkouts (backend-only forks) have no desktop tree
+        pytest.skip("desktop sources are not present in this checkout")
+    client_models = set(re.findall(r'"(gemini-[^"]+)"', qos.read_text()))
+    assert client_models
+    assert client_models <= desktop_proxy._ALLOWED_MODELS
 
 
 def test_vertex_embedding_translation_round_trip():


### PR DESCRIPTION
## Bug

Desktop live notch suggestions have been silently dead for premium-tier (default) desktop users. The client asks the desktop Gemini proxy for `gemini-2.5-flash-lite`; the proxy's model allowlist does not contain it, so every call is answered `403 Gemini model or action is not allowed`.

Prod evidence (`desktop-backend`, Cloud Run, project `based-hardware`):

```
[11:28:45] [backend] gemini_proxy: blocked model 'gemini-2.5-flash-lite' in path 'models/gemini-2.5-flash-lite:generateContent'
```

1000+ such rejections in the 24h to 2026-07-29T11:30Z (the log read cap — the real number is higher), still arriving at roughly one a minute.

## Root cause

`25f1ab75aa` ("perf(desktop): cut live-suggestion cost by ~20x") moved `ModelQoS.Models.suggestions` to `gemini-2.5-flash-lite` for the premium tier. `backend/routers/desktop_proxy.py` gates the proxy on `_ALLOWED_MODELS`, which still listed only `gemini-2.5-flash`, `gemini-2.5-pro` and `gemini-embedding-001`. The client's model table and the gate that admits it drifted apart, and a gate that does not know a value rejects it rather than degrading.

## Fix

Add `gemini-2.5-flash-lite` to `_ALLOWED_MODELS` and `_VERTEX_MODELS`, so it forwards and Vertex-routes like the other tier models. Metering, body sanitizing and the pro → flash soft-limit downgrade are untouched; Flash-Lite is strictly cheaper than the Flash calls it replaced.

## Tested

- `tests/unit/test_desktop_proxy.py` — 7 passed. Two new tests: the Flash-Lite path (allowlist + Vertex URL) and a labelled static checker asserting every `gemini-*` literal in `ModelQoS.swift` is allowlisted. Both fail on the pre-fix allowlist (403 / assertion) and pass here.
- Exercised the real route end-to-end with `TestClient` against a local stub upstream, stubbing only the upstream host so path parsing, the allowlist, sanitizing, metering and response plumbing all ran production code:

```
gemini-2.5-flash-lite    -> HTTP 403 (pre-fix)  /  HTTP 200 (post-fix), body forwarded
gemini-2.5-flash         -> HTTP 200
gemini-9.9-ultra         -> HTTP 403
```

## Not fixed here

Prod `desktop-backend` still serves the pre-cutover Rust image, whose `is_gemini_model_allowed` has the same gap. Live users get this only once the Python desktop-backend is deployed.

## Product invariants

none

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

