### PR TITLE
fix(web): ignore superseded WebSocket events after a transcription token refresh

### DIFF
--- a/.github/failure-classes/FC-superseded-connection-mutates-live-session.json
+++ b/.github/failure-classes/FC-superseded-connection-mutates-live-session.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-superseded-connection-mutates-live-session",
+  "violated_contract": "A callback registered on a connection that has since been replaced may end only that connection's own lifecycle. Its late close, open, error, or timeout event must never mutate the session state its replacement now owns — marking a live session disconnected from a retired socket's event silently strands every subsequent send.",
+  "canonical_prevention": "Bind each connection callback to the connection instance that registered it and return early when the session no longer points at that instance, so a queued event from a retired connection cannot write session state. Prove it by delivering the retired connection's close event after the replacement is live and asserting the session still transmits.",
+  "evidence_prs": [
+    10941
+  ],
+  "scope_hints": [
+    "web/app/src/lib/**"
+  ],
+  "status": "open"
+}

--- a/web/app/src/lib/transcriptionSocket.ts
+++ b/web/app/src/lib/transcriptionSocket.ts
@@ -151,29 +151,39 @@ export class TranscriptionSocket {
 
       const wsUrl = `${WS_BASE_URL}/v4/web/listen?${params.toString()}`;
 
-      this.ws = new WebSocket(wsUrl);
+      // Every handler below is bound to THIS socket and must ignore events once it
+      // has been superseded (`this.ws !== socket`). A token refresh closes the old
+      // socket and opens a new one ~100ms later, but `close()` only queues the close
+      // event — on a slow round trip it is delivered after the replacement socket is
+      // live, and an unguarded handler then tears down the healthy connection
+      // (state -> disconnected, this.ws -> null). Audio is silently buffered into the
+      // 100-chunk ring from then on while the UI still shows "recording": the ~50
+      // minute refresh is why a long session loses its transcript (#5399).
+      const socket = new WebSocket(wsUrl);
+      this.ws = socket;
 
-      this.ws.binaryType = 'arraybuffer';
+      socket.binaryType = 'arraybuffer';
 
       // Set connection timeout
       this.connectionTimeout = setTimeout(() => {
-        if (this.state === 'connecting') {
+        if (this.ws === socket && this.state === 'connecting') {
           console.error('TranscriptionSocket: Connection timeout');
-          this.ws?.close();
+          socket.close();
           this.ws = null;
           this.state = 'disconnected';
           this.options.onError('Connection timeout - server unreachable');
         }
       }, TranscriptionSocket.CONNECTION_TIMEOUT_MS);
 
-      this.ws.onopen = () => {
+      socket.onopen = () => {
+        if (this.ws !== socket) return;
         this.clearConnectionTimeout();
         this.state = 'connected';
 
         // Send first-message authentication
-        if (this.ws && this.pendingToken) {
+        if (this.pendingToken) {
           try {
-            this.ws.send(
+            socket.send(
               JSON.stringify({
                 type: 'auth',
                 token: this.pendingToken,
@@ -185,22 +195,25 @@ export class TranscriptionSocket {
               'TranscriptionSocket: Failed to send auth message, closing socket.',
               err,
             );
-            this.ws?.close();
+            socket.close();
           }
         }
         // Note: onConnected() and buffer flush happen after auth_response in handleMessage
       };
 
-      this.ws.onmessage = (event) => {
+      socket.onmessage = (event) => {
+        if (this.ws !== socket) return;
         this.handleMessage(event);
       };
 
-      this.ws.onerror = (event) => {
+      socket.onerror = (event) => {
+        if (this.ws !== socket) return;
         this.clearConnectionTimeout();
         console.error('TranscriptionSocket: Error', event);
       };
 
-      this.ws.onclose = (event) => {
+      socket.onclose = (event) => {
+        if (this.ws !== socket) return;
         this.clearConnectionTimeout();
         this.state = 'disconnected';
         this.ws = null;
@@ -352,6 +365,9 @@ export class TranscriptionSocket {
     if (this.ws) {
       this.ws.close(1000, 'User stopped recording');
       this.ws = null;
+      // The retired socket's onclose is ignored now that it is superseded, so
+      // report the disconnect here — it used to arrive via that handler.
+      this.options.onDisconnected();
     }
 
     this.state = 'disconnected';


### PR DESCRIPTION
## What

Bind every `WebSocket` handler in the web recorder's `TranscriptionSocket` to the socket that registered it, and ignore events from a socket that has already been superseded.

## Why

`TranscriptionSocket` refreshes itself every 50 minutes to stay ahead of Firebase token expiry (`refreshConnection`): it closes the live socket, waits 100 ms, then opens a replacement. `close()` only *queues* the close event — the browser delivers it after the server completes the close handshake, one network round trip later. On any connection where that round trip outlasts the 100 ms gap plus the token fetch, the old socket's `onclose` runs against the **current** session and sets `state = 'disconnected'` / `ws = null` on a perfectly healthy connection.

From that moment `sendAudio()` takes the buffering branch: audio goes into the 100-chunk ring (~3 s) and is dropped from there on. Nothing reaches the backend, while `useRecording` still shows a running recording — the only consumer's `onDisconnected` is a no-op, so nothing surfaces. That is the "long session dies around the one-hour mark and the in-progress transcription is lost" report in #5399, and it lands at the 50-minute refresh.

Same class of stale-handler damage was possible from the retired socket's `onopen`, `onmessage`, `onerror`, and the connection-timeout callback, so all five are bound the same way.

## Evidence

Reproduced and fixed with a node harness that bundles the real module (only `./firebase` and `./clientDevice` stubbed) against a fake `WebSocket` whose close event is delayed by one round trip (400 ms), then drives `connect → refreshConnection → late close event → sendAudio`:

```
BEFORE (origin/main)   isConnected after stale close: false   audio frames on the new socket: 0/2   -> FAIL
AFTER  (this change)   isConnected after stale close: true    audio frames on the new socket: 2/2   -> PASS
```

A second harness pins the paths that must not change — a fast close handshake during a refresh, and an unexpected server drop (code 1006) — both still report `onDisconnected` and walk the auto-reconnect ladder identically before and after (`connected,connected,disconnected,connected`, 3 sockets, reconnected = true).

Repo checks for this path: `npx tsc --noEmit` clean, and `npm run build` in `web/app` (the `web-checks` lane for these files) succeeds with the workflow's dummy Firebase env.

## What is not covered

- **Not verified in a browser.** The trigger is a 50-minute timer plus network close-handshake timing; I could not run a real hour-long recording session. The harness drives the identical module code with the real event ordering, but a live-browser run remains unproven.
- **No committed regression test:** `web/app` has no test runner and no test lane in `web-checks.yml`; adding one is a separate change. The harness above is described fully enough to rebuild.
- #5399 also reports a browser *freeze* and an Android auto-reconnect gap. Neither is addressed here, so this refs the issue instead of closing it. The likeliest freeze candidate — the live transcript re-rendering an unbounded segment list on every incremental segment update (`useRecording`'s `onSegment` does a linear scan plus a full array copy, and the list is not virtualised) — is untouched.

Failure-Class: new

Refs #5399

Auto-generated from issue feedback by the mini issues-improver — verified at module level (harness above, typecheck, `web/app` build), **not merged**: the repo's auto-merge bar wants the real user-facing path exercised, and a live 50-minute browser recording is the one thing I could not run. Left for a maintainer to land.
