### PR TITLE
feat(app): Omi HUD on display-capable Meta glasses, gated on the capability

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
@@ -66,7 +66,7 @@ private object PigeonCommunicatorPigeonUtils {
     }
     return a == b
   }
-      
+
 }
 
 /**
@@ -898,7 +898,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onRecordingStopped(callback: (Result<Unit>) -> Unit)
@@ -915,7 +915,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onAudioData(audioDataArg: ByteArray, callback: (Result<Unit>) -> Unit)
@@ -932,7 +932,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onAudioChunk(audioChunkArg: ByteArray, chunkIndexArg: Long, isLastArg: Boolean, sampleRateArg: Double, callback: (Result<Unit>) -> Unit)
@@ -949,7 +949,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onRecordingError(errorArg: String, callback: (Result<Unit>) -> Unit)
@@ -966,7 +966,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onMicrophonePermissionResult(grantedArg: Boolean, callback: (Result<Unit>) -> Unit)
@@ -983,7 +983,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onMainAppMicrophonePermissionResult(grantedArg: Boolean, callback: (Result<Unit>) -> Unit)
@@ -1000,7 +1000,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onWatchBatteryUpdate(batteryLevelArg: Double, batteryStateArg: Long, callback: (Result<Unit>) -> Unit)
@@ -1017,7 +1017,7 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -1423,7 +1423,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onPeripheralDiscovered(peripheralArg: BlePeripheral, callback: (Result<Unit>) -> Unit)
@@ -1440,7 +1440,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onDeviceReady(peripheralUuidArg: String, servicesArg: List<BleService>, callback: (Result<Unit>) -> Unit)
@@ -1457,7 +1457,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onPeripheralDisconnected(peripheralUuidArg: String, errorArg: String?, callback: (Result<Unit>) -> Unit)
@@ -1474,7 +1474,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onCharacteristicValueUpdated(peripheralUuidArg: String, serviceUuidArg: String, characteristicUuidArg: String, valueArg: ByteArray, callback: (Result<Unit>) -> Unit)
@@ -1491,7 +1491,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onRssiUpdate(peripheralUuidArg: String, rssiArg: Long, callback: (Result<Unit>) -> Unit)
@@ -1508,7 +1508,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onStateRestored(peripheralUuidsArg: List<String>, callback: (Result<Unit>) -> Unit)
@@ -1525,7 +1525,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /**
@@ -1546,7 +1546,7 @@ class BleFlutterApi(private val binaryMessenger: BinaryMessenger, private val me
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -2030,7 +2030,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onGlassesDiscovered(glassesArg: RayBanMetaGlasses, callback: (Result<Unit>) -> Unit)
@@ -2047,7 +2047,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onConnectionStateChanged(deviceIdArg: String, stateArg: String, callback: (Result<Unit>) -> Unit)
@@ -2064,7 +2064,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /** PCM16 little-endian mono audio at [sampleRate] Hz from the glasses mic. */
@@ -2082,7 +2082,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /** Whether the glasses' HFP mic is the active input route right now. */
@@ -2100,7 +2100,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /** JPEG bytes plus clockwise orientation in degrees (0/90/180/270). */
@@ -2118,7 +2118,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /** 'stopped' | 'starting' | 'streaming' | 'paused'. */
@@ -2136,7 +2136,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onCameraPermissionChanged(statusArg: String, callback: (Result<Unit>) -> Unit)
@@ -2153,7 +2153,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onError(codeArg: String, messageArg: String, callback: (Result<Unit>) -> Unit)
@@ -2170,7 +2170,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /** 'unavailable' | 'detached' | 'attaching' | 'ready' | 'error'. */
@@ -2188,7 +2188,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   /** The id of the HudActionWire the wearer tapped. */
@@ -2206,7 +2206,7 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
         }
       } else {
         callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }

--- a/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
@@ -390,6 +390,119 @@ data class BluetoothHfpInput (
 
   override fun hashCode(): Int = toList().hashCode()
 }
+
+/**
+ * One rendered row of a HUD screen. [style] is 'heading' | 'body' | 'meta'.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class HudLineWire (
+  val text: String,
+  val style: String,
+  val muted: Boolean
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): HudLineWire {
+      val text = pigeonVar_list[0] as String
+      val style = pigeonVar_list[1] as String
+      val muted = pigeonVar_list[2] as Boolean
+      return HudLineWire(text, style, muted)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      text,
+      style,
+      muted,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is HudLineWire) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return PigeonCommunicatorPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
+ * A tappable control on a HUD screen; [id] comes back through
+ * RayBanMetaFlutterAPI.onDisplayActionTapped.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class HudActionWire (
+  val id: String,
+  val label: String
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): HudActionWire {
+      val id = pigeonVar_list[0] as String
+      val label = pigeonVar_list[1] as String
+      return HudActionWire(id, label)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      id,
+      label,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is HudActionWire) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return PigeonCommunicatorPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
+ * A whole HUD screen. The native side owns the translation into the vendor's
+ * renderer, so nothing here is Meta-specific.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class HudScreenWire (
+  val title: String,
+  val lines: List<HudLineWire>,
+  val actions: List<HudActionWire>
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): HudScreenWire {
+      val title = pigeonVar_list[0] as String
+      val lines = pigeonVar_list[1] as List<HudLineWire>
+      val actions = pigeonVar_list[2] as List<HudActionWire>
+      return HudScreenWire(title, lines, actions)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      title,
+      lines,
+      actions,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is HudScreenWire) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return PigeonCommunicatorPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
 private open class PigeonCommunicatorPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -428,6 +541,21 @@ private open class PigeonCommunicatorPigeonCodec : StandardMessageCodec() {
           BluetoothHfpInput.fromList(it)
         }
       }
+      136.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HudLineWire.fromList(it)
+        }
+      }
+      137.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HudActionWire.fromList(it)
+        }
+      }
+      138.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HudScreenWire.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -459,6 +587,18 @@ private open class PigeonCommunicatorPigeonCodec : StandardMessageCodec() {
       }
       is BluetoothHfpInput -> {
         stream.write(135)
+        writeValue(stream, value.toList())
+      }
+      is HudLineWire -> {
+        stream.write(136)
+        writeValue(stream, value.toList())
+      }
+      is HudActionWire -> {
+        stream.write(137)
+        writeValue(stream, value.toList())
+      }
+      is HudScreenWire -> {
+        stream.write(138)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -1462,6 +1602,21 @@ interface RayBanMetaHostAPI {
   fun stopCamera()
   /** Captures one photo; result arrives via RayBanMetaFlutterAPI.onPhotoCaptured. */
   fun capturePhoto()
+  /**
+   * Whether the connected glasses can render, from the toolkit's own
+   * capability check rather than the device type. False on builds without
+   * the Display module, so the HUD gate closes instead of throwing.
+   */
+  fun deviceSupportsDisplay(): Boolean
+  /**
+   * Attaches a display capability to the active device session. Requires the
+   * DAT App Model (DAMEnabled in Info.plist).
+   */
+  fun attachDisplay()
+  fun detachDisplay()
+  /** Renders [screen], replacing whatever the glasses currently show. */
+  fun sendDisplayScreen(screen: HudScreenWire)
+  fun clearDisplay()
 
   companion object {
     /** The codec used by RayBanMetaHostAPI. */
@@ -1765,6 +1920,87 @@ interface RayBanMetaHostAPI {
           channel.setMessageHandler(null)
         }
       }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.deviceSupportsDisplay$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              listOf(api.deviceSupportsDisplay())
+            } catch (exception: Throwable) {
+              PigeonCommunicatorPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.attachDisplay$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.attachDisplay()
+              listOf(null)
+            } catch (exception: Throwable) {
+              PigeonCommunicatorPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.detachDisplay$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.detachDisplay()
+              listOf(null)
+            } catch (exception: Throwable) {
+              PigeonCommunicatorPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.sendDisplayScreen$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val screenArg = args[0] as HudScreenWire
+            val wrapped: List<Any?> = try {
+              api.sendDisplayScreen(screenArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              PigeonCommunicatorPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.clearDisplay$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.clearDisplay()
+              listOf(null)
+            } catch (exception: Throwable) {
+              PigeonCommunicatorPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
     }
   }
 }
@@ -1926,6 +2162,42 @@ class RayBanMetaFlutterAPI(private val binaryMessenger: BinaryMessenger, private
     val channelName = "dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onError$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(codeArg, messageArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  /** 'unavailable' | 'detached' | 'attaching' | 'ready' | 'error'. */
+  fun onDisplayStateChanged(stateArg: String, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayStateChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(stateArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  /** The id of the HudActionWire the wearer tapped. */
+  fun onDisplayActionTapped(actionIdArg: String, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayActionTapped$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(actionIdArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		433B391DCC48F1EA64996624 /* PhoneMicConverterPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAADF00DF00DF00DF00DFD04 /* PhoneMicConverterPipeline.swift */; };
 		44E6D3550DDAC81C6ADF09ED /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		4C63D0133E38DE51BA55148C /* MWDATCamera in Frameworks */ = {isa = PBXBuildFile; productRef = E640392A2909606360520801 /* MWDATCamera */; };
+		A1D5093E7C40B1EE2F730AB4 /* MWDATDisplay in Frameworks */ = {isa = PBXBuildFile; productRef = B7C21A6F45E093DD18274C33 /* MWDATDisplay */; };
 		4D351AE1E3C89CD45ADBC99C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6436409C27A31CD800820AF7 /* InfoPlist.strings */; };
 		515BEA34860AB5238B369C52 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		51EC531CFC451A317C883EBA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A9F5F37DDF9FA87AC8A5CD /* GoogleService-Info.plist */; };
@@ -326,6 +327,7 @@
 				715D47AFEB21D49E37F16F3B /* WatchConnectivity.framework in Frameworks */,
 				3E200B606D3D02BFEF213BF1 /* MWDATCore in Frameworks */,
 				4C63D0133E38DE51BA55148C /* MWDATCamera in Frameworks */,
+				A1D5093E7C40B1EE2F730AB4 /* MWDATDisplay in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -565,6 +567,7 @@
 			packageProductDependencies = (
 				F954EF7C37697F83E05F20D8 /* MWDATCore */,
 				E640392A2909606360520801 /* MWDATCamera */,
+				B7C21A6F45E093DD18274C33 /* MWDATDisplay */,
 			);
 			productName = Runner;
 			productReference = 8AF672E55033617EF994D1BD /* Runner.app */;
@@ -3087,6 +3090,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8728540C6BEE8F267DB063FD /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
 			productName = MWDATCamera;
+		};
+		B7C21A6F45E093DD18274C33 /* MWDATDisplay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8728540C6BEE8F267DB063FD /* XCRemoteSwiftPackageReference "meta-wearables-dat-ios" */;
+			productName = MWDATDisplay;
 		};
 		F954EF7C37697F83E05F20D8 /* MWDATCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/app/ios/Runner/PigeonCommunicator.g.swift
+++ b/app/ios/Runner/PigeonCommunicator.g.swift
@@ -414,6 +414,109 @@ struct BluetoothHfpInput: Hashable {
   }
 }
 
+/// One rendered row of a HUD screen. [style] is 'heading' | 'body' | 'meta'.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct HudLineWire: Hashable {
+  var text: String
+  var style: String
+  var muted: Bool
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> HudLineWire? {
+    let text = pigeonVar_list[0] as! String
+    let style = pigeonVar_list[1] as! String
+    let muted = pigeonVar_list[2] as! Bool
+
+    return HudLineWire(
+      text: text,
+      style: style,
+      muted: muted
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      text,
+      style,
+      muted,
+    ]
+  }
+  static func == (lhs: HudLineWire, rhs: HudLineWire) -> Bool {
+    return deepEqualsPigeonCommunicator(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashPigeonCommunicator(value: toList(), hasher: &hasher)
+  }
+}
+
+/// A tappable control on a HUD screen; [id] comes back through
+/// RayBanMetaFlutterAPI.onDisplayActionTapped.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct HudActionWire: Hashable {
+  var id: String
+  var label: String
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> HudActionWire? {
+    let id = pigeonVar_list[0] as! String
+    let label = pigeonVar_list[1] as! String
+
+    return HudActionWire(
+      id: id,
+      label: label
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      id,
+      label,
+    ]
+  }
+  static func == (lhs: HudActionWire, rhs: HudActionWire) -> Bool {
+    return deepEqualsPigeonCommunicator(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashPigeonCommunicator(value: toList(), hasher: &hasher)
+  }
+}
+
+/// A whole HUD screen. The native side owns the translation into the vendor's
+/// renderer, so nothing here is Meta-specific.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct HudScreenWire: Hashable {
+  var title: String
+  var lines: [HudLineWire]
+  var actions: [HudActionWire]
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> HudScreenWire? {
+    let title = pigeonVar_list[0] as! String
+    let lines = pigeonVar_list[1] as! [HudLineWire]
+    let actions = pigeonVar_list[2] as! [HudActionWire]
+
+    return HudScreenWire(
+      title: title,
+      lines: lines,
+      actions: actions
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      title,
+      lines,
+      actions,
+    ]
+  }
+  static func == (lhs: HudScreenWire, rhs: HudScreenWire) -> Bool {
+    return deepEqualsPigeonCommunicator(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashPigeonCommunicator(value: toList(), hasher: &hasher)
+  }
+}
+
 private class PigeonCommunicatorPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -431,6 +534,12 @@ private class PigeonCommunicatorPigeonCodecReader: FlutterStandardReader {
       return RayBanMetaGlasses.fromList(self.readValue() as! [Any?])
     case 135:
       return BluetoothHfpInput.fromList(self.readValue() as! [Any?])
+    case 136:
+      return HudLineWire.fromList(self.readValue() as! [Any?])
+    case 137:
+      return HudActionWire.fromList(self.readValue() as! [Any?])
+    case 138:
+      return HudScreenWire.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -459,6 +568,15 @@ private class PigeonCommunicatorPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? BluetoothHfpInput {
       super.writeByte(135)
+      super.writeValue(value.toList())
+    } else if let value = value as? HudLineWire {
+      super.writeByte(136)
+      super.writeValue(value.toList())
+    } else if let value = value as? HudActionWire {
+      super.writeByte(137)
+      super.writeValue(value.toList())
+    } else if let value = value as? HudScreenWire {
+      super.writeByte(138)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -1415,6 +1533,17 @@ protocol RayBanMetaHostAPI {
   func stopCamera() throws
   /// Captures one photo; result arrives via RayBanMetaFlutterAPI.onPhotoCaptured.
   func capturePhoto() throws
+  /// Whether the connected glasses can render, from the toolkit's own
+  /// capability check rather than the device type. False on builds without
+  /// the Display module, so the HUD gate closes instead of throwing.
+  func deviceSupportsDisplay() throws -> Bool
+  /// Attaches a display capability to the active device session. Requires the
+  /// DAT App Model (DAMEnabled in Info.plist).
+  func attachDisplay() throws
+  func detachDisplay() throws
+  /// Renders [screen], replacing whatever the glasses currently show.
+  func sendDisplayScreen(screen: HudScreenWire) throws
+  func clearDisplay() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -1683,6 +1812,79 @@ class RayBanMetaHostAPISetup {
     } else {
       capturePhotoChannel.setMessageHandler(nil)
     }
+    /// Whether the connected glasses can render, from the toolkit's own
+    /// capability check rather than the device type. False on builds without
+    /// the Display module, so the HUD gate closes instead of throwing.
+    let deviceSupportsDisplayChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.deviceSupportsDisplay\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      deviceSupportsDisplayChannel.setMessageHandler { _, reply in
+        do {
+          let result = try api.deviceSupportsDisplay()
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      deviceSupportsDisplayChannel.setMessageHandler(nil)
+    }
+    /// Attaches a display capability to the active device session. Requires the
+    /// DAT App Model (DAMEnabled in Info.plist).
+    let attachDisplayChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.attachDisplay\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      attachDisplayChannel.setMessageHandler { _, reply in
+        do {
+          try api.attachDisplay()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      attachDisplayChannel.setMessageHandler(nil)
+    }
+    let detachDisplayChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.detachDisplay\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      detachDisplayChannel.setMessageHandler { _, reply in
+        do {
+          try api.detachDisplay()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      detachDisplayChannel.setMessageHandler(nil)
+    }
+    /// Renders [screen], replacing whatever the glasses currently show.
+    let sendDisplayScreenChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.sendDisplayScreen\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      sendDisplayScreenChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let screenArg = args[0] as! HudScreenWire
+        do {
+          try api.sendDisplayScreen(screen: screenArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      sendDisplayScreenChannel.setMessageHandler(nil)
+    }
+    let clearDisplayChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.clearDisplay\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      clearDisplayChannel.setMessageHandler { _, reply in
+        do {
+          try api.clearDisplay()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      clearDisplayChannel.setMessageHandler(nil)
+    }
   }
 }
 /// Native → Dart events for Ray-Ban Meta.
@@ -1702,6 +1904,10 @@ protocol RayBanMetaFlutterAPIProtocol {
   func onCameraStateChanged(state stateArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onCameraPermissionChanged(status statusArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onError(code codeArg: String, message messageArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  /// 'unavailable' | 'detached' | 'attaching' | 'ready' | 'error'.
+  func onDisplayStateChanged(state stateArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  /// The id of the HudActionWire the wearer tapped.
+  func onDisplayActionTapped(actionId actionIdArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class RayBanMetaFlutterAPI: RayBanMetaFlutterAPIProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -1865,6 +2071,44 @@ class RayBanMetaFlutterAPI: RayBanMetaFlutterAPIProtocol {
     let channelName: String = "dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onError\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([codeArg, messageArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  /// 'unavailable' | 'detached' | 'attaching' | 'ready' | 'error'.
+  func onDisplayStateChanged(state stateArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayStateChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([stateArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  /// The id of the HudActionWire the wearer tapped.
+  func onDisplayActionTapped(actionId actionIdArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayActionTapped\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([actionIdArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/app/ios/Runner/PigeonCommunicator.g.swift
+++ b/app/ios/Runner/PigeonCommunicator.g.swift
@@ -116,7 +116,7 @@ func deepHashPigeonCommunicator(value: Any?, hasher: inout Hasher) {
   }
 
   if let valueDict = value as? [AnyHashable: AnyHashable] {
-    for key in valueDict.keys { 
+    for key in valueDict.keys {
       hasher.combine(key)
       deepHashPigeonCommunicator(value: valueDict[key]!, hasher: &hasher)
     }
@@ -130,7 +130,7 @@ func deepHashPigeonCommunicator(value: Any?, hasher: inout Hasher) {
   return hasher.combine(String(describing: value))
 }
 
-    
+
 
 /// Discovered BLE peripheral info passed from native to Dart.
 ///

--- a/app/ios/Runner/RayBanMeta/RayBanMetaDisplayRenderer.swift
+++ b/app/ios/Runner/RayBanMeta/RayBanMetaDisplayRenderer.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+#if canImport(MWDATDisplay)
+    import MWDATDisplay
+
+    /// Translates the platform-neutral HUD screen into Meta's Display views.
+    ///
+    /// This file deliberately does not import SwiftUI: MWDATDisplay exports its
+    /// own `Text`, `Button`, and `Image`, and importing both makes those names
+    /// ambiguous (Meta documents this in the 0.7.0 release notes).
+    enum RayBanMetaDisplayRenderer {
+        static func flexBox(
+            for screen: HudScreenWire,
+            onAction: @escaping @Sendable (String) -> Void
+        ) -> FlexBox {
+            let lines = screen.lines
+            let actions = screen.actions
+            let title = screen.title
+
+            return FlexBox(direction: .column, spacing: 12) {
+                FlexBox(direction: .column, spacing: 4) {
+                    Text(title, style: .heading)
+                    for line in lines {
+                        Text(line.text, style: textStyle(for: line.style), color: line.muted ? .secondary : .primary)
+                    }
+                }
+                .padding(24)
+                .background(.card)
+
+                if !actions.isEmpty {
+                    FlexBox(direction: .row, spacing: 8, alignment: .center, crossAlignment: .center, wrap: true) {
+                        for action in actions {
+                            Button(label: action.label, onClick: { onAction(action.id) })
+                        }
+                    }
+                }
+            }
+        }
+
+        private static func textStyle(for style: String) -> TextStyle {
+            switch style {
+            case "heading": return .heading
+            case "meta": return .meta
+            default: return .body
+            }
+        }
+    }
+#endif

--- a/app/ios/Runner/RayBanMeta/RayBanMetaHostApiImpl.swift
+++ b/app/ios/Runner/RayBanMeta/RayBanMetaHostApiImpl.swift
@@ -9,6 +9,9 @@ import UIKit
 #if canImport(MWDATCamera)
     import MWDATCamera
 #endif
+#if canImport(MWDATDisplay)
+    import MWDATDisplay
+#endif
 
 /// Pigeon host API for Ray-Ban Meta glasses.
 ///
@@ -125,6 +128,11 @@ final class RayBanMetaHostApiImpl: NSObject, RayBanMetaHostAPI {
         #if canImport(MWDATCamera)
             private var cameraStream: MWDATCamera.Stream?
             private var cameraListenerTokens: [Any] = []
+        #endif
+
+        #if canImport(MWDATDisplay)
+            private var display: MWDATDisplay.Display?
+            private var displayStateTask: Task<Void, Never>?
         #endif
 
         func initialize() throws {
@@ -417,10 +425,137 @@ final class RayBanMetaHostApiImpl: NSObject, RayBanMetaHostAPI {
             #endif
         }
 
+        // MARK: - Display
+
+        func deviceSupportsDisplay() throws -> Bool {
+            #if canImport(MWDATDisplay)
+                guard configured, let deviceId = connectedDeviceId else { return false }
+                return Wearables.shared.deviceForIdentifier(deviceId)?.supportsDisplay() ?? false
+            #else
+                return false
+            #endif
+        }
+
+        func attachDisplay() throws {
+            #if canImport(MWDATDisplay)
+                guard display == nil else { return }
+                guard let session = session else {
+                    throw PigeonError(
+                        code: "display_no_session",
+                        message: "Connect the glasses before attaching the display",
+                        details: nil
+                    )
+                }
+                guard try deviceSupportsDisplay() else {
+                    throw PigeonError(
+                        code: "display_unsupported",
+                        message: "The connected glasses have no display",
+                        details: nil
+                    )
+                }
+
+                emitDisplayState("attaching")
+                let capability = try session.addDisplay()
+                display = capability
+
+                displayStateTask?.cancel()
+                displayStateTask = Task { [weak self] in
+                    for await state in capability.stateStream() {
+                        guard let self = self else { return }
+                        self.emitDisplayState(Self.normalizeDisplayState(state))
+                    }
+                }
+
+                capability.start()
+            #else
+                throw PigeonError(code: "display_unavailable", message: "MWDATDisplay not linked", details: nil)
+            #endif
+        }
+
+        func detachDisplay() throws {
+            #if canImport(MWDATDisplay)
+                displayStateTask?.cancel()
+                displayStateTask = nil
+                display?.stop()
+                if let capability = display {
+                    try? session?.removeDisplay(capability)
+                }
+                display = nil
+                emitDisplayState("detached")
+            #endif
+        }
+
+        func sendDisplayScreen(screen: HudScreenWire) throws {
+            #if canImport(MWDATDisplay)
+                guard let capability = display else {
+                    throw PigeonError(
+                        code: "display_not_attached",
+                        message: "Attach the display before sending a screen",
+                        details: nil
+                    )
+                }
+                let view = RayBanMetaDisplayRenderer.flexBox(for: screen) { [weak self] actionId in
+                    DispatchQueue.main.async {
+                        self?.flutterAPI.onDisplayActionTapped(actionId: actionId) { _ in }
+                    }
+                }
+                Task { [weak self] in
+                    do {
+                        try await capability.send(view)
+                    } catch {
+                        self?.emitError(
+                            code: "display_send_failed",
+                            message: (error as? DisplayError)?.description ?? error.localizedDescription
+                        )
+                    }
+                }
+            #else
+                throw PigeonError(code: "display_unavailable", message: "MWDATDisplay not linked", details: nil)
+            #endif
+        }
+
+        func clearDisplay() throws {
+            #if canImport(MWDATDisplay)
+                guard let capability = display else { return }
+                Task { try? await capability.clearDisplay() }
+            #endif
+        }
+
+        #if canImport(MWDATDisplay)
+            private func emitDisplayState(_ state: String) {
+                DispatchQueue.main.async {
+                    self.flutterAPI.onDisplayStateChanged(state: state) { _ in }
+                }
+            }
+
+            private static func normalizeDisplayState(_ state: DisplayState) -> String {
+                switch state {
+                case .started: return "ready"
+                case .starting: return "attaching"
+                case .stopped: return "detached"
+                default: return "error"
+                }
+            }
+        #endif
+
     #else
         // =====================================================================
         // Audio-only mode — no Meta Wearables toolkit in this build
         // =====================================================================
+
+        func deviceSupportsDisplay() throws -> Bool { return false }
+
+        func attachDisplay() throws {
+            throw PigeonError(code: "display_unavailable", message: "Meta Wearables SDK not in this build", details: nil)
+        }
+
+        func detachDisplay() throws {}
+
+        func sendDisplayScreen(screen: HudScreenWire) throws {
+            throw PigeonError(code: "display_unavailable", message: "Meta Wearables SDK not in this build", details: nil)
+        }
+
+        func clearDisplay() throws {}
 
         func initialize() throws {}
 

--- a/app/ios/test/rayban_dat_xcode_graph_test.rb
+++ b/app/ios/test/rayban_dat_xcode_graph_test.rb
@@ -46,15 +46,17 @@ class RayBanDatXcodeGraphTest < Minitest::Test
 
     refute_includes runner, 'MWDATCore'
     refute_includes runner, 'MWDATCamera'
+    refute_includes runner, 'MWDATDisplay'
   end
 
   def test_separate_dat_target_owns_only_the_required_meta_products
     dat = native_target('RunnerRayBanDat')
     product_names = package_product_names(dat)
 
-    assert_equal %w[MWDATCamera MWDATCore], product_names.sort
+    assert_equal %w[MWDATCamera MWDATCore MWDATDisplay], product_names.sort
     assert_package_product('MWDATCore')
     assert_package_product('MWDATCamera')
+    assert_package_product('MWDATDisplay')
   end
 
   def test_meta_package_is_pinned_to_exact_0_8_0
@@ -135,6 +137,7 @@ class RayBanDatXcodeGraphTest < Minitest::Test
     assert_includes frameworks, 'WatchConnectivity.framework in Frameworks'
     assert_includes frameworks, 'MWDATCore in Frameworks'
     assert_includes frameworks, 'MWDATCamera in Frameworks'
+    assert_includes frameworks, 'MWDATDisplay in Frameworks'
     refute_includes frameworks, 'Foundation.framework in Frameworks'
     refute_includes frameworks, 'Pods_Runner.framework in Frameworks'
   end
@@ -189,7 +192,7 @@ class RayBanDatXcodeGraphTest < Minitest::Test
   def package_product_names(target)
     list = target[/packageProductDependencies = \((.*?)\);/m, 1]
     refute_nil list, 'DAT target must declare packageProductDependencies'
-    list.scan(%r{/\* (MWDAT(?:Core|Camera)) \*/}).flatten
+    list.scan(%r{/\* (MWDAT\w+) \*/}).flatten
   end
 
   def assert_package_product(name)

--- a/app/lib/gen/pigeon_communicator.g.dart
+++ b/app/lib/gen/pigeon_communicator.g.dart
@@ -24,18 +24,20 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   }
   return <Object?>[error.code, error.message, error.details];
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
-    return a.length == b.length && a.indexed.every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+    return a.length == b.length &&
+        a.indexed
+        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length &&
-        a.entries.every((MapEntry<Object?, Object?> entry) =>
-            (b as Map<Object?, Object?>).containsKey(entry.key) && _deepEquals(entry.value, b[entry.key]));
+    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
+        (b as Map<Object?, Object?>).containsKey(entry.key) &&
+        _deepEquals(entry.value, b[entry.key]));
   }
   return a == b;
 }
+
 
 /// Discovered BLE peripheral info passed from native to Dart.
 class BlePeripheral {
@@ -64,8 +66,7 @@ class BlePeripheral {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static BlePeripheral decode(Object result) {
     result as List<Object?>;
@@ -91,7 +92,8 @@ class BlePeripheral {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// Discovered BLE service with its characteristic UUIDs.
@@ -113,8 +115,7 @@ class BleService {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static BleService decode(Object result) {
     result as List<Object?>;
@@ -138,7 +139,8 @@ class BleService {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// A single disconnect event stored in native preferences.
@@ -207,8 +209,7 @@ class BleDisconnectEvent {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static BleDisconnectEvent decode(Object result) {
     result as List<Object?>;
@@ -240,7 +241,8 @@ class BleDisconnectEvent {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// A single battery level reading persisted by the native BLE layer.
@@ -262,8 +264,7 @@ class BleBatteryPoint {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static BleBatteryPoint decode(Object result) {
     result as List<Object?>;
@@ -287,7 +288,8 @@ class BleBatteryPoint {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// Diagnostics data read from native preferences on demand.
@@ -319,8 +321,7 @@ class BleDeviceDiagnostics {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static BleDeviceDiagnostics decode(Object result) {
     result as List<Object?>;
@@ -346,7 +347,8 @@ class BleDeviceDiagnostics {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// A pair of Ray-Ban Meta glasses reported by the Meta Wearables toolkit.
@@ -368,8 +370,7 @@ class RayBanMetaGlasses {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static RayBanMetaGlasses decode(Object result) {
     result as List<Object?>;
@@ -393,7 +394,8 @@ class RayBanMetaGlasses {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// A Bluetooth Hands-Free Profile input exposed by iOS.
@@ -415,8 +417,7 @@ class BluetoothHfpInput {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static BluetoothHfpInput decode(Object result) {
     result as List<Object?>;
@@ -440,8 +441,163 @@ class BluetoothHfpInput {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
+
+/// One rendered row of a HUD screen. [style] is 'heading' | 'body' | 'meta'.
+class HudLineWire {
+  HudLineWire({
+    required this.text,
+    required this.style,
+    required this.muted,
+  });
+
+  String text;
+
+  String style;
+
+  bool muted;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      text,
+      style,
+      muted,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static HudLineWire decode(Object result) {
+    result as List<Object?>;
+    return HudLineWire(
+      text: result[0]! as String,
+      style: result[1]! as String,
+      muted: result[2]! as bool,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! HudLineWire || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList())
+;
+}
+
+/// A tappable control on a HUD screen; [id] comes back through
+/// RayBanMetaFlutterAPI.onDisplayActionTapped.
+class HudActionWire {
+  HudActionWire({
+    required this.id,
+    required this.label,
+  });
+
+  String id;
+
+  String label;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      id,
+      label,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static HudActionWire decode(Object result) {
+    result as List<Object?>;
+    return HudActionWire(
+      id: result[0]! as String,
+      label: result[1]! as String,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! HudActionWire || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList())
+;
+}
+
+/// A whole HUD screen. The native side owns the translation into the vendor's
+/// renderer, so nothing here is Meta-specific.
+class HudScreenWire {
+  HudScreenWire({
+    required this.title,
+    required this.lines,
+    required this.actions,
+  });
+
+  String title;
+
+  List<HudLineWire> lines;
+
+  List<HudActionWire> actions;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      title,
+      lines,
+      actions,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static HudScreenWire decode(Object result) {
+    result as List<Object?>;
+    return HudScreenWire(
+      title: result[0]! as String,
+      lines: (result[1] as List<Object?>?)!.cast<HudLineWire>(),
+      actions: (result[2] as List<Object?>?)!.cast<HudActionWire>(),
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! HudScreenWire || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList())
+;
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -450,26 +606,35 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is BlePeripheral) {
+    }    else if (value is BlePeripheral) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is BleService) {
+    }    else if (value is BleService) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is BleDisconnectEvent) {
+    }    else if (value is BleDisconnectEvent) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is BleBatteryPoint) {
+    }    else if (value is BleBatteryPoint) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is BleDeviceDiagnostics) {
+    }    else if (value is BleDeviceDiagnostics) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is RayBanMetaGlasses) {
+    }    else if (value is RayBanMetaGlasses) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is BluetoothHfpInput) {
+    }    else if (value is BluetoothHfpInput) {
       buffer.putUint8(135);
+      writeValue(buffer, value.encode());
+    }    else if (value is HudLineWire) {
+      buffer.putUint8(136);
+      writeValue(buffer, value.encode());
+    }    else if (value is HudActionWire) {
+      buffer.putUint8(137);
+      writeValue(buffer, value.encode());
+    }    else if (value is HudScreenWire) {
+      buffer.putUint8(138);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -479,20 +644,26 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         return BlePeripheral.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return BleService.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return BleDisconnectEvent.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return BleBatteryPoint.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return BleDeviceDiagnostics.decode(readValue(buffer)!);
-      case 134:
+      case 134: 
         return RayBanMetaGlasses.decode(readValue(buffer)!);
-      case 135:
+      case 135: 
         return BluetoothHfpInput.decode(readValue(buffer)!);
+      case 136: 
+        return HudLineWire.decode(readValue(buffer)!);
+      case 137: 
+        return HudActionWire.decode(readValue(buffer)!);
+      case 138: 
+        return HudScreenWire.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -513,15 +684,15 @@ class WatchRecorderHostAPI {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> startRecording() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.startRecording$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.startRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -536,15 +707,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<void> stopRecording() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.stopRecording$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.stopRecording$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -559,15 +730,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<void> sendAudioData(Uint8List audioData) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.sendAudioData$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.sendAudioData$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[audioData]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -582,16 +753,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<void> sendAudioChunk(Uint8List audioChunk, int chunkIndex, bool isLast, double sampleRate) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.sendAudioChunk$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.sendAudioChunk$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[audioChunk, chunkIndex, isLast, sampleRate]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[audioChunk, chunkIndex, isLast, sampleRate]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -606,15 +776,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<bool> isWatchPaired() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchPaired$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchPaired$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -634,15 +804,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<bool> isWatchReachable() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchReachable$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchReachable$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -662,15 +832,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<bool> isWatchSessionSupported() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchSessionSupported$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchSessionSupported$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -690,15 +860,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<bool> isWatchAppInstalled() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchAppInstalled$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.isWatchAppInstalled$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -718,15 +888,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<void> requestWatchMicrophonePermission() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.requestWatchMicrophonePermission$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.requestWatchMicrophonePermission$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -741,15 +911,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<void> requestMainAppMicrophonePermission() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.requestMainAppMicrophonePermission$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.requestMainAppMicrophonePermission$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -764,15 +934,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<bool> checkMainAppMicrophonePermission() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.checkMainAppMicrophonePermission$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.checkMainAppMicrophonePermission$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -792,15 +962,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<double> getWatchBatteryLevel() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.getWatchBatteryLevel$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.getWatchBatteryLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -820,15 +990,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<int> getWatchBatteryState() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.getWatchBatteryState$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.getWatchBatteryState$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -848,15 +1018,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<void> requestWatchBatteryUpdate() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.requestWatchBatteryUpdate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.requestWatchBatteryUpdate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -871,15 +1041,15 @@ class WatchRecorderHostAPI {
   }
 
   Future<Map<String, String>> getWatchInfo() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.getWatchInfo$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.WatchRecorderHostAPI.getWatchInfo$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -918,16 +1088,11 @@ abstract class WatchRecorderFlutterAPI {
 
   void onWatchBatteryUpdate(double batteryLevel, int batteryState);
 
-  static void setUp(
-    WatchRecorderFlutterAPI? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
+  static void setUp(WatchRecorderFlutterAPI? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingStarted$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingStarted$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
@@ -938,7 +1103,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -946,8 +1111,7 @@ abstract class WatchRecorderFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingStopped$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingStopped$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
@@ -958,7 +1122,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -973,7 +1137,7 @@ abstract class WatchRecorderFlutterAPI {
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onAudioData was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onAudioData was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final Uint8List? arg_audioData = (args[0] as Uint8List?);
           assert(arg_audioData != null,
@@ -983,7 +1147,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -998,7 +1162,7 @@ abstract class WatchRecorderFlutterAPI {
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onAudioChunk was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onAudioChunk was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final Uint8List? arg_audioChunk = (args[0] as Uint8List?);
           assert(arg_audioChunk != null,
@@ -1017,7 +1181,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1025,15 +1189,14 @@ abstract class WatchRecorderFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingError$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingError$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingError was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onRecordingError was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_error = (args[0] as String?);
           assert(arg_error != null,
@@ -1043,7 +1206,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1051,15 +1214,14 @@ abstract class WatchRecorderFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMicrophonePermissionResult$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMicrophonePermissionResult$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMicrophonePermissionResult was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMicrophonePermissionResult was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final bool? arg_granted = (args[0] as bool?);
           assert(arg_granted != null,
@@ -1069,7 +1231,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1077,15 +1239,14 @@ abstract class WatchRecorderFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMainAppMicrophonePermissionResult$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMainAppMicrophonePermissionResult$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMainAppMicrophonePermissionResult was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onMainAppMicrophonePermissionResult was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final bool? arg_granted = (args[0] as bool?);
           assert(arg_granted != null,
@@ -1095,7 +1256,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1103,15 +1264,14 @@ abstract class WatchRecorderFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchBatteryUpdate$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchBatteryUpdate$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchBatteryUpdate was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchBatteryUpdate was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final double? arg_batteryLevel = (args[0] as double?);
           assert(arg_batteryLevel != null,
@@ -1124,7 +1284,7 @@ abstract class WatchRecorderFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1148,15 +1308,15 @@ class BleHostApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> startScan(int timeoutSeconds, List<String> serviceUuids) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.startScan$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.startScan$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[timeoutSeconds, serviceUuids]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1171,15 +1331,15 @@ class BleHostApi {
   }
 
   Future<void> stopScan() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.stopScan$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.stopScan$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1194,15 +1354,15 @@ class BleHostApi {
   }
 
   Future<void> manageDevice(String uuid, bool requiresBond) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.manageDevice$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.manageDevice$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid, requiresBond]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1217,15 +1377,15 @@ class BleHostApi {
   }
 
   Future<void> unmanageDevice(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.unmanageDevice$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.unmanageDevice$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1240,15 +1400,15 @@ class BleHostApi {
   }
 
   Future<bool> requestBond(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.requestBond$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.requestBond$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1268,16 +1428,15 @@ class BleHostApi {
   }
 
   Future<Uint8List> readCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.readCharacteristic$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.readCharacteristic$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1296,18 +1455,16 @@ class BleHostApi {
     }
   }
 
-  Future<void> writeCharacteristic(
-      String peripheralUuid, String serviceUuid, String characteristicUuid, Uint8List data) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.writeCharacteristic$pigeonVar_messageChannelSuffix';
+  Future<void> writeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid, Uint8List data) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.writeCharacteristic$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid, data]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid, data]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1322,16 +1479,15 @@ class BleHostApi {
   }
 
   Future<void> subscribeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.subscribeCharacteristic$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.subscribeCharacteristic$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1346,16 +1502,15 @@ class BleHostApi {
   }
 
   Future<void> unsubscribeCharacteristic(String peripheralUuid, String serviceUuid, String characteristicUuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.unsubscribeCharacteristic$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.unsubscribeCharacteristic$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[peripheralUuid, serviceUuid, characteristicUuid]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1370,15 +1525,15 @@ class BleHostApi {
   }
 
   Future<String> getBluetoothState() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.getBluetoothState$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.getBluetoothState$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1400,15 +1555,15 @@ class BleHostApi {
   /// (Android only) Show the system "enable Bluetooth" prompt. Resolves to true
   /// once Bluetooth is on. No-op on iOS — returns whether the adapter is powered on.
   Future<bool> enableBluetooth() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.enableBluetooth$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.enableBluetooth$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1428,15 +1583,15 @@ class BleHostApi {
   }
 
   Future<bool> isPeripheralConnected(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.isPeripheralConnected$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.isPeripheralConnected$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1456,15 +1611,15 @@ class BleHostApi {
   }
 
   Future<void> startRssiStreaming(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.startRssiStreaming$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.startRssiStreaming$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1479,15 +1634,15 @@ class BleHostApi {
   }
 
   Future<void> stopRssiStreaming(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.stopRssiStreaming$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.stopRssiStreaming$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1502,15 +1657,15 @@ class BleHostApi {
   }
 
   Future<BleDeviceDiagnostics> getDeviceDiagnostics(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.getDeviceDiagnostics$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.getDeviceDiagnostics$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1530,15 +1685,15 @@ class BleHostApi {
   }
 
   Future<List<BleBatteryPoint>> getBatteryHistory(String uuid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.getBatteryHistory$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.getBatteryHistory$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1559,15 +1714,15 @@ class BleHostApi {
 
   /// (Android only) Check if any CompanionDeviceManager association exists.
   Future<bool> hasCompanionDeviceAssociation() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.hasCompanionDeviceAssociation$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.hasCompanionDeviceAssociation$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1588,15 +1743,15 @@ class BleHostApi {
 
   /// (Android only) Initiate CompanionDeviceManager association for a device.
   Future<String> requestCompanionDeviceAssociation(String deviceAddress) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.BleHostApi.requestCompanionDeviceAssociation$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.requestCompanionDeviceAssociation$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[deviceAddress]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1627,8 +1782,7 @@ abstract class BleFlutterApi {
 
   void onPeripheralDisconnected(String peripheralUuid, String? error);
 
-  void onCharacteristicValueUpdated(
-      String peripheralUuid, String serviceUuid, String characteristicUuid, Uint8List value);
+  void onCharacteristicValueUpdated(String peripheralUuid, String serviceUuid, String characteristicUuid, Uint8List value);
 
   void onRssiUpdate(String peripheralUuid, int rssi);
 
@@ -1638,23 +1792,18 @@ abstract class BleFlutterApi {
   /// Dart can rescan the recordings dir without waiting for a disconnect.
   void onBatchRecordingFinalized(String fileName);
 
-  static void setUp(
-    BleFlutterApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
+  static void setUp(BleFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBluetoothStateChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBluetoothStateChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBluetoothStateChanged was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBluetoothStateChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_state = (args[0] as String?);
           assert(arg_state != null,
@@ -1664,7 +1813,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1679,7 +1828,7 @@ abstract class BleFlutterApi {
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onPeripheralDiscovered was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onPeripheralDiscovered was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final BlePeripheral? arg_peripheral = (args[0] as BlePeripheral?);
           assert(arg_peripheral != null,
@@ -1689,7 +1838,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1703,7 +1852,8 @@ abstract class BleFlutterApi {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null, 'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onDeviceReady was null.');
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onDeviceReady was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_peripheralUuid = (args[0] as String?);
           assert(arg_peripheralUuid != null,
@@ -1716,7 +1866,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1724,15 +1874,14 @@ abstract class BleFlutterApi {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onPeripheralDisconnected$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onPeripheralDisconnected$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onPeripheralDisconnected was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onPeripheralDisconnected was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_peripheralUuid = (args[0] as String?);
           assert(arg_peripheralUuid != null,
@@ -1743,7 +1892,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1751,15 +1900,14 @@ abstract class BleFlutterApi {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onCharacteristicValueUpdated$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onCharacteristicValueUpdated$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onCharacteristicValueUpdated was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onCharacteristicValueUpdated was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_peripheralUuid = (args[0] as String?);
           assert(arg_peripheralUuid != null,
@@ -1774,12 +1922,11 @@ abstract class BleFlutterApi {
           assert(arg_value != null,
               'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onCharacteristicValueUpdated was null, expected non-null Uint8List.');
           try {
-            api.onCharacteristicValueUpdated(
-                arg_peripheralUuid!, arg_serviceUuid!, arg_characteristicUuid!, arg_value!);
+            api.onCharacteristicValueUpdated(arg_peripheralUuid!, arg_serviceUuid!, arg_characteristicUuid!, arg_value!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1793,7 +1940,8 @@ abstract class BleFlutterApi {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null, 'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onRssiUpdate was null.');
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onRssiUpdate was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_peripheralUuid = (args[0] as String?);
           assert(arg_peripheralUuid != null,
@@ -1806,7 +1954,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1820,7 +1968,8 @@ abstract class BleFlutterApi {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null, 'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onStateRestored was null.');
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onStateRestored was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final List<String>? arg_peripheralUuids = (args[0] as List<Object?>?)?.cast<String>();
           assert(arg_peripheralUuids != null,
@@ -1830,7 +1979,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1838,15 +1987,14 @@ abstract class BleFlutterApi {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBatchRecordingFinalized$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBatchRecordingFinalized$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBatchRecordingFinalized was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.BleFlutterApi.onBatchRecordingFinalized was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_fileName = (args[0] as String?);
           assert(arg_fileName != null,
@@ -1856,7 +2004,7 @@ abstract class BleFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -1886,15 +2034,15 @@ class RayBanMetaHostAPI {
   /// 'full' (DAT SDK linked + Meta app credentials configured),
   /// 'audio_only' (no DAT — platform Bluetooth audio route only), or 'none'.
   Future<String> getAvailabilityMode() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getAvailabilityMode$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getAvailabilityMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1914,15 +2062,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<void> initialize() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.initialize$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.initialize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1938,15 +2086,15 @@ class RayBanMetaHostAPI {
 
   /// 'unregistered' | 'registering' | 'registered' ('unavailable' without DAT).
   Future<String> getRegistrationState() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getRegistrationState$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getRegistrationState$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1967,15 +2115,15 @@ class RayBanMetaHostAPI {
 
   /// Launches the Meta AI companion app to authorize this app for the glasses.
   Future<void> startRegistration() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.startRegistration$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.startRegistration$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -1990,15 +2138,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<void> unregister() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.unregister$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.unregister$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2013,15 +2161,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<List<RayBanMetaGlasses>> getAvailableGlasses() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getAvailableGlasses$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getAvailableGlasses$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2041,15 +2189,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<void> connect(String deviceId) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.connect$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.connect$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[deviceId]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2064,15 +2212,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<void> disconnect() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.disconnect$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.disconnect$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2088,15 +2236,15 @@ class RayBanMetaHostAPI {
 
   /// 'disconnected' | 'connecting' | 'connected'.
   Future<String> getConnectionState() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getConnectionState$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getConnectionState$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2117,15 +2265,15 @@ class RayBanMetaHostAPI {
 
   /// DAT camera permission for the glasses: resolves 'granted' | 'denied'.
   Future<String> requestCameraPermission() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.requestCameraPermission$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.requestCameraPermission$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2146,15 +2294,15 @@ class RayBanMetaHostAPI {
 
   /// 'granted' | 'denied' | 'not_determined' | 'unavailable'.
   Future<String> getCameraPermissionStatus() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getCameraPermissionStatus$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getCameraPermissionStatus$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2176,15 +2324,15 @@ class RayBanMetaHostAPI {
   /// Starts capturing the glasses microphone over the Bluetooth HFP route and
   /// streaming PCM16 mono frames to RayBanMetaFlutterAPI.onAudioFrame.
   Future<void> startAudioCapture(String? inputUid) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.startAudioCapture$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.startAudioCapture$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[inputUid]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2199,15 +2347,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<void> stopAudioCapture() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.stopAudioCapture$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.stopAudioCapture$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2223,15 +2371,15 @@ class RayBanMetaHostAPI {
 
   /// True when the active audio input route is the glasses' Bluetooth HFP mic.
   Future<bool> isGlassesAudioRouteActive() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.isGlassesAudioRouteActive$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.isGlassesAudioRouteActive$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2254,15 +2402,15 @@ class RayBanMetaHostAPI {
   /// fallback when the DAT SDK is not part of this build. The UID is the
   /// stable identity; the user-visible name may change.
   Future<List<BluetoothHfpInput>> getBluetoothHfpInputs() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getBluetoothHfpInputs$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.getBluetoothHfpInputs$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2284,15 +2432,15 @@ class RayBanMetaHostAPI {
   /// Starts the DAT camera stream session so photo capture is ready. While
   /// active the glasses' capture LED is on (hardware-enforced by Meta).
   Future<void> startCamera() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.startCamera$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.startCamera$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2307,15 +2455,15 @@ class RayBanMetaHostAPI {
   }
 
   Future<void> stopCamera() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.stopCamera$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.stopCamera$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2331,15 +2479,141 @@ class RayBanMetaHostAPI {
 
   /// Captures one photo; result arrives via RayBanMetaFlutterAPI.onPhotoCaptured.
   Future<void> capturePhoto() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.capturePhoto$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.capturePhoto$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Whether the connected glasses can render, from the toolkit's own
+  /// capability check rather than the device type. False on builds without
+  /// the Display module, so the HUD gate closes instead of throwing.
+  Future<bool> deviceSupportsDisplay() async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.deviceSupportsDisplay$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
+
+  /// Attaches a display capability to the active device session. Requires the
+  /// DAT App Model (DAMEnabled in Info.plist).
+  Future<void> attachDisplay() async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.attachDisplay$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> detachDisplay() async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.detachDisplay$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Renders [screen], replacing whatever the glasses currently show.
+  Future<void> sendDisplayScreen(HudScreenWire screen) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.sendDisplayScreen$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[screen]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> clearDisplay() async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.omi_pigeon.RayBanMetaHostAPI.clearDisplay$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -2380,23 +2654,24 @@ abstract class RayBanMetaFlutterAPI {
 
   void onError(String code, String message);
 
-  static void setUp(
-    RayBanMetaFlutterAPI? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
+  /// 'unavailable' | 'detached' | 'attaching' | 'ready' | 'error'.
+  void onDisplayStateChanged(String state);
+
+  /// The id of the HudActionWire the wearer tapped.
+  void onDisplayActionTapped(String actionId);
+
+  static void setUp(RayBanMetaFlutterAPI? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onRegistrationStateChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onRegistrationStateChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onRegistrationStateChanged was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onRegistrationStateChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_state = (args[0] as String?);
           assert(arg_state != null,
@@ -2406,7 +2681,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2414,15 +2689,14 @@ abstract class RayBanMetaFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onGlassesDiscovered$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onGlassesDiscovered$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onGlassesDiscovered was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onGlassesDiscovered was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final RayBanMetaGlasses? arg_glasses = (args[0] as RayBanMetaGlasses?);
           assert(arg_glasses != null,
@@ -2432,7 +2706,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2440,15 +2714,14 @@ abstract class RayBanMetaFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onConnectionStateChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onConnectionStateChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onConnectionStateChanged was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onConnectionStateChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_deviceId = (args[0] as String?);
           assert(arg_deviceId != null,
@@ -2461,7 +2734,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2476,7 +2749,7 @@ abstract class RayBanMetaFlutterAPI {
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onAudioFrame was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onAudioFrame was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final Uint8List? arg_pcm16Frame = (args[0] as Uint8List?);
           assert(arg_pcm16Frame != null,
@@ -2489,7 +2762,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2497,15 +2770,14 @@ abstract class RayBanMetaFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onAudioRouteChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onAudioRouteChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onAudioRouteChanged was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onAudioRouteChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final bool? arg_glassesRouteActive = (args[0] as bool?);
           assert(arg_glassesRouteActive != null,
@@ -2515,7 +2787,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2530,7 +2802,7 @@ abstract class RayBanMetaFlutterAPI {
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onPhotoCaptured was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onPhotoCaptured was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final Uint8List? arg_jpegBytes = (args[0] as Uint8List?);
           assert(arg_jpegBytes != null,
@@ -2543,7 +2815,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2551,15 +2823,14 @@ abstract class RayBanMetaFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraStateChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraStateChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraStateChanged was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraStateChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_state = (args[0] as String?);
           assert(arg_state != null,
@@ -2569,7 +2840,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2577,15 +2848,14 @@ abstract class RayBanMetaFlutterAPI {
     }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraPermissionChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraPermissionChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraPermissionChanged was null.');
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onCameraPermissionChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_status = (args[0] as String?);
           assert(arg_status != null,
@@ -2595,7 +2865,7 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
@@ -2609,7 +2879,8 @@ abstract class RayBanMetaFlutterAPI {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null, 'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onError was null.');
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onError was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_code = (args[0] as String?);
           assert(arg_code != null,
@@ -2622,7 +2893,57 @@ abstract class RayBanMetaFlutterAPI {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayStateChanged$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayStateChanged was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_state = (args[0] as String?);
+          assert(arg_state != null,
+              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayStateChanged was null, expected non-null String.');
+          try {
+            api.onDisplayStateChanged(arg_state!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayActionTapped$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayActionTapped was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_actionId = (args[0] as String?);
+          assert(arg_actionId != null,
+              'Argument for dev.flutter.pigeon.omi_pigeon.RayBanMetaFlutterAPI.onDisplayActionTapped was null, expected non-null String.');
+          try {
+            api.onDisplayActionTapped(arg_actionId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
             return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });

--- a/app/lib/gen/pigeon_communicator.g.dart
+++ b/app/lib/gen/pigeon_communicator.g.dart
@@ -644,25 +644,25 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129: 
+      case 129:
         return BlePeripheral.decode(readValue(buffer)!);
-      case 130: 
+      case 130:
         return BleService.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return BleDisconnectEvent.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return BleBatteryPoint.decode(readValue(buffer)!);
-      case 133: 
+      case 133:
         return BleDeviceDiagnostics.decode(readValue(buffer)!);
-      case 134: 
+      case 134:
         return RayBanMetaGlasses.decode(readValue(buffer)!);
-      case 135: 
+      case 135:
         return BluetoothHfpInput.decode(readValue(buffer)!);
-      case 136: 
+      case 136:
         return HudLineWire.decode(readValue(buffer)!);
-      case 137: 
+      case 137:
         return HudActionWire.decode(readValue(buffer)!);
-      case 138: 
+      case 138:
         return HudScreenWire.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/app/lib/pigeon_interfaces.dart
+++ b/app/lib/pigeon_interfaces.dart
@@ -274,6 +274,34 @@ class BluetoothHfpInput {
   BluetoothHfpInput({required this.uid, required this.name});
 }
 
+/// One rendered row of a HUD screen. [style] is 'heading' | 'body' | 'meta'.
+class HudLineWire {
+  final String text;
+  final String style;
+  final bool muted;
+
+  HudLineWire({required this.text, required this.style, required this.muted});
+}
+
+/// A tappable control on a HUD screen; [id] comes back through
+/// RayBanMetaFlutterAPI.onDisplayActionTapped.
+class HudActionWire {
+  final String id;
+  final String label;
+
+  HudActionWire({required this.id, required this.label});
+}
+
+/// A whole HUD screen. The native side owns the translation into the vendor's
+/// renderer, so nothing here is Meta-specific.
+class HudScreenWire {
+  final String title;
+  final List<HudLineWire> lines;
+  final List<HudActionWire> actions;
+
+  HudScreenWire({required this.title, required this.lines, required this.actions});
+}
+
 /// Dart → native. Camera/photo capture goes through the Meta Wearables Device
 /// Access Toolkit (DAT); the toolkit has no microphone API, so audio capture
 /// uses the platform Bluetooth HFP route as Meta's docs prescribe. All methods
@@ -353,6 +381,27 @@ abstract class RayBanMetaHostAPI {
   /// Captures one photo; result arrives via RayBanMetaFlutterAPI.onPhotoCaptured.
   @SwiftFunction('capturePhoto()')
   void capturePhoto();
+
+  /// Whether the connected glasses can render, from the toolkit's own
+  /// capability check rather than the device type. False on builds without
+  /// the Display module, so the HUD gate closes instead of throwing.
+  @SwiftFunction('deviceSupportsDisplay()')
+  bool deviceSupportsDisplay();
+
+  /// Attaches a display capability to the active device session. Requires the
+  /// DAT App Model (DAMEnabled in Info.plist).
+  @SwiftFunction('attachDisplay()')
+  void attachDisplay();
+
+  @SwiftFunction('detachDisplay()')
+  void detachDisplay();
+
+  /// Renders [screen], replacing whatever the glasses currently show.
+  @SwiftFunction('sendDisplayScreen(screen:)')
+  void sendDisplayScreen(HudScreenWire screen);
+
+  @SwiftFunction('clearDisplay()')
+  void clearDisplay();
 }
 
 /// Native → Dart events for Ray-Ban Meta.
@@ -375,4 +424,10 @@ abstract class RayBanMetaFlutterAPI {
   void onCameraStateChanged(String state);
   void onCameraPermissionChanged(String status);
   void onError(String code, String message);
+
+  /// 'unavailable' | 'detached' | 'attaching' | 'ready' | 'error'.
+  void onDisplayStateChanged(String state);
+
+  /// The id of the HudActionWire the wearer tapped.
+  void onDisplayActionTapped(String actionId);
 }

--- a/app/lib/services/bridges/rayban_meta_bridge.dart
+++ b/app/lib/services/bridges/rayban_meta_bridge.dart
@@ -13,6 +13,8 @@ class RayBanMetaFlutterBridge implements RayBanMetaFlutterAPI {
   final void Function(String state)? onCameraStateChangedCb;
   final void Function(String status)? onCameraPermissionChangedCb;
   final void Function(String code, String message)? onErrorCb;
+  final void Function(String state)? onDisplayStateChangedCb;
+  final void Function(String actionId)? onDisplayActionTappedCb;
 
   RayBanMetaFlutterBridge({
     this.onRegistrationStateChangedCb,
@@ -24,6 +26,8 @@ class RayBanMetaFlutterBridge implements RayBanMetaFlutterAPI {
     this.onCameraStateChangedCb,
     this.onCameraPermissionChangedCb,
     this.onErrorCb,
+    this.onDisplayStateChangedCb,
+    this.onDisplayActionTappedCb,
   });
 
   @override
@@ -69,5 +73,15 @@ class RayBanMetaFlutterBridge implements RayBanMetaFlutterAPI {
   @override
   void onError(String code, String message) {
     onErrorCb?.call(code, message);
+  }
+
+  @override
+  void onDisplayStateChanged(String state) {
+    onDisplayStateChangedCb?.call(state);
+  }
+
+  @override
+  void onDisplayActionTapped(String actionId) {
+    onDisplayActionTappedCb?.call(actionId);
   }
 }

--- a/app/lib/services/devices/display/glasses_display.dart
+++ b/app/lib/services/devices/display/glasses_display.dart
@@ -1,0 +1,47 @@
+import 'hud_content.dart';
+
+/// The display surface a connector exposes when its device can render.
+///
+/// Capability-keyed, never device-type-keyed: a connector reports this because
+/// its SDK says the connected hardware has a display, not because of which
+/// vendor it is. Meta's DAT sources it from `Device.supportsDisplay()`.
+abstract class GlassesDisplay {
+  Future<void> attach();
+
+  Future<void> detach();
+
+  Future<void> send(HudScreen screen);
+
+  Future<void> clear();
+
+  Stream<String> get actionTaps;
+
+  Stream<GlassesDisplayState> get stateStream;
+
+  GlassesDisplayState get state;
+}
+
+enum GlassesDisplayState { unavailable, detached, attaching, ready, error }
+
+/// Gate for the HUD feature as a whole.
+///
+/// Two independent conditions, deliberately separate: the device must actually
+/// have a display, and the user must have opted in. Neither implies the other,
+/// and a device without a display can never be turned on by the flag.
+class GlassesDisplayGate {
+  final bool deviceSupportsDisplay;
+  final bool userEnabled;
+
+  const GlassesDisplayGate({
+    required this.deviceSupportsDisplay,
+    required this.userEnabled,
+  });
+
+  bool get isOpen => deviceSupportsDisplay && userEnabled;
+
+  String get closedReason {
+    if (!deviceSupportsDisplay) return 'device_has_no_display';
+    if (!userEnabled) return 'user_disabled';
+    return '';
+  }
+}

--- a/app/lib/services/devices/display/hud_content.dart
+++ b/app/lib/services/devices/display/hud_content.dart
@@ -1,0 +1,79 @@
+/// Device-agnostic HUD content model.
+///
+/// Display glasses differ in renderer (Meta DAT ships FlexBox/Text/Button;
+/// other vendors ship text lines), so nothing here names a vendor type. A
+/// connector translates [HudScreen] into whatever its SDK draws.
+library;
+
+enum HudScreenKind { idle, tasks, capture, answer }
+
+enum HudLineStyle { heading, body, meta }
+
+class HudLine {
+  final String text;
+  final HudLineStyle style;
+  final bool muted;
+
+  const HudLine(this.text, {this.style = HudLineStyle.body, this.muted = false});
+
+  @override
+  bool operator ==(Object other) =>
+      other is HudLine && other.text == text && other.style == style && other.muted == muted;
+
+  @override
+  int get hashCode => Object.hash(text, style, muted);
+
+  @override
+  String toString() => 'HudLine($text, $style, muted=$muted)';
+}
+
+class HudAction {
+  final String id;
+  final String label;
+
+  const HudAction(this.id, this.label);
+
+  @override
+  bool operator ==(Object other) => other is HudAction && other.id == id && other.label == label;
+
+  @override
+  int get hashCode => Object.hash(id, label);
+}
+
+class HudScreen {
+  final HudScreenKind kind;
+  final String title;
+  final List<HudLine> lines;
+  final List<HudAction> actions;
+
+  const HudScreen({
+    required this.kind,
+    required this.title,
+    this.lines = const [],
+    this.actions = const [],
+  });
+
+  static const HudScreen idle = HudScreen(kind: HudScreenKind.idle, title: 'Omi');
+
+  bool get isEmpty => lines.isEmpty && actions.isEmpty;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! HudScreen) return false;
+    if (other.kind != kind || other.title != title) return false;
+    if (other.lines.length != lines.length || other.actions.length != actions.length) return false;
+    for (var i = 0; i < lines.length; i++) {
+      if (other.lines[i] != lines[i]) return false;
+    }
+    for (var i = 0; i < actions.length; i++) {
+      if (other.actions[i] != actions[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(kind, title, Object.hashAll(lines), Object.hashAll(actions));
+
+  @override
+  String toString() => 'HudScreen($kind, "$title", ${lines.length} lines)';
+}

--- a/app/lib/services/devices/display/hud_projector.dart
+++ b/app/lib/services/devices/display/hud_projector.dart
@@ -1,0 +1,136 @@
+import 'hud_content.dart';
+
+/// A task reduced to what a HUD can show. Keeping the projector off the wire
+/// schema means it stays unit-testable without generated types.
+class HudTask {
+  final String description;
+  final DateTime? dueAt;
+  final String? priority;
+  final bool completed;
+
+  const HudTask({
+    required this.description,
+    this.dueAt,
+    this.priority,
+    this.completed = false,
+  });
+}
+
+/// Projects app state onto a display-glasses HUD.
+///
+/// The line budget is the whole problem: a glasses HUD shows a handful of
+/// lines, so the projector decides what survives rather than letting a caller
+/// push an unbounded list and have the renderer clip it silently.
+class HudProjector {
+  final int maxLines;
+  final int maxLineChars;
+
+  const HudProjector({this.maxLines = 5, this.maxLineChars = 48});
+
+  static const Map<String, int> _priorityRank = {'high': 0, 'medium': 1, 'low': 2};
+
+  HudScreen tasks(List<HudTask> tasks, {DateTime? now}) {
+    final pending = tasks.where((t) => !t.completed).toList();
+    if (pending.isEmpty) {
+      return const HudScreen(
+        kind: HudScreenKind.tasks,
+        title: 'Tasks',
+        lines: [HudLine('Nothing due', style: HudLineStyle.meta, muted: true)],
+      );
+    }
+
+    final reference = now ?? DateTime.now();
+    pending.sort((a, b) => _taskOrder(a, b, reference));
+
+    final overflow = pending.length > maxLines;
+    final shown = overflow ? pending.take(maxLines - 1) : pending.take(maxLines);
+
+    final lines = <HudLine>[
+      for (final task in shown) HudLine(_truncate(task.description)),
+    ];
+    if (overflow) {
+      lines.add(HudLine('+${pending.length - lines.length} more', style: HudLineStyle.meta, muted: true));
+    }
+
+    return HudScreen(
+      kind: HudScreenKind.tasks,
+      title: 'Tasks',
+      lines: lines,
+      actions: const [HudAction('tasks.next', 'Next'), HudAction('tasks.done', 'Done')],
+    );
+  }
+
+  HudScreen capture({required bool recording, String? lastLine}) {
+    final lines = <HudLine>[
+      HudLine(recording ? 'Listening' : 'Paused', style: HudLineStyle.meta, muted: !recording),
+    ];
+    final trimmed = lastLine?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) {
+      lines.add(HudLine(_truncate(trimmed)));
+    }
+    return HudScreen(
+      kind: HudScreenKind.capture,
+      title: 'Omi',
+      lines: lines,
+      actions: [HudAction('capture.toggle', recording ? 'Pause' : 'Resume')],
+    );
+  }
+
+  HudScreen answer(String question, String answer) {
+    final lines = <HudLine>[
+      HudLine(_truncate(question.trim()), style: HudLineStyle.meta, muted: true),
+      ..._wrap(answer.trim(), maxLines - 1),
+    ];
+    return HudScreen(
+      kind: HudScreenKind.answer,
+      title: 'Omi',
+      lines: lines,
+      actions: const [HudAction('answer.dismiss', 'Dismiss')],
+    );
+  }
+
+  int _taskOrder(HudTask a, HudTask b, DateTime now) {
+    final aDue = a.dueAt;
+    final bDue = b.dueAt;
+    if (aDue != null && bDue != null && aDue != bDue) return aDue.compareTo(bDue);
+    if (aDue != null && bDue == null) return -1;
+    if (aDue == null && bDue != null) return 1;
+
+    final aRank = _priorityRank[a.priority?.toLowerCase()] ?? _priorityRank.length;
+    final bRank = _priorityRank[b.priority?.toLowerCase()] ?? _priorityRank.length;
+    if (aRank != bRank) return aRank.compareTo(bRank);
+
+    return a.description.compareTo(b.description);
+  }
+
+  String _truncate(String text) {
+    final collapsed = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (collapsed.length <= maxLineChars) return collapsed;
+    return '${collapsed.substring(0, maxLineChars - 1).trimRight()}…';
+  }
+
+  List<HudLine> _wrap(String text, int budget) {
+    if (budget <= 0) return const [];
+    final collapsed = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (collapsed.isEmpty) return const [];
+
+    final lines = <String>[];
+    var remaining = collapsed;
+    while (remaining.isNotEmpty && lines.length < budget) {
+      if (remaining.length <= maxLineChars) {
+        lines.add(remaining);
+        break;
+      }
+      final isLast = lines.length == budget - 1;
+      if (isLast) {
+        lines.add(_truncate(remaining));
+        break;
+      }
+      var cut = remaining.lastIndexOf(' ', maxLineChars);
+      if (cut <= 0) cut = maxLineChars;
+      lines.add(remaining.substring(0, cut).trimRight());
+      remaining = remaining.substring(cut).trimLeft();
+    }
+    return [for (final line in lines) HudLine(line)];
+  }
+}

--- a/app/test/unit/hud_projector_test.dart
+++ b/app/test/unit/hud_projector_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/devices/display/glasses_display.dart';
+import 'package:omi/services/devices/display/hud_content.dart';
+import 'package:omi/services/devices/display/hud_projector.dart';
+
+void main() {
+  final now = DateTime(2026, 8, 1, 9);
+  const projector = HudProjector();
+
+  group('HudProjector.tasks', () {
+    test('drops completed tasks and says so when nothing is pending', () {
+      final screen = projector.tasks([
+        const HudTask(description: 'Ship the PR', completed: true),
+      ], now: now);
+
+      expect(screen.kind, HudScreenKind.tasks);
+      expect(screen.lines.single.text, 'Nothing due');
+      expect(screen.lines.single.muted, isTrue);
+    });
+
+    test('orders by due date, then priority, before falling back to text', () {
+      final screen = projector.tasks([
+        const HudTask(description: 'No due, low', priority: 'low'),
+        HudTask(description: 'Due later', dueAt: now.add(const Duration(days: 2))),
+        const HudTask(description: 'No due, high', priority: 'high'),
+        HudTask(description: 'Due soon', dueAt: now.add(const Duration(hours: 1))),
+      ], now: now);
+
+      expect(
+        screen.lines.map((l) => l.text).toList(),
+        ['Due soon', 'Due later', 'No due, high', 'No due, low'],
+      );
+    });
+
+    test('never exceeds the line budget and reports what it hid', () {
+      final screen = projector.tasks([
+        for (var i = 0; i < 12; i++) HudTask(description: 'Task $i', priority: 'high'),
+      ], now: now);
+
+      expect(screen.lines.length, 5);
+      expect(screen.lines.last.text, '+8 more');
+      expect(screen.lines.last.muted, isTrue);
+    });
+
+    test('fills the budget exactly when the count fits, with no overflow line', () {
+      final screen = projector.tasks([
+        for (var i = 0; i < 5; i++) HudTask(description: 'Task $i'),
+      ], now: now);
+
+      expect(screen.lines.length, 5);
+      expect(screen.lines.every((l) => l.text.startsWith('Task')), isTrue);
+    });
+
+    test('collapses whitespace and truncates an over-long description', () {
+      final screen = projector.tasks([
+        HudTask(description: 'a  b\n\tc ${'x' * 80}'),
+      ], now: now);
+
+      final text = screen.lines.single.text;
+      expect(text.length, lessThanOrEqualTo(48));
+      expect(text, startsWith('a b c'));
+      expect(text, endsWith('…'));
+    });
+  });
+
+  group('HudProjector.answer', () {
+    test('wraps on word boundaries within the remaining budget', () {
+      final screen = projector.answer('What is left?', List.filled(40, 'word').join(' '));
+
+      expect(screen.lines.length, lessThanOrEqualTo(5));
+      expect(screen.lines.first.text, 'What is left?');
+      expect(screen.lines.skip(1).every((l) => l.text.length <= 48), isTrue);
+      expect(screen.lines.last.text, endsWith('…'));
+    });
+
+    test('keeps a short answer on one line', () {
+      final screen = projector.answer('Ping?', 'Pong');
+      expect(screen.lines.map((l) => l.text).toList(), ['Ping?', 'Pong']);
+    });
+  });
+
+  group('HudProjector.capture', () {
+    test('marks the paused state muted and offers resume', () {
+      final screen = projector.capture(recording: false);
+      expect(screen.lines.single.text, 'Paused');
+      expect(screen.lines.single.muted, isTrue);
+      expect(screen.actions.single.label, 'Resume');
+    });
+
+    test('omits a blank transcript line rather than rendering an empty row', () {
+      final screen = projector.capture(recording: true, lastLine: '   ');
+      expect(screen.lines.length, 1);
+      expect(screen.lines.single.text, 'Listening');
+    });
+  });
+
+  group('GlassesDisplayGate', () {
+    test('a display-less device stays closed even when the user opts in', () {
+      const gate = GlassesDisplayGate(deviceSupportsDisplay: false, userEnabled: true);
+      expect(gate.isOpen, isFalse);
+      expect(gate.closedReason, 'device_has_no_display');
+    });
+
+    test('a display device stays closed until the user opts in', () {
+      const gate = GlassesDisplayGate(deviceSupportsDisplay: true, userEnabled: false);
+      expect(gate.isOpen, isFalse);
+      expect(gate.closedReason, 'user_disabled');
+    });
+
+    test('opens only when both conditions hold', () {
+      const gate = GlassesDisplayGate(deviceSupportsDisplay: true, userEnabled: true);
+      expect(gate.isOpen, isTrue);
+      expect(gate.closedReason, isEmpty);
+    });
+  });
+}

--- a/docs/rayban-meta-device.md
+++ b/docs/rayban-meta-device.md
@@ -53,6 +53,33 @@ Bluetooth HFP route (microphone) ───┘        │  Pigeon: RayBanMetaHost
 | iOS bridge | `app/ios/Runner/RayBanMeta/` | `RayBanMetaHostApiImpl.swift` (DAT under `#if canImport(MWDATCore)`), `RayBanMetaAudioCapture.swift` (HFP mic → PCM16/16 kHz) |
 | Backend | `backend/models/conversation_enums.py`, `backend/routers/transcribe.py` | `ConversationSource.rayban_meta`; photo-source flip preserves `rayban_meta` |
 
+### Display path
+
+DAT **0.7.0** added the Display capability and **0.8.0** ships it (plus
+`clearDisplay()`); the repo already pinned 0.8.0, so linking `MWDATDisplay`
+into `RunnerRayBanDat` was the only missing step. It stays out of default
+`Runner` for the same reason `MWDATCore` does — see the SwiftProtobuf
+duplicate-class crash in `rayban-meta-troubleshooting.md`.
+
+The HUD is gated on **capability, not device type**: `deviceSupportsDisplay()`
+returns `Device.supportsDisplay()` from the toolkit, so any display-capable
+Meta hardware lights up without a new device case, and Ray-Ban Meta Gen 1/2
+(no display) reports false. `GlassesDisplayGate` then requires a separate user
+opt-in; neither condition implies the other.
+
+Content is device-neutral. `HudScreen`/`HudLine` (`app/lib/services/devices/display/`)
+describe *what* to show; `RayBanMetaDisplayRenderer` translates that into
+Meta's `FlexBox`/`Text`/`Button`. `HudProjector` owns the line budget — a HUD
+shows about five lines, so the projector decides what survives and appends an
+explicit `+N more` rather than letting the renderer clip silently.
+
+`RayBanMetaDisplayRenderer.swift` deliberately does not import SwiftUI:
+`MWDATDisplay` exports its own `Text`, `Button`, and `Image`, and importing
+both makes those names ambiguous (Meta documents this in the 0.7.0 notes).
+
+Display requires the DAT App Model — the `DAMEnabled` key already present in
+the `MWDAT` Info.plist dictionary.
+
 ### Audio path
 
 The Meta Wearables Device Access Toolkit (DAT 0.8) has **no microphone API**.


### PR DESCRIPTION
## What this is

The Omi HUD on display-capable Meta glasses, gated on the capability rather than on the device being a Ray-Ban.

## The finding this rests on

`docs/rayban-meta-device.md` said the toolkit gives us camera only. That was true when written and is now stale: **DAT 0.7.0 (2026-05-14) added the Display capability**, and **0.8.0 ships it** plus `clearDisplay()`. The repo already pinned `meta-wearables-dat-ios` at exact 0.8.0 — it just never linked `MWDATDisplay`, so the display was sitting behind an unlinked module the whole time.

The no-microphone finding still holds. Audio remains the Bluetooth HFP route; nothing in the audio path changes here.

## Capability, not device type

`deviceSupportsDisplay()` returns the toolkit's own `Device.supportsDisplay()`. Any display-capable Meta hardware lights up with no new device case, and Ray-Ban Meta Gen 1/2 reports `false`. This is the same signal Meta's own sample uses to filter devices (`AutoDeviceSelector(wearables:filter:{ $0.supportsDisplay() })`).

`GlassesDisplayGate` keeps two conditions deliberately separate — the device can render, and the user opted in. Neither implies the other, so a display-less device can never be switched on by the flag alone.

## Content is device-neutral

`HudScreen`/`HudLine` describe *what* to show without naming an SDK; `RayBanMetaDisplayRenderer` translates into Meta's `FlexBox`/`Text`/`Button`. A future vendor implements `GlassesDisplay` and reuses the projector unchanged.

`HudProjector` owns the line budget, which is the actual design problem — a HUD shows roughly five lines and `TaskActionItem` alone carries ~30 fields. The projector decides what survives (due date, then priority, then text) and appends an explicit `+N more` rather than letting the renderer clip silently.

## Two things found on the way

**The graph test's exactness assertion was vacuous.** `test_separate_dat_target_owns_only_the_required_meta_products` asserts an exact module set, but `package_product_names` scanned for `MWDAT(?:Core|Camera)` — a newly linked product was invisible to it, so the assertion passed without checking anything. Broadened to `MWDAT\w+`, which is what makes the new `assert_equal` meaningful.

**Pigeon emits trailing whitespace** (`case 134: `) into generated Dart, which `diff-hygiene` rejects. Stripped in this PR; it will recur on the next `pigeon` run, so it likely wants a generator post-step rather than a manual fix each time. Not addressed here.

`MWDATDisplay` is linked into `RunnerRayBanDat` only, never default `Runner` — linking it there would re-trigger the `MWDATCore` SwiftProtobuf duplicate-class launch crash documented in `rayban-meta-troubleshooting.md`.

`RayBanMetaDisplayRenderer.swift` does not import SwiftUI: `MWDATDisplay` exports its own `Text`, `Button`, and `Image`, and importing both makes those names ambiguous (Meta documents this in the 0.7.0 notes).

## Verification

```
flutter test test/unit/hud_projector_test.dart                    12 passed
flutter test test/unit/rayban_meta_device_test.dart
             test/unit/rayban_meta_source_mapping_test.dart       22 passed (no regression)
ruby app/ios/test/rayban_dat_xcode_graph_test.rb                   9 runs, 402 assertions, 0 failures
ruby app/ios/test/rayban_dat_plugin_boundary_test.rb               9 runs,  99 assertions, 0 failures
ruby app/ios/test/rayban_dat_build_wrapper_test.rb                12 runs, 129 assertions, 0 failures
plutil -lint app/ios/Runner.xcodeproj/project.pbxproj              OK
scripts/pre-push (bounded preflight gate)                          passed
```

The graph-test count moving 393 → 402 is the evidence the pbxproj wiring actually took: the broadened scan now sees `MWDATDisplay` in `packageProductDependencies`.

## Not verified — please read before merging

**I did not run this on glasses.** No display hardware here, and the DAT target needs Xcode 26 + a resolved Meta package, so the `#if canImport(MWDATDisplay)` branch has never been compiled — only the audio-only `#else` stubs are exercised by the tests above. What is proven is the Dart projection logic, the target/module boundary, and that the default `Runner` stays clean.

Before this merges it wants one run against `MockDeviceKit.pairGlasses(model: .metaGlasses)` with `MockCaptouchKit` for the tap path — that is simulator-only and needs no physical glasses, I just could not resolve the package here.

Treat the display rendering as unproven until someone does that.

## Product invariants affected

none

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native Meta DAT display session lifecycle and a large generated bridge surface; behavior is capability-gated and isolated to the DAT iOS target, but display rendering is not verified on hardware in this PR.
> 
> **Overview**
> Adds **glasses HUD plumbing** so Flutter can drive Meta’s Display capability over Pigeon, gated on toolkit support rather than device model.
> 
> **Pigeon contract:** New wire types `HudLineWire`, `HudActionWire`, and `HudScreenWire`, plus `RayBanMetaHostAPI` methods (`deviceSupportsDisplay`, `attachDisplay` / `detachDisplay`, `sendDisplayScreen`, `clearDisplay`) and Flutter callbacks (`onDisplayStateChanged`, `onDisplayActionTapped`). Generated bindings and `RayBanMetaFlutterBridge` are updated accordingly.
> 
> **iOS (`RunnerRayBanDat` only):** Links **MWDATDisplay**, implements display lifecycle in `RayBanMetaHostApiImpl` (session `addDisplay`, state stream, async send/clear), and maps neutral HUD screens to Meta views in `RayBanMetaDisplayRenderer`. Audio-only builds keep stub implementations that return false / throw unavailable.
> 
> **Tests / wiring:** `rayban_dat_xcode_graph_test.rb` now expects `MWDATDisplay` in the DAT target and uses a broader `MWDAT\w+` product scan so new Meta modules can’t slip in unnoticed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c4e2f7c4a69473be42aabc5a3b7bc3e5002ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->