### PR TITLE
fix(backend): exempt the release probe UID from the chat quota paywall

### DIFF
--- a/backend/tests/unit/test_chat_quota.py
+++ b/backend/tests/unit/test_chat_quota.py
@@ -419,3 +419,29 @@ class TestEnforceChatQuota:
             },
         ):
             sub_mod.enforce_chat_quota("uid123")
+
+    def test_enforcement_exempts_release_probe_past_free_cap(self, monkeypatch):
+        """The deploy gate's probe UID is never 402'd by its own metered turns.
+
+        Regression: the desktop-backend deploy probe signs in as the fixed
+        non-human UID `omi-release-probe` on the Free plan, so after 30 probe
+        turns every `Auto Deploy Desktop Backend to Development` run failed at
+        `initial_turn: HTTP 402`.
+        """
+        sub_mod = _reload_subscription_module()
+
+        with patch.object(
+            sub_mod,
+            "get_chat_quota_snapshot",
+            return_value={
+                'allowed': False,
+                'plan': PlanType.basic,
+                'unit': 'questions',
+                'used': 30,
+                'limit': 30,
+                'reset_at': _RESET_AT,
+            },
+        ) as snapshot:
+            sub_mod.enforce_chat_quota(sub_mod.RELEASE_PROBE_UID, platform="desktop")
+
+        snapshot.assert_not_called()

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -726,6 +726,13 @@ BASIC_TIER_MONTHLY_SECONDS_LIMIT = BASIC_TIER_MINUTES_LIMIT_PER_MONTH * 60
 BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH', '0'))
 BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH', '0'))
 
+# Fixed non-human UID the desktop-backend release probe signs in as
+# (`PROBE_UID` in backend/scripts/firebase_release_probe_token.py). Its chat turns
+# are deploy-gate traffic, not a user's questions, so they must never be metered
+# against a plan cap — otherwise the gate blocks itself once the probe's own turns
+# exhaust the Free allowance and every desktop-backend deploy fails with 402.
+RELEASE_PROBE_UID = 'omi-release-probe'
+
 # Chat caps per plan. Env-overridable for ops.
 FREE_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('FREE_CHAT_QUESTIONS_PER_MONTH', '30'))
 NEO_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('NEO_CHAT_QUESTIONS_PER_MONTH', '200'))
@@ -827,6 +834,12 @@ def enforce_chat_quota(uid: str, platform: Optional[str] = None) -> None:
     - Free plan past its cap: blocked (no card on file) → 402, which the
       chat endpoint converts into a canned AI reply for mobile UX.
     """
+    # Release-probe traffic is the deploy gate proving the candidate can chat at
+    # all — never paywall it, or the gate hard-blocks its own deploys once the
+    # probe's turns exhaust the Free cap.
+    if uid == RELEASE_PROBE_UID:
+        return
+
     # Paywall test override — bypass BYOK + plan checks so the same 402
     # surfaces that a free user past 30 questions would hit. Desktop only;
     # mobile callers continue down the normal plan path.


### PR DESCRIPTION
## Bug

`Auto Deploy Desktop Backend to Development` has failed on **every** push to `main` since 2026-07-30T05:57Z (last green: `fa7963a9dbaa`, 03:12Z). All 12+ runs die at the same step:

```
Prove candidate chat compatibility
desktop-backend candidate probe failed: initial_turn: HTTP 402
```

The dev desktop-backend deploy lane has been fully blocked for ~32 hours.

## Root cause

The deploy gate signs in as the fixed non-human UID `omi-release-probe` (`PROBE_UID` in `backend/scripts/firebase_release_probe_token.py`) and sends two chat turns per run through `POST /v2/chat/completions` to prove the no-traffic candidate can actually chat.

Since the Python desktop backend cutover (`778bb38c52`, 2026-07-26), that router calls `enforce_chat_quota` and records `quota_questions` — so the probe accrues metered usage against the **Free plan's 30-questions-per-month cap**, exactly like a real user.

Live Firestore, `users/omi-release-probe/llm_usage` (project `based-hardware`):

| doc | `backend_chat.quota_questions` |
|---|---|
| `2026-07-29` | 22 |
| `2026-07-30` | 8 |
| **total** | **30** = `FREE_CHAT_QUESTIONS_PER_MONTH` |

`last_updated` on the 07-30 doc is `03:15:14Z` — the last green run. Every run after that hits `used=30, limit=30 -> allowed=False -> 402`.

So the gate blocks its own deploys after roughly 15 runs a month, then silently un-blocks at the UTC month rollover (which is why this would have "fixed itself" tomorrow and re-broken mid-August).

## Fix

`enforce_chat_quota` returns early for the release-probe UID, ahead of both the trial-paywall override and the plan snapshot. Deploy-gate traffic is not a user's questions and must never be paywalled.

Not a paywall hole: the UID is only reachable by minting a custom token with the deploy identity's signer (`FC-release-probe-signer-identity` governs that path); no ordinary account can authenticate as it. A real Free user at the cap is still blocked — asserted below.

## Verification

- `backend/tests/unit/test_chat_quota.py` — **17 passed**. The new `test_enforcement_exempts_release_probe_past_free_cap` fails on `main` (`AttributeError: module 'utils.subscription' has no attribute 'RELEASE_PROBE_UID'`) and passes with the fix.
- Real chain, **no patching of `get_chat_quota_snapshot`**, seeded with the live numbers above (30 questions, Free plan):
  - `get_chat_quota_snapshot` -> `allowed=False used=30.0 limit=30.0` (the exact live state)
  - `enforce_chat_quota("a-real-free-user")` -> `HTTP 402 quota_exceeded` — paywall intact
  - `enforce_chat_quota("omi-release-probe")` -> allowed, with and without `platform="desktop"` — the probe's `initial_turn` now proceeds
- Adjacent suites green: `test_byok_security`, `test_chat_quota_counting_router`, `test_desktop_message_quota_router`, `test_neo_desktop_grandfather` — **140 passed**.
- `make preflight` — all selected manifest checks pass.

Post-merge signal: the next `Auto Deploy Desktop Backend to Development` run on `main` should clear `Prove candidate chat compatibility` and shift traffic.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

