### PR TITLE
feat: add private conversation map locations

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -4,7 +4,7 @@
     "backend/routers/chat.py": 1634,
     "backend/routers/developer.py": 2282,
     "backend/routers/mcp_sse.py": 1873,
-    "backend/routers/sync.py": 2058,
+    "backend/routers/sync.py": 2044,
     "backend/routers/users.py": 2083
   },
   "raise_justifications": {

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -8,7 +8,7 @@
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1587,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
-    "backend/utils/sync/pipeline.py": 2491
+    "backend/utils/sync/pipeline.py": 2489
   },
   "raise_justifications": {
     "backend/utils/apps.py": "get_available_app_model_by_id: the set-preferred-app availability authority as a validated App model, so the summary path honors what the setter admitted instead of re-deciding with the installed slice (#10074).",

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/BaseBatchAudioWriter.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/BaseBatchAudioWriter.kt
@@ -103,6 +103,7 @@ abstract class BaseBatchAudioWriter(
             currentBytes = file.length()
             currentFrames = 0
             lastFsyncMs = nowMs
+            onOpenedLocked(file)
             Log.i(tag, "opened batch file $fileName")
             true
         } catch (e: Exception) {
@@ -209,6 +210,9 @@ abstract class BaseBatchAudioWriter(
 
     /** Hook for subclasses to reset their gap/session tracking when a file closes. */
     protected open fun onClosedLocked() {}
+
+    /** Hook for recording-owned metadata that must be copied beside a new file. */
+    protected open fun onOpenedLocked(partFile: File) {}
 
     /** Notify Dart (when the engine is alive) that a file finalized, so the
      *  recordings list rescans without waiting for a BLE disconnect. */

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/NativeBatchGeolocationSidecar.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/NativeBatchGeolocationSidecar.kt
@@ -1,0 +1,30 @@
+package com.friend.ios.batch
+
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
+
+internal const val NATIVE_BATCH_GEOLOCATION_SIDECAR_SUFFIX = ".geolocation.json"
+internal const val NATIVE_BATCH_GEOLOCATION_MAX_BYTES = 4096
+
+/** Copy one validated, bounded private snapshot beside a native batch file. */
+internal fun persistNativeBatchGeolocationSidecar(audioFile: File, rawGeolocation: String, tag: String) {
+    if (rawGeolocation.isBlank() || rawGeolocation.toByteArray(Charsets.UTF_8).size > NATIVE_BATCH_GEOLOCATION_MAX_BYTES) {
+        return
+    }
+    try {
+        JSONObject(rawGeolocation)
+        val sidecar = File(audioFile.path + NATIVE_BATCH_GEOLOCATION_SIDECAR_SUFFIX)
+        val pending = File(sidecar.path + ".part")
+        FileOutputStream(pending).use { output ->
+            output.write(rawGeolocation.toByteArray(Charsets.UTF_8))
+            output.fd.sync()
+        }
+        if (sidecar.exists()) sidecar.delete()
+        if (!pending.renameTo(sidecar)) pending.delete()
+    } catch (error: Exception) {
+        // Location is optional: never interrupt or discard audio capture.
+        runCatching { Log.w(tag, "failed to persist bounded recording location sidecar: ${error.javaClass.simpleName}") }
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/NativeBleGeolocationHeader.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/NativeBleGeolocationHeader.kt
@@ -1,0 +1,21 @@
+package com.friend.ios.batch
+
+import okhttp3.Request
+import org.json.JSONObject
+
+internal const val CONVERSATION_GEOLOCATION_HEADER = "X-Omi-Conversation-Geolocation"
+internal const val CONVERSATION_GEOLOCATION_HEADER_MAX_BYTES = 4096
+
+internal fun addConversationGeolocationHeader(builder: Request.Builder, rawGeolocation: String?): Request.Builder {
+    if (rawGeolocation.isNullOrBlank() ||
+        rawGeolocation.toByteArray(Charsets.UTF_8).size > CONVERSATION_GEOLOCATION_HEADER_MAX_BYTES
+    ) {
+        return builder
+    }
+    return try {
+        JSONObject(rawGeolocation)
+        builder.header(CONVERSATION_GEOLOCATION_HEADER, rawGeolocation)
+    } catch (_: Exception) {
+        builder
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
@@ -49,7 +49,8 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         val apiBaseUrl: String,
         val serviceUuid: String,
         val characteristicUuid: String,
-        val deviceType: String
+        val deviceType: String,
+        val geolocation: String?,
     )
 
     private val client = OkHttpClient.Builder()
@@ -152,7 +153,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         if (now - lastFailureAtMs < RECONNECT_BACKOFF_MS) return
 
         val url = buildUrl(config) ?: return
-        val request = buildRequest(url) ?: return
+        val request = buildRequest(url, config) ?: return
 
         synchronized(lock) {
             if ((connecting || connected) && activeUrl == url && activeConfig == config && socket != null) {
@@ -290,7 +291,8 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
                 apiBaseUrl = json.optString("apiBaseUrl"),
                 serviceUuid = serviceUuid,
                 characteristicUuid = characteristicUuid,
-                deviceType = json.optString("deviceType")
+                deviceType = json.optString("deviceType"),
+                geolocation = json.optJSONObject("geolocation")?.toString(),
             )
         } catch (e: Exception) {
             Log.w(TAG, "Invalid native BLE stream config: ${e.message}")
@@ -298,21 +300,21 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         }
     }
 
-    private fun buildRequest(url: String): Request? {
+    private fun buildRequest(url: String, config: Config): Request? {
         val token = stringPref("authToken")
         if (token.isEmpty()) {
             Log.w(TAG, "Cannot open background transcription socket without auth token")
             return null
         }
 
-        return Request.Builder()
+        val builder = Request.Builder()
             .url(url)
             .header("Authorization", "Bearer $token")
             .header("X-Request-Start-Time", (System.currentTimeMillis().toDouble() / 1000.0).toString())
             .header("X-App-Platform", "android")
             .header("X-Device-Id-Hash", stringPref("deviceIdHash"))
             .header("X-App-Version", BuildConfig.VERSION_NAME)
-            .build()
+        return addConversationGeolocationHeader(builder, config.geolocation).build()
     }
 
     private fun buildUrl(config: Config): String? {

--- a/app/android/app/src/main/kotlin/com/friend/ios/phonemic/PhoneMicBatchAudioWriter.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/phonemic/PhoneMicBatchAudioWriter.kt
@@ -1,8 +1,10 @@
 package com.friend.ios.phonemic
 
 import com.friend.ios.batch.BaseBatchAudioWriter
+import com.friend.ios.batch.persistNativeBatchGeolocationSidecar
 
 import android.content.Context
+import java.io.File
 
 /**
  * Batch (transcribe-later) capture sink for the phone microphone — the Kotlin peer of
@@ -49,6 +51,11 @@ class PhoneMicBatchAudioWriter(context: Context, private val dirPath: String) :
     // controller's heartbeat so a single onCaptureError fires per storage-full event.
     private var pendingStorageFullReport = false
     private var wasStorageFull = false
+
+    override fun onOpenedLocked(partFile: File) {
+        val audioFile = File(partFile.parentFile, partFile.name.removeSuffix(PART_SUFFIX))
+        persistNativeBatchGeolocationSidecar(audioFile, stringPref("phoneBatchGeolocation"), TAG)
+    }
 
     /**
      * Append the opus packets for one converted PCM chunk. Called on the writer's serial

--- a/app/android/app/src/test/kotlin/com/friend/ios/batch/NativeBatchGeolocationSidecarTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/batch/NativeBatchGeolocationSidecarTest.kt
@@ -1,0 +1,43 @@
+package com.friend.ios.batch
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class NativeBatchGeolocationSidecarTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `copies a bounded snapshot beside explicit and automatic phone batch files`() {
+        val raw = """{"latitude":37.7749,"longitude":-122.4194,"capture_source":"current_position"}"""
+        for (marker in listOf("omibatchphone", "omibatchphoneauto")) {
+            val audio = File(temporaryFolder.root, "audio_${marker}_opus_fs320_16000_1_fs320_1.bin")
+
+            persistNativeBatchGeolocationSidecar(audio, raw, "test")
+
+            val sidecar = File(audio.path + NATIVE_BATCH_GEOLOCATION_SIDECAR_SUFFIX)
+            assertTrue(sidecar.isFile)
+            assertEquals(raw, sidecar.readText())
+        }
+    }
+
+    @Test
+    fun `malformed or oversized snapshots fail soft without a sidecar`() {
+        val malformedAudio = File(temporaryFolder.root, "malformed.bin")
+        persistNativeBatchGeolocationSidecar(malformedAudio, "{not-json", "test")
+        assertFalse(File(malformedAudio.path + NATIVE_BATCH_GEOLOCATION_SIDECAR_SUFFIX).exists())
+
+        val oversizedAudio = File(temporaryFolder.root, "oversized.bin")
+        persistNativeBatchGeolocationSidecar(
+            oversizedAudio,
+            "x".repeat(NATIVE_BATCH_GEOLOCATION_MAX_BYTES + 1),
+            "test",
+        )
+        assertFalse(File(oversizedAudio.path + NATIVE_BATCH_GEOLOCATION_SIDECAR_SUFFIX).exists())
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/batch/NativeBleGeolocationHeaderTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/batch/NativeBleGeolocationHeaderTest.kt
@@ -1,0 +1,28 @@
+package com.friend.ios.batch
+
+import okhttp3.Request
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NativeBleGeolocationHeaderTest {
+    @Test
+    fun `authenticated native listen request carries the bounded private snapshot`() {
+        val raw = """{"latitude":37.7749,"longitude":-122.4194,"capture_source":"current_position"}"""
+        val request = addConversationGeolocationHeader(
+            Request.Builder().url("https://api.omiapi.com/v4/listen").header("Authorization", "Bearer token"),
+            raw,
+        ).build()
+
+        assertEquals("Bearer token", request.header("Authorization"))
+        assertEquals(raw, request.header(CONVERSATION_GEOLOCATION_HEADER))
+    }
+
+    @Test
+    fun `missing malformed and oversized snapshots omit the header`() {
+        for (raw in listOf<String?>(null, "", "{not-json", "x".repeat(CONVERSATION_GEOLOCATION_HEADER_MAX_BYTES + 1))) {
+            val request = addConversationGeolocationHeader(Request.Builder().url("https://example.test/v4/listen"), raw).build()
+            assertNull(request.header(CONVERSATION_GEOLOCATION_HEADER))
+        }
+    }
+}

--- a/app/ios/Runner/Batch/BaseBatchAudioWriter.swift
+++ b/app/ios/Runner/Batch/BaseBatchAudioWriter.swift
@@ -99,6 +99,7 @@ class BaseBatchAudioWriter {
         currentBytes = Int64(end)
         currentFrames = 0
         lastFsyncMs = nowMs
+        onOpenedLocked(url)
         NSLog("[\(tag)] opened \(fileName)")
         return true
     }
@@ -191,6 +192,9 @@ class BaseBatchAudioWriter {
 
     /// Hook for subclasses to reset their gap/session tracking when a file closes.
     func onClosedLocked() {}
+
+    /// Hook for recording-owned metadata that must be copied beside a new file.
+    func onOpenedLocked(_ partURL: URL) {}
 
     /// Notify Dart that a file finalized, so the recordings list rescans without
     /// waiting for a BLE disconnect.

--- a/app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift
+++ b/app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift
@@ -28,6 +28,24 @@ final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
     private var pendingStorageFullReport = false
     private var wasStorageFull = false
 
+    override func onOpenedLocked(_ partURL: URL) {
+        guard let raw = UserDefaults.standard.string(forKey: "flutter.phoneBatchGeolocation"),
+              let data = raw.data(using: .utf8),
+              !data.isEmpty,
+              data.count <= 4_096,
+              (try? JSONSerialization.jsonObject(with: data)) is [String: Any]
+        else { return }
+
+        let audioURL = partURL.deletingPathExtension()
+        let sidecarURL = URL(fileURLWithPath: audioURL.path + ".geolocation.json")
+        do {
+            try data.write(to: sidecarURL, options: .atomic)
+        } catch {
+            // Location is optional: never interrupt or discard audio capture.
+            NSLog("[PhoneBatchWriter] failed to persist bounded recording location sidecar: \(type(of: error))")
+        }
+    }
+
     /// `dir` is resolved once at bring-up (a missing/empty `flutter.batchAudioDir`
     /// fails the session with batch_dir_unavailable before this writer is created),
     /// so it is never re-checked per append. The recovery prefix `audio_omibatchphone`

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -489,9 +489,7 @@ Future<String?> _createSyncCaptureManifest(List<File> files, String conversation
     method: 'POST',
   );
   if (response?.statusCode != 200) return null;
-  final body = wire.GeneratedSyncCaptureManifestResponse.fromJson(
-    jsonDecode(response!.body) as Map<String, dynamic>,
-  );
+  final body = wire.GeneratedSyncCaptureManifestResponse.fromJson(jsonDecode(response!.body) as Map<String, dynamic>);
   return body.manifest;
 }
 
@@ -560,6 +558,7 @@ Future<UploadFilesResult> uploadLocalFilesV2(
   UploadProgressCallback? onUploadProgress,
   String? conversationId,
   SyncUploadLane syncLane = SyncUploadLane.fresh,
+  Geolocation? geolocation,
 }) async {
   String? captureManifest;
   if (shouldRequestSyncCaptureManifest(conversationId, syncLane)) {
@@ -576,6 +575,7 @@ Future<UploadFilesResult> uploadLocalFilesV2(
     headers: {
       'X-Omi-Sync-Lane-Hint': syncLane.name,
       if (captureManifest != null) 'X-Omi-Sync-Capture-Manifest': captureManifest,
+      if (geolocation != null) 'X-Omi-Conversation-Geolocation': jsonEncode(geolocation.toJson()),
     },
     onUploadProgress: onUploadProgress,
   );
@@ -587,9 +587,7 @@ Future<UploadFilesResult> uploadLocalFilesV2(
     final completed = SyncLocalFilesResponse.fromGenerated(
       wire.GeneratedSyncLocalFilesResultResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>),
     );
-    return UploadFilesResult.done(
-      requireCompleteSyncUpload(completed),
-    );
+    return UploadFilesResult.done(requireCompleteSyncUpload(completed));
   }
   if (response.statusCode == 202) {
     final start = SyncJobStartResponse.fromGenerated(

--- a/app/lib/backend/schema/gen/conversation_wire.g.dart
+++ b/app/lib/backend/schema/gen/conversation_wire.g.dart
@@ -283,14 +283,22 @@ class GeneratedStructured {
 }
 
 class GeneratedGeolocation {
+  final double? accuracy;
   final String? address;
+  final double? altitude;
+  final String? captureSource;
+  final DateTime? capturedAt;
   final String? googlePlaceId;
   final double latitude;
   final String? locationType;
   final double longitude;
 
   const GeneratedGeolocation({
+    this.accuracy,
     this.address,
+    this.altitude,
+    this.captureSource,
+    this.capturedAt,
     this.googlePlaceId,
     required this.latitude,
     this.locationType,
@@ -299,7 +307,11 @@ class GeneratedGeolocation {
 
   factory GeneratedGeolocation.fromJson(Map<String, dynamic> json) {
     return GeneratedGeolocation(
+      accuracy: _readFieldValue<double>(_readField(json, const ["accuracy"]), "accuracy", _readDouble, requiredField: false, nullable: true),
       address: _readFieldValue<String>(_readField(json, const ["address"]), "address", _readString, requiredField: false, nullable: true),
+      altitude: _readFieldValue<double>(_readField(json, const ["altitude"]), "altitude", _readDouble, requiredField: false, nullable: true),
+      captureSource: _readFieldValue<String>(_readField(json, const ["capture_source"]), "capture_source", _readString, requiredField: false, nullable: true),
+      capturedAt: _readFieldValue<DateTime>(_readField(json, const ["captured_at"]), "captured_at", _readDateTime, requiredField: false, nullable: true),
       googlePlaceId: _readFieldValue<String>(_readField(json, const ["google_place_id", "googlePlaceId"]), "google_place_id", _readString, requiredField: false, nullable: true),
       latitude: _required(_readFieldValue<double>(_readField(json, const ["latitude"]), "latitude", _readDouble, requiredField: true, nullable: false), "latitude"),
       locationType: _readFieldValue<String>(_readField(json, const ["location_type", "locationType"]), "location_type", _readString, requiredField: false, nullable: true),
@@ -309,7 +321,11 @@ class GeneratedGeolocation {
 
   Map<String, dynamic> toJson() {
     return {
+      'accuracy': accuracy,
       'address': address,
+      'altitude': altitude,
+      'capture_source': captureSource,
+      'captured_at': capturedAt?.toUtc().toIso8601String(),
       'google_place_id': googlePlaceId,
       'latitude': latitude,
       'location_type': locationType,

--- a/app/lib/backend/schema/geolocation.dart
+++ b/app/lib/backend/schema/geolocation.dart
@@ -1,9 +1,6 @@
-// Phase 4.1 SKIPPED — not a pure 1:1 wrapper, so not typedef'd here.
-// GeneratedGeolocation (gen/conversation_wire.g.dart) only carries latitude, longitude,
-// googlePlaceId, address, locationType. This class additionally holds
-// id/altitude/accuracy/time, treats latitude/longitude as nullable (the generated type
-// requires them), and throws a StateError from toGenerated() when lat/lon are absent.
-// Typedefing would drop the extra fields and change nullability + the throw contract.
+// Not a pure 1:1 wrapper: this class additionally holds the legacy local id,
+// treats latitude/longitude as nullable (the wire type requires them), and
+// throws from toGenerated() when either coordinate is absent.
 
 import 'package:omi/backend/schema/gen/conversation_wire.g.dart' as wire;
 
@@ -18,6 +15,7 @@ class Geolocation {
   double? accuracy;
 
   DateTime? time;
+  String? captureSource;
 
   String? googlePlaceId;
   String? address;
@@ -29,6 +27,7 @@ class Geolocation {
     this.altitude,
     this.accuracy,
     this.time,
+    this.captureSource,
     this.googlePlaceId,
     this.address,
     this.locationType,
@@ -40,10 +39,10 @@ class Geolocation {
     var geolocation = Geolocation(
       latitude: generated.latitude,
       longitude: generated.longitude,
-      altitude: json['altitude'],
-      accuracy: json['accuracy'],
-      // not in server
-      time: json['time'] == null ? null : DateTime.parse(json['time']),
+      altitude: generated.altitude,
+      accuracy: generated.accuracy,
+      time: generated.capturedAt?.toUtc() ?? (json['time'] == null ? null : DateTime.parse(json['time']).toUtc()),
+      captureSource: generated.captureSource,
       // google_place_id server
       googlePlaceId: generated.googlePlaceId,
       address: generated.address,
@@ -57,6 +56,10 @@ class Geolocation {
     return Geolocation(
       latitude: generated.latitude,
       longitude: generated.longitude,
+      altitude: generated.altitude,
+      accuracy: generated.accuracy,
+      time: generated.capturedAt?.toUtc(),
+      captureSource: generated.captureSource,
       googlePlaceId: generated.googlePlaceId,
       address: generated.address,
       locationType: generated.locationType,
@@ -72,6 +75,10 @@ class Geolocation {
     return wire.GeneratedGeolocation(
       latitude: lat,
       longitude: lon,
+      altitude: altitude,
+      accuracy: accuracy,
+      capturedAt: time,
+      captureSource: captureSource,
       googlePlaceId: googlePlaceId,
       address: address,
       locationType: locationType,
@@ -85,7 +92,8 @@ class Geolocation {
       'id': id,
       'altitude': altitude,
       'accuracy': accuracy,
-      'time': time?.toUtc().toIso8601String(),
+      'captured_at': time?.toUtc().toIso8601String(),
+      'capture_source': captureSource,
       'google_place_id': googlePlaceId,
       'location_type': locationType,
       'address': address,

--- a/app/lib/models/local_recording.dart
+++ b/app/lib/models/local_recording.dart
@@ -1,4 +1,5 @@
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/utils/batch_recording.dart';
 
 /// Lifecycle of a local recording captured in batch/offline mode.
@@ -41,6 +42,9 @@ class LocalRecording {
   /// Estimated duration in seconds (the backend computes the exact value).
   final int seconds;
 
+  /// Canonical start-location snapshot copied beside the native batch file.
+  final Geolocation? geolocation;
+
   /// Server job id once uploaded (HTTP 202); null while [LocalRecordingState.pending].
   final String? jobId;
 
@@ -55,6 +59,7 @@ class LocalRecording {
     required this.sizeBytes,
     required this.seconds,
     required this.state,
+    this.geolocation,
     this.jobId,
   });
 
@@ -73,6 +78,7 @@ class LocalRecording {
     required String filePath,
     required int sizeBytes,
     int? seconds,
+    Geolocation? geolocation,
     String? jobId,
     required LocalRecordingState state,
   }) {
@@ -86,6 +92,7 @@ class LocalRecording {
       frameSize: info.frameSize,
       sizeBytes: sizeBytes,
       seconds: seconds ?? info.estimateSeconds(sizeBytes),
+      geolocation: geolocation,
       jobId: jobId,
       state: state,
     );

--- a/app/lib/pages/conversations/conversation_map_page.dart
+++ b/app/lib/pages/conversations/conversation_map_page.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
+import 'package:omi/pages/conversation_detail/page.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/ui_guidelines.dart';
+
+class ConversationMapGroup {
+  const ConversationMapGroup({required this.latitude, required this.longitude, required this.conversations});
+
+  final double latitude;
+  final double longitude;
+  final List<ServerConversation> conversations;
+
+  /// Stable cluster membership identity for widget automation. Sorting makes
+  /// this independent of fetch/group insertion order.
+  String get membershipKey {
+    final ids = conversations.map((conversation) => conversation.id).toList()..sort();
+    return Uri.encodeComponent(ids.join(','));
+  }
+}
+
+/// Builds stable ~100m clusters and drops malformed/missing coordinates without
+/// affecting the surrounding conversation surface.
+List<ConversationMapGroup> buildConversationMapGroups(Iterable<ServerConversation> conversations) {
+  final grouped = <String, List<ServerConversation>>{};
+  final coordinates = <String, (double, double)>{};
+  for (final conversation in conversations) {
+    final latitude = conversation.geolocation?.latitude;
+    final longitude = conversation.geolocation?.longitude;
+    if (conversation.discarded ||
+        latitude == null ||
+        longitude == null ||
+        !latitude.isFinite ||
+        !longitude.isFinite ||
+        latitude < -90 ||
+        latitude > 90 ||
+        longitude < -180 ||
+        longitude > 180) {
+      continue;
+    }
+    final key = '${latitude.toStringAsFixed(3)},${longitude.toStringAsFixed(3)}';
+    coordinates.putIfAbsent(key, () => (latitude, longitude));
+    (grouped[key] ??= []).add(conversation);
+  }
+  return [
+    for (final entry in grouped.entries)
+      ConversationMapGroup(
+        latitude: coordinates[entry.key]!.$1,
+        longitude: coordinates[entry.key]!.$2,
+        conversations: entry.value,
+      ),
+  ];
+}
+
+class ConversationMapPage extends StatelessWidget {
+  const ConversationMapPage({super.key, required this.conversations, this.tileProvider});
+
+  final List<ServerConversation> conversations;
+  final TileProvider? tileProvider;
+
+  Future<void> _openConversation(BuildContext context, ServerConversation conversation) async {
+    final timestamp = conversation.startedAt ?? conversation.createdAt;
+    final day = DateTime(timestamp.year, timestamp.month, timestamp.day);
+    context.read<ConversationDetailProvider>().updateConversation(conversation.id, day);
+    await Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => ConversationDetailPage(conversation: conversation)));
+  }
+
+  void _openGroup(BuildContext context, ConversationMapGroup group) {
+    if (group.conversations.length == 1) {
+      _openConversation(context, group.conversations.single);
+      return;
+    }
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppStyles.backgroundSecondary,
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 18, 20, 8),
+              child: Text(
+                '${group.conversations.length} ${context.l10n.conversations}',
+                style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w600),
+              ),
+            ),
+            for (final conversation in group.conversations)
+              ListTile(
+                key: ValueKey('conversation_map_cluster_row_${conversation.id}'),
+                title: Text(
+                  conversation.structured.title.isEmpty
+                      ? context.l10n.untitledConversation
+                      : conversation.structured.title,
+                  style: const TextStyle(color: Colors.white),
+                ),
+                subtitle: Text(
+                  (conversation.startedAt ?? conversation.createdAt).toLocal().toString(),
+                  style: const TextStyle(color: Colors.white60),
+                ),
+                trailing: const Icon(Icons.chevron_right, color: Colors.white70),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  _openConversation(context, conversation);
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = buildConversationMapGroups(conversations);
+    return Scaffold(
+      backgroundColor: AppStyles.backgroundPrimary,
+      appBar: AppBar(
+        backgroundColor: AppStyles.backgroundPrimary,
+        foregroundColor: Colors.white,
+        title: Text('${context.l10n.conversations} · ${context.l10n.location}'),
+      ),
+      body: groups.isEmpty
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Text(
+                  context.l10n.noConversationsYet,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.white70, fontSize: 16),
+                ),
+              ),
+            )
+          : FlutterMap(
+              options: MapOptions(
+                initialCenter: LatLng(groups.first.latitude, groups.first.longitude),
+                initialZoom: groups.length == 1 ? 14 : 11,
+                initialCameraFit: groups.length == 1
+                    ? null
+                    : CameraFit.bounds(
+                        bounds: LatLngBounds.fromPoints(
+                          groups.map((group) => LatLng(group.latitude, group.longitude)).toList(),
+                        ),
+                        padding: const EdgeInsets.all(48),
+                      ),
+                backgroundColor: AppStyles.backgroundPrimary,
+              ),
+              children: [
+                TileLayer(
+                  urlTemplate: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+                  subdomains: const ['a', 'b', 'c', 'd'],
+                  userAgentPackageName: 'me.omi.app',
+                  retinaMode: RetinaMode.isHighDensity(context),
+                  tileProvider: tileProvider,
+                ),
+                MarkerLayer(
+                  markers: [
+                    for (final group in groups)
+                      Marker(
+                        point: LatLng(group.latitude, group.longitude),
+                        width: 44,
+                        height: 44,
+                        child: Semantics(
+                          button: true,
+                          label: group.conversations.length == 1
+                              ? (group.conversations.single.structured.title.isEmpty
+                                  ? context.l10n.untitledConversation
+                                  : group.conversations.single.structured.title)
+                              : '${group.conversations.length} ${context.l10n.conversations}',
+                          child: GestureDetector(
+                            key: ValueKey('conversation_map_marker_${group.membershipKey}'),
+                            onTap: () => _openGroup(context, group),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                shape: BoxShape.circle,
+                                border: Border.all(color: Colors.black, width: 2),
+                                boxShadow: const [BoxShadow(color: Colors.black54, blurRadius: 8)],
+                              ),
+                              alignment: Alignment.center,
+                              child: group.conversations.length == 1
+                                  ? const Icon(Icons.location_on, color: Colors.black, size: 24)
+                                  : Text(
+                                      '${group.conversations.length}',
+                                      style: const TextStyle(color: Colors.black, fontWeight: FontWeight.w700),
+                                    ),
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -8,6 +8,7 @@ import 'package:visibility_detector/visibility_detector.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/pages/capture/widgets/widgets.dart';
 import 'package:omi/pages/conversations/widgets/daily_summaries_list.dart';
+import 'package:omi/pages/conversations/conversation_map_page.dart';
 import 'package:omi/pages/conversations/widgets/folder_tabs.dart';
 import 'package:omi/pages/conversations/widgets/goals_widget.dart';
 import 'package:omi/pages/conversations/widgets/processing_capture.dart';
@@ -346,6 +347,19 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                             convoProvider.showDailySummaries ? context.l10n.dailyRecaps : context.l10n.conversations,
                             style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
                           ),
+                          if (!convoProvider.showDailySummaries)
+                            IconButton(
+                              key: const Key('conversation_map_button'),
+                              tooltip: '${context.l10n.conversations} · ${context.l10n.location}',
+                              icon: const Icon(Icons.map_outlined, color: Colors.white),
+                              onPressed: () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => ConversationMapPage(
+                                    conversations: convoProvider.displayedConversations,
+                                  ),
+                                ),
+                              ),
+                            ),
                         ],
                       ),
                     ),

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -93,6 +93,14 @@ class ConversationProvider extends ChangeNotifier {
   bool get isAwaitingInitialFetchRetry => _initialFetchRetryTimer?.isActive ?? false;
   bool get hasActiveSearch => previousQuery.isNotEmpty || selectedSpeakerId != null;
 
+  /// The exact ordered set currently rendered by the conversation groups.
+  ///
+  /// Consumers that mirror the list (for example the map) must use this
+  /// boundary instead of [conversations], because grouping already applies
+  /// text/speaker search and every client-side visibility filter.
+  List<ServerConversation> get displayedConversations =>
+      List<ServerConversation>.unmodifiable(groupedConversations.values.expand((group) => group));
+
   final ConversationListFetcher? _conversationListFetcher;
   final DailySummariesChecker? _dailySummariesChecker;
   final ConversationSearchFetcher _conversationSearchFetcher;

--- a/app/lib/providers/local_recordings_provider.dart
+++ b/app/lib/providers/local_recordings_provider.dart
@@ -6,10 +6,12 @@ import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/models/local_recording.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/services/connectivity_service.dart';
+import 'package:omi/services/capture/native_batch_geolocation.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/audio_player_utils.dart';
 import 'package:omi/utils/batch_recording.dart';
@@ -142,6 +144,7 @@ class LocalRecordingsProvider extends ChangeNotifier {
           filePath: entity.path,
           sizeBytes: size,
           seconds: await _durationSeconds(name, entity.path, size),
+          geolocation: await readNativeBatchGeolocation(entity.path),
           jobId: _jobs[name],
           state: _stateFor(name),
         );
@@ -223,7 +226,7 @@ class LocalRecordingsProvider extends ChangeNotifier {
           DateTime.now().millisecondsSinceEpoch ~/ 1000,
           hasServerCaptureProof: false,
         );
-        final result = await SyncUploadGate.instance.upload([file], lane: lane);
+        final result = await uploadNativeBatchRecording(rec, file: file, lane: lane);
 
         if (result.completed != null) {
           await _deleteFileOnly(rec.fileName);
@@ -412,6 +415,8 @@ class LocalRecordingsProvider extends ChangeNotifier {
       if (dir == null) return;
       final file = File('${dir.path}/$fileName');
       if (file.existsSync()) await file.delete();
+      final sidecar = File(nativeBatchGeolocationSidecarPath(file.path));
+      if (sidecar.existsSync()) await sidecar.delete();
     } catch (e) {
       Logger.error('LocalRecordings: delete failed for $fileName: $e');
     }
@@ -515,6 +520,20 @@ class LocalRecordingsProvider extends ChangeNotifier {
     _audio.removeListener(_onAudioChanged);
     super.dispose();
   }
+}
+
+@visibleForTesting
+Future<UploadFilesResult> uploadNativeBatchRecording(
+  LocalRecording recording, {
+  required File file,
+  required SyncUploadLane lane,
+  SyncUploadGate? uploadGate,
+}) {
+  return (uploadGate ?? SyncUploadGate.instance).upload(
+    [file],
+    lane: lane,
+    geolocation: recording.geolocation,
+  );
 }
 
 /// Counts complete length-prefixed frames (`[4-byte LE length][payload]`) in a

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -18,6 +18,7 @@ import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
@@ -29,6 +30,7 @@ import 'package:omi/services/capture/capture_external_actions.dart';
 import 'package:omi/services/capture/capture_metrics_tracker.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
+import 'package:omi/services/capture/native_ble_stream_config.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
@@ -71,6 +73,7 @@ class CaptureController extends ChangeNotifier
   static const Duration _inProgressConversationRefreshInterval = Duration(seconds: 2);
 
   final ConversationLocationCapture _conversationLocationCapture = ConversationLocationCapture();
+  Geolocation? _sessionGeolocation;
 
   CaptureExternalActions externalActions;
   DeviceOnboardingProvider? deviceOnboardingProvider;
@@ -661,6 +664,7 @@ class CaptureController extends ChangeNotifier
           force: force,
           source: source,
           customSttConfig: effectiveConfig,
+          geolocation: _sessionGeolocation,
         );
     if (_socket == null) {
       _startKeepAliveServices();
@@ -1064,16 +1068,19 @@ class CaptureController extends ChangeNotifier
 
     await SharedPreferencesUtil().saveString(
       'nativeBleStreamConfig',
-      jsonEncode({
-        'deviceId': device.id,
-        'codec': codec.toString(),
-        'sampleRate': mapCodecToSampleRate(codec),
-        'source': _getConversationSourceFromDevice(),
-        'apiBaseUrl': Env.apiBaseUrl ?? 'https://api.omiapi.com/',
-        'serviceUuid': audioTarget.key,
-        'characteristicUuid': audioTarget.value,
-        'deviceType': device.type.name,
-      }),
+      jsonEncode(
+        buildNativeBleStreamConfig(
+          deviceId: device.id,
+          codec: codec.toString(),
+          sampleRate: mapCodecToSampleRate(codec),
+          source: _getConversationSourceFromDevice(),
+          apiBaseUrl: Env.apiBaseUrl ?? 'https://api.omiapi.com/',
+          serviceUuid: audioTarget.key,
+          characteristicUuid: audioTarget.value,
+          deviceType: device.type.name,
+          geolocation: _sessionGeolocation,
+        ),
+      ),
     );
     // Batch (offline) capture: tell the native writer where to store .bin files
     // and ensure the native realtime socket is disabled while batch mode is on
@@ -1320,11 +1327,15 @@ class CaptureController extends ChangeNotifier
     notifyListeners();
   }
 
+  Future<void> _captureSessionLocation() async {
+    _sessionGeolocation = await _conversationLocationCapture.captureAndUpload();
+    _wal.getSyncs().phone.setSessionGeolocation(_sessionGeolocation);
+  }
+
   streamRecording() async {
-    // The backend snapshots its cached location when finalizing a conversation.
-    // Complete this bounded update before any live or batch capture path can
-    // create/finalize that conversation.
-    await _conversationLocationCapture.captureAndUpload();
+    // Capture once at session start. The snapshot is carried privately in the
+    // live handshake and inherited by any WAL written for delayed/offline sync.
+    await _captureSessionLocation();
 
     // Mode is fixed for the whole session at start. On iOS and Android the phone
     // mic can capture Transcribe Later (batch) audio: explicitly when the user
@@ -1452,6 +1463,12 @@ class CaptureController extends ChangeNotifier
     final docs = await getApplicationDocumentsDirectory();
     await SharedPreferencesUtil().saveString('batchAudioDir', docs.path);
     await SharedPreferencesUtil().saveBool('phoneBatchAuto', auto);
+    final geolocation = _sessionGeolocation;
+    if (geolocation == null) {
+      await SharedPreferencesUtil().remove('phoneBatchGeolocation');
+    } else {
+      await SharedPreferencesUtil().saveString('phoneBatchGeolocation', jsonEncode(geolocation.toJson()));
+    }
     if (SharedPreferencesUtil().batchMuted) SharedPreferencesUtil().batchMuted = false;
     if (SharedPreferencesUtil().batchCutRequested) SharedPreferencesUtil().batchCutRequested = false;
 
@@ -1521,7 +1538,7 @@ class CaptureController extends ChangeNotifier
 
     // Ensure even very short device recordings have a location in Redis before
     // the backend is able to finalize their conversation.
-    await _conversationLocationCapture.captureAndUpload();
+    await _captureSessionLocation();
 
     await _resetStateVariables();
     await _resetState();

--- a/app/lib/services/capture/conversation_location_capture.dart
+++ b/app/lib/services/capture/conversation_location_capture.dart
@@ -11,6 +11,7 @@ typedef LocationPermissionReader = Future<LocationPermission> Function();
 typedef CurrentPositionReader = Future<Position> Function();
 typedef LastPositionReader = Future<Position?> Function();
 typedef GeolocationUploader = Future<bool> Function(Geolocation geolocation);
+typedef LocationClock = DateTime Function();
 
 /// Captures the location that belongs to a recording before the backend can
 /// finalize its conversation.
@@ -21,64 +22,85 @@ class ConversationLocationCapture {
     CurrentPositionReader? getCurrentPosition,
     LastPositionReader? getLastKnownPosition,
     GeolocationUploader? upload,
+    LocationClock? now,
     this.currentPositionTimeout = const Duration(seconds: 1),
     this.totalTimeout = const Duration(seconds: 3),
+    this.maxLastKnownAge = const Duration(minutes: 15),
   })  : _isLocationServiceEnabled = isLocationServiceEnabled ?? Geolocator.isLocationServiceEnabled,
         _checkPermission = checkPermission ?? Geolocator.checkPermission,
         _getCurrentPosition = getCurrentPosition ?? Geolocator.getCurrentPosition,
         _getLastKnownPosition = getLastKnownPosition ?? Geolocator.getLastKnownPosition,
-        _upload = upload ?? ((geolocation) => updateUserGeolocation(geolocation: geolocation));
+        _upload = upload ?? ((geolocation) => updateUserGeolocation(geolocation: geolocation)),
+        _now = now ?? DateTime.now;
 
   final LocationServiceEnabled _isLocationServiceEnabled;
   final LocationPermissionReader _checkPermission;
   final CurrentPositionReader _getCurrentPosition;
   final LastPositionReader _getLastKnownPosition;
   final GeolocationUploader _upload;
+  final LocationClock _now;
   final Duration currentPositionTimeout;
   final Duration totalTimeout;
+  final Duration maxLastKnownAge;
 
-  Future<bool> captureAndUpload() async {
+  /// Returns the start-time snapshot even when the compatibility upload fails,
+  /// so the caller can persist it with the recording/WAL.
+  Future<Geolocation?> captureAndUpload() async {
+    Geolocation? geolocation;
     try {
-      return await _captureAndUpload().timeout(totalTimeout);
+      geolocation = await _capture().timeout(totalTimeout);
     } on TimeoutException {
       Logger.log('Conversation location capture timed out; recording will continue');
-      return false;
+      return null;
     } catch (e) {
       Logger.error('Error capturing conversation location: $e');
-      return false;
+      return null;
     }
+    if (geolocation == null) return null;
+    try {
+      await _upload(geolocation).timeout(totalTimeout);
+    } catch (e) {
+      Logger.log('Conversation location compatibility upload failed; preserving recording snapshot');
+    }
+    return geolocation;
   }
 
-  Future<bool> _captureAndUpload() async {
+  Future<Geolocation?> _capture() async {
     if (!await _isLocationServiceEnabled()) {
       Logger.log('Location service is not enabled, skipping conversation location');
-      return false;
+      return null;
     }
 
     final permission = await _checkPermission();
     if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
       Logger.log('Location permission not granted, skipping conversation location');
-      return false;
+      return null;
     }
 
     Position? position;
+    var captureSource = 'current_position';
     try {
       position = await _getCurrentPosition().timeout(currentPositionTimeout);
     } on TimeoutException {
       // A recent OS fix is preferable to losing the conversation location when
       // a fresh GPS fix is slow indoors.
       position = await _getLastKnownPosition();
+      captureSource = 'last_known_position';
     }
-    if (position == null) return false;
+    if (position == null) return null;
+    if (captureSource == 'last_known_position' &&
+        _now().toUtc().difference(position.timestamp.toUtc()) > maxLastKnownAge) {
+      Logger.log('Last known location is stale, skipping conversation location');
+      return null;
+    }
 
-    return _upload(
-      Geolocation(
-        latitude: position.latitude,
-        longitude: position.longitude,
-        altitude: position.altitude,
-        accuracy: position.accuracy,
-        time: position.timestamp.toUtc(),
-      ),
+    return Geolocation(
+      latitude: position.latitude,
+      longitude: position.longitude,
+      altitude: position.altitude,
+      accuracy: position.accuracy,
+      time: position.timestamp.toUtc(),
+      captureSource: captureSource,
     );
   }
 }

--- a/app/lib/services/capture/native_batch_geolocation.dart
+++ b/app/lib/services/capture/native_batch_geolocation.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:omi/backend/schema/geolocation.dart';
+
+const String nativeBatchGeolocationSidecarSuffix = '.geolocation.json';
+const int nativeBatchGeolocationMaxBytes = 4096;
+
+String nativeBatchGeolocationSidecarPath(String audioPath) => '$audioPath$nativeBatchGeolocationSidecarSuffix';
+
+/// Reads the private start-location snapshot copied by the native phone-batch
+/// writer when it opens the corresponding audio file. Missing, oversized, or
+/// malformed sidecars fail soft so recording discovery and upload still work.
+Future<Geolocation?> readNativeBatchGeolocation(String audioPath) async {
+  try {
+    final sidecar = File(nativeBatchGeolocationSidecarPath(audioPath));
+    if (!await sidecar.exists()) return null;
+    final bytes = await sidecar.readAsBytes();
+    if (bytes.isEmpty || bytes.length > nativeBatchGeolocationMaxBytes) return null;
+    final decoded = jsonDecode(utf8.decode(bytes));
+    if (decoded is! Map<String, dynamic>) return null;
+    return Geolocation.fromJson(decoded);
+  } catch (_) {
+    return null;
+  }
+}

--- a/app/lib/services/capture/native_ble_stream_config.dart
+++ b/app/lib/services/capture/native_ble_stream_config.dart
@@ -1,0 +1,28 @@
+import 'package:omi/backend/schema/geolocation.dart';
+
+/// Private Dart-to-Android handoff contract for background BLE streaming.
+/// The snapshot is recording-owned and copied once; native code validates and
+/// forwards it only on the authenticated `/v4/listen` request.
+Map<String, dynamic> buildNativeBleStreamConfig({
+  required String deviceId,
+  required String codec,
+  required int sampleRate,
+  required String? source,
+  required String apiBaseUrl,
+  required String serviceUuid,
+  required String characteristicUuid,
+  required String deviceType,
+  Geolocation? geolocation,
+}) {
+  return {
+    'deviceId': deviceId,
+    'codec': codec,
+    'sampleRate': sampleRate,
+    'source': source,
+    'apiBaseUrl': apiBaseUrl,
+    'serviceUuid': serviceUuid,
+    'characteristicUuid': characteristicUuid,
+    'deviceType': deviceType,
+    if (geolocation != null) 'geolocation': geolocation.toJson(),
+  };
+}

--- a/app/lib/services/sockets.dart
+++ b/app/lib/services/sockets.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/services/sockets/transcription_service.dart';
 import 'package:omi/utils/logger.dart';
@@ -20,6 +21,7 @@ abstract class ISocketService {
     bool force = false,
     String? source,
     CustomSttConfig? customSttConfig,
+    Geolocation? geolocation,
   });
 
   Future<TranscriptSegmentSocketService?> speechProfile({
@@ -56,6 +58,7 @@ class SocketServicePool extends ISocketService {
     bool force = false,
     String? source,
     CustomSttConfig? customSttConfig,
+    Geolocation? geolocation,
   }) async {
     await _mutex.acquire();
     try {
@@ -66,7 +69,8 @@ class SocketServicePool extends ISocketService {
           _socket?.codec == codec &&
           _socket?.sampleRate == sampleRate &&
           _socket?.state == SocketServiceState.connected &&
-          _socket?.sttConfigId == sttConfigId) {
+          _socket?.sttConfigId == sttConfigId &&
+          _socket?.geolocation?.time == geolocation?.time) {
         Logger.debug("Reusing existing socket connection");
         return _socket;
       }
@@ -85,6 +89,7 @@ class SocketServicePool extends ISocketService {
           language,
           customSttConfig,
           source: source,
+          geolocation: geolocation,
         );
       } else {
         _socket = TranscriptSocketServiceFactory.createDefault(
@@ -93,6 +98,7 @@ class SocketServicePool extends ISocketService {
           language,
           source: source,
           sttConfigId: sttConfigId,
+          geolocation: geolocation,
         );
       }
 
@@ -115,6 +121,7 @@ class SocketServicePool extends ISocketService {
     bool force = false,
     String? source,
     CustomSttConfig? customSttConfig,
+    Geolocation? geolocation,
   }) async {
     Logger.debug(
       "socket conversation > $codec $sampleRate $force source: $source customStt: ${customSttConfig?.provider}",
@@ -126,6 +133,7 @@ class SocketServicePool extends ISocketService {
       force: force,
       source: source,
       customSttConfig: customSttConfig,
+      geolocation: geolocation,
     );
   }
 

--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -59,8 +59,9 @@ class PureSocket implements IPureSocket {
   String url;
   final SocketHeadersProvider _headersProvider;
 
-  PureSocket(this.url, {SocketHeadersProvider? headersProvider})
-      : _headersProvider = headersProvider ?? (() => buildHeaders(requireAuthCheck: true));
+  PureSocket(this.url, {SocketHeadersProvider? headersProvider, Map<String, String> extraHeaders = const {}})
+      : _headersProvider =
+            headersProvider ?? (() async => {...await buildHeaders(requireAuthCheck: true), ...extraHeaders});
 
   @override
   void setListener(IPureSocketListener listener) {

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/env/env.dart';
@@ -45,6 +46,7 @@ class SpeechProfileTranscriptSegmentSocketService extends TranscriptSegmentSocke
     super.source,
     super.customSttMode,
     super.onboardingMode,
+    super.geolocation,
   }) : super.create(includeSpeechProfile: false);
 }
 
@@ -55,12 +57,18 @@ class ConversationTranscriptSegmentSocketService extends TranscriptSegmentSocket
     super.language, {
     super.source,
     super.customSttMode,
+    super.geolocation,
   }) : super.create(includeSpeechProfile: true);
 }
 
 class CustomSttTranscriptSegmentSocketService extends TranscriptSegmentSocketService {
-  CustomSttTranscriptSegmentSocketService.create(super.sampleRate, super.codec, super.language, {super.source})
-      : super.create(includeSpeechProfile: true, customSttMode: true);
+  CustomSttTranscriptSegmentSocketService.create(
+    super.sampleRate,
+    super.codec,
+    super.language, {
+    super.source,
+    super.geolocation,
+  }) : super.create(includeSpeechProfile: true, customSttMode: true);
 }
 
 enum SocketServiceState { connected, disconnected }
@@ -84,6 +92,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
   String? sttConfigId;
 
   bool onboardingMode;
+  Geolocation? geolocation;
 
   TranscriptSegmentSocketService.create(
     this.sampleRate,
@@ -94,6 +103,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     this.customSttMode = false,
     this.sttConfigId,
     this.onboardingMode = false,
+    this.geolocation,
   }) {
     var params = '?language=$language&sample_rate=$sampleRate&codec=$codec&uid=${SharedPreferencesUtil().uid}'
         '&include_speech_profile=$includeSpeechProfile&stt_service=${SharedPreferencesUtil().transcriptionModel}'
@@ -126,7 +136,10 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     String url =
         Env.apiBaseUrl!.replaceFirst('https://', 'wss://').replaceFirst('http://', 'ws://') + 'v4/listen$params';
 
-    _socket = PureSocket(url);
+    _socket = PureSocket(
+      url,
+      extraHeaders: {if (geolocation != null) 'X-Omi-Conversation-Geolocation': jsonEncode(geolocation!.toJson())},
+    );
     _socket.setListener(this);
   }
 
@@ -140,6 +153,7 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     this.customSttMode = false,
     this.sttConfigId,
     this.onboardingMode = false,
+    this.geolocation,
   }) {
     _socket = socket;
     _socket.setListener(this);
@@ -308,6 +322,7 @@ class TranscriptSocketServiceFactory {
     bool includeSpeechProfile = true,
     String? source,
     String? sttConfigId,
+    Geolocation? geolocation,
   }) {
     return TranscriptSegmentSocketService.create(
       sampleRate,
@@ -316,6 +331,7 @@ class TranscriptSocketServiceFactory {
       includeSpeechProfile: includeSpeechProfile,
       source: source,
       sttConfigId: sttConfigId ?? 'omi:default',
+      geolocation: geolocation,
     );
   }
 
@@ -337,9 +353,10 @@ class TranscriptSocketServiceFactory {
     String language,
     CustomSttConfig config, {
     String? source,
+    Geolocation? geolocation,
   }) {
     if (!config.isEnabled) {
-      return createDefault(sampleRate, codec, language, source: source);
+      return createDefault(sampleRate, codec, language, source: source, geolocation: geolocation);
     }
 
     final sttConfigId = config.sttConfigId;
@@ -361,6 +378,7 @@ class TranscriptSocketServiceFactory {
       effectiveLang,
       primarySocket: primarySocket,
       source: source,
+      geolocation: geolocation,
       sttConfigId: sttConfigId,
       sttProvider: config.provider.name,
     );
@@ -489,12 +507,14 @@ class TranscriptSocketServiceFactory {
     String? source,
     String? sttConfigId,
     String? sttProvider,
+    Geolocation? geolocation,
   }) {
     final secondaryService = CustomSttTranscriptSegmentSocketService.create(
       sampleRate,
       codec,
       language,
       source: source,
+      geolocation: geolocation,
     );
     final compositeSocket = CompositeTranscriptionSocket(
       primarySocket: primarySocket,
@@ -509,6 +529,7 @@ class TranscriptSocketServiceFactory {
       source: source,
       customSttMode: true,
       sttConfigId: sttConfigId,
+      geolocation: geolocation,
     );
   }
 }

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/services/wals/wal_interfaces.dart';
@@ -91,6 +92,12 @@ Set<String> oversizedFreshConversationIds(List<Wal> pending, int nowSeconds) {
   return counts.entries.where((entry) => entry.value > 20).map((entry) => entry.key).toSet();
 }
 
+String? _walLocationBatchKey(Wal wal) {
+  final geolocation = wal.geolocation;
+  if (geolocation == null) return null;
+  return '${geolocation.time?.toUtc().toIso8601String()}|${geolocation.latitude}|${geolocation.longitude}';
+}
+
 @visibleForTesting
 List<Wal> nextSyncUploadBatch(
   List<Wal> pending,
@@ -111,8 +118,14 @@ List<Wal> nextSyncUploadBatch(
   if (ordered.isEmpty) return const [];
   final lane = effectiveLane(ordered.first);
   final conversationId = ordered.first.conversationId;
+  final locationKey = _walLocationBatchKey(ordered.first);
   return ordered
-      .where((wal) => effectiveLane(wal) == lane && wal.conversationId == conversationId)
+      .where(
+        (wal) =>
+            effectiveLane(wal) == lane &&
+            wal.conversationId == conversationId &&
+            _walLocationBatchKey(wal) == locationKey,
+      )
       .take(_syncUploadBatchLimit)
       .toList();
 }
@@ -132,6 +145,8 @@ class LocalWalSyncImpl implements LocalWalSync {
   BleAudioCodec _codec = BleAudioCodec.opus;
   String? _deviceId;
   String? _deviceModel;
+  Geolocation? _sessionGeolocation;
+  int? _sessionGeolocationSetAt;
 
   bool _isCancelled = false;
 
@@ -170,6 +185,15 @@ class LocalWalSyncImpl implements LocalWalSync {
 
   @override
   Future<void> addExternalWal(Wal wal) async {
+    // Native-storage recovery can surface old WALs while a new recording is
+    // active. Only inherit the current session's location for WALs that began
+    // at (or after) this session, never for historical recordings.
+    if (wal.geolocation == null &&
+        _sessionGeolocation != null &&
+        _sessionGeolocationSetAt != null &&
+        wal.timerStart >= _sessionGeolocationSetAt! - 60) {
+      wal.geolocation = _sessionGeolocation;
+    }
     final existingIndex = _wals.indexWhere((w) => w.id == wal.id);
     if (existingIndex >= 0) {
       Logger.debug("LocalWalSync: WAL ${wal.id} already exists, skipping");
@@ -264,6 +288,12 @@ class LocalWalSyncImpl implements LocalWalSync {
     _deviceModel = deviceModel;
   }
 
+  @override
+  void setSessionGeolocation(Geolocation? geolocation) {
+    _sessionGeolocation = geolocation;
+    _sessionGeolocationSetAt = geolocation == null ? null : DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  }
+
   Future _chunk() async {
     if (_frames.isEmpty) {
       Logger.debug("Frames are empty");
@@ -327,6 +357,7 @@ class LocalWalSyncImpl implements LocalWalSync {
           seconds: chunkFrameCount ~/ _framesPerSecond,
           totalFrames: chunkFrameCount,
           syncedFrameOffset: syncedOffset,
+          geolocation: _sessionGeolocation,
         );
         _wals.add(wal);
       } else {
@@ -513,6 +544,7 @@ class LocalWalSyncImpl implements LocalWalSync {
             seconds: chunkFrameCount ~/ _framesPerSecond,
             totalFrames: chunkFrameCount,
             syncedFrameOffset: syncedOffset,
+            geolocation: _sessionGeolocation,
           ),
         );
     }
@@ -793,7 +825,12 @@ class LocalWalSyncImpl implements LocalWalSync {
         // wait for server-side processing here; the reconciler resolves the
         // job_id later. Only WALs that actually became files (batchWals) are
         // mutated — corrupted ones already short-circuited above.
-        final result = await _uploadGate.upload(files, lane: batchLane, conversationId: batchWals.first.conversationId);
+        final result = await _uploadGate.upload(
+          files,
+          lane: batchLane,
+          conversationId: batchWals.first.conversationId,
+          geolocation: batchWals.first.geolocation,
+        );
 
         if (result.completed != null) {
           // 200 fast-path: server processed synchronously and returned a result.
@@ -948,7 +985,12 @@ class LocalWalSyncImpl implements LocalWalSync {
         // conversation batching.
         if (pendingForConversation.length > 1) lane = SyncUploadLane.backfill;
       }
-      final result = await _uploadGate.upload([walFile], lane: lane, conversationId: walToSync.conversationId);
+      final result = await _uploadGate.upload(
+        [walFile],
+        lane: lane,
+        conversationId: walToSync.conversationId,
+        geolocation: walToSync.geolocation,
+      );
 
       if (result.completed != null) {
         final r = result.completed!;

--- a/app/lib/services/wals/sync_upload_gate.dart
+++ b/app/lib/services/wals/sync_upload_gate.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/http/shared.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/services/wals/sync_rate_limit_reconciliation.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
 import 'package:omi/utils/mutex.dart';
@@ -13,6 +14,7 @@ typedef SyncFilesUploader = Future<UploadFilesResult> Function(
   UploadProgressCallback? onUploadProgress,
   String? conversationId,
   SyncUploadLane syncLane,
+  Geolocation? geolocation,
 });
 typedef FairUseStatusLoader = Future<Map<String, dynamic>?> Function();
 
@@ -95,6 +97,7 @@ class SyncUploadGate {
     UploadProgressCallback? onUploadProgress,
     String? conversationId,
     SyncUploadLane lane = SyncUploadLane.fresh,
+    Geolocation? geolocation,
   }) async {
     await _uploadMutex.acquire();
     try {
@@ -122,6 +125,7 @@ class SyncUploadGate {
           onUploadProgress: onUploadProgress,
           conversationId: conversationId,
           syncLane: lane,
+          geolocation: geolocation,
         );
         _limiter.clearForLane(lane.name);
         return result;

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -1,6 +1,7 @@
 import 'package:path_provider/path_provider.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 
 const chunkSizeInSeconds = 60;
 const flushIntervalInSeconds = 90;
@@ -117,6 +118,9 @@ class Wal {
   /// arrives so WALs survive app kill and can be recovered on startup.
   String? conversationId;
 
+  /// Canonical start-time location snapshot for delayed/offline finalization.
+  Geolocation? geolocation;
+
   /// Number of sync retry attempts for this WAL.
   int retryCount;
 
@@ -186,6 +190,7 @@ class Wal {
     this.syncedFrameOffset = 0,
     this.originalStorage,
     this.conversationId,
+    this.geolocation,
     this.retryCount = 0,
     this.lastRetryAt = 0,
     this.jobId,
@@ -214,6 +219,9 @@ class Wal {
       originalStorage:
           json['original_storage'] != null ? WalStorage.values.asNameMap()[json['original_storage']] : null,
       conversationId: json['conversation_id'],
+      geolocation: json['geolocation'] is Map<String, dynamic>
+          ? Geolocation.fromJson(json['geolocation'] as Map<String, dynamic>)
+          : null,
       retryCount: json['retry_count'] ?? 0,
       lastRetryAt: json['last_retry_at'] ?? 0,
       jobId: json['job_id'],
@@ -240,6 +248,7 @@ class Wal {
       'synced_frame_offset': syncedFrameOffset,
       'original_storage': originalStorage?.name,
       'conversation_id': conversationId,
+      'geolocation': geolocation?.toJson(),
       'retry_count': retryCount,
       'last_retry_at': lastRetryAt,
       'job_id': jobId,

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -1,5 +1,6 @@
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/wal.dart';
@@ -82,6 +83,9 @@ abstract class LocalWalSync implements IWalSync {
 
   /// Set device metadata for WAL file naming.
   void setDeviceInfo(String? deviceId, String? deviceModel);
+
+  /// Set the snapshot inherited by WALs created for the active session.
+  void setSessionGeolocation(Geolocation? geolocation);
 }
 
 abstract class SDCardWalSync implements IWalSync {

--- a/app/test/providers/conversation_map_provider_boundary_test.dart
+++ b/app/test/providers/conversation_map_provider_boundary_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('map boundary follows active text and speaker search groups', () {
+    final feed = _conversation('feed');
+    final searchMatch = _conversation('search-match');
+    final provider = _provider()..conversations = [feed];
+    addTearDown(provider.dispose);
+
+    provider
+      ..previousQuery = 'alice'
+      ..selectedSpeakerId = 'speaker-1'
+      ..searchedConversations = [searchMatch]
+      ..groupConversationsByDate();
+
+    expect(provider.displayedConversations.map((conversation) => conversation.id), ['search-match']);
+  });
+
+  test('map boundary follows client-side short, starred, date, and folder filters', () {
+    final visible = _conversation(
+      'visible',
+      durationSeconds: 120,
+      starred: true,
+      folderId: 'folder-1',
+      startedAt: DateTime.utc(2026, 8, 1, 12),
+    );
+    final short = _conversation(
+      'short',
+      durationSeconds: 10,
+      starred: true,
+      folderId: 'folder-1',
+      startedAt: DateTime.utc(2026, 8, 1, 13),
+    );
+    final unstarred = _conversation(
+      'unstarred',
+      durationSeconds: 120,
+      folderId: 'folder-1',
+      startedAt: DateTime.utc(2026, 8, 1, 14),
+    );
+    final wrongFolder = _conversation(
+      'wrong-folder',
+      durationSeconds: 120,
+      starred: true,
+      folderId: 'folder-2',
+      startedAt: DateTime.utc(2026, 8, 1, 15),
+    );
+    final wrongDate = _conversation(
+      'wrong-date',
+      durationSeconds: 120,
+      starred: true,
+      folderId: 'folder-1',
+      startedAt: DateTime.utc(2026, 8, 2, 12),
+    );
+    final provider = _provider()
+      ..showShortConversations = false
+      ..shortConversationThreshold = 60
+      ..showStarredOnly = true
+      ..selectedFolderId = 'folder-1'
+      ..selectedDate = DateTime(2026, 8, 1)
+      ..conversations = [visible, short, unstarred, wrongFolder, wrongDate];
+    addTearDown(provider.dispose);
+
+    provider.groupConversationsByDate();
+
+    expect(provider.displayedConversations.map((conversation) => conversation.id), ['visible']);
+  });
+}
+
+ConversationProvider _provider() => ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      isSignedIn: () => true,
+    );
+
+ServerConversation _conversation(
+  String id, {
+  int durationSeconds = 120,
+  bool starred = false,
+  String? folderId,
+  DateTime? startedAt,
+}) {
+  final start = startedAt ?? DateTime.utc(2026, 8, 1, 12);
+  return ServerConversation(
+    id: id,
+    createdAt: start,
+    startedAt: start,
+    finishedAt: start.add(Duration(seconds: durationSeconds)),
+    structured: Structured('Title', 'Overview'),
+    starred: starred,
+    folderId: folderId,
+  );
+}

--- a/app/test/providers/sync_provider_startup_reconciliation_test.dart
+++ b/app/test/providers/sync_provider_startup_reconciliation_test.dart
@@ -25,7 +25,7 @@ void main() {
         statusCalls++;
         return {'stage': 'none'};
       },
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async =>
           UploadFilesResult.queued('unused'),
     );
     final provider = SyncProvider(walService: WalService(), uploadGate: gate, startBackgroundSync: false);
@@ -46,7 +46,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async =>
           UploadFilesResult.queued('unused'),
     );
     var startupWakes = 0;

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -74,7 +74,7 @@ Wal _wal({required int timerStart, required String? filePath}) {
 SyncUploadGate _offlineGate() {
   return SyncUploadGate(
     limiter: SyncRateLimiter.instance,
-    uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+    uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
       throw StateError('unexpected upload in terminal WAL-state test');
     },
     fairUseStatusLoader: () async => {'stage': 'none'},

--- a/app/test/unit/conversation_location_capture_test.dart
+++ b/app/test/unit/conversation_location_capture_test.dart
@@ -21,9 +21,11 @@ void main() {
       },
     );
 
-    expect(await capture.captureAndUpload(), isTrue);
+    final result = await capture.captureAndUpload();
+    expect(result, isNotNull);
     expect(uploaded?.latitude, 28.6139);
     expect(uploaded?.longitude, 77.2090);
+    expect(result?.captureSource, 'current_position');
   });
 
   test('uses the last known position when a fresh fix is slow', () async {
@@ -38,11 +40,14 @@ void main() {
         return true;
       },
       currentPositionTimeout: const Duration(milliseconds: 1),
+      now: () => DateTime.utc(2026, 7, 21, 0, 10),
     );
 
-    expect(await capture.captureAndUpload(), isTrue);
+    final result = await capture.captureAndUpload();
+    expect(result, isNotNull);
     expect(uploaded?.latitude, 51.5072);
     expect(uploaded?.longitude, -0.1276);
+    expect(result?.captureSource, 'last_known_position');
   });
 
   test('does not upload without location permission', () async {
@@ -58,8 +63,34 @@ void main() {
       },
     );
 
-    expect(await capture.captureAndUpload(), isFalse);
+    expect(await capture.captureAndUpload(), isNull);
     expect(uploads, 0);
+  });
+
+  test('rejects a stale last-known position', () async {
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () => Completer<Position>().future,
+      getLastKnownPosition: () async => _position(latitude: 51.5072, longitude: -0.1276),
+      upload: (_) async => true,
+      currentPositionTimeout: const Duration(milliseconds: 1),
+      now: () => DateTime.utc(2026, 7, 21, 0, 16),
+    );
+
+    expect(await capture.captureAndUpload(), isNull);
+  });
+
+  test('preserves the snapshot when the compatibility upload fails', () async {
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.always,
+      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      getLastKnownPosition: () async => null,
+      upload: (_) async => false,
+    );
+
+    expect((await capture.captureAndUpload())?.latitude, 1);
   });
 }
 

--- a/app/test/unit/conversation_map_groups_test.dart
+++ b/app/test/unit/conversation_map_groups_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/conversation_map_page.dart';
+
+void main() {
+  test('omits missing and invalid locations without failing the map', () {
+    final groups = buildConversationMapGroups([
+      _conversation('missing'),
+      _conversation('invalid', latitude: 91, longitude: 0),
+      _conversation('valid', latitude: 37.7749, longitude: -122.4194),
+    ]);
+
+    expect(groups, hasLength(1));
+    expect(groups.single.conversations.single.id, 'valid');
+  });
+
+  test('clusters dense repeated locations into one selectable marker', () {
+    final groups = buildConversationMapGroups([
+      _conversation('first', latitude: 37.77491, longitude: -122.41941),
+      _conversation('second', latitude: 37.77494, longitude: -122.41944),
+    ]);
+
+    expect(groups, hasLength(1));
+    expect(groups.single.conversations.map((conversation) => conversation.id), ['first', 'second']);
+    expect(groups.single.membershipKey, 'first%2Csecond');
+  });
+
+  test('cluster membership key is stable across provider ordering', () {
+    final first = buildConversationMapGroups([
+      _conversation('second', latitude: 37.77494, longitude: -122.41944),
+      _conversation('first', latitude: 37.77491, longitude: -122.41941),
+    ]).single.membershipKey;
+    final second = buildConversationMapGroups([
+      _conversation('first', latitude: 37.77491, longitude: -122.41941),
+      _conversation('second', latitude: 37.77494, longitude: -122.41944),
+    ]).single.membershipKey;
+
+    expect(first, second);
+  });
+
+  testWidgets('empty map remains usable when the filtered view has no locations', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: ConversationMapPage(conversations: []),
+      ),
+    );
+
+    expect(find.text('Conversations · Location'), findsOneWidget);
+    expect(find.text('No conversations yet'), findsOneWidget);
+  });
+
+  testWidgets('markers and clustered rows expose stable descriptive keys', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: ConversationMapPage(
+          conversations: [
+            _conversation('first', latitude: 37.77491, longitude: -122.41941),
+            _conversation('second', latitude: 37.77494, longitude: -122.41944),
+          ],
+          tileProvider: _MemoryTileProvider(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final marker = find.byKey(const ValueKey('conversation_map_marker_first%2Csecond'));
+    expect(marker, findsOneWidget);
+
+    await tester.tap(marker);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('conversation_map_cluster_row_first')), findsOneWidget);
+    expect(find.byKey(const ValueKey('conversation_map_cluster_row_second')), findsOneWidget);
+  });
+}
+
+class _MemoryTileProvider extends TileProvider {
+  static final _tile = MemoryImage(
+    base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='),
+  );
+
+  @override
+  ImageProvider getImage(TileCoordinates coordinates, TileLayer options) => _tile;
+}
+
+ServerConversation _conversation(String id, {double? latitude, double? longitude}) => ServerConversation(
+      id: id,
+      createdAt: DateTime.utc(2026, 8, 1),
+      structured: Structured('Title', 'Overview'),
+      geolocation: latitude == null || longitude == null ? null : Geolocation(latitude: latitude, longitude: longitude),
+    );

--- a/app/test/unit/local_wal_sync_test.dart
+++ b/app/test/unit/local_wal_sync_test.dart
@@ -9,6 +9,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
@@ -302,6 +303,32 @@ void main() {
 
       expect(batch.length, 20);
       expect(batch.map((wal) => wal.timerStart), historical.take(20).map((wal) => wal.timerStart));
+    });
+
+    test('historical WALs with different recording locations are never uploaded as one conversation batch', () {
+      const now = 2000000000;
+      final firstCapture = Geolocation(
+        latitude: 40.7128,
+        longitude: -74.0060,
+        time: DateTime.utc(2033, 5, 18, 3, 30),
+        captureSource: 'current_position',
+      );
+      final secondCapture = Geolocation(
+        latitude: 34.0522,
+        longitude: -118.2437,
+        time: DateTime.utc(2033, 5, 18, 4, 30),
+        captureSource: 'current_position',
+      );
+      final wals = [
+        Wal(timerStart: now - 7 * 60 * 60, codec: BleAudioCodec.opus, seconds: 60, geolocation: firstCapture),
+        Wal(timerStart: now - 7 * 60 * 60 - 60, codec: BleAudioCodec.opus, seconds: 60, geolocation: firstCapture),
+        Wal(timerStart: now - 8 * 60 * 60, codec: BleAudioCodec.opus, seconds: 60, geolocation: secondCapture),
+      ];
+
+      final batch = nextSyncUploadBatch(wals, now);
+
+      expect(batch, hasLength(2));
+      expect(batch.every((wal) => identical(wal.geolocation, firstCapture)), isTrue);
     });
 
     test('an oversized fresh conversation is downgraded as one unit', () {

--- a/app/test/unit/native_batch_geolocation_test.dart
+++ b/app/test/unit/native_batch_geolocation_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/conversations.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/models/local_recording.dart';
+import 'package:omi/providers/local_recordings_provider.dart';
+import 'package:omi/services/capture/native_batch_geolocation.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
+
+void main() {
+  late Directory directory;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+    directory = await Directory.systemTemp.createTemp('omi-native-batch-location-');
+  });
+
+  tearDown(() async {
+    if (await directory.exists()) await directory.delete(recursive: true);
+  });
+
+  for (final marker in ['omibatchphone', 'omibatchphoneauto']) {
+    test('$marker sidecar survives discovery and reaches SyncUploadGate', () async {
+      final file = File('${directory.path}/audio_${marker}_opus_fs320_16000_1_fs320_1720000000.bin');
+      await file.writeAsBytes([1]);
+      await File(nativeBatchGeolocationSidecarPath(file.path)).writeAsString(
+        jsonEncode({
+          'latitude': 37.7749,
+          'longitude': -122.4194,
+          'accuracy': 8.0,
+          'captured_at': '2026-08-01T12:30:00.000Z',
+          'capture_source': 'current_position',
+        }),
+      );
+
+      final snapshot = await readNativeBatchGeolocation(file.path);
+      final recording = LocalRecording.fromFile(
+        fileName: file.path.split('/').last,
+        filePath: file.path,
+        sizeBytes: 1,
+        seconds: 1,
+        state: LocalRecordingState.pending,
+        geolocation: snapshot,
+      )!;
+      Geolocation? uploaded;
+      final gate = SyncUploadGate(
+        limiter: SyncRateLimiter.instance,
+        fairUseStatusLoader: () async => {'stage': 'none'},
+        uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
+          uploaded = geolocation;
+          return UploadFilesResult.queued('job-1');
+        },
+      );
+
+      await uploadNativeBatchRecording(recording, file: file, lane: SyncUploadLane.fresh, uploadGate: gate);
+
+      expect(uploaded?.latitude, 37.7749);
+      expect(uploaded?.longitude, -122.4194);
+      expect(uploaded?.captureSource, 'current_position');
+      expect(uploaded?.time, DateTime.utc(2026, 8, 1, 12, 30));
+    });
+  }
+
+  test('missing, malformed, and oversized sidecars fail soft', () async {
+    final file = File('${directory.path}/audio_omibatchphone_opus_fs320_16000_1_fs320_1.bin');
+    await file.writeAsBytes([1]);
+
+    expect(await readNativeBatchGeolocation(file.path), isNull);
+
+    final sidecar = File(nativeBatchGeolocationSidecarPath(file.path));
+    await sidecar.writeAsString('{not-json');
+    expect(await readNativeBatchGeolocation(file.path), isNull);
+
+    await sidecar.writeAsString('x' * (nativeBatchGeolocationMaxBytes + 1));
+    expect(await readNativeBatchGeolocation(file.path), isNull);
+  });
+}

--- a/app/test/unit/native_ble_stream_config_test.dart
+++ b/app/test/unit/native_ble_stream_config_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/services/capture/native_ble_stream_config.dart';
+
+void main() {
+  test('native BLE handoff config includes the canonical start snapshot and provenance', () {
+    final config = buildNativeBleStreamConfig(
+      deviceId: 'device-1',
+      codec: 'opus',
+      sampleRate: 16000,
+      source: 'omi',
+      apiBaseUrl: 'https://api.omiapi.com/',
+      serviceUuid: 'service',
+      characteristicUuid: 'characteristic',
+      deviceType: 'omi',
+      geolocation: Geolocation(
+        latitude: 37.7749,
+        longitude: -122.4194,
+        accuracy: 8,
+        time: DateTime.utc(2026, 8, 1, 12, 30),
+        captureSource: 'current_position',
+      ),
+    );
+
+    expect(config['geolocation'], {
+      'latitude': 37.7749,
+      'longitude': -122.4194,
+      'id': 0,
+      'altitude': null,
+      'accuracy': 8.0,
+      'captured_at': '2026-08-01T12:30:00.000Z',
+      'capture_source': 'current_position',
+      'google_place_id': null,
+      'location_type': null,
+      'address': null,
+    });
+  });
+
+  test('native BLE handoff config omits location when capture failed soft', () {
+    final config = buildNativeBleStreamConfig(
+      deviceId: 'device-1',
+      codec: 'opus',
+      sampleRate: 16000,
+      source: 'omi',
+      apiBaseUrl: 'https://api.omiapi.com/',
+      serviceUuid: 'service',
+      characteristicUuid: 'characteristic',
+      deviceType: 'omi',
+    );
+
+    expect(config, isNot(contains('geolocation')));
+  });
+}

--- a/app/test/unit/sync_lane_aware_gating_test.dart
+++ b/app/test/unit/sync_lane_aware_gating_test.dart
@@ -152,7 +152,7 @@ void main() {
           statusFetches++;
           return {'stage': 'none'};
         },
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+        uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async =>
             UploadFilesResult.queued('job-1'),
       );
 
@@ -174,7 +174,7 @@ void main() {
           statusFetches++;
           return {'stage': 'none'};
         },
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+        uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async =>
             UploadFilesResult.queued('job-2'),
       );
 

--- a/app/test/unit/sync_upload_gate_test.dart
+++ b/app/test/unit/sync_upload_gate_test.dart
@@ -23,7 +23,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         return UploadFilesResult.queued('job-1');
       },
@@ -43,7 +43,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'throttle'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         return UploadFilesResult.queued('job-after-expiry');
       },
@@ -63,7 +63,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => null,
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         return UploadFilesResult.queued('unexpected');
       },
@@ -82,7 +82,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'future_stage'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         return UploadFilesResult.queued('unexpected');
       },
@@ -106,7 +106,7 @@ void main() {
         statusCalls++;
         throw Exception('offline');
       },
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         return UploadFilesResult.queued('legacy-cleared');
       },
@@ -129,7 +129,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'restrict'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         return UploadFilesResult.queued('unexpected');
       },
@@ -154,7 +154,7 @@ void main() {
         statusCalls++;
         return response.future;
       },
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async =>
           UploadFilesResult.queued('job'),
     );
 
@@ -174,7 +174,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async =>
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async =>
           UploadFilesResult.queued('job'),
     );
 
@@ -189,7 +189,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => null,
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         throw SyncRateLimitedException(
           kind: SyncRateLimitKind.backendCapacity,
@@ -219,7 +219,7 @@ void main() {
         statusCalls++;
         return {'stage': 'none'};
       },
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploads++;
         throw SyncRateLimitedException(kind: SyncRateLimitKind.fairUse, retryAfterSeconds: 30 * 24 * 60 * 60);
       },
@@ -243,7 +243,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => {'stage': 'none'},
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         uploadedLanes.add(syncLane);
         return UploadFilesResult.queued('fresh-job');
       },
@@ -272,7 +272,7 @@ void main() {
     final gate = SyncUploadGate(
       limiter: limiter,
       fairUseStatusLoader: () async => null,
-      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+      uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
         seenLane = syncLane;
         return UploadFilesResult.queued('backfill-job');
       },

--- a/app/test/unit/wal_sync_display_state_test.dart
+++ b/app/test/unit/wal_sync_display_state_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/geolocation.dart';
 import 'package:omi/services/wals/wal.dart';
 
 /// Pure mapping that the entire sync UI + provider classification depends on.
@@ -91,5 +92,25 @@ void main() {
       expect(back.uploadedAt, 0);
       expect(back.status, WalStatus.miss);
     });
+  });
+
+  test('recording location round-trips for delayed sync', () {
+    final capturedAt = DateTime.utc(2026, 8, 1, 12, 30);
+    final wal = makeWal(status: WalStatus.miss)
+      ..geolocation = Geolocation(
+        latitude: 40.7128,
+        longitude: -74.0060,
+        accuracy: 8.5,
+        time: capturedAt,
+        captureSource: 'current_position',
+      );
+
+    final restored = Wal.fromJson(wal.toJson());
+
+    expect(restored.geolocation?.latitude, 40.7128);
+    expect(restored.geolocation?.longitude, -74.0060);
+    expect(restored.geolocation?.accuracy, 8.5);
+    expect(restored.geolocation?.time, capturedAt);
+    expect(restored.geolocation?.captureSource, 'current_position');
   });
 }

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -86,7 +86,7 @@ void main() {
       listener,
       uploadGate: SyncUploadGate(
         limiter: SyncRateLimiter.instance,
-        uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+        uploader: (files, {onUploadProgress, conversationId, geolocation, syncLane = SyncUploadLane.fresh}) async {
           throw StateError('deterministic test upload failure');
         },
         fairUseStatusLoader: () async => {'stage': 'none'},

--- a/backend/models/geolocation.py
+++ b/backend/models/geolocation.py
@@ -1,4 +1,6 @@
-from typing import Optional
+import json
+from datetime import datetime
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -9,6 +11,10 @@ class Geolocation(BaseModel):
     longitude: float = Field(ge=-180, le=180)
     address: Optional[str] = None
     location_type: Optional[str] = None
+    captured_at: Optional[datetime] = None
+    capture_source: Optional[Literal['current_position', 'last_known_position', 'manual', 'integration']] = None
+    accuracy: Optional[float] = Field(default=None, ge=0)
+    altitude: Optional[float] = None
 
 
 class GeolocationInput(BaseModel):
@@ -24,6 +30,10 @@ class GeolocationInput(BaseModel):
     longitude: float
     address: Optional[str] = None
     location_type: Optional[str] = None
+    captured_at: Optional[datetime] = None
+    capture_source: Optional[Literal['current_position', 'last_known_position', 'manual', 'integration']] = None
+    accuracy: Optional[float] = None
+    altitude: Optional[float] = None
 
 
 def validated_geolocation_or_none(geolocation: Optional[GeolocationInput]) -> Optional[Geolocation]:
@@ -32,4 +42,17 @@ def validated_geolocation_or_none(geolocation: Optional[GeolocationInput]) -> Op
     try:
         return Geolocation.model_validate(geolocation.model_dump())
     except ValueError:
+        return None
+
+
+def geolocation_from_private_header(value: Optional[str]) -> Optional[Geolocation]:
+    """Parse a bounded, authenticated transport header without ever logging coordinates."""
+    # Direct endpoint calls in tests (and internal callers) can leave FastAPI's
+    # Header sentinel in place. Treat every non-string as absent.
+    if not isinstance(value, str) or not value or len(value) > 4096:
+        return None
+    try:
+        payload = json.loads(value)
+        return validated_geolocation_or_none(GeolocationInput.model_validate(payload))
+    except (json.JSONDecodeError, TypeError, ValueError):
         return None

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -70,7 +70,8 @@ from utils.conversations.calendar_linking import (
 from utils.conversations.calendar_utils import extract_attendees, parse_event_times
 from utils.retrieval.tools.calendar_tools import get_google_calendar_event
 from utils.retrieval.tools.google_utils import refresh_google_token
-from utils.conversations.location import get_google_maps_location
+from utils.conversations.location import resolve_geolocation
+from utils.observability.fallback import record_fallback
 import logging
 
 logger = logging.getLogger(__name__)
@@ -186,10 +187,20 @@ def process_in_progress_conversation(
         conversation.external_data['calendar_meeting_context'] = request.calendar_meeting_context.model_dump()
 
     # Geolocation
-    geolocation = redis_db.get_cached_user_geolocation(uid)
-    if geolocation:
-        geolocation = Geolocation(**geolocation)
-        conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
+    if conversation.geolocation:
+        conversation.geolocation = resolve_geolocation(conversation.geolocation)
+    else:
+        geolocation = redis_db.get_cached_user_geolocation(uid)
+        if geolocation:
+            record_fallback(
+                component='conversation_finalization',
+                from_mode='conversation_snapshot',
+                to_mode='redis_user_cache',
+                reason='other',
+                outcome='degraded',
+                log=logger,
+            )
+            conversation.geolocation = resolve_geolocation(Geolocation(**geolocation))
 
     if not lifecycle_service.admit_processing(uid, conversation.id):
         latest = _get_valid_conversation_by_id(uid, conversation.id)

--- a/backend/routers/listen/contracts.py
+++ b/backend/routers/listen/contracts.py
@@ -13,6 +13,7 @@ from enum import Enum
 from typing import Any, Optional
 
 from utils.client_device import ClientDeviceContext
+from models.geolocation import Geolocation
 
 
 class CustomSttMode(str, Enum):
@@ -40,6 +41,7 @@ class ListenRequest:
     call_id: Optional[str] = None
     client_conversation_id: Optional[str] = None
     client_device_context: Optional[ClientDeviceContext] = None
+    geolocation: Optional[Geolocation] = None
 
 
 @dataclass

--- a/backend/routers/listen/conversations.py
+++ b/backend/routers/listen/conversations.py
@@ -229,6 +229,7 @@ class LiveConversationController:
             call_id=request.call_id if self.host.is_multi_channel else None,
             client_device_id=context.client_device_id,
             client_platform=context.platform,
+            geolocation=request.geolocation,
         )
         await self.host.persistence.call(
             lifecycle_service.create_in_progress_conversation,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -38,6 +39,7 @@ from database.sync_ledger import (
     release_sync_content_claim_after_job_retired,
 )
 from models.conversation_enums import ConversationSource
+from models.geolocation import geolocation_from_private_header
 from models.sync_audio import AudioPrecacheResponse, AudioUrlsResponse
 from utils.analytics import record_usage
 from utils.other import endpoints as auth
@@ -138,7 +140,8 @@ from utils.sync.capture_manifest import (
     manifest_claims_match_paths,
     verify_capture_manifest,
 )
-from utils.sync.lanes import SyncLane, capture_times_within_window, classify_sync_lane
+from utils.sync.lanes import SyncLane, classify_sync_lane
+from utils.sync.provenance import capture_matches_server_conversation as _capture_matches_server_conversation
 
 logger = logging.getLogger(__name__)
 
@@ -148,31 +151,6 @@ AUDIO_SAMPLE_RATE = 16000
 _V1_DEPRECATION_HEADERS = {'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'}
 
 router = APIRouter(route_class=MultipartMaxPartSizeRoute)
-
-_CAPTURE_PROVENANCE_SLOP_SECONDS = 30 * 60
-
-
-def _capture_matches_server_conversation(
-    uid: str,
-    conversation_id: Optional[str],
-    filenames: List[str],
-    client_device_id: Optional[str],
-) -> bool:
-    """Bind fresh classification to a server-created conversation time window."""
-    if not conversation_id or not client_device_id:
-        return False
-    conversation = conversations_db.get_conversation(uid, conversation_id)
-    if not conversation:
-        return False
-    if conversation.get('client_device_id') != client_device_id:
-        return False
-    started_at = conversation.get('started_at')
-    finished_at = conversation.get('finished_at') or started_at
-    if not isinstance(started_at, datetime) or not isinstance(finished_at, datetime):
-        return False
-    lower = started_at.timestamp() - _CAPTURE_PROVENANCE_SLOP_SECONDS
-    upper = finished_at.timestamp() + _CAPTURE_PROVENANCE_SLOP_SECONDS
-    return capture_times_within_window(filenames, lower, upper)
 
 
 class SyncLocalFilesResultResponse(BaseModel):
@@ -870,6 +848,7 @@ async def sync_local_files_v2(
     x_request_id: Optional[str] = Header(None, alias='X-Request-ID'),
     x_cloud_trace_context: Optional[str] = Header(None, alias='X-Cloud-Trace-Context'),
     x_omi_sync_capture_manifest: Optional[str] = Header(None, alias='X-Omi-Sync-Capture-Manifest'),
+    x_omi_conversation_geolocation: Optional[str] = Header(None, alias='X-Omi-Conversation-Geolocation'),
 ):
     """
     Async version of sync-local-files. Saves raw files and returns 202
@@ -898,6 +877,7 @@ async def sync_local_files_v2(
         x_device_id_hash=x_device_id_hash if isinstance(x_device_id_hash, str) else None,
         x_app_version=x_app_version if isinstance(x_app_version, str) else None,
     )
+    geolocation = geolocation_from_private_header(x_omi_conversation_geolocation)
 
     filenames = [f.filename or '' for f in files]
     manifest_claims = verify_capture_manifest(
@@ -1189,6 +1169,7 @@ async def sync_local_files_v2(
                 'source': source.value,
                 'should_lock': should_lock,
                 'conversation_id': conversation_id,
+                'geolocation': geolocation.model_dump(mode='json') if geolocation else None,
                 'client_device_id': client_device_context.client_device_id,
                 'client_platform': client_device_context.platform,
                 'enqueued_at': time.time(),
@@ -1340,6 +1321,7 @@ async def sync_local_files_v2(
                             should_lock,
                             job_dir,
                             conversation_id,
+                            geolocation=geolocation,
                             client_device_id=client_device_context.client_device_id,
                             client_platform=client_device_context.platform,
                             sync_lane=lane_decision.lane.value,
@@ -1548,6 +1530,9 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
         source = ConversationSource(payload.get('source') or 'omi')
         should_lock = bool(payload.get('should_lock', False))
         conversation_id = payload.get('conversation_id')
+        geolocation = geolocation_from_private_header(
+            json.dumps(payload.get('geolocation')) if payload.get('geolocation') else None
+        )
         client_device_id = payload.get('client_device_id')
         client_platform = payload.get('client_platform')
         sync_lane = payload.get('lane') if payload.get('lane') in ('fresh', 'backfill') else SyncLane.FRESH.value
@@ -1669,6 +1654,7 @@ async def run_sync_job(request: Request, task_retry_count: int = Depends(verify_
                 should_lock,
                 job_dir,
                 conversation_id,
+                geolocation=geolocation,
                 task_mode=True,
                 client_device_id=client_device_id,
                 client_platform=client_platform,

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends
 from fastapi.websockets import WebSocket, WebSocketDisconnect
 from firebase_admin.auth import InvalidIdTokenError
 
+from models.geolocation import Geolocation, geolocation_from_private_header
 from routers.listen.contracts import CustomSttMode, ListenRequest
 from routers.listen.runtime import run_listen_session
 from utils.client_device import (
@@ -47,6 +48,7 @@ async def _stream_handler(
     call_id: Optional[str] = None,
     client_conversation_id: Optional[str] = None,
     client_device_context: Optional[ClientDeviceContext] = None,
+    geolocation: Optional[Geolocation] = None,
 ) -> None:
     """Compatibility facade for the accepted-socket listen session."""
     await run_listen_session(
@@ -69,6 +71,7 @@ async def _stream_handler(
             call_id=call_id,
             client_conversation_id=client_conversation_id,
             client_device_context=client_device_context,
+            geolocation=geolocation,
         )
     )
 
@@ -91,6 +94,7 @@ async def _listen(
     vad_gate_override: Optional[str] = None,
     call_id: Optional[str] = None,
     client_conversation_id: Optional[str] = None,
+    geolocation: Optional[Geolocation] = None,
 ) -> None:
     try:
         await websocket.accept()
@@ -115,6 +119,7 @@ async def _listen(
         vad_gate_override=vad_gate_override,
         call_id=call_id,
         client_conversation_id=client_conversation_id,
+        geolocation=geolocation,
     )
 
 
@@ -138,6 +143,7 @@ async def listen_handler(
     call_id: Optional[str] = None,
     client_conversation_id: Optional[str] = None,
 ) -> None:
+    geolocation = geolocation_from_private_header(websocket.headers.get('x-omi-conversation-geolocation'))
     await _listen(
         websocket,
         uid,
@@ -156,6 +162,7 @@ async def listen_handler(
         vad_gate_override=vad_gate if vad_gate in ('enabled', 'disabled') else None,
         call_id=call_id,
         client_conversation_id=client_conversation_id,
+        geolocation=geolocation,
     )
 
 
@@ -201,6 +208,7 @@ async def web_listen_handler(
         await websocket.close(code=1008, reason='Auth error')
         return
     context = resolve_client_device_from_websocket_auth_message(first_message)
+    geolocation = geolocation_from_private_header(websocket.headers.get('x-omi-conversation-geolocation'))
     await websocket.send_json({'type': 'auth_response', 'success': True})
     await _stream_handler(
         websocket,
@@ -218,4 +226,5 @@ async def web_listen_handler(
         call_id=call_id,
         client_conversation_id=client_conversation_id,
         client_device_context=context,
+        geolocation=geolocation,
     )

--- a/backend/testing/e2e/conftest.py
+++ b/backend/testing/e2e/conftest.py
@@ -275,6 +275,14 @@ def _create_backend_app(fake_firestore_instance, fake_redis_instance, fake_stora
     old_r = redis_db.r
     db_client.db = fake_firestore_instance
     redis_db.r = fake_redis_instance
+    # Redis Script objects retain the client that registered them. Relinking
+    # only redis_db.r leaves rate limits and other Lua-backed paths talking to
+    # the developer's localhost Redis, which both violates hermeticity and leaks
+    # counters across wrapper runs. Re-register every module script on FakeRedis.
+    for attr_name, attr_value in list(vars(redis_db).items()):
+        script = getattr(attr_value, 'script', None)
+        if attr_name.endswith('_LUA') and isinstance(script, str):
+            setattr(redis_db, attr_name, fake_redis_instance.register_script(script))
     for module in list(sys.modules.values()):
         if module is None:
             continue

--- a/backend/testing/e2e/test_harness_guards.py
+++ b/backend/testing/e2e/test_harness_guards.py
@@ -74,3 +74,12 @@ def test_backend_database_globals_are_fake_after_app_import(client, fake_firesto
     assert redis_db.r is fake_redis
     assert webhook_health.r is fake_redis
     assert fair_use.redis_client is fake_redis
+
+
+def test_backend_registered_redis_scripts_are_rebound_to_fake(client, fake_redis):
+    """Lua-backed boundaries must not retain the localhost client from import."""
+    import database.redis_db as redis_db
+
+    redis_db._RATE_LIMIT_LUA(keys=['e2e:script-client-guard'], args=[60])
+
+    assert fake_redis.get('e2e:script-client-guard') == b'1'

--- a/backend/testing/e2e/test_listen_stt.py
+++ b/backend/testing/e2e/test_listen_stt.py
@@ -41,6 +41,7 @@ def test_web_listen_custom_stt_dispatches_to_stream_handler(client, monkeypatch)
         call_id=None,
         client_conversation_id=None,
         client_device_context=None,
+        geolocation=None,
     ):
         captured.update(
             {
@@ -59,6 +60,7 @@ def test_web_listen_custom_stt_dispatches_to_stream_handler(client, monkeypatch)
                 "client_conversation_id": client_conversation_id,
                 "client_device_id": getattr(client_device_context, "client_device_id", None),
                 "client_platform": getattr(client_device_context, "platform", None),
+                "geolocation": geolocation.model_dump(mode="json") if geolocation else None,
             }
         )
         await websocket.send_json({"type": "fake_stt_ready", "uid": uid, "custom_stt": captured["custom_stt_mode"]})
@@ -68,7 +70,17 @@ def test_web_listen_custom_stt_dispatches_to_stream_handler(client, monkeypatch)
     monkeypatch.setattr(transcribe_router, "_stream_handler", fake_stream_handler)
 
     with client.websocket_connect(
-        "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&conversation_timeout=1&source=e2e"
+        "/v4/web/listen?custom_stt=enabled&sample_rate=8000&codec=pcm8&conversation_timeout=1&source=e2e",
+        headers={
+            "X-Omi-Conversation-Geolocation": json.dumps(
+                {
+                    "latitude": 37.7749,
+                    "longitude": -122.4194,
+                    "captured_at": "2026-08-01T12:30:00Z",
+                    "capture_source": "current_position",
+                }
+            )
+        },
     ) as websocket:
         websocket.send_text(json.dumps({"type": "auth", "token": "dev-token", "device_id_hash": "a1b2c3d4"}))
         auth_response = websocket.receive_json()
@@ -88,6 +100,17 @@ def test_web_listen_custom_stt_dispatches_to_stream_handler(client, monkeypatch)
     assert captured["custom_stt_mode"] == "enabled"
     assert captured["client_device_id"] == "web_a1b2c3d4"
     assert captured["client_platform"] == "web"
+    assert captured["geolocation"] == {
+        "latitude": 37.7749,
+        "longitude": -122.4194,
+        "altitude": None,
+        "accuracy": None,
+        "captured_at": "2026-08-01T12:30:00Z",
+        "capture_source": "current_position",
+        "google_place_id": None,
+        "address": None,
+        "location_type": None,
+    }
 
 
 def test_web_listen_custom_stt_suggested_transcript_is_emitted_and_persisted(client, auth_headers, test_uid):

--- a/backend/testing/sync_cloud_tasks_stack/cloud_tasks.py
+++ b/backend/testing/sync_cloud_tasks_stack/cloud_tasks.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 from google.api_core.exceptions import AlreadyExists
 from google.cloud import tasks_v2
 
-from utils.cloud_tasks import DISPATCH_DEADLINE_SECONDS
+from utils.cloud_tasks import DISPATCH_DEADLINE_SECONDS, SYNC_JOB_TASK_PAYLOAD_KEYS
 
 from .events import write_event
 
@@ -77,26 +77,9 @@ class CloudTasksRecorder:
             raise RuntimeError('Sync task body is not valid JSON') from error
         if not isinstance(body, dict):
             raise RuntimeError('Sync task body must be a JSON object')
-        expected_keys = {
-            'schema_version',
-            'job_id',
-            'uid',
-            'raw_blob_paths',
-            'source',
-            'should_lock',
-            'conversation_id',
-            'client_device_id',
-            'client_platform',
-            'enqueued_at',
-            'lane',
-            'capture_time_trust',
-            'recording_age_seconds',
-            'content_id',
-            'ledger_fence_mode',
-        }
         task_id = body.get('job_id')
         if (
-            set(body) != expected_keys
+            set(body) != SYNC_JOB_TASK_PAYLOAD_KEYS
             or not isinstance(task_id, str)
             or not task_id
             or not isinstance(body.get('raw_blob_paths'), list)

--- a/backend/testing/sync_cloud_tasks_stack/run.py
+++ b/backend/testing/sync_cloud_tasks_stack/run.py
@@ -496,6 +496,7 @@ def _assert_task_contract(stack: Stack, job_id: str, uid: str, conversation_id: 
         body.get('job_id') != job_id
         or body.get('uid') != uid
         or body.get('conversation_id') != conversation_id
+        or body.get('geolocation') is not None
         or body.get('client_device_id') != DEVICE_ID
         or body.get('client_platform') != 'ios'
         or body.get('lane') != 'fresh'

--- a/backend/testing/sync_cloud_tasks_stack/run.sh
+++ b/backend/testing/sync_cloud_tasks_stack/run.sh
@@ -22,11 +22,12 @@ if ! java -version >/dev/null 2>&1; then
   exit 1
 fi
 
-emulator_port="$(node -e 'const net = require("net"); const server = net.createServer(); server.listen(0, "127.0.0.1", () => { console.log(server.address().port); server.close(); });')"
+emulator_ports="$(node -e 'const net = require("net"); const servers = [net.createServer(), net.createServer()]; let ready = 0; for (const server of servers) server.listen(0, "127.0.0.1", () => { if (++ready === servers.length) { console.log(servers.map(item => item.address().port).join(" ")); for (const item of servers) item.close(); } });')"
+read -r emulator_port emulator_websocket_port <<< "$emulator_ports"
 emulator_config="$(mktemp "${TMPDIR:-/tmp}/omi-sync-cloud-tasks-firebase.XXXXXX")"
 trap 'rm -f "$emulator_config"' EXIT
-node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({emulators: {firestore: {host: "127.0.0.1", port: Number(process.argv[2])}}}))' \
-  "$emulator_config" "$emulator_port"
+node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({emulators: {firestore: {host: "127.0.0.1", port: Number(process.argv[2]), websocketPort: Number(process.argv[3])}}}))' \
+  "$emulator_config" "$emulator_port" "$emulator_websocket_port"
 
 runner_command="PYTHONPATH=backend backend/.venv/bin/python -m testing.sync_cloud_tasks_stack.run"
 for argument in "$@"; do

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -64,6 +64,7 @@ _stubs = [
     'utils.conversations.calendar_linking',
     'utils.conversations.calendar_utils',
     'utils.conversations.location',
+    'utils.observability.fallback',
     'utils.executors',
     'utils.llm.conversation_processing',
     'utils.speaker_identification',
@@ -581,6 +582,38 @@ def test_legacy_finalize_claim_loser_returns_latest_without_processing_or_integr
     process.assert_not_called()
     integrations.assert_not_called()
     assert response.conversation.status == ConversationStatus.failed
+
+
+def test_synchronous_finalizer_records_degraded_redis_location_fallback():
+    target = _conversation(status=ConversationStatus.in_progress)
+    processed = _conversation(status=ConversationStatus.completed)
+
+    with (
+        patch.object(conv, 'retrieve_in_progress_conversation', return_value={'id': 'conv-1'}),
+        patch.object(conv, 'deserialize_conversation', return_value=target),
+        patch.object(conv.lifecycle_service, 'admit_processing', return_value=True),
+        patch.object(
+            conv.redis_db,
+            'get_cached_user_geolocation',
+            return_value={'latitude': 37.7749, 'longitude': -122.4194},
+        ),
+        patch.object(conv, 'record_fallback') as fallback,
+        patch.object(conv, 'resolve_geolocation', side_effect=lambda value: value),
+        patch.object(conv.redis_db, 'get_in_progress_conversation_id', return_value='conv-1'),
+        patch.object(conv.redis_db, 'remove_in_progress_conversation_id'),
+        patch.object(conv, 'process_conversation', side_effect=_process_result(processed, persisted=True)),
+        patch.object(conv, 'trigger_external_integrations', AsyncMock(return_value=[])),
+    ):
+        conv.process_in_progress_conversation(uid='test-uid')
+
+    fallback.assert_called_once_with(
+        component='conversation_finalization',
+        from_mode='conversation_snapshot',
+        to_mode='redis_user_cache',
+        reason='other',
+        outcome='degraded',
+        log=conv.logger,
+    )
 
 
 def test_finalize_conversation_returns_queued_outbox_after_uncertain_task_acknowledgement():

--- a/backend/tests/unit/test_geolocation_resolve.py
+++ b/backend/tests/unit/test_geolocation_resolve.py
@@ -19,18 +19,28 @@ os.environ.setdefault(
 import asyncio  # noqa: E402
 
 from models.geolocation import Geolocation  # noqa: E402
+from models.geolocation import geolocation_from_private_header  # noqa: E402
 
 import utils.conversations.location as loc  # noqa: E402
 
 
 def _raw():
-    return Geolocation(latitude=37.78, longitude=-122.41)  # coordinates, no google_place_id
+    return Geolocation(
+        latitude=37.78,
+        longitude=-122.41,
+        captured_at='2026-08-01T12:00:00Z',
+        capture_source='current_position',
+        accuracy=8,
+    )  # coordinates, no google_place_id
 
 
 def test_resolve_geolocation_keeps_enrichment():
     enriched = Geolocation(latitude=37.78, longitude=-122.41, google_place_id="ChIJ_test", address="1 St")
     with patch.object(loc, "get_google_maps_location", return_value=enriched):
-        assert loc.resolve_geolocation(_raw()).google_place_id == "ChIJ_test"
+        result = loc.resolve_geolocation(_raw())
+        assert result.google_place_id == "ChIJ_test"
+        assert result.capture_source == 'current_position'
+        assert result.accuracy == 8
 
 
 def test_resolve_geolocation_keeps_raw_on_miss():
@@ -63,6 +73,7 @@ def test_async_resolve_geolocation_keeps_enrichment():
     with patch.object(loc, "async_get_google_maps_location", new=AsyncMock(return_value=enriched)):
         result = asyncio.run(loc.async_resolve_geolocation(_raw()))
     assert result.google_place_id == "ChIJ_async"
+    assert result.capture_source == 'current_position'
 
 
 def test_async_resolve_geolocation_keeps_raw_on_miss():
@@ -70,3 +81,7 @@ def test_async_resolve_geolocation_keeps_raw_on_miss():
         raw = _raw()
         result = asyncio.run(loc.async_resolve_geolocation(raw))
     assert result is raw  # cached coordinates preserved on a miss, not dropped to None
+
+
+def test_private_header_parser_treats_non_string_sentinels_as_absent():
+    assert geolocation_from_private_header(object()) is None

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -1066,6 +1066,54 @@ async def test_completed_conversation_replays_only_the_durable_fanout_boundary(m
 
 
 @pytest.mark.anyio
+async def test_async_finalizer_records_degraded_redis_location_fallback(monkeypatch):
+    conversation = SimpleNamespace(id='conversation-1', status=ConversationStatus.completed, language='en')
+    fallback = MagicMock()
+    resolved = MagicMock()
+    integrations = AsyncMock(return_value=[])
+    monkeypatch.setattr(persisted_finalizer, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        persisted_finalizer.conversations_db,
+        'get_conversation',
+        lambda *args: {'id': 'conversation-1', 'status': ConversationStatus.completed.value},
+    )
+    monkeypatch.setattr(persisted_finalizer, 'deserialize_conversation', lambda value: conversation)
+    monkeypatch.setattr(
+        persisted_finalizer,
+        'get_cached_user_geolocation',
+        lambda uid: {'latitude': 37.7749, 'longitude': -122.4194},
+    )
+    monkeypatch.setattr(persisted_finalizer, 'record_fallback', fallback)
+    monkeypatch.setattr(persisted_finalizer, 'async_resolve_geolocation', AsyncMock(return_value=resolved))
+    monkeypatch.setattr(
+        persisted_finalizer.lifecycle_service,
+        'claim_finalization_fanout',
+        lambda *args: {'status': 'claimed', 'fanout_key': 'conversation:conversation-1:finalization'},
+    )
+    monkeypatch.setattr(persisted_finalizer.lifecycle_service, 'complete_finalization_fanout', lambda *args: True)
+    monkeypatch.setattr(persisted_finalizer, 'extract_memories', MagicMock())
+    monkeypatch.setattr(persisted_finalizer, 'trigger_external_integrations', integrations)
+
+    await persisted_finalizer.finalize_persisted_conversation(
+        'uid-1',
+        'conversation-1',
+        finalization_job_id='job-1',
+        dispatch_generation=2,
+        lease_epoch=3,
+    )
+
+    fallback.assert_called_once_with(
+        component='conversation_finalization',
+        from_mode='conversation_snapshot',
+        to_mode='redis_user_cache',
+        reason='other',
+        outcome='degraded',
+        log=persisted_finalizer.logger,
+    )
+    assert conversation.geolocation is resolved
+
+
+@pytest.mark.anyio
 async def test_finalizer_fences_a_deleted_conversation_before_processing(monkeypatch):
     async def inline_run_blocking(_executor, func, *args, **kwargs):
         return func(*args, **kwargs)

--- a/backend/tests/unit/test_prompt_metadata_safety.py
+++ b/backend/tests/unit/test_prompt_metadata_safety.py
@@ -1,6 +1,11 @@
 from pydantic import ValidationError
 
-from models.geolocation import Geolocation, GeolocationInput, validated_geolocation_or_none
+from models.geolocation import (
+    Geolocation,
+    GeolocationInput,
+    geolocation_from_private_header,
+    validated_geolocation_or_none,
+)
 from utils.llm.chat import get_current_datetime_block
 
 
@@ -23,3 +28,20 @@ def test_released_geolocation_input_remains_accepted_but_invalid_values_are_neve
     legacy_input = GeolocationInput(latitude=90.1, longitude=180.1)
 
     assert validated_geolocation_or_none(legacy_input) is None
+
+
+def test_private_location_header_is_bounded_and_fails_soft():
+    assert geolocation_from_private_header('{not json') is None
+    assert geolocation_from_private_header('{"latitude":91,"longitude":0}') is None
+    assert geolocation_from_private_header('x' * 4097) is None
+
+
+def test_private_location_header_keeps_capture_provenance():
+    result = geolocation_from_private_header(
+        '{"latitude":40.7,"longitude":-74.0,"captured_at":"2026-08-01T12:00:00Z",'
+        '"capture_source":"last_known_position","accuracy":12}'
+    )
+
+    assert result is not None
+    assert result.capture_source == 'last_known_position'
+    assert result.accuracy == 12

--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -900,6 +900,7 @@ def _load_sync_router_for_fast_path():
     import importlib.util
     from io import BytesIO
     from fastapi.routing import APIRoute
+    from models.geolocation import geolocation_from_private_header as actual_geolocation_from_private_header
     from pydantic import BaseModel
     from database.sync_jobs import SyncLedgerFenceMode
     from utils.stt import outcomes as actual_outcomes
@@ -926,6 +927,7 @@ def _load_sync_router_for_fast_path():
         'models',
         'models.conversation',
         'models.conversation_enums',
+        'models.geolocation',
         'models.sync_audio',
         'models.transcript_segment',
         'utils',
@@ -1099,6 +1101,7 @@ def _load_sync_router_for_fast_path():
 
     sys.modules['models.sync_audio'].AudioPrecacheResponse = _AudioPrecacheResponse
     sys.modules['models.sync_audio'].AudioUrlsResponse = _AudioUrlsResponse
+    sys.modules['models.geolocation'].geolocation_from_private_header = actual_geolocation_from_private_header
 
     sys.modules.pop('routers.sync', None)
     sys.modules.pop('utils.sync.pipeline', None)
@@ -2320,6 +2323,52 @@ async def test_sync_dispatch_carries_device_provenance_into_cloud_task(monkeypat
         payload = module.enqueue_sync_job.call_args.args[0]
         assert payload['client_device_id'] == 'ios_a1b2c3d4'
         assert payload['client_platform'] == 'ios'
+    finally:
+        sys.modules.pop('routers.sync', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+
+@pytest.mark.asyncio
+async def test_sync_dispatch_carries_private_recording_location_into_cloud_task():
+    from starlette.datastructures import UploadFile
+
+    module, saved_modules, _, BytesIO, _, _ = _load_sync_router_for_fast_path()
+    module.start_background_task = MagicMock()
+    header = json.dumps(
+        {
+            'latitude': 40.7128,
+            'longitude': -74.006,
+            'captured_at': '2026-08-01T12:30:00Z',
+            'capture_source': 'current_position',
+            'accuracy': 8.5,
+        }
+    )
+
+    try:
+        upload = UploadFile(filename='test.opus', file=BytesIO(b'\x00' * 10))
+        response = await module.sync_local_files_v2(
+            files=[upload],
+            uid='test-uid',
+            x_omi_conversation_geolocation=header,
+        )
+
+        assert response.status_code == 202
+        payload = module.enqueue_sync_job.call_args.args[0]
+        assert payload['geolocation'] == {
+            'latitude': 40.7128,
+            'longitude': -74.006,
+            'google_place_id': None,
+            'address': None,
+            'location_type': None,
+            'captured_at': '2026-08-01T12:30:00Z',
+            'capture_source': 'current_position',
+            'accuracy': 8.5,
+            'altitude': None,
+        }
     finally:
         sys.modules.pop('routers.sync', None)
         for mod_name, orig in saved_modules.items():

--- a/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
+++ b/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from utils.cloud_tasks import SYNC_JOB_TASK_PAYLOAD_KEYS
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -38,6 +40,18 @@ def test_sync_cloud_tasks_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -
     assert 'npm run test:sync-cloud-tasks-stack:emulator' in job
 
     assert package['scripts']['test:sync-cloud-tasks-stack:emulator'] == 'backend/testing/sync_cloud_tasks_stack/run.sh'
+    run_script = (_REPO_ROOT / 'backend' / 'testing' / 'sync_cloud_tasks_stack' / 'run.sh').read_text(encoding='utf-8')
+    assert 'websocketPort' in run_script
     sync_contract = next(contract for contract in contracts['workflows'] if contract['id'] == 'sync_cloud_tasks')
     assert 'backend/testing/sync_cloud_tasks_stack/**' in sync_contract['sources']
     assert 'tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py' in sync_contract['tests']
+
+
+def test_gauntlet_recorder_shares_the_production_task_payload_schema() -> None:
+    """The recorder must accept every durable field admission can enqueue."""
+    recorder = (_REPO_ROOT / 'backend' / 'testing' / 'sync_cloud_tasks_stack' / 'cloud_tasks.py').read_text(
+        encoding='utf-8'
+    )
+
+    assert 'set(body) != SYNC_JOB_TASK_PAYLOAD_KEYS' in recorder
+    assert 'geolocation' in SYNC_JOB_TASK_PAYLOAD_KEYS

--- a/backend/utils/cloud_tasks.py
+++ b/backend/utils/cloud_tasks.py
@@ -31,6 +31,30 @@ logger = logging.getLogger(__name__)
 # (HTTP_SYNC_JOBS_RUN_TIMEOUT); see the run-lock TTL invariant in sync_jobs.py.
 DISPATCH_DEADLINE_SECONDS = 1500
 
+# Shared by the production admission boundary and the hermetic recorder. A
+# recorder-local allowlist previously rejected new durable fields only after
+# admission had already returned 202.
+SYNC_JOB_TASK_PAYLOAD_KEYS = frozenset(
+    {
+        'schema_version',
+        'job_id',
+        'uid',
+        'raw_blob_paths',
+        'source',
+        'should_lock',
+        'conversation_id',
+        'geolocation',
+        'client_device_id',
+        'client_platform',
+        'enqueued_at',
+        'lane',
+        'capture_time_trust',
+        'recording_age_seconds',
+        'content_id',
+        'ledger_fence_mode',
+    }
+)
+
 _tasks_client: Optional[tasks_v2.CloudTasksClient] = None
 _google_auth_request: Optional[google_auth_requests.Request] = None
 

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -19,6 +19,7 @@ from utils.conversations.location import async_resolve_geolocation
 from utils.conversations.process_conversation import extract_memories, process_conversation
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, postprocess_executor, run_blocking
+from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -81,11 +82,25 @@ async def finalize_persisted_conversation(
         conversation.status = ConversationStatus.processing
 
     try:
-        geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
-        if geolocation:
-            geolocation = Geolocation(**geolocation)
-            # Keep the cached coordinates when the geocode lookup misses instead of dropping them.
-            conversation.geolocation = await async_resolve_geolocation(geolocation)
+        # A location persisted with the recording session or WAL is the
+        # canonical start-time snapshot. Redis remains only a compatibility
+        # fallback for clients released before that contract.
+        persisted_geolocation = getattr(conversation, 'geolocation', None)
+        if isinstance(persisted_geolocation, Geolocation):
+            conversation.geolocation = await async_resolve_geolocation(persisted_geolocation)
+        else:
+            geolocation = await run_blocking(db_executor, get_cached_user_geolocation, uid)
+            if geolocation:
+                record_fallback(
+                    component='conversation_finalization',
+                    from_mode='conversation_snapshot',
+                    to_mode='redis_user_cache',
+                    reason='other',
+                    outcome='degraded',
+                    log=logger,
+                )
+                geolocation = Geolocation(**geolocation)
+                conversation.geolocation = await async_resolve_geolocation(geolocation)
 
         # The post-processing bulkhead preserves request context (including
         # validated live BYOK keys) while isolating this expensive sync path

--- a/backend/utils/conversations/location.py
+++ b/backend/utils/conversations/location.py
@@ -75,7 +75,16 @@ def resolve_geolocation(geolocation: Optional[Geolocation]) -> Optional[Geolocat
     except Exception as e:
         logger.error('resolve_geolocation enrichment failed: %s', e)
         return geolocation
-    return enriched or geolocation
+    if not enriched:
+        return geolocation
+    return enriched.model_copy(
+        update={
+            'captured_at': geolocation.captured_at,
+            'capture_source': geolocation.capture_source,
+            'accuracy': geolocation.accuracy,
+            'altitude': geolocation.altitude,
+        }
+    )
 
 
 async def async_get_google_maps_location(latitude: float, longitude: float) -> Optional[Geolocation]:
@@ -141,7 +150,16 @@ async def async_resolve_geolocation(geolocation: Optional[Geolocation]) -> Optio
     except Exception as e:
         logger.error('async_resolve_geolocation enrichment failed: %s', e)
         return geolocation
-    return enriched or geolocation
+    if not enriched:
+        return geolocation
+    return enriched.model_copy(
+        update={
+            'captured_at': geolocation.captured_at,
+            'capture_source': geolocation.capture_source,
+            'accuracy': geolocation.accuracy,
+            'altitude': geolocation.altitude,
+        }
+    )
 
 
 async def async_get_google_maps_city(latitude: float, longitude: float) -> Optional[str]:

--- a/backend/utils/observability/fallback.py
+++ b/backend/utils/observability/fallback.py
@@ -67,6 +67,7 @@ ALLOWED_COMPONENTS = frozenset(
         'silent_mic',
         'firestore_read',
         'agent_tools',
+        'conversation_finalization',
         'other',
     }
 )

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -66,6 +66,7 @@ from database.sync_ledger import (
 )
 from models.conversation import CreateConversation
 from models.conversation_enums import ConversationSource
+from models.geolocation import Geolocation
 from models.transcript_segment import TranscriptSegment
 from utils.analytics import record_usage
 from utils.byok import get_byok_keys, set_byok_keys, set_byok_uid
@@ -117,6 +118,9 @@ from utils.sync.files import decode_files_to_wav, get_timestamp_from_path, get_w
 from utils.sync.backfill import release_backfill_slot, reserve_backfill_speech
 from utils.sync.content_id import compute_sync_segment_id
 from utils.sync.lanes import SyncLane
+from utils.sync.telemetry import bounded_exception_type as _bounded_exception_type
+from utils.sync.telemetry import bounded_sync_lane as _bounded_sync_lane
+from utils.sync.telemetry import bounded_sync_model as _bounded_sync_model
 from utils.metrics import OMI_SYNC_BACKFILL_DAILY_USED_MS, OMI_SYNC_LANE_SPEECH_MS_TOTAL
 
 logger = logging.getLogger(__name__)
@@ -125,7 +129,6 @@ MAX_VAD_SEGMENT_SECONDS = int(os.getenv('SYNC_MAX_VAD_SEGMENT_SECONDS', '300'))
 
 # Valid terminal segment results — a transcript, or audio with no speech. All else is a failure.
 _NON_ERROR_SEGMENT_OUTCOMES = frozenset({TranscriptionOutcome.SUCCESS, TranscriptionOutcome.EXPECTED_SILENCE})
-_SYNC_STT_MODELS = {'nova-3', 'velma-2', 'parakeet'}
 _PARTIAL_RESULT_FENCED_CONVERSATION_IDS = 'fenced_conversation_ids'
 _RESPONSE_FENCED_CONVERSATION_IDS = '_fenced_conversation_ids'
 _SYNC_FAILURE_REASON_CODES = {
@@ -147,20 +150,6 @@ _SYNC_FAILURE_REASON_CODES = {
     'sync_vad_failed',
     'sync_worker_stale',
 }
-
-
-def _bounded_sync_model(model: str | None) -> str:
-    normalized = (model or '').strip().lower()
-    return normalized if normalized in _SYNC_STT_MODELS else 'unknown'
-
-
-def _bounded_sync_lane(lane: str | None) -> str:
-    return lane if lane in {SyncLane.FRESH.value, SyncLane.BACKFILL.value} else 'unknown'
-
-
-def _bounded_exception_type(error: BaseException) -> str:
-    name = error.__class__.__name__
-    return name if name.replace('_', '').isalnum() and len(name) <= 64 else 'Exception'
 
 
 async def _resolve_fair_use_soft_cap_plan(uid: str):
@@ -1042,6 +1031,7 @@ def process_segment(
     client_platform: Optional[str] = None,
     sync_lane: str = SyncLane.FRESH.value,
     deferred_outcome: dict | None = None,
+    geolocation: Optional[Geolocation] = None,
 ):
     provider = 'unknown'
     model = 'unknown'
@@ -1153,6 +1143,7 @@ def process_segment(
                 private_cloud_sync_enabled=private_cloud_sync_enabled,
                 client_device_id=client_device_id,
                 client_platform=client_platform,
+                geolocation=geolocation,
             )
             created = process_conversation(
                 uid,
@@ -1165,6 +1156,11 @@ def process_segment(
             if private_cloud_sync_enabled:
                 _store_sync_audio_chunk(uid, created.id, timestamp, audio_bytes, data_protection_level)
         else:
+            if geolocation and not closest_memory.get('geolocation'):
+                conversations_db.update_conversation(
+                    uid, closest_memory['id'], {'geolocation': geolocation.model_dump()}
+                )
+                closest_memory['geolocation'] = geolocation.model_dump()
             transcript_segments = [s.model_dump() for s in transcript_segments]
 
             # assign timestamps to each segment
@@ -1622,6 +1618,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
     should_lock: bool,
     job_dir: str,
     target_conversation_id: str = None,
+    geolocation: Optional[Geolocation] = None,
     task_mode: bool = False,
     client_device_id: Optional[str] = None,
     client_platform: Optional[str] = None,
@@ -2096,6 +2093,7 @@ async def _run_full_pipeline_background_async(  # pyright: ignore[reportGeneralT
                     client_platform=client_platform,
                     sync_lane=sync_lane,
                     deferred_outcome=deferred_outcome,
+                    geolocation=geolocation,
                 )
                 if ok:
                     # Persist result contributions before the processed marker.

--- a/backend/utils/sync/provenance.py
+++ b/backend/utils/sync/provenance.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import List, Optional
+
+from database import conversations as conversations_db
+from utils.sync.lanes import capture_times_within_window
+
+_CAPTURE_PROVENANCE_SLOP_SECONDS = 30 * 60
+
+
+def capture_matches_server_conversation(
+    uid: str,
+    conversation_id: Optional[str],
+    filenames: List[str],
+    client_device_id: Optional[str],
+) -> bool:
+    """Bind fresh classification to a server-created conversation time window."""
+    if not conversation_id or not client_device_id:
+        return False
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if not conversation or conversation.get('client_device_id') != client_device_id:
+        return False
+    started_at = conversation.get('started_at')
+    finished_at = conversation.get('finished_at') or started_at
+    if not isinstance(started_at, datetime) or not isinstance(finished_at, datetime):
+        return False
+    lower = started_at.timestamp() - _CAPTURE_PROVENANCE_SLOP_SECONDS
+    upper = finished_at.timestamp() + _CAPTURE_PROVENANCE_SLOP_SECONDS
+    return capture_times_within_window(filenames, lower, upper)

--- a/backend/utils/sync/telemetry.py
+++ b/backend/utils/sync/telemetry.py
@@ -1,0 +1,17 @@
+from utils.sync.lanes import SyncLane
+
+_SYNC_STT_MODELS = {'nova-3', 'velma-2', 'parakeet'}
+
+
+def bounded_sync_model(model: str | None) -> str:
+    normalized = (model or '').strip().lower()
+    return normalized if normalized in _SYNC_STT_MODELS else 'unknown'
+
+
+def bounded_sync_lane(lane: str | None) -> str:
+    return lane if lane in {SyncLane.FRESH.value, SyncLane.BACKFILL.value} else 'unknown'
+
+
+def bounded_exception_type(error: BaseException) -> str:
+    name = error.__class__.__name__
+    return name if name.replace('_', '').isalnum() and len(name) <= 64 else 'Exception'

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -2065,14 +2065,22 @@ public enum OmiAPI {
 
 
   public struct Geolocation: Codable {
+    public let accuracy: Double?
     public let address: String?
+    public let altitude: Double?
+    public let captureSource: String?
+    public let capturedAt: String?
     public let googlePlaceId: String?
     public let latitude: Double
     public let locationType: String?
     public let longitude: Double
 
     private enum CodingKeys: String, CodingKey {
+      case accuracy
       case address
+      case altitude
+      case captureSource = "capture_source"
+      case capturedAt = "captured_at"
       case googlePlaceId = "google_place_id"
       case latitude
       case locationType = "location_type"
@@ -2081,15 +2089,23 @@ public enum OmiAPI {
 
     public init(from decoder: Decoder) throws {
       let c = try decoder.container(keyedBy: CodingKeys.self)
+      accuracy = try c.decodeIfPresent(Double.self, forKey: .accuracy)
       address = try c.decodeIfPresent(String.self, forKey: .address)
+      altitude = try c.decodeIfPresent(Double.self, forKey: .altitude)
+      captureSource = try c.decodeIfPresent(String.self, forKey: .captureSource)
+      capturedAt = try c.decodeIfPresent(String.self, forKey: .capturedAt)
       googlePlaceId = try c.decodeIfPresent(String.self, forKey: .googlePlaceId)
       latitude = try c.decode(Double.self, forKey: .latitude)
       locationType = try c.decodeIfPresent(String.self, forKey: .locationType)
       longitude = try c.decode(Double.self, forKey: .longitude)
     }
 
-    public init(address: String?, googlePlaceId: String?, latitude: Double, locationType: String?, longitude: Double) {
+    public init(accuracy: Double?, address: String?, altitude: Double?, captureSource: String?, capturedAt: String?, googlePlaceId: String?, latitude: Double, locationType: String?, longitude: Double) {
+      self.accuracy = accuracy
       self.address = address
+      self.altitude = altitude
+      self.captureSource = captureSource
+      self.capturedAt = capturedAt
       self.googlePlaceId = googlePlaceId
       self.latitude = latitude
       self.locationType = locationType
@@ -13895,7 +13911,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  public static func syncLocalFilesV2V2SyncLocalFilesPost(client: OmiApiClient, conversationId: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, xRequestID: String? = nil, xCloudTraceContext: String? = nil, xOmiSyncCaptureManifest: String? = nil, authorization: String? = nil) async throws -> Void {
+  public static func syncLocalFilesV2V2SyncLocalFilesPost(client: OmiApiClient, conversationId: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, xRequestID: String? = nil, xCloudTraceContext: String? = nil, xOmiSyncCaptureManifest: String? = nil, xOmiConversationGeolocation: String? = nil, authorization: String? = nil) async throws -> Void {
     let _path = "/v2/sync-local-files"
     guard var components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -13918,6 +13934,7 @@ public enum OmiAPI {
     if let xRequestID { req.setValue(String(xRequestID), forHTTPHeaderField: "X-Request-ID") }
     if let xCloudTraceContext { req.setValue(String(xCloudTraceContext), forHTTPHeaderField: "X-Cloud-Trace-Context") }
     if let xOmiSyncCaptureManifest { req.setValue(String(xOmiSyncCaptureManifest), forHTTPHeaderField: "X-Omi-Sync-Capture-Manifest") }
+    if let xOmiConversationGeolocation { req.setValue(String(xOmiConversationGeolocation), forHTTPHeaderField: "X-Omi-Conversation-Geolocation") }
     if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
     let (data, resp) = try await URLSession.shared.data(for: req)
     guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1787,7 +1787,11 @@ export interface GenerateWrappedResponse {
 }
 
 export interface Geolocation {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -1795,7 +1799,11 @@ export interface Geolocation {
 }
 
 export interface GeolocationInput {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -15381,7 +15389,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, X_Omi_Conversation_Geolocation?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)
@@ -15399,6 +15407,7 @@ export async function sync_local_files_v2_v2_sync_local_files_post(query: { conv
       ...(header.X_Request_ID !== undefined ? { "X-Request-ID": String(header.X_Request_ID) } : {}),
       ...(header.X_Cloud_Trace_Context !== undefined ? { "X-Cloud-Trace-Context": String(header.X_Cloud_Trace_Context) } : {}),
       ...(header.X_Omi_Sync_Capture_Manifest !== undefined ? { "X-Omi-Sync-Capture-Manifest": String(header.X_Omi_Sync_Capture_Manifest) } : {}),
+      ...(header.X_Omi_Conversation_Geolocation !== undefined ? { "X-Omi-Conversation-Geolocation": String(header.X_Omi_Conversation_Geolocation) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
     },
   });

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -11069,6 +11069,18 @@
       },
       "Geolocation": {
         "properties": {
+          "accuracy": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accuracy"
+          },
           "address": {
             "anyOf": [
               {
@@ -11079,6 +11091,46 @@
               }
             ],
             "title": "Address"
+          },
+          "altitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Altitude"
+          },
+          "capture_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "current_position",
+                  "last_known_position",
+                  "manual",
+                  "integration"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Source"
+          },
+          "captured_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Captured At"
           },
           "google_place_id": {
             "anyOf": [
@@ -11125,6 +11177,17 @@
       "GeolocationInput": {
         "description": "Released wire contract for coordinates accepted at legacy API boundaries.\n\nBounds are enforced before any value is cached, geocoded, or persisted. Keeping\nthis transport shape broad preserves clients released before the bound contract\nexisted, while ``Geolocation`` remains the only usable server-side value.",
         "properties": {
+          "accuracy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accuracy"
+          },
           "address": {
             "anyOf": [
               {
@@ -11135,6 +11198,46 @@
               }
             ],
             "title": "Address"
+          },
+          "altitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Altitude"
+          },
+          "capture_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "current_position",
+                  "last_known_position",
+                  "manual",
+                  "integration"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Source"
+          },
+          "captured_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Captured At"
           },
           "google_place_id": {
             "anyOf": [
@@ -54747,6 +54850,22 @@
                 }
               ],
               "title": "X-Omi-Sync-Capture-Manifest"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Omi-Conversation-Geolocation",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Omi-Conversation-Geolocation"
             }
           },
           {

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1689,6 +1689,18 @@
       },
       "Geolocation": {
         "properties": {
+          "accuracy": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accuracy"
+          },
           "address": {
             "anyOf": [
               {
@@ -1699,6 +1711,46 @@
               }
             ],
             "title": "Address"
+          },
+          "altitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Altitude"
+          },
+          "capture_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "current_position",
+                  "last_known_position",
+                  "manual",
+                  "integration"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Source"
+          },
+          "captured_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Captured At"
           },
           "google_place_id": {
             "anyOf": [
@@ -1745,6 +1797,17 @@
       "GeolocationInput": {
         "description": "Released wire contract for coordinates accepted at legacy API boundaries.\n\nBounds are enforced before any value is cached, geocoded, or persisted. Keeping\nthis transport shape broad preserves clients released before the bound contract\nexisted, while ``Geolocation`` remains the only usable server-side value.",
         "properties": {
+          "accuracy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accuracy"
+          },
           "address": {
             "anyOf": [
               {
@@ -1755,6 +1818,46 @@
               }
             ],
             "title": "Address"
+          },
+          "altitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Altitude"
+          },
+          "capture_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "current_position",
+                  "last_known_position",
+                  "manual",
+                  "integration"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Source"
+          },
+          "captured_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Captured At"
           },
           "google_place_id": {
             "anyOf": [

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -6,7 +6,7 @@ description: "Sequence diagrams for the /v4/listen WebSocket and Pusher processi
 
 # Listen + Pusher Pipeline — Sequence Diagrams
 
-> Last updated: 2026-07-26 (bounded Pusher delivery, validated frames, and durable finalization ownership)
+> Last updated: 2026-08-01 (conversation start-location provenance)
 >
 > These diagrams document the real behavior observed during E2E testing with
 > live services (backend, pusher, STT providers, embedding API). Update when the
@@ -106,6 +106,24 @@ custom upgrade headers, so `/v4/web/listen` carries the hash in its required
 first auth message; the backend fixes its platform to `web` before creating
 the conversation. Missing provenance remains unknown rather than being
 assigned to a different device.
+
+## Conversation start location
+
+Mobile clients may send one bounded `X-Omi-Conversation-Geolocation` header on
+the authenticated WebSocket upgrade. It contains the position captured at
+recording start, its capture timestamp/source, and optional accuracy. The
+backend validates the coordinates and persists the snapshot on the initial
+conversation document; it never logs the header. A last-known position is used
+only when the client cannot obtain a fresh fix and the OS timestamp is no more
+than 15 minutes old.
+
+The same snapshot is stored with local WAL metadata and sent on a later
+`/v2/sync-local-files` upload, so delayed/offline processing uses the recording's
+own location instead of whichever user location happens to be newest. Existing
+conversation location always wins. The 30-minute Redis user-location cache is
+retained only for compatibility with older clients. Missing permission, invalid
+coordinates, stale fixes, upload failure, and reverse-geocode failure all fail
+open; raw valid coordinates remain usable even without an address.
 
 ```mermaid
 sequenceDiagram

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1787,7 +1787,11 @@ export interface GenerateWrappedResponse {
 }
 
 export interface Geolocation {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -1795,7 +1799,11 @@ export interface Geolocation {
 }
 
 export interface GeolocationInput {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -15381,7 +15389,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, X_Omi_Conversation_Geolocation?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)
@@ -15399,6 +15407,7 @@ export async function sync_local_files_v2_v2_sync_local_files_post(query: { conv
       ...(header.X_Request_ID !== undefined ? { "X-Request-ID": String(header.X_Request_ID) } : {}),
       ...(header.X_Cloud_Trace_Context !== undefined ? { "X-Cloud-Trace-Context": String(header.X_Cloud_Trace_Context) } : {}),
       ...(header.X_Omi_Sync_Capture_Manifest !== undefined ? { "X-Omi-Sync-Capture-Manifest": String(header.X_Omi_Sync_Capture_Manifest) } : {}),
+      ...(header.X_Omi_Conversation_Geolocation !== undefined ? { "X-Omi-Conversation-Geolocation": String(header.X_Omi_Conversation_Geolocation) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
     },
   });

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1787,7 +1787,11 @@ export interface GenerateWrappedResponse {
 }
 
 export interface Geolocation {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -1795,7 +1799,11 @@ export interface Geolocation {
 }
 
 export interface GeolocationInput {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -15381,7 +15389,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, X_Omi_Conversation_Geolocation?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)
@@ -15399,6 +15407,7 @@ export async function sync_local_files_v2_v2_sync_local_files_post(query: { conv
       ...(header.X_Request_ID !== undefined ? { "X-Request-ID": String(header.X_Request_ID) } : {}),
       ...(header.X_Cloud_Trace_Context !== undefined ? { "X-Cloud-Trace-Context": String(header.X_Cloud_Trace_Context) } : {}),
       ...(header.X_Omi_Sync_Capture_Manifest !== undefined ? { "X-Omi-Sync-Capture-Manifest": String(header.X_Omi_Sync_Capture_Manifest) } : {}),
+      ...(header.X_Omi_Conversation_Geolocation !== undefined ? { "X-Omi-Conversation-Geolocation": String(header.X_Omi_Conversation_Geolocation) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
     },
   });

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1787,7 +1787,11 @@ export interface GenerateWrappedResponse {
 }
 
 export interface Geolocation {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -1795,7 +1799,11 @@ export interface Geolocation {
 }
 
 export interface GeolocationInput {
+  accuracy?: number | null;
   address?: string | null;
+  altitude?: number | null;
+  capture_source?: "current_position" | "last_known_position" | "manual" | "integration" | null;
+  captured_at?: string | null;
   google_place_id?: string | null;
   latitude: number;
   location_type?: string | null;
@@ -15381,7 +15389,7 @@ export async function create_sync_capture_manifest_v2_sync_capture_manifest_post
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
+export async function sync_local_files_v2_v2_sync_local_files_post(query: { conversation_id?: string }, header: { X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string, X_Request_ID?: string | null, X_Cloud_Trace_Context?: string | null, X_Omi_Sync_Capture_Manifest?: string | null, X_Omi_Conversation_Geolocation?: string | null, authorization?: string }, init?: OmiApiClientInit): Promise<void> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/sync-local-files`;
   const _params = query ? Object.entries(query)
@@ -15399,6 +15407,7 @@ export async function sync_local_files_v2_v2_sync_local_files_post(query: { conv
       ...(header.X_Request_ID !== undefined ? { "X-Request-ID": String(header.X_Request_ID) } : {}),
       ...(header.X_Cloud_Trace_Context !== undefined ? { "X-Cloud-Trace-Context": String(header.X_Cloud_Trace_Context) } : {}),
       ...(header.X_Omi_Sync_Capture_Manifest !== undefined ? { "X-Omi-Sync-Capture-Manifest": String(header.X_Omi_Sync_Capture_Manifest) } : {}),
+      ...(header.X_Omi_Conversation_Geolocation !== undefined ? { "X-Omi-Conversation-Geolocation": String(header.X_Omi_Conversation_Geolocation) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
     },
   });


### PR DESCRIPTION
## Summary

- add a private conversation map sourced from the exact displayed/grouped conversation boundary, including active text/speaker search and client-side filters
- omit invalid or missing coordinates, cluster dense pins, expose stable marker/cluster-row keys, and open conversation detail
- capture one start-time location snapshot with timestamp/source/accuracy provenance and carry it through authenticated live WebSocket creation, durable WAL metadata, native phone-batch sidecars, SyncUploadGate, and Android background BLE `/v4/listen`
- prefer the conversation/WAL snapshot during finalization, retaining the Redis user-location cache only as an older-client compatibility fallback with bounded degraded fallback telemetry
- keep Cloud Tasks admission and its hermetic recorder on one durable payload schema, including geolocation

## Privacy and resilience

Location is sent only in a bounded authenticated header or recording-owned private sidecar, is validated without logging coordinates, and is persisted on the private conversation document. Missing permission, disabled location services, a stale last-known fix, malformed transport data, compatibility-upload failure, and reverse-geocode failure all fail open. Historical WAL/native batches are separated by capture provenance so one recording's location cannot be applied to another.

This PR does not invent memory-level coordinates. The current memory model exposes one legacy `conversation_id`, not canonical multi-source provenance, so memory mapping remains staged until canonical source provenance is available.

## Review/CI repairs

- map entry now receives `ConversationProvider.displayedConversations`; provider-boundary tests cover text/speaker search plus short/starred/date/folder filters
- explicit and automatic offline phone batches persist and upload the same start snapshot on Android/iOS
- Android native BLE config and authenticated `/v4/listen` request carry the bounded private snapshot
- async and sync Redis finalization fallbacks emit `record_fallback(... outcome='degraded')`
- public OpenAPI artifact regenerated with the prescribed exporter
- hermetic STT fake accepts and asserts geolocation
- Cloud Tasks recorder accepts the shared geolocation field; the emulator wrapper also allocates its Firestore websocket port dynamically
- hermetic Redis Lua scripts are rebound to FakeRedis so rate-limit state cannot escape to localhost or leak across wrapper runs

## Verification

- `cd app && bash scripts/analyze_ratchet.sh` — passed
- focused Flutter map/location/native-batch/WAL suite — 29 passed
- focused backend Cloud Tasks/finalization/search suite — 196 passed
- `cd backend && E2E_PYTEST_TIMEOUT=120s bash testing/e2e/run.sh -q --tb=short` — 118 passed, 3 skipped
- `npm run test:sync-cloud-tasks-stack:emulator` — passed all scenarios
- public OpenAPI exact check — passed
- `make preflight` — 32 checks passed

Local Android native compilation/tests could not be run because this host has no Android SDK (`ANDROID_HOME`/SDK absent); the checked-in Kotlin unit coverage and CI Android compile smoke will run on the replacement head.

Exact head SHA: `298e757b4df6d4c187ee1a95a6c7987817ae2c96`
