### PR TITLE
fix(desktop-windows): fail closed when meeting capture cannot start

### DIFF
--- a/desktop/macos/changelog/unreleased/20260729-windows-meeting-capture-startup.json
+++ b/desktop/macos/changelog/unreleased/20260729-windows-meeting-capture-startup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Windows meeting prompts that could claim capture started when audio or transcription was unavailable."
+}

--- a/desktop/windows/e2e/meeting.spec.mjs
+++ b/desktop/windows/e2e/meeting.spec.mjs
@@ -119,23 +119,23 @@ withApp('auto mode: idle → candidate → active (toast + capture cmd) → endi
   await meeting.inject(app, zoomAgreed)
   await pollUntil(async () => (await meeting.phase(app)) === 'active', 'phase=active')
 
-  // The toast rendered the capturing notice (auto mode is never silent).
   const toast = await findPage(app, 'insight-toast')
-  await pollUntil(
-    async () => (await toast.textContent('body'))?.includes('Omi is capturing'),
-    'capturing toast text'
-  )
 
   // The capture window received meeting-capture-start, ran the session host,
   // failed its unauthenticated listen start, and reported back to main.
   const log = await pollUntil(
     async () => {
       const l = await meeting.statusLog(app)
-      return l.some((s) => s.endsWith(':error')) ? l : null
+      return l.some((s) => s.endsWith(':startup-error')) ? l : null
     },
     'meeting-capture-status round trip'
   )
   assert.ok(log[0].startsWith('meeting-'), `status carries the meeting id: ${log[0]}`)
+  await pollUntil(
+    async () => (await toast.textContent('body'))?.includes("Capture didn't start"),
+    'failure toast text'
+  )
+  assert.equal((await toast.textContent('body'))?.includes('Omi is capturing'), false)
 
   // Tier 2 quiet → ending → (grace) → idle.
   await meeting.inject(app, quiet)
@@ -165,11 +165,12 @@ withApp('ask mode: toast buttons drive capture start/stop', async (app) => {
     async () => (await meeting.statusLog(app)).length > 0,
     'capture round trip after Start click'
   )
-  // The toast swapped to the capturing notice.
+  // The unauthenticated harness must fail closed rather than claiming capture.
   await pollUntil(
-    async () => (await toast.textContent('body'))?.includes('Omi is capturing'),
-    'toast swapped to capturing'
+    async () => (await toast.textContent('body'))?.includes("Capture didn't start"),
+    'toast swapped to retryable failure'
   )
+  assert.equal(await meeting.capturing(app), false)
 })
 
 withApp('false positive: media playing without a Tier 1 match never activates', async (app) => {

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -20,6 +20,7 @@ import { installContextMenu } from './contextMenu'
 import { GPU_CONTEXT_LOST_CHANNEL } from '../shared/types'
 import type { ConversationFolder, LiveNote } from '../shared/types'
 import {
+  isListenSessionOwnedBy,
   registerOmiListenHandlers,
   startTestListenSession,
   stopTestListenSession
@@ -833,12 +834,18 @@ app.whenReady().then(async () => {
   // Sign-out teardown: clear every user-scoped table so a second account on this
   // machine can't see the prior user's local data (renderer authTeardown.ts).
   ipcMain.handle('db:wipeUserData', async () => wipeUserData())
-  registerOmiListenHandlers()
+  registerOmiListenHandlers((ownerId) => {
+    const captureWc = getCaptureWc()
+    const mainWc = mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null
+    return ownerId === mainWc?.id || ownerId === captureWc?.id
+  })
   // Capture bridge: routes commands from UI windows to the hidden capture window
   // and events back. Registered before the capture window is created so no early
   // command/event is missed. Reads the capture wc live so a respawn is picked up.
-  registerCaptureBridge(getCaptureWc, () =>
-    mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null
+  registerCaptureBridge(
+    getCaptureWc,
+    () => (mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null),
+    isListenSessionOwnedBy
   )
   // Soak telemetry (inert unless OMI_SOAK=1): samples process metrics + listen
   // byte counters to userData/soak.jsonl for the 8h idle-soak verification.

--- a/desktop/windows/src/main/insight/toastWindow.ts
+++ b/desktop/windows/src/main/insight/toastWindow.ts
@@ -169,7 +169,9 @@ export function showMeetingToast(payload: MeetingToastPayload): void {
   }
   if (win.webContents.isLoading()) win.webContents.once('did-finish-load', send)
   else send()
-  armDismiss(payload.kind === 'ask' ? MEETING_ASK_DISMISS_MS : AUTO_DISMISS_MS)
+  armDismiss(
+    payload.kind === 'ask' || payload.kind === 'error' ? MEETING_ASK_DISMISS_MS : AUTO_DISMISS_MS
+  )
 }
 
 /** Show the post-update what's-new card in the shared toast window (Phase 8).

--- a/desktop/windows/src/main/ipc/captureBridge.test.ts
+++ b/desktop/windows/src/main/ipc/captureBridge.test.ts
@@ -1,15 +1,27 @@
-import { describe, it, expect } from 'vitest'
-import { routeCaptureEvent, isOwnedCaptureEvent } from './captureBridge'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  canForwardRendererCaptureCommand,
+  emitCaptureEventFromMain,
+  isOwnedCaptureEvent,
+  onCaptureEventInMain,
+  routeCaptureEvent
+} from './captureBridge'
 import type { CaptureEvent } from '../../shared/types'
 
-// The bridge's routing decision is pure: owned events (audio errors, PTT) go to
-// the single UI window that issued the command; every other event through this
+vi.mock('electron', () => ({
+  ipcMain: { on: vi.fn() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}))
+
+// The bridge's routing decision is pure: owned events (audio readiness/errors, PTT) go to
+// the single window that issued the command; every other event through this
 // path (live-store mirror, meeting-capture-status) is consumed only by the main
 // window, so it targets the main window rather than fanning out to the
 // bar/glow/toast windows that just drop it. These tests pin that decision without
 // Electron.
 
 const owned: CaptureEvent[] = [
+  { type: 'audio-source-ready', sessionId: 's' },
   { type: 'audio-source-error', sessionId: 's', name: 'NotAllowedError', message: 'x' },
   { type: 'ptt-chunk', captureId: 'c', pcm: new ArrayBuffer(4) },
   { type: 'ptt-drained', captureId: 'c', pcm: new ArrayBuffer(4) },
@@ -23,7 +35,7 @@ const owned: CaptureEvent[] = [
 // originates in main via emitCaptureEventFromMain — so it isn't exercised here.)
 const mainWindowOnly: CaptureEvent[] = [
   { type: 'live', op: { op: 'reset' } },
-  { type: 'meeting-capture-status', meetingId: 'm', status: 'started' },
+  { type: 'meeting-capture-status', meetingId: 'm', attemptId: 1, status: 'started' },
   { type: 'capture-window-restarted' }
 ]
 
@@ -40,6 +52,13 @@ describe('routeCaptureEvent', () => {
       // main window id present but irrelevant for owned events.
       expect(routeCaptureEvent(e, 2, [1, 2, 3], 1)).toEqual([2])
     }
+  })
+
+  it('routes an owned event back to the capture window when it is the owner', () => {
+    const captureWindowId = 4
+    expect(routeCaptureEvent(owned[0], captureWindowId, [1, 2, captureWindowId], 1)).toEqual([
+      captureWindowId
+    ])
   })
 
   it('drops an owned event when its owner window is gone', () => {
@@ -65,5 +84,76 @@ describe('routeCaptureEvent', () => {
 
   it('routes to nobody when there are no candidate windows', () => {
     expect(routeCaptureEvent(mainWindowOnly[0], undefined, [], 1)).toEqual([])
+  })
+})
+
+describe('emitCaptureEventFromMain', () => {
+  it('notifies main-process listeners as well as renderer windows', () => {
+    const seen: CaptureEvent[] = []
+    const off = onCaptureEventInMain((event) => seen.push(event))
+    const event: CaptureEvent = { type: 'capture-window-restarted' }
+
+    emitCaptureEventFromMain(event, null)
+
+    expect(seen).toEqual([event])
+    off()
+  })
+})
+
+describe('canForwardRendererCaptureCommand', () => {
+  const owns = (sessionId: string, ownerId: number): boolean =>
+    sessionId === 'owned' && ownerId === 7
+
+  it('rejects renderer attempts to invoke main-only meeting capture', () => {
+    expect(
+      canForwardRendererCaptureCommand(
+        {
+          type: 'meeting-capture-start',
+          meetingId: 'meeting-1',
+          attemptId: 1,
+          appName: 'Meet'
+        },
+        7,
+        owns
+      )
+    ).toBe(false)
+  })
+
+  it('binds audio commands to a listen session owned by the sender', () => {
+    expect(
+      canForwardRendererCaptureCommand(
+        { type: 'audio-start', sessionId: 'owned', source: 'mic' },
+        7,
+        owns
+      )
+    ).toBe(true)
+    expect(
+      canForwardRendererCaptureCommand(
+        { type: 'audio-start', sessionId: 'other', source: 'mic' },
+        7,
+        owns
+      )
+    ).toBe(false)
+    expect(
+      canForwardRendererCaptureCommand({ type: 'audio-stop', sessionId: 'owned' }, 9, owns)
+    ).toBe(false)
+  })
+
+  it('allows UI controls only from the main window', () => {
+    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 7, owns, 7)).toBe(true)
+    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 8, owns, 7)).toBe(false)
+  })
+
+  it('rejects unknown runtime commands instead of forwarding them', () => {
+    expect(
+      canForwardRendererCaptureCommand(
+        { type: 'not-a-capture-command' } as unknown as Parameters<
+          typeof canForwardRendererCaptureCommand
+        >[0],
+        7,
+        owns,
+        7
+      )
+    ).toBe(false)
   })
 })

--- a/desktop/windows/src/main/ipc/captureBridge.ts
+++ b/desktop/windows/src/main/ipc/captureBridge.ts
@@ -13,14 +13,16 @@ import type { CaptureCommand, CaptureEvent } from '../../shared/types'
 // The main process still owns every listen WebSocket, so audio origin (capture
 // window) and transcript destination (any UI window) stay decoupled.
 
-// CaptureEvent types that target a single owning UI window (the window that
-// issued the originating command). Everything else that flows through this path
+// CaptureEvent types that target a single owning window (the window that issued
+// the originating command, including the capture window itself). Everything else
+// that flows through this path
 // (`live`, `meeting-capture-status`) is consumed only by the MAIN window's hosts
 // (LiveMirrorHost) or by main's own event tap, so it is routed to the main window
 // rather than fanned out to the bar/glow/toast/capture windows that just drop it.
 // (`capture-window-restarted` does NOT flow through here — it originates in main
 // and uses emitCaptureEventFromMain below.)
 const OWNED_EVENT_TYPES = new Set<CaptureEvent['type']>([
+  'audio-source-ready',
   'audio-source-error',
   'ptt-chunk',
   'ptt-drained',
@@ -43,9 +45,19 @@ export function onCaptureEventInMain(cb: (event: CaptureEvent) => void): () => v
   return () => mainEventListeners.delete(cb)
 }
 
+function notifyMainEventListeners(event: CaptureEvent): void {
+  for (const cb of mainEventListeners) {
+    try {
+      cb(event)
+    } catch (err) {
+      console.warn('[capture] main event listener threw:', err)
+    }
+  }
+}
+
 /**
  * Pure routing decision: given an event, the ownerId the capture window tagged it
- * with (if any), the ids of the candidate (non-capture) windows, and the main
+ * with (if any), the ids of the candidate windows, and the main
  * window's id, return the window ids that should receive it. Owned events go to
  * their owner only; every other event through this path is main-window-only
  * (LiveMirrorHost / main's tap are the sole consumers) — both are dropped if their
@@ -63,12 +75,50 @@ export function routeCaptureEvent(
   return mainWindowId !== undefined && windowIds.includes(mainWindowId) ? [mainWindowId] : []
 }
 
+export function canForwardRendererCaptureCommand(
+  command: CaptureCommand,
+  senderId: number,
+  ownsListenSession: (sessionId: string, ownerId: number) => boolean,
+  mainWindowId?: number
+): boolean {
+  // Meeting capture is main-process policy. No renderer may bypass the detector
+  // and consent flow by issuing these commands through the public preload API.
+  switch (command.type) {
+    case 'meeting-capture-start':
+    case 'meeting-capture-stop':
+      return false
+    // Audio capture must be attached to a listen socket already owned by the same
+    // renderer; this also permits the capture window's continuous/meeting lanes.
+    case 'audio-start':
+    case 'audio-stop':
+      return ownsListenSession(command.sessionId, senderId)
+    // All remaining controls originate in the main UI. Keeping them off auxiliary
+    // renderers prevents a compromised toast/glow window from controlling capture.
+    case 'live-finalize':
+    case 'live-view':
+    case 'ptt-warm':
+    case 'ptt-release':
+    case 'ptt-start':
+    case 'ptt-drain':
+    case 'ptt-dispose':
+    case 'ptt-rebuild':
+    case 'screen-view':
+    case 'assistant-speaking':
+    case 'assistant-utterance':
+    case 'auth-changed':
+      return senderId === mainWindowId
+    default:
+      return false
+  }
+}
+
 /**
  * Emit a capture event that ORIGINATES in main (e.g. capture-window-restarted)
  * to every UI window, skipping the capture window itself. Used for events the
  * capture window can't send about itself (its own recreation).
  */
 export function emitCaptureEventFromMain(event: CaptureEvent, captureWcId: number | null): void {
+  notifyMainEventListeners(event)
   for (const w of BrowserWindow.getAllWindows()) {
     if (w.isDestroyed() || w.webContents.id === captureWcId) continue
     w.webContents.send('omi-capture:event', event)
@@ -82,11 +132,19 @@ export function emitCaptureEventFromMain(event: CaptureEvent, captureWcId: numbe
  */
 export function registerCaptureBridge(
   getCaptureWc: () => WebContents | null,
-  getMainWc: () => WebContents | null
+  getMainWc: () => WebContents | null,
+  ownsListenSession: (sessionId: string, ownerId: number) => boolean
 ): void {
   ipcMain.on('omi-capture:cmd', (e, cmd: CaptureCommand) => {
     const wc = getCaptureWc()
     if (!wc || wc.isDestroyed()) return
+    if (!cmd || typeof cmd !== 'object' || typeof cmd.type !== 'string') return
+    const mainWc = getMainWc()
+    const mainWindowId = mainWc && !mainWc.isDestroyed() ? mainWc.id : undefined
+    if (!canForwardRendererCaptureCommand(cmd, e.sender.id, ownsListenSession, mainWindowId)) {
+      console.warn('[capture] rejected unauthorized command:', cmd.type)
+      return
+    }
     // Forward to the capture window tagged with the sender's id (ownerId) so owned
     // events (audio errors, PTT) route back to it. The capture window's OWN
     // continuous-mic lane also issues audio-start (its omiListenClient runs in this
@@ -102,16 +160,12 @@ export function registerCaptureBridge(
     // inject capture events (it would let a hostile/XSS'd UI window forge PTT
     // audio or live-store ops into other windows).
     if (!wc || wc.isDestroyed() || e.sender.id !== wc.id) return
-    for (const cb of mainEventListeners) {
-      try {
-        cb(payload.event)
-      } catch (err) {
-        console.warn('[capture] main event listener threw:', err)
-      }
-    }
-    const targets = BrowserWindow.getAllWindows().filter(
-      (w) => !w.isDestroyed() && w.webContents.id !== wc.id
-    )
+    notifyMainEventListeners(payload.event)
+    // Include the capture window in the candidate set. Its own continuous-mic
+    // and meeting hosts issue audio-start commands from inside that window, so
+    // their owned ready/error events must route back to the same renderer.
+    // Non-owned events still resolve only to the main window below.
+    const targets = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed())
     const mainWc = getMainWc()
     const mainWindowId = mainWc && !mainWc.isDestroyed() ? mainWc.id : undefined
     const targetIds = routeCaptureEvent(

--- a/desktop/windows/src/main/ipc/omiListen.finalize.test.ts
+++ b/desktop/windows/src/main/ipc/omiListen.finalize.test.ts
@@ -40,6 +40,10 @@ const h = vi.hoisted(() => {
       this.readyState = FakeWebSocket.OPEN
       for (const fn of this.listeners.get('open') ?? []) fn()
     }
+    simulateClose(code = 1006, reason = ''): void {
+      this.readyState = FakeWebSocket.CLOSED
+      for (const fn of this.listeners.get('close') ?? []) fn(code, Buffer.from(reason))
+    }
   }
   const ipcHandlers = new Map<string, (...args: unknown[]) => void>()
   return { FakeWebSocket, ipcHandlers }
@@ -56,17 +60,24 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { registerOmiListenHandlers } from './omiListen'
+import { isListenSessionOwnedBy, registerOmiListenHandlers } from './omiListen'
 
 const ipc = {
   start: (sessionId: string, ownerId = 1, mode = 'ptt') =>
     h.ipcHandlers.get('omi-listen:start')!(
-      { sender: { id: ownerId } },
+      { sender: { id: ownerId, once: vi.fn() } },
       { sessionId, token: 'tok', language: 'en', source: 'mic', mode }
     ),
-  feed: (sessionId: string, bytes: number) =>
-    h.ipcHandlers.get('omi-listen:feed')!(null, sessionId, new ArrayBuffer(bytes)),
-  finalize: (sessionId: string) => h.ipcHandlers.get('omi-listen:finalize')!(null, sessionId)
+  feed: (sessionId: string, bytes: number, ownerId = 1) =>
+    h.ipcHandlers.get('omi-listen:feed')!(
+      { sender: { id: ownerId } },
+      sessionId,
+      new ArrayBuffer(bytes)
+    ),
+  finalize: (sessionId: string, ownerId = 1) =>
+    h.ipcHandlers.get('omi-listen:finalize')!({ sender: { id: ownerId } }, sessionId),
+  stop: (sessionId: string, ownerId = 1) =>
+    h.ipcHandlers.get('omi-listen:stop')!({ sender: { id: ownerId } }, sessionId)
 }
 
 function lastWs(): InstanceType<typeof h.FakeWebSocket> {
@@ -74,10 +85,16 @@ function lastWs(): InstanceType<typeof h.FakeWebSocket> {
 }
 
 beforeAll(() => {
-  registerOmiListenHandlers()
+  registerOmiListenHandlers((ownerId) => ownerId !== 99)
 })
 
 describe('PTT stream lane', () => {
+  it('rejects session creation from an untrusted window', () => {
+    expect(() => ipc.start('denied-lane', 99)).toThrow(
+      'listen session is not allowed from this window'
+    )
+  })
+
   it('buffers pre-OPEN audio and flushes it in order on open', () => {
     ipc.start('flush-1')
     const ws = lastWs()
@@ -122,7 +139,7 @@ describe('PTT stream lane', () => {
     expect(first.sent).toHaveLength(0)
   })
 
-  it('does not supersede a different window\'s PTT session', () => {
+  it("does not supersede a different window's PTT session", () => {
     ipc.start('win1-hold', 11)
     const first = lastWs()
     ipc.start('win2-hold', 12)
@@ -142,7 +159,34 @@ describe('PTT stream lane', () => {
     ipc.start('screen-sys', 22, 'transcribe')
     const ws = lastWs()
     ws.simulateOpen()
-    ipc.finalize('screen-sys')
+    ipc.finalize('screen-sys', 22)
     expect(ws.sent).toContain('finalize')
+  })
+
+  it('rejects cross-window feed, finalize, and stop operations', () => {
+    ipc.start('owned-lane', 31, 'transcribe')
+    const ws = lastWs()
+    ws.simulateOpen()
+
+    ipc.feed('owned-lane', 64, 32)
+    ipc.finalize('owned-lane', 32)
+    ipc.stop('owned-lane', 32)
+
+    expect(ws.sent).toHaveLength(0)
+    expect(ws.readyState).toBe(h.FakeWebSocket.OPEN)
+    ipc.stop('owned-lane', 31)
+    expect(ws.readyState).toBe(h.FakeWebSocket.CLOSED)
+  })
+
+  it('retains ownership after a socket drop so the owner can stop local audio', () => {
+    ipc.start('dropped-lane', 41, 'transcribe')
+    const ws = lastWs()
+    ws.simulateClose()
+
+    expect(isListenSessionOwnedBy('dropped-lane', 41)).toBe(true)
+    expect(isListenSessionOwnedBy('dropped-lane', 42)).toBe(false)
+
+    ipc.stop('dropped-lane', 41)
+    expect(isListenSessionOwnedBy('dropped-lane', 41)).toBe(false)
   })
 })

--- a/desktop/windows/src/main/ipc/omiListen.ts
+++ b/desktop/windows/src/main/ipc/omiListen.ts
@@ -169,6 +169,11 @@ type Session = {
 }
 
 const sessions = new Map<string, Session>()
+// Ownership outlives the WebSocket itself. A socket can close before the
+// renderer sends audio-stop; retaining this record lets the same renderer tear
+// down its local capture pipeline without opening control to other windows.
+const sessionOwners = new Map<string, number>()
+const ownersWithDestroyHook = new Set<number>()
 
 // Base headers every v4/listen WS carries: auth plus the platform/device
 // identity the backend's platform normalization reads (X-App-Platform,
@@ -273,10 +278,23 @@ function killSession(id: string, s: Session, why: string): void {
 }
 
 function startSession(args: ListenStartArgs, owner: WebContents): void {
+  const registeredOwner = sessionOwners.get(args.sessionId)
+  if (registeredOwner !== undefined && registeredOwner !== owner.id) {
+    console.warn('[omi-listen] rejected cross-owner session replacement')
+    return
+  }
   const existing = sessions.get(args.sessionId)
   if (existing) {
     // Already running under the same id — caller bug; tear down to avoid leaks.
     killSession(args.sessionId, existing, 'replace')
+  }
+  sessionOwners.set(args.sessionId, owner.id)
+  if (!ownersWithDestroyHook.has(owner.id)) {
+    ownersWithDestroyHook.add(owner.id)
+    owner.once('destroyed', () => {
+      ownersWithDestroyHook.delete(owner.id)
+      killSessionsForOwner(owner.id)
+    })
   }
   const mode: ListenMode = args.mode ?? 'conversation'
 
@@ -490,9 +508,11 @@ function finalizeSession(sessionId: string): void {
   }
 }
 
-function stopSession(sessionId: string): void {
+function stopSession(sessionId: string, ownerId?: number): void {
+  if (ownerId !== undefined && sessionOwners.get(sessionId) !== ownerId) return
   const s = sessions.get(sessionId)
   if (s) killSession(sessionId, s, 'stop')
+  sessionOwners.delete(sessionId)
 }
 
 /** Close every session owned by a webContents that no longer exists — a crashed
@@ -502,9 +522,18 @@ export function killSessionsForOwner(ownerId: number): void {
   for (const [id, s] of sessions) {
     if (s.ownerId === ownerId) killSession(id, s, `owner ${ownerId} gone`)
   }
+  for (const [id, registeredOwner] of sessionOwners) {
+    if (registeredOwner === ownerId) sessionOwners.delete(id)
+  }
 }
 
-export function registerOmiListenHandlers(): void {
+/** Authorization seam for captureBridge: an audio command may only control the
+ * listen session opened by that same renderer. */
+export function isListenSessionOwnedBy(sessionId: string, ownerId: number): boolean {
+  return sessionOwners.get(sessionId) === ownerId
+}
+
+export function registerOmiListenHandlers(canStartSession: (ownerId: number) => boolean): void {
   // Expose the byte counters to the E2E harnesses (VAD-playback / soak) so a
   // Playwright electronApp.evaluate can read them from the main process. Gated on
   // OMI_E2E — inert in production.
@@ -512,16 +541,21 @@ export function registerOmiListenHandlers(): void {
     ;(globalThis as Record<string, unknown>).__omiGetListenStats = getListenStats
   }
   ipcMain.handle('omi-listen:start', (e, args: ListenStartArgs) => {
+    if (!canStartSession(e.sender.id)) {
+      throw new Error('listen session is not allowed from this window')
+    }
     startSession(args, e.sender)
   })
-  ipcMain.handle('omi-listen:stop', (_e, sessionId: string) => {
-    stopSession(sessionId)
+  ipcMain.handle('omi-listen:stop', (e, sessionId: string) => {
+    stopSession(sessionId, e.sender.id)
   })
   // `on` (not `handle`) — feed is fire-and-forget to keep audio throughput cheap.
-  ipcMain.on('omi-listen:feed', (_e, sessionId: string, pcm: ArrayBuffer) => {
+  ipcMain.on('omi-listen:feed', (e, sessionId: string, pcm: ArrayBuffer) => {
+    if (!isListenSessionOwnedBy(sessionId, e.sender.id)) return
     feedSession(sessionId, pcm)
   })
-  ipcMain.on('omi-listen:finalize', (_e, sessionId: string) => {
+  ipcMain.on('omi-listen:finalize', (e, sessionId: string) => {
+    if (!isListenSessionOwnedBy(sessionId, e.sender.id)) return
     finalizeSession(sessionId)
   })
 }

--- a/desktop/windows/src/main/meeting/meetingMonitor.ts
+++ b/desktop/windows/src/main/meeting/meetingMonitor.ts
@@ -36,6 +36,7 @@ import type { CaptureCommand, MeetingToastAction } from '../../shared/types'
 
 const DEBOUNCE_MS = 3000
 const COALESCE_MS = 250
+const CAPTURE_START_TIMEOUT_MS = 5000
 
 type Deps = { getCaptureWc: () => WebContents | null }
 
@@ -47,11 +48,18 @@ let unsubForeground: (() => void) | null = null
 let unsubCaptureEvents: (() => void) | null = null
 let coalesceTimer: NodeJS.Timeout | null = null
 let deadlineTimer: NodeJS.Timeout | null = null
+let captureStartupTimer: NodeJS.Timeout | null = null
 let running = false
 
 // The meeting currently being surfaced/captured (set on 'meeting-started').
-let currentMeeting: { id: string; appName: string; capturing: boolean } | null = null
+let currentMeeting: {
+  id: string
+  appName: string
+  capturing: boolean
+  captureAttemptId: number | null
+} | null = null
 let nextMeetingSeq = 1
+let nextCaptureAttemptSeq = 1
 
 // E2E only (OMI_E2E=1): when set, evaluate() uses these signals instead of the
 // native sources, so the whole pipeline (machine → toast → capture command) is
@@ -122,23 +130,60 @@ function sendCaptureCommand(cmd: CaptureCommand): boolean {
   return true
 }
 
-function startCapture(): void {
-  if (!currentMeeting || currentMeeting.capturing) return
+function startCapture(): boolean {
+  if (!currentMeeting) return false
+  if (currentMeeting.capturing) return true
+  const attemptId = nextCaptureAttemptSeq++
   // Only mark capturing once the command actually reached a live capture
   // window — otherwise `capturing` would latch true (toast lying "Omi is
   // capturing") with nothing recording when the capture window is absent.
   const sent = sendCaptureCommand({
     type: 'meeting-capture-start',
     meetingId: currentMeeting.id,
+    attemptId,
     appName: currentMeeting.appName
   })
-  if (sent) currentMeeting.capturing = true
+  if (sent) {
+    currentMeeting.capturing = true
+    currentMeeting.captureAttemptId = attemptId
+    armCaptureStartupTimeout(currentMeeting.id, attemptId)
+  }
+  return sent
+}
+
+function clearCaptureStartupTimeout(): void {
+  if (captureStartupTimer) clearTimeout(captureStartupTimer)
+  captureStartupTimer = null
+}
+
+function armCaptureStartupTimeout(meetingId: string, attemptId: number): void {
+  clearCaptureStartupTimeout()
+  captureStartupTimer = setTimeout(() => {
+    captureStartupTimer = null
+    if (
+      !currentMeeting?.capturing ||
+      currentMeeting.id !== meetingId ||
+      currentMeeting.captureAttemptId !== attemptId
+    )
+      return
+    console.warn('[meeting] capture startup timed out')
+    stopCapture()
+    showMeetingToast({
+      meetingId: currentMeeting.id,
+      appName: currentMeeting.appName,
+      kind: 'error',
+      errorKind: 'startup'
+    })
+  }, CAPTURE_START_TIMEOUT_MS)
 }
 
 function stopCapture(): void {
-  if (!currentMeeting?.capturing) return
+  if (!currentMeeting?.capturing || currentMeeting.captureAttemptId === null) return
+  clearCaptureStartupTimeout()
+  const attemptId = currentMeeting.captureAttemptId
   currentMeeting.capturing = false
-  sendCaptureCommand({ type: 'meeting-capture-stop', meetingId: currentMeeting.id })
+  currentMeeting.captureAttemptId = null
+  sendCaptureCommand({ type: 'meeting-capture-stop', meetingId: currentMeeting.id, attemptId })
 }
 
 /** Hide the shared toast window ONLY if the meeting card currently on it belongs
@@ -160,16 +205,18 @@ function handleEffect(effect: DetectorEffect): void {
     currentMeeting = {
       id: `meeting-${Date.now()}-${nextMeetingSeq++}`,
       appName: effect.match.name,
-      capturing: false
+      capturing: false,
+      captureAttemptId: null
     }
     console.log(
       `[meeting] started: ${effect.match.name} (${effect.match.tier2Key}) mode=${effect.mode}`
     )
-    if (effect.mode === 'auto') startCapture()
+    const captureSent = effect.mode === 'auto' ? startCapture() : false
     showMeetingToast({
       meetingId: currentMeeting.id,
       appName: currentMeeting.appName,
-      kind: effect.mode === 'auto' ? 'capturing' : 'ask',
+      kind: effect.mode === 'auto' ? (captureSent ? 'starting' : 'error') : 'ask',
+      ...(effect.mode === 'auto' && !captureSent ? { errorKind: 'startup' as const } : {}),
       firstRun: takeFirstRun()
     })
   } else {
@@ -224,8 +271,13 @@ export function meetingToastAction(meetingId: string, action: MeetingToastAction
     return
   }
   if (action === 'start') {
-    startCapture()
-    showMeetingToast({ meetingId: currentMeeting.id, appName: currentMeeting.appName, kind: 'capturing' })
+    const sent = startCapture()
+    showMeetingToast({
+      meetingId: currentMeeting.id,
+      appName: currentMeeting.appName,
+      kind: sent ? 'starting' : 'error',
+      ...(!sent ? { errorKind: 'startup' as const } : {})
+    })
   } else if (action === 'stop') {
     stopCapture()
     hideMeetingToast()
@@ -256,8 +308,16 @@ export function startMeetingMonitor(d: Deps): void {
     // toast keeps claiming capture.
     if (ev.type === 'capture-window-restarted') {
       if (currentMeeting?.capturing) {
+        clearCaptureStartupTimeout()
         currentMeeting.capturing = false // startCapture re-sets it on a live send
-        startCapture()
+        currentMeeting.captureAttemptId = null
+        const sent = startCapture()
+        showMeetingToast({
+          meetingId: currentMeeting.id,
+          appName: currentMeeting.appName,
+          kind: sent ? 'starting' : 'error',
+          ...(!sent ? { errorKind: 'startup' as const } : {})
+        })
       }
       return
     }
@@ -266,10 +326,43 @@ export function startMeetingMonitor(d: Deps): void {
     if (ev.type !== 'meeting-capture-status') return
     if (process.env.OMI_E2E === '1') statusLog.push(`${ev.meetingId}:${ev.status}`)
     if (!currentMeeting || ev.meetingId !== currentMeeting.id) return
-    if (ev.status === 'error') {
+    if (ev.status === 'save-error') {
+      // A save can finish after Stop cleared the active attempt. Never let an
+      // older save failure overwrite a newer capture attempt.
+      if (currentMeeting.captureAttemptId === null) {
+        showMeetingToast({
+          meetingId: currentMeeting.id,
+          appName: currentMeeting.appName,
+          kind: 'error',
+          errorKind: 'save'
+        })
+      }
+      return
+    }
+    if (ev.attemptId !== currentMeeting.captureAttemptId) return
+    if (ev.status === 'started') {
+      clearCaptureStartupTimeout()
+      if (currentMeeting.capturing && getCurrentMeetingToast()?.meetingId === currentMeeting.id) {
+        // Do not resurrect a success notice the user dismissed, or replace an
+        // insight that took over the shared toast while startup was pending.
+        showMeetingToast({
+          meetingId: currentMeeting.id,
+          appName: currentMeeting.appName,
+          kind: 'capturing'
+        })
+      }
+    } else if (ev.status === 'startup-error' || ev.status === 'runtime-error') {
+      clearCaptureStartupTimeout()
       console.warn('[meeting] capture failed:', ev.message)
-      currentMeeting.capturing = false
-      hideOwnMeetingToast()
+      // Stop every sibling lane before clearing the state. Otherwise one lane
+      // can keep recording after the other fails while the notice is gone.
+      stopCapture()
+      showMeetingToast({
+        meetingId: currentMeeting.id,
+        appName: currentMeeting.appName,
+        kind: 'error',
+        errorKind: ev.status === 'startup-error' ? 'startup' : 'runtime'
+      })
     }
   })
   // Pick up a meeting already in progress at app start — coalesced, so the
@@ -291,6 +384,7 @@ export function stopMeetingMonitor(): void {
   coalesceTimer = null
   if (deadlineTimer) clearTimeout(deadlineTimer)
   deadlineTimer = null
+  clearCaptureStartupTimeout()
   stopCapture()
   currentMeeting = null
   state = initialDetectorState

--- a/desktop/windows/src/renderer/src/capture/AudioSessionHost.test.tsx
+++ b/desktop/windows/src/renderer/src/capture/AudioSessionHost.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CaptureCommand, CaptureEvent } from '../../../shared/types'
+import type { PipelineSetupResult } from '../lib/capture/pipelineHandle'
+
+const h = vi.hoisted(() => ({
+  commandHandler: null as null | ((command: CaptureCommand, ownerId: number) => void),
+  pipelineReady: Promise.resolve({ ok: true } as PipelineSetupResult),
+  pipelineStop: vi.fn(),
+  gateStop: vi.fn(),
+  trackStop: vi.fn(),
+  captureEmit: vi.fn()
+}))
+
+vi.mock('../lib/audio', () => ({
+  acquireMicStream: async () => ({ getTracks: () => [{ stop: h.trackStop }] })
+}))
+vi.mock('../lib/capture/systemAudio', () => ({
+  getSystemAudioStream: async () => ({ getTracks: () => [{ stop: h.trackStop }] })
+}))
+vi.mock('../lib/capture/captureEngine', () => ({
+  createPcmPipeline: () => ({ stop: h.pipelineStop, ready: h.pipelineReady }),
+  createVadGate: () => ({ push: vi.fn(), stop: h.gateStop })
+}))
+vi.mock('../lib/capture/loopbackMusicFilter', () => ({
+  createLoopbackMusicFilter: () => ({ push: vi.fn(), stop: vi.fn(), verdict: vi.fn() })
+}))
+vi.mock('../lib/preferences', () => ({ getPreferences: () => ({ vadGateEnabled: true }) }))
+vi.mock('./assistantGate', () => ({
+  assistantGate: { setSpeaking: vi.fn() },
+  wrapFeed: (feed: unknown) => feed
+}))
+vi.mock('../lib/capture/vadGate', () => ({ resolveVadGateMode: () => 'gated' }))
+
+import { AudioSessionHost } from './AudioSessionHost'
+
+beforeEach(() => {
+  h.commandHandler = null
+  h.pipelineReady = Promise.resolve({ ok: true })
+  h.pipelineStop.mockReset()
+  h.gateStop.mockReset()
+  h.trackStop.mockReset()
+  h.captureEmit.mockReset()
+  Object.defineProperty(window, 'omi', {
+    configurable: true,
+    value: {
+      listenFeed: vi.fn(),
+      captureEmit: h.captureEmit,
+      onCaptureCommand: (handler: (command: CaptureCommand, ownerId: number) => void) => {
+        h.commandHandler = handler
+        return () => {
+          h.commandHandler = null
+        }
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('AudioSessionHost readiness', () => {
+  it('emits ready only after the PCM pipeline setup resolves', async () => {
+    let resolveSetup!: (result: PipelineSetupResult) => void
+    h.pipelineReady = new Promise((resolve) => {
+      resolveSetup = resolve
+    })
+    render(<AudioSessionHost />)
+
+    act(() => {
+      h.commandHandler?.({ type: 'audio-start', sessionId: 'delayed', source: 'mic' }, 42)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(h.captureEmit).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveSetup({ ok: true })
+      await h.pipelineReady
+    })
+    expect(h.captureEmit).toHaveBeenCalledWith(
+      { type: 'audio-source-ready', sessionId: 'delayed' },
+      42
+    )
+
+    act(() => {
+      h.commandHandler?.({ type: 'audio-stop', sessionId: 'delayed' }, 42)
+    })
+  })
+
+  it('reports pipeline setup failure without claiming the source is ready', async () => {
+    h.pipelineReady = Promise.resolve({ ok: false, error: new Error('audio graph failed') })
+    render(<AudioSessionHost />)
+
+    act(() => {
+      h.commandHandler?.({ type: 'audio-start', sessionId: 'failed', source: 'mic' }, 7)
+    })
+    await act(async () => {
+      await h.pipelineReady
+    })
+
+    const events = h.captureEmit.mock.calls.map(([event]) => event as CaptureEvent)
+    expect(events).toContainEqual({
+      type: 'audio-source-error',
+      sessionId: 'failed',
+      name: 'Error',
+      message: 'audio graph failed'
+    })
+    expect(events.some((event) => event.type === 'audio-source-ready')).toBe(false)
+    expect(h.pipelineStop).toHaveBeenCalledOnce()
+  })
+})

--- a/desktop/windows/src/renderer/src/capture/AudioSessionHost.ts
+++ b/desktop/windows/src/renderer/src/capture/AudioSessionHost.ts
@@ -79,31 +79,65 @@ async function startAudioSession(
     return
   }
 
-  const feed = (pcm: Int16Array): void =>
-    window.omi?.listenFeed(sessionId, pcm.buffer as ArrayBuffer)
-  // Loopback lane: classify VAD-gated windows (YAMNet) so a confident music
-  // verdict closes the lane — ambient/meeting capture never transcribes a
-  // movie. The mic lane never classifies (the user's own voice always counts).
-  let onVoiced = feed
-  if (source !== 'mic') {
-    const filter = createLoopbackMusicFilter(feed)
-    session.musicFilter = filter
-    onVoiced = filter.push
+  try {
+    const feed = (pcm: Int16Array): void =>
+      window.omi?.listenFeed(sessionId, pcm.buffer as ArrayBuffer)
+    // Loopback lane: classify VAD-gated windows (YAMNet) so a confident music
+    // verdict closes the lane — ambient/meeting capture never transcribes a
+    // movie. The mic lane never classifies (the user's own voice always counts).
+    let onVoiced = feed
+    if (source !== 'mic') {
+      const filter = createLoopbackMusicFilter(feed)
+      session.musicFilter = filter
+      onVoiced = filter.push
+    }
+    // Read the local-VAD-gate preference at session start (Settings → Transcription).
+    // Disabled → passthrough, so every frame reaches the backend ungated.
+    const gate = createVadGate({
+      onVoiced,
+      mode: resolveVadGateMode(getPreferences().vadGateEnabled)
+    })
+    session.gate = gate
+    // Echo gate (Phase 6): while Omi's voice plays, drop frames BEFORE the VAD
+    // gate so Omi's speech never enters the pre-roll ring either. Applies to both
+    // lanes — mic (acoustic echo) and system audio (Omi's voice IS system output).
+    session.pipeline = createPcmPipeline(
+      stream,
+      wrapFeed((pcm) => gate.push(pcm))
+    )
+  } catch (e) {
+    session.pipeline?.stop()
+    if (!session.pipeline) stream.getTracks().forEach((t) => t.stop())
+    session.gate?.stop()
+    session.musicFilter?.stop()
+    sessions.delete(sessionId)
+    const err = e instanceof Error ? e : new Error(String(e))
+    window.omi?.captureEmit(
+      { type: 'audio-source-error', sessionId, name: err.name, message: err.message },
+      ownerId
+    )
+    return
   }
-  // Read the local-VAD-gate preference at session start (Settings → Transcription).
-  // Disabled → passthrough, so every frame reaches the backend ungated.
-  const gate = createVadGate({
-    onVoiced,
-    mode: resolveVadGateMode(getPreferences().vadGateEnabled)
-  })
-  session.gate = gate
-  // Echo gate (Phase 6): while Omi's voice plays, drop frames BEFORE the VAD
-  // gate so Omi's speech never enters the pre-roll ring either. Applies to both
-  // lanes — mic (acoustic echo) and system audio (Omi's voice IS system output).
-  session.pipeline = createPcmPipeline(
-    stream,
-    wrapFeed((pcm) => gate.push(pcm))
-  )
+
+  const setup = await session.pipeline.ready
+  if (session.stopped) return
+  if (!setup.ok) {
+    session.pipeline.stop()
+    session.gate?.stop()
+    session.musicFilter?.stop()
+    sessions.delete(sessionId)
+    window.omi?.captureEmit(
+      {
+        type: 'audio-source-error',
+        sessionId,
+        name: setup.error.name,
+        message: setup.error.message
+      },
+      ownerId
+    )
+    return
+  }
+  window.omi?.captureEmit({ type: 'audio-source-ready', sessionId }, ownerId)
 }
 
 /** Test-only (read via the OMI_E2E-gated capture hook): current music-gate

--- a/desktop/windows/src/renderer/src/capture/MeetingSessionHost.test.tsx
+++ b/desktop/windows/src/renderer/src/capture/MeetingSessionHost.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CaptureCommand, CaptureEvent } from '../../../shared/types'
+import type { MeetingSessionHandle } from './meetingSession'
+
+type PendingStart = {
+  resolve: (handle: MeetingSessionHandle) => void
+  reject: (error: Error) => void
+  signal: AbortSignal
+  onError: (message: string) => void
+}
+
+const h = vi.hoisted(() => ({
+  commandHandler: null as null | ((command: CaptureCommand) => void),
+  pending: [] as PendingStart[],
+  captureEmit: vi.fn(),
+  stopAttempt1: vi.fn(async () => {}),
+  stopAttempt2: vi.fn(async () => {})
+}))
+
+vi.mock('./meetingSession', () => ({
+  startMeetingSession: vi.fn(
+    (args: { signal: AbortSignal; onError: (message: string) => void }) =>
+      new Promise<MeetingSessionHandle>((resolve, reject) => {
+        h.pending.push({ resolve, reject, signal: args.signal, onError: args.onError })
+      })
+  )
+}))
+
+import { MeetingSessionHost } from './MeetingSessionHost'
+
+beforeEach(() => {
+  h.commandHandler = null
+  h.pending.length = 0
+  h.captureEmit.mockReset()
+  h.stopAttempt1.mockClear()
+  h.stopAttempt2.mockClear()
+  Object.defineProperty(window, 'omi', {
+    configurable: true,
+    value: {
+      captureEmit: h.captureEmit,
+      onCaptureCommand: (handler: (command: CaptureCommand) => void) => {
+        h.commandHandler = handler
+        return () => {
+          h.commandHandler = null
+        }
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MeetingSessionHost attempts', () => {
+  it('allows Retry while an older cancelled startup is still settling', async () => {
+    render(<MeetingSessionHost />)
+    act(() => {
+      h.commandHandler?.({
+        type: 'meeting-capture-start',
+        meetingId: 'meeting-1',
+        attemptId: 1,
+        appName: 'Google Meet'
+      })
+    })
+    expect(h.pending).toHaveLength(1)
+
+    act(() => {
+      h.commandHandler?.({ type: 'meeting-capture-stop', meetingId: 'meeting-1', attemptId: 1 })
+      h.commandHandler?.({
+        type: 'meeting-capture-start',
+        meetingId: 'meeting-1',
+        attemptId: 2,
+        appName: 'Google Meet'
+      })
+    })
+    expect(h.pending).toHaveLength(2)
+    expect(h.pending[0].signal.aborted).toBe(true)
+
+    await act(async () => {
+      h.pending[1].resolve({ stop: h.stopAttempt2 })
+      await Promise.resolve()
+    })
+    expect(h.captureEmit).toHaveBeenCalledWith({
+      type: 'meeting-capture-status',
+      meetingId: 'meeting-1',
+      attemptId: 2,
+      status: 'started'
+    })
+
+    await act(async () => {
+      h.pending[0].resolve({ stop: h.stopAttempt1 })
+      await Promise.resolve()
+    })
+    expect(h.stopAttempt1).toHaveBeenCalledOnce()
+    const events = h.captureEmit.mock.calls.map(([event]) => event as CaptureEvent)
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'meeting-capture-status' &&
+          event.attemptId === 1 &&
+          event.status === 'started'
+      )
+    ).toBe(false)
+
+    act(() => {
+      h.commandHandler?.({ type: 'meeting-capture-stop', meetingId: 'meeting-1', attemptId: 2 })
+    })
+  })
+
+  it('fails closed when a ready lane drops while its sibling is still starting', async () => {
+    render(<MeetingSessionHost />)
+    act(() => {
+      h.commandHandler?.({
+        type: 'meeting-capture-start',
+        meetingId: 'meeting-early-drop',
+        attemptId: 3,
+        appName: 'Google Meet'
+      })
+    })
+
+    act(() => {
+      h.pending[0].onError('system: socket closed')
+    })
+    await act(async () => {
+      h.pending[0].resolve({ stop: h.stopAttempt1 })
+      await Promise.resolve()
+    })
+
+    expect(h.stopAttempt1).toHaveBeenCalledOnce()
+    expect(h.captureEmit).toHaveBeenCalledWith({
+      type: 'meeting-capture-status',
+      meetingId: 'meeting-early-drop',
+      attemptId: 3,
+      status: 'startup-error',
+      message: 'system: socket closed'
+    })
+    const events = h.captureEmit.mock.calls.map(([event]) => event as CaptureEvent)
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'meeting-capture-status' &&
+          event.attemptId === 3 &&
+          event.status === 'started'
+      )
+    ).toBe(false)
+  })
+})

--- a/desktop/windows/src/renderer/src/capture/MeetingSessionHost.tsx
+++ b/desktop/windows/src/renderer/src/capture/MeetingSessionHost.tsx
@@ -9,55 +9,110 @@ import { startMeetingSession, type MeetingSessionHandle } from './meetingSession
 // Lifecycle is reported back over the capture-event channel as
 // 'meeting-capture-status' — main uses it to keep the toast honest.
 
-type Slot = { handle: MeetingSessionHandle | null; stopped: boolean }
-const sessions = new Map<string, Slot>()
+type Slot = {
+  meetingId: string
+  attemptId: number
+  handle: MeetingSessionHandle | null
+  abort: AbortController
+  stopped: boolean
+  errorReported: boolean
+  pendingStartupError: string | null
+}
+const sessions = new Map<number, Slot>()
 
-function emitStatus(meetingId: string, status: 'started' | 'error' | 'saved', message?: string): void {
-  window.omi?.captureEmit({ type: 'meeting-capture-status', meetingId, status, ...(message ? { message } : {}) })
+function emitStatus(
+  meetingId: string,
+  attemptId: number,
+  status: 'started' | 'startup-error' | 'runtime-error' | 'saved' | 'save-error',
+  message?: string
+): void {
+  window.omi?.captureEmit({
+    type: 'meeting-capture-status',
+    meetingId,
+    attemptId,
+    status,
+    ...(message ? { message } : {})
+  })
 }
 
-async function start(meetingId: string, appName: string): Promise<void> {
-  if (sessions.has(meetingId)) return // duplicate command
-  const slot: Slot = { handle: null, stopped: false }
-  sessions.set(meetingId, slot)
+async function start(meetingId: string, attemptId: number, appName: string): Promise<void> {
+  if (sessions.has(attemptId)) return // duplicate command
+  const slot: Slot = {
+    meetingId,
+    attemptId,
+    handle: null,
+    abort: new AbortController(),
+    stopped: false,
+    errorReported: false,
+    pendingStartupError: null
+  }
+  sessions.set(attemptId, slot)
+  const reportRuntimeError = (message: string): void => {
+    if (slot.stopped || slot.errorReported || sessions.get(attemptId) !== slot) return
+    slot.errorReported = true
+    emitStatus(meetingId, attemptId, 'runtime-error', message)
+  }
   try {
     const handle = await startMeetingSession({
       appName,
-      onError: (message) => emitStatus(meetingId, 'error', message)
+      // Startup failures reject startMeetingSession after every sibling lane has
+      // settled and been cleaned up. A lane can still drop after becoming ready
+      // while its sibling is starting, so hold that early error until the startup
+      // handle exists and can be torn down.
+      onError: (message) => {
+        if (slot.handle) reportRuntimeError(message)
+        else slot.pendingStartupError ??= message
+      },
+      signal: slot.abort.signal
     })
     if (slot.stopped) {
       // stop landed while lanes were connecting — finalize immediately.
       await handle.stop()
-      sessions.delete(meetingId)
+      sessions.delete(attemptId)
+      return
+    }
+    if (slot.pendingStartupError) {
+      slot.stopped = true
+      try {
+        await handle.stop()
+      } catch {
+        /* the original startup failure remains the actionable error */
+      }
+      sessions.delete(attemptId)
+      emitStatus(meetingId, attemptId, 'startup-error', slot.pendingStartupError)
       return
     }
     slot.handle = handle
-    emitStatus(meetingId, 'started')
+    emitStatus(meetingId, attemptId, 'started')
   } catch (e) {
-    sessions.delete(meetingId)
-    emitStatus(meetingId, 'error', (e as Error).message)
+    if (!slot.stopped) {
+      emitStatus(meetingId, attemptId, 'startup-error', (e as Error).message)
+    }
+    sessions.delete(attemptId)
   }
 }
 
-async function stop(meetingId: string): Promise<void> {
-  const slot = sessions.get(meetingId)
-  if (!slot) return
+async function stop(meetingId: string, attemptId: number): Promise<void> {
+  const slot = sessions.get(attemptId)
+  if (!slot || slot.meetingId !== meetingId) return
   slot.stopped = true
+  slot.abort.abort()
   if (!slot.handle) return // start() will see `stopped` and finalize
-  sessions.delete(meetingId)
+  sessions.delete(attemptId)
   try {
     await slot.handle.stop()
-    emitStatus(meetingId, 'saved')
+    emitStatus(meetingId, attemptId, 'saved')
   } catch (e) {
-    emitStatus(meetingId, 'error', (e as Error).message)
+    emitStatus(meetingId, attemptId, 'save-error', (e as Error).message)
   }
 }
 
 export function MeetingSessionHost(): null {
   useEffect(() => {
     return window.omi?.onCaptureCommand?.((cmd) => {
-      if (cmd.type === 'meeting-capture-start') void start(cmd.meetingId, cmd.appName)
-      else if (cmd.type === 'meeting-capture-stop') void stop(cmd.meetingId)
+      if (cmd.type === 'meeting-capture-start')
+        void start(cmd.meetingId, cmd.attemptId, cmd.appName)
+      else if (cmd.type === 'meeting-capture-stop') void stop(cmd.meetingId, cmd.attemptId)
     })
   }, [])
   return null

--- a/desktop/windows/src/renderer/src/capture/liveMicSession.test.ts
+++ b/desktop/windows/src/renderer/src/capture/liveMicSession.test.ts
@@ -72,7 +72,12 @@ vi.mock('../lib/sync/conversationSync', () => ({
   syncLocalConversation: (row: unknown) => syncLocalConversation(row)
 }))
 
-import { startLiveMicSession, isLiveMicSessionActive } from './liveMicSession'
+import {
+  getLiveMicSessionHealth,
+  isLiveMicSessionActive,
+  startLiveMicSession,
+  waitForLiveMicSessionReady
+} from './liveMicSession'
 import { MAX_RECONNECT_ATTEMPTS } from './liveRescue'
 
 const insertLocalConversation = vi.fn(async (_row: unknown) => {})
@@ -191,10 +196,28 @@ describe('startLiveMicSession', () => {
   it('reports active while running and clears on stop (C6 defer signal)', async () => {
     const ctrl = startLiveMicSession()
     expect(isLiveMicSessionActive()).toBe(true)
+    expect(getLiveMicSessionHealth()).toBe('connecting')
     await vi.advanceTimersByTimeAsync(0)
+    const ready = waitForLiveMicSessionReady()
+    latest().cb.onBackend('omi')
+    await expect(ready).resolves.toBe(true)
+    expect(getLiveMicSessionHealth()).toBe('ready')
     ctrl.stop()
     expect(isLiveMicSessionActive()).toBe(false)
+    expect(getLiveMicSessionHealth()).toBe('inactive')
     ctrl.stop() // idempotent — must not drive the count negative
     expect(isLiveMicSessionActive()).toBe(false)
+  })
+
+  it('reports terminal startup failure to delegated meeting readiness', async () => {
+    const ctrl = startLiveMicSession()
+    await vi.advanceTimersByTimeAsync(0)
+    const ready = waitForLiveMicSessionReady()
+
+    latest().cb.onError(new Error('Omi transcription unavailable (not signed in)'))
+
+    await expect(ready).resolves.toBe(false)
+    expect(getLiveMicSessionHealth()).toBe('failed')
+    ctrl.stop()
   })
 })

--- a/desktop/windows/src/renderer/src/capture/liveMicSession.ts
+++ b/desktop/windows/src/renderer/src/capture/liveMicSession.ts
@@ -27,18 +27,83 @@ export type LiveMicController = {
   stop: () => void
 }
 
-// How many always-on mic controllers are live right now. The continuous mic
-// session already streams the mic to the backend's /v4/listen conversation, so a
-// concurrently-detected meeting must NOT open a second mic /v4/listen for the same
-// audio (C6). Both hosts run in the capture window, so this module-level count is
-// the shared "is the mic already owned?" signal. Kept as a count (not a boolean)
-// so a StrictMode double-mount never wedges it false.
-let liveMicActiveCount = 0
+export type LiveMicSessionHealth = 'inactive' | 'connecting' | 'ready' | 'failed'
+
+// Track each controller independently so React StrictMode overlap cannot make a
+// stopped controller overwrite the health of its replacement.
+let nextControllerId = 1
+const controllerHealth = new Map<number, Exclude<LiveMicSessionHealth, 'inactive'>>()
+const healthListeners = new Set<(health: LiveMicSessionHealth) => void>()
+let aggregateHealth: LiveMicSessionHealth = 'inactive'
+
+function computeAggregateHealth(): LiveMicSessionHealth {
+  const states = [...controllerHealth.values()]
+  if (states.includes('ready')) return 'ready'
+  if (states.includes('connecting')) return 'connecting'
+  return states.length > 0 ? 'failed' : 'inactive'
+}
+
+function setControllerHealth(
+  controllerId: number,
+  health: Exclude<LiveMicSessionHealth, 'inactive'> | null
+): void {
+  if (health) controllerHealth.set(controllerId, health)
+  else controllerHealth.delete(controllerId)
+  const next = computeAggregateHealth()
+  if (next === aggregateHealth) return
+  aggregateHealth = next
+  for (const listener of healthListeners) listener(next)
+}
 
 /** True when an always-on continuous mic session is running. Read by the meeting
  *  session to defer to it instead of opening a duplicate mic /v4/listen. */
 export function isLiveMicSessionActive(): boolean {
-  return liveMicActiveCount > 0
+  return controllerHealth.size > 0
+}
+
+export function getLiveMicSessionHealth(): LiveMicSessionHealth {
+  return aggregateHealth
+}
+
+export function onLiveMicSessionHealth(
+  listener: (health: LiveMicSessionHealth) => void
+): () => void {
+  healthListeners.add(listener)
+  listener(aggregateHealth)
+  return () => healthListeners.delete(listener)
+}
+
+/** Wait for an in-flight continuous mic to become usable. A meeting uses this
+ *  as part of its own startup barrier instead of assuming controller existence
+ *  means the user's voice is already being captured. */
+export function waitForLiveMicSessionReady(
+  signal?: AbortSignal,
+  timeoutMs = 3_500
+): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(false)
+  if (aggregateHealth === 'ready') return Promise.resolve(true)
+  if (aggregateHealth !== 'connecting') return Promise.resolve(false)
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (ready: boolean): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      healthListeners.delete(onHealth)
+      signal?.removeEventListener('abort', onAbort)
+      resolve(ready)
+    }
+    const onHealth = (health: LiveMicSessionHealth): void => {
+      if (health === 'ready') finish(true)
+      else if (health === 'failed' || health === 'inactive') finish(false)
+    }
+    const onAbort = (): void => finish(false)
+    const timer = setTimeout(() => finish(false), timeoutMs)
+    healthListeners.add(onHealth)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    // Close the subscribe-after-check race.
+    onHealth(aggregateHealth)
+  })
 }
 
 /**
@@ -69,7 +134,8 @@ export function isLiveMicSessionActive(): boolean {
  */
 export function startLiveMicSession(): LiveMicController {
   let cancelled = false
-  liveMicActiveCount++ // mark the mic as owned (see isLiveMicSessionActive / C6)
+  const controllerId = nextControllerId++
+  setControllerHealth(controllerId, 'connecting')
   let handle: TranscriptionHandle | null = null
   let hasSpeech = false
   let silenceTimer: ReturnType<typeof setTimeout> | null = null
@@ -166,6 +232,7 @@ export function startLiveMicSession(): LiveMicController {
   // Open (or reconnect) the socket for the CURRENT conversation, re-sending the
   // same clientConversationId so a reconnect resumes it.
   const connect = (): void => {
+    setControllerHealth(controllerId, 'connecting')
     captureLiveStore.setStatus('connecting')
     void startTranscription(
       'mic',
@@ -173,6 +240,7 @@ export function startLiveMicSession(): LiveMicController {
         onLine: (line) => {
           if (cancelled) return
           reconnectAttempt = 0 // a delivered segment proves the socket is healthy
+          setControllerHealth(controllerId, 'ready')
           captureLiveStore.setStatus('live')
           captureLiveStore.appendLine(line)
           hasSpeech = true
@@ -182,6 +250,7 @@ export function startLiveMicSession(): LiveMicController {
         onBackend: () => {
           if (cancelled) return
           reconnectAttempt = 0
+          setControllerHealth(controllerId, 'ready')
           captureLiveStore.setStatus('live')
         },
         onSegments: (segs) => {
@@ -216,6 +285,7 @@ export function startLiveMicSession(): LiveMicController {
             // raises the "Upgrade" modal. Do NOT call showUsageLimit here: this
             // hidden capture window is a separate renderer, so its in-memory popup
             // signal never reaches the popup host.
+            setControllerHealth(controllerId, 'failed')
             captureLiveStore.setStatus('error', (e as Error).message)
             return
           }
@@ -225,6 +295,7 @@ export function startLiveMicSession(): LiveMicController {
             // 429 handshake rejection backs off from a longer floor (don't hammer a
             // server that just rate-limited us); jitter decorrelates lanes in a storm.
             reconnectAttempt++
+            setControllerHealth(controllerId, 'connecting')
             const rateLimited = isRateLimitedDropError((e as Error).message)
             captureLiveStore.setStatus('connecting')
             timers.push(
@@ -238,23 +309,28 @@ export function startLiveMicSession(): LiveMicController {
           } else {
             // Exhausted — rescue the recording via from-segments, then surface the error.
             rescue()
+            setControllerHealth(controllerId, 'failed')
             captureLiveStore.setStatus('error', (e as Error).message)
           }
         }
       },
       'conversation',
       clientConversationId
-    ).then((h) => {
-      if (cancelled) {
-        try {
-          h.stop()
-        } catch {
-          /* ignore */
+    )
+      .then((h) => {
+        if (cancelled) {
+          try {
+            h.stop()
+          } catch {
+            /* ignore */
+          }
+          return
         }
-        return
-      }
-      handle = h
-    })
+        handle = h
+      })
+      // startTranscription reports the same initial failure through onError,
+      // which already owns retry/quota handling above.
+      .catch(() => {})
   }
 
   // Begin a fresh conversation: new resumable id, cleared retainer, reset backoff.
@@ -277,7 +353,7 @@ export function startLiveMicSession(): LiveMicController {
     stop: (): void => {
       if (cancelled) return // idempotent — decrement the active count exactly once
       cancelled = true
-      liveMicActiveCount = Math.max(0, liveMicActiveCount - 1)
+      setControllerHealth(controllerId, null)
       clearSilence()
       timers.forEach(clearTimeout)
       unsubFinalize()

--- a/desktop/windows/src/renderer/src/capture/meetingSession.test.ts
+++ b/desktop/windows/src/renderer/src/capture/meetingSession.test.ts
@@ -19,11 +19,24 @@ vi.mock('../lib/transcriptionClient', () => ({
   })
 }))
 
-// The meeting session defers its mic lane to the continuous mic session (C6);
-// mock the signal so each test controls whether the mic is already owned.
-let continuousMicActive = false
+// The meeting session defers its mic lane only to a healthy continuous mic (C6).
+const live = vi.hoisted(() => ({
+  health: 'inactive' as 'inactive' | 'connecting' | 'ready' | 'failed',
+  waitForReady: vi.fn(async () => true),
+  listeners: [] as Array<(health: 'inactive' | 'connecting' | 'ready' | 'failed') => void>
+}))
 vi.mock('./liveMicSession', () => ({
-  isLiveMicSessionActive: () => continuousMicActive
+  getLiveMicSessionHealth: () => live.health,
+  waitForLiveMicSessionReady: live.waitForReady,
+  onLiveMicSessionHealth: (
+    listener: (health: 'inactive' | 'connecting' | 'ready' | 'failed') => void
+  ) => {
+    live.listeners.push(listener)
+    listener(live.health)
+    return () => {
+      live.listeners = live.listeners.filter((candidate) => candidate !== listener)
+    }
+  }
 }))
 
 import { startMeetingSession, formatMeetingTranscript } from './meetingSession'
@@ -39,7 +52,13 @@ beforeEach(() => {
   laneModes.mic = undefined
   laneModes.system = undefined
   systemShouldFail = false
-  continuousMicActive = false
+  live.health = 'inactive'
+  live.waitForReady.mockReset()
+  live.waitForReady.mockImplementation(async () => {
+    live.health = 'ready'
+    return true
+  })
+  live.listeners = []
   insertLocalConversation.mockClear()
   notifyConversationsChanged.mockClear()
   // meetingSession reads window.omi.* and the global crypto.randomUUID.
@@ -86,7 +105,7 @@ describe('startMeetingSession', () => {
   })
 
   it('does NOT open a second mic lane when a continuous mic session is already active (C6)', async () => {
-    continuousMicActive = true
+    live.health = 'ready'
     const session = await startMeetingSession({ appName: 'Zoom', onError: vi.fn() })
     // Only the system lane runs; the mic is left to the continuous session so no
     // duplicate /v4/listen mic socket is opened for the same audio.
@@ -98,6 +117,39 @@ describe('startMeetingSession', () => {
     expect(stops.mic).not.toHaveBeenCalled()
     expect(stops.system).toHaveBeenCalledOnce()
     expect(insertLocalConversation).toHaveBeenCalledOnce()
+  })
+
+  it('includes a connecting continuous mic in the startup readiness barrier', async () => {
+    live.health = 'connecting'
+    const session = await startMeetingSession({ appName: 'Zoom', onError: vi.fn() })
+
+    expect(live.waitForReady).toHaveBeenCalledOnce()
+    expect(laneCbs.mic).toBeUndefined()
+    await session.stop()
+  })
+
+  it('reports a delegated continuous mic that fails after startup', async () => {
+    live.health = 'ready'
+    const onError = vi.fn()
+    const session = await startMeetingSession({ appName: 'Zoom', onError })
+
+    live.health = 'failed'
+    for (const listener of live.listeners) listener(live.health)
+
+    expect(onError).toHaveBeenCalledWith('microphone: continuous transcription stopped')
+    await session.stop()
+    expect(live.listeners).toHaveLength(0)
+  })
+
+  it('fails startup and stops system audio when the delegated mic never becomes ready', async () => {
+    live.health = 'connecting'
+    live.waitForReady.mockResolvedValue(false)
+
+    await expect(startMeetingSession({ appName: 'Zoom', onError: vi.fn() })).rejects.toThrow(
+      'continuous microphone transcription did not become ready'
+    )
+    expect(stops.system).toHaveBeenCalledOnce()
+    expect(laneCbs.mic).toBeUndefined()
   })
 
   it('skips the save when the system lane produced nothing', async () => {

--- a/desktop/windows/src/renderer/src/capture/meetingSession.ts
+++ b/desktop/windows/src/renderer/src/capture/meetingSession.ts
@@ -24,7 +24,11 @@
 // conversation, via either the continuous session or this meeting's mic lane), so
 // saving mic lines here too would duplicate it.
 import { startTranscription, type TranscriptionHandle } from '../lib/transcriptionClient'
-import { isLiveMicSessionActive } from './liveMicSession'
+import {
+  getLiveMicSessionHealth,
+  onLiveMicSessionHealth,
+  waitForLiveMicSessionReady
+} from './liveMicSession'
 import type { ListenSource, TranscriptLine } from '../../../shared/types'
 
 export type MeetingSessionHandle = {
@@ -45,10 +49,24 @@ export function formatMeetingTranscript(system: TranscriptLine[]): string {
 export async function startMeetingSession(args: {
   appName: string
   onError: (message: string) => void
+  signal?: AbortSignal
 }): Promise<MeetingSessionHandle> {
   const startedAt = Date.now()
   const systemLines: TranscriptLine[] = []
-  let stopped = false
+  let stopped = args.signal?.aborted ?? false
+  const startingHandles = new Set<TranscriptionHandle>()
+
+  const stopStartingHandles = (): void => {
+    stopped = true
+    for (const handle of startingHandles) {
+      try {
+        handle.stop()
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  args.signal?.addEventListener('abort', stopStartingHandles, { once: true })
 
   // Both lanes ride the normal capture path: startTranscription opens the
   // main-process listen WS and issues the audio-start command that
@@ -72,49 +90,68 @@ export async function startMeetingSession(args: {
           if (!stopped) args.onError(`${source}: ${e.message}`)
         }
       },
-      mode
-    )
+      mode,
+      undefined,
+      args.signal
+    ).then((handle) => {
+      if (stopped) {
+        handle.stop()
+        const error = new Error('Meeting capture startup cancelled')
+        error.name = 'AbortError'
+        throw error
+      }
+      startingHandles.add(handle)
+      return handle
+    })
 
   // The remote/system side is always captured. The mic lane is opened here only
   // if no continuous mic session already owns the mic (C6) — otherwise we'd open a
   // second, racing /v4/listen for the same audio.
-  const lanes: { source: ListenSource; mode: 'conversation' | 'transcribe' }[] = [
-    { source: 'system', mode: 'transcribe' }
-  ]
-  if (!isLiveMicSessionActive()) lanes.push({ source: 'mic', mode: 'conversation' })
+  const starts: Promise<TranscriptionHandle | null>[] = [startLane('system', 'transcribe')]
+  const liveMicHealth = getLiveMicSessionHealth()
+  const delegatedMic = liveMicHealth === 'connecting' || liveMicHealth === 'ready'
+  if (liveMicHealth === 'connecting') {
+    starts.push(
+      waitForLiveMicSessionReady(args.signal).then((ready) => {
+        if (!ready) throw new Error('continuous microphone transcription did not become ready')
+        return null
+      })
+    )
+  } else if (liveMicHealth !== 'ready') {
+    starts.push(startLane('mic', 'conversation'))
+  }
 
   // allSettled (not all): if one lane fails to start, the sibling lane has
   // ALREADY opened its WS + acquired its stream — Promise.all's reject would
   // strand that resolved handle with no reference (a hot mic with no way to
   // stop it). Collect every fulfilled handle so a failure can tear them ALL
   // down before rethrowing.
-  const results = await Promise.allSettled(lanes.map((l) => startLane(l.source, l.mode)))
-  const handles = results
-    .filter((r): r is PromiseFulfilledResult<TranscriptionHandle> => r.status === 'fulfilled')
-    .map((r) => r.value)
+  const results = await Promise.allSettled(starts)
   const failed = results.find((r) => r.status === 'rejected') as PromiseRejectedResult | undefined
   if (failed) {
-    for (const h of handles) {
-      try {
-        h.stop()
-      } catch {
-        /* ignore */
-      }
-    }
+    stopStartingHandles()
+    args.signal?.removeEventListener('abort', stopStartingHandles)
     throw failed.reason
   }
+  if (delegatedMic && getLiveMicSessionHealth() !== 'ready') {
+    stopStartingHandles()
+    args.signal?.removeEventListener('abort', stopStartingHandles)
+    throw new Error('continuous microphone transcription did not remain ready')
+  }
+  args.signal?.removeEventListener('abort', stopStartingHandles)
+  const offLiveMicHealth = delegatedMic
+    ? onLiveMicSessionHealth((health) => {
+        if (!stopped && health !== 'ready') {
+          args.onError('microphone: continuous transcription stopped')
+        }
+      })
+    : () => {}
 
   return {
     stop: async (): Promise<void> => {
       if (stopped) return
-      stopped = true
-      for (const h of handles) {
-        try {
-          h.stop()
-        } catch {
-          /* ignore */
-        }
-      }
+      stopStartingHandles()
+      offLiveMicHealth()
       const transcript = formatMeetingTranscript(systemLines)
       // Nothing on the system lane worth saving (mic already went to the
       // backend's own conversation pipeline) — skip the empty row.

--- a/desktop/windows/src/renderer/src/components/insight/InsightToast.test.tsx
+++ b/desktop/windows/src/renderer/src/components/insight/InsightToast.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MeetingToastPayload } from '../../../../shared/types'
+import { InsightToast } from './InsightToast'
+
+let onMeetingToast: ((payload: MeetingToastPayload) => void) | null = null
+const meetingAction = vi.fn()
+
+beforeEach(() => {
+  onMeetingToast = null
+  meetingAction.mockReset()
+  vi.stubGlobal('window', {
+    omi: {
+      onInsightShow: () => () => {},
+      onMeetingToast: (cb: (payload: MeetingToastPayload) => void) => {
+        onMeetingToast = cb
+        return () => {}
+      },
+      onWhatsNewToast: () => () => {},
+      meetingGetToast: async () => null,
+      whatsNewGetPending: async () => null,
+      meetingAction,
+      insightHoverStart: vi.fn(),
+      insightHoverEnd: vi.fn()
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function show(kind: MeetingToastPayload['kind']): void {
+  act(() => {
+    onMeetingToast?.({ meetingId: 'meeting-1', appName: 'Google Meet', kind })
+  })
+}
+
+function showError(errorKind: NonNullable<MeetingToastPayload['errorKind']>): void {
+  act(() => {
+    onMeetingToast?.({
+      meetingId: 'meeting-1',
+      appName: 'Google Meet',
+      kind: 'error',
+      errorKind
+    })
+  })
+}
+
+describe('meeting capture status toast', () => {
+  it('shows startup progress without claiming capture is live', () => {
+    render(<InsightToast />)
+    show('starting')
+
+    expect(screen.getByText('Starting capture — Google Meet')).toBeTruthy()
+    expect(screen.queryByText(/Omi is capturing/)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy()
+  })
+
+  it('shows a retry action after startup fails', () => {
+    render(<InsightToast />)
+    show('error')
+
+    expect(screen.getByText("Capture didn't start — Google Meet")).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(meetingAction).toHaveBeenCalledWith('meeting-1', 'start')
+  })
+
+  it('does not offer Retry for a save failure', () => {
+    render(<InsightToast />)
+    showError('save')
+
+    expect(screen.getByText("Capture couldn't be saved — Google Meet")).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+    fireEvent.click(screen.getByText('Dismiss', { selector: '.meeting-btn' }))
+    expect(meetingAction).toHaveBeenCalledWith('meeting-1', 'dismiss')
+  })
+})

--- a/desktop/windows/src/renderer/src/components/insight/InsightToast.tsx
+++ b/desktop/windows/src/renderer/src/components/insight/InsightToast.tsx
@@ -47,6 +47,9 @@ function WhatsNewCard({ p }: { p: WhatsNewPayload }): React.JSX.Element {
 
 function MeetingCard({ p }: { p: MeetingToastPayload }): React.JSX.Element {
   const capturing = p.kind === 'capturing'
+  const starting = p.kind === 'starting'
+  const failed = p.kind === 'error'
+  const errorKind = p.errorKind ?? 'startup'
   return (
     <div
       className="insight-card"
@@ -64,23 +67,46 @@ function MeetingCard({ p }: { p: MeetingToastPayload }): React.JSX.Element {
         </button>
       </div>
       <div className="insight-headline">
-        {capturing ? `Omi is capturing — ${p.appName}` : `${p.appName} looks like a meeting`}
+        {capturing
+          ? `Omi is capturing — ${p.appName}`
+          : starting
+            ? `Starting capture — ${p.appName}`
+            : failed
+              ? errorKind === 'runtime'
+                ? `Capture stopped — ${p.appName}`
+                : errorKind === 'save'
+                  ? `Capture couldn't be saved — ${p.appName}`
+                  : `Capture didn't start — ${p.appName}`
+              : `${p.appName} looks like a meeting`}
       </div>
       <div className="insight-advice">
         {capturing
           ? 'Audio is being transcribed into a conversation.'
-          : 'Capture and transcribe this meeting?'}
+          : starting
+            ? 'Connecting audio and transcription…'
+            : failed
+              ? errorKind === 'save'
+                ? 'The recording ended, but Omi could not save the local meeting transcript.'
+                : 'Check your sign-in, internet connection, and Windows microphone access, then retry.'
+              : 'Capture and transcribe this meeting?'}
       </div>
       {p.firstRun ? (
         <div className="insight-foot">First run — change this in Settings → General.</div>
       ) : null}
       <div className="meeting-actions">
-        {capturing ? (
+        {capturing || starting ? (
           <button
             className="meeting-btn"
             onClick={() => window.omi.meetingAction(p.meetingId, 'stop')}
           >
-            Stop
+            {starting ? 'Cancel' : 'Stop'}
+          </button>
+        ) : failed && errorKind === 'save' ? (
+          <button
+            className="meeting-btn"
+            onClick={() => window.omi.meetingAction(p.meetingId, 'dismiss')}
+          >
+            Dismiss
           </button>
         ) : (
           <>
@@ -88,7 +114,7 @@ function MeetingCard({ p }: { p: MeetingToastPayload }): React.JSX.Element {
               className="meeting-btn meeting-btn-primary"
               onClick={() => window.omi.meetingAction(p.meetingId, 'start')}
             >
-              Start capturing
+              {failed ? 'Retry' : 'Start capturing'}
             </button>
             <button
               className="meeting-btn"

--- a/desktop/windows/src/renderer/src/hooks/useRecorder.startup.test.tsx
+++ b/desktop/windows/src/renderer/src/hooks/useRecorder.startup.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  failSource: 'system' as 'mic' | 'system',
+  micStop: vi.fn(),
+  systemStop: vi.fn(),
+  startSession: vi.fn(),
+  stopSession: vi.fn(() => null),
+  startTranscription: vi.fn(),
+  navigate: vi.fn()
+}))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => h.navigate }))
+vi.mock('./useRecording', () => ({
+  useRecording: () => ({
+    state: 'idle',
+    start: h.startSession,
+    stop: h.stopSession
+  })
+}))
+vi.mock('../lib/transcriptionClient', () => ({
+  startTranscription: h.startTranscription
+}))
+vi.mock('../lib/pageCache', () => ({
+  invalidateConversationsCache: vi.fn(),
+  refreshCloudConversations: vi.fn()
+}))
+vi.mock('../lib/sync/segmentRetention', () => ({
+  createSegmentStore: () => ({ add: vi.fn(), list: () => [] })
+}))
+vi.mock('../lib/sync/mergeLanes', () => ({ mergeLanes: () => [] }))
+vi.mock('../lib/sync/outbox', () => ({ queueForSync: vi.fn() }))
+vi.mock('../lib/sync/conversationSync', () => ({ syncLocalConversation: vi.fn() }))
+
+import { useRecorder } from './useRecorder'
+
+beforeEach(() => {
+  h.failSource = 'system'
+  h.micStop.mockReset()
+  h.systemStop.mockReset()
+  h.startSession.mockReset()
+  h.stopSession.mockReset()
+  h.stopSession.mockReturnValue(null)
+  h.navigate.mockReset()
+  h.startTranscription.mockReset()
+  h.startTranscription.mockImplementation(async (source: 'mic' | 'system') => {
+    if (source === h.failSource) throw new Error(`${source} unavailable`)
+    return {
+      stop: source === 'mic' ? h.micStop : h.systemStop,
+      finalize: vi.fn()
+    }
+  })
+  Object.defineProperty(window, 'omi', {
+    configurable: true,
+    value: {
+      onCaptureEvent: () => () => {},
+      captureCommand: vi.fn()
+    }
+  })
+  vi.stubGlobal('alert', vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('useRecorder transactional lane startup', () => {
+  it.each([
+    ['system', 'mic'],
+    ['mic', 'system']
+  ] as const)('stops the %s sibling when the %s lane fails', async (healthy, failed) => {
+    h.failSource = failed
+    const { result } = renderHook(() => useRecorder())
+
+    await act(async () => {
+      await result.current.start({ system: true })
+    })
+
+    expect(healthy === 'mic' ? h.micStop : h.systemStop).toHaveBeenCalledOnce()
+    expect(h.stopSession).toHaveBeenCalledOnce()
+    expect(alert).toHaveBeenCalledWith(`Recording failed: ${failed} unavailable`)
+  })
+})

--- a/desktop/windows/src/renderer/src/hooks/useRecorder.ts
+++ b/desktop/windows/src/renderer/src/hooks/useRecorder.ts
@@ -115,7 +115,7 @@ export function useRecorder(): UseRecorder {
     try {
       // The two lanes are independent sockets — connect them concurrently so a
       // screen-session start pays one handshake latency, not the sum of two.
-      const [mic, system] = await Promise.all([
+      const [micResult, systemResult] = await Promise.allSettled([
         startTranscription(
           'mic',
           {
@@ -145,10 +145,18 @@ export function useRecorder(): UseRecorder {
               },
               mode
             )
-          : Promise.resolve(null)
+          : Promise.resolve<TranscriptionHandle | null>(null)
       ])
-      micRef.current = mic
-      systemRef.current = system
+      if (micResult.status === 'rejected' || systemResult.status === 'rejected') {
+        // Both starts run concurrently. If one fails after its sibling already
+        // opened, tear the sibling down before surfacing the startup failure.
+        if (micResult.status === 'fulfilled') micResult.value?.stop()
+        if (systemResult.status === 'fulfilled') systemResult.value?.stop()
+        if (micResult.status === 'rejected') throw micResult.reason
+        if (systemResult.status === 'rejected') throw systemResult.reason
+      }
+      micRef.current = micResult.value
+      systemRef.current = systemResult.value
     } catch (e) {
       micRef.current?.stop()
       micRef.current = null

--- a/desktop/windows/src/renderer/src/lib/capture/captureEngine.ts
+++ b/desktop/windows/src/renderer/src/lib/capture/captureEngine.ts
@@ -5,7 +5,7 @@
 // feed BOTH the WebSocket AND the Silero detector — no second getUserMedia, no
 // second AudioContext. The mic is released the moment the pipeline stops (privacy),
 // while the InferenceSession persists for the whole process.
-import { makePipelineHandle } from './pipelineHandle'
+import { makePipelineHandle, type PipelineHandle } from './pipelineHandle'
 import { createPcmPipeline as createWorkletPipeline } from './pcmPipeline'
 import { VadGate as PureVadGate, type VadGateMode } from './vadGate'
 import { createSileroDetector, SILERO_FRAME_SAMPLES, type SileroDetector } from './vadModel'
@@ -14,7 +14,7 @@ import { classifyVadFailure } from './vadFallback'
 import { trackEvent } from '../analytics'
 
 // ── Contract shared with the capture hosts ────────────────────────────────────────
-export type PcmPipeline = { stop: () => void }
+export type PcmPipeline = PipelineHandle
 export type VadMode = 'gated' | 'fallback'
 export type VadGateConfig = {
   /** Audio that passed the gate (or ALL audio while falling open) — forward to WS. */

--- a/desktop/windows/src/renderer/src/lib/capture/pipelineHandle.test.ts
+++ b/desktop/windows/src/renderer/src/lib/capture/pipelineHandle.test.ts
@@ -13,7 +13,7 @@ describe('makePipelineHandle', () => {
     const pipeStop = vi.fn()
     const { stream, stops } = fakeStream()
     const handle = makePipelineHandle(stream, Promise.resolve({ stop: pipeStop }))
-    await Promise.resolve() // let the setup .then run
+    await expect(handle.ready).resolves.toEqual({ ok: true })
     handle.stop()
     expect(pipeStop).toHaveBeenCalledOnce()
     for (const s of stops) expect(s).toHaveBeenCalledOnce()
@@ -31,15 +31,16 @@ describe('makePipelineHandle', () => {
     expect(pipeStop).not.toHaveBeenCalled() // nothing to tear down yet
 
     resolveSetup({ stop: pipeStop })
-    await Promise.resolve()
+    await expect(handle.ready).resolves.toEqual({ ok: true })
     expect(pipeStop).toHaveBeenCalledOnce() // late pipeline torn down on arrival
   })
 
-  it('still releases the mic when setup rejects (pipeline failed to start)', async () => {
+  it('reports setup failure and still releases the mic when stopped', async () => {
     const { stream, stops } = fakeStream()
     const handle = makePipelineHandle(stream, Promise.reject(new Error('addModule failed')))
-    await Promise.resolve()
-    await Promise.resolve()
+    const result = await handle.ready
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.message).toBe('addModule failed')
     handle.stop()
     expect(stops[0]).toHaveBeenCalledOnce()
   })
@@ -48,7 +49,7 @@ describe('makePipelineHandle', () => {
     const pipeStop = vi.fn()
     const { stream, stops } = fakeStream()
     const handle = makePipelineHandle(stream, Promise.resolve({ stop: pipeStop }))
-    await Promise.resolve()
+    await handle.ready
     handle.stop()
     handle.stop()
     expect(pipeStop).toHaveBeenCalledOnce()

--- a/desktop/windows/src/renderer/src/lib/capture/pipelineHandle.ts
+++ b/desktop/windows/src/renderer/src/lib/capture/pipelineHandle.ts
@@ -9,6 +9,12 @@
 export type StoppableTrack = { stop: () => void }
 export type TrackedStream = { getTracks: () => StoppableTrack[] }
 export type Teardownable = { stop: () => void }
+export type PipelineSetupResult = { ok: true } | { ok: false; error: Error }
+export type PipelineHandle = {
+  stop: () => void
+  /** Resolves after the real audio graph is usable, or with its setup error. */
+  ready: Promise<PipelineSetupResult>
+}
 
 /**
  * Wrap an in-flight pipeline `setup` promise in a synchronous handle.
@@ -20,20 +26,25 @@ export type Teardownable = { stop: () => void }
 export function makePipelineHandle(
   stream: TrackedStream,
   setup: Promise<Teardownable>
-): { stop: () => void } {
+): PipelineHandle {
   let stopped = false
   let teardown: (() => void) | null = null
 
-  setup
-    .then((p) => {
+  const ready: Promise<PipelineSetupResult> = setup
+    .then((p): PipelineSetupResult => {
       if (stopped) p.stop()
       else teardown = (): void => p.stop()
+      return { ok: true }
     })
-    .catch(() => {
-      /* setup failed — stop() still releases the tracks below */
-    })
+    .catch(
+      (error: unknown): PipelineSetupResult => ({
+        ok: false,
+        error: error instanceof Error ? error : new Error(String(error))
+      })
+    )
 
   return {
+    ready,
     stop: (): void => {
       if (stopped) return
       stopped = true

--- a/desktop/windows/src/renderer/src/lib/omiListenClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/omiListenClient.test.ts
@@ -3,8 +3,8 @@ import type { CaptureCommand, CaptureEvent, ListenMessage } from '../../../share
 
 // omiListenClient now owns the transcript flow in the CALLING window but drives
 // capture REMOTELY: it opens the listen session, sends audio-start to the capture
-// window, maps listen messages to callbacks, maps a routed audio-source-error to
-// a fatal error, and tears down (audio-stop + listenStop) on stop.
+// window, reports connected only after both transport and source are ready, maps
+// a routed audio-source-error to a fatal error, and tears down on stop.
 
 vi.mock('./firebase', () => ({
   auth: { currentUser: { getIdToken: vi.fn(async () => 'test-token') } }
@@ -99,6 +99,7 @@ describe('startOmiListen', () => {
     await startOmiListen('mic', cb)
     const sessionId = startedSessionId()
     emitMsg({ sessionId, kind: 'connected' })
+    emitEvent({ type: 'audio-source-ready', sessionId })
     emitMsg({
       sessionId,
       kind: 'segments',
@@ -108,11 +109,27 @@ describe('startOmiListen', () => {
     expect(cb.onSegments).toHaveBeenCalledWith([{ text: 'hi', is_user: true, start: 0, end: 1 }])
   })
 
+  it('does not report connected until both the backend and audio source are ready', async () => {
+    const cb = callbacks()
+    await startOmiListen('system', cb)
+    const sessionId = startedSessionId()
+
+    emitMsg({ sessionId, kind: 'connected' })
+    expect(cb.onConnected).not.toHaveBeenCalled()
+
+    emitEvent({ type: 'audio-source-ready', sessionId })
+    expect(cb.onConnected).toHaveBeenCalledOnce()
+
+    emitEvent({ type: 'audio-source-ready', sessionId })
+    expect(cb.onConnected).toHaveBeenCalledOnce()
+  })
+
   it('a close AFTER connect calls onClosed; a close BEFORE connect is a fatal error', async () => {
     const cb = callbacks()
     await startOmiListen('mic', cb)
     const sessionId = startedSessionId()
     emitMsg({ sessionId, kind: 'connected' })
+    emitEvent({ type: 'audio-source-ready', sessionId })
     emitMsg({ sessionId, kind: 'closed', code: 1000, reason: 'bye' })
     expect(cb.onClosed).toHaveBeenCalledWith(1000, 'bye')
 
@@ -136,6 +153,7 @@ describe('startOmiListen', () => {
     })
     expect(cb.onError).toHaveBeenCalledWith(expect.any(Error), true)
     expect((cb.onError.mock.calls[0][0] as Error).message).toBe('blocked')
+    expect((cb.onError.mock.calls[0][0] as Error).name).toBe('NotAllowedError')
   })
 
   it('ignores messages/events for a different session', async () => {
@@ -154,7 +172,11 @@ describe('startOmiListen', () => {
     emitEvent({ type: 'capture-window-restarted' })
     const starts = bridge.commands.filter((c) => c.type === 'audio-start')
     expect(starts.length).toBe(startsBefore + 1)
-    expect(starts[starts.length - 1]).toMatchObject({ type: 'audio-start', sessionId, source: 'mic' })
+    expect(starts[starts.length - 1]).toMatchObject({
+      type: 'audio-start',
+      sessionId,
+      source: 'mic'
+    })
   })
 
   it('does NOT re-issue audio-start after stop()', async () => {

--- a/desktop/windows/src/renderer/src/lib/omiListenClient.ts
+++ b/desktop/windows/src/renderer/src/lib/omiListenClient.ts
@@ -4,7 +4,7 @@ import { getPreferences } from './preferences'
 import { getWindowsDeviceIdHash } from './clientDevice'
 
 export type OmiListenCallbacks = {
-  /** Fires once when the v4/listen WS reaches OPEN. */
+  /** Fires once both the v4/listen WS and the requested audio source are ready. */
   onConnected: () => void
   /** Fires for each batch of finalized segments. */
   onSegments: (segments: BackendSegment[]) => void
@@ -57,13 +57,21 @@ export async function startOmiListen(
   const sessionId = `omi-listen-${Date.now()}-${nextSessionId++}`
 
   let stopped = false
-  let connected = false
+  let backendConnected = false
+  let audioSourceReady = false
+  let readyNotified = false
+
+  const notifyReady = (): void => {
+    if (stopped || readyNotified || !backendConnected || !audioSourceReady) return
+    readyNotified = true
+    cb.onConnected()
+  }
 
   const unsubMsg = window.omi.onListenMessage((msg) => {
     if (msg.sessionId !== sessionId) return
     if (msg.kind === 'connected') {
-      connected = true
-      cb.onConnected()
+      backendConnected = true
+      notifyReady()
     } else if (msg.kind === 'segments') {
       cb.onSegments(msg.segments)
     } else if (msg.kind === 'event') {
@@ -72,14 +80,14 @@ export async function startOmiListen(
       cb.onError(new Error(msg.message), msg.fatal)
     } else if (msg.kind === 'closed') {
       if (stopped) return
-      if (connected) {
+      if (readyNotified) {
         // Connected then dropped (clean, quota, or abnormal) → let the caller
         // end the session and surface an error. Pass the reason so a 1008
         // entitlement/quota close can be reported as such, not a bare code.
         cb.onClosed(msg.code, msg.reason)
       } else {
-        // Never connected → an initial failure; surface as fatal so the caller
-        // reports that transcription couldn't start.
+        // The full source + transport lane never became usable. Surface this as
+        // an initial failure even when the backend socket briefly reached OPEN.
         cb.onError(new Error(`v4/listen closed (${msg.code}) ${msg.reason}`.trim()), true)
       }
     }
@@ -95,11 +103,19 @@ export async function startOmiListen(
     // Re-issue audio-start — AudioSessionHost re-acquires the source and resumes
     // feeding this session. One seam covers every startOmiListen consumer.
     if (ev.type === 'capture-window-restarted') {
+      audioSourceReady = false
       window.omi.captureCommand({ type: 'audio-start', sessionId, source })
       return
     }
+    if (ev.type === 'audio-source-ready' && ev.sessionId === sessionId) {
+      audioSourceReady = true
+      notifyReady()
+      return
+    }
     if (ev.type !== 'audio-source-error' || ev.sessionId !== sessionId) return
-    cb.onError(new Error(ev.message || 'audio source failed'), true)
+    const error = new Error(ev.message || 'audio source failed')
+    if (ev.name) error.name = ev.name
+    cb.onError(error, true)
   })
 
   try {

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.test.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  auth: { currentUser: null as null | { uid: string } },
+  startOmiListen: vi.fn()
+}))
+
+vi.mock('./firebase', () => ({ auth: h.auth }))
+vi.mock('./omiListenClient', () => ({ startOmiListen: h.startOmiListen }))
+
+import { startTranscription, type TranscriptionCallbacks } from './transcriptionClient'
+
+function callbacks(): TranscriptionCallbacks {
+  return {
+    onLine: vi.fn(),
+    onInterim: vi.fn(),
+    onBackend: vi.fn(),
+    onError: vi.fn()
+  }
+}
+
+beforeEach(() => {
+  h.auth.currentUser = null
+  h.startOmiListen.mockReset()
+})
+
+describe('startTranscription startup contract', () => {
+  it('rejects instead of returning an empty handle when the user is not signed in', async () => {
+    const cb = callbacks()
+
+    await expect(startTranscription('system', cb, 'transcribe')).rejects.toThrow(
+      'Omi transcription unavailable (not signed in)'
+    )
+    expect(cb.onError).toHaveBeenCalledOnce()
+    expect(h.startOmiListen).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the source or transport fails before readiness', async () => {
+    h.auth.currentUser = { uid: 'user-1' }
+    const stop = vi.fn()
+    h.startOmiListen.mockImplementation(
+      async (_source: string, listener: { onError: (error: Error, fatal: boolean) => void }) => {
+        const error = new Error('loopback unavailable')
+        error.name = 'NotAllowedError'
+        setTimeout(() => listener.onError(error, true), 0)
+        return { stop, finalize: vi.fn() }
+      }
+    )
+    const cb = callbacks()
+
+    await expect(startTranscription('system', cb, 'transcribe')).rejects.toMatchObject({
+      name: 'NotAllowedError',
+      message: 'loopback unavailable'
+    })
+    expect(cb.onError).toHaveBeenCalledOnce()
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it('aborts and tears down an in-flight startup immediately', async () => {
+    h.auth.currentUser = { uid: 'user-1' }
+    const stop = vi.fn()
+    h.startOmiListen.mockResolvedValue({ stop, finalize: vi.fn() })
+    const cb = callbacks()
+    const controller = new AbortController()
+
+    const startup = startTranscription('system', cb, 'transcribe', undefined, controller.signal)
+    await Promise.resolve()
+    controller.abort()
+
+    await expect(startup).rejects.toMatchObject({ name: 'AbortError' })
+    expect(stop).toHaveBeenCalledOnce()
+    expect(cb.onError).toHaveBeenCalledOnce()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
+++ b/desktop/windows/src/renderer/src/lib/transcriptionClient.ts
@@ -86,44 +86,83 @@ function isQuotaClose(code: number, reason: string): boolean {
 const QUOTA_MESSAGE =
   'free Omi transcription quota is used up (1008) — add an Omi subscription or sign in with an entitled account to keep transcribing'
 
-/**
- * Start an Omi v4/listen session for one source. Resolves the handle once the
- * socket connects, or null on an initial failure (connect timeout, fatal WS
- * error, no signed-in user, or quota exhausted before connect). `onLost` fires
- * when a CONNECTED session can no longer continue (quota exhausted or socket
- * dropped) so the caller can surface an error to the user.
- */
+type OmiStartOutcome = {
+  handle: OmiListenHandle | null
+  error: Error | null
+}
+
+function startupAbortError(): Error {
+  const error = new Error('Transcription startup cancelled')
+  error.name = 'AbortError'
+  return error
+}
+
+/** Start one Omi lane and return its handle or the exact startup failure. */
 async function startWithOmi(
   source: ListenSource,
   cb: TranscriptionCallbacks,
   onLost: (reason: string) => void,
   mode: TranscriptionMode,
-  clientConversationId?: string
-): Promise<OmiListenHandle | null> {
-  if (!auth.currentUser) return null
-  let outcome: 'pending' | 'omi' | 'failed' = 'pending'
-  return new Promise<OmiListenHandle | null>((resolve) => {
+  clientConversationId?: string,
+  signal?: AbortSignal
+): Promise<OmiStartOutcome> {
+  if (!auth.currentUser) {
+    return {
+      handle: null,
+      error: new Error('Omi transcription unavailable (not signed in)')
+    }
+  }
+  return new Promise<OmiStartOutcome>((resolve) => {
+    let outcome: 'pending' | 'omi' | 'failed' = 'pending'
     let handle: OmiListenHandle | null = null
-    const timeout = setTimeout(() => {
-      if (outcome !== 'pending') return
-      outcome = 'failed'
+    let readySignaled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    const stopHandle = (): void => {
       try {
         handle?.stop()
       } catch {
         /* ignore */
       }
-      resolve(null)
+    }
+    const cleanupStartup = (): void => {
+      if (timeout) clearTimeout(timeout)
+      timeout = null
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const fail = (error: Error): void => {
+      if (outcome !== 'pending') return
+      outcome = 'failed'
+      cleanupStartup()
+      stopHandle()
+      resolve({ handle: null, error })
+    }
+    const maybeSucceed = (): void => {
+      if (outcome !== 'pending' || !readySignaled || !handle) return
+      outcome = 'omi'
+      cleanupStartup()
+      cb.onBackend('omi')
+      resolve({ handle, error: null })
+    }
+    const onAbort = (): void => fail(startupAbortError())
+
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    timeout = setTimeout(() => {
+      const error = new Error('Omi transcription unavailable (connection or audio timed out)')
+      error.name = 'TimeoutError'
+      fail(error)
     }, CONNECT_TIMEOUT_MS)
 
     startOmiListen(
       source,
       {
         onConnected: () => {
-          if (outcome !== 'pending') return
-          outcome = 'omi'
-          clearTimeout(timeout)
-          cb.onBackend('omi')
-          resolve(handle)
+          readySignaled = true
+          maybeSucceed()
         },
         onSegments: (segs) => {
           if (outcome !== 'omi') return
@@ -136,14 +175,7 @@ async function startWithOmi(
           // Free quota is used up — the cloud STT will never emit transcripts.
           if (outcome === 'pending') {
             // Never connected as the winner yet: treat as an initial failure.
-            outcome = 'failed'
-            clearTimeout(timeout)
-            try {
-              handle?.stop()
-            } catch {
-              /* ignore */
-            }
-            resolve(null)
+            fail(new Error(QUOTA_MESSAGE))
           } else if (outcome === 'omi') {
             // Already connected and committed: tell the caller the session is over.
             onLost('Omi free quota exhausted')
@@ -162,15 +194,8 @@ async function startWithOmi(
         },
         onError: (err, fatal) => {
           if (outcome === 'pending' && fatal) {
-            outcome = 'failed'
-            clearTimeout(timeout)
-            try {
-              handle?.stop()
-            } catch {
-              /* ignore */
-            }
             console.warn(`[v4/listen ${source}] initial failure:`, err.message)
-            resolve(null)
+            fail(err)
             return
           }
           // Only surface post-connect errors when Omi actually connected.
@@ -202,14 +227,13 @@ async function startWithOmi(
           }
         } else {
           handle = h
+          maybeSucceed()
         }
       })
       .catch((err) => {
         if (outcome !== 'pending') return
-        outcome = 'failed'
-        clearTimeout(timeout)
         console.warn(`[v4/listen ${source}] start threw:`, err)
-        resolve(null)
+        fail(err instanceof Error ? err : new Error(String(err)))
       })
   })
 }
@@ -233,31 +257,30 @@ export async function startTranscription(
   source: ListenSource,
   cb: TranscriptionCallbacks,
   mode: TranscriptionMode = 'conversation',
-  clientConversationId?: string
+  clientConversationId?: string,
+  signal?: AbortSignal
 ): Promise<TranscriptionHandle> {
   let active: OmiListenHandle | null = null
 
-  const omi = await startWithOmi(
+  const startup = await startWithOmi(
     source,
     cb,
     (reason) => {
       cb.onError(new Error(`Omi transcription stopped: ${reason}`))
     },
     mode,
-    clientConversationId
+    clientConversationId,
+    signal
   )
 
-  if (omi) {
-    active = omi
-  } else {
-    cb.onError(
-      new Error(
-        auth.currentUser
-          ? 'Omi transcription unavailable (could not connect)'
-          : 'Omi transcription unavailable (not signed in)'
-      )
-    )
+  if (!startup.handle) {
+    const error =
+      startup.error ??
+      new Error('Omi transcription unavailable (could not connect or acquire audio)')
+    cb.onError(error)
+    throw error
   }
+  active = startup.handle
 
   return {
     stop: (): void => {

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -288,8 +288,8 @@ export type CaptureCommand =
   // Meeting detection (Phase 5, sent by MAIN): start/stop the auto-capture
   // session (mic + system lanes) for a detected meeting. Serviced by
   // MeetingSessionHost in the capture window.
-  | { type: 'meeting-capture-start'; meetingId: string; appName: string }
-  | { type: 'meeting-capture-stop'; meetingId: string }
+  | { type: 'meeting-capture-start'; meetingId: string; attemptId: number; appName: string }
+  | { type: 'meeting-capture-stop'; meetingId: string; attemptId: number }
 
 /** A mutation to the shared live-conversation store, emitted by the capture
  *  window as it owns the always-on mic session. UI windows apply these via
@@ -307,6 +307,8 @@ export type LiveStoreOp =
 export type CaptureEvent =
   // Live-conversation store mirror (broadcast).
   | { type: 'live'; op: LiveStoreOp }
+  // An audio lane acquired its source and built the PCM pipeline (routed to the owner).
+  | { type: 'audio-source-ready'; sessionId: string }
   // An audio lane's source (mic/system stream) failed (routed to the owner).
   | { type: 'audio-source-error'; sessionId: string; name: string; message: string }
   // Push-to-talk streamed data / lifecycle (routed to the owner).
@@ -328,7 +330,8 @@ export type CaptureEvent =
   | {
       type: 'meeting-capture-status'
       meetingId: string
-      status: 'started' | 'error' | 'saved'
+      attemptId: number
+      status: 'started' | 'startup-error' | 'runtime-error' | 'saved' | 'save-error'
       message?: string
     }
 
@@ -2526,8 +2529,10 @@ export type MeetingSettings = {
 export type MeetingToastPayload = {
   meetingId: string
   appName: string
-  /** 'ask' → "Meeting detected — start capturing?"; 'capturing' → live notice. */
-  kind: 'ask' | 'capturing'
+  /** Ask, startup progress, confirmed live capture, or a retryable startup failure. */
+  kind: 'ask' | 'starting' | 'capturing' | 'error'
+  /** Distinguishes a failed start, interrupted capture, and final-save failure. */
+  errorKind?: 'startup' | 'runtime' | 'save'
   /** Show the one-time first-run hint line. */
   firstRun?: boolean
 }


### PR DESCRIPTION
## What changed and why

Closes #10851.

Windows meeting capture now reports `started` only after both the requested audio pipelines and Omi transcription transports are ready. Startup failures, dropped lanes, capture-window restarts, cancellation, and retries now tear down the affected attempt and show an actionable error instead of leaving a false "capturing" state.

Capture and listen IPC commands are also bound to trusted windows and session owners so readiness/error events and cleanup reach the renderer that owns the lane.

## Product invariants affected

none

## How it was verified

- `npx vitest run` over 13 focused main/renderer test files: 79 tests passed.
- `npm run typecheck`: node and web TypeScript checks passed.
- Targeted `npx eslint` over every changed TypeScript/TSX file: 0 errors.
- `npm run build`: production Electron build, bytecode verification, and extension bundling passed.
- `npm run test:e2e:meeting`: 3 end-to-end Electron scenarios passed; the optional YAMNet fixture scenario was skipped because speech fixtures are not installed.

## Tests

Regression coverage now pins the real audio-pipeline readiness barrier, exact startup rejection and cancellation, transactional mic/system startup, continuous-mic health delegation, attempt-isolated retry, early lane failure, capture-window restart routing, owner-bound IPC, and the retry/error toast states.

The meeting E2E now verifies that an unauthenticated startup reports `startup-error`, clears the capturing state, and never displays "Omi is capturing".

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

