### PR TITLE
fix(backend): stop 500ing the OAuth token exchange on a non-object setup_completed body

### DIFF
--- a/backend/routers/oauth.py
+++ b/backend/routers/oauth.py
@@ -150,6 +150,18 @@ def oauth_authorize(
     return response
 
 
+def _setup_completed_from_payload(payload: object) -> bool:
+    """Read `is_setup_completed` from a third-party setup_completed_url body.
+
+    Mirrors `routers.apps._setup_completed_from_response`: the body is
+    developer-controlled, so a JSON scalar or array is as likely as the documented
+    object. Anything that is not an object carrying a truthy `is_setup_completed`
+    means setup is not completed. A non-JSON body still raises ValueError out of
+    `res.json()` and is answered with the 503 below.
+    """
+    return isinstance(payload, dict) and bool(payload.get('is_setup_completed', False))
+
+
 @router.post("/v1/oauth/token", response_model=OAuthTokenResponse)
 async def oauth_token(
     firebase_id_token: str = Form(...),
@@ -206,7 +218,7 @@ async def oauth_token(
                     follow_redirects=False,
                 )
                 res.raise_for_status()
-                if not res.json().get('is_setup_completed', False):
+                if not _setup_completed_from_payload(res.json()):
                     raise HTTPException(
                         status_code=400,
                         detail='App setup is not completed. Please complete app setup before authorizing.',

--- a/backend/tests/unit/test_oauth_token_setup_completed_response.py
+++ b/backend/tests/unit/test_oauth_token_setup_completed_response.py
@@ -1,0 +1,104 @@
+"""Regression: POST /v1/oauth/token must not 500 on a malformed setup_completed_url body.
+
+`routers/oauth.oauth_token` auto-enables the app before handing back the redirect, and that
+check reads the developer-controlled `setup_completed_url` body with
+`res.json().get('is_setup_completed', False)`. When an app answered with a bare JSON scalar
+(e.g. `true`) that raised `AttributeError: 'bool' object has no attribute 'get'`, so the
+intended 400 "App setup is not completed" became an unhandled 500 (prod, 2026-07-30). The
+same crasher was fixed for POST /v1/apps/enable in ff286b0b but this sibling call site was
+missed.
+
+Drives the real `oauth_token` coroutine through the existing stub harness. No live services.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from tests.unit.test_oauth_token_async_boundaries import _loaded_oauth_router
+
+SETUP_URL = 'https://app.test/setup-completed'
+
+
+def _install_pending_setup_app(oauth, body: bytes, content_type: str = 'application/json') -> None:
+    """Point the loaded router at a not-yet-enabled external app whose setup URL returns `body`."""
+
+    class _ExternalApp(oauth.AppModel):
+        def __init__(self, **values):
+            super().__init__(**values)
+            self.external_integration = SimpleNamespace(
+                app_home_url='https://app.test/complete',
+                setup_completed_url=SETUP_URL,
+                actions=[],
+                triggers_on=None,
+            )
+
+        def works_externally(self) -> bool:
+            return True
+
+    class _Client:
+        async def get(self, url, **_kwargs):
+            return httpx.Response(
+                200,
+                content=body,
+                headers={'Content-Type': content_type},
+                request=httpx.Request('GET', url),
+            )
+
+    oauth.AppModel = _ExternalApp
+    oauth.is_user_app_enabled = lambda _uid, _app_id: False
+    oauth.get_auth_client = lambda: _Client()
+
+
+def _exchange(oauth):
+    return asyncio.run(
+        oauth.oauth_token(
+            firebase_id_token='token',
+            app_id='app-1',
+            state='opaque',
+            csrf_token='matching-csrf-token',
+            oauth_csrf_cookie='matching-csrf-token',
+        )
+    )
+
+
+@pytest.mark.parametrize('body', [b'true', b'false', b'"ok"', b'null', b'[{"is_setup_completed": true}]'])
+def test_non_object_setup_body_is_a_400_not_a_crash(body: bytes) -> None:
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        _install_pending_setup_app(oauth, body)
+
+        with pytest.raises(HTTPException) as exc:
+            _exchange(oauth)
+
+        assert exc.value.status_code == 400
+        assert 'setup is not completed' in exc.value.detail
+
+
+def test_non_json_setup_body_still_reports_an_invalid_response() -> None:
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        _install_pending_setup_app(oauth, b'<html>OK</html>', 'text/html')
+
+        with pytest.raises(HTTPException) as exc:
+            _exchange(oauth)
+
+        assert exc.value.status_code == 503
+
+
+def test_completed_setup_still_authorizes() -> None:
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        _install_pending_setup_app(oauth, b'{"is_setup_completed": true}')
+
+        assert _exchange(oauth)['redirect_url'] == 'https://app.test/complete'
+
+
+def test_incomplete_setup_is_still_rejected() -> None:
+    with _loaded_oauth_router() as (oauth, _firebase_auth, _apps_db):
+        _install_pending_setup_app(oauth, b'{"is_setup_completed": false}')
+
+        with pytest.raises(HTTPException) as exc:
+            _exchange(oauth)
+
+        assert exc.value.status_code == 400


### PR DESCRIPTION
## Bug

`POST /v1/oauth/token` auto-enables the app before handing back the redirect. That check calls the app's developer-controlled `setup_completed_url` and reads the flag with `res.json().get('is_setup_completed', False)`.

When an app answers with a bare JSON scalar (`true`, `false`, `"ok"`, `null`) or an array, `res.json()` is not a dict and the call raises `AttributeError: 'bool' object has no attribute 'get'`. The intended `400 App setup is not completed. Please complete app setup before authorizing.` became an unhandled **500**, so the user could not finish authorizing the app.

Live in prod on 2026-07-30 04:09 UTC:

```
File "/app/routers/oauth.py", line 209, in oauth_token
    if not res.json().get('is_setup_completed', False):
AttributeError: 'bool' object has no attribute 'get'
```

## Root cause

The identical crasher was fixed for `POST /v1/apps/enable` in ff286b0b (2026-07-28). That PR repaired `routers/apps.py` and missed this sibling call site, which reads the same third-party contract the same unguarded way.

## Fix

Read the flag through `_setup_completed_from_payload`, mirroring `routers.apps._setup_completed_from_response`: anything that is not a JSON object carrying a truthy `is_setup_completed` means setup is not completed. A non-JSON body still raises `ValueError` out of `res.json()` and keeps the existing 503 "invalid response from the app" answer — only the crash path changes.

## What I tested

New regression test `backend/tests/unit/test_oauth_token_setup_completed_response.py` drives the **real** `oauth_token` coroutine through the existing `_loaded_oauth_router` stub harness with a stubbed `setup_completed_url`.

- Reverting just the one-line call-site change reproduces the exact prod failure on 5 of the new cases (`'bool'/'str'/'NoneType'/'list' object has no attribute 'get'` at `routers/oauth.py`).
- With the fix: `true`, `false`, `"ok"`, `null`, `[{...}]` → 400; `<html>OK</html>` → 503 (unchanged); `{"is_setup_completed": true}` → authorized and `{"is_setup_completed": false}` → 400 (both unchanged).
- `pytest tests/unit/test_oauth_token_setup_completed_response.py tests/unit/test_oauth_token_async_boundaries.py tests/unit/test_oauth_csrf.py` → **18 passed**.
- `black --line-length 120 --skip-string-normalization --check` clean; `make preflight` run locally.

## Product invariants

none

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

