### PR TITLE
fix(desktop): sidebar Conversations now selects the Conversations hub

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -8,7 +8,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4427,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1646,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 5716,
-    "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1690
+    "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1627
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "Final-assistant Omi mark ownership and canonical expandable tool-call presentation are row-level rendering contracts that belong with bubble equality and layout. The mark remains an overlay so it cannot shift bubbles horizontally, while its owner row reserves the mark's height to prevent an empty streaming reply from clipping at the transcript live edge.",

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1024,12 +1024,12 @@ struct DesktopHomeView: View {
           SidebarView(
             selectedIndex: $selectedIndex,
             isCollapsed: $isSidebarCollapsed,
+            memoryDestinationRawValue: $memoryDestinationRawValue,
             appState: appState
           )
           .opacity(0)
           .allowsHitTesting(false)
         }
-
         SettingsSidebar(
           selectedSection: $selectedSettingsSection,
           highlightedSettingId: $highlightedSettingId,
@@ -1051,12 +1051,12 @@ struct DesktopHomeView: View {
           SidebarView(
             selectedIndex: $selectedIndex,
             isCollapsed: $isSidebarCollapsed,
+            memoryDestinationRawValue: $memoryDestinationRawValue,
             appState: appState
           )
           .opacity(isInSettings ? 0 : 1)
           .allowsHitTesting(!isInSettings)
         }
-
       }
       .fixedSize(horizontal: true, vertical: false)
       .clipped()

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -832,10 +832,10 @@ struct DesktopHomeView: View {
     let scheduled = viewModelContainer.scheduleSessionWarmup(
       id: .agentVMProvisioning,
       delay: StartupWarmupPolicy.agentVMProvisioningDelay,
-      onCancel: { didScheduleAgentVMProvisioning = false }
-    ) {
-      await AgentVMService.shared.ensureProvisioned()
-    }
+      onCancel: { didScheduleAgentVMProvisioning = false },
+      operation: {
+        await AgentVMService.shared.ensureProvisioned()
+      })
     if !scheduled { didScheduleAgentVMProvisioning = false }
   }
 
@@ -846,16 +846,16 @@ struct DesktopHomeView: View {
     let scheduled = viewModelContainer.scheduleSessionWarmup(
       id: .conversationWarmup,
       delay: StartupWarmupPolicy.conversationWarmupDelay,
-      onCancel: { didScheduleConversationWarmup = false }
-    ) {
-      async let conversations: Void = loadConversationsIfNeeded()
-      async let folders: Void = loadFoldersIfNeeded()
-      // Warm memories + tasks too so the top bar's new-item counter has data
-      // even before those tabs are visited.
-      async let memories: Void = viewModelContainer.memoriesViewModel.loadMemoriesIfNeeded()
-      async let tasks: Void = viewModelContainer.tasksStore.loadTasksIfNeeded()
-      _ = await (conversations, folders, memories, tasks)
-    }
+      onCancel: { didScheduleConversationWarmup = false },
+      operation: {
+        async let conversations: Void = loadConversationsIfNeeded()
+        async let folders: Void = loadFoldersIfNeeded()
+        // Warm memories + tasks too so the top bar's new-item counter has data
+        // even before those tabs are visited.
+        async let memories: Void = viewModelContainer.memoriesViewModel.loadMemoriesIfNeeded()
+        async let tasks: Void = viewModelContainer.tasksStore.loadTasksIfNeeded()
+        _ = await (conversations, folders, memories, tasks)
+      })
     if !scheduled { didScheduleConversationWarmup = false }
   }
 
@@ -876,30 +876,30 @@ struct DesktopHomeView: View {
     else { return }
 
     let sessionScope = StartupWarmupSessionScope(
-      userId: UserDefaults.standard.string(forKey: "auth_userId"))
+      userId: UserDefaults.standard.string(forKey: .authUserId))
     let scheduled = viewModelContainer.scheduleSessionWarmup(
       id: .initialFileIndexing,
       delay: StartupWarmupPolicy.initialFileIndexingDelay,
-      onCancel: { initialFileIndexingBackfill.releaseReservation() }
-    ) {
-      log("DesktopHomeView: Running delayed background file scan for existing user")
-      await FileIndexerService.shared.backgroundRescan()
-      guard !Task.isCancelled,
-        sessionScope.matches(
-          currentUserId: UserDefaults.standard.string(forKey: "auth_userId"),
-          isSignedIn: AuthState.shared.isSignedIn)
-      else {
-        initialFileIndexingBackfill.releaseReservation()
-        return
-      }
-      initialFileIndexingBackfill.markScanCompleted()
-      if initialFileIndexingBackfill.shouldMarkComplete {
-        UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
-        log(
-          "DesktopHomeView: Marked existing-user file indexing backfill complete after background scan returned"
-        )
-      }
-    }
+      onCancel: { initialFileIndexingBackfill.releaseReservation() },
+      operation: {
+        log("DesktopHomeView: Running delayed background file scan for existing user")
+        await FileIndexerService.shared.backgroundRescan()
+        guard !Task.isCancelled,
+          sessionScope.matches(
+            currentUserId: UserDefaults.standard.string(forKey: .authUserId),
+            isSignedIn: AuthState.shared.isSignedIn)
+        else {
+          initialFileIndexingBackfill.releaseReservation()
+          return
+        }
+        initialFileIndexingBackfill.markScanCompleted()
+        if initialFileIndexingBackfill.shouldMarkComplete {
+          UserDefaults.standard.set(true, forKey: .hasCompletedFileIndexing)
+          log(
+            "DesktopHomeView: Marked existing-user file indexing backfill complete after background scan returned"
+          )
+        }
+      })
     if !scheduled { initialFileIndexingBackfill.releaseReservation() }
   }
 
@@ -914,32 +914,32 @@ struct DesktopHomeView: View {
     let scheduled = viewModelContainer.scheduleSessionWarmup(
       id: .proactiveAssistantsStart,
       delay: delay,
-      onCancel: { proactiveMonitoringStartGate.finishAttempt() }
-    ) {
-      let plugin = ProactiveAssistantsPlugin.shared
-      guard AssistantSettings.shared.screenAnalysisEnabled, !plugin.isMonitoring else {
-        proactiveMonitoringStartGate.finishAttempt()
-        return
-      }
-      guard APIKeyService.keysAvailable else {
-        proactiveMonitoringStartGate.finishAttempt()
-        log("DesktopHomeView: Screen analysis still deferred after \(reason) — API keys not yet loaded")
-        return
-      }
-
-      plugin.startMonitoring { success, error in
-        Task { @MainActor in
+      onCancel: { proactiveMonitoringStartGate.finishAttempt() },
+      operation: {
+        let plugin = ProactiveAssistantsPlugin.shared
+        guard AssistantSettings.shared.screenAnalysisEnabled, !plugin.isMonitoring else {
           proactiveMonitoringStartGate.finishAttempt()
-          if success {
-            log("DesktopHomeView: Screen analysis started (\(reason), delayed)")
-          } else {
-            log(
-              "DesktopHomeView: Screen analysis failed to start (\(reason)): \(error ?? "unknown") — setting remains enabled for next launch"
-            )
+          return
+        }
+        guard APIKeyService.keysAvailable else {
+          proactiveMonitoringStartGate.finishAttempt()
+          log("DesktopHomeView: Screen analysis still deferred after \(reason) — API keys not yet loaded")
+          return
+        }
+
+        plugin.startMonitoring { success, error in
+          Task { @MainActor in
+            proactiveMonitoringStartGate.finishAttempt()
+            if success {
+              log("DesktopHomeView: Screen analysis started (\(reason), delayed)")
+            } else {
+              log(
+                "DesktopHomeView: Screen analysis failed to start (\(reason)): \(error ?? "unknown") — setting remains enabled for next launch"
+              )
+            }
           }
         }
-      }
-    }
+      })
     if !scheduled { proactiveMonitoringStartGate.finishAttempt() }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -39,6 +39,17 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     guard let requestedRawValue else { return .conversations }
     return MemoryHubDestination(rawValue: requestedRawValue) ?? .conversations
   }
+
+  static func applySidebarSelection(
+    _ item: SidebarNavItem,
+    selectedIndex: inout Int,
+    memoryDestinationRawValue: inout Int
+  ) {
+    if let destination = destination(for: item) {
+      memoryDestinationRawValue = destination.rawValue
+    }
+    selectedIndex = item.rawValue
+  }
 }
 
 /// Deterministic interaction state for the Memory dropdown.

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
@@ -1,0 +1,64 @@
+// MARK: - Navigation Item Model
+enum SidebarNavItem: Int, CaseIterable {
+  case dashboard = 0
+  case conversations = 1
+  case chat = 2
+  case memories = 3
+  case tasks = 4
+  case focus = 5
+  case insight = 6
+  case rewind = 7
+  case apps = 8
+  case settings = 9
+  case permissions = 10
+  case help = 12
+  var title: String {
+    switch self {
+    case .dashboard: return "Home"
+    case .conversations: return "Conversations"
+    case .chat: return "Chat"
+    case .memories: return "Memories"
+    case .tasks: return "Tasks"
+    case .focus: return "Focus"
+    case .insight: return "Insights"
+    case .rewind: return "Rewind"
+    case .apps: return "Apps"
+    case .settings: return "Settings"
+    case .permissions: return "Permissions"
+    case .help: return "Help from Founder"
+    }
+  }
+  var icon: String {
+    switch self {
+    case .dashboard: return "house.fill"
+    case .conversations: return "text.bubble.fill"
+    case .chat: return "bubble.left.and.bubble.right.fill"
+    case .memories: return "brain"
+    case .tasks: return "checklist"
+    case .focus: return "eye.fill"
+    case .insight: return "lightbulb.fill"
+    case .rewind: return "clock.arrow.circlepath"
+    case .apps: return "puzzlepiece.fill"
+    case .settings: return "gearshape.fill"
+    case .permissions: return "exclamationmark.triangle.fill"
+    case .help: return "bubble.left.fill"
+    }
+  }
+  /// Minimum tier level required to access this item (0 = always available)
+  var requiredTier: Int {
+    switch self {
+    case .conversations, .rewind: return 1
+    case .memories: return 2
+    case .tasks: return 3
+    case .chat: return 4
+    case .dashboard: return 5
+    case .apps: return 6
+    default: return 0
+    }
+  }
+
+  /// Items shown in the main navigation (top section)
+  static var mainItems: [SidebarNavItem] {
+    [.dashboard, .conversations, .memories, .tasks, .focus, .insight, .rewind, .apps]
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
@@ -2,78 +2,11 @@
 import OmiTheme
 import SwiftUI
 
-// MARK: - Navigation Item Model
-enum SidebarNavItem: Int, CaseIterable {
-  case dashboard = 0
-  case conversations = 1
-  case chat = 2
-  case memories = 3
-  case tasks = 4
-  case focus = 5
-  case insight = 6
-  case rewind = 7
-  case apps = 8
-  case settings = 9
-  case permissions = 10
-  case help = 12
-
-  var title: String {
-    switch self {
-    case .dashboard: return "Home"
-    case .conversations: return "Conversations"
-    case .chat: return "Chat"
-    case .memories: return "Memories"
-    case .tasks: return "Tasks"
-    case .focus: return "Focus"
-    case .insight: return "Insights"
-    case .rewind: return "Rewind"
-    case .apps: return "Apps"
-    case .settings: return "Settings"
-    case .permissions: return "Permissions"
-    case .help: return "Help from Founder"
-    }
-  }
-
-  var icon: String {
-    switch self {
-    case .dashboard: return "house.fill"
-    case .conversations: return "text.bubble.fill"
-    case .chat: return "bubble.left.and.bubble.right.fill"
-    case .memories: return "brain"
-    case .tasks: return "checklist"
-    case .focus: return "eye.fill"
-    case .insight: return "lightbulb.fill"
-    case .rewind: return "clock.arrow.circlepath"
-    case .apps: return "puzzlepiece.fill"
-    case .settings: return "gearshape.fill"
-    case .permissions: return "exclamationmark.triangle.fill"
-    case .help: return "bubble.left.fill"
-    }
-  }
-
-  /// Minimum tier level required to access this item (0 = always available)
-  var requiredTier: Int {
-    switch self {
-    case .conversations, .rewind: return 1
-    case .memories: return 2
-    case .tasks: return 3
-    case .chat: return 4
-    case .dashboard: return 5
-    case .apps: return 6
-    default: return 0
-    }
-  }
-
-  /// Items shown in the main navigation (top section)
-  static var mainItems: [SidebarNavItem] {
-    [.dashboard, .conversations, .memories, .tasks, .focus, .insight, .rewind, .apps]
-  }
-}
-
 // MARK: - Sidebar View
 struct SidebarView: View {
   @Binding var selectedIndex: Int
   @Binding var isCollapsed: Bool
+  @Binding var memoryDestinationRawValue: Int
   @ObservedObject var appState: AppState
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var insightStorage = InsightStorage.shared
@@ -172,7 +105,11 @@ struct SidebarView: View {
                         }
                       }
                     }
-                    selectedIndex = item.rawValue
+                    MemoryHubDestination.applySidebarSelection(
+                      item,
+                      selectedIndex: &selectedIndex,
+                      memoryDestinationRawValue: &memoryDestinationRawValue
+                    )
                     AnalyticsManager.shared.tabChanged(tabName: item.title)
                   },
                   onToggle: {

--- a/desktop/macos/Desktop/Tests/MemoryHubSidebarRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryHubSidebarRoutingTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MemoryHubSidebarRoutingTests: XCTestCase {
+  func testConversationsSidebarSelectionUpdatesRailAndDestination() {
+    var selectedIndex = SidebarNavItem.dashboard.rawValue
+    var memoryDestinationRawValue = MemoryHubDestination.memories.rawValue
+
+    MemoryHubDestination.applySidebarSelection(
+      .conversations,
+      selectedIndex: &selectedIndex,
+      memoryDestinationRawValue: &memoryDestinationRawValue
+    )
+
+    XCTAssertEqual(selectedIndex, SidebarNavItem.conversations.rawValue)
+    XCTAssertEqual(memoryDestinationRawValue, MemoryHubDestination.conversations.rawValue)
+  }
+
+  func testOtherSidebarSelectionsPreserveMemoryDestination() {
+    var selectedIndex = SidebarNavItem.dashboard.rawValue
+    var memoryDestinationRawValue = MemoryHubDestination.conversations.rawValue
+
+    MemoryHubDestination.applySidebarSelection(
+      .tasks,
+      selectedIndex: &selectedIndex,
+      memoryDestinationRawValue: &memoryDestinationRawValue
+    )
+
+    XCTAssertEqual(selectedIndex, SidebarNavItem.tasks.rawValue)
+    XCTAssertEqual(memoryDestinationRawValue, MemoryHubDestination.conversations.rawValue)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260731-sidebar-conversations-routing.json
+++ b/desktop/macos/changelog/unreleased/20260731-sidebar-conversations-routing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Conversations sidebar item opening the Conversations hub"
+}

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -6,6 +6,7 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
   - desktop/macos/Desktop/Sources/MainWindow/EscapeKeyHandler.swift


### PR DESCRIPTION
## Summary

`SidebarView` only updated `selectedIndex`; the memory hub still defaulted to `.memories`, so tapping **Conversations** in the sidebar opened the **Memories** page. Add the `memoryDestinationRawValue` binding, set it to `.conversations` on the Conversations item tap, and wire the binding through both `SidebarView` call sites in `DesktopHomeView`.

## Invariants

none

## Failure-Class

Failure-Class: none

## Test plan

- [x] `git diff --check` — clean
- [x] `xcrun swift build -c debug --package-path Desktop` — passed
- [x] `make preflight` — passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation state fix with unit tests; no auth, data, or security surface changes.
> 
> **Overview**
> Fixes legacy sidebar **Conversations** opening the Memory hub on **Memories** because only `selectedIndex` changed while persisted `memoryDestinationRawValue` stayed on `.memories`.
> 
> **Sidebar** now takes a `memoryDestinationRawValue` binding from `DesktopHomeView` and uses `MemoryHubDestination.applySidebarSelection` on Conversations tap so the hub lands on **Conversations**; other items still only update `selectedIndex` and leave the stored destination alone.
> 
> Adds **`MemoryHubDestination.applySidebarSelection`** as the shared routing helper (aligned with top-bar / notification paths), moves **`SidebarNavItem`** into its own file, and includes unit tests plus an unreleased changelog entry. `DesktopHomeView` startup warmup calls are refactored to the labeled `operation:` `scheduleSessionWarmup` API and typed UserDefaults keys where touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b365b1e16e312394e0f67729aadff692db00491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

