### PR TITLE
fix(desktop): mute Floating Bar notification previews independently

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -52,6 +52,7 @@ enum DefaultsKey: String {
   /// Test hook: forces TTS playback start to report failure (non-prod gauntlets).
   case forceTTSPlaybackStartFalse = "forceTTSPlaybackStartFalse"
   case shortcutPTTInputDeviceUID = "shortcut_pttInputDeviceUID"
+  case floatingBarNotificationPreviewsEnabled = "shortcut_floatingBarNotificationPreviewsEnabled"
   case desktopIsPaywalled = "desktop_isPaywalled"
   case rewindDisableContentCache = "rewindDisableContentCache"
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -322,7 +322,7 @@ class ShortcutSettings: ObservableObject {
   @Published var floatingBarNotificationPreviewsEnabled: Bool {
     didSet {
       UserDefaults.standard.set(
-        floatingBarNotificationPreviewsEnabled, forKey: "shortcut_floatingBarNotificationPreviewsEnabled")
+        floatingBarNotificationPreviewsEnabled, forKey: .floatingBarNotificationPreviewsEnabled)
     }
   }
 
@@ -596,7 +596,7 @@ class ShortcutSettings: ObservableObject {
 
     self.askOmiEnabled = UserDefaults.standard.object(forKey: "shortcut_askOmiEnabled") as? Bool ?? true
     self.floatingBarNotificationPreviewsEnabled =
-      UserDefaults.standard.object(forKey: "shortcut_floatingBarNotificationPreviewsEnabled") as? Bool ?? true
+      UserDefaults.standard.object(forKey: .floatingBarNotificationPreviewsEnabled) as? Bool ?? true
     self.pttEnabled = UserDefaults.standard.object(forKey: "shortcut_pttEnabled") as? Bool ?? true
     self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
     self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -319,6 +319,13 @@ class ShortcutSettings: ObservableObject {
     }
   }
 
+  @Published var floatingBarNotificationPreviewsEnabled: Bool {
+    didSet {
+      UserDefaults.standard.set(
+        floatingBarNotificationPreviewsEnabled, forKey: "shortcut_floatingBarNotificationPreviewsEnabled")
+    }
+  }
+
   /// Keeps the registration owner from observing a half-applied Ask Omi selection.
   /// The individual published values still update for SwiftUI, but the hotkey owner
   /// receives one notification only after both persisted values are final.
@@ -588,6 +595,8 @@ class ShortcutSettings: ObservableObject {
       ) ?? Self.defaultAskOmiShortcut
 
     self.askOmiEnabled = UserDefaults.standard.object(forKey: "shortcut_askOmiEnabled") as? Bool ?? true
+    self.floatingBarNotificationPreviewsEnabled =
+      UserDefaults.standard.object(forKey: "shortcut_floatingBarNotificationPreviewsEnabled") as? Bool ?? true
     self.pttEnabled = UserDefaults.standard.object(forKey: "shortcut_pttEnabled") as? Bool ?? true
     self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
     self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -28,6 +28,22 @@ extension SettingsContentView {
         }
       }
 
+      settingsCard(settingId: "floatingbar.notificationpreviews") {
+        HStack(spacing: OmiSpacing.lg) {
+          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+            Text("Notification Previews")
+              .scaledFont(size: OmiType.subheading, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+            Text("Show assistant notifications under the Floating Bar. When off, notifications use macOS banners instead.")
+              .scaledFont(size: OmiType.body)
+              .foregroundColor(OmiColors.textSecondary)
+          }
+          Spacer()
+          Toggle("", isOn: $shortcutSettings.floatingBarNotificationPreviewsEnabled)
+            .toggleStyle(OmiToggleStyle())
+        }
+      }
+
       settingsCard(settingId: "floatingbar.background") {
         VStack(alignment: .leading, spacing: OmiSpacing.lg) {
           Text("Background Style")

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -256,6 +256,11 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["floating bar", "ask omi", "show bar"], section: .floatingBar, icon: "sparkles",
       settingId: "floatingbar.show"),
     SettingsSearchItem(
+      name: "Notification Previews",
+      subtitle: "Show assistant notifications under the Floating Bar",
+      keywords: ["notification preview", "floating bar notification", "mute preview", "focus", "dnd"],
+      section: .floatingBar, icon: "sparkles", settingId: "floatingbar.notificationpreviews"),
+    SettingsSearchItem(
       name: "Background Style", subtitle: "Toggle between solid and transparent background",
       keywords: ["background", "solid", "transparent", "blur"], section: .floatingBar,
       icon: "sparkles", settingId: "floatingbar.background"),

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
@@ -5,10 +5,18 @@ enum FloatingBarNotificationPreviewPolicy {
     previewsEnabled && floatingBarEnabled
   }
 
+  /// The system-banner fallback only fires when the user explicitly muted in-bar
+  /// previews (`previewsEnabled == false`) while the Floating Bar is otherwise on —
+  /// that's the one case where the user asked to be notified some other way.
+  ///
+  /// It deliberately does NOT fire just because the Floating Bar itself is
+  /// disabled/hidden: `NotificationService` documents that a bare system banner
+  /// with no conversation context was previously reported as confusing, which is
+  /// why floating-bar-only notifications stay floating-bar-only (i.e. silent)
+  /// when the bar is off, matching pre-existing behavior.
   static func shouldDeliverSystemBanner(
     previewsEnabled: Bool, floatingBarEnabled: Bool, deliverSystemBanner: Bool
   ) -> Bool {
-    deliverSystemBanner
-      || !shouldShowInBarPreview(previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled)
+    deliverSystemBanner || (!previewsEnabled && floatingBarEnabled)
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum FloatingBarNotificationPreviewPolicy {
+  static func shouldShowInBarPreview(previewsEnabled: Bool, floatingBarEnabled: Bool) -> Bool {
+    previewsEnabled && floatingBarEnabled
+  }
+
+  static func shouldDeliverSystemBanner(
+    previewsEnabled: Bool, floatingBarEnabled: Bool, deliverSystemBanner: Bool
+  ) -> Bool {
+    deliverSystemBanner
+      || !shouldShowInBarPreview(previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled)
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -409,21 +409,35 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       UserDefaults.standard.set(true, forKey: Self.screenCaptureResetShownKey)
     }
 
-    FloatingControlBarManager.shared.showNotification(
-      ownerID: ownerID,
-      title: title,
-      message: message,
-      assistantId: assistantId,
-      sound: sound,
-      context: context,
-      action: action,
-      suggestionTelemetryIdentity: suggestionTelemetryIdentity,
-      screenshotData: screenshotData
-    )
+    let previewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
+    let floatingBarEnabled = FloatingControlBarManager.shared.isEnabled
+
+    if FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+      previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled
+    ) {
+      FloatingControlBarManager.shared.showNotification(
+        ownerID: ownerID,
+        title: title,
+        message: message,
+        assistantId: assistantId,
+        sound: sound,
+        context: context,
+        action: action,
+        suggestionTelemetryIdentity: suggestionTelemetryIdentity,
+        screenshotData: screenshotData
+      )
+    }
 
     // Default path: floating-bar only. Functional callers opt-in via
-    // `deliverSystemBanner: true` (see the parameter doc above).
-    guard deliverSystemBanner else { return }
+    // `deliverSystemBanner: true` (see the parameter doc above). When the
+    // in-bar preview is muted (or the bar itself is disabled), fall back to
+    // the system banner so the notification is never fully silenced.
+    guard
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
+        deliverSystemBanner: deliverSystemBanner
+      )
+    else { return }
 
     UserNotificationCallbackBridge.authorizationStatus { [weak self] authorizationStatus in
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -318,12 +318,21 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// Send a notification via the floating bar, and optionally as a native macOS system banner.
   ///
   /// `deliverSystemBanner` defaults to `false` because proactive AI notifications are
-  /// floating-bar only — users who disabled the floating bar reported clicking the
-  /// top-right system banner and getting no conversation context, which was confusing.
+  /// floating-bar only by default — users who disabled the floating bar reported clicking
+  /// the top-right system banner and getting no conversation context, which was confusing.
   /// Functional notifications (Crisp support replies, screen-recording permission
   /// prompts with a repair action) must pass `deliverSystemBanner: true` so they
   /// still surface as a system banner — they either have no floating-bar equivalent
   /// or must reach the user even when the floating bar is hidden/snoozed.
+  ///
+  /// That default is no longer absolute: `FloatingBarNotificationPreviewPolicy` forces a
+  /// system banner anyway once the user has explicitly muted in-bar previews
+  /// (`ShortcutSettings.floatingBarNotificationPreviewsEnabled == false`) while the Floating
+  /// Bar is still enabled, so the notification is never fully silenced (#6765). That banner
+  /// still lacks the in-bar conversation context noted above — the tradeoff is accepted only
+  /// for that explicit opt-out, not by default. Disabling the Floating Bar itself does
+  /// *not* force a banner: floating-bar-only notifications stay silent in that case, same
+  /// as before this policy existed, per the contentless-banner confusion noted above.
   func sendNotification(
     ownerID: String,
     title: String,
@@ -429,9 +438,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     // Default path: floating-bar only. Functional callers opt-in via
-    // `deliverSystemBanner: true` (see the parameter doc above). When the
-    // in-bar preview is muted (or the bar itself is disabled), fall back to
-    // the system banner so the notification is never fully silenced.
+    // `deliverSystemBanner: true` (see the parameter doc above). When the user
+    // explicitly muted in-bar previews (bar still enabled), fall back to the
+    // system banner so the notification is never fully silenced. Disabling the
+    // Floating Bar itself does not force a banner — see the parameter doc.
     guard
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
         previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -8,7 +8,12 @@ import XCTest
 /// Floating Bar in-app preview is their only delivery path today. Muting that
 /// preview without a fallback would silence those notifications entirely.
 /// These tests pin the policy that keeps a notification delivered via the
-/// native system banner whenever the in-bar preview is suppressed.
+/// native system banner only when the user *explicitly* muted in-bar previews
+/// while the Floating Bar stayed enabled. Merely disabling the Floating Bar
+/// must not force a banner: `NotificationService.sendNotification` documents
+/// that a contentless system banner (no conversation context) was previously
+/// reported as confusing, which is why floating-bar-only notifications stay
+/// silent when the bar itself is off — same as before this policy existed.
 final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testPreviewsAndBarEnabledShowsPreviewWithNoForcedBanner() {
     XCTAssertTrue(
@@ -19,11 +24,11 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
         previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: false))
   }
 
-  func testFloatingBarDisabledSkipsPreviewAndFallsBackToBanner() {
+  func testFloatingBarDisabledSkipsPreviewWithNoForcedBanner() {
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
         previewsEnabled: true, floatingBarEnabled: false))
-    XCTAssertTrue(
+    XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
         previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false))
   }
@@ -35,6 +40,15 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
         previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false))
+  }
+
+  func testFloatingBarDisabledStillNoForcedBannerEvenWithPreviewsMuted() {
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: false, floatingBarEnabled: false))
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: false, floatingBarEnabled: false, deliverSystemBanner: false))
   }
 
   func testExplicitSystemBannerAlwaysDeliversRegardlessOfPreviewState() {

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `FloatingBarNotificationPreviewPolicy` (issue #6765).
+///
+/// Proactive notifications default to `deliverSystemBanner: false`, so the
+/// Floating Bar in-app preview is their only delivery path today. Muting that
+/// preview without a fallback would silence those notifications entirely.
+/// These tests pin the policy that keeps a notification delivered via the
+/// native system banner whenever the in-bar preview is suppressed.
+final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
+  func testPreviewsAndBarEnabledShowsPreviewWithNoForcedBanner() {
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: true, floatingBarEnabled: true))
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: false))
+  }
+
+  func testFloatingBarDisabledSkipsPreviewAndFallsBackToBanner() {
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: true, floatingBarEnabled: false))
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false))
+  }
+
+  func testPreviewsMutedSkipsPreviewAndFallsBackToBanner() {
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: false, floatingBarEnabled: true))
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false))
+  }
+
+  func testExplicitSystemBannerAlwaysDeliversRegardlessOfPreviewState() {
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: true))
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
+        previewsEnabled: false, floatingBarEnabled: false, deliverSystemBanner: true))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260731-mute-floating-bar-notification-previews.json
+++ b/desktop/macos/changelog/unreleased/20260731-mute-floating-bar-notification-previews.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Floating Bar setting to mute in-app notification previews while keeping macOS notifications"
+}


### PR DESCRIPTION
## What changed and why

Floating Bar in-app notification previews had no independent off switch and
weren't affected by macOS Focus/DND, so proactive notifications showed
twice (in-bar preview + native banner) and the bar would temporarily
reappear just to render a preview users couldn't silence. Adds a
"Notification Previews" toggle (default on) so users can mute in-bar
previews while keeping native macOS notifications. Closes #6765.

## Out of scope

Real macOS Focus/DND auto-muting (the other optional item from #6765) is
deferred to a follow-up issue/PR, not included here. It requires
`INFocusStatusCenter`, which needs the `com.apple.developer.focus-status`
entitlement — an Apple-gated capability requiring a manual approval request
filed with Apple, not a self-service Xcode checkbox. This repo has no
existing usage of it and doesn't hold the entitlement today (`Omi.entitlements`
/ `Omi-Release.entitlements` only grant `applesignin`, audio-input,
screen-capture, and automation). Since that approval can't be obtained as
part of this PR, code built against it couldn't be exercised or verified, so
it's scoped out rather than shipped as unverifiable. The other optional item
from the issue — "only show in-bar previews when Floating Bar is enabled" —
is *not* deferred; the policy's `floatingBarEnabled` check already prevents
the in-bar preview (and the earlier forced bar reveal) whenever the bar is
off, with no separate toggle needed. That case intentionally stays silent
rather than falling back to a system banner, matching pre-existing behavior
and avoiding the contentless-banner confusion noted in `NotificationService`.

## Product invariants affected

- INV-CHAT-1 (path-matched via `desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift`; the toggle only mutes in-bar preview rendering and does not fork the shared transcript)

## How it was verified

- `xcrun swift build -c debug --package-path Desktop`
- `./scripts/dev-feedback.py --once swift 'FloatingBarNotificationPreviewPolicyTests'`
- Manual QA on a named dev bundle (`OMI_APP_NAME=omi-fix-6765 ./run.sh --yolo`):
  - Previews ON → proactive notification still shows under the Floating Bar (unchanged default behavior)
  - Previews OFF (bar enabled) → no in-bar card; native macOS banner still appears instead
  - Floating Bar disabled → no in-bar card and no temporary bar reveal for notifications; no forced system banner either (matches pre-existing silent behavior for this case, since a contentless banner was previously reported as confusing)
  - Snooze still suppresses both paths
  - Master Notifications toggle OFF still suppresses proactive notifications
- Screen recording of the above QA checklist attached

## Tests

Added `FloatingBarNotificationPreviewPolicyTests` covering the policy matrix:
previews+bar enabled (preview shown, no forced banner), bar disabled with
previews on (no preview, no forced banner), previews muted with bar enabled
(no preview, banner fallback), bar disabled with previews also muted (still
no forced banner), and explicit `deliverSystemBanner: true` (always delivers
regardless of preview state).

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

None.


##Video proof


https://github.com/user-attachments/assets/5d365549-0875-4c88-b1b9-ea901a1e0790


