### PR TITLE
fix(deploy): allow tag-only Cloud Run targets in manual fence gate

### DIFF
--- a/.github/failure-classes/FC-workflow-script-input-contract.json
+++ b/.github/failure-classes/FC-workflow-script-input-contract.json
@@ -3,6 +3,10 @@
   "id": "FC-workflow-script-input-contract",
   "violated_contract": "Every workflow invocation of a repository deployment script must use its declared argument grammar and provide each required workflow input.",
   "canonical_prevention": "Exercise rendered workflow callers against deterministic script seams and statically require every deployment-script caller to bind its required environment inputs before expensive deployment work begins.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_sync_two_lane.py",
+    "backend/tests/unit/test_verify_sync_ledger_fence_transition.py"
+  ],
   "evidence_prs": [9945],
   "scope_hints": [".github/workflows/**", "backend/scripts/**", "backend/tests/unit/test_*deploy_contract.py"],
   "status": "open"

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -418,10 +418,15 @@ jobs:
         env:
           SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}
         run: |
+          # Match auto-dev: complete tag-only targets (revision+tag+https URL, no
+          # percent) are not serving traffic. Without this flag the verifier
+          # misreports them as "non-integer Cloud Run traffic percentage" and
+          # blocks manual deploys whenever diagnostic tags remain on the service.
           python3 "$DEPLOY_CONTROL_SCRIPTS/verify_sync_ledger_fence_transition.py" \
             --project=${{ vars.GCP_PROJECT_ID }} \
             --region=${{ env.REGION }} \
-            --desired-mode="$SYNC_LEDGER_FENCE_MODE"
+            --desired-mode="$SYNC_LEDGER_FENCE_MODE" \
+            --allow-tagged-no-percent-targets
 
       - name: Login to GCR
         run: gcloud auth configure-docker

--- a/backend/tests/unit/test_sync_two_lane.py
+++ b/backend/tests/unit/test_sync_two_lane.py
@@ -258,6 +258,7 @@ def test_normal_backend_deploys_fail_closed_on_fence_transitions_and_gate_stt_ca
     for workflow in (manual, auto_dev):
         assert 'verify_sync_ledger_fence_transition.py' in workflow
         assert '--desired-mode="$SYNC_LEDGER_FENCE_MODE"' in workflow
+        assert '--allow-tagged-no-percent-targets' in workflow
         assert workflow.count("SYNC_LEDGER_FENCE_MODE: ${{ vars.SYNC_LEDGER_FENCE_MODE || 'legacy' }}") >= 2
 
     assert "TRANSCRIPTION_CANDIDATE_TAG: stt-gate-${{ github.run_id }}-${{ github.run_attempt }}" in manual


### PR DESCRIPTION
## Summary

Manual `Deploy Backend to Cloud RUN` (`gcp_backend.yml`) failed the pre-deploy sync-ledger fence check with:

```text
ERROR: backend has a non-integer Cloud Run traffic percentage
```

Live investigation showed this was **not** a fractional/split traffic state. Development Cloud Run services keep complete **tag-only** targets (revision + tag + HTTPS URL, no `percent`) for diagnostics such as `pusher-gke` / `pusher-cleanup` / `candidate`. The verifier intentionally treats those as non-serving **only** when called with `--allow-tagged-no-percent-targets`.

- Auto-dev already passed that flag.
- Manual deploy did not, so any remaining diagnostic tag blocked the fence step with a misleading error.

This change aligns the manual fence step with auto-dev and locks the flag into the static two-lane workflow contract test.

### Live traffic evidence (read-only)

| Env | Project | Serving | Tags without percent |
|---|---|---|---|
| prod | `based-hardware` | 100% integer on `*-f23e8f2-30360282504-1` | none — fence passes **without** the flag |
| dev | `based-hardware-dev` | 100% integer on `*-90e06ae-30603594563-1` | present — fence fails without flag, passes with flag |

Failed cited run [30601638009](https://github.com/BasedHardware/omi/actions/runs/30601638009) was `environment=development` / `based-hardware-dev`, not production.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: FC-workflow-script-input-contract

## Test plan

- [x] `backend/.venv/bin/python -m pytest tests/unit/test_sync_two_lane.py::test_normal_backend_deploys_fail_closed_on_fence_transitions_and_gate_stt_candidates tests/unit/test_verify_sync_ledger_fence_transition.py -q` → 12 passed
- [x] Reproduced live: dev fence fails without flag, passes with flag; prod fence passes either way
- [ ] CI workflow contract / backend unit checks on this PR

## Out of scope

- No Cloud Run traffic mutation (prod and dev serving traffic already 100% integer).
- No production rollout of #10907 / current main (separate release-admission decision; prod still on `f23e8f2`).

Closes SCA-265 via Multica handoff (issue key for linking: SCA-265).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

