### PR TITLE
fix(desktop): admit Flash-Lite in the shared desktop model policy

### DIFF
--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -75,6 +75,24 @@ def test_every_model_the_desktop_client_ships_is_proxy_allowlisted():
     assert client_models <= desktop_proxy._ALLOWED_MODELS
 
 
+def test_shared_desktop_policy_admits_every_model_the_client_ships():
+    """The same static checker over the shared Rust policy's copy of the proxy allowlist.
+
+    desktop/shared-rust carries the pre-cutover Rust gate's allowlist. Pinning only this
+    module let that copy keep the Flash-Lite gap that #10848 closed here, so the client's
+    model table is checked against every in-repo copy of the gate, not just the live one.
+    """
+    qos = BACKEND_DIR.parent / "desktop/macos/Desktop/Sources/ModelQoS.swift"
+    policy = BACKEND_DIR.parent / "desktop/shared-rust/src/model_qos.rs"
+    if not qos.exists() or not policy.exists():  # partial checkouts have no desktop tree
+        pytest.skip("desktop sources are not present in this checkout")
+    client_models = set(re.findall(r'"(gemini-[^"]+)"', qos.read_text()))
+    allowed_body = re.search(r"fn gemini_proxy_allowed\(\).*?\n\}", policy.read_text(), re.DOTALL)
+    assert allowed_body, "gemini_proxy_allowed() is no longer readable in the shared policy"
+    assert client_models
+    assert client_models <= set(re.findall(r'"(gemini-[^"]+)"', allowed_body.group()))
+
+
 def test_vertex_embedding_translation_round_trip():
     request = desktop_proxy._vertex_embedding_request(
         b'{"content":{"parts":[{"text":"hello"}]},"taskType":"RETRIEVAL_QUERY","title":"note"}'

--- a/desktop/shared-rust/src/model_qos.rs
+++ b/desktop/shared-rust/src/model_qos.rs
@@ -49,6 +49,7 @@ pub fn active_tier() -> ModelTier {
 pub const fn gemini_proxy_allowed() -> &'static [&'static str] {
     &[
         "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
         "gemini-2.5-pro",
         "gemini-3-flash-preview",
         "gemini-embedding-001",
@@ -60,7 +61,12 @@ pub const fn gemini_degrade_target() -> &'static str {
     "gemini-2.5-flash"
 }
 
-const VERTEX_AI_MODELS: &[&str] = &["gemini-2.5-flash", "gemini-2.5-pro", "gemini-embedding-001"];
+const VERTEX_AI_MODELS: &[&str] = &[
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "gemini-2.5-pro",
+    "gemini-embedding-001",
+];
 
 /// Returns whether a model is available on Vertex AI.
 pub fn is_vertex_available(model: &str) -> bool {
@@ -179,6 +185,15 @@ mod tests {
         assert_eq!(route.vertex_action, Some("predict"));
         assert_eq!(route.request_transform, BodyTransform::EmbedToPredict);
         assert_eq!(route.response_transform, ResponseTransform::PredictToEmbed);
+    }
+
+    #[test]
+    fn resolve_route_should_send_live_suggestions_to_vertex() {
+        // ModelQoS.Gemini.suggestions ships Flash-Lite on the default premium tier.
+        assert_eq!(
+            resolve_route("gemini-2.5-flash-lite", "generateContent").provider,
+            Provider::VertexAi
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`ModelQoS.Gemini.suggestions` has shipped `gemini-2.5-flash-lite` on the default premium tier since 25f1ab75aa "cut live-suggestion cost by ~20x" (2026-07-26). #10848 widened the Python desktop proxy's allowlist to match, but the shared Rust policy crate added two days later by #10115 was ported from the pre-cutover Rust backend and carried the old list forward: `gemini_proxy_allowed()` still rejects the one model the desktop's highest-volume assistant asks for, and `VERTEX_AI_MODELS` still routes it to AI Studio instead of Vertex.

## Root cause

The registered failure class recurring in a second home, not a new defect. The live prod desktop-backend is still the pre-cutover Rust image (revision `desktop-backend-6e319bade93b`, created 2026-07-27, built before #10848 landed on 07-29), and its `is_gemini_model_allowed` reads exactly this list. Prod Cloud Run logs for `POST /v1/proxy/gemini/models/gemini-2.5-flash-lite:generateContent`:

| window (10 min) | 403s |
|---|---|
| 2026-07-26T16:00Z | 0 |
| 2026-07-29T16:00Z | 15 |
| 2026-07-30T16:00Z | 111 |

Live notch suggestions are silently dead for premium-tier (default) macOS users, and the rate climbs as the client build rolls out. Deploying main fixes production; leaving the shared policy stale re-ships the same 403 the moment anything consumes the crate.

## Fix

- `desktop/shared-rust/src/model_qos.rs`: add `gemini-2.5-flash-lite` to `gemini_proxy_allowed()` and `VERTEX_AI_MODELS`, matching the Python gate that superseded it.
- `backend/tests/unit/test_desktop_proxy.py`: extend the failure class's canonical prevention artifact so the client's model table is checked against **every** in-repo copy of the gate, not only the live one — pinning just the Python allowlist is what let the Rust copy keep the gap.

## What I tested

- `tests/unit/test_desktop_proxy.py::test_shared_desktop_policy_admits_every_model_the_client_ships` fails on the unfixed policy with `Extra items in the left set: 'gemini-2.5-flash-lite'` and passes here; 8 passed in the file.
- `resolve_route_should_send_live_suggestions_to_vertex` fails on the unfixed routing list (`left: AiStudio, right: VertexAi`) and passes here. `cargo test` 7 passed; `cargo fmt --check` and `cargo clippy --all-targets` clean.
- `make preflight` green.
- **Not** exercised against the running desktop app: the crate has no consumer yet and prod serves the pre-cutover image, so live recovery of notch suggestions needs the desktop-backend prod deploy, not this commit.

Failure-Class: FC-client-model-outside-proxy-allowlist

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

