### PR TITLE
fix(ci): repair and wire the release-process guard self-tests (#10351)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -61,6 +61,11 @@ checks:
     triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", ".github/scripts/git_bash.py", "scripts/dev-harness/_resolve_python.sh", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
+  - id: desktop-release-process-guard-self-tests
+    command: ["bash", "scripts/run-release-process-guard-tests.sh"]
+    triggers: [".github/scripts/check-release-process-guards.py", ".github/scripts/test_check_release_process_guards.py", ".github/scripts/fixtures/codemagic_workflow_contract/v1.json", "codemagic.yaml", "scripts/run-release-process-guard-tests.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10351: the guard's own regression suite ran in no lane, so 9 of its cases silently rotted on main against a codemagic.yaml the pinned parent no longer recognised"
   - id: failure-class-retirement-author
     command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
     triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -19,6 +19,10 @@ GUARDS = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(GUARDS)
 REVIEWED_PARENT = "4e391ee726642d99abc2c61966dcd80a836e6c1c"
 RAW_SCANNER_PARENT = "11ac6d9e9d27677d06d513364f2e658f5ed99870"
+# The reviewed parent predates the INV-BETA-1 "Create Omi Beta variant" step, so it counts 21
+# canonical script steps where main now approves 22. These probes assert what the parent's
+# narrower publisher lock accepted, not the step inventory, so its era's count is noise here.
+STALE_PARENT_STEP_COUNT_ERROR = "canonical workflow must retain exactly 21 approved script steps"
 
 
 def _copy_contract_tree(tmp_path: Path, monkeypatch) -> Path:
@@ -60,6 +64,12 @@ def _load_parent_guard(tmp_path: Path, revision: str = REVIEWED_PARENT):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _reviewed_parent_errors(parent) -> list[str]:
+    return [
+        error for error in parent.check_codemagic_release_publishers() if error != STALE_PARENT_STEP_COUNT_ERROR
+    ]
 
 
 def _append_unreviewed_workflow(
@@ -453,7 +463,7 @@ def test_reviewed_parent_accepts_unreviewed_publisher_bypasses_but_global_lock_r
 
     parent = _load_parent_guard(tmp_path)
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == [], script
+    assert _reviewed_parent_errors(parent) == [], script
 
     errors = GUARDS.check_codemagic_release_publishers()
     assert any("entire document" in error for error in errors), errors
@@ -470,7 +480,7 @@ def test_reviewed_parent_accepts_unknown_credential_group_with_publisher_but_glo
 
     parent = _load_parent_guard(tmp_path)
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == []
+    assert _reviewed_parent_errors(parent) == []
 
     errors = GUARDS.check_codemagic_release_publishers()
     assert any("entire document" in error for error in errors), errors
@@ -511,7 +521,7 @@ def test_global_document_lock_rejects_every_codemagic_mutation(tmp_path, monkeyp
     parent = _load_parent_guard(tmp_path)
     _restore_parent_preview_credential_shape(codemagic)
     parent.ROOT = tmp_path
-    parent_errors = parent.check_codemagic_release_publishers()
+    parent_errors = _reviewed_parent_errors(parent)
     assert (parent_errors == []) is parent_accepts, parent_errors
 
     errors = GUARDS.check_codemagic_release_publishers()
@@ -532,7 +542,7 @@ def test_global_document_raw_lock_rejects_semantically_equivalent_yaml_rewrite(t
     parent = _load_parent_guard(tmp_path)
     _restore_parent_preview_credential_shape(codemagic)
     parent.ROOT = tmp_path
-    assert parent.check_codemagic_release_publishers() == []
+    assert _reviewed_parent_errors(parent) == []
 
     _mutate(
         codemagic,

--- a/scripts/run-release-process-guard-tests.sh
+++ b/scripts/run-release-process-guard-tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run the release-process guard self-tests with the repository's locked PyYAML dependency.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=dev-harness/_resolve_python.sh
+source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
+
+if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
+  || ! "$BACKEND_PYTHON" -c "import pytest, yaml" >/dev/null 2>&1; then
+  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
+    echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
+    exit 1
+  fi
+fi
+
+exec "$BACKEND_PYTHON" -m pytest "$ROOT_DIR/.github/scripts/test_check_release_process_guards.py" -q "$@"


### PR DESCRIPTION
Fixes #10351.

## Bug

`.github/scripts/test_check_release_process_guards.py` had **9 of 92 cases failing on main**, and the suite ran in **no lane at all** — it is absent from `.github/checks-manifest.yaml` and no workflow invokes it. The guard it covers (`check-release-process-guards.py`) runs in `repo-checks.yml` and is green, so the rot was invisible.

Reproduced on a clean `origin/main` (72e730a961):

```
$ backend/.venv/bin/python -m pytest .github/scripts/test_check_release_process_guards.py -q
9 failed, 83 passed in 27.85s
```

## Root cause

All 9 failures are one cause. The historical-parent probes load the guard as of the pinned `REVIEWED_PARENT` (`4e391ee7`) and run it against **today's** `codemagic.yaml`. That revision hard-codes `len(canonical_scripts) != 21`; main approves 22 since the INV-BETA-1 "Create Omi Beta variant" step landed (PR #10317, where the live guard was updated 21 → 22). So every probe collected

```
canonical workflow must retain exactly 21 approved script steps
```

from the parent, and its `parent_errors == []` assertion failed — on an inventory detail none of these probes are about.

## Fix

1. **Drop exactly that one stale error** from the reviewed-parent probes (`_reviewed_parent_errors`). Every other parent error stays asserted, so the probes keep their teeth — the `anchor-spelling` case still asserts the parent *rejects* (`parent_accepts=False`) and passes.
2. **Wire the suite into the manifest** as `desktop-release-process-guard-self-tests` (`local` + `ci` lanes) via `scripts/run-release-process-guard-tests.sh`, which reuses the same locked-PyYAML interpreter contract as the existing `scripts/run-release-process-guards.sh`. Triggered by the guard, the suite, the workflow-contract fixture and `codemagic.yaml` — so the next `codemagic.yaml` step change fails a check instead of rotting silently.

No production code, no workflow, no `codemagic.yaml`, and no guard-logic change: the guard's own 22-step rule is untouched.

## What I tested

```
# the failing suite, before and after
before: 9 failed, 83 passed in 27.85s
after:  92 passed in 31.04s

# the new runner script, standalone
$ bash scripts/run-release-process-guard-tests.sh
92 passed in 29.24s

# the new check through the real CI-lane runner
$ .github/scripts/run_checks.py --lane ci --check-id desktop-release-process-guard-self-tests
<== PASS desktop-release-process-guard-self-tests (30.15s)

# selection: the check is picked up by this PR's own diff
$ .github/scripts/run_checks.py --lane ci --base origin/main --list
  SELECTED desktop-release-process-guard-self-tests ...

# manifest contract
$ .github/scripts/test_run_checks.py
Ran 40 tests ... OK
```

All 81 CI-lane checks selected by this diff were run individually: **80 pass**. The one failure, `setup-pre-push-prerequisites`, reproduces identically on unmodified `origin/main` in a clean worktree — a local macOS `/private/var` vs `/var` symlink artifact, not from this change.

Hatches used on push, both disclosed: `PRE_PUSH_SKIP_PR_PREFLIGHT=1` (the shared preflight aborts on that same pre-existing `setup-pre-push-prerequisites` failure; the full selection was run manually instead, as above) and `PRE_PUSH_SKIP_FLUTTER_GENERATED=1` (touching `.github/checks-manifest.yaml` wakes the Flutter codegen lane; this diff contains no Dart). CI runs both lanes unhatched.

Failure-Class: FC-nonexecuting-verification-command

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

