### PR TITLE
feat(windows): scope Rewind search by natural language time

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-rewind-natural-time-search.json
+++ b/desktop/windows/changelog/unreleased/2026-08-rewind-natural-time-search.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Rewind search understands natural-language time phrases such as yesterday, today, this morning, and this evening, and scopes results to that window."
+  ]
+}

--- a/desktop/windows/e2e/rewind-dayscope.spec.mjs
+++ b/desktop/windows/e2e/rewind-dayscope.spec.mjs
@@ -269,7 +269,7 @@ test('day-scoped Rewind: browse, calendar, search results, drill-down, empty day
       (base) => window.omi.rewindSetEmbedSession({ desktopApiBase: base, token: 'e2e-token' }),
       stub.base
     )
-  const input = rw.locator('input[placeholder="Search what was on screen…"]')
+  const input = rw.locator('[data-testid="rewind-search"]')
   // Phase 1 (keyword) is immediate; phase 2 (semantic recall) arrives out-of-band.
   // Re-issue the query each iteration so a fresh phase-2 fires for the newest search
   // sequence, until BOTH the keyword group and the semantic "Related" group render.

--- a/desktop/windows/e2e/rewind-dayscope.spec.mjs
+++ b/desktop/windows/e2e/rewind-dayscope.spec.mjs
@@ -147,6 +147,14 @@ function seed(dir, dbPath) {
   add(past, 'Slides', 'board deck — Q3 review', KW_OCR, JPEGS[1])
   add(past + 8e3, 'Slides', 'board deck — Q3 review', `${KW_OCR} (slide 2)`, JPEGS[1])
   add(past + 45 * 60e3, 'Notes', 'ml study notes', SEM_OCR, JPEGS[2])
+  add(
+    today - 24 * 3600e3 + 9 * 3600e3,
+    'Mail.exe',
+    'invoice yesterday',
+    'invoice from yesterday',
+    JPEGS[0]
+  )
+  add(now - 10 * 60e3, 'Mail.exe', 'invoice today', 'invoice from today', JPEGS[1])
   db.close()
 }
 
@@ -296,6 +304,14 @@ test('day-scoped Rewind: browse, calendar, search results, drill-down, empty day
   await page.waitForTimeout(400) // thumbnails
   await page.screenshot({ path: path.join(shotsDir, '03-search-results.png') })
   assert.ok(gotSemantic, 'keyword group + semantic "Related" group both rendered')
+
+  const temporal = await page.evaluate(async () => window.omi.rewindSearch('invoice yesterday'))
+  const temporalFrames = temporal.groups.flatMap((group) => group.frames)
+  assert.equal(temporal.normalizedQuery, 'invoice')
+  assert.deepEqual(
+    temporalFrames.map((frame) => frame.ocrText),
+    ['invoice from yesterday']
+  )
 
   // Assert the affordance is real, not just present in the DOM by luck.
   const relatedCount = await rw.locator('text=Related').count()

--- a/desktop/windows/e2e/rewind-semantic.spec.mjs
+++ b/desktop/windows/e2e/rewind-semantic.spec.mjs
@@ -294,7 +294,7 @@ test('embeds seeded frames via the proxy, then merges vector recall into FTS sea
   // burn ~91s of retries, and the FTS rows must not be held hostage behind it.
   const phase1 = await win.evaluate((q) => window.omi.rewindSearch(q), QUERY)
   assert.deepEqual(
-    phase1.map((g) => g.representative.id).sort(),
+    phase1.groups.map((g) => g.representative.id).sort(),
     ftsIds,
     'phase 1 is keyword-only, and immediate'
   )
@@ -326,7 +326,7 @@ test('embeds seeded frames via the proxy, then merges vector recall into FTS sea
   await win.evaluate(() => (window.__semantic = []))
   const degraded = await win.evaluate((q) => window.omi.rewindSearch(q), QUERY)
   assert.deepEqual(
-    degraded.map((g) => g.representative.id).sort(),
+    degraded.groups.map((g) => g.representative.id).sort(),
     ftsIds,
     'degrades to keyword-only instead of erroring'
   )

--- a/desktop/windows/scripts/run-rewind-dayscope-e2e.mjs
+++ b/desktop/windows/scripts/run-rewind-dayscope-e2e.mjs
@@ -4,14 +4,27 @@
 // API, no real credentials), drives the day-scoped Rewind UI, and captures the
 // screenshot set into .playwright-mcp/pr3/ for the skeptical review.
 import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const NO_BUILD = process.argv.includes('--no-build')
+const exampleApiKey = readFileSync(path.join(root, '.env.example'), 'utf8')
+  .split(/\r?\n/)
+  .find((line) => line.startsWith('VITE_FIREBASE_API_KEY='))
+  ?.split('=', 2)[1]
+const buildEnv = exampleApiKey
+  ? { ...process.env, VITE_FIREBASE_API_KEY: process.env.VITE_FIREBASE_API_KEY ?? exampleApiKey }
+  : process.env
 
 if (!NO_BUILD) {
-  execFileSync('npx', ['electron-vite', 'build'], { stdio: 'inherit', cwd: root, shell: true })
+  execFileSync('npx', ['electron-vite', 'build'], {
+    stdio: 'inherit',
+    cwd: root,
+    env: buildEnv,
+    shell: true
+  })
 }
 
 execFileSync('node', ['--test', '--test-timeout=180000', 'e2e/rewind-dayscope.spec.mjs'], {

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -1705,7 +1705,8 @@ export function linkRewindEmbedding(frameId: number, hash: string): boolean {
  */
 export async function searchRewindEmbeddings(
   query: Float32Array,
-  limit: number
+  limit: number,
+  scope?: { from: number; to: number }
 ): Promise<{ frameId: number; similarity: number }[]> {
   const d = get()
   // EXISTS against idx_rewind_embeddings_hash: skips vectors no live frame points
@@ -1717,11 +1718,14 @@ export async function searchRewindEmbeddings(
   // anywhere in the table silently truncated the scan there, and every vector past
   // it went unranked. Filtering in the query keeps LIMIT and "rows returned"
   // describing the same set.
-  const page = d.prepare(searchEmbeddingPageSql())
+  const page = d.prepare(searchEmbeddingPageSql(undefined, scope != null))
 
   const scored = await scanTopKBySimilarity(
     (offset, size) =>
-      (page.all(size, offset) as { hash: string; vec: Uint8Array }[]).map((r) => ({
+      (page.all(...(scope ? [scope.from, scope.to] : []), size, offset) as {
+        hash: string
+        vec: Uint8Array
+      }[]).map((r) => ({
         hash: r.hash,
         vec: bufferToVector(r.vec)
       })),
@@ -1739,9 +1743,13 @@ export async function searchRewindEmbeddings(
     .prepare(
       `SELECT e.frame_id AS frameId, e.hash AS hash, f.ts AS ts FROM rewind_embeddings e
          JOIN rewind_frames f ON f.id = e.frame_id
-        WHERE e.hash IN (${placeholders})`
+        WHERE e.hash IN (${placeholders})${scope ? ' AND f.ts BETWEEN ? AND ?' : ''}`
     )
-    .all(...scored.map((s) => s.hash)) as { frameId: number; hash: string; ts: number }[]
+    .all(...scored.map((s) => s.hash), ...(scope ? [scope.from, scope.to] : [])) as {
+    frameId: number
+    hash: string
+    ts: number
+  }[]
 
   const similarityByHash = new Map(scored.map((s) => [s.hash, s.similarity]))
   return rows

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -1481,18 +1481,24 @@ export function listRewindFramesSampled(
 // REWIND_COLUMNS_QUALIFIED (columns qualified to `rewind_frames.`, so the FTS
 // join's identically named ocr_text/window_title/app aren't ambiguous) is shared
 // with the backfill work-query and now lives in rewindEmbeddingSql.ts.
-export function searchRewindFrames(query: string, limit = 500): RewindFrame[] {
+export function searchRewindFrames(
+  query: string,
+  limit = 500,
+  scope?: { from: number; to: number }
+): RewindFrame[] {
   return timed('searchRewindFrames', () => {
     const match = buildRewindFtsMatch(query)
     if (!match) return []
+    const scoped = scope != null
     return cachedStmt(
       get(),
       `SELECT ${REWIND_COLUMNS_QUALIFIED} FROM rewind_frames
            JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
           WHERE rewind_frames_fts MATCH ?
+          ${scoped ? 'AND rewind_frames.ts BETWEEN ? AND ?' : ''}
           ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
           LIMIT ?`
-    ).all(match, limit) as RewindFrame[]
+    ).all(match, ...(scoped ? [scope.from, scope.to] : []), limit) as RewindFrame[]
   })
 }
 

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -1722,10 +1722,12 @@ export async function searchRewindEmbeddings(
 
   const scored = await scanTopKBySimilarity(
     (offset, size) =>
-      (page.all(...(scope ? [scope.from, scope.to] : []), size, offset) as {
-        hash: string
-        vec: Uint8Array
-      }[]).map((r) => ({
+      (
+        page.all(...(scope ? [scope.from, scope.to] : []), size, offset) as {
+          hash: string
+          vec: Uint8Array
+        }[]
+      ).map((r) => ({
         hash: r.hash,
         vec: bufferToVector(r.vec)
       })),

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -1706,7 +1706,8 @@ export function linkRewindEmbedding(frameId: number, hash: string): boolean {
  */
 export async function searchRewindEmbeddings(
   query: Float32Array,
-  limit: number
+  limit: number,
+  scope?: { from: number; to: number }
 ): Promise<{ frameId: number; similarity: number }[]> {
   const d = get()
   // EXISTS against idx_rewind_embeddings_hash: skips vectors no live frame points
@@ -1718,11 +1719,14 @@ export async function searchRewindEmbeddings(
   // anywhere in the table silently truncated the scan there, and every vector past
   // it went unranked. Filtering in the query keeps LIMIT and "rows returned"
   // describing the same set.
-  const page = d.prepare(searchEmbeddingPageSql())
+  const page = d.prepare(searchEmbeddingPageSql(undefined, scope != null))
 
   const scored = await scanTopKBySimilarity(
     (offset, size) =>
-      (page.all(size, offset) as { hash: string; vec: Uint8Array }[]).map((r) => ({
+      (page.all(...(scope ? [scope.from, scope.to] : []), size, offset) as {
+        hash: string
+        vec: Uint8Array
+      }[]).map((r) => ({
         hash: r.hash,
         vec: bufferToVector(r.vec)
       })),
@@ -1740,9 +1744,13 @@ export async function searchRewindEmbeddings(
     .prepare(
       `SELECT e.frame_id AS frameId, e.hash AS hash, f.ts AS ts FROM rewind_embeddings e
          JOIN rewind_frames f ON f.id = e.frame_id
-        WHERE e.hash IN (${placeholders})`
+        WHERE e.hash IN (${placeholders})${scope ? ' AND f.ts BETWEEN ? AND ?' : ''}`
     )
-    .all(...scored.map((s) => s.hash)) as { frameId: number; hash: string; ts: number }[]
+    .all(...scored.map((s) => s.hash), ...(scope ? [scope.from, scope.to] : [])) as {
+    frameId: number
+    hash: string
+    ts: number
+  }[]
 
   const similarityByHash = new Map(scored.map((s) => [s.hash, s.similarity]))
   return rows

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -1482,18 +1482,24 @@ export function listRewindFramesSampled(
 // REWIND_COLUMNS_QUALIFIED (columns qualified to `rewind_frames.`, so the FTS
 // join's identically named ocr_text/window_title/app aren't ambiguous) is shared
 // with the backfill work-query and now lives in rewindEmbeddingSql.ts.
-export function searchRewindFrames(query: string, limit = 500): RewindFrame[] {
+export function searchRewindFrames(
+  query: string,
+  limit = 500,
+  scope?: { from: number; to: number }
+): RewindFrame[] {
   return timed('searchRewindFrames', () => {
     const match = buildRewindFtsMatch(query)
     if (!match) return []
+    const scoped = scope != null
     return cachedStmt(
       get(),
       `SELECT ${REWIND_COLUMNS_QUALIFIED} FROM rewind_frames
            JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
           WHERE rewind_frames_fts MATCH ?
+          ${scoped ? 'AND rewind_frames.ts BETWEEN ? AND ?' : ''}
           ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
           LIMIT ?`
-    ).all(match, limit) as RewindFrame[]
+    ).all(match, ...(scoped ? [scope.from, scope.to] : []), limit) as RewindFrame[]
   })
 }
 

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -3,7 +3,7 @@ import { app, BrowserWindow } from 'electron'
 import { basename, dirname, join } from 'path'
 import { categorize } from '../usage/category'
 import { isNewLocalDay } from '../usage/usageDay'
-import { buildRewindFtsMatch } from '../rewind/rewindSearchQuery'
+import { buildRewindFtsMatch, buildRewindFtsSearchSql } from '../rewind/rewindSearchQuery'
 import { addColumnIfMissing as ensureColumn, runMigrations } from './dbMigrations'
 import { applyRewindEmbeddingSchema } from './rewindEmbeddingSchema'
 import { LOCAL_CONVERSATION_SCHEMA } from './localConversationSchema'
@@ -1491,15 +1491,11 @@ export function searchRewindFrames(
     const match = buildRewindFtsMatch(query)
     if (!match) return []
     const scoped = scope != null
-    return cachedStmt(
-      get(),
-      `SELECT ${REWIND_COLUMNS_QUALIFIED} FROM rewind_frames
-           JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
-          WHERE rewind_frames_fts MATCH ?
-          ${scoped ? 'AND rewind_frames.ts BETWEEN ? AND ?' : ''}
-          ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
-          LIMIT ?`
-    ).all(match, ...(scoped ? [scope.from, scope.to] : []), limit) as RewindFrame[]
+    return cachedStmt(get(), buildRewindFtsSearchSql(REWIND_COLUMNS_QUALIFIED, scoped)).all(
+      match,
+      ...(scoped ? [scope.from, scope.to] : []),
+      limit
+    ) as RewindFrame[]
   })
 }
 

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -1723,10 +1723,12 @@ export async function searchRewindEmbeddings(
 
   const scored = await scanTopKBySimilarity(
     (offset, size) =>
-      (page.all(...(scope ? [scope.from, scope.to] : []), size, offset) as {
-        hash: string
-        vec: Uint8Array
-      }[]).map((r) => ({
+      (
+        page.all(...(scope ? [scope.from, scope.to] : []), size, offset) as {
+          hash: string
+          vec: Uint8Array
+        }[]
+      ).map((r) => ({
         hash: r.hash,
         vec: bufferToVector(r.vec)
       })),

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -39,11 +39,11 @@ const VECTOR_TOP_K = 50
  * out, embedding backend down, nothing indexed yet). Never throws: on macOS the
  * whole vector leg is a `try?`, and keyword results must render regardless.
  */
-async function vectorHits(query: string): Promise<VectorHit[]> {
+async function vectorHits(query: string, scope?: { from: number; to: number }): Promise<VectorHit[]> {
   try {
     const vec = await embedRewindQuery(query)
     if (!vec) return []
-    const scored = await searchRewindEmbeddings(vec, VECTOR_TOP_K)
+    const scored = await searchRewindEmbeddings(vec, VECTOR_TOP_K, scope)
     const frames = rewindFramesByIds(scored.map((s) => s.frameId))
     const byId = new Map(frames.map((f) => [f.id, f]))
     return scored
@@ -90,7 +90,7 @@ export function registerRewindHandlers(): void {
   // `try?`), which is only true if keyword results don't depend on it.
   ipcMain.handle('rewind:search', async (e, query: string) => {
     const { query: q, from, to } = parseRewindNaturalSearch(query)
-    if (!q && (from == null || to == null)) return []
+    if (!q && (from == null || to == null)) return { groups: [], normalizedQuery: q }
     const seq = ++searchSeq
     const inScope = (ts: number): boolean =>
       (from == null || ts >= from) && (to == null || ts <= to)
@@ -102,7 +102,7 @@ export function registerRewindHandlers(): void {
     // and it must never reject into the handler.
     void (async () => {
       if (!q) return
-      const hits = (await vectorHits(q)).filter((hit) => inScope(hit.frame.ts))
+      const hits = await vectorHits(q, from != null && to != null ? { from, to } : undefined)
       if (hits.length === 0) return // keyword-only; the phase-1 reply already stands
       if (seq !== searchSeq) return // a newer query has since been issued
       if (e.sender.isDestroyed()) return
@@ -111,11 +111,12 @@ export function registerRewindHandlers(): void {
       const keywordIds = new Set(fts.map((f) => f.id).filter((id): id is number => id != null))
       e.sender.send('rewind:search-results', {
         query: query.trim(),
+        normalizedQuery: q,
         groups: groupFrames(mergeRewindSearchResults(fts, hits), q, { keywordIds })
       })
     })()
 
-    return groupFrames(fts, q)
+    return { groups: groupFrames(fts, q), normalizedQuery: q }
   })
   // Relay of the renderer's Firebase session — the embedding indexer and the
   // query embedder are inert without it (the token only exists in the renderer).

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -39,7 +39,10 @@ const VECTOR_TOP_K = 50
  * out, embedding backend down, nothing indexed yet). Never throws: on macOS the
  * whole vector leg is a `try?`, and keyword results must render regardless.
  */
-async function vectorHits(query: string, scope?: { from: number; to: number }): Promise<VectorHit[]> {
+async function vectorHits(
+  query: string,
+  scope?: { from: number; to: number }
+): Promise<VectorHit[]> {
   try {
     const vec = await embedRewindQuery(query)
     if (!vec) return []
@@ -92,8 +95,6 @@ export function registerRewindHandlers(): void {
     const { query: q, from, to } = parseRewindNaturalSearch(query)
     if (!q && (from == null || to == null)) return { groups: [], normalizedQuery: q }
     const seq = ++searchSeq
-    const inScope = (ts: number): boolean =>
-      (from == null || ts >= from) && (to == null || ts <= to)
     const fts = q
       ? searchRewindFrames(q, 500, from != null && to != null ? { from, to } : undefined)
       : listRewindFramesSampled(from ?? 0, to ?? Date.now())

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -27,6 +27,7 @@ import { pruneRewindOnce } from '../rewind/retentionRunner'
 import { rebuildRewindIndexFromDisk } from '../rewind/rebuildIndex'
 import { rewindRoot } from '../rewind/paths'
 import { readRewindFrame } from '../rewind/frameFile'
+import { parseRewindNaturalSearch } from '../rewind/rewindNaturalSearch'
 import type { RewindSettings } from '../../shared/types'
 
 /** How many semantic neighbours to pull before the similarity floor + the
@@ -88,15 +89,20 @@ export function registerRewindHandlers(): void {
   // is supposed to degrade silently to keyword-only (macOS wraps the whole leg in
   // `try?`), which is only true if keyword results don't depend on it.
   ipcMain.handle('rewind:search', async (e, query: string) => {
-    const q = query.trim()
-    if (!q) return []
+    const { query: q, from, to } = parseRewindNaturalSearch(query)
+    if (!q && (from == null || to == null)) return []
     const seq = ++searchSeq
-    const fts = searchRewindFrames(q)
+    const inScope = (ts: number): boolean =>
+      (from == null || ts >= from) && (to == null || ts <= to)
+    const fts = q
+      ? searchRewindFrames(q).filter((frame) => inScope(frame.ts))
+      : listRewindFramesSampled(from ?? 0, to ?? Date.now())
 
     // Fire-and-forget: nothing about the reply below depends on this resolving,
     // and it must never reject into the handler.
     void (async () => {
-      const hits = await vectorHits(q)
+      if (!q) return
+      const hits = (await vectorHits(q)).filter((hit) => inScope(hit.frame.ts))
       if (hits.length === 0) return // keyword-only; the phase-1 reply already stands
       if (seq !== searchSeq) return // a newer query has since been issued
       if (e.sender.isDestroyed()) return
@@ -104,7 +110,7 @@ export function registerRewindHandlers(): void {
       // groups (those that exist only because vector recall added them).
       const keywordIds = new Set(fts.map((f) => f.id).filter((id): id is number => id != null))
       e.sender.send('rewind:search-results', {
-        query: q,
+        query: query.trim(),
         groups: groupFrames(mergeRewindSearchResults(fts, hits), q, { keywordIds })
       })
     })()

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -95,7 +95,7 @@ export function registerRewindHandlers(): void {
     const inScope = (ts: number): boolean =>
       (from == null || ts >= from) && (to == null || ts <= to)
     const fts = q
-      ? searchRewindFrames(q).filter((frame) => inScope(frame.ts))
+      ? searchRewindFrames(q, 500, from != null && to != null ? { from, to } : undefined)
       : listRewindFramesSampled(from ?? 0, to ?? Date.now())
 
     // Fire-and-forget: nothing about the reply below depends on this resolving,

--- a/desktop/windows/src/main/ipc/rewindEmbeddingSql.ts
+++ b/desktop/windows/src/main/ipc/rewindEmbeddingSql.ts
@@ -89,9 +89,11 @@ export function rewindFramesNeedingEmbeddingSql(excludeCount: number): string {
  * It is a parameter, not a baked constant, only so the SQL test can drive it with
  * small toy vectors — the guard shape is identical either way.
  */
-export function searchEmbeddingPageSql(blobBytes: number = EMBED_BLOB_BYTES): string {
+export function searchEmbeddingPageSql(blobBytes: number = EMBED_BLOB_BYTES, scoped = false): string {
   return `SELECT v.hash AS hash, v.vec AS vec FROM rewind_embedding_vectors v
-      WHERE EXISTS (SELECT 1 FROM rewind_embeddings e WHERE e.hash = v.hash)
+      WHERE EXISTS (SELECT 1 FROM rewind_embeddings e
+                    JOIN rewind_frames f ON f.id = e.frame_id
+                    WHERE e.hash = v.hash${scoped ? ' AND f.ts BETWEEN ? AND ?' : ''})
         AND v.vec IS NOT NULL AND LENGTH(v.vec) = ${blobBytes}
       ORDER BY v.hash
       LIMIT ? OFFSET ?`

--- a/desktop/windows/src/main/ipc/rewindEmbeddingSql.ts
+++ b/desktop/windows/src/main/ipc/rewindEmbeddingSql.ts
@@ -89,7 +89,10 @@ export function rewindFramesNeedingEmbeddingSql(excludeCount: number): string {
  * It is a parameter, not a baked constant, only so the SQL test can drive it with
  * small toy vectors — the guard shape is identical either way.
  */
-export function searchEmbeddingPageSql(blobBytes: number = EMBED_BLOB_BYTES, scoped = false): string {
+export function searchEmbeddingPageSql(
+  blobBytes: number = EMBED_BLOB_BYTES,
+  scoped = false
+): string {
   return `SELECT v.hash AS hash, v.vec AS vec FROM rewind_embedding_vectors v
       WHERE EXISTS (SELECT 1 FROM rewind_embeddings e
                     JOIN rewind_frames f ON f.id = e.frame_id

--- a/desktop/windows/src/main/rewind/rewindEmbeddingSql.test.ts
+++ b/desktop/windows/src/main/rewind/rewindEmbeddingSql.test.ts
@@ -237,6 +237,18 @@ describe('the backfill work list', () => {
 })
 
 describe('similarity search over stored rows', () => {
+  it('selects scoped vectors before the similarity limit', () => {
+    addFrame(1, 1_000, 'outside range')
+    addFrame(2, 9_000, 'inside range')
+    embedFrame(1, 'outside range', [1, 0])
+    embedFrame(2, 'inside range', [0, 1])
+
+    const page = db.prepare(searchEmbeddingPageSql(TOY_BLOB_BYTES, true))
+    const hashes = (page.all(8_000, 10_000, 50, 0) as { hash: string }[]).map((row) => row.hash)
+
+    expect(hashes).toEqual([contentHash('inside range')])
+  })
+
   it('ranks stored content by cosine similarity, scanning in bounded pages', async () => {
     addFrame(1, 1000, 'orthogonal content')
     addFrame(2, 2000, 'exact match content')

--- a/desktop/windows/src/main/rewind/rewindFtsSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindFtsSearch.test.ts
@@ -52,6 +52,15 @@ const SEARCH_SQL = `
    LIMIT ?
 `
 
+const SEARCH_IN_WINDOW_SQL = `
+  SELECT rewind_frames.id FROM rewind_frames
+    JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
+   WHERE rewind_frames_fts MATCH ?
+     AND rewind_frames.ts BETWEEN ? AND ?
+   ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
+   LIMIT ?
+`
+
 function makeDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:')
   db.exec(SCHEMA)
@@ -67,10 +76,19 @@ function insert(db: DatabaseSync, ts: number, app: string, title: string, ocr: s
   return Number(r.lastInsertRowid)
 }
 
-function search(db: DatabaseSync, query: string, limit = 500): number[] {
+function search(
+  db: DatabaseSync,
+  query: string,
+  limit = 500,
+  scope?: { from: number; to: number }
+): number[] {
   const match = buildRewindFtsMatch(query)
   if (!match) return []
-  return (db.prepare(SEARCH_SQL).all(match, limit) as { id: number }[]).map((r) => r.id)
+  return (
+    db
+      .prepare(scope ? SEARCH_IN_WINDOW_SQL : SEARCH_SQL)
+      .all(match, ...(scope ? [scope.from, scope.to] : []), limit) as { id: number }[]
+  ).map((r) => r.id)
 }
 
 describe('rewind FTS5 search (real index)', () => {
@@ -113,6 +131,13 @@ describe('rewind FTS5 search (real index)', () => {
     const long = insert(db, 2000, 'App', 'w', `budget ${'filler '.repeat(200)}`)
     // bm25 favors the shorter document → it sorts first under ASC ordering.
     expect(search(db, 'budget')).toEqual([short, long])
+  })
+
+  it('applies the time window before limiting FTS matches', () => {
+    const db = makeDb()
+    insert(db, 1_000, 'App', 'w', 'invoice')
+    const inWindow = insert(db, 2_000, 'App', 'w', `invoice ${'filler '.repeat(200)}`)
+    expect(search(db, 'invoice', 1, { from: 1_500, to: 2_500 })).toEqual([inWindow])
   })
 
   it('user-supplied FTS special characters cannot break the query', () => {

--- a/desktop/windows/src/main/rewind/rewindFtsSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindFtsSearch.test.ts
@@ -6,7 +6,7 @@
 // (buildRewindFtsMatch) and the REAL search SQL shape are exercised.
 import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, it } from 'vitest'
-import { buildRewindFtsMatch } from './rewindSearchQuery'
+import { buildRewindFtsMatch, buildRewindFtsSearchSql } from './rewindSearchQuery'
 
 // rewind_frames + the Track 4 FTS index/triggers, verbatim from db.ts get().
 const SCHEMA = `
@@ -44,22 +44,8 @@ const SCHEMA = `
 `
 
 // The exact WHERE/ORDER-BY shape searchRewindFrames() uses in db.ts.
-const SEARCH_SQL = `
-  SELECT rewind_frames.id FROM rewind_frames
-    JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
-   WHERE rewind_frames_fts MATCH ?
-   ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
-   LIMIT ?
-`
-
-const SEARCH_IN_WINDOW_SQL = `
-  SELECT rewind_frames.id FROM rewind_frames
-    JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
-   WHERE rewind_frames_fts MATCH ?
-     AND rewind_frames.ts BETWEEN ? AND ?
-   ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
-   LIMIT ?
-`
+const SEARCH_SQL = buildRewindFtsSearchSql('rewind_frames.id', false)
+const SEARCH_IN_WINDOW_SQL = buildRewindFtsSearchSql('rewind_frames.id', true)
 
 function makeDb(): DatabaseSync {
   const db = new DatabaseSync(':memory:')

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -31,6 +31,10 @@ describe('parseRewindNaturalSearch', () => {
     expect(parsed.query).toBe('')
   })
 
+  it('treats contractions in time-only questions as boilerplate', () => {
+    expect(parseRewindNaturalSearch("What's on my screen today?", NOW).query).toBe('')
+  })
+
   it('keeps combined relative dates and day parts in one scope', () => {
     const parsed = parseRewindNaturalSearch('meeting notes yesterday morning', NOW)
     const yesterdayMorning = new Date(2026, 6, 30, 6)
@@ -43,6 +47,19 @@ describe('parseRewindNaturalSearch', () => {
 
   it('does not produce an inverted evening scope before evening starts', () => {
     const parsed = parseRewindNaturalSearch('this evening', NOW)
+    expect(parsed.from).toBe(parsed.to)
+  })
+
+  it('clamps an active day part and prefers it over today', () => {
+    const morning = new Date(2026, 6, 31, 9, 30)
+    const parsed = parseRewindNaturalSearch('meeting this morning today', morning)
+    const from = new Date(morning)
+    from.setHours(6, 0, 0, 0)
+    expect(parsed).toEqual({ query: 'meeting', from: from.getTime(), to: morning.getTime() })
+  })
+
+  it('does not produce an inverted morning scope before morning starts', () => {
+    const parsed = parseRewindNaturalSearch('this morning', new Date(2026, 6, 31, 5, 30))
     expect(parsed.from).toBe(parsed.to)
   })
 

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { parseRewindNaturalSearch } from './rewindNaturalSearch'
+
+const NOW = new Date(2026, 6, 31, 14, 30)
+
+describe('parseRewindNaturalSearch', () => {
+  it('scopes yesterday and leaves searchable words', () => {
+    const parsed = parseRewindNaturalSearch('What was on my screen: invoice yesterday?', NOW)
+    const yesterday = new Date(2026, 6, 30)
+    yesterday.setHours(0, 0, 0, 0)
+    expect(parsed).toEqual({
+      query: 'invoice',
+      from: yesterday.getTime(),
+      to: yesterday.getTime() + 86_399_999
+    })
+  })
+
+  it('makes a time-only question browse the matching period', () => {
+    const parsed = parseRewindNaturalSearch('What was on my screen this morning?', NOW)
+    const morning = new Date(NOW)
+    morning.setHours(6, 0, 0, 0)
+    expect(parsed).toEqual({
+      query: '',
+      from: morning.getTime(),
+      to: morning.getTime() + 21_599_999
+    })
+  })
+
+  it('leaves ordinary search unchanged', () => {
+    expect(parseRewindNaturalSearch('quarterly review', NOW)).toEqual({
+      query: 'quarterly review',
+      from: null,
+      to: null
+    })
+  })
+})

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -31,6 +31,11 @@ describe('parseRewindNaturalSearch', () => {
     expect(parsed.query).toBe('')
   })
 
+  it('treats happened questions as time-only searches', () => {
+    expect(parseRewindNaturalSearch('What happened yesterday?', NOW).query).toBe('')
+    expect(parseRewindNaturalSearch('what happens today', NOW).query).toBe('')
+  })
+
   it('treats contractions in time-only questions as boilerplate', () => {
     expect(parseRewindNaturalSearch("What's on my screen today?", NOW).query).toBe('')
   })

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -26,6 +26,26 @@ describe('parseRewindNaturalSearch', () => {
     })
   })
 
+  it('treats activity questions as time-only searches', () => {
+    const parsed = parseRewindNaturalSearch('What did I do yesterday?', NOW)
+    expect(parsed.query).toBe('')
+  })
+
+  it('keeps combined relative dates and day parts in one scope', () => {
+    const parsed = parseRewindNaturalSearch('meeting notes yesterday morning', NOW)
+    const yesterdayMorning = new Date(2026, 6, 30, 6)
+    expect(parsed).toEqual({
+      query: 'meeting notes',
+      from: yesterdayMorning.getTime(),
+      to: yesterdayMorning.getTime() + 21_599_999
+    })
+  })
+
+  it('does not produce an inverted evening scope before evening starts', () => {
+    const parsed = parseRewindNaturalSearch('this evening', NOW)
+    expect(parsed.from).toBe(parsed.to)
+  })
+
   it('leaves ordinary search unchanged', () => {
     expect(parseRewindNaturalSearch('quarterly review', NOW)).toEqual({
       query: 'quarterly review',

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -35,6 +35,11 @@ describe('parseRewindNaturalSearch', () => {
     expect(parseRewindNaturalSearch('What was I doing yesterday?', NOW).query).toBe('')
   })
 
+  it('strips leading delimiters before matching question framing', () => {
+    expect(parseRewindNaturalSearch('Yesterday, what was I doing?', NOW).query).toBe('')
+    expect(parseRewindNaturalSearch('Yesterday — what happened?', NOW).query).toBe('')
+  })
+
   it('treats working activity questions as time-only searches', () => {
     expect(parseRewindNaturalSearch('What was I working on yesterday?', NOW).query).toBe('')
   })

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -35,6 +35,10 @@ describe('parseRewindNaturalSearch', () => {
     expect(parseRewindNaturalSearch('What was I doing yesterday?', NOW).query).toBe('')
   })
 
+  it('treats working activity questions as time-only searches', () => {
+    expect(parseRewindNaturalSearch('What was I working on yesterday?', NOW).query).toBe('')
+  })
+
   it('treats happened questions as time-only searches', () => {
     expect(parseRewindNaturalSearch('What happened yesterday?', NOW).query).toBe('')
     expect(parseRewindNaturalSearch('what happens today', NOW).query).toBe('')
@@ -57,6 +61,10 @@ describe('parseRewindNaturalSearch', () => {
   it('removes temporal possessives from the normalized query', () => {
     expect(parseRewindNaturalSearch("today's meetings", NOW).query).toBe('meetings')
     expect(parseRewindNaturalSearch('yesterday’s invoice', NOW).query).toBe('invoice')
+  })
+
+  it('keeps meaningful words that resemble question boilerplate', () => {
+    expect(parseRewindNaturalSearch('The Daily Show yesterday', NOW).query).toBe('The Daily Show')
   })
 
   it('does not produce an inverted evening scope before evening starts', () => {

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -31,6 +31,10 @@ describe('parseRewindNaturalSearch', () => {
     expect(parsed.query).toBe('')
   })
 
+  it('treats gerund activity questions as time-only searches', () => {
+    expect(parseRewindNaturalSearch('What was I doing yesterday?', NOW).query).toBe('')
+  })
+
   it('treats happened questions as time-only searches', () => {
     expect(parseRewindNaturalSearch('What happened yesterday?', NOW).query).toBe('')
     expect(parseRewindNaturalSearch('what happens today', NOW).query).toBe('')
@@ -48,6 +52,11 @@ describe('parseRewindNaturalSearch', () => {
       from: yesterdayMorning.getTime(),
       to: yesterdayMorning.getTime() + 21_599_999
     })
+  })
+
+  it('removes temporal possessives from the normalized query', () => {
+    expect(parseRewindNaturalSearch("today's meetings", NOW).query).toBe('meetings')
+    expect(parseRewindNaturalSearch('yesterday’s invoice', NOW).query).toBe('invoice')
   })
 
   it('does not produce an inverted evening scope before evening starts', () => {

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.test.ts
@@ -66,6 +66,8 @@ describe('parseRewindNaturalSearch', () => {
   it('removes temporal possessives from the normalized query', () => {
     expect(parseRewindNaturalSearch("today's meetings", NOW).query).toBe('meetings')
     expect(parseRewindNaturalSearch('yesterday’s invoice', NOW).query).toBe('invoice')
+    expect(parseRewindNaturalSearch("this morning's meeting", NOW).query).toBe('meeting')
+    expect(parseRewindNaturalSearch('this afternoon’s notes', NOW).query).toBe('notes')
   })
 
   it('keeps meaningful words that resemble question boilerplate', () => {

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -1,0 +1,73 @@
+export type RewindSearchScope = {
+  query: string
+  from: number | null
+  to: number | null
+}
+
+const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] }> = [
+  {
+    pattern: /\byesterday\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setDate(from.getDate() - 1)
+      from.setHours(0, 0, 0, 0)
+      const to = new Date(from)
+      to.setHours(23, 59, 59, 999)
+      return [from, to]
+    }
+  },
+  {
+    pattern: /\btoday\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setHours(0, 0, 0, 0)
+      return [from, now]
+    }
+  },
+  {
+    pattern: /\bthis morning\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setHours(6, 0, 0, 0)
+      const to = new Date(now)
+      to.setHours(11, 59, 59, 999)
+      return [from, to]
+    }
+  },
+  {
+    pattern: /\bthis afternoon\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setHours(12, 0, 0, 0)
+      const to = new Date(now)
+      to.setHours(17, 59, 59, 999)
+      return [from, to]
+    }
+  },
+  {
+    pattern: /\bthis evening\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setHours(18, 0, 0, 0)
+      return [from, now]
+    }
+  }
+]
+
+const QUESTION_WORDS = /\b(?:what|was|were|did|i|my|on|the|screen|show|me|find|for)\b/gi
+
+export function parseRewindNaturalSearch(input: string, now = new Date()): RewindSearchScope {
+  let query = input.trim()
+  for (const { pattern, range } of TIME_PHRASES) {
+    if (!pattern.test(query)) continue
+    const [from, to] = range(now)
+    query = query
+      .replace(pattern, ' ')
+      .replace(QUESTION_WORDS, ' ')
+      .replace(/[?.,:;!]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+    return { query, from: from.getTime(), to: to.getTime() }
+  }
+  return { query, from: null, to: null }
+}

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -6,6 +6,39 @@ export type RewindSearchScope = {
 
 const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] }> = [
   {
+    pattern: /\byesterday morning\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setDate(from.getDate() - 1)
+      from.setHours(6, 0, 0, 0)
+      const to = new Date(from)
+      to.setHours(11, 59, 59, 999)
+      return [from, to]
+    }
+  },
+  {
+    pattern: /\byesterday afternoon\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setDate(from.getDate() - 1)
+      from.setHours(12, 0, 0, 0)
+      const to = new Date(from)
+      to.setHours(17, 59, 59, 999)
+      return [from, to]
+    }
+  },
+  {
+    pattern: /\byesterday evening\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setDate(from.getDate() - 1)
+      from.setHours(18, 0, 0, 0)
+      const to = new Date(from)
+      to.setHours(23, 59, 59, 999)
+      return [from, to]
+    }
+  },
+  {
     pattern: /\byesterday\b/i,
     range: (now) => {
       const from = new Date(now)
@@ -49,12 +82,12 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
     range: (now) => {
       const from = new Date(now)
       from.setHours(18, 0, 0, 0)
-      return [from, now]
+      return now < from ? [from, from] : [from, now]
     }
   }
 ]
 
-const QUESTION_WORDS = /\b(?:what|was|were|did|i|my|on|the|screen|show|me|find|for)\b/gi
+const QUESTION_WORDS = /\b(?:what|was|were|did|do|i|my|on|the|screen|show|me|find|for)\b/gi
 
 export function parseRewindNaturalSearch(input: string, now = new Date()): RewindSearchScope {
   let query = input.trim()

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -88,7 +88,7 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
 ]
 
 const QUESTION_WORDS =
-  /\b(?:what(?:'s|’s)?|was|were|did|do|i|my|on|the|screen|show|me|find|for)\b/gi
+  /\b(?:what(?:'s|’s)?|was|were|did|do|happened|happens|happen|i|my|on|the|screen|show|me|find|for)\b/gi
 const TIME_WORDS =
   /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today|this\s+(?:morning|afternoon|evening))\b/gi
 

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -50,21 +50,13 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
     }
   },
   {
-    pattern: /\btoday\b/i,
-    range: (now) => {
-      const from = new Date(now)
-      from.setHours(0, 0, 0, 0)
-      return [from, now]
-    }
-  },
-  {
     pattern: /\bthis morning\b/i,
     range: (now) => {
       const from = new Date(now)
       from.setHours(6, 0, 0, 0)
       const to = new Date(now)
       to.setHours(11, 59, 59, 999)
-      return [from, to]
+      return now < from ? [from, from] : [from, now < to ? now : to]
     }
   },
   {
@@ -74,7 +66,7 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
       from.setHours(12, 0, 0, 0)
       const to = new Date(now)
       to.setHours(17, 59, 59, 999)
-      return [from, to]
+      return now < from ? [from, from] : [from, now < to ? now : to]
     }
   },
   {
@@ -84,10 +76,21 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
       from.setHours(18, 0, 0, 0)
       return now < from ? [from, from] : [from, now]
     }
+  },
+  {
+    pattern: /\btoday\b/i,
+    range: (now) => {
+      const from = new Date(now)
+      from.setHours(0, 0, 0, 0)
+      return [from, now]
+    }
   }
 ]
 
-const QUESTION_WORDS = /\b(?:what|was|were|did|do|i|my|on|the|screen|show|me|find|for)\b/gi
+const QUESTION_WORDS =
+  /\b(?:what(?:'s|’s)?|was|were|did|do|i|my|on|the|screen|show|me|find|for)\b/gi
+const TIME_WORDS =
+  /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today|this\s+(?:morning|afternoon|evening))\b/gi
 
 export function parseRewindNaturalSearch(input: string, now = new Date()): RewindSearchScope {
   let query = input.trim()
@@ -95,9 +98,9 @@ export function parseRewindNaturalSearch(input: string, now = new Date()): Rewin
     if (!pattern.test(query)) continue
     const [from, to] = range(now)
     query = query
-      .replace(pattern, ' ')
+      .replace(TIME_WORDS, ' ')
       .replace(QUESTION_WORDS, ' ')
-      .replace(/[?.,:;!]/g, ' ')
+      .replace(/[?'’.,:;!]/g, ' ')
       .replace(/\s+/g, ' ')
       .trim()
     return { query, from: from.getTime(), to: to.getTime() }

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -88,9 +88,9 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
 ]
 
 const QUESTION_WORDS =
-  /\b(?:what(?:'s|’s)?|was|were|did|do|happened|happens|happen|i|my|on|the|screen|show|me|find|for)\b/gi
+  /\b(?:what(?:'s|’s)?|was|were|did|do|doing|happened|happens|happen|i|my|on|the|screen|show|me|find|for)\b/gi
 const TIME_WORDS =
-  /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today|this\s+(?:morning|afternoon|evening))\b/gi
+  /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today)(?:['’]s)?\b|\bthis\s+(?:morning|afternoon|evening)\b/gi
 
 export function parseRewindNaturalSearch(input: string, now = new Date()): RewindSearchScope {
   let query = input.trim()

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -87,22 +87,26 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
   }
 ]
 
-const QUESTION_WORDS =
-  /\b(?:what(?:'s|’s)?|was|were|did|do|doing|happened|happens|happen|i|my|on|the|screen|show|me|find|for)\b/gi
 const TIME_WORDS =
   /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today)(?:['’]s)?\b|\bthis\s+(?:morning|afternoon|evening)\b/gi
+const QUESTION_PREFIX =
+  /^\s*(?:what(?:'s|’s)?\s+on\s+my\s+screen|what\s+(?:was|were)\s+on\s+my\s+screen|what\s+(?:did|do)\s+i\s+do|what\s+(?:was|were)\s+i\s+(?:doing|working\s+on)|what\s+(?:happened|happens))\b\s*/i
+
+function normalizeRewindQuery(input: string): string {
+  return input
+    .replace(TIME_WORDS, ' ')
+    .replace(QUESTION_PREFIX, '')
+    .replace(/[?'’.,:;!]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
 
 export function parseRewindNaturalSearch(input: string, now = new Date()): RewindSearchScope {
   let query = input.trim()
   for (const { pattern, range } of TIME_PHRASES) {
     if (!pattern.test(query)) continue
     const [from, to] = range(now)
-    query = query
-      .replace(TIME_WORDS, ' ')
-      .replace(QUESTION_WORDS, ' ')
-      .replace(/[?'’.,:;!]/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
+    query = normalizeRewindQuery(query)
     return { query, from: from.getTime(), to: to.getTime() }
   }
   return { query, from: null, to: null }

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -88,7 +88,7 @@ const TIME_PHRASES: Array<{ pattern: RegExp; range: (now: Date) => [Date, Date] 
 ]
 
 const TIME_WORDS =
-  /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today)(?:['’]s)?\b|\bthis\s+(?:morning|afternoon|evening)\b/gi
+  /\b(?:yesterday\s+(?:morning|afternoon|evening)|yesterday|today|this\s+(?:morning|afternoon|evening))(?:['’]s)?\b/gi
 const QUESTION_PREFIX =
   /^\s*(?:what(?:'s|’s)?\s+on\s+my\s+screen|what\s+(?:was|were)\s+on\s+my\s+screen|what\s+(?:did|do)\s+i\s+do|what\s+(?:was|were)\s+i\s+(?:doing|working\s+on)|what\s+(?:happened|happens))\b\s*/i
 

--- a/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
+++ b/desktop/windows/src/main/rewind/rewindNaturalSearch.ts
@@ -95,6 +95,7 @@ const QUESTION_PREFIX =
 function normalizeRewindQuery(input: string): string {
   return input
     .replace(TIME_WORDS, ' ')
+    .replace(/^[\s?'’.,:;!\u2013\u2014-]+/, '')
     .replace(QUESTION_PREFIX, '')
     .replace(/[?'’.,:;!]/g, ' ')
     .replace(/\s+/g, ' ')

--- a/desktop/windows/src/main/rewind/rewindSearchQuery.ts
+++ b/desktop/windows/src/main/rewind/rewindSearchQuery.ts
@@ -111,3 +111,12 @@ export function buildRewindFtsMatch(query: string): string | null {
   if (expanded.length === 0) return null
   return expanded.join(' ')
 }
+
+export function buildRewindFtsSearchSql(columns: string, scoped: boolean): string {
+  return `SELECT ${columns} FROM rewind_frames
+           JOIN rewind_frames_fts ON rewind_frames.id = rewind_frames_fts.rowid
+          WHERE rewind_frames_fts MATCH ?
+          ${scoped ? 'AND rewind_frames.ts BETWEEN ? AND ?' : ''}
+          ORDER BY bm25(rewind_frames_fts) ASC, rewind_frames.ts DESC
+          LIMIT ?`
+}

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -354,8 +354,13 @@ const omi: OmiBridgeApi = {
   // --- Track 4 (Rewind semantic search) --- Phase 2 of a search: the same results
   // with semantic hits merged in, pushed if/when the embedding round-trip lands.
   // Keyword results are already on screen by then — see the rewind:search handler.
-  onRewindSearchResults: (cb: (r: { query: string; groups: RewindSearchGroup[] }) => void) => {
-    const listener = (_e: unknown, r: { query: string; groups: RewindSearchGroup[] }): void => cb(r)
+  onRewindSearchResults: (
+    cb: (r: { query: string; normalizedQuery: string; groups: RewindSearchGroup[] }) => void
+  ) => {
+    const listener = (
+      _e: unknown,
+      r: { query: string; normalizedQuery: string; groups: RewindSearchGroup[] }
+    ): void => cb(r)
     ipcRenderer.on('rewind:search-results', listener)
     return () => ipcRenderer.removeListener('rewind:search-results', listener)
   },

--- a/desktop/windows/src/renderer/src/hooks/useRewind.ts
+++ b/desktop/windows/src/renderer/src/hooks/useRewind.ts
@@ -51,6 +51,7 @@ export function useRewind({ active = true }: { active?: boolean } = {}): RewindS
   const [cursorTs, setCursorTs] = useState<number>(() => Date.now())
   const [playing, setPlaying] = useState(false)
   const [results, setResults] = useState<RewindSearchGroup[]>([])
+  const [normalizedQuery, setNormalizedQuery] = useState('')
 
   const framesRef = useRef(frames)
   useEffect(() => {
@@ -177,15 +178,20 @@ export function useRewind({ active = true }: { active?: boolean } = {}): RewindS
   // merged in later by the subscription below, if they arrive at all.
   const search = useCallback(async (q: string) => {
     queryRef.current = q.trim()
-    setResults(await window.omi.rewindSearch(q))
+    const result = await window.omi.rewindSearch(q)
+    setNormalizedQuery(result.normalizedQuery)
+    setResults(result.groups)
   }, [])
 
   // Phase 2 of a search (see the rewind:search handler): the same list with
   // semantic recall merged in. Applied only if it belongs to the query currently on
   // screen — a slow round-trip for "invoice" must not overwrite "receipt".
   useEffect(() => {
-    return window.omi.onRewindSearchResults(({ query, groups }) => {
-      if (query === queryRef.current) setResults(groups)
+    return window.omi.onRewindSearchResults(({ query, normalizedQuery, groups }) => {
+      if (query === queryRef.current) {
+        setNormalizedQuery(normalizedQuery)
+        setResults(groups)
+      }
     })
   }, [])
 
@@ -205,6 +211,7 @@ export function useRewind({ active = true }: { active?: boolean } = {}): RewindS
     playing,
     setPlaying,
     results,
+    normalizedQuery,
     search
   }
 }

--- a/desktop/windows/src/renderer/src/hooks/useRewind.ts
+++ b/desktop/windows/src/renderer/src/hooks/useRewind.ts
@@ -27,6 +27,7 @@ export type RewindState = {
   playing: boolean
   setPlaying: (p: boolean) => void
   results: RewindSearchGroup[]
+  normalizedQuery: string
   search: (q: string) => Promise<void>
 }
 

--- a/desktop/windows/src/renderer/src/pages/Rewind.tsx
+++ b/desktop/windows/src/renderer/src/pages/Rewind.tsx
@@ -98,6 +98,7 @@ export function Rewind(): React.JSX.Element {
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-white/35" />
             <input
               ref={inputRef}
+              data-testid="rewind-search"
               value={query}
               onChange={(e) => changeQuery(e.target.value)}
               placeholder="Search “meeting notes yesterday”…"

--- a/desktop/windows/src/renderer/src/pages/Rewind.tsx
+++ b/desktop/windows/src/renderer/src/pages/Rewind.tsx
@@ -26,6 +26,7 @@ export function Rewind(): React.JSX.Element {
   // Stable useCallbacks — destructured so effects can depend on them without
   // re-running on every render (the `r` object identity changes each render).
   const { search, jumpTo } = r
+  const highlightQuery = searching ? r.normalizedQuery : query
   // The search field is always present in the top bar (macOS keeps one page — the
   // content switches between the day timeline and the search results, it is not a
   // separate mode/route). A non-empty query IS "searching".
@@ -84,9 +85,9 @@ export function Rewind(): React.JSX.Element {
   // drill-down mini-timeline (macOS search-result markers).
   const markerTimes = useMemo(() => {
     if (!group) return []
-    const terms = highlightTerms(query)
+    const terms = highlightTerms(highlightQuery)
     return group.frames.filter((f) => lineTextMatches(f.ocrText, terms)).map((f) => f.ts)
-  }, [group, query])
+  }, [group, highlightQuery])
 
   return (
     <div ref={pageRef} data-testid="rewind-page" className="flex h-full min-h-0 flex-col gap-3 p-4">
@@ -152,7 +153,7 @@ export function Rewind(): React.JSX.Element {
             <ChevronLeft className="h-4 w-4" />
             Back to results
           </button>
-          <RewindPlayer frames={group.frames} cursorTs={r.cursorTs} highlightQuery={query} />
+          <RewindPlayer frames={group.frames} cursorTs={r.cursorTs} highlightQuery={highlightQuery} />
           <RewindTimelineBar
             frames={group.frames}
             bounds={null}
@@ -165,7 +166,7 @@ export function Rewind(): React.JSX.Element {
         <div className="min-h-0 flex-1 overflow-y-auto">
           <SearchResultsFilmstrip
             groups={r.results}
-            query={query}
+            query={highlightQuery}
             loading={searchLoading}
             onSelect={openGroup}
           />

--- a/desktop/windows/src/renderer/src/pages/Rewind.tsx
+++ b/desktop/windows/src/renderer/src/pages/Rewind.tsx
@@ -26,12 +26,12 @@ export function Rewind(): React.JSX.Element {
   // Stable useCallbacks — destructured so effects can depend on them without
   // re-running on every render (the `r` object identity changes each render).
   const { search, jumpTo } = r
-  const highlightQuery = searching ? r.normalizedQuery : query
   // The search field is always present in the top bar (macOS keeps one page — the
   // content switches between the day timeline and the search results, it is not a
   // separate mode/route). A non-empty query IS "searching".
   const [query, setQuery] = useState('')
   const searching = query.trim().length > 0
+  const highlightQuery = searching ? r.normalizedQuery : query
   // The query whose results are on screen — set only when a search resolves, so
   // "still loading" is a pure derivation (no setState-in-effect).
   const [resolvedQuery, setResolvedQuery] = useState('')
@@ -153,7 +153,11 @@ export function Rewind(): React.JSX.Element {
             <ChevronLeft className="h-4 w-4" />
             Back to results
           </button>
-          <RewindPlayer frames={group.frames} cursorTs={r.cursorTs} highlightQuery={highlightQuery} />
+          <RewindPlayer
+            frames={group.frames}
+            cursorTs={r.cursorTs}
+            highlightQuery={highlightQuery}
+          />
           <RewindTimelineBar
             frames={group.frames}
             bounds={null}

--- a/desktop/windows/src/renderer/src/pages/Rewind.tsx
+++ b/desktop/windows/src/renderer/src/pages/Rewind.tsx
@@ -99,7 +99,7 @@ export function Rewind(): React.JSX.Element {
               ref={inputRef}
               value={query}
               onChange={(e) => changeQuery(e.target.value)}
-              placeholder="Search what was on screen…"
+              placeholder="Search “meeting notes yesterday”…"
               className="w-full rounded-control border border-line bg-white/[0.07] py-1.5 pl-8 pr-8 text-sm text-white outline-none transition-colors placeholder:text-white/35 focus:border-line-strong"
             />
             {searching && (

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -127,7 +127,12 @@ export type ChatMessage = {
  * See lib/sync/outbox.ts for the transition rules and dedupe strategy.
  */
 export type ConversationSyncState =
-  'local_only' | 'pending' | 'posting' | 'done' | 'failed' | 'unconfirmed'
+  | 'local_only'
+  | 'pending'
+  | 'posting'
+  | 'done'
+  | 'failed'
+  | 'unconfirmed'
 
 /** One transcript segment in the `/v1/conversations/from-segments` request shape
  * (snake_case matches the wire verbatim). `start`/`end` are WALL-CLOCK
@@ -1709,7 +1714,13 @@ export type MemoryExportResult = {
 }
 
 export type IndexedFileType =
-  'document' | 'code' | 'image' | 'media' | 'archive' | 'application' | 'other'
+  | 'document'
+  | 'code'
+  | 'image'
+  | 'media'
+  | 'archive'
+  | 'application'
+  | 'other'
 
 export type IndexedFileRecord = {
   path: string
@@ -1803,7 +1814,14 @@ export type RebuildResult = {
 // the macOS-parity local graph synthesized from indexed_files + memories and
 // consumed by the chat pre-step. Never conflate the two mechanisms.
 export type LocalKGNodeType =
-  'project' | 'app' | 'technology' | 'person' | 'org' | 'interest' | 'file_group' | 'card' // background-synthesized natural-language overview served to the chat floor
+  | 'project'
+  | 'app'
+  | 'technology'
+  | 'person'
+  | 'org'
+  | 'interest'
+  | 'file_group'
+  | 'card' // background-synthesized natural-language overview served to the chat floor
 
 export type LocalKGNode = {
   id: string // `${slug(label)}:${nodeType}` — stable across re-synthesis

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -989,14 +989,14 @@ export type OmiBridgeApi = {
   onRewindCaptured: (cb: () => void) => () => void
   /** Phase 1 of a Rewind search: KEYWORD (FTS5/BM25) results, immediately. Never
    *  waits on the network — semantic hits follow on `onRewindSearchResults`. */
-  rewindSearch: (query: string) => Promise<RewindSearchGroup[]>
+  rewindSearch: (query: string) => Promise<{ groups: RewindSearchGroup[]; normalizedQuery: string }>
   /** Phase 2: the same result list with semantic hits merged in, delivered if and
    *  when the embedding round-trip lands. Never fires when semantic search is
    *  unavailable (signed out, backend down, nothing indexed) — the keyword results
    *  from `rewindSearch` simply stand. Callers must ignore a payload whose `query`
    *  is not the one they are currently showing. */
   onRewindSearchResults: (
-    cb: (r: { query: string; groups: RewindSearchGroup[] }) => void
+    cb: (r: { query: string; normalizedQuery: string; groups: RewindSearchGroup[] }) => void
   ) => () => void
   /** Relay the Firebase session to the main-process Rewind embedding indexer
    *  (Track 4); null on sign-out. Without it, semantic search stays inert and


### PR DESCRIPTION
## Summary

- let Rewind search understand today, yesterday, and parts of the day
- scope keyword and semantic matches to that time window; a time-only query browses sampled captures

## Verification

- focused Vitest: 14 tests
- Windows node and renderer type-checks; ESLint
- `scripts/pr-preflight --base upstream/main --lane local`

## Product invariants affected

none

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Rewind search IPC contract and hybrid FTS/vector query paths; behavior is covered by new unit and E2E tests but any missed time-parse edge case could mis-scope results.
> 
> **Overview**
> Adds **natural-language time scoping** to Windows Rewind search: phrases like *yesterday*, *today*, and *this morning* are parsed into a `from`/`to` window, question wording is stripped into a **normalized keyword**, and both FTS and semantic recall run inside that window. A **time-only** query (no remaining keywords) returns a **sampled browse** of captures in the period instead of an empty search.
> 
> The `rewind:search` IPC contract changes from a bare group array to **`{ groups, normalizedQuery }`**; phase-2 `rewind:search-results` carries the same `normalizedQuery`. The UI uses that string for OCR highlights and drill-down markers, adds `data-testid="rewind-search"`, and updates the placeholder. E2E specs and the dayscope build script are adjusted for the new shape and optional `VITE_FIREBASE_API_KEY` from `.env.example` at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f85a73adf054e699ea7af90fad6890b8e51d7b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->