### PR TITLE
fix(desktop): stop reporting an aged idle realtime socket reset as an error

### DIFF
--- a/.github/failure-classes/FC-lifecycle-close-classified-by-transport-phase.json
+++ b/.github/failure-classes/FC-lifecycle-close-classified-by-transport-phase.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-lifecycle-close-classified-by-transport-phase",
+  "violated_contract": "A connection teardown the system already recognizes as an expected lifecycle event must classify as expected on every path it can arrive on. Dispatching on the transport phase that surfaced the close ahead of the lifecycle predicate reports an ordinary teardown as a production fault and as a dependency-health failure, and buries the genuine fast-fail closes the classifier exists to surface.",
+  "canonical_prevention": "Evaluate the expected-lifecycle predicate before dispatching on transport phase or failure kind, key it on typed signals the transport already carries (errno, elapsed socket lifetime, turn ownership) rather than localized failure text, and cover both an expected instance and its adjacent genuine failure — the same errno seen fast, or during an owned turn — in the classifier's regression suite.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift",
+    "desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift"
+  ],
+  "evidence_prs": [
+    10935
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -252,6 +252,32 @@ enum RealtimeHubSchemaRefreshPolicy {
 enum RealtimeHubCloseClassifier {
   static let idleTeardownThreshold: TimeInterval = 60
 
+  /// Errnos a socket reports once the peer (or an intermediary) has dropped it.
+  /// Read from the typed errno rather than the localized failure text.
+  private static let idleDisconnectPOSIXCodes: Set<Int> = [
+    Int(POSIXErrorCode.ECONNABORTED.rawValue),
+    Int(POSIXErrorCode.ECONNRESET.rawValue),
+    Int(POSIXErrorCode.ENOTCONN.rawValue),
+    Int(POSIXErrorCode.ETIMEDOUT.rawValue),
+  ]
+
+  /// A warm socket that outlived the idle window while owning no turn is dropped by
+  /// the peer as an ordinary idle teardown — the recovery path already reads
+  /// `aliveFor > 60` that way and re-warms the same provider. On the read/write side
+  /// that arrives as ECONNRESET/ENOTCONN rather than a provider close, so the
+  /// failure-kind switch used to label it a transport error and report it. A fast
+  /// disconnect, or one during an active turn, is a genuine transport failure and
+  /// still falls through as reportable.
+  private static func isAgedIdleDisconnect(
+    _ failure: RealtimeHubTransportFailure,
+    aliveFor: TimeInterval,
+    hasActiveTurn: Bool
+  ) -> Bool {
+    guard !hasActiveTurn, aliveFor >= idleTeardownThreshold else { return false }
+    guard failure.systemDomain == "posix", let code = failure.systemCode else { return false }
+    return idleDisconnectPOSIXCodes.contains(code)
+  }
+
   static func category(
     failure: RealtimeHubTransportFailure,
     aliveFor: TimeInterval,
@@ -267,10 +293,11 @@ enum RealtimeHubCloseClassifier {
       return .transportConnect
     case .handshake:
       return .transportHandshake
-    case .receive:
-      return .transportReceive
-    case .send:
-      return .transportSend
+    case .receive, .send:
+      if isAgedIdleDisconnect(failure, aliveFor: aliveFor, hasActiveTurn: hasActiveTurn) {
+        return .expectedIdleTeardown
+      }
+      return failure.kind == .receive ? .transportReceive : .transportSend
     case .protocolViolation:
       return .transportProtocolViolation
     case .providerError:

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionTypes.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionTypes.swift
@@ -74,7 +74,7 @@ struct RealtimeHubTransportFailure: Equatable, Sendable {
       kind: kind(for: failure.phase),
       message: failure.message,
       systemDomain: boundedSystemDomain(failure.underlyingError),
-      systemCode: failure.underlyingError.map { ($0 as NSError).code })
+      systemCode: failure.underlyingError.map { posixCode($0) ?? ($0 as NSError).code })
   }
 
   static func providerClose(code: Int, reason: String) -> Self {
@@ -101,7 +101,7 @@ struct RealtimeHubTransportFailure: Equatable, Sendable {
       kind: phase,
       message: error.localizedDescription,
       systemDomain: boundedSystemDomain(error),
-      systemCode: (error as NSError).code)
+      systemCode: posixCode(error) ?? (error as NSError).code)
   }
 
   private static func kind(
@@ -128,12 +128,25 @@ struct RealtimeHubTransportFailure: Equatable, Sendable {
       && nsError.code == Int(POSIXErrorCode.EADDRNOTAVAIL.rawValue)
   }
 
+  /// The POSIX errno behind a transport failure, if it has one. `NWError.posix` is
+  /// the shape the read/write path actually produces and it does not bridge into
+  /// `NSPOSIXErrorDomain`, so it has to be unwrapped explicitly — the same typed
+  /// read `isLocalAddressUnavailable` already performs.
+  static func posixCode(_ error: Error) -> Int? {
+    if let networkError = error as? NWError,
+      case .posix(let code) = networkError
+    {
+      return Int(code.rawValue)
+    }
+    let nsError = error as NSError
+    return nsError.domain == NSPOSIXErrorDomain ? nsError.code : nil
+  }
+
   private static func boundedSystemDomain(_ error: Error?) -> String? {
     guard let error else { return nil }
+    if posixCode(error) != nil { return "posix" }
     if error is NWError { return "network" }
-    let domain = (error as NSError).domain
-    if domain == NSPOSIXErrorDomain { return "posix" }
-    if domain == NSURLErrorDomain { return "url" }
+    if (error as NSError).domain == NSURLErrorDomain { return "url" }
     return "other"
   }
 }

--- a/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
@@ -1,3 +1,4 @@
+import Network
 import XCTest
 
 @testable import Omi_Computer
@@ -166,6 +167,74 @@ final class RealtimeHubCloseClassifierTests: XCTestCase {
       aliveFor: 120)
 
     XCTAssertNil(category)
+    XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testRecordsTypedPOSIXErrnoForNetworkFrameworkFailures() {
+    let failure = RealtimeHubTransportFailure.system(
+      NWError.posix(.ECONNRESET), phase: .receive)
+
+    XCTAssertEqual(failure.systemDomain, "posix")
+    XCTAssertEqual(failure.systemCode, Int(POSIXErrorCode.ECONNRESET.rawValue))
+  }
+
+  func testClassifiesAgedIdleReceiveResetAsExpectedTeardown() {
+    let failure = RealtimeHubTransportFailure.system(
+      NWError.posix(.ECONNRESET), phase: .receive)
+    let category = RealtimeHubCloseClassifier.category(
+      failure: failure,
+      aliveFor: RealtimeHubCloseClassifier.idleTeardownThreshold + 1,
+      provider: .gemini)
+
+    XCTAssertEqual(category, .expectedIdleTeardown)
+    XCTAssertFalse(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testClassifiesAgedIdleSendDisconnectAsExpectedTeardown() {
+    let failure = RealtimeHubTransportFailure.system(
+      NWError.posix(.ENOTCONN), phase: .send)
+    let category = RealtimeHubCloseClassifier.category(
+      failure: failure,
+      aliveFor: 600,
+      provider: .gemini)
+
+    XCTAssertEqual(category, .expectedIdleTeardown)
+  }
+
+  func testClassifiesFastReceiveResetAsReportableTransportError() {
+    let failure = RealtimeHubTransportFailure.system(
+      NWError.posix(.ECONNRESET), phase: .receive)
+    let category = RealtimeHubCloseClassifier.category(
+      failure: failure,
+      aliveFor: 3,
+      provider: .gemini)
+
+    XCTAssertEqual(category, .transportReceive)
+    XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testClassifiesAgedReceiveResetDuringTurnAsReportableTransportError() {
+    let failure = RealtimeHubTransportFailure.system(
+      NWError.posix(.ECONNRESET), phase: .receive)
+    let category = RealtimeHubCloseClassifier.category(
+      failure: failure,
+      aliveFor: 600,
+      hasActiveTurn: true,
+      provider: .gemini)
+
+    XCTAssertEqual(category, .transportReceive)
+    XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
+  }
+
+  func testClassifiesAgedIdleNonDisconnectReceiveFailureAsReportableTransportError() {
+    let failure = RealtimeHubTransportFailure.system(
+      NWError.posix(.EHOSTUNREACH), phase: .receive)
+    let category = RealtimeHubCloseClassifier.category(
+      failure: failure,
+      aliveFor: 600,
+      provider: .gemini)
+
+    XCTAssertEqual(category, .transportReceive)
     XCTAssertTrue(RealtimeHubCloseClassifier.shouldReportToSentry(category))
   }
 

--- a/desktop/macos/changelog/unreleased/20260731-realtime-idle-socket-reset.json
+++ b/desktop/macos/changelog/unreleased/20260731-realtime-idle-socket-reset.json
@@ -1,0 +1,1 @@
+{"change":"Stopped reporting an ordinary idle voice-socket disconnect as a realtime session error"}


### PR DESCRIPTION
## Bug

The two largest live macOS realtime clusters in Sentry — `Desktop error [realtime/missing_underlying_error/runtime]`, ~51k events across ~1.7k users, first seen 2026-07-24 and still firing — are ordinary idle socket deaths reported as production errors.

Sampling 37 recent events from those clusters and reading their incident attachments: **34 are `transport_receive` with `activeTurn=false`**, and **30** carry `receive: POSIXErrorCode(rawValue: 54): Connection reset by peer` after **108–1019 s** alive. Example tail:

```
RealtimeHub: session closed category=transport_receive provider=gemini aliveFor=1019s detail=receive: POSIXErrorCode(rawValue: 54): Connection reset by peer
RealtimeHub: session error category=transport_receive provider=gemini activeTurn=false
```

## Root cause

`RealtimeHubCloseClassifier` already models this: a warm socket that outlived `idleTeardownThreshold` (60 s) while owning no turn is `.expectedIdleTeardown`, which re-warms quietly instead of reporting — and the recovery path reads the same `aliveFor > 60` predicate to reset its reconnect strike budget.

But `category(failure:)` dispatches on `failure.kind` **first** and returns `.transportReceive` / `.transportSend` before that predicate runs. The rule was therefore only ever reachable for `.providerClose` / `.unknown` kinds (the ENOTCONN write race it was written against). In production the idle socket almost always dies on the **read** side, as ECONNRESET — so every one of those closes was captured as a Sentry error and recorded as a `provider_transient` credential failure.

This is the same failure the in-code OMI-DESKTOP-27C mitigation was written for, recurring on the read path.

## Fix

- Classify an aged, turn-less read/write disconnect (`ECONNABORTED`, `ECONNRESET`, `ENOTCONN`, `ETIMEDOUT`) as `.expectedIdleTeardown`. A fast disconnect, one during an active turn, or any other errno still falls through as a reportable transport error.
- Read the errno from the typed failure fields, not the localized message: `NWError.posix` does not bridge into `NSPOSIXErrorDomain`, so `RealtimeHubTransportFailure` now unwraps it the way `isLocalAddressUnavailable` already did and records `systemDomain: "posix"` with the real errno instead of `"network"` and an enum case index.

Recovery is unchanged: only `.expectedSessionRotation` short-circuits the recovery path, so a reclassified close still falls through to the same re-warm.

## What I tested

- `swift test --package-path Desktop --filter RealtimeHubCloseClassifierTests` — **22/22 green**, 6 new.
- **Mutation check**: dropping the classifier branch fails exactly the 3 new expected-teardown assertions and nothing else, so the guard is real; restored and re-run green.
- Neighbouring suites green: `VoiceTurnReducerTests` 74/74, `RealtimeHubBargeInContinuityTests` 67/67, `RealtimeHubSessionInputLifecycleTests` 21/21, `DesktopDiagnosticsManagerTests` 31/31, `DesktopErrorTelemetryTests` 6/6.
- `RealtimeHubSessionHandoffPolicyTests` shows 7 failures under a raw `swift test --filter`; **confirmed identical on unmodified `main`** (stash + rerun), so pre-existing and unrelated.
- Not exercised against a live provider socket dying idle — that needs a real long-lived Gemini Live session. The classifier is a pure function and is covered by the hermetic tests above.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Neither behavior changes: this only relabels the close category for an aged, turn-less socket disconnect. Recovery is untouched (only `.expectedSessionRotation` short-circuits it), and the `hasActiveTurn` guard keeps every close that could interrupt a live voice turn on the reportable path.

Failure-Class: new

New class `FC-lifecycle-close-classified-by-transport-phase` (definition added in this PR): an expected-lifecycle teardown must classify as expected on every path it can arrive on, not only the one the original mitigation happened to see. It is not a shared primitive because the predicate is per-transport; the reusable surface is the classifier's own regression suite, which now pins both the expected instance and its adjacent genuine failure.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

