### PR TITLE
fix(desktop): unblock the release lane's INV-6 contract self-check

### DIFF
--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -4147,7 +4147,7 @@ def continuity_contract_self_check_failures() -> list[str]:
         "func testHydratePreferencePrefersRunThenSessionThenPill(",
         "func testFindPillMatchesByHydratePreferenceOrder(",
         "func testAgentCompletionBlockExposesOpenRefAndStaysVisible(",
-        "func testChatSelectionIsLimitedToSettledMessageBodies(",
+        "func testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes(",
         "func testAgentPreviewTextPrefersPromptOverOutput(",
         "func testAgentCompletionCardsUsePromptPreviewHelper(",
         "func testFloatingResourceStripsBindPerMessageNotProviderWide(",


### PR DESCRIPTION
## Bug

Every **Build Desktop Release Candidate** run has failed since 19:18 UTC today — the `tag-release` job dies in *Run ownership-scoped M1 pre-tag readiness*:

```
self-check failed: INV-6 hermetic contract coverage missing
  ['ChatTimelineContinuityTests.testChatSelectionIsLimitedToSettledMessageBodies']
```

Failed runs: 30574233502 (`afa5a990`), 30581710658 (`891813db`), 30583095844 (`65fba020`). Desktop tagging/release is blocked while it is red.

## Root cause

`agent-continuity-gauntlet-lib.py`'s `continuity_contract_self_check_failures()` requires a fixed list of test names to be present in `ChatTimelineContinuityTests.swift`.

PR #10904 (`e74755cd69`) removed `testChatSelectionIsLimitedToSettledMessageBodies` — the source-inspection tripwire — and replaced it with the manifest-backed `.github/scripts/check_chat_selection_boundary.py`, whose own docstring records where the Swift-side coverage went: *"Behavioral resize coverage remains in ChatTimelineContinuityTests."* That coverage is `testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes`, added by the same PR. The INV-6 needle was never repointed.

## Fix

One line: point the INV-6 needle at the surviving behavioral test for the same failure class. This is the same repair as #10873, which repointed this identical needle after the previous rename.

The gate is not weakened — the static boundary it used to assert now runs as a first-class manifest check (`chat-selection-boundary`), and INV-6 keeps requiring real coverage in the file.

## Tested

- Reproduced the exact CI failure on `origin/main` (`65fba020`): `python3 desktop/macos/scripts/agent-continuity-gauntlet-lib.py --self-check` → same INV-6 message, exit 1.
- After the fix the full self-check passes: `self-check passed (R3 race actions + resilience wiring + exact voice authority + query-specific terminal evidence + rotation-aware trace cursor + INV-6 hermetic contract gates + owner-switch)` — including the owner-switch vitest kernel check (ran `npm ci` in `desktop/macos/agent` first).
- Ran the same entry point CI uses: `desktop/macos/scripts/desktop-core-harness.sh --self-check --skip-backend-contracts` → `desktop-flow-lint OK (59 flows, 142 registered actions)` then `desktop-core-harness self-check passed`.
- Confirmed `testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes` exists in `ChatTimelineContinuityTests.swift`, and that no other file still references the removed name.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

