### PR TITLE
ci: bound hermetic backend scope checkout

### DIFF
--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -18,7 +18,7 @@ jobs:
   scope:
     name: Detect Hermetic Backend Scope
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     outputs:
       applies: ${{ steps.scope.outputs.applies }}
     steps:
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Decide whether hermetic backend coverage applies
         id: scope

--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -39,6 +39,8 @@ jobs:
           PR_BASE_REF: origin/${{ github.base_ref }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
+          set -euo pipefail
+
           case "$EVENT_NAME" in
             pull_request) base_sha="$PR_BASE_REF" ;;
             merge_group) base_sha="$MERGE_GROUP_BASE_SHA" ;;
@@ -52,11 +54,17 @@ jobs:
               ;;
           esac
 
+          # Fail closed: if the scope base cannot be resolved (missing event sha,
+          # shallow/failed no-blob history fetch, or on-demand missing object),
+          # fail the job rather than silently treating the repo as out of scope.
+          # A silent `applies=false` would skip the hermetic backend gate.
           if [[ -z "$base_sha" ]] || ! git cat-file -e "${base_sha}^{commit}"; then
             echo "Cannot resolve hermetic backend scope base: ${base_sha:-<empty>}" >&2
             exit 1
           fi
 
+          # set -euo pipefail aborts here if the (partial-clone) history fetch
+          # fails mid-diff; a failed diff must never yield empty -> applies=false.
           changed_files="$(git diff --name-only "$base_sha"...HEAD)"
           printf '%s\n' "$changed_files"
           if grep -Eq '^(backend/|package\.json$|package-lock\.json$|\.github/workflows/backend-hermetic-e2e\.yml$)' <<<"$changed_files"; then

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -93,6 +93,9 @@ def test_backend_hermetic_gate_is_always_reported_and_fails_closed() -> None:
     scope = workflow.split('  scope:\n', 1)[1].split('\n  hermetic-e2e:\n', 1)[0]
     assert 'github.event.pull_request.base.sha' in scope
     assert 'github.event.merge_group.base_sha' in scope
+    assert 'timeout-minutes: 5' in scope
+    assert 'fetch-depth: 0' in scope
+    assert 'filter: blob:none' in scope
     assert 'git diff --name-only "$base_sha"...HEAD' in scope
     assert "^(backend/|package\\.json$|package-lock\\.json$|\\.github/workflows/backend-hermetic-e2e\\.yml$)" in scope
 

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -106,6 +106,9 @@ def test_backend_hermetic_gate_is_always_reported_and_fails_closed() -> None:
     assert 'github.event.pull_request.base.sha' not in scope
     assert 'PR_BASE_REF: origin/${{ github.base_ref }}' in scope
     assert 'github.event.merge_group.base_sha' in scope
+    assert 'timeout-minutes: 5' in scope
+    assert 'fetch-depth: 0' in scope
+    assert 'filter: blob:none' in scope
     assert 'git diff --name-only "$base_sha"...HEAD' in scope
     assert "^(backend/|package\\.json$|package-lock\\.json$|\\.github/workflows/backend-hermetic-e2e\\.yml$)" in scope
 

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -112,6 +112,21 @@ def test_backend_hermetic_gate_is_always_reported_and_fails_closed() -> None:
     assert 'git diff --name-only "$base_sha"...HEAD' in scope
     assert "^(backend/|package\\.json$|package-lock\\.json$|\\.github/workflows/backend-hermetic-e2e\\.yml$)" in scope
 
+    # #10945: fail closed on unresolvable scope base or a failed (partial-clone)
+    # history fetch. The scope job must FAIL rather than silently emit
+    # applies=false, which would skip the hermetic backend gate entirely.
+    run_block = scope.split('run: |', 1)[1]
+    assert 'set -euo pipefail' in run_block
+    assert 'if [[ -z "$base_sha" ]] || ! git cat-file -e "${base_sha}^{commit}"; then' in run_block
+    assert 'Cannot resolve hermetic backend scope base' in run_block
+    assert 'exit 1' in run_block
+    assert 'a failed diff must never yield empty -> applies=false' in run_block
+    # applies=false must be reachable only AFTER a successful diff, never as a fallback.
+    diff_index = run_block.index('changed_files="$(git diff')
+    applies_false_index = run_block.index('echo "applies=false" >> "$GITHUB_OUTPUT"')
+    assert diff_index < applies_false_index
+    # The two exit-1 guards precede the diff; a failed scope never reaches applies=false.
+
     for job_name in ('hermetic-e2e', 'listen-pusher-stack-gauntlet', 'sync-cloud-tasks-stack-gauntlet'):
         job = workflow.split(f'  {job_name}:\n', 1)[1]
         assert 'needs: scope' in job


### PR DESCRIPTION
## Summary

- Keep the hermetic-backend scope check fail-closed while fetching commit history without blobs.
- Increase only the lightweight scope job timeout from two to five minutes.

## Root cause

The full-history scope checkout exceeded its two-minute job timeout, which cancelled the scope job and correctly caused the merge gate to fail closed.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_listen_pusher_stack_ci_wiring.py backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py`
- `backend/.venv/bin/python backend/scripts/check_workflow_contracts.py --changed-files /tmp/omi-backend-hermetic-changed-files.txt`
- `actionlint .github/workflows/backend-hermetic-e2e.yml`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CI scope detection for the hermetic backend workflow; fail-closed behavior reduces the risk of silently skipping required checks.
> 
> **Overview**
> The **hermetic backend scope** job in `backend-hermetic-e2e.yml` now checks out full commit history with **`filter: blob:none`** (no blobs) and bumps the job timeout from **2 to 5 minutes** so the lightweight scope step can finish without hitting the ceiling that was failing the merge gate.
> 
> The scope shell script adds **`set -euo pipefail`** and **fail-closed** checks: if the diff base cannot be resolved (`git cat-file`) or **`git diff`** fails (e.g. partial-clone fetch issues), the job **exits 1** instead of quietly emitting **`applies=false`** and skipping hermetic backend jobs.
> 
> Unit tests in **`test_listen_pusher_stack_ci_wiring.py`** lock in the new checkout options, timeout, and ordering so **`applies=false`** only runs after a successful diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70fdd934aff0b57975283ed98a71ed6d3aeacd5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->