### PR TITLE
fix(app): make firmware update prompt reliably dismissible

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -25,6 +25,7 @@ import 'package:omi/services/wals/wal_syncs.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/firmware_update_build_policy.dart';
+import 'package:omi/utils/firmware_update_prompt_coordinator.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/debouncer.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
@@ -65,7 +66,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   // Track firmware update state to prevent showing dialog during updates
   bool _isCheckingFirmware = false;
-  bool _isFirmwareDialogShowing = false;
+  final FirmwareUpdatePromptCoordinator _firmwareUpdatePromptCoordinator = FirmwareUpdatePromptCoordinator();
   bool _pairingLostDialogShowing = false;
   bool _isFirmwareUpdateInProgress = false;
   bool get isFirmwareUpdateInProgress => _isFirmwareUpdateInProgress;
@@ -454,6 +455,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   @override
   void dispose() {
+    _firmwareUpdatePromptCoordinator.invalidatePresentation();
     if (BleBridge.instance.pairingLostCallback == _showPairingLostDialog) {
       BleBridge.instance.pairingLostCallback = null;
     }
@@ -469,7 +471,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void onDeviceDisconnected() async {
     Logger.debug('onDisconnected inside: $connectedDevice');
     _havingNewFirmware = false;
-    _isFirmwareDialogShowing = false;
+    _firmwareUpdatePromptCoordinator.invalidatePresentation();
     _bleChargingStatusListener?.cancel();
     isCharging = false;
     setConnectedDevice(null);
@@ -710,6 +712,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void _checkFirmwareUpdates() async {
     if (!_allowsFirmwareUpdateForPairedDevice) {
       _havingNewFirmware = false;
+      _firmwareUpdatePromptCoordinator.setAvailableVersion(null);
       return;
     }
     if (_isFirmwareUpdateInProgress || _isCheckingFirmware) {
@@ -754,6 +757,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         var (message, hasUpdate, version, firmwareDetails) = await shouldUpdateFirmware();
         _havingNewFirmware = hasUpdate;
         _latestFirmwareVersion = version.isNotEmpty ? version : message;
+        _firmwareUpdatePromptCoordinator.setAvailableVersion(hasUpdate ? _latestFirmwareVersion : null);
 
         // For OmiGlass devices, populate the firmware details for the OTA UI
         if (_isOmiGlassDevice && firmwareDetails.isNotEmpty) {
@@ -789,6 +793,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         if (retryCount == maxRetries) {
           Logger.debug('Max retries reached, giving up');
           _havingNewFirmware = false;
+          _firmwareUpdatePromptCoordinator.setAvailableVersion(null);
           notifyListeners();
           break;
         }
@@ -803,6 +808,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   bool _isOnFirmwareUpdatePage = false;
   void setOnFirmwareUpdatePage(bool value) {
     _isOnFirmwareUpdatePage = value;
+    if (value) {
+      _firmwareUpdatePromptCoordinator.invalidatePresentation();
+    }
   }
 
   void showFirmwareUpdateDialog(BuildContext context) {
@@ -810,39 +818,59 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         !_havingNewFirmware ||
         !SharedPreferencesUtil().showFirmwareUpdateDialog ||
         _isFirmwareUpdateInProgress ||
-        _isFirmwareDialogShowing ||
         _isOnFirmwareUpdatePage) {
       return;
     }
 
-    _isFirmwareDialogShowing = true;
-    showDialog(
+    final prompt = _firmwareUpdatePromptCoordinator.beginPresentation();
+    if (prompt == null) return;
+
+    showDialog<void>(
       context: context,
-      builder: (context) => ConfirmationDialog(
-        title: context.l10n.firmwareUpdateAvailable,
-        description: context.l10n.firmwareUpdateAvailableDescription(_latestFirmwareVersion),
-        confirmText: context.l10n.update,
-        cancelText: context.l10n.later,
-        onConfirm: () {
-          Navigator.of(context).pop();
-          setFirmwareUpdateInProgress(true);
-          if (_isOmiGlassDevice) {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) =>
-                    OmiGlassOtaUpdate(device: pairedDevice, latestFirmwareDetails: _latestOmiGlassFirmwareDetails),
-              ),
-            );
-          } else {
-            Navigator.of(context).push(MaterialPageRoute(builder: (context) => FirmwareUpdate(device: pairedDevice)));
-          }
-        },
-        onCancel: () {
-          Navigator.of(context).pop();
-        },
-      ),
-    ).then((_) {
-      _isFirmwareDialogShowing = false;
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        final route = ModalRoute.of(dialogContext);
+        final navigator = Navigator.of(dialogContext);
+        _firmwareUpdatePromptCoordinator.attachDismissal(prompt, () {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!dialogContext.mounted || route == null || !route.isActive) return;
+            if (route.isCurrent) {
+              navigator.pop();
+            } else {
+              navigator.removeRoute(route);
+            }
+          });
+        });
+
+        return ConfirmationDialog(
+          title: dialogContext.l10n.firmwareUpdateAvailable,
+          description: dialogContext.l10n.firmwareUpdateAvailableDescription(_latestFirmwareVersion),
+          confirmText: dialogContext.l10n.update,
+          cancelText: dialogContext.l10n.later,
+          onConfirm: () {
+            if (!_firmwareUpdatePromptCoordinator.accept(prompt)) return;
+            Logger.info('Firmware update prompt accepted');
+            setFirmwareUpdateInProgress(true);
+            if (_isOmiGlassDevice) {
+              navigator.push(
+                MaterialPageRoute(
+                  builder: (context) =>
+                      OmiGlassOtaUpdate(device: pairedDevice, latestFirmwareDetails: _latestOmiGlassFirmwareDetails),
+                ),
+              );
+            } else {
+              navigator.push(MaterialPageRoute(builder: (context) => FirmwareUpdate(device: pairedDevice)));
+            }
+          },
+          onCancel: () {
+            if (_firmwareUpdatePromptCoordinator.defer(prompt)) {
+              Logger.info('Firmware update prompt deferred by user');
+            }
+          },
+        );
+      },
+    ).whenComplete(() {
+      _firmwareUpdatePromptCoordinator.complete(prompt);
     });
   }
 
@@ -900,6 +928,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   // Set firmware update state when starting an update
   void setFirmwareUpdateInProgress(bool inProgress) {
     _isFirmwareUpdateInProgress = inProgress;
+    if (inProgress) {
+      _firmwareUpdatePromptCoordinator.invalidatePresentation();
+    }
     notifyListeners();
   }
 }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -25,6 +25,7 @@ import 'package:omi/services/wals/wal_syncs.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/firmware_update_build_policy.dart';
+import 'package:omi/utils/firmware_update_check_session.dart';
 import 'package:omi/utils/firmware_update_prompt_coordinator.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/debouncer.dart';
@@ -65,7 +66,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       _havingNewFirmware && pairedDevice != null && isConnected && _allowsFirmwareUpdateForPairedDevice;
 
   // Track firmware update state to prevent showing dialog during updates
-  bool _isCheckingFirmware = false;
+  final FirmwareUpdateCheckSessionGuard _firmwareUpdateCheckSessionGuard = FirmwareUpdateCheckSessionGuard();
+  FirmwareUpdateCheckSession? _checkingFirmwareSession;
+  String? _firmwareUpdateDeviceId;
   final FirmwareUpdatePromptCoordinator _firmwareUpdatePromptCoordinator = FirmwareUpdatePromptCoordinator();
   bool _pairingLostDialogShowing = false;
   bool _isFirmwareUpdateInProgress = false;
@@ -130,8 +133,14 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     connectedDevice = device;
     pairedDevice = device;
     if (isNewConnection) {
+      if (_firmwareUpdateDeviceId != null && _firmwareUpdateDeviceId != device.id) {
+        _firmwareUpdatePromptCoordinator.clearAvailableVersion(invalidateDeferral: true);
+      }
+      _firmwareUpdateDeviceId = device.id;
+      _firmwareUpdateCheckSessionGuard.start(device.id);
       _deviceSessionStartedAt = now;
     } else if (device == null) {
+      _firmwareUpdateCheckSessionGuard.invalidate();
       _deviceSessionStartedAt = null;
     }
     await getDeviceInfo();
@@ -534,7 +543,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void _onDeviceConnected(BtDevice device) async {
     Logger.debug('_onConnected inside: $connectedDevice');
-    setConnectedDevice(device);
+    await setConnectedDevice(device);
 
     if (captureProvider != null) {
       captureProvider?.updateRecordingDevice(device);
@@ -712,21 +721,31 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void _checkFirmwareUpdates() async {
     if (!_allowsFirmwareUpdateForPairedDevice) {
       _havingNewFirmware = false;
-      _firmwareUpdatePromptCoordinator.setAvailableVersion(null);
+      _firmwareUpdatePromptCoordinator.clearAvailableVersion(invalidateDeferral: true);
       return;
     }
-    if (_isFirmwareUpdateInProgress || _isCheckingFirmware) {
+    final checkSession = _firmwareUpdateCheckSessionGuard.capture();
+    if (checkSession == null || !_isCurrentFirmwareCheckSession(checkSession)) {
+      return;
+    }
+    if (_isFirmwareUpdateInProgress ||
+        (_checkingFirmwareSession != null && _firmwareUpdateCheckSessionGuard.isCurrent(_checkingFirmwareSession!))) {
       return;
     }
 
-    _isCheckingFirmware = true;
+    _checkingFirmwareSession = checkSession;
     try {
-      await checkFirmwareUpdates();
+      final hasUpdate = await checkFirmwareUpdates(session: checkSession);
+      if (!_isCurrentFirmwareCheckSession(checkSession)) {
+        Logger.debug('Discarding firmware update prompt from a stale device session');
+        return;
+      }
 
       // Show firmware update dialog if needed
-      if (_havingNewFirmware) {
+      if (hasUpdate && _havingNewFirmware) {
         // Use a small delay to ensure the UI is ready
         Future.delayed(const Duration(milliseconds: 500), () {
+          if (!_isCurrentFirmwareCheckSession(checkSession)) return;
           final context = globalNavigatorKey.currentContext;
           if (context != null && context.mounted) {
             showFirmwareUpdateDialog(context);
@@ -734,8 +753,17 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         });
       }
     } finally {
-      _isCheckingFirmware = false;
+      if (identical(_checkingFirmwareSession, checkSession)) {
+        _checkingFirmwareSession = null;
+      }
     }
+  }
+
+  bool _isCurrentFirmwareCheckSession(FirmwareUpdateCheckSession session) {
+    return _firmwareUpdateCheckSessionGuard.isCurrent(session) &&
+        connectedDevice?.id == session.deviceId &&
+        pairedDevice?.id == session.deviceId &&
+        isConnected;
   }
 
   bool get _isOmiGlassDevice => FirmwareUpdateBuildPolicy.current.isOpenGlassDevice(pairedDevice);
@@ -743,9 +771,14 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   bool get _allowsFirmwareUpdateForPairedDevice =>
       FirmwareUpdateBuildPolicy.current.allowsFirmwareUpdateForDevice(pairedDevice);
 
-  Future checkFirmwareUpdates() async {
+  Future<bool> checkFirmwareUpdates({FirmwareUpdateCheckSession? session}) async {
+    final checkSession = session ?? _firmwareUpdateCheckSessionGuard.capture();
+    if (checkSession == null || !_isCurrentFirmwareCheckSession(checkSession)) {
+      return false;
+    }
     if (!_allowsFirmwareUpdateForPairedDevice) {
       _havingNewFirmware = false;
+      _firmwareUpdatePromptCoordinator.clearAvailableVersion(invalidateDeferral: true);
       return false;
     }
     int retryCount = 0;
@@ -753,11 +786,18 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     const retryDelay = Duration(seconds: 3);
 
     while (retryCount < maxRetries) {
+      if (!_isCurrentFirmwareCheckSession(checkSession)) {
+        return false;
+      }
       try {
         var (message, hasUpdate, version, firmwareDetails) = await shouldUpdateFirmware();
-        _havingNewFirmware = hasUpdate;
-        _latestFirmwareVersion = version.isNotEmpty ? version : message;
-        _firmwareUpdatePromptCoordinator.setAvailableVersion(hasUpdate ? _latestFirmwareVersion : null);
+        if (!_isCurrentFirmwareCheckSession(checkSession)) {
+          Logger.debug('Discarding firmware update result from a stale device session');
+          return false;
+        }
+
+        final latestFirmwareVersion = version.isNotEmpty ? version : message;
+        Map<String, dynamic>? latestOmiGlassFirmwareDetails;
 
         // For OmiGlass devices, populate the firmware details for the OTA UI
         if (_isOmiGlassDevice && firmwareDetails.isNotEmpty) {
@@ -767,7 +807,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           final changelog = firmwareDetails['changelog'];
           final changelogStr = changelog is List ? changelog.join('\n') : (changelog?.toString() ?? '');
 
-          _latestOmiGlassFirmwareDetails = {
+          latestOmiGlassFirmwareDetails = {
             'version': cleanVersion,
             'download_url': firmwareDetails['zip_url'] ?? '',
             'changelog': changelogStr,
@@ -775,33 +815,65 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         }
 
         // Fetch latest stable version for rollback comparison
+        String? latestStableFirmwareVersion;
         try {
           var stableDetails = await getStableFirmwareVersion(deviceModelNumber: pairedDevice?.modelNumber ?? '');
+          if (!_isCurrentFirmwareCheckSession(checkSession)) {
+            Logger.debug('Discarding stable firmware result from a stale device session');
+            return false;
+          }
           var stableVersion = stableDetails['version']?.toString() ?? '';
           if (stableVersion.startsWith('v')) stableVersion = stableVersion.substring(1);
-          _latestStableFirmwareVersion = stableVersion;
+          latestStableFirmwareVersion = stableVersion;
         } catch (e) {
+          if (!_isCurrentFirmwareCheckSession(checkSession)) {
+            Logger.debug('Discarding firmware update result from a stale device session');
+            return false;
+          }
           Logger.debug('Error fetching stable firmware version: $e');
         }
 
+        if (!_isCurrentFirmwareCheckSession(checkSession)) {
+          return false;
+        }
+        _havingNewFirmware = hasUpdate;
+        _latestFirmwareVersion = latestFirmwareVersion;
+        if (hasUpdate) {
+          _firmwareUpdatePromptCoordinator.setAvailableVersion(latestFirmwareVersion);
+        } else {
+          _firmwareUpdatePromptCoordinator.clearAvailableVersion();
+        }
+        if (latestOmiGlassFirmwareDetails != null) {
+          _latestOmiGlassFirmwareDetails = latestOmiGlassFirmwareDetails;
+        }
+        if (latestStableFirmwareVersion != null) {
+          _latestStableFirmwareVersion = latestStableFirmwareVersion;
+        }
         notifyListeners();
         return hasUpdate;
       } catch (e) {
+        if (!_isCurrentFirmwareCheckSession(checkSession)) {
+          Logger.debug('Discarding firmware check failure from a stale device session');
+          return false;
+        }
         retryCount++;
         Logger.debug('Error checking firmware update (attempt $retryCount): $e');
 
         if (retryCount == maxRetries) {
           Logger.debug('Max retries reached, giving up');
           _havingNewFirmware = false;
-          _firmwareUpdatePromptCoordinator.setAvailableVersion(null);
+          _firmwareUpdatePromptCoordinator.clearAvailableVersion();
           notifyListeners();
-          break;
+          return false;
         }
 
         await Future.delayed(retryDelay);
+        if (!_isCurrentFirmwareCheckSession(checkSession)) {
+          return false;
+        }
       }
     }
-    return;
+    return false;
   }
 
   // Track if user is currently viewing a firmware update page

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -543,7 +543,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void _onDeviceConnected(BtDevice device) async {
     Logger.debug('_onConnected inside: $connectedDevice');
-    await setConnectedDevice(device);
+    final deviceSetup = setConnectedDevice(device);
+    final connectionSession = _firmwareUpdateCheckSessionGuard.capture();
+    await deviceSetup;
+    if (connectionSession == null || !_isCurrentDeviceSession(connectionSession)) {
+      Logger.debug('Discarding device setup continuation from a stale connection session');
+      return;
+    }
 
     if (captureProvider != null) {
       captureProvider?.updateRecordingDevice(device);
@@ -760,10 +766,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   bool _isCurrentFirmwareCheckSession(FirmwareUpdateCheckSession session) {
+    return _isCurrentDeviceSession(session) && isConnected;
+  }
+
+  bool _isCurrentDeviceSession(FirmwareUpdateCheckSession session) {
     return _firmwareUpdateCheckSessionGuard.isCurrent(session) &&
         connectedDevice?.id == session.deviceId &&
-        pairedDevice?.id == session.deviceId &&
-        isConnected;
+        pairedDevice?.id == session.deviceId;
   }
 
   bool get _isOmiGlassDevice => FirmwareUpdateBuildPolicy.current.isOpenGlassDevice(pairedDevice);

--- a/app/lib/utils/firmware_update_check_session.dart
+++ b/app/lib/utils/firmware_update_check_session.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class FirmwareUpdateCheckSession {
+  const FirmwareUpdateCheckSession._({required this.deviceId, required this.generation});
+
+  final String deviceId;
+  final int generation;
+}
+
+/// Identifies the exact device connection that owns an asynchronous firmware
+/// check. Reconnecting the same physical device still creates a new session.
+class FirmwareUpdateCheckSessionGuard {
+  int _generation = 0;
+  String? _deviceId;
+
+  void start(String deviceId) {
+    _generation++;
+    _deviceId = deviceId;
+  }
+
+  void invalidate() {
+    _generation++;
+    _deviceId = null;
+  }
+
+  FirmwareUpdateCheckSession? capture() {
+    final deviceId = _deviceId;
+    if (deviceId == null) return null;
+    return FirmwareUpdateCheckSession._(deviceId: deviceId, generation: _generation);
+  }
+
+  bool isCurrent(FirmwareUpdateCheckSession session) {
+    return session.generation == _generation && session.deviceId == _deviceId;
+  }
+}

--- a/app/lib/utils/firmware_update_prompt_coordinator.dart
+++ b/app/lib/utils/firmware_update_prompt_coordinator.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class FirmwareUpdatePrompt {
+  const FirmwareUpdatePrompt._({required this.id, required this.version});
+
+  final int id;
+  final String version;
+}
+
+class FirmwareUpdatePromptCoordinator {
+  int _nextPromptId = 0;
+  String? _availableVersion;
+  String? _deferredVersion;
+  _ActiveFirmwareUpdatePrompt? _activePrompt;
+
+  void setAvailableVersion(String? version) {
+    final normalizedVersion = version?.trim();
+    if (normalizedVersion == null || normalizedVersion.isEmpty) {
+      _availableVersion = null;
+      _deferredVersion = null;
+      _requestActiveDismissal();
+      return;
+    }
+
+    if (_availableVersion != null && _availableVersion != normalizedVersion) {
+      _requestActiveDismissal();
+    }
+    _availableVersion = normalizedVersion;
+  }
+
+  FirmwareUpdatePrompt? beginPresentation() {
+    final version = _availableVersion;
+    if (version == null || version == _deferredVersion || _activePrompt != null) {
+      return null;
+    }
+
+    final prompt = FirmwareUpdatePrompt._(id: _nextPromptId++, version: version);
+    _activePrompt = _ActiveFirmwareUpdatePrompt(prompt);
+    return prompt;
+  }
+
+  void attachDismissal(FirmwareUpdatePrompt prompt, VoidCallback dismiss) {
+    final activePrompt = _activePrompt;
+    if (activePrompt == null || activePrompt.prompt.id != prompt.id) {
+      dismiss();
+      return;
+    }
+
+    activePrompt.dismiss = dismiss;
+    if (activePrompt.dismissalRequested) {
+      dismiss();
+    }
+  }
+
+  bool defer(FirmwareUpdatePrompt prompt) {
+    final activePrompt = _activePrompt;
+    if (activePrompt == null || activePrompt.prompt.id != prompt.id) {
+      return false;
+    }
+
+    _deferredVersion = prompt.version;
+    _requestActiveDismissal();
+    return true;
+  }
+
+  bool accept(FirmwareUpdatePrompt prompt) {
+    final activePrompt = _activePrompt;
+    if (activePrompt == null || activePrompt.prompt.id != prompt.id) {
+      return false;
+    }
+
+    _requestActiveDismissal();
+    return true;
+  }
+
+  void invalidatePresentation() {
+    _requestActiveDismissal();
+  }
+
+  void complete(FirmwareUpdatePrompt prompt) {
+    if (_activePrompt?.prompt.id == prompt.id) {
+      _activePrompt = null;
+    }
+  }
+
+  void _requestActiveDismissal() {
+    final activePrompt = _activePrompt;
+    if (activePrompt == null || activePrompt.dismissalRequested) {
+      return;
+    }
+
+    activePrompt.dismissalRequested = true;
+    activePrompt.dismiss?.call();
+  }
+}
+
+class _ActiveFirmwareUpdatePrompt {
+  _ActiveFirmwareUpdatePrompt(this.prompt);
+
+  final FirmwareUpdatePrompt prompt;
+  VoidCallback? dismiss;
+  bool dismissalRequested = false;
+}

--- a/app/lib/utils/firmware_update_prompt_coordinator.dart
+++ b/app/lib/utils/firmware_update_prompt_coordinator.dart
@@ -14,19 +14,28 @@ class FirmwareUpdatePromptCoordinator {
   String? _deferredVersion;
   _ActiveFirmwareUpdatePrompt? _activePrompt;
 
-  void setAvailableVersion(String? version) {
-    final normalizedVersion = version?.trim();
-    if (normalizedVersion == null || normalizedVersion.isEmpty) {
-      _availableVersion = null;
-      _deferredVersion = null;
-      _requestActiveDismissal();
+  void setAvailableVersion(String version) {
+    final normalizedVersion = version.trim();
+    if (normalizedVersion.isEmpty) {
+      clearAvailableVersion();
       return;
     }
 
     if (_availableVersion != null && _availableVersion != normalizedVersion) {
       _requestActiveDismissal();
     }
+    if (_deferredVersion != null && _deferredVersion != normalizedVersion) {
+      _deferredVersion = null;
+    }
     _availableVersion = normalizedVersion;
+  }
+
+  void clearAvailableVersion({bool invalidateDeferral = false}) {
+    _availableVersion = null;
+    if (invalidateDeferral) {
+      _deferredVersion = null;
+    }
+    _requestActiveDismissal();
   }
 
   FirmwareUpdatePrompt? beginPresentation() {
@@ -55,7 +64,7 @@ class FirmwareUpdatePromptCoordinator {
 
   bool defer(FirmwareUpdatePrompt prompt) {
     final activePrompt = _activePrompt;
-    if (activePrompt == null || activePrompt.prompt.id != prompt.id) {
+    if (activePrompt == null || activePrompt.prompt.id != prompt.id || activePrompt.dismissalRequested) {
       return false;
     }
 
@@ -66,7 +75,7 @@ class FirmwareUpdatePromptCoordinator {
 
   bool accept(FirmwareUpdatePrompt prompt) {
     final activePrompt = _activePrompt;
-    if (activePrompt == null || activePrompt.prompt.id != prompt.id) {
+    if (activePrompt == null || activePrompt.prompt.id != prompt.id || activePrompt.dismissalRequested) {
       return false;
     }
 

--- a/app/test/unit/firmware_update_check_session_test.dart
+++ b/app/test/unit/firmware_update_check_session_test.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/firmware_update_check_session.dart';
+
+void main() {
+  test('reconnecting the same device rejects an in-flight firmware result', () async {
+    final guard = FirmwareUpdateCheckSessionGuard()..start('device-a');
+    final firstSession = guard.capture()!;
+    final resultReady = Completer<void>();
+
+    final canApplyResult = () async {
+      expect(guard.isCurrent(firstSession), isTrue);
+      await resultReady.future;
+      return guard.isCurrent(firstSession);
+    }();
+
+    guard
+      ..invalidate()
+      ..start('device-a');
+    resultReady.complete();
+
+    expect(await canApplyResult, isFalse);
+    expect(guard.isCurrent(guard.capture()!), isTrue);
+  });
+}

--- a/app/test/unit/firmware_update_check_session_test.dart
+++ b/app/test/unit/firmware_update_check_session_test.dart
@@ -24,4 +24,20 @@ void main() {
     expect(await canApplyResult, isFalse);
     expect(guard.isCurrent(guard.capture()!), isTrue);
   });
+
+  test('disconnect while device setup awaits rejects its continuation', () async {
+    final guard = FirmwareUpdateCheckSessionGuard()..start('device-a');
+    final setupSession = guard.capture()!;
+    final setupReady = Completer<void>();
+
+    final canContinueSetup = () async {
+      await setupReady.future;
+      return guard.isCurrent(setupSession);
+    }();
+
+    guard.invalidate();
+    setupReady.complete();
+
+    expect(await canContinueSetup, isFalse);
+  });
 }

--- a/app/test/unit/firmware_update_prompt_coordinator_test.dart
+++ b/app/test/unit/firmware_update_prompt_coordinator_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/firmware_update_prompt_coordinator.dart';
+
+void main() {
+  group('FirmwareUpdatePromptCoordinator', () {
+    test('Later dismisses immediately and defers only the current version', () {
+      final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
+      final prompt = coordinator.beginPresentation()!;
+      var dismissals = 0;
+      coordinator.attachDismissal(prompt, () => dismissals++);
+
+      expect(coordinator.defer(prompt), isTrue);
+      expect(dismissals, 1);
+
+      coordinator.complete(prompt);
+      expect(coordinator.beginPresentation(), isNull);
+
+      coordinator.setAvailableVersion('3.0.21');
+      expect(coordinator.beginPresentation(), isNotNull);
+    });
+
+    test('cleared availability dismisses an active prompt and permits a legitimate future prompt', () {
+      final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
+      final prompt = coordinator.beginPresentation()!;
+      var dismissals = 0;
+      coordinator.attachDismissal(prompt, () => dismissals++);
+
+      coordinator.setAvailableVersion(null);
+
+      expect(dismissals, 1);
+      coordinator.complete(prompt);
+      coordinator.setAvailableVersion('3.0.20');
+      expect(coordinator.beginPresentation(), isNotNull);
+    });
+
+    test('Update dismisses without deferring the available version', () {
+      final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
+      final prompt = coordinator.beginPresentation()!;
+      var dismissals = 0;
+      coordinator.attachDismissal(prompt, () => dismissals++);
+
+      expect(coordinator.accept(prompt), isTrue);
+      expect(dismissals, 1);
+
+      coordinator.complete(prompt);
+      expect(coordinator.beginPresentation(), isNotNull);
+    });
+
+    test('stale presentation is dismissed even when its route attaches after invalidation', () {
+      final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
+      final stalePrompt = coordinator.beginPresentation()!;
+
+      coordinator.invalidatePresentation();
+
+      var dismissals = 0;
+      coordinator.attachDismissal(stalePrompt, () => dismissals++);
+      expect(dismissals, 1);
+
+      coordinator.complete(stalePrompt);
+      final freshPrompt = coordinator.beginPresentation();
+      expect(freshPrompt, isNotNull);
+
+      coordinator.complete(stalePrompt);
+      expect(coordinator.beginPresentation(), isNull);
+    });
+  });
+}

--- a/app/test/unit/firmware_update_prompt_coordinator_test.dart
+++ b/app/test/unit/firmware_update_prompt_coordinator_test.dart
@@ -20,17 +20,31 @@ void main() {
       expect(coordinator.beginPresentation(), isNotNull);
     });
 
-    test('cleared availability dismisses an active prompt and permits a legitimate future prompt', () {
+    test('invalidated availability dismisses an active prompt and permits a legitimate future prompt', () {
       final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
       final prompt = coordinator.beginPresentation()!;
       var dismissals = 0;
       coordinator.attachDismissal(prompt, () => dismissals++);
 
-      coordinator.setAvailableVersion(null);
+      coordinator.clearAvailableVersion(invalidateDeferral: true);
 
       expect(dismissals, 1);
       coordinator.complete(prompt);
       coordinator.setAvailableVersion('3.0.20');
+      expect(coordinator.beginPresentation(), isNotNull);
+    });
+
+    test('transient availability reset preserves a Later deferral', () {
+      final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
+      final prompt = coordinator.beginPresentation()!;
+
+      expect(coordinator.defer(prompt), isTrue);
+      coordinator.complete(prompt);
+      coordinator.clearAvailableVersion();
+      coordinator.setAvailableVersion('3.0.20');
+
+      expect(coordinator.beginPresentation(), isNull);
+      coordinator.setAvailableVersion('3.0.21');
       expect(coordinator.beginPresentation(), isNotNull);
     });
 
@@ -63,6 +77,19 @@ void main() {
 
       coordinator.complete(stalePrompt);
       expect(coordinator.beginPresentation(), isNull);
+    });
+
+    test('Update is rejected after dismissal has been requested', () {
+      final coordinator = FirmwareUpdatePromptCoordinator()..setAvailableVersion('3.0.20');
+      final stalePrompt = coordinator.beginPresentation()!;
+      var dismissals = 0;
+      coordinator.attachDismissal(stalePrompt, () => dismissals++);
+
+      coordinator.invalidatePresentation();
+
+      expect(dismissals, 1);
+      expect(coordinator.accept(stalePrompt), isFalse);
+      expect(coordinator.defer(stalePrompt), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary

- replace the firmware alert's loose `isShowing` boolean with a version-aware lifecycle coordinator
- make `Later` retire the exact alert route immediately and defer only that firmware version for the current app session
- dismiss stale alerts when availability, device connection, provider ownership, update-page state, or update progress invalidates them
- keep `Update` on the existing firmware navigation path and add privacy-safe accepted/deferred diagnostics

## Root cause

Disconnect handling cleared the `isShowing` flag without removing the active dialog route. A reconnect could then present a second firmware alert over the stale first route, so `Later` popped only the top alert and appeared to do nothing.

## Verification

- `flutter test test/unit/firmware_update_prompt_coordinator_test.dart` — 4 tests passed
- `bash test.sh` — 994 tests passed
- `bash scripts/analyze_ratchet.sh` — passed
- `make preflight` — passed

The regression coverage exercises deferred dismissal, cleared availability, a stale route that attaches after invalidation, and the unchanged update-acceptance path.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

No existing semantic failure class covers a modal route outliving the state flag that claimed ownership of it. The reusable guard surface is `FirmwareUpdatePromptCoordinator` plus its lifecycle regression suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

