### PR TITLE
fix(app): offer sync when the lane the backlog needs is free

### DIFF
--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -143,7 +143,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
     final hasAnyRecording = p.allWals.isNotEmpty;
 
     final isActive = s.isSyncing || s.isFetchingConversations;
-    final bool showSpinner = (isActive || uploaded > 0) && !p.isRateLimited;
+    final bool showSpinner = (isActive || uploaded > 0) && !p.isRateLimitedForPendingUploads;
 
     String title;
     String? progressText;
@@ -175,7 +175,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
           title = s.isFetchingConversations ? l.syncCardProcessing : l.syncCardUploadingTitle;
       }
       action = _statusActionPill(l.cancel, Colors.redAccent, () => _confirmCancel(context, p));
-    } else if (p.isRateLimited) {
+    } else if (p.isRateLimitedForPendingUploads) {
       title = switch (p.rateLimitReason) {
         RateLimitReason.backendBusy => l.syncCardBackendBusy,
         RateLimitReason.backfillPaced => l.syncCardReadyCount(readyToBackUp),

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -496,7 +496,7 @@ class _SyncPageState extends State<SyncPage> {
     final isActive = syncProvider.isSyncing;
     final uploaded = syncProvider.uploadedWals.length;
     final readyToSync = syncProvider.missingWals.length;
-    final bool showSpinner = (isActive || uploaded > 0) && !syncProvider.isRateLimited;
+    final bool showSpinner = (isActive || uploaded > 0) && !syncProvider.isRateLimitedForPendingUploads;
 
     String title;
     String? subtitle;
@@ -533,7 +533,7 @@ class _SyncPageState extends State<SyncPage> {
           }
           break;
       }
-    } else if (syncProvider.isRateLimited) {
+    } else if (syncProvider.isRateLimitedForPendingUploads) {
       title = switch (syncProvider.rateLimitReason) {
         RateLimitReason.backendBusy => l.syncCardBackendBusy,
         RateLimitReason.backfillPaced => l.syncCardReadyCount(readyToSync),

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/connectivity_service.dart';
@@ -152,8 +153,33 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// Recordings that the storage sheet's Clear All action can remove.
   int get clearableWalsCount => syncedWals.length + pendingDeletableWals.length + corruptedWals.length;
 
-  /// True while a fair-use (429) cooldown is active — uploads are paused.
+  /// True while any cooldown is active, in any lane.
+  ///
+  /// Prefer [isRateLimitedForPendingUploads] for anything that decides whether the user can act:
+  /// cooldowns are per lane, and this is true even when the lane the pending work needs is free.
   bool get isRateLimited => SyncRateLimiter.instance.isLimited;
+
+  /// The upload lanes the recordings still to back up would use.
+  Set<SyncUploadLane> get pendingUploadLanes => pendingSyncUploadLanes(
+        displaySortedWals
+            .where((wal) =>
+                wal.syncDisplayState == WalSyncDisplayState.waiting ||
+                wal.syncDisplayState == WalSyncDisplayState.retrying ||
+                wal.syncDisplayState == WalSyncDisplayState.failed)
+            .toList(),
+        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+
+  /// True only when every lane the pending recordings need is in cooldown.
+  ///
+  /// The upload path gates per lane (`SyncRateLimiter.isLimitedForLane`), so a UI that gates on
+  /// the global flag hides the Sync control for work the sync layer would happily accept — a
+  /// fresh-lane cooldown stranding a backlog that uploads through backfill.
+  bool get isRateLimitedForPendingUploads => allSyncLanesLimited(
+        pendingUploadLanes,
+        SyncRateLimiter.instance.isLimitedForLane,
+        fallback: SyncRateLimiter.instance.isLimited,
+      );
   DateTime? get rateLimitedUntil => SyncRateLimiter.instance.until;
   RateLimitReason? get rateLimitReason => SyncRateLimiter.instance.reason;
 

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -63,6 +63,23 @@ SyncUploadLane syncUploadLaneForTimestamp(int captureSeconds, int nowSeconds, {r
 SyncUploadLane _syncLaneForWal(Wal wal, int nowSeconds) =>
     syncUploadLaneForTimestamp(wal.timerStart, nowSeconds, hasServerCaptureProof: wal.conversationId != null);
 
+/// The upload lanes [pending] would actually use.
+///
+/// Rate-limit cooldowns are per lane, so callers deciding whether uploading is possible at all
+/// must ask about the lanes the work needs — a fresh-lane cooldown says nothing about a backlog
+/// that uploads through backfill.
+Set<SyncUploadLane> pendingSyncUploadLanes(List<Wal> pending, int nowSeconds) =>
+    pending.map((wal) => _syncLaneForWal(wal, nowSeconds)).toSet();
+
+/// True only when every lane in [lanes] is in cooldown. With nothing pending there is no lane to
+/// judge, so [fallback] decides.
+bool allSyncLanesLimited(
+  Set<SyncUploadLane> lanes,
+  bool Function(String lane) isLaneLimited, {
+  required bool fallback,
+}) =>
+    lanes.isEmpty ? fallback : lanes.every((lane) => isLaneLimited(lane.name));
+
 @visibleForTesting
 Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
   final counts = <String, int>{};

--- a/app/lib/services/wals/sync_upload_gate.dart
+++ b/app/lib/services/wals/sync_upload_gate.dart
@@ -48,7 +48,10 @@ class SyncUploadGate {
   /// Reconciles a previously confirmed fair-use restriction with the server.
   /// Returns whether uploads are currently allowed after all cooldowns.
   Future<bool> prepareToUpload({SyncUploadLane lane = SyncUploadLane.fresh}) async {
-    if (lane == SyncUploadLane.fresh && _limiter.hasPersistedFairUseState) {
+    // Reconcile on every lane, not just fresh. A persisted fair-use cooldown does not gate
+    // backfill, but it keeps the account in a limited state that nothing else clears, so a user
+    // whose whole backlog is backfill never reaches the self-heal.
+    if (_limiter.hasPersistedFairUseState) {
       await reconcileFairUseStatus();
     }
     return !_limiter.isLimitedForLane(lane.name);

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1369,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -2145,10 +2145,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/app/test/unit/sync_lane_aware_gating_test.dart
+++ b/app/test/unit/sync_lane_aware_gating_test.dart
@@ -1,0 +1,202 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Sync cooldowns are per lane. The regression these cover: the sync pages gated the Sync
+/// control on the account-wide `isLimited`, while uploads gate on `isLimitedForLane`. A
+/// fair-use cooldown does not block the backfill lane, so a backlog that uploads through
+/// backfill was left with no Sync button and no automatic drain — the app refusing a sync its
+/// own upload path would have accepted.
+
+SyncRateLimiter get limiter => SyncRateLimiter.instance;
+
+const int _hour = 3600;
+
+Wal _wal({required int ageSeconds, String? conversationId, int nowSeconds = 1000000}) => Wal(
+      timerStart: nowSeconds - ageSeconds,
+      codec: BleAudioCodec.opus,
+      seconds: 30,
+      conversationId: conversationId,
+    );
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    limiter.clear();
+  });
+
+  group('pendingSyncUploadLanes', () {
+    const now = 1000000;
+
+    test('a recent recording with server capture proof is fresh', () {
+      final lanes = pendingSyncUploadLanes([_wal(ageSeconds: _hour, conversationId: 'conv-1')], now);
+      expect(lanes, {SyncUploadLane.fresh});
+    });
+
+    test('an old recording is backfill even with capture proof', () {
+      final lanes = pendingSyncUploadLanes([_wal(ageSeconds: 48 * _hour, conversationId: 'conv-1')], now);
+      expect(lanes, {SyncUploadLane.backfill});
+    });
+
+    test('a recording with no conversation is backfill however recent', () {
+      final lanes = pendingSyncUploadLanes([_wal(ageSeconds: 60)], now);
+      expect(lanes, {SyncUploadLane.backfill});
+    });
+
+    test('a mixed backlog reports both lanes', () {
+      final lanes = pendingSyncUploadLanes([
+        _wal(ageSeconds: _hour, conversationId: 'conv-1'),
+        _wal(ageSeconds: 48 * _hour, conversationId: 'conv-2'),
+      ], now);
+      expect(lanes, {SyncUploadLane.fresh, SyncUploadLane.backfill});
+    });
+
+    test('nothing pending reports no lanes', () {
+      expect(pendingSyncUploadLanes(const [], now), isEmpty);
+    });
+  });
+
+  group('allSyncLanesLimited', () {
+    bool onlyFreshLimited(String lane) => lane == SyncUploadLane.fresh.name;
+
+    test('a backlog on a free lane is not blocked by another lane cooldown', () {
+      expect(
+        allSyncLanesLimited({SyncUploadLane.backfill}, onlyFreshLimited, fallback: true),
+        isFalse,
+      );
+    });
+
+    test('work on the limited lane is blocked', () {
+      expect(allSyncLanesLimited({SyncUploadLane.fresh}, onlyFreshLimited, fallback: false), isTrue);
+    });
+
+    test('a mixed backlog is not blocked while either lane is free', () {
+      expect(
+        allSyncLanesLimited({SyncUploadLane.fresh, SyncUploadLane.backfill}, onlyFreshLimited, fallback: true),
+        isFalse,
+      );
+    });
+
+    test('every lane limited is blocked', () {
+      expect(
+        allSyncLanesLimited({SyncUploadLane.fresh, SyncUploadLane.backfill}, (_) => true, fallback: false),
+        isTrue,
+      );
+    });
+
+    test('with nothing pending the fallback decides', () {
+      expect(allSyncLanesLimited(const {}, (_) => false, fallback: true), isTrue);
+      expect(allSyncLanesLimited(const {}, (_) => true, fallback: false), isFalse);
+    });
+  });
+
+  group('the UI gate matches the upload gate', () {
+    test('a fair-use cooldown leaves a backfill backlog actionable', () {
+      limiter.markLimited(retryAfterSeconds: 30 * 24 * _hour, reason: RateLimitReason.fairUse);
+
+      // What the old UI read: account-wide, and true.
+      expect(limiter.isLimited, isTrue);
+      // What the upload path reads: the backfill lane is free, so an upload would be accepted.
+      expect(limiter.isLimitedForLane(SyncUploadLane.backfill.name), isFalse);
+
+      // The gate the UI now reads must agree with the upload path, or it hides a sync that works.
+      final blocked = allSyncLanesLimited(
+        {SyncUploadLane.backfill},
+        limiter.isLimitedForLane,
+        fallback: limiter.isLimited,
+      );
+      expect(blocked, isFalse);
+    });
+
+    test('a fair-use cooldown still blocks fresh work', () {
+      limiter.markLimited(retryAfterSeconds: 1800, reason: RateLimitReason.fairUse);
+
+      expect(limiter.isLimitedForLane(SyncUploadLane.fresh.name), isTrue);
+      expect(
+        allSyncLanesLimited({SyncUploadLane.fresh}, limiter.isLimitedForLane, fallback: limiter.isLimited),
+        isTrue,
+      );
+    });
+
+    test('a backend-busy cooldown blocks both lanes', () {
+      limiter.markLimited(retryAfterSeconds: 600, reason: RateLimitReason.backendBusy);
+
+      expect(
+        allSyncLanesLimited(
+          {SyncUploadLane.fresh, SyncUploadLane.backfill},
+          limiter.isLimitedForLane,
+          fallback: limiter.isLimited,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('backfill reconciliation', () {
+    test('a stale fair-use cooldown self-heals on a backfill upload', () async {
+      SharedPreferencesUtil().saveInt('syncRateLimitedUntilMs', DateTime.now().millisecondsSinceEpoch + 60000);
+      SharedPreferencesUtil().saveString('syncRateLimitedReason', RateLimitReason.fairUse.name);
+      var statusFetches = 0;
+      final gate = SyncUploadGate(
+        limiter: limiter,
+        fairUseStatusLoader: () async {
+          statusFetches++;
+          return {'stage': 'none'};
+        },
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+            UploadFilesResult.queued('job-1'),
+      );
+
+      final allowed = await gate.prepareToUpload(lane: SyncUploadLane.backfill);
+
+      // Previously the backfill lane skipped reconciliation entirely, so the persisted cooldown
+      // outlived the server state that had already cleared.
+      expect(statusFetches, 1);
+      expect(allowed, isTrue);
+      expect(limiter.hasPersistedFairUseState, isFalse);
+      expect(limiter.isLimited, isFalse);
+    });
+
+    test('reconciliation is skipped when nothing is persisted', () async {
+      var statusFetches = 0;
+      final gate = SyncUploadGate(
+        limiter: limiter,
+        fairUseStatusLoader: () async {
+          statusFetches++;
+          return {'stage': 'none'};
+        },
+        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+            UploadFilesResult.queued('job-2'),
+      );
+
+      expect(await gate.prepareToUpload(lane: SyncUploadLane.backfill), isTrue);
+      expect(statusFetches, 0);
+    });
+  });
+
+  // Static wiring check, not behavioural coverage: the widget tree is not exercised here, so
+  // this only pins which getter the pages read. The behaviour it protects is covered above.
+  group('sync pages read the lane-aware gate (static)', () {
+    for (final path in const [
+      'lib/pages/conversations/auto_sync_page.dart',
+      'lib/pages/conversations/sync_page.dart',
+    ]) {
+      test(path, () {
+        final source = File(path).readAsStringSync();
+        expect(source.contains('isRateLimitedForPendingUploads'), isTrue,
+            reason: '$path must gate on the lanes the pending work needs');
+        expect(RegExp(r'isRateLimited\b(?!ForPendingUploads)').hasMatch(source), isFalse,
+            reason: '$path must not gate on the account-wide cooldown; uploads gate per lane');
+      });
+    }
+  });
+}


### PR DESCRIPTION
## What changed and why

Reported: an account showing a backlog of recordings "waiting to sync", with no Sync button and no automatic drain. The backend shows nothing wrong for that account because the app never calls it — the block is entirely client-side.

Two layers disagree about what "rate limited" means:

- **Uploads** gate per lane — `SyncRateLimiter.isLimitedForLane(lane)`. A `fairUse` cooldown does **not** block the `backfill` lane.
- **The sync pages** gated on the account-wide `SyncRateLimiter.isLimited`, true when *any* lane is in cooldown.

So a fair-use cooldown hid the Sync control for exactly the files that upload through backfill — the app refusing a sync its own upload path would have accepted. It disappears completely rather than being disabled, because the card's rate-limited branch is evaluated before the two branches that render the Sync pill (`attention > 0`, `readyToBackUp > 0`).

The account-wide getter was correct when written — there was a single cooldown then, so global *was* per-lane. It became wrong when #9412 split the lanes underneath it without moving the callers.

### Changes

- **`pendingSyncUploadLanes(pending, now)`** — the lanes the pending recordings would actually use, from the existing rule (server capture proof plus the 6h fresh cutoff). No new policy.
- **`isRateLimitedForPendingUploads`** — true only when *every* lane the pending work needs is in cooldown. Both sync pages read this instead of the account-wide flag.
- **`prepareToUpload` reconciles on every lane**, not only `fresh`. This is the second half of the trap: a persisted fair-use cooldown does not gate backfill, but nothing else clears it, so a user whose whole backlog is backfill never reached the self-heal and a cooldown the server had already lifted could outlive it locally for up to 30 days.

Informative titles are unchanged — when the needed lanes really are limited, the card still explains why.

## Product invariants affected

none

<!-- `scripts/pr-preflight --suggest` reports no invariant path globs matched by this diff. -->

## How it was verified

- **`app/test.sh` — 972 tests pass.**
- **`test/unit/sync_lane_aware_gating_test.dart` (17 new).** Reverting just the reconciliation change turns the file red (`+13 -1`), so it fails against the pre-fix code rather than restating the new code. Covers lane classification (fresh vs backfill, mixed, empty), the all-lanes-limited truth table, and the UI-gate/upload-gate contract across all three cooldown kinds (`fairUse`, `backfill`, `backendBusy`).
- The page wiring is asserted by reading the two page sources. That is a static tripwire, not behavioural coverage, and is labelled as such in the file — the widget tree is not exercised, so it only pins which getter the pages call.

**Not verified against the reporting device.** This fixes a defect that produces exactly the reported symptoms, but two other branches render an actionless card as well — a stuck `isSyncing` (spinner + Cancel) and `uploaded > 0` ("Processing"). Distinguishing them needs a screenshot of the sync card or app logs. If that device turns out to be in one of those branches, this PR is not its fix.

## Tests

`app/test/unit/sync_lane_aware_gating_test.dart`.

## Failure class (fixes)

Failure-Class: none

<!--
No existing FC-* class covers it: a caller left reading a coarse predicate after the predicate it
wraps was split into finer ones, so two layers enforce different rules. Arguably a class, but one
instance is thin evidence, and the guard that would prevent recurrence lands here — a contract
test pinning the UI gate to the upload gate.
-->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

