### PR TITLE
fix(desktop): serialize mic watchdog reset

### DIFF
--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -163,6 +163,7 @@ class AudioCaptureService: @unchecked Sendable {
   // so we can detect a Bluetooth mic that's alive-but-silent (A2DP profile conflict).
   private var watchdogWindowPeak: Int16 = 0
   private var watchdogWindowStart: CFAbsoluteTime = 0
+  private let silentMicWatchdogLock = NSLock()
 
   /// Dedicated queue for CoreAudio device operations (start/stop/reconfigure)
   /// to avoid blocking the main thread on AudioDeviceStart/Stop calls.
@@ -171,6 +172,8 @@ class AudioCaptureService: @unchecked Sendable {
   // MARK: - Public Methods
 
   func resetSilentMicWatchdog() {
+    silentMicWatchdogLock.lock()
+    defer { silentMicWatchdogLock.unlock() }
     consecutiveSilentWindows = 0
     silentMicDetectedFired = false
     silentMicFireCount = 0
@@ -192,6 +195,16 @@ class AudioCaptureService: @unchecked Sendable {
   /// `internal` (not `private`) so the recover-more-than-once-per-session contract can be
   /// unit-tested without driving real CoreAudio buffers.
   func evaluateSilentMicWindow(peak: Int16, isBluetooth: Bool, now: CFAbsoluteTime) -> SilentMicDetection? {
+    silentMicWatchdogLock.lock()
+    defer { silentMicWatchdogLock.unlock() }
+    return evaluateSilentMicWindowLocked(peak: peak, isBluetooth: isBluetooth, now: now)
+  }
+
+  private func evaluateSilentMicWindowLocked(
+    peak: Int16,
+    isBluetooth: Bool,
+    now: CFAbsoluteTime
+  ) -> SilentMicDetection? {
     // peak ≤ 5 (≈ -76 dBFS) is effectively silent compared to real speech.
     if peak <= 5 {
       consecutiveSilentWindows += 1
@@ -781,6 +794,7 @@ class AudioCaptureService: @unchecked Sendable {
     let processedFrameLength = Int(outputBuffer.frameLength)
     var pcmData = [Int16]()
     pcmData.reserveCapacity(processedFrameLength)
+    var windowPeak: Int16 = 0
 
     for i in 0..<processedFrameLength {
       let sample = channelData[i]
@@ -791,7 +805,7 @@ class AudioCaptureService: @unchecked Sendable {
       // Accumulate the silent-mic peak while converting samples to avoid an
       // extra pass on the audio callback hot path.
       let absoluteSample = pcmSample == Int16.min ? Int16.max : Int16(pcmSample.magnitude)
-      if absoluteSample > watchdogWindowPeak { watchdogWindowPeak = absoluteSample }
+      if absoluteSample > windowPeak { windowPeak = absoluteSample }
     }
 
     // Convert to Data (little-endian, which is native on Apple platforms)
@@ -806,24 +820,31 @@ class AudioCaptureService: @unchecked Sendable {
     // one-shot latch) so the watchdog observes recovery and can re-arm for a second
     // episode — see `evaluateSilentMicWindow`.
     let nowAbs = CFAbsoluteTimeGetCurrent()
+    let isBluetooth = Self.isBluetoothTransport(deviceID: deviceID)
+    silentMicWatchdogLock.lock()
+    if windowPeak > watchdogWindowPeak { watchdogWindowPeak = windowPeak }
     if watchdogWindowStart == 0 { watchdogWindowStart = nowAbs }
+    let detection: SilentMicDetection?
     if nowAbs - watchdogWindowStart >= 1.0 {
-      let isBluetooth = Self.isBluetoothTransport(deviceID: deviceID)
-      if let detection = evaluateSilentMicWindow(peak: watchdogWindowPeak, isBluetooth: isBluetooth, now: nowAbs) {
-        if isBluetooth {
-          log(
-            "AudioCapture: Bluetooth mic returning silence for \(detection.consecutiveSilentWindows)s — falling back to built-in mic"
-          )
-        } else {
-          log(
-            "AudioCapture: Input device returning silence for \(detection.consecutiveSilentWindows)s — rebuilding CoreAudio capture"
-          )
-        }
-        let handler = onSilentMicDetected
-        DispatchQueue.main.async { handler?(detection) }
-      }
+      detection = evaluateSilentMicWindowLocked(peak: watchdogWindowPeak, isBluetooth: isBluetooth, now: nowAbs)
       watchdogWindowPeak = 0
       watchdogWindowStart = nowAbs
+    } else {
+      detection = nil
+    }
+    silentMicWatchdogLock.unlock()
+    if let detection {
+      if isBluetooth {
+        log(
+          "AudioCapture: Bluetooth mic returning silence for \(detection.consecutiveSilentWindows)s — falling back to built-in mic"
+        )
+      } else {
+        log(
+          "AudioCapture: Input device returning silence for \(detection.consecutiveSilentWindows)s — rebuilding CoreAudio capture"
+        )
+      }
+      let handler = onSilentMicDetected
+      DispatchQueue.main.async { handler?(detection) }
     }
 
     // Calculate and report audio level (RMS normalized to 0.0 - 1.0)

--- a/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
@@ -36,7 +36,7 @@ enum CaptureListeningLogic {
       let name = appState.recordingInputDeviceName
     {
       if AudioCaptureService.isMetaGlassesName(name) {
-        return "Ray-Ban Meta"
+        return name.localizedCaseInsensitiveContains("oakley") ? name : "Ray-Ban Meta"
       }
       let preferredUID =
         UserDefaults.standard.string(

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -3,6 +3,17 @@ import XCTest
 @testable import Omi_Computer
 
 final class DashboardCaptureStateTests: XCTestCase {
+  @MainActor
+  func testListeningModeTitlePreservesOakleyMetaName() {
+    let appState = AppState()
+    appState.isTranscribing = true
+    appState.recordingInputDeviceName = "Oakley Meta Vanguard"
+
+    XCTAssertEqual(
+      CaptureListeningLogic.listeningModeTitle(appState: appState, raw: "always"),
+      "Oakley Meta Vanguard")
+  }
+
   func testDashboardCaptureStatusUsesLiveMonitoringState() throws {
     let source = try dashboardSource()
     let logic = try captureLogicSource()

--- a/desktop/macos/Desktop/Tests/SilentMicWatchdogRearmTests.swift
+++ b/desktop/macos/Desktop/Tests/SilentMicWatchdogRearmTests.swift
@@ -9,6 +9,17 @@ import XCTest
 /// audio callback) so the fire-more-than-once contract is verified without real CoreAudio buffers.
 final class SilentMicWatchdogRearmTests: XCTestCase {
 
+  func testResetClearsWatchdogEvaluationState() {
+    let svc = AudioCaptureService()
+    svc.detectSilentMicOnAnyTransport = true
+
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 0))
+    svc.resetSilentMicWatchdog()
+
+    XCTAssertNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 1))
+    XCTAssertNotNil(svc.evaluateSilentMicWindow(peak: 0, isBluetooth: false, now: 2))
+  }
+
   /// PTT opts every transport into detection; without this only Bluetooth inputs fire.
   private func makeWatchdog(anyTransport: Bool = true) -> AudioCaptureService {
     let svc = AudioCaptureService()

--- a/desktop/macos/changelog/unreleased/20260731-mic-watchdog-oakley-meta.json
+++ b/desktop/macos/changelog/unreleased/20260731-mic-watchdog-oakley-meta.json
@@ -1,0 +1,1 @@
+{"change":"Improved reliability for microphone monitoring and device names when using Oakley Meta glasses"}


### PR DESCRIPTION
Fixes two remaining Codex findings from #10917:

- Serialize silent-mic watchdog resets with HAL callback evaluation.
- Preserve the supplied Oakley Meta device name in Listening status.

Checks:
- swift-format lint passed.
- desktop test quality passed.
- Focused XCTest build compiled, but XCTest could not load Sparkle.framework in this fresh worktree.

Failure-Class: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time CoreAudio capture and silent-mic recovery threading; incorrect locking could miss or duplicate recovery, but scope is limited to watchdog bookkeeping and display strings.
> 
> **Overview**
> **Serializes silent-mic watchdog state** so HAL audio callbacks and `resetSilentMicWatchdog()` (start/stop, PTT reuse) cannot race. A `silentMicWatchdogLock` guards window peaks, evaluation, and resets; the IOProc uses a per-buffer `windowPeak` merged under the lock and calls `evaluateSilentMicWindowLocked` without re-entering the public evaluator. Detection callbacks still run on the main queue **after** the lock is released.
> 
> **Listening status** for Meta glasses no longer always collapses to “Ray-Ban Meta”: when the input name contains “Oakley”, the UI shows the **actual device name** (e.g. Oakley Meta Vanguard).
> 
> Adds XCTest coverage for reset/re-arm behavior and Oakley title display, plus an unreleased changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bb46e648b228ccb9907b9cb05310e3e8e77268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->