### PR TITLE
fix(app): sync offline recordings when capture provenance is denied (#10948)

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -457,6 +457,17 @@ enum SyncUploadLane { fresh, backfill }
 bool shouldRequestSyncCaptureManifest(String? conversationId, SyncUploadLane syncLane) =>
     conversationId != null && syncLane == SyncUploadLane.fresh;
 
+/// The lane a batch actually uploads on once fresh-capture provenance resolved.
+///
+/// A batch with no capture manifest is exactly what the server classifies as
+/// backfill (`unbound_capture_time`), so it uploads on the paced backfill lane.
+/// Holding it back on the client instead strands the account: a manifest denial
+/// is often permanent (403 unverifiable provenance, 409 already claimed), so a
+/// client-side cooldown retries the same denial forever and never uploads.
+@visibleForTesting
+SyncUploadLane syncUploadLaneForCaptureManifest(SyncUploadLane requestedLane, String? captureManifest) =>
+    captureManifest == null ? SyncUploadLane.backfill : requestedLane;
+
 Future<String?> _createSyncCaptureManifest(List<File> files, String conversationId) async {
   final claims = <Map<String, String>>[];
   for (final file in files) {
@@ -553,12 +564,7 @@ Future<UploadFilesResult> uploadLocalFilesV2(
   String? captureManifest;
   if (shouldRequestSyncCaptureManifest(conversationId, syncLane)) {
     captureManifest = await _createSyncCaptureManifest(files, conversationId!);
-    if (captureManifest == null) {
-      throw SyncRateLimitedException(
-        kind: SyncRateLimitKind.backfillPaced,
-        retryAfterSeconds: 30,
-      );
-    }
+    syncLane = syncUploadLaneForCaptureManifest(syncLane, captureManifest);
   }
   var url = '${Env.apiBaseUrl}v2/sync-local-files';
   if (conversationId != null) {

--- a/app/test/unit/sync_rate_limit_response_test.dart
+++ b/app/test/unit/sync_rate_limit_response_test.dart
@@ -9,6 +9,15 @@ void main() {
       expect(shouldRequestSyncCaptureManifest('conversation', SyncUploadLane.backfill), isFalse);
       expect(shouldRequestSyncCaptureManifest(null, SyncUploadLane.fresh), isFalse);
     });
+
+    test('a batch with no issued manifest uploads on the backfill lane instead of stalling', () {
+      expect(syncUploadLaneForCaptureManifest(SyncUploadLane.fresh, null), SyncUploadLane.backfill);
+    });
+
+    test('an issued manifest keeps the requested lane', () {
+      expect(syncUploadLaneForCaptureManifest(SyncUploadLane.fresh, 'manifest-token'), SyncUploadLane.fresh);
+      expect(syncUploadLaneForCaptureManifest(SyncUploadLane.backfill, 'manifest-token'), SyncUploadLane.backfill);
+    });
   });
 
   group('syncRateLimitKindForResponse', () {


### PR DESCRIPTION
## Bug (#10948)

Offline sync sits in "ready to sync" for hours — the whole day, for the reporter — and never uploads. The attached log repeats the same three events every 30 seconds:

```
local_upload_started      walCount 4
local_upload_rate_limited until <+30s>
local_upload_finished     batchesUploaded 0 ... newConversations 0
```

No batch is ever uploaded, no conversation is ever created, and the UI shows no error — just the ready-count.

## Root cause

Before a conversation-targeted fresh upload, `uploadLocalFilesV2` asks `/v2/sync-capture-manifest` for capture provenance. It treated **any** non-200 as a rate limit and threw `SyncRateLimitedException(kind: backfillPaced, retryAfterSeconds: 30)` — without ever sending the audio. That is wrong twice:

1. **The rejection is usually permanent for that batch.** The endpoint returns 403 (`Fresh capture provenance could not be verified`) or 409 (`Conversation fresh content was already claimed`). Sleeping 30s and replaying the identical request can never succeed, so the batch retries forever — matching the 30-second period in the log exactly (the only `retryAfterSeconds: 30` in the sync path).
2. **The fabricated cooldown is account-global and hits the wrong lane.** `SyncUploadGate` maps the exception to `RateLimitReason.backfillPaced`, which parks the **backfill** lane. So a *fresh* batch's manifest denial also blocked the unrelated backlog (25 pending WALs in the report) behind a cooldown that re-armed every 30 seconds. And because `backfillPaced` renders as the benign ready-count copy (`syncCardReadyCount`) rather than an error, the user got no actionable message — the silent stuck state the issue describes.

## Fix

When no manifest is issued, upload the batch on the paced backfill lane instead of stalling the client. That is exactly what the server already does with a manifest-less upload:

- `classify_sync_lane` returns `BACKFILL` / `unbound_capture_time` when there is no capture proof (`backend/utils/sync/lanes.py`), and the route accepts it (`backend/routers/sync.py`).
- `conversation_id` still rides the job payload, so the audio attaches to the same conversation.
- Duplicate protection is unaffected: it keys off the server-computed `content_id` ledger, not the manifest.
- Pacing becomes the server's real 429/503 + `Retry-After` instead of a client-invented cooldown, so a genuine backfill-capacity limit still parks the backfill lane — correctly, and with a deadline the server owns.

Net: a recording whose provenance cannot be proven now syncs on the slower lane instead of never syncing, and it no longer blocks the rest of the account's backlog.

## What I tested

- `cd app && ./test.sh -r compact` → **975 tests, all passed**
- `cd app && ./test.sh test/unit/sync_rate_limit_response_test.dart` → 6 passed, including the new regression cases: a batch with no issued manifest resolves to the backfill lane instead of stalling; an issued manifest keeps the requested lane.
- `make preflight` (deterministic check manifest) green.
- Not exercised against a live 403 from `/v2/sync-capture-manifest` on a real device — that needs the reporter's account state. The reproduction is the log in #10948, whose 30-second period and `batchesUploaded: 0` match this path exactly.

## Product invariants

`scripts/pr-preflight --suggest` → none affected.

Failure-Class: FC-permanent-write-rejection-retried-forever

Refs #10948

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

