### PR TITLE
fix(backend): stop pushing the conversation-search speaker filter into a Typesense field that does not exist

### DIFF
--- a/.github/failure-classes/FC-serving-index-missing-filter-field.json
+++ b/.github/failure-classes/FC-serving-index-missing-filter-field.json
@@ -1,0 +1,16 @@
+{
+    "schema_version": 1,
+    "id": "FC-serving-index-missing-filter-field",
+    "violated_contract": "A serving search query may only filter on fields its serving index actually carries. A search engine rejects the whole query when filter_by names an unknown field, so one predicate on an unindexed field does not degrade its own filter, it fails the entire feature closed in production for every request that supplies it.",
+    "canonical_prevention": "Bind the query builder's filter fields to the serving index's real schema: either declare and index the field, or drop the predicate from the engine query and apply it at the layer that owns the data (post-hydration from the authoritative store). Guard it with a test that pins the serving schema's filterable field set and asserts every argument combination builds a filter_by referencing only those fields, plus a behavioral test of the predicate at its new layer.",
+    "canonical_prevention_artifact": [
+        "backend/tests/unit/test_conversation_search_speaker_filter.py"
+    ],
+    "evidence_prs": [
+        10850
+    ],
+    "scope_hints": [
+        "backend/utils/conversations/search.py"
+    ],
+    "status": "open"
+}

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -52,7 +52,11 @@ from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils import byok
 from utils.memory.surface_routing import pin_memory_system
-from utils.conversations.search import ConversationSearchUnavailableError, search_conversations
+from utils.conversations.search import (
+    ConversationSearchUnavailableError,
+    conversation_matches_speaker,
+    search_conversations,
+)
 from utils.llm.conversation_processing import generate_summary_with_prompt
 from utils.speaker_identification import extract_speaker_samples
 from utils.other import endpoints as auth
@@ -1204,6 +1208,14 @@ def search_conversations_endpoint(
     # Typesense filters locked hits, but the index can lag Firestore. Re-check after hydration
     # so search never leaks that a locked conversation matched a query.
     conversations = [conversation for conversation in conversations if not conversation.get('is_locked')]
+    # Speaker filtering happens here, not in Typesense: the index has no transcript_segments field, so
+    # asking Typesense for one 400'd and 500'd the request. The hydrated Firestore documents do carry
+    # transcript_segments, so match against those.
+    conversations = [
+        conversation
+        for conversation in conversations
+        if conversation_matches_speaker(conversation, search_request.speaker_id)
+    ]
     redact_conversations_for_list(conversations)
     search_results['items'] = conversations
     # Recompute total_pages from the effective (clamped) pagination the search actually ran with, not the

--- a/backend/tests/unit/test_conversation_hybrid_search.py
+++ b/backend/tests/unit/test_conversation_hybrid_search.py
@@ -148,7 +148,10 @@ class TestSpeakerFilteredConversationSearch:
         collection.documents.search = search
         return search, {'conversations': collection}
 
-    def test_named_speaker_filter_combines_with_existing_filters(self):
+    def test_named_speaker_filter_keeps_other_filters_and_stays_out_of_typesense(self):
+        # transcript_segments is not in the Typesense schema, so a speaker clause here made Typesense
+        # reject the whole query (400) and 500 the request. Speaker matching moved to the hydrated
+        # Firestore documents (conversation_matches_speaker); the other filters still go to Typesense.
         search, collections = self._search_mock()
         with patch.object(search_module.client, 'collections', collections, create=True):
             search_conversations(
@@ -162,19 +165,16 @@ class TestSpeakerFilteredConversationSearch:
 
         params = search.call_args.args[0]
         assert params['q'] == 'launch'
-        assert params['filter_by'] == (
-            'userId:=uid1 && discarded:=false && created_at:>=100 && created_at:<=200 '
-            '&& transcript_segments.person_id:=person-1'
-        )
+        assert params['filter_by'] == ('userId:=uid1 && discarded:=false && created_at:>=100 && created_at:<=200')
 
-    def test_user_speaker_filter_uses_is_user_field(self):
+    def test_user_speaker_filter_still_browses_without_a_schema_filter(self):
         search, collections = self._search_mock()
         with patch.object(search_module.client, 'collections', collections, create=True):
             search_conversations(uid='uid1', query='', speaker_id='user')
 
         params = search.call_args.args[0]
         assert params['q'] == '*'
-        assert params['filter_by'] == 'userId:=uid1 && transcript_segments.is_user:=true'
+        assert params['filter_by'] == 'userId:=uid1'
 
     def test_empty_query_without_structured_filter_returns_empty_without_wildcard_search(self):
         search, collections = self._search_mock()

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -307,6 +307,92 @@ def _conversation(conversation_id='conv-1', status=ConversationStatus.in_progres
     )
 
 
+def _conversation_dict(conversation_id, segments):
+    data = _conversation(conversation_id=conversation_id).model_dump(mode='json')
+    data['transcript_segments'] = segments
+    return data
+
+
+def _segment(*, is_user=False, person_id=None):
+    return {
+        'id': 'seg-1',
+        'text': 'hello',
+        'speaker': 'SPEAKER_00',
+        'is_user': is_user,
+        'person_id': person_id,
+        'start': 0.0,
+        'end': 1.0,
+    }
+
+
+@pytest.mark.parametrize(
+    'speaker_id,matching_segments',
+    [
+        ('user', [_segment(is_user=True)]),
+        ('person-1', [_segment(person_id='person-1')]),
+    ],
+)
+def test_speaker_filter_is_applied_after_hydration(speaker_id, matching_segments):
+    # The speaker filter used to be pushed to Typesense as transcript_segments.is_user / .person_id,
+    # which are not in the `conversations` schema -- Typesense answered 400 "Could not find a filter
+    # field named ... in the schema" and every speaker-filtered search 500'd. The filter now runs over
+    # the hydrated Firestore documents, which do carry transcript_segments.
+    from utils.conversations.search import conversation_matches_speaker as real_matcher
+
+    hydrated = [
+        _conversation_dict('conv-match', matching_segments),
+        _conversation_dict('conv-other', [_segment(person_id='someone-else')]),
+    ]
+    with (
+        patch.object(conv, 'conversation_matches_speaker', real_matcher),
+        patch.object(conv.users_db, 'get_person', return_value={'id': speaker_id}),
+        patch.object(
+            conv,
+            'search_conversations',
+            return_value={
+                'items': [{'id': 'conv-match'}, {'id': 'conv-other'}],
+                'total_pages': 1,
+                'current_page': 1,
+                'per_page': 10,
+            },
+        ),
+        patch.object(conv.conversations_db, 'get_conversations_by_id_without_photos', return_value=hydrated),
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': 'hi', 'speaker_id': speaker_id})
+
+    assert resp.status_code == 200
+    assert [item['id'] for item in resp.json()['items']] == ['conv-match']
+
+
+def test_search_without_speaker_keeps_every_hydrated_conversation():
+    from utils.conversations.search import conversation_matches_speaker as real_matcher
+
+    hydrated = [
+        _conversation_dict('conv-1', [_segment(person_id='person-1')]),
+        _conversation_dict('conv-2', []),
+    ]
+    with (
+        patch.object(conv, 'conversation_matches_speaker', real_matcher),
+        patch.object(
+            conv,
+            'search_conversations',
+            return_value={
+                'items': [{'id': 'conv-1'}, {'id': 'conv-2'}],
+                'total_pages': 1,
+                'current_page': 1,
+                'per_page': 10,
+            },
+        ),
+        patch.object(conv.conversations_db, 'get_conversations_by_id_without_photos', return_value=hydrated),
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': 'hi'})
+
+    assert resp.status_code == 200
+    assert [item['id'] for item in resp.json()['items']] == ['conv-1', 'conv-2']
+
+
 def _process_result(result, *, persisted: bool):
     def process(*_args, persistence_observer=None, **_kwargs):
         assert persistence_observer is not None

--- a/backend/tests/unit/test_conversation_search_speaker_filter.py
+++ b/backend/tests/unit/test_conversation_search_speaker_filter.py
@@ -1,0 +1,122 @@
+"""Regression: POST /v1/conversations/search 500s whenever speaker_id is set.
+
+The speaker filter was pushed into Typesense as `transcript_segments.is_user:=true` /
+`transcript_segments.person_id:=<id>`, but the `conversations` collection has no transcript_segments
+field at all (the Firestore -> Typesense sync only carries userId/created_at/discarded/started_at/
+finished_at/structured.*). Typesense rejected the whole query with
+400 "Could not find a filter field named `transcript_segments.is_user` in the schema", which
+search_conversations re-raised and surfaced as HTTP 500 -- so speaker-filtered search had been 100%
+broken in prod since it shipped.
+
+The filter now runs against the hydrated Firestore documents instead. Pinned against a fake Typesense
+client, no live services.
+"""
+
+import os
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+# The Typesense client validates its config, so give it inert values. It never connects in these
+# tests: the client attribute is replaced with a fake before any call.
+os.environ.setdefault("TYPESENSE_HOST", "localhost")
+os.environ.setdefault("TYPESENSE_HOST_PORT", "8108")
+os.environ.setdefault("TYPESENSE_PROTOCOL", "http")
+os.environ.setdefault("TYPESENSE_API_KEY", "test-key")
+
+from unittest.mock import MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+import utils.conversations.search as search_mod  # noqa: E402
+
+
+def _fake_client(recorder):
+    fake = MagicMock()
+    fake.collections.__getitem__.return_value.documents.search.side_effect = lambda params: recorder.update(
+        params=dict(params)
+    ) or {"hits": []}
+    return fake
+
+
+@pytest.mark.parametrize("speaker_id", ["user", "person-123"])
+def test_speaker_id_never_reaches_typesense_filter_by(monkeypatch, speaker_id):
+    rec = {}
+    monkeypatch.setattr(search_mod, "client", _fake_client(rec))
+    search_mod.search_conversations(uid="u1", query="hi", speaker_id=speaker_id)
+    # Before the fix filter_by carried transcript_segments.*, which is not in the schema -> 400 -> 500.
+    assert "transcript_segments" not in rec["params"]["filter_by"]
+    assert rec["params"]["filter_by"].startswith("userId:=u1")
+
+
+def test_speaker_id_alone_still_browses_instead_of_early_returning(monkeypatch):
+    # An empty query plus a speaker filter must still hit Typesense (browse), not short-circuit to [].
+    rec = {}
+    monkeypatch.setattr(search_mod, "client", _fake_client(rec))
+    search_mod.search_conversations(uid="u1", query="", speaker_id="user")
+    assert rec["params"]["q"] == "*"
+
+
+# Fields the live Typesense `conversations` collection actually indexes, i.e. the only fields
+# filter_by may reference. Verified against the prod collection schema: everything else it carries is
+# under structured.*, which conversation search does not filter on.
+_TYPESENSE_FILTERABLE_FIELDS = {"userId", "created_at", "discarded", "started_at", "finished_at"}
+
+
+def _filter_fields(filter_by):
+    fields = set()
+    for clause in filter_by.split("&&"):
+        clause = clause.strip()
+        if clause:
+            fields.add(clause.split(":", 1)[0].strip())
+    return fields
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"include_discarded": False},
+        {"start_date": 100, "end_date": 200},
+        {"speaker_id": "user"},
+        {"speaker_id": "person-1"},
+        {"include_discarded": False, "start_date": 100, "end_date": 200, "speaker_id": "user"},
+    ],
+)
+def test_every_filter_field_exists_in_the_typesense_schema(monkeypatch, kwargs):
+    """Guard: no argument combination may build a filter on a field the serving index lacks.
+
+    Typesense rejects the entire query (400) when filter_by names an unknown field, so one such
+    field breaks the whole search rather than just its own predicate.
+    """
+    rec = {}
+    monkeypatch.setattr(search_mod, "client", _fake_client(rec))
+    search_mod.search_conversations(uid="u1", query="hi", **kwargs)
+    assert _filter_fields(rec["params"]["filter_by"]) <= _TYPESENSE_FILTERABLE_FIELDS
+
+
+def _conv(segments):
+    return {"id": "c1", "transcript_segments": segments}
+
+
+@pytest.mark.parametrize(
+    "conversation,speaker_id,expected",
+    [
+        (_conv([{"is_user": True, "person_id": None}]), "user", True),
+        (_conv([{"is_user": False, "person_id": "p1"}]), "user", False),
+        (_conv([{"is_user": False, "person_id": "p1"}]), "p1", True),
+        (_conv([{"is_user": False, "person_id": "p2"}]), "p1", False),
+        (_conv([{"is_user": False, "person_id": None}, {"is_user": True}]), "user", True),
+        # No filter requested -> everything matches, even without a transcript.
+        (_conv([]), None, True),
+        ({"id": "c1"}, None, True),
+        # Missing/degenerate transcripts must not raise; they simply do not match.
+        ({"id": "c1"}, "user", False),
+        ({"id": "c1", "transcript_segments": None}, "user", False),
+        ({"id": "c1", "transcript_segments": "oops"}, "user", False),
+        (_conv([None, {"is_user": True}]), "user", True),
+    ],
+)
+def test_conversation_matches_speaker(conversation, speaker_id, expected):
+    assert search_mod.conversation_matches_speaker(conversation, speaker_id) is expected

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -99,6 +99,28 @@ def _utc_iso(ts: int) -> str:
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
+def conversation_matches_speaker(conversation: Dict[str, Any], speaker_id: Optional[str]) -> bool:
+    """Whether a hydrated Firestore conversation has at least one segment from the requested speaker.
+
+    speaker_id == 'user' means the account owner (segment.is_user), any other value is a person id
+    (segment.person_id). Falsy speaker_id means "no speaker filter" and matches everything.
+    """
+    if not speaker_id:
+        return True
+    segments = conversation.get('transcript_segments') or []
+    if not isinstance(segments, list):
+        return False
+    for segment in segments:
+        if not isinstance(segment, dict):
+            continue
+        if speaker_id == 'user':
+            if segment.get('is_user'):
+                return True
+        elif segment.get('person_id') == speaker_id:
+            return True
+    return False
+
+
 def search_conversations(
     uid: str,
     query: str,
@@ -136,10 +158,14 @@ def search_conversations(
         if end_date is not None:
             filter_by = filter_by + f' && created_at:<={end_date}'
 
-        if speaker_id == 'user':
-            filter_by = filter_by + ' && transcript_segments.is_user:=true'
-        elif speaker_id:
-            filter_by = filter_by + f' && transcript_segments.person_id:={speaker_id}'
+        # No speaker clause is added to filter_by on purpose. transcript_segments is not part of the
+        # Typesense `conversations` schema (the Firestore -> Typesense sync only carries
+        # userId/created_at/discarded/started_at/finished_at/structured.*), so
+        # `transcript_segments.is_user` / `.person_id` made Typesense reject the whole query with
+        # 400 "Could not find a filter field named ... in the schema" and 500 every speaker-filtered
+        # search. The filter is applied by conversation_matches_speaker after the router hydrates the
+        # Firestore documents, which do carry transcript_segments; here speaker_id only widens the
+        # browse (see has_filter_only_browse above).
 
         search_parameters = {
             'q': stripped_query or '*',


### PR DESCRIPTION
## Bug

`POST /v1/conversations/search` returns **HTTP 500 for every request that carries `speaker_id`**. Live in prod today (`backend` Cloud Run, `2026-07-29`):

```
Exception: Failed to search conversations: [Errno 400] Could not find a filter field named `transcript_segments.is_user` in the schema.
  File "/app/routers/conversations.py", line 1186, in search_conversations_endpoint
  File "/app/utils/conversations/search.py", line 155, in search_conversations
```

## Root cause

`search_conversations` translated the speaker filter into `transcript_segments.is_user:=true` / `transcript_segments.person_id:=<id>`, but the Typesense `conversations` collection has no `transcript_segments` field at all. Its indexed fields are only `userId`, `created_at`, `discarded`, `started_at`, `finished_at` and `structured.*` — the Firestore -> Typesense sync never carried transcript segments, and the stored documents do not contain them either.

Typesense rejects the *entire* query when `filter_by` names an unknown field, so the predicate did not degrade — it failed the whole feature closed. Speaker-filtered search has been 100% broken since it shipped in `ac6f4194f6` (2026-06-25).

## Fix

The speaker clause no longer goes to Typesense. Matching runs against the hydrated Firestore documents in the router — which *do* carry `transcript_segments` — right next to the existing post-hydration `is_locked` filter. `speaker_id` still widens the Typesense browse, so an empty query plus a speaker filter keeps working.

## Verified

- **Live prod Typesense probe** (read-only search against the real `conversations` collection, 9.3M docs):
  - old filter `userId:=… && transcript_segments.is_user:=true` -> `{"message": "Could not find a filter field named 'transcript_segments.is_user' in the schema."}`
  - old filter `… && transcript_segments.person_id:=p1` -> same rejection
  - new filter `userId:=…` -> `200`, `{"found":0,"hits":[],"out_of":9303340}`
  - collection schema dumped: no `transcript_segments` field; a sampled document's keys are `created_at, discarded, finished_at, id, started_at, structured, userId`
- **Endpoint-level regression tests** through FastAPI `TestClient` (`test_conversation_search_date_validation.py`): posting `speaker_id: user` / `speaker_id: person-1` returns 200 and only the conversation whose segments match; no speaker returns everything.
- **Regression proof**: reverting only the two source files and re-running makes 18 tests fail; with the fix `65 passed` across the seven conversation-search test files.
- Guard test pins the serving schema's filterable field set and asserts every argument combination of `search_conversations` builds a `filter_by` inside it.

Commands: `pytest tests/unit/test_conversation_search_speaker_filter.py tests/unit/test_conversation_search_date_validation.py tests/unit/test_conversation_hybrid_search.py tests/unit/test_conversation_search_pagination_clamp.py tests/unit/test_search_conversations_utc_timestamps.py tests/unit/test_search_conversations_typesense_timeout_failsoft.py tests/unit/test_integration_search_include_discarded.py` -> `65 passed`.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

