### PR TITLE
fix(backend): keep action-item vector indexing out of the write's failure path

### DIFF
--- a/.github/failure-classes/FC-post-commit-index-maintenance-terminal.json
+++ b/.github/failure-classes/FC-post-commit-index-maintenance-terminal.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-post-commit-index-maintenance-terminal",
+  "violated_contract": "Search-index maintenance that runs after a request's authoritative write has already committed is best-effort: its failure may not terminate that request. A raise from the index boundary turns a landed create/update/delete into a 5xx the client reads as 'the write failed', which drives retries of an applied mutation and shows the user an error for state that changed.",
+  "canonical_prevention": "Contain the failure inside the index boundary itself rather than at each call site: the vector helpers log and return their empty result (None / 0) on any embedding or index error, exactly as find_similar_action_items already degrades, so no post-commit caller can propagate an indexing fault. Deletes that carry a retention obligation stay loud and are not covered by this class.",
+  "evidence_prs": [
+    10871
+  ],
+  "scope_hints": [
+    "backend/database/vector_db.py",
+    "backend/routers/**"
+  ],
+  "canonical_prevention_artifact": [
+    "backend/database/vector_db.py",
+    "backend/tests/unit/test_action_item_vector_best_effort.py"
+  ],
+  "status": "open"
+}

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -880,26 +880,44 @@ ACTION_ITEMS_NAMESPACE = "ns4"
 
 
 def upsert_action_item_vector(uid: str, action_item_id: str, description: str) -> List[float] | None:
+    """Index one action item for semantic search.
+
+    Every caller runs this *after* the Firestore write has already committed, so an
+    embedding/Pinecone failure must not propagate: it would turn a successful
+    create/update into an HTTP 500 (and make clients retry a write that landed).
+    Degrades to ``None`` — the task is simply absent from semantic search until it
+    is next indexed, matching ``find_similar_action_items``.
+    """
     if index is None:
         logger.warning('Pinecone index not initialized, skipping action item vector upsert')
         return None
 
-    vector = embeddings.embed_query(description)
-    data: VectorRecordDoc = {
-        "id": f'{uid}-ai-{action_item_id}',
-        "values": vector,
-        "metadata": {
-            "uid": uid,
-            "action_item_id": action_item_id,
-            "created_at": int(datetime.now(timezone.utc).timestamp()),
-        },
-    }
-    res = index.upsert(vectors=[data], namespace=ACTION_ITEMS_NAMESPACE)
-    logger.info(f'upsert_action_item_vector {action_item_id} {res}')
-    return vector
+    try:
+        vector = embeddings.embed_query(description)
+        data: VectorRecordDoc = {
+            "id": f'{uid}-ai-{action_item_id}',
+            "values": vector,
+            "metadata": {
+                "uid": uid,
+                "action_item_id": action_item_id,
+                "created_at": int(datetime.now(timezone.utc).timestamp()),
+            },
+        }
+        res = index.upsert(vectors=[data], namespace=ACTION_ITEMS_NAMESPACE)
+        logger.info(f'upsert_action_item_vector {action_item_id} {res}')
+        return vector
+    except Exception as e:
+        logger.exception(
+            f'upsert_action_item_vector failed uid={uid} action_item_id={action_item_id} '
+            f'(task saved, vector missing): {e}'
+        )
+        return None
 
 
 def upsert_action_item_vectors_batch(uid: str, items: List[Dict[str, Any]]) -> int:
+    """Index a batch of action items. Best-effort, for the same reason as
+    ``upsert_action_item_vector``: returns 0 instead of raising into a caller
+    whose Firestore writes already succeeded."""
     if index is None:
         logger.warning('Pinecone index not initialized, skipping action item vector batch upsert')
         return 0
@@ -907,25 +925,32 @@ def upsert_action_item_vectors_batch(uid: str, items: List[Dict[str, Any]]) -> i
     if not items:
         return 0
 
-    descriptions: List[str] = [item['description'] for item in items]
-    vectors: List[List[float]] = embeddings.embed_documents(descriptions)
+    try:
+        descriptions: List[str] = [item['description'] for item in items]
+        vectors: List[List[float]] = embeddings.embed_documents(descriptions)
 
-    now_ts = int(datetime.now(timezone.utc).timestamp())
-    payload: List[VectorRecordDoc] = [
-        {
-            "id": f"{uid}-ai-{item['action_item_id']}",
-            "values": vectors[i],
-            "metadata": {
-                "uid": uid,
-                "action_item_id": item['action_item_id'],
-                "created_at": now_ts,
-            },
-        }
-        for i, item in enumerate(items)
-    ]
-    res = index.upsert(vectors=payload, namespace=ACTION_ITEMS_NAMESPACE)
-    logger.info(f'upsert_action_item_vectors_batch count={len(payload)} {res}')
-    return len(payload)
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        payload: List[VectorRecordDoc] = [
+            {
+                "id": f"{uid}-ai-{item['action_item_id']}",
+                "values": vectors[i],
+                "metadata": {
+                    "uid": uid,
+                    "action_item_id": item['action_item_id'],
+                    "created_at": now_ts,
+                },
+            }
+            for i, item in enumerate(items)
+        ]
+        res = index.upsert(vectors=payload, namespace=ACTION_ITEMS_NAMESPACE)
+        logger.info(f'upsert_action_item_vectors_batch count={len(payload)} {res}')
+        return len(payload)
+    except Exception as e:
+        logger.exception(
+            f'upsert_action_item_vectors_batch failed uid={uid} count={len(items)} '
+            f'(tasks saved, vectors missing): {e}'
+        )
+        return 0
 
 
 def search_action_items_by_vector(uid: str, query: str, limit: int = 10, min_score: float = 0.3) -> List[str]:

--- a/backend/migrations/007_backfill_action_item_vectors.py
+++ b/backend/migrations/007_backfill_action_item_vectors.py
@@ -85,8 +85,11 @@ def process_user(uid: str, dry_run: bool = False) -> dict:
         batch = eligible[i : i + BATCH_SIZE]
         batch_items = [{'action_item_id': item['id'], 'description': item['description']} for item in batch]
         try:
+            # The helper is best-effort for request paths (it returns 0 instead of raising),
+            # so a backfill has to read the shortfall to keep its error count honest.
             written = upsert_action_item_vectors_batch(uid, batch_items)
             results['success'] += written
+            results['errors'] += len(batch) - written
         except Exception as e:
             results['errors'] += len(batch)
             logger.error(f"  Batch error at offset {i}: {e}")

--- a/backend/tests/unit/test_action_item_vector_best_effort.py
+++ b/backend/tests/unit/test_action_item_vector_best_effort.py
@@ -1,0 +1,92 @@
+"""Action-item vector indexing must never fail the write it follows.
+
+Prod incident (2026-07-29 20:47-20:51Z, `backend`/`backend-sync`): every
+embeddings call returned ``openai.NotFoundError: 404 Invalid URL (POST
+/v1/embeddings)``. ``PATCH /v1/action-items/{id}`` returned HTTP 500 *after*
+``action_items_db.update_action_item`` had already committed the Firestore write
+— the user saw "failed" on a task edit that had actually landed (and retries
+re-applied it). The create / batch / accept-share paths had the same shape.
+
+Index maintenance is best-effort by design (like ``find_similar_action_items``):
+losing the vector only drops the task out of semantic search until it is next
+indexed, which is strictly better than reporting a committed write as failed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from database import vector_db
+from routers import action_items as action_items_router
+from utils.other import endpoints as auth
+
+
+class _EmbeddingsOutage:
+    """Stands in for `clients.embeddings` while the embeddings provider is 404ing."""
+
+    def embed_query(self, text):
+        raise RuntimeError('404 Invalid URL (POST /v1/embeddings)')
+
+    def embed_documents(self, texts):
+        raise RuntimeError('404 Invalid URL (POST /v1/embeddings)')
+
+
+@pytest.fixture
+def embeddings_down(monkeypatch):
+    monkeypatch.setattr(vector_db, 'index', MagicMock(), raising=False)
+    monkeypatch.setattr(vector_db, 'embeddings', _EmbeddingsOutage(), raising=False)
+
+
+def test_upsert_action_item_vector_degrades_to_none(embeddings_down):
+    assert vector_db.upsert_action_item_vector('uid-1', 'task-1', 'Ship the fix') is None
+
+
+def test_upsert_action_item_vectors_batch_degrades_to_zero(embeddings_down):
+    items = [
+        {'action_item_id': 'task-1', 'description': 'Ship the fix'},
+        {'action_item_id': 'task-2', 'description': 'Write the test'},
+    ]
+    assert vector_db.upsert_action_item_vectors_batch('uid-1', items) == 0
+
+
+@pytest.fixture
+def committed_description_edit(monkeypatch):
+    """Firestore accepts the edit; only the vector index is broken."""
+    existing = {'id': 'task-1', 'description': 'Old text', 'completed': False}
+    updated = {'id': 'task-1', 'description': 'New text', 'completed': False}
+
+    monkeypatch.setattr(action_items_router, '_get_valid_action_item', lambda *args, **kwargs: existing)
+    monkeypatch.setattr(action_items_router.task_links, 'validate_task_links', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        action_items_router.action_items_db, 'update_action_item', lambda *args, **kwargs: True, raising=False
+    )
+    monkeypatch.setattr(
+        action_items_router.action_items_db, 'get_action_item', lambda *args, **kwargs: updated, raising=False
+    )
+    monkeypatch.setattr(action_items_router, 'sync_action_item_reminder', lambda *args, **kwargs: None, raising=False)
+
+
+def test_patch_action_item_succeeds_while_embeddings_are_down(embeddings_down, committed_description_edit):
+    """The handler must return the updated task, not raise, when indexing it fails."""
+    response = action_items_router.update_action_item(
+        'task-1',
+        action_items_router.ActionItemUpdateRequest(description='New text'),
+        uid='uid-1',
+    )
+
+    assert response.description == 'New text'
+
+
+def test_patch_action_item_http_200_while_embeddings_are_down(embeddings_down, committed_description_edit):
+    """The same edit over HTTP: the client saw 500 during the incident even though the
+    write had committed, so assert the real status code the app returns."""
+    app = FastAPI()
+    app.include_router(action_items_router.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: 'uid-1'
+
+    response = TestClient(app).patch('/v1/action-items/task-1', json={'description': 'New text'})
+
+    assert response.status_code == 200
+    assert response.json()['description'] == 'New text'


### PR DESCRIPTION
## Bug (live prod)

2026-07-29 20:47–20:51Z, prod `backend` + `backend-sync` (image `f23e8f2`): every embeddings call returned
`openai.NotFoundError: 404 - Invalid URL (POST /v1/embeddings)` (~51 log entries, first at 20:47:58Z).

11 of them were **unhandled request exceptions → HTTP 500**, e.g.

```
File "/app/routers/action_items.py", line 453, in update_action_item
File "/app/database/vector_db.py", line 903, in upsert_action_item_vector
File "/app/utils/llm/clients.py", line 272, in embed_query
openai.NotFoundError: 404 ... Invalid URL (POST /v1/embeddings)
```

`action_items_db.update_action_item` had **already committed** the Firestore write at that point, so the user
saw a failed task edit that had in fact landed — and a client retry re-applied it. The same shape existed on
`POST /v1/action-items`, `/batch`, `/batch-sync`, and accept-share (which has no idempotency key, so a retry
there duplicates tasks).

## Root cause

The index-maintenance call is the last statement of each handler and was unguarded, so a provider fault
propagated out of a request whose authoritative write had already succeeded. `find_similar_action_items` and
the memories router already treat vector work as best-effort ("memory saved, vector missing"); the
action-item upserts were the outlier.

## Fix

Contain the failure in the index boundary instead of at each call site:

- `upsert_action_item_vector` → returns `None` on any failure (its existing `index is None` result).
- `upsert_action_item_vectors_batch` → returns `0`.
- Both log at exception level with uid/ids, so the missing vectors stay diagnosable.

Every caller is covered — routers (8 sites), `utils/mcp_action_items.py`, `process_conversation` — with no
call-site changes. Deletes are deliberately left raising: `delete_action_item_vectors_batch` backs
account-deletion purge, where swallowing an error would be a retention bug, and deletes never touch
embeddings so they were not part of this incident.

## What I tested

`backend/test.sh` runner (python 3.11.15, `BACKEND_UNIT_TEST_FILE_LIST`):

- New `backend/tests/unit/test_action_item_vector_best_effort.py` — **4 passed**. On `origin/main` all 4 fail
  with `RuntimeError: 404 Invalid URL (POST /v1/embeddings)`, including the `TestClient` case that reproduces
  the HTTP 500 the incident produced; with the fix it returns 200 and the updated description.
- 11 adjacent files (action-item router/idempotency/canonical contract/dedup/pagination, task sharing, MCP
  writes, candidate capture, `process_conversation` usage context, account-deletion purge ×2) — **201 passed**.
- `make preflight` (local lane) green with this body.

## Product invariants affected

none

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

