### PR TITLE
fix(release): avoid beta promotion blob reads

### DIFF
--- a/.github/scripts/desktop_qualification_evidence.py
+++ b/.github/scripts/desktop_qualification_evidence.py
@@ -3,9 +3,11 @@
 
 The evidence is uploaded as a GitHub Actions artifact by the trusted
 qualification run.  Its run ID is the authority boundary: promotion verifies
-that run came from this workflow on main and then compares freshly downloaded
-release bytes with this document.  GitHub release bodies/assets are never the
-qualification authority.
+that run came from this workflow on main and then binds the evidence to the
+release using GitHub's immutable per-asset SHA-256 digests (the ``digest``
+field exposed by the REST release-assets API).  Release assets are never
+downloaded during promotion; their content-addressed digests are compared
+against the trusted artifact instead.
 """
 
 from __future__ import annotations

--- a/backend/tests/unit/test_qualified_beta_promotion.py
+++ b/backend/tests/unit/test_qualified_beta_promotion.py
@@ -711,6 +711,26 @@ async def test_server_admits_a_candidate_that_ships_the_side_by_side_beta_assets
 
 
 @pytest.mark.asyncio
+async def test_server_admits_a_candidate_from_github_release_digests_without_blob_reads():
+    release, evidence, run = _candidate_with_beta()[:3]
+    reader = FakeQualifiedBetaReader(release, evidence, run)
+    # Normal promotion only downloads the small, retained Actions artifact.
+    # It must not traverse the release binaries' temporary blob redirects.
+    reader.downloaded = {}
+
+    manifest = await build_qualified_beta_manifest(
+        TAG,
+        reader=reader,
+        now=datetime(2026, 7, 21, 12, 2, tzinfo=timezone.utc),
+    )
+
+    assert manifest["release_id"] == TAG
+    assert manifest["zip_sha256"] == release["assets"][0]["digest"]
+    assert manifest["dmg_sha256"] == release["assets"][1]["digest"]
+    assert reader.download_calls == []
+
+
+@pytest.mark.asyncio
 async def test_server_rejects_a_non_sanctioned_beta_like_identity():
     release, evidence, run = _candidate()
     release["assets"].append(

--- a/backend/tests/unit/test_qualified_beta_promotion.py
+++ b/backend/tests/unit/test_qualified_beta_promotion.py
@@ -14,6 +14,7 @@ from routers.updates import router as updates_router
 from utils.qualified_beta_promotion import (
     MAX_QUALIFICATION_ARTIFACT_BYTES,
     REPOSITORY,
+    SANCTIONED_BETA_ASSET_NAMES,
     GitHubQualifiedBetaReader,
     QualifiedBetaAdmissionError,
     _asset_url,
@@ -727,6 +728,27 @@ async def test_server_admits_a_candidate_from_github_release_digests_without_blo
     assert manifest["release_id"] == TAG
     assert manifest["zip_sha256"] == release["assets"][0]["digest"]
     assert manifest["dmg_sha256"] == release["assets"][1]["digest"]
+    assert reader.download_calls == []
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_a_beta_asset_with_a_noncanonical_release_url():
+    # The beta asset digest is valid and the trusted artifact matches, but the
+    # beta asset's browser_download_url is not the canonical release-asset URL.
+    # Admission must fail without reading any blob bytes.
+    release, evidence, run = _candidate_with_beta()[:3]
+    for asset in release["assets"]:
+        if asset["name"] in SANCTIONED_BETA_ASSET_NAMES:
+            asset["browser_download_url"] = "https://example.com/evil-beta"
+    reader = FakeQualifiedBetaReader(release, evidence, run)
+    reader.downloaded = {}
+
+    with pytest.raises(QualifiedBetaAdmissionError, match="identity does not match"):
+        await build_qualified_beta_manifest(
+            TAG,
+            reader=reader,
+            now=datetime(2026, 7, 21, 12, 2, tzinfo=timezone.utc),
+        )
     assert reader.download_calls == []
 
 

--- a/backend/utils/qualified_beta_promotion.py
+++ b/backend/utils/qualified_beta_promotion.py
@@ -499,12 +499,10 @@ async def build_qualified_beta_manifest(
     if not re.fullmatch(r"[0-9a-f]{40}", source_sha) or merged_source is not True:
         _fail("candidate source is not a trusted merged source")
     evidence_asset, evidence_name = _qualification_evidence_asset(assets, source_sha=source_sha)
-    zip_url, dmg_url, evidence_url = (
-        _asset_url(zip_asset, tag, "Omi.zip"),
-        _asset_url(dmg_asset, tag, "omi.dmg"),
-        _asset_url(evidence_asset, tag, evidence_name),
-    )
-    expected_digests = {
+    zip_url = _asset_url(zip_asset, tag, "Omi.zip")
+    dmg_url = _asset_url(dmg_asset, tag, "omi.dmg")
+    _asset_url(evidence_asset, tag, evidence_name)
+    release_digests = {
         "Omi.zip": _asset_digest(zip_asset),
         "omi.dmg": _asset_digest(dmg_asset),
         evidence_name: _asset_digest(evidence_asset),
@@ -514,7 +512,7 @@ async def build_qualified_beta_manifest(
         for beta_name in SANCTIONED_BETA_ASSET_NAMES:
             beta_asset = _asset(assets, beta_name)
             beta_assets[beta_name] = beta_asset
-            expected_digests[beta_name] = _asset_digest(beta_asset)
+            release_digests[beta_name] = _asset_digest(beta_asset)
     _, run_id, run_attempt = _select_qualification_run(
         await _read_github(source, "runs"), tag, source_sha, current_time
     )
@@ -530,31 +528,25 @@ async def build_qualified_beta_manifest(
         _fail("candidate trusted qualification evidence does not bind its run")
     if not _is_exact_integer(evidence.get("schema_version")) or evidence.get("schema_version") != 1:
         _fail("candidate trusted qualification evidence is invalid")
-    download_targets = [("Omi.zip", zip_url), ("omi.dmg", dmg_url), (evidence_name, evidence_url)]
-    for beta_name in SANCTIONED_BETA_ASSET_NAMES:
-        if beta_name in beta_assets:
-            download_targets.append((beta_name, _asset_url(beta_assets[beta_name], tag, beta_name)))
-    downloaded: dict[str, bytes] = {}
-    for name, url in download_targets:
-        content = await _read_github(source, "download", url)
-        if not isinstance(content, bytes):
-            _fail("candidate GitHub asset is unavailable")
-        downloaded[name] = content
-    actual_digests = {name: "sha256:" + hashlib.sha256(content).hexdigest() for name, content in downloaded.items()}
-    if actual_digests != expected_digests:
-        _fail("candidate asset digest does not match GitHub release metadata")
-    if downloaded[evidence_name] != trusted_evidence_bytes:
+    # GitHub exposes an immutable SHA-256 digest for each release asset. The
+    # qualification evidence is content-addressed by that digest and is also
+    # retained in the trusted Actions artifact. Rehash that small artifact to
+    # bind it to the release, rather than downloading every large release
+    # binary through GitHub's temporary blob redirects during promotion.
+    trusted_evidence_digest = "sha256:" + hashlib.sha256(trusted_evidence_bytes).hexdigest()
+    if trusted_evidence_digest != release_digests[evidence_name]:
         _fail("candidate release qualification evidence differs from its trusted run artifact")
     contract_release = _release_for_contract(release, assets)
-    # verify_evidence requires the digest set to equal the evidence's artifact set;
-    # when the beta identity ships, its two assets are in the evidence too.
+    # verify_evidence requires the digest set to equal the evidence's artifact
+    # set; GitHub's immutable release digests are the authoritative values.
+    # When the beta identity ships, its two assets are in the evidence too.
     verify_digests = {
-        "Omi.zip": actual_digests["Omi.zip"].removeprefix("sha256:"),
-        "omi.dmg": actual_digests["omi.dmg"].removeprefix("sha256:"),
+        "Omi.zip": release_digests["Omi.zip"].removeprefix("sha256:"),
+        "omi.dmg": release_digests["omi.dmg"].removeprefix("sha256:"),
     }
     for beta_name in SANCTIONED_BETA_ASSET_NAMES:
         if beta_name in beta_assets:
-            verify_digests[beta_name] = actual_digests[beta_name].removeprefix("sha256:")
+            verify_digests[beta_name] = release_digests[beta_name].removeprefix("sha256:")
     try:
         verify_evidence(
             evidence,
@@ -577,12 +569,12 @@ async def build_qualified_beta_manifest(
         "build_number": int(match.group("build")),
         "app_source_sha": source_sha,
         "zip_url": zip_url,
-        "zip_sha256": actual_digests["Omi.zip"],
+        "zip_sha256": release_digests["Omi.zip"],
         "dmg_url": dmg_url,
-        "dmg_sha256": actual_digests["omi.dmg"],
+        "dmg_sha256": release_digests["omi.dmg"],
         "ed_signature": signature,
         "qualification_evidence_asset": evidence_name,
-        "qualification_evidence_sha256": actual_digests[evidence_name],
+        "qualification_evidence_sha256": release_digests[evidence_name],
         "qualification_tier": "T2",
         "qualification_passed": True,
         "backend_mode": "app_only",

--- a/backend/utils/qualified_beta_promotion.py
+++ b/backend/utils/qualified_beta_promotion.py
@@ -511,6 +511,10 @@ async def build_qualified_beta_manifest(
     if has_beta_identity:
         for beta_name in SANCTIONED_BETA_ASSET_NAMES:
             beta_asset = _asset(assets, beta_name)
+            # Validate the canonical release URL for each beta asset. Unlike the
+            # blob downloads removed by this change, this is a pure identity
+            # check (no bytes fetched) and must not be skipped for beta assets.
+            _asset_url(beta_asset, tag, beta_name)
             beta_assets[beta_name] = beta_asset
             release_digests[beta_name] = _asset_digest(beta_asset)
     _, run_id, run_attempt = _select_qualification_run(


### PR DESCRIPTION
## Summary

- Admit qualified macOS Beta candidates from GitHub's immutable release-asset digests.
- Keep the retained, trusted qualification artifact as the content-addressed evidence authority.
- Eliminate normal-promotion reads of the large release binaries and their temporary blob redirects.

## Verification

- Qualified-beta promotion unit suite via `backend/test.sh` (CI 1.0s fast-unit guard) — 186 passed
- `black --check --line-length 120 --skip-string-normalization backend/utils/qualified_beta_promotion.py backend/tests/unit/test_qualified_beta_promotion.py`
- `PYTHON=.venv/bin/python python backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

