### PR TITLE
SCA-261: tighten knowledge graph read budget

### DIFF
--- a/.github/failure-classes/FC-bounded-read-exceeds-request-budget.json
+++ b/.github/failure-classes/FC-bounded-read-exceeds-request-budget.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-bounded-read-exceeds-request-budget",
+  "violated_contract": "A request-scoped collection read must bound its aggregate document work low enough to finish within the request middleware budget; a large per-query limit is not a sufficient bound when several reads compose.",
+  "canonical_prevention": "Choose deterministic per-collection limits from one aggregate request budget, return explicit truncation metadata, and exercise the production assembler with a large fixture that rejects uncapped stream consumption.",
+  "canonical_prevention_artifact": ["backend/tests/unit/test_bounded_firestore_list_reads.py"],
+  "evidence_prs": [10750],
+  "scope_hints": ["backend/**"],
+  "status": "open"
+}

--- a/app/lib/backend/schema/gen/misc_wire.g.dart
+++ b/app/lib/backend/schema/gen/misc_wire.g.dart
@@ -43,15 +43,19 @@ class GeneratedDeleteKnowledgeGraphResponse {
 }
 
 class GeneratedKnowledgeGraphResponse {
+  final int edgeCount;
   final int? edgeLimit;
   final List<Map<String, dynamic>> edges;
+  final int nodeCount;
   final int? nodeLimit;
   final List<Map<String, dynamic>> nodes;
   final bool truncated;
 
   const GeneratedKnowledgeGraphResponse({
+    this.edgeCount = 0,
     this.edgeLimit,
     required this.edges,
+    this.nodeCount = 0,
     this.nodeLimit,
     required this.nodes,
     this.truncated = false,
@@ -59,8 +63,10 @@ class GeneratedKnowledgeGraphResponse {
 
   factory GeneratedKnowledgeGraphResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedKnowledgeGraphResponse(
+      edgeCount: _required(_readFieldValue<int>(_readField(json, const ["edge_count"]), "edge_count", _readInt, requiredField: false, nullable: false, defaultValue: 0), "edge_count"),
       edgeLimit: _readFieldValue<int>(_readField(json, const ["edge_limit"]), "edge_limit", _readInt, requiredField: false, nullable: true),
       edges: _required(_readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["edges"]), "edges", _readMapList, requiredField: true, nullable: false), "edges"),
+      nodeCount: _required(_readFieldValue<int>(_readField(json, const ["node_count"]), "node_count", _readInt, requiredField: false, nullable: false, defaultValue: 0), "node_count"),
       nodeLimit: _readFieldValue<int>(_readField(json, const ["node_limit"]), "node_limit", _readInt, requiredField: false, nullable: true),
       nodes: _required(_readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["nodes"]), "nodes", _readMapList, requiredField: true, nullable: false), "nodes"),
       truncated: _required(_readFieldValue<bool>(_readField(json, const ["truncated"]), "truncated", _readBool, requiredField: false, nullable: false, defaultValue: false), "truncated"),
@@ -69,8 +75,10 @@ class GeneratedKnowledgeGraphResponse {
 
   Map<String, dynamic> toJson() {
     return {
+      'edge_count': edgeCount,
       'edge_limit': edgeLimit,
       'edges': edges,
+      'node_count': nodeCount,
       'node_limit': nodeLimit,
       'nodes': nodes,
       'truncated': truncated,

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -17,11 +17,14 @@ knowledge_edges_collection = 'knowledge_edges'
 memory_graph_assertions_collection = 'memory_graph_assertions'
 memory_items_collection = 'memory_items'
 
-# GET /v1/knowledge-graph must not stream unbounded nodes/edges (prod 30s GET 504s).
-MAX_KNOWLEDGE_GRAPH_NODES = 2000
-MAX_KNOWLEDGE_GRAPH_EDGES = 5000
-MAX_KNOWLEDGE_GRAPH_ASSERTIONS = 2000
+# GET /v1/knowledge-graph feeds force-graph UIs, so a compact snapshot is both
+# cheaper to read and more usable than thousands of rendered entities. The
+# previous 2,000-node / 5,000-edge bounds still produced prod 30s GET 504s.
+MAX_KNOWLEDGE_GRAPH_NODES = 500
+MAX_KNOWLEDGE_GRAPH_EDGES = 1000
+MAX_KNOWLEDGE_GRAPH_ASSERTIONS = 500
 MAX_KNOWLEDGE_GRAPH_CITATION_FENCES = 500
+KNOWLEDGE_GRAPH_DOCUMENT_ORDER = '__name__'
 
 
 def _firestore_client(db_client: Any = None) -> Any:
@@ -160,7 +163,8 @@ def get_knowledge_nodes(
     capped = max(0, min(int(limit), MAX_KNOWLEDGE_GRAPH_NODES + 1))
     if capped == 0:
         return []
-    return [_typed_doc(doc) for doc in nodes_ref.limit(capped).stream()]
+    query = nodes_ref.order_by(KNOWLEDGE_GRAPH_DOCUMENT_ORDER).limit(capped)
+    return [_typed_doc(doc) for doc in query.stream()]
 
 
 def get_knowledge_node(uid: str, node_id: str, *, db_client: Any = None) -> Optional[Dict[str, Any]]:
@@ -258,7 +262,8 @@ def get_knowledge_edges(
     capped = max(0, min(int(limit), MAX_KNOWLEDGE_GRAPH_EDGES + 1))
     if capped == 0:
         return []
-    return [_typed_doc(doc) for doc in edges_ref.limit(capped).stream()]
+    query = edges_ref.order_by(KNOWLEDGE_GRAPH_DOCUMENT_ORDER).limit(capped)
+    return [_typed_doc(doc) for doc in query.stream()]
 
 
 def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any], *, db_client: Any = None) -> Dict[str, Any]:
@@ -361,7 +366,8 @@ def _load_active_memory_graph_assertions(
         truncated = False
     else:
         bounded_limit = max(0, int(scan_limit))
-        snapshots = list(assertions_ref.limit(bounded_limit + 1).stream())
+        query = assertions_ref.order_by(KNOWLEDGE_GRAPH_DOCUMENT_ORDER).limit(bounded_limit + 1)
+        snapshots = list(query.stream())
         truncated = len(snapshots) > bounded_limit
         snapshots = snapshots[:bounded_limit]
 
@@ -726,10 +732,13 @@ def get_knowledge_graph(uid: str, *, db_client: Any = None) -> Dict[str, Any]:
         or assertions_truncated
         or citation_fences_truncated
     )
+    edge_page = referentially_closed_edges[:MAX_KNOWLEDGE_GRAPH_EDGES]
     return {
         'nodes': node_page,
-        'edges': referentially_closed_edges[:MAX_KNOWLEDGE_GRAPH_EDGES],
+        'edges': edge_page,
         'truncated': nodes_truncated or edges_truncated,
+        'node_count': len(node_page),
+        'edge_count': len(edge_page),
         'node_limit': MAX_KNOWLEDGE_GRAPH_NODES,
         'edge_limit': MAX_KNOWLEDGE_GRAPH_EDGES,
     }

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -71,6 +71,8 @@ class KnowledgeGraphResponse(BaseModel):
     nodes: List[Dict[str, Any]]
     edges: List[Dict[str, Any]]
     truncated: bool = False
+    node_count: int = 0
+    edge_count: int = 0
     node_limit: int | None = None
     edge_limit: int | None = None
 
@@ -88,10 +90,14 @@ class DeleteKnowledgeGraphResponse(BaseModel):
 @router.get('/v1/knowledge-graph', tags=['knowledge_graph'], response_model=KnowledgeGraphResponse)
 def get_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
     graph = get_knowledge_graph_payload(uid)
+    nodes = graph.get('nodes', [])
+    edges = graph.get('edges', [])
     return KnowledgeGraphResponse(
-        nodes=graph.get('nodes', []),
-        edges=graph.get('edges', []),
+        nodes=nodes,
+        edges=edges,
         truncated=bool(graph.get('truncated', False)),
+        node_count=graph.get('node_count', len(nodes)),
+        edge_count=graph.get('edge_count', len(edges)),
         node_limit=graph.get('node_limit'),
         edge_limit=graph.get('edge_limit'),
     )

--- a/backend/tests/unit/test_bounded_firestore_list_reads.py
+++ b/backend/tests/unit/test_bounded_firestore_list_reads.py
@@ -10,6 +10,8 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 
 
@@ -183,17 +185,35 @@ def test_get_action_items_skips_deleted_in_active_bucket(ai_mod, monkeypatch):
     assert ids[0] == 'a1'
 
 
-def test_knowledge_graph_get_is_bounded(monkeypatch, kg_module):
+@pytest.mark.parametrize(
+    ('node_total', 'edge_total', 'expected_nodes', 'expected_edges', 'expected_truncated'),
+    (
+        (0, 0, 0, 0, False),
+        (3, 2, 3, 2, False),
+        (20_000, 20_000, 500, 1000, True),
+    ),
+)
+def test_knowledge_graph_get_is_deterministic_and_bounded_for_large_fixtures(
+    kg_module,
+    node_total,
+    edge_total,
+    expected_nodes,
+    expected_edges,
+    expected_truncated,
+):
     kg = kg_module
-    monkeypatch.setattr(kg, 'MAX_KNOWLEDGE_GRAPH_NODES', 2)
-    monkeypatch.setattr(kg, 'MAX_KNOWLEDGE_GRAPH_EDGES', 3)
-    monkeypatch.setattr(kg, 'MAX_KNOWLEDGE_GRAPH_ASSERTIONS', 4)
 
     class _StreamColl:
         def __init__(self, n, *, edge=False):
             self.n = n
             self.edge = edge
             self.limit_n = None
+            self.order_fields = []
+            self.streamed = 0
+
+        def order_by(self, field_path, *args, **kwargs):
+            self.order_fields.append(field_path)
+            return self
 
         def limit(self, n):
             self.limit_n = n
@@ -212,10 +232,11 @@ def test_knowledge_graph_get_is_bounded(monkeypatch, kg_module):
                     if self.edge
                     else {'id': f'n{i}', 'label': f'L{i}'}
                 )
+                self.streamed += 1
                 yield SimpleNamespace(to_dict=lambda payload=payload: payload)
 
-    nodes = _StreamColl(10)
-    edges = _StreamColl(10, edge=True)
+    nodes = _StreamColl(node_total)
+    edges = _StreamColl(edge_total, edge=True)
     assertions = _StreamColl(0)
 
     collections = {
@@ -227,12 +248,19 @@ def test_knowledge_graph_get_is_bounded(monkeypatch, kg_module):
     client = SimpleNamespace(collection=lambda name: SimpleNamespace(document=lambda uid: user_ref))
 
     graph = kg.get_knowledge_graph('uid', db_client=client)
-    assert len(graph['nodes']) == kg.MAX_KNOWLEDGE_GRAPH_NODES
-    assert len(graph['edges']) == kg.MAX_KNOWLEDGE_GRAPH_EDGES
-    assert graph['truncated'] is True
+    assert len(graph['nodes']) == expected_nodes
+    assert len(graph['edges']) == expected_edges
+    assert graph['node_count'] == expected_nodes
+    assert graph['edge_count'] == expected_edges
+    assert graph['truncated'] is expected_truncated
     assert nodes.limit_n == kg.MAX_KNOWLEDGE_GRAPH_NODES + 1
     assert edges.limit_n == kg.MAX_KNOWLEDGE_GRAPH_EDGES + 1
     assert assertions.limit_n == kg.MAX_KNOWLEDGE_GRAPH_ASSERTIONS + 1
+    assert nodes.streamed <= kg.MAX_KNOWLEDGE_GRAPH_NODES + 1
+    assert edges.streamed <= kg.MAX_KNOWLEDGE_GRAPH_EDGES + 1
+    assert nodes.order_fields == [kg.KNOWLEDGE_GRAPH_DOCUMENT_ORDER]
+    assert edges.order_fields == [kg.KNOWLEDGE_GRAPH_DOCUMENT_ORDER]
+    assert assertions.order_fields == [kg.KNOWLEDGE_GRAPH_DOCUMENT_ORDER]
 
 
 def test_legacy_get_memories_no_first_page_5000_force():
@@ -260,12 +288,24 @@ def test_knowledge_graph_route_exposes_truncation(monkeypatch):
         'nodes': [{'id': 'n1'}],
         'edges': [],
         'truncated': True,
-        'node_limit': 2000,
-        'edge_limit': 5000,
+        'node_count': 1,
+        'edge_count': 0,
+        'node_limit': 500,
+        'edge_limit': 1000,
     }
     monkeypatch.setattr(kg_router, 'get_knowledge_graph_payload', lambda uid: payload)
-    resp = kg_router.get_knowledge_graph(uid='u')
-    assert resp.truncated is True
-    assert resp.node_limit == 2000
-    assert resp.edge_limit == 5000
-    assert resp.nodes == payload['nodes']
+    app = FastAPI()
+    app.include_router(kg_router.router)
+    app.dependency_overrides[kg_router.auth.get_current_user_uid] = lambda: 'u'
+
+    response = TestClient(app).get('/v1/knowledge-graph')
+
+    assert response.status_code == 200
+    assert response.json() == payload
+
+
+def test_knowledge_graph_route_keeps_firebase_auth_dependency():
+    from routers import knowledge_graph as kg_router
+
+    route = next(route for route in kg_router.router.routes if route.path == '/v1/knowledge-graph')
+    assert [dependency.call for dependency in route.dependant.dependencies] == [kg_router.auth.get_current_user_uid]

--- a/backend/tests/unit/test_kg_prompt_node_cap.py
+++ b/backend/tests/unit/test_kg_prompt_node_cap.py
@@ -109,3 +109,51 @@ def test_node_omitted_from_prompt_still_merges_into_its_existing_id(monkeypatch)
     kg.extract_knowledge_from_memory('uid-1', 'user likes coffee', 'memory-1')
 
     assert [node['id'] for node in upserts] == [oldest['id']]
+
+
+def test_upsert_resolved_id_is_used_for_edges_when_existing_node_was_not_loaded(monkeypatch):
+    """The GET snapshot cap must not leave extraction edges on provisional IDs."""
+    monkeypatch.setattr(kg.kg_db, 'get_knowledge_nodes', lambda uid, db_client=None: [])
+    monkeypatch.setattr(kg, 'track_usage', lambda *args, **kwargs: nullcontext())
+
+    extraction = json.dumps(
+        {
+            'nodes': [
+                {'label': 'Legacy entity', 'node_type': 'concept', 'aliases': []},
+                {'label': 'New entity', 'node_type': 'concept', 'aliases': []},
+            ],
+            'edges': [
+                {
+                    'source_label': 'Legacy entity',
+                    'target_label': 'New entity',
+                    'label': 'relates to',
+                }
+            ],
+        }
+    )
+    client = MagicMock()
+    client.invoke.return_value = MagicMock(content=extraction)
+    monkeypatch.setattr(kg, 'get_llm', lambda feature: client)
+
+    def upsert_node(uid, node_data, db_client=None):
+        resolved_id = 'legacy-existing-id' if node_data['label'] == 'Legacy entity' else 'new-created-id'
+        return {**node_data, 'id': resolved_id}
+
+    saved_edges: list[dict] = []
+    monkeypatch.setattr(kg.kg_db, 'upsert_knowledge_node', upsert_node)
+    monkeypatch.setattr(
+        kg.kg_db,
+        'upsert_knowledge_edge',
+        lambda uid, edge_data, db_client=None: saved_edges.append(edge_data) or edge_data,
+    )
+
+    kg.extract_knowledge_from_memory('uid-1', 'legacy relates to new', 'memory-1')
+
+    assert saved_edges == [
+        {
+            'source_id': 'legacy-existing-id',
+            'target_id': 'new-created-id',
+            'label': 'relates to',
+            'memory_ids': ['memory-1'],
+        }
+    ]

--- a/backend/tests/unit/test_memory_graph_assertion_read.py
+++ b/backend/tests/unit/test_memory_graph_assertion_read.py
@@ -57,6 +57,9 @@ class _CollectionRef:
         self._limit = count
         return self
 
+    def order_by(self, _field_path: str, *_args, **_kwargs):
+        return self
+
     def stream(self):
         prefix = f"{self.path}/"
         depth = self.path.count("/")
@@ -218,6 +221,8 @@ def test_loader_excludes_assertions_not_fenced_to_an_active_current_item(item_ov
         "nodes": [],
         "edges": [],
         "truncated": False,
+        "node_count": 0,
+        "edge_count": 0,
         "node_limit": kg_db.MAX_KNOWLEDGE_GRAPH_NODES,
         "edge_limit": kg_db.MAX_KNOWLEDGE_GRAPH_EDGES,
     }
@@ -259,6 +264,8 @@ def test_tombstoned_canonical_item_fences_legacy_graph_before_projection_prune()
         "nodes": [],
         "edges": [],
         "truncated": False,
+        "node_count": 0,
+        "edge_count": 0,
         "node_limit": kg_db.MAX_KNOWLEDGE_GRAPH_NODES,
         "edge_limit": kg_db.MAX_KNOWLEDGE_GRAPH_EDGES,
     }

--- a/backend/utils/llm/knowledge_graph.py
+++ b/backend/utils/llm/knowledge_graph.py
@@ -167,9 +167,9 @@ def extract_knowledge_from_memory(
 
             saved_node = kg_db.upsert_knowledge_node(uid, node_data, db_client=db_client)
             created_nodes.append(saved_node)
-            label_to_node_id[node.label.lower()] = node_id
+            label_to_node_id[node.label.lower()] = saved_node['id']
             for alias in node.aliases:
-                label_to_node_id[alias.lower()] = node_id
+                label_to_node_id[alias.lower()] = saved_node['id']
 
         created_edges: List[Any] = []
         for edge in extraction.edges:

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2016,8 +2016,10 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_count?: number;
   edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_count?: number;
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -12442,6 +12442,11 @@
       },
       "KnowledgeGraphResponse": {
         "properties": {
+          "edge_count": {
+            "default": 0,
+            "title": "Edge Count",
+            "type": "integer"
+          },
           "edge_limit": {
             "anyOf": [
               {
@@ -12460,6 +12465,11 @@
             },
             "title": "Edges",
             "type": "array"
+          },
+          "node_count": {
+            "default": 0,
+            "title": "Node Count",
+            "type": "integer"
           },
           "node_limit": {
             "anyOf": [

--- a/docs/doc/developer/backend/canonical_memory_architecture.md
+++ b/docs/doc/developer/backend/canonical_memory_architecture.md
@@ -223,12 +223,13 @@ without its version-fenced per-memory graph representation.
 `memory_graph_assertions/{memory_id}` is graph authority for canonical memory.
 The shared knowledge graph merges current assertions with retained legacy graph
 data on read; it is a derived view, not a second LLM extraction or admission
-authority. That overlay scans at most 2,000 assertions plus the bounded legacy
-inputs, returns at most 2,000 nodes and 5,000 edges, and reports
-`truncated=true` whenever an input or merged result exceeds its cap. Returned
-edges are referentially closed over the returned node page; filtering a dangling
-edge also marks the response truncated. Public graph delete and rebuild return
-HTTP 409 for canonical or retained-assertion accounts at
+authority. That overlay reads stable document-ID-ordered pages of at most 500
+assertions plus the bounded legacy inputs, returns at most 500 nodes and 1,000
+edges, and reports `truncated=true` whenever an input or merged result exceeds
+its cap. `node_count` and `edge_count` report the records included in that
+bounded snapshot. Returned edges are referentially closed over the returned
+node page; filtering a dangling edge also marks the response truncated. Public
+graph delete and rebuild return HTTP 409 for canonical or retained-assertion accounts at
 `DELETE /v1/knowledge-graph` and `POST /v1/knowledge-graph/rebuild` because
 those assertions, not the mutable shared projection, are authority.
 

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2016,8 +2016,10 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_count?: number;
   edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_count?: number;
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2016,8 +2016,10 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_count?: number;
   edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_count?: number;
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2016,8 +2016,10 @@ export interface InterventionRecord {
 export type InterventionSurface = "suggested" | "what_matters_now";
 
 export interface KnowledgeGraphResponse {
+  edge_count?: number;
   edge_limit?: number | null;
   edges: Array<Record<string, unknown>>;
+  node_count?: number;
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;


### PR DESCRIPTION
## Summary

Tighten `GET /v1/knowledge-graph` to a deterministic snapshot of at most 500 nodes, 1,000 edges, and 500 canonical assertions, and expose additive returned-count metadata.

Multica: [SCA-261](https://multica-01.tail76ea03.ts.net/scaling-forever/issues/1b92e010-c172-496a-829a-74407c911d6d)

## Root cause

`TimeoutMiddleware` applies `HTTP_GET_TIMEOUT` and returns a bare 504 when the request exceeds the production 30-second GET budget. The deployed commit already contains #10750's original 2,000-node / 5,000-edge caps, but production heavy-tail requests still pin that ceiling. Including the canonical assertion and privacy-fence reads, that path could consume roughly 11,500 Firestore documents before serialization.

The prior cap was therefore bounded in name but still too large for the request budget. Raising `HTTP_GET_TIMEOUT` would retain the excessive read and worker cost, so this PR does not change any timeout.

## Fix

- Reduce the server-enforced snapshot to 500 nodes, 1,000 edges, and 500 assertions (roughly 3,000 maximum Firestore documents including active-item and citation-fence reads).
- Explicitly order each capped Firestore page by document ID so repeated reads select a deterministic subset without requiring a new composite index.
- Preserve the required `nodes` and `edges` arrays and existing truncation/limit fields.
- Add optional-compatible `node_count` and `edge_count` fields describing the records returned in the bounded snapshot.
- Keep edges referentially closed over the returned node page.

## Product invariants affected

- INV-MEM-4 (proposed): the canonical assertion privacy fence and derived-view ownership remain intact.

## Failure-Class

Failure-Class: new

Guard artifact: the 20,000-node / 20,000-edge behavioral fixture fails if the production loader omits its Firestore cap or deterministic ordering, while the HTTP-level regression verifies the additive response and unchanged Firebase dependency.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_bounded_firestore_list_reads.py backend/tests/unit/test_memory_graph_assertion_read.py backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py backend/tests/unit/test_timeout_middleware.py backend/tests/unit/test_http_timeout_defaults.py` — 47 passed.
- `backend/.venv/bin/pyright --pythonpath backend/.venv/bin/python backend/database/knowledge_graph.py backend/routers/knowledge_graph.py` — 0 errors.
- App-client OpenAPI, Dart DTO, and TypeScript client generation checks — current.
- `OMI_PR_BODY_FILE=pr-body.md make preflight` — 27 checks passed.

The repository `backend/test.sh` wrapper executed all focused assertions successfully, but its Mac CPU-time ratchet rejected an unchanged 5,000-item action-items fixture at 0.17–0.19s (limit 0.12s). The same files pass under focused pytest; this PR does not alter action-items policy.

## Operational notes

- No production deployment, traffic change, rollback, Firestore mutation, or timeout increase.
- A rollback is not recommended for this chronic heavy-tail class; the serving revision is healthy and the mechanism predates the current chat-stream revision.
- Action-items, memories, and other GET heavy tails remain outside this PR and require separate production validation even where #10750 added initial caps.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

