### PR TITLE
fix(app): label import-history rows from the viewer's local day (#10984)

### DIFF
--- a/app/lib/pages/settings/import_history_page.dart
+++ b/app/lib/pages/settings/import_history_page.dart
@@ -11,8 +11,35 @@ import 'package:pull_down_button/pull_down_button.dart';
 import 'package:omi/widgets/shimmer_with_timeout.dart';
 
 import 'package:omi/backend/http/api/imports.dart';
+import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
+
+/// Renders an import job's creation timestamp for its history row.
+///
+/// [createdAt] is a server timestamp and parses as UTC, so both the day the row
+/// is labelled with and the clock time it shows must come from the *local*
+/// projection: reading the raw UTC components puts the row on the wrong day and
+/// at the wrong time for every viewer whose local day differs from the UTC day.
+/// [now] exists for tests; production passes the real clock.
+String formatImportJobTimestamp(AppLocalizations l10n, DateTime createdAt, {DateTime? now}) {
+  final local = createdAt.toLocal();
+  final reference = (now ?? DateTime.now()).toLocal();
+  final today = DateTime(reference.year, reference.month, reference.day);
+  final jobDay = DateTime(local.year, local.month, local.day);
+  final time = '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+
+  if (jobDay == today) {
+    return l10n.todayAtTime(time);
+  }
+  // Calendar arithmetic, not a 24h subtraction: on either DST transition
+  // `today - Duration(days: 1)` lands at 23:00 or 01:00 rather than midnight,
+  // so it never equals a day key and the yesterday row silently falls through.
+  if (jobDay == DateTime(reference.year, reference.month, reference.day - 1)) {
+    return l10n.yesterdayAtTime(time);
+  }
+  return '${local.day}/${local.month}/${local.year} at $time';
+}
 
 class ImportHistoryPage extends StatefulWidget {
   const ImportHistoryPage({super.key});
@@ -445,26 +472,8 @@ class _ImportHistoryPageState extends State<ImportHistoryPage> {
         break;
     }
 
-    // Format date/time
-    String dateTimeStr = '';
-    if (job.createdAt != null) {
-      final now = DateTime.now();
-      final today = DateTime(now.year, now.month, now.day);
-      final jobDate = DateTime(job.createdAt!.year, job.createdAt!.month, job.createdAt!.day);
-
-      if (jobDate == today) {
-        dateTimeStr = context.l10n.todayAtTime(
-          '${job.createdAt!.hour.toString().padLeft(2, '0')}:${job.createdAt!.minute.toString().padLeft(2, '0')}',
-        );
-      } else if (jobDate == today.subtract(const Duration(days: 1))) {
-        dateTimeStr = context.l10n.yesterdayAtTime(
-          '${job.createdAt!.hour.toString().padLeft(2, '0')}:${job.createdAt!.minute.toString().padLeft(2, '0')}',
-        );
-      } else {
-        dateTimeStr =
-            '${job.createdAt!.day}/${job.createdAt!.month}/${job.createdAt!.year} at ${job.createdAt!.hour.toString().padLeft(2, '0')}:${job.createdAt!.minute.toString().padLeft(2, '0')}';
-      }
-    }
+    final createdAt = job.createdAt;
+    final String dateTimeStr = createdAt == null ? '' : formatImportJobTimestamp(context.l10n, createdAt);
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),

--- a/app/test/unit/import_job_timestamp_test.dart
+++ b/app/test/unit/import_job_timestamp_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/api/imports.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/settings/import_history_page.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+/// Regression coverage for #10984: the import-history row compared an import
+/// job's raw UTC `year/month/day` against a *local* `today`, and rendered the
+/// raw UTC `hour`/`minute`. For any viewer off UTC that flips the row between
+/// the today / yesterday / absolute-date branches at the wrong boundary and
+/// prints the wrong clock time (a 21:00 New York import rendered as 01:00, on
+/// the following day).
+///
+/// Every case builds `createdAt` as a UTC instant projected from a known *local*
+/// wall-clock time, which is how the server timestamp actually reaches the page.
+/// The hour sweep keeps this honest in whatever timezone the suite runs in — a
+/// single pinned hour only trips the bug at some UTC offsets.
+String _two(int value) => value.toString().padLeft(2, '0');
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  test('a job created earlier the same local day reads as today at its local time', () {
+    final now = DateTime(2026, 8, 1, 12);
+    for (var hour = 0; hour < 24; hour++) {
+      final localCreatedAt = DateTime(2026, 8, 1, hour, 30);
+      final label = formatImportJobTimestamp(l10n, localCreatedAt.toUtc(), now: now);
+
+      expect(label, 'Today at ${_two(hour)}:30', reason: 'local hour $hour');
+    }
+  });
+
+  test('a job created the previous local day reads as yesterday at its local time', () {
+    final now = DateTime(2026, 8, 1, 12);
+    for (var hour = 0; hour < 24; hour++) {
+      final localCreatedAt = DateTime(2026, 7, 31, hour, 30);
+      final label = formatImportJobTimestamp(l10n, localCreatedAt.toUtc(), now: now);
+
+      expect(label, 'Yesterday at ${_two(hour)}:30', reason: 'local hour $hour');
+    }
+  });
+
+  test('the yesterday branch survives every calendar day, including DST shifts', () {
+    // `today - Duration(days: 1)` lands at 23:00 or 01:00 on a DST transition
+    // day and never equals a midnight day key, so the row silently degrades to
+    // the absolute-date branch. Sweeping a full year covers both transitions in
+    // whichever timezone the suite runs in (2/366 days in America/New_York).
+    for (var day = 0; day < 366; day++) {
+      final now = DateTime(2026, 1, 1 + day, 12);
+      final localCreatedAt = DateTime(2026, 1, day, 12);
+      final label = formatImportJobTimestamp(l10n, localCreatedAt.toUtc(), now: now);
+
+      expect(label, 'Yesterday at 12:00', reason: 'local day ${localCreatedAt.toIso8601String()}');
+    }
+  });
+
+  test('an older job reads as its local date and local time', () {
+    final now = DateTime(2026, 8, 1, 12);
+    final localCreatedAt = DateTime(2026, 7, 20, 9, 5);
+
+    expect(formatImportJobTimestamp(l10n, localCreatedAt.toUtc(), now: now), '20/7/2026 at 09:05');
+  });
+
+  testWidgets('the job card renders the label the page builds from context.l10n', (tester) async {
+    // The page's own expression, driven through a real localized context: a job
+    // whose server timestamp is decoded exactly as ImportJobResponse decodes it.
+    final job = ImportJobResponse.fromJson({
+      'job_id': 'job-1',
+      'status': 'completed',
+      'created_at': DateTime(2026, 8, 1, 21, 0).toUtc().toIso8601String(),
+    });
+
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) =>
+            Text(formatImportJobTimestamp(context.l10n, job.createdAt!, now: DateTime(2026, 8, 1, 22))),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Today at 21:00'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Bug

#10984 — every row in Settings → Import History labels the wrong day and shows the wrong clock time for any viewer whose local day differs from the UTC day.

## Root cause

`_buildJobCard` mixed two clocks in one comparison (`app/lib/pages/settings/import_history_page.dart`):

```dart
final now = DateTime.now();                                   // local
final today = DateTime(now.year, now.month, now.day);         // local day
final jobDate = DateTime(job.createdAt!.year, ...);           // UTC day
```

`job.createdAt` is a server timestamp (`datetime.now(timezone.utc).isoformat()`, `backend/models/import_job.py:28`) and parses UTC-flagged, so `jobDate` is its **UTC** day while `today` is the **local** day. The row therefore flips between the today / yesterday / absolute-date branches at the wrong boundary, and each branch independently renders raw UTC `hour`/`minute`.

Second, latent defect on the same lines: the yesterday key used `today.subtract(const Duration(days: 1))`, which on a DST transition day lands at 23:00 or 01:00 rather than midnight and never equals a day key.

## Fix

The formatting moves into a top-level `formatImportJobTimestamp(l10n, createdAt, {now})`: it projects with `toLocal()` before reading any component, so both sides of the comparison and the rendered time come from the viewer's local calendar; and it derives the yesterday key with calendar arithmetic (`day - 1`). `now` is injectable so the branch behavior is testable.

Not routed through `conversationLocalDayKey`: that key is owned by `ConversationProvider` and scoped to conversation grouping — importing the provider into a settings page to reuse three lines would be worse coupling than the duplication. If a shared local-day util lands, this is a caller to migrate.

## What I tested

New `app/test/unit/import_job_timestamp_test.dart` (4 cases: today sweep over all 24 local hours, yesterday sweep over all 24 local hours, yesterday across all 366 calendar days, absolute-date branch, plus a widget case that renders the page's own `context.l10n` expression from an `ImportJobResponse.fromJson` decode).

- New test green under `TZ=UTC`, `America/New_York`, `Asia/Kolkata`, `Pacific/Auckland`, `Pacific/Kiritimati`, `Pacific/Midway`.
- **It fails on the pre-fix code**, which is the point. Running the old derivation against the same expectations:
  - `TZ=America/New_York`: 24/24 hours wrong — e.g. local 20:30 rendered `2/8/2026 at 00:30` (tomorrow's date), local 00:30 rendered `Today at 04:30`.
  - `TZ=Asia/Kolkata`: 24/24 wrong — local 00:30 rendered `Yesterday at 19:00`.
  - `TZ=Pacific/Auckland`: 24/24 wrong — local 00:30 rendered `Yesterday at 12:30`.
- DST half isolated separately (correct `toLocal()`, old `Duration(days: 1)` key): 2/366 days wrong in `America/New_York` (2026-03-08, 2026-11-01), 2/366 in `Pacific/Auckland` (2026-04-05, 2026-09-27) — each degraded the yesterday row to the absolute date.
- `app/test.sh`: **995 tests passed**.
- `flutter analyze` on both changed files: no issues. `dart format --line-length 120`: clean.

Not exercised in a running build: reaching this page needs a signed-in account with a real Limitless import job. The widget case drives the exact production expression (`formatImportJobTimestamp(context.l10n, job.createdAt!)`) through a localized `BuildContext` instead.

## Product invariants affected

none (`scripts/pr-preflight --suggest`)

## Failure class

A derived day-bucket key has exactly one authority; a consumer that re-derives it from raw UTC calendar fields disagrees with that authority for every off-UTC viewer. Same class as #10980 / PR #10987, which fixed the conversation-grouping instance and filed this one.

Failure-Class: FC-day-bucket-key-recomputed

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

