### PR TITLE
fix(macos): harden onboarding permissions and dev bundles

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-chat.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": 2204,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4369
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4380
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Chat/AgentBridge.swift": "deleteBackend flag threaded through both clearJournalTurns variants so a reset is local-only",
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Typed failed-start context records checked binary/permission/port facts, elapsed timeout, and exit code at the existing runtime owner; the one-time diagnostics handoff keeps the UI owner as the sole Sentry event surface."
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": "Typed failed-start context records checked binary/permission/port facts, elapsed timeout, and exit code at the existing runtime owner; the one-time diagnostics handoff keeps the UI owner as the sole Sentry event surface. Bundle-relative runtime resource resolution belongs with the process that launches it."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1869,
-    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1636,
+    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1634,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3626,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4459,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3516,

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1869,
-    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1634,
+    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1625,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3626,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4459,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3516,

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-providers.json
@@ -1,11 +1,11 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6269,
-    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2913
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 6290,
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": 2946
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ACP authentication terminalizes the active turn with an explicit disposition instead of awaiting OAuth, and failed bridge starts consume typed runtime diagnostics at the sole user-facing error surface to avoid a duplicate Sentry event; a component split is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "update_action_item accepts the realtime `id` alias and backend task writes refresh TasksStore so agent-created tasks appear immediately; already-granted permissions still gate their Settings/drag-card opens behind the granted result. Swift 6: explicit @preconcurrency import ApplicationServices for AX APIs used by tool execution path."
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": "ACP authentication terminalizes the active turn with an explicit disposition instead of awaiting OAuth, and failed bridge starts consume typed runtime diagnostics at the sole user-facing error surface to avoid a duplicate Sentry event; a component split is tracked follow-up. The sole provider request context also carries the user's selected response language.",
+    "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift": "update_action_item accepts the realtime `id` alias and backend task writes refresh TasksStore so agent-created tasks appear immediately; already-granted permissions still gate their Settings/drag-card opens behind the granted result. Swift 6: explicit @preconcurrency import ApplicationServices for AX APIs used by tool execution path. The shared permission executor requests weather location at query time."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Info.plist
+++ b/desktop/macos/Desktop/Info.plist
@@ -39,6 +39,8 @@
     <string>Omi needs permission to detect which application is currently active.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Omi needs microphone access to transcribe your conversations in real-time.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Omi uses your location to answer weather questions.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>Omi needs permission to capture system audio for transcription of calls and meetings.</string>
     <key>NSBluetoothAlwaysUsageDescription</key>

--- a/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
+++ b/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
@@ -166,8 +166,9 @@ struct BrowserGoogleSession: Equatable {
     }
   }
 
-  static func configsForPython(logPrefix: String) -> [[String: String]] {
-    all().compactMap { session in
+  static func configsForPython(logPrefix: String, userInitiated: Bool = true) -> [[String: String]] {
+    guard userInitiated else { return [] }
+    return BrowserGoogleSession.all().compactMap { session in
       guard FileManager.default.fileExists(atPath: session.cookiePath) else { return nil }
       guard
         let password = BrowserKeychainCache.shared.password(

--- a/desktop/macos/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/macos/Desktop/Sources/CalendarReaderService.swift
@@ -225,12 +225,20 @@ actor CalendarReaderService {
   /// Read calendar events using browser cookies + SAPISID auth.
   /// Tries Arc, Chrome, Brave, and Edge across all Chromium profiles.
   /// Fetches events from `daysBack` days ago to `daysForward` days from now.
-  func readEvents(daysBack: Int = 90, daysForward: Int = 14, maxResults: Int = 200) async throws
+  func readEvents(
+    daysBack: Int = 90,
+    daysForward: Int = 14,
+    maxResults: Int = 200,
+    userInitiated: Bool = true
+  ) async throws
     -> [CalendarEvent]
   {
     await APIKeyService.shared.waitForKeys()
     let events = try fetchCalendarViaCookies(
-      daysBack: daysBack, daysForward: daysForward, maxResults: maxResults)
+      daysBack: daysBack,
+      daysForward: daysForward,
+      maxResults: maxResults,
+      userInitiated: userInitiated)
     return events.sorted { $0.startTime > $1.startTime }
   }
 
@@ -489,7 +497,12 @@ actor CalendarReaderService {
 
   // MARK: - Python: decrypt cookies + fetch Calendar events via SAPISID auth
 
-  private func fetchCalendarViaCookies(daysBack: Int, daysForward: Int, maxResults: Int) throws
+  private func fetchCalendarViaCookies(
+    daysBack: Int,
+    daysForward: Int,
+    maxResults: Int,
+    userInitiated: Bool = true
+  ) throws
     -> [CalendarEvent]
   {
     let parameters = CalendarFetchParameters.normalized(
@@ -505,7 +518,10 @@ actor CalendarReaderService {
 
     // Build browser configs as JSON for Python
     // Pass the ORIGINAL db path — Python opens it read-only to avoid WAL/journal corruption from file copy
-    let browserConfigs = BrowserGoogleSession.configsForPython(logPrefix: "CalendarReaderService")
+    let browserConfigs = BrowserGoogleSession.configsForPython(
+      logPrefix: "CalendarReaderService",
+      userInitiated: userInitiated
+    )
 
     guard !browserConfigs.isEmpty else {
       throw CalendarReaderError.noBrowserFound

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -4221,6 +4221,17 @@ actor AgentRuntimeProcess {
         bundleURL
           .appendingPathComponent("Contents/Resources")
           .appendingPathComponent(bundleName)
+          .appendingPathComponent("Contents/Resources")
+          .appendingPathComponent(resourceName))
+      append(
+        bundleURL
+          .appendingPathComponent("Contents/Resources")
+          .appendingPathComponent(bundleName)
+          .appendingPathComponent(resourceName))
+      append(
+        bundleURL
+          .appendingPathComponent(bundleName)
+          .appendingPathComponent("Contents/Resources")
           .appendingPathComponent(resourceName))
       append(
         bundleURL

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
@@ -527,7 +527,8 @@ enum GeneratedRealtimeTools {
             "notifications",
             "accessibility",
             "automation",
-            "full_disk_access"
+            "full_disk_access",
+            "location"
           ],
           "description": "Optional permission type. Omit to return all supported permissions."
         }
@@ -538,7 +539,7 @@ enum GeneratedRealtimeTools {
   {
     "type": "function",
     "name": "request_permission",
-    "description": "Request Omi's macOS permission through the kernel-authorized native executor by opening the native prompt or relevant System Settings pane. Screen share, screen sharing, and screen-share mean Screen Recording. Supports Screen Recording, microphone, notifications, Accessibility, Automation, and Full Disk Access.",
+    "description": "Request Omi's macOS permission through the kernel-authorized native executor by opening the native prompt or relevant System Settings pane. Screen share, screen sharing, and screen-share mean Screen Recording. Supports Screen Recording, microphone, notifications, Accessibility, Automation, Full Disk Access, and Location.",
     "parameters": {
       "type": "object",
       "properties": {
@@ -550,9 +551,10 @@ enum GeneratedRealtimeTools {
             "notifications",
             "accessibility",
             "automation",
-            "full_disk_access"
+            "full_disk_access",
+            "location"
           ],
-          "description": "Permission type: screen_recording, microphone, notifications, accessibility, automation, or full_disk_access"
+          "description": "Permission type: screen_recording, microphone, notifications, accessibility, automation, full_disk_access, or location"
         }
       },
       "required": [

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -496,6 +496,7 @@ enum GeneratedToolCapabilities {
       bullets: [
       "Call only when the current user message names one permission, clearly affirms your immediately preceding one-permission request, or directly says to request it/that permission.",
       "Treat screen share, screen sharing, and screen-share as the screen_recording permission type.",
+      "For a weather question without an explicit place, call request_permission with type=location at query time instead of asking where the user is.",
       "Ask the user to choose when their request is generic or names multiple permissions.",
       "The user must still complete the native macOS prompt or Settings toggle.",
       "Call only when the current user message explicitly requests one named permission, clearly affirms your immediately preceding one-permission request, or directly says to request it/that permission.",

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -41,7 +41,7 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:63a4895fd703c99bd01ea56ed74a06c003ffe23d5dd20a18c1499975a7b04e34"
+  static let manifestDigest = "sha256:7e03a23498be78e39b79b8c5ff131bbc655b309794fa4f7143338c0a3f85ca8d"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/macos/Desktop/Sources/GmailReaderService.swift
@@ -145,7 +145,11 @@ actor GmailReaderService {
   /// - Parameters:
   ///   - maxResults: Maximum number of emails to return
   ///   - query: Gmail search query (default: "newer_than:1d"). For onboarding use "newer_than:30d".
-  func readRecentEmails(maxResults: Int = 50, query: String = "newer_than:1d") async throws
+  func readRecentEmails(
+    maxResults: Int = 50,
+    query: String = "newer_than:1d",
+    userInitiated: Bool = true
+  ) async throws
     -> [GmailEmail]
   {
     let emails: [GmailEmail]
@@ -154,9 +158,14 @@ actor GmailReaderService {
         maxResults: maxResults,
         query: query,
         feedPath: nil,
-        allowBootstrap: false
+        allowBootstrap: false,
+        userInitiated: userInitiated
       )
-      let labelEmails = try fetchGmailViaLabelFeeds(maxResults: maxResults, query: query)
+      let labelEmails = try fetchGmailViaLabelFeeds(
+        maxResults: maxResults,
+        query: query,
+        userInitiated: userInitiated
+      )
       var merged: [String: GmailEmail] = [:]
       for email in queryEmails + labelEmails {
         let existing = merged[email.id]
@@ -169,7 +178,11 @@ actor GmailReaderService {
         .prefix(maxResults)
         .map(\.self)
     } else {
-      emails = try fetchGmailViaAtomFeedSingle(maxResults: maxResults, query: query)
+      emails = try fetchGmailViaAtomFeedSingle(
+        maxResults: maxResults,
+        query: query,
+        userInitiated: userInitiated
+      )
     }
     return emails.sorted { $0.date > $1.date }
   }
@@ -405,14 +418,18 @@ actor GmailReaderService {
     maxResults: Int,
     query: String = "newer_than:1d",
     feedPath: String? = nil,
-    allowBootstrap: Bool? = nil
+    allowBootstrap: Bool? = nil,
+    userInitiated: Bool = true
   ) throws
     -> [GmailEmail]
   {
     let shouldUseBootstrapPage =
       allowBootstrap ?? (feedPath == nil && Self.parseNewerThanDays(query) != nil)
 
-    let browserConfigs = BrowserGoogleSession.configsForPython(logPrefix: "GmailReaderService")
+    let browserConfigs = BrowserGoogleSession.configsForPython(
+      logPrefix: "GmailReaderService",
+      userInitiated: userInitiated
+    )
 
     guard !browserConfigs.isEmpty else {
       throw GmailReaderError.noBrowserFound
@@ -759,7 +776,11 @@ actor GmailReaderService {
     }
   }
 
-  private func fetchGmailViaLabelFeeds(maxResults: Int, query: String) throws -> [GmailEmail] {
+  private func fetchGmailViaLabelFeeds(
+    maxResults: Int,
+    query: String,
+    userInitiated: Bool
+  ) throws -> [GmailEmail] {
     guard maxResults > 0 else { return [] }
 
     let feedPaths = [
@@ -784,7 +805,8 @@ actor GmailReaderService {
         maxResults: min(20, maxResults),
         query: query,
         feedPath: feedPath,
-        allowBootstrap: false
+        allowBootstrap: false,
+        userInitiated: userInitiated
       )
       for email in feedEmails {
         let existing = merged[email.id]

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -31,8 +31,6 @@ private protocol HostingSizingConfigurable: AnyObject {
 extension NSHostingView: HostingSizingConfigurable {}
 
 struct DesktopHomeView: View {
-  private let minimumWindowWidth: CGFloat = 1200
-  private let minimumWindowHeight: CGFloat = 680
   private static let pageNavigationAnimation = Animation.easeOut(duration: 0.08)
 
   @EnvironmentObject private var appState: AppState
@@ -402,7 +400,7 @@ struct DesktopHomeView: View {
       }
     }
     .background(OmiColors.backgroundPrimary)
-    .frame(minWidth: minimumWindowWidth, minHeight: minimumWindowHeight)
+    .frame(minWidth: DesktopWindowLayoutPolicy.width, minHeight: DesktopWindowLayoutPolicy.height)
     .preferredColorScheme(.dark)
     .tint(OmiColors.accent)
     .onAppear {
@@ -491,7 +489,7 @@ struct DesktopHomeView: View {
   }
 
   private func enforceMainWindowMinimumSize() {
-    let minimumContentSize = NSSize(width: minimumWindowWidth, height: minimumWindowHeight)
+    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
     DispatchQueue.main.async {
       for window in NSApp.windows where window.title.lowercased().hasPrefix("omi") {
         window.appearance = NSAppearance(named: .darkAqua)
@@ -525,7 +523,7 @@ struct DesktopHomeView: View {
   private func installMinimumSizeGuardIfNeeded() {
     guard !Self.minimumSizeGuardInstalled else { return }
     Self.minimumSizeGuardInstalled = true
-    let minimumContentSize = NSSize(width: minimumWindowWidth, height: minimumWindowHeight)
+    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
     NotificationCenter.default.addObserver(
       forName: NSWindow.didResizeNotification, object: nil, queue: .main
     ) { notification in

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -95,21 +95,12 @@ struct DesktopHomeView: View {
     Group {
       if authState.isRestoringAuth {
         // State 0: Restoring auth session - show loading
-        VStack(spacing: OmiSpacing.lg) {
-          if let nsImage = Self.heroLogoImage {
-            Image(nsImage: nsImage)
-              .resizable()
-              .scaledToFit()
-              .frame(width: 64, height: 64)
+        Color.clear
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .background(OmiColors.backgroundPrimary)
+          .onAppear {
+            log("DesktopHomeView: Showing auth loading splash")
           }
-          ProgressView()
-            .scaleEffect(0.8)
-            .tint(.white.opacity(0.6))
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-          log("DesktopHomeView: Showing auth loading splash")
-        }
       } else if authState.sessionPhase == .recoveryRequired {
         SessionRecoveryView()
           .onAppear {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -341,10 +341,22 @@ private struct TopNavigationBarRowLayout: Layout {
     let settingsX = bounds.maxX
     let controlsX = settingsX - sizes.settings.width - Self.controlsToSettingsSpacing
 
+    // Cap navigation to the space available before the persistent controls so
+    // that an enlarged font scale (where even the compact fallback overflows)
+    // constrains navigation instead of overlapping capture/settings controls.
+    let availableNavigationWidth = max(
+      0,
+      controlsX - Self.navigationToControlsSpacing - bounds.minX
+    )
+    let navigationProposal = CGSize(
+      width: min(sizes.navigation.width, availableNavigationWidth),
+      height: sizes.navigation.height
+    )
+
     subviews[0].place(
       at: CGPoint(x: bounds.minX, y: bounds.midY),
       anchor: .leading,
-      proposal: ProposedViewSize(sizes.navigation)
+      proposal: ProposedViewSize(navigationProposal)
     )
     subviews[1].place(
       at: CGPoint(x: controlsX, y: bounds.midY),

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -19,21 +19,7 @@ struct DesktopTopBar: View {
   @State private var memoryDropdownTask: Task<Void, Never>?
   @State private var isMemoryButtonHovered = false
 
-  private struct NavItem: Identifiable {
-    let index: Int
-    let title: String
-    let icon: String
-    var id: Int { index }
-  }
-
-  private var navItems: [NavItem] {
-    [
-      NavItem(index: SidebarNavItem.dashboard.rawValue, title: "Home", icon: "house.fill"),
-      NavItem(index: SidebarNavItem.conversations.rawValue, title: "Memory", icon: "brain"),
-      NavItem(index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist"),
-      NavItem(index: SidebarNavItem.apps.rawValue, title: "Apps", icon: "puzzlepiece.fill"),
-    ]
-  }
+  private var navItems: [TopNavigationItem] { TopNavigationRoutes.primaryItems }
 
   private var newConversations: Int {
     appState.conversations.filter { $0.createdAt > sinceDate && $0.deleted != true }.count
@@ -46,17 +32,61 @@ struct DesktopTopBar: View {
   }
 
   var body: some View {
-    HStack(spacing: OmiSpacing.md) {
-      navPills
-      Spacer(minLength: OmiSpacing.md)
-      CaptureListeningControls(appState: appState, onRewind: onRewind)
-      settingsButton
-    }
+    TopNavigationBarLayout(
+      expandedNavigation: { navPills },
+      compactNavigation: { compactNavigationMenu },
+      persistentControls: { CaptureListeningControls(appState: appState, onRewind: onRewind) },
+      settings: { settingsButton }
+    )
+    .frame(maxWidth: .infinity)
     .frame(height: 44)
     .padding(.horizontal, OmiSpacing.lg)
     .padding(.vertical, OmiSpacing.sm)
     .onDisappear {
       memoryDropdownTask?.cancel()
+    }
+  }
+
+  /// The complete primary navigation remains available when the full set of
+  /// fixed-width pills will not fit beside the persistent status controls.
+  private var compactNavigationMenu: some View {
+    Menu {
+      ForEach(navItems) { item in
+        compactNavigationItem(item)
+      }
+    } label: {
+      Label("Navigate", systemImage: "sidebar.left")
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .frame(height: 32)
+    }
+    .help("Navigate")
+    .accessibilityLabel("Navigate")
+    .accessibilityIdentifier("compact-navigation-menu")
+  }
+
+  @ViewBuilder
+  private func compactNavigationItem(_ item: TopNavigationItem) -> some View {
+    if item.index == SidebarNavItem.conversations.rawValue {
+      Menu {
+        ForEach(TopNavigationRoutes.memoryDestinations) { destination in
+          Button {
+            selectMemoryDestination(destination)
+          } label: {
+            Label(destination.title, systemImage: destination.icon)
+          }
+        }
+      } label: {
+        Label(item.title, systemImage: item.icon)
+      }
+    } else {
+      Button {
+        dismissMemoryDropdown()
+        OmiMotion.withGated(.easeOut(duration: 0.08)) {
+          selectedIndex = item.index
+        }
+      } label: {
+        Label(item.title, systemImage: item.icon)
+      }
     }
   }
 
@@ -121,7 +151,7 @@ struct DesktopTopBar: View {
     }
   }
 
-  private func memoryNavigationItem(_ item: NavItem) -> some View {
+  private func memoryNavigationItem(_ item: TopNavigationItem) -> some View {
     let isSelected =
       selectedIndex == item.index && memoryDestination == .memories
     let badgeCount = newCount(for: item)
@@ -227,13 +257,134 @@ struct DesktopTopBar: View {
   /// New-item count to badge on a nav button (since Omi was last in front).
   /// The Memory hub holds both memories and conversations, so its badge sums
   /// them; Tasks badges new tasks. Home/Apps have no counter.
-  private func newCount(for item: NavItem) -> Int {
+  private func newCount(for item: TopNavigationItem) -> Int {
     switch item.index {
     case SidebarNavItem.conversations.rawValue: return newMemories + newConversations
     case SidebarNavItem.tasks.rawValue: return newTasks
     default: return 0
     }
   }
+}
+
+/// Keeps the persistent capture and settings controls visible while replacing
+/// only primary navigation with its compact menu when a whole top-bar row no
+/// longer fits. Keeping the alternatives at this level means SwiftUI measures
+/// the complete row instead of an unconstrained child of an `HStack`.
+struct TopNavigationBarLayout<
+  ExpandedNavigation: View,
+  CompactNavigation: View,
+  PersistentControls: View,
+  Settings: View
+>: View {
+  let expandedNavigation: ExpandedNavigation
+  let compactNavigation: CompactNavigation
+  let persistentControls: PersistentControls
+  let settings: Settings
+
+  init(
+    @ViewBuilder expandedNavigation: () -> ExpandedNavigation,
+    @ViewBuilder compactNavigation: () -> CompactNavigation,
+    @ViewBuilder persistentControls: () -> PersistentControls,
+    @ViewBuilder settings: () -> Settings
+  ) {
+    self.expandedNavigation = expandedNavigation()
+    self.compactNavigation = compactNavigation()
+    self.persistentControls = persistentControls()
+    self.settings = settings()
+  }
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      TopNavigationBarRowLayout {
+        expandedNavigation
+        persistentControls
+        settings
+      }
+      TopNavigationBarRowLayout {
+        compactNavigation
+        persistentControls
+        settings
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+}
+
+/// Measures a top-bar row at its no-overflow width, then pins its persistent
+/// controls to the trailing edge once `ViewThatFits` has selected it.
+private struct TopNavigationBarRowLayout: Layout {
+  private static let navigationToControlsSpacing = OmiSpacing.md * 3
+  private static let controlsToSettingsSpacing = OmiSpacing.md
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    let sizes = sizes(for: subviews)
+    return CGSize(
+      width: sizes.navigation.width + Self.navigationToControlsSpacing + sizes.controls.width
+        + Self.controlsToSettingsSpacing + sizes.settings.width,
+      height: max(sizes.navigation.height, sizes.controls.height, sizes.settings.height)
+    )
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    let sizes = sizes(for: subviews)
+    guard subviews.count == 3 else { return }
+
+    let settingsX = bounds.maxX
+    let controlsX = settingsX - sizes.settings.width - Self.controlsToSettingsSpacing
+
+    subviews[0].place(
+      at: CGPoint(x: bounds.minX, y: bounds.midY),
+      anchor: .leading,
+      proposal: ProposedViewSize(sizes.navigation)
+    )
+    subviews[1].place(
+      at: CGPoint(x: controlsX, y: bounds.midY),
+      anchor: .trailing,
+      proposal: ProposedViewSize(sizes.controls)
+    )
+    subviews[2].place(
+      at: CGPoint(x: settingsX, y: bounds.midY),
+      anchor: .trailing,
+      proposal: ProposedViewSize(sizes.settings)
+    )
+  }
+
+  private func sizes(for subviews: Subviews) -> (navigation: CGSize, controls: CGSize, settings: CGSize) {
+    guard subviews.count == 3 else { return (.zero, .zero, .zero) }
+    return (
+      subviews[0].sizeThatFits(.unspecified),
+      subviews[1].sizeThatFits(.unspecified),
+      subviews[2].sizeThatFits(.unspecified)
+    )
+  }
+}
+
+struct TopNavigationItem: Identifiable, Equatable {
+  let index: Int
+  let title: String
+  let icon: String
+
+  var id: Int { index }
+}
+
+enum TopNavigationRoutes {
+  static let primaryItems = [
+    TopNavigationItem(index: SidebarNavItem.dashboard.rawValue, title: "Home", icon: "house.fill"),
+    TopNavigationItem(index: SidebarNavItem.conversations.rawValue, title: "Memory", icon: "brain"),
+    TopNavigationItem(index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist"),
+    TopNavigationItem(index: SidebarNavItem.apps.rawValue, title: "Apps", icon: "puzzlepiece.fill"),
+  ]
+
+  static let memoryDestinations = MemoryHubDestination.allCases
 }
 
 enum TopNavigationPillMetrics {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+/// The full desktop experience must fit on a 1024pt-wide display. Individual
+/// rows choose compact layouts below their preferred width; this is only the
+/// floor that keeps AppKit from restoring a window wider than the display.
+enum DesktopWindowLayoutPolicy {
+  static let width: CGFloat = 800
+  static let height: CGFloat = 680
+  static let minimumContentSize = NSSize(width: width, height: height)
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPageHeaderControls.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 enum AppsHeaderMetrics {
   static let searchFieldMaxWidth: CGFloat = 360
+  static let searchFieldMinWidth: CGFloat = 200
   static let controlIconSize: CGFloat = 16
   static let controlHeight: CGFloat = 44
 }
@@ -31,7 +32,10 @@ struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: 
     ViewThatFits(in: .horizontal) {
       HStack(spacing: OmiSpacing.md) {
         search
-          .frame(maxWidth: AppsHeaderMetrics.searchFieldMaxWidth)
+          .frame(
+            minWidth: AppsHeaderMetrics.searchFieldMinWidth,
+            maxWidth: AppsHeaderMetrics.searchFieldMaxWidth
+          )
         filters
           .fixedSize(horizontal: true, vertical: false)
         create
@@ -40,7 +44,7 @@ struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: 
 
       VStack(alignment: .leading, spacing: OmiSpacing.sm) {
         HStack(spacing: OmiSpacing.sm) {
-          search
+          search.frame(minWidth: AppsHeaderMetrics.searchFieldMinWidth)
           dismiss
         }
 
@@ -49,6 +53,20 @@ struct AppsHeaderRow<Search: View, Filters: View, Create: View, Dismiss: View>: 
             .fixedSize(horizontal: true, vertical: false)
           create
         }
+      }
+
+      // The real filter controls have a fixed minimum width. Once they no
+      // longer fit with Create App, give each control group its own row.
+      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+        HStack(spacing: OmiSpacing.sm) {
+          search
+          dismiss
+        }
+
+        filters
+          .fixedSize(horizontal: true, vertical: false)
+
+        create
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -4,6 +4,15 @@ import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
 
+enum SubscriptionPlanPresentation {
+  static func selectionLabel(planTitle: String, startingPrice: String?) -> String {
+    guard let startingPrice, !startingPrice.isEmpty else {
+      return "Select \(planTitle)"
+    }
+    return "Select \(planTitle) · \(startingPrice)"
+  }
+}
+
 extension SettingsContentView {
   var hasPaidSubscription: Bool {
     guard let subscription = userSubscription?.subscription else { return false }
@@ -140,6 +149,13 @@ extension SettingsContentView {
 
   func planSummaryText(for plan: SubscriptionPlanOption) -> String {
     preferredStartingPrice(for: plan)?.priceString ?? ""
+  }
+
+  func planSelectionLabel(for plan: SubscriptionPlanOption) -> String {
+    SubscriptionPlanPresentation.selectionLabel(
+      planTitle: plan.title,
+      startingPrice: preferredStartingPrice(for: plan)?.priceString
+    )
   }
 
   func preferredStartingPrice(for plan: SubscriptionPlanOption) -> SubscriptionPriceOption? {
@@ -431,16 +447,13 @@ extension SettingsContentView {
                         .scaledFont(size: OmiType.caption, weight: .bold)
                       Text(price.priceString)
                         .scaledFont(size: OmiType.caption)
-                        .foregroundColor(OmiColors.backgroundPrimary.opacity(0.92))
+                        .foregroundColor(OmiColors.textSecondary)
                     }
-                    .foregroundColor(OmiColors.backgroundPrimary)
                     .frame(maxWidth: .infinity)
                   }
                 }
-                .padding(.vertical, OmiSpacing.sm)
               }
-              .buttonStyle(.borderedProminent)
-              .tint(accent)
+              .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
               .disabled(activeCheckoutPriceId != nil)
             }
           }
@@ -460,17 +473,15 @@ extension SettingsContentView {
           selectedPlanIdForCheckout = plan.id
         }) {
           HStack {
-            Text("Select \(plan.title)")
+            Text(planSelectionLabel(for: plan))
               .scaledFont(size: OmiType.caption, weight: .bold)
             Spacer()
             Image(systemName: "arrow.right")
               .scaledFont(size: OmiType.caption, weight: .bold)
           }
-          .foregroundColor(OmiColors.backgroundPrimary)
-          .padding(.vertical, OmiSpacing.sm)
+          .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderedProminent)
-        .tint(accent)
+        .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
       }
     }
     .padding(OmiSpacing.xxl)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
@@ -69,8 +69,7 @@ extension SettingsContentView {
                   .scaledFont(size: OmiType.body, weight: .semibold)
               }
             }
-            .buttonStyle(.borderedProminent)
-            .tint(OmiColors.error)
+            .buttonStyle(OmiButtonStyle(.destructive, size: .compact))
             .disabled(isDeletingAccount)
           }
 
@@ -348,11 +347,8 @@ extension SettingsContentView {
             }) {
               Text("Try Operator")
                 .scaledFont(size: OmiType.body, weight: .semibold)
-                .padding(.horizontal, OmiSpacing.lg)
-                .padding(.vertical, OmiSpacing.sm)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(OmiColors.success)
+            .buttonStyle(OmiButtonStyle(.primary, size: .compact))
           }
         }
       }
@@ -360,16 +356,6 @@ extension SettingsContentView {
       if shouldShowPlanPurchaseOptions {
         settingsCard(settingId: "planusage.purchase") {
           VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-            VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-              Text("Choose a plan")
-                .scaledFont(size: OmiType.subheading, weight: .semibold)
-                .foregroundColor(OmiColors.textPrimary)
-
-              Text("Pick one plan first. Billing options appear only after the card is selected.")
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(OmiColors.textTertiary)
-            }
-
             // All plan cards share the row width — no horizontal scrolling.
             HStack(alignment: .top, spacing: OmiSpacing.lg) {
               ForEach(subscriptionPlansForDisplay) { plan in

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -153,25 +153,9 @@ extension SettingsContentView {
               .scaledFont(size: OmiType.subheading)
               .foregroundColor(OmiColors.textTertiary)
 
-            VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
-              Text("AI Provider")
-                .scaledFont(size: OmiType.body)
-                .foregroundColor(OmiColors.textSecondary)
-
-              if let provider = AIProvider.from(bridgeMode: chatBridgeMode) {
-                if let url = provider.attributionURL {
-                  Link(destination: url) {
-                    Text("\(provider.tagline) · \(url.host ?? "")")
-                      .scaledFont(size: OmiType.caption)
-                      .foregroundColor(OmiColors.textTertiary)
-                  }
-                } else {
-                  Text(provider.tagline)
-                    .scaledFont(size: OmiType.caption)
-                    .foregroundColor(OmiColors.textTertiary)
-                }
-              }
-            }
+            Text("AI Provider")
+              .scaledFont(size: OmiType.subheading, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
 
             Spacer()
 
@@ -186,6 +170,20 @@ extension SettingsContentView {
                   await chatProvider?.switchBridgeMode(to: mode)
                 }
               }
+            }
+          }
+
+          if let provider = AIProvider.from(bridgeMode: chatBridgeMode) {
+            if let url = provider.attributionURL {
+              Link(destination: url) {
+                Text("\(provider.tagline) · \(url.host ?? "")")
+                  .scaledFont(size: OmiType.caption)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            } else {
+              Text(provider.tagline)
+                .scaledFont(size: OmiType.caption)
+                .foregroundColor(OmiColors.textTertiary)
             }
           }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -319,6 +319,12 @@ struct SettingsSearchItem: Identifiable {
   ]
 }
 
+enum SettingsSidebarMetrics {
+  static let expandedWidth: CGFloat = 260
+  static let horizontalInset: CGFloat = OmiSpacing.sm
+  static let itemAvailableWidth = expandedWidth - 2 * horizontalInset
+}
+
 /// Settings sidebar that replaces the main sidebar when in settings
 struct SettingsSidebar: View {
   @Binding var selectedSection: SettingsContentView.SettingsSection
@@ -329,7 +335,6 @@ struct SettingsSidebar: View {
   @State private var searchQuery = ""
   @FocusState private var isSearchFocused: Bool
 
-  private let expandedWidth: CGFloat = 260
   private let iconWidth: CGFloat = 20
   // Merged nav: `.account` hosts Account & Plan (renders `.planUsage` content
   // too) and `.notifications` hosts Notifications & Privacy (renders `.privacy`
@@ -411,7 +416,7 @@ struct SettingsSidebar: View {
 
       Spacer()
     }
-    .frame(width: expandedWidth)
+    .frame(width: SettingsSidebarMetrics.expandedWidth)
     .background(OmiColors.backgroundPrimary)
   }
 
@@ -548,6 +553,9 @@ struct SettingsSidebarItem: View {
             Text(section.displayTitle)
               .scaledFont(size: OmiType.body, weight: isSelected ? .medium : .regular)
               .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
+              .lineLimit(1)
+              .fixedSize(horizontal: true, vertical: false)
+              .layoutPriority(1)
 
             Spacer()
           }

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -554,7 +554,7 @@ struct SettingsSidebarItem: View {
               .scaledFont(size: OmiType.body, weight: isSelected ? .medium : .regular)
               .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
               .lineLimit(1)
-              .fixedSize(horizontal: true, vertical: false)
+              .truncationMode(.tail)
               .layoutPriority(1)
 
             Spacer()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -1580,7 +1580,7 @@ struct OnboardingChatView: View {
     gmailReadingTask = Task {
       do {
         let emails = try await GmailReaderService.shared.readRecentEmails(
-          maxResults: 50, query: "newer_than:30d"
+          maxResults: 50, query: "newer_than:30d", userInitiated: false
         )
         guard !emails.isEmpty else {
           log("OnboardingChat: No Gmail emails found, skipping synthesis")
@@ -1645,7 +1645,7 @@ struct OnboardingChatView: View {
     calendarReadingTask = Task {
       do {
         let events = try await CalendarReaderService.shared.readEvents(
-          daysBack: 90, daysForward: 14, maxResults: 200
+          daysBack: 90, daysForward: 14, maxResults: 200, userInitiated: false
         )
         guard !events.isEmpty else {
           log("OnboardingChat: No calendar events found, skipping synthesis")

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarDemoView.swift
@@ -49,83 +49,82 @@ struct OnboardingFloatingBarDemoView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
-
-      // Content
-      VStack(spacing: OmiSpacing.xxl) {
-        VStack(spacing: OmiSpacing.md) {
-          if !barActivated {
-            Text("Omi sees your screen and gives you hyper-personalized responses")
-              .font(.system(size: 20, weight: .bold))
-              .foregroundColor(OmiColors.textPrimary)
-              .multilineTextAlignment(.center)
-              .frame(maxWidth: 560)
-
-            Text("Press this shortcut to try it.")
-              .font(.system(size: 18, weight: .medium))
-              .foregroundColor(OmiColors.textSecondary)
-              .multilineTextAlignment(.center)
-          } else {
-            Text("Omi is answering 'Which computer should I buy?' in the floating bar")
-              .font(.system(size: 24, weight: .bold))
-              .foregroundColor(OmiColors.textPrimary)
-              .lineLimit(1)
-              .fixedSize()
-          }
-        }
-
-        if !barActivated {
+      // Keep the header/progress chrome fixed. The interactive content is
+      // centered when it fits and becomes vertically scrollable when a compact
+      // display or expanded response would otherwise clip the action row.
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
           VStack(spacing: OmiSpacing.md) {
-            HStack(spacing: OmiSpacing.xs) {
-              ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) {
-                index, symbol in
-                if index > 0 {
-                  Text("+")
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(OmiColors.textTertiary)
-                }
-                keyCap(symbol, isPressed: pressedTokens.contains(symbol))
-              }
+            if !barActivated {
+              Text("Omi sees your screen and gives you hyper-personalized responses")
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(OmiColors.textPrimary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 560)
+
+              Text("Press this shortcut to try it.")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(OmiColors.textSecondary)
+                .multilineTextAlignment(.center)
+            } else {
+              Text("Omi is answering 'Which computer should I buy?' in the floating bar")
+                .font(.system(size: 24, weight: .bold))
+                .foregroundColor(OmiColors.textPrimary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
             }
-
-            Text("Omi answers in the floating bar at the top of your screen.")
-              .font(.system(size: 13))
-              .foregroundColor(OmiColors.textTertiary)
           }
-          .padding(.top, OmiSpacing.xxs)
-          .transition(.opacity)
-        } else {
-          MacLineupPreview()
-            .frame(maxWidth: 980)
-            .transition(.opacity.combined(with: .move(edge: .bottom)))
-        }
 
-      }
-      .padding(.top, 88)
-      .padding(.horizontal, OmiSpacing.page)
+          if !barActivated {
+            VStack(spacing: OmiSpacing.md) {
+              HStack(spacing: OmiSpacing.xs) {
+                ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) {
+                  index, symbol in
+                  if index > 0 {
+                    Text("+")
+                      .font(.system(size: 15, weight: .medium))
+                      .foregroundColor(OmiColors.textTertiary)
+                  }
+                  keyCap(symbol, isPressed: pressedTokens.contains(symbol))
+                }
+              }
 
-      Spacer()
-
-      // Bottom row — back is always available; Continue appears after the AI responds
-      HStack(spacing: OmiSpacing.md) {
-        OnboardingBackButton()
-
-        if showContinue {
-          Button(action: onComplete) {
-            Text("Continue")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundColor(.black)
-              .frame(maxWidth: 280)
-              .padding(.vertical, OmiSpacing.md)
-              .background(Color.white)
-              .cornerRadius(OmiChrome.smallControlRadius)
+              Text("Omi answers in the floating bar at the top of your screen.")
+                .font(.system(size: 13))
+                .foregroundColor(OmiColors.textTertiary)
+            }
+            .padding(.top, OmiSpacing.xxs)
+            .transition(.opacity)
+          } else {
+            MacLineupPreview()
+              .frame(maxWidth: 980)
+              .transition(.opacity.combined(with: .move(edge: .bottom)))
           }
-          .buttonStyle(.plain)
-          .keyboardShortcut(.defaultAction)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+
         }
+        .frame(maxWidth: 980)
+      } actions: {
+        // Back/Continue stays visible while the response preview scrolls.
+        HStack(spacing: OmiSpacing.md) {
+          OnboardingBackButton()
+
+          if showContinue {
+            Button(action: onComplete) {
+              Text("Continue")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.black)
+                .frame(maxWidth: 280)
+                .padding(.vertical, OmiSpacing.md)
+                .background(Color.white)
+                .cornerRadius(OmiChrome.smallControlRadius)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+          }
+        }
+        .frame(maxWidth: 980)
       }
-      .padding(.bottom, OmiSpacing.section)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarShortcutStepView.swift
@@ -243,10 +243,7 @@ struct OnboardingFloatingBarShortcutStepView: View {
   private func shortcutChoiceButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
     let isSelected = shortcutSettings.askOmiShortcut == shortcut && !shortcutSettings.askOmiUsesCustomShortcut
     return Button {
-      shortcutSettings.askOmiShortcut = shortcut
-      isRecordingCustomShortcut = false
-      captureError = nil
-      resetDetectionState()
+      beginCustomShortcutCapture()
     } label: {
       HStack(spacing: OmiSpacing.xxs) {
         ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, symbol in

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFloatingBarShortcutStepView.swift
@@ -52,39 +52,45 @@ struct OnboardingFloatingBarShortcutStepView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
+          Text("Let's set the \"Open Omi\" shortcut.\nPress this shortcut. Do the buttons light up?")
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundColor(OmiColors.textPrimary)
+            .multilineTextAlignment(.center)
 
-      VStack(spacing: OmiSpacing.xxl) {
-        Text("Let's set the \"Open Omi\" shortcut.\nPress this shortcut. Do the buttons light up?")
-          .font(.system(size: 22, weight: .semibold))
-          .foregroundColor(OmiColors.textPrimary)
-          .multilineTextAlignment(.center)
-
-        RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
-          .fill(OmiColors.backgroundSecondary)
-          .frame(height: 152)
-          .frame(maxWidth: 480)
-          .overlay {
-            shortcutKeyPreview
-          }
-
-        VStack(spacing: OmiSpacing.md) {
-          Text("Choose a different shortcut:")
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-
-          HStack(spacing: OmiSpacing.sm) {
-            ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
-              shortcutChoiceButton(shortcut)
+          RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+            .frame(height: 152)
+            .frame(maxWidth: 480)
+            .overlay {
+              shortcutKeyPreview
             }
-            customShortcutButton
+
+          VStack(spacing: OmiSpacing.md) {
+            Text("Choose a different shortcut:")
+              .font(.system(size: 14, weight: .medium))
+              .foregroundColor(OmiColors.textSecondary)
+
+            LazyVGrid(
+              columns: [GridItem(.adaptive(minimum: 92), spacing: OmiSpacing.sm)],
+              alignment: .center,
+              spacing: OmiSpacing.sm
+            ) {
+              ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
+                shortcutChoiceButton(shortcut)
+              }
+              customShortcutButton
+            }
+
+            if isRecordingCustomShortcut || shortcutSettings.askOmiUsesCustomShortcut || captureError != nil {
+              customShortcutRecorder
+            }
           }
 
-          if isRecordingCustomShortcut || shortcutSettings.askOmiUsesCustomShortcut || captureError != nil {
-            customShortcutRecorder
-          }
         }
-
+        .frame(maxWidth: 480)
+      } actions: {
         HStack(spacing: OmiSpacing.md) {
           OnboardingBackButton()
 
@@ -105,9 +111,8 @@ struct OnboardingFloatingBarShortcutStepView: View {
             .transition(.move(edge: .bottom).combined(with: .opacity))
           }
         }
+        .frame(maxWidth: 480)
       }
-
-      Spacer()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
@@ -847,7 +847,8 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       do {
         let emails = try await GmailReaderService.shared.readRecentEmails(
           maxResults: 300,
-          query: "newer_than:365d"
+          query: "newer_than:365d",
+          userInitiated: false
         )
         guard !Task.isCancelled else { return }
 
@@ -908,7 +909,8 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         let events = try await CalendarReaderService.shared.readEvents(
           daysBack: 365,
           daysForward: 90,
-          maxResults: 1000
+          maxResults: 1000,
+          userInitiated: false
         )
         guard !Task.isCancelled else { return }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingStepScaffold.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingStepScaffold.swift
@@ -52,6 +52,58 @@ enum OnboardingLayoutMode {
   case centered
 }
 
+/// Keeps the onboarding chrome visible while allowing a step's content to
+/// scroll only when a compact window cannot contain it. The minimum-height
+/// frame preserves the existing centered composition at ordinary sizes.
+struct OnboardingCenteredContentRegion<Content: View>: View {
+  let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      ScrollView(showsIndicators: false) {
+        content
+          .frame(maxWidth: .infinity)
+          .frame(minHeight: geometry.size.height, alignment: .center)
+          .padding(.horizontal, OmiSpacing.page)
+          .padding(.vertical, OmiSpacing.section)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+    }
+  }
+}
+
+/// Splits an onboarding step into scrollable content and persistent navigation
+/// actions. Keeping the footer outside the scroll view ensures users can
+/// always go back or continue, even while a compact-height window scrolls the
+/// larger instructional content.
+struct OnboardingContentWithPinnedActions<Content: View, Actions: View>: View {
+  let content: Content
+  let actions: Actions
+
+  init(
+    @ViewBuilder content: () -> Content,
+    @ViewBuilder actions: () -> Actions
+  ) {
+    self.content = content()
+    self.actions = actions()
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      OnboardingCenteredContentRegion { content }
+        .frame(maxHeight: .infinity)
+
+      actions
+        .padding(.horizontal, OmiSpacing.page)
+        .padding(.bottom, OmiSpacing.section)
+    }
+  }
+}
+
 struct OnboardingStepScaffold<Content: View>: View {
   @ObservedObject private var graphViewModel: MemoryGraphViewModel
   @Environment(\.onboardingJumpTo) private var onboardingJumpTo

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceDemoView.swift
@@ -45,71 +45,70 @@ struct OnboardingVoiceDemoView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
-
-      VStack(spacing: OmiSpacing.xxl) {
-        VStack(spacing: OmiSpacing.md) {
-          Text("Hold \(shortcutSettings.pttShortcut.displayLabel) and Ask")
-            .font(.system(size: 24, weight: .bold))
-            .foregroundColor(OmiColors.textPrimary)
-
-          Text("Try asking: What's on my screen?")
-            .font(.system(size: 18, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-            .multilineTextAlignment(.center)
-        }
-
-        if outputReadiness.shouldAskUserToTurnUpVolume {
-          volumeWarning
-            .transition(.opacity)
-        } else if !observedShortcutPress {
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
           VStack(spacing: OmiSpacing.md) {
-            Text("Hold the shortcut, speak, then release")
-              .font(.system(size: 13))
-              .foregroundColor(OmiColors.textTertiary)
+            Text("Hold \(shortcutSettings.pttShortcut.displayLabel) and Ask")
+              .font(.system(size: 24, weight: .bold))
+              .foregroundColor(OmiColors.textPrimary)
 
-            HStack(spacing: OmiSpacing.xs) {
-              ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
-                keyCap(token)
-              }
-              Text("hold")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(OmiColors.textTertiary)
-            }
+            Text("Try asking: What's on my screen?")
+              .font(.system(size: 18, weight: .medium))
+              .foregroundColor(OmiColors.textSecondary)
+              .multilineTextAlignment(.center)
           }
-          .padding(.top, OmiSpacing.xxs)
-          .transition(.opacity)
-        } else if !showContinue {
-          Text(waitingForResponse ? "Waiting for omi to respond..." : "Listening... release when done")
-            .font(.system(size: 13))
-            .foregroundColor(OmiColors.textTertiary)
+
+          if outputReadiness.shouldAskUserToTurnUpVolume {
+            volumeWarning
+              .transition(.opacity)
+          } else if !observedShortcutPress {
+            VStack(spacing: OmiSpacing.md) {
+              Text("Hold the shortcut, speak, then release")
+                .font(.system(size: 13))
+                .foregroundColor(OmiColors.textTertiary)
+
+              HStack(spacing: OmiSpacing.xs) {
+                ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                  keyCap(token)
+                }
+                Text("hold")
+                  .font(.system(size: 13, weight: .medium))
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            }
             .padding(.top, OmiSpacing.xxs)
             .transition(.opacity)
-        }
-      }
-      .padding(.horizontal, OmiSpacing.page)
-
-      Spacer()
-
-      HStack(spacing: OmiSpacing.md) {
-        OnboardingBackButton()
-
-        if showContinue {
-          Button(action: onComplete) {
-            Text("Continue")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundColor(.black)
-              .frame(maxWidth: 280)
-              .padding(.vertical, OmiSpacing.md)
-              .background(Color.white)
-              .cornerRadius(OmiChrome.smallControlRadius)
+          } else if !showContinue {
+            Text(waitingForResponse ? "Waiting for omi to respond..." : "Listening... release when done")
+              .font(.system(size: 13))
+              .foregroundColor(OmiColors.textTertiary)
+              .padding(.top, OmiSpacing.xxs)
+              .transition(.opacity)
           }
-          .buttonStyle(.plain)
-          .keyboardShortcut(.defaultAction)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+
         }
+        .frame(maxWidth: 420)
+      } actions: {
+        HStack(spacing: OmiSpacing.md) {
+          OnboardingBackButton()
+
+          if showContinue {
+            Button(action: onComplete) {
+              Text("Continue")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.black)
+                .frame(maxWidth: 280)
+                .padding(.vertical, OmiSpacing.md)
+                .background(Color.white)
+                .cornerRadius(OmiChrome.smallControlRadius)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.defaultAction)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+          }
+        }
+        .frame(maxWidth: 420)
       }
-      .padding(.bottom, OmiSpacing.section)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
@@ -46,39 +46,45 @@ struct OnboardingVoiceShortcutStepView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, OmiSpacing.xl)
 
-      Spacer()
+      OnboardingContentWithPinnedActions {
+        VStack(spacing: OmiSpacing.xxl) {
+          Text("Let's set \"Audio ask a question\" shortcut.\nPress and hold to test. Does the button light up?")
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundColor(OmiColors.textPrimary)
+            .multilineTextAlignment(.center)
 
-      VStack(spacing: OmiSpacing.xxl) {
-        Text("Let's set \"Audio ask a question\" shortcut.\nPress and hold to test. Does the button light up?")
-          .font(.system(size: 22, weight: .semibold))
-          .foregroundColor(OmiColors.textPrimary)
-          .multilineTextAlignment(.center)
-
-        RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
-          .fill(OmiColors.backgroundSecondary)
-          .frame(height: 128)
-          .frame(maxWidth: 420)
-          .overlay {
-            shortcutKeyPreview
-          }
-
-        VStack(spacing: OmiSpacing.md) {
-          Text("Try another shortcut if it doesn't react:")
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-
-          HStack(spacing: OmiSpacing.sm) {
-            ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
-              shortcutChoiceButton(shortcut)
+          RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+            .frame(height: 128)
+            .frame(maxWidth: 420)
+            .overlay {
+              shortcutKeyPreview
             }
-            customShortcutButton
+
+          VStack(spacing: OmiSpacing.md) {
+            Text("Try another shortcut if it doesn't react:")
+              .font(.system(size: 14, weight: .medium))
+              .foregroundColor(OmiColors.textSecondary)
+
+            LazyVGrid(
+              columns: [GridItem(.adaptive(minimum: 92), spacing: OmiSpacing.sm)],
+              alignment: .center,
+              spacing: OmiSpacing.sm
+            ) {
+              ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
+                shortcutChoiceButton(shortcut)
+              }
+              customShortcutButton
+            }
+
+            if isRecordingCustomShortcut || shortcutSettings.pttUsesCustomShortcut || captureError != nil {
+              customShortcutRecorder
+            }
           }
 
-          if isRecordingCustomShortcut || shortcutSettings.pttUsesCustomShortcut || captureError != nil {
-            customShortcutRecorder
-          }
         }
-
+        .frame(maxWidth: 420)
+      } actions: {
         HStack(spacing: OmiSpacing.md) {
           OnboardingBackButton()
 
@@ -99,9 +105,8 @@ struct OnboardingVoiceShortcutStepView: View {
             .transition(.move(edge: .trailing).combined(with: .opacity))
           }
         }
+        .frame(maxWidth: 420)
       }
-
-      Spacer()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
@@ -245,10 +245,7 @@ struct OnboardingVoiceShortcutStepView: View {
   private func shortcutChoiceButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
     let isSelected = shortcutSettings.pttShortcut == shortcut && !shortcutSettings.pttUsesCustomShortcut
     return Button {
-      shortcutSettings.pttShortcut = shortcut
-      isRecordingCustomShortcut = false
-      captureError = nil
-      resetDetectionState()
+      beginCustomShortcutCapture()
     } label: {
       HStack(spacing: OmiSpacing.xs) {
         ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -23,8 +23,14 @@ extension SBOnboardingModel {
       pollPermission(key)
     case "screen_recording":
       scrState = .waiting
-      ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
-      pollPermission(key)
+      appState.checkScreenRecordingPermission()
+      if appState.hasScreenRecordingPermission {
+        setPermOn(key)
+        autoAdvanceIfCurrent(key)
+      } else {
+        ScreenCaptureService.requestScreenRecordingAccessAndOpenSettings()
+        pollPermission(key)
+      }
     case "full_disk_access":
       requestFullDiskAccess()
     case "accessibility":
@@ -131,7 +137,6 @@ extension SBOnboardingModel {
         }
 
         self.setPermOn("system_audio")
-        try? await Task.sleep(nanoseconds: 600_000_000)
         guard !Task.isCancelled else { return }
         self.autoAdvanceIfCurrent("system_audio")
         return
@@ -320,17 +325,17 @@ extension SBOnboardingModel {
       // .registerCommandO), so it reliably summons Omi globally — the natural,
       // expected "open" chord. Offer it first. (⌘J was dropped: onboarding testers
       // read it as arbitrary/random with no mnemonic, unlike ⌘O = "open".)
-      ("cmdO", ShortcutSettings.askOmiCommandOShortcut, "tap to open"),
-      ("cmdReturn", ShortcutSettings.askOmiCommandReturnShortcut, "tap to open"),
+      ("cmdO", ShortcutSettings.askOmiCommandOShortcut, "press to set"),
+      ("cmdReturn", ShortcutSettings.askOmiCommandReturnShortcut, "press to set"),
     ]
   }
 
   /// Push-to-talk options (hold to talk, hands-free).
   var talkShortcutOptions: [(id: String, shortcut: ShortcutSettings.KeyboardShortcut, sub: String)] {
     [
-      ("fn", ShortcutSettings.KeyboardShortcut(modifierOnly: .function), "hold to talk"),
-      ("opt", ShortcutSettings.KeyboardShortcut(modifierOnly: .option), "hold to talk"),
-      ("ctrl", ShortcutSettings.KeyboardShortcut(modifierOnly: .control), "hold to talk"),
+      ("fn", ShortcutSettings.KeyboardShortcut(modifierOnly: .function), "press to set"),
+      ("opt", ShortcutSettings.KeyboardShortcut(modifierOnly: .option), "press to set"),
+      ("ctrl", ShortcutSettings.KeyboardShortcut(modifierOnly: .control), "press to set"),
     ]
   }
 
@@ -350,6 +355,7 @@ extension SBOnboardingModel {
     }
     shortcutPicked = rememberedSelection != nil
     shortcutPressed = false
+    shortcutRecording = false
     shortcutTokens = rememberedSelection?.displayTokens ?? []
     chosenShortcut = rememberedSelection
     GlobalShortcutManager.shared.setRegistrationSuspended(true)
@@ -404,6 +410,9 @@ extension SBOnboardingModel {
   }
 
   private func handleShortcutEvent(_ event: NSEvent) -> Bool {
+    if shortcutRecording {
+      return recordShortcut(from: event)
+    }
     guard !shortcutPressed else { return false }
     // If the user already tapped a row, honor that exact pick; otherwise let ANY
     // offered combo select itself on press, so "just press the key" works and the
@@ -437,6 +446,7 @@ extension SBOnboardingModel {
     shortcutTokens = shortcut.displayTokens
     shortcutPicked = true
     shortcutPressed = false
+    shortcutRecording = false
     if isTalk {
       talkShortcutSelection = shortcut
       ShortcutSettings.shared.pttShortcut = shortcut
@@ -446,6 +456,29 @@ extension SBOnboardingModel {
       ShortcutSettings.shared.askOmiShortcut = shortcut
       ShortcutSettings.shared.askOmiEnabled = true
     }
+  }
+
+  func beginShortcutRecording(isTalk: Bool) {
+    chosenShortcut = nil
+    chosenShortcutIsPTT = isTalk
+    shortcutTokens = []
+    shortcutPicked = false
+    shortcutPressed = false
+    shortcutRecording = true
+  }
+
+  func recordShortcut(from event: NSEvent) -> Bool {
+    let isTalk = step == .shortcutTalk
+    guard
+      let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(
+        event,
+        allowModifierOnly: isTalk
+      )
+    else {
+      return event.type == .flagsChanged
+    }
+    pickShortcut(shortcut, isTalk: isTalk)
+    return true
   }
 
   func answerShortcutOpen() {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -70,6 +70,7 @@ final class SBOnboardingModel: ObservableObject {
   // Per-step answers / state
   @Published var nameDraft = ""
   @Published var languageDraft = ""
+  @Published private(set) var languageIsDetectedFromMac = false
   @Published var languageName: String?
   @Published var howHeard: String?
   @Published var roleDraft = ""
@@ -464,6 +465,7 @@ final class SBOnboardingModel: ObservableObject {
   func pickLanguage(code: String, name: String) {
     languageName = name
     languageDraft = name
+    languageIsDetectedFromMac = false
     AssistantSettings.shared.voiceLanguages = [code]
     answerWriteGate.enqueue(.language) { [code] in
       _ = try? await APIClient.shared.updateUserLanguage(code)
@@ -474,11 +476,18 @@ final class SBOnboardingModel: ObservableObject {
   /// Auto-detect the Mac's language and pre-fill it so the picker defaults to it
   /// (the user can still type to change). Only fills an empty field once.
   func prefillDetectedLanguage() {
-    guard languageDraft.isEmpty, languageName == nil else { return }
     let raw = Locale.current.language.languageCode?.identifier ?? Locale.preferredLanguages.first ?? "en"
+    prefillDetectedLanguage(from: raw)
+  }
+
+  /// Records that the draft came from the Mac locale, rather than a saved or
+  /// fallback language, so the UI can accurately disclose its source.
+  func prefillDetectedLanguage(from raw: String) {
+    guard languageDraft.isEmpty, languageName == nil else { return }
     let code = AssistantSettings.normalizeTranscriptionLanguageCode(raw)
     if let match = AssistantSettings.supportedLanguages.first(where: { $0.code == code }) {
       languageDraft = match.name
+      languageIsDetectedFromMac = true
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -13,6 +13,24 @@ import Foundation
 /// `SBOnboardingModel+Steps.swift`.
 @MainActor
 final class SBOnboardingModel: ObservableObject {
+  enum CaptureSelection: Equatable {
+    case onlyDuringMeetings
+    case continuous
+
+    var systemAudioCaptureMode: AssistantSettings.SystemAudioCaptureMode {
+      switch self {
+      case .onlyDuringMeetings: .onlyDuringMeetings
+      case .continuous: .always
+      }
+    }
+
+    var startsListeningImmediately: Bool {
+      self == .continuous
+    }
+  }
+
+  static let defaultCaptureSelection: CaptureSelection = .onlyDuringMeetings
+
   enum Step: Int, CaseIterable {
     case promise, name, howHeard, language, role
     case mic, systemAudio, screen, files, accessibility, automation
@@ -66,7 +84,6 @@ final class SBOnboardingModel: ObservableObject {
   @Published var shortcutTokens: [String] = []
   @Published var shortcutPicked = false
   @Published var shortcutPressed = false
-  @Published var shortcutRecording = false
   /// The chosen shortcut + which mechanism it uses (key hotkey vs modifier-hold).
   var chosenShortcut: ShortcutSettings.KeyboardShortcut?
   var chosenShortcutIsPTT = false
@@ -203,7 +220,7 @@ final class SBOnboardingModel: ObservableObject {
     case .shortcutOpen:
       return "How do you want to open me? Just press one of these to set it."
     case .shortcutTalk:
-      return "And to talk to me hands-free? Press one of these to set it."
+      return "And to talk to me, hands-free? Just hold one of these and say something."
     case .screenDemo:
       return "Here's the fun part."
     case .agents:
@@ -211,8 +228,6 @@ final class SBOnboardingModel: ObservableObject {
     case .context:
       return "The more I can see, the more I can help. Connect anything you want me to know:"
     case .capture:
-      // The shortcut chord is rendered as keycap chips in `captureWidget` (a
-      // streamed Text can't host inline keycap views), so it's omitted here.
       return
         "You're all set, \(name). One last thing: should I listen all the time, or only during your meetings?"
     }
@@ -225,18 +240,6 @@ final class SBOnboardingModel: ObservableObject {
     if !stored.isEmpty { return stored }
     return "friend"
   }
-
-  var selectedResponseLanguageName: String {
-    let code = AssistantSettings.shared.voiceLanguages.first ?? "en"
-    let baseCode = AssistantSettings.baseLanguageCode(code)
-    return AssistantSettings.supportedLanguages.first {
-      AssistantSettings.baseLanguageCode($0.code) == baseCode
-    }?.name ?? code
-  }
-
-  /// The chosen open-Omi chord as individual tokens, rendered as keycap chips in
-  /// `captureWidget` (e.g. ⌘ + O) rather than plain glyphs in the message copy.
-  var summonTokens: [String] { ShortcutSettings.shared.askOmiShortcut.displayTokens }
 
   // MARK: lifecycle
 
@@ -491,14 +494,9 @@ final class SBOnboardingModel: ObservableObject {
 
   // MARK: capture choice → completes onboarding
 
-  func captureContinuous() {
-    AssistantSettings.shared.systemAudioCaptureMode = .always
-    complete(startListening: true)
-  }
-
-  func captureMeetingsOnly() {
-    AssistantSettings.shared.systemAudioCaptureMode = .onlyDuringMeetings
-    complete(startListening: false)
+  func capture(_ selection: CaptureSelection) {
+    AssistantSettings.shared.systemAudioCaptureMode = selection.systemAudioCaptureMode
+    complete(startListening: selection.startsListeningImmediately)
   }
 
   /// Skip the rest of onboarding: mark it complete and drop straight to the Chat
@@ -603,5 +601,6 @@ final class SBOnboardingModel: ObservableObject {
     pollTasks.removeAll()
     disarmShortcutSummon()
     teardownVoiceDemo()
+    FloatingControlBarManager.shared.hide()
   }
 }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -66,6 +66,7 @@ final class SBOnboardingModel: ObservableObject {
   @Published var shortcutTokens: [String] = []
   @Published var shortcutPicked = false
   @Published var shortcutPressed = false
+  @Published var shortcutRecording = false
   /// The chosen shortcut + which mechanism it uses (key hotkey vs modifier-hold).
   var chosenShortcut: ShortcutSettings.KeyboardShortcut?
   var chosenShortcutIsPTT = false
@@ -202,7 +203,7 @@ final class SBOnboardingModel: ObservableObject {
     case .shortcutOpen:
       return "How do you want to open me? Just press one of these to set it."
     case .shortcutTalk:
-      return "And to talk to me, hands-free? Just hold one of these and say something."
+      return "And to talk to me hands-free? Press one of these to set it."
     case .screenDemo:
       return "Here's the fun part."
     case .agents:
@@ -223,6 +224,14 @@ final class SBOnboardingModel: ObservableObject {
     if !n.isEmpty { return n.components(separatedBy: " ").first ?? n }
     if !stored.isEmpty { return stored }
     return "friend"
+  }
+
+  var selectedResponseLanguageName: String {
+    let code = AssistantSettings.shared.voiceLanguages.first ?? "en"
+    let baseCode = AssistantSettings.baseLanguageCode(code)
+    return AssistantSettings.supportedLanguages.first {
+      AssistantSettings.baseLanguageCode($0.code) == baseCode
+    }?.name ?? code
   }
 
   /// The chosen open-Omi chord as individual tokens, rendered as keycap chips in

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -95,6 +95,7 @@ final class SBOnboardingModel: ObservableObject {
   @Published var shortcutTokens: [String] = []
   @Published var shortcutPicked = false
   @Published var shortcutPressed = false
+  @Published var shortcutRecording = false
   /// The chosen shortcut + which mechanism it uses (key hotkey vs modifier-hold).
   var chosenShortcut: ShortcutSettings.KeyboardShortcut?
   var chosenShortcutIsPTT = false
@@ -229,7 +230,7 @@ final class SBOnboardingModel: ObservableObject {
     case .automation:
       return "Turn on Automation, so I can help with tasks in the apps you choose."
     case .shortcutOpen:
-      return "How do you want to open me? Just press one of these to set it."
+      return "How do you want to open me? Just press any key, or one of these to set it."
     case .shortcutTalk:
       return "And to talk to me, hands-free? Just hold one of these and say something."
     case .screenDemo:
@@ -250,6 +251,14 @@ final class SBOnboardingModel: ObservableObject {
     if !n.isEmpty { return n.components(separatedBy: " ").first ?? n }
     if !stored.isEmpty { return stored }
     return "friend"
+  }
+
+  var selectedResponseLanguageName: String {
+    let code = AssistantSettings.shared.voiceLanguages.first ?? "en"
+    let baseCode = AssistantSettings.baseLanguageCode(code)
+    return AssistantSettings.supportedLanguages.first {
+      AssistantSettings.baseLanguageCode($0.code) == baseCode
+    }?.name ?? code
   }
 
   // MARK: lifecycle

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -2,6 +2,16 @@ import AppKit
 import Combine
 import Foundation
 
+enum SBOnboardingLanguageCopy {
+  static let question = "What language should Omi listen and reply in?"
+  static let detectedLanguageDetail = "· detected from your Mac"
+  static let changeSpokenLanguageAction = "Change spoken language"
+
+  static func continueAction(for language: String) -> String {
+    "Continue in \(language)"
+  }
+}
+
 /// Drives the Second Brain conversational onboarding: a real chat with Omi that
 /// streams word-by-word, collects answers, and performs the SAME live side-effects
 /// as the legacy wizard (name/language → backend, every permission, the summon
@@ -200,7 +210,7 @@ final class SBOnboardingModel: ObservableObject {
     case .name: return "What should I call you?"
     case .howHeard: return "Quick one. How did you hear about Omi?"
     case .language:
-      return "What language do you speak? I'll listen and reply in it."
+      return SBOnboardingLanguageCopy.question
     case .role:
       return
         "Nice to meet you, \(name). What do your days look like? Pick the closest, or tell me. It shapes what I make for you."

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -172,6 +172,7 @@ struct SBOnboardingView: View {
       }
       .buttonStyle(.plain)
       .help("Go back and change an earlier answer")
+      .padding(.trailing, 12)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -312,9 +312,11 @@ struct SBOnboardingView: View {
         // Auto-detected default: accept with one tap, or reveal the picker.
         HStack(spacing: 8) {
           Text(draft).geist(size: 17, weight: .medium).foregroundStyle(sb.ink)
-          Text("· detected").geist(size: 12.5).foregroundStyle(sb.ink(.w4))
+          Text(SBOnboardingLanguageCopy.detectedLanguageDetail)
+            .geist(size: 12.5)
+            .foregroundStyle(sb.ink(.w4))
         }
-        SBInkButton(title: "Continue", isDefaultAction: true) {
+        SBInkButton(title: SBOnboardingLanguageCopy.continueAction(for: draft), isDefaultAction: true) {
           if let m = all.first(where: { $0.name.lowercased() == draft.lowercased() }) {
             model.pickLanguage(code: m.code, name: m.name)
           } else {
@@ -324,7 +326,9 @@ struct SBOnboardingView: View {
         Button {
           languageChanging = true
         } label: {
-          Text("Change language").geist(size: 13).foregroundStyle(sb.ink(.w45))
+          Text(SBOnboardingLanguageCopy.changeSpokenLanguageAction)
+            .geist(size: 13)
+            .foregroundStyle(sb.ink(.w45))
         }
         .buttonStyle(.plain)
       } else {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -698,33 +698,24 @@ struct SBOnboardingView: View {
 
   private var captureWidget: some View {
     VStack(spacing: 8) {
-      // The chosen open-Omi chord as keycap chips (e.g. ⌘ O), matching the ⌥ keycap
-      // on the demo step — instead of plain "⌘O" glyphs buried in the message copy.
-      if !model.summonTokens.isEmpty {
-        HStack(spacing: 5) {
-          ForEach(model.summonTokens, id: \.self) { tok in keycap(tok) }
-          Text("reaches me anytime").geist(size: 14).foregroundStyle(sb.ink(.w85))
-          Spacer(minLength: 0)
-        }
-        .padding(.bottom, 2)
-      }
       Button {
-        model.captureContinuous()
-      } label: {
-        Text("● Start listening — continuously").geist(size: 14, weight: .semibold).foregroundStyle(sb.inkInverted)
-          .frame(maxWidth: .infinity).padding(.vertical, 11)
-          .background(RoundedRectangle(cornerRadius: 11).fill(sb.ink))
-      }
-      .buttonStyle(.plain)
-      Button {
-        model.captureMeetingsOnly()
+        model.capture(SBOnboardingModel.defaultCaptureSelection)
       } label: {
         HStack(spacing: 4) {
-          Text("Only during meetings").geist(size: 14).foregroundStyle(sb.ink(.w85))
-          Text("· from my calendar").geist(size: 12).foregroundStyle(sb.ink(.w4))
+          Text("● Only during meetings").geist(size: 14, weight: .semibold).foregroundStyle(sb.inkInverted)
+          Text("· from my calendar").geist(size: 12).foregroundStyle(sb.inkInverted.opacity(0.7))
         }
         .frame(maxWidth: .infinity).padding(.vertical, 11)
-        .overlay(RoundedRectangle(cornerRadius: 11).stroke(sb.ink(.w18), lineWidth: 1))
+        .background(RoundedRectangle(cornerRadius: 11).fill(sb.ink))
+      }
+      .buttonStyle(.plain)
+      .keyboardShortcut(.defaultAction)
+      Button {
+        model.capture(.continuous)
+      } label: {
+        Text("Start listening — continuously").geist(size: 14).foregroundStyle(sb.ink(.w85))
+          .frame(maxWidth: .infinity).padding(.vertical, 11)
+          .overlay(RoundedRectangle(cornerRadius: 11).stroke(sb.ink(.w18), lineWidth: 1))
       }
       .buttonStyle(.plain)
     }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -6,6 +6,19 @@ enum SBOnboardingRepository {
   static let url = URL(string: "https://github.com/BasedHardware/omi")!
 }
 
+enum SBOnboardingPanelLayout {
+  static let maximumSize = CGSize(width: 540, height: 640)
+  static let horizontalInset: CGFloat = 24
+  static let verticalInset: CGFloat = 20
+
+  static func size(in availableSize: CGSize) -> CGSize {
+    CGSize(
+      width: min(maximumSize.width, max(0, availableSize.width - horizontalInset * 2)),
+      height: min(maximumSize.height, max(0, availableSize.height - verticalInset * 2))
+    )
+  }
+}
+
 /// The Second Brain conversational onboarding — a chat with Omi that streams
 /// word-by-word and performs real side-effects. Replaces the legacy wizard.
 struct SBOnboardingView: View {
@@ -56,39 +69,23 @@ struct SBOnboardingView: View {
       } else {
         SBWallpaper()
       }
-      panel
-        .frame(width: 540, height: min(640, 900))
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      GeometryReader { geometry in
+        let panelSize = SBOnboardingPanelLayout.size(in: geometry.size)
+        panel
+          .frame(width: panelSize.width, height: panelSize.height)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
     }
     .overlay(alignment: .topTrailing) {
-      HStack(spacing: 8) {
-        if model.canGoBack {
-          Button(action: { model.goBack() }) {
-            Text("← Back")
-              .geist(size: 13).foregroundStyle(sb.ink(.w75))
-              .padding(.horizontal, 14).padding(.vertical, 7)
-              .background(
-                Capsule().fill(Color.white.opacity(0.06))
-                  .background(.ultraThinMaterial, in: Capsule())
-              )
-              .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
-          }
-          .buttonStyle(.plain)
-          .help("Go back and change an earlier answer")
+      ViewThatFits(in: .horizontal) {
+        HStack(spacing: 8) {
+          backButton
+          skipButton
         }
-
-        Button(action: { model.skip() }) {
-          Text("Skip")
-            .geist(size: 13).foregroundStyle(sb.ink(.w45))
-            .padding(.horizontal, 14).padding(.vertical, 7)
-            .background(
-              Capsule().fill(Color.white.opacity(0.06))
-                .background(.ultraThinMaterial, in: Capsule())
-            )
-            .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+        VStack(alignment: .trailing, spacing: 8) {
+          backButton
+          skipButton
         }
-        .buttonStyle(.plain)
-        .help("Skip onboarding and go to your second brain")
       }
       .padding(.top, 20).padding(.trailing, 24)
     }
@@ -159,6 +156,38 @@ struct SBOnboardingView: View {
     )
     .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(Color.white.opacity(0.12), lineWidth: 1))
     .shadow(color: .black.opacity(0.5), radius: 60, y: 30)
+  }
+
+  @ViewBuilder private var backButton: some View {
+    if model.canGoBack {
+      Button(action: { model.goBack() }) {
+        Text("← Back")
+          .geist(size: 13).foregroundStyle(sb.ink(.w75))
+          .padding(.horizontal, 14).padding(.vertical, 7)
+          .background(
+            Capsule().fill(Color.white.opacity(0.06))
+              .background(.ultraThinMaterial, in: Capsule())
+          )
+          .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+      }
+      .buttonStyle(.plain)
+      .help("Go back and change an earlier answer")
+    }
+  }
+
+  private var skipButton: some View {
+    Button(action: { model.skip() }) {
+      Text("Skip")
+        .geist(size: 13).foregroundStyle(sb.ink(.w45))
+        .padding(.horizontal, 14).padding(.vertical, 7)
+        .background(
+          Capsule().fill(Color.white.opacity(0.06))
+            .background(.ultraThinMaterial, in: Capsule())
+        )
+        .overlay(Capsule().stroke(Color.white.opacity(0.12), lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+    .help("Skip onboarding and go to your second brain")
   }
 
   private func scrollDown(_ proxy: ScrollViewProxy) {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -312,9 +312,11 @@ struct SBOnboardingView: View {
         // Auto-detected default: accept with one tap, or reveal the picker.
         HStack(spacing: 8) {
           Text(draft).geist(size: 17, weight: .medium).foregroundStyle(sb.ink)
-          Text(SBOnboardingLanguageCopy.detectedLanguageDetail)
-            .geist(size: 12.5)
-            .foregroundStyle(sb.ink(.w4))
+          if model.languageIsDetectedFromMac {
+            Text(SBOnboardingLanguageCopy.detectedLanguageDetail)
+              .geist(size: 12.5)
+              .foregroundStyle(sb.ink(.w4))
+          }
         }
         SBInkButton(title: SBOnboardingLanguageCopy.continueAction(for: draft), isDefaultAction: true) {
           if let m = all.first(where: { $0.name.lowercased() == draft.lowercased() }) {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -15,6 +15,7 @@ struct SBOnboardingView: View {
   @State private var selectedImportConnector: ImportConnector?
   /// Language step: false shows the detected default + Continue; true reveals the picker.
   @State private var languageChanging = false
+  @State private var showAIAssistants = false
 
   /// Same dune background as sign-in, for a continuous entry experience.
   private static let backgroundImage: NSImage? = {
@@ -236,7 +237,7 @@ struct SBOnboardingView: View {
           }
         }
         Divider().overlay(sb.ink(.w08))
-        trustRow("PRIVATE") { Text("Your data is encrypted, and only yours.") }
+        trustRow("PRIVATE") { Text("Your data is encrypted, and only yours.").lineLimit(1) }
         Divider().overlay(sb.ink(.w08))
         trustRow("YOURS") { Text("Pause me anytime. Delete anything, forever.") }
       }
@@ -446,7 +447,7 @@ struct SBOnboardingView: View {
     return VStack(alignment: .leading, spacing: 9) {
       ForEach(options, id: \.id) { opt in
         Button {
-          model.pickShortcut(opt.shortcut, isTalk: isTalk)
+          model.beginShortcutRecording(isTalk: isTalk)
         } label: {
           HStack(spacing: 8) {
             HStack(spacing: 5) {
@@ -454,7 +455,9 @@ struct SBOnboardingView: View {
             }
             Text(opt.sub).geist(size: 13).foregroundStyle(sb.ink(.w45))
             Spacer()
-            if model.chosenShortcut == opt.shortcut {
+            if model.shortcutRecording {
+              Text("Press a key").geist(size: 12).foregroundStyle(sb.ink(.w45))
+            } else if model.chosenShortcut == opt.shortcut {
               Text("✓").geist(size: 14).foregroundStyle(sb.ink(.w7))
             }
           }
@@ -467,7 +470,12 @@ struct SBOnboardingView: View {
         }
         .buttonStyle(.plain)
       }
-      if model.shortcutPicked {
+      if model.shortcutRecording {
+        Text("Press the shortcut you want to use.")
+          .geist(size: 15, weight: .medium)
+          .foregroundStyle(sb.ink(.w6))
+          .padding(.top, 6)
+      } else if model.shortcutPicked {
         VStack(alignment: .leading, spacing: 10) {
           HStack(spacing: 6) {
             ForEach(model.shortcutTokens, id: \.self) { tok in keycap(tok, active: model.shortcutPressed) }
@@ -475,7 +483,7 @@ struct SBOnboardingView: View {
           Text(
             model.shortcutPressed
               ? "Perfect, that works."
-              : (isTalk ? "Now hold it and say something." : "Now give it a tap.")
+              : "Now press it to test."
           )
           .geist(size: 15, weight: .medium)
           .foregroundStyle(model.shortcutPressed ? sb.ink(.w85) : sb.ink(.w6))
@@ -515,7 +523,7 @@ struct SBOnboardingView: View {
             Text("and ask me about it, out loud.").geist(size: 14).foregroundStyle(sb.ink(.w85))
           }
           Text(
-            "Try \u{201c}what's on my screen right now?\u{201d} I can see it, and I answer at the top of your screen."
+            "Ask me what’s on your screen in \(model.selectedResponseLanguageName). I can see it, and I answer at the top of your screen."
           )
           .geist(size: 12.5).foregroundStyle(sb.ink(.w45))
           .fixedSize(horizontal: false, vertical: true)
@@ -565,11 +573,27 @@ struct SBOnboardingView: View {
   private var agentsWidget: some View {
     VStack(alignment: .leading, spacing: 12) {
       VStack(spacing: 0) {
-        ForEach(Array(model.agentRows.enumerated()), id: \.element.id) { i, row in
-          connectRow(id: row.id, row.name, row.detail, state: model.agentStates[row.id] ?? "idle") {
-            model.connectAgent(row.id)
+        Button {
+          showAIAssistants.toggle()
+        } label: {
+          HStack {
+            Text("AI assistants").geist(size: 14, weight: .medium).foregroundStyle(sb.ink)
+            Spacer()
+            Image(systemName: showAIAssistants ? "chevron.up" : "chevron.down")
+              .font(.system(size: 11, weight: .semibold))
+              .foregroundStyle(sb.ink(.w45))
           }
-          if i < model.agentRows.count - 1 { Divider().overlay(sb.ink(.w08)) }
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 12)
+        if showAIAssistants {
+          Divider().overlay(sb.ink(.w08))
+          ForEach(Array(model.agentRows.enumerated()), id: \.element.id) { i, row in
+            connectRow(id: row.id, row.name, row.detail, state: model.agentStates[row.id] ?? "idle") {
+              model.connectAgent(row.id)
+            }
+            if i < model.agentRows.count - 1 { Divider().overlay(sb.ink(.w08)) }
+          }
         }
       }
       .padding(.horizontal, 14)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1748,6 +1748,18 @@ class ChatProvider: ObservableObject {
     let snapshot: AgentContextSnapshot
   }
 
+  static func responseLanguageInstruction(languageCodes: [String]) -> String? {
+    guard let code = languageCodes.first?.trimmingCharacters(in: .whitespacesAndNewlines), !code.isEmpty else {
+      return nil
+    }
+    let baseCode = AssistantSettings.baseLanguageCode(code)
+    let name =
+      AssistantSettings.supportedLanguages.first {
+        AssistantSettings.baseLanguageCode($0.code) == baseCode
+      }?.name ?? code
+    return "Reply in \(name) (\(code)) unless the user asks for another language."
+  }
+
   private func resolveKernelQuerySession(
     surface: AgentSurfaceReference,
     requestedModelProfile: String?
@@ -1805,8 +1817,17 @@ class ChatProvider: ObservableObject {
     if let systemPromptPrefix, !systemPromptPrefix.isEmpty {
       surfacePayload["experienceContext"] = systemPromptPrefix
     }
-    if let systemPromptSuffix, !systemPromptSuffix.isEmpty {
-      surfacePayload["responseContext"] = systemPromptSuffix
+    let responseContext = [
+      systemPromptSuffix?.trimmingCharacters(in: .whitespacesAndNewlines),
+      AssistantSettings.shared.hasExplicitVoiceLanguages
+        ? Self.responseLanguageInstruction(languageCodes: AssistantSettings.shared.voiceLanguages)
+        : nil,
+    ]
+    .compactMap { $0 }
+    .filter { !$0.isEmpty }
+    .joined(separator: "\n")
+    if !responseContext.isEmpty {
+      surfacePayload["responseContext"] = responseContext
     }
     if let notificationContext, !notificationContext.isEmpty {
       surfacePayload["notificationContext"] = notificationContext

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -91,6 +91,7 @@ class ChatToolExecutor {
     "accessibility",
     "automation",
     "full_disk_access",
+    "location",
   ]
 
   nonisolated static var onboardingPermissionTypesDescription: String {
@@ -103,7 +104,8 @@ class ChatToolExecutor {
     notifications: Bool,
     accessibility: Bool,
     automation: Bool,
-    fullDiskAccess: Bool
+    fullDiskAccess: Bool,
+    location: Bool
   ) -> [String: String] {
     [
       "screen_recording": screenRecording ? "granted" : "not_granted",
@@ -112,6 +114,7 @@ class ChatToolExecutor {
       "accessibility": accessibility ? "granted" : "not_granted",
       "automation": automation ? "granted" : "not_granted",
       "full_disk_access": fullDiskAccess ? "granted" : "not_granted",
+      "location": location ? "granted" : "not_granted",
     ]
   }
 
@@ -1877,6 +1880,34 @@ class ChatToolExecutor {
         requiresRestart: true
       )
 
+    case "location":
+      switch await LocationPermissionService.shared.requestCurrentLocation() {
+      case .location(let coordinate):
+        return permissionJSON([
+          "ok": true,
+          "permission": type,
+          "status": "granted",
+          "latitude": coordinate.latitude,
+          "longitude": coordinate.longitude,
+          "requires_restart": false,
+        ])
+      case .denied:
+        return permissionRequestResult(
+          type: type,
+          granted: false,
+          pendingMessage: "User needs to allow Location for Omi in the system dialog or System Settings.",
+          requiresRestart: false
+        )
+      case .unavailable:
+        return permissionJSON([
+          "ok": false,
+          "permission": type,
+          "status": "unavailable",
+          "message": "Omi could not determine the current location.",
+          "requires_restart": false,
+        ])
+      }
+
     default:
       return permissionJSON([
         "ok": false,
@@ -1979,6 +2010,7 @@ class ChatToolExecutor {
     let accessibilityGranted = AXIsProcessTrusted()
     let automationStatus = AppState.queryAutomationPermissionStatus()
     let fullDiskAccessGranted = checkFullDiskAccessDirectly()
+    let locationGranted = LocationPermissionService.shared.isAuthorized
     guard
       isPermissionAuthorizationCurrent(
         expectedOwnerID,
@@ -2000,7 +2032,8 @@ class ChatToolExecutor {
       notifications: notificationsGranted,
       accessibility: accessibilityGranted,
       automation: automationStatus == noErr,
-      fullDiskAccess: fullDiskAccessGranted
+      fullDiskAccess: fullDiskAccessGranted,
+      location: locationGranted
     )
   }
 

--- a/desktop/macos/Desktop/Sources/Providers/LocationPermissionService.swift
+++ b/desktop/macos/Desktop/Sources/Providers/LocationPermissionService.swift
@@ -1,0 +1,87 @@
+@preconcurrency import CoreLocation
+import Foundation
+
+enum LocationPermissionResult {
+  case location(CLLocationCoordinate2D)
+  case denied
+  case unavailable
+}
+
+@MainActor
+final class LocationPermissionService: NSObject {
+  static let shared = LocationPermissionService()
+
+  private let manager = CLLocationManager()
+  private let delegate = LocationPermissionDelegate()
+  private var authorizationContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
+  private var locationContinuation: CheckedContinuation<LocationPermissionResult, Never>?
+
+  override init() {
+    super.init()
+    delegate.owner = self
+    manager.delegate = delegate
+  }
+
+  var isAuthorized: Bool {
+    manager.authorizationStatus == .authorizedAlways
+  }
+
+  func requestCurrentLocation() async -> LocationPermissionResult {
+    let status = manager.authorizationStatus
+    let authorization: CLAuthorizationStatus
+    if status == .notDetermined {
+      authorization = await withCheckedContinuation { continuation in
+        authorizationContinuation = continuation
+        manager.requestWhenInUseAuthorization()
+      }
+    } else {
+      authorization = status
+    }
+    guard authorization == .authorizedAlways else { return .denied }
+    return await withCheckedContinuation { continuation in
+      locationContinuation = continuation
+      manager.requestLocation()
+    }
+  }
+
+  func authorizationChanged(_ status: CLAuthorizationStatus) {
+    authorizationContinuation?.resume(returning: status)
+    authorizationContinuation = nil
+  }
+
+  func received(locations: [CLLocation]) {
+    guard let coordinate = locations.last?.coordinate else { return }
+    locationContinuation?.resume(returning: .location(coordinate))
+    locationContinuation = nil
+  }
+
+  func failedLocationRequest() {
+    locationContinuation?.resume(returning: .unavailable)
+    locationContinuation = nil
+  }
+}
+
+private final class LocationPermissionDelegate: NSObject, CLLocationManagerDelegate {
+  weak var owner: LocationPermissionService?
+
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    let owner = owner
+    Task { @MainActor [weak owner] in
+      owner?.authorizationChanged(manager.authorizationStatus)
+    }
+  }
+
+  func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    let owner = owner
+    Task { @MainActor [weak owner] in
+      owner?.received(locations: locations)
+    }
+  }
+
+  func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    let owner = owner
+    Task { @MainActor [weak owner] in
+      owner?.failedLocationRequest()
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/LocationPermissionService.swift
+++ b/desktop/macos/Desktop/Sources/Providers/LocationPermissionService.swift
@@ -12,14 +12,14 @@ final class LocationPermissionService: NSObject {
   static let shared = LocationPermissionService()
 
   private let manager = CLLocationManager()
-  private let delegate = LocationPermissionDelegate()
+  private let callbackBridge = LocationPermissionDelegate()
   private var authorizationContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
   private var locationContinuation: CheckedContinuation<LocationPermissionResult, Never>?
 
   override init() {
     super.init()
-    delegate.owner = self
-    manager.delegate = delegate
+    callbackBridge.owner = self
+    manager.delegate = callbackBridge
   }
 
   var isAuthorized: Bool {

--- a/desktop/macos/Desktop/Sources/SignInView.swift
+++ b/desktop/macos/Desktop/Sources/SignInView.swift
@@ -91,7 +91,11 @@ struct SignInView: View {
                 leading: { GoogleLogo().frame(width: 15, height: 15) },
                 action: { signIn(apple: false) })
             }
-            .frame(width: 320)
+            // This used to be a fixed 320pt column. When the window was
+            // narrower (or its usable width was reduced by window chrome),
+            // both sign-in actions extended past the visible content area.
+            .frame(maxWidth: 320)
+            .frame(maxWidth: .infinity)
             .padding(.top, 34)
 
             if authState.isLoading {
@@ -110,7 +114,8 @@ struct SignInView: View {
               Text(UserFacingErrorPresentation.message(from: error, while: .signIn))
                 .geist(size: 12.5).foregroundStyle(sb.ink(.w6))
                 .multilineTextAlignment(.center)
-                .frame(width: 320)
+                .frame(maxWidth: 320)
+                .frame(maxWidth: .infinity)
                 .padding(.top, 12)
             }
 
@@ -123,6 +128,7 @@ struct SignInView: View {
         }
       }
       .frame(maxWidth: 460)
+      .padding(.horizontal, 24)
       .animation(.easeOut(duration: 0.5), value: introRevealed)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/desktop/macos/Desktop/Sources/Theme/OmiButtonStyle.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiButtonStyle.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
 /// The app's single button primitive. Primary: accent (white) fill with ink
-/// content; secondary: dark fill with a subtle border. Use this instead of
-/// per-view ButtonStyle structs so CTAs look and press the same everywhere.
+/// content; secondary: dark fill with a subtle border; destructive: error fill
+/// with white content. Use this instead of per-view ButtonStyle structs so CTAs
+/// look and press the same everywhere.
 package struct OmiButtonStyle: ButtonStyle {
   package enum Kind {
     case primary
     case secondary
+    case destructive
   }
 
   package enum Size {
@@ -38,15 +40,63 @@ package struct OmiButtonStyle: ButtonStyle {
     size == .regular ? OmiChrome.chipRadius : OmiChrome.smallControlRadius
   }
 
+  private var foregroundColor: Color {
+    switch kind {
+    case .primary:
+      OmiColors.backgroundPrimary
+    case .secondary, .destructive:
+      OmiColors.textPrimary
+    }
+  }
+
+  private var backgroundColor: Color {
+    switch kind {
+    case .primary:
+      OmiColors.accent
+    case .secondary:
+      OmiColors.backgroundTertiary
+    case .destructive:
+      OmiColors.error
+    }
+  }
+
   package func makeBody(configuration: Configuration) -> some View {
+    OmiButtonContent(
+      configuration: configuration,
+      kind: kind,
+      fontSize: fontSize,
+      foregroundColor: foregroundColor,
+      backgroundColor: backgroundColor,
+      horizontalPadding: horizontalPadding,
+      verticalPadding: verticalPadding,
+      radius: radius
+    )
+  }
+}
+
+/// Extracted body so it can read `@Environment(\.isEnabled)` — `ButtonStyle`
+/// configurations do not expose enabled state directly.
+private struct OmiButtonContent: View {
+  let configuration: ButtonStyle.Configuration
+  let kind: OmiButtonStyle.Kind
+  let fontSize: CGFloat
+  let foregroundColor: Color
+  let backgroundColor: Color
+  let horizontalPadding: CGFloat
+  let verticalPadding: CGFloat
+  let radius: CGFloat
+
+  @Environment(\.isEnabled) private var isEnabled
+
+  var body: some View {
     configuration.label
       .scaledFont(size: fontSize, weight: .semibold)
-      .foregroundColor(kind == .primary ? OmiColors.backgroundPrimary : OmiColors.textPrimary)
+      .foregroundColor(foregroundColor)
       .padding(.horizontal, horizontalPadding)
       .padding(.vertical, verticalPadding)
       .background(
         RoundedRectangle(cornerRadius: radius, style: .continuous)
-          .fill(kind == .primary ? OmiColors.accent : OmiColors.backgroundTertiary)
+          .fill(backgroundColor)
       )
       .overlay {
         if kind == .secondary {
@@ -54,7 +104,7 @@ package struct OmiButtonStyle: ButtonStyle {
             .stroke(Color.white.opacity(0.08), lineWidth: 1)
         }
       }
-      .opacity(configuration.isPressed ? 0.92 : 1)
+      .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.45)
       .scaleEffect(configuration.isPressed ? 0.985 : 1)
       .omiAnimation(.easeOut(duration: 0.12), value: configuration.isPressed)
   }

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -657,6 +657,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
 
     XCTAssertTrue(
       candidates.contains(
+        "/Applications/omi-test.app/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"))
+    XCTAssertTrue(
+      candidates.contains(
         "/Applications/omi-test.app/Contents/Resources/Omi Computer_Omi Computer.bundle/node"))
     XCTAssertTrue(
       candidates.contains(

--- a/desktop/macos/Desktop/Tests/AppsHeaderRowLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsHeaderRowLayoutTests.swift
@@ -32,6 +32,30 @@ final class AppsHeaderRowLayoutTests: XCTestCase {
     }
   }
 
+  func testCreateControlMovesBelowFiltersWhenTheCompactRowWouldOverflow() {
+    let recorder = AppsHeaderLayoutRecorder()
+    let width: CGFloat = 380
+    layOut(
+      width: width,
+      recorder: recorder,
+      filters: Color.clear.frame(width: 280, height: AppsHeaderMetrics.controlHeight)
+    )
+
+    guard let filters = recorder.frame(of: .filters),
+      let create = recorder.frame(of: .create)
+    else {
+      return XCTFail("the compact header controls never laid out")
+    }
+
+    XCTAssertLessThanOrEqual(filters.maxX, width + 0.5)
+    XCTAssertLessThanOrEqual(create.maxX, width + 0.5)
+    XCTAssertGreaterThanOrEqual(
+      create.minY,
+      filters.maxY - 0.5,
+      "Create App should move below filters instead of extending the compact row"
+    )
+  }
+
   func testAppsToolbarControlsShareTheSearchFieldHeight() {
     let recorder = AppsHeaderLayoutRecorder()
     let host = NSHostingView(
@@ -77,6 +101,14 @@ final class AppsHeaderRowLayoutTests: XCTestCase {
   }
 
   private func layOut(width: CGFloat, recorder: AppsHeaderLayoutRecorder) {
+    layOut(width: width, recorder: recorder, filters: AppsHeaderFilterFixture())
+  }
+
+  private func layOut<Filters: View>(
+    width: CGFloat,
+    recorder: AppsHeaderLayoutRecorder,
+    filters: Filters
+  ) {
     let host = NSHostingView(
       rootView: AppsHeaderRow(
         search: {
@@ -86,10 +118,14 @@ final class AppsHeaderRowLayoutTests: XCTestCase {
         },
         filters: {
           AppsHeaderLayoutProbe(recorder: recorder, slot: .filters) {
-            AppsHeaderFilterFixture()
+            filters
           }
         },
-        create: { Color.clear.frame(width: 100, height: AppsHeaderMetrics.controlHeight) },
+        create: {
+          AppsHeaderLayoutProbe(recorder: recorder, slot: .create) {
+            Color.clear.frame(width: 100, height: AppsHeaderMetrics.controlHeight)
+          }
+        },
         dismiss: { EmptyView() }
       )
       .frame(width: width)

--- a/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
@@ -101,6 +101,15 @@ final class BrowserGoogleSessionTests: XCTestCase {
     BrowserKeychainCache.shared.invalidate(cacheKey: cacheKey)
   }
 
+  func testBackgroundGoogleWorkSkipsSafeStorageAccess() {
+    XCTAssertTrue(
+      BrowserGoogleSession.configsForPython(
+        logPrefix: "BrowserGoogleSessionTests",
+        userInitiated: false
+      ).isEmpty
+    )
+  }
+
   func testUnknownVersionCookieBlobIsSkippedInsteadOfEmittedAsPlaintext() throws {
     let databasePath = tempRoot.appendingPathComponent("Cookies").path
     let script =

--- a/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
@@ -48,4 +48,13 @@ final class ChatPromptsTests: XCTestCase {
     XCTAssertGreaterThan(gateRange.lowerBound, step4Range.lowerBound)
     XCTAssertLessThan(gateRange.lowerBound, step5Range.lowerBound)
   }
+
+  @MainActor
+  func testPreferredResponseLanguageCreatesAnExplicitKernelDirective() {
+    XCTAssertEqual(
+      ChatProvider.responseLanguageInstruction(languageCodes: ["es-MX"]),
+      "Reply in Spanish (es-MX) unless the user asks for another language."
+    )
+    XCTAssertNil(ChatProvider.responseLanguageInstruction(languageCodes: []))
+  }
 }

--- a/desktop/macos/Desktop/Tests/DesktopWindowLayoutPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopWindowLayoutPolicyTests.swift
@@ -1,0 +1,15 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopWindowLayoutPolicyTests: XCTestCase {
+  func testMainWindowMinimumFitsA1024PointWideDisplay() {
+    XCTAssertLessThanOrEqual(
+      DesktopWindowLayoutPolicy.minimumContentSize.width,
+      1024,
+      "The responsive main window must fit common compact desktop displays."
+    )
+    XCTAssertEqual(DesktopWindowLayoutPolicy.minimumContentSize.height, 680)
+  }
+}

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -437,7 +437,8 @@ final class OnboardingFlowTests: XCTestCase {
       continuousChoice.lowerBound,
       "Meeting-only recording must be the first capture choice")
     XCTAssertTrue(
-      secondBrainSource[defaultChoice.lowerBound...].prefix(500).contains(".keyboardShortcut(.defaultAction)"),
+      secondBrainSource[defaultChoice.lowerBound..<continuousChoice.lowerBound]
+        .contains(".keyboardShortcut(.defaultAction)"),
       "Return must choose the meeting-only capture default")
     XCTAssertFalse(secondBrainSource.contains("reaches me anytime"))
   }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -425,6 +425,23 @@ final class OnboardingFlowTests: XCTestCase {
       "SBInkButton must wire opted-in proceed actions to Return")
   }
 
+  func testSecondBrainCaptureDefaultsToMeetingsWithoutShortcutReminder() throws {
+    // omi-test-quality: source-inspection -- static contract: verifies the SwiftUI capture-choice hierarchy and copy
+    let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
+    let defaultChoice = try XCTUnwrap(
+      secondBrainSource.range(of: "model.capture(SBOnboardingModel.defaultCaptureSelection)"))
+    let continuousChoice = try XCTUnwrap(secondBrainSource.range(of: "model.capture(.continuous)"))
+
+    XCTAssertLessThan(
+      defaultChoice.lowerBound,
+      continuousChoice.lowerBound,
+      "Meeting-only recording must be the first capture choice")
+    XCTAssertTrue(
+      secondBrainSource[defaultChoice.lowerBound...].prefix(500).contains(".keyboardShortcut(.defaultAction)"),
+      "Return must choose the meeting-only capture default")
+    XCTAssertFalse(secondBrainSource.contains("reaches me anytime"))
+  }
+
   // Regression: arrow navigation must be computed from persisted step state and
   // applied by the mounted view — the NSEvent monitor's captured view copy drops
   // @AppStorage writes on some macOS versions. These cover the extracted

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -10,7 +10,8 @@ final class OnboardingPermissionToolTests: XCTestCase {
       notifications: false,
       accessibility: false,
       automation: false,
-      fullDiskAccess: false
+      fullDiskAccess: false,
+      location: false
     )
 
     XCTAssertEqual(
@@ -18,6 +19,7 @@ final class OnboardingPermissionToolTests: XCTestCase {
       Set(ChatToolExecutor.onboardingPermissionTypes)
     )
     XCTAssertTrue(statuses.keys.contains("notifications"))
+    XCTAssertTrue(statuses.keys.contains("location"))
   }
 
   func testSupportedPermissionTypesIncludeNotifications() {
@@ -30,6 +32,7 @@ final class OnboardingPermissionToolTests: XCTestCase {
         "accessibility",
         "automation",
         "full_disk_access",
+        "location",
       ])
   }
 

--- a/desktop/macos/Desktop/Tests/OnboardingPinnedActionsLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPinnedActionsLayoutTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class OnboardingPinnedActionsLayoutTests: XCTestCase {
+  func testActionsStayInsideCompactViewportWhenContentOverflows() {
+    let recorder = OnboardingActionLayoutRecorder()
+    let host = NSHostingView(
+      rootView: OnboardingContentWithPinnedActions {
+        Color.clear.frame(width: 280, height: 600)
+      } actions: {
+        OnboardingActionLayoutProbe(recorder: recorder) {
+          Color.clear.frame(width: 160, height: 40)
+        }
+      }
+      .frame(width: 320, height: 180)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+    host.layoutSubtreeIfNeeded()
+
+    guard let actionFrame = recorder.frame else {
+      return XCTFail("the pinned action row was never placed")
+    }
+    XCTAssertGreaterThanOrEqual(actionFrame.minY, -0.5)
+    XCTAssertLessThanOrEqual(actionFrame.maxY, 180.5)
+  }
+}
+
+private final class OnboardingActionLayoutRecorder: @unchecked Sendable {
+  private(set) var frame: CGRect?
+
+  func record(_ frame: CGRect) {
+    self.frame = frame
+  }
+}
+
+private struct OnboardingActionLayoutProbe: Layout {
+  let recorder: OnboardingActionLayoutRecorder
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    subviews.first?.sizeThatFits(proposal) ?? .zero
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    recorder.record(bounds)
+    for subview in subviews {
+      subview.place(at: bounds.origin, proposal: ProposedViewSize(bounds.size))
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
@@ -93,4 +93,38 @@ final class SBOnboardingBackNavigationTests: XCTestCase {
     XCTAssertFalse(model.screenDemoPTTReady)
     XCTAssertTrue(model.screenDemoPTTUnavailable)
   }
+
+  func testShortcutSuggestionRecordsTheNextOpenChord() throws {
+    let settings = ShortcutSettings.shared
+    let previousShortcut = settings.askOmiShortcut
+    let previousEnabled = settings.askOmiEnabled
+    defer {
+      settings.askOmiShortcut = previousShortcut
+      settings.askOmiEnabled = previousEnabled
+    }
+
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.step = .shortcutOpen
+    model.beginShortcutRecording(isTalk: false)
+    let event = try XCTUnwrap(
+      NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: .command,
+        timestamp: 0,
+        windowNumber: 0,
+        context: nil,
+        characters: "j",
+        charactersIgnoringModifiers: "j",
+        isARepeat: false,
+        keyCode: 38
+      ))
+
+    XCTAssertTrue(model.recordShortcut(from: event))
+    XCTAssertFalse(model.shortcutRecording)
+    XCTAssertEqual(model.chosenShortcut?.keyCode, 38)
+    XCTAssertEqual(settings.askOmiShortcut.keyCode, 38)
+  }
+
 }

--- a/desktop/macos/Desktop/Tests/SBOnboardingCaptureSelectionTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCaptureSelectionTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SBOnboardingCaptureSelectionTests: XCTestCase {
+  func testDefaultCaptureSelectionRecordsOnlyDuringMeetings() {
+    let selection = SBOnboardingModel.defaultCaptureSelection
+
+    XCTAssertEqual(selection.systemAudioCaptureMode, .onlyDuringMeetings)
+    XCTAssertFalse(selection.startsListeningImmediately)
+  }
+
+  func testContinuousCaptureSelectionStartsListeningImmediately() {
+    let selection = SBOnboardingModel.CaptureSelection.continuous
+
+    XCTAssertEqual(selection.systemAudioCaptureMode, .always)
+    XCTAssertTrue(selection.startsListeningImmediately)
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Omi_Computer
 
+@MainActor
 final class SBOnboardingLanguageCopyTests: XCTestCase {
 
   func testLanguagePickerCopyExplainsTheSpokenLanguagePreference() {
@@ -9,5 +10,24 @@ final class SBOnboardingLanguageCopyTests: XCTestCase {
     XCTAssertEqual(SBOnboardingLanguageCopy.detectedLanguageDetail, "· detected from your Mac")
     XCTAssertEqual(SBOnboardingLanguageCopy.continueAction(for: "English"), "Continue in English")
     XCTAssertEqual(SBOnboardingLanguageCopy.changeSpokenLanguageAction, "Change spoken language")
+  }
+
+  func testDetectedLanguageDetailIsShownOnlyForAMacLocalePrefill() {
+    let model = SBOnboardingModel(appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+
+    model.prefillDetectedLanguage(from: "es")
+
+    XCTAssertEqual(model.languageDraft, "Spanish")
+    XCTAssertTrue(model.languageIsDetectedFromMac)
+  }
+
+  func testExistingLanguageDraftIsNotRelabeledAsMacDetected() {
+    let model = SBOnboardingModel(appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.languageDraft = "English"
+
+    model.prefillDetectedLanguage(from: "es")
+
+    XCTAssertEqual(model.languageDraft, "English")
+    XCTAssertFalse(model.languageIsDetectedFromMac)
   }
 }

--- a/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingLanguageCopyTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SBOnboardingLanguageCopyTests: XCTestCase {
+
+  func testLanguagePickerCopyExplainsTheSpokenLanguagePreference() {
+    XCTAssertEqual(SBOnboardingLanguageCopy.question, "What language should Omi listen and reply in?")
+    XCTAssertEqual(SBOnboardingLanguageCopy.detectedLanguageDetail, "· detected from your Mac")
+    XCTAssertEqual(SBOnboardingLanguageCopy.continueAction(for: "English"), "Continue in English")
+    XCTAssertEqual(SBOnboardingLanguageCopy.changeSpokenLanguageAction, "Change spoken language")
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingLayoutTests.swift
@@ -1,0 +1,23 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+final class SBOnboardingLayoutTests: XCTestCase {
+  func testPanelKeepsItsDesignedSizeWhenThereIsRoom() {
+    XCTAssertEqual(
+      SBOnboardingPanelLayout.size(in: CGSize(width: 1_200, height: 680)),
+      SBOnboardingPanelLayout.maximumSize
+    )
+  }
+
+  func testPanelStaysInsideCompactWindowContent() {
+    let availableSize = CGSize(width: 480, height: 420)
+    let panelSize = SBOnboardingPanelLayout.size(in: availableSize)
+
+    XCTAssertEqual(panelSize.width, 432)
+    XCTAssertEqual(panelSize.height, 380)
+    XCTAssertLessThanOrEqual(panelSize.width + SBOnboardingPanelLayout.horizontalInset * 2, availableSize.width)
+    XCTAssertLessThanOrEqual(panelSize.height + SBOnboardingPanelLayout.verticalInset * 2, availableSize.height)
+  }
+}

--- a/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
@@ -37,6 +37,30 @@ final class SettingsSidebarItemLayoutTests: XCTestCase {
     )
   }
 
+  func testNotificationsLabelTruncatesGracefullyAtConstrainedWidth() {
+    // At a narrower-than-default width the label must not overflow the row —
+    // it should truncate with an ellipsis rather than being clipped or wrapped.
+    let narrowWidth: CGFloat = 120
+    let host = NSHostingView(
+      rootView: SettingsSidebarItem(
+        section: .notifications,
+        isSelected: true,
+        iconWidth: 20,
+        onTap: {}
+      )
+      .frame(width: narrowWidth)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: narrowWidth, height: 100)
+    host.layoutSubtreeIfNeeded()
+
+    // The item should remain a single line (no wrapping) even when truncated.
+    XCTAssertLessThan(
+      host.fittingSize.height,
+      60,
+      "constrained sidebar label should stay on one line (truncate, not wrap)"
+    )
+  }
+
   private func itemHeight(isSelected: Bool) -> CGFloat {
     let host = NSHostingView(
       rootView: SettingsSidebarItem(

--- a/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SettingsSidebarItemLayoutTests: XCTestCase {
+  func testMergedNotificationsAndPrivacyLabelStaysOnOneLineWhenSelected() {
+    let labelWidth = NSHostingView(
+      rootView: Text(SettingsContentView.SettingsSection.notifications.displayTitle)
+        .scaledFont(size: OmiType.body, weight: .medium)
+        .fixedSize()
+    ).fittingSize.width
+    let requiredWidth = labelWidth + 20 + OmiSpacing.md + 2 * OmiSpacing.md
+
+    XCTAssertLessThanOrEqual(
+      requiredWidth,
+      SettingsSidebarMetrics.itemAvailableWidth,
+      "the merged label must fit in the fixed settings-sidebar row"
+    )
+
+    let unselectedHeight = itemHeight(isSelected: false)
+    let selectedHeight = itemHeight(isSelected: true)
+
+    XCTAssertEqual(
+      selectedHeight,
+      unselectedHeight,
+      accuracy: 0.5,
+      "selection styling must not make the merged navigation label wrap"
+    )
+    XCTAssertLessThan(
+      selectedHeight,
+      60,
+      "the merged navigation label should retain the row's single-line height"
+    )
+  }
+
+  private func itemHeight(isSelected: Bool) -> CGFloat {
+    let host = NSHostingView(
+      rootView: SettingsSidebarItem(
+        section: .notifications,
+        isSelected: isSelected,
+        iconWidth: 20,
+        onTap: {}
+      )
+      .frame(width: SettingsSidebarMetrics.itemAvailableWidth)
+    )
+    host.frame = NSRect(
+      x: 0,
+      y: 0,
+      width: SettingsSidebarMetrics.itemAvailableWidth,
+      height: 100
+    )
+    host.layoutSubtreeIfNeeded()
+    return host.fittingSize.height
+  }
+}

--- a/desktop/macos/Desktop/Tests/SubscriptionPlanPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionPlanPresentationTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SubscriptionPlanPresentationTests: XCTestCase {
+  func testSelectionLabelIncludesTheStartingPrice() {
+    XCTAssertEqual(
+      SubscriptionPlanPresentation.selectionLabel(
+        planTitle: "Operator", startingPrice: "$49.00/month"),
+      "Select Operator · $49.00/month"
+    )
+  }
+
+  func testSelectionLabelOmitsTheSeparatorWhenNoPriceIsAvailable() {
+    XCTAssertEqual(
+      SubscriptionPlanPresentation.selectionLabel(planTitle: "Operator", startingPrice: nil),
+      "Select Operator"
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -53,6 +53,53 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertLessThanOrEqual(settings.maxX, 300.5)
   }
 
+  func testNavigationIsClippedRatherThanOverlappingPersistentControlsWhenCompactRowOverflows() {
+    // Expanded = 500pt nav, compact = 200pt nav, controls = 200pt, settings = 32pt.
+    // At a 300pt host the compact row (200 + spacing*3 + 200 + spacing + 32 ≈ 642)
+    // still overflows. Verify navigation does not overlap the persistent controls.
+    let recorder = TopNavigationLayoutRecorder()
+    let host = NSHostingView(
+      rootView: TopNavigationBarLayout(
+        expandedNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .expanded) {
+            Color.clear.frame(width: 500, height: 32)
+          }
+        },
+        compactNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .compact) {
+            Color.clear.frame(width: 200, height: 32)
+          }
+        },
+        persistentControls: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .persistentControls) {
+            Color.clear.frame(width: 200, height: 32)
+          }
+        },
+        settings: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .settings) {
+            Color.clear.frame(width: 32, height: 32)
+          }
+        }
+      )
+      .frame(width: 300, height: 44)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 300, height: 44)
+    host.layoutSubtreeIfNeeded()
+
+    guard
+      let navigation = recorder.frame(of: .compact),
+      let controls = recorder.frame(of: .persistentControls)
+    else {
+      return XCTFail("expected compact navigation and persistent controls to be placed")
+    }
+    // Navigation's proposed width must not cause it to overlap the controls.
+    XCTAssertLessThanOrEqual(
+      navigation.maxX,
+      controls.minX,
+      "compact navigation must not overlap persistent controls even when the row overflows"
+    )
+  }
+
   func testCompactNavigationRetainsEveryPrimaryRouteAndMemoryDestination() {
     XCTAssertEqual(
       TopNavigationRoutes.primaryItems.map(\.index),

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class TopNavigationBarLayoutTests: XCTestCase {
+  func testCompactNavigationIsPlacedWhenTheFullTopBarWouldOverflow() {
+    let recorder = TopNavigationLayoutRecorder()
+    let host = NSHostingView(
+      rootView: TopNavigationBarLayout(
+        expandedNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .expanded) {
+            Color.clear.frame(width: 420, height: 32)
+          }
+        },
+        compactNavigation: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .compact) {
+            Color.clear.frame(width: 68, height: 32)
+          }
+        },
+        persistentControls: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .persistentControls) {
+            Color.clear.frame(width: 150, height: 32)
+          }
+        },
+        settings: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .settings) {
+            Color.clear.frame(width: 32, height: 32)
+          }
+        }
+      )
+      .frame(width: 300, height: 44)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 300, height: 44)
+    host.layoutSubtreeIfNeeded()
+
+    XCTAssertNil(recorder.frame(of: .expanded))
+    guard let compact = recorder.frame(of: .compact) else {
+      return XCTFail("the compact navigation was never placed")
+    }
+    XCTAssertLessThanOrEqual(compact.maxX, 300.5)
+
+    guard
+      let persistentControls = recorder.frame(of: .persistentControls),
+      let settings = recorder.frame(of: .settings)
+    else {
+      return XCTFail("the persistent controls were never placed")
+    }
+    XCTAssertGreaterThan(persistentControls.minX, compact.maxX)
+    XCTAssertGreaterThanOrEqual(settings.maxX, 299)
+    XCTAssertLessThanOrEqual(settings.maxX, 300.5)
+  }
+
+  func testCompactNavigationRetainsEveryPrimaryRouteAndMemoryDestination() {
+    XCTAssertEqual(
+      TopNavigationRoutes.primaryItems.map(\.index),
+      [
+        SidebarNavItem.dashboard.rawValue,
+        SidebarNavItem.conversations.rawValue,
+        SidebarNavItem.tasks.rawValue,
+        SidebarNavItem.apps.rawValue,
+      ]
+    )
+    XCTAssertEqual(TopNavigationRoutes.memoryDestinations, [.memories, .conversations, .brainMap])
+  }
+}
+
+private enum TopNavigationLayoutSlot: Hashable {
+  case expanded
+  case compact
+  case persistentControls
+  case settings
+}
+
+private final class TopNavigationLayoutRecorder: @unchecked Sendable {
+  private var frames: [TopNavigationLayoutSlot: CGRect] = [:]
+
+  func record(_ slot: TopNavigationLayoutSlot, _ frame: CGRect) {
+    frames[slot] = frame
+  }
+
+  func frame(of slot: TopNavigationLayoutSlot) -> CGRect? {
+    frames[slot]
+  }
+}
+
+private struct TopNavigationLayoutProbe: Layout {
+  let recorder: TopNavigationLayoutRecorder
+  let slot: TopNavigationLayoutSlot
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    subviews.first?.sizeThatFits(proposal) ?? .zero
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    recorder.record(slot, bounds)
+    for subview in subviews {
+      subview.place(at: bounds.origin, proposal: ProposedViewSize(bounds.size))
+    }
+  }
+}

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -516,12 +516,13 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
     capabilityDoc: doc("Request Permission", "Open or guide the user through granting a required macOS permission. Screen sharing is the macOS Screen Recording permission.", [
       "Call only when the current user message names one permission, clearly affirms your immediately preceding one-permission request, or directly says to request it/that permission.",
       "Treat screen share, screen sharing, and screen-share as the screen_recording permission type.",
+      "For a weather question without an explicit place, call request_permission with type=location at query time instead of asking where the user is.",
       "Ask the user to choose when their request is generic or names multiple permissions.",
       "The user must still complete the native macOS prompt or Settings toggle.",
     ]),
     voice: {
       realtimeDescription:
-        "Request Omi's macOS permission through the kernel-authorized native executor by opening the native prompt or relevant System Settings pane. Screen share, screen sharing, and screen-share mean Screen Recording. Supports Screen Recording, microphone, notifications, Accessibility, Automation, and Full Disk Access.",
+        "Request Omi's macOS permission through the kernel-authorized native executor by opening the native prompt or relevant System Settings pane. Screen share, screen sharing, and screen-share mean Screen Recording. Supports Screen Recording, microphone, notifications, Accessibility, Automation, Full Disk Access, and Location.",
     },
   },
   scan_files: {
@@ -1100,7 +1101,7 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
     inputSchema: schema({
       type: {
         type: "string",
-        enum: ["screen_recording", "microphone", "notifications", "accessibility", "automation", "full_disk_access"],
+        enum: ["screen_recording", "microphone", "notifications", "accessibility", "automation", "full_disk_access", "location"],
         description: "Optional permission type. Omit to return all supported permissions.",
       },
     }),
@@ -1120,6 +1121,7 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
     promptGuidelines: [
       "Call only when the current user message explicitly requests one named permission, clearly affirms your immediately preceding one-permission request, or directly says to request it/that permission.",
       "Treat screen share, screen sharing, and screen-share as the screen_recording permission type.",
+      "For a weather question without an explicit place, call request_permission with type=location at query time instead of asking where the user is.",
       "For generic or multi-permission requests, ask the user which permission they want to grant.",
       "Use strict permission types only. Do not invent permission names.",
       "After requesting, explain any returned requires_restart or pending status.",
@@ -1129,9 +1131,9 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
       {
         type: {
           type: "string",
-          enum: ["screen_recording", "microphone", "notifications", "accessibility", "automation", "full_disk_access"],
+          enum: ["screen_recording", "microphone", "notifications", "accessibility", "automation", "full_disk_access", "location"],
           description:
-            "Permission type: screen_recording, microphone, notifications, accessibility, automation, or full_disk_access",
+            "Permission type: screen_recording, microphone, notifications, accessibility, automation, full_disk_access, or location",
         },
       },
       ["type"],

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -4140,7 +4140,8 @@
             "notifications",
             "accessibility",
             "automation",
-            "full_disk_access"
+            "full_disk_access",
+            "location"
           ],
           "description": "Optional permission type. Omit to return all supported permissions."
         }
@@ -4195,6 +4196,7 @@
     "promptGuidelines": [
       "Call only when the current user message explicitly requests one named permission, clearly affirms your immediately preceding one-permission request, or directly says to request it/that permission.",
       "Treat screen share, screen sharing, and screen-share as the screen_recording permission type.",
+      "For a weather question without an explicit place, call request_permission with type=location at query time instead of asking where the user is.",
       "For generic or multi-permission requests, ask the user which permission they want to grant.",
       "Use strict permission types only. Do not invent permission names.",
       "After requesting, explain any returned requires_restart or pending status."
@@ -4211,9 +4213,10 @@
             "notifications",
             "accessibility",
             "automation",
-            "full_disk_access"
+            "full_disk_access",
+            "location"
           ],
-          "description": "Permission type: screen_recording, microphone, notifications, accessibility, automation, or full_disk_access"
+          "description": "Permission type: screen_recording, microphone, notifications, accessibility, automation, full_disk_access, or location"
         }
       },
       "required": [
@@ -4254,12 +4257,13 @@
       "bullets": [
         "Call only when the current user message names one permission, clearly affirms your immediately preceding one-permission request, or directly says to request it/that permission.",
         "Treat screen share, screen sharing, and screen-share as the screen_recording permission type.",
+        "For a weather question without an explicit place, call request_permission with type=location at query time instead of asking where the user is.",
         "Ask the user to choose when their request is generic or names multiple permissions.",
         "The user must still complete the native macOS prompt or Settings toggle."
       ]
     },
     "voice": {
-      "realtimeDescription": "Request Omi's macOS permission through the kernel-authorized native executor by opening the native prompt or relevant System Settings pane. Screen share, screen sharing, and screen-share mean Screen Recording. Supports Screen Recording, microphone, notifications, Accessibility, Automation, and Full Disk Access."
+      "realtimeDescription": "Request Omi's macOS permission through the kernel-authorized native executor by opening the native prompt or relevant System Settings pane. Screen share, screen sharing, and screen-share mean Screen Recording. Supports Screen Recording, microphone, notifications, Accessibility, Automation, Full Disk Access, and Location."
     }
   },
   {

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -188,7 +188,7 @@ describe("omi tool manifest", () => {
     expect(askFollowup?.inputSchema.properties.options).toMatchObject({ type: "array" });
     expect(askFollowup?.inputSchema.required).toEqual(["question", "options"]);
     expect(requestPermission?.inputSchema.properties.type).toMatchObject({
-      enum: ["screen_recording", "microphone", "notifications", "accessibility", "automation", "full_disk_access"],
+      enum: ["screen_recording", "microphone", "notifications", "accessibility", "automation", "full_disk_access", "location"],
     });
   });
 

--- a/desktop/macos/changelog/unreleased/20260729-clarify-onboarding-language-picker.json
+++ b/desktop/macos/changelog/unreleased/20260729-clarify-onboarding-language-picker.json
@@ -1,0 +1,3 @@
+{
+  "change": "Clarified that the onboarding language picker controls how Omi listens and replies"
+}

--- a/desktop/macos/changelog/unreleased/20260729-meeting-recording-onboarding.json
+++ b/desktop/macos/changelog/unreleased/20260729-meeting-recording-onboarding.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made meeting-only recording the default onboarding choice and clarified the capture options"
+}

--- a/desktop/macos/changelog/unreleased/20260729-onboarding-permissions-and-shortcuts.json
+++ b/desktop/macos/changelog/unreleased/20260729-onboarding-permissions-and-shortcuts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved onboarding shortcuts, assistant setup, language-aware screen demos, and permission handling."
+}

--- a/desktop/macos/changelog/unreleased/20260729-responsive-layouts.json
+++ b/desktop/macos/changelog/unreleased/20260729-responsive-layouts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop navigation, settings, and onboarding layouts so controls stay usable on compact screens."
+}

--- a/desktop/macos/changelog/unreleased/20260729-settings-style-consistency.json
+++ b/desktop/macos/changelog/unreleased/20260729-settings-style-consistency.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS settings controls with consistent provider, account, and plan selection styling"
+}

--- a/desktop/macos/e2e/flows/delete-account.yaml
+++ b/desktop/macos/e2e/flows/delete-account.yaml
@@ -5,6 +5,7 @@ description: Delete Account confirmation sheet only — never confirm deletion (
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiButtonStyle.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
 preconditions:
   - auth_ready

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -6,6 +6,7 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+  - desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/FocusPage.swift
 preconditions:
   - auth_ready

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -29,6 +29,7 @@ covers:
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+  - desktop/macos/Desktop/Sources/Providers/LocationPermissionService.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/OnboardingOpenerComposer.swift
   - desktop/macos/Desktop/Sources/MainWindow/OnboardingOpenerView.swift
   - desktop/macos/Desktop/Sources/MainWindow/OnboardingWalkthroughOverlay.swift

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -196,6 +196,7 @@ trap 'omi_run_sh_release_build_lock' EXIT INT TERM
 
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
+DESKTOP_PRODUCTS_DIR="Desktop/.build/out/Products/Debug"
 source "$SCRIPT_DIR/scripts/app-config.sh"
 derive_omi_app_config "${OMI_APP_NAME:-Omi Dev}" || exit 1
 LOCAL_PROFILE=false
@@ -476,7 +477,7 @@ sign_app_bundle() {
             substep "Signing libwebp"
             codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/libwebp.7.dylib"
         fi
-        local node_bin="$bundle/Contents/Resources/Omi Computer_Omi Computer.bundle/node"
+        local node_bin="$bundle/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"
         if [ -f "$node_bin" ]; then
             substep "Signing bundled node binary"
             codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$node_bin"
@@ -963,7 +964,7 @@ substep "Adding rpath for Frameworks"
 install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_BUNDLE/Contents/MacOS/$BINARY_NAME" 2>/dev/null || true
 
 # Copy Sparkle framework
-SPARKLE_FRAMEWORK="Desktop/.build/arm64-apple-macosx/debug/Sparkle.framework"
+SPARKLE_FRAMEWORK="$DESKTOP_PRODUCTS_DIR/Sparkle.framework"
 if [ -d "$SPARKLE_FRAMEWORK" ]; then
     substep "Copying Sparkle framework ($(du -sh "$SPARKLE_FRAMEWORK" 2>/dev/null | cut -f1))"
     rm -rf "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
@@ -971,7 +972,7 @@ if [ -d "$SPARKLE_FRAMEWORK" ]; then
 fi
 
 # Copy Sentry framework
-SENTRY_FRAMEWORK="Desktop/.build/arm64-apple-macosx/debug/Sentry.framework"
+SENTRY_FRAMEWORK="$DESKTOP_PRODUCTS_DIR/Sentry.framework"
 if [ -d "$SENTRY_FRAMEWORK" ]; then
     substep "Copying Sentry framework"
     rm -rf "$APP_BUNDLE/Contents/Frameworks/Sentry.framework"
@@ -979,7 +980,7 @@ if [ -d "$SENTRY_FRAMEWORK" ]; then
 fi
 
 # Copy onnxruntime framework
-ONNX_FRAMEWORK="Desktop/.build/arm64-apple-macosx/debug/onnxruntime.framework"
+ONNX_FRAMEWORK="$DESKTOP_PRODUCTS_DIR/onnxruntime.framework"
 if [ -d "$ONNX_FRAMEWORK" ]; then
     substep "Copying onnxruntime framework"
     rm -rf "$APP_BUNDLE/Contents/Frameworks/onnxruntime.framework"
@@ -1024,7 +1025,7 @@ fi
 /usr/libexec/PlistBuddy -c "Set :BUNDLE_ID $BUNDLE_ID" "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist" 2>/dev/null || true
 
 # Copy resource bundle (contains app assets like permissions.gif, herologo.png, etc.)
-RESOURCE_BUNDLE="Desktop/.build/arm64-apple-macosx/debug/Omi Computer_Omi Computer.bundle"
+RESOURCE_BUNDLE="$DESKTOP_PRODUCTS_DIR/Omi Computer_Omi Computer.bundle"
 if [ -d "$RESOURCE_BUNDLE" ]; then
     substep "Copying resource bundle ($(du -sh "$RESOURCE_BUNDLE" 2>/dev/null | cut -f1))"
     macos_copy_tree "$RESOURCE_BUNDLE" "$APP_BUNDLE/Contents/Resources/$(basename "$RESOURCE_BUNDLE")"

--- a/desktop/macos/scripts/audit-desktop-bundle-deps.sh
+++ b/desktop/macos/scripts/audit-desktop-bundle-deps.sh
@@ -111,25 +111,27 @@ resolve_rpath_dependency() {
   local resolved_rpath
   local resolved_dep
 
-  for rpath in "${candidate_rpaths[@]}"; do
-    case "$rpath" in
-      @executable_path/*|@loader_path/*)
-        resolved_rpath="$(resolve_token_path "$rpath" "$binary")" || continue
-        ;;
-      "$APP_BUNDLE"/*)
-        resolved_rpath="$rpath"
-        ;;
-      /*)
-        continue
-        ;;
-      *)
-        continue
-        ;;
-    esac
+  if [[ ${#candidate_rpaths[@]} -gt 0 ]]; then
+    for rpath in "${candidate_rpaths[@]}"; do
+      case "$rpath" in
+        @executable_path/*|@loader_path/*)
+          resolved_rpath="$(resolve_token_path "$rpath" "$binary")" || continue
+          ;;
+        "$APP_BUNDLE"/*)
+          resolved_rpath="$rpath"
+          ;;
+        /*)
+          continue
+          ;;
+        *)
+          continue
+          ;;
+      esac
 
-    resolved_dep="$resolved_rpath/$dep_name"
-    path_inside_bundle "$resolved_dep" && return 0
-  done
+      resolved_dep="$resolved_rpath/$dep_name"
+      path_inside_bundle "$resolved_dep" && return 0
+    done
+  fi
 
   dependency_exists_in_bundle "$dep_name"
 }
@@ -231,7 +233,7 @@ done < <(
     -print0
 )
 
-node_bin="$CONTENTS_DIR/Resources/Omi Computer_Omi Computer.bundle/node"
+node_bin="$CONTENTS_DIR/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"
 if [[ -x "$node_bin" ]]; then
   "$node_bin" --version >/dev/null 2>&1 || report_error "bundled node failed runtime probe: $node_bin"
   codesign --verify --verbose=1 "$node_bin" >/dev/null 2>&1 || report_error "bundled node failed codesign verification: $node_bin"

--- a/desktop/macos/scripts/bundle-size-harness.sh
+++ b/desktop/macos/scripts/bundle-size-harness.sh
@@ -178,7 +178,7 @@ human_size() {
 
 smoke_packaged_runtime() {
   local app="$1"
-  local node="$app/Contents/Resources/Omi Computer_Omi Computer.bundle/node"
+  local node="$app/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"
   local pi_dir="$app/Contents/Resources/pi-mono-extension"
 
   "$node" --version >/dev/null

--- a/desktop/macos/scripts/prepare-desktop-bundle-native-deps.sh
+++ b/desktop/macos/scripts/prepare-desktop-bundle-native-deps.sh
@@ -88,7 +88,9 @@ strip_main_executable() {
     return 0
   fi
 
-  if ! command -v strip >/dev/null 2>&1; then
+  local strip_bin
+  strip_bin="$(xcrun --find strip 2>/dev/null || true)"
+  if [[ -z "$strip_bin" ]]; then
     echo "WARNING: strip not found; leaving main app executable unstripped" >&2
     return 0
   fi
@@ -120,7 +122,7 @@ strip_main_executable() {
   before_bytes="$(file_size_bytes "$executable_path")"
   before_arches="$(macho_arches "$executable_path")"
   chmod u+w "$executable_path" 2>/dev/null || true
-  strip -x "$executable_path"
+  "$strip_bin" -x "$executable_path"
   after_bytes="$(file_size_bytes "$executable_path")"
   after_arches="$(macho_arches "$executable_path")"
 

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -534,7 +534,7 @@ assert_helper_runtime_integrity() {
   [[ -d "$resources/agent" ]] || fail "agent runtime missing"
   [[ -f "$resources/agent/src/runtime/omi-tool-manifest.ts" ]] || fail "agent tool manifest missing"
   [[ -d "$resources/pi-mono-extension" ]] || fail "pi-mono-extension missing"
-  [[ -x "$resources/Omi Computer_Omi Computer.bundle/node" ]] || fail "bundled node missing"
+  [[ -x "$resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node" ]] || fail "bundled node missing"
   local sharp_arch expected_arch sharp_native libvips_native
   for sharp_arch in arm64 x64; do
     expected_arch="$sharp_arch"

--- a/desktop/macos/tests/test-prepare-desktop-bundle-native-deps.sh
+++ b/desktop/macos/tests/test-prepare-desktop-bundle-native-deps.sh
@@ -47,13 +47,28 @@ perl -e 'truncate $ARGV[0], $ARGV[1] or die "truncate: $!"' "$target" "$after"
 EOF
 chmod +x "$fakebin/strip"
 
+cat > "$fakebin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$TEST_XCRUN_CALLS"
+if [[ "${1:-}" == "--find" && "${2:-}" == "strip" ]]; then
+  printf '%s/strip\n' "$(dirname "$0")"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$fakebin/xcrun"
+
 head -c 4096 /dev/zero > "$main_binary"
 chmod +x "$main_binary"
 
 before="$(wc -c < "$main_binary" | tr -d ' ')"
-output="$(PATH="$fakebin:$PATH" "$MACOS_DIR/scripts/prepare-desktop-bundle-native-deps.sh" "$app_bundle")"
+xcrun_calls="$tmpdir/xcrun-calls"
+output="$(PATH="$fakebin:$PATH" TEST_XCRUN_CALLS="$xcrun_calls" "$MACOS_DIR/scripts/prepare-desktop-bundle-native-deps.sh" "$app_bundle")"
 after="$(wc -c < "$main_binary" | tr -d ' ')"
 
+if [[ "$(cat "$xcrun_calls")" != "--find strip" ]]; then
+  fail "main executable strip must resolve the Apple strip tool through xcrun"
+fi
 if [ "$after" -ge "$before" ]; then
   fail "main executable was not stripped: before=$before after=$after"
 fi

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -149,7 +149,7 @@ make_signed_smoke_fixture() {
     "$app/Contents/Resources/agent/node_modules/@img/sharp-libvips-darwin-arm64/lib" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-libvips-darwin-x64/lib" \
     "$app/Contents/Resources/pi-mono-extension" \
-    "$app/Contents/Resources/Omi Computer_Omi Computer.bundle"
+    "$app/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources"
   cat > "$app/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -170,8 +170,8 @@ OMI_PYTHON_API_URL=https://api.omi.me
 OMI_DESKTOP_API_URL=https://desktop-backend-hhibjajaja-uc.a.run.app/
 ENV
   printf '#!/usr/bin/env bash\nexit 0\n' > "$app/Contents/MacOS/Omi Computer"
-  printf '#!/usr/bin/env bash\nexit 0\n' > "$app/Contents/Resources/Omi Computer_Omi Computer.bundle/node"
-  chmod +x "$app/Contents/MacOS/Omi Computer" "$app/Contents/Resources/Omi Computer_Omi Computer.bundle/node"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$app/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"
+  chmod +x "$app/Contents/MacOS/Omi Computer" "$app/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"
   touch \
     "$app/Contents/Resources/agent/src/runtime/omi-tool-manifest.ts" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node" \


### PR DESCRIPTION
## Summary

- Make macOS onboarding language and permission handling complete at the point of use, including weather location requests and background connector safety.
- Package runtime resources correctly and use Apple’s strip tool so named development bundles launch reliably.
- Remove the transient authentication loading artifact and keep onboarding state resilient while users grant permissions.

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1
- INV-INT-1

## Validation

- `xcrun swift build -c debug --package-path Desktop`
- focused macOS permission tests and tool-manifest tests
- upstream-based pre-push checks, including Swift format/lint, e2e coverage, tool-surface generation, and dev-bundle tests

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

