### PR TITLE
fix(desktop): chat-history popover actions no longer bounce you to home (#10895, #10896)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-chat-history-popover-dismiss.json
+++ b/desktop/windows/changelog/unreleased/2026-07-chat-history-popover-dismiss.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Creating, renaming or picking a chat from the chat-history popover no longer drops you back on the home screen — the action now goes through and the chat stays open."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.test.tsx
@@ -1,14 +1,27 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { render, cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 // The Hub drives the app's ONE chat engine — asserted here by checking that a submit
 // calls the shared chat.send, not some second message array of its own.
 
 type ChatMsg = { id?: string; role: 'user' | 'assistant'; content: string }
-let chat: { history: ChatMsg[]; sending: boolean; send: ReturnType<typeof vi.fn> }
+let chat: {
+  history: ChatMsg[]
+  sending: boolean
+  send: ReturnType<typeof vi.fn>
+  // The multi-chat header's slice of the engine (used only by the popover suite).
+  selectedAppId?: string | null
+  currentThreadId?: string | null
+  switchThread?: ReturnType<typeof vi.fn>
+}
 vi.mock('../../../state/appState', () => ({ useAppState: () => ({ chat }) }))
+
+// The multi-chat header's session list. Stubbed so the popover suite exercises the
+// real header + real Radix popover without a live sessions backend.
+let sessions: Record<string, unknown>
+vi.mock('../../../hooks/useChatSessions', () => ({ useChatSessions: () => sessions }))
 
 let memories: { memories: { id: string }[]; loading: boolean; error?: string | null }
 vi.mock('../../../hooks/useMemories', () => ({ useMemories: () => memories }))
@@ -29,6 +42,7 @@ vi.mock('../QuickGoalsWidget', () => ({
 
 import { publishConversationsCache, invalidateConversationsCache } from '../../../lib/pageCache'
 import type { ConversationRow } from '../../../lib/pageCache'
+import { setPreferences } from '../../../lib/preferences'
 
 const convRow = (id: string, source: 'cloud' | 'local'): ConversationRow =>
   ({ id, title: id, subtitle: '', preview: '', source, sortAt: 0 }) as ConversationRow
@@ -57,6 +71,7 @@ const askBar = (): HTMLElement => screen.getByLabelText('Ask omi anything')
 
 beforeEach(() => {
   chat = { history: [], sending: false, send: vi.fn() }
+  sessions = {}
   memories = { memories: [{ id: 'm1' }, { id: 'm2' }, { id: 'm3' }], loading: false }
   actionItems = [{ id: 't1' }, { id: 't2' }]
   invalidateConversationsCache()
@@ -240,5 +255,114 @@ describe('HomeHub — stat ribbon counts come from the real sources', () => {
     renderHub()
     expect(cell(/Memories/).textContent).toContain('—')
     expect(cell(/Memories/).textContent).not.toContain('0')
+  })
+})
+
+describe('HomeHub — portaled panel UI does not read as a click-outside', () => {
+  // #10895 / #10896: with the multi-chat header on, clicking "+" or rename inside
+  // the chat-history popover dropped the user back on the resting hub and the
+  // button never fired. The popover is PORTALED to <body>, so the panel's
+  // click-outside check ("not inside the stage") counted a mousedown on it as a
+  // dismiss — which unmounted the popover before the click landed.
+  const SESSION = {
+    id: 's1',
+    title: 'Trip planning',
+    preview: 'where should we go',
+    createdAt: 0,
+    updatedAt: Date.now(),
+    messageCount: 2,
+    starred: false
+  }
+
+  let createNewSession: ReturnType<typeof vi.fn>
+  let renameSession: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    // Radix Popover needs a couple of DOM APIs jsdom lacks; stub them so open works.
+    if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false
+    if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {}
+
+    setPreferences({ multiChatEnabled: true })
+    ;(window as unknown as { omi: Record<string, unknown> }).omi.chatGetEngine = vi
+      .fn()
+      .mockResolvedValue('pi_mono')
+
+    chat.selectedAppId = null
+    chat.currentThreadId = null
+    chat.switchThread = vi.fn()
+
+    createNewSession = vi.fn().mockResolvedValue({ ...SESSION, id: 's2' })
+    renameSession = vi.fn().mockResolvedValue(undefined)
+    sessions = {
+      sessions: [SESSION],
+      filteredSessions: [SESSION],
+      groupedSessions: [{ label: 'Today', sessions: [SESSION] }],
+      currentSessionId: null,
+      loading: false,
+      error: null,
+      createError: null,
+      searchQuery: '',
+      showStarredOnly: false,
+      setSearchQuery: vi.fn(),
+      toggleStarredFilter: vi.fn(),
+      retryLoad: vi.fn(),
+      clearCreateError: vi.fn(),
+      selectSession: vi.fn(),
+      createNewSession,
+      renameSession,
+      toggleStar: vi.fn().mockResolvedValue(undefined),
+      removeSession: vi.fn().mockResolvedValue(undefined)
+    }
+  })
+  afterEach(() => setPreferences({ multiChatEnabled: false }))
+
+  /** Open the chat panel, then the chat-history popover, and return its panel. */
+  const openHistory = async (): Promise<HTMLElement> => {
+    renderHub()
+    fireEvent.focus(askBar())
+    expect(mode()).toBe('chat')
+    const trigger = await screen.findByTitle('Chat history')
+    fireEvent.click(trigger)
+    return await screen.findByRole('dialog')
+  }
+
+  it('keeps the chat panel open when "+" in the chat-history popover is pressed', async () => {
+    const popover = await openHistory()
+    const plus = within(popover).getByTitle('New chat')
+
+    // A real press is mousedown → click; the dismiss listener rides mousedown.
+    fireEvent.mouseDown(plus)
+    fireEvent.click(plus)
+
+    expect(mode()).toBe('chat')
+    expect(createNewSession).toHaveBeenCalled()
+    await waitFor(() => expect(chat.switchThread).toHaveBeenCalledWith('s2'))
+  })
+
+  it('keeps the chat panel open while renaming a chat from the popover', async () => {
+    const popover = await openHistory()
+    const rename = within(popover).getByTitle('Rename')
+
+    fireEvent.mouseDown(rename)
+    fireEvent.click(rename)
+    expect(mode()).toBe('chat')
+
+    const input = within(await screen.findByRole('dialog')).getByDisplayValue('Trip planning')
+    fireEvent.change(input, { target: { value: 'Iceland trip' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mode()).toBe('chat')
+    expect(renameSession).toHaveBeenCalledWith('s1', 'Iceland trip')
+  })
+
+  it('still dismisses the panel on a mousedown on the Hub paper outside the stage', () => {
+    // The guard above must not disable click-outside itself: the Hub's own paper
+    // (here, the floating header band) still returns the stage to the resting hub.
+    renderHub()
+    fireEvent.focus(askBar())
+    expect(mode()).toBe('chat')
+
+    fireEvent.mouseDown(screen.getByText('Capture'))
+    expect(mode()).toBe('hub')
   })
 })

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.tsx
@@ -71,6 +71,7 @@ export function HomeHub(): React.JSX.Element {
   // the ask bar, not the shell and every mounted page.
   const [input, setInput] = useState('')
   const stageRef = useRef<HTMLDivElement>(null)
+  const hubRef = useRef<HTMLDivElement>(null)
 
   const dispatch = useCallback((event: HomeStageEvent): void => {
     setMode((m) => nextStage(m, event))
@@ -105,8 +106,15 @@ export function HomeHub(): React.JSX.Element {
   )
 
   // Esc leaves any panel. Click-outside does the same — but only from a panel, and
-  // only for clicks that land outside the stage content, so a click on the paper
-  // around the panel dismisses it while a click inside does not.
+  // only for clicks that land on the Hub's own paper around the stage content, so a
+  // click inside the stage does not dismiss it.
+  //
+  // The paper test is a containment test against the Hub root, NOT just "outside the
+  // stage": UI the panel raises through a portal (the chat-history popover, the app
+  // picker, modals, toasts) is mounted on <body>, outside the Hub's tree entirely, so
+  // "outside the stage" read a mousedown on the popover's "+"/rename as a dismiss —
+  // which unmounted the popover mid-click, so the button never got its click and the
+  // user landed back on the resting hub instead (#10895, #10896).
   useEffect(() => {
     if (!isPanelMode(mode)) return
     const onKey = (e: KeyboardEvent): void => {
@@ -114,7 +122,11 @@ export function HomeHub(): React.JSX.Element {
     }
     const onDown = (e: MouseEvent): void => {
       const stage = stageRef.current
-      if (stage && !stage.contains(e.target as Node)) dispatch({ type: 'dismissed' })
+      const hub = hubRef.current
+      if (!stage || !hub) return
+      const target = e.target as Node
+      if (!hub.contains(target)) return
+      if (!stage.contains(target)) dispatch({ type: 'dismissed' })
     }
     window.addEventListener('keydown', onKey)
     window.addEventListener('mousedown', onDown)
@@ -143,7 +155,7 @@ export function HomeHub(): React.JSX.Element {
   )
 
   return (
-    <div className="relative h-full overflow-hidden">
+    <div ref={hubRef} className="relative h-full overflow-hidden">
       <HomeCanvasBackground />
 
       {/* The header FLOATS over the stage; it does not sit in the column.


### PR DESCRIPTION
## Bug

Two reports, one defect (#10895, #10896). With the multi-chat header on (Settings → General → Multi-chat), in the Hub chat panel:

- clicking `+` in the chat-history popover → no new chat, app returns to the home screen (#10895)
- renaming a chat from the chat-history popover → no rename, app returns to the home screen (#10896)

## Root cause

Not the popover's handlers — the Hub's click-outside dismiss. `HomeHub` dismissed the panel on any `mousedown` whose target was not inside `stageRef`. The chat-history popover is a Radix **portal** mounted on `<body>`, outside the Hub's tree entirely, so pressing `+`/Rename read as a click on the paper around the panel: `setMode('hub')` ran on `mousedown`, `HubChatHeader` unmounted with the panel, and the button was gone before the `click` event — so `createNewSession` / `renameSession` never fired and the user landed on home. The same hazard covered the chat-app picker, modals and toasts.

## Fix

Make the paper test a containment test against the Hub root: a `mousedown` must land **inside the Hub and outside the stage** to dismiss. Portaled UI is outside the Hub root, so it no longer counts as a click-outside; the Hub's own paper (side/bottom insets, the floating header band) still dismisses as before. One boundary repaired, not two call-site guards.

## What I tested

- 3 new regression tests in `HomeHub.test.tsx` drive the real `HomeHub` + `HubChatHeader` + Radix popover + `HistorySessionRow` through the real `mousedown` → `click` sequence:
  - `+` in the popover: on the parent commit fails with the reported symptom (`expected 'hub' to be 'chat'`); on the fix the panel stays open, `createNewSession` runs and the engine re-threads to the new session.
  - rename from the popover: same pre-fix failure; on the fix the inline editor opens, Enter commits and `renameSession('s1', 'Iceland trip')` fires with the panel still open.
  - a third test pins the behavior that must NOT change: a mousedown on the Hub's own paper still returns the stage to the resting hub.
- `npx vitest run src/renderer/src/components/home src/renderer/src/components/chat` → **20 files, 156 tests passed**.
- `tsc --noEmit -p tsconfig.web.json` clean; `eslint` clean; `prettier --check` clean.
- Manifest preflight (`run_checks.py --lane local`) green.
- **Not exercised in a running Windows build** — this ran on macOS; coverage is component-level through the real UI tree, plus the pre-fix/post-fix behavior difference above.

Changelog fragment added (`desktop/windows/changelog/unreleased/`).

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

