### PR TITLE
chore: add build artifacts and generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,28 @@ builds-snapshot.md
 .hermes/
 backend/.venv
 backend/.harness/
+
+# Rust / Cargo
+target/
+
+# Python bytecode
+*.pyc
+
+# Python test / lint caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage output
+coverage/
+htmlcov/
+.coverage
+
+# Python packaging
+*.egg-info/
+
+# macOS finder (recursive)
+**/.DS_Store
+
+# pnpm store
+.pnpm-store/


### PR DESCRIPTION
## What

Adds common build artifacts and generated files to `.gitignore` that are currently untracked and cluttering the working tree:

- **`target/`** — Rust/Cargo build output (currently **979MB** untracked in `desktop/target/`)
- **`*.pyc`** — Python bytecode
- **`.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`** — Python tool caches
- **`coverage/`, `htmlcov/`, `.coverage`** — coverage report output
- **`*.egg-info/`** — Python packaging artifacts
- **`**/.DS_Store`** — macOS Finder metadata (recursive, currently only root-level covered)
- **`.pnpm-store/`** — pnpm virtual store

## Why

Keeps the tree clean when running `cargo`, `pytest`, `pnpm`, etc. locally.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

