### PR TITLE
Add parity capture for memory input surfaces

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -1,17 +1,17 @@
 {
   "files": {
     "backend/routers/apps.py": 2386,
-    "backend/routers/chat.py": 1588,
-    "backend/routers/developer.py": 2263,
-    "backend/routers/mcp_sse.py": 1865,
+    "backend/routers/chat.py": 1634,
+    "backend/routers/developer.py": 2282,
+    "backend/routers/mcp_sse.py": 1873,
     "backend/routers/sync.py": 2058,
     "backend/routers/users.py": 2076
   },
   "raise_justifications": {
     "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract.",
-    "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
-    "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
-    "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +7 so a refused memory read reports its reason instead of an empty success (#10735): the classification and wire shape live in utils/mcp_memories.mcp_denied_read_payload, leaving only the raise at the two tool branches that own the response contract.",
+    "backend/routers/chat.py": "The HTTP and streaming PTT routes own the raw-audio and final-transcript boundaries; dev-only allowlisted capture therefore starts and persists at those two route seams while serialization, bounds, redaction, and export stay in testing.parity_pack_v0.live_capture.",
+    "backend/routers/developer.py": "Developer memory create and batch routes must record their accepted write result at the authoritative API boundary; the shared dev-only allowlisted serializer/exporter lives in testing.parity_pack_v0.live_capture.",
+    "backend/routers/mcp_sse.py": "The MCP SSE tool handler owns the successful memory-write response boundary; its one shared dev-only allowlisted capture call records accepted memory without duplicating serialization or export logic.",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first. +30 for the disclosed, expiring city-context consent routes and legacy geolocation input boundary; they remain with the authenticated user route owner to prevent invalid coordinates reaching cache/provider paths (SCA-174)."
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "backend/utils/apps.py": 1652,
-    "backend/utils/conversations/process_conversation.py": 1896,
+    "backend/utils/conversations/process_conversation.py": 1971,
     "backend/utils/memory/canonical_consolidation.py": 1935,
     "backend/utils/memory/canonical_memory_adapter.py": 2012,
     "backend/utils/memory/legacy_backfill.py": 1723,
@@ -12,7 +12,7 @@
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
-    "backend/utils/conversations/process_conversation.py": "Exclude own and merge-source conversation action items from reprocess/merge dedup candidates so tasks are not silently deleted.",
+    "backend/utils/conversations/process_conversation.py": "Conversation finalization owns the transcript-to-memory transaction across canonical and legacy paths, so it supplies the shared dev-only allowlisted capture observer with the accepted-write result; cassette bounds, redaction, and export remain in testing.parity_pack_v0.live_capture.",
     "backend/utils/memory/canonical_consolidation.py": "Candidate selection, bounded retry leases, atomic promotion planning, and batch-level duplicate-supersede rejection remain one canonical long-term admission authority; extracting them would permit competing admission state machines (FC-split-mutation-authority).",
     "backend/utils/memory/canonical_memory_adapter.py": "Canonical conversation replacement coordinates source-generation fencing, bounded lineage discovery, and atomic replacement application; splitting this state machine would duplicate lifecycle authority (FC-split-mutation-authority).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -12,6 +12,7 @@ on:
       - 'backend/models/**'
       - 'backend/routers/**'
       - 'backend/services/**'
+      - 'backend/testing/parity_pack_v0/**'
       - 'backend/utils/**'
       - 'backend/pusher/**'
       - 'backend/charts/pusher/**'

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -309,6 +309,24 @@ environments:
             OMI_ENV_STAGE:
               value: dev
               category: runtime_identity
+            # Dev-only, exact-principal replay capture. Cloud Run's writable
+            # scratch is ephemeral; persist synchronously to the private dev
+            # bucket and never copy these values into the prod manifest.
+            OMI_PARITY_PACK_CAPTURE:
+              value: '1'
+              category: replay_capture
+            OMI_PARITY_PACK_ALLOWED_PRINCIPALS:
+              value: vi7SA9ckQCe4ccobWNxlbdcNdC23
+              category: replay_capture
+            OMI_PARITY_PACK_ROOT:
+              value: /tmp/omi-parity-pack
+              category: replay_capture
+            OMI_PARITY_PACK_GCS_URI:
+              value: gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0
+              category: replay_capture
+            OMI_PARITY_PACK_EXPORT_INTERVAL_SECONDS:
+              value: '3600'
+              category: replay_capture
             GOOGLE_CLIENT_ID:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
@@ -443,6 +461,21 @@ environments:
             OMI_ENV_STAGE:
               value: dev
               category: runtime_identity
+            OMI_PARITY_PACK_CAPTURE:
+              value: '1'
+              category: replay_capture
+            OMI_PARITY_PACK_ALLOWED_PRINCIPALS:
+              value: vi7SA9ckQCe4ccobWNxlbdcNdC23
+              category: replay_capture
+            OMI_PARITY_PACK_ROOT:
+              value: /tmp/omi-parity-pack
+              category: replay_capture
+            OMI_PARITY_PACK_GCS_URI:
+              value: gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0
+              category: replay_capture
+            OMI_PARITY_PACK_EXPORT_INTERVAL_SECONDS:
+              value: '3600'
+              category: replay_capture
             GOOGLE_CLIENT_ID:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata
@@ -544,6 +577,21 @@ environments:
             OMI_ENV_STAGE:
               value: dev
               category: runtime_identity
+            OMI_PARITY_PACK_CAPTURE:
+              value: '1'
+              category: replay_capture
+            OMI_PARITY_PACK_ALLOWED_PRINCIPALS:
+              value: vi7SA9ckQCe4ccobWNxlbdcNdC23
+              category: replay_capture
+            OMI_PARITY_PACK_ROOT:
+              value: /tmp/omi-parity-pack
+              category: replay_capture
+            OMI_PARITY_PACK_GCS_URI:
+              value: gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0
+              category: replay_capture
+            OMI_PARITY_PACK_EXPORT_INTERVAL_SECONDS:
+              value: '3600'
+              category: replay_capture
             GOOGLE_CLIENT_ID:
               env_var: GOOGLE_CLIENT_ID
               category: oauth_metadata

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -78,6 +78,7 @@ COPY backend/database/ ./database/
 COPY backend/models/ ./models/
 COPY backend/routers/ ./routers/
 COPY backend/services/ ./services/
+COPY backend/testing/parity_pack_v0/ ./testing/parity_pack_v0/
 COPY backend/utils/ ./utils/
 COPY backend/pusher/ ./pusher/
 

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -90,6 +90,7 @@ from utils.voice_duration_limiter import (
     check_budget,
     record_actual_duration,
 )
+from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 import logging
 
 logger = logging.getLogger(__name__)
@@ -785,6 +786,23 @@ async def transcribe_voice_message(
                 )
             )
 
+        parity_capture = SurfaceParityCapture.from_environ(
+            principal_id=uid,
+            session_id=str(uuid.uuid4()),
+            surface="ptt",
+            source="desktop_ptt_http",
+            provider_lane="stt",
+            route_or_model=stt_model or stt_provider or "prerecorded",
+            request={
+                "encoding": encoding,
+                "sample_rate": sample_rate,
+                "channels": channels,
+                "language": resolved_language,
+                "keyword_count": len(context_keywords),
+            },
+        )
+        parity_capture.observe_audio("client", audio_bytes)
+
         # Daily budget check
         duration_ms = compute_pcm_duration_ms(len(audio_bytes), sample_rate, channels)
         allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
@@ -810,6 +828,15 @@ async def transcribe_voice_message(
                 keywords=context_keywords,
             )
             outcome = TranscriptionOutcome.SUCCESS if transcript else TranscriptionOutcome.EXPECTED_SILENCE
+            parity_capture.observe(
+                "inbound",
+                {
+                    "type": "transcript",
+                    "text": transcript or "",
+                    "detected_language": detected_language,
+                    "outcome": outcome.value,
+                },
+            )
             attempt.finish(outcome)
         except Exception as error:
             failure = failure_from_exception(error, provider=stt_provider)
@@ -818,6 +845,7 @@ async def transcribe_voice_message(
         finally:
             if not attempt.finished:
                 attempt.finish(TranscriptionOutcome.UPSTREAM_ERROR)
+            parity_capture.persist()
             del audio_bytes
 
         response = {
@@ -1083,6 +1111,21 @@ async def transcribe_voice_message_stream(
         await websocket.close(code=1011, reason='Transcription service unavailable')
         return
     context_keywords = _parse_context_keywords(keywords)
+    parity_capture = SurfaceParityCapture.from_environ(
+        principal_id=uid,
+        session_id=str(uuid.uuid4()),
+        surface="ptt",
+        source="desktop_ptt_stream",
+        provider_lane="stt",
+        route_or_model=stt_model,
+        request={
+            "codec": codec,
+            "sample_rate": sample_rate,
+            "channels": channels,
+            "language": stt_language,
+            "keyword_count": len(context_keywords),
+        },
+    )
 
     loop = asyncio.get_running_loop()
 
@@ -1092,6 +1135,7 @@ async def transcribe_voice_message_stream(
     segment_queue = asyncio.Queue()
 
     def stream_transcript(segments):
+        parity_capture.observe("inbound", {"type": "transcript", "segments": segments})
         loop.call_soon_threadsafe(segment_queue.put_nowait, segments)
 
     async def segment_sender():
@@ -1263,6 +1307,7 @@ async def transcribe_voice_message_stream(
                     break
 
             received_audio_bytes += len(data)
+            parity_capture.observe_audio("client", data)
             stt_audio_buffer.extend(data)
 
             # Flush to the selected provider in 30ms chunks.
@@ -1314,6 +1359,7 @@ async def transcribe_voice_message_stream(
                     pass
 
         del stt_audio_buffer
+        parity_capture.persist()
 
 
 @router.post('/v2/files', response_model=List[FileChat], tags=['chat'])

--- a/backend/routers/desktop_screen_crisp.py
+++ b/backend/routers/desktop_screen_crisp.py
@@ -14,6 +14,7 @@ from database.vector_db import upsert_screen_activity_vectors
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.other.endpoints import get_current_user_uid, get_user
 from utils.subscription import is_trial_paywalled
+from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -50,6 +51,19 @@ async def _authorized_desktop_user(uid: str = Depends(get_current_user_uid)) -> 
 
 def _empty_unread_response() -> dict[str, Any]:
     return {"unread_count": 0, "messages": []}
+
+
+def _parity_screen_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep screen capture text-only and bounded; never retain embeddings/video."""
+    return [
+        {
+            "timestamp": str(row.get("timestamp") or ""),
+            "app_name": str(row.get("appName") or "")[:512],
+            "window_title": str(row.get("windowTitle") or "")[:2048],
+            "ocr_text": str(row.get("ocrText") or "")[:8192],
+        }
+        for row in rows[:100]
+    ]
 
 
 def _cached_session(email: str) -> str | None:
@@ -104,18 +118,33 @@ async def sync_screen_activity(
     if not request.rows:
         return {"synced": 0, "last_id": 0}
     rows = [{**row.model_dump(by_alias=True), "storageId": row.storage_id()} for row in request.rows]
+    parity_capture = SurfaceParityCapture.from_environ(
+        principal_id=uid,
+        session_id=f"{rows[0]['storageId']}:{rows[-1]['storageId']}",
+        surface="screen",
+        source="desktop_screen_activity_sync",
+        provider_lane="screen",
+        route_or_model="screen-activity-sync",
+        request={"row_count": len(rows), "has_embeddings": any(row.get("embedding") for row in rows)},
+    )
+    parity_capture.observe("client", {"type": "screen_activity_rows", "rows": _parity_screen_rows(rows)})
     try:
-        written = await run_blocking(db_executor, upsert_screen_activity, uid, rows)
-    except Exception as exc:
-        logger.exception("Screen activity Firestore write failed for uid=%s", uid)
-        raise HTTPException(status_code=500, detail="Firestore write failed") from exc
-    embedded_rows = [row for row in rows if row.get("embedding")]
-    if embedded_rows:
         try:
-            await run_blocking(db_executor, upsert_screen_activity_vectors, uid, embedded_rows)
-        except Exception:
-            logger.exception("Screen activity vector write failed for uid=%s", uid)
-    return {"synced": written, "last_id": max(row.id for row in request.rows)}
+            written = await run_blocking(db_executor, upsert_screen_activity, uid, rows)
+        except Exception as exc:
+            logger.exception("Screen activity Firestore write failed for uid=%s", uid)
+            raise HTTPException(status_code=500, detail="Firestore write failed") from exc
+        embedded_rows = [row for row in rows if row.get("embedding")]
+        if embedded_rows:
+            try:
+                await run_blocking(db_executor, upsert_screen_activity_vectors, uid, embedded_rows)
+            except Exception:
+                logger.exception("Screen activity vector write failed for uid=%s", uid)
+        response = {"synced": written, "last_id": max(row.id for row in request.rows)}
+        parity_capture.observe("inbound", {"type": "screen_activity_sync_result", **response})
+        return response
+    finally:
+        parity_capture.persist()
 
 
 @router.get("/v1/crisp/unread")

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -63,6 +63,7 @@ from utils.request_validation import HistoryDays
 from utils.llm.memories import identify_category_for_memory
 from utils.memory.canonical_memory_adapter import _read_canonical_memory_item, memory_item_to_memorydb
 from utils.memory.memory_service import MemoryService
+from testing.parity_pack_v0.live_capture import capture_memory_write
 from utils.memory.memory_system import MemorySystem
 from utils.memory.surface_routing import memorydb_list_with_locked_preview, pin_memory_system
 from utils.mcp_memories import collect_filtered_memories
@@ -638,6 +639,12 @@ def create_memory(
             upsert_vector=False,
             require_canonical_promotion=True,
         )
+        capture_memory_write(
+            principal_id=uid,
+            source="developer_memory_create",
+            session_id=memory_db.id,
+            memories=[memory_db],
+        )
         if memory.visibility == 'public':
             postprocess_executor.submit(update_personas_async, uid)
         return DeveloperMemory(
@@ -667,6 +674,12 @@ def create_memory(
         operation='create_memory',
         upsert_vector=False,
         require_canonical_promotion=True,
+    )
+    capture_memory_write(
+        principal_id=uid,
+        source="developer_memory_create",
+        session_id=memory_db.id,
+        memories=[memory_db],
     )
     if memory.visibility == 'public':
         postprocess_executor.submit(update_personas_async, uid)
@@ -741,6 +754,12 @@ def create_memories_batch(
         operation='batch_create_memories',
         upsert_vectors=memory_system != MemorySystem.CANONICAL,
         require_canonical_promotion=True,
+    )
+    capture_memory_write(
+        principal_id=uid,
+        source="developer_memory_batch_create",
+        session_id=str(uuid.uuid4()),
+        memories=created_dbs,
     )
     if has_public:
         postprocess_executor.submit(update_personas_async, uid)

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -30,6 +30,7 @@ from utils.apps import update_personas_async
 from utils.llm.memories import identify_category_for_memory
 from utils.memory.canonical_memory_adapter import _read_canonical_memory_item, memory_item_to_memorydb
 from utils.memory.memory_service import MemoryService, fetch_memory_dict
+from testing.parity_pack_v0.live_capture import capture_memory_write
 from utils.memory.memory_system import MemorySystem
 from utils.memory.surface_routing import memorydb_list_with_locked_preview, pin_memory_system
 from dependencies import (
@@ -138,6 +139,12 @@ def create_memory(
         consumer='mcp',
         operation="mcp_memory_create",
         require_canonical_promotion=True,
+    )
+    capture_memory_write(
+        principal_id=uid,
+        source="mcp_memory_create",
+        session_id=memory_db.id,
+        memories=[memory_db],
     )
     postprocess_executor.submit(update_personas_async, uid)
     return memory_db

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -53,6 +53,7 @@ from utils.memory.memory_service import (
     resolve_external_memory_write_context,
 )
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload
+from testing.parity_pack_v0.live_capture import capture_memory_write
 from utils.memory.memory_system import MemorySystem
 from utils.memory.product_authorization import (
     ProductAuthorizationContext,
@@ -928,6 +929,13 @@ def execute_tool(
             )
         except HTTPException as exc:
             _raise_tool_error_from_http(exc)
+
+        capture_memory_write(
+            principal_id=user_id,
+            source="mcp_tool_memory_create",
+            session_id=memory_db.id,
+            memories=[memory_db],
+        )
 
         exposure = (
             MemoryApiExposure.CANONICAL

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Literal, Optional, cast
 
@@ -32,6 +33,7 @@ from utils.memory.canonical_memory_adapter import (
     read_canonical_memory_item,
 )
 from utils.memory.memory_service import MemoryPayload, MemoryService, fetch_memory_dict
+from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 from utils.memory.import_write_guard import (
     import_write_block_mode,
     import_write_violation_for_guard,
@@ -154,6 +156,41 @@ class BatchDeleteMemoriesRequest(BaseModel):
         description="Memory IDs to delete in a single batch request",
         max_length=MEMORIES_BATCH_DELETE_MAX,
     )
+
+
+def _parity_memory_payload(memories: List[MemoryDB]) -> list[dict[str, Any]]:
+    """Small, redaction-ready accepted-memory view for restricted dev cassettes."""
+    return [
+        {
+            "id": memory.id,
+            "content": (memory.content or "")[:8192],
+            "category": memory.category.value,
+            "visibility": memory.visibility,
+            "source_type": memory.evidence[0].source_type if memory.evidence else "unknown",
+        }
+        for memory in memories[:100]
+    ]
+
+
+def _start_memory_parity_capture(
+    uid: str, *, source: str, session_id: str, memories: List[MemoryDB]
+) -> SurfaceParityCapture:
+    capture = SurfaceParityCapture.from_environ(
+        principal_id=uid,
+        session_id=session_id,
+        surface="memory_write",
+        source=source,
+        provider_lane="memory",
+        route_or_model="memory-write",
+        request={"memory_count": len(memories), "source": source},
+    )
+    capture.observe("client", {"type": "memory_write_request", "memories": _parity_memory_payload(memories)})
+    return capture
+
+
+def _finish_memory_parity_capture(capture: SurfaceParityCapture, memories: List[MemoryDB]) -> None:
+    capture.observe("inbound", {"type": "accepted_memories", "memories": _parity_memory_payload(memories)})
+    capture.persist()
 
 
 class ReviewResolutionRequest(BaseModel):
@@ -455,11 +492,17 @@ async def create_memory(
         logger.info("memory_import.per_file_item_dropped endpoint=/v3/memories uid=%s", uid)
         return _legacy_memory_response(memory_db)
 
+    parity_capture = _start_memory_parity_capture(
+        uid,
+        source="v3_memory_create",
+        session_id=memory_db.id,
+        memories=[memory_db],
+    )
     db_client = getattr(db_client_module, 'db', None)
     if _canonical_write_enabled_or_fail_closed(uid, db_client=db_client):
         try:
             memory_service = MemoryService(db_client=db_client)
-            return await run_blocking(
+            created = await run_blocking(
                 db_executor,
                 memory_service.create_external_memory,
                 uid,
@@ -470,6 +513,8 @@ async def create_memory(
                 upsert_vector=False,
                 require_canonical_promotion=True,
             )
+            _finish_memory_parity_capture(parity_capture, [created])
+            return created
         except Exception:
             logger.exception("Canonical create_memory failed uid=%s", uid)
             raise HTTPException(status_code=503, detail="Service temporarily unavailable")
@@ -484,6 +529,8 @@ async def create_memory(
     except Exception:
         logger.exception("Firestore create_memory failed uid=%s", uid)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
+    _finish_memory_parity_capture(parity_capture, [memory_db])
 
     try:
         await run_blocking(
@@ -567,6 +614,13 @@ async def create_memories_batch(
         if memory.visibility == 'public':
             has_public = True
 
+    parity_capture = _start_memory_parity_capture(
+        uid,
+        source="v3_memory_batch_create",
+        session_id=str(uuid.uuid4()),
+        memories=memory_dbs,
+    )
+
     db_client = getattr(db_client_module, 'db', None)
     if _canonical_write_enabled_or_fail_closed(uid, db_client=db_client):
         memory_service = MemoryService(db_client=db_client)
@@ -605,6 +659,7 @@ async def create_memories_batch(
             else:
                 logger.error("Canonical create_memories_batch readback missing uid=%s memory_id=%s", uid, memory_id)
                 raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+        _finish_memory_parity_capture(parity_capture, server_memories)
         return BatchMemoriesResponse(memories=server_memories, created_count=len(server_memories))
 
     # Persist to Firestore first — that write is the authoritative result.
@@ -622,6 +677,8 @@ async def create_memories_batch(
     except Exception:
         logger.exception("Firestore save_memories failed uid=%s count=%s", uid, len(memory_dbs))
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
+    _finish_memory_parity_capture(parity_capture, memory_dbs)
 
     # Pinecone batch upsert runs on a worker thread (postprocess pool, like the
     # single-create path) so a slow embeddings/Pinecone call can't starve the
@@ -679,11 +736,36 @@ async def create_memory_import_batch(
         logger.warning("memory import ingest disabled uid=%s reason=%s", uid, write_decision.reason)
         raise HTTPException(status_code=503, detail="memory_import_canonical_not_ready")
 
+    parity_capture = SurfaceParityCapture.from_environ(
+        principal_id=uid,
+        session_id=str(uuid.uuid4()),
+        surface="memory_import",
+        source="v3_memory_import_batch",
+        provider_lane="memory",
+        route_or_model="memory-import",
+        request={"source_type": request.source_type, "item_count": len(request.items)},
+    )
+    parity_capture.observe(
+        "client",
+        {
+            "type": "memory_import_artifacts",
+            "items": [
+                {
+                    "title": (item.title or "")[:2048],
+                    "snippet": (item.snippet or "")[:4096],
+                    "content": (item.content or "")[:8192],
+                }
+                for item in request.items[:100]
+            ],
+        },
+    )
     try:
         result = await run_blocking(db_executor, ingest_memory_import_batch, uid, request, db_client=db_client)
     except Exception:
         logger.exception("Memory import ingest failed uid=%s source_type=%s", uid, request.source_type)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+    parity_capture.observe("inbound", {"type": "memory_import_result", **result.response.model_dump(mode="json")})
+    parity_capture.persist()
     return result.response
 
 

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -26,7 +26,7 @@ manifests, reports, or Git.
 wire observations using relative milliseconds. A whitelist miss writes no
 cassette bytes and retains only bounded lane/reason metadata.
 
-## Live listen wiring
+## Live surface wiring
 
 The `/v4/listen` runtime creates `routers.listen.parity_capture.ListenParityCapture`
 only after Firebase WebSocket authentication and STT provider selection. It uses
@@ -47,6 +47,19 @@ disabled; `OMI_ENV_STAGE` other than `dev`, a missing `OMI_PARITY_PACK_CAPTURE=1
 or an allowlist miss is also disabled. No Helm or production default enables this
 path. The local cassette may include restricted audio/transcript event payloads,
 so keep its root outside Git and never attach it to a PR.
+
+`SurfaceParityCapture` uses the same gate/exporter for the additional
+memory-forming surfaces below.  It extends the cassette document with optional
+top-level discriminators while leaving the v1 identity, fingerprint, and event
+contract unchanged for existing players:
+
+| `surface` | `source` | Captured seam |
+| --- | --- | --- |
+| `ptt` | `desktop_ptt_http`, `desktop_ptt_stream` | Desktop PCM PTT and live PTT STT (bounded audio + transcript events) |
+| `screen` | `desktop_screen_activity_sync` | Text-only screen activity/context sync; no video or embedding vectors |
+| `conversation_finalization` | `conversation_<source>` | Transcript input, memory extraction result, and accepted memories |
+| `memory_write` | `v3_memory_create`, `v3_memory_batch_create`, `integration_<app>`, `twitter_<persona>` | Manual/API, integration, and social memory writers |
+| `memory_import` | `v3_memory_import_batch` | Bounded import artifacts and ingestion result (not raw media) |
 
 The development listen deployment mounts `/var/omi-parity-pack` as an `emptyDir`
 for explicitly allowlisted dogfood principals and best-effort exports cassette

--- a/backend/testing/parity_pack_v0/capture.py
+++ b/backend/testing/parity_pack_v0/capture.py
@@ -9,6 +9,7 @@ import time
 from typing import Any, Callable, Mapping
 
 from .schema import CassetteIdentity, RequestFingerprint
+from .redaction import redact_value
 from .whitelist import CaptureWhitelist
 
 
@@ -33,34 +34,74 @@ class CaptureTap:
         self.denied_metadata: list[dict[str, str]] = []
 
     def start(
-        self, principal_id: str | None, identity: CassetteIdentity, request: Mapping[str, Any]
+        self,
+        principal_id: str | None,
+        identity: CassetteIdentity,
+        request: Mapping[str, Any],
+        *,
+        surface: str | None = None,
+        source: str | None = None,
     ) -> "CaptureInvocation | None":
         if not self.whitelist.allows(principal_id):
             self.denied_metadata.append({"provider_lane": identity.provider_lane, "reason": "whitelist_miss"})
             del self.denied_metadata[:-100]
             return None
-        return CaptureInvocation(self.root, identity, RequestFingerprint.from_request(request), self._clock)
+        return CaptureInvocation(
+            self.root,
+            identity,
+            RequestFingerprint.from_request(request),
+            self._clock,
+            surface=surface,
+            source=source,
+        )
 
 
 class CaptureInvocation:
     def __init__(
-        self, root: Path, identity: CassetteIdentity, fingerprint: RequestFingerprint, clock: Callable[[], float]
+        self,
+        root: Path,
+        identity: CassetteIdentity,
+        fingerprint: RequestFingerprint,
+        clock: Callable[[], float],
+        *,
+        surface: str | None = None,
+        source: str | None = None,
     ) -> None:
         self.root, self.identity, self.fingerprint, self._clock = root, identity, fingerprint, clock
+        self.surface = surface.strip() if isinstance(surface, str) and surface.strip() else None
+        self.source = source.strip() if isinstance(source, str) and source.strip() else None
         self._started_at = clock()
         self._events: list[CassetteEvent] = []
 
     def observe(self, direction: str, payload: Mapping[str, Any]) -> None:
-        self._events.append(CassetteEvent(direction, round((self._clock() - self._started_at) * 1000), dict(payload)))
+        safe_payload = redact_value(dict(payload))
+        # Base64 audio is opaque binary, not free text. Running text-pattern
+        # redaction across it can corrupt a replayable audio event by mistaking
+        # a run of base64 digits for a phone number.
+        if isinstance(payload.get("audio_b64"), str):
+            safe_payload["audio_b64"] = payload["audio_b64"]
+        self._events.append(
+            CassetteEvent(
+                direction,
+                round((self._clock() - self._started_at) * 1000),
+                safe_payload,
+            )
+        )
 
     def persist(self) -> Path:
         path = self.root / "cassettes" / f"{self.identity.key()}.json"
         path.parent.mkdir(parents=True, exist_ok=True)
-        document = {
+        document: dict[str, Any] = {
             "schema_version": 1,
             "identity": self.identity.as_dict(),
             "request_fingerprint": self.fingerprint.as_dict(),
             "events": [asdict(event) for event in self._events],
         }
+        # Optional discriminators extend the v1 document without changing the
+        # existing identity/fingerprint/event contract consumed by players.
+        if self.surface is not None:
+            document["surface"] = self.surface
+        if self.source is not None:
+            document["source"] = self.source
         path.write_text(json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
         return path

--- a/backend/testing/parity_pack_v0/live_capture.py
+++ b/backend/testing/parity_pack_v0/live_capture.py
@@ -1,0 +1,208 @@
+"""Reusable live adapters for dev-only, allowlisted parity-pack capture.
+
+This module is intentionally small enough to use from HTTP routers and
+background finalizers.  It only serializes data after ``CaptureWhitelist``
+permits the principal, never accepts a repository-local root, bounds raw audio
+and event count, and treats persistence/export failures as non-fatal.
+"""
+
+from __future__ import annotations
+
+import base64
+from hashlib import sha256
+import logging
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from .capture import CaptureInvocation, CaptureTap
+from .schema import CassetteIdentity
+from .whitelist import CaptureWhitelist
+
+logger = logging.getLogger(__name__)
+
+MAX_CAPTURE_EVENTS = 1_000
+MAX_CAPTURE_AUDIO_BYTES = 8 * 1024 * 1024
+MAX_CAPTURE_TEXT_CHARS = 16 * 1024
+MAX_CAPTURE_SEQUENCE_ITEMS = 1_000
+
+
+def _anonymous_id(*parts: str) -> str:
+    return sha256("\0".join(parts).encode("utf-8")).hexdigest()[:32]
+
+
+def _capture_root(environ: Mapping[str, str]) -> Path | None:
+    value = environ.get("OMI_PARITY_PACK_ROOT", "").strip()
+    if not value:
+        return None
+    root = Path(value).expanduser()
+    if not root.is_absolute():
+        return None
+    repository_root = Path(__file__).resolve().parents[3]
+    try:
+        root.resolve().relative_to(repository_root)
+    except ValueError:
+        return root
+    return None
+
+
+def _bounded_capture_value(value: Any, *, key: str | None = None) -> Any:
+    """Normalize provider objects and bound text before persistence is possible."""
+    if isinstance(value, str):
+        # Audio is already separately byte-bounded and must remain replayable.
+        return value if key == "audio_b64" else value[:MAX_CAPTURE_TEXT_CHARS]
+    if isinstance(value, Mapping):
+        return {str(item_key): _bounded_capture_value(item, key=str(item_key)) for item_key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_bounded_capture_value(item) for item in value[:MAX_CAPTURE_SEQUENCE_ITEMS]]
+    if hasattr(value, "model_dump"):
+        try:
+            return _bounded_capture_value(value.model_dump(mode="json"), key=key)
+        except Exception:
+            pass
+    if hasattr(value, "value") and isinstance(value.value, (str, int, float, bool)):
+        return _bounded_capture_value(value.value, key=key)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return str(value)[:MAX_CAPTURE_TEXT_CHARS]
+
+
+class SurfaceParityCapture:
+    """Bounded, fail-open capture for a memory-forming production seam."""
+
+    def __init__(self, invocation: CaptureInvocation | None) -> None:
+        self._invocation = invocation
+        self._event_count = 0
+        self._audio_bytes = 0
+        self._limit_reached = False
+
+    @classmethod
+    def from_environ(
+        cls,
+        *,
+        principal_id: str,
+        session_id: str,
+        surface: str,
+        source: str,
+        provider_lane: str,
+        route_or_model: str,
+        request: Mapping[str, Any],
+        environ: Mapping[str, str] | None = None,
+    ) -> "SurfaceParityCapture":
+        env = os.environ if environ is None else environ
+        root = _capture_root(env)
+        if root is None:
+            return cls(None)
+        identity = CassetteIdentity(
+            anon_session=_anonymous_id(principal_id, session_id),
+            provider_lane=provider_lane,
+            route_or_model=route_or_model or surface,
+            call_ordinal=0,
+            retry_attempt=0,
+            parent_event_anon=_anonymous_id(session_id, surface, source),
+        )
+        try:
+            invocation = CaptureTap(root, CaptureWhitelist.from_environ(dict(env))).start(
+                principal_id,
+                identity,
+                request,
+                surface=surface,
+                source=source,
+            )
+            return cls(invocation)
+        except Exception as error:
+            logger.warning("Parity pack surface capture initialization failed error_type=%s", type(error).__name__)
+            return cls(None)
+
+    @property
+    def enabled(self) -> bool:
+        return self._invocation is not None
+
+    def observe(self, direction: str, payload: Mapping[str, Any]) -> None:
+        if not self._can_observe():
+            return
+        try:
+            invocation = self._invocation
+            if invocation is not None:
+                invocation.observe(direction, _bounded_capture_value(payload))
+                self._event_count += 1
+        except Exception as error:
+            logger.warning("Parity pack surface capture observe failed error_type=%s", type(error).__name__)
+
+    def observe_audio(self, direction: str, audio: bytes) -> None:
+        if not self._can_observe(len(audio)):
+            return
+        self.observe(direction, {"type": "audio", "audio_b64": base64.b64encode(audio).decode("ascii")})
+        self._audio_bytes += len(audio)
+
+    def _can_observe(self, audio_bytes: int = 0) -> bool:
+        if self._invocation is None or self._limit_reached:
+            return False
+        if self._event_count >= MAX_CAPTURE_EVENTS or self._audio_bytes + audio_bytes > MAX_CAPTURE_AUDIO_BYTES:
+            self._limit_reached = True
+            logger.warning("Parity pack surface capture limit reached; dropping subsequent events")
+            return False
+        return True
+
+    def persist(self) -> None:
+        if self._invocation is None:
+            return
+        try:
+            path = self._invocation.persist()
+        except Exception as error:
+            logger.warning("Parity pack surface capture persist failed error_type=%s", type(error).__name__)
+            return
+        try:
+            # Keep the exporter as one shared implementation while it remains
+            # located beside the originally shipped listen adapter.
+            from routers.listen.parity_pack_export import ensure_reconcile_loop, export_cassette_file
+
+            ensure_reconcile_loop()
+            export_cassette_file(path)
+        except Exception as error:
+            logger.warning("Parity pack surface capture export failed error_type=%s", type(error).__name__)
+
+
+def _memory_payload(value: Any) -> dict[str, Any]:
+    """Return the narrow memory shape suitable for a restricted cassette."""
+    if hasattr(value, "model_dump"):
+        try:
+            value = value.model_dump(mode="json")
+        except Exception:
+            value = {}
+    if not isinstance(value, Mapping):
+        return {"content": str(value)[:MAX_CAPTURE_TEXT_CHARS]}
+    evidence = value.get("evidence")
+    source_type = "unknown"
+    if isinstance(evidence, list) and evidence and isinstance(evidence[0], Mapping):
+        source_type = str(evidence[0].get("source_type") or source_type)
+    return {
+        "id": value.get("id"),
+        "content": str(value.get("content") or "")[:MAX_CAPTURE_TEXT_CHARS],
+        "category": value.get("category"),
+        "visibility": value.get("visibility"),
+        "source_type": source_type,
+    }
+
+
+def capture_memory_write(
+    *,
+    principal_id: str,
+    source: str,
+    session_id: str,
+    memories: list[Any],
+) -> None:
+    """Persist one accepted memory-write cassette without exposing a UID."""
+    capture = SurfaceParityCapture.from_environ(
+        principal_id=principal_id,
+        session_id=session_id,
+        surface="memory_write",
+        source=source,
+        provider_lane="memory",
+        route_or_model="memory-write",
+        request={"memory_count": len(memories), "source": source},
+    )
+    payload = [_memory_payload(memory) for memory in memories[:100]]
+    capture.observe("client", {"type": "memory_write_request", "memories": payload})
+    capture.observe("inbound", {"type": "accepted_memories", "memories": payload})
+    capture.persist()

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -106,6 +106,19 @@ def with_listen_finalization_orphan_env(payload: str) -> str:
     )
 
 
+def with_parity_pack_env(payload: str) -> str:
+    """Keep offline dev Cloud Run states aligned with replay-capture bindings."""
+    return payload.replace(
+        '        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},',
+        '        {"name": "GOOGLE_CLOUD_PROJECT", "value": "based-hardware"},\n'
+        '        {"name": "OMI_PARITY_PACK_CAPTURE", "value": "1"},\n'
+        '        {"name": "OMI_PARITY_PACK_ALLOWED_PRINCIPALS", "value": "vi7SA9ckQCe4ccobWNxlbdcNdC23"},\n'
+        '        {"name": "OMI_PARITY_PACK_ROOT", "value": "/tmp/omi-parity-pack"},\n'
+        '        {"name": "OMI_PARITY_PACK_GCS_URI", "value": "gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0"},\n'
+        '        {"name": "OMI_PARITY_PACK_EXPORT_INTERVAL_SECONDS", "value": "3600"},',
+    )
+
+
 GOOGLE_OAUTH_SECRETS = '''\
         {"name": "GOOGLE_CLIENT_SECRET", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_CLIENT_SECRET"}}},
         {"name": "MODULATE_API_KEY", "valueFrom": {"secretKeyRef": {"name": "MODULATE_API_KEY", "key": "latest"}}},'''
@@ -114,7 +127,9 @@ GOOGLE_OAUTH_SECRETS = '''\
 def with_cloud_run_oauth_secrets(payload: str) -> str:
     payload = with_backend_public_shared_chat_auth_env(
         with_backend_pusher_env(
-            with_listen_finalization_orphan_env(with_memory_env(with_sync_ledger_fence_mode(payload)))
+            with_parity_pack_env(
+                with_listen_finalization_orphan_env(with_memory_env(with_sync_ledger_fence_mode(payload)))
+            )
         )
     )
     return re.sub(

--- a/backend/tests/unit/test_memory_import_static_guards.py
+++ b/backend/tests/unit/test_memory_import_static_guards.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DESKTOP_SOURCES = REPO_ROOT / "desktop" / "macos" / "Desktop" / "Sources"
@@ -51,7 +52,7 @@ def test_desktop_importers_pair_legacy_payloads_with_import_evidence_calls():
 
 def test_import_evidence_client_targets_import_endpoint():
     source = "\n".join(path.read_text(encoding="utf-8") for path in sorted(DESKTOP_SOURCES.rglob("APIClient*.swift")))
-    assert 'post("v3/memory-imports/batch"' in source
+    assert re.search(r'post\(\s*"v3/memory-imports/batch"', source)
     assert "func createMemoryImportBatch" in source
 
 

--- a/backend/tests/unit/test_pusher_auto_deploy_paths.py
+++ b/backend/tests/unit/test_pusher_auto_deploy_paths.py
@@ -22,6 +22,7 @@ def test_pusher_auto_deploy_tracks_its_shared_lifecycle_and_observability_import
         'backend/routers/**',
         'backend/services/**',
         'backend/utils/**',
+        'backend/testing/parity_pack_v0/**',
         'backend/pusher/**',
         'backend/charts/pusher/**',
         '.dockerignore',

--- a/backend/tests/unit/test_surface_parity_capture.py
+++ b/backend/tests/unit/test_surface_parity_capture.py
@@ -1,0 +1,60 @@
+"""Coverage for the shared dev-only capture adapter used beyond listen."""
+
+import base64
+import json
+
+from testing.parity_pack_v0.live_capture import SurfaceParityCapture
+
+
+def _env(root):
+    return {
+        "OMI_ENV_STAGE": "dev",
+        "OMI_PARITY_PACK_CAPTURE": "1",
+        "OMI_PARITY_PACK_ALLOWED_PRINCIPALS": "allowed-user",
+        "OMI_PARITY_PACK_ROOT": str(root),
+    }
+
+
+def _capture(root, *, principal_id="allowed-user"):
+    return SurfaceParityCapture.from_environ(
+        principal_id=principal_id,
+        session_id="surface-session",
+        surface="screen",
+        source="desktop_screen_activity_sync",
+        provider_lane="screen",
+        route_or_model="screen-activity-sync",
+        request={"row_count": 1},
+        environ=_env(root),
+    )
+
+
+def test_surface_capture_persists_discriminators_and_redacts_text_payloads(tmp_path):
+    capture = _capture(tmp_path)
+
+    capture.observe(
+        "client",
+        {"type": "screen_activity_rows", "email": "dogfood@example.com", "token": "do-not-keep"},
+    )
+    capture.persist()
+
+    cassette = json.loads(next((tmp_path / "cassettes").glob("*.json")).read_text())
+    assert cassette["surface"] == "screen"
+    assert cassette["source"] == "desktop_screen_activity_sync"
+    assert cassette["identity"]["anon_session"] != "allowed-user"
+    assert cassette["events"][0]["payload"]["email"] == "[REDACTED_EMAIL]"
+    assert cassette["events"][0]["payload"]["token"] == "[REDACTED]"
+
+
+def test_surface_capture_preserves_binary_audio_encoding_and_denies_non_allowlisted_users(tmp_path):
+    allowed = _capture(tmp_path)
+    audio = b"12345678901234567890"
+    allowed.observe_audio("client", audio)
+    allowed.persist()
+
+    cassette = json.loads(next((tmp_path / "cassettes").glob("*.json")).read_text())
+    assert cassette["events"][0]["payload"]["audio_b64"] == base64.b64encode(audio).decode("ascii")
+
+    denied = _capture(tmp_path / "denied", principal_id="not-allowlisted")
+    denied.observe("client", {"must": "not-persist"})
+    denied.persist()
+    assert not (tmp_path / "denied" / "cassettes").exists()

--- a/backend/tests/unit/test_verify_pusher_source_closure.py
+++ b/backend/tests/unit/test_verify_pusher_source_closure.py
@@ -36,6 +36,7 @@ def test_source_closure_includes_all_dockerfile_copy_dirs() -> None:
             "backend/models/",
             "backend/routers/",
             "backend/services/",
+            "backend/testing/parity_pack_v0/",
             "backend/utils/",
             "backend/pusher/",
         ]
@@ -62,6 +63,7 @@ def test_source_closure_cli_output_includes_chart_dir() -> None:
         "backend/models/",
         "backend/routers/",
         "backend/services/",
+        "backend/testing/parity_pack_v0/",
         "backend/utils/",
         "backend/pusher/",
     ]:

--- a/backend/utils/conversations/memories.py
+++ b/backend/utils/conversations/memories.py
@@ -10,6 +10,7 @@ from utils.llm.memories import extract_memories_from_text
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
+from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 import logging
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,32 @@ def _artifact_ref(
     if source_url:
         ref['url'] = source_url
     return ref
+
+
+def _capture_external_memory_write(uid: str, *, source: str, memories: List[MemoryDB]) -> None:
+    if not memories:
+        return
+    capture = SurfaceParityCapture.from_environ(
+        principal_id=uid,
+        session_id=f"{source}:{memories[0].id}",
+        surface="memory_write",
+        source=source,
+        provider_lane="memory",
+        route_or_model="external-memory-write",
+        request={"memory_count": len(memories), "source": source},
+    )
+    payload = [
+        {
+            "id": memory.id,
+            "content": (memory.content or "")[:8192],
+            "category": memory.category.value,
+            "source_type": memory.evidence[0].source_type if memory.evidence else "unknown",
+        }
+        for memory in memories[:100]
+    ]
+    capture.observe("client", {"type": "external_memory_write_request", "memories": payload})
+    capture.observe("inbound", {"type": "accepted_memories", "memories": payload})
+    capture.persist()
 
 
 def process_external_integration_memory(
@@ -144,6 +171,8 @@ def process_external_integration_memory(
                 [memory_write_payload(fact_db, MemoryApiExposure.LEGACY) for fact_db in saved_memories],
             )
 
+        _capture_external_memory_write(uid, source=f"integration_{app_id}", memories=saved_memories)
+
     return saved_memories
 
 
@@ -188,5 +217,7 @@ def process_twitter_memories(uid: str, tweets_text: str, persona_id: str) -> Lis
                 uid,
                 [memory_write_payload(memory_db, MemoryApiExposure.LEGACY) for memory_db in saved_memories],
             )
+
+        _capture_external_memory_write(uid, source=f"twitter_{persona_id}", memories=saved_memories)
 
     return saved_memories

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -51,6 +51,7 @@ from utils.conversations import lifecycle as lifecycle_service
 from utils.conversations.subjects import infer_subject_from_segments
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
+from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 from utils.memory.memory_system import MemorySystem
 from utils.memory.memory_system_pin import memory_system_request_scope
 from utils.memory.canonical_memory_adapter import extraction_memory_id
@@ -529,14 +530,67 @@ def _update_goal_progress(uid: str, conversation: Conversation) -> None:
         logger.error(f"[GOAL] Error updating progress: {e}")
 
 
+def _parity_transcript_segments(conversation: Conversation) -> list[dict[str, Any]]:
+    segments = getattr(conversation, "transcript_segments", None) or []
+    return [
+        {
+            "start": segment.start,
+            "end": segment.end,
+            "speaker": segment.speaker,
+            "text": (segment.text or "")[:8192],
+        }
+        for segment in segments[:1000]
+    ]
+
+
+def _parity_accepted_memories(memories: List[MemoryDB]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": memory.id,
+            "content": (memory.content or "")[:8192],
+            "category": memory.category.value,
+            "visibility": memory.visibility,
+        }
+        for memory in memories[:100]
+    ]
+
+
 def extract_memories(uid: str, conversation: Conversation) -> None:
     """Extract one conversation's memories through the selected memory system.
 
     Finalization workers use this public boundary while holding their durable
     lease. Keep the private helper below for existing in-module async callers.
     """
-    with track_usage(uid, Features.MEMORIES):
-        result = _extract_memories_inner(uid, conversation)
+    source = source_for_conversation(conversation)
+    parity_capture = SurfaceParityCapture.from_environ(
+        principal_id=uid,
+        session_id=conversation.id,
+        surface="conversation_finalization",
+        source=f"conversation_{source}",
+        provider_lane="memory",
+        route_or_model="memory-extraction",
+        request={
+            "conversation_source": str(source),
+            "segment_count": len(getattr(conversation, "transcript_segments", None) or []),
+            "locked": bool(getattr(conversation, "is_locked", False)),
+        },
+    )
+    parity_capture.observe(
+        "client",
+        {"type": "conversation_transcript", "segments": _parity_transcript_segments(conversation)},
+    )
+    try:
+        with track_usage(uid, Features.MEMORIES):
+            if parity_capture.enabled:
+                result = _extract_memories_inner(uid, conversation, parity_capture=parity_capture)
+            else:
+                result = _extract_memories_inner(uid, conversation)
+        parity_capture.observe(
+            "inbound",
+            {"type": "memory_extraction_result", "count": result.count, "path": result.path},
+        )
+    finally:
+        parity_capture.persist()
     # Product-analytics telemetry (Conversation Memories Extracted): at most one
     # analytics success per (uid, conversation) across retries — zero-extraction
     # (count == 0) and persistence exceptions emit nothing; the durable
@@ -821,7 +875,7 @@ def _canonical_conversation_write_payload(
 
 
 def _extract_memories_canonical(
-    uid: str, conversation: Conversation, *, db_client: Any
+    uid: str, conversation: Conversation, *, db_client: Any, parity_capture: SurfaceParityCapture | None = None
 ) -> ConversationMemoryExtractionResult:
     """Canonical-cohort extraction with one atomic source replacement."""
     source = source_for_conversation(conversation)
@@ -966,6 +1020,14 @@ def _extract_memories_canonical(
         return ConversationMemoryExtractionResult(count=0, source=source, path=PATH_CANONICAL)
 
     logger.info(f"Saving {len(parsed_memories)} canonical memories for conversation {conversation.id}")
+    if parity_capture is not None:
+        parity_capture.observe(
+            "inbound",
+            {
+                "type": "accepted_memories",
+                "memories": _parity_accepted_memories([memory for memory, *_ in parsed_memories]),
+            },
+        )
 
     if not is_locked:
         memory_refs = [
@@ -1009,17 +1071,25 @@ def _extract_memories_canonical(
     return ConversationMemoryExtractionResult(count=len(parsed_memories), source=source, path=PATH_CANONICAL)
 
 
-def _extract_memories_inner(uid: str, conversation: Conversation) -> ConversationMemoryExtractionResult:
+def _extract_memories_inner(
+    uid: str, conversation: Conversation, *, parity_capture: SurfaceParityCapture | None = None
+) -> ConversationMemoryExtractionResult:
     with memory_system_request_scope(uid) as memory_system:
         db_client = getattr(db_client_module, 'db', None)
         if memory_system == MemorySystem.CANONICAL:
             MemoryService(db_client=db_client).ensure_canonical_mutation_ready(uid)
-            return _extract_memories_canonical(uid, conversation, db_client=db_client)
+            return _extract_memories_canonical(uid, conversation, db_client=db_client, parity_capture=parity_capture)
 
-        return _extract_memories_legacy(uid, conversation)
+        if parity_capture is None:
+            # Preserve the direct legacy helper shape used by non-live callers
+            # and its contract tests; live finalization supplies the observer.
+            return _extract_memories_legacy(uid, conversation)
+        return _extract_memories_legacy(uid, conversation, parity_capture=parity_capture)
 
 
-def _extract_memories_legacy(uid: str, conversation: Conversation) -> ConversationMemoryExtractionResult:
+def _extract_memories_legacy(
+    uid: str, conversation: Conversation, *, parity_capture: SurfaceParityCapture | None = None
+) -> ConversationMemoryExtractionResult:
     source = source_for_conversation(conversation)
     language = users_db.get_user_language_preference(uid)
     new_memories: List[Memory] = []
@@ -1150,6 +1220,11 @@ def _extract_memories_legacy(uid: str, conversation: Conversation) -> Conversati
 
     logger.info(f"Saving {len(parsed_memories)} memories for conversation {conversation.id}")
     memories_db.save_memories(uid, [memory_write_payload(fact, MemoryApiExposure.LEGACY) for fact in parsed_memories])
+    if parity_capture is not None:
+        parity_capture.observe(
+            "inbound",
+            {"type": "accepted_memories", "memories": _parity_accepted_memories(parsed_memories)},
+        )
 
     for memory_db_obj in parsed_memories:
         upsert_memory_vector(

--- a/backend/utils/retrieval/tools/preference_tools.py
+++ b/backend/utils/retrieval/tools/preference_tools.py
@@ -17,6 +17,7 @@ import logging
 from models.memories import MemoryDB
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
+from testing.parity_pack_v0.live_capture import capture_memory_write
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +117,12 @@ def save_user_preference_tool(preference: str, config: RunnableConfig = None) ->
             )
         else:
             memory_db.create_memory(uid, memory_data)
+        capture_memory_write(
+            principal_id=uid,
+            source="agent_preference_memory_create",
+            session_id=memory_id,
+            memories=[memory_data],
+        )
         logger.info(f"Saved user preference: {preference[:80]}")
         return f"Preference saved: {preference}"
     except Exception as e:

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -38,6 +38,7 @@ from utils.llm.memories import extract_memories_from_text
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_write_payload
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
+from testing.parity_pack_v0.live_capture import capture_memory_write
 from utils.executors import db_executor, run_blocking
 from utils.log_sanitizer import sanitize
 from utils import social
@@ -390,6 +391,12 @@ def _extract_and_index(uid: str, posts: List[Dict]) -> int:
                         for m in memory_dbs
                     ],
                 )
+            capture_memory_write(
+                principal_id=uid,
+                source="twitter_x_connector",
+                session_id=source_id,
+                memories=memory_dbs,
+            )
             total += len(memory_dbs)
 
         # Do not acknowledge this raw source until every write above succeeds.


### PR DESCRIPTION
## Summary

- Add bounded, redacted, dev-only parity cassettes for PTT, screen activity, conversation finalization, memory APIs, imports, integrations, MCP, and developer tooling.
- Export allowlisted dev captures through the existing GCS reconciliation path; production configuration remains unchanged.
- Cover the shared adapter and affected capture boundaries with backend unit tests.

## Product invariants affected

- INV-MEM-1

## Validation

- `backend/.venv/bin/pytest -q tests/unit/test_surface_parity_capture.py tests/unit/test_parity_pack_v0.py tests/unit/test_listen_parity_capture.py tests/unit/test_desktop_screen_crisp.py tests/unit/test_memories_create.py tests/unit/test_memories_batch.py tests/unit/test_backend_runtime_env_validator.py tests/unit/test_render_backend_runtime_env.py tests/unit/test_desktop_transcribe.py tests/unit/test_developer_memory_adapter.py tests/unit/test_mcp_memory_adapter.py tests/unit/test_ws_i_write_convergence.py tests/unit/test_per_file_import_guard.py`
- `backend/.venv/bin/pytest -q tests/unit/test_upstream_boundary.py`
- `backend/.venv/bin/pytest -q tests/unit/test_memory_replace_policy.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

