### PR TITLE
fix(app): transcript readiness is socket-driven, not connectivity-driven (#6311)

### DIFF
--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -411,7 +411,13 @@ class CaptureController extends ChangeNotifier
 
   bool _transcriptServiceReady = false;
 
-  bool get transcriptServiceReady => _transcriptServiceReady && _isConnected;
+  // The transcript service readiness is driven solely by the socket lifecycle
+  // (set true on subscribe, false on close). The `&& _isConnected` gate was
+  // removed (#6311): ConnectivityService can flicker false during a WiFi↔cellular
+  // handoff or a brief DNS hiccup even while the WebSocket is alive and segments
+  // are flowing, which made the UI show "Recording, reconnecting" over healthy
+  // transcription. The socket is the authoritative connectivity signal.
+  bool get transcriptServiceReady => _transcriptServiceReady;
 
   // having a connected device or using the phone's mic for recording.
   // Includes `interrupted` so the keep-alive/reconnect path keeps running

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -1130,18 +1130,28 @@ void main() {
   // lifecycle is the authoritative signal; a connectivity change must never
   // change transcript-service readiness.
   group('transcriptServiceReady is socket-driven, not connectivity-driven (#6311)', () {
-    test('connectivity flicker does not toggle transcript readiness', () {
+    test('connectivity flicker does not toggle readiness of a ready socket', () {
       final provider = CaptureProvider();
-      // Fresh provider: socket not yet ready, so readiness must be false.
-      expect(provider.transcriptServiceReady, isFalse);
 
-      // A connectivity flip must not change readiness on its own — before the
-      // fix, onConnectionStateChanged(false) ANDed _isConnected into the getter
-      // and could manufacture a "reconnecting" state from a healthy socket.
+      // Drive the provider into the socket-subscribed state (the scenario the
+      // old getter got wrong): onConnected mirrors the transcript WebSocket
+      // subscribing, which sets _transcriptServiceReady = true.
+      provider.onConnected();
+      expect(provider.transcriptServiceReady, isTrue);
+
+      // A connectivity flicker must not toggle readiness off. Before the fix
+      // this ANDed _isConnected=false into the getter and manufactured a false
+      // "Recording, reconnecting" over a healthy socket.
       provider.onConnectionStateChanged(false);
-      expect(provider.transcriptServiceReady, isFalse);
+      expect(provider.transcriptServiceReady, isTrue, reason: 'ready socket must survive a connectivity flicker');
+
+      // And it must not depend on connectivity coming back either.
       provider.onConnectionStateChanged(true);
-      expect(provider.transcriptServiceReady, isFalse);
+      expect(provider.transcriptServiceReady, isTrue);
+
+      // A socket close is the only thing that should end readiness.
+      provider.onClosed();
+      expect(provider.transcriptServiceReady, isFalse, reason: 'socket close must end transcript readiness');
       provider.dispose();
     });
   });

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -1121,4 +1121,28 @@ void main() {
       provider.dispose();
     });
   });
+
+  // Regression coverage for issue #6311: before this change
+  // `transcriptServiceReady` was `_transcriptServiceReady && _isConnected`, so a
+  // transient ConnectivityService flicker (WiFi↔cellular handoff, brief DNS
+  // hiccup) flipped the header to "Recording, reconnecting" even while the
+  // transcript WebSocket was alive and segments were flowing. The socket
+  // lifecycle is the authoritative signal; a connectivity change must never
+  // change transcript-service readiness.
+  group('transcriptServiceReady is socket-driven, not connectivity-driven (#6311)', () {
+    test('connectivity flicker does not toggle transcript readiness', () {
+      final provider = CaptureProvider();
+      // Fresh provider: socket not yet ready, so readiness must be false.
+      expect(provider.transcriptServiceReady, isFalse);
+
+      // A connectivity flip must not change readiness on its own — before the
+      // fix, onConnectionStateChanged(false) ANDed _isConnected into the getter
+      // and could manufacture a "reconnecting" state from a healthy socket.
+      provider.onConnectionStateChanged(false);
+      expect(provider.transcriptServiceReady, isFalse);
+      provider.onConnectionStateChanged(true);
+      expect(provider.transcriptServiceReady, isFalse);
+      provider.dispose();
+    });
+  });
 }


### PR DESCRIPTION
Fixes #6311

## What changed and why

`transcriptServiceReady` was `_transcriptServiceReady && _isConnected`, where `_isConnected` comes from `ConnectivityService`. That service can flicker `false` during a WiFi↔cellular handoff or a brief DNS hiccup even while the transcript WebSocket is alive and segments are flowing — so the recording header showed "Recording, reconnecting" (red dot + cloud-off icon) over perfectly healthy transcription.

`_transcriptServiceReady` is already the authoritative signal (set `true` on socket subscribe, `false` on close/error). This drops the `_isConnected` AND so the UI reflects the actual transcript pipeline rather than a network check.

`ConnectivityService` state remains in use where it belongs — `hasNetwork` for the recording manager and `onConnectionStateChanged` mirroring — only the readiness getter changes.

## Product invariants affected

None (UI state fix on an existing path).

## How it was verified

- `flutter test test/providers/capture_provider_test.dart` → **67 passed** (66 existing + 1 new regression).
- `flutter analyze lib/services/capture/capture_controller.dart test/providers/capture_provider_test.dart` → no new issues (3 pre-existing infos in the test file, untouched by this change).
- `dart format --line-length 120` clean.

## Tests

New `transcriptServiceReady is socket-driven, not connectivity-driven (#6311)` group: asserts a connectivity flicker (`onConnectionStateChanged(false)` → `true`) cannot toggle transcript readiness — the exact regression that showed a false "reconnecting" state.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups

None.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

