### PR TITLE
fix(stt): keep Velma off undecoded PCM codecs and log frame shape on rejection

### DIFF
--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -94,6 +94,12 @@ MODULATE_SUPPORTED_LANGUAGES: Final[frozenset[str]] = frozenset(
     }
 )
 
+# Client codecs whose bytes reach the provider without a decoder in between, so
+# nothing guarantees each frame is a whole number of 16-bit samples. Velma closes
+# the stream on any frame that is not, and live sessions have no in-session
+# failover, so it is not served these codecs until the cause is confirmed.
+MODULATE_EXCLUDED_CODECS: Final[frozenset[str]] = frozenset({'pcm16', 'linear16'})
+
 # This is the single source of truth for provider enablement. Cloud Deepgram is
 # intentionally absent from every serving surface. Self-hosted Deepgram is a
 # distinct product and remains available only to the streaming runtime that has
@@ -197,6 +203,11 @@ def normalized_stt_language(language: str | None) -> str:
 def modulate_supports_language(language: str | None) -> bool:
     """Return whether Velma-2 accepts a language code on a serving surface."""
     return normalized_stt_language(language) in MODULATE_SUPPORTED_LANGUAGES
+
+
+def modulate_supports_codec(codec: str | None) -> bool:
+    """Return whether a client codec may be served by Velma-2."""
+    return (codec or '').strip().lower() not in MODULATE_EXCLUDED_CODECS
 
 
 def supports_live_multilingual_mode(language: str | None) -> bool:

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -165,6 +165,7 @@ class ListenReceiver:
                     modulate_callback or callback,
                     sample_rate,
                     self.host.stt_language,
+                    codec=self.host.request.codec,
                 ),
             )
             self.host.stt_service = actual_service
@@ -172,7 +173,12 @@ class ListenReceiver:
                 self.host.stt_model = 'velma-2'
             return socket
         if self.host.stt_service == STTService.modulate:
-            return await process_audio_modulate(modulate_callback or callback, sample_rate, self.host.stt_language)
+            return await process_audio_modulate(
+                modulate_callback or callback,
+                sample_rate,
+                self.host.stt_language,
+                codec=self.host.request.codec,
+            )
         if self.host.stt_service == STTService.deepgram:
             return await process_audio_dg(
                 callback,

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -268,6 +268,7 @@ class ListenSessionRuntime:
             self.language,
             multi_lang_enabled=not single_language_mode,
             preferred_service=request.stt_service,
+            codec=request.codec,
         )
         self.parity_capture = ListenParityCapture.from_environ(
             principal_id=request.uid,

--- a/backend/tests/unit/test_modulate_codec_gate.py
+++ b/backend/tests/unit/test_modulate_codec_gate.py
@@ -1,0 +1,115 @@
+import asyncio
+
+import pytest
+
+from config.stt_provider_policy import STTServingSurface, modulate_supports_codec
+from utils.stt import streaming
+from utils.stt.streaming import STTService, SafeModulateSocket, get_stt_service_for_language
+
+DECODED_CODECS = ['opus', 'opus_fs320', 'aac', 'lc3', 'lc3_fs1030', 'pcm8']
+UNDECODED_CODECS = ['pcm16', 'linear16', 'PCM16', ' linear16 ']
+
+
+@pytest.mark.parametrize('codec', DECODED_CODECS)
+def test_decoded_codecs_stay_eligible_for_velma(codec):
+    assert modulate_supports_codec(codec) is True
+
+
+@pytest.mark.parametrize('codec', UNDECODED_CODECS)
+def test_undecoded_pcm_codecs_are_excluded_from_velma(codec):
+    assert modulate_supports_codec(codec) is False
+
+
+def test_unknown_codec_is_not_excluded():
+    assert modulate_supports_codec(None) is True
+    assert modulate_supports_codec('') is True
+
+
+def test_selection_routes_decoded_codec_to_velma(monkeypatch):
+    monkeypatch.setattr(streaming, 'stt_service_models', ['modulate-velma-2', 'parakeet'])
+    service, language, model = get_stt_service_for_language('en', surface=STTServingSurface.STREAMING, codec='opus')
+    assert service == STTService.modulate
+    assert model == 'velma-2'
+    assert language == 'multi'
+
+
+def test_selection_skips_velma_for_raw_pcm(monkeypatch):
+    monkeypatch.setattr(streaming, 'stt_service_models', ['modulate-velma-2', 'parakeet'])
+    monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.invalid')
+    service, _, _ = get_stt_service_for_language('en', surface=STTServingSurface.STREAMING, codec='pcm16')
+    assert service != STTService.modulate
+
+
+def test_selection_without_codec_is_unchanged(monkeypatch):
+    monkeypatch.setattr(streaming, 'stt_service_models', ['modulate-velma-2', 'parakeet'])
+    service, _, _ = get_stt_service_for_language('en', surface=STTServingSurface.STREAMING)
+    assert service == STTService.modulate
+
+
+def test_preferred_service_cannot_bypass_the_codec_gate(monkeypatch):
+    monkeypatch.setattr(streaming, 'stt_service_models', ['parakeet', 'modulate-velma-2'])
+    monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.invalid')
+    service, _, _ = get_stt_service_for_language(
+        'en', surface=STTServingSurface.STREAMING, preferred_service='modulate', codec='linear16'
+    )
+    assert service != STTService.modulate
+
+
+class _StubWS:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        return None
+
+    def __aiter__(self):
+        async def _gen():
+            if False:
+                yield None
+
+        return _gen()
+
+
+def _socket(loop, context=None):
+    sock = SafeModulateSocket(_StubWS(), lambda segments: None, loop, stream_context=context)
+    sock._recv_task.cancel()
+    sock._send_task.cancel()
+    return sock
+
+
+def test_stream_shape_log_reports_frame_geometry():
+    loop = asyncio.new_event_loop()
+    try:
+        sock = _socket(loop, {'codec': 'pcm16', 'sample_rate': 16000, 'language': 'en'})
+        sock.send(b'\x00' * 960)
+        sock.send(b'\x00' * 320)
+        line = sock._stream_shape_log()
+    finally:
+        loop.close()
+
+    assert 'codec=pcm16' in line
+    assert 'sample_rate=16000' in line
+    assert 'language=en' in line
+    assert 'frames=2' in line
+    assert 'bytes=1280' in line
+    assert 'odd_frames=0' in line
+    assert 'min_frame=320' in line
+    assert 'max_frame=960' in line
+    assert 'last_frame=320' in line
+
+
+def test_stream_shape_log_counts_odd_frames():
+    loop = asyncio.new_event_loop()
+    try:
+        sock = _socket(loop)
+        sock.send(b'\x00' * 101)
+        sock.send(b'\x00' * 100)
+        line = sock._stream_shape_log()
+    finally:
+        loop.close()
+
+    assert 'odd_frames=1' in line
+    assert 'frames=2' in line

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -20,6 +20,7 @@ from config.stt_provider_policy import (
     PARAKEET_PROVIDER,
     STTServingSurface,
     default_models_for_surface,
+    modulate_supports_codec,
     modulate_supports_language,
     normalized_stt_language,
     parakeet_supports_language,
@@ -307,6 +308,7 @@ def get_stt_service_for_language(
     *,
     surface: STTServingSurface = STTServingSurface.STREAMING,
     preferred_service: Optional[str] = None,
+    codec: Optional[str] = None,
 ) -> Tuple[Optional[STTService], Optional[str], Optional[str]]:
     """Select a serving STT provider allowed for the requested product surface.
 
@@ -353,6 +355,7 @@ def get_stt_service_for_language(
                 model == 'modulate-velma-2'
                 and provider_is_enabled(MODULATE_PROVIDER, surface)
                 and modulate_supports_language(requested_language)
+                and modulate_supports_codec(codec)
             ):
                 return (STTService.modulate, requested_language, 'velma-2'), parakeet_fallback_reason
         return None, parakeet_fallback_reason
@@ -678,6 +681,7 @@ class SafeModulateSocket(STTSocket):
         stream_transcript: Callable[[List[Dict[str, Any]]], None],
         loop: asyncio.AbstractEventLoop,
         preseconds: int = 0,
+        stream_context: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._ws: Any = ws
         self._stream_transcript: Callable[[List[Dict[str, Any]]], None] = stream_transcript
@@ -699,6 +703,15 @@ class SafeModulateSocket(STTSocket):
         # single odd-length frame ends the session even after valid audio. Nothing upstream
         # guarantees even-length buffers, so carry a trailing odd byte to the next frame.
         self._pending_odd_byte: bytes = b''
+        # Frame shape is the only thing a rejection is known to depend on, and it is
+        # invisible once the socket dies, so it is tallied for the failure log.
+        self._stream_context: Dict[str, Any] = dict(stream_context or {})
+        self._frames_sent = 0
+        self._bytes_sent = 0
+        self._odd_frames = 0
+        self._min_frame = 0
+        self._max_frame = 0
+        self._last_frame = 0
         self._recv_task: asyncio.Task[None] = asyncio.ensure_future(self._recv_loop(), loop=loop)
         self._send_task: asyncio.Task[None] = asyncio.ensure_future(self._send_loop(), loop=loop)
 
@@ -719,6 +732,19 @@ class SafeModulateSocket(STTSocket):
                 self._dead = True
                 self._death_reason = reason
 
+    def _stream_shape_log(self) -> str:
+        """Return the frame-shape tally a provider rejection has to be explained by."""
+        fields = {
+            **self._stream_context,
+            'frames': self._frames_sent,
+            'bytes': self._bytes_sent,
+            'odd_frames': self._odd_frames,
+            'min_frame': self._min_frame,
+            'max_frame': self._max_frame,
+            'last_frame': self._last_frame,
+        }
+        return ' '.join(f'{key}={value}' for key, value in fields.items())
+
     def send(self, data: bytes) -> bool:
         """Synchronously accept audio only when it reaches the provider queue.
 
@@ -737,6 +763,13 @@ class SafeModulateSocket(STTSocket):
                 # later frame would be queued and never sent. The Parakeet sockets guard the same
                 # way. The header stays pending because _header_sent is only set once it is queued.
                 return True
+            self._frames_sent += 1
+            self._bytes_sent += len(data)
+            self._last_frame = len(data)
+            self._max_frame = max(self._max_frame, len(data))
+            self._min_frame = len(data) if self._frames_sent == 1 else min(self._min_frame, len(data))
+            if len(data) % 2:
+                self._odd_frames += 1
             aligned = self._pending_odd_byte + data
             self._pending_odd_byte = aligned[-1:] if len(aligned) % 2 else b''
             if self._pending_odd_byte:
@@ -853,7 +886,7 @@ class SafeModulateSocket(STTSocket):
                 msg_type = msg.get('type', '')
                 if msg_type == 'error':
                     err = msg.get('error', msg.get('message', 'unknown error'))
-                    logger.error(f'Modulate streaming error: {err}')
+                    logger.error('Modulate streaming error: %s %s', err, self._stream_shape_log())
                     if self._prev_partial_text:
                         self._flush_partial()
                     self._done_event.set()
@@ -969,6 +1002,7 @@ async def process_audio_modulate(
     sample_rate: int,
     language: str,
     preseconds: int = 0,
+    codec: Optional[str] = None,
 ) -> SafeModulateSocket:
     api_key = os.getenv('MODULATE_API_KEY')
     if not api_key:
@@ -989,7 +1023,13 @@ async def process_audio_modulate(
     logger.info(f'Connecting to Modulate Velma-2 streaming sample_rate={sample_rate} language={language}')
     ws = await websockets.connect(uri, ping_timeout=10, ping_interval=10)
     loop = asyncio.get_running_loop()
-    sock = SafeModulateSocket(ws, stream_transcript, loop, preseconds=preseconds)
+    sock = SafeModulateSocket(
+        ws,
+        stream_transcript,
+        loop,
+        preseconds=preseconds,
+        stream_context={'codec': codec or 'unknown', 'sample_rate': sample_rate, 'language': language},
+    )
     logger.info('Modulate Velma-2 streaming connection established')
     return sock
 


### PR DESCRIPTION
Velma is not served client codecs whose bytes reach the provider without a decoder in between, and a Velma rejection now logs the frame geometry it has to be explained by.

## Why

Velma-first was tried in prod on 07-31 and rolled back. Errors were confined to one code path:

| client / codec | reconnects per uid, Deepgram-first | reconnects per uid, Velma-first | change |
|---|---|---|---|
| `desktop` / `pcm16` | 2.00 | 9.17 | **4.58x** |
| `omi` / `opus_fs320` | 9.85 | 6.46 | 0.66x |
| `omi` / `opus` | 10.00 | 8.38 | 0.84x |

Two equal 10-minute windows. 80% of traffic is opus and did not move; only the raw-PCM path amplified. Velma was serving virtually everything in that window (1269 Modulate connections against 3 Parakeet), so this is not a routing artifact.

`pcm16`/`linear16` are the only codecs the listen receiver forwards verbatim — `decoded: bytes = data`. Every other codec passes through opus/aac/lc3 decoding or `audioop.lin2lin`, all of which emit whole 16-bit samples by construction.

## What this does NOT claim

**The mechanism is not proven.** The obvious candidate — frames that are not a whole number of samples — is ruled out as the production cause: `8fba206` shipped the alignment fix from #10558 to prod on 07-25, and pods running it produced 1,894 `Invalid input audio` errors while `omi_live_stt_misaligned_frames_total` never materialised at all. Those pods were scraped throughout; sibling metrics are present. Zero misaligned frames, ~1,900 rejections.

So the correlation above is solid and the mechanism behind it is open. This change is scoped to match: it removes the exposure and adds the measurement, rather than asserting a cause.

A probe against the live API (prod's exact connection parameters, 5 trials per case) does confirm what the error responds to in isolation — odd byte counts and nothing else:

```
ok    baseline even 300ms          ok    single 2-byte frame
FAIL  odd-length frame (961B)      ok    zero-filled silence 300ms
FAIL  odd tail after valid audio   ok    very large frame 640KB
ok    960B frames x10              ok    no language param / empty EOS
```

That is a property of the provider, not evidence about our traffic.

## Change

`modulate_supports_codec()` in the provider policy, consulted in `get_stt_service_for_language` alongside the existing language and surface checks. `preferred_service` cannot bypass it — the gate sits inside the same branch that selects Velma. Sessions on excluded codecs fall through to the next model in the list exactly as an unsupported language already does.

`SafeModulateSocket` tallies frame geometry and emits it with the rejection:

```
Modulate streaming error: Invalid input audio codec=pcm16 sample_rate=16000 language=en
  frames=412 bytes=395520 odd_frames=0 min_frame=640 max_frame=1280 last_frame=960
```

`odd_frames` is counted on the frame as received, before alignment, so it stays truthful even though the socket then corrects it. This is the field that distinguishes "we sent a bad frame" from "the provider rejected a well-formed stream" — the question three attempts have not been able to answer.

## Scope

Streaming only. `chat.py` (PTT) also calls `process_audio_modulate` and is left on its current behaviour; the codec parameter defaults to `None`, which is not excluded, so every other caller is unchanged.

The gate is deliberately a list of two codecs rather than an allowlist, so a new device codec is not silently denied Velma.

## Tests

`test_modulate_codec_gate.py`: decoded codecs stay eligible; `pcm16`/`linear16` are excluded including case and whitespace variants; absent codec is not excluded; selection routes a decoded codec to Velma and skips it for raw PCM; `preferred_service='modulate'` cannot bypass the gate; the shape log reports frame geometry and counts odd frames.

238 passed across the Modulate, live-STT-failure, Parakeet fallback, clean-close latch, Deepgram-serving and prerecorded-coverage suites. CI lane: 10/10 checks pass.

Note: a broad `pytest -k` collection segfaults on this machine inside `google.cloud.firestore` protobuf imports. It reproduces on unmodified `main` with this branch's test file excluded, so it is environmental; suites were run as an explicit file list.

## Rollout

This only takes effect where Velma is actually first. Prod `backend-listen` is currently `dg-nova-3,modulate-velma-2,parakeet`, so merging changes nothing until that ordering is moved back — at which point desktop and phone raw-PCM sessions stay on Deepgram and everything else goes to Velma.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

