### PR TITLE
SCA-264: Fix desktop_auto_release planner CI gate timeout

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -20,12 +20,13 @@ REQUIRED_SOURCE_CHECK_NAMES = (
     "Desktop Swift Release Compile",
 )
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
-# The exact-SHA aggregate can complete after the former 12-minute boundary on
-# a healthy run. Give the normal 20-minute CI budget time to settle while
-# retaining a bounded, fail-closed source-check gate.
-SOURCE_CHECK_WAIT_SECONDS = 20 * 60
+# Desktop Swift CI regularly takes 30-45 minutes. Keep a 60-minute exact-SHA
+# gate budget so healthy builds are not timed out while still running. Override
+# via CI_GATE_TIMEOUT_SECONDS or --source-check-wait-seconds.
+SOURCE_CHECK_WAIT_SECONDS = 60 * 60
 SOURCE_CHECK_POLL_SECONDS = 30
 MAX_SOURCE_STATUS_POLLS = 20
+CI_GATE_TIMEOUT_ENV = "CI_GATE_TIMEOUT_SECONDS"
 # Short debounce so a merge is tagged within ~a minute instead of waiting ten.
 # The one-active-release fence (Codemagic build status on the latest tag) already
 # collapses rapid bursts to the newest SHA while a build runs, so this window only
@@ -240,6 +241,20 @@ def required_source_checks_gate(repository: str, sha: str) -> SourceCheckGate:
     return SourceCheckGate("ready")
 
 
+def default_source_check_wait_seconds() -> int:
+    """Resolve the CI gate wait budget from CI_GATE_TIMEOUT_SECONDS or the default."""
+    raw = os.environ.get(CI_GATE_TIMEOUT_ENV)
+    if raw is None or raw.strip() == "":
+        return SOURCE_CHECK_WAIT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{CI_GATE_TIMEOUT_ENV} must be an integer, got {raw!r}") from exc
+    if value < 0:
+        raise SystemExit(f"{CI_GATE_TIMEOUT_ENV} must be non-negative")
+    return value
+
+
 def wait_for_required_source_checks(
     repository: str, sha: str, *, wait_seconds: int, poll_seconds: int
 ) -> SourceCheckGate:
@@ -252,6 +267,12 @@ def wait_for_required_source_checks(
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
+            # One final look before giving up: GitHub check-run visibility can
+            # lag the true completion enough that the last poll still looked
+            # missing/in-progress even though the required checks are ready.
+            gate = required_source_checks_gate(repository, sha)
+            if gate.state != "waiting":
+                return gate
             return SourceCheckGate(
                 "blocked",
                 f"timed out after {wait_seconds}s waiting for required exact-SHA checks: {gate.reason}",
@@ -390,14 +411,27 @@ def set_output(name: str, value: str) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repository", required=True)
-    parser.add_argument("--source-check-wait-seconds", type=int, default=SOURCE_CHECK_WAIT_SECONDS)
+    parser.add_argument(
+        "--source-check-wait-seconds",
+        type=int,
+        default=None,
+        help=(
+            "Seconds to wait for required exact-SHA checks "
+            f"(default: ${{{CI_GATE_TIMEOUT_ENV}}} or {SOURCE_CHECK_WAIT_SECONDS})"
+        ),
+    )
     parser.add_argument("--source-check-poll-seconds", type=int, default=SOURCE_CHECK_POLL_SECONDS)
     parser.add_argument("--watch-source-sha")
     parser.add_argument("--watch-max-polls", type=int, default=1)
     parser.add_argument("--watch-poll-seconds", type=int, default=SOURCE_CHECK_POLL_SECONDS)
     args = parser.parse_args()
 
-    if args.source_check_wait_seconds < 0:
+    source_check_wait_seconds = (
+        args.source_check_wait_seconds
+        if args.source_check_wait_seconds is not None
+        else default_source_check_wait_seconds()
+    )
+    if source_check_wait_seconds < 0:
         parser.error("--source-check-wait-seconds must be non-negative")
     if args.source_check_poll_seconds <= 0:
         parser.error("--source-check-poll-seconds must be positive")
@@ -467,7 +501,7 @@ def main() -> int:
     source_check_gate = wait_for_required_source_checks(
         args.repository,
         source_sha,
-        wait_seconds=args.source_check_wait_seconds,
+        wait_seconds=source_check_wait_seconds,
         poll_seconds=args.source_check_poll_seconds,
     )
     if source_check_gate.state == "waiting":

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -319,15 +319,39 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
     def test_transient_check_state_is_bounded_then_times_out_as_blocked(self) -> None:
         waiting = planner.SourceCheckGate("waiting", "required check is missing for exact source SHA")
         with (
-            patch.object(planner, "required_source_checks_gate", return_value=waiting),
+            patch.object(planner, "required_source_checks_gate", return_value=waiting) as gate,
             patch.object(planner.time, "monotonic", side_effect=(100, 100, 121)),
             patch.object(planner.time, "sleep") as sleep,
         ):
+            result = planner.wait_for_required_source_checks(REPOSITORY, SOURCE_SHA, wait_seconds=20, poll_seconds=10)
+
+        self.assertEqual(result.state, "blocked")
+        self.assertIn("timed out after 20s", result.reason or "")
+        sleep.assert_called_once_with(10)
+        # Initial probe + post-sleep probe + final re-check before timeout.
+        self.assertEqual(gate.call_count, 3)
+
+    def test_timeout_final_recheck_admits_late_exact_sha_success(self) -> None:
+        waiting = planner.SourceCheckGate("waiting", "required check is missing for exact source SHA")
+        ready = planner.SourceCheckGate("ready")
+        with (
+            patch.object(
+                planner,
+                "required_source_checks_gate",
+                side_effect=(waiting, waiting, ready),
+            ),
+            patch.object(planner.time, "monotonic", side_effect=(100, 100, 121)),
+            patch.object(planner.time, "sleep"),
+        ):
             gate = planner.wait_for_required_source_checks(REPOSITORY, SOURCE_SHA, wait_seconds=20, poll_seconds=10)
 
-        self.assertEqual(gate.state, "blocked")
-        self.assertIn("timed out after 20s", gate.reason or "")
-        sleep.assert_called_once_with(10)
+        self.assertEqual(gate.state, "ready")
+
+    def test_ci_gate_timeout_env_overrides_default_wait_budget(self) -> None:
+        with patch.dict(os.environ, {planner.CI_GATE_TIMEOUT_ENV: "4500"}, clear=False):
+            self.assertEqual(planner.default_source_check_wait_seconds(), 4500)
+        with patch.dict(os.environ, {planner.CI_GATE_TIMEOUT_ENV: ""}, clear=False):
+            self.assertEqual(planner.default_source_check_wait_seconds(), planner.SOURCE_CHECK_WAIT_SECONDS)
 
     def test_extended_wait_admits_observed_late_exact_sha_success(self) -> None:
         # Run 30179919353 timed out at the former 12-minute boundary, then its
@@ -482,9 +506,17 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
-        self.assertEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 20 * 60)
-        self.assertEqual(workflow.count("--source-check-wait-seconds 1200"), 3)
+        self.assertEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 60 * 60)
+        self.assertGreaterEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 45 * 60)
+        self.assertEqual(workflow.count('--source-check-wait-seconds "${CI_GATE_TIMEOUT_SECONDS}"'), 3)
         self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 3)
+        self.assertIn("CI_GATE_TIMEOUT_SECONDS:", workflow)
+        self.assertIn("vars.DESKTOP_CI_GATE_TIMEOUT_SECONDS || '3600'", workflow)
+        self.assertIn("timeout-minutes: 75", workflow)
+        self.assertIn("Surface planner non-release decision", workflow)
+        self.assertIn("::error::Desktop release planner blocked:", workflow)
+        self.assertIn("::warning::Desktop release planner skipped tagging:", workflow)
+        self.assertIn('if: steps.plan.outputs.should_release != \'true\'', workflow)
         self.assertLess(
             workflow.index("Create and regular-merge PR to sync changelog back to main"),
             workflow.index("Publish immutable tag from exact live main source"),

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -14,9 +14,14 @@ permissions:
 jobs:
   plan-release:
     runs-on: ubuntu-latest
+    # Allow the full CI gate wait (default 60m) plus planner overhead.
+    timeout-minutes: 75
     concurrency:
       group: desktop-release-planner-main
       cancel-in-progress: false
+    env:
+      # Override via repo Actions variable DESKTOP_CI_GATE_TIMEOUT_SECONDS if needed.
+      CI_GATE_TIMEOUT_SECONDS: ${{ vars.DESKTOP_CI_GATE_TIMEOUT_SECONDS || '3600' }}
     outputs:
       should_release: ${{ steps.plan.outputs.should_release }}
       reason: ${{ steps.plan.outputs.reason }}
@@ -41,11 +46,33 @@ jobs:
         run: |
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}" \
-            --source-check-wait-seconds 1200 \
+            --source-check-wait-seconds "${CI_GATE_TIMEOUT_SECONDS}" \
             --source-check-poll-seconds 30
 
       - name: Show release plan
         run: echo "${{ steps.plan.outputs.reason }}"
+
+      # tag-release is skipped whenever should_release!=true. Make that decision
+      # obvious in the Actions UI: fail hard on source-gate blocks/timeouts, and
+      # emit a warning annotation for intentional deferrals so a green run with
+      # only plan-release is never silent.
+      - name: Surface planner non-release decision
+        if: steps.plan.outputs.should_release != 'true'
+        env:
+          PLAN_REASON: ${{ steps.plan.outputs.reason }}
+        run: |
+          set -euo pipefail
+          reason="${PLAN_REASON:-unknown reason}"
+          echo "Planner decided not to release: ${reason}"
+          case "${reason}" in
+            *"source gate blocked"*|*"Could not resolve the newest releasable desktop source SHA"*)
+              echo "::error::Desktop release planner blocked: ${reason}"
+              exit 1
+              ;;
+            *)
+              echo "::warning::Desktop release planner skipped tagging: ${reason}"
+              ;;
+          esac
 
   # Candidate publication is one serialized trusted-M1 transaction: after the
   # immutable final-source binding it runs offline readiness, verifies that
@@ -58,6 +85,8 @@ jobs:
     concurrency:
       group: desktop-auto-release-tag-main
       cancel-in-progress: false
+    env:
+      CI_GATE_TIMEOUT_SECONDS: ${{ vars.DESKTOP_CI_GATE_TIMEOUT_SECONDS || '3600' }}
     steps:
       - name: Generate Omi Bot token
         id: app-token
@@ -87,7 +116,7 @@ jobs:
 
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}" \
-            --source-check-wait-seconds 1200 \
+            --source-check-wait-seconds "${CI_GATE_TIMEOUT_SECONDS}" \
             --source-check-poll-seconds 30
 
       - name: Checkout exact releasable desktop source
@@ -340,7 +369,7 @@ jobs:
 
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}" \
-            --source-check-wait-seconds 1200 \
+            --source-check-wait-seconds "${CI_GATE_TIMEOUT_SECONDS}" \
             --source-check-poll-seconds 30
 
       - name: Select final release plan


### PR DESCRIPTION
## Summary
- Raise the desktop auto-release exact-SHA CI gate wait from 20 minutes to **60 minutes** (Desktop Swift CI regularly takes 30–45 minutes), configurable via `CI_GATE_TIMEOUT_SECONDS` / repo variable `DESKTOP_CI_GATE_TIMEOUT_SECONDS`.
- On timeout, perform one final re-check for GitHub check-run eventual consistency before blocking.
- When the planner decides not to release: fail the `plan-release` job with `::error::` on source-gate blocks/timeouts; emit `::warning::` for intentional skips so skipped `tag-release` is never silent.

Closes SCA-264

Failure-Class: FC-gate-timeout-below-cold-cost

## Test plan
- [x] `python3 .github/scripts/test_plan_desktop_release.py`
- [x] `python3 .github/scripts/test_publish_desktop_candidate_tag.py`
- [x] `python3 .github/scripts/test_desktop_swift_ci_contract.py`
- [ ] Confirm Desktop Swift CI + contracts pass on the PR
- [ ] Manual `workflow_dispatch` of Build Desktop Release Candidate after merge once Desktop Swift is in flight past ~20m (should wait rather than skip)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

