### PR TITLE
fix(app): resolve the conversation detail page by local day key (#10976)

### DIFF
--- a/.github/failure-classes/FC-day-bucket-key-recomputed.json
+++ b/.github/failure-classes/FC-day-bucket-key-recomputed.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-day-bucket-key-recomputed",
+  "violated_contract": "A derived day-bucket key has exactly one authority. A consumer that re-derives the bucket from a timestamp's raw UTC year/month/day disagrees with the authority for every viewer whose local day differs from the UTC day, so a record present in a bucket reads as absent.",
+  "canonical_prevention": "Call the shared key function (app: conversationLocalDayKey) on both sides of any day-bucket comparison instead of comparing raw calendar fields, and cover the invariant with a test that sweeps the whole day so a single pinned hour cannot keep it green at the runner's UTC offset.",
+  "evidence_prs": [10398],
+  "scope_hints": ["app/lib/providers/**", "app/lib/pages/conversation_detail/**"],
+  "status": "open",
+  "canonical_prevention_artifact": ["app/test/providers/conversation_detail_provider_selection_test.dart"]
+}

--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -84,15 +84,15 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
     result ??= _cachedConversation;
     if (result != null && id != null && result.id != id) return null;
     if (result != null) {
-      // Validate against the same effective date used to group conversations
-      // (startedAt ?? createdAt). Using createdAt alone breaks for
-      // conversations whose startedAt lands on a different calendar day, which
-      // would otherwise make this getter return null for a conversation that is
-      // actually present in the selected day-group.
+      // Validate with the *same* key function the list groups by
+      // (`conversationLocalDayKey` over startedAt ?? createdAt). Comparing the
+      // raw UTC year/month/day instead made this getter reject a conversation
+      // that is actually present in the selected day-group whenever the
+      // viewer's local day differs from the UTC day — an evening conversation
+      // for any UTC+ viewer, a post-UTC-midnight one for any UTC- viewer —
+      // blanking the detail page it was opened from (#10976).
       final effectiveDate = result.startedAt ?? result.createdAt;
-      if (effectiveDate.year == selectedDate.year &&
-          effectiveDate.month == selectedDate.month &&
-          effectiveDate.day == selectedDate.day) {
+      if (conversationLocalDayKey(effectiveDate) == conversationLocalDayKey(selectedDate)) {
         return _cachedConversation = result;
       }
     }

--- a/app/test/providers/conversation_detail_provider_selection_test.dart
+++ b/app/test/providers/conversation_detail_provider_selection_test.dart
@@ -13,41 +13,51 @@ void main() {
     await SharedPreferencesUtil.init();
   });
 
-  test('conversation getter resolves when startedAt and createdAt fall on different days', () {
+  test('conversation getter resolves at every hour of the day, whatever the viewer timezone', () {
     // Regression for "Bad state: No conversation available": conversations are
-    // grouped by their effective date (startedAt ?? createdAt), and tapping a
-    // list item selects that group's date. When startedAt lands on an earlier
-    // calendar day than createdAt (session spanning midnight / timezone edge),
-    // the detail provider must still resolve the conversation instead of
-    // throwing from the non-null `conversation` getter.
-    final convo = ServerConversation(
-      id: 'c1',
-      startedAt: DateTime.utc(2026, 7, 18, 23, 30),
-      createdAt: DateTime.utc(2026, 7, 19, 0, 15),
-      structured: Structured('Title', 'Overview'),
-      status: ConversationStatus.completed,
-    );
+    // grouped by the *local* calendar day of their effective date
+    // (`conversationLocalDayKey` over startedAt ?? createdAt), and tapping a
+    // list item selects that group's key. The getter used to validate the raw
+    // UTC year/month/day instead, so it rejected a conversation that is present
+    // in the selected group whenever the local day and the UTC day disagree —
+    // an evening conversation for a UTC+ viewer, a post-UTC-midnight one for a
+    // UTC- viewer — blanking the detail page (#10976).
+    //
+    // Sweeping every hour rather than pinning one timestamp keeps this honest
+    // in whatever timezone the suite runs in; a single fixed hour only trips
+    // the bug at some UTC offsets, which is how it reached main green.
+    for (var hour = 0; hour < 24; hour++) {
+      final startedAt = DateTime.utc(2026, 7, 18, hour, 30);
+      final convo = ServerConversation(
+        id: 'c1',
+        startedAt: startedAt,
+        // Later than startedAt, so the last hour still spans UTC midnight.
+        createdAt: startedAt.add(const Duration(minutes: 45)),
+        structured: Structured('Title', 'Overview'),
+        status: ConversationStatus.completed,
+      );
 
-    final conversationProvider = ConversationProvider(
-      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
-      isSignedIn: () => true,
-    );
-    addTearDown(conversationProvider.dispose);
-    conversationProvider.conversations = [convo];
-    conversationProvider.groupConversationsByDate();
+      final conversationProvider = ConversationProvider(
+        conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+        isSignedIn: () => true,
+      );
+      addTearDown(conversationProvider.dispose);
+      conversationProvider.conversations = [convo];
+      conversationProvider.groupConversationsByDate();
 
-    // The date key the list item passes on tap is the group key.
-    final groupDate = conversationProvider.groupedConversations.keys.single;
+      // The date key the list item passes on tap is the group key.
+      final groupDate = conversationProvider.groupedConversations.keys.single;
 
-    final detailProvider = ConversationDetailProvider();
-    addTearDown(detailProvider.dispose);
-    detailProvider.conversationProvider = conversationProvider;
+      final detailProvider = ConversationDetailProvider();
+      addTearDown(detailProvider.dispose);
+      detailProvider.conversationProvider = conversationProvider;
 
-    detailProvider.updateConversation(convo.id, groupDate);
+      detailProvider.updateConversation(convo.id, groupDate);
 
-    expect(detailProvider.conversationOrNull, isNotNull);
-    expect(detailProvider.conversation.id, 'c1');
-    expect(detailProvider.conversation.structured.title, 'Title');
+      expect(detailProvider.conversationOrNull, isNotNull, reason: 'startedAt ${startedAt.toIso8601String()}');
+      expect(detailProvider.conversation.id, 'c1');
+      expect(detailProvider.conversation.structured.title, 'Title');
+    }
   });
 
   test('selected conversation is never replaced by another one in the day group', () {

--- a/app/test/providers/conversation_detail_provider_selection_test.dart
+++ b/app/test/providers/conversation_detail_provider_selection_test.dart
@@ -66,8 +66,8 @@ void main() {
     // wrong one. When the selected conversation leaves the group (deleted on
     // another device, merged away, or filtered out by the discarded/short
     // toggles) the getter must report a miss rather than substitute a sibling.
-    final selected = _conversationAt('selected', DateTime.utc(2026, 7, 18, 9));
-    final sibling = _conversationAt('sibling', DateTime.utc(2026, 7, 18, 11));
+    final selected = _conversationAt('selected', _localHourOnFixedDay(9));
+    final sibling = _conversationAt('sibling', _localHourOnFixedDay(11));
 
     final conversationProvider = ConversationProvider(
       conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
@@ -98,7 +98,7 @@ void main() {
   test('selected conversation survives a transient empty day group', () {
     // A refresh can momentarily empty the group; the page must keep showing the
     // conversation it was opened with instead of blanking or retargeting.
-    final selected = _conversationAt('selected', DateTime.utc(2026, 7, 18, 9));
+    final selected = _conversationAt('selected', _localHourOnFixedDay(9));
 
     final conversationProvider = ConversationProvider(
       conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
@@ -121,6 +121,12 @@ void main() {
     expect(detailProvider.conversationOrNull?.id, 'selected');
   });
 }
+
+/// A UTC instant that falls at [hour] o'clock local time on a fixed day, so
+/// fixtures meant to share one day-group stay in the same group at any UTC
+/// offset. Pinning the UTC hour instead split them across two local days at
+/// extreme offsets (UTC+14, UTC-11) and blew up on `keys.single`.
+DateTime _localHourOnFixedDay(int hour) => DateTime(2026, 7, 18, hour).toUtc();
 
 ServerConversation _conversationAt(String id, DateTime startedAt) {
   return ServerConversation(


### PR DESCRIPTION
Fixes #10976.

## Bug

Opening a conversation whose **local** calendar day differs from its **UTC** day blanks the detail page. `ConversationDetailProvider.conversationOrNull` returns null for a conversation that is present in the day group the user just tapped, and the non-null `conversation` accessor throws `StateError` on the gesture paths (delete / rename / visibility).

It bites an evening conversation for any UTC+ viewer and a post-UTC-midnight one for any UTC- viewer — i.e. a slice of every day for most of the world.

## Root cause

The list groups by `conversationLocalDayKey(startedAt ?? createdAt)` — the **local** calendar day (that function exists because bucketing by raw UTC filed early-morning-local conversations under the previous day, #10198 / #10398).

`conversationOrNull` then validated the resolved conversation by comparing the effective date's **raw UTC** `year/month/day` against `selectedDate`, which is one of those local-day group keys. Two different derivations of the same bucket, so they disagree exactly when local day != UTC day.

Same contract #10398 fixed for grouping, broken again in the consumer.

## Fix

Compare through `conversationLocalDayKey` on both sides. One expression, no behavior change where the two already agreed.

## Why CI stayed green

The existing regression test pinned one absolute timestamp (`2026-07-18 23:30Z`). That only trips the bug at some UTC offsets — red on a UTC+5:30 machine (how #10976 was found), green in UTC CI. The test now sweeps all 24 hours of a day, which exposes it at **every** non-zero offset. At UTC exactly the bug is unobservable and the old code correct, so no fixture can catch it there.

Second commit: the two-conversation fixtures in the same file pinned 09:00/11:00 UTC and asserted one day group — at UTC+14 / UTC-11 those land on different local days and `keys.single` threw before any assertion. Pre-existing red on `main`, unrelated to the getter, found while sweeping. Anchored to a fixed local day instead.

## Tested

- `app/test.sh` — **987 passed**, in local `America/New_York` (UTC-4) and in `TZ=UTC`.
- `flutter test test/providers/conversation_detail_provider_selection_test.dart` green in `UTC`, `Asia/Kolkata`, `America/New_York`, `Europe/Berlin`, `Pacific/Auckland`, `Pacific/Kiritimati`, `Pacific/Midway`, `Australia/Adelaide`.
- **The test fails without the fix**: reverting only the `lib/` hunk turns it red in `America/New_York`, `Asia/Kolkata`, `Europe/Berlin`, `Pacific/Auckland` (and green in `UTC`, as expected).
- `make preflight` green.

Not exercised in a running app build — the assertion drives the production getter through the same seam the detail page uses.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

Registers `FC-day-bucket-key-recomputed`: a derived day-bucket key has one authority, and a consumer that re-derives it from raw UTC calendar fields reads a present record as absent for every viewer whose local day differs. Second instance of the cause behind #10398, so it gets a registry entry with a guard artifact (the sweeping contract test) rather than another one-off declaration.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

