### PR TITLE
chore(desktop): remove swift-format drift from two macOS Swift files

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -14,7 +14,6 @@ func byokMissingKeysHint(_ keys: [String]) -> String? {
     "Still missing: \(missing.joined(separator: ", ")). All 4 keys must be entered at the same time to activate the free plan."
 }
 
-
 extension SettingsContentView {
   var developerKeysSubsection: some View {
     VStack(spacing: OmiSpacing.xl) {
@@ -80,7 +79,6 @@ extension SettingsContentView {
     .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
     .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
   }
-
 
   var byokIncompleteHint: String? {
     byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -84,7 +84,6 @@ final class StartupWarmupPolicyTests: XCTestCase {
     )
   }
 
-
   func testConversationWarmupWaitsUntilAfterDeferredWarmupStarts() {
     XCTAssertGreaterThan(
       StartupWarmupPolicy.conversationWarmupDelay,


### PR DESCRIPTION
## What

`desktop-swift-format-lint` enforces formatter idempotency over every first-party Swift file (958 in scope), not only the files a PR touches. Two files on `main` had a stray extra blank line, so any PR whose diff merely *selects* that check — including one touching only the generated `OmiApi.generated.swift` — failed on drift it did not introduce. This blocked the push on #10314.

Formatting only: three collapsed double-blank-lines, no semantic change.

- `desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift` (2)
- `desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift` (1)

## Why this is separate

The drift is pre-existing debt in `main`, not something #10314 introduced. Landing it there would have mixed unrelated formatting into a security-reviewed public API surface. Two blank-line deletions off `main` review in seconds.

## Verification

Pinned `swift-format` 602.0.0 @ `62eaad2822b8` (the version `desktop/macos/scripts/swift-format-wrapper.sh` bootstraps):

- **before** — both files drift against a pristine `git show origin/main:` blob, confirming the drift predates any local edit
- **after** — `swift-format-wrapper.sh lint-scope` over all 958 in-scope files: `swift-format: clean (no formatting drift in scope)`

`desktop-swiftlint` also passes on this branch: `0 violations, 0 serious in 958 files`.

## Failure class

Failure-Class: none

Formatting-only change to two files. No behavioral surface, no query shape, no serving path, so there is no failure mode to declare a class for. The mechanism this unblocks — a check selected by a generated file then linting a much wider scope — is existing intended design in `.github/checks-manifest.yaml`, not a defect being papered over.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

