### PR TITLE
fix(release): bind beta promotion to qualification evidence

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -880,9 +880,9 @@ def check_desktop_qualification_runner() -> list[str]:
         'workflows: ["Qualify Desktop Beta Candidate"]',
         "types: [completed]",
         "github.event.workflow_run.conclusion == 'success'",
-        "github.event.workflow_run.event == 'workflow_dispatch'",
-        "github.event.workflow_run.head_branch",
-        "github.event.workflow_run.head_sha",
+        "github.event.workflow_run.id",
+        "qualification-evidence.json",
+        "EVIDENCE_SOURCE_SHA",
         "/v2/desktop/beta/promote-qualified",
         "environment: beta",
     ):

--- a/.github/scripts/desktop_qualification_admission.py
+++ b/.github/scripts/desktop_qualification_admission.py
@@ -6,11 +6,18 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 
 def validate_qualification_run(run: object, repository: str, release_tag: str, candidate_sha: str) -> None:
-    """Require a successful same-repository workflow dispatched on the candidate tag."""
+    """Require a successful trusted qualification run for the candidate.
+
+    A workflow dispatch can start from the candidate tag (the normal planner
+    path) or from ``main`` (a manual dispatch). The workflow's own isolated
+    checkout and the evidence artifact bind the latter to the exact tag; only
+    the tag-dispatched path can use GitHub's workflow-run SHA as that proof.
+    """
     if not isinstance(run, dict):
         raise ValueError("qualification run must be an object")
     required = {
@@ -18,17 +25,21 @@ def validate_qualification_run(run: object, repository: str, release_tag: str, c
         "conclusion": "success",
         "event": "workflow_dispatch",
         "path": ".github/workflows/desktop_qualify_beta.yml",
-        "head_branch": release_tag,
-        "head_sha": candidate_sha,
         "name": "Qualify Desktop Beta Candidate",
     }
     for key, expected in required.items():
         if run.get(key) != expected:
-            if key == "head_branch":
-                raise ValueError("qualification run must execute the candidate tag controls")
-            if key == "head_sha":
-                raise ValueError("qualification run must execute the candidate source SHA")
             raise ValueError(f"qualification run {key} must equal {expected!r}")
+    head_branch = run.get("head_branch")
+    head_sha = run.get("head_sha")
+    if head_branch == release_tag:
+        if head_sha != candidate_sha:
+            raise ValueError("qualification run must execute the candidate source SHA")
+    elif head_branch == "main":
+        if not isinstance(head_sha, str) or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None:
+            raise ValueError("manual qualification run must have an immutable dispatch SHA")
+    else:
+        raise ValueError("qualification run must execute the candidate tag controls or trusted main controls")
     for key in ("repository", "head_repository"):
         value = run.get(key)
         if not isinstance(value, dict) or value.get("full_name") != repository:

--- a/.github/scripts/test_desktop_release_flow_contract.py
+++ b/.github/scripts/test_desktop_release_flow_contract.py
@@ -164,6 +164,7 @@ class DesktopReleaseFlowContractTests(unittest.TestCase):
             "--max-reclaim-kib 134217728",
             "33554432",
             "desktop-qualification-evidence-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}",
+            "desktop-qualification-backend-compatibility-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}",
             "overwrite: false",
             "qualification-evidence-${TARGET_SHA}-${digest}.json",
         ):

--- a/.github/workflows/desktop_promote_beta.yml
+++ b/.github/workflows/desktop_promote_beta.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: desktop-beta-promotion
@@ -38,10 +39,63 @@ jobs:
         id: candidate
         env:
           EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.release_tag }}
-          QUALIFICATION_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+          GH_TOKEN: ${{ github.token }}
+          QUALIFICATION_RUN_ID: ${{ github.event.workflow_run.id || '' }}
+          QUALIFICATION_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt || '' }}
+          REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag || '' }}
         run: |
           set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            artifacts="$RUNNER_TEMP/qualification-artifacts.json"
+            archive="$RUNNER_TEMP/qualification-evidence.zip"
+            evidence="$RUNNER_TEMP/qualification-evidence.json"
+            test -n "$QUALIFICATION_RUN_ID"
+            test -n "$QUALIFICATION_RUN_ATTEMPT"
+            gh api "repos/$REPO/actions/runs/$QUALIFICATION_RUN_ID/artifacts?per_page=100" > "$artifacts"
+            artifact_id=$(jq -er --arg run_id "$QUALIFICATION_RUN_ID" --arg run_attempt "$QUALIFICATION_RUN_ATTEMPT" '
+              [
+                .artifacts[]
+                | select(
+                    (.name | type == "string")
+                    and (.name | test("^desktop-qualification-evidence-v[0-9]+\\.[0-9]+\\.[0-9]+\\+[1-9][0-9]*-macos-m1-" + $run_id + "-" + $run_attempt + "$"))
+                  )
+              ] as $matches
+              | if ($matches | length) == 1
+                   and $matches[0].expired == false
+                   and ($matches[0].id | type == "number")
+                   and $matches[0].id > 0
+                   and ($matches[0].size_in_bytes | type == "number")
+                   and $matches[0].size_in_bytes > 0
+                   and $matches[0].size_in_bytes <= 1048576
+                then $matches[0].id
+                else error("expected one retained qualification evidence artifact")
+                end
+            ' "$artifacts")
+            gh api "repos/$REPO/actions/artifacts/$artifact_id/zip" > "$archive"
+            test "$(unzip -Z1 "$archive")" = qualification-evidence.json
+            unzip -p "$archive" qualification-evidence.json > "$evidence"
+            RELEASE_TAG=$(jq -er '
+              if .schema_version == 1
+                 and (.release_id | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+\\+[1-9][0-9]*-macos$"))
+                then .release_id
+                else error("qualification evidence has no immutable macOS release tag")
+                end
+            ' "$evidence")
+            EVIDENCE_SOURCE_SHA=$(jq -er '
+              if (.source_sha | type == "string" and test("^[0-9a-f]{40}$"))
+                then .source_sha
+                else error("qualification evidence has no immutable source SHA")
+                end
+            ' "$evidence")
+            EVIDENCE_RUN_ID=$(jq -er '
+              if (.qualification_run_id | type == "number" and . > 0)
+                then .qualification_run_id
+                else error("qualification evidence has no run identity")
+                end
+            ' "$evidence")
+            test "$EVIDENCE_RUN_ID" = "$QUALIFICATION_RUN_ID"
+          fi
           if ! printf '%s\n' "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+-macos$'; then
             echo "Invalid immutable macOS release tag: $RELEASE_TAG" >&2
             exit 1
@@ -49,8 +103,8 @@ jobs:
 
           git fetch --force origin "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           TAG_SHA=$(git rev-list -n1 "$RELEASE_TAG")
-          if [[ "$EVENT_NAME" == "workflow_run" && "$TAG_SHA" != "$QUALIFICATION_SHA" ]]; then
-            echo "Tag $RELEASE_TAG at $TAG_SHA does not match successful qualification SHA $QUALIFICATION_SHA." >&2
+          if [[ "$EVENT_NAME" == "workflow_run" && "$TAG_SHA" != "$EVIDENCE_SOURCE_SHA" ]]; then
+            echo "Tag $RELEASE_TAG at $TAG_SHA does not match qualification evidence source $EVIDENCE_SOURCE_SHA." >&2
             exit 1
           fi
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop_qualify_beta.yml
+++ b/.github/workflows/desktop_qualify_beta.yml
@@ -208,8 +208,13 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: desktop-qualification-evidence-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/qualification-evidence.json
+          if-no-files-found: error
+          overwrite: false
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktop-qualification-backend-compatibility-${{ inputs.release_tag }}-m1-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/qualification-evidence.json
             ${{ runner.temp }}/desktop-beta-qualification/${{ github.run_id }}-${{ github.run_attempt }}/desktop-backend-compatibility.json
           if-no-files-found: error
           overwrite: false

--- a/backend/tests/unit/test_desktop_release_scripts.py
+++ b/backend/tests/unit/test_desktop_release_scripts.py
@@ -78,11 +78,23 @@ def test_canonical_manifest_is_the_exact_immutable_object_registered_and_promote
     assert pointer["release_id"] == accepted["release_id"]
 
 
+# omi-test-quality: source-inspection -- static contract: GitHub cannot execute a workflow_run fixture locally.
 def test_beta_workflow_has_only_the_narrow_server_owned_promotion_capability():
     workflow = PROMOTE_BETA_WORKFLOW.read_text(encoding="utf-8")
     assert "/v2/desktop/beta/promote-qualified" in workflow
     assert 'Authorization: Bearer ${BETA_PROMOTION_TOKEN}' in workflow
     assert '--data "{\\"tag\\":\\"${RELEASE_TAG}\\"}"' in workflow
+    for required in (
+        "actions: read",
+        "github.event.workflow_run.id",
+        "github.event.workflow_run.run_attempt",
+        "actions/runs/$QUALIFICATION_RUN_ID/artifacts",
+        "qualification-evidence.json",
+        "EVIDENCE_SOURCE_SHA",
+    ):
+        assert required in workflow
+    assert "github.event.workflow_run.head_branch" not in workflow
+    assert "github.event.workflow_run.head_sha" not in workflow
     for forbidden in (
         "gcloud",
         "google-github-actions/auth",
@@ -160,9 +172,14 @@ def test_qualification_workflow_binds_immutable_controls_and_candidate_identity(
     }
 
     admission.validate_qualification_run(trusted_tag_run, "BasedHardware/omi", tag, candidate_sha)
-    drifted_main_run = {**trusted_tag_run, "head_branch": "main", "head_sha": "b" * 40}
-    with pytest.raises(ValueError, match="candidate tag"):
-        admission.validate_qualification_run(drifted_main_run, "BasedHardware/omi", tag, candidate_sha)
+    manual_main_run = {**trusted_tag_run, "head_branch": "main", "head_sha": "b" * 40}
+    admission.validate_qualification_run(manual_main_run, "BasedHardware/omi", tag, candidate_sha)
+    untrusted_control_run = {**trusted_tag_run, "head_branch": "release", "head_sha": "b" * 40}
+    with pytest.raises(ValueError, match="candidate tag controls or trusted main controls"):
+        admission.validate_qualification_run(untrusted_control_run, "BasedHardware/omi", tag, candidate_sha)
+    malformed_manual_run = {**trusted_tag_run, "head_branch": "main", "head_sha": "not-a-commit"}
+    with pytest.raises(ValueError, match="immutable dispatch SHA"):
+        admission.validate_qualification_run(malformed_manual_run, "BasedHardware/omi", tag, candidate_sha)
 
     codemagic = CODEMAGIC_CONFIG.read_text(encoding="utf-8")
     qualification = QUALIFY_BETA_WORKFLOW.read_text(encoding="utf-8")
@@ -173,6 +190,7 @@ def test_qualification_workflow_binds_immutable_controls_and_candidate_identity(
     assert 'asset="qualification-evidence-${TARGET_SHA}-${digest}.json"' in qualification
     assert 'digest=$(shasum -a 256 "$QUALIFICATION_STAGE/qualification-evidence.json"' in qualification
     assert "gh release upload" in qualification
+    assert "desktop-qualification-backend-compatibility-" in qualification
 
 
 def test_codemagic_produces_canonical_app_and_strictly_verifiable_dmg():

--- a/backend/tests/unit/test_qualified_beta_promotion.py
+++ b/backend/tests/unit/test_qualified_beta_promotion.py
@@ -69,7 +69,7 @@ class FakeQualifiedBetaReader:
         self.artifacts_payload = [
             {
                 "id": 456,
-                "name": f"desktop-qualification-evidence-{release['tag_name']}",
+                "name": f"desktop-qualification-evidence-{release['tag_name']}-m1-{run['id']}-{run['run_attempt']}",
                 "expired": False,
                 "size_in_bytes": len(artifact),
                 "archive_download_url": "https://api.github.com/repos/BasedHardware/omi/actions/artifacts/456/zip",
@@ -242,6 +242,7 @@ def _candidate():
     }
     run = {
         "id": 123,
+        "run_attempt": 1,
         "status": "completed",
         "conclusion": "success",
         "repository": {"full_name": "BasedHardware/omi"},
@@ -728,6 +729,47 @@ async def test_server_rejects_a_non_sanctioned_beta_like_identity():
 
 
 @pytest.mark.asyncio
+async def test_manual_main_qualification_is_bound_by_its_run_evidence():
+    release, evidence, run = _candidate()
+    run["head_branch"] = "main"
+    run["head_sha"] = "b" * 40
+
+    manifest = await build_qualified_beta_manifest(
+        TAG,
+        reader=FakeQualifiedBetaReader(release, evidence, run),
+        now=datetime(2026, 7, 21, 12, 2, tzinfo=timezone.utc),
+    )
+
+    assert manifest["release_id"] == TAG
+
+
+@pytest.mark.asyncio
+async def test_requalified_run_uses_only_its_current_attempt_evidence():
+    release, evidence, run = _candidate()
+    run["run_attempt"] = 2
+    reader = FakeQualifiedBetaReader(release, evidence, run)
+    reader.artifacts_payload.insert(
+        0,
+        {
+            "id": 455,
+            "name": f"desktop-qualification-evidence-{TAG}-m1-{run['id']}-1",
+            "expired": False,
+            "size_in_bytes": len(_artifact_archive(b"untrusted previous attempt")),
+            "archive_download_url": "https://api.github.com/repos/BasedHardware/omi/actions/artifacts/455/zip",
+        },
+    )
+    reader.artifact_downloads[455] = _artifact_archive(b"untrusted previous attempt")
+
+    manifest = await build_qualified_beta_manifest(
+        TAG,
+        reader=reader,
+        now=datetime(2026, 7, 21, 12, 2, tzinfo=timezone.utc),
+    )
+
+    assert manifest["release_id"] == TAG
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("field", "expected_error"),
     [
@@ -744,6 +786,7 @@ async def test_boolean_security_integer_metadata_is_rejected(field, expected_err
 
     if field == "qualification_run_id":
         run["id"] = 1
+        reader.artifacts_payload[0]["name"] = f"desktop-qualification-evidence-{TAG}-m1-{run['id']}-1"
         evidence = json.loads(evidence_bytes)
         evidence["qualification_run_id"] = True
         _replace_trusted_evidence(reader, evidence)
@@ -949,6 +992,7 @@ async def test_documented_unrelated_github_member_shapes_do_not_reject_a_valid_c
     ("field", "value"),
     [
         ("id", True),
+        ("run_attempt", True),
         ("status", 1),
         ("conclusion", []),
         ("event", {}),
@@ -1070,7 +1114,7 @@ async def test_release_asset_replacement_with_self_consistent_release_evidence_i
     reader.artifacts_payload = [
         {
             "id": 456,
-            "name": f"desktop-qualification-evidence-{TAG}",
+            "name": f"desktop-qualification-evidence-{TAG}-m1-{run['id']}-1",
             "expired": False,
             "size_in_bytes": len(_artifact_archive(trusted_evidence)),
             "archive_download_url": "https://api.github.com/repos/BasedHardware/omi/actions/artifacts/456/zip",
@@ -1196,14 +1240,14 @@ async def test_corrupted_deflated_artifact_returns_typed_rejection_without_post_
         [
             {
                 "id": 456,
-                "name": f"desktop-qualification-evidence-{TAG}",
+                "name": f"desktop-qualification-evidence-{TAG}-m1-123-1",
                 "expired": False,
                 "size_in_bytes": 1,
                 "archive_download_url": "https://api.github.com/repos/BasedHardware/omi/actions/artifacts/456/zip",
             },
             {
                 "id": 457,
-                "name": f"desktop-qualification-evidence-{TAG}",
+                "name": f"desktop-qualification-evidence-{TAG}-m1-123-1",
                 "expired": False,
                 "size_in_bytes": 1,
                 "archive_download_url": "https://api.github.com/repos/BasedHardware/omi/actions/artifacts/457/zip",
@@ -1212,7 +1256,7 @@ async def test_corrupted_deflated_artifact_returns_typed_rejection_without_post_
         [
             {
                 "id": 456,
-                "name": f"desktop-qualification-evidence-{TAG}",
+                "name": f"desktop-qualification-evidence-{TAG}-m1-123-1",
                 "expired": True,
                 "size_in_bytes": 1,
                 "archive_download_url": "https://api.github.com/repos/BasedHardware/omi/actions/artifacts/456/zip",

--- a/backend/utils/qualified_beta_promotion.py
+++ b/backend/utils/qualified_beta_promotion.py
@@ -152,6 +152,8 @@ def _validate_qualification_run_member(run: dict[str, Any]) -> None:
     """Reject malformed run members while permitting documented nullable unrelated fields."""
     if not _is_exact_integer(run.get("id")) or run["id"] <= 0:
         _fail("candidate qualification run has no trusted identity")
+    if not _is_exact_integer(run.get("run_attempt")) or run["run_attempt"] <= 0:
+        _fail("candidate qualification run has no trusted attempt")
     for field in ("status", "conclusion", "event", "path", "head_sha"):
         _nonempty_string(run.get(field), "candidate qualification runs are invalid")
     for field in ("head_branch", "name"):
@@ -164,15 +166,23 @@ def _validate_qualification_run_member(run: dict[str, Any]) -> None:
     _timestamp(run.get("updated_at"))
 
 
-def _validate_selected_qualification_run(run: dict[str, Any]) -> tuple[int, datetime]:
+def _trusted_run_attempt(run: dict[str, Any]) -> int:
+    run_attempt = run.get("run_attempt")
+    if not _is_exact_integer(run_attempt) or run_attempt <= 0:
+        _fail("candidate qualification run has no trusted attempt")
+    return run_attempt
+
+
+def _validate_selected_qualification_run(run: dict[str, Any]) -> tuple[int, int, datetime]:
     """Apply exact identity and freshness requirements only after a run is trusted."""
     run_id = _trusted_run_id(run)
+    run_attempt = _trusted_run_attempt(run)
     for field in ("status", "conclusion", "event", "path", "head_branch", "head_sha", "name"):
         _nonempty_string(run.get(field), "candidate qualification runs are invalid")
     for field in ("repository", "head_repository"):
         repository = _github_object(run.get(field), "candidate qualification runs are invalid")
         _nonempty_string(repository.get("full_name"), "candidate qualification runs are invalid")
-    return run_id, _timestamp(run.get("updated_at"))
+    return run_id, run_attempt, _timestamp(run.get("updated_at"))
 
 
 def _qualification_runs(value: object) -> list[dict[str, Any]]:
@@ -243,9 +253,11 @@ def _trusted_run_id(run: dict[str, Any]) -> int:
     return run_id
 
 
-def _select_qualification_run(runs: object, tag: str, source_sha: str, now: datetime) -> tuple[dict[str, Any], int]:
+def _select_qualification_run(
+    runs: object, tag: str, source_sha: str, now: datetime
+) -> tuple[dict[str, Any], int, int]:
     """Choose the newest fully trusted retry without caller-selected run state."""
-    acceptable: list[tuple[datetime, int, dict[str, Any]]] = []
+    acceptable: list[tuple[datetime, int, int, dict[str, Any]]] = []
     for run in _qualification_runs(runs):
         try:
             validate_qualification_run(run, REPOSITORY, tag, source_sha)
@@ -253,19 +265,23 @@ def _select_qualification_run(runs: object, tag: str, source_sha: str, now: date
             raise
         except ValueError:
             continue
-        run_id, completed_at = _validate_selected_qualification_run(run)
+        run_id, run_attempt, completed_at = _validate_selected_qualification_run(run)
         if not _is_fresh(completed_at, now):
             continue
-        acceptable.append((completed_at, run_id, run))
+        acceptable.append((completed_at, run_id, run_attempt, run))
     if not acceptable:
         _fail("candidate has no fresh trusted qualification run")
-    _, run_id, run = max(acceptable, key=lambda item: (item[0], item[1]))
-    return run, run_id
+    _, run_id, run_attempt, run = max(acceptable, key=lambda item: (item[0], item[1], item[2]))
+    return run, run_id, run_attempt
 
 
-def _qualification_artifact_id(artifacts: object, tag: str) -> int:
-    expected_name = f"{QUALIFICATION_ARTIFACT_PREFIX}{tag}"
-    matches = [artifact for artifact in _qualification_artifacts(artifacts) if artifact.get("name") == expected_name]
+def _qualification_artifact_id(artifacts: object, tag: str, run_id: int, run_attempt: int) -> int:
+    expected_name = re.compile(rf"^{re.escape(QUALIFICATION_ARTIFACT_PREFIX + tag)}-m1-{run_id}-{run_attempt}$")
+    matches = [
+        artifact
+        for artifact in _qualification_artifacts(artifacts)
+        if isinstance(artifact.get("name"), str) and expected_name.fullmatch(artifact["name"])
+    ]
     if len(matches) != 1:
         _fail("candidate qualification artifact is missing or ambiguous")
     artifact = matches[0]
@@ -499,8 +515,10 @@ async def build_qualified_beta_manifest(
             beta_asset = _asset(assets, beta_name)
             beta_assets[beta_name] = beta_asset
             expected_digests[beta_name] = _asset_digest(beta_asset)
-    _, run_id = _select_qualification_run(await _read_github(source, "runs"), tag, source_sha, current_time)
-    artifact_id = _qualification_artifact_id(await _read_github(source, "artifacts", run_id), tag)
+    _, run_id, run_attempt = _select_qualification_run(
+        await _read_github(source, "runs"), tag, source_sha, current_time
+    )
+    artifact_id = _qualification_artifact_id(await _read_github(source, "artifacts", run_id), tag, run_id, run_attempt)
     trusted_evidence_bytes = _evidence_from_artifact(await _read_github(source, "download_artifact", artifact_id))
     try:
         evidence: object = json.loads(trusted_evidence_bytes)


### PR DESCRIPTION
## Summary

- Derive automatic Beta promotion candidates from the successful qualification run's immutable evidence artifact, not its dispatch branch.
- Keep evidence immutable across retries, bind it to the exact run attempt, and retain backend-compatibility evidence separately.
- Preserve the existing backend admission authority while permitting a manually dispatched qualification from `main` only when its evidence binds the release tag and source SHA.

## Verification

- `make preflight`
- `actionlint .github/workflows/desktop_qualify_beta.yml .github/workflows/desktop_promote_beta.yml`
- `BACKEND_PYTEST_FILE_ISOLATION=0 BACKEND_PYTEST_XDIST=0 ... bash backend/test.sh` (`test_qualified_beta_promotion.py`, 185 passed)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

