### PR TITLE
fix(android): re-emit device-ready when Background Mode's BLE service outlives the Flutter engine

### DIFF
--- a/.github/failure-classes/FC-already-satisfied-request-as-noop.json
+++ b/.github/failure-classes/FC-already-satisfied-request-as-noop.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-already-satisfied-request-as-noop",
+  "violated_contract": "A request to establish a session must still deliver the observation its requester depends on when the target is already in the desired state. A native owner that outlives its client — a foreground service holding a BLE link across a Flutter engine restart — makes \"already satisfied\" the ordinary case, and answering it with a bare early return strands the client projection with no path back to the truth.",
+  "canonical_prevention": "Route every establish request through one policy that separates not-established, already-established, and in-progress, and make the already-established branch re-emit the readiness event the client consumes instead of returning. Prove the policy through its own seam rather than by driving the platform service.",
+  "canonical_prevention_artifact": [
+    "app/android/app/src/main/kotlin/com/friend/ios/ble/BleConnectRouter.kt",
+    "app/android/app/src/test/kotlin/com/friend/ios/ble/BleConnectRouterTest.kt"
+  ],
+  "evidence_prs": [6987],
+  "scope_hints": [
+    "app/android/app/src/main/kotlin/com/friend/ios/ble/**",
+    "app/lib/services/devices/transports/**"
+  ],
+  "status": "open"
+}

--- a/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
@@ -100,8 +100,16 @@ class MainActivity: FlutterActivity() {
     }
 
     override fun onDestroy() {
+        // The engine dies with the activity whether or not it is finishing, so these flags
+        // must clear outside the isFinishing guard — a system-initiated destroy otherwise
+        // leaves native deferring audio to an engine that is gone (issue #10847).
+        // configureFlutterEngine re-arms both on the next attach.
+        OmiBleManager.isFlutterAlive = false
+        getSharedPreferences("FlutterSharedPreferences", MODE_PRIVATE)
+            .edit()
+            .putBoolean("flutter.nativeBleForegroundReady", false)
+            .apply()
         if (isFinishing) {
-            OmiBleManager.isFlutterAlive = false
             // Engine + main isolate die with the activity; a live capture session must not outlive its consumer.
             if (PhoneMicController.isInitialized) PhoneMicController.instance.onFlutterEngineDestroyed()
             // Background Mode and Transcribe Later both need the foreground service to keep

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleConnectRouter.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleConnectRouter.kt
@@ -1,0 +1,30 @@
+package com.friend.ios.ble
+
+/**
+ * What a "please connect this device" request must do, given the current native link state.
+ *
+ * Requests arrive from Dart (`manageDevice` on app start / user reconnect), from
+ * CompanionDeviceManager appear events, and from the sticky-service restore after a
+ * process kill. Background Mode keeps OmiBleForegroundService — and the GATT link —
+ * alive after the Flutter engine dies, so a request routinely arrives for a peripheral
+ * that is *already* connected. That case owns the only path a fresh Flutter engine has
+ * to learn it is connected, so it must re-emit device-ready rather than be treated as
+ * "nothing to do".
+ */
+internal enum class ConnectRequestAction {
+    /** No service instance yet — start it; onStartCommand runs the full manage flow. */
+    StartService,
+
+    /** Link is already up: re-emit device-ready so Dart adopts the live connection. */
+    ResyncReady,
+
+    /** Link is down: abandon any stuck passive scan and open a fresh GATT connection. */
+    Reconnect,
+}
+
+internal fun routeConnectRequest(serviceRunning: Boolean, peripheralConnected: Boolean): ConnectRequestAction =
+    when {
+        !serviceRunning -> ConnectRequestAction.StartService
+        peripheralConnected -> ConnectRequestAction.ResyncReady
+        else -> ConnectRequestAction.Reconnect
+    }

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -112,10 +112,11 @@ class OmiBleForegroundService : Service() {
             val inst = instance
             if (inst != null) {
                 // Service already running — any startService call is effectively a
-                // "please (re)connect this device" signal. Always force a fresh attempt
-                // so a stuck autoConnect=true passive scan doesn't silently swallow it.
-                Log.d(TAG, "startService($caller): service running, forcing reconnect for $deviceAddress")
-                inst.forceReconnect(deviceAddress, requiresBond, caller)
+                // "please (re)connect this device" signal. onConnectRequest either
+                // re-emits ready (link already up) or forces a fresh attempt so a
+                // stuck autoConnect=true passive scan doesn't silently swallow it.
+                Log.d(TAG, "startService($caller): service running, routing connect request for $deviceAddress")
+                inst.onConnectRequest(deviceAddress, requiresBond, caller)
                 return
             }
 
@@ -281,9 +282,10 @@ class OmiBleForegroundService : Service() {
     }
 
     private fun ensureBackgroundAudioSubscription(address: String, services: List<BleService>) {
-        if (OmiBleManager.isFlutterAlive) return
         // Subscribe for background streaming OR batch capture (whichever is configured)
-        // so native keeps receiving audio after the Flutter engine is gone.
+        // so native keeps receiving audio after the Flutter engine is gone. Never deferred
+        // to Dart: enabling notifications is idempotent, and waiting on an engine that is
+        // gone left the characteristic subscribed by nobody (issue #10847).
         val target = backgroundAudioStreamer.configuredAudioTargetFor(address)
             ?: batchAudioWriter.configuredAudioTargetFor(address)
             ?: return
@@ -343,18 +345,12 @@ class OmiBleForegroundService : Service() {
             return
         }
 
-        val existing = managedDevices[addr]
-        if (existing != null && bleManager.isPeripheralConnected(addr)) {
-            if (requiresBond && !existing.requiresBond) existing.requiresBond = true
-            existing.retryCount = 0
-            existing.currentGattHash = bleManager.connectedGatts[addr]?.hashCode()
-            existing.hasEverConnected = true
-            existing.currentAttemptEstablished = true
-            updateNotification("Connected to Omi")
-            notifyReadyForConnectedGatt(addr)
+        if (bleManager.isPeripheralConnected(addr)) {
+            adoptConnectedDevice(addr, requiresBond)
             return
         }
 
+        val existing = managedDevices[addr]
         if (existing != null) {
             if (requiresBond && !existing.requiresBond) existing.requiresBond = true
             // Don't interfere with pending GATT connection or scheduled retry
@@ -439,13 +435,47 @@ class OmiBleForegroundService : Service() {
     }
 
     /**
-     * Called from startService() when CompanionDeviceManager fires EVENT_BLE_APPEARED.
+     * Every "please connect this device" request that arrives while the service is already
+     * running: Dart's manageDevice on app start, a CompanionDeviceManager EVENT_BLE_APPEARED,
+     * or a user-initiated reconnect. Background Mode keeps the link alive past the Flutter
+     * engine, so an already-connected request must re-emit ready — onDeviceReady is Dart's
+     * only "connected" signal — instead of being swallowed (issue #10847).
+     */
+    fun onConnectRequest(address: String, requiresBond: Boolean, source: String) {
+        val addr = address.uppercase()
+        when (routeConnectRequest(serviceRunning = true, peripheralConnected = bleManager.isPeripheralConnected(addr))) {
+            ConnectRequestAction.ResyncReady -> {
+                Log.i(TAG, "onConnectRequest($source): $addr already connected, re-emitting ready")
+                adoptConnectedDevice(addr, requiresBond)
+            }
+            else -> forceReconnect(addr, requiresBond, source)
+        }
+    }
+
+    /**
+     * Take ownership of a link that is already up and re-emit device-ready so Dart
+     * adopts it. Deliberately does not touch the managed-device or user-disconnected
+     * prefs — only manageDevice() owns those, so a CompanionDeviceManager appear
+     * event can never resurrect a device the user explicitly disconnected.
+     */
+    private fun adoptConnectedDevice(address: String, requiresBond: Boolean) {
+        val addr = address.uppercase()
+        val managed = managedDevices.getOrPut(addr) { ManagedDevice(address = addr, requiresBond = requiresBond) }
+        if (requiresBond && !managed.requiresBond) managed.requiresBond = true
+        managed.retryCount = 0
+        managed.currentGattHash = bleManager.connectedGatts[addr]?.hashCode()
+        managed.hasEverConnected = true
+        managed.currentAttemptEstablished = true
+        updateNotification("Connected to Omi")
+        notifyReadyForConnectedGatt(addr)
+    }
+
+    /**
      * The OS has confirmed the device is in range right now, so abandon any stuck
      * autoConnect=true passive scan and force a fresh connection attempt.
      */
-    fun forceReconnect(address: String, requiresBond: Boolean, source: String) {
+    private fun forceReconnect(address: String, requiresBond: Boolean, source: String) {
         val addr = address.uppercase()
-        if (bleManager.isPeripheralConnected(addr)) return
 
         synchronized(syncLock) {
             val managed = managedDevices[addr] ?: run {

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/BleConnectRouterTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/BleConnectRouterTest.kt
@@ -1,0 +1,42 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BleConnectRouterTest {
+
+    /**
+     * Regression for issue #10847. Background Mode keeps OmiBleForegroundService and the
+     * GATT link alive after the Flutter engine dies, so the connect request a fresh engine
+     * sends on app start lands while the peripheral is still connected. Routing that to a
+     * plain reconnect made it a silent no-op: Dart never received onDeviceReady, its connect
+     * timed out after 60s, and the app sat on "disconnected" with the link up.
+     */
+    @Test
+    fun `already-connected request re-emits ready instead of being swallowed`() {
+        assertEquals(
+            ConnectRequestAction.ResyncReady,
+            routeConnectRequest(serviceRunning = true, peripheralConnected = true),
+        )
+    }
+
+    @Test
+    fun `running service with a down link reconnects`() {
+        assertEquals(
+            ConnectRequestAction.Reconnect,
+            routeConnectRequest(serviceRunning = true, peripheralConnected = false),
+        )
+    }
+
+    @Test
+    fun `no service instance starts one`() {
+        assertEquals(
+            ConnectRequestAction.StartService,
+            routeConnectRequest(serviceRunning = false, peripheralConnected = false),
+        )
+        assertEquals(
+            ConnectRequestAction.StartService,
+            routeConnectRequest(serviceRunning = false, peripheralConnected = true),
+        )
+    }
+}

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -14,7 +14,7 @@ import 'device_transport.dart';
 class NativeBleTransport extends DeviceTransport {
   final String _peripheralUuid;
   final bool requiresBond;
-  final BleHostApi _hostApi = BleHostApi();
+  final BleHostApi _hostApi;
   final StreamController<DeviceTransportState> _connectionStateController =
       StreamController<DeviceTransportState>.broadcast();
 
@@ -28,7 +28,8 @@ class NativeBleTransport extends DeviceTransport {
 
   DeviceTransportState _state = DeviceTransportState.disconnected;
 
-  NativeBleTransport(this._peripheralUuid, {this.requiresBond = false}) {
+  NativeBleTransport(this._peripheralUuid, {this.requiresBond = false, BleHostApi? hostApi})
+      : _hostApi = hostApi ?? BleHostApi() {
     BleBridge.instance.registerPeripheral(
       peripheralUuid: _peripheralUuid,
       onConnectionState: _handleConnectionState,
@@ -298,7 +299,7 @@ class NativeBleTransport extends DeviceTransport {
     try {
       _services = services;
 
-      // Re-create stream controllers and re-subscribe to previously active characteristics
+      // Native re-emits ready for a link that is already up, so keep live controllers.
       for (final key in _activeSubscriptionKeys) {
         final parts = key.split(':');
         if (parts.length == 2) {

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -13,7 +13,7 @@ import 'device_transport.dart';
 class NativeBleTransport extends DeviceTransport {
   final String _peripheralUuid;
   final bool requiresBond;
-  final BleHostApi _hostApi = BleHostApi();
+  final BleHostApi _hostApi;
   final StreamController<DeviceTransportState> _connectionStateController =
       StreamController<DeviceTransportState>.broadcast();
 
@@ -27,7 +27,8 @@ class NativeBleTransport extends DeviceTransport {
 
   DeviceTransportState _state = DeviceTransportState.disconnected;
 
-  NativeBleTransport(this._peripheralUuid, {this.requiresBond = false}) {
+  NativeBleTransport(this._peripheralUuid, {this.requiresBond = false, BleHostApi? hostApi})
+      : _hostApi = hostApi ?? BleHostApi() {
     BleBridge.instance.registerPeripheral(
       peripheralUuid: _peripheralUuid,
       onConnectionState: _handleConnectionState,
@@ -271,11 +272,14 @@ class NativeBleTransport extends DeviceTransport {
     try {
       _services = services;
 
-      // Re-create stream controllers and re-subscribe to previously active characteristics
+      // Native re-emits ready for a link that is already up, so keep live controllers.
       for (final key in _activeSubscriptionKeys) {
         final parts = key.split(':');
         if (parts.length == 2) {
-          _streamControllers[key] = StreamController<List<int>>.broadcast();
+          final existing = _streamControllers[key];
+          if (existing == null || existing.isClosed) {
+            _streamControllers[key] = StreamController<List<int>>.broadcast();
+          }
           _subscribeCharacteristic(parts[0], parts[1]);
         }
       }

--- a/app/test/unit/native_ble_transport_resync_test.dart
+++ b/app/test/unit/native_ble_transport_resync_test.dart
@@ -1,0 +1,78 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/gen/pigeon_communicator.g.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+import 'package:omi/services/devices/transports/native_ble_transport.dart';
+
+class _FakeBleHostApi extends BleHostApi {
+  final List<String> subscribed = [];
+
+  @override
+  Future<void> manageDevice(String uuid, bool requiresBond) async {}
+
+  @override
+  Future<void> subscribeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {
+    subscribed.add('$serviceUuid:$characteristicUuid');
+  }
+
+  @override
+  Future<void> unsubscribeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {}
+}
+
+void main() {
+  const uuid = 'AA:BB:CC:DD:EE:FF';
+  const serviceUuid = '19b10000-e8f2-537e-4f6c-d104768a1214';
+  const charUuid = '19b10001-e8f2-537e-4f6c-d104768a1214';
+
+  final services = [
+    BleService(uuid: serviceUuid, characteristicUuids: [charUuid]),
+  ];
+
+  late NativeBleTransport transport;
+
+  setUp(() {
+    transport = NativeBleTransport(uuid, hostApi: _FakeBleHostApi());
+  });
+
+  tearDown(() async {
+    await transport.dispose();
+  });
+
+  test('a repeated device-ready for a live link keeps existing subscribers streaming', () async {
+    BleBridge.instance.onDeviceReady(uuid, services);
+    transport.getCharacteristicStream(serviceUuid, charUuid).listen((_) {});
+
+    BleBridge.instance.onPeripheralDisconnected(uuid, null);
+    BleBridge.instance.onDeviceReady(uuid, services);
+
+    final received = <List<int>>[];
+    final subscription = transport.getCharacteristicStream(serviceUuid, charUuid).listen(received.add);
+    addTearDown(subscription.cancel);
+
+    // Native re-emits ready when Dart asks to connect a link that is already up.
+    BleBridge.instance.onDeviceReady(uuid, services);
+    BleBridge.instance.onCharacteristicValueUpdated(uuid, serviceUuid, charUuid, Uint8List.fromList([1, 2, 3]));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(received, [
+      [1, 2, 3]
+    ]);
+  });
+
+  test('device-ready after a disconnect restores the transport to connected', () async {
+    BleBridge.instance.onDeviceReady(uuid, services);
+
+    final states = <DeviceTransportState>[];
+    final subscription = transport.connectionStateStream.listen(states.add);
+    addTearDown(subscription.cancel);
+
+    BleBridge.instance.onPeripheralDisconnected(uuid, null);
+    BleBridge.instance.onDeviceReady(uuid, services);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(states, [DeviceTransportState.disconnected, DeviceTransportState.connected]);
+  });
+}

--- a/app/test/unit/native_ble_transport_resync_test.dart
+++ b/app/test/unit/native_ble_transport_resync_test.dart
@@ -1,0 +1,84 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/gen/pigeon_communicator.g.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+import 'package:omi/services/devices/transports/native_ble_transport.dart';
+
+class _FakeBleHostApi extends BleHostApi {
+  final List<String> subscribed = [];
+
+  @override
+  Future<void> manageDevice(String uuid, bool requiresBond) async {}
+
+  @override
+  Future<void> subscribeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {
+    subscribed.add('$serviceUuid:$characteristicUuid');
+  }
+
+  @override
+  Future<void> unsubscribeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {}
+}
+
+void main() {
+  const uuid = 'AA:BB:CC:DD:EE:FF';
+  const serviceUuid = '19b10000-e8f2-537e-4f6c-d104768a1214';
+  const charUuid = '19b10001-e8f2-537e-4f6c-d104768a1214';
+
+  final services = [
+    BleService(uuid: serviceUuid, characteristicUuids: [charUuid]),
+  ];
+
+  late _FakeBleHostApi hostApi;
+  late NativeBleTransport transport;
+
+  setUp(() {
+    hostApi = _FakeBleHostApi();
+    transport = NativeBleTransport(uuid, hostApi: hostApi);
+  });
+
+  tearDown(() async {
+    await transport.dispose();
+  });
+
+  test('a repeated device-ready for a live link keeps existing subscribers streaming', () async {
+    final connectFuture = transport.connect();
+    BleBridge.instance.onDeviceReady(uuid, services);
+    await connectFuture;
+
+    transport.getCharacteristicStream(serviceUuid, charUuid).listen((_) {});
+    BleBridge.instance.onPeripheralDisconnected(uuid, null);
+    BleBridge.instance.onDeviceReady(uuid, services);
+
+    final received = <List<int>>[];
+    final subscription = transport.getCharacteristicStream(serviceUuid, charUuid).listen(received.add);
+    addTearDown(subscription.cancel);
+
+    // Native re-emits ready when Dart asks to connect a link that is already up.
+    BleBridge.instance.onDeviceReady(uuid, services);
+    BleBridge.instance.onCharacteristicValueUpdated(uuid, serviceUuid, charUuid, Uint8List.fromList([1, 2, 3]));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(received, [
+      [1, 2, 3]
+    ]);
+  });
+
+  test('device-ready after a disconnect restores the transport to connected', () async {
+    final connectFuture = transport.connect();
+    BleBridge.instance.onDeviceReady(uuid, services);
+    await connectFuture;
+
+    final states = <DeviceTransportState>[];
+    final subscription = transport.connectionStateStream.listen(states.add);
+    addTearDown(subscription.cancel);
+
+    BleBridge.instance.onPeripheralDisconnected(uuid, null);
+    BleBridge.instance.onDeviceReady(uuid, services);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(states, [DeviceTransportState.disconnected, DeviceTransportState.connected]);
+  });
+}

--- a/scripts/dev-harness/_resolve_python.sh
+++ b/scripts/dev-harness/_resolve_python.sh
@@ -47,7 +47,9 @@ dev_harness_python_uses_windows_paths() {
   local python_bin="$1"
   local resolved
   resolved="$(command -v "$python_bin" 2>/dev/null || printf '%s' "$python_bin")"
-  case "${resolved,,}" in
+  # ${var,,} is bash 4+; macOS ships bash 3.2 and expands it to a fatal syntax error.
+  resolved="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
+  case "$resolved" in
     *.exe)
       return 0
       ;;


### PR DESCRIPTION
Fixes #10847.

## Symptom

On Android with Background Mode on, the app shows the device as disconnected while the
LED is blue, the foreground-service notification says "Connected to Omi", and the
diagnostics page still counts connection uptime. Transcription stops silently. The only
recovery is a manual disconnect + reconnect.

## Root cause

Background Mode's whole point is that `OmiBleForegroundService` — and the GATT link it
owns — outlive the Flutter engine. When the user reopens the app, a fresh engine and a
fresh Dart isolate start at `isConnected = false` and call `manageDevice` to re-establish
their side of a link that is already up.

`startService()` routes that call to `forceReconnect()` when the service instance already
exists, and `forceReconnect()` returned immediately if the peripheral was connected. The
"already connected → re-emit ready" resync (`notifyReadyForConnectedGatt`) lives only in
`manageDevice()`, which that branch bypasses. `onDeviceReady` is the only signal Dart has
for "connected", so `NativeBleTransport.connect()` waited out its 60s timeout and settled
on `disconnected` — permanently, since nothing reconciles Dart state against native.

This is a regression from #6987, which replaced `inst.manageDevice(...)` with
`inst.forceReconnect(...)` to break stuck `autoConnect` passive scans. The already-connected
case was never the stuck case, and it lost its resync in the swap.

Two adjacent defects turn "wrong badge" into "silent loss of transcription":

- `ensureBackgroundAudioSubscription()` returned early whenever `isFlutterAlive` was true,
  deferring the audio CCCD subscribe to Dart. With Dart stuck disconnected, any subsequent
  BLE drop/reconnect left the audio characteristic subscribed by nobody — link up, zero
  packets.
- `isFlutterAlive` was cleared only when the activity was *finishing*. A system-initiated
  destroy (memory pressure while the foreground service pins the process) left it `true`
  pointing at a dead binary messenger, alongside a stale `nativeBleForegroundReady` that
  makes `OmiBackgroundAudioStreamer` bail with `foreground_ready`.

## Change

- `startService` → `onConnectRequest`, which adopts the live link and re-emits ready when
  the peripheral is connected, and otherwise forces a fresh attempt exactly as before.
  `manageDevice` shares the same `adoptConnectedDevice` helper. The decision is a pure
  policy function (`BleConnectRouter.kt`) so the contract is testable off-device.
- `adoptConnectedDevice` deliberately does not touch the managed-device or
  user-disconnected prefs, so a CompanionDeviceManager appear event can never resurrect a
  device the user explicitly disconnected.
- Native always ensures the audio subscription; enabling notifications is idempotent.
- `MainActivity.onDestroy` clears `isFlutterAlive` and `nativeBleForegroundReady` whether
  or not the activity is finishing. `configureFlutterEngine` re-arms both on attach.
- Dart: a guard test pinning that a device-ready never replaces stream controllers that
  still have subscribers. The native resync makes a repeated `onDeviceReady` routinely
  reachable, and replacing live controllers orphans every subscriber — the same silent
  audio stop in a new shape. `main` landed the controller-preservation branch itself while
  this PR was open (b0e2b2bd6f, d5b35a414b), so this commit is now the test plus a
  `hostApi` seam that lets the transport be driven without a platform channel.

## Verification

```
cd app/android && ./gradlew :app:testDevDebugUnitTest      # 15 tests, 0 failures (3 new)
cd app && flutter test test/unit/native_ble_transport_resync_test.dart   # 2 passed
cd app && flutter analyze <changed dart files>             # No issues found
cd app && flutter build apk --flavor dev --debug           # built
cd app && ./test.sh                                        # 956 passed, 1 failed
```

The new Dart test is a real guard: removing the controller-preservation branch makes it
fail with `Expected: [[1, 2, 3]] Actual: []`.

The single `./test.sh` failure is
`conversation_detail_provider_selection_test.dart: conversation getter resolves when
startedAt and createdAt fall on different days`, a date-boundary test unrelated to this
change. Confirmed pre-existing: it fails identically on `origin/main` with these commits
stashed.

Not verified by me: the on-device repro (Background Mode on, close the app, reopen, confirm
the app adopts the live link and resumes transcription) needs the pendant. `BleConnectRouterTest`
is a contract test on new code rather than a regression test, and Android unit tests are not
currently run by any CI workflow — a pre-existing gap, worth wiring into
`mobile-app-checks.yml` in its own change.

Failure-Class: new

---

Rebased on `main`, and re-verified there: `./gradlew :app:testDevDebugUnitTest`,
`flutter test test/unit/native_ble_transport_resync_test.dart`, `flutter analyze`, and
`flutter build apk --flavor dev --debug` all pass on the rebased branch.

The branch originally carried a fourth commit fixing `${resolved,,}` (a bash 4+ expansion)
in `scripts/dev-harness/_resolve_python.sh`, which crashed `pre-push-singleflight` on macOS
bash 3.2. `main` fixed the same defect in 5c8f8f62e4 / cd997c08c3, so that commit is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
