### PR TITLE
fix(app): key the synced-conversation pointer by the local day (#10980)

### DIFF
--- a/app/lib/utils/conversation_sync_utils.dart
+++ b/app/lib/utils/conversation_sync_utils.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/providers/conversation_provider.dart';
 
 class ConversationSyncUtils {
   static const Duration _fetchTimeout = Duration(seconds: 30);
@@ -41,11 +44,19 @@ class ConversationSyncUtils {
     final validConversations = conversations.where((conversation) => conversation != null).toList();
     final completedConversations =
         validConversations.where((conversation) => conversation!.status == ConversationStatus.completed).toList();
-    return completedConversations.map((conversation) => _createPointer(conversation!, type)).toList();
+    return completedConversations.map((conversation) => createPointer(conversation!, type)).toList();
   }
 
-  static SyncedConversationPointer _createPointer(ServerConversation conversation, SyncedConversationType type) {
-    final date = DateTime(conversation.createdAt.year, conversation.createdAt.month, conversation.createdAt.day);
+  /// The pointer's `key` is handed straight to `ConversationDetailProvider` when
+  /// a synced row is tapped, so it must be the key the list groups by:
+  /// [conversationLocalDayKey] over `startedAt ?? createdAt`. Reading
+  /// `createdAt`'s raw year/month/day instead read *UTC* fields — server
+  /// timestamps parse as UTC — so for any viewer off UTC near local midnight the
+  /// key matched no group, the tap-time selection silently no-opped and the
+  /// detail page opened on whatever conversation was still cached (#10980).
+  @visibleForTesting
+  static SyncedConversationPointer createPointer(ServerConversation conversation, SyncedConversationType type) {
+    final date = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
 
     return SyncedConversationPointer(type: type, index: 0, key: date, conversation: conversation);
   }

--- a/app/test/providers/conversation_day_key_call_sites_test.dart
+++ b/app/test/providers/conversation_day_key_call_sites_test.dart
@@ -5,6 +5,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/utils/conversation_sync_utils.dart';
 
 /// Regression coverage for #10980: call sites that look a conversation up by day
 /// derived the key from the timestamp's raw UTC `year/month/day` instead of
@@ -69,6 +70,25 @@ void main() {
 
     provider.groupedConversations = {};
     expect(provider.getConversationDateAndIndexById(convo.id), isNull);
+  });
+
+  test('the synced-conversation pointer carries the same key grouping uses', () {
+    for (var hour = 0; hour < 24; hour++) {
+      final startedAt = DateTime.utc(2026, 7, 18, hour, 30);
+      final convo = _conversationAt(startedAt);
+      final reason = 'startedAt ${startedAt.toIso8601String()}';
+
+      final grouped = _providerWith([convo]);
+      addTearDown(grouped.dispose);
+      grouped.groupConversationsByDate();
+
+      final pointer = ConversationSyncUtils.createPointer(convo, SyncedConversationType.newConversation);
+
+      // The sync page hands this key to ConversationDetailProvider on tap; it
+      // must address the group the conversation is actually in.
+      expect(pointer.key, grouped.groupedConversations.keys.single, reason: reason);
+      expect(grouped.groupedConversations[pointer.key]!.single.id, convo.id, reason: reason);
+    }
   });
 
   test('ensureConversationInGroup files the conversation under the same key grouping uses', () {


### PR DESCRIPTION
## Bug

On the **Processed Conversations** page (`synced_conversations_page.dart`), tapping a synced row could open the detail page against the wrong conversation — the one previously cached — instead of the row that was tapped.

## Root cause

`ConversationSyncUtils._createPointer` built each pointer's `key` from `createdAt`'s raw `year/month/day`:

```dart
final date = DateTime(conversation.createdAt.year, conversation.createdAt.month, conversation.createdAt.day);
```

Server timestamps parse as **UTC**, so those are UTC fields. The conversation list groups by `conversationLocalDayKey(startedAt ?? createdAt)` — the viewer's **local** day. The pointer's key is handed straight to `ConversationDetailProvider.updateConversation` on tap, which looks the day-group up by that key:

```dart
final list = conversationProvider?.groupedConversations[date];
if (list != null) { ... }   // silently no-ops on a miss
```

The two keys disagree in two independent ways:

1. **UTC vs local** — for any viewer off UTC whose local calendar day differs from the UTC one (evening ahead of UTC, post-UTC-midnight behind it).
2. **`createdAt` vs `startedAt ?? createdAt`** — a conversation whose start and creation land on different days misses at *every* offset, UTC included.

On a miss the selection no-ops, so `selectedDate`/`_cachedConversationId` keep pointing at the previously opened conversation and `conversationOrNull` resolves to it. `ConversationDetailPage`'s post-frame callback re-resolves the day correctly, so the wrong conversation is what the page renders until that callback runs.

## Fix

Call the one authority, `conversationLocalDayKey(startedAt ?? createdAt)` — the same function the grouper uses — and expose the pointer builder (`@visibleForTesting`) so the guard file can drive it.

This is the **fourth instance of `FC-day-bucket-key-recomputed`** and the last call site in the conversation-grouping family that still re-derived the key; #10981, #10987 and #10988 fixed the others. No new guard surface is added because the class already has one — `app/test/providers/conversation_day_key_call_sites_test.dart` — and this call site joins it.

## What I tested

- Added the case to the class's existing guard file, which sweeps **all 24 hours** so a single pinned hour cannot stay green at the runner's UTC offset.
- `flutter test test/providers/conversation_day_key_call_sites_test.dart` — **passes** in `TZ=UTC`, `Asia/Kolkata`, `Europe/Berlin`, `America/Los_Angeles`, `Pacific/Kiritimati`, `Pacific/Midway`.
- With the `lib/` change reverted, that same file **fails `+3 -1` in every one of those zones** (including UTC, via the `startedAt`/`createdAt` divergence).
- Full app suite `flutter test`: **996 passed, 0 failed**.

Not exercised on a device: reproducing the original symptom needs a real device sync producing synced-conversation pointers. Verification here is the unit-level guard through the production call site.

Failure-Class: FC-day-bucket-key-recomputed

Refs #10980

🤖 automated by hourly watchdog — tested and merged
