### PR TITLE
fix(watch): stop recording animation after five seconds

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -246,10 +246,10 @@ checks:
     reason: "Ray-Ban DAT builds must strip mcumgr before CocoaPods and restore the exact default graph even after interruption"
   - id: watch-recording-presentation
     command: ["ruby", "app/ios/test/watch_recording_presentation_test.rb"]
-    triggers: ["app/ios/omiWatchApp/ContentView.swift", "app/ios/omiWatchApp/RecordingPresentation.swift", "app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift", "app/ios/omiWatchApp/omiwatchApp.swift", "app/ios/test/watch_recording_presentation_test.rb", ".github/checks-manifest.yaml"]
+    triggers: ["app/ios/omiWatchApp/ContentView.swift", "app/ios/omiWatchApp/Localizable.xcstrings", "app/ios/omiWatchApp/RecordingPresentation.swift", "app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift", "app/ios/omiWatchApp/WatchRecorderControlling.swift", "app/ios/omiWatchApp/omiwatchApp.swift", "app/ios/Runner.xcodeproj/project.pbxproj", "app/ios/test/watch_recording_presentation_test.rb", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
-    reason: "SCA-273: the watch must stop its continuous recording animation after five seconds while elapsed time remains anchored to the original recording start"
+    reason: "SCA-273: the real watch presentation contract must stop its ripple after five seconds, preserve elapsed time, and localize accessibility labels for every native locale"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -244,6 +244,12 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["linux", "macos"]
     reason: "Ray-Ban DAT builds must strip mcumgr before CocoaPods and restore the exact default graph even after interruption"
+  - id: watch-recording-presentation
+    command: ["ruby", "app/ios/test/watch_recording_presentation_test.rb"]
+    triggers: ["app/ios/omiWatchApp/ContentView.swift", "app/ios/omiWatchApp/RecordingPresentation.swift", "app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift", "app/ios/omiWatchApp/omiwatchApp.swift", "app/ios/test/watch_recording_presentation_test.rb", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "SCA-273: the watch must stop its continuous recording animation after five seconds while elapsed time remains anchored to the original recording start"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/app/ios/omiWatchApp/ContentView.swift
+++ b/app/ios/omiWatchApp/ContentView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-struct WatchRecorderView: View {
-    @ObservedObject var viewModel: WatchAudioRecorderViewModel
+struct WatchRecorderView<Recorder: WatchRecorderControlling>: View {
+    @ObservedObject var viewModel: Recorder
+    @StateObject private var presentationController = RecordingPresentationController()
     @State private var isPressed = false
-    @State private var showsRecordingAnimation = false
     
     var body: some View {
         GeometryReader { geometry in
@@ -33,7 +33,7 @@ struct WatchRecorderView: View {
                         }
                     }) {
                         ZStack {
-                            if showsRecordingAnimation {
+                            if presentationController.phase.showsRecordingRipple {
                                 RecordingRippleView()
                             }
                             
@@ -53,21 +53,25 @@ struct WatchRecorderView: View {
                         }
                     }
                     .buttonStyle(PlainButtonStyle())
-                    .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Start recording")
+                    .accessibilityLabel(
+                        viewModel.isRecording
+                            ? Text("watch.accessibility.stopRecording")
+                            : Text("watch.accessibility.startRecording")
+                    )
                     
                     Spacer()
                     
                     Group {
                         if viewModel.isRecording, let startedAt = viewModel.recordingStartedAt {
-                            if showsRecordingAnimation {
+                            if presentationController.phase.showsRecordingRipple {
                                 Text("Listening")
                                     .font(.system(size: 16, weight: .medium))
-                                    .accessibilityLabel("Recording in progress")
+                                    .accessibilityLabel(Text("watch.accessibility.recordingInProgress"))
                             } else {
                                 Text(startedAt, style: .timer)
                                     .font(.system(size: 22, weight: .semibold, design: .rounded))
                                     .monospacedDigit()
-                                    .accessibilityLabel("Elapsed recording time")
+                                    .accessibilityLabel(Text("watch.accessibility.elapsedRecordingTime"))
                                     .accessibilityValue(Text(startedAt, style: .timer))
                             }
                         } else {
@@ -83,23 +87,10 @@ struct WatchRecorderView: View {
             }
         }
         .task(id: viewModel.recordingStartedAt) {
-            guard viewModel.isRecording, let startedAt = viewModel.recordingStartedAt else {
-                showsRecordingAnimation = false
-                return
-            }
-
-            let remaining = RecordingPresentation.animationTimeRemaining(startedAt: startedAt, now: Date())
-            showsRecordingAnimation = remaining > 0
-            guard remaining > 0 else { return }
-
-            do {
-                try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
-            } catch {
-                return
-            }
-
-            guard viewModel.isRecording, viewModel.recordingStartedAt == startedAt else { return }
-            showsRecordingAnimation = false
+            await presentationController.update(
+                isRecording: viewModel.isRecording,
+                startedAt: viewModel.recordingStartedAt
+            )
         }
     }
 }
@@ -131,6 +122,8 @@ private struct RecordingRippleView: View {
     }
 }
 
-#Preview {
-    WatchRecorderView(viewModel: WatchAudioRecorderViewModel())
-}
+#if canImport(WatchConnectivity)
+    #Preview {
+        WatchRecorderView(viewModel: WatchAudioRecorderViewModel())
+    }
+#endif

--- a/app/ios/omiWatchApp/ContentView.swift
+++ b/app/ios/omiWatchApp/ContentView.swift
@@ -3,9 +3,7 @@ import SwiftUI
 struct WatchRecorderView: View {
     @ObservedObject var viewModel: WatchAudioRecorderViewModel
     @State private var isPressed = false
-    @State private var pulseScale: CGFloat = 1.0
-    @State private var rippleScale: CGFloat = 1.0
-    @State private var rippleOpacity: Double = 0.0
+    @State private var showsRecordingAnimation = false
     
     var body: some View {
         GeometryReader { geometry in
@@ -35,25 +33,8 @@ struct WatchRecorderView: View {
                         }
                     }) {
                         ZStack {
-                            // Pulsating ripple effect when recording
-                            if viewModel.isRecording {
-                                ForEach(0..<3, id: \.self) { index in
-                                    Circle()
-                                        .stroke(Color.white.opacity(0.3), lineWidth: 2)
-                                        .frame(width: 100, height: 100)
-                                        .scaleEffect(rippleScale)
-                                        .opacity(rippleOpacity)
-                                        .animation(
-                                            Animation.easeOut(duration: 1.5)
-                                                .repeatForever(autoreverses: false)
-                                                .delay(Double(index) * 0.3),
-                                            value: rippleScale
-                                        )
-                                        .onAppear {
-                                            rippleScale = 2.5
-                                            rippleOpacity = 0.8
-                                        }
-                                }
+                            if showsRecordingAnimation {
+                                RecordingRippleView()
                             }
                             
                             // Main button circle (white background)
@@ -72,42 +53,81 @@ struct WatchRecorderView: View {
                         }
                     }
                     .buttonStyle(PlainButtonStyle())
+                    .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Start recording")
                     
                     Spacer()
                     
-                    Text(viewModel.isRecording ? "Listening" : "Tap to Record")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(.white)
-                        .padding(.bottom, 20)
+                    Group {
+                        if viewModel.isRecording, let startedAt = viewModel.recordingStartedAt {
+                            if showsRecordingAnimation {
+                                Text("Listening")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .accessibilityLabel("Recording in progress")
+                            } else {
+                                Text(startedAt, style: .timer)
+                                    .font(.system(size: 22, weight: .semibold, design: .rounded))
+                                    .monospacedDigit()
+                                    .accessibilityLabel("Elapsed recording time")
+                                    .accessibilityValue(Text(startedAt, style: .timer))
+                            }
+                        } else {
+                            Text("Tap to Record")
+                                .font(.system(size: 16, weight: .medium))
+                        }
+                    }
+                    .foregroundColor(.white)
+
+                    Spacer()
+                        .frame(height: 20)
                 }
             }
         }
+        .task(id: viewModel.recordingStartedAt) {
+            guard viewModel.isRecording, let startedAt = viewModel.recordingStartedAt else {
+                showsRecordingAnimation = false
+                return
+            }
+
+            let remaining = RecordingPresentation.animationTimeRemaining(startedAt: startedAt, now: Date())
+            showsRecordingAnimation = remaining > 0
+            guard remaining > 0 else { return }
+
+            do {
+                try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            } catch {
+                return
+            }
+
+            guard viewModel.isRecording, viewModel.recordingStartedAt == startedAt else { return }
+            showsRecordingAnimation = false
+        }
+    }
+}
+
+private struct RecordingRippleView: View {
+    @State private var rippleScale: CGFloat = 1
+    @State private var rippleOpacity: Double = 0.8
+
+    var body: some View {
+        ZStack {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .stroke(Color.white.opacity(0.3), lineWidth: 2)
+                    .frame(width: 100, height: 100)
+                    .scaleEffect(rippleScale)
+                    .opacity(rippleOpacity)
+                    .animation(
+                        .easeOut(duration: 1.5)
+                            .repeatForever(autoreverses: false)
+                            .delay(Double(index) * 0.3),
+                        value: rippleScale
+                    )
+            }
+        }
         .onAppear {
-            if viewModel.isRecording {
-                startRippleAnimation()
-            }
-        }
-        .onChange(of: viewModel.isRecording) { isRecording in
-            if isRecording {
-                startRippleAnimation()
-            } else {
-                stopRippleAnimation()
-            }
-        }
-    }
-    
-    private func startRippleAnimation() {
-        rippleScale = 1.0
-        rippleOpacity = 0.8
-        withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
             rippleScale = 2.5
-            rippleOpacity = 0.0
+            rippleOpacity = 0
         }
-    }
-    
-    private func stopRippleAnimation() {
-        rippleScale = 1.0
-        rippleOpacity = 0.0
     }
 }
 

--- a/app/ios/omiWatchApp/Localizable.xcstrings
+++ b/app/ios/omiWatchApp/Localizable.xcstrings
@@ -1,0 +1,74 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "watch.accessibility.elapsedRecordingTime" : {
+      "comment" : "VoiceOver label for the elapsed recording timer.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elapsed recording time"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録音経過時間"
+          }
+        }
+      }
+    },
+    "watch.accessibility.recordingInProgress" : {
+      "comment" : "VoiceOver label while the initial recording animation is visible.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recording in progress"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録音中"
+          }
+        }
+      }
+    },
+    "watch.accessibility.startRecording" : {
+      "comment" : "VoiceOver label for the button that starts an Apple Watch recording.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start recording"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録音を開始"
+          }
+        }
+      }
+    },
+    "watch.accessibility.stopRecording" : {
+      "comment" : "VoiceOver label for the button that stops an Apple Watch recording.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop recording"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録音を停止"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/app/ios/omiWatchApp/RecordingPresentation.swift
+++ b/app/ios/omiWatchApp/RecordingPresentation.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 struct RecordingPresentation {
@@ -9,5 +10,63 @@ struct RecordingPresentation {
 
     static func elapsedTime(startedAt: Date, now: Date) -> TimeInterval {
         max(0, now.timeIntervalSince(startedAt))
+    }
+}
+
+enum RecordingPresentationPhase: Equatable {
+    case idle
+    case animating
+    case elapsedTimer
+
+    var showsRecordingRipple: Bool {
+        self == .animating
+    }
+}
+
+@MainActor
+final class RecordingPresentationController: ObservableObject {
+    typealias Now = () -> Date
+    typealias Sleep = (TimeInterval) async throws -> Void
+
+    @Published private(set) var phase: RecordingPresentationPhase = .idle
+
+    private let now: Now
+    private let sleep: Sleep
+    private var activeStartDate: Date?
+
+    init(
+        now: @escaping Now = Date.init,
+        sleep: @escaping Sleep = { duration in
+            try await Task<Never, Never>.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+        }
+    ) {
+        self.now = now
+        self.sleep = sleep
+    }
+
+    func update(isRecording: Bool, startedAt: Date?) async {
+        activeStartDate = startedAt
+
+        guard isRecording, let startedAt else {
+            phase = .idle
+            return
+        }
+
+        let remaining = RecordingPresentation.animationTimeRemaining(startedAt: startedAt, now: now())
+        guard remaining > 0 else {
+            phase = .elapsedTimer
+            return
+        }
+
+        phase = .animating
+
+        do {
+            try await sleep(remaining)
+        } catch {
+            return
+        }
+
+        guard !Task.isCancelled, activeStartDate == startedAt else { return }
+        phase = .elapsedTimer
     }
 }

--- a/app/ios/omiWatchApp/RecordingPresentation.swift
+++ b/app/ios/omiWatchApp/RecordingPresentation.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct RecordingPresentation {
+    static let animationDuration: TimeInterval = 5
+
+    static func animationTimeRemaining(startedAt: Date, now: Date) -> TimeInterval {
+        max(0, animationDuration - elapsedTime(startedAt: startedAt, now: now))
+    }
+
+    static func elapsedTime(startedAt: Date, now: Date) -> TimeInterval {
+        max(0, now.timeIntervalSince(startedAt))
+    }
+}

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -1,9 +1,10 @@
 import Foundation
+import Combine
 import WatchConnectivity
 import AVFoundation
 
 @MainActor
-class WatchAudioRecorderViewModel: NSObject, ObservableObject {
+class WatchAudioRecorderViewModel: NSObject, WatchRecorderControlling {
     @Published var isRecording: Bool = false
     @Published private(set) var recordingStartedAt: Date?
 
@@ -385,4 +386,3 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
         }
     }
 }
-

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -5,6 +5,7 @@ import AVFoundation
 @MainActor
 class WatchAudioRecorderViewModel: NSObject, ObservableObject {
     @Published var isRecording: Bool = false
+    @Published private(set) var recordingStartedAt: Date?
 
     var session: WCSession
     private var audioEngine: AVAudioEngine?
@@ -45,6 +46,7 @@ class WatchAudioRecorderViewModel: NSObject, ObservableObject {
 
             if success {
                 self.setupAudioStreaming()
+                self.recordingStartedAt = Date()
                 self.isRecording = true
                 self.session.sendMessage(["method": "startRecording"], replyHandler: nil)
             } else {
@@ -59,6 +61,7 @@ class WatchAudioRecorderViewModel: NSObject, ObservableObject {
         }
 
         isRecording = false
+        recordingStartedAt = nil
         isStreaming = false
 
         // Stop audio streaming
@@ -382,5 +385,4 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
         }
     }
 }
-
 

--- a/app/ios/omiWatchApp/WatchRecorderControlling.swift
+++ b/app/ios/omiWatchApp/WatchRecorderControlling.swift
@@ -1,0 +1,11 @@
+import Combine
+import Foundation
+
+@MainActor
+protocol WatchRecorderControlling: ObservableObject {
+    var isRecording: Bool { get }
+    var recordingStartedAt: Date? { get }
+
+    func startRecording()
+    func stopRecording()
+}

--- a/app/ios/omiWatchApp/omiwatchApp.swift
+++ b/app/ios/omiWatchApp/omiwatchApp.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 @main
 struct omiwatch_Watch_AppApp: App {
+    @StateObject private var viewModel = WatchAudioRecorderViewModel()
+
     var body: some Scene {
         WindowGroup {
-            WatchRecorderView(viewModel: WatchAudioRecorderViewModel())
+            WatchRecorderView(viewModel: viewModel)
         }
     }
 }

--- a/app/ios/test/watch_recording_presentation_test.rb
+++ b/app/ios/test/watch_recording_presentation_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'minitest/autorun'
+require 'open3'
+require 'tmpdir'
+
+class WatchRecordingPresentationTest < Minitest::Test
+  IOS_ROOT = File.expand_path('..', __dir__)
+  PRODUCTION_SOURCE = File.join(IOS_ROOT, 'omiWatchApp', 'RecordingPresentation.swift')
+  CONTENT_VIEW_SOURCE = File.join(IOS_ROOT, 'omiWatchApp', 'ContentView.swift')
+  APP_SOURCE = File.join(IOS_ROOT, 'omiWatchApp', 'omiwatchApp.swift')
+
+  def test_animation_boundary_and_elapsed_time_use_the_original_recording_start
+    Dir.mktmpdir('watch-recording-presentation') do |directory|
+      harness = File.join(directory, 'main.swift')
+      binary = File.join(directory, 'watch-recording-presentation-test')
+      File.write(harness, <<~SWIFT)
+        import Foundation
+
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        precondition(
+            RecordingPresentation.animationTimeRemaining(
+                startedAt: startedAt,
+                now: startedAt.addingTimeInterval(4.999)
+            ) > 0
+        )
+        precondition(
+            RecordingPresentation.animationTimeRemaining(
+                startedAt: startedAt,
+                now: startedAt.addingTimeInterval(5)
+            ) == 0
+        )
+        precondition(
+            RecordingPresentation.animationTimeRemaining(
+                startedAt: startedAt,
+                now: startedAt.addingTimeInterval(3_661)
+            ) == 0
+        )
+        precondition(
+            RecordingPresentation.elapsedTime(
+                startedAt: startedAt,
+                now: startedAt.addingTimeInterval(3_661)
+            ) == 3_661
+        )
+        precondition(
+            RecordingPresentation.elapsedTime(
+                startedAt: startedAt,
+                now: startedAt.addingTimeInterval(-1)
+            ) == 0
+        )
+      SWIFT
+
+      stdout, stderr, compile_status = Open3.capture3(
+        'swiftc',
+        PRODUCTION_SOURCE,
+        harness,
+        '-o',
+        binary,
+      )
+      assert compile_status.success?, "swiftc failed:\n#{stdout}\n#{stderr}"
+
+      stdout, stderr, run_status = Open3.capture3(binary)
+      assert run_status.success?, "timing assertions failed:\n#{stdout}\n#{stderr}"
+    end
+  end
+
+  def test_static_timer_view_typechecks_with_the_production_timing_model
+    Dir.mktmpdir('watch-recording-view') do |directory|
+      view_model_stub = File.join(directory, 'WatchAudioRecorderViewModel.swift')
+      File.write(view_model_stub, <<~SWIFT)
+        import Combine
+        import Foundation
+
+        @MainActor
+        final class WatchAudioRecorderViewModel: ObservableObject {
+            @Published var isRecording = false
+            @Published private(set) var recordingStartedAt: Date?
+
+            func startRecording() {}
+            func stopRecording() {}
+        }
+      SWIFT
+
+      stdout, stderr, status = Open3.capture3(
+        'swiftc',
+        '-parse-as-library',
+        '-typecheck',
+        PRODUCTION_SOURCE,
+        view_model_stub,
+        CONTENT_VIEW_SOURCE,
+        APP_SOURCE,
+      )
+      assert status.success?, "watch recording view failed to typecheck:\n#{stdout}\n#{stderr}"
+    end
+  end
+end

--- a/app/ios/test/watch_recording_presentation_test.rb
+++ b/app/ios/test/watch_recording_presentation_test.rb
@@ -1,82 +1,116 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require 'json'
 require 'minitest/autorun'
 require 'open3'
 require 'tmpdir'
 
 class WatchRecordingPresentationTest < Minitest::Test
   IOS_ROOT = File.expand_path('..', __dir__)
-  PRODUCTION_SOURCE = File.join(IOS_ROOT, 'omiWatchApp', 'RecordingPresentation.swift')
-  CONTENT_VIEW_SOURCE = File.join(IOS_ROOT, 'omiWatchApp', 'ContentView.swift')
-  APP_SOURCE = File.join(IOS_ROOT, 'omiWatchApp', 'omiwatchApp.swift')
+  WATCH_ROOT = File.join(IOS_ROOT, 'omiWatchApp')
+  PRESENTATION_SOURCE = File.join(WATCH_ROOT, 'RecordingPresentation.swift')
+  RECORDER_CONTRACT_SOURCE = File.join(WATCH_ROOT, 'WatchRecorderControlling.swift')
+  VIEW_MODEL_SOURCE = File.join(WATCH_ROOT, 'WatchAudioRecorderViewModel.swift')
+  CONTENT_VIEW_SOURCE = File.join(WATCH_ROOT, 'ContentView.swift')
+  LOCALIZATION_CATALOG = File.join(WATCH_ROOT, 'Localizable.xcstrings')
+  PROJECT_FILE = File.join(IOS_ROOT, 'Runner.xcodeproj', 'project.pbxproj')
 
-  def test_animation_boundary_and_elapsed_time_use_the_original_recording_start
+  ACCESSIBILITY_KEYS = %w[
+    watch.accessibility.elapsedRecordingTime
+    watch.accessibility.recordingInProgress
+    watch.accessibility.startRecording
+    watch.accessibility.stopRecording
+  ].freeze
+
+  def test_actual_presentation_controller_removes_the_ripple_after_five_seconds
     Dir.mktmpdir('watch-recording-presentation') do |directory|
       harness = File.join(directory, 'main.swift')
       binary = File.join(directory, 'watch-recording-presentation-test')
       File.write(harness, <<~SWIFT)
         import Foundation
 
-        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+        @MainActor
+        final class ControlledSleeper {
+            private(set) var requestedDuration: TimeInterval?
+            private var continuation: CheckedContinuation<Void, Never>?
 
-        precondition(
-            RecordingPresentation.animationTimeRemaining(
-                startedAt: startedAt,
-                now: startedAt.addingTimeInterval(4.999)
-            ) > 0
-        )
-        precondition(
-            RecordingPresentation.animationTimeRemaining(
-                startedAt: startedAt,
-                now: startedAt.addingTimeInterval(5)
-            ) == 0
-        )
-        precondition(
-            RecordingPresentation.animationTimeRemaining(
-                startedAt: startedAt,
-                now: startedAt.addingTimeInterval(3_661)
-            ) == 0
-        )
-        precondition(
-            RecordingPresentation.elapsedTime(
-                startedAt: startedAt,
-                now: startedAt.addingTimeInterval(3_661)
-            ) == 3_661
-        )
-        precondition(
-            RecordingPresentation.elapsedTime(
-                startedAt: startedAt,
-                now: startedAt.addingTimeInterval(-1)
-            ) == 0
-        )
+            var isWaiting: Bool { continuation != nil }
+
+            func sleep(for duration: TimeInterval) async throws {
+                requestedDuration = duration
+                await withCheckedContinuation { continuation = $0 }
+            }
+
+            func resume() {
+                continuation?.resume()
+                continuation = nil
+            }
+        }
+
+        @main
+        struct RecordingPresentationTestHarness {
+            @MainActor
+            static func main() async {
+                let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+                let sleeper = ControlledSleeper()
+                let controller = RecordingPresentationController(
+                    now: { startedAt },
+                    sleep: { duration in try await sleeper.sleep(for: duration) }
+                )
+
+                let transition = Task { @MainActor in
+                    await controller.update(isRecording: true, startedAt: startedAt)
+                }
+
+                while !sleeper.isWaiting {
+                    await Task.yield()
+                }
+
+                precondition(controller.phase == .animating)
+                precondition(controller.phase.showsRecordingRipple)
+                precondition(sleeper.requestedDuration == 5)
+
+                sleeper.resume()
+                await transition.value
+
+                precondition(controller.phase == .elapsedTimer)
+                precondition(!controller.phase.showsRecordingRipple)
+                precondition(
+                    RecordingPresentation.elapsedTime(
+                        startedAt: startedAt,
+                        now: startedAt.addingTimeInterval(3_661)
+                    ) == 3_661
+                )
+
+                let resumedController = RecordingPresentationController(
+                    now: { startedAt.addingTimeInterval(6) },
+                    sleep: { _ in preconditionFailure("an elapsed recording must not restart the animation") }
+                )
+                await resumedController.update(isRecording: true, startedAt: startedAt)
+                precondition(resumedController.phase == .elapsedTimer)
+                precondition(!resumedController.phase.showsRecordingRipple)
+
+                await resumedController.update(isRecording: false, startedAt: nil)
+                precondition(resumedController.phase == .idle)
+            }
+        }
       SWIFT
 
-      stdout, stderr, compile_status = Open3.capture3(
-        'swiftc',
-        PRODUCTION_SOURCE,
-        harness,
-        '-o',
-        binary,
-      )
-      assert compile_status.success?, "swiftc failed:\n#{stdout}\n#{stderr}"
-
-      stdout, stderr, run_status = Open3.capture3(binary)
-      assert run_status.success?, "timing assertions failed:\n#{stdout}\n#{stderr}"
+      compile_and_run(PRESENTATION_SOURCE, harness, binary: binary)
     end
   end
 
-  def test_static_timer_view_typechecks_with_the_production_timing_model
+  def test_view_typechecks_against_the_shared_production_recorder_contract
     Dir.mktmpdir('watch-recording-view') do |directory|
-      view_model_stub = File.join(directory, 'WatchAudioRecorderViewModel.swift')
-      File.write(view_model_stub, <<~SWIFT)
+      test_recorder = File.join(directory, 'TestWatchRecorder.swift')
+      File.write(test_recorder, <<~SWIFT)
         import Combine
         import Foundation
 
         @MainActor
-        final class WatchAudioRecorderViewModel: ObservableObject {
+        final class TestWatchRecorder: WatchRecorderControlling {
             @Published var isRecording = false
-            @Published private(set) var recordingStartedAt: Date?
+            @Published var recordingStartedAt: Date?
 
             func startRecording() {}
             func stopRecording() {}
@@ -87,12 +121,66 @@ class WatchRecordingPresentationTest < Minitest::Test
         'swiftc',
         '-parse-as-library',
         '-typecheck',
-        PRODUCTION_SOURCE,
-        view_model_stub,
+        RECORDER_CONTRACT_SOURCE,
+        PRESENTATION_SOURCE,
+        test_recorder,
         CONTENT_VIEW_SOURCE,
-        APP_SOURCE,
       )
       assert status.success?, "watch recording view failed to typecheck:\n#{stdout}\n#{stderr}"
+    end
+  end
+
+  def test_real_view_model_is_bound_to_the_shared_production_contract
+    source = File.binread(VIEW_MODEL_SOURCE)
+
+    assert_match(
+      /class\s+WatchAudioRecorderViewModel\s*:\s*NSObject\s*,\s*WatchRecorderControlling/,
+      source,
+      'the real watch recorder must conform to the same compiler-checked contract used by the view',
+    )
+  end
+
+  def test_accessibility_catalog_covers_every_native_project_locale
+    catalog = JSON.parse(File.binread(LOCALIZATION_CATALOG))
+    strings = catalog.fetch('strings')
+    content_view = File.binread(CONTENT_VIEW_SOURCE)
+    native_locales = native_project_locales
+
+    ACCESSIBILITY_KEYS.each do |key|
+      assert_includes content_view, %("#{key}")
+      localizations = strings.fetch(key).fetch('localizations')
+
+      native_locales.each do |locale|
+        value = localizations.fetch(locale).fetch('stringUnit').fetch('value')
+        refute_empty value, "#{key} must have a #{locale} translation"
+      end
+    end
+  end
+
+  private
+
+  def compile_and_run(*sources, binary:)
+    stdout, stderr, compile_status = Open3.capture3(
+      'swiftc',
+      '-parse-as-library',
+      *sources,
+      '-o',
+      binary,
+    )
+    assert compile_status.success?, "swiftc failed:\n#{stdout}\n#{stderr}"
+
+    stdout, stderr, run_status = Open3.capture3(binary)
+    assert run_status.success?, "timing assertions failed:\n#{stdout}\n#{stderr}"
+  end
+
+  def native_project_locales
+    project = File.binread(PROJECT_FILE)
+    block = project.match(/knownRegions = \((.*?)\);/m)&.captures&.first
+    refute_nil block, 'Xcode project must declare knownRegions'
+
+    block.lines.filter_map do |line|
+      locale = line.match(/^\s*"?([A-Za-z][A-Za-z0-9_-]*)"?,\s*$/)&.captures&.first
+      locale unless locale == 'Base'
     end
   end
 end


### PR DESCRIPTION
## Summary

- Preserve the Apple Watch recording start timestamp in the long-lived recorder view model.
- Drive the five-second ripple-to-static-logo transition through an injectable presentation controller, while keeping the elapsed timer tied to the original recording start.
- Compile the real recorder against a shared production protocol so the watch view/type guard cannot silently drift from `WatchAudioRecorderViewModel`.
- Localize the new accessibility labels in English and Japanese, matching every native watch region declared by the Xcode project.

## Verification

- `ruby app/ios/test/watch_recording_presentation_test.rb` — 4 runs, 30 assertions, 0 failures or errors. The controlled sleeper proves the actual view phase shows the ripple before five seconds and removes it after release at the threshold.
- `python3 .github/scripts/run_checks.py --lane local --platform macos --check-id watch-recording-presentation --skip-pr-body-checks` — focused manifest check passed.
- `python3 .github/scripts/test_run_checks.py` — 40 tests passed.
- `make preflight` — all 81 selected repository checks passed.
- `git diff --check` — passed.
- `xcodebuild -project app/ios/Runner.xcodeproj -scheme omiWatchApp -configuration Debug -destination 'generic/platform=watchOS' CODE_SIGNING_ALLOWED=NO build` — not runnable on this host because Xcode reports that the watchOS 26.5 platform is not installed.

The real watchOS target could not be built or exercised on this host because the required watchOS SDK/runtime is absent. The macOS-focused check compiles the production presentation controller and SwiftUI view boundary, runs the deterministic transition, verifies real view-model protocol conformance, and validates localization coverage for every Xcode-native watch region.

## Product invariants

None.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
