### PR TITLE
SCA-259: make _resolve_python.sh compatible with bash 3.2

### DIFF
--- a/scripts/dev-harness/_resolve_python.sh
+++ b/scripts/dev-harness/_resolve_python.sh
@@ -45,9 +45,11 @@ dev_harness_python() {
 
 dev_harness_python_uses_windows_paths() {
   local python_bin="$1"
-  local resolved
+  local resolved resolved_lower
   resolved="$(command -v "$python_bin" 2>/dev/null || printf '%s' "$python_bin")"
-  case "${resolved,,}" in
+  # bash 3.2 (macOS) has no ${var,,}; use tr for case-insensitive .exe match
+  resolved_lower="$(echo "$resolved" | tr '[:upper:]' '[:lower:]')"
+  case "$resolved_lower" in
     *.exe)
       return 0
       ;;


### PR DESCRIPTION
## What changed and why

Replace bash-4 `${var,,}` lowercase expansion in `scripts/dev-harness/_resolve_python.sh` with a `tr`-based approach so macOS bash 3.2 can run the Windows-path helper. Without this, M1 pre-tag readiness aborts with `bad substitution` before PYTHONPATH is set (`ModuleNotFoundError: No module named 'dev_harness'`). Closes SCA-259.

## Product invariants affected

none

## How it was verified

- Host bash: `GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)`
- `bash -n scripts/dev-harness/_resolve_python.sh` (syntax OK)
- Sourced the helper under bash 3.2:
  - posix path → not treated as Windows
  - `python.EXE` / `python.exe` → treated as Windows paths
- Pre-push gate passed (including `dev-harness-unit-tests`: 73 passed, 9 skipped)

## Tests

No new test. Script-only bash-3.2 compatibility fix; verified with `bash -n` and functional smoke of `dev_harness_python_uses_windows_paths` on the M1 host bash.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

