### PR TITLE
fix(windows): skip the trailing pacing wait after the last memory delete

### DIFF
--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.test.ts
@@ -199,16 +199,19 @@ describe('deleteMemoriesPaced Stop responsiveness', () => {
   })
 
   // retentionSweep.ts calls this with no `shouldStop`, so that path keeps its
-  // single unsliced timer rather than polling it can never use.
+  // single unsliced timer rather than polling it can never use. Two ids are
+  // used (not one) so the pacing wait between them still fires: the tail wait
+  // after the *last* id is skipped entirely (see the pacing-tail describe
+  // block below), so a single-id fixture would no longer exercise this timer.
   it('does not slice its waits for a caller that passes no shouldStop', async () => {
     omiApiDelete.mockResolvedValue({ data: {} })
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
 
-    const run = deleteMemoriesPaced(['a'], () => {})
+    const run = deleteMemoriesPaced(['a', 'b'], () => {})
     await vi.advanceTimersByTimeAsync(1100)
     await run
 
-    expect(setTimeoutSpy).toHaveBeenCalledTimes(1) // one 1100ms wait, not five slices
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1) // one 1100ms wait between ids, not five slices
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1100)
   })
 
@@ -239,5 +242,81 @@ describe('deleteMemoriesPaced Stop responsiveness', () => {
 
     expect(omiApiDelete).toHaveBeenCalledTimes(2) // rate-limited, then retried
     expect(tally).toEqual({ deleted: 1, failed: 0, firstError: undefined })
+  })
+})
+
+// The 1100ms pacing wait exists to space out *requests*. After the last id
+// there is no next request, so serving it only delays the caller (e.g.
+// Memories.tsx's setDeleting(false) / completion toast) by ~1.1s for no
+// reason. This applies regardless of whether the caller passes shouldStop.
+describe('deleteMemoriesPaced trailing pacing wait', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('does not pace after the only (and last) id for a caller with no shouldStop', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    let settled = false
+
+    const run = deleteMemoriesPaced(['a'], () => {})
+    void run.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(true) // no 1.1s tail wait after the last id
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+
+    const tally = await run
+    expect(omiApiDelete).toHaveBeenCalledTimes(1)
+    expect(tally).toEqual({ deleted: 1, failed: 0, firstError: undefined })
+  })
+
+  it('does not pace after the only (and last) id when the caller passes shouldStop', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    let settled = false
+
+    const run = deleteMemoriesPaced(
+      ['a'],
+      () => {},
+      () => false
+    )
+    void run.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(true) // no 1.1s tail wait after the last id
+
+    const tally = await run
+    expect(tally).toEqual({ deleted: 1, failed: 0, firstError: undefined })
+  })
+
+  it('paces between ids but skips the tail wait after the last one', async () => {
+    omiApiDelete.mockResolvedValue({ data: {} })
+    const onResult = vi.fn()
+    let settled = false
+
+    const run = deleteMemoriesPaced(['a', 'b'], onResult, () => false)
+    void run.then(() => {
+      settled = true
+    })
+
+    // Only the wait between 'a' and 'b' should exist. If the trailing wait
+    // after 'b' were still served, 1100ms would not be enough to settle.
+    await vi.advanceTimersByTimeAsync(1100)
+    expect(settled).toBe(true)
+
+    const tally = await run
+    expect(omiApiDelete).toHaveBeenCalledTimes(2)
+    expect(tally).toEqual({ deleted: 2, failed: 0, firstError: undefined })
+    expect(onResult).toHaveBeenNthCalledWith(1, 'a', true, { deleted: 1, failed: 0 })
+    expect(onResult).toHaveBeenNthCalledWith(2, 'b', true, { deleted: 2, failed: 0 })
   })
 })

--- a/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
+++ b/desktop/windows/src/renderer/src/lib/memoriesBulk.ts
@@ -112,7 +112,8 @@ export async function deleteMemoriesPaced(
   let deleted = 0
   let failed = 0
   let firstError: string | undefined
-  for (const id of ids) {
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i]
     if (shouldStop?.()) break
     let ok = false
     let stopped = false
@@ -153,7 +154,12 @@ export async function deleteMemoriesPaced(
     if (ok) deleted++
     else failed++
     onResult(id, ok, { deleted, failed })
-    await waitInterruptible(1100, shouldStop) // stay under ~60/hour; Stop skips the tail
+    // Only pace before the *next* request. After the last id there is nothing
+    // left to space out, so serving this wait would just delay the caller
+    // (e.g. Memories.tsx's setDeleting(false) / completion toast) by ~1.1s.
+    if (i < ids.length - 1) {
+      await waitInterruptible(1100, shouldStop) // space out consecutive deletes; Stop skips the wait
+    }
   }
   return { deleted, failed, firstError }
 }


### PR DESCRIPTION
## What changed and why

`deleteMemoriesPaced` awaited its 1100ms pacing wait after every id, including the last one. That
wait spaces out consecutive delete requests, but after the final id there is no next request to
space out, so it only delayed the caller by ~1.1s for nothing. A single-memory delete, or the tail
of any batch, delayed `Memories.tsx` calling `setDeleting(false)` and showing the completion toast
until over a second after the work was already done.

Follow-up to #10974, called out by review on that PR.

## Product invariants affected

No product invariant intentionally changed. Intra-call spacing between ids remains 1100ms; what is
removed is the cooldown after the final request, which delayed the caller without spacing anything.

## How it was verified

- `corepack pnpm exec vitest run src/renderer/src/lib/memoriesBulk.test.ts` (targeted file, 13 passed)
- `corepack pnpm test` (full suite: 534 passed | 6 skipped files, 5141 passed | 18 skipped tests, 0 failed)
- `corepack pnpm typecheck` (clean, no errors)
- `corepack pnpm exec eslint` on both changed files (clean)
- `corepack pnpm exec prettier --check` on both changed files (all files use Prettier code style)
- Red-first: restored `memoriesBulk.ts` to its `main` state with `git checkout main -- <path>`,
  keeping this PR's tests, then ran the targeted file. Against `main`'s implementation 4 tests
  failed: the 3 new trailing-wait tests, plus the existing no-shouldStop timer test, which times
  out at the 5000ms harness limit rather than asserting. Re-applied the fix and reran: all 13
  passed.

## Tests

Bug fix, so the regression tests live in `memoriesBulk.test.ts`, new `deleteMemoriesPaced trailing
pacing wait` describe block:
- skips the tail wait after the only (and last) id, for a caller with no `shouldStop`
- skips the tail wait after the only (and last) id, for a caller that does pass `shouldStop`
- still paces between ids, but skips the tail wait after the last one

The pre-existing `does not slice its waits for a caller that passes no shouldStop` test moved from a
one-id to a two-id fixture, because a one-id call no longer produces a pacing wait to observe. Its
assertion is unchanged: exactly one timer, of exactly 1100ms.

## Pre-existing pacing observation

Not part of this change, and flagged only in case it is useful. The comment on this function
describes the 1100ms pacing as keeping the client "under the server's 60-per-hour delete cap".
`backend/utils/rate_limit_config.py` has `"memories:delete": (60, 3600)`, i.e. 60 requests per 3600
seconds, while a 1100ms interval corresponds to an unconstrained rate of roughly 3,270 requests per
hour. So the pacing constant does not by itself keep a bulk delete inside that window. The code
also has 429 / `Retry-After` handling, which this PR does not change; I did not verify here how that
handling and the configured limit behave together during a sustained bulk delete.

Whether 1100ms is the intended value is a product decision, so I have not touched it.

That context matters for one behavioural consequence of this change, which I want to state plainly
rather than bury: the trailing wait also acted as an incidental cooldown *between* separate calls, so
after this change two back-to-back invocations can issue their boundary requests ~1.1s closer
together. I have not assessed what that does to 429 behaviour for a caller that chains
`deleteMemoriesPaced` calls. The callers in-tree do not chain it (`Memories.tsx` runs one batch per
user action, `retentionSweep.ts` makes a single call with the full id list), so I did not treat it as
blocking, but it is a real change and not merely a note.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

None. This PR touches only `deleteMemoriesPaced`'s loop and its own test file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

