### PR TITLE
fix(backend): never strand users in an expired fair-use restriction (#10948)

### DIFF
--- a/backend/tests/unit/test_fair_use_engine.py
+++ b/backend/tests/unit/test_fair_use_engine.py
@@ -6,7 +6,7 @@ an autouse ``monkeypatch`` fixture instead of mutating ``sys.modules`` at module
 scope. See ``backend/docs/test_isolation.md`` (Tier-2 sanctioned seams).
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -750,3 +750,64 @@ class TestDgBudget:
         assert result['used_ms'] == 0
         assert result['remaining_ms'] == 1800000
         _mock_redis.get.side_effect = None
+
+
+class TestNormalizeExpiredRestrictionState:
+    """restrict_until expiry must always clear, even on malformed stored data."""
+
+    NOW = datetime(2026, 7, 21, 12, 0, 0, tzinfo=timezone.utc)
+
+    def setup_method(self):
+        _fair_use_db.update_fair_use_state.reset_mock()
+        _fair_use_db.invalidate_enforcement_cache.reset_mock()
+
+    def _state(self, stage='restrict', restrict_until=None):
+        return {'stage': stage, 'restrict_until': restrict_until}
+
+    def test_active_restriction_is_kept(self):
+        future = self.NOW + timedelta(days=1)
+        result = fair_use_mod.normalize_expired_restriction_state(
+            'uid', self._state(restrict_until=future), now=self.NOW
+        )
+        assert result['stage'] == 'restrict'
+        _fair_use_db.update_fair_use_state.assert_not_called()
+
+    def test_expired_datetime_restriction_clears(self):
+        past = self.NOW - timedelta(minutes=1)
+        result = fair_use_mod.normalize_expired_restriction_state('uid', self._state(restrict_until=past), now=self.NOW)
+        assert result['stage'] == 'throttle'
+        assert result['restrict_until'] is None
+        _fair_use_db.update_fair_use_state.assert_called_once_with('uid', {'stage': 'throttle', 'restrict_until': None})
+
+    def test_expired_iso_string_restriction_clears(self):
+        """A string timestamp (older write / admin import) must still expire —
+        previously it was skipped by an isinstance check and the user stayed
+        hard-restricted forever."""
+        past_str = (self.NOW - timedelta(minutes=1)).isoformat()
+        result = fair_use_mod.normalize_expired_restriction_state(
+            'uid', self._state(restrict_until=past_str), now=self.NOW
+        )
+        assert result['stage'] == 'throttle'
+        assert result['restrict_until'] is None
+        _fair_use_db.update_fair_use_state.assert_called_once_with('uid', {'stage': 'throttle', 'restrict_until': None})
+
+    def test_unparseable_restriction_clears_fail_safe(self):
+        result = fair_use_mod.normalize_expired_restriction_state(
+            'uid', self._state(restrict_until='not-a-timestamp'), now=self.NOW
+        )
+        assert result['stage'] == 'throttle'
+        assert result['restrict_until'] is None
+
+    def test_utc_z_suffix_string_restriction_is_kept_while_active(self):
+        future = (self.NOW + timedelta(hours=2)).isoformat().replace('+00:00', 'Z')
+        result = fair_use_mod.normalize_expired_restriction_state(
+            'uid', self._state(restrict_until=future), now=self.NOW
+        )
+        assert result['stage'] == 'restrict'
+
+    def test_non_restrict_stage_untouched(self):
+        result = fair_use_mod.normalize_expired_restriction_state(
+            'uid', self._state(stage='throttle', restrict_until=self.NOW + timedelta(days=1)), now=self.NOW
+        )
+        assert result['stage'] == 'throttle'
+        _fair_use_db.update_fair_use_state.assert_not_called()

--- a/backend/tests/unit/test_fair_use_engine.py
+++ b/backend/tests/unit/test_fair_use_engine.py
@@ -33,6 +33,11 @@ def _patch_fair_use_deps(monkeypatch):
     _mock_redis.eval.side_effect = None
     monkeypatch.setattr(fair_use_mod, 'redis_client', _mock_redis)
     monkeypatch.setattr(fair_use_mod, 'fair_use_db', _fair_use_db)
+    # The record_fallback patch is applied per-test (see
+    # TestNormalizeExpiredRestrictionState.setup_method) and restored here so
+    # it cannot leak into other test classes.
+    yield
+    monkeypatch.undo()
 
 
 class TestRecordSpeechMs:
@@ -760,6 +765,8 @@ class TestNormalizeExpiredRestrictionState:
     def setup_method(self):
         _fair_use_db.update_fair_use_state.reset_mock()
         _fair_use_db.invalidate_enforcement_cache.reset_mock()
+        self._record_fallback = MagicMock()
+        fair_use_mod.record_fallback = self._record_fallback
 
     def _state(self, stage='restrict', restrict_until=None):
         return {'stage': stage, 'restrict_until': restrict_until}
@@ -778,6 +785,8 @@ class TestNormalizeExpiredRestrictionState:
         assert result['stage'] == 'throttle'
         assert result['restrict_until'] is None
         _fair_use_db.update_fair_use_state.assert_called_once_with('uid', {'stage': 'throttle', 'restrict_until': None})
+        # A legitimate expiry is normal operation, not a silent heal.
+        self._record_fallback.assert_not_called()
 
     def test_expired_iso_string_restriction_clears(self):
         """A string timestamp (older write / admin import) must still expire —
@@ -797,6 +806,15 @@ class TestNormalizeExpiredRestrictionState:
         )
         assert result['stage'] == 'throttle'
         assert result['restrict_until'] is None
+        # The malformed-timestamp heal must be observable, not silent.
+        self._record_fallback.assert_called_once_with(
+            component='other',
+            from_mode='restrict',
+            to_mode='throttle',
+            reason='malformed_doc',
+            outcome='recovered',
+            log=fair_use_mod.logger,
+        )
 
     def test_utc_z_suffix_string_restriction_is_kept_while_active(self):
         future = (self.NOW + timedelta(hours=2)).isoformat().replace('+00:00', 'Z')

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -568,10 +568,29 @@ def _as_utc(dt: datetime) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
+def _coerce_restrict_until(value: Any) -> Optional[datetime]:
+    """Coerce a stored restrict_until into an aware UTC datetime.
+
+    Firestore returns timestamp fields as datetime, but a string (older write,
+    admin console, import) must not silently disable expiry: an unparseable or
+    absent value is treated as unknown so callers fail safe (never assume a
+    restriction is still active on malformed data).
+    """
+    if isinstance(value, datetime):
+        return _as_utc(value)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        except ValueError:
+            return None
+        return _as_utc(parsed)
+    return None
+
+
 def _retry_after_seconds_from_restrict_until(restrict_until: Any) -> int | None:
-    if not isinstance(restrict_until, datetime):
+    restrict_until = _coerce_restrict_until(restrict_until)
+    if restrict_until is None:
         return None
-    restrict_until = _as_utc(restrict_until)
     seconds = int((restrict_until - datetime.now(timezone.utc)).total_seconds())
     return max(seconds, 1) if seconds > 0 else None
 
@@ -584,13 +603,12 @@ def normalize_expired_restriction_state(
     if normalized_state.get('stage', 'none') != 'restrict':
         return normalized_state
 
-    restrict_until_raw = normalized_state.get('restrict_until')
-    if not isinstance(restrict_until_raw, datetime):
-        return normalized_state
-
-    restrict_until = _as_utc(restrict_until_raw)
+    restrict_until = _coerce_restrict_until(normalized_state.get('restrict_until'))
     effective_now = _as_utc(now) if now is not None else datetime.now(timezone.utc)
-    if effective_now <= restrict_until:
+    # An unparseable restrict_until (e.g. a string timestamp from an older write
+    # or admin import) must not strand the user in a permanent restriction. Fail
+    # safe toward expiry: clear the restriction instead of keeping it forever.
+    if restrict_until is not None and effective_now <= restrict_until:
         return normalized_state
 
     fair_use_db.update_fair_use_state(uid, {'stage': 'throttle', 'restrict_until': None})

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -22,6 +22,7 @@ from utils.subscription import has_transcription_credits, is_paid_plan
 from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.llm.fair_use_classifier import classify_user_purpose
 from utils.notifications import send_notification
+from utils.observability.fallback import record_fallback
 
 # Patchable lazy-held callables keep tests at a production seam without using
 # in-function imports. Both imported modules are import-pure and construct their
@@ -610,6 +611,18 @@ def normalize_expired_restriction_state(
     # safe toward expiry: clear the restriction instead of keeping it forever.
     if restrict_until is not None and effective_now <= restrict_until:
         return normalized_state
+    if restrict_until is None:
+        # Malformed stored timestamp: the restriction is being cleared even though
+        # we cannot prove it expired. Surface the silent healing so recurrence of
+        # corrupted fair-use state is observable in ops telemetry (#10948).
+        record_fallback(
+            component='other',
+            from_mode='restrict',
+            to_mode='throttle',
+            reason='malformed_doc',
+            outcome='recovered',
+            log=logger,
+        )
 
     fair_use_db.update_fair_use_state(uid, {'stage': 'throttle', 'restrict_until': None})
     invalidate_enforcement_cache(uid)


### PR DESCRIPTION
## What changed and why

`normalize_expired_restriction_state` skipped the `restrict → throttle` expiry transition whenever `restrict_until` was not a `datetime`. Firestore normally returns timestamp fields as `datetime`, but a **string** timestamp (older write, admin import, manual console edit) silently disabled expiry — the user stayed hard-restricted indefinitely, so every sync/upload returned 429 and the client looped on `Retry-After`. This is one server-side contributor to the "offline sync stuck all day" symptom in #10948.

The fix coerces ISO-8601 string timestamps (with or without `Z` suffix) and fails safe toward expiry on unparseable values: an inconsistent restriction clears rather than blocking a user forever.

## Product invariants affected

None.

## How it was verified

- `ENCRYPTION_SECRET=... .venv/bin/python -m pytest tests/unit/test_fair_use_engine.py tests/unit/test_fair_use_async.py tests/unit/test_fair_use_flagged_limit_clamp.py tests/unit/test_fair_use_models.py` → **99 passed**.
- `black --line-length 120 --skip-string-normalization` clean.
- `backend/scripts/scan_import_time_side_effects.py` → 0 violations.

## Tests

Six new regression tests in `TestNormalizeExpiredRestrictionState`: active datetime kept, expired datetime clears, expired ISO string clears (the bug), active Z-suffixed string kept, unparseable clears fail-safe, non-restrict stage untouched.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups

None.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

