### PR TITLE
fix(app): stop retrying a recording the server refuses for good (#10975)

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -506,6 +506,33 @@ class SyncRateLimitedException implements Exception {
   String toString() => 'SyncRateLimitedException(kind=$kind, retryAfter=$retryAfterSeconds)';
 }
 
+/// Thrown when the server permanently refuses a recording because its capture
+/// time is older than the automatic-recovery window (HTTP 422
+/// `backfill_lookback_exceeded`). No amount of retrying can make this upload
+/// succeed, so callers must stop re-offering the file instead of spending the
+/// recording's retry budget on it.
+class SyncRecoveryWindowExceededException implements Exception {
+  const SyncRecoveryWindowExceededException();
+
+  @override
+  String toString() => 'SyncRecoveryWindowExceededException()';
+}
+
+/// Classifies a sync 422 as the backend's terminal lookback rejection.
+///
+/// Keyed on the bounded `code` the sync routes emit, never on human-readable
+/// detail text: any other 422 stays a generic retryable failure.
+@visibleForTesting
+bool isSyncRecoveryWindowExceededResponse(http.Response response) {
+  if (response.statusCode != 422) return false;
+  try {
+    final body = jsonDecode(response.body);
+    return body is Map && body['code'] == 'backfill_lookback_exceeded';
+  } catch (_) {
+    return false;
+  }
+}
+
 /// A synchronous upload response that durably reached the server but did not
 /// transcribe every segment. Callers keep the local WAL and retry it; the
 /// backend deduplicates any segments that already succeeded.
@@ -611,6 +638,8 @@ Future<UploadFilesResult> uploadLocalFilesV2(
       kind: syncRateLimitKindForResponse(response),
       retryAfterSeconds: _parseRetryAfterSeconds(response),
     );
+  } else if (isSyncRecoveryWindowExceededResponse(response)) {
+    throw const SyncRecoveryWindowExceededException();
   } else if (response.statusCode >= 500) {
     throw Exception('Server is temporarily unavailable');
   }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2960,6 +2960,7 @@
     "syncStatusWaiting": "في انتظار المزامنة",
     "syncStatusRetrying": "تعذّرت المعالجة — جارٍ إعادة المحاولة",
     "syncStatusFailed": "فشل — اضغط إعادة المحاولة",
+    "syncStatusTooOld": "قديم جدًا للمزامنة — لا يمكن لـ Omi قبوله",
     "syncStatusFileUnavailable": "الملف غير متوفر",
     "syncStatusUploaded": "تم الرفع · قيد المعالجة على Omi",
     "noRecordingsYet": "لا توجد تسجيلات بعد",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Чакае сінхранізацыі",
     "syncStatusRetrying": "Не атрымалася апрацаваць — паўтор",
     "syncStatusFailed": "Памылка — націсніце «Паўтарыць»",
+    "syncStatusTooOld": "Занадта старое для сінхранізацыі — Omi не можа яго прыняць",
     "syncStatusFileUnavailable": "Файл недаступны",
     "syncStatusUploaded": "Запампавана · апрацоўка ў Omi",
     "noRecordingsYet": "Запісаў пакуль няма",

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2962,6 +2962,7 @@
     "syncStatusWaiting": "Чака синхронизация",
     "syncStatusRetrying": "Неуспешна обработка — нов опит",
     "syncStatusFailed": "Неуспешно — натиснете „Опитай отново“",
+    "syncStatusTooOld": "Твърде стар за синхронизиране — Omi не може да го приеме",
     "syncStatusFileUnavailable": "Файлът е недостъпен",
     "syncStatusUploaded": "Качено · обработва се в Omi",
     "noRecordingsYet": "Все още няма записи",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "সিঙ্কের অপেক্ষায়",
     "syncStatusRetrying": "প্রক্রিয়া করা যায়নি — আবার চেষ্টা চলছে",
     "syncStatusFailed": "ব্যর্থ — Retry চাপুন",
+    "syncStatusTooOld": "সিঙ্ক করার জন্য খুব পুরনো — Omi এটি গ্রহণ করতে পারে না",
     "syncStatusFileUnavailable": "ফাইল অনুপলব্ধ",
     "syncStatusUploaded": "আপলোড হয়েছে · Omi-তে প্রক্রিয়াধীন",
     "noRecordingsYet": "এখনও কোনো রেকর্ডিং নেই",

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Čeka sinkronizaciju",
     "syncStatusRetrying": "Obrada nije uspjela — ponovni pokušaj",
     "syncStatusFailed": "Neuspjelo — dodirnite Ponovi",
+    "syncStatusTooOld": "Prestaro za sinkronizaciju — Omi ga ne može prihvatiti",
     "syncStatusFileUnavailable": "Datoteka nije dostupna",
     "syncStatusUploaded": "Otpremljeno · obrada na Omi",
     "noRecordingsYet": "Još nema snimaka",

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2962,6 +2962,7 @@
     "syncStatusWaiting": "Esperant a sincronitzar",
     "syncStatusRetrying": "No s'ha pogut processar — reintentant",
     "syncStatusFailed": "Ha fallat — toca Reintenta",
+    "syncStatusTooOld": "Massa antic per sincronitzar — Omi no el pot acceptar",
     "syncStatusFileUnavailable": "Fitxer no disponible",
     "syncStatusUploaded": "Pujat · processant-se a Omi",
     "noRecordingsYet": "Encara no hi ha enregistraments",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2962,6 +2962,7 @@
     "syncStatusWaiting": "Čeká na synchronizaci",
     "syncStatusRetrying": "Zpracování selhalo — opakuji",
     "syncStatusFailed": "Selhalo — klepněte na Opakovat",
+    "syncStatusTooOld": "Příliš staré na synchronizaci — Omi ho nemůže přijmout",
     "syncStatusFileUnavailable": "Soubor není k dispozici",
     "syncStatusUploaded": "Nahráno · zpracovává se v Omi",
     "noRecordingsYet": "Zatím žádné nahrávky",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3002,6 +3002,7 @@
     "syncStatusWaiting": "Venter på synkronisering",
     "syncStatusRetrying": "Kunne ikke behandles — prøver igen",
     "syncStatusFailed": "Mislykkedes — tryk på Prøv igen",
+    "syncStatusTooOld": "For gammel til at synkronisere — Omi kan ikke acceptere den",
     "syncStatusFileUnavailable": "Filen er utilgængelig",
     "syncStatusUploaded": "Uploadet · behandles på Omi",
     "noRecordingsYet": "Ingen optagelser endnu",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2961,6 +2961,7 @@
     "syncStatusWaiting": "Wartet auf Synchronisierung",
     "syncStatusRetrying": "Verarbeitung fehlgeschlagen — wird wiederholt",
     "syncStatusFailed": "Fehlgeschlagen — auf Wiederholen tippen",
+    "syncStatusTooOld": "Zu alt für die Synchronisierung — Omi kann sie nicht annehmen",
     "syncStatusFileUnavailable": "Datei nicht verfügbar",
     "syncStatusUploaded": "Hochgeladen · wird auf Omi verarbeitet",
     "noRecordingsYet": "Noch keine Aufnahmen",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Σε αναμονή συγχρονισμού",
     "syncStatusRetrying": "Αποτυχία επεξεργασίας — νέα προσπάθεια",
     "syncStatusFailed": "Απέτυχε — πατήστε Επανάληψη",
+    "syncStatusTooOld": "Πολύ παλιά για συγχρονισμό — το Omi δεν μπορεί να τη δεχτεί",
     "syncStatusFileUnavailable": "Το αρχείο δεν είναι διαθέσιμο",
     "syncStatusUploaded": "Μεταφορτώθηκε · επεξεργασία στο Omi",
     "noRecordingsYet": "Δεν υπάρχουν ακόμη ηχογραφήσεις",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11554,5 +11554,6 @@
     "rayBanMetaMicPickerConnectError": "Could not connect to that microphone. Make sure it is connected in iPhone Settings.",
     "@rayBanMetaMicPickerConnectError": {
         "description": "Error shown when the selected Bluetooth HFP microphone cannot connect"
-    }
+    },
+    "syncStatusTooOld": "Too old to sync — Omi can't accept it"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2994,6 +2994,7 @@
     "syncStatusWaiting": "Esperando para sincronizar",
     "syncStatusRetrying": "No se pudo procesar — reintentando",
     "syncStatusFailed": "Falló — toca Reintentar",
+    "syncStatusTooOld": "Demasiado antigua para sincronizar — Omi no puede aceptarla",
     "syncStatusFileUnavailable": "Archivo no disponible",
     "syncStatusUploaded": "Subido · procesándose en Omi",
     "noRecordingsYet": "Aún no hay grabaciones",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Ootab sünkroonimist",
     "syncStatusRetrying": "Töötlemine ebaõnnestus — proovin uuesti",
     "syncStatusFailed": "Ebaõnnestus — puuduta Proovi uuesti",
+    "syncStatusTooOld": "Sünkroonimiseks liiga vana — Omi ei saa seda vastu võtta",
     "syncStatusFileUnavailable": "Fail pole saadaval",
     "syncStatusUploaded": "Üles laaditud · töödeldakse Omis",
     "noRecordingsYet": "Salvestisi veel pole",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "در انتظار همگام‌سازی",
     "syncStatusRetrying": "پردازش ناموفق — تلاش مجدد",
     "syncStatusFailed": "ناموفق — روی تلاش مجدد بزنید",
+    "syncStatusTooOld": "برای همگام‌سازی خیلی قدیمی است — Omi نمی‌تواند آن را بپذیرد",
     "syncStatusFileUnavailable": "فایل در دسترس نیست",
     "syncStatusUploaded": "بارگذاری شد · در حال پردازش در Omi",
     "noRecordingsYet": "هنوز ضبطی وجود ندارد",

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Odottaa synkronointia",
     "syncStatusRetrying": "Käsittely epäonnistui — yritetään uudelleen",
     "syncStatusFailed": "Epäonnistui — napauta Yritä uudelleen",
+    "syncStatusTooOld": "Liian vanha synkronoitavaksi — Omi ei voi hyväksyä sitä",
     "syncStatusFileUnavailable": "Tiedosto ei ole käytettävissä",
     "syncStatusUploaded": "Ladattu · käsitellään Omissa",
     "noRecordingsYet": "Ei vielä tallenteita",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3028,6 +3028,7 @@
     "syncStatusWaiting": "En attente de synchronisation",
     "syncStatusRetrying": "Échec du traitement — nouvelle tentative",
     "syncStatusFailed": "Échec — appuyez sur Réessayer",
+    "syncStatusTooOld": "Trop ancien pour être synchronisé — Omi ne peut pas l'accepter",
     "syncStatusFileUnavailable": "Fichier indisponible",
     "syncStatusUploaded": "Envoyé · traitement sur Omi",
     "noRecordingsYet": "Aucun enregistrement pour l'instant",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "ממתין לסנכרון",
     "syncStatusRetrying": "העיבוד נכשל — מנסה שוב",
     "syncStatusFailed": "נכשל — הקש על נסה שוב",
+    "syncStatusTooOld": "ישן מדי לסנכרון — Omi לא יכול לקבל אותו",
     "syncStatusFileUnavailable": "הקובץ אינו זמין",
     "syncStatusUploaded": "הועלה · בעיבוד ב-Omi",
     "noRecordingsYet": "אין הקלטות עדיין",

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2994,6 +2994,7 @@
     "syncStatusWaiting": "सिंक होने की प्रतीक्षा",
     "syncStatusRetrying": "प्रोसेस नहीं हो सका — फिर कोशिश हो रही है",
     "syncStatusFailed": "विफल — Retry दबाएँ",
+    "syncStatusTooOld": "सिंक करने के लिए बहुत पुराना — Omi इसे स्वीकार नहीं कर सकता",
     "syncStatusFileUnavailable": "फ़ाइल उपलब्ध नहीं",
     "syncStatusUploaded": "अपलोड हो गया · Omi पर प्रोसेस हो रहा है",
     "noRecordingsYet": "अभी तक कोई रिकॉर्डिंग नहीं",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Čeka sinkronizaciju",
     "syncStatusRetrying": "Obrada nije uspjela — ponovni pokušaj",
     "syncStatusFailed": "Neuspjelo — dodirnite Pokušaj ponovno",
+    "syncStatusTooOld": "Prestaro za sinkronizaciju — Omi ga ne može prihvatiti",
     "syncStatusFileUnavailable": "Datoteka nije dostupna",
     "syncStatusUploaded": "Učitano · obrađuje se na Omi",
     "noRecordingsYet": "Još nema snimaka",

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3089,6 +3089,7 @@
     "syncStatusWaiting": "Szinkronizálásra vár",
     "syncStatusRetrying": "A feldolgozás sikertelen — újrapróbálkozás",
     "syncStatusFailed": "Sikertelen — koppintson az Újra gombra",
+    "syncStatusTooOld": "Túl régi a szinkronizáláshoz — az Omi nem tudja elfogadni",
     "syncStatusFileUnavailable": "A fájl nem érhető el",
     "syncStatusUploaded": "Feltöltve · feldolgozás az Omin",
     "noRecordingsYet": "Még nincs felvétel",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3035,6 +3035,7 @@
     "syncStatusWaiting": "Menunggu sinkronisasi",
     "syncStatusRetrying": "Gagal diproses — mencoba lagi",
     "syncStatusFailed": "Gagal — ketuk Coba Lagi",
+    "syncStatusTooOld": "Terlalu lama untuk disinkronkan — Omi tidak dapat menerimanya",
     "syncStatusFileUnavailable": "File tidak tersedia",
     "syncStatusUploaded": "Diunggah · diproses di Omi",
     "noRecordingsYet": "Belum ada rekaman",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "In attesa di sincronizzazione",
     "syncStatusRetrying": "Elaborazione non riuscita — nuovo tentativo",
     "syncStatusFailed": "Non riuscito — tocca Riprova",
+    "syncStatusTooOld": "Troppo vecchia per la sincronizzazione — Omi non può accettarla",
     "syncStatusFileUnavailable": "File non disponibile",
     "syncStatusUploaded": "Caricato · elaborazione su Omi",
     "noRecordingsYet": "Ancora nessuna registrazione",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2994,6 +2994,7 @@
     "syncStatusWaiting": "同期を待機中",
     "syncStatusRetrying": "処理できませんでした — 再試行中",
     "syncStatusFailed": "失敗 — 「再試行」をタップ",
+    "syncStatusTooOld": "古すぎて同期できません — Omi は受け付けられません",
     "syncStatusFileUnavailable": "ファイルを利用できません",
     "syncStatusUploaded": "アップロード済み · Omi で処理中",
     "noRecordingsYet": "まだ録音がありません",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "ಸಿಂಕ್ ಆಗಲು ಕಾಯುತ್ತಿದೆ",
     "syncStatusRetrying": "ಪ್ರಕ್ರಿಯೆ ವಿಫಲ — ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಲಾಗುತ್ತಿದೆ",
     "syncStatusFailed": "ವಿಫಲ — Retry ಒತ್ತಿ",
+    "syncStatusTooOld": "ಸಿಂಕ್ ಮಾಡಲು ತುಂಬಾ ಹಳೆಯದು — Omi ಅದನ್ನು ಸ್ವೀಕರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ",
     "syncStatusFileUnavailable": "ಫೈಲ್ ಲಭ್ಯವಿಲ್ಲ",
     "syncStatusUploaded": "ಅಪ್‌ಲೋಡ್ ಆಗಿದೆ · Omi ನಲ್ಲಿ ಪ್ರಕ್ರಿಯೆ ನಡೆಯುತ್ತಿದೆ",
     "noRecordingsYet": "ಇನ್ನೂ ಯಾವುದೇ ರೆಕಾರ್ಡಿಂಗ್ ಇಲ್ಲ",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "동기화 대기 중",
     "syncStatusRetrying": "처리하지 못함 — 다시 시도 중",
     "syncStatusFailed": "실패 — 다시 시도를 누르세요",
+    "syncStatusTooOld": "너무 오래되어 동기화할 수 없습니다 — Omi가 받을 수 없습니다",
     "syncStatusFileUnavailable": "파일을 사용할 수 없음",
     "syncStatusUploaded": "업로드됨 · Omi에서 처리 중",
     "noRecordingsYet": "아직 녹음이 없습니다",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -18218,6 +18218,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not connect to that microphone. Make sure it is connected in iPhone Settings.'**
   String get rayBanMetaMicPickerConnectError;
+
+  /// No description provided for @syncStatusTooOld.
+  ///
+  /// In en, this message translates to:
+  /// **'Too old to sync — Omi can\'t accept it'**
+  String get syncStatusTooOld;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9711,4 +9711,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get rayBanMetaMicPickerConnectError => 'تعذر الاتصال بهذا الميكروفون. تأكد من أنه متصل في إعدادات iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'قديم جدًا للمزامنة — لا يمكن لـ Omi قبوله';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9801,4 +9801,7 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Не ўдалося падключыцца да гэтага мікрафона. Праверце, ці падключаны ён у наладах iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Занадта старое для сінхранізацыі — Omi не можа яго прыняць';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9808,4 +9808,7 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Неуспешно свързване с този микрофон. Уверете се, че е свързан в настройките на iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Твърде стар за синхронизиране — Omi не може да го приеме';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9777,4 +9777,7 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'ওই মাইক্রোফোনে সংযোগ করা যায়নি। iPhone সেটিংসে এটি সংযুক্ত আছে কিনা নিশ্চিত করুন।';
+
+  @override
+  String get syncStatusTooOld => 'সিঙ্ক করার জন্য খুব পুরনো — Omi এটি গ্রহণ করতে পারে না';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9798,4 +9798,7 @@ class AppLocalizationsBs extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Povezivanje s tim mikrofonom nije uspjelo. Provjerite je li povezan u postavkama iPhonea.';
+
+  @override
+  String get syncStatusTooOld => 'Prestaro za sinkronizaciju — Omi ga ne može prihvatiti';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9827,4 +9827,7 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'No s\'ha pogut connectar a aquest micròfon. Assegura\'t que estigui connectat a la configuració de l\'iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Massa antic per sincronitzar — Omi no el pot acceptar';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9771,4 +9771,7 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'K tomuto mikrofonu se nepodařilo připojit. Ověřte, že je připojený v Nastavení iPhonu.';
+
+  @override
+  String get syncStatusTooOld => 'Příliš staré na synchronizaci — Omi ho nemůže přijmout';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9757,4 +9757,7 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Der kunne ikke oprettes forbindelse til mikrofonen. Sørg for, at den er tilsluttet i iPhone-indstillinger.';
+
+  @override
+  String get syncStatusTooOld => 'For gammel til at synkronisere — Omi kan ikke acceptere den';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9853,4 +9853,7 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Verbindung mit diesem Mikrofon fehlgeschlagen. Stelle sicher, dass es in den iPhone-Einstellungen verbunden ist.';
+
+  @override
+  String get syncStatusTooOld => 'Zu alt für die Synchronisierung — Omi kann sie nicht annehmen';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9840,4 +9840,7 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Δεν ήταν δυνατή η σύνδεση σε αυτό το μικρόφωνο. Βεβαιωθείτε ότι είναι συνδεδεμένο στις Ρυθμίσεις του iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Πολύ παλιά για συγχρονισμό — το Omi δεν μπορεί να τη δεχτεί';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9765,4 +9765,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Could not connect to that microphone. Make sure it is connected in iPhone Settings.';
+
+  @override
+  String get syncStatusTooOld => 'Too old to sync — Omi can\'t accept it';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9795,4 +9795,7 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'No se pudo conectar con ese micrófono. Asegúrate de que esté conectado en los ajustes del iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Demasiado antigua para sincronizar — Omi no puede aceptarla';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9767,4 +9767,7 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Selle mikrofoniga ei saanud ühendust luua. Veenduge, et see oleks iPhone\'i seadetes ühendatud.';
+
+  @override
+  String get syncStatusTooOld => 'Sünkroonimiseks liiga vana — Omi ei saa seda vastu võtta';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9773,4 +9773,7 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'اتصال به این میکروفون ممکن نشد. مطمئن شوید در تنظیمات iPhone متصل است.';
+
+  @override
+  String get syncStatusTooOld => 'برای همگام‌سازی خیلی قدیمی است — Omi نمی‌تواند آن را بپذیرد';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9772,4 +9772,7 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Mikrofoniin ei voitu muodostaa yhteyttä. Varmista, että se on yhdistetty iPhonen asetuksissa.';
+
+  @override
+  String get syncStatusTooOld => 'Liian vanha synkronoitavaksi — Omi ei voi hyväksyä sitä';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9858,4 +9858,7 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Impossible de se connecter à ce micro. Vérifiez qu\'il est connecté dans les réglages de l\'iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Trop ancien pour être synchronisé — Omi ne peut pas l\'accepter';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9696,4 +9696,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get rayBanMetaMicPickerConnectError => 'לא ניתן היה להתחבר למיקרופון הזה. ודאו שהוא מחובר בהגדרות ה-iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'ישן מדי לסנכרון — Omi לא יכול לקבל אותו';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9750,4 +9750,7 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'उस माइक्रोफ़ोन से कनेक्ट नहीं हो सके। सुनिश्चित करें कि वह iPhone सेटिंग्स में कनेक्ट है।';
+
+  @override
+  String get syncStatusTooOld => 'सिंक करने के लिए बहुत पुराना — Omi इसे स्वीकार नहीं कर सकता';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9805,4 +9805,7 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Povezivanje s tim mikrofonom nije uspjelo. Provjerite je li povezan u postavkama iPhonea.';
+
+  @override
+  String get syncStatusTooOld => 'Prestaro za sinkronizaciju — Omi ga ne može prihvatiti';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9811,4 +9811,7 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Nem sikerült csatlakozni ehhez a mikrofonhoz. Ellenőrizd, hogy csatlakoztatva van-e az iPhone Beállításokban.';
+
+  @override
+  String get syncStatusTooOld => 'Túl régi a szinkronizáláshoz — az Omi nem tudja elfogadni';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9781,4 +9781,7 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Tidak dapat terhubung ke mikrofon tersebut. Pastikan mikrofon terhubung di Pengaturan iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Terlalu lama untuk disinkronkan — Omi tidak dapat menerimanya';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9828,4 +9828,7 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Impossibile connettersi a quel microfono. Assicurati che sia connesso nelle Impostazioni dell\'iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Troppo vecchia per la sincronizzazione — Omi non può accettarla';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9609,4 +9609,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get rayBanMetaMicPickerConnectError => 'そのマイクに接続できませんでした。iPhone の設定で接続されていることを確認してください。';
+
+  @override
+  String get syncStatusTooOld => '古すぎて同期できません — Omi は受け付けられません';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9803,4 +9803,7 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'ಆ ಮೈಕ್ರೊಫೋನ್‌ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ಅದು iPhone ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಸಂಪರ್ಕಗೊಂಡಿದೆಯೇ ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
+
+  @override
+  String get syncStatusTooOld => 'ಸಿಂಕ್ ಮಾಡಲು ತುಂಬಾ ಹಳೆಯದು — Omi ಅದನ್ನು ಸ್ವೀಕರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9610,4 +9610,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get rayBanMetaMicPickerConnectError => '해당 마이크에 연결할 수 없습니다. iPhone 설정에서 연결되어 있는지 확인하세요.';
+
+  @override
+  String get syncStatusTooOld => '너무 오래되어 동기화할 수 없습니다 — Omi가 받을 수 없습니다';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9788,4 +9788,7 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Nepavyko prisijungti prie šio mikrofono. Įsitikinkite, kad jis prijungtas iPhone nustatymuose.';
+
+  @override
+  String get syncStatusTooOld => 'Per senas sinchronizuoti — „Omi“ negali jo priimti';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9793,4 +9793,7 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Neizdevās izveidot savienojumu ar šo mikrofonu. Pārliecinieties, ka tas ir pievienots iPhone iestatījumos.';
+
+  @override
+  String get syncStatusTooOld => 'Pārāk vecs, lai sinhronizētu — Omi to nevar pieņemt';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9823,4 +9823,7 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Не може да се поврзе со тој микрофон. Проверете дали е поврзан во поставките на iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Премногу стар за синхронизација — Omi не може да го прифати';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9780,4 +9780,7 @@ class AppLocalizationsMr extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'त्या मायक्रोफोनशी कनेक्ट करता आले नाही. तो iPhone सेटिंग्जमध्ये कनेक्ट असल्याची खात्री करा.';
+
+  @override
+  String get syncStatusTooOld => 'सिंक करण्यासाठी खूप जुने — Omi ते स्वीकारू शकत नाही';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9796,4 +9796,7 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Tidak dapat menyambung ke mikrofon itu. Pastikan ia disambungkan dalam Tetapan iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Terlalu lama untuk disegerakkan — Omi tidak boleh menerimanya';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9798,4 +9798,7 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Kan geen verbinding maken met die microfoon. Controleer of deze verbonden is in de iPhone-instellingen.';
+
+  @override
+  String get syncStatusTooOld => 'Te oud om te synchroniseren — Omi kan deze niet accepteren';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9770,4 +9770,7 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Kunne ikke koble til mikrofonen. Sørg for at den er tilkoblet i iPhone-innstillingene.';
+
+  @override
+  String get syncStatusTooOld => 'For gammel til å synkroniseres — Omi kan ikke ta imot den';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9798,4 +9798,7 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Nie udało się połączyć z tym mikrofonem. Upewnij się, że jest połączony w Ustawieniach iPhone\'a.';
+
+  @override
+  String get syncStatusTooOld => 'Zbyt stare, aby zsynchronizować — Omi nie może tego przyjąć';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9780,4 +9780,7 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Não foi possível ligar a esse microfone. Certifique-se de que está ligado nas Definições do iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Demasiado antiga para sincronizar — o Omi não pode aceitá-la';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9817,4 +9817,7 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Nu s-a putut conecta la acel microfon. Asigură-te că este conectat în Configurările iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Prea veche pentru sincronizare — Omi nu o poate accepta';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9807,4 +9807,7 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Не удалось подключиться к этому микрофону. Убедитесь, что он подключён в настройках iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Слишком старая для синхронизации — Omi не может её принять';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9763,4 +9763,7 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'K tomuto mikrofónu sa nepodarilo pripojiť. Uistite sa, že je pripojený v nastaveniach iPhonu.';
+
+  @override
+  String get syncStatusTooOld => 'Príliš staré na synchronizáciu — Omi ho nemôže prijať';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9799,4 +9799,7 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'S tem mikrofonom se ni bilo mogoče povezati. Prepričajte se, da je povezan v nastavitvah iPhona.';
+
+  @override
+  String get syncStatusTooOld => 'Prestaro za sinhronizacijo — Omi ga ne more sprejeti';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9785,4 +9785,7 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Повезивање са тим микрофоном није успело. Проверите да ли је повезан у подешавањима iPhone-а.';
+
+  @override
+  String get syncStatusTooOld => 'Превише стара за синхронизацију — Omi не може да је прихвати';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9776,4 +9776,7 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Det gick inte att ansluta till mikrofonen. Kontrollera att den är ansluten i iPhone-inställningarna.';
+
+  @override
+  String get syncStatusTooOld => 'För gammal för att synkas — Omi kan inte ta emot den';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9841,4 +9841,7 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'அந்த மைக்ரோஃபோனுடன் இணைக்க முடியவில்லை. அது iPhone அமைப்புகளில் இணைக்கப்பட்டுள்ளதா என உறுதிசெய்யவும்.';
+
+  @override
+  String get syncStatusTooOld => 'ஒத்திசைக்க மிகவும் பழையது — Omi இதை ஏற்க முடியாது';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9820,4 +9820,7 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'ఆ మైక్రోఫోన్‌కు కనెక్ట్ కాలేకపోయాము. అది iPhone సెట్టింగ్‌లలో కనెక్ట్ అయిందని నిర్ధారించుకోండి.';
+
+  @override
+  String get syncStatusTooOld => 'సింక్ చేయడానికి చాలా పాతది — Omi దీన్ని అంగీకరించలేదు';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9717,4 +9717,7 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'เชื่อมต่อกับไมโครโฟนนั้นไม่ได้ ตรวจสอบว่าเชื่อมต่ออยู่ในการตั้งค่า iPhone';
+
+  @override
+  String get syncStatusTooOld => 'เก่าเกินกว่าจะซิงค์ — Omi รับไม่ได้';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9861,4 +9861,7 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Hindi makakonekta sa mikroponong iyon. Tiyaking nakakonekta ito sa Mga Setting ng iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Masyadong luma para i-sync — hindi ito matatanggap ng Omi';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9783,4 +9783,7 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Bu mikrofona bağlanılamadı. iPhone Ayarları\'nda bağlı olduğundan emin olun.';
+
+  @override
+  String get syncStatusTooOld => 'Eşitlemek için çok eski — Omi bunu kabul edemez';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9791,4 +9791,7 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Не вдалося підключитися до цього мікрофона. Переконайтеся, що його підключено в параметрах iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Занадто старий для синхронізації — Omi не може його прийняти';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9785,4 +9785,7 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'اس مائیکروفون سے منسلک نہیں ہو سکے۔ یقینی بنائیں کہ یہ iPhone کی ترتیبات میں منسلک ہے۔';
+
+  @override
+  String get syncStatusTooOld => 'ہم آہنگ کرنے کے لیے بہت پرانا — Omi اسے قبول نہیں کر سکتا';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9767,4 +9767,7 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get rayBanMetaMicPickerConnectError =>
       'Không thể kết nối với micrô đó. Hãy đảm bảo micrô đã được kết nối trong Cài đặt iPhone.';
+
+  @override
+  String get syncStatusTooOld => 'Quá cũ để đồng bộ — Omi không thể chấp nhận';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9591,4 +9591,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get rayBanMetaMicPickerConnectError => '无法连接到该麦克风。请确保它已在 iPhone 设置中连接。';
+
+  @override
+  String get syncStatusTooOld => '太旧，无法同步 — Omi 无法接收';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Laukiama sinchronizavimo",
     "syncStatusRetrying": "Nepavyko apdoroti — bandoma dar kartą",
     "syncStatusFailed": "Nepavyko — palieskite Bandyti dar kartą",
+    "syncStatusTooOld": "Per senas sinchronizuoti — „Omi“ negali jo priimti",
     "syncStatusFileUnavailable": "Failas nepasiekiamas",
     "syncStatusUploaded": "Įkelta · apdorojama Omi",
     "noRecordingsYet": "Įrašų dar nėra",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Gaida sinhronizāciju",
     "syncStatusRetrying": "Neizdevās apstrādāt — mēģina vēlreiz",
     "syncStatusFailed": "Neizdevās — pieskarieties Mēģināt vēlreiz",
+    "syncStatusTooOld": "Pārāk vecs, lai sinhronizētu — Omi to nevar pieņemt",
     "syncStatusFileUnavailable": "Fails nav pieejams",
     "syncStatusUploaded": "Augšupielādēts · tiek apstrādāts Omi",
     "noRecordingsYet": "Vēl nav ierakstu",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Чека синхронизација",
     "syncStatusRetrying": "Обработката не успеа — нов обид",
     "syncStatusFailed": "Неуспешно — допрете Обиди се повторно",
+    "syncStatusTooOld": "Премногу стар за синхронизација — Omi не може да го прифати",
     "syncStatusFileUnavailable": "Датотеката е недостапна",
     "syncStatusUploaded": "Поставено · се обработува на Omi",
     "noRecordingsYet": "Сè уште нема снимки",

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "सिंक होण्याची प्रतीक्षा",
     "syncStatusRetrying": "प्रक्रिया करता आली नाही — पुन्हा प्रयत्न",
     "syncStatusFailed": "अयशस्वी — Retry दाबा",
+    "syncStatusTooOld": "सिंक करण्यासाठी खूप जुने — Omi ते स्वीकारू शकत नाही",
     "syncStatusFileUnavailable": "फाइल उपलब्ध नाही",
     "syncStatusUploaded": "अपलोड झाले · Omi वर प्रक्रिया सुरू",
     "noRecordingsYet": "अद्याप कोणतीही रेकॉर्डिंग नाही",

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Menunggu untuk segerak",
     "syncStatusRetrying": "Gagal diproses — mencuba semula",
     "syncStatusFailed": "Gagal — ketik Cuba Lagi",
+    "syncStatusTooOld": "Terlalu lama untuk disegerakkan — Omi tidak boleh menerimanya",
     "syncStatusFileUnavailable": "Fail tidak tersedia",
     "syncStatusUploaded": "Dimuat naik · diproses di Omi",
     "noRecordingsYet": "Belum ada rakaman",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Wacht op synchronisatie",
     "syncStatusRetrying": "Verwerken mislukt — opnieuw proberen",
     "syncStatusFailed": "Mislukt — tik op Opnieuw",
+    "syncStatusTooOld": "Te oud om te synchroniseren — Omi kan deze niet accepteren",
     "syncStatusFileUnavailable": "Bestand niet beschikbaar",
     "syncStatusUploaded": "Geüpload · wordt verwerkt op Omi",
     "noRecordingsYet": "Nog geen opnames",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Venter på synkronisering",
     "syncStatusRetrying": "Kunne ikke behandles — prøver igjen",
     "syncStatusFailed": "Mislyktes — trykk på Prøv igjen",
+    "syncStatusTooOld": "For gammel til å synkroniseres — Omi kan ikke ta imot den",
     "syncStatusFileUnavailable": "Filen er utilgjengelig",
     "syncStatusUploaded": "Lastet opp · behandles på Omi",
     "noRecordingsYet": "Ingen opptak ennå",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3028,6 +3028,7 @@
     "syncStatusWaiting": "Oczekuje na synchronizację",
     "syncStatusRetrying": "Przetwarzanie nie powiodło się — ponawianie",
     "syncStatusFailed": "Niepowodzenie — naciśnij Ponów",
+    "syncStatusTooOld": "Zbyt stare, aby zsynchronizować — Omi nie może tego przyjąć",
     "syncStatusFileUnavailable": "Plik niedostępny",
     "syncStatusUploaded": "Przesłano · przetwarzanie w Omi",
     "noRecordingsYet": "Brak nagrań",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3029,6 +3029,7 @@
     "syncStatusWaiting": "Aguardando para sincronizar",
     "syncStatusRetrying": "Falha ao processar — tentando novamente",
     "syncStatusFailed": "Falhou — toque em Tentar novamente",
+    "syncStatusTooOld": "Demasiado antiga para sincronizar — o Omi não pode aceitá-la",
     "syncStatusFileUnavailable": "Arquivo indisponível",
     "syncStatusUploaded": "Enviado · processando no Omi",
     "noRecordingsYet": "Ainda não há gravações",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Așteaptă sincronizarea",
     "syncStatusRetrying": "Procesarea a eșuat — se reîncearcă",
     "syncStatusFailed": "A eșuat — atinge Reîncearcă",
+    "syncStatusTooOld": "Prea veche pentru sincronizare — Omi nu o poate accepta",
     "syncStatusFileUnavailable": "Fișierul nu este disponibil",
     "syncStatusUploaded": "Încărcat · se procesează pe Omi",
     "noRecordingsYet": "Încă nu există înregistrări",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3028,6 +3028,7 @@
     "syncStatusWaiting": "Ожидает синхронизации",
     "syncStatusRetrying": "Не удалось обработать — повтор",
     "syncStatusFailed": "Ошибка — нажмите «Повторить»",
+    "syncStatusTooOld": "Слишком старая для синхронизации — Omi не может её принять",
     "syncStatusFileUnavailable": "Файл недоступен",
     "syncStatusUploaded": "Загружено · обработка в Omi",
     "noRecordingsYet": "Записей пока нет",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2998,6 +2998,7 @@
     "syncStatusWaiting": "Čaká na synchronizáciu",
     "syncStatusRetrying": "Spracovanie zlyhalo — opakuje sa",
     "syncStatusFailed": "Zlyhalo — ťuknite na Skúsiť znova",
+    "syncStatusTooOld": "Príliš staré na synchronizáciu — Omi ho nemôže prijať",
     "syncStatusFileUnavailable": "Súbor nie je dostupný",
     "syncStatusUploaded": "Nahraté · spracúva sa v Omi",
     "noRecordingsYet": "Zatiaľ žiadne nahrávky",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Čaka na sinhronizacijo",
     "syncStatusRetrying": "Obdelava ni uspela — vnovični poskus",
     "syncStatusFailed": "Ni uspelo — tapnite Poskusi znova",
+    "syncStatusTooOld": "Prestaro za sinhronizacijo — Omi ga ne more sprejeti",
     "syncStatusFileUnavailable": "Datoteka ni na voljo",
     "syncStatusUploaded": "Naloženo · obdelava v Omi",
     "noRecordingsYet": "Še ni posnetkov",

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Чека синхронизацију",
     "syncStatusRetrying": "Обрада није успела — нови покушај",
     "syncStatusFailed": "Неуспело — додирните Покушај поново",
+    "syncStatusTooOld": "Превише стара за синхронизацију — Omi не може да је прихвати",
     "syncStatusFileUnavailable": "Датотека није доступна",
     "syncStatusUploaded": "Отпремљено · обрада на Omi",
     "noRecordingsYet": "Још нема снимака",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Väntar på synkronisering",
     "syncStatusRetrying": "Kunde inte bearbetas — försöker igen",
     "syncStatusFailed": "Misslyckades — tryck på Försök igen",
+    "syncStatusTooOld": "För gammal för att synkas — Omi kan inte ta emot den",
     "syncStatusFileUnavailable": "Filen är inte tillgänglig",
     "syncStatusUploaded": "Uppladdad · bearbetas på Omi",
     "noRecordingsYet": "Inga inspelningar än",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "ஒத்திசைவுக்காக காத்திருக்கிறது",
     "syncStatusRetrying": "செயலாக்க முடியவில்லை — மீண்டும் முயற்சிக்கிறது",
     "syncStatusFailed": "தோல்வி — Retry-ஐ அழுத்தவும்",
+    "syncStatusTooOld": "ஒத்திசைக்க மிகவும் பழையது — Omi இதை ஏற்க முடியாது",
     "syncStatusFileUnavailable": "கோப்பு கிடைக்கவில்லை",
     "syncStatusUploaded": "பதிவேற்றப்பட்டது · Omi-இல் செயலாக்கப்படுகிறது",
     "noRecordingsYet": "இன்னும் பதிவுகள் இல்லை",

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "సింక్ కోసం వేచి ఉంది",
     "syncStatusRetrying": "ప్రాసెస్ చేయలేకపోయింది — మళ్లీ ప్రయత్నిస్తోంది",
     "syncStatusFailed": "విఫలమైంది — Retry నొక్కండి",
+    "syncStatusTooOld": "సింక్ చేయడానికి చాలా పాతది — Omi దీన్ని అంగీకరించలేదు",
     "syncStatusFileUnavailable": "ఫైల్ అందుబాటులో లేదు",
     "syncStatusUploaded": "అప్‌లోడ్ అయింది · Omiలో ప్రాసెస్ అవుతోంది",
     "noRecordingsYet": "ఇంకా రికార్డింగ్‌లు లేవు",

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "รอการซิงค์",
     "syncStatusRetrying": "ประมวลผลไม่สำเร็จ — กำลังลองใหม่",
     "syncStatusFailed": "ล้มเหลว — แตะ ลองใหม่",
+    "syncStatusTooOld": "เก่าเกินกว่าจะซิงค์ — Omi รับไม่ได้",
     "syncStatusFileUnavailable": "ไม่พบไฟล์",
     "syncStatusUploaded": "อัปโหลดแล้ว · กำลังประมวลผลบน Omi",
     "noRecordingsYet": "ยังไม่มีการบันทึก",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "Naghihintay na mag-sync",
     "syncStatusRetrying": "Hindi naproseso — sinusubukang muli",
     "syncStatusFailed": "Nabigo — i-tap ang Subukan Muli",
+    "syncStatusTooOld": "Masyadong luma para i-sync — hindi ito matatanggap ng Omi",
     "syncStatusFileUnavailable": "Hindi available ang file",
     "syncStatusUploaded": "Na-upload · pinoproseso sa Omi",
     "noRecordingsYet": "Wala pang mga recording",

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3028,6 +3028,7 @@
     "syncStatusWaiting": "Eşitleme bekleniyor",
     "syncStatusRetrying": "İşlenemedi — yeniden deneniyor",
     "syncStatusFailed": "Başarısız — Yeniden Dene'ye dokunun",
+    "syncStatusTooOld": "Eşitlemek için çok eski — Omi bunu kabul edemez",
     "syncStatusFileUnavailable": "Dosya kullanılamıyor",
     "syncStatusUploaded": "Yüklendi · Omi'de işleniyor",
     "noRecordingsYet": "Henüz kayıt yok",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2993,6 +2993,7 @@
     "syncStatusWaiting": "Очікує синхронізації",
     "syncStatusRetrying": "Не вдалося обробити — повтор",
     "syncStatusFailed": "Помилка — натисніть «Повторити»",
+    "syncStatusTooOld": "Занадто старий для синхронізації — Omi не може його прийняти",
     "syncStatusFileUnavailable": "Файл недоступний",
     "syncStatusUploaded": "Завантажено · обробка в Omi",
     "noRecordingsYet": "Записів ще немає",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10567,6 +10567,7 @@
     "syncStatusWaiting": "سنک ہونے کا منتظر",
     "syncStatusRetrying": "پروسیس نہیں ہو سکا — دوبارہ کوشش",
     "syncStatusFailed": "ناکام — Retry دبائیں",
+    "syncStatusTooOld": "ہم آہنگ کرنے کے لیے بہت پرانا — Omi اسے قبول نہیں کر سکتا",
     "syncStatusFileUnavailable": "فائل دستیاب نہیں",
     "syncStatusUploaded": "اپ لوڈ ہو گیا · Omi پر پروسیسنگ جاری",
     "noRecordingsYet": "ابھی تک کوئی ریکارڈنگ نہیں",

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2998,6 +2998,7 @@
     "syncStatusWaiting": "Đang chờ đồng bộ",
     "syncStatusRetrying": "Không xử lý được — đang thử lại",
     "syncStatusFailed": "Thất bại — nhấn Thử lại",
+    "syncStatusTooOld": "Quá cũ để đồng bộ — Omi không thể chấp nhận",
     "syncStatusFileUnavailable": "Tệp không khả dụng",
     "syncStatusUploaded": "Đã tải lên · đang xử lý trên Omi",
     "noRecordingsYet": "Chưa có bản ghi nào",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3015,6 +3015,7 @@
     "syncStatusWaiting": "等待同步",
     "syncStatusRetrying": "无法处理 — 正在重试",
     "syncStatusFailed": "失败 — 点按“重试”",
+    "syncStatusTooOld": "太旧，无法同步 — Omi 无法接收",
     "syncStatusFileUnavailable": "文件不可用",
     "syncStatusUploaded": "已上传 · 正在 Omi 上处理",
     "noRecordingsYet": "暂无录音",

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -682,6 +682,8 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
         return (Colors.redAccent, FontAwesomeIcons.circleExclamation, context.l10n.syncStatusFailed);
       case WalSyncDisplayState.corrupted:
         return (Colors.redAccent, FontAwesomeIcons.triangleExclamation, context.l10n.syncStatusFileUnavailable);
+      case WalSyncDisplayState.outsideRecoveryWindow:
+        return (Colors.redAccent, FontAwesomeIcons.clockRotateLeft, context.l10n.syncStatusTooOld);
     }
   }
 

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -74,6 +74,8 @@ class WalListItem extends StatelessWidget {
         return (Colors.redAccent, l.syncStatusFailed);
       case WalSyncDisplayState.corrupted:
         return (Colors.redAccent, l.syncStatusFileUnavailable);
+      case WalSyncDisplayState.outsideRecoveryWindow:
+        return (Colors.redAccent, l.syncStatusTooOld);
       case WalSyncDisplayState.waiting:
       case WalSyncDisplayState.syncing:
         return (Colors.grey.shade500, l.syncStatusWaiting);

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -97,7 +97,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     for (final w in _allWals) {
       if (w.status == WalStatus.synced) {
         synced.add(w);
-      } else if (w.status == WalStatus.corrupted) {
+      } else if (w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow) {
         corrupted.add(w);
       } else if (_isPending(w)) {
         pending.add(w);
@@ -226,10 +226,13 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   int get waitingWalsCount => _countWhere((s) => s == WalSyncDisplayState.waiting || s == WalSyncDisplayState.syncing);
 
   /// Recordings that need the user's attention: a sync failed (auto-retries
-  /// exhausted) or the file is unreadable. Surfaced explicitly so a failure is
-  /// never mistaken for a recording that simply hasn't synced yet.
-  int get needsAttentionWalsCount =>
-      _countWhere((s) => s == WalSyncDisplayState.failed || s == WalSyncDisplayState.corrupted);
+  /// exhausted), the file is unreadable, or the server permanently refused it
+  /// for being too old. Surfaced explicitly so a failure is never mistaken for
+  /// a recording that simply hasn't synced yet.
+  int get needsAttentionWalsCount => _countWhere((s) =>
+      s == WalSyncDisplayState.failed ||
+      s == WalSyncDisplayState.corrupted ||
+      s == WalSyncDisplayState.outsideRecoveryWindow);
 
   int get retryingWalsCount => _countWhere((s) => s == WalSyncDisplayState.retrying);
 
@@ -240,7 +243,9 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         case WalDisplayFilter.all:
           return true;
         case WalDisplayFilter.pending:
-          return w.status != WalStatus.corrupted && w.syncDisplayState != WalSyncDisplayState.synced;
+          return w.status != WalStatus.corrupted &&
+              w.status != WalStatus.outsideRecoveryWindow &&
+              w.syncDisplayState != WalSyncDisplayState.synced;
         case WalDisplayFilter.synced:
           return w.syncDisplayState == WalSyncDisplayState.synced;
       }

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -607,7 +607,8 @@ class LocalWalSyncImpl implements LocalWalSync {
   /// retryable Pending action.
   @override
   Future<void> deleteAllCorruptedWals() async {
-    final corruptedWals = _wals.where((w) => w.status == WalStatus.corrupted).toList();
+    final corruptedWals =
+        _wals.where((w) => w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow).toList();
     for (final wal in corruptedWals) {
       await _deleteWal(wal);
     }
@@ -843,6 +844,16 @@ class LocalWalSyncImpl implements LocalWalSync {
         await _saveWalsToFile();
         listener.onWalUpdated();
         continue;
+      } on SyncRecoveryWindowExceededException {
+        final retired = _retireOutsideRecoveryWindow(batchWals);
+        DebugLogManager.logEvent('local_upload_outside_recovery_window', {
+          'batchWalIds': batchWals.map((w) => w.id).toList(),
+          'retiredWalIds': retired.map((w) => w.id).toList(),
+          'lane': batchLane.name,
+        });
+        await _saveWalsToFile();
+        listener.onWalUpdated();
+        continue;
       } catch (e) {
         print('Local WAL upload batch failed: $e, continuing with remaining files');
         batchesFailed++;
@@ -985,6 +996,17 @@ class LocalWalSyncImpl implements LocalWalSync {
       await _saveWalsToFile();
       listener.onWalUpdated();
       return resp;
+    } on SyncRecoveryWindowExceededException {
+      // Terminal: older than the server's automatic-recovery window. A manual
+      // retry cannot succeed either, so stop presenting it as retryable work.
+      final retired = _retireOutsideRecoveryWindow([walToSync]);
+      DebugLogManager.logEvent('single_wal_outside_recovery_window', {
+        'walId': wal.id,
+        'retiredWalIds': retired.map((w) => w.id).toList(),
+      });
+      await _saveWalsToFile();
+      listener.onWalUpdated();
+      return resp;
     } catch (e) {
       Logger.debug('Single WAL upload failed: $e');
       DebugLogManager.logError(e, null, 'Single WAL upload failed: ${e.toString()}', {'walId': wal.id});
@@ -999,6 +1021,29 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     progress?.onWalSyncedProgress(1.0);
     return resp;
+  }
+
+  /// Retires the recordings a `backfill_lookback_exceeded` rejection proves the
+  /// server will never accept, and only those.
+  ///
+  /// The backend decides the lookback from the OLDEST capture in the upload
+  /// (`classify_sync_lane` measures `now - oldest_capture_at`), so a rejection
+  /// only proves that one recording is outside the window — a batch mixes ages,
+  /// and retiring all of it would strand recordings the server would still take.
+  /// Everything captured no later than the proven-too-old one is necessarily
+  /// outside the window as well, so the whole tail retires in one pass instead
+  /// of costing another doomed upload per recording. The rest of the batch stays
+  /// `miss` and re-forms into a batch without the poison on the next drain.
+  List<Wal> _retireOutsideRecoveryWindow(List<Wal> rejectedBatch) {
+    if (rejectedBatch.isEmpty) return const [];
+    final provenTooOld = rejectedBatch.map((w) => w.timerStart).reduce(min);
+    final retired = _wals
+        .where((w) => w.status == WalStatus.miss && w.storage == WalStorage.disk && w.timerStart <= provenTooOld)
+        .toList();
+    for (final wal in retired) {
+      wal.markOutsideRecoveryWindow();
+    }
+    return retired;
   }
 
   Future<bool> _localFileExists(Wal wal) async {

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -845,6 +845,14 @@ class LocalWalSyncImpl implements LocalWalSync {
         listener.onWalUpdated();
         continue;
       } on SyncRecoveryWindowExceededException {
+        // Clear the in-flight flag on the whole batch first: the members the
+        // rejection does NOT prove too old stay `miss` and must not be left
+        // rendering as an upload that never finishes.
+        for (final wal in batchWals) {
+          wal.isSyncing = false;
+          wal.syncStartedAt = null;
+          wal.syncEtaSeconds = null;
+        }
         final retired = _retireOutsideRecoveryWindow(batchWals);
         DebugLogManager.logEvent('local_upload_outside_recovery_window', {
           'batchWalIds': batchWals.map((w) => w.id).toList(),
@@ -999,6 +1007,9 @@ class LocalWalSyncImpl implements LocalWalSync {
     } on SyncRecoveryWindowExceededException {
       // Terminal: older than the server's automatic-recovery window. A manual
       // retry cannot succeed either, so stop presenting it as retryable work.
+      walToSync.isSyncing = false;
+      walToSync.syncStartedAt = null;
+      walToSync.syncEtaSeconds = null;
       final retired = _retireOutsideRecoveryWindow([walToSync]);
       DebugLogManager.logEvent('single_wal_outside_recovery_window', {
         'walId': wal.id,

--- a/app/lib/services/wals/wal.dart
+++ b/app/lib/services/wals/wal.dart
@@ -19,7 +19,12 @@ const secondsPerFlashPage = 1.4;
 ///                  resolves the job_id to [synced] / [miss] / [corrupted].
 /// - [synced]     — server job confirmed success; conversation created. Safe to clean up.
 /// - [corrupted]  — the underlying local file is missing/unreadable.
-enum WalStatus { inProgress, miss, uploaded, synced, corrupted }
+/// - [outsideRecoveryWindow] — the server permanently refused this recording
+///                  because it is older than the automatic-recovery window
+///                  (HTTP 422 `backfill_lookback_exceeded`). The local file is
+///                  intact, but re-uploading it can never succeed, so it is
+///                  terminal for sync rather than pending work.
+enum WalStatus { inProgress, miss, uploaded, synced, corrupted, outsideRecoveryWindow }
 
 enum WalStorage { mem, disk, sdcard, flashPage }
 
@@ -36,7 +41,10 @@ enum SyncMethod { ble }
 /// - [retrying]   — a sync attempt failed; will be retried automatically
 /// - [failed]     — auto-retries exhausted; needs a manual retry
 /// - [corrupted]  — the underlying file is missing/unreadable
-enum WalSyncDisplayState { syncing, uploaded, synced, waiting, retrying, failed, corrupted }
+/// - [outsideRecoveryWindow] — too old for the server to accept; retrying
+///                  cannot help, so the row explains that instead of offering
+///                  a Retry the user would spend forever
+enum WalSyncDisplayState { syncing, uploaded, synced, waiting, retrying, failed, corrupted, outsideRecoveryWindow }
 
 /// Max automatic sync attempts before a recording is considered [WalSyncDisplayState.failed].
 /// Mirrors the `maxRetries` used by the auto-sync loop in capture_provider.
@@ -137,9 +145,11 @@ class Wal {
   /// user. The sync page renders an explicit label + icon for every value so a
   /// not-yet-synced recording is never visually identical to a failed one.
   WalSyncDisplayState get syncDisplayState {
-    // Corruption is terminal. It must not be visually downgraded to an active
-    // upload if a transient flag was left behind by an interrupted attempt.
+    // Corruption and a server lookback rejection are terminal. Neither must be
+    // visually downgraded to an active upload if a transient flag was left
+    // behind by an interrupted attempt.
     if (status == WalStatus.corrupted) return WalSyncDisplayState.corrupted;
+    if (status == WalStatus.outsideRecoveryWindow) return WalSyncDisplayState.outsideRecoveryWindow;
     if (isSyncing) return WalSyncDisplayState.syncing;
     switch (status) {
       case WalStatus.uploaded:
@@ -148,6 +158,8 @@ class Wal {
         return WalSyncDisplayState.synced;
       case WalStatus.corrupted:
         return WalSyncDisplayState.corrupted;
+      case WalStatus.outsideRecoveryWindow:
+        return WalSyncDisplayState.outsideRecoveryWindow;
       case WalStatus.miss:
         if (retryCount >= walMaxAutoRetries) return WalSyncDisplayState.failed;
         if (retryCount > 0) return WalSyncDisplayState.retrying;
@@ -161,6 +173,17 @@ class Wal {
   /// upload presentation left by an interrupted attempt.
   void markCorrupted() {
     status = WalStatus.corrupted;
+    isSyncing = false;
+    syncStartedAt = null;
+    syncEtaSeconds = null;
+    syncSpeedKBps = null;
+  }
+
+  /// Marks this recording as permanently refused by the server for being older
+  /// than the automatic-recovery window. The local file is deliberately kept —
+  /// only the sync attempt is terminal.
+  void markOutsideRecoveryWindow() {
+    status = WalStatus.outsideRecoveryWindow;
     isSyncing = false;
     syncStartedAt = null;
     syncEtaSeconds = null;

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -13,7 +13,8 @@ export 'package:omi/backend/http/api/conversations.dart'
         SyncJobFetch,
         SyncJobFetchOutcome,
         SyncRateLimitedException,
-        SyncRateLimitKind;
+        SyncRateLimitKind,
+        SyncRecoveryWindowExceededException;
 
 abstract class IWalSyncProgressListener {
   void onWalSyncedProgress(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -1369,18 +1369,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   mcumgr_flutter:
     dependency: "direct main"
     description:
@@ -2145,10 +2145,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.7"
   time:
     dependency: transitive
     description:

--- a/app/test/providers/sync_provider_terminal_wal_state_test.dart
+++ b/app/test/providers/sync_provider_terminal_wal_state_test.dart
@@ -171,4 +171,36 @@ void main() {
 
     expect(syncProvider.allWals, isEmpty);
   });
+
+  test('a recording refused for being older than the recovery window is terminal, not pending', () async {
+    // #10975: the server answers 422 `backfill_lookback_exceeded` for a capture
+    // past SYNC_BACKFILL_MAX_AGE_SECONDS. Retrying can never succeed, so the
+    // recording must leave the pending pool instead of being offered as work
+    // sync can still complete.
+    final tooOld = _wal(timerStart: 1000, filePath: 'too_old_audio.bin')..markOutsideRecoveryWindow();
+    final retryable = _wal(timerStart: 2000, filePath: 'retryable_audio.bin');
+    localSync.testWals = [tooOld, retryable];
+
+    final syncProvider = SyncProvider(
+      walService: _WalService(_LocalSyncs(localSync)),
+      uploadGate: _offlineGate(),
+      startBackgroundSync: false,
+    );
+    provider = syncProvider;
+    await syncProvider.initialized;
+
+    // A persisted stale flag must not reclassify or lock a terminal row.
+    tooOld.isSyncing = true;
+
+    expect(syncProvider.pendingWals, [retryable]);
+    expect(syncProvider.pendingDeletableWals, [retryable]);
+    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.pending), [retryable]);
+    expect(syncProvider.corruptedWals, [tooOld], reason: 'it belongs with the terminal, non-retryable recordings');
+    expect(syncProvider.needsAttentionWalsCount, 1);
+    expect(syncProvider.walsForDisplayFilter(WalDisplayFilter.all), containsAll([tooOld, retryable]));
+
+    await syncProvider.deleteAllClearableWals();
+
+    expect(syncProvider.allWals, isEmpty, reason: 'Clear All must still be able to remove it');
+  });
 }

--- a/app/test/unit/sync_rate_limit_response_test.dart
+++ b/app/test/unit/sync_rate_limit_response_test.dart
@@ -44,4 +44,33 @@ void main() {
       expect(syncRateLimitKindForResponse(html), SyncRateLimitKind.backendCapacity);
     });
   });
+
+  group('isSyncRecoveryWindowExceededResponse', () {
+    test('recognizes the backend lookback rejection on both sync routes', () {
+      final v2 = http.Response(
+        '{"code":"backfill_lookback_exceeded","detail":"Recording is older than the automatic recovery window; '
+        'local audio was not consumed","lane":"backfill"}',
+        422,
+      );
+      final v1 = http.Response(
+        '{"code":"backfill_lookback_exceeded","detail":"Recording is older than the automatic recovery window; '
+        'local audio was not consumed"}',
+        422,
+      );
+
+      expect(isSyncRecoveryWindowExceededResponse(v2), isTrue);
+      expect(isSyncRecoveryWindowExceededResponse(v1), isTrue);
+    });
+
+    test('does not widen to other 422s, other statuses, or unparseable bodies', () {
+      expect(isSyncRecoveryWindowExceededResponse(http.Response('{"code":"validation_error"}', 422)), isFalse);
+      expect(isSyncRecoveryWindowExceededResponse(http.Response('<html>Unprocessable</html>', 422)), isFalse);
+      expect(isSyncRecoveryWindowExceededResponse(http.Response('', 422)), isFalse);
+      expect(
+        isSyncRecoveryWindowExceededResponse(http.Response('{"code":"backfill_lookback_exceeded"}', 400)),
+        isFalse,
+        reason: 'only the 422 contract is terminal; a 400 stays the generic unprocessable-audio path',
+      );
+    });
+  });
 }

--- a/app/test/unit/wal_sync_display_state_test.dart
+++ b/app/test/unit/wal_sync_display_state_test.dart
@@ -19,8 +19,10 @@ void main() {
   }
 
   group('Wal.syncDisplayState', () {
+    const terminalStatuses = {WalStatus.corrupted, WalStatus.outsideRecoveryWindow};
+
     test('isSyncing wins over every non-terminal status', () {
-      for (final s in WalStatus.values.where((status) => status != WalStatus.corrupted)) {
+      for (final s in WalStatus.values.where((status) => !terminalStatuses.contains(status))) {
         final w = makeWal(status: s, isSyncing: true);
         expect(w.syncDisplayState, WalSyncDisplayState.syncing, reason: 'status=$s');
       }
@@ -28,6 +30,24 @@ void main() {
 
     test('corrupted wins over a stale syncing flag', () {
       expect(makeWal(status: WalStatus.corrupted, isSyncing: true).syncDisplayState, WalSyncDisplayState.corrupted);
+    });
+
+    test('outsideRecoveryWindow wins over a stale syncing flag', () {
+      expect(
+        makeWal(status: WalStatus.outsideRecoveryWindow, isSyncing: true).syncDisplayState,
+        WalSyncDisplayState.outsideRecoveryWindow,
+        reason: 'a recording the server refused for good must never render as an active upload',
+      );
+    });
+
+    test('outsideRecoveryWindow -> outsideRecoveryWindow regardless of retry count', () {
+      for (final r in [0, 1, walMaxAutoRetries]) {
+        expect(
+          makeWal(status: WalStatus.outsideRecoveryWindow, retryCount: r).syncDisplayState,
+          WalSyncDisplayState.outsideRecoveryWindow,
+          reason: 'retryCount=$r must not downgrade it to waiting/retrying/failed',
+        );
+      }
     });
 
     test('uploaded -> uploaded (processing on server)', () {
@@ -80,6 +100,11 @@ void main() {
       expect(back.status, WalStatus.uploaded);
       expect(back.jobId, 'job-xyz');
       expect(back.uploadedAt, 1700000123);
+    });
+
+    test('outsideRecoveryWindow survives a restart', () {
+      final w = makeWal(status: WalStatus.outsideRecoveryWindow);
+      expect(Wal.fromJson(w.toJson()).status, WalStatus.outsideRecoveryWindow);
     });
 
     test('legacy json without job fields defaults safely', () {

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -430,6 +430,14 @@ void main() {
       expect(oldest.status, WalStatus.outsideRecoveryWindow, reason: 'the rejection proves this one is outside');
       expect(middle.status, WalStatus.miss, reason: 'nothing proves this one is outside — it must stay retryable');
       expect(newest.status, WalStatus.miss);
+      // The survivors were flagged in-flight before the batch was rejected. If
+      // that flag is left behind they render as "Syncing…" forever and drop out
+      // of the deletable-pending set, so a rejection two recordings away silently
+      // strands them.
+      for (final survivor in [middle, newest]) {
+        expect(survivor.isSyncing, isFalse, reason: 'a rejected batch must not leave its survivors stuck in-flight');
+        expect(survivor.syncDisplayState, isNot(WalSyncDisplayState.syncing));
+      }
     });
 
     test('recordings outside this batch but at least as old also retire, in the same pass', () async {

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -64,6 +64,9 @@ void main() {
   late LocalWalSyncImpl sync;
   late _MockListener listener;
   late Directory tempDir;
+  // What the injected uploader throws. Defaults to a generic failure; groups
+  // that exercise a specific server rejection override it in their own setUp.
+  late Object uploadFailure;
 
   setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -82,12 +85,13 @@ void main() {
     await WalFileManager.init();
     listener = _MockListener();
     SyncRateLimiter.instance.clear();
+    uploadFailure = StateError('deterministic test upload failure');
     sync = LocalWalSyncImpl(
       listener,
       uploadGate: SyncUploadGate(
         limiter: SyncRateLimiter.instance,
         uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
-          throw StateError('deterministic test upload failure');
+          throw uploadFailure;
         },
         fairUseStatusLoader: () async => {'stage': 'none'},
       ),
@@ -351,6 +355,115 @@ void main() {
         false,
         reason: 'isSyncing cleared confirms syncAll processed this WAL, '
             'despite retryCount=50 — no cap is enforced',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Recording older than the server's automatic-recovery window (#10975).
+  //
+  // `/v2/sync-local-files` answers 422 `backfill_lookback_exceeded` for a
+  // capture older than SYNC_BACKFILL_MAX_AGE_SECONDS. No retry can ever make
+  // that succeed, so it must leave the retry pool with an explicit state
+  // instead of re-uploading the same bytes on every sync pass forever.
+  // -------------------------------------------------------------------------
+
+  group('recording older than the automatic-recovery window', () {
+    setUp(() {
+      uploadFailure = const SyncRecoveryWindowExceededException();
+    });
+
+    Future<File> writeAudio(String filename) async {
+      final file = File('${tempDir.path}/$filename');
+      await file.writeAsBytes([0xAA, 0xBB]);
+      return file;
+    }
+
+    test('a batch upload rejection is terminal and is never retried', () async {
+      const filename = 'too_old_8000.bin';
+      final file = await writeAudio(filename);
+      final wal = _makeWal(timerStart: 8000, filePath: filename);
+      sync.testWals = [wal];
+
+      await sync.syncAll();
+
+      final refused = sync.testWals.first;
+      expect(refused.status, WalStatus.outsideRecoveryWindow);
+      expect(
+        refused.syncDisplayState,
+        WalSyncDisplayState.outsideRecoveryWindow,
+        reason: 'the row must say why, not read as an unexplained failure',
+      );
+      expect(refused.isSyncing, isFalse);
+      expect(refused.retryCount, 0, reason: 'a rejection that can never succeed must not spend the retry budget');
+      expect(await sync.getMissingWals(), isEmpty, reason: 'it must leave the retry pool');
+      expect(await sync.syncAll(), isNull, reason: 'a second sync pass must not re-upload it');
+      expect(file.existsSync(), isTrue, reason: 'the local audio is intact — only the sync attempt is terminal');
+    });
+
+    test('a manual single-recording sync is terminal too', () async {
+      const filename = 'too_old_9000.bin';
+      await writeAudio(filename);
+      final wal = _makeWal(timerStart: 9000, filePath: filename);
+      sync.testWals = [wal];
+
+      await sync.syncWal(wal: wal);
+
+      expect(sync.testWals.first.status, WalStatus.outsideRecoveryWindow);
+      expect(sync.testWals.first.isSyncing, isFalse);
+    });
+
+    test('a mixed-age batch retires only what the rejection proves is too old', () async {
+      // The backend measures the lookback from the OLDEST capture in the
+      // upload, so a rejected batch says nothing about its newer members.
+      // Retiring the whole batch would strand recordings the server accepts.
+      for (final t in [8100, 8200, 8300]) {
+        await writeAudio('mixed_$t.bin');
+      }
+      final oldest = _makeWal(timerStart: 8100, filePath: 'mixed_8100.bin');
+      final middle = _makeWal(timerStart: 8200, filePath: 'mixed_8200.bin');
+      final newest = _makeWal(timerStart: 8300, filePath: 'mixed_8300.bin');
+      sync.testWals = [oldest, middle, newest];
+
+      await sync.syncAll();
+
+      expect(oldest.status, WalStatus.outsideRecoveryWindow, reason: 'the rejection proves this one is outside');
+      expect(middle.status, WalStatus.miss, reason: 'nothing proves this one is outside — it must stay retryable');
+      expect(newest.status, WalStatus.miss);
+    });
+
+    test('recordings outside this batch but at least as old also retire, in the same pass', () async {
+      // Otherwise a long backlog costs one doomed batch upload per recording.
+      // `outsideBatch` is held out of the batch by its conversation grouping,
+      // but it is older than a capture the server just proved is out of range,
+      // so it can only be out of range too.
+      for (final t in [8000, 8100, 8400]) {
+        await writeAudio('tail_$t.bin');
+      }
+      final outsideBatch = _makeWal(timerStart: 8000, filePath: 'tail_8000.bin')..conversationId = 'other-conversation';
+      final oldestInBatch = _makeWal(timerStart: 8100, filePath: 'tail_8100.bin');
+      final newest = _makeWal(timerStart: 8400, filePath: 'tail_8400.bin');
+      sync.testWals = [outsideBatch, oldestInBatch, newest];
+
+      await sync.syncAll();
+
+      expect(oldestInBatch.status, WalStatus.outsideRecoveryWindow);
+      expect(outsideBatch.status, WalStatus.outsideRecoveryWindow, reason: 'older than a proven-rejected capture');
+      expect(newest.status, WalStatus.miss, reason: 'newer than the proven bound — still the server\'s call');
+    });
+
+    test('a generic upload failure stays retryable', () async {
+      uploadFailure = StateError('transient server error');
+      const filename = 'transient_8400.bin';
+      await writeAudio(filename);
+      sync.testWals = [_makeWal(timerStart: 8400, filePath: filename)];
+
+      await sync.syncAll();
+
+      expect(
+        sync.testWals.first.status,
+        WalStatus.miss,
+        reason: 'only the bounded lookback code is terminal — everything else keeps retrying',
       );
     });
   });

--- a/app/test/widgets/sync_row_recovery_window_test.dart
+++ b/app/test/widgets/sync_row_recovery_window_test.dart
@@ -1,0 +1,168 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/conversations.dart' show SyncUploadLane;
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/sync_page.dart';
+import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/local_wal_sync.dart';
+import 'package:omi/services/wals/sync_rate_limiter.dart';
+import 'package:omi/services/wals/sync_upload_gate.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+import 'package:omi/utils/wal_file_manager.dart';
+
+/// A recording the server permanently refused for being older than the
+/// automatic-recovery window must say so on its row, and must not offer a
+/// Retry that can never succeed (#10975).
+
+class _Listener implements IWalSyncListener {
+  @override
+  void onWalSynced(Wal wal, {ServerConversation? conversation}) {}
+
+  @override
+  void onWalUpdated() {}
+}
+
+class _LocalSyncs {
+  _LocalSyncs(this.phone);
+
+  final LocalWalSyncImpl phone;
+
+  Future<List<Wal>> getAllWals() => phone.getAllWals();
+}
+
+class _WalService implements IWalService {
+  _WalService(this.syncs);
+
+  final _LocalSyncs syncs;
+
+  @override
+  dynamic getSyncs() => syncs;
+
+  @override
+  void start() {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  void subscribe(IWalServiceListener subscription, Object context) {}
+
+  @override
+  void unsubscribe(Object context) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+SyncUploadGate _offlineGate() => SyncUploadGate(
+      limiter: SyncRateLimiter.instance,
+      uploader: (files, {onUploadProgress, conversationId, syncLane = SyncUploadLane.fresh}) async {
+        throw StateError('unexpected upload in a widget test');
+      },
+      fairUseStatusLoader: () async => {'stage': 'none'},
+    );
+
+Widget _app(Widget child, SyncProvider provider) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: ChangeNotifierProvider<SyncProvider>.value(
+      value: provider,
+      child: Scaffold(backgroundColor: Colors.black, body: child),
+    ),
+  );
+}
+
+void main() {
+  late Directory tempDir;
+  late LocalWalSyncImpl localSync;
+  SyncProvider? provider;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    tempDir = await Directory.systemTemp.createTemp('sync_row_recovery_window_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    await WalFileManager.init();
+    localSync = LocalWalSyncImpl(_Listener(), uploadGate: _offlineGate());
+  });
+
+  tearDown(() async {
+    provider?.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    SyncRateLimiter.instance.clear();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  Future<SyncProvider> pumpRow(WidgetTester tester, Wal wal) async {
+    localSync.testWals = [wal];
+    final syncProvider = SyncProvider(
+      walService: _WalService(_LocalSyncs(localSync)),
+      uploadGate: _offlineGate(),
+      startBackgroundSync: false,
+    );
+    provider = syncProvider;
+    await syncProvider.initialized;
+    await tester.pumpWidget(
+      _app(
+        WalListItem(wal: wal, date: DateTime.fromMillisecondsSinceEpoch(wal.timerStart * 1000), walIdx: 0),
+        syncProvider,
+      ),
+    );
+    await tester.pump();
+    return syncProvider;
+  }
+
+  Wal makeWal(WalStatus status) => Wal(
+        timerStart: 1700000000,
+        codec: BleAudioCodec.opus,
+        seconds: 60,
+        status: status,
+        storage: WalStorage.disk,
+        device: 'omi',
+        filePath: 'too_old_audio.bin',
+      );
+
+  testWidgets('the row explains the rejection and offers no Retry', (tester) async {
+    await pumpRow(tester, makeWal(WalStatus.outsideRecoveryWindow));
+
+    expect(find.text("Too old to sync — Omi can't accept it"), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+    expect(find.text('Waiting to sync'), findsNothing);
+  });
+
+  testWidgets('a still-retryable recording keeps its Retry affordance', (tester) async {
+    await pumpRow(tester, makeWal(WalStatus.miss)..retryCount = walMaxAutoRetries);
+
+    expect(find.text('Failed — tap Retry'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
`/v2/sync-local-files` answers `422 backfill_lookback_exceeded` for a capture
older than `SYNC_BACKFILL_MAX_AGE_SECONDS` (30 days in
`backend/deploy/runtime_env.yaml`). `uploadLocalFilesV2` had no 422 branch, so
that response fell past every case to `Exception('Upload failed unexpectedly')`
— a generic, retryable failure. The batch handler clears `isSyncing` and leaves
the WAL `miss`, which is exactly the state `syncAll()` selects from, so the
same bytes are re-offered on every sync pass forever while the row reads
"Waiting to sync" and never explains anything. Anyone draining a backlog older
than a month — the long-offline case sync exists for — pays that upload
repeatedly for a rejection that can never succeed.

Classify the bounded `code` at the HTTP boundary into a typed
`SyncRecoveryWindowExceededException`, and give the recording a terminal status
(`WalStatus.outsideRecoveryWindow`) that leaves the retry pool and renders its
own reason instead of an unexplained failure.

Which recordings that terminal applies to is the load-bearing part. The backend
decides the lookback from the OLDEST capture in the upload
(`classify_sync_lane` measures `now - oldest_capture_at`), and a batch mixes
ages, so a rejection only proves that one recording is out of range — retiring
the whole batch would strand recordings the server would still accept. So
`_retireOutsideRecoveryWindow` retires exactly the proven capture and every
recording at least as old as it, which is sound (nothing older can be inside a
window that one fell outside of) and drains a long backlog in one pass instead
of costing another doomed upload per recording. The rest of the batch stays
`miss` and re-forms without the poison on the next drain.

Only the sync attempt is terminal: the local audio file is kept, the row stays
visible and individually deletable, and Clear All still removes it. No Retry
affordance is offered, because a manual retry cannot succeed either.

Deliberately not addressed here: whether the 30-day cliff should exist at all
(decision 1 in #10975) — that is a product/ops call, and widening the window
later would need its own pass to re-arm recordings already marked terminal.

Second instance of FC-permanent-write-rejection-retried-forever, and the first
outside `backend/database/`: a rejection no retry of the same payload can
satisfy must move the row to a terminal path rather than replaying it forever.

Tested:
- `flutter test test/unit/wal_upload_resilience_test.dart` — new group drives
  the production state machine through the injected uploader seam: the batch
  and single-recording paths both land on `outsideRecoveryWindow`, `retryCount`
  stays 0, `getMissingWals()` is empty, a second `syncAll()` is a no-op, the
  audio file still exists, and a generic failure still stays `miss`. Two cases
  pin the scoping: a mixed-age batch retires only the proven-oldest and leaves
  its newer members retryable, and a recording held out of the batch by its
  conversation grouping but older than the proven capture retires in the same
  pass. Mutating the bound to retire the whole batch fails both (+15 -2), so
  they are not tautological.
- `flutter test test/widgets/sync_row_recovery_window_test.dart` — pumps the
  real `WalListItem`: the row renders "Too old to sync — Omi can't accept it"
  and offers no Retry, while a retry-exhausted recording still shows both
  "Failed — tap Retry" and its Retry button.
- `flutter test test/unit/sync_rate_limit_response_test.dart` — the classifier
  matches both sync routes' real 422 bodies and does not widen to other 422s,
  other statuses, or unparseable bodies.
- `flutter test test/providers/sync_provider_terminal_wal_state_test.dart`,
  `test/unit/wal_sync_display_state_test.dart` — provider partitioning and the
  display-state mapping.
- Full suite `bash test.sh`: 1009 passed, 0 failed.
- `make preflight`: 11/11 manifest checks pass.

Not verified against a live 30-day-old recording — that needs a real month-old
WAL against prod, which this change could not reproduce.

Fixes #10975

Failure-Class: FC-permanent-write-rejection-retried-forever
