### PR TITLE
fix(gauntlet): update INV-6 self-check needle for renamed ChatTimeline test

### DIFF
--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -4134,7 +4134,7 @@ def continuity_contract_self_check_failures() -> list[str]:
         "func testHydratePreferencePrefersRunThenSessionThenPill(",
         "func testFindPillMatchesByHydratePreferenceOrder(",
         "func testAgentCompletionBlockExposesOpenRefAndStaysVisible(",
-        "func testChatSelectionDoesNotWrapStackChromeInSelectionOverlay(",
+        "func testChatSelectionIsLimitedToSettledMessageBodies(",
         "func testAgentPreviewTextPrefersPromptOverOutput(",
         "func testAgentCompletionCardsUsePromptPreviewHelper(",
         "func testFloatingResourceStripsBindPerMessageNotProviderWide(",


### PR DESCRIPTION
## Summary
INV-6 hermetic contract coverage self-check referenced the old test name
`testChatSelectionDoesNotWrapStackChromeInSelectionOverlay` which was renamed
to `testChatSelectionIsLimitedToSettledMessageBodies`. Updated the needle in
`agent-continuity-gauntlet-lib.py`.

## Root cause
Test was renamed in a prior PR but the self-check needle list wasn't updated
in sync. This caused M1 pre-tag readiness to fail with:
> INV-6 hermetic contract coverage missing ChatTimelineContinuityTests.testChatSelectionDoesNotWrapStackChromeInSelectionOverlay

## Fix
Single-line change: updated needle string in `continuity_contract_self_check_failures()`
from old test name to new test name.

## Failure class (fixes)
Failure-Class: none
