### PR TITLE
refactor(task-integrations): drop dead token locals

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -413,9 +413,7 @@ async def get_asana_workspaces(uid: str = Depends(auth.get_current_user_uid)):
     if not data.get('connected'):
         raise HTTPException(status_code=401, detail="Asana token refresh failed. Please reconnect.")
 
-    access_token = data.get('access_token')
-
-    if not access_token:
+    if not data.get('access_token'):
         raise HTTPException(status_code=401, detail="Asana not authenticated")
 
     try:
@@ -457,9 +455,7 @@ async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_cur
     if not data.get('connected'):
         raise HTTPException(status_code=401, detail="Asana token refresh failed. Please reconnect.")
 
-    access_token = data.get('access_token')
-
-    if not access_token:
+    if not data.get('access_token'):
         raise HTTPException(status_code=401, detail="Asana not authenticated")
 
     try:
@@ -497,9 +493,7 @@ async def get_clickup_teams(uid: str = Depends(auth.get_current_user_uid)):
     if not data.get('connected'):
         raise HTTPException(status_code=401, detail="ClickUp token refresh failed. Please reconnect.")
 
-    access_token = data.get('access_token')
-
-    if not access_token:
+    if not data.get('access_token'):
         raise HTTPException(status_code=401, detail="ClickUp not authenticated")
 
     try:
@@ -539,9 +533,7 @@ async def get_clickup_spaces(team_id: str, uid: str = Depends(auth.get_current_u
     if not data.get('connected'):
         raise HTTPException(status_code=401, detail="ClickUp token refresh failed. Please reconnect.")
 
-    access_token = data.get('access_token')
-
-    if not access_token:
+    if not data.get('access_token'):
         raise HTTPException(status_code=401, detail="ClickUp not authenticated")
 
     try:
@@ -581,9 +573,7 @@ async def get_clickup_lists(space_id: str, uid: str = Depends(auth.get_current_u
     if not data.get('connected'):
         raise HTTPException(status_code=401, detail="ClickUp token refresh failed. Please reconnect.")
 
-    access_token = data.get('access_token')
-
-    if not access_token:
+    if not data.get('access_token'):
         raise HTTPException(status_code=401, detail="ClickUp not authenticated")
 
     try:


### PR DESCRIPTION
## Summary

Remove unused OAuth token locals while retaining the existing access-token validation.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_task_integrations_oauth_atomic.py`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

