### PR TITLE
fix(app): derive conversation day keys from the local-day authority (#10980)

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -806,9 +806,12 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
                 final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
                 if (connectivityProvider.isConnected) {
                   var memProvider = Provider.of<ConversationProvider>(context, listen: false);
-                  var idx = -1;
-                  var date = DateTime(data.$2.createdAt.year, data.$2.createdAt.month, data.$2.createdAt.day);
-                  idx = memProvider.groupedConversations[date]?.indexWhere((element) => element.id == data.$2.id) ?? -1;
+                  // Groups are keyed by the local day of `startedAt ?? createdAt`; deriving the
+                  // key from the message's raw UTC `createdAt` missed the group for anyone off
+                  // UTC and the tap silently did nothing (#10980).
+                  final located = memProvider.getConversationDateAndIndexById(data.$2.id);
+                  var idx = located?.$2 ?? -1;
+                  var date = located?.$1 ?? conversationLocalDayKey(data.$2.createdAt);
 
                   if (idx != -1) {
                     context.read<ConversationDetailProvider>().updateConversation(data.$2.id, date);

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -208,7 +208,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
         provider.updateConversation(widget.conversation.id, date);
       } else {
         final effectiveDate = widget.conversation.startedAt ?? widget.conversation.createdAt;
-        provider.selectedDate = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+        provider.selectedDate = conversationLocalDayKey(effectiveDate);
       }
 
       await provider.initConversation();

--- a/app/lib/pages/memories/widgets/memory_item.dart
+++ b/app/lib/pages/memories/widgets/memory_item.dart
@@ -196,20 +196,6 @@ class MemoryItem extends StatelessWidget {
     );
   }
 
-  DateTime _getConversationDate(DateTime createdAt) {
-    return DateTime(createdAt.year, createdAt.month, createdAt.day);
-  }
-
-  void _ensureConversationInGroup(ConversationProvider conversationProvider, dynamic conversation) {
-    final date = _getConversationDate(conversation.createdAt);
-    conversationProvider.groupedConversations.putIfAbsent(date, () => []);
-
-    final conversations = conversationProvider.groupedConversations[date]!;
-    if (!conversations.any((c) => c.id == conversation.id)) {
-      conversations.insert(0, conversation);
-    }
-  }
-
   Future<void> _navigateToConversation(BuildContext context) async {
     if (memory.conversationId == null) return;
 
@@ -228,9 +214,10 @@ class MemoryItem extends StatelessWidget {
       final conversationProvider = Provider.of<ConversationProvider>(context, listen: false);
       final detailProvider = Provider.of<ConversationDetailProvider>(context, listen: false);
 
-      _ensureConversationInGroup(conversationProvider, conversation);
-
-      final conversationDate = _getConversationDate(conversation.createdAt);
+      // One derivation for both the group insert and the selected day, in local
+      // time — inserting under the UTC day and selecting another key opened the
+      // detail page on a day nothing was grouped under (#10980).
+      final conversationDate = conversationProvider.ensureConversationInGroup(conversation);
       detailProvider.updateConversation(conversation.id, conversationDate);
 
       Navigator.of(

--- a/app/lib/pages/onboarding/conversation_created_widget.dart
+++ b/app/lib/pages/onboarding/conversation_created_widget.dart
@@ -16,7 +16,7 @@ Future updateConvoDetailProvider(BuildContext context, ServerConversation conver
   return Future.microtask(() {
     if (!context.mounted) return;
     context.read<ConversationProvider>().addConversation(conversation);
-    var date = DateTime(conversation.createdAt.year, conversation.createdAt.month, conversation.createdAt.day);
+    var date = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
     context.read<ConversationDetailProvider>().updateConversation(conversation.id, date);
   });
 }

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -1072,6 +1072,28 @@ class ConversationProvider extends ChangeNotifier {
     return (date, idx);
   }
 
+  /// Same lookup as [getConversationDateAndIndex] for callers that only hold an
+  /// id (a chat message's conversation reference, a memory's `conversationId`).
+  /// Resolving through the loaded conversation keeps the day key derived from
+  /// `startedAt ?? createdAt` in local time — the contract the groups use.
+  (DateTime, int)? getConversationDateAndIndexById(String conversationId) {
+    final idx = conversations.indexWhere((c) => c.id == conversationId);
+    if (idx == -1) return null;
+    return getConversationDateAndIndex(conversations[idx]);
+  }
+
+  /// Places [conversation] in its local-day group if it isn't there yet and
+  /// returns that group's key, so a caller navigating straight to a detail page
+  /// selects the same day the list groups it under.
+  DateTime ensureConversationInGroup(ServerConversation conversation) {
+    final date = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
+    final group = groupedConversations.putIfAbsent(date, () => []);
+    if (!group.any((c) => c.id == conversation.id)) {
+      group.insert(0, conversation);
+    }
+    return date;
+  }
+
   int getConversationIndexById(String id, DateTime date) {
     final normalizedDate = DateTime(date.year, date.month, date.day);
     final list = groupedConversations[normalizedDate] ?? [];

--- a/app/test/providers/conversation_day_key_call_sites_test.dart
+++ b/app/test/providers/conversation_day_key_call_sites_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+/// Regression coverage for #10980: call sites that look a conversation up by day
+/// derived the key from the timestamp's raw UTC `year/month/day` instead of
+/// [conversationLocalDayKey] over `startedAt ?? createdAt` — the key the groups
+/// actually use. For any viewer off UTC the two disagree near local midnight, so
+/// tapping a conversation link in chat did nothing and opening one from a memory
+/// selected a day with no group.
+///
+/// Both cases now go through the provider, which is what these tests drive. The
+/// hour sweep keeps them honest in whatever timezone the suite runs in: a single
+/// pinned hour only trips the bug at some UTC offsets.
+ServerConversation _conversationAt(DateTime startedAt) => ServerConversation(
+      id: 'c1',
+      startedAt: startedAt,
+      // Later than startedAt, so the last hour of the sweep still spans UTC midnight.
+      createdAt: startedAt.add(const Duration(minutes: 45)),
+      structured: Structured('Title', 'Overview'),
+      status: ConversationStatus.completed,
+    );
+
+ConversationProvider _providerWith(List<ServerConversation> conversations) {
+  final provider = ConversationProvider(
+    conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+    isSignedIn: () => true,
+  );
+  provider.conversations = conversations;
+  return provider;
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('getConversationDateAndIndexById resolves the grouped conversation at every hour of the day', () {
+    for (var hour = 0; hour < 24; hour++) {
+      final startedAt = DateTime.utc(2026, 7, 18, hour, 30);
+      final convo = _conversationAt(startedAt);
+
+      final provider = _providerWith([convo]);
+      addTearDown(provider.dispose);
+      provider.groupConversationsByDate();
+
+      final located = provider.getConversationDateAndIndexById(convo.id);
+      final reason = 'startedAt ${startedAt.toIso8601String()}';
+
+      expect(located, isNotNull, reason: reason);
+      // The key must be the group key, i.e. what the list item would pass on tap.
+      expect(located!.$1, provider.groupedConversations.keys.single, reason: reason);
+      expect(provider.groupedConversations[located.$1]![located.$2].id, convo.id, reason: reason);
+    }
+  });
+
+  test('getConversationDateAndIndexById returns null for an unknown or ungrouped conversation', () {
+    final convo = _conversationAt(DateTime.utc(2026, 7, 18, 12, 0));
+    final provider = _providerWith([convo]);
+    addTearDown(provider.dispose);
+    provider.groupConversationsByDate();
+
+    expect(provider.getConversationDateAndIndexById('nope'), isNull);
+
+    provider.groupedConversations = {};
+    expect(provider.getConversationDateAndIndexById(convo.id), isNull);
+  });
+
+  test('ensureConversationInGroup files the conversation under the same key grouping uses', () {
+    for (var hour = 0; hour < 24; hour++) {
+      final startedAt = DateTime.utc(2026, 7, 18, hour, 30);
+      final convo = _conversationAt(startedAt);
+      final reason = 'startedAt ${startedAt.toIso8601String()}';
+
+      // Nothing loaded yet — the memory tap path inserts the conversation itself.
+      final empty = _providerWith([]);
+      addTearDown(empty.dispose);
+      final insertedKey = empty.ensureConversationInGroup(convo);
+      expect(empty.groupedConversations[insertedKey]!.single.id, convo.id, reason: reason);
+
+      // The key it chose must match what grouping would have produced.
+      final grouped = _providerWith([convo]);
+      addTearDown(grouped.dispose);
+      grouped.groupConversationsByDate();
+      expect(insertedKey, grouped.groupedConversations.keys.single, reason: reason);
+
+      // Already grouped — same key, no duplicate row.
+      expect(grouped.ensureConversationInGroup(convo), insertedKey, reason: reason);
+      expect(grouped.groupedConversations[insertedKey]!.length, 1, reason: reason);
+    }
+  });
+}


### PR DESCRIPTION
Fixes #10980.

## The bug

Conversations are bucketed by `conversationLocalDayKey(startedAt ?? createdAt)` — the viewer's **local** calendar day (`app/lib/providers/conversation_provider.dart`, used by `_buildGroupedByDate`). Four call sites re-derived the key from the timestamp's raw UTC `year/month/day`. Server timestamps parse as UTC, so for every viewer off UTC the two keys disagree near local midnight and a conversation that *is* in the group reads as absent:

- `app/lib/pages/chat/widgets/ai_message.dart` — tapping a conversation link in chat resolved `idx == -1`, so the tap silently did nothing.
- `app/lib/pages/memories/widgets/memory_item.dart` — inserted the conversation under one key and selected another, opening the detail page on a day nothing was grouped under.
- `app/lib/pages/onboarding/conversation_created_widget.dart` — the onboarding hand-off selected a day with no group.
- `app/lib/pages/conversation_detail/page.dart` — the `getConversationDateAndIndex` fallback set `selectedDate` from raw components.

Same defect as #10976 (`conversationOrNull`), split out by that PR because these are widget paths with no test seam.

## The fix

The two id-based lookups now go through the provider, which owns the derivation, so there is one authority instead of four copies:

- `getConversationDateAndIndexById(id)` — resolves the loaded conversation, then reuses `getConversationDateAndIndex` (chat link tap). This also fixes a second miss: the chat message only carries `createdAt`, while grouping keys on `startedAt ?? createdAt`.
- `ensureConversationInGroup(conversation)` — files the conversation under its local-day key and returns that key, replacing the widget-local grouping copy in `memory_item.dart` so the insert and the selection can no longer disagree.

The two remaining sites call `conversationLocalDayKey` directly. That is the test seam the issue asked for.

## Verification

- **Reproduced pre-fix.** A scratch test replaying the old raw-UTC derivation against the real group key missed 5–6 of 24 hours under `TZ=Asia/Kolkata`, `America/New_York` and `Pacific/Auckland` — e.g. `18:30Z → old key 2026-07-18 vs group key 2026-07-19` (Kolkata).
- **New regression test** `app/test/providers/conversation_day_key_call_sites_test.dart` sweeps all 24 hours (a single pinned hour stays green at some UTC offsets): green under `TZ=UTC`, `Asia/Kolkata`, `America/New_York`, `Pacific/Auckland`, `Pacific/Kiritimati`, `Pacific/Midway`.
- `app/test.sh` — **990 tests passed**.
- `flutter analyze` on the five changed files + the test — no new issues; `dart format --line-length 120` clean.
- `make preflight` — all manifest checks pass.

## Product invariants affected

- INV-MEM-1

`memory_item.dart` is matched by the invariant's path globs. This change only alters which day key the memory→conversation tap selects; memory tier behavior, storage, and rendering are untouched.

## Failure class

A derived day-bucket key has exactly one authority; a consumer that re-derives it from raw UTC fields disagrees with that authority. Guard surface added in this PR: the two provider methods (so widgets can no longer re-derive) plus the whole-day-sweep behavioral test.

Failure-Class: FC-day-bucket-key-recomputed

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

