### PR TITLE
fix(desktop): restore byte-exact test-install contract fixture

### DIFF
--- a/desktop/macos/tests/fixtures/test-install-job-contract.yml
+++ b/desktop/macos/tests/fixtures/test-install-job-contract.yml
@@ -1,190 +1,198 @@
----
-test-install:
-  runs-on: macos-15
-  timeout-minutes: 15
-  steps:
-  - name: System Info
-    run: |
-      echo "## System Information" >> $GITHUB_STEP_SUMMARY
-      echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
-      echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-      echo "| macOS Version | $(sw_vers -productVersion) |" >> $GITHUB_STEP_SUMMARY
-      echo "| Build | $(sw_vers -buildVersion) |" >> $GITHUB_STEP_SUMMARY
-      echo "| Architecture | $(uname -m) |" >> $GITHUB_STEP_SUMMARY
-      echo "| Gatekeeper | $(spctl --status 2>&1 || echo 'unknown') |" >> $GITHUB_STEP_SUMMARY
-      echo "" >> $GITHUB_STEP_SUMMARY
-  - name: Download DMG from GitHub Release
-    id: download
-    env:
-      GH_TOKEN: "${{ github.token }}"
-    run: |
-      echo "=== Downloading DMG ==="
+  test-install:
+    runs-on: macos-15
+    timeout-minutes: 15
 
-      # Get release tag from various sources
-      TAG="${{ github.event.inputs.release_tag }}"
-      if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
-        TAG="${{ github.event.client_payload.release_tag }}"
-      fi
-      if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
-        TAG=$(gh release list --repo BasedHardware/omi --limit 1 --json tagName --jq '.[0].tagName')
-      fi
-      echo "Testing release: $TAG"
-      echo "release_tag=$TAG" >> $GITHUB_OUTPUT
+    steps:
+      - name: System Info
+        run: |
+          echo "## System Information" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| macOS Version | $(sw_vers -productVersion) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build | $(sw_vers -buildVersion) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Architecture | $(uname -m) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gatekeeper | $(spctl --status 2>&1 || echo 'unknown') |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
 
-      DOWNLOAD_DIR="$RUNNER_TEMP/omi-install-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-      DMG_PATH="$DOWNLOAD_DIR/omi.dmg"
-      mkdir -p "$DOWNLOAD_DIR"
+      - name: Download DMG from GitHub Release
+        id: download
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "=== Downloading DMG ==="
 
-      # Download only the canonical disk image, never another release asset.
-      gh release download "$TAG" \
-        --repo BasedHardware/omi \
-        --pattern "omi.dmg" \
-        --dir "$DOWNLOAD_DIR"
-      test -f "$DMG_PATH"
-      echo "dmg_path=$DMG_PATH" >> $GITHUB_OUTPUT
+          # Get release tag from various sources
+          TAG="${{ github.event.inputs.release_tag }}"
+          if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
+            TAG="${{ github.event.client_payload.release_tag }}"
+          fi
+          if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
+            TAG=$(gh release list --repo BasedHardware/omi --limit 1 --json tagName --jq '.[0].tagName')
+          fi
+          echo "Testing release: $TAG"
+          echo "release_tag=$TAG" >> $GITHUB_OUTPUT
 
-      echo "## Release Under Test" >> $GITHUB_STEP_SUMMARY
-      echo "**Tag:** \`$TAG\`" >> $GITHUB_STEP_SUMMARY
-      echo "" >> $GITHUB_STEP_SUMMARY
-  - name: Mount DMG and Install
-    run: |
-      set -euo pipefail
-      DMG_PATH="${{ steps.download.outputs.dmg_path }}"
-      MOUNTPOINT="$RUNNER_TEMP/omi-install-mount-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-      DEVICE=""
+          DOWNLOAD_DIR="$RUNNER_TEMP/omi-install-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          DMG_PATH="$DOWNLOAD_DIR/omi.dmg"
+          mkdir -p "$DOWNLOAD_DIR"
 
-      cleanup() {
-        local exit_code=$?
-        if [[ -n "$DEVICE" ]]; then
-          hdiutil detach "$DEVICE" -quiet || true
-        fi
-        rm -rf "$MOUNTPOINT" "$(dirname "$DMG_PATH")"
-        exit "$exit_code"
-      }
-      trap cleanup EXIT
+          # Download only the canonical disk image, never another release asset.
+          gh release download "$TAG" \
+            --repo BasedHardware/omi \
+            --pattern "omi.dmg" \
+            --dir "$DOWNLOAD_DIR"
+          test -f "$DMG_PATH"
+          echo "dmg_path=$DMG_PATH" >> $GITHUB_OUTPUT
 
-      mkdir -p "$MOUNTPOINT"
-      xattr -d com.apple.quarantine "$DMG_PATH" 2>/dev/null || true
-      DEVICE=$(hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$MOUNTPOINT" | awk '/^\/dev\// { print $1; exit }')
-      [[ -n "$DEVICE" ]]
-      [[ -d "$MOUNTPOINT/Omi.app" ]]
-      echo "Mounted $DMG_PATH at $MOUNTPOINT ($DEVICE)"
+          echo "## Release Under Test" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** \`$TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
 
-      # Use ditto to preserve extended attributes from the exact mounted image.
-      ditto "$MOUNTPOINT/Omi.app" "/Applications/Omi.app"
+      - name: Mount DMG and Install
+        run: |
+          set -euo pipefail
+          DMG_PATH="${{ steps.download.outputs.dmg_path }}"
+          MOUNTPOINT="$RUNNER_TEMP/omi-install-mount-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          DEVICE=""
 
-      echo "App installed to /Applications"
-  - name: Verify Code Signature
-    id: codesign
-    run: |
-      echo "## Code Signature" >> $GITHUB_STEP_SUMMARY
+          cleanup() {
+            local exit_code=$?
+            if [[ -n "$DEVICE" ]]; then
+              hdiutil detach "$DEVICE" -quiet || true
+            fi
+            rm -rf "$MOUNTPOINT" "$(dirname "$DMG_PATH")"
+            exit "$exit_code"
+          }
+          trap cleanup EXIT
 
-      # Get signing info
-      SIGNING_INFO=$(codesign -dv --verbose=2 "/Applications/Omi.app" 2>&1)
-      AUTHORITY=$(echo "$SIGNING_INFO" | grep "Authority=" | head -1 | cut -d= -f2)
-      TEAM=$(echo "$SIGNING_INFO" | grep "TeamIdentifier=" | cut -d= -f2)
+          mkdir -p "$MOUNTPOINT"
+          xattr -d com.apple.quarantine "$DMG_PATH" 2>/dev/null || true
+          DEVICE=$(hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$MOUNTPOINT" | awk '/^\/dev\// { print $1; exit }')
+          [[ -n "$DEVICE" ]]
+          [[ -d "$MOUNTPOINT/Omi.app" ]]
+          echo "Mounted $DMG_PATH at $MOUNTPOINT ($DEVICE)"
 
-      echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
-      echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-      echo "| Signing Authority | $AUTHORITY |" >> $GITHUB_STEP_SUMMARY
-      echo "| Team ID | $TEAM |" >> $GITHUB_STEP_SUMMARY
+          # Use ditto to preserve extended attributes from the exact mounted image.
+          ditto "$MOUNTPOINT/Omi.app" "/Applications/Omi.app"
 
-      # Deep verification (MUST pass)
-      if codesign --verify --deep --strict --verbose=2 "/Applications/Omi.app" 2>&1; then
-        echo "| Deep Verification | ✅ Pass |" >> $GITHUB_STEP_SUMMARY
-      else
-        echo "| Deep Verification | ❌ FAIL |" >> $GITHUB_STEP_SUMMARY
-        echo "::error::Code signature deep verification failed"
-        exit 1
-      fi
-  - name: Verify Gatekeeper Assessment
-    id: gatekeeper
-    run: |
-      echo "" >> $GITHUB_STEP_SUMMARY
-      echo "## Gatekeeper Assessment" >> $GITHUB_STEP_SUMMARY
-      echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
-      echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "App installed to /Applications"
 
-      # Gatekeeper assessment (MUST pass)
-      GK_RESULT=$(spctl --assess --verbose=4 "/Applications/Omi.app" 2>&1)
-      if echo "$GK_RESULT" | grep -q "accepted"; then
-        SOURCE=$(echo "$GK_RESULT" | grep "source=" | cut -d= -f2)
-        echo "| Assessment | ✅ Accepted |" >> $GITHUB_STEP_SUMMARY
-        echo "| Source | $SOURCE |" >> $GITHUB_STEP_SUMMARY
-      else
-        echo "| Assessment | ❌ REJECTED |" >> $GITHUB_STEP_SUMMARY
-        echo "::error::Gatekeeper rejected the app: $GK_RESULT"
-        exit 1
-      fi
-  - name: Verify Notarization Stapling
-    id: stapling
-    run: |
-      echo "" >> $GITHUB_STEP_SUMMARY
-      echo "## Notarization Stapling" >> $GITHUB_STEP_SUMMARY
-      echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
-      echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+      - name: Verify Code Signature
+        id: codesign
+        run: |
+          echo "## Code Signature" >> $GITHUB_STEP_SUMMARY
 
-      # Stapler validation (MUST pass - this was the bug!)
-      if xcrun stapler validate "/Applications/Omi.app" 2>&1 | grep -q "valid"; then
-        echo "| Stapled Ticket | ✅ Present |" >> $GITHUB_STEP_SUMMARY
-      else
-        echo "| Stapled Ticket | ❌ MISSING |" >> $GITHUB_STEP_SUMMARY
-        echo "::error::Notarization ticket is NOT stapled to the app. Users may have issues launching the app offline or with slow internet."
-        exit 1
-      fi
-  - name: Test App Launch
-    id: launch
-    run: |
-      echo "" >> $GITHUB_STEP_SUMMARY
-      echo "## App Launch Test" >> $GITHUB_STEP_SUMMARY
-      echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
-      echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          # Get signing info
+          SIGNING_INFO=$(codesign -dv --verbose=2 "/Applications/Omi.app" 2>&1)
+          AUTHORITY=$(echo "$SIGNING_INFO" | grep "Authority=" | head -1 | cut -d= -f2)
+          TEAM=$(echo "$SIGNING_INFO" | grep "TeamIdentifier=" | cut -d= -f2)
 
-      # Clear quarantine (simulates user clicking "Open" in Gatekeeper dialog)
-      xattr -cr "/Applications/Omi.app"
+          echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Signing Authority | $AUTHORITY |" >> $GITHUB_STEP_SUMMARY
+          echo "| Team ID | $TEAM |" >> $GITHUB_STEP_SUMMARY
 
-      # Register with LaunchServices
-      /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "/Applications/Omi.app"
+          # Deep verification (MUST pass)
+          if codesign --verify --deep --strict --verbose=2 "/Applications/Omi.app" 2>&1; then
+            echo "| Deep Verification | ✅ Pass |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Deep Verification | ❌ FAIL |" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Code signature deep verification failed"
+            exit 1
+          fi
 
-      # Launch the app
-      open "/Applications/Omi.app"
+      - name: Verify Gatekeeper Assessment
+        id: gatekeeper
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Gatekeeper Assessment" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
 
-      # Wait for app to start
-      sleep 5
+          # Gatekeeper assessment (MUST pass)
+          GK_RESULT=$(spctl --assess --verbose=4 "/Applications/Omi.app" 2>&1)
+          if echo "$GK_RESULT" | grep -q "accepted"; then
+            SOURCE=$(echo "$GK_RESULT" | grep "source=" | cut -d= -f2)
+            echo "| Assessment | ✅ Accepted |" >> $GITHUB_STEP_SUMMARY
+            echo "| Source | $SOURCE |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Assessment | ❌ REJECTED |" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Gatekeeper rejected the app: $GK_RESULT"
+            exit 1
+          fi
 
-      # Check if running
-      if pgrep -x "Omi Computer" > /dev/null; then
-        echo "| Process Running | ✅ Yes |" >> $GITHUB_STEP_SUMMARY
-        PID=$(pgrep -x "Omi Computer")
-        echo "| PID | $PID |" >> $GITHUB_STEP_SUMMARY
-      else
-        echo "| Process Running | ⚠️ No (may need UI interaction) |" >> $GITHUB_STEP_SUMMARY
-        # Don't fail - headless CI may not support GUI apps fully
-      fi
+      - name: Verify Notarization Stapling
+        id: stapling
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Notarization Stapling" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
 
-      # Check for crash reports
-      if ls ~/Library/Logs/DiagnosticReports/*Omi* 2>/dev/null; then
-        echo "| Crash Reports | ❌ Found |" >> $GITHUB_STEP_SUMMARY
-        echo "::error::Crash report found!"
-        cat ~/Library/Logs/DiagnosticReports/*Omi*.crash | head -100
-        exit 1
-      else
-        echo "| Crash Reports | ✅ None |" >> $GITHUB_STEP_SUMMARY
-      fi
-  - name: Final Summary
-    if: always()
-    run: |
-      echo "" >> $GITHUB_STEP_SUMMARY
-      echo "---" >> $GITHUB_STEP_SUMMARY
-      echo "## Test Result" >> $GITHUB_STEP_SUMMARY
-      if [ "${{ job.status }}" = "success" ]; then
-        echo "### ✅ All checks passed" >> $GITHUB_STEP_SUMMARY
-      else
-        echo "### ❌ Some checks failed" >> $GITHUB_STEP_SUMMARY
-        echo "See individual step results above for details." >> $GITHUB_STEP_SUMMARY
-      fi
-  - name: Cleanup
-    if: always()
-    run: |
-      pkill -9 "Omi Computer" 2>/dev/null || true
-      rm -rf "/Applications/Omi.app"
+          # Stapler validation (MUST pass - this was the bug!)
+          if xcrun stapler validate "/Applications/Omi.app" 2>&1 | grep -q "valid"; then
+            echo "| Stapled Ticket | ✅ Present |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Stapled Ticket | ❌ MISSING |" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Notarization ticket is NOT stapled to the app. Users may have issues launching the app offline or with slow internet."
+            exit 1
+          fi
+
+      - name: Test App Launch
+        id: launch
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## App Launch Test" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+
+          # Clear quarantine (simulates user clicking "Open" in Gatekeeper dialog)
+          xattr -cr "/Applications/Omi.app"
+
+          # Register with LaunchServices
+          /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "/Applications/Omi.app"
+
+          # Launch the app
+          open "/Applications/Omi.app"
+
+          # Wait for app to start
+          sleep 5
+
+          # Check if running
+          if pgrep -x "Omi Computer" > /dev/null; then
+            echo "| Process Running | ✅ Yes |" >> $GITHUB_STEP_SUMMARY
+            PID=$(pgrep -x "Omi Computer")
+            echo "| PID | $PID |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Process Running | ⚠️ No (may need UI interaction) |" >> $GITHUB_STEP_SUMMARY
+            # Don't fail - headless CI may not support GUI apps fully
+          fi
+
+          # Check for crash reports
+          if ls ~/Library/Logs/DiagnosticReports/*Omi* 2>/dev/null; then
+            echo "| Crash Reports | ❌ Found |" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Crash report found!"
+            cat ~/Library/Logs/DiagnosticReports/*Omi*.crash | head -100
+            exit 1
+          else
+            echo "| Crash Reports | ✅ None |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Final Summary
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "## Test Result" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "### ✅ All checks passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ Some checks failed" >> $GITHUB_STEP_SUMMARY
+            echo "See individual step results above for details." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: |
+          pkill -9 "Omi Computer" 2>/dev/null || true
+          rm -rf "/Applications/Omi.app"


### PR DESCRIPTION
## Bug

`Desktop Swift CI` is red on `main` for every desktop-touching commit since b8a07d66b5 — both required jobs fail:

- `Desktop Swift Static & Test Contracts` → `desktop launcher script tests` → `tests/test-test-install-workflow-contract.sh` → `FAIL: admitted canonical test-install block must occur exactly once`
- `Desktop Swift Build & Tests` → `Require static contracts and Swift tests` (mirrors the verdict above)

Red runs: https://github.com/BasedHardware/omi/actions/runs/30601451952 (be04764efc) and https://github.com/BasedHardware/omi/actions/runs/30603540493 (90e06ae0a5, the v0.12.148 candidate).

## Root cause

b8a07d66b5 ("fix: update test-install workflow fixture + advance release path") rewrote `desktop/macos/tests/fixtures/test-install-job-contract.yml` through a YAML round-trip: it added a `---` document marker, dedented the block to 2-space indentation, stripped the blank lines between steps, and quoted `${{ github.token }}`.

That fixture backs a **byte-exact** contract. `tests/test-test-install-workflow-contract.sh` asserts `workflow_bytes.count(contract_bytes) == 1` and that the extracted `jobs.test-install` block byte-matches the fixture — the point of d2f60932b1 ("fix(release): lock installer test job bytes") is that no reserialization is admissible. After the round-trip the fixture occurs **zero** times in `desktop/macos/.github/workflows/test-install.yml`, so the check fails closed.

The workflow itself was never stale: the pre-b8a07d66b5 fixture still matches it exactly (`workflow_bytes.count(old_fixture) == 1`).

## Fix

Restore the pre-b8a07d66b5 fixture bytes verbatim. One file, fixture-only; the workflow is untouched.

Ignoring whitespace the diff is **+10/-2** (the `---` marker, the blank lines, the token quoting); the 388-line raw count is purely the reindentation artifact.

## Verification

```
# on origin/main (90e06ae0a5) — reproduces the exact CI message
$ bash desktop/macos/tests/test-test-install-workflow-contract.sh
FAIL: admitted canonical test-install block must occur exactly once

# on this branch — the same script CI discovers, full mutation suite
$ bash desktop/macos/tests/test-test-install-workflow-contract.sh; echo EXIT=$?
test-install workflow exact-DMG contract passed
EXIT=0
```

All 90 `run_mutation` cases still behave as specified — every hostile mutation is rejected, and the `canonical` / `unrelated-job-defaults-shell` benign cases are still accepted. `make preflight` passes.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

Same declaration as d2f60932b1, the commit that established this byte-lock contract.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

