### PR TITLE
fix(windows): let Stop cancel a memories bulk delete during a rate-li…

### DIFF
--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { Memory } from '../hooks/useMemories'
 
 const omiApiGet = vi.fn()
-vi.mock('./apiClient', () => ({ omiApi: { get: (...args: unknown[]) => omiApiGet(...args) } }))
+const omiApiDelete = vi.fn()
+vi.mock('./apiClient', () => ({
+  omiApi: {
+    get: (...args: unknown[]) => omiApiGet(...args),
+    delete: (...args: unknown[]) => omiApiDelete(...args)
+  }
+}))
 
-import { fetchAllMemories } from './memoriesBulk'
+import { fetchAllMemories, deleteMemoriesPaced } from './memoriesBulk'
 
 function page(ids: string[]): { data: Partial<Memory>[] } {
   return { data: ids.map((id) => ({ id, uid: 'u', content: id, created_at: '', updated_at: '' })) }
@@ -12,6 +18,7 @@ function page(ids: string[]): { data: Partial<Memory>[] } {
 
 beforeEach(() => {
   omiApiGet.mockReset()
+  omiApiDelete.mockReset()
 })
 
 // Fakes GET /v3/memories: hard page cap 500, no first-page expansion.
@@ -67,5 +74,170 @@ describe('fetchAllMemories', () => {
 
     expect(all).toHaveLength(200)
     expect(omiApiGet).toHaveBeenCalledTimes(2)
+  })
+})
+
+// A 429 pause is a normal part of any real bulk delete here, and Retry-After is
+// measured in tens of seconds, so the pause has to stay cancellable.
+describe('deleteMemoriesPaced Stop responsiveness', () => {
+  const RETRY_AFTER_S = 30
+  const rateLimited = (): unknown => ({
+    response: { status: 429, headers: { 'retry-after': String(RETRY_AFTER_S) } }
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('does not delete one more memory when Stop is pressed during a rate-limit pause', async () => {
+    // First attempt on 'a' is rate-limited; every later attempt would succeed.
+    omiApiDelete.mockRejectedValueOnce(rateLimited()).mockResolvedValue({ data: {} })
+    let stop = false
+    const onResult = vi.fn()
+
+    const run = deleteMemoriesPaced(['a', 'b'], onResult, () => stop)
+
+    await vi.advanceTimersByTimeAsync(250) // first slice of the pause
+    stop = true
+    await vi.advanceTimersByTimeAsync(250) // next slice observes the Stop
+    const tally = await run
+
+    // Only the initial attempt on 'a' ever reached the server.
+    expect(omiApiDelete).toHaveBeenCalledTimes(1)
+    expect(omiApiDelete).toHaveBeenCalledWith('/v3/memories/a', expect.anything())
+    // 'a' was cancelled mid-retry, so it is neither deleted nor failed, and its
+    // row must not be dropped from the UI.
+    expect(tally).toEqual({ deleted: 0, failed: 0, firstError: undefined })
+    expect(onResult).not.toHaveBeenCalled()
+  })
+
+  it('ends the rate-limit pause within a poll interval instead of serving it out', async () => {
+    omiApiDelete.mockRejectedValueOnce(rateLimited()).mockResolvedValue({ data: {} })
+    let stop = false
+    let settled = false
+
+    const run = deleteMemoriesPaced(
+      ['a'],
+      () => {},
+      () => stop
+    )
+    void run.then(() => {
+      settled = true
+    })
+
+    // Prove the run actually reached the 429 pause before advancing any timer,
+    // so the assertions below cannot pass on mock-flush ordering alone.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(omiApiDelete).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(250)
+    expect(settled).toBe(false) // still waiting out the 429, as it should be
+    stop = true
+
+    await vi.advanceTimersByTimeAsync(250)
+    expect(settled).toBe(true) // returned on the next slice, not after 30s
+
+    await run
+  })
+
+  it('returns without serving the pacing tail when Stop is already set', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    let stop = false
+    let settled = false
+
+    const run = deleteMemoriesPaced(
+      ['a', 'b'],
+      () => {
+        stop = true // user hits Stop the moment the first row disappears
+      },
+      () => stop
+    )
+    void run.then(() => {
+      settled = true
+    })
+
+    // Stop is already set when the tail begins, so no tail timer is ever
+    // scheduled and the run settles without virtual time passing at all.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+
+    const tally = await run
+    expect(omiApiDelete).toHaveBeenCalledTimes(1)
+    expect(tally).toEqual({ deleted: 1, failed: 0, firstError: undefined })
+  })
+
+  it('cuts the pacing tail short when Stop lands after the wait has begun', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    let stop = false
+    let settled = false
+
+    const run = deleteMemoriesPaced(
+      ['a', 'b'],
+      () => {},
+      () => stop
+    )
+    void run.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(250) // tail underway, Stop not yet pressed
+    expect(settled).toBe(false)
+    stop = true
+
+    await vi.advanceTimersByTimeAsync(250) // next slice observes it
+    expect(settled).toBe(true) // not after the full 1100ms
+
+    const tally = await run
+    expect(omiApiDelete).toHaveBeenCalledTimes(1) // 'b' never attempted
+    expect(tally).toEqual({ deleted: 1, failed: 0, firstError: undefined })
+  })
+
+  // retentionSweep.ts calls this with no `shouldStop`, so that path keeps its
+  // single unsliced timer rather than polling it can never use.
+  it('does not slice its waits for a caller that passes no shouldStop', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+    const run = deleteMemoriesPaced(['a'], () => {})
+    await vi.advanceTimersByTimeAsync(1100)
+    await run
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1) // one 1100ms wait, not five slices
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1100)
+  })
+
+  it('still deletes every id and paces between them when Stop is never pressed', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    const onResult = vi.fn()
+
+    const run = deleteMemoriesPaced(['a', 'b'], onResult, () => false)
+    await vi.advanceTimersByTimeAsync(1100 * 2 + 250)
+    const tally = await run
+
+    expect(omiApiDelete).toHaveBeenCalledTimes(2)
+    expect(tally).toEqual({ deleted: 2, failed: 0, firstError: undefined })
+    expect(onResult).toHaveBeenNthCalledWith(1, 'a', true, { deleted: 1, failed: 0 })
+    expect(onResult).toHaveBeenNthCalledWith(2, 'b', true, { deleted: 2, failed: 0 })
+  })
+
+  it('waits out a rate limit and completes when the user lets it run', async () => {
+    omiApiDelete.mockRejectedValueOnce(rateLimited()).mockResolvedValue({ data: {} })
+
+    const run = deleteMemoriesPaced(
+      ['a'],
+      () => {},
+      () => false
+    )
+    await vi.advanceTimersByTimeAsync(RETRY_AFTER_S * 1000 + 1100 + 250)
+    const tally = await run
+
+    expect(omiApiDelete).toHaveBeenCalledTimes(2) // rate-limited, then retried
+    expect(tally).toEqual({ deleted: 1, failed: 0, firstError: undefined })
   })
 })

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
@@ -3,6 +3,19 @@ import type { Memory } from '../hooks/useMemories'
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
+// Sleep in short slices, returning as soon as shouldStop() flips. A single
+// `await sleep(retryAfterMs)` is unobservable, so a Stop pressed during a pause
+// cannot take effect until the whole wait has elapsed. Callers with no
+// cancellation get the original single timer, unsliced.
+const STOP_POLL_MS = 250
+async function waitInterruptible(ms: number, shouldStop?: () => boolean): Promise<void> {
+  if (!shouldStop) return sleep(ms)
+  for (let waited = 0; waited < ms; waited += STOP_POLL_MS) {
+    if (shouldStop()) return
+    await sleep(Math.min(STOP_POLL_MS, ms - waited))
+  }
+}
+
 // A raw axios response, narrowed to just what the pager's onResponse hook reads
 // (headers) — avoids coupling this module to the full axios type surface.
 type MemoriesResponse = { data: unknown; headers?: Record<string, unknown> }
@@ -87,8 +100,10 @@ export type BulkDeleteTally = { deleted: number; failed: number; firstError?: st
 // Delete memories by id, paced under the server's 60-per-hour delete cap: one at
 // a time at ~1.1s, waiting out 429s (honoring Retry-After) and retrying the same
 // id rather than failing. 404 = already gone (idempotent). `onResult` fires after
-// each id so the UI can drop the row and show progress. `shouldStop` lets the
-// caller cancel between ids.
+// each id so the UI can drop the row and show progress. `shouldStop` is
+// rechecked after every wait, rate-limit pauses included. An id cancelled
+// mid-retry counts as neither deleted nor failed and fires no `onResult`,
+// because it still exists.
 export async function deleteMemoriesPaced(
   ids: string[],
   onResult: (id: string, ok: boolean, tally: { deleted: number; failed: number }) => void,
@@ -100,6 +115,7 @@ export async function deleteMemoriesPaced(
   for (const id of ids) {
     if (shouldStop?.()) break
     let ok = false
+    let stopped = false
     for (let attempt = 0; attempt < 30; attempt++) {
       try {
         // __noRetry: this loop owns 429 handling, so the axios interceptor's
@@ -117,19 +133,27 @@ export async function deleteMemoriesPaced(
         }
         if (status === 429) {
           const ra = Number(resp?.headers?.['retry-after'])
-          await sleep(
-            Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000)
+          await waitInterruptible(
+            Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(3000 * 1.6 ** attempt, 60_000),
+            shouldStop
           )
+          // Without this recheck the pause ends and the retry deletes one more
+          // memory after the user already asked to stop.
+          if (shouldStop?.()) {
+            stopped = true
+            break
+          }
           continue
         }
         if (!firstError) firstError = status ? `HTTP ${status}` : (e as Error).message
         break
       }
     }
+    if (stopped) break // cancelled mid-retry: neither deleted nor failed
     if (ok) deleted++
     else failed++
     onResult(id, ok, { deleted, failed })
-    await sleep(1100) // stay under ~60/hour
+    await waitInterruptible(1100, shouldStop) // stay under ~60/hour; Stop skips the tail
   }
   return { deleted, failed, firstError }
 }


### PR DESCRIPTION
## What changed and why

`deleteMemoriesPaced` only observed `shouldStop()` between ids, so both of its waits were uninterruptible. A Stop pressed during a 429 `Retry-After` pause could not take effect until the whole pause elapsed, and when it ended the loop retried and deleted one more memory after the user had already asked to stop. The 1100ms pacing tail had the same property.

`waitInterruptible(ms, shouldStop)` now sleeps in 250ms slices and returns as soon as `shouldStop()` flips, and the 429 branch rechecks it after the pause and stops without deleting. An id cancelled mid-retry counts as neither deleted nor failed and fires no `onResult`, so its row stays: that memory still exists.

Callers that pass no `shouldStop` (`retentionSweep.ts`) take an early return, so each wait creates exactly one timer for exactly the original duration, with no polling and no repeated callback evaluation.

Deleting memories is irreversible, so an unresponsive Stop fails in the wrong direction. No API change, no new dependency, no UI change.

## Product invariants affected

none

## How it was verified

Run from `desktop/windows` on Node 22.23.2 with pnpm 11.18.0 and `--frozen-lockfile`:

- `pnpm test src/renderer/src/lib/memoriesBulk.test.ts` -> 10 passed
- `pnpm test` (full suite) -> 533 files / 5131 tests passed, 6 files and 18 tests skipped, 0 failed
- `pnpm typecheck` -> clean (node and web)
- `pnpm exec eslint` and `pnpm exec prettier --check` on both changed files -> clean

Stated explicitly, since it matters: I did not exercise this through the signed-in desktop UI. A source build cannot complete Google sign-in without Omi's production OAuth client secret, which is not in the public repo, so the running app was not driven end to end. The behavior is covered at the module boundary instead, through the same `shouldStop` callback `Memories.tsx` passes, with the delete client mocked and fake timers driving the pauses.

## Tests

7 cases added to `src/renderer/src/lib/memoriesBulk.test.ts`.

Four of them fail on `main` and pass with this change, so they are the regression tests that would have caught the bug:

- a Stop during a rate-limit pause no longer lets one more delete through (asserts exactly one request reached the server, tally `{deleted: 0, failed: 0}`, and no `onResult`)
- the rate-limit pause ends within a poll interval instead of being served out
- the pacing tail is not served at all when Stop is already set (asserts zero scheduled timers)
- the pacing tail is cut short when Stop lands after the wait has begun

The other three pass on `main` by design, as non-regression guards: the no-`shouldStop` path still schedules a single unsliced 1100ms timer, normal completion still deletes every id and paces between them, and a rate limit still gets waited out and completes when the user lets it run.

## Failure class (fixes)

Failure-Class: none