### PR TITLE
SCA-245: validate development Firestore project

### DIFF
--- a/.github/failure-classes/FC-firestore-readiness-project-mismatch.json
+++ b/.github/failure-classes/FC-firestore-readiness-project-mismatch.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-firestore-readiness-project-mismatch",
+  "violated_contract": "A deployment's read-only Firestore readiness credential and its runtime project setting must identify the same GCP project, so readiness proves the schema that the deployment will serve.",
+  "canonical_prevention": "After authenticating the read-only Firestore credential and before evaluating index readiness, compare its configured GCP project with RUNTIME_GCP_PROJECT_ID and fail the deployment when they differ. Preserve that ordering with the backend release-vector workflow contract test.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_verify_backend_release_vector.py"
+  ],
+  "evidence_prs": [
+    9756
+  ],
+  "scope_hints": [
+    ".github/workflows/gcp_backend_auto_dev.yml",
+    "backend/tests/unit/test_verify_backend_release_vector.py"
+  ],
+  "status": "open"
+}

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -200,6 +200,21 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
 
+      - name: Verify read-only Firestore credentials target the development runtime project
+        env:
+          RUNTIME_GCP_PROJECT_ID: ${{ vars.RUNTIME_GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          credential_project="$(gcloud config get-value project 2>/dev/null)"
+          if [[ -z "$credential_project" || "$credential_project" == "(unset)" ]]; then
+            echo "::error title=Missing Firestore credential project::The read-only Firestore credentials do not select a GCP project."
+            exit 1
+          fi
+          if [[ "$credential_project" != "$RUNTIME_GCP_PROJECT_ID" ]]; then
+            echo "::error title=Firestore project mismatch::Read-only Firestore credentials target $credential_project, but RUNTIME_GCP_PROJECT_ID is $RUNTIME_GCP_PROJECT_ID."
+            exit 1
+          fi
+
       - name: Verify serving Firestore indexes
         id: firestore_readiness
         env:

--- a/backend/tests/unit/test_verify_backend_release_vector.py
+++ b/backend/tests/unit/test_verify_backend_release_vector.py
@@ -408,6 +408,23 @@ def test_static_backend_deploys_only_check_the_serving_firestore_schema() -> Non
         assert 'needs: firestore_readiness' in text
 
 
+def test_dev_firestore_readiness_requires_read_only_credentials_for_the_runtime_project() -> None:
+    workflow = BACKEND_DIR.parent / '.github/workflows/gcp_backend_auto_dev.yml'
+    text = workflow.read_text(encoding='utf-8')
+    readiness = text.split('\n  firestore_readiness:\n', 1)[1].split('\n  deploy:\n', 1)[0]
+
+    assert 'Verify read-only Firestore credentials target the development runtime project' in readiness
+    assert 'RUNTIME_GCP_PROJECT_ID: ${{ vars.RUNTIME_GCP_PROJECT_ID }}' in readiness
+    assert 'credential_project="$(gcloud config get-value project 2>/dev/null)"' in readiness
+    assert '"$credential_project" != "$RUNTIME_GCP_PROJECT_ID"' in readiness
+    assert readiness.index('Google Auth for read-only Firestore inventory') < readiness.index(
+        'Verify read-only Firestore credentials target the development runtime project'
+    )
+    assert readiness.index(
+        'Verify read-only Firestore credentials target the development runtime project'
+    ) < readiness.index('Verify serving Firestore indexes')
+
+
 def test_firestore_readiness_fails_before_admitted_source_checkout_when_read_only_credentials_are_missing() -> None:
     workflows = (
         BACKEND_DIR.parent / '.github/workflows/gcp_backend_auto_dev.yml',


### PR DESCRIPTION
## Summary

- fail the automatic development backend deploy before Firestore readiness when its read-only credential targets a different GCP project than the runtime project
- cover the credential/project alignment guard with the existing deployment workflow contract suite

## Verification

- `backend/.venv/bin/pytest backend/tests/unit/test_verify_backend_release_vector.py backend/tests/unit/test_backend_runtime_env_validator.py -q` — 122 passed
- `make preflight` — passed (11 deterministic checks)

Related to SCA-245.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

