### PR TITLE
fix(backend): bound extracted conversation dates relative to the content date

### DIFF
--- a/.github/failure-classes/FC-hardcoded-absolute-date-bound.json
+++ b/.github/failure-classes/FC-hardcoded-absolute-date-bound.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-hardcoded-absolute-date-bound",
+  "violated_contract": "A plausibility bound on dates must be expressed relative to the data's own reference date. A hardcoded absolute year or date inverts once real time passes it: it stops rejecting implausible values and starts discarding every valid one, silently.",
+  "canonical_prevention": "Bound extracted or user-supplied dates against a reference date carried with the content (e.g. utils.llm.temporal.normalize_extracted_dates, which offsets from the conversation's own date), never against a literal calendar year in code or in an LLM prompt.",
+  "evidence_prs": [10864],
+  "scope_hints": ["backend/utils/llm/**"],
+  "status": "open",
+  "canonical_prevention_artifact": ["backend/utils/llm/temporal.py"]
+}

--- a/backend/tests/unit/test_extracted_date_bounds.py
+++ b/backend/tests/unit/test_extracted_date_bounds.py
@@ -1,0 +1,71 @@
+"""Contract tests for utils.llm.temporal.normalize_extracted_dates.
+
+The conversation metadata-extraction paths in utils/llm/chat.py turn model-extracted dates into
+the ``dates`` search filters (``add_filter_category_item(uid, 'dates', ...)`` plus the conversation
+vector metadata). They used to bound those dates with a hardcoded ``if date.year > 2025: continue``
+and a prompt line saying "Do not include dates greater than 2025". Once 2025 passed, that stopped
+rejecting implausible dates and started discarding every real one: external-integration
+conversations (message/text sources) recorded no dates at all, and the prompt actively steered the
+model away from the correct year.
+
+The bound is now relative to the content's own date. These tests lock that: a present-day date
+survives, a far-future one is still rejected, a partial date the model sometimes emits (e.g.
+``'2027-02'``, seen in prod logs) is dropped without raising, and an unusable reference date never
+discards the whole set.
+"""
+
+from utils.llm.temporal import MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS, normalize_extracted_dates
+
+
+class TestPresentDayDatesSurvive:
+    def test_date_in_the_reference_year_is_kept(self):
+        # The regression: with the hardcoded 2025 cutoff this returned [].
+        assert normalize_extracted_dates(['2026-07-29'], '2026-07-29') == ['2026-07-29']
+
+    def test_next_year_within_the_lookahead_is_kept(self):
+        assert normalize_extracted_dates(['2027-01-15'], '2026-07-29') == ['2027-01-15']
+
+    def test_real_far_ahead_plan_is_kept(self):
+        # "the wedding is in about 18 months" must not be discarded as a hallucination.
+        assert normalize_extracted_dates(['2028-01-15'], '2026-07-29') == ['2028-01-15']
+
+    def test_past_dates_are_kept(self):
+        assert normalize_extracted_dates(['2019-03-04'], '2026-07-29') == ['2019-03-04']
+
+    def test_reference_year_rolls_forward_without_a_code_change(self):
+        assert normalize_extracted_dates(['2031-05-02'], '2031-05-02') == ['2031-05-02']
+
+
+class TestImplausibleDatesRejected:
+    def test_date_beyond_the_lookahead_is_dropped(self):
+        assert normalize_extracted_dates(['2030-01-01'], '2026-07-29') == []
+
+    def test_lookahead_boundary_is_inclusive(self):
+        # 2026-07-29 + 731 days = 2028-07-29.
+        assert MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS == 731
+        assert normalize_extracted_dates(['2028-07-29'], '2026-07-29') == ['2028-07-29']
+        assert normalize_extracted_dates(['2028-07-30'], '2026-07-29') == []
+
+
+class TestUnparseableInput:
+    def test_partial_date_is_dropped_without_raising(self):
+        assert normalize_extracted_dates(['2027-02'], '2026-07-29') == []
+
+    def test_free_text_is_dropped_without_raising(self):
+        assert normalize_extracted_dates(['next tuesday', ''], '2026-07-29') == []
+
+    def test_none_dates_returns_empty(self):
+        assert normalize_extracted_dates(None, '2026-07-29') == []
+
+    def test_good_dates_survive_alongside_bad_ones(self):
+        assert normalize_extracted_dates(['2027-02', '2026-08-01'], '2026-07-29') == ['2026-08-01']
+
+
+class TestUnusableReferenceDate:
+    def test_empty_reference_keeps_parseable_dates(self):
+        # A missing reference must not silently discard the whole set — that is the failure mode
+        # this helper exists to prevent.
+        assert normalize_extracted_dates(['2026-08-01'], '') == ['2026-08-01']
+
+    def test_malformed_reference_keeps_parseable_dates(self):
+        assert normalize_extracted_dates(['2026-08-01'], 'not-a-date') == ['2026-08-01']

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -21,7 +21,7 @@ from models.other import Person
 from models.transcript_segment import TranscriptSegment
 from utils.llms.memory import get_prompt_memories
 from utils.llm.usage_tracker import track_usage, Features
-from utils.llm.temporal import date_in_tz
+from utils.llm.temporal import MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS, date_in_tz, normalize_extracted_dates
 
 from .clients import get_llm
 import logging
@@ -1192,6 +1192,7 @@ def retrieve_metadata_fields_from_transcript(
         return {'people': [], 'topics': [], 'entities': [], 'dates': []}
 
     full_context = "\n\n".join(context_parts)
+    today = date_in_tz(created_at, tz)
 
     # TODO: ask it to use max 2 words? to have more standardization possibilities
     prompt = f'''
@@ -1201,12 +1202,12 @@ def retrieve_metadata_fields_from_transcript(
 
     Make sure as a first step, you infer and fix any raw transcript errors and then proceed to extract the information from the entire content.
 
-    For context when extracting dates, today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
+    For context when extracting dates, today is {today} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
     If one says "today", it means the current day.
     If one says "tomorrow", it means the next day after today.
     If one says "yesterday", it means the day before today.
     If one says "next week", it means the next monday.
-    Do not include dates greater than 2025.
+    Do not include dates more than {MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS} days after {today}.
 
     Content:
     ```
@@ -1227,17 +1228,8 @@ def retrieve_metadata_fields_from_transcript(
         people=[normalize_filter(p) for p in result.people],
         topics=[normalize_filter(t) for t in result.topics],
         entities=[normalize_filter(e) for e in result.entities],
-        dates=[],
+        dates=normalize_extracted_dates(result.dates, today),
     ).to_vector_metadata()
-    # 'dates': [date.strftime('%Y-%m-%d') for date in result.dates],
-    for date in result.dates:
-        try:
-            date = datetime.strptime(date, '%Y-%m-%d')
-            # if date.year > 2025:
-            #    continue
-            metadata['dates'].append(date.strftime('%Y-%m-%d'))
-        except Exception as e:
-            logger.error(f'Error parsing date: {e}')
 
     for p in metadata['people']:
         add_filter_category_item(uid, 'people', p)
@@ -1256,6 +1248,7 @@ def retrieve_metadata_from_message(
 ) -> dict[str, Any]:
     """Extract metadata from messaging app content"""
     source_context = f"from {source_spec}" if source_spec else "from a messaging application"
+    today = date_in_tz(created_at, tz)
 
     prompt = f'''
     You will be given the content of a message or conversation {source_context}.
@@ -1268,13 +1261,13 @@ def retrieve_metadata_from_message(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone). 
+    For context when extracting dates, today is {today} in {tz} (user's local timezone).
     {tz} is the user's timezone, respond in user local timezone.
     If the message mentions "today", it means the current day.
     If the message mentions "tomorrow", it means the next day after today.
     If the message mentions "yesterday", it means the day before today.
     If the message mentions "next week", it means the next monday.
-    Do not include dates greater than 2025.
+    Do not include dates more than {MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS} days after {today}.
 
     Message Content:
     ```
@@ -1282,7 +1275,7 @@ def retrieve_metadata_from_message(
     ```
     '''.replace('    ', '')
 
-    return _process_extracted_metadata(uid, prompt)
+    return _process_extracted_metadata(uid, prompt, today)
 
 
 def retrieve_metadata_from_text(
@@ -1290,6 +1283,7 @@ def retrieve_metadata_from_text(
 ) -> dict[str, Any]:
     """Extract metadata from generic text content"""
     source_context = f"from {source_spec}" if source_spec else "from a text document"
+    today = date_in_tz(created_at, tz)
 
     prompt = f'''
     You will be given the content of a text {source_context}.
@@ -1302,13 +1296,13 @@ def retrieve_metadata_from_text(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {date_in_tz(created_at, tz)} in {tz} (user's local timezone). 
+    For context when extracting dates, today is {today} in {tz} (user's local timezone).
     {tz} is the user's timezone, respond in user local timezone.
     If the text mentions "today", it means the current day.
     If the text mentions "tomorrow", it means the next day after today.
     If the text mentions "yesterday", it means the day before today.
     If the text mentions "next week", it means the next monday.
-    Do not include dates greater than 2025.
+    Do not include dates more than {MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS} days after {today}.
 
     Text Content:
     ```
@@ -1316,10 +1310,10 @@ def retrieve_metadata_from_text(
     ```
     '''.replace('    ', '')
 
-    return _process_extracted_metadata(uid, prompt)
+    return _process_extracted_metadata(uid, prompt, today)
 
 
-def _process_extracted_metadata(uid: str, prompt: str) -> dict[str, Any]:
+def _process_extracted_metadata(uid: str, prompt: str, reference_date: str) -> dict[str, Any]:
     """Process the extracted metadata from any source"""
     try:
         with track_usage(uid, Features.CONVERSATION_PROCESSING):
@@ -1335,17 +1329,8 @@ def _process_extracted_metadata(uid: str, prompt: str) -> dict[str, Any]:
         people=[normalize_filter(p) for p in result.people],
         topics=[normalize_filter(t) for t in result.topics],
         entities=[normalize_filter(e) for e in result.entities],
-        dates=[],
+        dates=normalize_extracted_dates(result.dates, reference_date),
     ).to_vector_metadata()
-
-    for date in result.dates:
-        try:
-            date = datetime.strptime(date, '%Y-%m-%d')
-            if date.year > 2025:
-                continue
-            metadata['dates'].append(date.strftime('%Y-%m-%d'))
-        except Exception as e:
-            logger.error(f'Error parsing date: {e}')
 
     for p in metadata['people']:
         add_filter_category_item(uid, 'people', p)

--- a/backend/utils/llm/temporal.py
+++ b/backend/utils/llm/temporal.py
@@ -7,14 +7,17 @@ training-cutoff year, so it flags correctly recorded future-year dates as errors
 clock is wrong", "this date is two years in the future"). These helpers produce a date to
 inject into those prompts.
 
-``current_date_in_tz`` and ``date_in_tz`` are pure and import no DB layer, so a module can
-use them without pulling the Firestore client in at import time; only ``current_date_for_uid``
-touches the database, and it does so lazily.
+``normalize_extracted_dates`` is the other half: it bounds the dates the model hands back,
+relative to the content's own date rather than a fixed calendar year.
+
+``current_date_in_tz``, ``date_in_tz`` and ``normalize_extracted_dates`` are pure and import no
+DB layer, so a module can use them without pulling the Firestore client in at import time; only
+``current_date_for_uid`` touches the database, and it does so lazily.
 """
 
 import logging
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, List, Optional
 from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
@@ -46,6 +49,39 @@ def date_in_tz(dt: datetime, tz: Optional[str] = None) -> str:
     """
     aware = dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
     return aware.astimezone(_zone(tz)).strftime('%Y-%m-%d')
+
+
+# Extracted dates become search filters, so a hallucinated far-future date is worse than no
+# date. The bound is deliberately relative to the content's own date: a hardcoded calendar year
+# stops rejecting anything implausible and starts discarding every real date once it passes.
+# Two years is generous on purpose — the bound exists to drop hallucinations, and people do plan
+# real events well ahead, so erring wide keeps this from becoming the silent-loss bug it replaced.
+MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS = 731
+
+
+def normalize_extracted_dates(dates: Optional[Iterable[str]], reference_date: str) -> List[str]:
+    """Parse model-extracted ``YYYY-MM-DD`` dates, bounded relative to ``reference_date``.
+
+    Values the model did not emit as a full date, and dates more than
+    ``MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS`` after the reference, are dropped. An unparseable
+    reference keeps every parseable date rather than discarding the whole set.
+    """
+    try:
+        cutoff = datetime.strptime(reference_date, '%Y-%m-%d') + timedelta(days=MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS)
+    except (TypeError, ValueError):
+        cutoff = None
+
+    normalized: List[str] = []
+    for raw in dates or []:
+        try:
+            parsed = datetime.strptime(raw, '%Y-%m-%d')
+        except (TypeError, ValueError) as e:
+            logger.warning(f'normalize_extracted_dates - dropping unparseable date: {e}')
+            continue
+        if cutoff is not None and parsed > cutoff:
+            continue
+        normalized.append(parsed.strftime('%Y-%m-%d'))
+    return normalized
 
 
 def current_date_for_uid(uid: str) -> str:


### PR DESCRIPTION
## Summary

Conversation metadata extraction bounded model-extracted dates with a hardcoded calendar year. Once 2025 passed, the guard inverted — it stopped rejecting implausible dates and started discarding every real one.

- `_process_extracted_metadata` (external-integration message/text sources) did `if date.year > 2025: continue`, so those conversations recorded **no dates at all** — the `dates` search-filter category and vector metadata stayed empty.
- All three extraction prompts told the model *"Do not include dates greater than 2025"*, actively steering it away from the correct year.
- `retrieve_metadata_fields_from_transcript` had the same guard commented out, so it had **no** plausibility bound — a hallucinated far-future date became a permanent search filter.

Prod evidence (`based-hardware`, 2026-07-29): `ERROR:utils.llm.chat:Error parsing date: time data '2027-02' does not match format '%Y-%m-%d'`, which is how the partial-date case surfaced.

## Fix

One shared helper, `utils.llm.temporal.normalize_extracted_dates`, used by both extraction paths — placed next to `date_in_tz`, which exists for the same class of prompt-date bug (#4643, #6214). The bound is relative to the content's own date (`MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS = 731`), so it never needs a yearly code change. Two years is deliberately generous: the bound only needs to drop hallucinations, and people plan real events well ahead, so erring wide keeps it from recreating the silent-loss bug it replaces. Unparseable values are dropped without raising; an unusable reference date keeps every parseable date rather than discarding the set. The prompts now state the bound relative to `today`.

## What I tested

Exercised the real production entry points (`retrieve_metadata_from_message`, `retrieve_metadata_fields_from_transcript`) with a stubbed LLM returning `['2026-07-30', '2027-02', '2030-01-01']` at `created_at` 2026-07-29, tz `America/Los_Angeles`, and a recording stub for `add_filter_category_item`:

| | message dates | transcript dates | prompt says 2025 |
|---|---|---|---|
| before (origin/main) | `[]` | `['2026-07-30', '2030-01-01']` | yes |
| after | `['2026-07-30']` | `['2026-07-30']` | no |

After the fix the filter store receives `['2026-07-30', '2026-07-30']` and the prompt line reads `Do not include dates more than 731 days after 2026-07-29.`

```
backend/.venv/bin/python -m pytest tests/unit/test_extracted_date_bounds.py \
  tests/unit/test_temporal_date_in_tz.py tests/unit/test_kg_user_type_mismatch.py \
  tests/unit/test_process_conversation_usage_context.py -q
```

`backend/tests/unit/test_extracted_date_bounds.py` is the regression test: it locks that a present-day date survives, an 18-month-out real plan survives, the boundary is inclusive at +731 days, a far-future date is still rejected, `'2027-02'` is dropped without raising, and an unusable reference date never discards the whole set.

## Product invariants affected

none

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged
