### PR TITLE
fix(desktop): terminalize cold-start ACP auth

### DIFF
--- a/desktop/macos/agent/src/acp-initialize-auth.ts
+++ b/desktop/macos/agent/src/acp-initialize-auth.ts
@@ -1,0 +1,32 @@
+import { AcpError } from "./adapters/acp.js";
+
+type InitializeAcpWithDetachedAuthInput<T> = {
+  initialize: () => Promise<T>;
+  onAuthRequired: (error: AcpError) => void;
+  signalAuthRequired: () => void;
+  startAuthFlow: () => Promise<void>;
+  reinitialize: () => Promise<void>;
+  log: (message: string) => void;
+};
+
+export async function initializeAcpWithDetachedAuth<T>({
+  initialize,
+  onAuthRequired,
+  signalAuthRequired,
+  startAuthFlow,
+  reinitialize,
+  log,
+}: InitializeAcpWithDetachedAuthInput<T>): Promise<T> {
+  try {
+    return await initialize();
+  } catch (error) {
+    if (error instanceof AcpError && error.code === -32000) {
+      onAuthRequired(error);
+      signalAuthRequired();
+      void startAuthFlow()
+        .then(reinitialize)
+        .catch((authError) => log(`ACP authentication retry failed: ${authError}`));
+    }
+    throw error;
+  }
+}

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -79,6 +79,7 @@ import {
   journalTerminalizationDisposition,
 } from "./protocol.js";
 import { startOAuthFlow, type OAuthFlowHandle } from "./oauth-flow.js";
+import { initializeAcpWithDetachedAuth } from "./acp-initialize-auth.js";
 import { isProductionAdapterId, type PromptBlock, type RuntimeAdapter } from "./adapters/interface.js";
 import { detectImageMimeType } from "./mime-detect.js";
 import { AcpError, AcpRuntimeAdapter, isAcpProviderAuthFailure } from "./adapters/acp.js";
@@ -204,14 +205,13 @@ function send(msg: OutboundMessageDraft): void {
 }
 
 function runtimeErrorEnvelope(error: unknown): { message: string; failure: ReturnType<typeof failureFromError> } {
-  const message = sanitizeProcessDiagnostic(error instanceof Error ? error.message : String(error))
-    || "Runtime request rejected";
-  const failure = {
+  const failure = failureFromError(error, {
     code: "runtime_error",
     source: "runtime" as const,
     retryable: false,
-    userMessage: message,
-  };
+    userMessage: sanitizeProcessDiagnostic(error instanceof Error ? error.message : String(error))
+      || "Runtime request rejected",
+  });
   return { message: failure.userMessage, failure };
 }
 
@@ -1001,45 +1001,11 @@ async function startAuthFlow(): Promise<void> {
 async function initializeAcp(): Promise<void> {
   if (isInitialized) return;
 
-  try {
-    const result = (await acpRequest("initialize", {
+  const result = (await initializeAcpWithDetachedAuth({
+    initialize: () => acpRequest("initialize", {
       protocolVersion: 1,
-    })) as {
-      protocolVersion: number;
-      agentCapabilities?: Record<string, unknown>;
-      agentInfo?: { name: string; version: string };
-      authMethods?: Array<{
-        id: string;
-        name: string;
-        description?: string;
-        type?: string;
-        args?: string[];
-        env?: Record<string, string>;
-      }>;
-    };
-
-    logErr(
-      `ACP initialized: protocol=${result.protocolVersion}, capabilities=${JSON.stringify(result.agentCapabilities)}`
-    );
-
-    // Store auth methods for potential later use
-    if (result.authMethods && result.authMethods.length > 0) {
-      authMethods = result.authMethods.map((m) => ({
-        id: m.id,
-        type: (m.type ?? "agent_auth") as AuthMethod["type"],
-        displayName: m.name || m.description || m.id,
-        args: m.args,
-        env: m.env,
-      }));
-      logErr(
-        `Auth methods: ${authMethods.map((m) => `${m.id}(${m.displayName})`).join(", ")}`
-      );
-    }
-
-    isInitialized = true;
-  } catch (err) {
-    if (err instanceof AcpError && err.code === -32000) {
-      // AUTH_REQUIRED
+    }),
+    onAuthRequired: (err) => {
       const data = err.data as {
         authMethods?: Array<{
           id: string;
@@ -1056,14 +1022,44 @@ async function initializeAcp(): Promise<void> {
         }));
       }
       logErr(`ACP requires authentication: ${JSON.stringify(authMethods)}`);
-      await startAuthFlow();
+    },
+    signalAuthRequired: signalProviderAuthRequired,
+    startAuthFlow,
+    reinitialize: initializeAcp,
+    log: logErr,
+  })) as {
+    protocolVersion: number;
+    agentCapabilities?: Record<string, unknown>;
+    agentInfo?: { name: string; version: string };
+    authMethods?: Array<{
+      id: string;
+      name: string;
+      description?: string;
+      type?: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }>;
+  };
 
-      // Retry initialization after auth (ACP subprocess already restarted)
-      await initializeAcp();
-      return;
-    }
-    throw err;
+  logErr(
+    `ACP initialized: protocol=${result.protocolVersion}, capabilities=${JSON.stringify(result.agentCapabilities)}`
+  );
+
+  // Store auth methods for potential later use
+  if (result.authMethods && result.authMethods.length > 0) {
+    authMethods = result.authMethods.map((m) => ({
+      id: m.id,
+      type: (m.type ?? "agent_auth") as AuthMethod["type"],
+      displayName: m.name || m.description || m.id,
+      args: m.args,
+      env: m.env,
+    }));
+    logErr(
+      `Auth methods: ${authMethods.map((m) => `${m.id}(${m.displayName})`).join(", ")}`
+    );
   }
+
+  isInitialized = true;
 }
 
 // --- MCP server config builder ---

--- a/desktop/macos/agent/tests/acp-auth-terminal.test.ts
+++ b/desktop/macos/agent/tests/acp-auth-terminal.test.ts
@@ -2,10 +2,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { initializeAcpWithDetachedAuth } from "../src/acp-initialize-auth.js";
 import { AcpError, isAcpProviderAuthFailure } from "../src/adapters/acp.js";
 import type { OutboundMessageDraft, QueryMessage } from "../src/protocol.js";
+import { failureFromError } from "../src/runtime/failures.js";
 import { JsonlTransport } from "../src/runtime/jsonl-transport.js";
 import { createKernelHarness } from "./kernel-fakes.js";
 
@@ -64,7 +66,86 @@ function query(sessionId: string, overrides: Partial<QueryMessage> = {}): QueryM
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("ACP provider auth terminalize-first (T1/T2)", () => {
+  it("terminalizes initialize auth-required before OAuth completes, then reinitializes after success", async () => {
+    const oauth = deferred<void>();
+    const authRequired = new AcpError("Authentication required", -32000);
+    const signalAuthRequired = vi.fn();
+    const reinitialize = vi.fn(async () => {});
+    const log = vi.fn();
+    const sent: OutboundMessageDraft[] = [];
+
+    await (async () => {
+      try {
+        await initializeAcpWithDetachedAuth({
+          initialize: async () => {
+            throw authRequired;
+          },
+          onAuthRequired: () => {},
+          signalAuthRequired,
+          startAuthFlow: () => oauth.promise,
+          reinitialize,
+          log,
+        });
+      } catch (error) {
+        const failure = failureFromError(error, {
+          code: "runtime_error",
+          source: "runtime",
+          retryable: false,
+        });
+        sent.push({ type: "error", message: failure.userMessage, failure });
+      }
+    })();
+
+    expect(signalAuthRequired).toHaveBeenCalledOnce();
+    expect(sent).toMatchObject([{
+      type: "error",
+      failure: { failureCode: "authentication" },
+    }]);
+    expect(reinitialize).not.toHaveBeenCalled();
+
+    oauth.resolve();
+    await Promise.resolve();
+
+    expect(reinitialize).toHaveBeenCalledOnce();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("logs a detached OAuth failure after terminalizing initialize auth-required", async () => {
+    const oauth = deferred<void>();
+    const authRequired = new AcpError("Authentication required", -32000);
+    const log = vi.fn();
+
+    await expect(
+      initializeAcpWithDetachedAuth({
+        initialize: async () => {
+          throw authRequired;
+        },
+        onAuthRequired: () => {},
+        signalAuthRequired: () => {},
+        startAuthFlow: () => oauth.promise,
+        reinitialize: async () => {},
+        log,
+      }),
+    ).rejects.toBe(authRequired);
+
+    oauth.reject(new Error("OAuth callback timed out"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(log).toHaveBeenCalledWith("ACP authentication retry failed: Error: OAuth callback timed out");
+  });
+
   it("T1: -32000 auth failure terminalizes immediately without OAuth retry", async () => {
     const { store, adapter, session, sent, logs, transport, authSignals } = acpAuthFixture();
     adapter.failNextExecutionError = new AcpError("Authentication required", -32000);

--- a/desktop/macos/changelog/unreleased/20260729-nonblocking-acp-auth.json
+++ b/desktop/macos/changelog/unreleased/20260729-nonblocking-acp-auth.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop chat startup freezing while an AI provider asks you to sign in."
+}


### PR DESCRIPTION
## What

Fixes #10407. ACP cold-start authentication no longer awaits the OAuth callback inside `initializeAcp()`.

When ACP initialization returns `-32000` auth-required, the bridge now:

1. records the advertised auth methods;
2. signals the desktop surface immediately;
3. returns the authentication failure through the existing query terminalization path; and
4. starts OAuth detached, logging failure and reinitializing ACP only after OAuth succeeds.

This prevents a chat request from waiting for the OAuth callback timeout.

## Tests

- Added behavioral coverage for auth-required initialization terminalization before the OAuth promise resolves, success-triggered reinitialization, and detached OAuth errors.
- `bun run test -- tests/acp-auth-terminal.test.ts` exercises the new tests, but an existing timing-based T1 assertion failed locally (`~2.1s < 1s`) in the runtime harness. The new initialization-specific tests passed. This needs CI confirmation under the pinned runner rather than being represented as locally green.
- Local manifest preflight passed after adding the required desktop changelog fragment.

## Product invariants

None affected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

