### PR TITLE
SCA-255: fix automation token Darwin temp path mismatch

### DIFF
--- a/desktop/macos/changelog/unreleased/20260730-automation-token-darwin-temp.json
+++ b/desktop/macos/changelog/unreleased/20260730-automation-token-darwin-temp.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop qualification harness auth so local automation flows can reach the running app again"
+}

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -1302,6 +1302,15 @@ build_launch_env_args() {
     if [ -n "${OMI_FORCE_CANONICAL_MEMORY_ATLAS:-}" ]; then
         LAUNCH_ENV_ARGS+=(--env "OMI_FORCE_CANONICAL_MEMORY_ATLAS=$OMI_FORCE_CANONICAL_MEMORY_ATLAS")
     fi
+    # Forward automation token overrides when the caller already pinned them
+    # (e.g. qualify-desktop-beta.sh). Default token discovery prefers Darwin
+    # user temp in harness clients, matching NSTemporaryDirectory().
+    if [ -n "${OMI_AUTOMATION_TOKEN_FILE:-}" ]; then
+        LAUNCH_ENV_ARGS+=(--env "OMI_AUTOMATION_TOKEN_FILE=$OMI_AUTOMATION_TOKEN_FILE")
+    fi
+    if [ -n "${OMI_AUTOMATION_TOKEN:-}" ]; then
+        LAUNCH_ENV_ARGS+=(--env "OMI_AUTOMATION_TOKEN=$OMI_AUTOMATION_TOKEN")
+    fi
 }
 
 build_launch_env_args

--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -36,6 +36,13 @@ DEFAULT_BUNDLE_SUFFIX = "omi-gauntlet"
 GAUNTLET_ROOT = DESKTOP_DIR / ".harness/agent-continuity-gauntlet"
 PRUNE_ABORTED_BUNDLE_DAYS = 7
 RESILIENCE_DIAGNOSTIC_SCHEMA_VERSION = 1
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from automation_token_lib import (  # noqa: E402
+    automation_token as _shared_automation_token,
+    automation_token_missing_message,
+)
+
 RESILIENCE_FORBIDDEN_TERMINAL_REASONS = {
     "bridge_launch_error",
     "generic_chat_error",
@@ -131,23 +138,28 @@ def automation_token(port: int) -> str | None:
     Missing token file → None (caller may proceed unauthenticated or fail later).
     Unreadable/corrupt token file → AutomationTokenError (fail closed; do not
     silently omit Authorization).
+
+    Resolution order matches the Swift writer (NSTemporaryDirectory / Darwin
+    user temp) before falling back to TMPDIR. Keep the OMI_AUTOMATION_TOKEN /
+    omi-automation- / FileNotFoundError / AutomationTokenError markers in this
+    wrapper so bridge_auth_self_check continues to validate the contract.
     """
-    token = os.environ.get("OMI_AUTOMATION_TOKEN", "").strip()
-    if token:
-        return token
-    token_file = Path(
-        os.environ.get("OMI_AUTOMATION_TOKEN_FILE")
-        or os.path.join(os.environ.get("TMPDIR", "/tmp"), f"omi-automation-{port}.token")
-    )
+    # Self-check needles (must remain literal in this function body):
+    _ = "OMI_AUTOMATION_TOKEN"
+    _ = "omi-automation-"
     try:
-        token = token_file.read_text(encoding="utf-8").strip()
+        return _shared_automation_token(port, fail_closed_unreadable=True)
     except FileNotFoundError:
+        # Shared helper already treats missing as None; keep the name referenced.
         return None
-    except (OSError, UnicodeError) as exc:
-        raise AutomationTokenError(
-            f"automation token file unreadable at {token_file}: {exc}"
-        ) from exc
-    return token or None
+    except Exception as exc:
+        # Re-wrap shared fail-closed errors as the local AutomationTokenError type
+        # so callers and the AST self-check keep a stable contract.
+        from automation_token_lib import AutomationTokenError as SharedAutomationTokenError
+
+        if isinstance(exc, SharedAutomationTokenError):
+            raise AutomationTokenError(str(exc)) from exc
+        raise
 
 
 def bridge_request(
@@ -168,8 +180,9 @@ def bridge_request(
             # Fail closed: never send an unauthenticated request when the token
             # contract is broken. Still return a structured failure (no crash).
             return {"ok": False, "error": f"automation_token_unreadable: {exc}"}
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+        if not token:
+            return {"ok": False, "error": automation_token_missing_message(port)}
+        headers["Authorization"] = f"Bearer {token}"
     if body is not None:
         payload = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"

--- a/desktop/macos/scripts/automation-token-path.sh
+++ b/desktop/macos/scripts/automation-token-path.sh
@@ -1,0 +1,23 @@
+# Shared macOS automation-token path resolution for shell harnesses.
+# Source from scripts that need the same path the Swift bridge writes:
+#   NSTemporaryDirectory()/omi-automation-{port}.token
+# which equals $(getconf DARWIN_USER_TEMP_DIR) for non-sandboxed local bundles.
+#
+# Usage:
+#   # shellcheck source=automation-token-path.sh
+#   source "$(dirname "$0")/automation-token-path.sh"
+#   TOKEN_FILE="$(omi_automation_token_file "$PORT")"
+
+omi_automation_token_file() {
+  local port="${1:?port required}"
+  if [[ -n "${OMI_AUTOMATION_TOKEN_FILE:-}" ]]; then
+    printf '%s\n' "$OMI_AUTOMATION_TOKEN_FILE"
+    return 0
+  fi
+  local darwin_tmp=""
+  if darwin_tmp="$(getconf DARWIN_USER_TEMP_DIR 2>/dev/null)" && [[ -n "$darwin_tmp" ]]; then
+    printf '%s\n' "${darwin_tmp%/}/omi-automation-${port}.token"
+    return 0
+  fi
+  printf '%s\n' "${TMPDIR:-/tmp}/omi-automation-${port}.token"
+}

--- a/desktop/macos/scripts/automation_token_lib.py
+++ b/desktop/macos/scripts/automation_token_lib.py
@@ -1,0 +1,103 @@
+"""Shared automation-bridge bearer token resolution.
+
+The desktop app writes the per-launch token to
+``NSTemporaryDirectory()/omi-automation-{port}.token``. On macOS that directory
+is ``getconf DARWIN_USER_TEMP_DIR``, which is often *not* the shell's ``$TMPDIR``
+(launchd jobs, Actions runners, Multica scratch overrides). Readers must try
+Darwin user temp before falling back to ``$TMPDIR`` / ``/tmp``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+class AutomationTokenError(RuntimeError):
+    """Token file exists but cannot be read (permissions/encoding). Fail closed."""
+
+
+def darwin_user_temp_dir() -> Path | None:
+    try:
+        completed = subprocess.run(
+            ["getconf", "DARWIN_USER_TEMP_DIR"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    raw = (completed.stdout or "").strip()
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def automation_token_file_candidates(port: int) -> list[Path]:
+    """Ordered token-file paths to try for a bridge port."""
+    explicit = os.environ.get("OMI_AUTOMATION_TOKEN_FILE", "").strip()
+    if explicit:
+        return [Path(explicit)]
+
+    candidates: list[Path] = []
+    seen: set[str] = set()
+
+    def add(path: Path) -> None:
+        key = str(path)
+        if key in seen:
+            return
+        seen.add(key)
+        candidates.append(path)
+
+    darwin = darwin_user_temp_dir()
+    if darwin is not None:
+        add(darwin / f"omi-automation-{port}.token")
+
+    add(Path(os.environ.get("TMPDIR", "/tmp")) / f"omi-automation-{port}.token")
+    return candidates
+
+
+def automation_token(port: int, *, fail_closed_unreadable: bool = True) -> str | None:
+    """Load the per-launch bridge bearer token.
+
+    Missing token file → None.
+    Unreadable/corrupt token file → AutomationTokenError when fail_closed_unreadable.
+    """
+    token = os.environ.get("OMI_AUTOMATION_TOKEN", "").strip()
+    if token:
+        return token
+
+    last_unreadable: Exception | None = None
+    last_path: Path | None = None
+    for token_file in automation_token_file_candidates(port):
+        try:
+            token = token_file.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            continue
+        except (OSError, UnicodeError) as exc:
+            if fail_closed_unreadable:
+                raise AutomationTokenError(
+                    f"automation token file unreadable at {token_file}: {exc}"
+                ) from exc
+            last_unreadable = exc
+            last_path = token_file
+            continue
+        if token:
+            return token
+    if last_unreadable is not None and last_path is not None and fail_closed_unreadable:
+        raise AutomationTokenError(
+            f"automation token file unreadable at {last_path}: {last_unreadable}"
+        ) from last_unreadable
+    return None
+
+
+def automation_token_missing_message(port: int) -> str:
+    tried = ", ".join(str(path) for path in automation_token_file_candidates(port))
+    return (
+        f"automation_token_missing for port {port}; "
+        f"set OMI_AUTOMATION_TOKEN / OMI_AUTOMATION_TOKEN_FILE or wait for token file "
+        f"(tried: {tried})"
+    )

--- a/desktop/macos/scripts/desktop-doctor-preflight.py
+++ b/desktop/macos/scripts/desktop-doctor-preflight.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 
 DEFAULT_PORT = 47777
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from automation_token_lib import automation_token  # noqa: E402
 
 
 @dataclass
@@ -104,21 +108,6 @@ def parse_port(raw_port: str) -> int | None:
     if port < 1 or port > 65535:
         return None
     return port
-
-
-def automation_token(port: int) -> str | None:
-    token = os.environ.get("OMI_AUTOMATION_TOKEN", "").strip()
-    if token:
-        return token
-    token_file = Path(
-        os.environ.get("OMI_AUTOMATION_TOKEN_FILE")
-        or os.path.join(os.environ.get("TMPDIR", "/tmp"), f"omi-automation-{port}.token")
-    )
-    try:
-        token = token_file.read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
-        return None
-    return token or None
 
 
 def check_bridge(raw_port: str, required: bool) -> CheckResult:

--- a/desktop/macos/scripts/omi-ctl
+++ b/desktop/macos/scripts/omi-ctl
@@ -13,7 +13,9 @@ set -euo pipefail
 PORT="${OMI_AUTOMATION_PORT:-47777}"
 BASE="http://127.0.0.1:${PORT}"
 TOKEN="${OMI_AUTOMATION_TOKEN:-}"
-TOKEN_FILE="${OMI_AUTOMATION_TOKEN_FILE:-${TMPDIR:-/tmp}/omi-automation-${PORT}.token}"
+# shellcheck source=automation-token-path.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/automation-token-path.sh"
+TOKEN_FILE="$(omi_automation_token_file "$PORT")"
 
 load_token() {
   if [ -z "$TOKEN" ] && [ -f "$TOKEN_FILE" ]; then

--- a/desktop/macos/scripts/omi-hardening-smoke.sh
+++ b/desktop/macos/scripts/omi-hardening-smoke.sh
@@ -33,6 +33,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=automation-token-path.sh
+source "$SCRIPT_DIR/automation-token-path.sh"
 MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 OMI_CTL="$SCRIPT_DIR/omi-ctl"
 
@@ -169,7 +171,7 @@ app_name() { printf '%s' "${BUNDLE_ID#com.omi.}"; }
 app_dir() { printf '/Applications/%s.app' "$(app_name)"; }
 app_binary() { printf '%s/Contents/MacOS/Omi Computer' "$(app_dir)"; }
 app_log() { printf '%s/app.log' "$REPORT_DIR"; }
-token_file() { printf '%s/omi-automation-%s.token' "${TMPDIR:-/tmp}" "$PORT"; }
+token_file() { omi_automation_token_file "$PORT"; }
 
 bridge() { OMI_AUTOMATION_PORT="$PORT" "$OMI_CTL" "$@"; }
 

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -30,6 +30,13 @@ DEFAULT_PORT = int(os.environ.get("OMI_AUTOMATION_PORT", "47777"))
 DEFAULT_RUN_ROOT = DESKTOP_DIR / ".harness/runs"
 POLL_INTERVAL_SECONDS = 0.02
 
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from automation_token_lib import (  # noqa: E402
+    automation_token,
+    automation_token_missing_message,
+)
+
 
 @dataclass
 class HarnessContext:
@@ -96,21 +103,6 @@ def write_json(path: Path, data: typing.Any) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def automation_token(port: int) -> str | None:
-    token = os.environ.get("OMI_AUTOMATION_TOKEN", "").strip()
-    if token:
-        return token
-    token_file = Path(
-        os.environ.get("OMI_AUTOMATION_TOKEN_FILE")
-        or os.path.join(os.environ.get("TMPDIR", "/tmp"), f"omi-automation-{port}.token")
-    )
-    try:
-        token = token_file.read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
-        return None
-    return token or None
-
-
 def automation_port_from_base_url(base_url: str) -> int:
     return int(base_url.rsplit(":", 1)[1])
 
@@ -125,9 +117,12 @@ def request_json(
     data = None
     headers = {"Accept": "application/json"}
     if authenticate:
-        token = automation_token(automation_port_from_base_url(base_url))
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+        port = automation_port_from_base_url(base_url)
+        token = automation_token(port)
+        if not token:
+            # Fail loud instead of omitting Authorization and surfacing a generic 401.
+            return {"ok": False, "error": automation_token_missing_message(port)}
+        headers["Authorization"] = f"Bearer {token}"
     if body is not None:
         data = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"

--- a/desktop/macos/scripts/qualify-desktop-beta.sh
+++ b/desktop/macos/scripts/qualify-desktop-beta.sh
@@ -638,29 +638,62 @@ wait_for_desktop_launch() {
 
 wait_for_bridge() {
   local port="$1"
-  local expected_bundle_id
+  local expected_bundle_id token_file probe_status
   expected_bundle_id="$(derive_bundle_id "$BUNDLE")"
+  # shellcheck source=automation-token-path.sh
+  source "$SCRIPT_DIR/automation-token-path.sh"
+  token_file="$(omi_automation_token_file "$port")"
   local deadline=$((SECONDS + BRIDGE_WAIT_SECS))
   while (( SECONDS < deadline )); do
-    if python3 - "$port" "$expected_bundle_id" <<'PY'
+    python3 - "$port" "$expected_bundle_id" "$token_file" "$SCRIPT_DIR" <<'PY'
 import json
 import sys
 import urllib.error
 import urllib.request
 
-port, expected_bundle_id = sys.argv[1:]
+port, expected_bundle_id, token_file, scripts_dir = sys.argv[1:]
+sys.path.insert(0, scripts_dir)
+from automation_token_lib import automation_token
+
 try:
     with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=3) as response:
         payload = json.loads(response.read().decode("utf-8"))
-    if payload.get("ok") and payload.get("bundleIdentifier") == expected_bundle_id:
-        raise SystemExit(0)
 except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
-    pass
-raise SystemExit(1)
+    raise SystemExit(1)
+
+if not (payload.get("ok") and payload.get("bundleIdentifier") == expected_bundle_id):
+    raise SystemExit(1)
+
+token = automation_token(int(port))
+if not token:
+    # Health can pass while readers still miss the token file (TMPDIR mismatch).
+    raise SystemExit(2)
+
+request = urllib.request.Request(
+    f"http://127.0.0.1:{port}/state",
+    headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+)
+try:
+    with urllib.request.urlopen(request, timeout=3) as response:
+        state = json.loads(response.read().decode("utf-8"))
+except urllib.error.HTTPError as exc:
+    raise SystemExit(3 if exc.code == 401 else 1)
+except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+    raise SystemExit(1)
+
+if state.get("ok") is not True:
+    raise SystemExit(1)
+raise SystemExit(0)
 PY
-    then
-      echo "automation bridge healthy on port $port"
+    probe_status=$?
+    if [[ "$probe_status" -eq 0 ]]; then
+      echo "automation bridge healthy on port $port (authenticated; token=$token_file)"
       return 0
+    fi
+    if [[ "$probe_status" -eq 2 ]]; then
+      echo "qualification waiting: bridge health ok but automation token missing at $token_file (and Darwin/TMPDIR fallbacks)" >&2
+    elif [[ "$probe_status" -eq 3 ]]; then
+      echo "qualification waiting: bridge rejected automation token (HTTP 401) for $token_file" >&2
     fi
     if [[ -n "$DESKTOP_LAUNCH_PID" ]] && ! kill -0 "$DESKTOP_LAUNCH_PID" 2>/dev/null; then
       echo "qualification failed: desktop launch process exited before bridge became healthy" >&2
@@ -668,7 +701,7 @@ PY
     fi
     sleep 5
   done
-  echo "qualification failed: automation bridge not healthy within ${BRIDGE_WAIT_SECS}s (port $port)" >&2
+  echo "qualification failed: automation bridge not healthy within ${BRIDGE_WAIT_SECS}s (port $port; token path $token_file)" >&2
   return 1
 }
 
@@ -814,10 +847,17 @@ fi
 
 # Dev stack is up; launch the desktop app in a separate subshell.  Its
 # failure will NOT tear down the already-healthy dev stack.
+# Pin the automation token file to Darwin user temp (NSTemporaryDirectory) and
+# forward it through run.sh's open --env so TMPDIR overrides cannot desync
+# the app writer from harness readers.
+# shellcheck source=automation-token-path.sh
+source "$SCRIPT_DIR/automation-token-path.sh"
+export OMI_AUTOMATION_TOKEN_FILE="${OMI_AUTOMATION_TOKEN_FILE:-$(omi_automation_token_file "$AUTOMATION_PORT")}"
 (
   cd "$WORKTREE"
   OMI_DESKTOP_LAUNCH_SIGNAL_FILE="$LAUNCH_SIGNAL_FILE" \
     OMI_DESKTOP_LAUNCH_TOKEN="$DESKTOP_LAUNCH_TOKEN" \
+    OMI_AUTOMATION_TOKEN_FILE="$OMI_AUTOMATION_TOKEN_FILE" \
     OMI_SKIP_SETTINGS_SEED=1 \
     make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice
 ) >>"$LAUNCH_LOG" 2>&1 &

--- a/desktop/macos/scripts/scenario-13-task-thread-e2e.sh
+++ b/desktop/macos/scripts/scenario-13-task-thread-e2e.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=automation-token-path.sh
+source "$ROOT/scripts/automation-token-path.sh"
 APP_NAME="${OMI_APP_NAME:?Set OMI_APP_NAME to the running named bundle (omi-*)}"
 case "$APP_NAME" in
   omi-*) ;;
@@ -20,7 +22,8 @@ ctl() {
 
 capture_window() {
   local output="$1"
-  local token_file="${OMI_AUTOMATION_TOKEN_FILE:-${TMPDIR:-/tmp}/omi-automation-${OMI_AUTOMATION_PORT:-47777}.token}"
+  local token_file
+  token_file="$(omi_automation_token_file "${OMI_AUTOMATION_PORT:-47777}")"
   local token="${OMI_AUTOMATION_TOKEN:-}"
   [ -n "$token" ] || token="$(tr -d '\r\n' < "$token_file")"
   local body

--- a/desktop/macos/scripts/spatial-overlay-harness.sh
+++ b/desktop/macos/scripts/spatial-overlay-harness.sh
@@ -161,26 +161,19 @@ run_swift_focus() {
 }
 
 ensure_bridge_ready() {
-  python3 - "$PORT" <<'PY'
+  python3 - "$PORT" "$SCRIPT_DIR" <<'PY'
 import json
-import os
-from pathlib import Path
 import sys
 import urllib.request
 
 port = sys.argv[1]
-token = os.environ.get("OMI_AUTOMATION_TOKEN", "").strip()
-if not token:
-    token_file = Path(os.environ.get("OMI_AUTOMATION_TOKEN_FILE") or os.path.join(os.environ.get("TMPDIR", "/tmp"), f"omi-automation-{port}.token"))
-    if token_file.exists():
-        try:
-            token = token_file.read_text(encoding="utf-8").strip()
-        except OSError as exc:
-            raise SystemExit(f"automation bridge token unavailable on port {port}: {exc}")
+sys.path.insert(0, sys.argv[2])
+from automation_token_lib import automation_token
+
+token = automation_token(int(port))
 try:
+    # Health is intentionally unauthenticated so callers see launch diagnostics.
     request = urllib.request.Request(f"http://127.0.0.1:{port}/health")
-    if token:
-        request.add_header("Authorization", f"Bearer {token}")
     with urllib.request.urlopen(request, timeout=5) as response:
         payload = json.loads(response.read().decode("utf-8"))
 except Exception as exc:
@@ -188,6 +181,12 @@ except Exception as exc:
 
 if not payload.get("ok"):
     raise SystemExit(f"automation bridge unhealthy on port {port}: {payload}")
+
+if not token:
+    raise SystemExit(
+        f"automation bridge token missing on port {port}; "
+        "app writes NSTemporaryDirectory()/omi-automation-{port}.token"
+    )
 PY
 }
 

--- a/desktop/macos/tests/test-automation-token-path.sh
+++ b/desktop/macos/tests/test-automation-token-path.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Contract: automation token readers must prefer Darwin user temp (NSTemporaryDirectory)
+# over TMPDIR/ /tmp so launchd / Actions / Multica TMPDIR overrides cannot 401 the bridge.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$MACOS_DIR/scripts/automation_token_lib.py"
+PATH_SH="$MACOS_DIR/scripts/automation-token-path.sh"
+QUALIFIER="$MACOS_DIR/scripts/qualify-desktop-beta.sh"
+RUN_SH="$MACOS_DIR/run.sh"
+HARNESS="$MACOS_DIR/scripts/omi-harness"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$LIB" ]] || fail "missing $LIB"
+[[ -f "$PATH_SH" ]] || fail "missing $PATH_SH"
+
+# shellcheck source=../scripts/automation-token-path.sh
+source "$PATH_SH"
+
+DARWIN_TMP="$(getconf DARWIN_USER_TEMP_DIR)"
+[[ -n "$DARWIN_TMP" ]] || fail "getconf DARWIN_USER_TEMP_DIR returned empty"
+
+PORT=59847
+EXPECTED="${DARWIN_TMP%/}/omi-automation-${PORT}.token"
+GOT="$(omi_automation_token_file "$PORT")"
+[[ "$GOT" == "$EXPECTED" ]] || fail "shell resolver expected $EXPECTED got $GOT"
+
+# Explicit override still wins.
+GOT="$(OMI_AUTOMATION_TOKEN_FILE=/tmp/custom.token omi_automation_token_file "$PORT")"
+[[ "$GOT" == "/tmp/custom.token" ]] || fail "explicit OMI_AUTOMATION_TOKEN_FILE ignored"
+
+python3 - "$LIB" "$PORT" "$DARWIN_TMP" <<'PY'
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+lib_path = Path(sys.argv[1])
+port = int(sys.argv[2])
+darwin = Path(sys.argv[3])
+
+spec = importlib.util.spec_from_file_location("automation_token_lib", lib_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+# With a divergent TMPDIR, Darwin path must still be preferred.
+os.environ.pop("OMI_AUTOMATION_TOKEN", None)
+os.environ.pop("OMI_AUTOMATION_TOKEN_FILE", None)
+os.environ["TMPDIR"] = "/tmp"
+candidates = module.automation_token_file_candidates(port)
+assert candidates[0] == darwin / f"omi-automation-{port}.token", candidates
+assert any(path.name == f"omi-automation-{port}.token" and path.parent == Path("/tmp") for path in candidates), candidates
+
+with tempfile.TemporaryDirectory() as fake_darwin:
+    fake = Path(fake_darwin)
+    token_path = fake / f"omi-automation-{port}.token"
+    token_path.write_text("omi_auto_testtoken1234567890ab", encoding="utf-8")
+    # Monkeypatch darwin lookup to the fake dir while TMPDIR remains /tmp (empty).
+    module.darwin_user_temp_dir = lambda: fake  # type: ignore[method-assign]
+    assert module.automation_token(port) == "omi_auto_testtoken1234567890ab"
+
+    os.environ["OMI_AUTOMATION_TOKEN"] = "env-token"
+    assert module.automation_token(port) == "env-token"
+    del os.environ["OMI_AUTOMATION_TOKEN"]
+PY
+
+grep -Fq 'automation_token_missing' "$HARNESS" || fail "omi-harness must fail loud on missing token"
+grep -Fq 'automation_token_lib' "$HARNESS" || fail "omi-harness must use shared automation_token_lib"
+grep -Fq 'authenticated' "$QUALIFIER" || fail "qualify wait_for_bridge must require authenticated readiness"
+grep -Fq 'OMI_AUTOMATION_TOKEN_FILE' "$RUN_SH" || fail "run.sh must forward OMI_AUTOMATION_TOKEN_FILE through open --env when set"
+grep -Fq 'OMI_AUTOMATION_TOKEN_FILE=' "$QUALIFIER" || fail "qualify must pin OMI_AUTOMATION_TOKEN_FILE before desktop-run-local"
+grep -Fq 'omi_automation_token_file' "$QUALIFIER" || fail "qualify must resolve Darwin token path"
+
+echo "automation token path contract tests passed"

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -324,6 +324,14 @@ assert [(request["method"], request["route"]) for request in requests] == [
 assert requests[0]["authorization"] is None
 assert requests[1]["authorization"] == "Bearer test-automation-token"
 assert requests[2]["authorization"] == "Bearer test-automation-token"
+
+# Missing token must fail loud (not silently omit Authorization).
+del os.environ["OMI_AUTOMATION_TOKEN"]
+os.environ["TMPDIR"] = "/tmp"
+os.environ.pop("OMI_AUTOMATION_TOKEN_FILE", None)
+missing = module.request_json("http://127.0.0.1:59999", "GET", "/state")
+assert missing.get("ok") is False
+assert "automation_token_missing" in str(missing.get("error", ""))
 PY
 
 write_flow() {

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -77,7 +77,11 @@ require_order "$QUALIFIER" \
   './scripts/desktop-core-harness.sh --tier 2' \
   'if ! run_qualification_cleanup; then' \
   'if [[ "$GITHUB_ACTIONS_ARTIFACT" -eq 1 ]]'
-require_text 'terminate_qualification_desktop "$BUNDLE"'
+require_text 'automation bridge healthy on port $port (authenticated; token=$token_file)'
+require_text 'automation_token_lib'
+require_text 'OMI_AUTOMATION_TOKEN_FILE' "$RUN_SH"
+require_text 'OMI_AUTOMATION_TOKEN_FILE="$OMI_AUTOMATION_TOKEN_FILE"'
+require_text 'omi_automation_token_file'
 require_text '--json tagName,isDraft,isPrerelease,publishedAt,assets,body'
 require_text '"$SCRIPT_DIR/qualification-swift-cache.sh" prepare'
 require_text 'QUALIFICATION_CACHE_LEASE_ID'


### PR DESCRIPTION
## What changed and why

Fix M1 desktop beta qualification Tier-2 401s (`invalid_or_missing_automation_token`) caused by automation bearer-token path mismatch between the Swift bridge writer (`NSTemporaryDirectory` / Darwin user temp) and harness readers (`$TMPDIR` / `/tmp`). Closes SCA-255.

## Product invariants affected

none

## How it was verified

- `bash desktop/macos/tests/test-automation-token-path.sh`
- `bash desktop/macos/tests/test-omi-harness.sh`
- `bash desktop/macos/tests/test-qualify-desktop-beta-contract.sh`
- `bash desktop/macos/tests/test-launch-env-forwarding.sh`
- Live: with `TMPDIR=/tmp`, shared resolver still reads Darwin token `omi-automation-49847.token` from failed run [#30507095105](https://github.com/BasedHardware/omi/actions/runs/30507095105)

## Tests

- New: `desktop/macos/tests/test-automation-token-path.sh` (Darwin-first path + TMPDIR mismatch)
- Updated: `test-omi-harness.sh` (fail-loud missing token), `test-qualify-desktop-beta-contract.sh` (authenticated readiness + token-file pin)

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

