### PR TITLE
SCA-267: fix(gauntlet): update INV-6 self-check for SelectionOverlay test rename

### DIFF
--- a/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
+++ b/desktop/macos/scripts/agent-continuity-gauntlet-lib.py
@@ -4147,7 +4147,7 @@ def continuity_contract_self_check_failures() -> list[str]:
         "func testHydratePreferencePrefersRunThenSessionThenPill(",
         "func testFindPillMatchesByHydratePreferenceOrder(",
         "func testAgentCompletionBlockExposesOpenRefAndStaysVisible(",
-        "func testChatSelectionIsLimitedToSettledMessageBodies(",
+        "func testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes(",
         "func testAgentPreviewTextPrefersPromptOverOutput(",
         "func testAgentCompletionCardsUsePromptPreviewHelper(",
         "func testFloatingResourceStripsBindPerMessageNotProviderWide(",


### PR DESCRIPTION
## What changed and why

Closes SCA-267. After `e74755cd69` removed native SwiftUI selection from the live transcript, `ChatTimelineContinuityTests` replaced `testChatSelectionIsLimitedToSettledMessageBodies` with `testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes`, but the INV-6 hermetic contract self-check needle was not updated. That stale needle fails pre-tag readiness and blocks `tag-release`.

## Product invariants affected

INV-6 (hermetic contract coverage self-check needle only; no write-path behavior change)

## How it was verified

- Confirmed `testChatSelectionIsLimitedToSettledMessageBodies` is absent from `ChatTimelineContinuityTests.swift` and `testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes` is present
- Confirmed all INV-6 hermetic timeline needles in `continuity_contract_self_check_failures()` resolve against the current test file (missing: NONE)
- `python3 .github/scripts/check_chat_selection_boundary.py` → `FC-selection-overlay-layout-loop boundary passed`

## Tests

No new test needed — this restores the self-check needle to the existing replacement layout-convergence test introduced by the SelectionOverlay freeze fix. Coverage of the selection ban remains in `.github/scripts/check_chat_selection_boundary.py`.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

