### PR TITLE
fix(app): resolve conversation detail through the local day key, not raw UTC fields

### DIFF
--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -84,15 +84,14 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
     result ??= _cachedConversation;
     if (result != null && id != null && result.id != id) return null;
     if (result != null) {
-      // Validate against the same effective date used to group conversations
-      // (startedAt ?? createdAt). Using createdAt alone breaks for
-      // conversations whose startedAt lands on a different calendar day, which
-      // would otherwise make this getter return null for a conversation that is
-      // actually present in the selected day-group.
+      // Validate through the same day key the grouping uses
+      // ([conversationLocalDayKey] of startedAt ?? createdAt). Reading the raw
+      // year/month/day off the conversation reads *UTC* fields — server
+      // timestamps parse as UTC — while the selected date is a *local* day key,
+      // so anywhere ahead of UTC a conversation started late in the UTC day
+      // resolved to null even though it sits in the selected day-group.
       final effectiveDate = result.startedAt ?? result.createdAt;
-      if (effectiveDate.year == selectedDate.year &&
-          effectiveDate.month == selectedDate.month &&
-          effectiveDate.day == selectedDate.day) {
+      if (conversationLocalDayKey(effectiveDate) == conversationLocalDayKey(selectedDate)) {
         return _cachedConversation = result;
       }
     }

--- a/app/test/providers/conversation_detail_provider_selection_test.dart
+++ b/app/test/providers/conversation_detail_provider_selection_test.dart
@@ -66,8 +66,8 @@ void main() {
     // wrong one. When the selected conversation leaves the group (deleted on
     // another device, merged away, or filtered out by the discarded/short
     // toggles) the getter must report a miss rather than substitute a sibling.
-    final selected = _conversationAt('selected', DateTime.utc(2026, 7, 18, 9));
-    final sibling = _conversationAt('sibling', DateTime.utc(2026, 7, 18, 11));
+    final selected = _conversationAt('selected', DateTime(2026, 7, 18, 9));
+    final sibling = _conversationAt('sibling', DateTime(2026, 7, 18, 11));
 
     final conversationProvider = ConversationProvider(
       conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
@@ -98,7 +98,7 @@ void main() {
   test('selected conversation survives a transient empty day group', () {
     // A refresh can momentarily empty the group; the page must keep showing the
     // conversation it was opened with instead of blanking or retargeting.
-    final selected = _conversationAt('selected', DateTime.utc(2026, 7, 18, 9));
+    final selected = _conversationAt('selected', DateTime(2026, 7, 18, 9));
 
     final conversationProvider = ConversationProvider(
       conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
@@ -132,6 +132,9 @@ DateTime _instantSplittingUtcAndLocalDay() {
   return offset.isNegative ? DateTime.utc(2026, 7, 18, 0, 0) : DateTime.utc(2026, 7, 18, 23, 59);
 }
 
+/// Both these fixtures must land in one day group, so they are anchored in
+/// local time: a UTC-pinned pair a couple of hours apart straddles local
+/// midnight at far-enough offsets and splits into two groups.
 ServerConversation _conversationAt(String id, DateTime startedAt) {
   return ServerConversation(
     id: id,

--- a/app/test/providers/conversation_detail_provider_selection_test.dart
+++ b/app/test/providers/conversation_detail_provider_selection_test.dart
@@ -15,15 +15,25 @@ void main() {
 
   test('conversation getter resolves when startedAt and createdAt fall on different days', () {
     // Regression for "Bad state: No conversation available": conversations are
-    // grouped by their effective date (startedAt ?? createdAt), and tapping a
-    // list item selects that group's date. When startedAt lands on an earlier
-    // calendar day than createdAt (session spanning midnight / timezone edge),
-    // the detail provider must still resolve the conversation instead of
-    // throwing from the non-null `conversation` getter.
+    // grouped by the *local* day of their effective date (startedAt ??
+    // createdAt), and tapping a list item selects that group's date. When
+    // startedAt lands on an earlier calendar day than createdAt (session
+    // spanning midnight / timezone edge), the detail provider must still
+    // resolve the conversation instead of throwing from the non-null
+    // `conversation` getter.
+    //
+    // The instant is derived from the host's UTC offset rather than pinned, so
+    // the case actually under test — an effective date whose local calendar day
+    // differs from its UTC one — is constructed on hosts either side of UTC.
+    // The previously pinned 23:30 UTC only diverged ahead of UTC, so the
+    // getter comparing raw (UTC) date components against the local day key
+    // stayed green everywhere behind it. On a host at UTC the two days can
+    // never diverge and this asserts plain resolution.
+    final startedAt = _instantSplittingUtcAndLocalDay();
     final convo = ServerConversation(
       id: 'c1',
-      startedAt: DateTime.utc(2026, 7, 18, 23, 30),
-      createdAt: DateTime.utc(2026, 7, 19, 0, 15),
+      startedAt: startedAt,
+      createdAt: startedAt.add(const Duration(minutes: 45)),
       structured: Structured('Title', 'Overview'),
       status: ConversationStatus.completed,
     );
@@ -110,6 +120,16 @@ void main() {
 
     expect(detailProvider.conversationOrNull?.id, 'selected');
   });
+}
+
+/// A UTC instant whose *local* calendar day differs from its UTC one, as
+/// server timestamps do for real users on both sides of UTC: late in the UTC
+/// day lands on the next local day ahead of UTC, the start of it on the
+/// previous local day behind. The offset is read at that instant, not now, so
+/// a DST boundary between the two cannot flip which side it falls on.
+DateTime _instantSplittingUtcAndLocalDay() {
+  final offset = DateTime.utc(2026, 7, 18, 12).toLocal().timeZoneOffset;
+  return offset.isNegative ? DateTime.utc(2026, 7, 18, 0, 0) : DateTime.utc(2026, 7, 18, 23, 59);
 }
 
 ServerConversation _conversationAt(String id, DateTime startedAt) {


### PR DESCRIPTION
## What

`ConversationDetailProvider.conversationOrNull` validated the conversation it resolved by comparing the **raw** `year`/`month`/`day` of its effective date (`startedAt ?? createdAt`) against `selectedDate`. Server timestamps parse as UTC, so those are UTC fields — while `selectedDate` is the **local** day key that `conversationLocalDayKey` produced when grouping.

Both sides now go through `conversationLocalDayKey`, so the getter can only accept or reject the very key the grouper produced.

## Why

Wherever a conversation's local calendar day differs from its UTC one — started late in the UTC day ahead of UTC, or at the start of it behind — the check failed for a conversation that *is* sitting in the selected day-group, and the getter returned null:

- build paths (`conversationOrNull`) render a blank detail page;
- gesture/async paths (`conversation`) throw `StateError: No valid conversation found`.

That is every user whose device is not at UTC, for any conversation near their local midnight.

Reported in #10976 as a red test on `main`. It is not fixture rot: the fixture was pinned at `23:30` UTC, which only diverges *ahead* of UTC, so the guard was green on every host behind UTC — including CI, which runs `ubuntu-latest` at UTC, where local and UTC calendar days can never diverge at all. That is why the defect shipped and why the test looked fine here until someone ran it from a positive offset.

## Second commit

The two sibling-identity tests in the same file pinned fixtures to UTC instants two hours apart. Those straddle local midnight at far-enough offsets and split into two day groups, so `groupedConversations.keys.single` threw `Bad state: Too many elements` under `TZ=Pacific/Kiritimati` (+14) and `Pacific/Midway` (-11). Neither test is about UTC/local divergence — both just need one group — so they are anchored in local time.

## What I tested

`flutter test test/providers/conversation_detail_provider_selection_test.dart`, run per timezone, on the parent commit and on this branch:

| TZ | offset | parent | this branch |
|---|---|---|---|
| `Pacific/Midway` | −11 | fail | pass |
| `America/Los_Angeles` | −7 | fail | pass |
| `America/New_York` | −4 | fail | pass |
| `UTC` | 0 | pass¹ | pass |
| `Europe/Berlin` | +2 | fail | pass |
| `Asia/Kathmandu` | +5:45 | fail | pass |
| `Asia/Tokyo` | +9 | fail | pass |
| `Australia/Sydney` | +10 | fail | pass |
| `Pacific/Kiritimati` | +14 | fail | pass |

¹ Stated plainly: at UTC the two calendar days cannot diverge, so the case under test cannot be constructed and the guard asserts only plain resolution there. CI runs at UTC, so **CI will not catch a regression of this bug** — the guard is real on every developer machine outside UTC, and inert on the runner. Pinning `TZ` for the app test lane would fix that, but it changes the CI workflow and is out of scope here.

Also run:

- full app suite `bash app/test.sh` → **987 passed, 0 failed** (issue reports 957 passed / 1 failed on `main`).
- `dart format --line-length 120` → 0 changed.
- `make preflight` → passing.

Not exercised in a running app build: this is a pure provider-lookup path with no UI change, covered by the unit test above driving the real `groupConversationsByDate` → `updateConversation` → `conversationOrNull` sequence.

## Notes

- `app/scripts/analyze_ratchet.sh` is red on my machine, on `main` as well as here, from one `deprecated_member_use_from_same_package` on `getDeviceImagePathByModel` (`lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart:634`). That is a local-toolchain artifact, not a repo state: the same run reports `experimental_member_use` 0-found against a baseline of 13, and this box is on Flutter 3.38.5 while CI takes current `stable`. CI's own ratchet is green on `main`. Nothing here touches either file.
- Four call sites still derive the day key with raw date components instead of `conversationLocalDayKey` (`chat/widgets/ai_message.dart`, `onboarding/conversation_created_widget.dart`, `memories/widgets/memory_item.dart`, `conversation_detail/page.dart` fallback). Same defect class, but in widget code I cannot unit-verify, so per the repo's "only make an opportunistic fix you can verify" rule they are filed as #10980 rather than changed blind.

Failure-Class: none

fixes #10976

Auto-generated from issue feedback by the mini issues-improver — tested and merged.
