### PR TITLE
fix(backend): own a gone peer in the listen keepalive instead of crashing

### DIFF
--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -346,12 +346,30 @@ class ListenSessionRuntime:
             self.onboarding_handler = OnboardingHandler(request.uid, send_onboarding, self.transcripts.enqueue)
         return True
 
+    async def _send_ping(self) -> bool:
+        """Write one keepalive frame, owning a gone peer the same way `asend_event` does.
+
+        The client can vanish between the `client_state` read and the write, so the
+        keepalive is the writer that most often observes the disconnect first. That is
+        an ordinary end of session, not a background-task crash.
+        """
+        try:
+            await self.request.websocket.send_text('ping')
+            return True
+        except WebSocketDisconnect:
+            self.state.active = False
+        except RuntimeError as error:
+            self.state.active = False
+            logger.warning('Listen heartbeat send after close type=%s', type(error).__name__)
+        return False
+
     async def _heartbeat(self) -> None:
         while self.state.active:
             if self.request.websocket.client_state != WebSocketState.CONNECTED:
                 self.state.active = False
                 break
-            await self.request.websocket.send_text('ping')
+            if not await self._send_ping():
+                break
             if self.state.last_activity_time and time.time() - self.state.last_activity_time > 90:
                 self.state.close_code = 1001
                 self.state.active = False

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+from fastapi.websockets import WebSocketDisconnect
 from unittest.mock import patch
 
 import utils.async_tasks as async_tasks_mod
@@ -387,6 +388,39 @@ class TestSuperviseTasks:
             )
             # finite completes, then receive completes -> disconnect
             assert result.reason == "disconnect"
+
+        asyncio.run(_run())
+
+    def test_same_round_disconnect_wins_over_bg_task_observing_it(self):
+        """A bg writer that sees the same client disconnect must not report a crash.
+
+        `asyncio.wait` returns a set, so scanning it in iteration order made the
+        classification depend on hash order alone; repeat the round so a pre-fix
+        supervisor cannot pass on luck.
+        """
+
+        async def _run():
+            for _ in range(25):
+
+                async def receive():
+                    return None
+
+                async def bg():
+                    raise WebSocketDisconnect()
+
+                recv = asyncio.create_task(receive(), name="receive")
+                bg_task = asyncio.create_task(bg(), name="heartbeat")
+                # Both land in the same asyncio.wait round.
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                assert recv.done() and bg_task.done()
+
+                result = await supervise_tasks(
+                    receive_task=recv,
+                    bg_tasks=[bg_task],
+                    label="test",
+                )
+                assert result.reason == "disconnect", result
 
         asyncio.run(_run())
 

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -492,3 +492,42 @@ async def test_custom_stt_flush_meters_speech_in_isolated_lane(monkeypatch):
     runtime.receiver = SimpleNamespace(vad_gate=SimpleNamespace(consume_speech_ms_delta=lambda: 0))
     assert await runtime._flush_usage(final=True) == 0
     assert recorded == [('custom-stt-user', 4200, 'custom_stt')]
+
+
+def _heartbeat_runtime(send_text):
+    from starlette.websockets import WebSocketState
+
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.request = SimpleNamespace(
+        websocket=SimpleNamespace(client_state=WebSocketState.CONNECTED, send_text=send_text)
+    )
+    runtime.state = SimpleNamespace(active=True, last_activity_time=None)
+    return runtime
+
+
+@pytest.mark.anyio
+async def test_heartbeat_treats_gone_peer_as_disconnect_not_crash():
+    """A client that vanishes between the state read and the keepalive write ends the
+    session as a disconnect; the heartbeat must not raise out of its supervised task."""
+    from fastapi.websockets import WebSocketDisconnect
+
+    async def send_text(_payload):
+        raise WebSocketDisconnect()
+
+    runtime = _heartbeat_runtime(send_text)
+    await runtime._heartbeat()
+
+    assert runtime.state.active is False
+
+
+@pytest.mark.anyio
+async def test_heartbeat_stops_after_close_message_instead_of_crashing():
+    """The ASGI server refuses a send once the close frame went out — same disconnect."""
+
+    async def send_text(_payload):
+        raise RuntimeError('Cannot call "send" once a close message has been sent.')
+
+    runtime = _heartbeat_runtime(send_text)
+    await runtime._heartbeat()
+
+    assert runtime.state.active is False

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -266,11 +266,15 @@ async def supervise_tasks(
         done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
 
         exit_result = None
-        for task in done:
-            if task is receive_task:
-                exit_result = SupervisorResult(reason="disconnect", task_name=task.get_name())
-                break
-            if not task.cancelled():
+        if receive_task in done:
+            # The client disconnect owns the exit reason for the round it lands in.
+            # `done` is a set, so scanning it in iteration order let a bg task that
+            # observed the same disconnect report "crash" on ordering luck alone.
+            exit_result = SupervisorResult(reason="disconnect", task_name=receive_task.get_name())
+        else:
+            for task in done:
+                if task.cancelled():
+                    continue
                 try:
                     exc = task.exception()
                 except asyncio.CancelledError:


### PR DESCRIPTION
## Bug

Prod `backend-listen` logs ~390 `BG task ws:<uid>:heartbeat crashed: WebSocketDisconnect()` errors per 24h (plus one post-close `RuntimeError: Cannot call "send" once a close message has been sent.`), and 17 of a 500-entry sample of supervisor exits land on `reason=crash task=heartbeat`. Every one of them is an ordinary client disconnect.

## Root cause

Two halves of the same boundary contract — a peer that has already gone is an expected end of delivery, not a fault of the task writing to it.

1. `_heartbeat` was the one writer in `ListenSessionRuntime` still calling the client socket outside the peer-gone seam `asend_event` established (#10840). The client can vanish between the `client_state` read and the write, so `send_text` raises straight out of a supervised background task.
2. `supervise_tasks`' docstring gives the client disconnect priority ("Exits when: receive_task completes (disconnect)"), but `done` is a `set` and the loop scanned it in iteration order. A bg task that observed the *same* disconnect could therefore win on hash order alone and report `crash`.

`reason=crash` sets `live_transcription_failed`, which terminalizes the live-STT attempt as `failure` instead of `cancelled` and inflates `async_supervisor_exit_total{reason="crash"}` — the reliability signal on-call reads.

## Fix

- `_send_ping` classifies `WebSocketDisconnect` and the ASGI post-close `RuntimeError` as end-of-delivery and marks the session inactive, exactly as `asend_event` already does. `_heartbeat` ends its loop on a false return.
- `supervise_tasks` checks `receive_task in done` before scanning the rest, so the disconnect deterministically owns the exit reason for the round it lands in.

+101 / -6 across 4 files, backend only.

## What I tested

**Real path, live server.** A probe drives the real `_heartbeat` + `WebSocketTaskSupervisor` + `supervise_tasks` under a live uvicorn WebSocket whose peer aborts its transport mid-session, 8 rounds:

- Pre-fix: `REASONS=['crash', 'crash', 'disconnect', 'lifetime_done', 'lifetime_done', 'disconnect', 'disconnect', 'disconnect']`, `CRASH_LOGS=2` — reproducing the exact production line `BG task ws:probe-uid:heartbeat crashed: WebSocketDisconnect() [listen]`, plus 3 `Unhandled exception in WebSocket task` errors.
- Post-fix: `REASONS=['disconnect'] x8`, `CRASH_LOGS=0`, `PROBE=PASS`.

**Regression tests.** 3 new tests, all failing on the parent commit and passing on the fix:

- `test_heartbeat_treats_gone_peer_as_disconnect_not_crash`
- `test_heartbeat_stops_after_close_message_instead_of_crashing`
- `TestSuperviseTasks::test_same_round_disconnect_wins_over_bg_task_observing_it` (25 rounds, so a pre-fix supervisor cannot pass on hash-order luck)

**Suites.** `pytest tests/unit/test_async_tasks.py tests/unit/test_listen_runtime_regressions.py tests/unit/test_live_stt_failure.py tests/unit/test_pusher_heartbeat.py` → 95 passed. `black --check --line-length 120 --skip-string-normalization` clean on all 4 files.

Failure-Class: FC-peer-close-aborts-owed-write

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

