### PR TITLE
feat(windows): show memory provenance

### DIFF
--- a/desktop/windows/src/renderer/src/components/memories/MemoryCard.memo.test.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/MemoryCard.memo.test.tsx
@@ -80,4 +80,17 @@ describe('MemoryCard memoization (nav-snappiness regression)', () => {
     rerender(<Harness memory={makeMemory('b')} />)
     expect(dateSpy).toHaveBeenCalledTimes(2)
   })
+
+  it('shows the recorded source on the card', () => {
+    const { getByText } = render(
+      <ul>
+        <MemoryCard
+          memory={{ ...makeMemory('a'), conversation_id: 'conversation-1' }}
+          onOpen={noopOpen}
+        />
+      </ul>
+    )
+
+    expect(getByText('Conversation')).not.toBeNull()
+  })
 })

--- a/desktop/windows/src/renderer/src/components/memories/MemoryCard.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/MemoryCard.tsx
@@ -11,6 +11,7 @@ import {
   isProtectedContent,
   layerLabel
 } from '../../lib/memoryFilters'
+import { memorySourceLabel } from '../../lib/memoryProvenance'
 import { Badge } from '../ui/Badge'
 import { NewBadge } from './NewBadge'
 
@@ -71,6 +72,7 @@ function MemoryCardImpl({ memory, onOpen, now }: MemoryCardProps): React.JSX.Ele
   const isNew = isNewMemory(memory, now)
   const protectedMem = isProtectedContent(memory.content)
   const layer = layerLabel(memory)
+  const source = memorySourceLabel(memory)
   const open = (): void => onOpen(memory)
 
   return (
@@ -103,6 +105,7 @@ function MemoryCardImpl({ memory, onOpen, now }: MemoryCardProps): React.JSX.Ele
 
       <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-text-quaternary">
         <time>{formatMemoryDate(memory.created_at, now)}</time>
+        <span className="text-text-quaternary">{source}</span>
         <Badge tone="neutral" size="xs">
           {CATEGORY_LABEL[categoryOf(memory)]}
         </Badge>

--- a/desktop/windows/src/renderer/src/components/memories/MemoryCard.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/MemoryCard.tsx
@@ -26,7 +26,7 @@ function InfoRows({ memory }: { memory: Memory }): React.JSX.Element {
   if (typeof memory.capture_confidence === 'number')
     rows.push(['Confidence', `${Math.round(memory.capture_confidence * 100)}%`])
   if (memory.app_id) rows.push(['App', memory.app_id])
-  if (memory.conversation_id) rows.push(['Source', 'Conversation'])
+  rows.push(['Source', memorySourceLabel(memory)])
   rows.push(['Created', formatMemoryDate(memory.created_at)])
   const tags = displayTags(memory)
   return (

--- a/desktop/windows/src/renderer/src/components/memories/MemoryDetailSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/memories/MemoryDetailSheet.tsx
@@ -10,6 +10,7 @@ import {
   isProtectedContent,
   layerLabel
 } from '../../lib/memoryFilters'
+import { memorySourceLabel } from '../../lib/memoryProvenance'
 import { Badge } from '../ui/Badge'
 import { Toggle } from '../ui/Toggle'
 
@@ -59,6 +60,7 @@ export function MemoryDetailSheet({
   const layer = layerLabel(memory)
   const isPublic = memory.visibility === 'public'
   const tags = displayTags(memory)
+  const source = memorySourceLabel(memory)
 
   const saveEdit = async (): Promise<void> => {
     const text = draft.trim()
@@ -184,6 +186,7 @@ export function MemoryDetailSheet({
 
               {/* Metadata panel */}
               <div className="mt-5 rounded-xl bg-[var(--bg-tertiary)] px-4 py-2">
+                <MetaRow label="Learned from" value={source} />
                 {typeof memory.capture_confidence === 'number' && (
                   <MetaRow
                     label="Confidence"

--- a/desktop/windows/src/renderer/src/hooks/useMemories.test.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.test.ts
@@ -69,6 +69,18 @@ afterEach(cleanup)
 // per module lifetime (`if (cache.loaded) return`) — that keeps tests
 // order-independent regardless of what a prior test left in the cache.
 describe('useMemories — edit/visibility query-param contract (C9)', () => {
+  it('createMemory sends the requested manual category', async () => {
+    omiApiPost.mockResolvedValue({ data: memory('m2', 'Added memory', 'private') })
+    const { result } = renderHook(() => useMemories())
+    await act(async () => {
+      await result.current.createMemory('Added memory', { category: 'manual' })
+    })
+    expect(omiApiPost).toHaveBeenCalledWith('/v3/memories', {
+      content: 'Added memory',
+      category: 'manual'
+    })
+  })
+
   it('editMemory sends the new content as a query param, not a JSON body', async () => {
     const { result } = renderHook(() => useMemories())
     await act(async () => {

--- a/desktop/windows/src/renderer/src/hooks/useMemories.ts
+++ b/desktop/windows/src/renderer/src/hooks/useMemories.ts
@@ -28,6 +28,7 @@ export type Memory = {
   manually_added?: boolean
   capture_confidence?: number | null
   app_id?: string | null
+  evidence?: Array<{ source_type?: string | null }>
 }
 
 // Axios lowercases response header keys.

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -25,12 +25,21 @@ describe('memorySource', () => {
     expect(memorySource(memory({ tags: ['sticky_notes/import/profile'] }))).toBe('sticky-notes')
   })
 
-  it('uses explicit manual, conversation, and app fields without guessing', () => {
+  it('uses explicit record fields and recorded evidence without guessing', () => {
     expect(memorySource(memory({ manually_added: true }))).toBe('manual')
     expect(memorySource(memory({ category: 'manual' }))).toBe('manual')
     expect(memorySource(memory({ conversation_id: 'conversation-1' }))).toBe('conversation')
     expect(memorySource(memory({ app_id: 'app-1' }))).toBe('app')
+    expect(memorySource(memory({ evidence: [{ source_type: 'manual' }] }))).toBe('manual')
+    expect(memorySource(memory({ evidence: [{ source_type: 'voice_transcript' }] }))).toBe(
+      'conversation'
+    )
+    expect(memorySource(memory({ evidence: [{ source_type: 'screenshot_ocr' }] }))).toBe('screen')
+    expect(memorySource(memory({ evidence: [{ source_type: 'api' }] }))).toBe('app')
+    expect(memorySource(memory({ evidence: [{ source_type: 'developer_api' }] }))).toBe('app')
+    expect(memorySource(memory({ evidence: [{ source_type: 'mcp' }] }))).toBe('app')
     expect(memorySource(memory({ evidence: [{ source_type: 'integration:gmail' }] }))).toBe('app')
+    expect(memorySource(memory({ evidence: [{ source_type: 'unknown' }] }))).toBe('unknown')
     expect(memorySource(memory())).toBe('unknown')
   })
 

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -30,6 +30,7 @@ describe('memorySource', () => {
     expect(memorySource(memory({ category: 'manual' }))).toBe('manual')
     expect(memorySource(memory({ conversation_id: 'conversation-1' }))).toBe('conversation')
     expect(memorySource(memory({ app_id: 'app-1' }))).toBe('app')
+    expect(memorySource(memory({ evidence: [{ source_type: 'integration:gmail' }] }))).toBe('app')
     expect(memorySource(memory())).toBe('unknown')
   })
 

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -43,6 +43,12 @@ describe('memorySource', () => {
     expect(memorySource(memory())).toBe('unknown')
   })
 
+  it('uses recorded API evidence before legacy source flags', () => {
+    expect(
+      memorySource(memory({ manually_added: true, evidence: [{ source_type: 'developer_api' }] }))
+    ).toBe('app')
+  })
+
   it('returns an honest fallback label when no origin was recorded', () => {
     expect(memorySourceLabel(memory())).toBe('Origin not recorded')
   })

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import type { Memory } from '../hooks/useMemories'
+import { APP_INDEX_TAG } from './memoryCleanup'
+import { memorySource, memorySourceLabel } from './memoryProvenance'
+import { SCREEN_TAG } from './screenTag'
+
+function memory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: 'memory-1',
+    uid: 'user-1',
+    content: 'A memory',
+    created_at: '2026-07-31T00:00:00Z',
+    updated_at: '2026-07-31T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('memorySource', () => {
+  it('uses explicit provenance tags before weaker record fields', () => {
+    expect(memorySource(memory({ tags: [SCREEN_TAG], conversation_id: 'conversation-1' }))).toBe(
+      'screen'
+    )
+    expect(memorySource(memory({ tags: [APP_INDEX_TAG] }))).toBe('file-index')
+    expect(memorySource(memory({ tags: ['gmail/import/note'] }))).toBe('gmail')
+    expect(memorySource(memory({ tags: ['sticky_notes/import/profile'] }))).toBe('sticky-notes')
+  })
+
+  it('uses explicit manual, conversation, and app fields without guessing', () => {
+    expect(memorySource(memory({ manually_added: true }))).toBe('manual')
+    expect(memorySource(memory({ category: 'manual' }))).toBe('manual')
+    expect(memorySource(memory({ conversation_id: 'conversation-1' }))).toBe('conversation')
+    expect(memorySource(memory({ app_id: 'app-1' }))).toBe('app')
+    expect(memorySource(memory())).toBe('unknown')
+  })
+
+  it('returns an honest fallback label when no origin was recorded', () => {
+    expect(memorySourceLabel(memory())).toBe('Origin not recorded')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
@@ -25,6 +25,9 @@ const sourceLabels: Record<MemorySource, string> = {
 
 export function memorySource(memory: Memory): MemorySource {
   const tags = memory.tags ?? []
+  const evidenceTypes = memory.evidence?.flatMap((evidence) =>
+    evidence.source_type ? [evidence.source_type] : []
+  )
   if (tags.includes(SCREEN_TAG)) return 'screen'
   if (tags.includes(APP_INDEX_TAG)) return 'file-index'
   if (tags.some((tag) => tag.startsWith('gmail/'))) return 'gmail'
@@ -32,7 +35,24 @@ export function memorySource(memory: Memory): MemorySource {
   if (memory.manually_added || memory.category === 'manual') return 'manual'
   if (memory.conversation_id) return 'conversation'
   if (memory.app_id) return 'app'
-  if (memory.evidence?.some((evidence) => evidence.source_type?.startsWith('integration:'))) {
+  if (evidenceTypes?.includes('manual')) return 'manual'
+  if (
+    evidenceTypes?.some((type) =>
+      ['conversation', 'chat', 'chat_exchange', 'transcript', 'voice_transcript'].includes(type)
+    )
+  ) {
+    return 'conversation'
+  }
+  if (evidenceTypes?.includes('screenshot_ocr')) return 'screen'
+  if (
+    evidenceTypes?.some(
+      (type) =>
+        type === 'api' ||
+        type === 'developer_api' ||
+        type === 'mcp' ||
+        type.startsWith('integration:')
+    )
+  ) {
     return 'app'
   }
   return 'unknown'

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
@@ -32,6 +32,9 @@ export function memorySource(memory: Memory): MemorySource {
   if (memory.manually_added || memory.category === 'manual') return 'manual'
   if (memory.conversation_id) return 'conversation'
   if (memory.app_id) return 'app'
+  if (memory.evidence?.some((evidence) => evidence.source_type?.startsWith('integration:'))) {
+    return 'app'
+  }
   return 'unknown'
 }
 

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
@@ -3,14 +3,7 @@ import { APP_INDEX_TAG } from './memoryCleanup'
 import { SCREEN_TAG } from './screenTag'
 
 export type MemorySource =
-  | 'screen'
-  | 'file-index'
-  | 'gmail'
-  | 'sticky-notes'
-  | 'manual'
-  | 'conversation'
-  | 'app'
-  | 'unknown'
+  'screen' | 'file-index' | 'gmail' | 'sticky-notes' | 'manual' | 'conversation' | 'app' | 'unknown'
 
 const sourceLabels: Record<MemorySource, string> = {
   screen: 'Screen capture',
@@ -32,9 +25,6 @@ export function memorySource(memory: Memory): MemorySource {
   if (tags.includes(APP_INDEX_TAG)) return 'file-index'
   if (tags.some((tag) => tag.startsWith('gmail/'))) return 'gmail'
   if (tags.some((tag) => tag.startsWith('sticky_notes/'))) return 'sticky-notes'
-  if (memory.manually_added || memory.category === 'manual') return 'manual'
-  if (memory.conversation_id) return 'conversation'
-  if (memory.app_id) return 'app'
   if (evidenceTypes?.includes('manual')) return 'manual'
   if (
     evidenceTypes?.some((type) =>
@@ -55,6 +45,9 @@ export function memorySource(memory: Memory): MemorySource {
   ) {
     return 'app'
   }
+  if (memory.manually_added || memory.category === 'manual') return 'manual'
+  if (memory.conversation_id) return 'conversation'
+  if (memory.app_id) return 'app'
   return 'unknown'
 }
 

--- a/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
+++ b/desktop/windows/src/renderer/src/lib/memoryProvenance.ts
@@ -1,0 +1,40 @@
+import type { Memory } from '../hooks/useMemories'
+import { APP_INDEX_TAG } from './memoryCleanup'
+import { SCREEN_TAG } from './screenTag'
+
+export type MemorySource =
+  | 'screen'
+  | 'file-index'
+  | 'gmail'
+  | 'sticky-notes'
+  | 'manual'
+  | 'conversation'
+  | 'app'
+  | 'unknown'
+
+const sourceLabels: Record<MemorySource, string> = {
+  screen: 'Screen capture',
+  'file-index': 'File index',
+  gmail: 'Gmail import',
+  'sticky-notes': 'Sticky Notes',
+  manual: 'Added by you',
+  conversation: 'Conversation',
+  app: 'App',
+  unknown: 'Origin not recorded'
+}
+
+export function memorySource(memory: Memory): MemorySource {
+  const tags = memory.tags ?? []
+  if (tags.includes(SCREEN_TAG)) return 'screen'
+  if (tags.includes(APP_INDEX_TAG)) return 'file-index'
+  if (tags.some((tag) => tag.startsWith('gmail/'))) return 'gmail'
+  if (tags.some((tag) => tag.startsWith('sticky_notes/'))) return 'sticky-notes'
+  if (memory.manually_added || memory.category === 'manual') return 'manual'
+  if (memory.conversation_id) return 'conversation'
+  if (memory.app_id) return 'app'
+  return 'unknown'
+}
+
+export function memorySourceLabel(memory: Memory): string {
+  return sourceLabels[memorySource(memory)]
+}

--- a/desktop/windows/src/renderer/src/pages/Memories.editDelete.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.editDelete.test.tsx
@@ -139,6 +139,21 @@ describe('Memories — detail sheet stays in sync after an edit (FIX 1)', () => 
   })
 })
 
+describe('Memories — composer provenance', () => {
+  it('creates a composed memory with the manual category', async () => {
+    await renderPage()
+    fireEvent.click(screen.getByText('New'))
+    fireEvent.change(screen.getByPlaceholderText('Something Omi should remember about you…'), {
+      target: { value: 'I prefer paper notes' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(createMemory).toHaveBeenCalledWith('I prefer paper notes', { category: 'manual' })
+    )
+  })
+})
+
 describe('Memories — a delete commits at most once (FIX 2)', () => {
   it('fires the backend delete exactly once when the pending delete is replaced under StrictMode', async () => {
     // StrictMode (on in main.tsx) double-invokes state updaters in dev. The old

--- a/desktop/windows/src/renderer/src/pages/Memories.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.tsx
@@ -202,7 +202,7 @@ export function Memories(): React.JSX.Element {
     if (!text || saving) return
     setSaving(true)
     try {
-      await createMemory(text)
+      await createMemory(text, { category: 'manual' })
       toast('Memory created', { tone: 'info' })
       closeCompose()
     } catch (e) {


### PR DESCRIPTION
## Summary

- show each Windows memory's recorded source on its card and in its detail sheet
- classify existing source fields without changing memory storage or APIs

## Verification

- focused Vitest: 6 tests
- Windows renderer type-check
- `scripts/pr-preflight --base upstream/main --lane local`

## Product invariants affected

none

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only provenance display plus an optional manual category on an existing create-memory POST; no auth or data-model changes.
> 
> **Overview**
> Adds **`memoryProvenance`** to derive a human-readable origin from existing memory fields (tags, `evidence.source_type`, `conversation_id`, `app_id`, manual flags, etc.) without new storage or backend APIs. The **`Memory`** type gains optional **`evidence`** so classification can use recorded source types.
> 
> **Memory cards** show that label in the footer and always include a **Source** row in the info tooltip (replacing the old conversation-only rule). The **detail sheet** adds a **Learned from** metadata row. When provenance is missing, the UI shows **Origin not recorded**.
> 
> User-composed memories now call **`createMemory`** with **`{ category: 'manual' }`** so manual adds are labeled consistently. Vitest covers classification priority, card display, hook POST shape, and the Memories composer flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346a9041df481075558767da74c0e5f26485a3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

