### PR TITLE
SCA-256: gate Windows releases on live update-feed route

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -24,6 +24,11 @@ checks:
     triggers: [".github/scripts/verify-pre-tag-readiness.py", ".github/scripts/test_verify_pre_tag_readiness.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "the receipt verifier must reject stale, non-offline, failed, and promotion-bearing readiness evidence before a tag mutation"
+  - id: windows-update-feed-probe-tests
+    command: ["python3", ".github/scripts/test_probe_windows_update_feed.py"]
+    triggers: [".github/scripts/probe_windows_update_feed.py", ".github/scripts/test_probe_windows_update_feed.py", ".github/workflows/desktop_windows_release.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "Windows releases must not tag while production is missing /v2/desktop/update-feed/windows; the probe's trust-boundary validation is the release-lane guard"
   - id: pre-push-final-pr-diff
     command: ["bash", "scripts/test-pre-push-diff-base.sh"]
     triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]

--- a/.github/failure-classes/FC-ship-before-required-route.json
+++ b/.github/failure-classes/FC-ship-before-required-route.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "FC-ship-before-required-route",
+  "violated_contract": "A client that hard-depends on a backend route and fails closed when that route is absent must not ship to users until the route is live in the environment the client calls.",
+  "canonical_prevention": "Gate the client release lane on a production probe of the required route (status, response shape, and trust boundary) before minting an immutable release tag; keep the deploy-before-ship note next to the client dependency.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/probe_windows_update_feed.py",
+    ".github/scripts/test_probe_windows_update_feed.py",
+    ".github/workflows/desktop_windows_release.yml"
+  ],
+  "evidence_prs": [10610],
+  "scope_hints": [
+    ".github/workflows/desktop_windows_release.yml",
+    ".github/scripts/probe_windows_update_feed.py",
+    "desktop/windows/src/main/updater.ts",
+    "desktop/windows/src/main/windowsUpdateFeed.ts",
+    "backend/routers/updates.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/probe_windows_update_feed.py
+++ b/.github/scripts/probe_windows_update_feed.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Prove production serves the Windows electron-updater feed resolver.
+
+Windows clients since #10610 call ``/v2/desktop/update-feed/windows`` before every
+update check and fail closed when that route is missing. Shipping another
+Windows build while production still 404s the route (OpenAPI/route absence, not
+an empty channel) permanently breaks auto-update for that cohort.
+
+This probe is the release-lane guard for that contract. It validates the same
+trust boundary the desktop client enforces: GitHub origin, Windows release
+directory path, and stable-channel non-fallthrough.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable
+
+DEFAULT_API_BASE = "https://api.omi.me"
+DEFAULT_TIMEOUT_SECONDS = 20
+CHANNELS = ("beta", "stable")
+WINDOWS_FEED_PATH = re.compile(
+    r"^/BasedHardware/omi/releases/download/v?\d+\.\d+(?:\.\d+)?(?:\+\d+)?-windows/$"
+)
+Fetcher = Callable[[str], tuple[int, object]]
+
+
+class ProbeError(RuntimeError):
+    """Production Windows update-feed probe failed."""
+
+
+def _require_object(payload: object, *, stage: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ProbeError(f"{stage}: expected a JSON object, got {type(payload).__name__}")
+    return payload
+
+
+def validate_feed_response(payload: object, *, requested_channel: str) -> dict[str, str]:
+    """Validate one successful update-feed JSON body against the client contract."""
+    if requested_channel not in CHANNELS:
+        raise ProbeError(f"requested channel must be beta or stable, got {requested_channel!r}")
+
+    response = _require_object(payload, stage="update-feed")
+    if response.get("requested_channel") != requested_channel:
+        raise ProbeError(
+            "update-feed: requested_channel mismatch "
+            f"(expected {requested_channel!r}, got {response.get('requested_channel')!r})"
+        )
+
+    served = response.get("served_channel")
+    if served not in CHANNELS:
+        raise ProbeError(f"update-feed: invalid served_channel {served!r}")
+    if requested_channel == "stable" and served != "stable":
+        raise ProbeError("update-feed: stable must never fall through to beta")
+
+    version = response.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ProbeError(f"update-feed: missing version, got {version!r}")
+
+    feed_url = response.get("feed_url")
+    if not isinstance(feed_url, str):
+        raise ProbeError(f"update-feed: missing feed_url, got {feed_url!r}")
+
+    try:
+        parsed = urllib.parse.urlparse(feed_url)
+    except ValueError as exc:
+        raise ProbeError(f"update-feed: invalid feed_url {feed_url!r}") from exc
+
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "github.com"
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or not WINDOWS_FEED_PATH.fullmatch(parsed.path)
+    ):
+        raise ProbeError(f"update-feed: untrusted feed_url {feed_url!r}")
+
+    return {
+        "requested_channel": requested_channel,
+        "served_channel": served,
+        "version": version,
+        "feed_url": feed_url,
+    }
+
+
+def classify_http_failure(status: int, payload: object) -> str:
+    """Turn a non-2xx response into a deploy-actionable error message."""
+    detail = None
+    if isinstance(payload, dict):
+        raw = payload.get("detail")
+        if isinstance(raw, str):
+            detail = raw
+
+    if status == 404 and detail in (None, "Not Found"):
+        return (
+            "production is missing /v2/desktop/update-feed/windows "
+            "(deploy backend commit that includes #10610 before cutting a Windows release)"
+        )
+    if status == 404:
+        return f"update-feed returned 404: {detail}"
+    if detail:
+        return f"update-feed returned HTTP {status}: {detail}"
+    return f"update-feed returned HTTP {status}"
+
+
+def _default_fetch(url: str, *, timeout: float = DEFAULT_TIMEOUT_SECONDS) -> tuple[int, object]:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "omi-windows-update-feed-probe"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 - fixed api.omi.me root
+            body = response.read()
+            status = int(getattr(response, "status", 200) or 200)
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        status = int(exc.code)
+    except urllib.error.URLError as exc:
+        raise ProbeError(f"update-feed request failed: {exc.reason}") from exc
+
+    if not body:
+        return status, None
+    try:
+        return status, json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProbeError(f"update-feed returned non-JSON body (HTTP {status})") from exc
+
+
+def probe_channel(
+    api_base: str,
+    channel: str,
+    *,
+    fetch: Fetcher | None = None,
+) -> dict[str, str]:
+    base = api_base.rstrip("/")
+    url = f"{base}/v2/desktop/update-feed/windows?channel={urllib.parse.quote(channel)}"
+    fetcher = fetch or _default_fetch
+    status, payload = fetcher(url)
+    if status != 200:
+        raise ProbeError(classify_http_failure(status, payload))
+    return validate_feed_response(payload, requested_channel=channel)
+
+
+def probe(
+    api_base: str = DEFAULT_API_BASE,
+    *,
+    channels: tuple[str, ...] = ("beta",),
+    fetch: Fetcher | None = None,
+) -> list[dict[str, str]]:
+    if not channels:
+        raise ProbeError("at least one channel is required")
+    results: list[dict[str, str]] = []
+    for channel in channels:
+        results.append(probe_channel(api_base, channel, fetch=fetch))
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-base",
+        default=DEFAULT_API_BASE,
+        help=f"Backend origin (default: {DEFAULT_API_BASE})",
+    )
+    parser.add_argument(
+        "--channel",
+        action="append",
+        choices=list(CHANNELS),
+        dest="channels",
+        help="Channel to probe (repeatable). Default: beta only — the auto-cut release channel.",
+    )
+    args = parser.parse_args(argv)
+    channels = tuple(args.channels) if args.channels else ("beta",)
+    try:
+        results = probe(args.api_base, channels=channels)
+    except ProbeError as exc:
+        print(f"Windows update-feed probe FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    for result in results:
+        print(
+            "Windows update-feed probe OK: "
+            f"requested={result['requested_channel']} "
+            f"served={result['served_channel']} "
+            f"version={result['version']} "
+            f"feed_url={result['feed_url']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_probe_windows_update_feed.py
+++ b/.github/scripts/test_probe_windows_update_feed.py
@@ -94,6 +94,30 @@ class ProbeWindowsUpdateFeedTests(unittest.TestCase):
         with self.assertRaisesRegex(PROBE.ProbeError, "missing /v2/desktop/update-feed/windows"):
             PROBE.probe_channel("https://api.omi.me", "beta", fetch=fetch_missing)
 
+    def test_probe_multiple_channels(self) -> None:
+        def fetch(url: str) -> tuple[int, object]:
+            if "channel=beta" in url:
+                return 200, ok_payload(requested="beta", served="beta")
+            if "channel=stable" in url:
+                return 200, ok_payload(requested="stable", served="stable")
+            raise AssertionError(f"unexpected url: {url}")
+
+        results = PROBE.probe("https://api.omi.me", channels=("beta", "stable"), fetch=fetch)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["served_channel"], "beta")
+        self.assertEqual(results[1]["served_channel"], "stable")
+
+    def test_probe_stable_missing_fails_without_fallthrough(self) -> None:
+        """If stable has no feed it must NOT fall through to beta."""
+        def fetch(url: str) -> tuple[int, object]:
+            if "channel=beta" in url:
+                return 200, ok_payload(requested="beta", served="beta")
+            # stable absent → backend returns 404 per its non-fallthrough contract
+            return 404, {"detail": "No Windows update feed found for channel: stable"}
+
+        with self.assertRaisesRegex(PROBE.ProbeError, "stable"):
+            PROBE.probe("https://api.omi.me", channels=("beta", "stable"), fetch=fetch)
+
     def test_main_exits_nonzero_when_route_missing(self) -> None:
         with mock.patch.object(
             PROBE,

--- a/.github/scripts/test_probe_windows_update_feed.py
+++ b/.github/scripts/test_probe_windows_update_feed.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Unit tests for the Windows update-feed production probe."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("probe_windows_update_feed.py")
+SPEC = importlib.util.spec_from_file_location("probe_windows_update_feed", SCRIPT)
+assert SPEC and SPEC.loader
+PROBE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PROBE
+SPEC.loader.exec_module(PROBE)
+
+
+def ok_payload(
+    *,
+    requested: str = "beta",
+    served: str = "beta",
+    version: str = "1.0.33",
+    feed_url: str = "https://github.com/BasedHardware/omi/releases/download/v1.0.33-windows/",
+) -> dict[str, str]:
+    return {
+        "requested_channel": requested,
+        "served_channel": served,
+        "version": version,
+        "feed_url": feed_url,
+    }
+
+
+class ProbeWindowsUpdateFeedTests(unittest.TestCase):
+    def test_validate_accepts_trusted_windows_feed(self) -> None:
+        result = PROBE.validate_feed_response(ok_payload(), requested_channel="beta")
+        self.assertEqual(result["version"], "1.0.33")
+        self.assertTrue(result["feed_url"].endswith("/v1.0.33-windows/"))
+
+    def test_validate_allows_beta_to_stable_fallback(self) -> None:
+        payload = ok_payload(
+            requested="beta",
+            served="stable",
+            version="1.0.1",
+            feed_url="https://github.com/BasedHardware/omi/releases/download/v1.0.1-windows/",
+        )
+        result = PROBE.validate_feed_response(payload, requested_channel="beta")
+        self.assertEqual(result["served_channel"], "stable")
+
+    def test_validate_rejects_stable_fallthrough_to_beta(self) -> None:
+        payload = ok_payload(requested="stable", served="beta")
+        with self.assertRaisesRegex(PROBE.ProbeError, "never fall through"):
+            PROBE.validate_feed_response(payload, requested_channel="stable")
+
+    def test_validate_rejects_untrusted_feed_url(self) -> None:
+        cases = (
+            "http://github.com/BasedHardware/omi/releases/download/v1.0.33-windows/",
+            "https://evil.example/BasedHardware/omi/releases/download/v1.0.33-windows/",
+            "https://github.com/BasedHardware/omi/releases/download/v1.0.33-macos/",
+            "https://github.com/BasedHardware/omi/releases/download/v1.0.33-windows/?x=1",
+            "https://github.com/BasedHardware/omi/releases/download/v1.0.33-windows/#frag",
+            "https://user:pass@github.com/BasedHardware/omi/releases/download/v1.0.33-windows/",
+        )
+        for feed_url in cases:
+            with self.subTest(feed_url=feed_url):
+                payload = ok_payload(feed_url=feed_url)
+                with self.assertRaisesRegex(PROBE.ProbeError, "untrusted feed_url"):
+                    PROBE.validate_feed_response(payload, requested_channel="beta")
+
+    def test_classify_missing_route_vs_empty_channel(self) -> None:
+        self.assertIn(
+            "missing /v2/desktop/update-feed/windows",
+            PROBE.classify_http_failure(404, {"detail": "Not Found"}),
+        )
+        self.assertIn(
+            "No Windows update feed found",
+            PROBE.classify_http_failure(
+                404, {"detail": "No Windows update feed found for channel: beta"}
+            ),
+        )
+
+    def test_probe_channel_success_and_failure(self) -> None:
+        def fetch_ok(url: str) -> tuple[int, object]:
+            self.assertIn("channel=beta", url)
+            return 200, ok_payload()
+
+        result = PROBE.probe_channel("https://api.omi.me", "beta", fetch=fetch_ok)
+        self.assertEqual(result["version"], "1.0.33")
+
+        def fetch_missing(_url: str) -> tuple[int, object]:
+            return 404, {"detail": "Not Found"}
+
+        with self.assertRaisesRegex(PROBE.ProbeError, "missing /v2/desktop/update-feed/windows"):
+            PROBE.probe_channel("https://api.omi.me", "beta", fetch=fetch_missing)
+
+    def test_main_exits_nonzero_when_route_missing(self) -> None:
+        with mock.patch.object(
+            PROBE,
+            "probe",
+            side_effect=PROBE.ProbeError(
+                "production is missing /v2/desktop/update-feed/windows"
+            ),
+        ):
+            self.assertEqual(PROBE.main([]), 1)
+
+    def test_main_prints_ok_on_success(self) -> None:
+        with mock.patch.object(PROBE, "probe", return_value=[ok_payload()]):
+            with mock.patch("builtins.print") as printer:
+                self.assertEqual(PROBE.main([]), 0)
+        messages = [call.args[0] for call in printer.call_args_list]
+        self.assertTrue(any("probe OK" in message for message in messages), messages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -227,12 +227,16 @@ jobs:
       # jobs), GitHub Actions reuses the cached plan-and-tag outputs and does not
       # re-execute the probe that ran there. Re-validate the route now so a
       # backend rollback between tagging and publishing cannot mint a broken cohort.
+      - name: Setup Python for re-probe
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
       - name: Re-probe production Windows update-feed before publish
         if: ${{ !contains(github.event.inputs.bypass_update_feed_probe_reason, 'I ACKNOWLEDGE THE ROUTE IS REQUIRED') }}
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
-          python3 .github/scripts/probe_windows_update_feed.py \
+          python .github/scripts/probe_windows_update_feed.py \
             --channel beta \
             --channel stable
 

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -41,7 +41,7 @@ on:
         required: false
         type: string
       bypass_update_feed_probe_reason:
-        description: 'Emergency only: type a tracking-issue/reason to skip the production update-feed probe. Empty = probe runs.'
+        description: 'Emergency only: supply a tracking-issue URL or reason AND the literal phrase I ACKNOWLEDGE THE ROUTE IS REQUIRED to skip the probe. Empty or any other text = probe runs.'
         required: false
         type: string
 
@@ -77,25 +77,28 @@ jobs:
       # stable (the default for fresh installs and un-toggled settings). The
       # backend never falls stable through to beta, so a beta-only probe passing
       # while stable 404s would still ship a broken default cohort.
+      #
+      # Break-glass: the probe is skipped only when the dispatcher supplies the
+      # literal confirmation sentinel "I ACKNOWLEDGE THE ROUTE IS REQUIRED" plus a
+      # tracking-issue/reason. An empty or arbitrary value still runs the probe.
+      # The sentinel is checked through an env var (not direct interpolation) so
+      # operator-supplied reason text is treated as data, not shell syntax.
       - name: Probe production Windows update-feed (beta + stable)
-        if: ${{ github.event.inputs.bypass_update_feed_probe_reason == '' }}
+        if: ${{ !contains(github.event.inputs.bypass_update_feed_probe_reason, 'I ACKNOWLEDGE THE ROUTE IS REQUIRED') }}
         shell: bash
         run: |
           python3 .github/scripts/probe_windows_update_feed.py \
             --channel beta \
             --channel stable
 
-      # Break-glass: probe itself broken, or the GitHub runner cannot reach
-      # api.omi.me. Requires a non-empty reason (tracked in the run log) so a
-      # transient probe failure cannot indefinitely block Windows hotfixes,
-      # while still preventing an un-audited release when the route is genuinely
-      # absent.
       - name: Probe bypassed (audited emergency release)
-        if: ${{ github.event.inputs.bypass_update_feed_probe_reason != '' }}
+        if: ${{ contains(github.event.inputs.bypass_update_feed_probe_reason, 'I ACKNOWLEDGE THE ROUTE IS REQUIRED') }}
         shell: bash
+        env:
+          BYPASS_REASON: ${{ github.event.inputs.bypass_update_feed_probe_reason }}
         run: |
           echo "::warning::Windows update-feed probe BYPASSED."
-          echo "Reason: ${{ github.event.inputs.bypass_update_feed_probe_reason }}"
+          printf 'Reason: %s\n' "$BYPASS_REASON"
           echo "This is recorded for audit. The route deploy (#10610) is still required."
 
       - name: Plan release (compute next version, tag, sync back to main)

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Windows clients since #10610 fail closed without this production route.
+      # Probe before tagging so a missing deploy cannot mint another broken cohort.
+      - name: Probe production Windows update-feed
+        shell: bash
+        run: python3 .github/scripts/probe_windows_update_feed.py --channel beta
+
       - name: Plan release (compute next version, tag, sync back to main)
         id: plan
         env:
@@ -308,7 +314,7 @@ jobs:
 
           ${SIGN_NOTE}
 
-          Install: download and run the \`.exe\`. Installed apps auto-update from stable releases."
+          Install: download and run the \`.exe\`. Installed apps auto-update through \`/v2/desktop/update-feed/windows\` (beta when Settings → Receive beta updates is on; otherwise stable)."
 
           # Create the release if the plan job did not (idempotent on re-run).
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -223,6 +223,19 @@ jobs:
         with:
           ref: ${{ needs.plan-and-tag.outputs.release_tag }}
 
+      # Re-probe at publish time: if build-and-publish is retried (re-run failed
+      # jobs), GitHub Actions reuses the cached plan-and-tag outputs and does not
+      # re-execute the probe that ran there. Re-validate the route now so a
+      # backend rollback between tagging and publishing cannot mint a broken cohort.
+      - name: Re-probe production Windows update-feed before publish
+        if: ${{ !contains(github.event.inputs.bypass_update_feed_probe_reason, 'I ACKNOWLEDGE THE ROUTE IS REQUIRED') }}
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          python3 .github/scripts/probe_windows_update_feed.py \
+            --channel beta \
+            --channel stable
+
       - uses: pnpm/action-setup@v6
         with:
           version: 10

--- a/.github/workflows/desktop_windows_release.yml
+++ b/.github/workflows/desktop_windows_release.yml
@@ -40,6 +40,10 @@ on:
         description: 'Optional explicit version to tag (for example, 1.2.0)'
         required: false
         type: string
+      bypass_update_feed_probe_reason:
+        description: 'Emergency only: type a tracking-issue/reason to skip the production update-feed probe. Empty = probe runs.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -69,10 +73,30 @@ jobs:
           fetch-depth: 0
 
       # Windows clients since #10610 fail closed without this production route.
-      # Probe before tagging so a missing deploy cannot mint another broken cohort.
-      - name: Probe production Windows update-feed
+      # Probe BOTH channels that real clients can request: beta (opt-in) and
+      # stable (the default for fresh installs and un-toggled settings). The
+      # backend never falls stable through to beta, so a beta-only probe passing
+      # while stable 404s would still ship a broken default cohort.
+      - name: Probe production Windows update-feed (beta + stable)
+        if: ${{ github.event.inputs.bypass_update_feed_probe_reason == '' }}
         shell: bash
-        run: python3 .github/scripts/probe_windows_update_feed.py --channel beta
+        run: |
+          python3 .github/scripts/probe_windows_update_feed.py \
+            --channel beta \
+            --channel stable
+
+      # Break-glass: probe itself broken, or the GitHub runner cannot reach
+      # api.omi.me. Requires a non-empty reason (tracked in the run log) so a
+      # transient probe failure cannot indefinitely block Windows hotfixes,
+      # while still preventing an un-audited release when the route is genuinely
+      # absent.
+      - name: Probe bypassed (audited emergency release)
+        if: ${{ github.event.inputs.bypass_update_feed_probe_reason != '' }}
+        shell: bash
+        run: |
+          echo "::warning::Windows update-feed probe BYPASSED."
+          echo "Reason: ${{ github.event.inputs.bypass_update_feed_probe_reason }}"
+          echo "This is recorded for audit. The route deploy (#10610) is still required."
 
       - name: Plan release (compute next version, tag, sync back to main)
         id: plan

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -91,6 +91,16 @@ tag with no `latest.yml`. Before every check, the app asks
 `/v2/desktop/update-feed/windows` for the selected Windows channel and points the
 generic provider at that immutable release directory.
 
+**Deploy before ship.** That backend route must be live on `api.omi.me` before
+any Windows build that contains the client change is published. The client fails
+closed when the route is missing (intentional — it must not fall back to the
+broken repository-wide provider). `desktop_windows_release.yml` runs
+`.github/scripts/probe_windows_update_feed.py` against production **before**
+tagging so a missing deploy cannot mint another broken cohort. If the probe
+fails with "missing /v2/desktop/update-feed/windows", deploy backend `main` via
+`gcp_backend.yml` (`environment=prod`, `deploy_targets=cloud-run-only`, and a
+release-eligible main SHA) and re-run the release.
+
 The workflow marks new Windows builds **prerelease**. Stable users receive only
 releases that have been promoted by clearing that flag; beta users receive the
 beta release and safely fall back to stable while the beta slot is empty after a

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -96,10 +96,18 @@ any Windows build that contains the client change is published. The client fails
 closed when the route is missing (intentional — it must not fall back to the
 broken repository-wide provider). `desktop_windows_release.yml` runs
 `.github/scripts/probe_windows_update_feed.py` against production **before**
-tagging so a missing deploy cannot mint another broken cohort. If the probe
+tagging so a missing deploy cannot mint another broken cohort. The probe covers
+both channels that real clients can request (`beta` and `stable`), because the
+backend deliberately does not fall stable through to beta. If the probe
 fails with "missing /v2/desktop/update-feed/windows", deploy backend `main` via
 `gcp_backend.yml` (`environment=prod`, `deploy_targets=cloud-run-only`, and a
 release-eligible main SHA) and re-run the release.
+
+**Break-glass.** If the probe itself is broken or the GitHub runner cannot reach
+`api.omi.me`, supply a `bypass_update_feed_probe_reason` (a tracking-issue URL or
+short rationale) when dispatching the workflow. That skips the probe for that one
+release while leaving the reason in the run log for audit. Do not use this to
+ship when the route is genuinely absent.
 
 The workflow marks new Windows builds **prerelease**. Stable users receive only
 releases that have been promoted by clearing that flag; beta users receive the

--- a/desktop/windows/docs/release-pipeline.md
+++ b/desktop/windows/docs/release-pipeline.md
@@ -104,10 +104,12 @@ fails with "missing /v2/desktop/update-feed/windows", deploy backend `main` via
 release-eligible main SHA) and re-run the release.
 
 **Break-glass.** If the probe itself is broken or the GitHub runner cannot reach
-`api.omi.me`, supply a `bypass_update_feed_probe_reason` (a tracking-issue URL or
-short rationale) when dispatching the workflow. That skips the probe for that one
-release while leaving the reason in the run log for audit. Do not use this to
-ship when the route is genuinely absent.
+`api.omi.me`, supply a `bypass_update_feed_probe_reason` that contains a
+tracking-issue URL or short rationale **and** the literal phrase
+`I ACKNOWLEDGE THE ROUTE IS REQUIRED` when dispatching the workflow. The
+sentinel must be present or the probe runs regardless. That skips the probe for
+that one release while leaving the reason in the run log for audit. Do not use
+this to ship when the route is genuinely absent.
 
 The workflow marks new Windows builds **prerelease**. Stable users receive only
 releases that have been promoted by clearing that flag; beta users receive the

--- a/scripts/dev-harness/_resolve_python.sh
+++ b/scripts/dev-harness/_resolve_python.sh
@@ -48,7 +48,7 @@ dev_harness_python_uses_windows_paths() {
   local resolved resolved_lower
   resolved="$(command -v "$python_bin" 2>/dev/null || printf '%s' "$python_bin")"
   # bash 3.2 (macOS) has no ${var,,}; use tr for case-insensitive .exe match
-  resolved_lower="$(echo "$resolved" | tr '[:upper:]' '[:lower:]')"
+  resolved_lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
   case "$resolved_lower" in
     *.exe)
       return 0


### PR DESCRIPTION
## Summary

- Root cause of Windows auto-update breakage after v1.0.30: production is missing `/v2/desktop/update-feed/windows` (merged in #10610) while Windows clients fail closed without it.
- Gate `desktop_windows_release.yml` on a production probe of that route **before** tagging, so a missing backend deploy cannot mint another broken cohort.
- Register failure class `FC-ship-before-required-route` and document the deploy-before-ship contract.
- Restore `--check-id` support in `run_checks.py` and the Windows portability manifest checks that #10825 dropped while `windows-preflight-portability.yml` still depends on them (fixes Native Windows process and launcher contracts).
- Keep the Windows python-path detect bash-3.2-safe so macOS pre-push can source the harness resolver.

Closes SCA-256

## Test plan

- [x] `python3 .github/scripts/test_probe_windows_update_feed.py` (8 passed)
- [x] `python3 .github/scripts/test_run_checks.py` (40 passed)
- [x] `python3 .github/scripts/run_checks.py --lane ci --base HEAD --head HEAD --platform windows --check-id check-manifest-contract --list`
- [ ] CI green on PR #10883

## Failure class

Failure-Class: new

## Product invariants

None matched by path globs for this change.
