### PR TITLE
Clarify onboarding spoken-language picker

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -2,6 +2,16 @@ import AppKit
 import Combine
 import Foundation
 
+enum SBOnboardingLanguageCopy {
+  static let question = "What language should Omi listen and reply in?"
+  static let detectedLanguageDetail = "· detected from your Mac"
+  static let changeSpokenLanguageAction = "Change spoken language"
+
+  static func continueAction(for language: String) -> String {
+    "Continue in \(language)"
+  }
+}
+
 /// Drives the Second Brain conversational onboarding: a real chat with Omi that
 /// streams word-by-word, collects answers, and performs the SAME live side-effects
 /// as the legacy wizard (name/language → backend, every permission, the summon
@@ -182,7 +192,7 @@ final class SBOnboardingModel: ObservableObject {
     case .name: return "What should I call you?"
     case .howHeard: return "Quick one. How did you hear about Omi?"
     case .language:
-      return "What language do you speak? I'll listen and reply in it."
+      return SBOnboardingLanguageCopy.question
     case .role:
       return
         "Nice to meet you, \(name). What do your days look like? Pick the closest, or tell me. It shapes what I make for you."

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -52,6 +52,7 @@ final class SBOnboardingModel: ObservableObject {
   // Per-step answers / state
   @Published var nameDraft = ""
   @Published var languageDraft = ""
+  @Published private(set) var languageIsDetectedFromMac = false
   @Published var languageName: String?
   @Published var howHeard: String?
   @Published var roleDraft = ""
@@ -452,6 +453,7 @@ final class SBOnboardingModel: ObservableObject {
   func pickLanguage(code: String, name: String) {
     languageName = name
     languageDraft = name
+    languageIsDetectedFromMac = false
     AssistantSettings.shared.voiceLanguages = [code]
     answerWriteGate.enqueue(.language) { [code] in
       _ = try? await APIClient.shared.updateUserLanguage(code)
@@ -462,11 +464,18 @@ final class SBOnboardingModel: ObservableObject {
   /// Auto-detect the Mac's language and pre-fill it so the picker defaults to it
   /// (the user can still type to change). Only fills an empty field once.
   func prefillDetectedLanguage() {
-    guard languageDraft.isEmpty, languageName == nil else { return }
     let raw = Locale.current.language.languageCode?.identifier ?? Locale.preferredLanguages.first ?? "en"
+    prefillDetectedLanguage(from: raw)
+  }
+
+  /// Records that the draft came from the Mac locale, rather than a saved or
+  /// fallback language, so the UI can accurately disclose its source.
+  func prefillDetectedLanguage(from raw: String) {
+    guard languageDraft.isEmpty, languageName == nil else { return }
     let code = AssistantSettings.normalizeTranscriptionLanguageCode(raw)
     if let match = AssistantSettings.supportedLanguages.first(where: { $0.code == code }) {
       languageDraft = match.name
+      languageIsDetectedFromMac = true
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -282,9 +282,11 @@ struct SBOnboardingView: View {
         // Auto-detected default: accept with one tap, or reveal the picker.
         HStack(spacing: 8) {
           Text(draft).geist(size: 17, weight: .medium).foregroundStyle(sb.ink)
-          Text("· detected").geist(size: 12.5).foregroundStyle(sb.ink(.w4))
+          Text(SBOnboardingLanguageCopy.detectedLanguageDetail)
+            .geist(size: 12.5)
+            .foregroundStyle(sb.ink(.w4))
         }
-        SBInkButton(title: "Continue", isDefaultAction: true) {
+        SBInkButton(title: SBOnboardingLanguageCopy.continueAction(for: draft), isDefaultAction: true) {
           if let m = all.first(where: { $0.name.lowercased() == draft.lowercased() }) {
             model.pickLanguage(code: m.code, name: m.name)
           } else {
@@ -294,7 +296,9 @@ struct SBOnboardingView: View {
         Button {
           languageChanging = true
         } label: {
-          Text("Change language").geist(size: 13).foregroundStyle(sb.ink(.w45))
+          Text(SBOnboardingLanguageCopy.changeSpokenLanguageAction)
+            .geist(size: 13)
+            .foregroundStyle(sb.ink(.w45))
         }
         .buttonStyle(.plain)
       } else {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -282,9 +282,11 @@ struct SBOnboardingView: View {
         // Auto-detected default: accept with one tap, or reveal the picker.
         HStack(spacing: 8) {
           Text(draft).geist(size: 17, weight: .medium).foregroundStyle(sb.ink)
-          Text(SBOnboardingLanguageCopy.detectedLanguageDetail)
-            .geist(size: 12.5)
-            .foregroundStyle(sb.ink(.w4))
+          if model.languageIsDetectedFromMac {
+            Text(SBOnboardingLanguageCopy.detectedLanguageDetail)
+              .geist(size: 12.5)
+              .foregroundStyle(sb.ink(.w4))
+          }
         }
         SBInkButton(title: SBOnboardingLanguageCopy.continueAction(for: draft), isDefaultAction: true) {
           if let m = all.first(where: { $0.name.lowercased() == draft.lowercased() }) {

--- a/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Omi_Computer
 
+@MainActor
 final class SBOnboardingLanguageCopyTests: XCTestCase {
 
   func testLanguagePickerCopyExplainsTheSpokenLanguagePreference() {
@@ -9,5 +10,24 @@ final class SBOnboardingLanguageCopyTests: XCTestCase {
     XCTAssertEqual(SBOnboardingLanguageCopy.detectedLanguageDetail, "· detected from your Mac")
     XCTAssertEqual(SBOnboardingLanguageCopy.continueAction(for: "English"), "Continue in English")
     XCTAssertEqual(SBOnboardingLanguageCopy.changeSpokenLanguageAction, "Change spoken language")
+  }
+
+  func testDetectedLanguageDetailIsShownOnlyForAMacLocalePrefill() {
+    let model = SBOnboardingModel(appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+
+    model.prefillDetectedLanguage(from: "es")
+
+    XCTAssertEqual(model.languageDraft, "Spanish")
+    XCTAssertTrue(model.languageIsDetectedFromMac)
+  }
+
+  func testExistingLanguageDraftIsNotRelabeledAsMacDetected() {
+    let model = SBOnboardingModel(appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.languageDraft = "English"
+
+    model.prefillDetectedLanguage(from: "es")
+
+    XCTAssertEqual(model.languageDraft, "English")
+    XCTAssertFalse(model.languageIsDetectedFromMac)
   }
 }

--- a/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SBOnboardingLanguageCopyTests: XCTestCase {
+
+  func testLanguagePickerCopyExplainsTheSpokenLanguagePreference() {
+    XCTAssertEqual(SBOnboardingLanguageCopy.question, "What language should Omi listen and reply in?")
+    XCTAssertEqual(SBOnboardingLanguageCopy.detectedLanguageDetail, "· detected from your Mac")
+    XCTAssertEqual(SBOnboardingLanguageCopy.continueAction(for: "English"), "Continue in English")
+    XCTAssertEqual(SBOnboardingLanguageCopy.changeSpokenLanguageAction, "Change spoken language")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260729-clarify-onboarding-language-picker.json
+++ b/desktop/macos/changelog/unreleased/20260729-clarify-onboarding-language-picker.json
@@ -1,0 +1,3 @@
+{
+  "change": "Clarified that the onboarding language picker controls how Omi listens and replies"
+}


### PR DESCRIPTION
## What changed and why

Clarifies that the macOS onboarding language picker sets the language Omi listens to and replies in. The picker now uses a language-specific continue action and calls the alternate picker “Change spoken language,” so it is not mistaken for an app-interface-language setting. It labels a selection as detected from the Mac only when it actually came from a supported macOS locale; saved or fallback values are not mislabeled.

## Product invariants affected

none

## How it was verified

- `xcrun swift test -c debug --package-path Desktop --filter SBOnboardingLanguageCopyTests` — built successfully.
- `xcrun swift test -c debug --package-path Desktop --skip-build --filter SBOnboardingLanguageCopyTests` — 3 tests passed.
- `xcrun swift build -c debug --package-path Desktop` — passed before the review follow-up.
- `OMI_APP_NAME="omi-language-copy" OMI_ALLOW_ADHOC_SIGN=1 /Users/david/.codex/bin/omi-run-adhoc --yolo` — built, ad-hoc signed, installed, and launched the named development bundle before the review follow-up.

The local profile was signed out and this host does not grant Accessibility permission, so I could not navigate to onboarding and verify the final UI visually.

## Tests

`SBOnboardingLanguageCopyTests` covers the spoken-language copy, a supported macOS locale prefill, and an existing/fallback language draft that must not be relabeled as Mac-detected.