### PR TITLE
fix(test): accept the codec kwarg in the listen bootstrap STT stubs (unblocks Backend Unit Tests on main)

### DIFF
--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -130,8 +130,8 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     )
     selected_multi_language_options = []
 
-    def select_stt(language, *, multi_lang_enabled, preferred_service=None):
-        selected_multi_language_options.append((language, multi_lang_enabled, preferred_service))
+    def select_stt(language, *, multi_lang_enabled, preferred_service=None, codec=None):
+        selected_multi_language_options.append((language, multi_lang_enabled, preferred_service, codec))
         return 'test-stt', 'es', 'test-model'
 
     monkeypatch.setattr(runtime_module, 'load_listen_connect_base', lambda *_args, **_kwargs: _async_result(base))
@@ -142,7 +142,7 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     monkeypatch.setattr(runtime_module, 'OnboardingHandler', lambda *_args: SimpleNamespace())
 
     assert await runtime._bootstrap() is True
-    assert selected_multi_language_options == [('es', False, None)]
+    assert selected_multi_language_options == [('es', False, None, 'pcm8')]
 
 
 @pytest.mark.anyio
@@ -153,6 +153,7 @@ async def test_bootstrap_passes_explicit_parakeet_through_capability_aware_selec
         websocket=SimpleNamespace(),
         uid='language-routing-user',
         language='es',
+        codec='opus',
         stt_service='parakeet',
     )
     runtime = object.__new__(ListenSessionRuntime)
@@ -177,8 +178,8 @@ async def test_bootstrap_passes_explicit_parakeet_through_capability_aware_selec
         fair_use_dg_budget_exhausted=False,
     )
 
-    def select_stt(language, *, multi_lang_enabled, preferred_service=None):
-        assert (language, multi_lang_enabled, preferred_service) == ('es', True, 'parakeet')
+    def select_stt(language, *, multi_lang_enabled, preferred_service=None, codec=None):
+        assert (language, multi_lang_enabled, preferred_service, codec) == ('es', True, 'parakeet', 'opus')
         return STTService.modulate, 'multi', 'velma-2'
 
     monkeypatch.setenv('HOSTED_PARAKEET_API_URL', 'http://parakeet.test')


### PR DESCRIPTION
Failure-Class: none

## Bug

`Backend Unit Tests` has been red on `main` since #10936 merged (07-31 07:13Z), and stayed red through every commit after it:

```
FAILED tests/unit/test_listen_runtime_regressions.py::test_bootstrap_forces_single_language_before_selecting_stt_for_onboarding
FAILED tests/unit/test_listen_runtime_regressions.py::test_bootstrap_passes_explicit_parakeet_through_capability_aware_selection
TypeError: select_stt() got an unexpected keyword argument 'codec'
```

## Root cause

#10936 added `codec=request.codec` to the `get_stt_service_for_language(...)` call in `ListenSessionRuntime._bootstrap` (`backend/routers/listen/runtime.py:267`) so Velma is kept off undecoded PCM codecs. The two bootstrap tests monkeypatch that selector with a local stub whose signature is `(language, *, multi_lang_enabled, preferred_service=None)`, so the new keyword raises `TypeError` before `_bootstrap` returns. Production behaviour is correct — only the test doubles were stale.

## Fix

Test-only, 6 insertions / 5 deletions in one file. Both stubs now take `codec` and **assert the value the runtime forwards** (`'pcm8'` default in the onboarding test, an explicit `codec='opus'` request in the parakeet test), so the pair guards #10936's new routing input instead of merely tolerating it.

## Tested

Run with the authoritative runner (`BACKEND_UNIT_TEST_FILE_LIST=... bash test.sh`, its timing guard included), Python 3.11:

- Reproduced first on unmodified `main`: 2 failed, 15 passed — identical to the CI failure.
- After the fix: `tests/unit/test_listen_runtime_regressions.py` 17/17 pass.
- Neighbours green: `test_modulate_codec_gate.py` 17/17, `test_modulate_stt.py` 10/10, `test_fallback_observability.py` 94/94.
- Mutation check: removing `codec=request.codec` from `runtime.py` makes exactly these two tests fail again, so the assertions are load-bearing.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

