### PR TITLE
fix(app): derive every conversation day key from the local day (#10980)

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -806,11 +806,10 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
                 final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
                 if (connectivityProvider.isConnected) {
                   var memProvider = Provider.of<ConversationProvider>(context, listen: false);
-                  var idx = -1;
-                  var date = DateTime(data.$2.createdAt.year, data.$2.createdAt.month, data.$2.createdAt.day);
-                  idx = memProvider.groupedConversations[date]?.indexWhere((element) => element.id == data.$2.id) ?? -1;
+                  final located = memProvider.findGroupedConversationById(data.$2.id);
 
-                  if (idx != -1) {
+                  if (located != null) {
+                    final (date, idx) = located;
                     context.read<ConversationDetailProvider>().updateConversation(data.$2.id, date);
                     var m = memProvider.groupedConversations[date]![idx];
                     PlatformManager.instance.analytics.chatMessageConversationClicked(m);
@@ -822,7 +821,7 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
                     setState(() => conversationDetailLoading[data.$1] = true);
                     ServerConversation? m = await getConversationById(data.$2.id);
                     if (m == null) return;
-                    (idx, date) = memProvider.addConversationWithDateGrouped(m);
+                    final date = memProvider.addConversationWithDateGrouped(m).$2;
                     PlatformManager.instance.analytics.chatMessageConversationClicked(m);
                     setState(() => conversationDetailLoading[data.$1] = false);
                     if (context.mounted) {

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -208,7 +208,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
         provider.updateConversation(widget.conversation.id, date);
       } else {
         final effectiveDate = widget.conversation.startedAt ?? widget.conversation.createdAt;
-        provider.selectedDate = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+        provider.selectedDate = conversationLocalDayKey(effectiveDate);
       }
 
       await provider.initConversation();

--- a/app/lib/pages/memories/widgets/memory_item.dart
+++ b/app/lib/pages/memories/widgets/memory_item.dart
@@ -196,20 +196,6 @@ class MemoryItem extends StatelessWidget {
     );
   }
 
-  DateTime _getConversationDate(DateTime createdAt) {
-    return DateTime(createdAt.year, createdAt.month, createdAt.day);
-  }
-
-  void _ensureConversationInGroup(ConversationProvider conversationProvider, dynamic conversation) {
-    final date = _getConversationDate(conversation.createdAt);
-    conversationProvider.groupedConversations.putIfAbsent(date, () => []);
-
-    final conversations = conversationProvider.groupedConversations[date]!;
-    if (!conversations.any((c) => c.id == conversation.id)) {
-      conversations.insert(0, conversation);
-    }
-  }
-
   Future<void> _navigateToConversation(BuildContext context) async {
     if (memory.conversationId == null) return;
 
@@ -228,9 +214,7 @@ class MemoryItem extends StatelessWidget {
       final conversationProvider = Provider.of<ConversationProvider>(context, listen: false);
       final detailProvider = Provider.of<ConversationDetailProvider>(context, listen: false);
 
-      _ensureConversationInGroup(conversationProvider, conversation);
-
-      final conversationDate = _getConversationDate(conversation.createdAt);
+      final conversationDate = conversationProvider.ensureConversationGrouped(conversation);
       detailProvider.updateConversation(conversation.id, conversationDate);
 
       Navigator.of(

--- a/app/lib/pages/onboarding/conversation_created_widget.dart
+++ b/app/lib/pages/onboarding/conversation_created_widget.dart
@@ -16,7 +16,7 @@ Future updateConvoDetailProvider(BuildContext context, ServerConversation conver
   return Future.microtask(() {
     if (!context.mounted) return;
     context.read<ConversationProvider>().addConversation(conversation);
-    var date = DateTime(conversation.createdAt.year, conversation.createdAt.month, conversation.createdAt.day);
+    var date = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
     context.read<ConversationDetailProvider>().updateConversation(conversation.id, date);
   });
 }

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -1072,6 +1072,35 @@ class ConversationProvider extends ChangeNotifier {
     return (date, idx);
   }
 
+  /// Locates a grouped conversation by id, returning its day-group key and index.
+  ///
+  /// For callers that hold only an id and a server timestamp (a chat message's
+  /// conversation reference, a memory's `conversationId`) and cannot derive the
+  /// group key themselves: the key is the *local* day of `startedAt ?? createdAt`,
+  /// and those callers have neither the local day nor `startedAt` (#10980).
+  (DateTime, int)? findGroupedConversationById(String id) {
+    for (final entry in groupedConversations.entries) {
+      final idx = entry.value.indexWhere((c) => c.id == id);
+      if (idx != -1) return (entry.key, idx);
+    }
+    return null;
+  }
+
+  /// Ensures [conversation] is in its day group and returns that group's key.
+  ///
+  /// Navigating to a conversation the list has not loaded must both file it under
+  /// and select the same key [groupConversationsByDate] would — hence the shared
+  /// [conversationLocalDayKey] derivation rather than the raw UTC components the
+  /// call site used to build (#10980).
+  DateTime ensureConversationGrouped(ServerConversation conversation) {
+    final date = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
+    final group = groupedConversations.putIfAbsent(date, () => []);
+    if (!group.any((c) => c.id == conversation.id)) {
+      group.insert(0, conversation);
+    }
+    return date;
+  }
+
   int getConversationIndexById(String id, DateTime date) {
     final normalizedDate = DateTime(date.year, date.month, date.day);
     final list = groupedConversations[normalizedDate] ?? [];

--- a/app/lib/utils/conversation_sync_utils.dart
+++ b/app/lib/utils/conversation_sync_utils.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/providers/conversation_provider.dart';
 
 class ConversationSyncUtils {
   static const Duration _fetchTimeout = Duration(seconds: 30);
@@ -41,11 +44,16 @@ class ConversationSyncUtils {
     final validConversations = conversations.where((conversation) => conversation != null).toList();
     final completedConversations =
         validConversations.where((conversation) => conversation!.status == ConversationStatus.completed).toList();
-    return completedConversations.map((conversation) => _createPointer(conversation!, type)).toList();
+    return completedConversations.map((conversation) => createPointer(conversation!, type)).toList();
   }
 
-  static SyncedConversationPointer _createPointer(ServerConversation conversation, SyncedConversationType type) {
-    final date = DateTime(conversation.createdAt.year, conversation.createdAt.month, conversation.createdAt.day);
+  /// The pointer's `key` is handed straight to `ConversationDetailProvider
+  /// .updateConversation` when the user taps a synced conversation, so it must be
+  /// the same day-bucket key the list groups by — the *local* day of
+  /// `startedAt ?? createdAt`, not the raw UTC components (#10980).
+  @visibleForTesting
+  static SyncedConversationPointer createPointer(ServerConversation conversation, SyncedConversationType type) {
+    final date = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
 
     return SyncedConversationPointer(type: type, index: 0, key: date, conversation: conversation);
   }

--- a/app/test/providers/conversation_day_key_call_sites_test.dart
+++ b/app/test/providers/conversation_day_key_call_sites_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
+import 'package:omi/pages/onboarding/conversation_created_widget.dart';
+import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/utils/conversation_sync_utils.dart';
+
+/// Regression for #10980: conversations are bucketed by
+/// `conversationLocalDayKey(startedAt ?? createdAt)` — the viewer's *local*
+/// calendar day. Call sites that navigate to a conversation used to rebuild that
+/// key from the raw UTC `year/month/day` of `createdAt`, which is a different day
+/// from the group key for every viewer whose local day disagrees with UTC. The
+/// lookup then missed (chat conversation links did nothing) or the detail page
+/// opened on a key nothing is grouped under.
+///
+/// Each test sweeps all 24 hours instead of pinning one timestamp: a single fixed
+/// hour only trips the bug at some UTC offsets, which is how these reached main
+/// green.
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('findGroupedConversationById locates the conversation at every hour of the day', () {
+    // The chat conversation-link path (ai_message.dart): it holds only the
+    // conversation id and a UTC `createdAt`, never `startedAt`, so it cannot
+    // derive the group key at all — it must look the conversation up by id.
+    for (var hour = 0; hour < 24; hour++) {
+      final convo = _conversationAt('c1', DateTime.utc(2026, 7, 18, hour, 30));
+      final provider = _providerWith([convo]);
+
+      final located = provider.findGroupedConversationById('c1');
+
+      expect(located, isNotNull, reason: 'startedAt hour $hour UTC');
+      final (date, idx) = located!;
+      expect(date, provider.groupedConversations.keys.single);
+      expect(provider.groupedConversations[date]![idx].id, 'c1');
+    }
+  });
+
+  test('findGroupedConversationById reports a miss for an unknown id', () {
+    final provider = _providerWith([_conversationAt('c1', DateTime.utc(2026, 7, 18, 9))]);
+
+    expect(provider.findGroupedConversationById('nope'), isNull);
+  });
+
+  test('ensureConversationGrouped files a conversation under its own group key', () {
+    // The memory -> conversation path (memory_item.dart): it inserted the
+    // conversation under one key and then selected another, so the detail page
+    // opened on an empty group.
+    for (var hour = 0; hour < 24; hour++) {
+      final convo = _conversationAt('c1', DateTime.utc(2026, 7, 18, hour, 30));
+      final provider = _providerWith([]);
+
+      final date = provider.ensureConversationGrouped(convo);
+
+      expect(provider.groupedConversations[date]?.map((c) => c.id), ['c1'], reason: 'startedAt hour $hour UTC');
+      // The key it files under must be the one the list itself would group by.
+      provider.conversations = [convo];
+      provider.groupConversationsByDate();
+      expect(date, provider.groupedConversations.keys.single);
+      expect(provider.findGroupedConversationById('c1')?.$1, date);
+    }
+  });
+
+  test('ensureConversationGrouped does not duplicate an already grouped conversation', () {
+    final convo = _conversationAt('c1', DateTime.utc(2026, 7, 18, 9));
+    final provider = _providerWith([convo]);
+
+    final date = provider.ensureConversationGrouped(convo);
+
+    expect(provider.groupedConversations[date]!.where((c) => c.id == 'c1').length, 1);
+  });
+
+  test('a synced-conversation pointer keys on the local day group', () {
+    // The sync-result path (conversation_sync_utils.dart): the pointer's key is
+    // handed to `updateConversation` when the user taps a just-synced
+    // conversation, so a raw-UTC key opened a day nothing is grouped under.
+    for (var hour = 0; hour < 24; hour++) {
+      final convo = _conversationAt('c1', DateTime.utc(2026, 7, 18, hour, 30));
+      final provider = _providerWith([convo]);
+
+      final pointer = ConversationSyncUtils.createPointer(convo, SyncedConversationType.newConversation);
+
+      expect(pointer.key, provider.groupedConversations.keys.single, reason: 'startedAt hour $hour UTC');
+    }
+  });
+
+  testWidgets('updateConvoDetailProvider selects the group key of the new conversation', (tester) async {
+    // The onboarding hand-off (conversation_created_widget.dart): it selected a
+    // day derived from raw UTC components, so the detail page it pushed had no
+    // matching group.
+    for (var hour = 0; hour < 24; hour++) {
+      final convo = _conversationAt('c1', DateTime.utc(2026, 7, 18, hour, 30));
+      final conversationProvider = _providerWith([]);
+      final detailProvider = ConversationDetailProvider();
+      addTearDown(detailProvider.dispose);
+      detailProvider.conversationProvider = conversationProvider;
+
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider<ConversationProvider>.value(value: conversationProvider),
+            ChangeNotifierProvider<ConversationDetailProvider>.value(value: detailProvider),
+          ],
+          child: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      await updateConvoDetailProvider(capturedContext, convo);
+      await tester.pumpAndSettle();
+
+      expect(detailProvider.selectedDate, conversationProvider.groupedConversations.keys.single,
+          reason: 'startedAt hour $hour UTC');
+      expect(detailProvider.conversationOrNull?.id, 'c1');
+    }
+  });
+}
+
+ConversationProvider _providerWith(List<ServerConversation> conversations) {
+  final provider = ConversationProvider(
+    conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+    isSignedIn: () => true,
+  );
+  addTearDown(provider.dispose);
+  provider.conversations = List.of(conversations);
+  provider.groupConversationsByDate();
+  return provider;
+}
+
+ServerConversation _conversationAt(String id, DateTime startedAt) {
+  return ServerConversation(
+    id: id,
+    startedAt: startedAt,
+    // Later than startedAt, so the last hour of the day still spans UTC midnight.
+    createdAt: startedAt.add(const Duration(minutes: 45)),
+    structured: Structured('Title', 'Overview'),
+    status: ConversationStatus.completed,
+  );
+}


### PR DESCRIPTION
Fixes #10980.

## Bug

Conversations are bucketed by `conversationLocalDayKey(startedAt ?? createdAt)` — the viewer's **local** calendar day (`app/lib/providers/conversation_provider.dart`, used by `_buildGroupedByDate`). Five call sites rebuilt that key from the raw UTC `year/month/day` of `createdAt` instead. Server timestamps parse as UTC, so for every viewer whose local day differs from their UTC day the rebuilt key names a different day than the group key, and `ConversationDetailProvider.updateConversation` silently no-ops because nothing is grouped under it.

| Site | User-visible effect |
|---|---|
| `chat/widgets/ai_message.dart` | tapping a conversation link in a chat message did nothing (`idx == -1`) |
| `onboarding/conversation_created_widget.dart` | the onboarding hand-off selected a day with no group |
| `memories/widgets/memory_item.dart` | inserted the conversation under one key and selected another |
| `conversation_detail/page.dart` | the not-found fallback set `selectedDate` to a key nothing is grouped under |
| `utils/conversation_sync_utils.dart` | **not in the issue** — the pointer `key` is handed straight to `updateConversation` when the user taps a just-synced conversation, so it is the same defect |

Two of them also used `createdAt` alone where the grouping uses `startedAt ?? createdAt`.

## Fix

The two sites that *cannot* derive the key correctly now go through the provider instead of deriving it at all:

- `ConversationProvider.findGroupedConversationById(id)` — a chat message's conversation reference carries only an id and a UTC `createdAt`, never `startedAt`, so it has nothing to derive the key from; it looks the conversation up by id.
- `ConversationProvider.ensureConversationGrouped(conversation)` — the memory path needs the conversation both filed under and selected by one key; the method returns the key it filed under.

The remaining three use the shared `conversationLocalDayKey(startedAt ?? createdAt)`.

This is the reusable guard surface FC-day-bucket-key-recomputed asks for on recurrence (third instance, after #10398 and #10981): the call sites no longer derive the key, so they can no longer derive it wrongly.

## Tested

- `app/test.sh` — **993 tests green** on the final tree.
- New `app/test/providers/conversation_day_key_call_sites_test.dart` green in UTC, `Asia/Kolkata`, `America/New_York`, `Europe/Berlin`, `Pacific/Auckland`, `Pacific/Kiritimati`, `Pacific/Midway`. Each test sweeps all 24 hours, because a single pinned hour only trips the bug at some UTC offsets — which is how these reached main green.
- **Red proof:** with the old raw-UTC derivation restored at the two call sites reachable from a test, both fail at `TZ=America/Los_Angeles` — `updateConvoDetailProvider` leaves `selectedDate` at its `DateTime.now()` default (because `updateConversation` no-ops on a key with no group, the exact reported symptom), and the sync pointer keys on `2026-07-18` where the group is `2026-07-17`.
- The three widget-only sites are the same substitution with no test seam; verified by `flutter analyze` (clean) and inspection. Called out rather than implied.

## Product invariants affected

- INV-MEM-1

## Failure class (fixes)

Failure-Class: FC-day-bucket-key-recomputed

---

Found while sweeping for this pattern, **not fixed here** (different subsystem, no way to exercise it in this run): `app/lib/pages/settings/import_history_page.dart:452-453` compares a UTC `job.createdAt` day against a local `today` and renders `job.createdAt.hour` raw, so import-history rows show the wrong Today/Yesterday label and the wrong time off-UTC. Filed separately as #10984.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

