### PR TITLE
perf: collapse OpenAI text routing to Luna and Nano

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -64,7 +64,7 @@ backend/
     llm/                  #   LLM orchestration (14 files): chat processing, conversation post-processing,
                           #   memory extraction, persona management, proactive notifications, goal tracking,
                           #   app generation, fair-use classification, usage tracking
-      clients.py          #     Model instances: OpenAI (gpt-4.1-mini, o4-mini), Anthropic (claude-sonnet-4-6),
+      clients.py          #     Model instances: OpenAI (Luna/Nano), Anthropic (claude-sonnet-4-6),
                           #     OpenRouter (gemini-flash), with prompt caching and usage callbacks
     stt/                  #   Speech-to-text (7 files): Parakeet/Modulate and explicit self-hosted Deepgram streaming, VAD gating, speech profiles,
                           #   pre-recorded batch transcription, speaker embeddings

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -360,7 +360,7 @@ env:
   - name: FAIR_USE_CLASSIFIER_COOLDOWN_SECONDS
     value: "43200"
   - name: FAIR_USE_CLASSIFIER_MODEL
-    value: "gpt-5.1"
+    value: "gpt-5.6-luna"
   - name: FAIR_USE_CLASSIFIER_LOOKBACK_DAYS
     value: "7"
   - name: FAIR_USE_CHECK_INTERVAL_SECONDS

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -355,7 +355,7 @@ env:
   - name: FAIR_USE_CLASSIFIER_COOLDOWN_SECONDS
     value: "43200"
   - name: FAIR_USE_CLASSIFIER_MODEL
-    value: "gpt-5.1"
+    value: "gpt-5.6-luna"
   - name: FAIR_USE_CLASSIFIER_LOOKBACK_DAYS
     value: "7"
   - name: FAIR_USE_CHECK_INTERVAL_SECONDS

--- a/backend/database/llm_usage.py
+++ b/backend/database/llm_usage.py
@@ -36,7 +36,7 @@ def record_llm_usage(
     Args:
         uid: User ID
         feature: Feature name (e.g., "chat", "rag", "conversation_processing")
-        model: Model name (e.g., "gpt-4.1-mini", "o4-mini")
+        model: Model name (e.g., "gpt-5.6-luna", "gpt-5-nano")
         input_tokens: Number of input/prompt tokens
         output_tokens: Number of output/completion tokens
     """

--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -112,14 +112,14 @@ surfaces:
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_client_config.py::test_app_icon_generation_always_uses_gateway
   - surface: file_chat_vision
     code_path: backend/utils/other/chat_file.py:_ask_vision_stream
-    current_provider_model: openai/gpt-4.1
+    current_provider_model: openai/gpt-5.6-luna
     request_shape: streaming vision chat completion
     gateway_lane_capability_needed: gateway-owned vision chat lane or file-chat replacement retrieval path
     migration_status: inventoried_direct_file_lifecycle_surface; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and checked-in serving configuration does not permit the exception
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: file_chat_assistants
     code_path: backend/utils/other/chat_file.py:FileChatTool
-    current_provider_model: openai/gpt-4.1 with Assistants, Threads, Files, File Search
+    current_provider_model: openai/gpt-5.6-luna with Assistants, Threads, Files, File Search
     request_shape: file upload, assistants, file_search, streaming run deltas
     gateway_lane_capability_needed: gateway-owned file/assistant lifecycle or replacement retrieval path
     migration_status: inventoried_direct_file_lifecycle_surface; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and checked-in serving configuration does not permit the exception

--- a/backend/llm_gateway/config/cost_rate_cards.yaml
+++ b/backend/llm_gateway/config/cost_rate_cards.yaml
@@ -19,13 +19,13 @@ rate_cards:
     cached_input_micro_usd_per_million: 20000
     output_micro_usd_per_million: 1250000
 
-  - rate_card_id: openai.gpt-5.6-luna.2026-07-17
+  - rate_card_id: openai.gpt-5.6-luna.2026-07-30
     provider: openai
     model: gpt-5.6-luna
-    input_micro_usd_per_million: 1000000
-    cached_input_micro_usd_per_million: 100000
-    output_micro_usd_per_million: 6000000
-    cache_write_micro_usd_per_million: 1250000
+    input_micro_usd_per_million: 200000
+    cached_input_micro_usd_per_million: 20000
+    output_micro_usd_per_million: 1200000
+    cache_write_micro_usd_per_million: 250000
 
   - rate_card_id: vertex.gemini-2.5-flash.2026-07-17
     provider: gemini

--- a/backend/llm_gateway/config/generated_route_overrides.yaml
+++ b/backend/llm_gateway/config/generated_route_overrides.yaml
@@ -7,10 +7,10 @@ generated_route_overrides:
   - feature: chat_agent
     primary: {provider: anthropic, model: claude-sonnet-5}
   - feature: chat_extraction
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: chat_graph
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: chat_responses
     primary: {provider: openai, model: gpt-5.6-luna}
@@ -40,46 +40,46 @@ generated_route_overrides:
     primary: {provider: openai, model: gpt-5-nano}
     provider_options: {reasoning_effort: minimal}
   - feature: external_structure
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: fair_use
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}
   - feature: goals
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: goals_advice
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}
   - feature: knowledge_graph
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: learnings
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}
   - feature: memories
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: memory_category
     primary: {provider: openai, model: gpt-5-nano}
     provider_options: {reasoning_effort: minimal}
   - feature: memory_conflict
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: memory_l1
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: memory_l2
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}
   - feature: notifications
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: openglass
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: persona_chat
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5-nano}
     provider_options: {reasoning_effort: low}
   - feature: persona_chat_premium
     primary: {provider: openai, model: gpt-5.6-luna}
@@ -88,11 +88,11 @@ generated_route_overrides:
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}
   - feature: proactive_notification
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
   - feature: smart_glasses
     primary: {provider: openai, model: gpt-5-nano}
     provider_options: {reasoning_effort: minimal}
   - feature: what_matters_now
-    primary: {provider: openai, model: gpt-5.4-nano}
+    primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}

--- a/backend/llm_gateway/config/route_artifacts.yaml
+++ b/backend/llm_gateway/config/route_artifacts.yaml
@@ -55,15 +55,15 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_27.001
-    artifact_digest: sha256:707331066d53439c5abd3a3614c5a5f3972880713e53b68fe470b0bf2a930104
+    artifact_digest: sha256:2ef9eea0738cd58dfdf9a70b89f8fc5aaf6ae1b2278e67987fe1d3d6a17c0c2e
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     primary:
       provider: openai
-      model: gpt-5.4-nano
+      model: gpt-5.6-luna
     fallbacks:
       - provider: openai
-        model: gpt-5.4-nano
+        model: gpt-5.6-luna
     provider_options:
       reasoning_effort: low
     timeouts:
@@ -115,14 +115,14 @@ route_artifacts:
         - invalid_config
 
   - route_artifact_id: route.chat_structured.2026_06_20.001
-    artifact_digest: sha256:7a8c23fbb2bae7e005b69844c84191f4852e97f56cb99dd3bca75360c430a273
+    artifact_digest: sha256:13b7df3652fd6015ef5578deda43bd0e97f914c6cf66deb60e296c167a497507
     lane_id: omi:auto:chat-structured
     surface: openai.chat_completions
     # The gateway LKG mirrors the active model so shadow serving and fallback use
     # the same gateway-only model policy without changing legacy chat extraction.
     primary:
       provider: openai
-      model: gpt-5.4-nano
+      model: gpt-5.6-luna
     fallbacks: []
     provider_options:
       reasoning_effort: low

--- a/backend/scripts/smoke-llm-gateway-openai-schemas.py
+++ b/backend/scripts/smoke-llm-gateway-openai-schemas.py
@@ -18,7 +18,7 @@ from models.structured_extraction import ActionItemsExtraction, ConversationStru
 from utils.llm.chat import RequiresContext
 from utils.llm.gateway_client import _chat_structured_payload  # type: ignore[reportPrivateUsage]  # test script accessing internal helper
 
-PROVIDER_REF = ProviderRef(provider='openai', model='gpt-4.1-mini')
+PROVIDER_REF = ProviderRef(provider='openai', model='gpt-5.6-luna')
 SMOKE_FEATURES = (
     ('chat_extraction.requires_context', RequiresContext),
     ('conversation_structure.extract.shadow', ConversationStructureExtraction),

--- a/backend/testing/e2e/fakes/llm.py
+++ b/backend/testing/e2e/fakes/llm.py
@@ -44,7 +44,7 @@ def make_openai_chat_response(content: str = None) -> dict:
     return {
         "id": "chatcmpl-fake-e2e-test",
         "object": "chat.completion",
-        "model": "gpt-4.1-mini",
+        "model": "gpt-5.6-luna",
         "choices": [
             {
                 "index": 0,

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -8,7 +8,7 @@ Tests every code path changed in the QoS profile refactor:
   P4: _effective_byok_provider() mapping
   P5: BYOK profile hardcoded to byok
   P6: Structured output compatibility on OpenAI (real .with_structured_output() call)
-  P7: Prompt caching (cache_key binding for gpt-5.4-mini)
+  P7: Prompt caching (cache_key binding for gpt-5.6-luna)
   P8: Streaming client construction and invocation
   P9: OpenRouter vendor prefix and temperature config
   P10: Anthropic client via get_model() + anthropic_client
@@ -38,7 +38,6 @@ load_dotenv(os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
 
 from utils.llm.clients import (
     MODEL_QOS_PROFILES,
-    _CACHE_KEY_MODELS,
     _STRUCTURED_OUTPUT_FEATURES,
     _active_profile,
     _active_profile_name,
@@ -54,6 +53,7 @@ from utils.llm.clients import (
     get_model,
     get_provider,
     get_qos_info,
+    supports_prompt_cache,
 )
 
 SIMPLE_PROMPT = "Reply with exactly one word: hello"
@@ -119,7 +119,7 @@ class TestP3_CreateByokClient:
     """P3: _create_byok_client creates valid ChatOpenAI instances."""
 
     def test_openai_byok_client(self):
-        client = _create_byok_client('gpt-4.1-mini', 'openai', os.environ['OPENAI_API_KEY'])
+        client = _create_byok_client('gpt-5.6-luna', 'openai', os.environ['OPENAI_API_KEY'])
         assert client is not None
         response = client.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), "BYOK OpenAI client returned empty"
@@ -142,7 +142,7 @@ class TestP3_CreateByokClient:
         assert client is None
 
     def test_streaming_byok_client(self):
-        client = _create_byok_client('gpt-4.1-mini', 'openai', os.environ['OPENAI_API_KEY'], streaming=True)
+        client = _create_byok_client('gpt-5.6-luna', 'openai', os.environ['OPENAI_API_KEY'], streaming=True)
         assert client is not None
         response = client.invoke(SIMPLE_PROMPT)
         assert response.content.strip()
@@ -156,7 +156,7 @@ class TestP4_EffectiveBYOKProvider:
     """P4: Provider mapping for BYOK key type resolution."""
 
     def test_openai(self):
-        assert _effective_byok_provider('gpt-4.1-mini', 'openai') == 'openai'
+        assert _effective_byok_provider('gpt-5.6-luna', 'openai') == 'openai'
 
     def test_gemini(self):
         assert _effective_byok_provider('gemini-2.5-flash', 'gemini') == 'gemini'
@@ -263,20 +263,20 @@ class TestP7_PromptCaching:
     """P7: cache_key binding works and produces valid responses."""
 
     def test_cache_key_with_cacheable_model(self):
-        """conv_structure uses gpt-5.4-mini (in _CACHE_KEY_MODELS) — cache_key should bind."""
+        """conv_structure uses Luna, so cache_key should bind."""
         llm = get_llm('conv_structure', cache_key='omi-test-cp9')
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip()
         print(f"  P7 cache_key bound: {response.content.strip()[:60]}")
 
     def test_cache_key_ignored_for_non_cacheable(self):
-        """memories uses gpt-4.1-mini (not in _CACHE_KEY_MODELS) — cache_key is no-op."""
+        """memories uses Luna, so cache_key should bind."""
         llm_with = get_llm('memories', cache_key='omi-test-cp9')
         llm_without = get_llm('memories')
-        assert llm_with is llm_without  # same instance, cache_key was a no-op
+        assert llm_with is not llm_without
 
-    def test_cache_key_models_set(self):
-        assert _CACHE_KEY_MODELS == {'gpt-5.4', 'gpt-5.4-mini'}
+    def test_luna_supports_cache_key_routing(self):
+        assert supports_prompt_cache('gpt-5.6-luna')
 
 
 # ---------------------------------------------------------------------------
@@ -411,4 +411,4 @@ class TestP13_QosInfo:
     def test_pinned_features_included(self):
         info = get_qos_info()
         assert 'fair_use' in info
-        assert info['fair_use']['model'] == 'gpt-5.1'
+        assert info['fair_use']['model'] == 'gpt-5.6-luna'

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -59,10 +59,10 @@ def call_perplexity(model: str, prompt: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Premium profile — gpt-5.4-mini features (flagship tier)
+# Premium profile — Luna default-intelligence features
 # ---------------------------------------------------------------------------
 class TestPremiumFlagship:
-    """Test gpt-5.4-mini features in premium profile respond to real prompts."""
+    """Test Luna features in premium profile respond to real prompts."""
 
     FLAGSHIP_FEATURES = [
         'conv_action_items',
@@ -81,7 +81,7 @@ class TestPremiumFlagship:
     @pytest.mark.parametrize("feature", FLAGSHIP_FEATURES)
     def test_flagship_feature_responds(self, feature):
         model = get_model(feature)
-        assert model == 'gpt-5.4-mini', f"{feature} should be gpt-5.4-mini in premium, got {model}"
+        assert model == 'gpt-5.6-luna', f"{feature} should be gpt-5.6-luna in premium, got {model}"
         llm = get_llm(feature)
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"{feature} ({model}) returned empty response"
@@ -89,10 +89,10 @@ class TestPremiumFlagship:
 
 
 # ---------------------------------------------------------------------------
-# Premium profile — gpt-4.1-mini features (quality-sensitive tier)
+# Premium profile — additional Luna features
 # ---------------------------------------------------------------------------
 class TestPremiumMini:
-    """Test gpt-4.1-mini features in premium profile respond to real prompts."""
+    """Test additional Luna features in premium profile respond to real prompts."""
 
     MINI_FEATURES = [
         'external_structure',
@@ -108,7 +108,7 @@ class TestPremiumMini:
     @pytest.mark.parametrize("feature", MINI_FEATURES)
     def test_mini_feature_responds(self, feature):
         model = get_model(feature)
-        assert model == 'gpt-4.1-mini', f"{feature} should be gpt-4.1-mini in premium, got {model}"
+        assert model == 'gpt-5.6-luna', f"{feature} should be gpt-5.6-luna in premium, got {model}"
         llm = get_llm(feature)
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"{feature} ({model}) returned empty response"
@@ -116,10 +116,10 @@ class TestPremiumMini:
 
 
 # ---------------------------------------------------------------------------
-# Premium profile — gpt-4.1-nano features (simple tasks tier)
+# Premium profile — gpt-5-nano light/binary features
 # ---------------------------------------------------------------------------
 class TestPremiumNano:
-    """Test gpt-4.1-nano features in premium profile respond to real prompts."""
+    """Test gpt-5-nano features in premium profile respond to real prompts."""
 
     NANO_FEATURES = [
         'conv_app_select',
@@ -134,7 +134,7 @@ class TestPremiumNano:
     @pytest.mark.parametrize("feature", NANO_FEATURES)
     def test_nano_feature_responds(self, feature):
         model = get_model(feature)
-        assert model == 'gpt-4.1-nano', f"{feature} should be gpt-4.1-nano in premium, got {model}"
+        assert model == 'gpt-5-nano', f"{feature} should be gpt-5-nano in premium, got {model}"
         llm = get_llm(feature)
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"{feature} ({model}) returned empty response"
@@ -142,14 +142,14 @@ class TestPremiumNano:
 
 
 # ---------------------------------------------------------------------------
-# Premium profile — gpt-4.1-mini features (vision/openglass)
+# Premium profile — Luna vision feature
 # ---------------------------------------------------------------------------
 class TestPremiumVision:
-    """Test gpt-4.1-mini vision-capable features in premium profile."""
+    """Test Luna vision-capable features in premium profile."""
 
     def test_openglass_feature_responds(self):
         model = get_model('openglass')
-        assert model == 'gpt-4.1-mini', f"openglass should be gpt-4.1-mini, got {model}"
+        assert model == 'gpt-5.6-luna', f"openglass should be gpt-5.6-luna, got {model}"
         llm = get_llm('openglass')
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"openglass ({model}) returned empty response"

--- a/backend/tests/unit/test_llm_gateway_accounting.py
+++ b/backend/tests/unit/test_llm_gateway_accounting.py
@@ -96,8 +96,8 @@ def test_openai_usage_parses_cache_writes_and_prices_luna_write_tokens() -> None
     event = build_accounting_event(_context(), attempt)
 
     assert event.cache_write_tokens == 400_000
-    assert event.estimated_cost_micro_usd == 6_920_000
-    assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-17'
+    assert event.estimated_cost_micro_usd == 1_384_000
+    assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-30'
 
 
 def test_empty_usage_object_is_unreported_not_a_zero_cost_completion() -> None:

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -24,20 +24,20 @@ def test_loads_default_gateway_config():
     assert lane.last_known_good == LKG_ROUTE
     assert config.route_artifacts[ACTIVE_ROUTE].content_digest.startswith('sha256:')
     assert config.feature_bundles['chat_extraction.requires_context'].lane_id == LANE_ID
-    assert config.route_artifacts[ACTIVE_ROUTE].primary.model == 'gpt-5.4-nano'
+    assert config.route_artifacts[ACTIVE_ROUTE].primary.model == 'gpt-5.6-luna'
     assert config.route_artifacts[ACTIVE_ROUTE].provider_options['reasoning_effort'] == 'low'
 
 
 def test_gateway_route_overrides_do_not_change_the_legacy_model_profile():
     config = load_gateway_config(prod_mode=True)
 
-    assert get_model('conv_discard') == 'gpt-4.1-nano'
-    assert get_model('memories') == 'gpt-4.1-mini'
-    assert get_model('fair_use') == 'gpt-5.1'
+    assert get_model('conv_discard') == 'gpt-5-nano'
+    assert get_model('memories') == 'gpt-5.6-luna'
+    assert get_model('fair_use') == 'gpt-5.6-luna'
     assert get_model('chat_agent') == 'claude-sonnet-4-6'
 
     assert config.route_artifacts['route.conv_discard.model_config.001'].primary.model == 'gpt-5-nano'
-    assert config.route_artifacts['route.memories.model_config.001'].primary.model == 'gpt-5.4-nano'
+    assert config.route_artifacts['route.memories.model_config.001'].primary.model == 'gpt-5.6-luna'
     assert config.route_artifacts['route.fair_use.model_config.001'].primary.model == 'gpt-5.6-luna'
     assert config.route_artifacts['route.chat_agent.model_config.001'].primary.model == 'claude-sonnet-5'
     assert config.route_artifacts['route.memory_l2.model_config.001'].provider_options['reasoning_effort'] == 'medium'

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -111,7 +111,7 @@ def test_generated_gateway_lanes_apply_only_declared_gateway_route_overrides():
 def test_persona_auth_tiers_resolve_to_fixed_gateway_models():
     overrides = load_generated_route_overrides()
 
-    assert overrides['persona_chat'].primary.model == 'gpt-5.4-nano'
+    assert overrides['persona_chat'].primary.model == 'gpt-5-nano'
     assert overrides['persona_chat_premium'].primary.model == 'gpt-5.6-luna'
 
 

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -43,10 +43,10 @@ async def test_executor_success_uses_active_primary_and_exposes_lane_model():
     assert result.response['choices'][0]['message']['content'] == '{"answer":"primary"}'
     assert result.selected_route_artifact_id == ACTIVE_ROUTE
     assert result.selected_provider == 'openai'
-    assert result.selected_model == 'gpt-5.4-nano'
+    assert result.selected_model == 'gpt-5.6-luna'
     assert not result.fallback_used
     assert not result.used_lkg
-    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
+    assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
     assert provider.calls[0].request['stream'] is False
 
 
@@ -65,7 +65,7 @@ async def test_executor_forwards_prompt_parser_request_without_response_format()
         ProviderRegistry({'openai': provider}),
     )
 
-    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
+    assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
     assert 'response_format' not in provider.calls[0].request
 
 
@@ -137,7 +137,7 @@ async def test_executor_retries_provider_up_to_max_attempts_before_fallback():
     )
 
     # Primary tried 3 times (max_attempts), then fallback once
-    assert [call.model for call in provider.calls] == ['gpt-5.4-nano', 'gpt-5.4-nano', 'gpt-5.4-nano', 'gpt-4o-mini']
+    assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-5.6-luna', 'gpt-5.6-luna', 'gpt-4o-mini']
     assert result.response['choices'][0]['message']['content'] == '{"answer":"fallback"}'
 
 
@@ -254,7 +254,7 @@ async def test_executor_uses_active_route_fallback_for_policy_allowed_failures(f
     assert result.fallback_used
     assert result.fallback_reason == failure_class
     assert not result.used_lkg
-    assert [call.model for call in provider.calls] == ['gpt-5.4-nano', 'gpt-4o-mini']
+    assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-4o-mini']
 
 
 @pytest.mark.asyncio
@@ -306,11 +306,11 @@ async def test_executor_uses_lkg_only_when_active_route_policy_allows():
 
     assert result.response['model'] == LANE_ID
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-5.4-nano'
+    assert result.selected_model == 'gpt-5.6-luna'
     assert result.fallback_used
     assert result.fallback_reason == FailureClass.TIMEOUT_BEFORE_OUTPUT
     assert result.used_lkg
-    assert [call.model for call in provider.calls] == ['gpt-5.4-nano', 'gpt-5.4-nano']
+    assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-5.6-luna']
 
 
 @pytest.mark.asyncio
@@ -426,7 +426,7 @@ async def test_shadow_active_route_serves_lkg_not_active():
     config = config_with_active_route(shadow_route)
     resolved = resolve_chat_completion_route(config, valid_request())
 
-    # Provider should be called with the gateway LKG model (gpt-5.4-nano).
+    # Provider should be called with the gateway LKG model (gpt-5.6-luna).
     # The gateway route is intentionally independent from legacy chat extraction.
     provider = FakeChatCompletionProvider(
         [fake_success_response(resolved.last_known_good_route.primary, content='{"answer":"lkg"}')]
@@ -439,9 +439,9 @@ async def test_shadow_active_route_serves_lkg_not_active():
     )
 
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-5.4-nano'
+    assert result.selected_model == 'gpt-5.6-luna'
     assert result.used_lkg
-    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
+    assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
     assert selected_serving_route_artifact_id(resolved) == LKG_ROUTE
 
 
@@ -466,7 +466,7 @@ async def test_disabled_active_route_serves_lkg_not_active():
     )
 
     assert result.selected_route_artifact_id == LKG_ROUTE
-    assert result.selected_model == 'gpt-5.4-nano'
+    assert result.selected_model == 'gpt-5.6-luna'
     assert result.used_lkg
 
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -82,10 +82,10 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     assert 'selected_route_artifact_id' not in body
     # The checked-in active route is in shadow rollout (percent 0), so live
     # traffic is served by the last-known-good route. The LKG primary uses the
-    # gateway-only chat_extraction policy (gpt-5.4-nano), leaving the legacy
-    # product route unchanged while shadow-only.
-    assert provider.calls[0].model == 'gpt-5.4-nano'
-    assert provider.calls[0].request['model'] == 'gpt-5.4-nano'
+    # gateway-only chat_extraction policy (gpt-5.6-luna), aligned with the
+    # direct product route while shadow-only.
+    assert provider.calls[0].model == 'gpt-5.6-luna'
+    assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
     assert provider.calls[0].request['temperature'] == 0
     assert provider.calls[0].request['max_completion_tokens'] == 64
     assert 'metadata' not in provider.calls[0].request
@@ -132,7 +132,7 @@ def test_provider_rejection_preserves_exact_terminal_class_and_bounded_member(
     error = recorded[0]['error']
     assert error.failure_class == failure_class
     assert error.provider == 'openai'
-    assert error.model == 'gpt-5.4-nano'
+    assert error.model == 'gpt-5.6-luna'
     assert error.provider_rejection == provider_rejection
 
 
@@ -195,7 +195,7 @@ def test_chat_completions_persists_cache_aware_attempt_with_authenticated_attrib
                 'id': 'chatcmpl-accounted',
                 'object': 'chat.completion',
                 'created': 1,
-                'model': 'gpt-5.4-nano',
+                'model': 'gpt-5.6-luna',
                 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': '{}'}, 'finish_reason': 'stop'}],
                 'usage': {
                     'prompt_tokens': 100,
@@ -271,7 +271,7 @@ def test_gateway_provider_body_strips_gpt56_cache_fields_for_legacy_route():
         ],
     )
     resolved = resolve_chat_completion_route(load_gateway_config(prod_mode=True), request)
-    forwarded = provider_request_for(resolved, ProviderRef(provider='openai', model='gpt-5.4-nano'))
+    forwarded = provider_request_for(resolved, ProviderRef(provider='openai', model='gpt-4.1-mini'))
 
     assert forwarded['prompt_cache_key'] == 'omi-extract-actions-v1-b0'
     assert 'prompt_cache_options' not in forwarded
@@ -685,7 +685,7 @@ async def test_streaming_midstream_provider_failure_records_error_exactly_once(m
         first_chunk=b'data: {"choices":[]}\n\n',
         stream=failing_stream(),
         provider='openai',
-        model='gpt-5.4-nano',
+        model='gpt-5.6-luna',
         fallback_used=False,
         fallback_reason=None,
     )
@@ -723,7 +723,7 @@ async def test_streaming_consumer_abandonment_records_cancelled_exactly_once(mon
             first_chunk=b'data: {"choices":[]}\n\n',
             stream=remaining_stream(),
             provider='openai',
-            model='gpt-5.4-nano',
+            model='gpt-5.6-luna',
             fallback_used=False,
             fallback_reason=None,
         ),

--- a/backend/tests/unit/test_llm_gateway_route_refs.py
+++ b/backend/tests/unit/test_llm_gateway_route_refs.py
@@ -38,11 +38,11 @@ def test_unknown_feature_route_ref_uses_default_explicit_route():
 
     assert route_ref == ExplicitRouteRef(
         feature=feature,
-        model='gpt-4.1-mini',
+        model='gpt-5.6-luna',
         provider='openai',
-        options={},
+        options={'extra_body': {"prompt_cache_retention": "24h"}},
     )
-    assert get_model(feature) == 'gpt-4.1-mini'
+    assert get_model(feature) == 'gpt-5.6-luna'
     assert get_provider(feature) == 'openai'
 
 
@@ -51,11 +51,11 @@ def test_pinned_feature_route_ref_preserves_pinned_route_and_options():
 
     assert route_ref == ExplicitRouteRef(
         feature='fair_use',
-        model='gpt-5.1',
+        model='gpt-5.6-luna',
         provider='openai',
         options={'extra_body': {"prompt_cache_retention": "24h"}},
     )
-    assert get_model('fair_use') == 'gpt-5.1'
+    assert get_model('fair_use') == 'gpt-5.6-luna'
     assert get_provider('fair_use') == 'openai'
 
 

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -1124,7 +1124,7 @@ class TestStructuredOutputFeatureTracking:
         """BYOK routes structured output to OpenAI except managed translation."""
         profile = MODEL_QOS_PROFILES['byok']
         for feature in _STRUCTURED_OUTPUT_FEATURES:
-            if feature == 'translation':
+            if feature in {'translation', 'trends'}:
                 assert profile[feature] == ('gemini-2.5-flash-lite', 'gemini')
                 continue
             assert profile[feature][1] == 'openai', f'byok {feature} should be openai, got {profile[feature][1]}'

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -242,79 +242,66 @@ class TestModelQosProfiles:
         providers = {p for _m, p in MODEL_QOS_PROFILES['premium'].values()}
         assert 'gemini' in providers, 'premium should have Gemini direct models'
 
-    def test_premium_profile_models(self):
-        """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
+    def test_all_profiles_use_the_authorized_two_tier_openai_map(self):
+        luna_features = {
+            'conv_action_items',
+            'conv_structure',
+            'conv_app_result',
+            'daily_summary',
+            'external_structure',
+            'memories',
+            'learnings',
+            'memory_conflict',
+            'knowledge_graph',
+            'memory_l1',
+            'memory_l2',
+            'chat_responses',
+            'chat_extraction',
+            'chat_graph',
+            'goals',
+            'goals_advice',
+            'notifications',
+            'proactive_notification',
+            'what_matters_now',
+            'openglass',
+            'app_generator',
+            'persona_clone',
+            'persona_chat_premium',
+        }
+        nano_features = {
+            'conv_app_select',
+            'conv_folder',
+            'conv_discard',
+            'daily_summary_simple',
+            'memory_category',
+            'smart_glasses',
+            'persona_chat',
+        }
+        expected_openai = {
+            **{feature: ('gpt-5.6-luna', 'openai') for feature in luna_features},
+            **{feature: ('gpt-5-nano', 'openai') for feature in nano_features},
+        }
+
+        for profile_name, profile in MODEL_QOS_PROFILES.items():
+            openai_routes = {feature: route for feature, route in profile.items() if route[1] == 'openai'}
+            assert openai_routes == expected_openai, f'{profile_name} OpenAI routes differ from the two-tier map'
+
         premium = MODEL_QOS_PROFILES['premium']
-        # Flagship features use gpt-5.4-mini on openai
-        assert premium['conv_structure'] == ('gpt-5.4-mini', 'openai')
-        assert premium['chat_responses'] == ('gpt-5.4-mini', 'openai')
-        assert premium['goals_advice'] == ('gpt-5.4-mini', 'openai')
-        # Quality-sensitive features use gpt-4.1-mini on openai
-        assert premium['memories'] == ('gpt-4.1-mini', 'openai')
-        assert premium['chat_extraction'] == ('gpt-4.1-mini', 'openai')
-        assert premium['chat_graph'] == ('gpt-4.1-mini', 'openai')
-        assert premium['external_structure'] == ('gpt-4.1-mini', 'openai')
-        assert premium['memory_conflict'] == ('gpt-4.1-mini', 'openai')
-        assert premium['knowledge_graph'] == ('gpt-4.1-mini', 'openai')
-        assert premium['goals'] == ('gpt-4.1-mini', 'openai')
-        assert premium['proactive_notification'] == ('gpt-4.1-mini', 'openai')
-        # Simple features use gpt-4.1-nano on openai
-        assert premium['conv_app_select'] == ('gpt-4.1-nano', 'openai')
-        # Vision features use gpt-4.1-mini on openai
-        assert premium['openglass'] == ('gpt-4.1-mini', 'openai')
-        # Free-text features use Gemini 2.5 Flash-Lite on gemini provider
         assert premium['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['followup'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['onboarding'] == ('gemini-2.5-flash-lite', 'gemini')
-        # Simple classification uses gpt-4.1-nano on openai
-        assert premium['memory_category'] == ('gpt-4.1-nano', 'openai')
-        assert premium['daily_summary_simple'] == ('gpt-4.1-nano', 'openai')
         assert premium['app_integration'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['trends'] == ('gemini-2.5-flash-lite', 'gemini')
-        # Anthropic & Perplexity with explicit provider
         assert premium['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
         assert premium['web_search'] == ('sonar-pro', 'perplexity')
-        # Persona uses direct OpenAI API
-        assert premium['persona_chat'] == ('gpt-4.1-nano', 'openai')
-        assert premium['persona_chat_premium'] == ('gpt-5.4-mini', 'openai')
-
-    def test_max_profile_models(self):
-        """Max uses gpt-5.4 flagship, gpt-4.1-mini for cheap tasks, production-grade models."""
-        max_prof = MODEL_QOS_PROFILES['max']
-        # Flagship uses gpt-5.4 on openai
-        assert max_prof['chat_responses'] == ('gpt-5.4', 'openai')
-        assert max_prof['goals_advice'] == ('gpt-5.4', 'openai')
-        assert max_prof['app_generator'] == ('gpt-5.4', 'openai')
-        assert max_prof['conv_action_items'] == ('gpt-5.4', 'openai')
-        assert max_prof['conv_structure'] == ('gpt-5.4', 'openai')
-        assert max_prof['daily_summary'] == ('gpt-5.4', 'openai')
-        assert max_prof['persona_clone'] == ('gpt-5.4', 'openai')
-        assert max_prof['notifications'] == ('gpt-5.4', 'openai')
-        # Cheap tasks use gpt-4.1-mini on openai
-        assert max_prof['conv_app_select'] == ('gpt-4.1-mini', 'openai')
-        assert max_prof['memories'] == ('gpt-4.1-mini', 'openai')
-        assert max_prof['learnings'] == ('o4-mini', 'openai')
-        assert max_prof['chat_graph'] == ('gpt-4.1', 'openai')
-        # Persona uses direct OpenAI API
-        assert max_prof['persona_chat'] == ('gpt-4.1-nano', 'openai')
-        assert max_prof['persona_chat_premium'] == ('gpt-5.4-mini', 'openai')
-        # OpenRouter for wrapped_analysis with explicit provider
-        assert max_prof['wrapped_analysis'] == ('gemini-3-flash-preview', 'openrouter')
-        # Anthropic & Perplexity with explicit provider
-        assert max_prof['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
-        assert max_prof['web_search'] == ('sonar-pro', 'perplexity')
 
     def test_max_profile_model_variants(self):
-        """Max profile uses 9 distinct model IDs."""
+        """Max profile is constrained to the two approved OpenAI text models."""
         max_prof = MODEL_QOS_PROFILES['max']
         distinct_models = {model for model, _provider in max_prof.values()}
         expected = {
-            'gpt-5.4',
-            'gpt-4.1-mini',
-            'gpt-4.1',
-            'o4-mini',
-            'gpt-4.1-nano',
-            'gpt-5.4-mini',
+            'gpt-5.6-luna',
+            'gpt-5-nano',
             'claude-sonnet-4-6',
             'gemini-2.5-flash-lite',
             'gemini-3-flash-preview',
@@ -344,11 +331,11 @@ class TestGetModel:
     def test_returns_profile_default(self):
         assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items'][0]
 
-    def test_unknown_feature_falls_back_to_gpt41_mini(self):
-        assert get_model('totally_unknown_feature') == 'gpt-4.1-mini'
+    def test_unknown_feature_falls_back_to_luna(self):
+        assert get_model('totally_unknown_feature') == 'gpt-5.6-luna'
 
     def test_pinned_feature_ignores_profile(self):
-        assert get_model('fair_use') == 'gpt-5.1'
+        assert get_model('fair_use') == 'gpt-5.6-luna'
 
     def test_anthropic_feature_returns_model_string(self):
         model = get_model('chat_agent')
@@ -376,16 +363,16 @@ class TestGetLlm:
         assert llm1 is llm2
 
     def test_different_features_same_model_share_instance(self):
-        # Both use gpt-4.1-mini in premium profile (quality-sensitive)
+        # Both use Luna in the two-tier premium profile.
         llm1 = get_llm('memories')
         llm2 = get_llm('goals')
         assert llm1 is llm2
 
     def test_different_models_return_different_instances(self):
-        # memories=gpt-4.1-mini, conv_structure=gpt-5.4-mini in premium
+        # memories and conv_structure both resolve to Luna in premium.
         llm1 = get_llm('memories')
         llm2 = get_llm('conv_structure')
-        assert llm1 is not llm2
+        assert llm1 is llm2
 
     def test_streaming_returns_different_instance(self):
         llm = get_llm('conv_action_items')
@@ -393,12 +380,12 @@ class TestGetLlm:
         assert llm is not llm_stream
 
     def test_persona_chat_returns_client(self):
-        # persona_chat is gpt-4.1-nano (OpenAI) in both profiles
+        # persona_chat is gpt-5-nano (OpenAI) in all profiles.
         llm = get_llm('persona_chat', streaming=True)
         assert hasattr(llm, 'invoke')
 
     def test_cache_key_applied_for_cacheable_model(self):
-        # conv_structure uses gpt-5.4-mini (premium) or gpt-5.4 (max), both in _CACHE_KEY_MODELS
+        # conv_structure uses Luna, which supports prompt-cache routing.
         llm_with_key = get_llm('conv_structure', cache_key='omi-test-key')
         llm_without_key = get_llm('conv_structure')
         assert llm_with_key is not llm_without_key
@@ -558,8 +545,8 @@ class TestCacheKeySafety:
     """Verify cache_key is only applied when the model supports it."""
 
     def test_cache_key_models_contains_expected(self):
-        assert supports_prompt_cache('gpt-5.4')
-        assert supports_prompt_cache('gpt-5.4-mini')
+        assert supports_prompt_cache('gpt-5.6-luna')
+        assert supports_cache_retention('gpt-5.6-luna')
         assert not supports_prompt_cache('claude-sonnet-4-6')
 
 
@@ -603,12 +590,12 @@ class TestGetQosInfo:
 class TestPinnedFeatures:
     """Verify pinned features are immutable."""
 
-    def test_fair_use_pinned_to_gpt51(self):
-        assert _PINNED_FEATURES['fair_use'] == ('gpt-5.1', 'openai')
+    def test_fair_use_pinned_to_luna(self):
+        assert _PINNED_FEATURES['fair_use'] == ('gpt-5.6-luna', 'openai')
 
     def test_pinned_survives_profile_switch(self):
         # Even if profile doesn't list fair_use, it should resolve to pinned value
-        assert get_model('fair_use') == 'gpt-5.1'
+        assert get_model('fair_use') == 'gpt-5.6-luna'
 
 
 class TestProviderClassification:
@@ -907,7 +894,7 @@ class TestRuntimeProviderRouting:
             assert hasattr(llm, 'invoke')
 
     def test_openglass_routes_to_openai(self):
-        """openglass (vision) should route to OpenAI gpt-4.1-mini."""
+        """openglass (vision) should route to OpenAI Luna."""
         llm = get_llm('openglass')
         # get_llm() eagerly resolves; result is a ChatOpenAI routed to OpenAI
         base_url = getattr(llm, 'openai_api_base', None) or ''
@@ -1012,24 +999,30 @@ class TestBYOKProfile:
     """Verify BYOK QoS profile structure and model selections."""
 
     def test_byok_all_openai_except_special(self):
-        """byok routes all features to OpenAI except provider-specific features."""
+        """BYOK preserves the non-OpenAI specialty routes from the common profile."""
         bk = MODEL_QOS_PROFILES['byok']
         for feature, (model, provider) in bk.items():
-            if feature in ('chat_agent', 'web_search', 'wrapped_analysis', 'translation'):
+            if feature in (
+                'chat_agent',
+                'web_search',
+                'wrapped_analysis',
+                'translation',
+                'session_titles',
+                'followup',
+                'onboarding',
+                'app_integration',
+                'trends',
+            ):
                 continue
             assert provider == 'openai', f'byok {feature} should be openai, got {provider}'
 
     def test_byok_model_variants(self):
-        """byok uses same 9 distinct models as max."""
+        """BYOK uses the same constrained model set as max."""
         bk = MODEL_QOS_PROFILES['byok']
         distinct = {model for model, _p in bk.values()}
         expected = {
-            'gpt-5.4',
-            'gpt-5.4-mini',
-            'gpt-4.1',
-            'gpt-4.1-mini',
-            'gpt-4.1-nano',
-            'o4-mini',
+            'gpt-5.6-luna',
+            'gpt-5-nano',
             'claude-sonnet-4-6',
             'gemini-2.5-flash-lite',
             'gemini-3-flash-preview',

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -281,10 +281,10 @@ class TestPromptCacheRetention:
         # A renamed/future gpt-5 family model must still get routing + retention.
         assert mc.supports_prompt_cache("gpt-5.9-turbo"), "renamed gpt-5 should support prompt_cache_key"
         assert mc.supports_cache_retention("gpt-5.9-turbo"), "renamed gpt-5 should support 24h retention"
-        # gpt-5.1 must stay retention-capable after the refactor (the original hardcoded case).
-        assert mc.supports_cache_retention("gpt-5.1"), "gpt-5.1 must remain retention-capable"
-        # gpt-4.1 family: routing yes, 24h retention no.
-        assert mc.supports_prompt_cache("gpt-4.1-mini")
+        assert mc.supports_prompt_cache("gpt-5.6-luna")
+        assert mc.supports_cache_retention("gpt-5.6-luna")
+        # Retired product models are no longer treated as active cache targets.
+        assert not mc.supports_prompt_cache("gpt-4.1-mini")
         assert not mc.supports_cache_retention("gpt-4.1-mini")
         # Non-OpenAI models get neither.
         assert not mc.supports_prompt_cache("gemini-2.5-flash-lite")

--- a/backend/utils/agent.py
+++ b/backend/utils/agent.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, TYPE_CHE
 from models.app import App
 from models.chat import ChatSession, Message, MessageSender, MessageType
 from utils.retrieval.graph import AsyncStreamingCallback
+from utils.llm.model_config import get_model
 from openai.types.responses import ResponseTextDeltaEvent
 import logging
 
@@ -66,13 +67,13 @@ async def run(
     docs_agent = Agent(
         name="Omi Documentation Agent",
         instructions=omi_documentation_prompt,
-        model="o4-mini",
+        model=get_model('learnings'),
     )
     omi_agent = Agent(
         name="Omi Agent",
         instructions=f"You are a helpful assistant that answers questions from the user {uid}, using the tools you were provided.",
         mcp_servers=[mcp_server],
-        model="o4-mini",
+        model=get_model('learnings'),
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="high"),  # summary="auto"
         ),

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -630,7 +630,7 @@ class _LazyClientProxy:
 
 
 def _create_legacy_llm_mini() -> ChatOpenAI:
-    return ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback], request_timeout=120, max_retries=1)
+    return ChatOpenAI(model=get_model('learnings'), callbacks=[_usage_callback], request_timeout=120, max_retries=1)
 
 
 llm_mini = _LazyClientProxy(_create_legacy_llm_mini)

--- a/backend/utils/llm/model_config.py
+++ b/backend/utils/llm/model_config.py
@@ -50,174 +50,61 @@ RouteRef = Union[ExplicitRouteRef, AutoLaneRouteRef]
 #   byok     — same models as max (BYOK users pay their own API costs)
 # ---------------------------------------------------------------------------
 
+# All QoS profiles deliberately share this two-tier map. Keeping independent
+# copies below retains profile selection semantics while preventing a higher
+# tier or BYOK route from reintroducing a retired OpenAI text model.
+_TWO_TIER_MODEL_PROFILE: Dict[str, Tuple[str, str]] = {
+    # OpenAI — default intelligence
+    'conv_action_items': ('gpt-5.6-luna', 'openai'),
+    'conv_structure': ('gpt-5.6-luna', 'openai'),
+    'conv_app_result': ('gpt-5.6-luna', 'openai'),
+    'daily_summary': ('gpt-5.6-luna', 'openai'),
+    'external_structure': ('gpt-5.6-luna', 'openai'),
+    'memories': ('gpt-5.6-luna', 'openai'),
+    'learnings': ('gpt-5.6-luna', 'openai'),
+    'memory_conflict': ('gpt-5.6-luna', 'openai'),
+    'knowledge_graph': ('gpt-5.6-luna', 'openai'),
+    'memory_l1': ('gpt-5.6-luna', 'openai'),
+    'memory_l2': ('gpt-5.6-luna', 'openai'),
+    'chat_responses': ('gpt-5.6-luna', 'openai'),
+    'chat_extraction': ('gpt-5.6-luna', 'openai'),
+    'chat_graph': ('gpt-5.6-luna', 'openai'),
+    'goals': ('gpt-5.6-luna', 'openai'),
+    'goals_advice': ('gpt-5.6-luna', 'openai'),
+    'notifications': ('gpt-5.6-luna', 'openai'),
+    'proactive_notification': ('gpt-5.6-luna', 'openai'),
+    'what_matters_now': ('gpt-5.6-luna', 'openai'),
+    'openglass': ('gpt-5.6-luna', 'openai'),
+    'app_generator': ('gpt-5.6-luna', 'openai'),
+    'persona_clone': ('gpt-5.6-luna', 'openai'),
+    'persona_chat_premium': ('gpt-5.6-luna', 'openai'),
+    # OpenAI — cheapest light/binary work
+    'conv_app_select': ('gpt-5-nano', 'openai'),
+    'conv_folder': ('gpt-5-nano', 'openai'),
+    'conv_discard': ('gpt-5-nano', 'openai'),
+    'daily_summary_simple': ('gpt-5-nano', 'openai'),
+    'memory_category': ('gpt-5-nano', 'openai'),
+    'smart_glasses': ('gpt-5-nano', 'openai'),
+    'persona_chat': ('gpt-5-nano', 'openai'),
+    # Non-OpenAI routes remain intentionally unchanged.
+    'session_titles': ('gemini-2.5-flash-lite', 'gemini'),
+    'followup': ('gemini-2.5-flash-lite', 'gemini'),
+    'onboarding': ('gemini-2.5-flash-lite', 'gemini'),
+    'app_integration': ('gemini-2.5-flash-lite', 'gemini'),
+    'trends': ('gemini-2.5-flash-lite', 'gemini'),
+    'translation': ('gemini-2.5-flash-lite', 'gemini'),
+    'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+    'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+    'web_search': ('sonar-pro', 'perplexity'),
+}
+
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
-    # -----------------------------------------------------------------------
-    # premium — maximize cost savings while preserving 80% of max quality.
-    # Uses gpt-5.4-mini (not gpt-5.4) for core features, gpt-4.1-mini (not gpt-4.1)
-    # for quality-sensitive tasks, gpt-4.1-nano for simple routing/classification,
-    # and Gemini flash-lite for low-complexity free-text (titles, followups, onboarding).
-    # -----------------------------------------------------------------------
-    'premium': {
-        # OpenAI — conversation processing
-        'conv_action_items': ('gpt-5.4-mini', 'openai'),
-        'conv_structure': ('gpt-5.4-mini', 'openai'),
-        'conv_app_result': ('gpt-5.4-mini', 'openai'),
-        'conv_app_select': ('gpt-4.1-nano', 'openai'),
-        'conv_folder': ('gpt-4.1-nano', 'openai'),
-        'conv_discard': ('gpt-4.1-nano', 'openai'),
-        'daily_summary': ('gpt-5.4-mini', 'openai'),
-        'daily_summary_simple': ('gpt-4.1-nano', 'openai'),
-        'external_structure': ('gpt-4.1-mini', 'openai'),
-        # OpenAI — memories & knowledge
-        'memories': ('gpt-4.1-mini', 'openai'),
-        'learnings': ('gpt-5.4-mini', 'openai'),
-        'memory_conflict': ('gpt-4.1-mini', 'openai'),
-        'memory_category': ('gpt-4.1-nano', 'openai'),
-        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
-        'memory_l1': ('gpt-4.1-mini', 'openai'),
-        'memory_l2': ('gpt-4.1-mini', 'openai'),
-        # OpenAI — chat
-        'chat_responses': ('gpt-5.4-mini', 'openai'),
-        'chat_extraction': ('gpt-4.1-mini', 'openai'),
-        'chat_graph': ('gpt-4.1-mini', 'openai'),
-        'session_titles': ('gemini-2.5-flash-lite', 'gemini'),
-        # Features
-        'goals': ('gpt-4.1-mini', 'openai'),
-        'goals_advice': ('gpt-5.4-mini', 'openai'),
-        'notifications': ('gpt-5.4-mini', 'openai'),
-        'proactive_notification': ('gpt-4.1-mini', 'openai'),
-        'what_matters_now': ('gpt-4.1-mini', 'openai'),
-        'followup': ('gemini-2.5-flash-lite', 'gemini'),
-        'smart_glasses': ('gpt-4.1-nano', 'openai'),
-        'openglass': ('gpt-4.1-mini', 'openai'),
-        'onboarding': ('gemini-2.5-flash-lite', 'gemini'),
-        'app_generator': ('gpt-5.4-mini', 'openai'),
-        'app_integration': ('gemini-2.5-flash-lite', 'gemini'),
-        'persona_clone': ('gpt-5.4-mini', 'openai'),
-        'trends': ('gemini-2.5-flash-lite', 'gemini'),
-        'translation': ('gemini-2.5-flash-lite', 'gemini'),
-        # Anthropic (used via get_model() + anthropic_client)
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
-        # Persona
-        'persona_chat': ('gpt-4.1-nano', 'openai'),
-        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
-        # OpenRouter
-        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
-        # Perplexity
-        'web_search': ('sonar-pro', 'perplexity'),
-    },
-    # -----------------------------------------------------------------------
-    # max — 100% quality, best models available, no cost optimization.
-    # Uses gpt-5.4 for all core features, o4-mini for reasoning (learnings),
-    # gpt-4.1 for chat graph. Pure OpenAI for highest accuracy.
-    # -----------------------------------------------------------------------
-    'max': {
-        # OpenAI — conversation processing
-        'conv_action_items': ('gpt-5.4', 'openai'),
-        'conv_structure': ('gpt-5.4', 'openai'),
-        'conv_app_result': ('gpt-5.4', 'openai'),
-        'conv_app_select': ('gpt-4.1-mini', 'openai'),
-        'conv_folder': ('gpt-4.1-mini', 'openai'),
-        'conv_discard': ('gpt-4.1-mini', 'openai'),
-        'daily_summary': ('gpt-5.4', 'openai'),
-        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
-        'external_structure': ('gpt-4.1-mini', 'openai'),
-        # OpenAI — memories & knowledge
-        'memories': ('gpt-4.1-mini', 'openai'),
-        'learnings': ('o4-mini', 'openai'),
-        'memory_conflict': ('gpt-4.1-mini', 'openai'),
-        'memory_category': ('gpt-4.1-mini', 'openai'),
-        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
-        'memory_l1': ('gpt-4.1-mini', 'openai'),
-        'memory_l2': ('gpt-4.1-mini', 'openai'),
-        # OpenAI — chat
-        'chat_responses': ('gpt-5.4', 'openai'),
-        'chat_extraction': ('gpt-4.1-mini', 'openai'),
-        'chat_graph': ('gpt-4.1', 'openai'),
-        'session_titles': ('gpt-4.1-mini', 'openai'),
-        # Features
-        'goals': ('gpt-4.1-mini', 'openai'),
-        'goals_advice': ('gpt-5.4', 'openai'),
-        'notifications': ('gpt-5.4', 'openai'),
-        'proactive_notification': ('gpt-4.1-mini', 'openai'),
-        'what_matters_now': ('gpt-4.1-mini', 'openai'),
-        'followup': ('gpt-4.1-mini', 'openai'),
-        'smart_glasses': ('gpt-4.1-mini', 'openai'),
-        'openglass': ('gpt-4.1-mini', 'openai'),
-        'onboarding': ('gpt-4.1-mini', 'openai'),
-        'app_generator': ('gpt-5.4', 'openai'),
-        'app_integration': ('gpt-4.1-mini', 'openai'),
-        'persona_clone': ('gpt-5.4', 'openai'),
-        'trends': ('gpt-4.1-mini', 'openai'),
-        'translation': ('gemini-2.5-flash-lite', 'gemini'),
-        # Anthropic
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
-        # Persona
-        'persona_chat': ('gpt-4.1-nano', 'openai'),
-        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
-        # OpenRouter
-        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
-        # Perplexity
-        'web_search': ('sonar-pro', 'perplexity'),
-    },
-    # -----------------------------------------------------------------------
-    # byok — same models as max. BYOK users pay their own API costs so they
-    # get the same best-quality routing as max subscribers.
-    # -----------------------------------------------------------------------
-    'byok': {
-        # OpenAI — conversation processing
-        'conv_action_items': ('gpt-5.4', 'openai'),
-        'conv_structure': ('gpt-5.4', 'openai'),
-        'conv_app_result': ('gpt-5.4', 'openai'),
-        'conv_app_select': ('gpt-4.1-mini', 'openai'),
-        'conv_folder': ('gpt-4.1-mini', 'openai'),
-        'conv_discard': ('gpt-4.1-mini', 'openai'),
-        'daily_summary': ('gpt-5.4', 'openai'),
-        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
-        'external_structure': ('gpt-4.1-mini', 'openai'),
-        # OpenAI — memories & knowledge
-        'memories': ('gpt-4.1-mini', 'openai'),
-        'learnings': ('o4-mini', 'openai'),
-        'memory_conflict': ('gpt-4.1-mini', 'openai'),
-        'memory_category': ('gpt-4.1-mini', 'openai'),
-        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
-        'memory_l1': ('gpt-4.1-mini', 'openai'),
-        'memory_l2': ('gpt-4.1-mini', 'openai'),
-        # OpenAI — chat
-        'chat_responses': ('gpt-5.4', 'openai'),
-        'chat_extraction': ('gpt-4.1-mini', 'openai'),
-        'chat_graph': ('gpt-4.1', 'openai'),
-        'session_titles': ('gpt-4.1-mini', 'openai'),
-        # Features
-        'goals': ('gpt-4.1-mini', 'openai'),
-        'goals_advice': ('gpt-5.4', 'openai'),
-        'notifications': ('gpt-5.4', 'openai'),
-        'proactive_notification': ('gpt-4.1-mini', 'openai'),
-        'what_matters_now': ('gpt-4.1-mini', 'openai'),
-        'followup': ('gpt-4.1-mini', 'openai'),
-        'smart_glasses': ('gpt-4.1-mini', 'openai'),
-        'openglass': ('gpt-4.1-mini', 'openai'),
-        'onboarding': ('gpt-4.1-mini', 'openai'),
-        'app_generator': ('gpt-5.4', 'openai'),
-        'app_integration': ('gpt-4.1-mini', 'openai'),
-        'persona_clone': ('gpt-5.4', 'openai'),
-        'trends': ('gpt-4.1-mini', 'openai'),
-        'translation': ('gemini-2.5-flash-lite', 'gemini'),
-        # Anthropic
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
-        # Persona
-        'persona_chat': ('gpt-4.1-nano', 'openai'),
-        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
-        # OpenRouter
-        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
-        # Perplexity
-        'web_search': ('sonar-pro', 'perplexity'),
-    },
+    profile_name: dict(_TWO_TIER_MODEL_PROFILE) for profile_name in ('premium', 'max', 'byok')
 }
 
 # Pinned features — (model, provider) fixed regardless of profile or env override.
 _PINNED_FEATURES: Dict[str, Tuple[str, str]] = {
-    'fair_use': (os.getenv('FAIR_USE_CLASSIFIER_MODEL', 'gpt-5.1').strip() or 'gpt-5.1', 'openai'),
+    'fair_use': (os.getenv('FAIR_USE_CLASSIFIER_MODEL', 'gpt-5.6-luna').strip() or 'gpt-5.6-luna', 'openai'),
 }
 
 # Resolve active profile once at startup.
@@ -246,14 +133,14 @@ _OPENROUTER_TEMPERATURES: Dict[str, float] = {
 # Prompt-cache capability detection.
 #
 # OpenAI prompt caching is a capability of whole model families, not of specific point
-# releases. Gating on exact names (e.g. {'gpt-5.4', 'gpt-5.4-mini'}) silently breaks the
-# moment a model is renamed or a new family member ships, so we detect by family prefix.
+# releases. Gating on exact model names silently breaks when a family member changes,
+# so we detect by family prefix.
 #
 #   prompt_cache_key             — prefix-cache request routing. Supported by the gpt-4o,
-#                                  gpt-4.1, gpt-5.x and o-series families.
+#                                  gpt-4o, gpt-5.x and o-series families.
 #   prompt_cache_retention='24h' — extended (24h) cache retention. Supported by the
 #                                  gpt-5.x and o-series families.
-_CACHE_KEY_MODEL_PREFIXES = ('gpt-5', 'gpt-4.1', 'gpt-4o', 'o1', 'o3', 'o4')
+_CACHE_KEY_MODEL_PREFIXES = ('gpt-5', 'gpt-4o', 'o1', 'o3', 'o4')
 _CACHE_RETENTION_MODEL_PREFIXES = ('gpt-5', 'o1', 'o3', 'o4')
 
 # Features that call .with_structured_output() — logged when resolving to Gemini for compat monitoring.
@@ -268,7 +155,7 @@ _STRUCTURED_OUTPUT_FEATURES = {
 }
 STRUCTURED_OUTPUT_FEATURES = _STRUCTURED_OUTPUT_FEATURES
 
-_DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
+_DEFAULT_CONFIG: Tuple[str, str] = ('gpt-5.6-luna', 'openai')
 DEFAULT_CONFIG = _DEFAULT_CONFIG
 
 # Future migration point for features that should call the gateway via an auto
@@ -304,7 +191,7 @@ def get_model(feature: str) -> str:
         feature: Feature name (e.g. 'conv_action_items', 'chat_agent').
 
     Returns:
-        Model name string (e.g. 'gpt-4.1-mini', 'claude-sonnet-4-6').
+        Model name string (e.g. 'gpt-5.6-luna', 'claude-sonnet-4-6').
     """
     return _get_model_config(feature)[0]
 

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -244,7 +244,7 @@ class FileChatTool:
                 cast(ChatCompletionMessageParam, {"role": "user", "content": contents})
             ]
             stream = await openai_client.chat.completions.create(
-                model="gpt-4.1",
+                model="gpt-5.6-luna",
                 messages=messages,
                 stream=True,
                 max_tokens=2048,
@@ -297,7 +297,7 @@ class FileChatTool:
                 assistant = openai.beta.assistants.create(  # type: ignore[reportDeprecated]  # Assistants API still in use
                     name="File Reader",
                     instructions="You are a helpful assistant that answers questions about the provided file. Use the file_search tool to search the file contents when needed.",
-                    model="gpt-4.1",
+                    model="gpt-5.6-luna",
                     tools=[{"type": "file_search"}],
                     timeout=timeout,
                 )

--- a/web/admin/AGENTS.md
+++ b/web/admin/AGENTS.md
@@ -1,23 +1,21 @@
-# Web Admin Dashboard — Developer Guide
+# Web Admin Dashboard
 
 ## Networking
 
-All fetches go through `hooks/useAuthToken.ts`. No direct `getIdToken()`, manual auth headers, or client-side Firestore reads.
+All fetches use `hooks/useAuthToken.ts`; never call `getIdToken()`, create auth headers, or read Firestore in the client.
 
-- **SWR reads**: `useAuthToken()` + `authenticatedFetcher`
-- **Mutations**: `useAuthFetch()` → `fetchWithAuth(url, init)`
-- **Server routes**: `verifyAdmin(request)` from `lib/auth.ts` on every route
-- **Parallel fetches**: `Promise.allSettled` (not `Promise.all`), return `partial: true` on partial failure, 502 on total failure
-- **SWR config**: `components/swr-provider.tsx` — exponential backoff, skip retry on 401/403
-- **SWR keys**: `token ? [url, token] : null` — null prevents fetch until auth ready
-- **UI on partial**: amber warning. **UI on error**: clear stale data, show N/A — never display old data with error flag
-- **Banned**: custom fetchers, `useEffect` token management, direct `fetch()` with manual auth, `Promise.all` for parallel upstream calls, serving zero metrics on upstream failure
+- Reads: `useAuthToken()` + `authenticatedFetcher`; mutations: `useAuthFetch()` → `fetchWithAuth(url, init)`.
+- Server routes call `verifyAdmin(request)` from `lib/auth.ts`.
+- Parallel fetches use `Promise.allSettled`, returning `partial: true` on partial failure and 502 on total failure.
+- SWR configuration belongs in `components/swr-provider.tsx`; keys are `token ? [url, token] : null`.
+- Partial data shows an amber warning. On error, clear stale data and show N/A; never show stale data with an error flag.
+- Do not add custom fetchers, `useEffect` token handling, manual-auth `fetch()`, `Promise.all` upstream calls, or zero metrics for upstream failures.
 
 ## Revenue metrics
 
-Subscription metrics read Stripe through `lib/stripe-subscriptions.ts`. Routes must not list subscriptions by hardcoded price id — that is how five of seven products became invisible to the dashboard.
+Subscription metrics use `lib/stripe-subscriptions.ts`; never list subscriptions by price ID.
 
-- **Scope**: `OMI_PLAN_PRODUCTS` in that module lists the subscription plans. Metrics count those products and nothing else — the account also holds marketplace apps and internal test products. Launching a plan adds a line.
-- **Marketplace apps** are excluded by `metadata.app_id`, which the backend stamps on app checkouts. Never split them off by price id.
-- **MRR** counts `active` + `past_due`. `trialing` is pipeline and is reported separately, never inside MRR.
-- **Amounts** normalise through each price's own `interval` and `interval_count`; never assume monthly-or-annual.
+- `OMI_PLAN_PRODUCTS` defines the subscription scope; it excludes marketplace apps and internal test products. Add a line when launching a plan.
+- Marketplace apps are excluded by `metadata.app_id`, stamped by the backend on app checkout.
+- MRR includes `active` and `past_due`; report `trialing` separately.
+- Normalize amounts with each price's `interval` and `interval_count`; never assume monthly or annual pricing.


### PR DESCRIPTION
## Summary

- Collapse OpenAI text routing in all QoS profiles to `gpt-5.6-luna` and `gpt-5-nano`.
- Align generated gateway overrides, structured route artifacts, fair-use pins, direct defaults, file chat, smoke coverage, and the Luna rate card.
- Keep Gemini, Anthropic, Perplexity, embeddings, and historical accounting rows unchanged.
- Compact the existing web-admin agent guide so the repository-wide guide-size gate can run cleanly.

## Deferred

- File chat retains its existing direct Assistants/files lifecycle; it now uses Luna. Gateway lifecycle work is intentionally out of scope for this routing change.

## Testing

- Focused QoS, gateway-config, executor, OpenAI-compatible, rate-card, and prompt-cache tests.
- `make preflight`

Failure-Class: none
