### PR TITLE
feat(desktop-windows): give the Hub chat panel a visible way back home

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-07-hub-chat-close.json
+++ b/desktop/windows/changelog/unreleased/2026-07-hub-chat-close.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "The chat panel now carries a close button, so there is a visible way back to the home screen — Esc still works."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.test.tsx
@@ -168,6 +168,24 @@ describe('HomeHub — stage machine', () => {
     expect(mode()).toBe('hub')
   })
 
+  it('returns to the hub from the chat panel own close control', () => {
+    // Esc and a click on the paper both leave the panel, but neither is VISIBLE:
+    // users reached the chat panel and could not tell how to get back (#10894).
+    renderHub()
+    expect(screen.queryByLabelText('Close chat')).toBeNull()
+
+    fireEvent.focus(askBar())
+    expect(mode()).toBe('chat')
+
+    // A real press is mousedown → click; the click-outside listener rides mousedown.
+    const close = screen.getByLabelText('Close chat')
+    fireEvent.mouseDown(close)
+    fireEvent.click(close)
+
+    expect(mode()).toBe('hub')
+    expect(screen.getByText('omi.')).not.toBeNull()
+  })
+
   it('toggles the connect stage from the ask bar and back', () => {
     renderHub()
     const connect = screen.getByRole('button', { name: 'Connect' })
@@ -353,6 +371,18 @@ describe('HomeHub — portaled panel UI does not read as a click-outside', () =>
 
     expect(mode()).toBe('chat')
     expect(renameSession).toHaveBeenCalledWith('s1', 'Iceland trip')
+  })
+
+  it('lays the close control out in the SAME row as the multi-chat controls', async () => {
+    // jsdom has no layout, so the only honest guard against the close control
+    // landing on top of "+" / history is structural: one flex row owns all three.
+    renderHub()
+    fireEvent.focus(askBar())
+    const history = await screen.findByTitle('Chat history')
+    const row = screen.getByLabelText('Close chat').parentElement as HTMLElement
+
+    expect(row.className).toContain('flex')
+    expect(row.contains(history)).toBe(true)
   })
 
   it('still dismisses the panel on a mousedown on the Hub paper outside the stage', () => {

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.tsx
@@ -220,6 +220,7 @@ export function HomeHub(): React.JSX.Element {
                 <HubChatPanel
                   messages={chat.history}
                   sending={chat.sending}
+                  onDismiss={() => dispatch({ type: 'dismissed' })}
                   header={
                     <>
                       <ChatAppPicker />

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.test.tsx
@@ -34,7 +34,7 @@ const messages: ChatMsg[] = [
 
 function renderPanel(): HTMLDivElement {
   const { container } = render(
-    <HubChatPanel messages={messages} sending={true}>
+    <HubChatPanel messages={messages} sending={true} onDismiss={() => {}}>
       <div>ask bar</div>
     </HubChatPanel>
   )

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react'
+import { X } from 'lucide-react'
 import { ChatMessages } from '../../chat/ChatMessages'
 import { useLiveEdgeFollow } from '../../../hooks/useLiveEdgeFollow'
 import type { ChatMsg } from '../../../hooks/useChat'
@@ -17,9 +18,13 @@ export function HubChatPanel(props: {
   // Optional row rendered above the scroll area (the multi-chat header). Renders
   // nothing when omitted, so the default single-thread panel is unchanged.
   header?: React.ReactNode
+  // Returns the stage to the resting hub. Esc and a click on the paper already do
+  // this, but neither is visible: users reported reaching the chat panel with no
+  // idea how to get back home (#10894), so the panel carries a close control.
+  onDismiss: () => void
   children: React.ReactNode
 }): React.JSX.Element {
-  const { messages, sending, header, children } = props
+  const { messages, sending, header, onDismiss, children } = props
   const scrollRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
 
@@ -37,7 +42,21 @@ export function HubChatPanel(props: {
         boxShadow: '0 18px 44px rgb(0 0 0 / 0.42)'
       }}
     >
-      {header}
+      {/* The header column keeps its own bottom margin (each header row owns one),
+          so the close button carries its own for the default panel, where the
+          column renders nothing and this row is the only thing above the thread. */}
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">{header}</div>
+        <button
+          type="button"
+          className="focus-ring mb-3 shrink-0 rounded-md p-1.5 text-white/55 transition-colors hover:bg-white/10 hover:text-white"
+          aria-label="Close chat"
+          title="Close chat (Esc)"
+          onClick={onDismiss}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         <div ref={contentRef} className="flex min-h-full flex-col gap-3">
           {messages.length === 0 && !sending ? (


### PR DESCRIPTION
## What

The Hub chat panel now carries a close control in its header row, so there is a
visible way back to the home screen.

## Why

#10894 (user report, Windows desktop): *"when opening a chat window, there is no
clear way to return to the home screen — no obvious home button, no clear X, the
navigation feels vague."*

They were right: the panel could only be left with `Esc` or a mousedown on the
Hub paper around the stage. Both work, neither is visible, and neither is
discoverable to a first-time user.

The control lives in the panel's own header row rather than floating in the
corner, so when the multi-chat header is on it sits **beside** the `+` / history
buttons instead of on top of them. Scope is deliberately just the affordance —
no redesign of the chat screen, as the issue asked.

## Tested

- `pnpm typecheck` — clean; `pnpm lint` — 0 errors; `pnpm test` — **5117 passed**, 24 skipped, 0 failed.
- **Real app, not a mock:** drove the built app (`out/main/index.js`) through
  Playwright `_electron` — clicked the ask bar, the chat panel took the stage with
  the close control visible, clicked the control, the stage returned to the
  resting hub with the `omi.` wordmark back on screen. Screenshots captured at
  each step.
- **Regression proof:** the new `HomeHub` test fails on the parent commit
  (`Unable to find a label with the text of: Close chat`) and passes here.
- `make preflight` — 10 checks passed. No product invariants affected.

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

