### PR TITLE
fix(app): keep live transcript at useful bottom

### DIFF
--- a/.github/failure-classes/FC-single-input-device-release.json
+++ b/.github/failure-classes/FC-single-input-device-release.json
@@ -3,6 +3,9 @@
   "id": "FC-single-input-device-release",
   "violated_contract": "A viewport that auto-follows live content must release that follow on the reader's navigation intent from every input path the platform can deliver (wheel, scrollbar, keyboard, touch), not from one device's event type.",
   "canonical_prevention": "Decide follow/release from the resulting scroll POSITION and its direction, which every input path produces identically, rather than from a device-specific event; keep that decision in one shared surface so no copy of it can drift.",
+  "canonical_prevention_artifact": [
+    "app/test/widgets/transcript_test.dart"
+  ],
   "evidence_prs": [
     10515,
     10562

--- a/app/lib/pages/capture/widgets/widgets.dart
+++ b/app/lib/pages/capture/widgets/widgets.dart
@@ -211,6 +211,10 @@ getTranscriptWidget(
   VoidCallback? onTapWhenSearchEmpty,
   Function(TranscriptSegment)? onSegmentTap,
   Function(int)? onEditSegmentText,
+  Key? transcriptKey,
+  bool followLatest = false,
+  TranscriptScrollState? scrollState,
+  double jumpToLatestButtonBottom = 16,
 }) {
   if (conversationCreating) {
     return const Padding(
@@ -228,6 +232,7 @@ getTranscriptWidget(
 
   Widget buildTranscriptSegments() {
     return TranscriptWidget(
+      key: transcriptKey,
       segments: segments,
       horizontalMargin: horizontalMargin,
       topMargin: topMargin,
@@ -243,6 +248,9 @@ getTranscriptWidget(
       onTapWhenSearchEmpty: onTapWhenSearchEmpty,
       onSegmentTap: onSegmentTap,
       onEditSegmentText: onEditSegmentText,
+      followLatest: followLatest,
+      scrollState: scrollState,
+      jumpToLatestButtonBottom: jumpToLatestButtonBottom,
     );
   }
 

--- a/app/lib/pages/capture/widgets/widgets.dart
+++ b/app/lib/pages/capture/widgets/widgets.dart
@@ -215,6 +215,11 @@ getTranscriptWidget(
   bool followLatest = false,
   TranscriptScrollState? scrollState,
   double jumpToLatestButtonBottom = 16,
+  int contentVersion = 0,
+  String layoutIdentity = 'transcript',
+  List<Widget> leadingItems = const [],
+  List<String> leadingItemIds = const [],
+  TranscriptSegmentBuilder? segmentBuilder,
 }) {
   if (conversationCreating) {
     return const Padding(
@@ -251,6 +256,11 @@ getTranscriptWidget(
       followLatest: followLatest,
       scrollState: scrollState,
       jumpToLatestButtonBottom: jumpToLatestButtonBottom,
+      contentVersion: contentVersion,
+      layoutIdentity: layoutIdentity,
+      leadingItems: leadingItems,
+      leadingItemIds: leadingItemIds,
+      segmentBuilder: segmentBuilder,
     );
   }
 

--- a/app/lib/pages/conversation_capturing/page.dart
+++ b/app/lib/pages/conversation_capturing/page.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter/services.dart';
 
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -42,14 +41,6 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   late bool showSummarizeConfirmation;
   late AnimationController _animationController;
   bool _isMuted = false;
-  final ScrollController _timelineScrollController = ScrollController();
-  TranscriptScrollState? _activeTimelineScrollState;
-  String? _timelineSessionId;
-  bool _timelinePositionRestored = false;
-  bool _isTimelineAutoScrolling = false;
-  bool _timelineUserInterruptedAutoScroll = false;
-  bool _isTimelineAtBottom = true;
-  int _previousTimelineItemCount = 0;
 
   @override
   void initState() {
@@ -58,7 +49,6 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
     showSummarizeConfirmation = SharedPreferencesUtil().showSummarizeConfirmation;
     _animationController = AnimationController(vsync: this, duration: const Duration(milliseconds: 1000))
       ..repeat(reverse: true);
-    _timelineScrollController.addListener(_onTimelineScroll);
     super.initState();
   }
 
@@ -68,64 +58,6 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
       _preservedTranscriptScrollState = TranscriptScrollState();
     }
     return _preservedTranscriptScrollState;
-  }
-
-  void _onTimelineScroll() {
-    if (!_timelineScrollController.hasClients) return;
-
-    final offset = _timelineScrollController.offset;
-    final isAtBottom = _timelineScrollController.position.maxScrollExtent - offset <= 24;
-    if (!_isTimelineAutoScrolling) {
-      _activeTimelineScrollState?.update(offset: offset, isAtBottom: isAtBottom);
-    }
-    if (_isTimelineAtBottom != isAtBottom && mounted) {
-      setState(() => _isTimelineAtBottom = isAtBottom);
-    }
-  }
-
-  Future<void> _scrollTimelineToBottom({bool animated = true}) async {
-    if (!_timelineScrollController.hasClients || _isTimelineAutoScrolling) return;
-
-    _isTimelineAutoScrolling = true;
-    _timelineUserInterruptedAutoScroll = false;
-    var firstPass = true;
-    for (var attempt = 0; attempt < 20; attempt++) {
-      final target = _timelineScrollController.position.maxScrollExtent;
-      if (animated) {
-        await _timelineScrollController.animateTo(
-          target,
-          duration: Duration(milliseconds: firstPass ? 500 : 100),
-          curve: Curves.easeInOut,
-        );
-      } else {
-        _timelineScrollController.jumpTo(target);
-      }
-      firstPass = false;
-
-      if (_timelineUserInterruptedAutoScroll) return;
-      await WidgetsBinding.instance.endOfFrame;
-      if (!mounted || !_timelineScrollController.hasClients || _timelineUserInterruptedAutoScroll) return;
-
-      final remaining = _timelineScrollController.position.maxScrollExtent - _timelineScrollController.offset;
-      if (remaining.abs() <= 0.5) break;
-    }
-
-    if (!mounted || !_timelineScrollController.hasClients) return;
-    final target = _timelineScrollController.position.maxScrollExtent;
-    if ((target - _timelineScrollController.offset).abs() > 0.5) {
-      _timelineScrollController.jumpTo(target);
-    }
-    _isTimelineAutoScrolling = false;
-    _activeTimelineScrollState?.update(offset: target, isAtBottom: true);
-    if (!_isTimelineAtBottom) setState(() => _isTimelineAtBottom = true);
-  }
-
-  bool _onTimelineUserScroll(UserScrollNotification notification) {
-    if (_isTimelineAutoScrolling && notification.direction != ScrollDirection.idle) {
-      _timelineUserInterruptedAutoScroll = true;
-      _isTimelineAutoScrolling = false;
-    }
-    return false;
   }
 
   Future<void> _toggleMute(CaptureProvider provider) async {
@@ -168,8 +100,6 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   void dispose() {
     _controller?.dispose();
     _animationController.dispose();
-    _timelineScrollController.removeListener(_onTimelineScroll);
-    _timelineScrollController.dispose();
     super.dispose();
   }
 
@@ -257,8 +187,9 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
     return Consumer2<CaptureProvider, DeviceProvider>(
       builder: (context, provider, deviceProvider, child) {
         final effectivelyMuted = _isMuted || provider.isCallActive;
-        final transcriptSessionId = provider.segments.isEmpty ? null : provider.segments.first.id;
-        final transcriptScrollState = transcriptSessionId == null ? null : _scrollStateFor(transcriptSessionId);
+        final transcriptSessionId =
+            provider.activeCaptureSessionId ?? widget.topConversationId ?? 'pending-live-capture';
+        final transcriptScrollState = _scrollStateFor(transcriptSessionId);
         return PopScope(
           canPop: true,
           child: Scaffold(
@@ -320,7 +251,11 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                                       ),
                                     )
                                   : provider.photos.isNotEmpty
-                                      ? _buildChronologicalTimeline(provider)
+                                      ? _buildChronologicalTimeline(
+                                          provider,
+                                          transcriptSessionId,
+                                          transcriptScrollState,
+                                        )
                                       : getTranscriptWidget(
                                           false,
                                           provider.segments,
@@ -333,6 +268,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                                           followLatest: true,
                                           scrollState: transcriptScrollState,
                                           jumpToLatestButtonBottom: MediaQuery.paddingOf(context).bottom + 84,
+                                          contentVersion: provider.segmentsPhotosVersion,
                                           onAcceptSuggestion: (suggestion) {
                                             provider.assignSpeakerToConversation(
                                               suggestion.speakerId,
@@ -473,7 +409,11 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   }
 
   /// Builds a chronological timeline interleaving photo groups and transcript segments.
-  Widget _buildChronologicalTimeline(CaptureProvider provider) {
+  Widget _buildChronologicalTimeline(
+    CaptureProvider provider,
+    String sessionId,
+    TranscriptScrollState scrollState,
+  ) {
     final photos = List<ConversationPhoto>.from(provider.photos)..sort((a, b) => a.createdAt.compareTo(b.createdAt));
     final segments = provider.segments;
 
@@ -492,89 +432,30 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
       photoGroups.add(currentGroup);
     }
 
-    final totalItems = photoGroups.length + segments.length;
-    final sessionId =
-        segments.isNotEmpty ? segments.first.id : 'photos-${photos.first.createdAt.microsecondsSinceEpoch}';
-    final scrollState = _scrollStateFor(sessionId);
-    if (_timelineSessionId != sessionId) {
-      _timelineSessionId = sessionId;
-      _timelinePositionRestored = false;
-      _previousTimelineItemCount = 0;
-      _isTimelineAtBottom = !scrollState.hasPosition || scrollState.isAtBottom;
-    }
-    _activeTimelineScrollState = scrollState;
-
-    final contentChanged = totalItems != _previousTimelineItemCount;
-    _previousTimelineItemCount = totalItems;
-    if (!_timelinePositionRestored || (contentChanged && scrollState.isAtBottom)) {
-      _timelinePositionRestored = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || !_timelineScrollController.hasClients) return;
-
-        final maxExtent = _timelineScrollController.position.maxScrollExtent;
-        final shouldRestore = scrollState.hasPosition && !scrollState.isAtBottom;
-        if (shouldRestore) {
-          final target = scrollState.offset.clamp(0.0, maxExtent);
-          _isTimelineAutoScrolling = true;
-          _timelineScrollController.jumpTo(target);
-          _isTimelineAutoScrolling = false;
-          final isAtBottom = maxExtent - target <= 24;
-          scrollState.update(offset: target, isAtBottom: isAtBottom);
-          if (_isTimelineAtBottom != isAtBottom) setState(() => _isTimelineAtBottom = isAtBottom);
-        } else {
-          _scrollTimelineToBottom(animated: false);
-        }
-      });
-    }
-
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: NotificationListener<UserScrollNotification>(
-            onNotification: _onTimelineUserScroll,
-            child: ListView.builder(
-              controller: _timelineScrollController,
-              padding: const EdgeInsets.only(top: 16, bottom: 120),
-              itemCount: totalItems,
-              itemBuilder: (context, index) {
-                // Show photo groups first, then transcript below
-                if (index < photoGroups.length) {
-                  return _buildPhotoGroupTimelineItem(photoGroups[index], photos);
-                }
-                final segIndex = index - photoGroups.length;
-                if (segIndex >= segments.length) return const SizedBox.shrink();
-                return _buildTranscriptTimelineItem(segments[segIndex], provider);
-              },
-            ),
-          ),
+    final leadingItems = [
+      for (var index = 0; index < photoGroups.length; index++)
+        Padding(
+          padding: EdgeInsets.only(top: index == 0 ? 16 : 0),
+          child: _buildPhotoGroupTimelineItem(photoGroups[index], photos),
         ),
-        PositionedDirectional(
-          end: 16,
-          bottom: MediaQuery.paddingOf(context).bottom + 84,
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 180),
-            transitionBuilder: (child, animation) => FadeTransition(
-              opacity: animation,
-              child: ScaleTransition(scale: animation, child: child),
-            ),
-            child: _isTimelineAtBottom
-                ? const SizedBox.shrink(key: ValueKey('timeline_jump_to_latest_hidden'))
-                : Semantics(
-                    button: true,
-                    label: context.l10n.jumpToLatestMessage,
-                    child: FloatingActionButton.small(
-                      key: const ValueKey('timeline_jump_to_latest'),
-                      heroTag: null,
-                      tooltip: context.l10n.jumpToLatestMessage,
-                      backgroundColor: const Color(0xFF35343B),
-                      foregroundColor: Colors.white,
-                      onPressed: () => _scrollTimelineToBottom(),
-                      child: const Icon(Icons.keyboard_arrow_down_rounded),
-                    ),
-                  ),
-          ),
-        ),
-      ],
+    ];
+
+    return TranscriptWidget(
+      key: ValueKey('live-transcript-$sessionId'),
+      segments: segments,
+      horizontalMargin: false,
+      topMargin: false,
+      separator: false,
+      canDisplaySeconds: false,
+      bottomMargin: 0,
+      followLatest: true,
+      scrollState: scrollState,
+      jumpToLatestButtonBottom: MediaQuery.paddingOf(context).bottom + 84,
+      contentVersion: provider.segmentsPhotosVersion,
+      layoutIdentity: 'photo-timeline',
+      leadingItems: leadingItems,
+      leadingItemIds: photoGroups.map((group) => group.first.id).toList(),
+      segmentBuilder: (context, segment, index) => _buildTranscriptTimelineItem(segment, provider),
     );
   }
 

--- a/app/lib/pages/conversation_capturing/page.dart
+++ b/app/lib/pages/conversation_capturing/page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter/services.dart';
 
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -21,6 +22,7 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/widgets/confirmation_dialog.dart';
 import 'package:omi/widgets/photo_viewer_page.dart';
+import 'package:omi/widgets/transcript.dart';
 
 class ConversationCapturingPage extends StatefulWidget {
   final String? topConversationId;
@@ -32,12 +34,22 @@ class ConversationCapturingPage extends StatefulWidget {
 }
 
 class _ConversationCapturingPageState extends State<ConversationCapturingPage> with TickerProviderStateMixin {
+  static String? _preservedTranscriptSessionId;
+  static TranscriptScrollState _preservedTranscriptScrollState = TranscriptScrollState();
+
   final scaffoldKey = GlobalKey<ScaffoldState>();
   TabController? _controller;
   late bool showSummarizeConfirmation;
   late AnimationController _animationController;
   bool _isMuted = false;
   final ScrollController _timelineScrollController = ScrollController();
+  TranscriptScrollState? _activeTimelineScrollState;
+  String? _timelineSessionId;
+  bool _timelinePositionRestored = false;
+  bool _isTimelineAutoScrolling = false;
+  bool _timelineUserInterruptedAutoScroll = false;
+  bool _isTimelineAtBottom = true;
+  int _previousTimelineItemCount = 0;
 
   @override
   void initState() {
@@ -46,7 +58,74 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
     showSummarizeConfirmation = SharedPreferencesUtil().showSummarizeConfirmation;
     _animationController = AnimationController(vsync: this, duration: const Duration(milliseconds: 1000))
       ..repeat(reverse: true);
+    _timelineScrollController.addListener(_onTimelineScroll);
     super.initState();
+  }
+
+  TranscriptScrollState _scrollStateFor(String sessionId) {
+    if (_preservedTranscriptSessionId != sessionId) {
+      _preservedTranscriptSessionId = sessionId;
+      _preservedTranscriptScrollState = TranscriptScrollState();
+    }
+    return _preservedTranscriptScrollState;
+  }
+
+  void _onTimelineScroll() {
+    if (!_timelineScrollController.hasClients) return;
+
+    final offset = _timelineScrollController.offset;
+    final isAtBottom = _timelineScrollController.position.maxScrollExtent - offset <= 24;
+    if (!_isTimelineAutoScrolling) {
+      _activeTimelineScrollState?.update(offset: offset, isAtBottom: isAtBottom);
+    }
+    if (_isTimelineAtBottom != isAtBottom && mounted) {
+      setState(() => _isTimelineAtBottom = isAtBottom);
+    }
+  }
+
+  Future<void> _scrollTimelineToBottom({bool animated = true}) async {
+    if (!_timelineScrollController.hasClients || _isTimelineAutoScrolling) return;
+
+    _isTimelineAutoScrolling = true;
+    _timelineUserInterruptedAutoScroll = false;
+    var firstPass = true;
+    for (var attempt = 0; attempt < 20; attempt++) {
+      final target = _timelineScrollController.position.maxScrollExtent;
+      if (animated) {
+        await _timelineScrollController.animateTo(
+          target,
+          duration: Duration(milliseconds: firstPass ? 500 : 100),
+          curve: Curves.easeInOut,
+        );
+      } else {
+        _timelineScrollController.jumpTo(target);
+      }
+      firstPass = false;
+
+      if (_timelineUserInterruptedAutoScroll) return;
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted || !_timelineScrollController.hasClients || _timelineUserInterruptedAutoScroll) return;
+
+      final remaining = _timelineScrollController.position.maxScrollExtent - _timelineScrollController.offset;
+      if (remaining.abs() <= 0.5) break;
+    }
+
+    if (!mounted || !_timelineScrollController.hasClients) return;
+    final target = _timelineScrollController.position.maxScrollExtent;
+    if ((target - _timelineScrollController.offset).abs() > 0.5) {
+      _timelineScrollController.jumpTo(target);
+    }
+    _isTimelineAutoScrolling = false;
+    _activeTimelineScrollState?.update(offset: target, isAtBottom: true);
+    if (!_isTimelineAtBottom) setState(() => _isTimelineAtBottom = true);
+  }
+
+  bool _onTimelineUserScroll(UserScrollNotification notification) {
+    if (_isTimelineAutoScrolling && notification.direction != ScrollDirection.idle) {
+      _timelineUserInterruptedAutoScroll = true;
+      _isTimelineAutoScrolling = false;
+    }
+    return false;
   }
 
   Future<void> _toggleMute(CaptureProvider provider) async {
@@ -89,6 +168,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   void dispose() {
     _controller?.dispose();
     _animationController.dispose();
+    _timelineScrollController.removeListener(_onTimelineScroll);
     _timelineScrollController.dispose();
     super.dispose();
   }
@@ -177,6 +257,8 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
     return Consumer2<CaptureProvider, DeviceProvider>(
       builder: (context, provider, deviceProvider, child) {
         final effectivelyMuted = _isMuted || provider.isCallActive;
+        final transcriptSessionId = provider.segments.isEmpty ? null : provider.segments.first.id;
+        final transcriptScrollState = transcriptSessionId == null ? null : _scrollStateFor(transcriptSessionId);
         return PopScope(
           canPop: true,
           child: Scaffold(
@@ -244,9 +326,13 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                                           provider.segments,
                                           provider.photos,
                                           deviceProvider.connectedDevice,
-                                          bottomMargin: 150,
+                                          bottomMargin: 0,
                                           suggestions: provider.suggestionsBySegmentId,
                                           taggingSegmentIds: provider.taggingSegmentIds,
+                                          transcriptKey: ValueKey('live-transcript-$transcriptSessionId'),
+                                          followLatest: true,
+                                          scrollState: transcriptScrollState,
+                                          jumpToLatestButtonBottom: MediaQuery.paddingOf(context).bottom + 84,
                                           onAcceptSuggestion: (suggestion) {
                                             provider.assignSpeakerToConversation(
                                               suggestion.speakerId,
@@ -407,27 +493,88 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
     }
 
     final totalItems = photoGroups.length + segments.length;
+    final sessionId =
+        segments.isNotEmpty ? segments.first.id : 'photos-${photos.first.createdAt.microsecondsSinceEpoch}';
+    final scrollState = _scrollStateFor(sessionId);
+    if (_timelineSessionId != sessionId) {
+      _timelineSessionId = sessionId;
+      _timelinePositionRestored = false;
+      _previousTimelineItemCount = 0;
+      _isTimelineAtBottom = !scrollState.hasPosition || scrollState.isAtBottom;
+    }
+    _activeTimelineScrollState = scrollState;
 
-    // Auto-scroll to bottom after frame renders
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_timelineScrollController.hasClients) {
-        _timelineScrollController.jumpTo(_timelineScrollController.position.maxScrollExtent);
-      }
-    });
+    final contentChanged = totalItems != _previousTimelineItemCount;
+    _previousTimelineItemCount = totalItems;
+    if (!_timelinePositionRestored || (contentChanged && scrollState.isAtBottom)) {
+      _timelinePositionRestored = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_timelineScrollController.hasClients) return;
 
-    return ListView.builder(
-      controller: _timelineScrollController,
-      padding: const EdgeInsets.only(top: 16, bottom: 180),
-      itemCount: totalItems,
-      itemBuilder: (context, index) {
-        // Show photo groups first, then transcript below
-        if (index < photoGroups.length) {
-          return _buildPhotoGroupTimelineItem(photoGroups[index], photos);
+        final maxExtent = _timelineScrollController.position.maxScrollExtent;
+        final shouldRestore = scrollState.hasPosition && !scrollState.isAtBottom;
+        if (shouldRestore) {
+          final target = scrollState.offset.clamp(0.0, maxExtent);
+          _isTimelineAutoScrolling = true;
+          _timelineScrollController.jumpTo(target);
+          _isTimelineAutoScrolling = false;
+          final isAtBottom = maxExtent - target <= 24;
+          scrollState.update(offset: target, isAtBottom: isAtBottom);
+          if (_isTimelineAtBottom != isAtBottom) setState(() => _isTimelineAtBottom = isAtBottom);
+        } else {
+          _scrollTimelineToBottom(animated: false);
         }
-        final segIndex = index - photoGroups.length;
-        if (segIndex >= segments.length) return const SizedBox.shrink();
-        return _buildTranscriptTimelineItem(segments[segIndex], provider);
-      },
+      });
+    }
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: NotificationListener<UserScrollNotification>(
+            onNotification: _onTimelineUserScroll,
+            child: ListView.builder(
+              controller: _timelineScrollController,
+              padding: const EdgeInsets.only(top: 16, bottom: 120),
+              itemCount: totalItems,
+              itemBuilder: (context, index) {
+                // Show photo groups first, then transcript below
+                if (index < photoGroups.length) {
+                  return _buildPhotoGroupTimelineItem(photoGroups[index], photos);
+                }
+                final segIndex = index - photoGroups.length;
+                if (segIndex >= segments.length) return const SizedBox.shrink();
+                return _buildTranscriptTimelineItem(segments[segIndex], provider);
+              },
+            ),
+          ),
+        ),
+        PositionedDirectional(
+          end: 16,
+          bottom: MediaQuery.paddingOf(context).bottom + 84,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 180),
+            transitionBuilder: (child, animation) => FadeTransition(
+              opacity: animation,
+              child: ScaleTransition(scale: animation, child: child),
+            ),
+            child: _isTimelineAtBottom
+                ? const SizedBox.shrink(key: ValueKey('timeline_jump_to_latest_hidden'))
+                : Semantics(
+                    button: true,
+                    label: context.l10n.jumpToLatestMessage,
+                    child: FloatingActionButton.small(
+                      key: const ValueKey('timeline_jump_to_latest'),
+                      heroTag: null,
+                      tooltip: context.l10n.jumpToLatestMessage,
+                      backgroundColor: const Color(0xFF35343B),
+                      foregroundColor: Colors.white,
+                      onPressed: () => _scrollTimelineToBottom(),
+                      child: const Icon(Icons.keyboard_arrow_down_rounded),
+                    ),
+                  ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -273,6 +273,11 @@ class CaptureController extends ChangeNotifier
   /// Used to scope WAL queries to only this session's audio.
   int _sessionStartSeconds = 0;
 
+  /// Stable identity for the active live-capture session. Unlike a transcript
+  /// segment ID, this does not change when the backend revises or deletes
+  /// segments during the capture.
+  String? get activeCaptureSessionId => _sessionStartSeconds == 0 ? null : 'live-$_sessionStartSeconds';
+
   @visibleForTesting
   set testSessionStartSeconds(int v) => _sessionStartSeconds = v;
 
@@ -1217,6 +1222,7 @@ class CaptureController extends ChangeNotifier
         // Add placeholder to UI for immediate feedback
         photos.add(ConversationPhoto(id: tempId, base64: base64Image, createdAt: DateTime.now()));
         photos = List.from(photos);
+        _segmentsPhotosVersion++;
         notifyListeners();
 
         // Chunking Logic

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter/services.dart';
 
 import 'package:omi/backend/preferences.dart';
@@ -36,6 +37,9 @@ class TranscriptWidget extends StatefulWidget {
   final VoidCallback? onTapWhenSearchEmpty;
   final Function(TranscriptSegment)? onSegmentTap;
   final Function(int segmentIndex)? onEditSegmentText;
+  final bool followLatest;
+  final TranscriptScrollState? scrollState;
+  final double jumpToLatestButtonBottom;
 
   const TranscriptWidget({
     super.key,
@@ -56,10 +60,25 @@ class TranscriptWidget extends StatefulWidget {
     this.onTapWhenSearchEmpty,
     this.onSegmentTap,
     this.onEditSegmentText,
+    this.followLatest = false,
+    this.scrollState,
+    this.jumpToLatestButtonBottom = 16,
   });
 
   @override
   State<TranscriptWidget> createState() => _TranscriptWidgetState();
+}
+
+class TranscriptScrollState {
+  bool hasPosition = false;
+  double offset = 0;
+  bool isAtBottom = true;
+
+  void update({required double offset, required bool isAtBottom}) {
+    hasPosition = true;
+    this.offset = offset;
+    this.isAtBottom = isAtBottom;
+  }
 }
 
 class _TranscriptWidgetState extends State<TranscriptWidget> {
@@ -69,16 +88,18 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   final Map<String, String> _decodedTextCache = {};
 
   // ScrollController to enable proper scrolling
-  final ScrollController _scrollController = ScrollController();
+  late final ScrollController _scrollController;
 
   // Auto-scroll state management
   bool _userHasScrolled = false;
   bool _isAutoScrolling = false;
+  bool _userInterruptedAutoScroll = false;
+  bool _isAtBottom = true;
   int _previousSegmentCount = 0;
 
   // Search result tracking
   List<GlobalKey> _segmentKeys = [];
-  List<GlobalKey> _matchKeys = [];
+  final List<GlobalKey> _matchKeys = [];
   int _previousSearchResultIndex = -1;
 
   Color _getSpeakerBubbleColor(bool isUser, int speakerId, Person? person) {
@@ -116,6 +137,11 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   @override
   void initState() {
     super.initState();
+    final savedState = widget.scrollState;
+    final shouldRestorePosition = savedState?.hasPosition == true && !savedState!.isAtBottom;
+    _scrollController = ScrollController(initialScrollOffset: shouldRestorePosition ? savedState.offset : 0);
+    _userHasScrolled = shouldRestorePosition;
+    _isAtBottom = !shouldRestorePosition;
     _previousSegmentCount = widget.segments.length;
     _initializeSegmentKeys();
     _rebuildMatchKeys();
@@ -126,9 +152,14 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     // Notify parent about scroll controller
     widget.onScrollControllerReady?.call(_scrollController);
 
-    if (widget.segments.isNotEmpty && widget.isConversationDetail) {
+    if (widget.segments.isNotEmpty && (widget.isConversationDetail || widget.followLatest)) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _scrollToBottomGently();
+        if (!mounted) return;
+        if (widget.followLatest && _userHasScrolled) {
+          _syncScrollPosition();
+        } else {
+          _scrollToBottomGently(animated: widget.isConversationDetail);
+        }
       });
     }
   }
@@ -201,42 +232,86 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   }
 
   void _onScroll() {
-    if (_isAutoScrolling) {
-      return;
+    if (!_scrollController.hasClients) return;
+
+    final currentScroll = _scrollController.offset;
+    final distanceFromBottom = _scrollController.position.maxScrollExtent - currentScroll;
+    final isAtBottom = distanceFromBottom <= 24;
+
+    if (!_isAutoScrolling) {
+      _userHasScrolled = !isAtBottom;
+      widget.scrollState?.update(offset: currentScroll, isAtBottom: isAtBottom);
     }
 
-    // Check if user manually scrolled up from the bottom
-    if (_scrollController.hasClients) {
-      final maxScroll = _scrollController.position.maxScrollExtent;
-      final currentScroll = _scrollController.offset;
-      const threshold = 100.0;
-      final distanceFromBottom = maxScroll - currentScroll;
-
-      if (distanceFromBottom > threshold) {
-        _userHasScrolled = true;
-      } else if (distanceFromBottom < 50.0) {
-        _userHasScrolled = false;
-      }
-    }
+    _setIsAtBottom(isAtBottom);
   }
 
-  void _scrollToBottomGently() {
+  void _syncScrollPosition() {
+    if (!_scrollController.hasClients) return;
+
+    final currentScroll = _scrollController.offset;
+    final isAtBottom = _scrollController.position.maxScrollExtent - currentScroll <= 24;
+    _userHasScrolled = !isAtBottom;
+    widget.scrollState?.update(offset: currentScroll, isAtBottom: isAtBottom);
+    _setIsAtBottom(isAtBottom);
+  }
+
+  void _setIsAtBottom(bool value) {
+    if (_isAtBottom == value || !mounted) return;
+    setState(() => _isAtBottom = value);
+  }
+
+  Future<void> _scrollToBottomGently({bool animated = true}) async {
     if (!_scrollController.hasClients) {
       return;
     }
 
-    final maxExtent = _scrollController.position.maxScrollExtent;
-
-    final startOffset = (maxExtent - 30).clamp(0.0, maxExtent);
-
-    _scrollController.jumpTo(startOffset);
-
     _isAutoScrolling = true;
-    _scrollController.animateTo(maxExtent, duration: const Duration(milliseconds: 500), curve: Curves.easeInOut).then((
-      _,
-    ) {
+    _userInterruptedAutoScroll = false;
+    var firstPass = true;
+
+    // ListView.builder refines maxScrollExtent as previously lazy rows are laid
+    // out. Keep following that moving edge so reopening a very long transcript
+    // cannot stop at an early estimate of the bottom.
+    for (var attempt = 0; attempt < 20; attempt++) {
+      final target = _scrollController.position.maxScrollExtent;
+      if (animated) {
+        await _scrollController.animateTo(
+          target,
+          duration: Duration(milliseconds: firstPass ? 500 : 100),
+          curve: Curves.easeInOut,
+        );
+      } else {
+        _scrollController.jumpTo(target);
+      }
+      firstPass = false;
+
+      if (_userInterruptedAutoScroll) return;
+
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted || !_scrollController.hasClients || _userInterruptedAutoScroll) return;
+
+      final remaining = _scrollController.position.maxScrollExtent - _scrollController.offset;
+      if (remaining.abs() <= 0.5) break;
+    }
+
+    if (!mounted || !_scrollController.hasClients) return;
+    final maxExtent = _scrollController.position.maxScrollExtent;
+    if ((maxExtent - _scrollController.offset).abs() > 0.5) {
+      _scrollController.jumpTo(maxExtent);
+    }
+    _isAutoScrolling = false;
+    _userHasScrolled = false;
+    widget.scrollState?.update(offset: maxExtent, isAtBottom: true);
+    _setIsAtBottom(true);
+  }
+
+  bool _onUserScroll(UserScrollNotification notification) {
+    if (_isAutoScrolling && notification.direction != ScrollDirection.idle) {
+      _userInterruptedAutoScroll = true;
       _isAutoScrolling = false;
-    });
+    }
+    return false;
   }
 
   @override
@@ -407,32 +482,70 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   @override
   Widget build(BuildContext context) {
     final searchBarHeight = widget.searchQuery.isNotEmpty ? 100.0 : 0.0;
-
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onTap: () {
-        if (widget.searchQuery.isEmpty && widget.onTapWhenSearchEmpty != null) {
-          widget.onTapWhenSearchEmpty!();
-        }
-      },
-      child: ListView.builder(
-        controller: _scrollController,
-        padding: EdgeInsets.only(top: searchBarHeight),
-        itemCount: widget.segments.length + 2,
-        itemBuilder: (context, idx) {
-          if (idx == 0) return SizedBox(height: widget.topMargin ? 32 : 0);
-          if (idx == widget.segments.length + 1) return SizedBox(height: widget.bottomMargin + 120);
-
-          if (widget.separator && idx > 1) {
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [const SizedBox(height: 4), _buildSegmentItem(idx - 1)],
-            );
+    final transcriptList = NotificationListener<UserScrollNotification>(
+      onNotification: _onUserScroll,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () {
+          if (widget.searchQuery.isEmpty && widget.onTapWhenSearchEmpty != null) {
+            widget.onTapWhenSearchEmpty!();
           }
-
-          return _buildSegmentItem(idx - 1);
         },
+        child: ListView.builder(
+          controller: _scrollController,
+          padding: EdgeInsets.only(top: searchBarHeight),
+          itemCount: widget.segments.length + 2,
+          itemBuilder: (context, idx) {
+            if (idx == 0) return SizedBox(height: widget.topMargin ? 32 : 0);
+            if (idx == widget.segments.length + 1) {
+              return SizedBox(key: const ValueKey('transcript_bottom_spacing'), height: widget.bottomMargin + 120);
+            }
+
+            if (widget.separator && idx > 1) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [const SizedBox(height: 4), _buildSegmentItem(idx - 1)],
+              );
+            }
+
+            return _buildSegmentItem(idx - 1);
+          },
+        ),
       ),
+    );
+
+    if (!widget.followLatest) return transcriptList;
+
+    return Stack(
+      children: [
+        Positioned.fill(child: transcriptList),
+        PositionedDirectional(
+          end: 16,
+          bottom: widget.jumpToLatestButtonBottom,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 180),
+            transitionBuilder: (child, animation) => FadeTransition(
+              opacity: animation,
+              child: ScaleTransition(scale: animation, child: child),
+            ),
+            child: _isAtBottom
+                ? const SizedBox.shrink(key: ValueKey('transcript_jump_to_latest_hidden'))
+                : Semantics(
+                    button: true,
+                    label: context.l10n.jumpToLatestMessage,
+                    child: FloatingActionButton.small(
+                      key: const ValueKey('transcript_jump_to_latest'),
+                      heroTag: null,
+                      tooltip: context.l10n.jumpToLatestMessage,
+                      backgroundColor: const Color(0xFF35343B),
+                      foregroundColor: Colors.white,
+                      onPressed: () => _scrollToBottomGently(),
+                      child: const Icon(Icons.keyboard_arrow_down_rounded),
+                    ),
+                  ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show ScrollDirection;
+import 'package:flutter/rendering.dart' show RenderAbstractViewport, RenderBox, ScrollDirection;
 import 'package:flutter/services.dart';
 
 import 'package:omi/backend/preferences.dart';
@@ -18,6 +18,12 @@ import 'package:omi/utils/other/temp.dart';
 
 // Use speaker colors from person.dart for bubble colors
 final List<Color> _speakerColors = speakerColors;
+
+typedef TranscriptSegmentBuilder = Widget Function(
+  BuildContext context,
+  TranscriptSegment segment,
+  int index,
+);
 
 class TranscriptWidget extends StatefulWidget {
   final List<TranscriptSegment> segments;
@@ -40,6 +46,11 @@ class TranscriptWidget extends StatefulWidget {
   final bool followLatest;
   final TranscriptScrollState? scrollState;
   final double jumpToLatestButtonBottom;
+  final int contentVersion;
+  final String layoutIdentity;
+  final List<Widget> leadingItems;
+  final List<String> leadingItemIds;
+  final TranscriptSegmentBuilder? segmentBuilder;
 
   const TranscriptWidget({
     super.key,
@@ -63,7 +74,12 @@ class TranscriptWidget extends StatefulWidget {
     this.followLatest = false,
     this.scrollState,
     this.jumpToLatestButtonBottom = 16,
-  });
+    this.contentVersion = 0,
+    this.layoutIdentity = 'transcript',
+    this.leadingItems = const [],
+    this.leadingItemIds = const [],
+    this.segmentBuilder,
+  }) : assert(leadingItems.length == leadingItemIds.length);
 
   @override
   State<TranscriptWidget> createState() => _TranscriptWidgetState();
@@ -73,11 +89,26 @@ class TranscriptScrollState {
   bool hasPosition = false;
   double offset = 0;
   bool isAtBottom = true;
+  String? anchorSegmentId;
+  int anchorSegmentIndex = 0;
+  double anchorViewportOffset = 0;
+  String? layoutIdentity;
 
-  void update({required double offset, required bool isAtBottom}) {
+  void update({
+    required double offset,
+    required bool isAtBottom,
+    String? anchorSegmentId,
+    int? anchorSegmentIndex,
+    double? anchorViewportOffset,
+    String? layoutIdentity,
+  }) {
     hasPosition = true;
     this.offset = offset;
     this.isAtBottom = isAtBottom;
+    if (anchorSegmentId != null) this.anchorSegmentId = anchorSegmentId;
+    if (anchorSegmentIndex != null) this.anchorSegmentIndex = anchorSegmentIndex;
+    if (anchorViewportOffset != null) this.anchorViewportOffset = anchorViewportOffset;
+    if (layoutIdentity != null) this.layoutIdentity = layoutIdentity;
   }
 }
 
@@ -94,11 +125,15 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   bool _userHasScrolled = false;
   bool _isAutoScrolling = false;
   bool _userInterruptedAutoScroll = false;
+  bool _isUserScrolling = false;
+  bool _isRestoringAnchor = false;
+  bool _pendingAnchorRestore = false;
   bool _isAtBottom = true;
-  int _previousSegmentCount = 0;
+  bool _followAgain = false;
+  Future<void>? _activeFollow;
 
   // Search result tracking
-  List<GlobalKey> _segmentKeys = [];
+  final Map<String, GlobalKey> _segmentKeys = {};
   final List<GlobalKey> _matchKeys = [];
   int _previousSearchResultIndex = -1;
 
@@ -139,11 +174,14 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     super.initState();
     final savedState = widget.scrollState;
     final shouldRestorePosition = savedState?.hasPosition == true && !savedState!.isAtBottom;
-    _scrollController = ScrollController(initialScrollOffset: shouldRestorePosition ? savedState.offset : 0);
+    final canUseRawOffset = savedState?.layoutIdentity == null || savedState?.layoutIdentity == widget.layoutIdentity;
+    _pendingAnchorRestore = shouldRestorePosition && !canUseRawOffset;
+    _scrollController = ScrollController(
+      initialScrollOffset: shouldRestorePosition && canUseRawOffset ? savedState.offset : 0,
+    );
     _userHasScrolled = shouldRestorePosition;
     _isAtBottom = !shouldRestorePosition;
-    _previousSegmentCount = widget.segments.length;
-    _initializeSegmentKeys();
+    _syncSegmentKeys();
     _rebuildMatchKeys();
 
     // Add scroll listener to detect manual scrolling
@@ -152,11 +190,16 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     // Notify parent about scroll controller
     widget.onScrollControllerReady?.call(_scrollController);
 
-    if (widget.segments.isNotEmpty && (widget.isConversationDetail || widget.followLatest)) {
+    if ((widget.segments.isNotEmpty || widget.leadingItems.isNotEmpty) &&
+        (widget.isConversationDetail || widget.followLatest)) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         if (widget.followLatest && _userHasScrolled) {
-          _syncScrollPosition();
+          if (canUseRawOffset) {
+            _setIsAtBottom(false);
+          } else {
+            _restoreAnchor();
+          }
         } else {
           _scrollToBottomGently(animated: widget.isConversationDetail);
         }
@@ -164,8 +207,12 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     }
   }
 
-  void _initializeSegmentKeys() {
-    _segmentKeys = List.generate(widget.segments.length, (index) => GlobalKey());
+  void _syncSegmentKeys() {
+    final currentIds = widget.segments.map((segment) => segment.id).toSet();
+    _segmentKeys.removeWhere((id, _) => !currentIds.contains(id));
+    for (final segment in widget.segments) {
+      _segmentKeys.putIfAbsent(segment.id, GlobalKey.new);
+    }
   }
 
   void _rebuildMatchKeys() {
@@ -187,10 +234,14 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   void didUpdateWidget(TranscriptWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    // Reinitialize keys if segment count changed
-    if (widget.segments.length != oldWidget.segments.length) {
-      _initializeSegmentKeys();
-    }
+    final contentChanged = widget.contentVersion != oldWidget.contentVersion ||
+        widget.segments.length != oldWidget.segments.length ||
+        widget.leadingItems.length != oldWidget.leadingItems.length ||
+        widget.layoutIdentity != oldWidget.layoutIdentity;
+    final shouldFollow = widget.scrollState?.isAtBottom ?? !_userHasScrolled;
+
+    if (contentChanged && !shouldFollow) _pendingAnchorRestore = true;
+    _syncSegmentKeys();
 
     if (widget.searchQuery != oldWidget.searchQuery) {
       _rebuildMatchKeys();
@@ -203,14 +254,15 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
       }
     }
 
-    // Check if new segments were added
-    if (widget.segments.length > _previousSegmentCount && !_userHasScrolled) {
-      _previousSegmentCount = widget.segments.length;
+    if (contentChanged) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _scrollToBottomGently();
+        if (!mounted) return;
+        if (shouldFollow) {
+          _scrollToBottomGently();
+        } else {
+          _restoreAnchor();
+        }
       });
-    } else {
-      _previousSegmentCount = widget.segments.length;
     }
 
     // Handle search result navigation
@@ -237,23 +289,108 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     final currentScroll = _scrollController.offset;
     final distanceFromBottom = _scrollController.position.maxScrollExtent - currentScroll;
     final isAtBottom = distanceFromBottom <= 24;
-
-    if (!_isAutoScrolling) {
-      _userHasScrolled = !isAtBottom;
-      widget.scrollState?.update(offset: currentScroll, isAtBottom: isAtBottom);
-    }
-
     _setIsAtBottom(isAtBottom);
   }
 
-  void _syncScrollPosition() {
+  void _captureCurrentPosition({String? layoutIdentity}) {
     if (!_scrollController.hasClients) return;
 
     final currentScroll = _scrollController.offset;
     final isAtBottom = _scrollController.position.maxScrollExtent - currentScroll <= 24;
     _userHasScrolled = !isAtBottom;
-    widget.scrollState?.update(offset: currentScroll, isAtBottom: isAtBottom);
+    final scrollState = widget.scrollState;
+    if (scrollState != null) {
+      String? anchorId;
+      var anchorIndex = 0;
+      var anchorViewportOffset = 0.0;
+      if (!isAtBottom) {
+        var closestTop = double.infinity;
+        for (var index = 0; index < widget.segments.length; index++) {
+          final segment = widget.segments[index];
+          final renderObject = _segmentKeys[segment.id]?.currentContext?.findRenderObject();
+          if (renderObject is! RenderBox) continue;
+          final viewport = RenderAbstractViewport.of(renderObject);
+          final top = viewport.getOffsetToReveal(renderObject, 0).offset - currentScroll;
+          final bottom = top + renderObject.size.height;
+          if (bottom > 0 && top < _scrollController.position.viewportDimension && top < closestTop) {
+            closestTop = top;
+            anchorId = segment.id;
+            anchorIndex = index;
+            anchorViewportOffset = top;
+          }
+        }
+      }
+      scrollState.update(
+        offset: currentScroll,
+        isAtBottom: isAtBottom,
+        anchorSegmentId: anchorId,
+        anchorSegmentIndex: anchorIndex,
+        anchorViewportOffset: anchorViewportOffset,
+        layoutIdentity: layoutIdentity ?? widget.layoutIdentity,
+      );
+    }
     _setIsAtBottom(isAtBottom);
+  }
+
+  Future<void> _restoreAnchor() async {
+    if (!_scrollController.hasClients) return;
+    final scrollState = widget.scrollState;
+    if (scrollState == null || scrollState.isAtBottom || widget.segments.isEmpty) {
+      _pendingAnchorRestore = false;
+      _captureCurrentPosition();
+      return;
+    }
+
+    var anchorIndex = widget.segments.indexWhere((segment) => segment.id == scrollState.anchorSegmentId);
+    if (anchorIndex < 0) {
+      anchorIndex = scrollState.anchorSegmentIndex.clamp(0, widget.segments.length - 1).toInt();
+    }
+    final anchorId = widget.segments[anchorIndex].id;
+
+    _isAutoScrolling = true;
+    _isRestoringAnchor = true;
+    try {
+      for (var attempt = 0; attempt < 20; attempt++) {
+        if (!mounted || !_scrollController.hasClients) return;
+        final anchorContext = _segmentKeys[anchorId]?.currentContext;
+        final anchor = anchorContext?.findRenderObject();
+        if (anchor is RenderBox) {
+          final viewport = RenderAbstractViewport.of(anchor);
+          final anchorViewportOffset = viewport.getOffsetToReveal(anchor, 0).offset - _scrollController.offset;
+          final correction = anchorViewportOffset - scrollState.anchorViewportOffset;
+          if (correction.abs() <= 0.5) break;
+          final target = (_scrollController.offset + correction).clamp(
+            _scrollController.position.minScrollExtent,
+            _scrollController.position.maxScrollExtent,
+          );
+          _scrollController.jumpTo(target);
+          await WidgetsBinding.instance.endOfFrame;
+          continue;
+        }
+
+        final itemIndex = widget.leadingItems.length + anchorIndex + 1;
+        final itemCount = widget.leadingItems.length + widget.segments.length + 2;
+        final fraction = itemIndex / max(1, itemCount - 1);
+        _scrollController.jumpTo(_scrollController.position.maxScrollExtent * fraction);
+        await WidgetsBinding.instance.endOfFrame;
+      }
+    } finally {
+      _pendingAnchorRestore = false;
+      _isRestoringAnchor = false;
+      _isAutoScrolling = false;
+    }
+
+    if (!mounted || !_scrollController.hasClients) return;
+    _userHasScrolled = true;
+    scrollState.update(
+      offset: _scrollController.offset,
+      isAtBottom: false,
+      anchorSegmentId: anchorId,
+      anchorSegmentIndex: anchorIndex,
+      anchorViewportOffset: scrollState.anchorViewportOffset,
+      layoutIdentity: widget.layoutIdentity,
+    );
+    _setIsAtBottom(false);
   }
 
   void _setIsAtBottom(bool value) {
@@ -261,55 +398,91 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     setState(() => _isAtBottom = value);
   }
 
-  Future<void> _scrollToBottomGently({bool animated = true}) async {
-    if (!_scrollController.hasClients) {
-      return;
-    }
-
+  Future<void> _runFollowToBottom({required bool animated}) async {
     _isAutoScrolling = true;
     _userInterruptedAutoScroll = false;
     var firstPass = true;
+    try {
+      do {
+        _followAgain = false;
 
-    // ListView.builder refines maxScrollExtent as previously lazy rows are laid
-    // out. Keep following that moving edge so reopening a very long transcript
-    // cannot stop at an early estimate of the bottom.
-    for (var attempt = 0; attempt < 20; attempt++) {
-      final target = _scrollController.position.maxScrollExtent;
-      if (animated) {
-        await _scrollController.animateTo(
-          target,
-          duration: Duration(milliseconds: firstPass ? 500 : 100),
-          curve: Curves.easeInOut,
-        );
-      } else {
-        _scrollController.jumpTo(target);
-      }
-      firstPass = false;
+        // ListView.builder refines maxScrollExtent as previously lazy rows are
+        // laid out. Follow that moving edge until both layout and queued content
+        // updates settle.
+        for (var attempt = 0; attempt < 20; attempt++) {
+          final target = _scrollController.position.maxScrollExtent;
+          if (animated) {
+            await _scrollController.animateTo(
+              target,
+              duration: Duration(milliseconds: firstPass ? 500 : 100),
+              curve: Curves.easeInOut,
+            );
+          } else {
+            _scrollController.jumpTo(target);
+          }
+          firstPass = false;
 
-      if (_userInterruptedAutoScroll) return;
+          if (_userInterruptedAutoScroll) return;
 
-      await WidgetsBinding.instance.endOfFrame;
+          await WidgetsBinding.instance.endOfFrame;
+          if (!mounted || !_scrollController.hasClients || _userInterruptedAutoScroll) return;
+
+          final remaining = _scrollController.position.maxScrollExtent - _scrollController.offset;
+          if (remaining.abs() <= 0.5) break;
+        }
+      } while (_followAgain && !_userInterruptedAutoScroll);
+
       if (!mounted || !_scrollController.hasClients || _userInterruptedAutoScroll) return;
-
-      final remaining = _scrollController.position.maxScrollExtent - _scrollController.offset;
-      if (remaining.abs() <= 0.5) break;
+      final maxExtent = _scrollController.position.maxScrollExtent;
+      if ((maxExtent - _scrollController.offset).abs() > 0.5) {
+        _scrollController.jumpTo(maxExtent);
+      }
+      _userHasScrolled = false;
+      widget.scrollState?.update(offset: maxExtent, isAtBottom: true, layoutIdentity: widget.layoutIdentity);
+      _setIsAtBottom(true);
+    } finally {
+      _isAutoScrolling = false;
     }
+  }
 
-    if (!mounted || !_scrollController.hasClients) return;
-    final maxExtent = _scrollController.position.maxScrollExtent;
-    if ((maxExtent - _scrollController.offset).abs() > 0.5) {
-      _scrollController.jumpTo(maxExtent);
-    }
-    _isAutoScrolling = false;
-    _userHasScrolled = false;
-    widget.scrollState?.update(offset: maxExtent, isAtBottom: true);
-    _setIsAtBottom(true);
+  Future<void> _scrollToBottomGently({bool animated = true}) {
+    if (!_scrollController.hasClients) return Future.value();
+    _followAgain = true;
+    final activeFollow = _activeFollow;
+    if (activeFollow != null) return activeFollow;
+
+    late final Future<void> trackedFollow;
+    trackedFollow = _runFollowToBottom(animated: animated).whenComplete(() {
+      if (identical(_activeFollow, trackedFollow)) _activeFollow = null;
+    });
+    _activeFollow = trackedFollow;
+    return trackedFollow;
   }
 
   bool _onUserScroll(UserScrollNotification notification) {
-    if (_isAutoScrolling && notification.direction != ScrollDirection.idle) {
-      _userInterruptedAutoScroll = true;
-      _isAutoScrolling = false;
+    if (_isRestoringAnchor || _pendingAnchorRestore) return false;
+    if (notification.direction != ScrollDirection.idle) {
+      _isUserScrolling = true;
+      if (_isAutoScrolling) {
+        _userInterruptedAutoScroll = true;
+        _followAgain = false;
+        _isAutoScrolling = false;
+      }
+      _captureCurrentPosition();
+    } else if (_isUserScrolling) {
+      _captureCurrentPosition();
+      _isUserScrolling = false;
+    }
+    return false;
+  }
+
+  bool _onScrollMetrics(ScrollMetricsNotification notification) {
+    if (!widget.followLatest || _isAutoScrolling) return false;
+    final shouldFollow = widget.scrollState?.isAtBottom ?? !_userHasScrolled;
+    if (shouldFollow && notification.metrics.extentAfter > 0.5) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _scrollToBottomGently(animated: false);
+      });
     }
     return false;
   }
@@ -378,9 +551,9 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     }
 
     if (targetSegmentIndex >= 0 && targetSegmentIndex < _segmentKeys.length) {
-      final segmentKey = _segmentKeys[targetSegmentIndex];
+      final segmentKey = _segmentKeys[widget.segments[targetSegmentIndex].id];
 
-      final segmentContext = segmentKey.currentContext;
+      final segmentContext = segmentKey?.currentContext;
       if (segmentContext != null) {
         _scrollToContext(segmentContext);
         return;
@@ -482,34 +655,60 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   @override
   Widget build(BuildContext context) {
     final searchBarHeight = widget.searchQuery.isNotEmpty ? 100.0 : 0.0;
-    final transcriptList = NotificationListener<UserScrollNotification>(
-      onNotification: _onUserScroll,
-      child: GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onTap: () {
-          if (widget.searchQuery.isEmpty && widget.onTapWhenSearchEmpty != null) {
-            widget.onTapWhenSearchEmpty!();
-          }
-        },
-        child: ListView.builder(
-          controller: _scrollController,
-          padding: EdgeInsets.only(top: searchBarHeight),
-          itemCount: widget.segments.length + 2,
-          itemBuilder: (context, idx) {
-            if (idx == 0) return SizedBox(height: widget.topMargin ? 32 : 0);
-            if (idx == widget.segments.length + 1) {
-              return SizedBox(key: const ValueKey('transcript_bottom_spacing'), height: widget.bottomMargin + 120);
+    final transcriptList = NotificationListener<ScrollMetricsNotification>(
+      onNotification: _onScrollMetrics,
+      child: NotificationListener<UserScrollNotification>(
+        onNotification: _onUserScroll,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () {
+            if (widget.searchQuery.isEmpty && widget.onTapWhenSearchEmpty != null) {
+              widget.onTapWhenSearchEmpty!();
             }
-
-            if (widget.separator && idx > 1) {
-              return Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [const SizedBox(height: 4), _buildSegmentItem(idx - 1)],
-              );
-            }
-
-            return _buildSegmentItem(idx - 1);
           },
+          child: ListView.builder(
+            controller: _scrollController,
+            padding: EdgeInsets.only(top: searchBarHeight),
+            itemCount: widget.leadingItems.length + widget.segments.length + 2,
+            findChildIndexCallback: _findChildIndex,
+            itemBuilder: (context, idx) {
+              if (idx == 0) {
+                return SizedBox(key: const ValueKey('transcript_header'), height: widget.topMargin ? 32 : 0);
+              }
+
+              final leadingIndex = idx - 1;
+              if (leadingIndex < widget.leadingItems.length) {
+                return KeyedSubtree(
+                  key: ValueKey('transcript-leading-${widget.leadingItemIds[leadingIndex]}'),
+                  child: widget.leadingItems[leadingIndex],
+                );
+              }
+
+              final segmentIndex = idx - widget.leadingItems.length - 1;
+              if (segmentIndex == widget.segments.length) {
+                return SizedBox(
+                  key: const ValueKey('transcript_bottom_spacing'),
+                  height: widget.bottomMargin + 120,
+                );
+              }
+
+              final segment = widget.segments[segmentIndex];
+              final customSegment = widget.segmentBuilder?.call(context, segment, segmentIndex);
+              Widget child = customSegment == null
+                  ? _buildSegmentItem(segmentIndex)
+                  : Container(key: _segmentKeys[segment.id], child: customSegment);
+              if (widget.separator && segmentIndex > 0) {
+                child = Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [const SizedBox(height: 4), child],
+                );
+              }
+              return KeyedSubtree(
+                key: ValueKey('transcript-segment-${segment.id}'),
+                child: child,
+              );
+            },
+          ),
         ),
       ),
     );
@@ -549,13 +748,35 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     );
   }
 
+  int? _findChildIndex(Key key) {
+    if (key == const ValueKey('transcript_header')) return 0;
+    if (key == const ValueKey('transcript_bottom_spacing')) {
+      return widget.leadingItems.length + widget.segments.length + 1;
+    }
+    if (key is! ValueKey<String>) return null;
+
+    const leadingPrefix = 'transcript-leading-';
+    const segmentPrefix = 'transcript-segment-';
+    if (key.value.startsWith(leadingPrefix)) {
+      final id = key.value.substring(leadingPrefix.length);
+      final index = widget.leadingItemIds.indexOf(id);
+      return index < 0 ? null : index + 1;
+    }
+    if (key.value.startsWith(segmentPrefix)) {
+      final id = key.value.substring(segmentPrefix.length);
+      final index = widget.segments.indexWhere((segment) => segment.id == id);
+      return index < 0 ? null : widget.leadingItems.length + index + 1;
+    }
+    return null;
+  }
+
   Widget _buildSegmentItem(int segmentIdx) {
     final data = widget.segments[segmentIdx];
     final Person? person = data.personId != null ? _getPersonById(data.personId) : null;
     final isTagging = widget.taggingSegmentIds.contains(data.id);
     final bool isUser = data.isUser;
     return Container(
-      key: segmentIdx >= 0 && segmentIdx < _segmentKeys.length ? _segmentKeys[segmentIdx] : null,
+      key: _segmentKeys[data.id],
       child: Padding(
         padding: EdgeInsetsDirectional.fromSTEB(
           widget.horizontalMargin ? 16 : 0,

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -162,6 +162,19 @@ void main() {
     expect(provider.hasTranscripts, true);
   });
 
+  test('active capture identity survives deletion of the first segment', () {
+    final provider = CaptureProvider();
+    provider.testSessionStartSeconds = 12345;
+    provider.segments = [_segment('first', 'one'), _segment('second', 'two')];
+
+    final captureIdentity = provider.activeCaptureSessionId;
+    provider.onMessageEventReceived(SegmentsDeletedEvent(segmentIds: ['first']));
+
+    expect(captureIdentity, 'live-12345');
+    expect(provider.activeCaptureSessionId, captureIdentity);
+    expect(provider.segments.single.id, 'second');
+  });
+
   group('metricsNotifyEnabled', () {
     test('defaults to not notifying on metrics update', () {
       final provider = CaptureProvider();

--- a/app/test/widgets/transcript_test.dart
+++ b/app/test/widgets/transcript_test.dart
@@ -141,8 +141,12 @@ void main() {
     late ScrollController controller;
     late TranscriptScrollState scrollState;
     late List<TranscriptSegment> segments;
+    late int contentVersion;
+    late String layoutIdentity;
+    late List<Widget> leadingItems;
+    late List<String> leadingItemIds;
 
-    Future<void> pumpTranscript(WidgetTester tester) async {
+    Future<void> pumpTranscript(WidgetTester tester, {bool settle = true}) async {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: const [
@@ -156,22 +160,31 @@ void main() {
             body: SizedBox(
               height: 320,
               child: TranscriptWidget(
+                key: const ValueKey('live-transcript-test-session'),
                 segments: segments,
                 bottomMargin: 0,
                 followLatest: true,
                 scrollState: scrollState,
                 jumpToLatestButtonBottom: 84,
                 onScrollControllerReady: (value) => controller = value,
+                contentVersion: contentVersion,
+                layoutIdentity: layoutIdentity,
+                leadingItems: leadingItems,
+                leadingItemIds: leadingItemIds,
               ),
             ),
           ),
         ),
       );
-      await tester.pumpAndSettle();
+      if (settle) await tester.pumpAndSettle();
     }
 
     setUp(() {
       scrollState = TranscriptScrollState();
+      contentVersion = 0;
+      layoutIdentity = 'transcript';
+      leadingItems = [];
+      leadingItemIds = [];
       segments = List.generate(
         30,
         (index) => TranscriptSegment(
@@ -222,6 +235,120 @@ void main() {
       expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
       expect(scrollState.isAtBottom, isTrue);
       expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
+    });
+
+    testWidgets('same-ID transcript growth keeps following the live edge', (tester) async {
+      await pumpTranscript(tester);
+
+      final last = segments.last;
+      segments = [
+        ...segments.take(segments.length - 1),
+        TranscriptSegment(
+          id: last.id,
+          text: List.filled(80, 'revised transcript text').join(' '),
+          speaker: last.speaker,
+          isUser: last.isUser,
+          personId: last.personId,
+          start: last.start,
+          end: last.end,
+          translations: const [],
+        ),
+      ];
+      contentVersion++;
+      await pumpTranscript(tester);
+
+      expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
+      expect(scrollState.isAtBottom, isTrue);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
+    });
+
+    testWidgets('growth inside an existing photo group keeps following the live edge', (tester) async {
+      layoutIdentity = 'photo-timeline';
+      leadingItemIds = ['photo-group-1'];
+      leadingItems = const [SizedBox(height: 80)];
+      await pumpTranscript(tester);
+
+      leadingItems = const [SizedBox(height: 280)];
+      contentVersion++;
+      await pumpTranscript(tester);
+
+      expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
+      expect(scrollState.isAtBottom, isTrue);
+    });
+
+    testWidgets('overlapping live updates coalesce into one settled bottom follow', (tester) async {
+      await pumpTranscript(tester);
+
+      for (var update = 0; update < 3; update++) {
+        segments = [
+          ...segments,
+          TranscriptSegment(
+            id: 'overlap-$update',
+            text: List.filled(12, 'new live words').join(' '),
+            speaker: 'SPEAKER_00',
+            isUser: false,
+            personId: null,
+            start: segments.length.toDouble(),
+            end: segments.length + 1.0,
+            translations: const [],
+          ),
+        ];
+        contentVersion++;
+        await pumpTranscript(tester, settle: false);
+        await tester.pump(const Duration(milliseconds: 40));
+      }
+      await tester.pumpAndSettle();
+
+      expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
+      expect(scrollState.isAtBottom, isTrue);
+    });
+
+    testWidgets('layout changes restore the same transcript anchor instead of a raw offset', (tester) async {
+      await pumpTranscript(tester);
+      await tester.drag(find.byType(ListView), const Offset(0, 260));
+      await tester.pumpAndSettle();
+
+      final anchorId = scrollState.anchorSegmentId;
+      expect(anchorId, isNotNull);
+      final anchorFinder = find.byKey(ValueKey('transcript-segment-$anchorId'));
+      final anchorTop = tester.getTopLeft(anchorFinder).dy - tester.getTopLeft(find.byType(ListView)).dy;
+      expect(scrollState.anchorViewportOffset, closeTo(anchorTop, 5));
+
+      layoutIdentity = 'photo-timeline';
+      leadingItemIds = ['new-photo-group'];
+      leadingItems = const [SizedBox(height: 240)];
+      contentVersion++;
+      await pumpTranscript(tester);
+
+      expect(scrollState.anchorSegmentId, anchorId);
+      final restoredTop = tester.getTopLeft(anchorFinder).dy - tester.getTopLeft(find.byType(ListView)).dy;
+      // Sliver layout may round the restored edge by the four-point separator,
+      // but it must keep the same segment at the same reading position.
+      expect(restoredTop, closeTo(anchorTop, 5));
+      expect(scrollState.isAtBottom, isFalse);
+    });
+
+    testWidgets('deleting the first segment preserves a later reading anchor', (tester) async {
+      await pumpTranscript(tester);
+      await tester.drag(find.byType(ListView), const Offset(0, 260));
+      await tester.pumpAndSettle();
+
+      final anchorId = scrollState.anchorSegmentId;
+      expect(anchorId, isNotNull);
+      final anchorFinder = find.byKey(ValueKey('transcript-segment-$anchorId'));
+      final anchorTop = tester.getTopLeft(anchorFinder).dy - tester.getTopLeft(find.byType(ListView)).dy;
+      expect(scrollState.anchorViewportOffset, closeTo(anchorTop, 5));
+
+      segments = segments.skip(1).toList();
+      contentVersion++;
+      await pumpTranscript(tester);
+
+      expect(scrollState.anchorSegmentId, anchorId);
+      final restoredTop = tester.getTopLeft(anchorFinder).dy - tester.getTopLeft(find.byType(ListView)).dy;
+      // Sliver layout may round the restored edge by the four-point separator,
+      // but it must keep the same segment at the same reading position.
+      expect(restoredTop, closeTo(anchorTop, 5));
+      expect(scrollState.isAtBottom, isFalse);
     });
 
     testWidgets('live controls reserve only the standard 120 point footer', (tester) async {

--- a/app/test/widgets/transcript_test.dart
+++ b/app/test/widgets/transcript_test.dart
@@ -136,4 +136,99 @@ void main() {
       expect(find.text('Tag'), findsNothing);
     });
   });
+
+  group('Live transcript scrolling', () {
+    late ScrollController controller;
+    late TranscriptScrollState scrollState;
+    late List<TranscriptSegment> segments;
+
+    Future<void> pumpTranscript(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              height: 320,
+              child: TranscriptWidget(
+                segments: segments,
+                bottomMargin: 0,
+                followLatest: true,
+                scrollState: scrollState,
+                jumpToLatestButtonBottom: 84,
+                onScrollControllerReady: (value) => controller = value,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    setUp(() {
+      scrollState = TranscriptScrollState();
+      segments = List.generate(
+        30,
+        (index) => TranscriptSegment(
+          id: 'live-$index',
+          text: 'Transcript segment $index with enough words to make this a long conversation.',
+          speaker: 'SPEAKER_0${index % 2}',
+          isUser: false,
+          personId: null,
+          start: index.toDouble(),
+          end: index + 1.0,
+          translations: const [],
+        ),
+      );
+    });
+
+    testWidgets('a fresh long transcript opens at the latest segment', (tester) async {
+      await pumpTranscript(tester);
+
+      expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
+      expect(scrollState.isAtBottom, isTrue);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
+    });
+
+    testWidgets('a user position away from the bottom survives reopening', (tester) async {
+      await pumpTranscript(tester);
+      await tester.drag(find.byType(ListView), const Offset(0, 260));
+      await tester.pumpAndSettle();
+
+      final preservedOffset = controller.offset;
+      expect(scrollState.isAtBottom, isFalse);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await pumpTranscript(tester);
+
+      expect(controller.offset, closeTo(preservedOffset, 0.1));
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+    });
+
+    testWidgets('the jump control animates to the latest segment and hides', (tester) async {
+      await pumpTranscript(tester);
+      await tester.drag(find.byType(ListView), const Offset(0, 260));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('transcript_jump_to_latest')));
+      await tester.pumpAndSettle();
+
+      expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
+      expect(scrollState.isAtBottom, isTrue);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
+    });
+
+    testWidgets('live controls reserve only the standard 120 point footer', (tester) async {
+      await pumpTranscript(tester);
+
+      final footer = tester.widget<SizedBox>(find.byKey(const ValueKey('transcript_bottom_spacing')));
+      expect(footer.height, 120);
+    });
+  });
 }


### PR DESCRIPTION
## What changed and why

Keep live capture views anchored to the newest content while the user intends to follow, including same-ID transcript revisions, photos joining an existing group, and other post-layout extent growth. Preserve an intentional reading position by stable capture identity and transcript anchor across segment deletion and transcript/photo layout switches.

The transcript-only and photo-interleaved layouts now share `TranscriptWidget`'s follow/jump behavior. Follow-to-bottom updates are serialized and coalesced so overlapping content changes cannot race or prematurely clear auto-scroll state. Capture persistence and backend semantics are unchanged.

## Product invariants affected

none

## How it was verified

- `cd app && flutter test --no-pub test/widgets/transcript_test.dart test/providers/capture_provider_test.dart` — 80 tests passed.
- `cd app && flutter test --no-pub test/widgets/transcript_test.dart` — all 12 transcript widget tests passed after the final assertion adjustment.
- `cd app && bash test.sh` — all 1,000 tests passed.
- `cd app && flutter analyze --no-pub lib/widgets/transcript.dart lib/pages/capture/widgets/widgets.dart lib/pages/conversation_capturing/page.dart lib/services/capture/capture_controller.dart test/widgets/transcript_test.dart` — no issues found.
- `cd app && bash scripts/analyze_ratchet.sh` — passed; `prefer_final_fields` improved from the baseline.
- `make preflight` — passed.

A booted iOS simulator/device and `agent-flutter` were not available in this workspace, so the real capture UI path was not exercised interactively.

## Tests

Focused regressions cover same-ID transcript growth, growth within an existing photo group, overlapping follow requests, stable capture identity after first-segment deletion, transcript-anchor preservation across layout switches and deletion, long-list initial follow, deliberate non-bottom restoration, jump-to-latest behavior, and footer spacing.

## Failure class (fixes)

Failure-Class: FC-single-input-device-release

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
