### PR TITLE
chore(app): apply the pinned dart formatter to 2 drift files

### DIFF
--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -526,21 +526,16 @@ class AnalyticsManager {
   void deviceConnected() {
     final device = _preferences.btDevice;
     final vendor = device.type.analyticsVendor;
-    track('Device Connected', properties: {
-      ...device.toJson(),
-      'type': device.type.name,
-      'device_vendor': vendor,
-    });
+    track('Device Connected', properties: {...device.toJson(), 'type': device.type.name, 'device_vendor': vendor});
     setUserProperty('device_vendor', vendor);
   }
 
   void devicePaired(String firstPairedAt) {
     final device = _preferences.btDevice;
-    track('Device Paired', properties: {
-      ...device.toJson(),
-      'type': device.type.name,
-      'device_vendor': device.type.analyticsVendor,
-    });
+    track(
+      'Device Paired',
+      properties: {...device.toJson(), 'type': device.type.name, 'device_vendor': device.type.analyticsVendor},
+    );
     _setUserPropertiesBatch({
       'has_paired_device': true,
       'first_paired_at': firstPairedAt,
@@ -550,12 +545,7 @@ class AnalyticsManager {
 
   void deviceDisconnected() => track('Device Disconnected');
 
-  void deviceSessionEnded({
-    required BtDevice device,
-    required Duration duration,
-    String? reason,
-    int? hciReasonCode,
-  }) {
+  void deviceSessionEnded({required BtDevice device, required Duration duration, String? reason, int? hciReasonCode}) {
     final properties = <String, Object>{
       'duration_seconds': duration.inMilliseconds / Duration.millisecondsPerSecond,
       'reason': _knownDeviceValue(reason ?? ''),

--- a/app/test/widgets/permissions_interstitial_analytics_test.dart
+++ b/app/test/widgets/permissions_interstitial_analytics_test.dart
@@ -20,16 +20,15 @@ void main() {
     AnalyticsManager.resetForTesting();
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-      permissionsChannel,
-      (call) async {
-        if (call.method == 'checkServiceStatus') return 0;
-        if (call.method == 'requestPermissions') {
-          return {for (final permission in call.arguments as List<dynamic>) permission: 0};
-        }
-        return null;
-      },
-    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(permissionsChannel, (
+      call,
+    ) async {
+      if (call.method == 'checkServiceStatus') return 0;
+      if (call.method == 'requestPermissions') {
+        return {for (final permission in call.arguments as List<dynamic>) permission: 0};
+      }
+      return null;
+    });
   });
 
   tearDown(() {
@@ -68,23 +67,17 @@ void main() {
     await tester.idle();
     await AnalyticsManager.flushPending(force: true);
 
-    expect(
-      analytics.events,
-      ['Permissions Interstitial Shown', 'Permissions Interstitial Completed'],
-    );
+    expect(analytics.events, ['Permissions Interstitial Shown', 'Permissions Interstitial Completed']);
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpWidget(app());
     await AnalyticsManager.flushPending(force: true);
 
-    expect(
-      analytics.events,
-      [
-        'Permissions Interstitial Shown',
-        'Permissions Interstitial Completed',
-        'Permissions Interstitial Shown',
-      ],
-    );
+    expect(analytics.events, [
+      'Permissions Interstitial Shown',
+      'Permissions Interstitial Completed',
+      'Permissions Interstitial Shown',
+    ]);
   });
 }
 


### PR DESCRIPTION
chore(app): apply the pinned dart formatter to 2 drift files

Formats app/lib/utils/analytics/analytics_manager.dart and
app/test/widgets/permissions_interstitial_analytics_test.dart to the
CI-pinned dart formatter (Flutter 3.44.5, line-length 120). These two
files drifted on main, forcing any PR whose merge touches them to carry
formatting churn. Same pattern as #10879 for Swift.

Product invariants affected
none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

