### PR TITLE
fix(desktop): stop dev-down SIGINT cascade during qualification desktop launch

### DIFF
--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -790,14 +790,37 @@ phase_begin "desktop-preparation" "runner-hygiene-cleanup"
 rm -f "$LAUNCH_SIGNAL_FILE"
 
 DESKTOP_LAUNCH_REQUESTED=1
+# Run dev-up first in its own tracked subshell so the dev stack (backend,
+# desktop-backend, firestore, redis, typesense) stays alive even if the
+# subsequent desktop app launch fails.  Previously both commands shared one
+# subshell; set -e caused the subshell to exit on desktop-run-local (or any
+# post-dev-up) failure, which triggered the EXIT trap → cleanup → dev-down
+# → SIGINT to every harness service including the healthy backend.
+# See FC-qualification-sigint-cascade.
 (
   cd "$WORKTREE"
   OMI_HARNESS_OWNERSHIP_TOKEN="$QUALIFICATION_LEASE_TOKEN" PROVIDER_MODE=offline make dev-up
+) >"$LAUNCH_LOG" 2>&1 &
+DEV_UP_PID=$!
+
+# Wait for dev-up to complete (success or fail).
+if ! wait "$DEV_UP_PID"; then
+  phase_end failed
+  echo "--- last 80 lines of $LAUNCH_LOG ---" >&2
+  tail -n 80 "$LAUNCH_LOG" >&2 || true
+  echo "qualification failed: dev stack startup failed" >&2
+  exit 1
+fi
+
+# Dev stack is up; launch the desktop app in a separate subshell.  Its
+# failure will NOT tear down the already-healthy dev stack.
+(
+  cd "$WORKTREE"
   OMI_DESKTOP_LAUNCH_SIGNAL_FILE="$LAUNCH_SIGNAL_FILE" \
     OMI_DESKTOP_LAUNCH_TOKEN="$DESKTOP_LAUNCH_TOKEN" \
     OMI_SKIP_SETTINGS_SEED=1 \
     make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice
-) >"$LAUNCH_LOG" 2>&1 &
+) >>"$LAUNCH_LOG" 2>&1 &
 DESKTOP_LAUNCH_PID=$!
 
 if ! wait_for_desktop_launch "$LAUNCH_SIGNAL_FILE"; then

--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -917,9 +917,16 @@ def cmd_summary(args: argparse.Namespace) -> int:
 
 
 def _signal_owned_process_group(pid: int, service: str) -> None:
+    # Use SIGTERM (not SIGINT) so Python services receive a clean
+    # shutdown signal instead of KeyboardInterrupt.  SIGINT triggers
+    # Python's default signal handler which cancels background tasks and
+    # raises KeyboardInterrupt — this caused qualification failures when
+    # dev-down sent SIGINT to a healthy backend whose parent subshell had
+    # already exited due to an unrelated desktop-launch failure.
+    # See FC-qualification-sigint-cascade.
     try:
-        os.killpg(pid, signal.SIGINT)
-        print(f"{service}: sent SIGINT to process group {pid}")
+        os.killpg(pid, signal.SIGTERM)
+        print(f"{service}: sent SIGTERM to process group {pid}")
     except ProcessLookupError:
         return
     except PermissionError as exc:


### PR DESCRIPTION
## Summary
Fix qualification SIGINT cascade: split dev-up/desktop-run-local subshells + SIGINT→SIGTERM.

## Failure class (fixes)
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

