### PR TITLE
fix(sync): replace previews from canonical capture

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,7 +4,7 @@
     "backend/routers/chat.py": 1588,
     "backend/routers/developer.py": 2263,
     "backend/routers/mcp_sse.py": 1865,
-    "backend/routers/sync.py": 2058,
+    "backend/routers/sync.py": 2087,
     "backend/routers/users.py": 2076
   },
   "raise_justifications": {
@@ -12,7 +12,7 @@
     "backend/routers/chat.py": "Merging the Windows-port chat surface with main combined the stream-error fallback (answered guard) with mains journey/attempt observability in the same SSE generators; +11 lines of combined guard flow, no new route.",
     "backend/routers/developer.py": "GET /v1/dev/user/memories and /vector/search both serve the authoritative legacy memories collection for legacy-cohort accounts with no rollout state (#9892/#10203), keeping the narrow deny/legacy-fallback decision in the route that owns the read contract.",
     "backend/routers/mcp_sse.py": "MCP SSE memory reads route their legacy-fallback decision through the shared mcp_legacy_read_authorized helper (#9892); one import line. +7 so a refused memory read reports its reason instead of an empty success (#10735): the classification and wire shape live in utils/mcp_memories.mcp_denied_read_payload, leaving only the raise at the two tool branches that own the response contract.",
-    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
+    "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033). +29 keeps the signed canonical-replacement admission and immutable Cloud Tasks mutation mode at the route boundary that owns request authorization.",
     "backend/routers/users.py": "GET /v1/users/subscription serializes the new mobile plus/max plans as `unlimited` for clients whose plan enum predates them, so day-one buyers read as paid instead of Free (mirrors the existing operator remap); real limits/grandfather are computed from the true plan first. +30 for the disclosed, expiring city-context consent routes and legacy geolocation input boundary; they remain with the authenticated user route owner to prevent invalid coordinates reaching cache/provider paths (SCA-174)."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -8,7 +8,7 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2491
+    "backend/utils/sync/pipeline.py": 2611
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
@@ -16,7 +16,7 @@
     "backend/utils/memory/canonical_consolidation.py": "Candidate selection, bounded retry leases, atomic promotion planning, and batch-level duplicate-supersede rejection remain one canonical long-term admission authority; extracting them would permit competing admission state machines (FC-split-mutation-authority).",
     "backend/utils/memory/canonical_memory_adapter.py": "Canonical conversation replacement coordinates source-generation fencing, bounded lineage discovery, and atomic replacement application; splitting this state machine would duplicate lifecycle authority (FC-split-mutation-authority).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator."
+    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. +120 keeps canonical transcript accumulation and its all-or-nothing commit inside the existing lease-, ledger-, and retry-fenced worker coordinator; extracting the state transition would split mutation authority (FC-split-mutation-authority)."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -8,7 +8,7 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1584,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2611
+    "backend/utils/sync/pipeline.py": 2619
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",
@@ -16,7 +16,7 @@
     "backend/utils/memory/canonical_consolidation.py": "Candidate selection, bounded retry leases, atomic promotion planning, and batch-level duplicate-supersede rejection remain one canonical long-term admission authority; extracting them would permit competing admission state machines (FC-split-mutation-authority).",
     "backend/utils/memory/canonical_memory_adapter.py": "Canonical conversation replacement coordinates source-generation fencing, bounded lineage discovery, and atomic replacement application; splitting this state machine would duplicate lifecycle authority (FC-split-mutation-authority).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873).",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. +120 keeps canonical transcript accumulation and its all-or-nothing commit inside the existing lease-, ledger-, and retry-fenced worker coordinator; extracting the state transition would split mutation authority (FC-split-mutation-authority)."
+    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator. +120 keeps canonical transcript accumulation and its all-or-nothing commit inside the existing lease-, ledger-, and retry-fenced worker coordinator; extracting the state transition would split mutation authority (FC-split-mutation-authority). +8 keeps explicit-target fence propagation inside that same coordinator so sibling isolation cannot swallow the target's terminal outcome."
   },
   "threshold": 1500
 }

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -6,7 +6,7 @@ import threading
 import time
 import uuid as _uuid
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Annotated, Dict, List, Optional
 
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, Query, Request, Response, Header
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -139,6 +139,7 @@ from utils.sync.capture_manifest import (
     verify_capture_manifest,
 )
 from utils.sync.lanes import SyncLane, capture_times_within_window, classify_sync_lane
+from utils.sync.transcript_mode import SyncTranscriptMode
 
 logger = logging.getLogger(__name__)
 
@@ -864,6 +865,10 @@ async def sync_local_files_v2(
     conversation_id: str = Query(
         None, description="Target conversation ID to attach audio to (auto-sync from live capture)"
     ),
+    transcript_mode: Annotated[
+        SyncTranscriptMode,
+        Query(description='Merge recovery fragments or replace a realtime preview with one verified canonical capture'),
+    ] = SyncTranscriptMode.MERGE,
     x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
     x_device_id_hash: Optional[str] = Header(None, alias='X-Device-Id-Hash'),
     x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
@@ -915,6 +920,16 @@ async def sync_local_files_v2(
         filenames,
         client_device_context.client_device_id,
     )
+    if transcript_mode is SyncTranscriptMode.REPLACE and (
+        not conversation_id or not has_server_capture_proof or len(files) != 1
+    ):
+        return JSONResponse(
+            status_code=422,
+            content={
+                'code': 'canonical_replacement_unverified',
+                'detail': 'Canonical replacement requires one server-bound, verified capture file',
+            },
+        )
     lane_decision = classify_sync_lane(
         filenames,
         client_device_id=client_device_context.client_device_id if has_server_capture_proof else None,
@@ -1043,7 +1058,17 @@ async def sync_local_files_v2(
                 },
             )
 
-        content_id = await run_blocking(sync_executor, compute_sync_content_id, uid, paths)
+        content_id = await run_blocking(
+            sync_executor,
+            compute_sync_content_id,
+            uid,
+            paths,
+            operation=(
+                f'{SyncTranscriptMode.REPLACE.value}:{conversation_id}'
+                if transcript_mode is SyncTranscriptMode.REPLACE
+                else None
+            ),
+        )
 
         # Create Redis job — total_segments=0 until VAD completes in background
         await run_blocking(
@@ -1189,6 +1214,7 @@ async def sync_local_files_v2(
                 'source': source.value,
                 'should_lock': should_lock,
                 'conversation_id': conversation_id,
+                'transcript_mode': transcript_mode.value,
                 'client_device_id': client_device_context.client_device_id,
                 'client_platform': client_device_context.platform,
                 'enqueued_at': time.time(),
@@ -1348,6 +1374,7 @@ async def sync_local_files_v2(
                             inline_run_lock_token=inline_run_lock_token,
                             content_run_bound=ledger_fence_active,
                             ledger_fence_active=ledger_fence_active,
+                            transcript_mode=transcript_mode,
                         ),
                         name=f'sync_pipeline:{job_id}',
                     )
@@ -1548,6 +1575,7 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
         source = ConversationSource(payload.get('source') or 'omi')
         should_lock = bool(payload.get('should_lock', False))
         conversation_id = payload.get('conversation_id')
+        transcript_mode = SyncTranscriptMode.from_task_payload(payload.get('transcript_mode'))
         client_device_id = payload.get('client_device_id')
         client_platform = payload.get('client_platform')
         sync_lane = payload.get('lane') if payload.get('lane') in ('fresh', 'backfill') else SyncLane.FRESH.value
@@ -1677,6 +1705,7 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
                 run_lock_token=lock_token if ledger_fence_active else None,
                 content_run_bound=ledger_fence_active,
                 ledger_fence_active=ledger_fence_active,
+                transcript_mode=transcript_mode,
             )
         except SyncConversationPersistenceFenced:
             latest_job = await run_blocking(db_executor, get_sync_job, job_id) or job

--- a/backend/testing/e2e/test_core_flow_expansion.py
+++ b/backend/testing/e2e/test_core_flow_expansion.py
@@ -221,7 +221,11 @@ def test_sync_v2_job_runs_pipeline_and_polls_completed_result(client, auth_heade
     monkeypatch.setattr(sync_pipeline, "retrieve_vad_segments", fake_retrieve_vad_segments)
     monkeypatch.setattr(sync_pipeline, "get_wav_duration", lambda path: 2.0)
     monkeypatch.setattr(sync_pipeline, "process_segment", fake_process_segment)
-    monkeypatch.setattr(sync_pipeline, "_reprocess_merged_conversations", lambda uid, response, on_fenced=None: None)
+    monkeypatch.setattr(
+        sync_pipeline,
+        "_reprocess_merged_conversations",
+        lambda uid, response, on_fenced=None, terminal_target_conversation_id=None: None,
+    )
     monkeypatch.setattr(sync_pipeline, "build_person_embeddings_cache", lambda uid: {})
     monkeypatch.setattr(sync_router, "get_hard_restriction_status", lambda uid: (False, None))
     monkeypatch.setattr(sync_router, "has_transcription_credits", lambda uid: True)

--- a/backend/testing/e2e/test_sync_lifecycle.py
+++ b/backend/testing/e2e/test_sync_lifecycle.py
@@ -4,6 +4,7 @@ from testing.e2e.sync_helpers import patch_fresh_sync_lane
 
 import time
 import asyncio
+import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -270,3 +271,97 @@ def test_sync_v2_merges_into_target_conversation_and_reprocesses_once(client, au
         "Existing live transcript.",
         "Merged sync transcript appended to the target conversation.",
     ]
+
+
+def test_sync_v2_verified_canonical_capture_atomically_replaces_live_preview(client, auth_headers, monkeypatch):
+    patch_fresh_sync_lane(monkeypatch)
+
+    target_id = "sync-canonical-target"
+    timestamp = int(time.time()) - 120
+    filename = f"audio_{timestamp}.bin"
+    audio = b"canonical-pcm-frame"
+    device_headers = {
+        **auth_headers,
+        "X-App-Platform": "ios",
+        "X-Device-Id-Hash": "a1b2c3d4",
+    }
+    seed_conversation(
+        "123",
+        {
+            "id": target_id,
+            "created_at": datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat(),
+            "started_at": datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat(),
+            "finished_at": datetime.fromtimestamp(timestamp + 30, tz=timezone.utc).isoformat(),
+            "source": "omi",
+            "language": "en",
+            "structured": {
+                "title": "Live Preview",
+                "overview": "",
+                "emoji": "🧠",
+                "category": "other",
+                "action_items": [],
+                "events": [],
+            },
+            "transcript_segments": [
+                {
+                    "id": "seg-preview",
+                    "text": "Duplicated live preview text.",
+                    "speaker": "SPEAKER_00",
+                    "is_user": True,
+                    "start": 0.0,
+                    "end": 30.0,
+                }
+            ],
+            "discarded": False,
+            "status": "completed",
+            "is_locked": False,
+            "client_device_id": "ios_a1b2c3d4",
+            "client_platform": "ios",
+            "data_protection_level": "standard",
+        },
+    )
+    reprocessed = []
+    pending_coroutines = _patch_sync_pipeline(
+        monkeypatch,
+        transcript_text="Canonical mobile transcript replaces the preview.",
+        reprocessed=reprocessed,
+    )
+
+    manifest_response = client.post(
+        "/v2/sync-capture-manifest",
+        json={
+            "conversation_id": target_id,
+            "files": [{"name": filename, "sha256": hashlib.sha256(audio).hexdigest()}],
+        },
+        headers=device_headers,
+    )
+    assert manifest_response.status_code == 200, manifest_response.text
+
+    response = client.post(
+        f"/v2/sync-local-files?conversation_id={target_id}&transcript_mode=replace",
+        files=[("files", (filename, audio, "application/octet-stream"))],
+        headers={
+            **device_headers,
+            "X-Omi-Sync-Capture-Manifest": manifest_response.json()["manifest"],
+        },
+    )
+    assert response.status_code == 202, response.text
+
+    _drain_background_coroutines(pending_coroutines)
+    job = _poll_sync_job(client, auth_headers, response.json()["job_id"])
+    assert job["status"] == "completed", job
+    assert job["result"]["new_memories"] == []
+    assert job["result"]["updated_memories"] == [target_id]
+    assert reprocessed == [target_id]
+
+    persisted = client.get(f"/v1/conversations/{target_id}", headers=auth_headers)
+    assert persisted.status_code == 200, persisted.text
+    body = persisted.json()
+    assert [segment["text"] for segment in body["transcript_segments"]] == [
+        "Canonical mobile transcript replaces the preview."
+    ]
+    assert body["structured"]["title"] == "Hermetic Sync Conversation Reprocessed"
+    started_at = datetime.fromisoformat(body["started_at"])
+    finished_at = datetime.fromisoformat(body["finished_at"])
+    assert started_at == datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    assert (finished_at - started_at).total_seconds() == 1.25

--- a/backend/testing/sync_cloud_tasks_stack/cloud_tasks.py
+++ b/backend/testing/sync_cloud_tasks_stack/cloud_tasks.py
@@ -85,6 +85,7 @@ class CloudTasksRecorder:
             'source',
             'should_lock',
             'conversation_id',
+            'transcript_mode',
             'client_device_id',
             'client_platform',
             'enqueued_at',

--- a/backend/testing/sync_cloud_tasks_stack/run.py
+++ b/backend/testing/sync_cloud_tasks_stack/run.py
@@ -496,6 +496,7 @@ def _assert_task_contract(stack: Stack, job_id: str, uid: str, conversation_id: 
         body.get('job_id') != job_id
         or body.get('uid') != uid
         or body.get('conversation_id') != conversation_id
+        or body.get('transcript_mode') != 'merge'
         or body.get('client_device_id') != DEVICE_ID
         or body.get('client_platform') != 'ios'
         or body.get('lane') != 'fresh'

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -2330,6 +2330,102 @@ async def test_sync_dispatch_carries_device_provenance_into_cloud_task(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_canonical_replacement_rejects_unverified_capture_before_staging():
+    from starlette.datastructures import UploadFile
+
+    module, saved_modules, mock_sync_jobs, BytesIO, _, _ = _load_sync_router_for_fast_path()
+    module.verify_capture_manifest.return_value = None
+
+    try:
+        upload = UploadFile(filename='canonical.opus', file=BytesIO(b'\x00' * 10))
+        response = await module.sync_local_files_v2(
+            files=[upload],
+            uid='test-uid',
+            conversation_id='conversation-1',
+            transcript_mode=module.SyncTranscriptMode.REPLACE,
+        )
+
+        assert response.status_code == 422
+        assert json.loads(response.body)['code'] == 'canonical_replacement_unverified'
+        module._retrieve_file_paths_v2.assert_not_called()
+        mock_sync_jobs.create_sync_job.assert_not_called()
+        module.enqueue_sync_job.assert_not_called()
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
+async def test_verified_canonical_replacement_reaches_one_cloud_task_as_replace():
+    from starlette.datastructures import UploadFile
+
+    module, saved_modules, _, BytesIO, _, _ = _load_sync_router_for_fast_path()
+    module.start_background_task = MagicMock()
+
+    try:
+        upload = UploadFile(filename='canonical.opus', file=BytesIO(b'\x00' * 10))
+        response = await module.sync_local_files_v2(
+            files=[upload],
+            uid='test-uid',
+            conversation_id='conversation-1',
+            transcript_mode=module.SyncTranscriptMode.REPLACE,
+            x_omi_sync_capture_manifest='signed-proof',
+        )
+
+        assert response.status_code == 202
+        module.compute_sync_content_id.assert_called_once()
+        assert module.compute_sync_content_id.call_args.kwargs['operation'] == 'replace:conversation-1'
+        payload = module.enqueue_sync_job.call_args.args[0]
+        assert payload['conversation_id'] == 'conversation-1'
+        assert payload['transcript_mode'] == 'replace'
+        assert payload['raw_blob_paths'] == ['syncing/test-uid/job-1/file.bin']
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
+async def test_cloud_task_rejects_unknown_transcript_mode_without_running_pipeline():
+    module, saved_modules, _, _, _, _ = _load_sync_router_for_fast_path()
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            'job_id': 'job-1',
+            'uid': 'test-uid',
+            'raw_blob_paths': ['staged/audio.opus'],
+            'source': 'omi',
+            'transcript_mode': 'append-sometimes',
+        }
+    )
+    module._run_full_pipeline_background_async = AsyncMock()
+
+    try:
+        response = await module.run_sync_job(request, task_retry_count=0)
+
+        assert response.status_code == 200
+        assert json.loads(response.body) == {'status': 'dropped', 'reason': 'invalid_payload'}
+        module._run_full_pipeline_background_async.assert_not_awaited()
+    finally:
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('utils.sync.pipeline', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
 async def test_sync_dispatch_enqueue_uncertain_keeps_durable_work_and_never_starts_inline(monkeypatch):
     from starlette.datastructures import UploadFile
 

--- a/backend/tests/unit/test_sync_silent_failure.py
+++ b/backend/tests/unit/test_sync_silent_failure.py
@@ -983,6 +983,193 @@ class TestProcessSegmentReal:
         assert len(errors) == 0
         assert 'conv-existing' in response['updated_memories']
 
+    def test_targeted_gap_repair_reprocesses_once_after_the_batch(self):
+        """A target conversation is summarized only after all job segments land."""
+        from datetime import datetime, timezone
+        from unittest.mock import MagicMock, patch
+
+        from models.conversation_enums import ConversationSource
+        from utils.sync.pipeline import _reprocess_merged_conversations
+
+        process_segment = self._import_process_segment()
+        response = {'updated_memories': set(), 'new_memories': set()}
+        errors = []
+        lock = threading.Lock()
+
+        segment = MagicMock()
+        segment.end = 1.0
+        segment.model_dump.return_value = {
+            'start': 0.0,
+            'end': 1.0,
+            'text': 'recovered words',
+            'speaker': 'SPEAKER_00',
+        }
+        existing = {
+            'id': 'live-conversation',
+            'started_at': datetime.fromtimestamp(1700000000, tz=timezone.utc),
+            'finished_at': datetime.fromtimestamp(1700000001, tz=timezone.utc),
+            'transcript_segments': [],
+            'discarded': False,
+        }
+
+        with patch('utils.sync.pipeline.prerecorded', return_value=([{'text': 'recovered words'}], 'en')), patch(
+            'utils.sync.pipeline.postprocess_words', return_value=[segment]
+        ), patch('utils.sync.pipeline.get_timestamp_from_path', return_value=1700000001.0), patch(
+            'utils.sync.pipeline.conversations_db.get_conversation', return_value=existing
+        ), patch(
+            'utils.sync.pipeline.conversations_db.eligible_merge_target', return_value=True, create=True
+        ), patch(
+            'utils.sync.pipeline.update_conversation_segments'
+        ), patch(
+            'utils.sync.pipeline._reprocess_conversation_after_update'
+        ) as reprocess, patch(
+            'utils.sync.pipeline.get_syncing_file_temporal_signed_url', return_value='https://fake'
+        ):
+            result = process_segment(
+                '/tmp/1700000001.wav',
+                'uid',
+                response,
+                lock,
+                errors,
+                ConversationSource.omi,
+                False,
+                target_conversation_id='live-conversation',
+            )
+
+            assert result is True
+            reprocess.assert_not_called()
+            assert response['_merged'] == {'live-conversation': 'en'}
+
+            _reprocess_merged_conversations('uid', response)
+            reprocess.assert_called_once_with('uid', 'live-conversation', 'en')
+
+        assert '_merged' not in response
+        assert errors == []
+
+    def test_canonical_repair_replaces_preview_once_after_every_segment_lands(self):
+        """Canonical capture is atomic: no partial segment mutates the live preview."""
+        from datetime import datetime, timezone
+        from unittest.mock import MagicMock, patch
+
+        from models.conversation_enums import ConversationSource
+        from utils.sync.pipeline import _commit_canonical_conversation_transcript
+        from utils.sync.transcript_mode import SyncTranscriptMode
+
+        process_segment = self._import_process_segment()
+        response = {'updated_memories': set(), 'new_memories': set()}
+        errors = []
+        lock = threading.Lock()
+
+        segment = MagicMock()
+        segment.end = 1.0
+        segment.model_dump.return_value = {
+            'start': 0.0,
+            'end': 1.0,
+            'text': 'canonical words',
+            'speaker': 'SPEAKER_00',
+        }
+        existing = {
+            'id': 'live-conversation',
+            'started_at': datetime.fromtimestamp(1700000000, tz=timezone.utc),
+            'finished_at': datetime.fromtimestamp(1700000010, tz=timezone.utc),
+            'transcript_segments': [{'start': 0.0, 'end': 1.0, 'text': 'preview'}],
+            'discarded': False,
+        }
+
+        with patch('utils.sync.pipeline.prerecorded', return_value=([{'text': 'canonical words'}], 'en')), patch(
+            'utils.sync.pipeline.postprocess_words', return_value=[segment]
+        ), patch('utils.sync.pipeline.get_timestamp_from_path', return_value=1700000005.0), patch(
+            'utils.sync.pipeline.update_conversation_segments'
+        ) as update, patch(
+            'utils.sync.pipeline._reprocess_conversation_after_update'
+        ) as reprocess, patch(
+            'utils.sync.pipeline.get_syncing_file_temporal_signed_url', return_value='https://fake'
+        ):
+            result = process_segment(
+                '/tmp/1700000005.wav',
+                'uid',
+                response,
+                lock,
+                errors,
+                ConversationSource.omi,
+                False,
+                target_conversation_id='live-conversation',
+                transcript_mode=SyncTranscriptMode.REPLACE,
+            )
+
+            assert result is True
+            update.assert_not_called()
+            reprocess.assert_not_called()
+
+            with patch('utils.sync.pipeline.conversations_db.get_conversation', return_value=existing), patch(
+                'utils.sync.pipeline.conversations_db.eligible_merge_target', return_value=True, create=True
+            ):
+                update.return_value = True
+                _commit_canonical_conversation_transcript(
+                    'uid',
+                    response,
+                    'live-conversation',
+                    1700000000.0,
+                    [],
+                )
+
+            update.assert_called_once()
+            args, kwargs = update.call_args
+            assert args[:2] == ('uid', 'live-conversation')
+            assert args[2] == [
+                {
+                    'start': 5.0,
+                    'end': 6.0,
+                    'text': 'canonical words',
+                    'speaker': 'SPEAKER_00',
+                }
+            ]
+            assert kwargs['started_at'] == datetime.fromtimestamp(1700000000, tz=timezone.utc)
+            assert kwargs['finished_at'] == datetime.fromtimestamp(1700000006, tz=timezone.utc)
+            reprocess.assert_called_once_with('uid', 'live-conversation', 'en')
+
+        assert response['updated_memories'] == {'live-conversation'}
+        assert '_replacement_segments' not in response
+        assert errors == []
+
+    def test_canonical_repair_failure_keeps_preview_and_accumulated_segments_for_retry(self):
+        """One failed STT segment prevents the canonical mutation and reprocess."""
+        from unittest.mock import patch
+
+        from utils.sync.pipeline import _commit_canonical_conversation_transcript
+
+        response = {
+            'updated_memories': set(),
+            'new_memories': set(),
+            '_replacement_segments': {
+                'live-conversation': [
+                    {
+                        'timestamp': 1700000005.0,
+                        'start': 0.0,
+                        'end': 1.0,
+                        'text': 'partial canonical words',
+                    }
+                ]
+            },
+        }
+
+        with patch('utils.sync.pipeline.update_conversation_segments') as update, patch(
+            'utils.sync.pipeline._reprocess_conversation_after_update'
+        ) as reprocess:
+            with pytest.raises(RuntimeError, match='one or more recovered segments failed'):
+                _commit_canonical_conversation_transcript(
+                    'uid',
+                    response,
+                    'live-conversation',
+                    1700000000.0,
+                    ['stt_timeout'],
+                )
+
+        update.assert_not_called()
+        reprocess.assert_not_called()
+        assert response['updated_memories'] == set()
+        assert response['_replacement_segments']['live-conversation'][0]['text'] == 'partial canonical words'
+
     def test_speech_eligible_empty_segments_complete_as_silence(self):
         """VAD-positive segments that all transcribe empty complete, not fail.
 

--- a/backend/tests/unit/test_sync_two_lane.py
+++ b/backend/tests/unit/test_sync_two_lane.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import hashlib
+import hmac
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -84,6 +85,41 @@ def test_content_identity_distinguishes_identical_audio_at_different_capture_tim
     assert content_id.compute_sync_content_id('uid', [str(first)]) != content_id.compute_sync_content_id(
         'uid', [str(second)]
     )
+
+
+def test_content_identity_separates_merge_from_canonical_replacement(tmp_path, monkeypatch):
+    monkeypatch.setenv('SYNC_CONTENT_ID_SECRET', 'test-secret')
+    recording = tmp_path / 'audio_cv1_opus_16000_1_fs160_1700000000.bin'
+    recording.write_bytes(b'audio')
+
+    merged = content_id.compute_sync_content_id('uid', [str(recording)])
+    replaced = content_id.compute_sync_content_id(
+        'uid',
+        [str(recording)],
+        operation='replace:conversation-1',
+    )
+    other_target = content_id.compute_sync_content_id(
+        'uid',
+        [str(recording)],
+        operation='replace:conversation-2',
+    )
+
+    assert len({merged, replaced, other_target}) == 3
+
+
+def test_default_merge_identity_remains_rolling_revision_compatible(tmp_path, monkeypatch):
+    monkeypatch.setenv('SYNC_CONTENT_ID_SECRET', 'test-secret')
+    recording = tmp_path / '100.opus'
+    recording.write_bytes(b'audio')
+    file_digest = hashlib.sha256(b'audio').hexdigest()
+    canonical = f'{recording.name}:{file_digest}'
+    deployed_identity = hmac.new(
+        b'test-secret',
+        f'uid\n{canonical}'.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    assert content_id.compute_sync_content_id('uid', [str(recording)]) == deployed_identity
 
 
 def test_cloud_run_clone_preserves_live_contract_and_overlays_lane_settings():

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1600,6 +1600,41 @@ class TestAsyncCoordinatorBehavioral:
             'uid', 'current-conversation', {'audio_files': [{'path': 'current.opus'}]}
         )
 
+    def test_targeted_reprocess_fence_supersedes_the_whole_job(self, fenced_worker_module):
+        """A stale explicit target is terminal, not a successful empty gap repair."""
+        _module, stubs = fenced_worker_module
+        pipeline = stubs['pipeline']
+
+        class ConversationPersistenceFenced(RuntimeError):
+            pass
+
+        pipeline.SyncConversationPersistenceFenced = ConversationPersistenceFenced
+        pipeline.logger = MagicMock()
+        pipeline._reprocess_conversation_after_update = MagicMock(
+            side_effect=ConversationPersistenceFenced('conversation replaced')
+        )
+        response = {
+            '_merged': {'target-conversation': 'en'},
+            'updated_memories': {'target-conversation'},
+            'new_memories': set(),
+        }
+        checkpointed_fences = []
+
+        with pytest.raises(ConversationPersistenceFenced):
+            pipeline._reprocess_merged_conversations(
+                'uid',
+                response,
+                on_fenced=lambda: checkpointed_fences.append(set(response['_fenced_conversation_ids'])),
+                terminal_target_conversation_id='target-conversation',
+            )
+
+        assert response == {
+            '_fenced_conversation_ids': {'target-conversation'},
+            'updated_memories': set(),
+            'new_memories': set(),
+        }
+        assert checkpointed_fences == [{'target-conversation'}]
+
     @pytest.mark.asyncio
     async def test_durable_completion_offloads_epoch_and_terminal_metric(self, fenced_worker_module):
         """Redis-backed fencing and telemetry never run on the async coordinator loop."""
@@ -2729,7 +2764,7 @@ class TestAsyncCoordinatorBehavioral:
 
             pipeline._update_sync_job_for_run = MagicMock(side_effect=_record_job_partial)
 
-            def _fence_in_sync_worker(_uid, response, on_fenced):
+            def _fence_in_sync_worker(_uid, response, on_fenced, **_kwargs):
                 response['_fenced_conversation_ids'].add('fenced-conversation')
                 on_fenced()
 
@@ -2793,7 +2828,7 @@ class TestAsyncCoordinatorBehavioral:
             pipeline.process_segment = MagicMock(return_value=False)
             pipeline.checkpoint_sync_content_partial_result = MagicMock(return_value=False)
 
-            def _fence_in_sync_worker(_uid, response, on_fenced):
+            def _fence_in_sync_worker(_uid, response, on_fenced, **_kwargs):
                 response['_fenced_conversation_ids'].add('fenced-conversation')
                 on_fenced()
 

--- a/backend/utils/sync/content_id.py
+++ b/backend/utils/sync/content_id.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable
 
 
-def compute_sync_content_id(uid: str, paths: Iterable[str]) -> str:
+def compute_sync_content_id(uid: str, paths: Iterable[str], *, operation: str | None = None) -> str:
     secret = os.getenv('SYNC_CONTENT_ID_SECRET') or os.getenv('ENCRYPTION_SECRET')
     if not secret:
         raise RuntimeError('SYNC_CONTENT_ID_SECRET or ENCRYPTION_SECRET is required for durable sync idempotency')
@@ -25,7 +25,11 @@ def compute_sync_content_id(uid: str, paths: Iterable[str]) -> str:
         file_digests.append(f'{Path(path).name}:{digest.hexdigest()}')
 
     canonical = '\n'.join(sorted(file_digests))
-    return hmac.new(secret.encode(), f'{uid}\n{canonical}'.encode(), hashlib.sha256).hexdigest()
+    # Preserve the deployed merge identity across rolling revisions. New
+    # mutation contracts add a domain tag so the same bytes cannot converge
+    # onto a ledger result produced under different write semantics.
+    identity = f'{uid}\n{canonical}' if operation is None else f'{uid}\n{operation}\n{canonical}'
+    return hmac.new(secret.encode(), identity.encode(), hashlib.sha256).hexdigest()
 
 
 def compute_sync_segment_id(uid: str, path: str) -> str:

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -117,6 +117,7 @@ from utils.sync.files import decode_files_to_wav, get_timestamp_from_path, get_w
 from utils.sync.backfill import release_backfill_slot, reserve_backfill_speech
 from utils.sync.content_id import compute_sync_segment_id
 from utils.sync.lanes import SyncLane
+from utils.sync.transcript_mode import SyncTranscriptMode
 from utils.metrics import OMI_SYNC_BACKFILL_DAILY_USED_MS, OMI_SYNC_LANE_SPEECH_MS_TOTAL
 
 logger = logging.getLogger(__name__)
@@ -1042,6 +1043,7 @@ def process_segment(
     client_platform: Optional[str] = None,
     sync_lane: str = SyncLane.FRESH.value,
     deferred_outcome: dict | None = None,
+    transcript_mode: SyncTranscriptMode = SyncTranscriptMode.MERGE,
 ):
     provider = 'unknown'
     model = 'unknown'
@@ -1128,6 +1130,44 @@ def process_segment(
 
         timestamp = get_timestamp_from_path(path)
         segment_end_timestamp = timestamp + transcript_segments[-1].end
+
+        if transcript_mode is SyncTranscriptMode.REPLACE:
+            if not target_conversation_id:
+                raise ValueError('Canonical transcript replacement requires a target conversation')
+            replacement_segments = []
+            for segment in transcript_segments:
+                replacement = segment.model_dump()
+                replacement['timestamp'] = timestamp + replacement['start']
+                replacement_segments.append(replacement)
+            with lock:
+                response.setdefault('_replacement_segments', {}).setdefault(target_conversation_id, []).extend(
+                    replacement_segments
+                )
+                response.setdefault('_replacement_languages', {})[target_conversation_id] = language
+            if private_cloud_sync_enabled:
+                _store_sync_audio_chunk(
+                    uid,
+                    target_conversation_id,
+                    timestamp,
+                    audio_bytes,
+                    data_protection_level,
+                )
+            _set_deferred_segment_outcome(
+                deferred_outcome,
+                outcome=TranscriptionOutcome.SUCCESS,
+                provider=provider,
+                model=model,
+                retryable=False,
+            )
+            if deferred_outcome is None:
+                _record_sync_segment_outcome(
+                    TranscriptionOutcome.SUCCESS,
+                    provider=provider,
+                    model=model,
+                    lane=sync_lane,
+                    retryable=False,
+                )
+            return True
 
         # When a target conversation is specified (auto-sync from live capture),
         # attach segments to it directly instead of searching by timestamp.
@@ -1246,17 +1286,12 @@ def process_segment(
             if is_locked:
                 conversations_db.update_conversation(uid, closest_memory['id'], {'is_locked': True})
 
-            # Reprocess if conversation was discarded or if auto-synced WALs added new segments
-            if closest_memory.get('discarded', False) or target_conversation_id:
-                reason = 'discarded' if closest_memory.get('discarded', False) else 'auto-sync'
-                logger.info(f'Conversation {closest_memory["id"]} reprocessing ({reason}) after segment merge')
-                _reprocess_conversation_after_update(uid, closest_memory['id'], language)
-            else:
-                # Summary/structured data is now stale (it predates the merged segments).
-                # Record it so the caller reprocesses once per conversation at batch end,
-                # instead of once per merged segment.
-                with lock:
-                    response.setdefault('_merged', {})[closest_memory['id']] = language
+            # Summary/structured data is stale until the complete batch lands.
+            # The map deduplicates every fragment targeting this conversation,
+            # preventing one LLM reprocess and partially rebuilt summary per
+            # recovered audio segment.
+            with lock:
+                response.setdefault('_merged', {})[closest_memory['id']] = language
         _set_deferred_segment_outcome(
             deferred_outcome,
             outcome=TranscriptionOutcome.SUCCESS,
@@ -1319,6 +1354,73 @@ def _reprocess_merged_conversations(uid: str, response: dict, on_fenced: Optiona
             logger.info('event=sync_conversation_reprocess outcome=fenced conversation_id=%s', conversation_id)
         except Exception as e:
             logger.error(f'sync: failed to reprocess merged conversation {conversation_id}: {e}')
+
+
+def _commit_canonical_conversation_transcript(
+    uid: str,
+    response: dict,
+    conversation_id: Optional[str],
+    capture_start: Optional[float],
+    segment_errors: list,
+):
+    """Replace a realtime preview only after its entire canonical capture succeeds."""
+    if segment_errors:
+        raise RuntimeError('Canonical transcript retained because one or more recovered segments failed')
+    if not conversation_id or capture_start is None:
+        raise ValueError('Canonical transcript replacement is missing its target or capture timestamp')
+
+    absolute_segments = response.get('_replacement_segments', {}).get(conversation_id, [])
+    if not absolute_segments:
+        # VAD/STT can authoritatively find no speech. Retaining the preview is
+        # safer than deleting user-visible text on an empty provider result.
+        return
+
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if not conversations_db.eligible_merge_target(conversation):
+        raise ValueError('Canonical transcript replacement target is unavailable')
+
+    absolute_segments.sort(key=lambda segment: (segment['timestamp'], segment['end'] - segment['start']))
+    deduped = []
+    seen = set()
+    for segment in absolute_segments:
+        duration = segment['end'] - segment['start']
+        key = (
+            round(segment['timestamp'], 2),
+            round(duration, 2),
+            segment.get('speaker', ''),
+            segment.get('text', ''),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        replacement = dict(segment)
+        replacement['start'] = replacement['timestamp'] - capture_start
+        replacement['end'] = replacement['start'] + duration
+        replacement.pop('timestamp', None)
+        deduped.append(replacement)
+
+    if not deduped:
+        return
+
+    started_at = datetime.fromtimestamp(capture_start, tz=timezone.utc)
+    finished_at = datetime.fromtimestamp(capture_start + max(segment['end'] for segment in deduped), tz=timezone.utc)
+    if not update_conversation_segments(
+        uid,
+        conversation_id,
+        deduped,
+        started_at=started_at,
+        finished_at=finished_at,
+    ):
+        raise ValueError('Canonical transcript replacement target disappeared before commit')
+
+    response.pop('_replacement_segments', None)
+    languages = response.pop('_replacement_languages', {})
+    response.setdefault('updated_memories', set()).add(conversation_id)
+    _reprocess_conversation_after_update(
+        uid,
+        conversation_id,
+        languages.get(conversation_id, 'en'),
+    )
 
 
 async def _checkpoint_fenced_conversations_for_run(
@@ -1631,6 +1733,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
     inline_run_lock_token: Optional[str] = None,
     content_run_bound: bool = False,
     ledger_fence_active: bool = True,
+    transcript_mode: SyncTranscriptMode = SyncTranscriptMode.MERGE,
 ):
     """Async coordinator for the full sync pipeline (decode → VAD → fair-use → STT → LLM).
 
@@ -1652,6 +1755,11 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
     sync_model = 'unknown'
     job_outcome_recorded = False
     preserve_retry_material = False
+    canonical_capture_start = (
+        min(float(get_timestamp_from_path(path)) for path in raw_paths)
+        if transcript_mode is SyncTranscriptMode.REPLACE and raw_paths
+        else None
+    )
     # Both dispatch modes own a Redis token for every worker-driven job write.
     # Inline additionally renews it because it can wait behind the local
     # semaphore; Cloud Tasks stays below the request-timeout < lease invariant.
@@ -2046,7 +2154,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
 
             # Segments that fully landed in a prior Cloud Tasks attempt are skipped
             already_processed = set()
-            if task_mode:
+            if task_mode and transcript_mode is not SyncTranscriptMode.REPLACE:
                 already_processed = await run_blocking(db_executor, get_processed_segments, job_id)
                 if already_processed:
                     logger.info(
@@ -2056,7 +2164,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
 
             durable_processed_segment_ids: set[str] = set()
             segment_ids_by_path: dict[str, str] = {}
-            if content_id:
+            if content_id and transcript_mode is not SyncTranscriptMode.REPLACE:
                 durable_processed_segment_ids = await run_blocking(
                     db_executor, get_processed_sync_segment_ids, uid, content_id
                 )
@@ -2096,6 +2204,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                     client_platform=client_platform,
                     sync_lane=sync_lane,
                     deferred_outcome=deferred_outcome,
+                    transcript_mode=transcript_mode,
                 )
                 if ok:
                     # Persist result contributions before the processed marker.
@@ -2122,9 +2231,9 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                             )
                             if not checkpointed:
                                 raise SyncJobRunLeaseLost(f'sync content ledger owner lost: job={job_id}')
-                if ok and task_mode:
+                if ok and task_mode and transcript_mode is not SyncTranscriptMode.REPLACE:
                     _add_processed_segment_for_run(job_id, active_run_lock_token, path)
-                if ok and content_id and segment_id:
+                if ok and content_id and segment_id and transcript_mode is not SyncTranscriptMode.REPLACE:
                     marked_segment = add_processed_sync_segment_id(
                         uid,
                         content_id,
@@ -2228,13 +2337,24 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                     coordinator_loop,
                 ).result()
 
-            await run_blocking(
-                sync_executor,
-                _reprocess_merged_conversations,
-                uid,
-                response,
-                on_fenced=_checkpoint_fenced_conversations,
-            )
+            if transcript_mode is SyncTranscriptMode.REPLACE:
+                await run_blocking(
+                    sync_executor,
+                    _commit_canonical_conversation_transcript,
+                    uid,
+                    response,
+                    target_conversation_id,
+                    canonical_capture_start,
+                    segment_errors,
+                )
+            else:
+                await run_blocking(
+                    sync_executor,
+                    _reprocess_merged_conversations,
+                    uid,
+                    response,
+                    on_fenced=_checkpoint_fenced_conversations,
+                )
 
             # Persist conversation audio (private-cloud chunks → audio_files) so synced
             # conversations play exactly like realtime ones. Gated on the user's setting.

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -1333,7 +1333,12 @@ def process_segment(
             turnstile.complete(path)
 
 
-def _reprocess_merged_conversations(uid: str, response: dict, on_fenced: Optional[Callable[[], None]] = None):
+def _reprocess_merged_conversations(
+    uid: str,
+    response: dict,
+    on_fenced: Optional[Callable[[], None]] = None,
+    terminal_target_conversation_id: Optional[str] = None,
+):
     """Regenerate summary/structured data for conversations that gained segments this batch.
 
     The merge path in process_segment only appends transcript segments; without this the
@@ -1352,6 +1357,8 @@ def _reprocess_merged_conversations(uid: str, response: dict, on_fenced: Optiona
             if on_fenced:
                 on_fenced()
             logger.info('event=sync_conversation_reprocess outcome=fenced conversation_id=%s', conversation_id)
+            if conversation_id == terminal_target_conversation_id:
+                raise
         except Exception as e:
             logger.error(f'sync: failed to reprocess merged conversation {conversation_id}: {e}')
 
@@ -2354,6 +2361,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                     uid,
                     response,
                     on_fenced=_checkpoint_fenced_conversations,
+                    terminal_target_conversation_id=target_conversation_id,
                 )
 
             # Persist conversation audio (private-cloud chunks → audio_files) so synced

--- a/backend/utils/sync/transcript_mode.py
+++ b/backend/utils/sync/transcript_mode.py
@@ -1,0 +1,20 @@
+"""Typed mutation contract for uploaded sync transcripts."""
+
+from enum import Enum
+
+
+class SyncTranscriptMode(str, Enum):
+    """Select how a completed sync job may mutate its target conversation."""
+
+    MERGE = 'merge'
+    REPLACE = 'replace'
+
+    @classmethod
+    def from_task_payload(cls, value: object) -> 'SyncTranscriptMode':
+        """Parse durable task input without silently changing mutation semantics."""
+        if value is None:
+            # Tasks admitted before this field existed are merge jobs.
+            return cls.MERGE
+        if not isinstance(value, str):
+            raise ValueError('transcript_mode must be a string')
+        return cls(value)

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -13863,7 +13863,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  public static func syncLocalFilesV2V2SyncLocalFilesPost(client: OmiApiClient, conversationId: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, xRequestID: String? = nil, xCloudTraceContext: String? = nil, xOmiSyncCaptureManifest: String? = nil, authorization: String? = nil) async throws -> Void {
+  public static func syncLocalFilesV2V2SyncLocalFilesPost(client: OmiApiClient, conversationId: String? = nil, transcriptMode: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, xRequestID: String? = nil, xCloudTraceContext: String? = nil, xOmiSyncCaptureManifest: String? = nil, authorization: String? = nil) async throws -> Void {
     let _path = "/v2/sync-local-files"
     guard var components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -13871,6 +13871,9 @@ public enum OmiAPI {
     var queryItems: [URLQueryItem] = []
     if let conversationId {
       queryItems.append(URLQueryItem(name: "conversation_id", value: String(conversationId)))
+    }
+    if let transcriptMode {
+      queryItems.append(URLQueryItem(name: "transcript_mode", value: String(transcriptMode)))
     }
     if !queryItems.isEmpty { components.queryItems = queryItems }
     guard let url = components.url else { throw OmiApiError.invalidURL }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -3104,6 +3104,8 @@ export interface SyncLocalFilesResultResponse {
   updated_memories?: Array<string>;
 }
 
+export type SyncTranscriptMode = "merge" | "replace";
+
 export interface Targeting {
   app_version_max?: string | null;
   app_version_min?: string | null;
@@ -4170,6 +4172,7 @@ export interface OmiApiSchemas {
   "SyncJobStartResponse": SyncJobStartResponse;
   "SyncJobStatusResponse": SyncJobStatusResponse;
   "SyncLocalFilesResultResponse": SyncLocalFilesResultResponse;
+  "SyncTranscriptMode": SyncTranscriptMode;
   "Targeting": Targeting;
   "TaskAssistantSettings": TaskAssistantSettings;
   "TaskCancelCandidate": TaskCancelCandidate;
@@ -15338,7 +15341,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string, transcript_mode?: SyncTranscriptMode }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -18686,6 +18686,15 @@
         "title": "SyncLocalFilesResultResponse",
         "type": "object"
       },
+      "SyncTranscriptMode": {
+        "description": "Select how a completed sync job may mutate its target conversation.",
+        "enum": [
+          "merge",
+          "replace"
+        ],
+        "title": "SyncTranscriptMode",
+        "type": "string"
+      },
       "Targeting": {
         "description": "Controls who sees the announcement",
         "properties": {
@@ -54511,6 +54520,17 @@
               "description": "Target conversation ID to attach audio to (auto-sync from live capture)",
               "title": "Conversation Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Merge recovery fragments or replace a realtime preview with one verified canonical capture",
+            "in": "query",
+            "name": "transcript_mode",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/SyncTranscriptMode",
+              "default": "merge",
+              "description": "Merge recovery fragments or replace a realtime preview with one verified canonical capture"
             }
           },
           {

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -6,7 +6,7 @@ description: "Sequence diagrams for the /v4/listen WebSocket and Pusher processi
 
 # Listen + Pusher Pipeline — Sequence Diagrams
 
-> Last updated: 2026-07-26 (bounded Pusher delivery, validated frames, and durable finalization ownership)
+> Last updated: 2026-07-29 (canonical mobile recovery and atomic transcript replacement)
 >
 > These diagrams document the real behavior observed during E2E testing with
 > live services (backend, pusher, STT providers, embedding API). Update when the
@@ -95,6 +95,31 @@ STT segments or photos, the late write is fenced rather than recreating the
 terminal parent; the listen handler opens one fresh generation and replays that
 buffer once. The first-segment `started_at` value commits in that same content
 transaction, so this recovery cannot leave a timestamp-only write behind.
+
+### Canonical mobile recovery
+
+Storage-authoritative mobile capture can repair a live preview through
+`POST /v2/sync-local-files?conversation_id=<id>&transcript_mode=replace`.
+Replacement is intentionally narrower than ordinary backlog sync:
+
+- the request contains exactly one app-assembled canonical recording;
+- its signed capture manifest binds the user, device, filename, and existing
+  server conversation;
+- the backend transcribes every VAD segment without publishing partial
+  transcript mutations;
+- only a fully successful batch transactionally replaces the conversation's
+  transcript, `started_at`, and `finished_at`, then runs conversation
+  processing once.
+
+If any segment fails, the live preview remains unchanged and the durable task
+retries the whole canonical recording. Unknown task mutation modes are rejected
+instead of falling back to merge. Existing queued tasks without a mode retain
+the deployed merge behavior.
+
+Ordinary gap repair and historical backlog uploads remain `merge`. When several
+recovered fragments target one conversation, their transcript writes may land
+incrementally, but summary and structured-data regeneration is deferred until
+the complete batch finishes and runs only once for that conversation.
 
 ## Capture-device provenance
 

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -3104,6 +3104,8 @@ export interface SyncLocalFilesResultResponse {
   updated_memories?: Array<string>;
 }
 
+export type SyncTranscriptMode = "merge" | "replace";
+
 export interface Targeting {
   app_version_max?: string | null;
   app_version_min?: string | null;
@@ -4170,6 +4172,7 @@ export interface OmiApiSchemas {
   "SyncJobStartResponse": SyncJobStartResponse;
   "SyncJobStatusResponse": SyncJobStatusResponse;
   "SyncLocalFilesResultResponse": SyncLocalFilesResultResponse;
+  "SyncTranscriptMode": SyncTranscriptMode;
   "Targeting": Targeting;
   "TaskAssistantSettings": TaskAssistantSettings;
   "TaskCancelCandidate": TaskCancelCandidate;
@@ -15338,7 +15341,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string, transcript_mode?: SyncTranscriptMode }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -3104,6 +3104,8 @@ export interface SyncLocalFilesResultResponse {
   updated_memories?: Array<string>;
 }
 
+export type SyncTranscriptMode = "merge" | "replace";
+
 export interface Targeting {
   app_version_max?: string | null;
   app_version_min?: string | null;
@@ -4170,6 +4172,7 @@ export interface OmiApiSchemas {
   "SyncJobStartResponse": SyncJobStartResponse;
   "SyncJobStatusResponse": SyncJobStatusResponse;
   "SyncLocalFilesResultResponse": SyncLocalFilesResultResponse;
+  "SyncTranscriptMode": SyncTranscriptMode;
   "Targeting": Targeting;
   "TaskAssistantSettings": TaskAssistantSettings;
   "TaskCancelCandidate": TaskCancelCandidate;
@@ -15338,7 +15341,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string, transcript_mode?: SyncTranscriptMode }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -3104,6 +3104,8 @@ export interface SyncLocalFilesResultResponse {
   updated_memories?: Array<string>;
 }
 
+export type SyncTranscriptMode = "merge" | "replace";
+
 export interface Targeting {
   app_version_max?: string | null;
   app_version_min?: string | null;
@@ -4170,6 +4172,7 @@ export interface OmiApiSchemas {
   "SyncJobStartResponse": SyncJobStartResponse;
   "SyncJobStatusResponse": SyncJobStatusResponse;
   "SyncLocalFilesResultResponse": SyncLocalFilesResultResponse;
+  "SyncTranscriptMode": SyncTranscriptMode;
   "Targeting": Targeting;
   "TaskAssistantSettings": TaskAssistantSettings;
   "TaskCancelCandidate": TaskCancelCandidate;
@@ -15338,7 +15341,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string, transcript_mode?: SyncTranscriptMode }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)


### PR DESCRIPTION
## Summary

- Add an explicit `merge | replace` transcript mutation contract to the v2
  sync endpoint and carry it unchanged through Cloud Tasks.
- Admit canonical replacement only for one signed mobile capture bound to the
  authenticated device and existing conversation.
- Accumulate every recovered STT segment, then atomically replace the live
  preview timeline and reprocess the conversation once only after the entire
  capture succeeds.
- Preserve the deployed merge/idempotency behavior for existing clients and
  queued tasks while domain-separating replacement content claims.
- Regenerate the app-client OpenAPI contract and generated Swift/TypeScript
  clients; document replacement and retry semantics.
- Raise the exact frozen line-count baselines for the two existing sync owner
  files, with checked-in justifications: request authorization stays at the
  route boundary, and the all-or-nothing transcript commit stays inside the
  existing lease/ledger/retry coordinator rather than creating another owner.

## Root cause

The mobile recovery client already requested `transcript_mode=replace`, but the
backend endpoint did not define or propagate that operation. Recovery therefore
fell through the ordinary fragment-merge path, which could leave preview text
in place, publish partial mutations, and re-run conversation processing once
per fragment. The API boundary did not own a typed distinction between gap
repair and authoritative capture replacement.

## Safety and compatibility

- Replacement fails admission before staging unless the upload has exactly one
  file, an existing target conversation, a valid signed capture manifest, and
  matching server capture provenance.
- Any VAD/STT segment failure leaves the live preview unchanged and retries the
  complete canonical capture.
- Unknown explicit task modes fail closed; tasks admitted before this field
  existed continue as `merge`.
- A lease/lifecycle fence for the explicitly targeted replacement conversation now terminalizes the whole targeted job as superseded; ordinary multi-conversation merge work still isolates a fenced sibling and continues safely.
- A no-speech provider result retains the preview instead of deleting
  user-visible text.
- No production deployment is part of this PR.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_sync_v2.py -k "merged_reprocess_fence_isolated or targeted_reprocess_fence_supersedes" -q` — 2 passed.
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_sync_v2.py -q` — 169 passed.
- `npm run test:sync-cloud-tasks-stack:emulator` — passed the exact Sync Cloud Tasks stack gauntlet that had failed in CI.
- `make preflight` — 34/34 deterministic checks passed on the final rebased SHA.
- `backend/.venv/bin/pytest -q backend/testing/e2e/test_sync_lifecycle.py` — 3 passed, including signed-manifest upload → inline decode/VAD/STT seams → atomic Firestore replacement → one reprocess → completed job poll.
- `backend/.venv/bin/python backend/scripts/export_openapi.py --surface app-client --check` — passed.
- The normal bounded pre-push gate passed, including the full desktop Swift debug compile.
- The broad `backend/test.sh` run reached one unrelated static-guard mismatch already present on `origin/main`: `test_memory_import_static_guards.py` expects a single-line `post("v3/memory-imports/batch"` call while the current source formats the argument on the following line. PR-specific sync tests and the exact failing gauntlet pass.
- Android and iOS both use the same Dart canonical phone-side assembler. The Android physical run proved one canonical WAL but its acceptance record explicitly left terminal server-result chronology untested. The iPhone run followed that final artifact and exposed the shared backend boundary: the client sent `transcript_mode=replace`, while the deployed endpoint ignored it. Live replacement proof remains intentionally pending a non-production backend deployment.

## Product invariants affected

None.

## Failure class

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

