### PR TITLE
SCA-266: require --admin for desktop changelog sync PR merge

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -329,10 +329,23 @@ jobs:
 
           PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
           if [ "$PR_STATE" != "MERGED" ]; then
-            # This remains a regular merge. If the bot lacks the protected
-            # branch override, the workflow must fail before it can create a
-            # tag instead of tagging a side branch.
-            gh pr merge "$PR_NUMBER" --merge --admin || gh pr merge "$PR_NUMBER" --merge
+            # main branch policy blocks ordinary merges. Use admin override so
+            # the Omi Bot can sync the changelog without waiting on checks.
+            # Do not fall back to a non-admin merge: a transient --admin failure
+            # (e.g. HTTP 502) would otherwise retry without override and fail
+            # on branch policy (see run 30581710658 / PR #10910).
+            merge_ok=0
+            for attempt in 1 2 3; do
+              if gh pr merge "$PR_NUMBER" --admin --merge; then
+                merge_ok=1
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "Admin merge attempt ${attempt}/3 failed; retrying in 5s..."
+                sleep 5
+              fi
+            done
+            test "$merge_ok" = "1"
           fi
 
           PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')


### PR DESCRIPTION
## Summary

- Desktop auto-release already attempted `gh pr merge --admin`, but a transient GraphQL 502 fell through to a non-admin merge that branch policy rejects (run [30581710658](https://github.com/BasedHardware/omi/actions/runs/30581710658), PR #10910).
- Keep admin-only merges for the changelog sync PR and retry briefly on transient failures.
- Manual `--admin --merge` of #10910 succeeded; the bot token has the privilege — the non-admin fallback was the bug.

Closes SCA-266

## Test plan

- [x] Confirm workflow uses `gh pr merge "$PR_NUMBER" --admin --merge` with no non-admin fallback
- [x] Confirm up to 3 admin-merge attempts with backoff between failures
- [ ] Desktop Swift CI / preflight green on this PR
- [ ] Next `Build Desktop Release Candidate` run merges changelog sync without manual intervention

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

