### PR TITLE
feat(desktop): keep password fields and private browsing out of screen capture

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": 1742,
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1739
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1775
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": "Task candidate context now carries only backend action-item IDs, while local SQLite/staged evidence remains id-less so the model cannot target it for a backend mutation.",
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "Rewind capture policy adds per-app heartbeat and preview skip logic inline; also registers SuggestionAssistant (event-driven) with logic in Assistants/Suggestions/."
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "Adds the secure-input and private-browsing capture skips at the one place the privacy gate lives; the deciding logic sits in Core/SecureInputCaptureGate.swift and Core/PrivateBrowsingWindow.swift, leaving only the call sites here."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/PrivateBrowsingWindow.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/PrivateBrowsingWindow.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Recognises a browser window in a private / incognito session so Rewind can skip that
+/// window alone, instead of forcing the user to exclude the whole browser and lose the
+/// regular browsing context Rewind exists to keep (#6677).
+///
+/// Matching is scoped by bundle identifier and anchored to the end of the window title, per
+/// `FC-meeting-trigger-title-identity-drift`: a title pattern must be bound to a known
+/// browser process and kept alongside negative near-suffix cases, or a generic title starts
+/// matching.
+///
+/// Suffixes were verified on macOS 25.5 by loading the same URL in a normal and a private
+/// window of each browser and diffing the accessibility title. A browser whose marker has
+/// not been measured is deliberately absent — a missing entry captures exactly as it does
+/// today, while a guessed one would claim protection nobody observed.
+///
+/// The marker exists only in the accessibility title. When `ScreenCaptureService` cannot use
+/// the Accessibility API it falls back to `kCGWindowName`, which was measured to carry the
+/// page title alone — a private Safari window arrives as `p6.html` and a Chrome incognito
+/// window as `New Incognito Tab`, with no marker to match. Detection therefore holds only
+/// while Omi is trusted for Accessibility, the permission it already requires.
+///
+/// Two further gaps, all three resolving toward capture rather than a false sense of privacy:
+/// a private window that has not loaded a page yet reports an empty title, and the markers
+/// are the English localizations.
+enum PrivateBrowsingWindow {
+  private static let privateTitleSuffixes: [String: String] = [
+    "com.apple.Safari": ", Private Browsing",
+    "com.google.Chrome": " (Incognito)",
+    "com.brave.Browser": " (Private)",
+  ]
+
+  static func isPrivate(windowTitle: String?, bundleIdentifier: String?) -> Bool {
+    guard let bundleIdentifier,
+      let suffix = privateTitleSuffixes[bundleIdentifier],
+      let windowTitle
+    else { return false }
+    return windowTitle.hasSuffix(suffix)
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/SecureInputCaptureGate.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/SecureInputCaptureGate.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Decides, once per capture tick, whether Omi must skip screen capture because macOS
+/// reports **secure keyboard entry** active — the process-wide flag an app raises while a
+/// password field holds focus (browser logins, `sudo`, the login window, 2FA prompts).
+///
+/// `RewindSettings.defaultExcludedApps` can only name password managers someone thought to
+/// list; secure input is raised by every app that handles a credential correctly, including
+/// a web form inside a browser that is otherwise captured normally. Both feed the same
+/// privacy gate established by #7098 — an excluded frame reaches no consumer.
+///
+/// A short backoff after the flag clears covers the frames where the credential is still
+/// on screen (reveal-password toggles, a filled field) before the app redraws.
+///
+/// An app can fail to clear the flag on exit, which would pause capture indefinitely.
+/// `stuckThreshold` does not change the decision — privacy still wins — but it reports once
+/// per continuous run so the pause is visible instead of silent.
+struct SecureInputCaptureGate {
+  enum Decision: Equatable {
+    case capture
+    /// `reportStuck` is true exactly once per continuous active run that outlives
+    /// `stuckThreshold`, so a stuck flag costs one telemetry event rather than one per tick.
+    case skip(reportStuck: Bool)
+  }
+
+  private var gate = ProactiveScreenshotCaptureGate()
+  private var activeSince: Date?
+  private var didReportStuck = false
+
+  mutating func nextDecision(
+    isSecureInputActive: Bool,
+    now: Date,
+    backoffDuration: TimeInterval,
+    stuckThreshold: TimeInterval
+  ) -> Decision {
+    var reportStuck = false
+    if isSecureInputActive {
+      let since = activeSince ?? now
+      activeSince = since
+      if !didReportStuck, now.timeIntervalSince(since) >= stuckThreshold {
+        didReportStuck = true
+        reportStuck = true
+      }
+    } else {
+      activeSince = nil
+      didReportStuck = false
+    }
+
+    switch gate.nextDecision(
+      isScreenshotAppFrontmost: isSecureInputActive,
+      now: now,
+      backoffDuration: backoffDuration
+    ) {
+    case .pause, .resumeIntoBackoff, .continueBackoff:
+      return .skip(reportStuck: reportStuck)
+    case .resumeAndCapture, .capture:
+      return .capture
+    }
+  }
+
+  mutating func reset() {
+    gate.reset()
+    activeSince = nil
+    didReportStuck = false
+  }
+
+  /// Records the one-shot report for a flag an app never cleared. Kept beside the gate so the
+  /// capture loop keeps a single call site.
+  static func reportStuckFlag(threshold: TimeInterval) {
+    DesktopDiagnosticsManager.shared.recordFallback(
+      area: "screen_capture",
+      from: "capture",
+      to: "paused",
+      reason: "policy",
+      outcome: .degraded,
+      extra: ["signal": "secure_input_stuck"]
+    )
+    log(
+      "SecureInputGate: secure keyboard entry still active after \(Int(threshold))s — capture stays paused"
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -731,6 +731,15 @@ public class ProactiveAssistantsPlugin: NSObject {
     captureTrigger.updateHeartbeatInterval(interval)
   }
 
+  /// Whether this frame must not reach Rewind or any assistant: the user's excluded-app
+  /// list, or a browser window in a private session. Both feed the privacy gate below.
+  private func isExcludedFromCapture(appName: String, windowTitle: String?) -> Bool {
+    if RewindSettings.shared.isAppExcluded(appName) { return true }
+    return PrivateBrowsingWindow.isPrivate(
+      windowTitle: windowTitle,
+      bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+  }
+
   private func captureFrame() async {
     guard isMonitoring, let screenCaptureService = screenCaptureService else { return }
 
@@ -809,7 +818,8 @@ public class ProactiveAssistantsPlugin: NSObject {
     }
 
     // Check if the current app is excluded from Rewind capture
-    var isRewindExcluded = realAppName.map { RewindSettings.shared.isAppExcluded($0) } ?? false
+    var isRewindExcluded =
+      realAppName.map { isExcludedFromCapture(appName: $0, windowTitle: windowTitle) } ?? false
 
     // Throttle capture when a video call app is frontmost to reduce CPU contention.
     // Captures 1 out of every N frames (e.g., effective ~5s interval at default 1s capture rate).
@@ -936,7 +946,8 @@ public class ProactiveAssistantsPlugin: NSObject {
         if let fallbackApp = fallbackApp {
           appName = fallbackApp
           currentWindowTitle = fallbackTitle
-          isRewindExcluded = RewindSettings.shared.isAppExcluded(fallbackApp)
+          isRewindExcluded = isExcludedFromCapture(
+            appName: fallbackApp, windowTitle: fallbackTitle)
         }
       }
       switch captureResult {
@@ -1030,7 +1041,7 @@ public class ProactiveAssistantsPlugin: NSObject {
       if let freshApp = freshApp {
         resolvedApp = freshApp
         currentWindowTitle = freshTitle
-        isRewindExcluded = RewindSettings.shared.isAppExcluded(freshApp)
+        isRewindExcluded = isExcludedFromCapture(appName: freshApp, windowTitle: freshTitle)
       }
 
       let recoveredAfterFailures = screenCaptureFailureTracker.recordCaptureSuccess()

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Cocoa
 import CoreGraphics
 @preconcurrency import UserNotifications
@@ -89,6 +90,12 @@ public class ProactiveAssistantsPlugin: NSObject {
   private var externalCaptureYield = ProactiveExternalCaptureYield()
   private let screenshotAppBackoffDuration: TimeInterval = 10
   private let screenShareBackoffDuration: TimeInterval = 10
+
+  // Pause capture while macOS reports secure keyboard entry (a password field holds focus).
+  // See SecureInputCaptureGate.
+  private var secureInputGate = SecureInputCaptureGate()
+  private let secureInputBackoffDuration: TimeInterval = 2
+  private let secureInputStuckThreshold: TimeInterval = 300
 
   // Change-gated distribution: only distribute frames to assistants when context changes.
   // Eliminates continuous polling when the user stays on the same app/window.
@@ -534,6 +541,7 @@ public class ProactiveAssistantsPlugin: NSObject {
     recoveryRetryCount = 0
     isInDelayPeriod = false
     externalCaptureYield.reset()
+    secureInputGate.reset()
     videoCallThrottleGate.reset()
     distributionGate.reset()
     captureTrigger.reset()
@@ -763,6 +771,23 @@ public class ProactiveAssistantsPlugin: NSObject {
       shareBackoffDuration: screenShareBackoffDuration
     ) {
       return
+    }
+
+    // Never capture pixels while a password field holds focus. Returning here — ahead of
+    // ScreenCaptureKit — means the credential is never imaged, not imaged then discarded.
+    switch secureInputGate.nextDecision(
+      isSecureInputActive: IsSecureEventInputEnabled(),
+      now: now,
+      backoffDuration: secureInputBackoffDuration,
+      stuckThreshold: secureInputStuckThreshold
+    ) {
+    case .skip(let reportStuck):
+      if reportStuck {
+        SecureInputCaptureGate.reportStuckFlag(threshold: secureInputStuckThreshold)
+      }
+      return
+    case .capture:
+      break
     }
 
     // Cheap early exits before resolving the active window.

--- a/desktop/macos/Desktop/Tests/PrivateBrowsingWindowTests.swift
+++ b/desktop/macos/Desktop/Tests/PrivateBrowsingWindowTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Contract for `PrivateBrowsingWindow`: a private / incognito browser window is recognised
+/// from its own title, so Rewind can skip it while the same browser's regular windows keep
+/// being captured (#6677).
+///
+/// The negative cases carry the weight here. Per `FC-meeting-trigger-title-identity-drift`,
+/// broader title coverage is what turns a marker into a generic-title false positive, so
+/// every positive case is paired with a near-miss that must not match.
+final class PrivateBrowsingWindowTests: XCTestCase {
+  private let safari = "com.apple.Safari"
+  private let chrome = "com.google.Chrome"
+  private let brave = "com.brave.Browser"
+
+  // MARK: - Measured markers
+
+  func testSafariPrivateWindowIsPrivate() {
+    XCTAssertTrue(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Example Domain, Private Browsing", bundleIdentifier: safari))
+  }
+
+  func testChromeIncognitoWindowIsPrivate() {
+    XCTAssertTrue(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Example Domain - Google Chrome (Incognito)", bundleIdentifier: chrome))
+  }
+
+  func testBravePrivateWindowIsPrivate() {
+    XCTAssertTrue(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Example Domain - Brave (Private)", bundleIdentifier: brave))
+  }
+
+  // MARK: - Regular windows of the same browsers keep capturing
+
+  func testChromeRegularWindowIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Example Domain - Google Chrome", bundleIdentifier: chrome),
+      "Excluding a private window must not cost the user their regular browsing context")
+  }
+
+  func testSafariRegularWindowIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(windowTitle: "Example Domain", bundleIdentifier: safari))
+  }
+
+  // MARK: - Near misses
+
+  func testMarkerMustBeASuffixNotASubstring() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Notes on Private Browsing, and other topics", bundleIdentifier: safari),
+      "A page that merely discusses private browsing is a regular window")
+  }
+
+  /// The marker embedded mid-title separates a suffix test from a substring test. Without
+  /// these two, relaxing `hasSuffix` to `contains` passes the whole suite while every article
+  /// that happens to name private browsing silently stops being captured.
+  func testSafariMarkerEmbeddedMidTitleIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Reading, Private Browsing explained | Blog", bundleIdentifier: safari))
+  }
+
+  func testChromeMarkerEmbeddedMidTitleIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Guide (Incognito) tips - Google Chrome", bundleIdentifier: chrome))
+  }
+
+  func testMarkerIsNotSharedAcrossBrowsers() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Example Domain, Private Browsing", bundleIdentifier: brave),
+      "Safari's marker must not be honoured for a browser that was never measured")
+  }
+
+  func testUnknownBundleNeverMatches() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Budget (Private)", bundleIdentifier: "com.apple.Numbers"),
+      "Title matching must stay scoped to known browser processes")
+  }
+
+  // MARK: - Missing signal resolves toward capture
+
+  func testEmptyTitleIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(windowTitle: "", bundleIdentifier: chrome),
+      "A blank title is an unloaded window, not evidence of a private session")
+  }
+
+  func testMissingTitleIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(windowTitle: nil, bundleIdentifier: chrome))
+  }
+
+  func testMissingBundleIdentifierIsNotPrivate() {
+    XCTAssertFalse(
+      PrivateBrowsingWindow.isPrivate(
+        windowTitle: "Example Domain - Google Chrome (Incognito)", bundleIdentifier: nil))
+  }
+}

--- a/desktop/macos/Desktop/Tests/SecureInputCaptureGateTests.swift
+++ b/desktop/macos/Desktop/Tests/SecureInputCaptureGateTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Contract for `SecureInputCaptureGate`: while macOS reports secure keyboard entry, the
+/// capture tick must skip, and it must keep skipping through a short backoff after the flag
+/// clears so a credential still on screen is not imaged by the next tick.
+///
+/// A flag an app never clears must not silently pause capture forever — the gate still
+/// skips, but reports exactly once per continuous run so the pause is observable.
+final class SecureInputCaptureGateTests: XCTestCase {
+  private let backoff: TimeInterval = 2
+  private let stuckThreshold: TimeInterval = 300
+  private let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+  func testSecureInputActiveSkipsCapture() {
+    var gate = SecureInputCaptureGate()
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: true, now: start, backoffDuration: backoff,
+        stuckThreshold: stuckThreshold),
+      .skip(reportStuck: false),
+      "A focused password field must never be captured")
+  }
+
+  func testIdleStateCaptures() {
+    var gate = SecureInputCaptureGate()
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: false, now: start, backoffDuration: backoff,
+        stuckThreshold: stuckThreshold),
+      .capture)
+  }
+
+  func testClearedFlagStillSkipsInsideBackoff() {
+    var gate = SecureInputCaptureGate()
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: start, backoffDuration: backoff,
+      stuckThreshold: stuckThreshold)
+
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: false, now: start.addingTimeInterval(1), backoffDuration: backoff,
+        stuckThreshold: stuckThreshold),
+      .skip(reportStuck: false),
+      "A revealed or filled credential can outlive the flag by a frame")
+  }
+
+  func testCaptureResumesAfterBackoff() {
+    var gate = SecureInputCaptureGate()
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: start, backoffDuration: backoff,
+      stuckThreshold: stuckThreshold)
+
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: false, now: start.addingTimeInterval(backoff + 1),
+        backoffDuration: backoff, stuckThreshold: stuckThreshold),
+      .capture,
+      "Capture must resume on its own; the gate is not a latch")
+  }
+
+  func testStuckFlagReportsOnceAndKeepsSkipping() {
+    var gate = SecureInputCaptureGate()
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: start, backoffDuration: backoff,
+      stuckThreshold: stuckThreshold)
+
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: true, now: start.addingTimeInterval(stuckThreshold),
+        backoffDuration: backoff, stuckThreshold: stuckThreshold),
+      .skip(reportStuck: true))
+
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: true, now: start.addingTimeInterval(stuckThreshold * 2),
+        backoffDuration: backoff, stuckThreshold: stuckThreshold),
+      .skip(reportStuck: false),
+      "A stuck flag must cost one telemetry event per run, not one per tick")
+  }
+
+  func testStuckReportArmsAgainForALaterRun() {
+    var gate = SecureInputCaptureGate()
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: start, backoffDuration: backoff,
+      stuckThreshold: stuckThreshold)
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: start.addingTimeInterval(stuckThreshold),
+      backoffDuration: backoff, stuckThreshold: stuckThreshold)
+
+    let cleared = start.addingTimeInterval(stuckThreshold + backoff + 1)
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: false, now: cleared, backoffDuration: backoff,
+        stuckThreshold: stuckThreshold),
+      .capture)
+
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: cleared, backoffDuration: backoff,
+      stuckThreshold: stuckThreshold)
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: true, now: cleared.addingTimeInterval(stuckThreshold),
+        backoffDuration: backoff, stuckThreshold: stuckThreshold),
+      .skip(reportStuck: true),
+      "A second stuck run is a new incident and must be reported")
+  }
+
+  func testResetClearsBackoffAndStuckState() {
+    var gate = SecureInputCaptureGate()
+    _ = gate.nextDecision(
+      isSecureInputActive: true, now: start, backoffDuration: backoff,
+      stuckThreshold: stuckThreshold)
+
+    gate.reset()
+
+    XCTAssertEqual(
+      gate.nextDecision(
+        isSecureInputActive: false, now: start, backoffDuration: backoff,
+        stuckThreshold: stuckThreshold),
+      .capture,
+      "stopMonitoring must not leave a backoff that gates the next start")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260729-private-browsing-capture-skip.json
+++ b/desktop/macos/changelog/unreleased/20260729-private-browsing-capture-skip.json
@@ -1,0 +1,3 @@
+{
+  "change": "Private and Incognito browser windows are no longer captured by Rewind, while your regular windows in the same browser still are"
+}

--- a/desktop/macos/changelog/unreleased/20260729-secure-input-capture-pause.json
+++ b/desktop/macos/changelog/unreleased/20260729-secure-input-capture-pause.json
@@ -1,0 +1,3 @@
+{
+  "change": "Screen capture now pauses automatically while you are typing a password, in any app"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -23,6 +23,8 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/CapturedFrame.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveExternalCaptureYield.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/SecureInputCaptureGate.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/PrivateBrowsingWindow.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+ScreenCaptureHealth.swift


### PR DESCRIPTION
## What changed and why

Closes #6677, and closes the same weakness on a second surface that no issue covers.

The Rewind privacy gate (#7098, built in #7512) is correct: an excluded frame reaches no consumer. Its only input is `RewindSettings.excludedApps`, a set of app display names the user maintains, which is why nine password managers ship as hardcoded defaults. An enumeration cannot express "this window, right now" or "the user is typing a credential".

- **Private browsing (#6677).** Exclusion is per app, so keeping private windows out meant excluding the whole browser. A private window is now recognized from its own title and skipped, while regular windows of the same browser still capture. Folded into `isRewindExcluded` at the three resolution points #7512 established: initial resolve, the `windowGone` retry, and the macOS 13.x fresh-capture path.
- **Secure keyboard entry.** `IsSecureEventInputEnabled()`, raised process-wide while any app holds focus on a password field, was not called anywhere in the repo. A credential typed into a web form inside a normally-captured browser was imaged, OCR'd, stored, and reachable by the agent through `get_work_context`. The gate now runs ahead of ScreenCaptureKit, so the frame is never imaged rather than imaged and discarded, with a 2s backoff after the flag clears.

A flag an app never clears would pause capture indefinitely. The gate keeps skipping and reports once per continuous run through `recordFallback` (`area=screen_capture`, `reason=policy`, `outcome=degraded`, both already allowlisted).

Private-window matching is scoped by bundle identifier and anchored to the title suffix per `FC-meeting-trigger-title-identity-drift`, whose canonical prevention names exactly that plus retained negative near-suffix cases.

## Product invariants affected

None. `scripts/pr-preflight --suggest` reports none for the changed paths.

## How it was verified

Measured on macOS 25.5.

Private-window markers, by loading the same URL in a normal and a private window of each browser and diffing the accessibility title:

| browser | private window | normal window |
|---|---|---|
| Safari | `Example Domain, Private Browsing` | `Example Domain` |
| Chrome | `Example Domain - Google Chrome (Incognito)` | `Example Domain - Google Chrome` |
| Brave | `Example Domain - Brave (Private)` | `Example Domain - Brave` |

Markers were stable across repeated samples and survived navigation. `AXIdentifier`'s `IsSecure=` field is TLS state, not privacy state, and reports `true` for a private window on an HTTPS page.

Confirmed through `ScreenCaptureService.getActiveWindowInfo`, the resolver the capture loop calls, with each window frontmost:

```
Safari private     p6.html, Private Browsing                     isPrivate=true
Safari normal      Example Domain                                isPrivate=false
Chrome incognito   Example Domain - Google Chrome (Incognito)    isPrivate=true
Chrome normal      (empty, unloaded tab)                         isPrivate=false
Brave private      Example Domain - Brave (Private)              isPrivate=true
```

Secure input, A/B/A on a named `omi-privacy` bundle with Rewind capturing. One Safari window cycling full-screen background colours so frame dedupe could not mask the result; only the focused field changed between phases. Counts are rows in the live Rewind DB:

| phase | focused field | `IsSecureEventInputEnabled()` | frames stored in 34s |
|---|---|---|---|
| A | text | false (30/30 samples) | 5 |
| B | password | true (30/30 samples) | **0** |
| A2 | text | false (30/30 samples) | 1 |

- `xcrun swift build --package-path Desktop` — Build complete
- `xcrun swift test --filter 'SecureInputCaptureGateTests|PrivateBrowsingWindowTests'` — 20 passed
- `desktop/macos/test.sh` — exit 0, 434 Swift suites
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed, at or below baseline
- `bash desktop/macos/scripts/swiftlint-wrapper.sh lint` — 0 violations across 962 files
- `OMI_PR_BODY_FILE=... make preflight` — 20 selected local checks passed

Not verified: browsers other than Safari, Chrome and Brave, none of which are installed on the test machine.

## Tests

Both policies are pure and injectable, driven through their production API with no wall-clock waits.

- `SecureInputCaptureGateTests` (7) — skip while active, skip inside the backoff, resume after it, stuck-flag reported once per run and re-armed for a later run, reset clears state.
- `PrivateBrowsingWindowTests` (13) — the three measured markers, plus negative cases: regular windows of the same browsers, a marker embedded mid-title, a marker from the wrong browser, an unknown bundle, and empty or missing title or bundle.

Both were mutation-tested. Relaxing `hasSuffix` to `contains` and dropping the backoff each fail the suite. The first mutation initially passed, which exposed a missing negative case; the two mid-title cases close it.

## Failure class (fixes)

Failure-Class: none

Both commits are `feat:`. No stated contract said an unexcluded app must not be captured, so this adds protection that did not exist rather than repairing a violated boundary. No registry class covers "the privacy boundary's only input is a user-maintained enumeration", and every one of the 55 classes cites a real prior instance, which this has none of.

## Scoped cleanups

None.

## Known limitations

All resolve toward capture rather than toward a false sense of privacy.

- The private-window marker exists only in the accessibility title. `ScreenCaptureService` falls back to `kCGWindowName`, which carries the page title alone: a private Safari window arrives as `p6.html`, a Chrome incognito window as `New Incognito Tab`. Detection therefore holds while Omi is trusted for Accessibility, the permission it already requires. Recorded in the `PrivateBrowsingWindow` doc comment. Secure input needs no Accessibility and is unaffected.
- A private window that has not loaded a page reports an empty title and is captured; the content there is the browser's own incognito splash.
- Markers are the English localizations. A non-English browser keeps today's behaviour.
- Arc, Firefox, Edge, Vivaldi and Opera are absent rather than guessed. Each is a one-line entry once measured.

## Line-count ratchet

`ProactiveAssistantsPlugin.swift` moves 1739 to 1775. Both deciding policies live in their own files under `Core/`, leaving only call sites in the plugin; the baseline is raised with a justification rather than splitting a 1775-line file inside this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

