### PR TITLE
SCA-251: skip dev startup Stripe price validation

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -13,7 +13,7 @@ source .venv/bin/activate
 uvicorn main:app --host 0.0.0.0 --port 8080
 ```
 
-**Env stages** (`OMI_ENV_STAGE`): `local` (emulator harness, `.env.local-dev`), `offline` (fake providers, `.env.offline`), `dev` (remote dev GCP, `.env.dev`), `prod` (reference only, `.env.prod`). `load_backend_env()` loads the stage file then `backend/.env` overrides. Templates: `backend/.env.*.template`. Harness: `PROVIDER_MODE=offline make dev-up` or `OMI_ENV_STAGE=offline`.
+**Env stages** (`OMI_ENV_STAGE`): `local` (emulator harness, `.env.local-dev`), `offline` (fake providers, `.env.offline`), `dev` (remote dev GCP, `.env.dev`), `prod` (reference only, `.env.prod`). `load_backend_env()` loads the stage file then `backend/.env` overrides. Templates: `backend/.env.*.template`. Harness: `PROVIDER_MODE=offline make dev-up` or `OMI_ENV_STAGE=offline`. Dev skips the startup-only Stripe price validation; plan catalog and checkout calls still require mode-matched Stripe credentials.
 
 When intentionally changing backend Python dependencies, edit the relevant `requirements*.txt` input file and refresh the lock:
 

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -62,13 +62,23 @@ def test_dev_startup_skips_stripe_price_validation(monkeypatch, subscription_mod
     caplog.set_level(logging.INFO, logger=subscription_module.__name__)
     definitions = MagicMock()
     retrieve = MagicMock()
+    fallback = MagicMock()
     monkeypatch.setattr(subscription_module, 'get_paid_plan_definitions', definitions)
     monkeypatch.setattr(subscription_module.stripe.Price, 'retrieve', retrieve)
+    monkeypatch.setattr(subscription_module, 'record_fallback', fallback)
 
     subscription_module.validate_stripe_price_ids()
 
     definitions.assert_not_called()
     retrieve.assert_not_called()
+    fallback.assert_called_once_with(
+        component='other',
+        from_mode='stripe_price_validation',
+        to_mode='dev_skip',
+        reason='policy',
+        outcome='degraded',
+        log=subscription_module.logger,
+    )
     assert 'Skipping Stripe price validation during dev startup.' in caplog.messages
 
 

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -9,11 +9,12 @@ with ``load_module_fresh``, then restores on teardown. See
 backend/docs/test_isolation.md and testing/import_isolation.py.
 """
 
+import logging
 import os
 from pathlib import Path
 from types import ModuleType
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -54,6 +55,42 @@ def test_architect_price_ids_map_to_architect_plan(monkeypatch, subscription_mod
     assert get_plan_type_from_price_id("price_unlimited_annual") == PlanType.unlimited
     assert get_plan_type_from_price_id("price_architect_monthly") == PlanType.architect
     assert get_plan_type_from_price_id("price_architect_annual") == PlanType.architect
+
+
+def test_dev_startup_skips_stripe_price_validation(monkeypatch, subscription_module, caplog):
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    caplog.set_level(logging.INFO, logger=subscription_module.__name__)
+    definitions = MagicMock()
+    retrieve = MagicMock()
+    monkeypatch.setattr(subscription_module, 'get_paid_plan_definitions', definitions)
+    monkeypatch.setattr(subscription_module.stripe.Price, 'retrieve', retrieve)
+
+    subscription_module.validate_stripe_price_ids()
+
+    definitions.assert_not_called()
+    retrieve.assert_not_called()
+    assert 'Skipping Stripe price validation during dev startup.' in caplog.messages
+
+
+def test_prod_startup_validates_stripe_price_ids(monkeypatch, subscription_module):
+    monkeypatch.setenv('OMI_ENV_STAGE', 'prod')
+    monkeypatch.setattr(
+        subscription_module,
+        'get_paid_plan_definitions',
+        lambda: [
+            {
+                'plan_id': 'operator',
+                'monthly_price_id': 'price_operator_monthly',
+                'annual_price_id': 'price_operator_annual',
+            }
+        ],
+    )
+    retrieve = MagicMock()
+    monkeypatch.setattr(subscription_module.stripe.Price, 'retrieve', retrieve)
+
+    subscription_module.validate_stripe_price_ids()
+
+    assert retrieve.call_args_list == [call('price_operator_monthly'), call('price_operator_annual')]
 
 
 def test_architect_is_treated_as_paid_unlimited_plan(subscription_module):

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -696,6 +696,14 @@ def get_plan_type_from_price_id(price_id: str) -> PlanType:
 def validate_stripe_price_ids():
     """Validate configured Stripe price IDs at startup outside the dev environment."""
     if os.getenv('OMI_ENV_STAGE', '').strip().lower() == 'dev':
+        record_fallback(
+            component='other',
+            from_mode='stripe_price_validation',
+            to_mode='dev_skip',
+            reason='policy',
+            outcome='degraded',
+            log=logger,
+        )
         logger.info('Skipping Stripe price validation during dev startup.')
         return
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -694,7 +694,11 @@ def get_plan_type_from_price_id(price_id: str) -> PlanType:
 
 
 def validate_stripe_price_ids():
-    """Validate all configured Stripe price IDs on startup. Logs errors for invalid/unreachable prices."""
+    """Validate configured Stripe price IDs at startup outside the dev environment."""
+    if os.getenv('OMI_ENV_STAGE', '').strip().lower() == 'dev':
+        logger.info('Skipping Stripe price validation during dev startup.')
+        return
+
     for definition in get_paid_plan_definitions():
         for interval in ('monthly', 'annual'):
             price_id = definition[f'{interval}_price_id']


### PR DESCRIPTION
## Summary

- Skip the diagnostic Stripe price-ID validation only during `OMI_ENV_STAGE=dev` startup.
- Keep the validation active in production and document that dev catalog/checkout calls still require mode-matched Stripe credentials.

## Verification

- `./backend/.venv/bin/pytest backend/tests/unit/test_subscription_plans.py -q` — 14 passed
- `black --check --line-length 120 --skip-string-normalization backend/utils/subscription.py backend/tests/unit/test_subscription_plans.py`
- `bash backend/test.sh` was stopped after unrelated fast-unit-duration guard failures in `tests/services/users/test_data_export.py` and `tests/unit/test_activate_task_intelligence_dogfood_user.py`; the touched subscription suite passed.

## Follow-up

The dev `STRIPE_API_KEY` must still be changed to the matching test-mode key (or the configured price IDs changed to prices for its current key) before the catalog and checkout flows can work in dev.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

