### PR TITLE
fix(tasks): fence legacy recovery deletes

### DIFF
--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -409,9 +409,14 @@ def restore_legacy_conversation_items(
         action_item.pop('id', None)
         action_item.pop('source', None)
 
+        staged_ref = staged_col.document(staged_snapshot.id)
         batch = client.batch()
         batch.create(action_item_ref, action_item)
-        batch.delete(staged_col.document(staged_snapshot.id))
+        # Keep the streamed staged row as the delete authority. If promotion
+        # or another recovery attempt updates it after the query, Firestore
+        # rejects the atomic batch instead of deleting the newer record.
+        delete_option = client.write_option(last_update_time=staged_snapshot.update_time)
+        batch.delete(staged_ref, option=delete_option)
         try:
             batch.commit()
         except (AlreadyExists, Conflict):

--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from google.api_core.exceptions import AlreadyExists, Conflict
+from google.api_core.exceptions import AlreadyExists, Conflict, FailedPrecondition
 from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
 
@@ -419,10 +419,10 @@ def restore_legacy_conversation_items(
         batch.delete(staged_ref, option=delete_option)
         try:
             batch.commit()
-        except (AlreadyExists, Conflict):
-            # A current action item has the authoritative identity. Preserve it
-            # and preserve the staged row for manual inspection rather than
-            # deleting either record after a race.
+        except (AlreadyExists, Conflict, FailedPrecondition):
+            # An action-item collision or staged-row update won the race. The
+            # batch is atomic, so preserve both records for the next recovery
+            # pass or manual inspection rather than deleting either one.
             skipped_existing += 1
             continue
         restored += 1

--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -24,6 +24,7 @@ BATCH_LIMIT = 500  # Firestore hard limit
 # enough that a user with a large historical migration never holds an HTTP
 # request open for an unbounded number of Firestore commits.
 LEGACY_CONVERSATION_RECOVERY_PAGE_SIZE = 50
+LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES = 3
 
 
 def _user_col(uid: str, collection: str):
@@ -395,37 +396,52 @@ def restore_legacy_conversation_items(
     skipped_existing = 0
 
     for staged_snapshot in page:
-        staged_row = staged_snapshot.to_dict() or {}
         # Keep the marker check in addition to the indexed query so a permissive
         # fake or future query refactor can never restore an ordinary staged row.
-        if staged_row.get('source') != 'conversation_migration' or staged_row.get('completed'):
-            continue
-
         action_item_ref = action_items_col.document(staged_snapshot.id)
-        action_item = dict(staged_row)
-        # `id` is document identity and `source` is the recovery marker, not
-        # original action-item data. Recreating either would mutate the legacy
-        # task's meaning rather than restoring it.
-        action_item.pop('id', None)
-        action_item.pop('source', None)
-
         staged_ref = staged_col.document(staged_snapshot.id)
-        batch = client.batch()
-        batch.create(action_item_ref, action_item)
-        # Keep the streamed staged row as the delete authority. If promotion
-        # or another recovery attempt updates it after the query, Firestore
-        # rejects the atomic batch instead of deleting the newer record.
-        delete_option = client.write_option(last_update_time=staged_snapshot.update_time)
-        batch.delete(staged_ref, option=delete_option)
-        try:
-            batch.commit()
-        except (AlreadyExists, Conflict, FailedPrecondition):
-            # An action-item collision or staged-row update won the race. The
-            # batch is atomic, so preserve both records for the next recovery
-            # pass or manual inspection rather than deleting either one.
-            skipped_existing += 1
-            continue
-        restored += 1
+        for attempt in range(LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES + 1):
+            staged_row = staged_snapshot.to_dict() or {}
+            if staged_row.get('source') != 'conversation_migration' or staged_row.get('completed'):
+                break
+
+            action_item = dict(staged_row)
+            # `id` is document identity and `source` is the recovery marker, not
+            # original action-item data. Recreating either would mutate the legacy
+            # task's meaning rather than restoring it.
+            action_item.pop('id', None)
+            action_item.pop('source', None)
+
+            batch = client.batch()
+            batch.create(action_item_ref, action_item)
+            # Keep the streamed staged row as the delete authority. If promotion
+            # or another recovery attempt updates it after the query, Firestore
+            # rejects the atomic batch instead of deleting the newer record.
+            delete_option = client.write_option(last_update_time=staged_snapshot.update_time)
+            batch.delete(staged_ref, option=delete_option)
+            try:
+                batch.commit()
+            except (AlreadyExists, Conflict):
+                # An action-item collision preserves both copies for the next
+                # recovery pass or manual inspection.
+                skipped_existing += 1
+                break
+            except FailedPrecondition:
+                # A stale-row update is not an identity collision: it may be a
+                # score or metadata write with no corresponding action item.
+                # Refresh the row and retry so recovery never acknowledges an
+                # arbitrary contention as complete. Exhaustion re-raises and
+                # leaves the sweep unacknowledged for a later request.
+                if attempt >= LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES:
+                    raise
+                refreshed_snapshot = staged_ref.get()
+                if not refreshed_snapshot.exists:
+                    break
+                staged_snapshot = refreshed_snapshot
+                continue
+            else:
+                restored += 1
+                break
 
     return {
         'restored': restored,

--- a/backend/scripts/inventory_app_client_schemas.py
+++ b/backend/scripts/inventory_app_client_schemas.py
@@ -41,6 +41,16 @@ STREAM_PROTOCOL_DECODER_FUNCTIONS = frozenset(
     }
 )
 
+# These helpers inspect a bounded error envelope to choose an application
+# control path; they do not decode an OpenAPI response DTO. Keep the allowlist
+# exact so normal REST response decoding remains covered by the migration gate.
+NON_REST_RESPONSE_DECODER_FUNCTIONS = frozenset(
+    {
+        (APP_API_DIR / 'conversations.dart', 'isSyncRecoveryWindowExceededResponse'),
+    }
+)
+NON_REST_DECODE_CONTEXTS = frozenset({'stream_protocol', 'error_discriminator'})
+
 CLASS_RE = re.compile(r'^\s*class\s+([A-Za-z_][A-Za-z0-9_]*)\b', re.MULTILINE)
 ENUM_RE = re.compile(r'^\s*enum\s+([A-Za-z_][A-Za-z0-9_]*)\b', re.MULTILINE)
 FROM_JSON_RE = re.compile(r'\b(?:factory|static)?\s*([A-Za-z_][A-Za-z0-9_]*)?\.?fromJson\s*\(')
@@ -202,7 +212,9 @@ class AppOperationManifestItem:
     def to_report(self) -> dict[str, Any]:
         stream_protocol_sites = [site for site in self.decode_sites if site.context == 'stream_protocol']
         raw_sites = [
-            site for site in self.decode_sites if not site.generated_backed and site.context != 'stream_protocol'
+            site
+            for site in self.decode_sites
+            if not site.generated_backed and site.context not in NON_REST_DECODE_CONTEXTS
         ]
         raw_response_sites = [site for site in raw_sites if site.context == 'response_decode']
         raw_request_sites = [site for site in raw_sites if site.context == 'request_encode']
@@ -315,6 +327,10 @@ def scan_dart_decode_sites() -> list[DartDecodeSite]:
             is_stream_protocol = (
                 enclosing_function is not None and (path, enclosing_function.name) in STREAM_PROTOCOL_DECODER_FUNCTIONS
             )
+            is_error_discriminator = (
+                enclosing_function is not None
+                and (path, enclosing_function.name) in NON_REST_RESPONSE_DECODER_FUNCTIONS
+            )
             sites.append(
                 DartDecodeSite(
                     path=path,
@@ -322,7 +338,11 @@ def scan_dart_decode_sites() -> list[DartDecodeSite]:
                     kind=decode_site_kind(line),
                     snippet=stripped[:220],
                     generated_backed=bool(WIRE_DECODE_RE.search(window) or _WIRE_BACKED_DECODE_RE.search(window)),
-                    context='stream_protocol' if is_stream_protocol else decode_site_context(line),
+                    context=(
+                        'stream_protocol'
+                        if is_stream_protocol
+                        else 'error_discriminator' if is_error_discriminator else decode_site_context(line)
+                    ),
                 )
             )
     return sites

--- a/backend/testing/desktop_beta_admission/firestore_contention_test.py
+++ b/backend/testing/desktop_beta_admission/firestore_contention_test.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from google.auth.credentials import AnonymousCredentials
+from google.api_core.exceptions import FailedPrecondition
 from google.cloud import firestore
 from google.cloud.firestore import transactional
 from google.cloud.firestore_v1.document import DocumentReference
@@ -38,6 +39,7 @@ from database.desktop_update_channels import (  # noqa: E402
     reserve_beta_candidate,
     set_beta_admission_enabled,
 )
+from database.staged_tasks import restore_legacy_conversation_items  # noqa: E402
 
 _WAIT_SECONDS = 20
 
@@ -290,6 +292,68 @@ def _run_pessimistic_serialization_case() -> None:
             _delete_if_present(ref)
 
 
+def _run_staged_recovery_delete_race() -> None:
+    """Prove a real update-time mismatch rolls back the batch and is retried."""
+    client = firestore.Client(project=PROJECT_ID, credentials=AnonymousCredentials())
+    uid = f'staged-recovery-{uuid.uuid4().hex}'
+    staged_ref = client.collection('users').document(uid).collection('staged_tasks').document('legacy-task')
+    action_item_ref = client.collection('users').document(uid).collection('action_items').document('legacy-task')
+    staged_ref.set(
+        {
+            'description': 'Call supplier',
+            'completed': False,
+            'source': 'conversation_migration',
+            'relevance_score': 10,
+            'updated_at': datetime.now(timezone.utc),
+        }
+    )
+    race_state = {'raced': False}
+
+    class RacingBatch:
+        def __init__(self, batch: Any):
+            self._batch = batch
+
+        def create(self, *args: Any, **kwargs: Any) -> None:
+            self._batch.create(*args, **kwargs)
+
+        def delete(self, *args: Any, **kwargs: Any) -> None:
+            self._batch.delete(*args, **kwargs)
+
+        def commit(self) -> Any:
+            if not race_state['raced']:
+                race_state['raced'] = True
+                staged_ref.update({'relevance_score': 20, 'updated_at': datetime.now(timezone.utc)})
+                try:
+                    return self._batch.commit()
+                except FailedPrecondition:
+                    assert not action_item_ref.get().exists
+                    assert staged_ref.get().to_dict()['relevance_score'] == 20
+                    raise
+            return self._batch.commit()
+
+    class RacingClient:
+        def __getattr__(self, name: str) -> Any:
+            return getattr(client, name)
+
+        def batch(self) -> RacingBatch:
+            return RacingBatch(client.batch())
+
+    try:
+        result = restore_legacy_conversation_items(uid, firestore_client=RacingClient())
+        assert result == {
+            'restored': 1,
+            'skipped_existing': 0,
+            'has_more': False,
+            'next_cursor': None,
+        }
+        assert action_item_ref.get().exists
+        assert not staged_ref.get().exists
+        print('staged recovery delete race: mismatch=rolled_back retry=restored staged_row_preserved=true')
+    finally:
+        _delete_if_present(action_item_ref)
+        _delete_if_present(staged_ref)
+
+
 def main() -> int:
     _require_safe_emulator()
     _run_stale_capture_case(
@@ -306,6 +370,7 @@ def main() -> int:
         "direct-generation-before-final-read", lambda client, _tag_b: _direct_generation_transition(client)
     )
     _run_pessimistic_serialization_case()
+    _run_staged_recovery_delete_race()
     print("desktop Beta admission Firestore emulator proof passed")
     return 0
 

--- a/backend/testing/desktop_beta_admission/run.sh
+++ b/backend/testing/desktop_beta_admission/run.sh
@@ -11,7 +11,8 @@ elif command -v uv >/dev/null 2>&1; then
   python_version="$(tr -d '[:space:]' < "$repo_root/backend/.python-version")"
   python_command=(
     uv run --no-project --python "$python_version"
-    --with "google-cloud-firestore==2.20.0" -- python
+    --with "google-cloud-firestore==2.20.0"
+    --with "prometheus-client==0.21.1" -- python
   )
 else
   echo "Missing backend/.venv and uv. Run backend/scripts/sync-python-deps.sh first." >&2

--- a/backend/testing/replay_harness_llm_gateway_fake_upstream/oracle.py
+++ b/backend/testing/replay_harness_llm_gateway_fake_upstream/oracle.py
@@ -95,8 +95,8 @@ class _LoopbackOpenAI:
                     self.send_header("Content-Type", "application/json")
                     self.send_header("Content-Length", str(len(encoded_response)))
                     self.end_headers()
-                    self.wfile.write(encoded_response)
                     upstream.events.append("upstream_response")
+                    self.wfile.write(encoded_response)
                 except BaseException as error:
                     upstream._handler_failure = error
                     self.send_response(500)

--- a/backend/tests/unit/test_app_client_schema_inventory.py
+++ b/backend/tests/unit/test_app_client_schema_inventory.py
@@ -260,6 +260,36 @@ final onlyBase = _baseUrl;
     )
 
 
+def test_inventory_classifies_bounded_error_discriminator_as_non_rest_decode(tmp_path, monkeypatch):
+    api_dir = tmp_path / 'api'
+    schema_dir = tmp_path / 'schema'
+    api_dir.mkdir()
+    schema_dir.mkdir()
+    (api_dir / 'conversations.dart').write_text("""
+bool isSyncRecoveryWindowExceededResponse(Response response) {
+  final body = jsonDecode(response.body);
+  return body is Map && body['code'] == 'backfill_lookback_exceeded';
+}
+""")
+
+    monkeypatch.setattr(inventory_app_client_schemas, 'APP_API_DIR', api_dir)
+    monkeypatch.setattr(inventory_app_client_schemas, 'APP_SCHEMA_DIR', schema_dir)
+    monkeypatch.setattr(inventory_app_client_schemas, 'MODEL_REST_DTO_FILES', ())
+    monkeypatch.setattr(inventory_app_client_schemas, 'LOCAL_NON_REST_SCHEMA_FILES', frozenset())
+    monkeypatch.setattr(
+        inventory_app_client_schemas,
+        'NON_REST_RESPONSE_DECODER_FUNCTIONS',
+        frozenset({(api_dir / 'conversations.dart', 'isSyncRecoveryWindowExceededResponse')}),
+    )
+
+    sites = inventory_app_client_schemas.scan_dart_decode_sites()
+
+    assert [(site.kind, site.context) for site in sites] == [
+        ('jsonDecode', 'error_discriminator'),
+        ('field_access', 'error_discriminator'),
+    ]
+
+
 def test_inventory_strict_raw_decode_site_gate_fails_with_actionable_sites():
     result = subprocess.run(
         [

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -2226,6 +2226,52 @@ class TestLegacyConversationRecovery:
         }
         batch.delete.assert_called_once()
 
+    def test_restore_legacy_conversation_items_skips_stale_row_and_continues(self):
+        """A staged-row precondition race preserves the row and does not abort the page."""
+        from google.api_core.exceptions import FailedPrecondition
+
+        snapshots = []
+        for index in range(2):
+            snapshot = MagicMock()
+            snapshot.id = f'legacy-task-{index}'
+            snapshot.update_time = object()
+            snapshot.to_dict.return_value = {
+                'id': snapshot.id,
+                'description': f'Call supplier {index}',
+                'completed': False,
+                'source': 'conversation_migration',
+            }
+            snapshots.append(snapshot)
+
+        action_items_col = MagicMock()
+        staged_col = MagicMock()
+        recovery_query = MagicMock()
+        recovery_query.order_by.return_value = recovery_query
+        recovery_query.limit.return_value = recovery_query
+        recovery_query.stream.return_value = snapshots
+        staged_col.where.return_value = recovery_query
+        batch = MagicMock()
+        batch.commit.side_effect = [FailedPrecondition('staged row changed'), None]
+
+        def col_side_effect(collection_name):
+            return action_items_col if collection_name == 'action_items' else staged_col
+
+        firestore_client = MagicMock()
+        firestore_client.collection.return_value.document.return_value.collection.side_effect = col_side_effect
+        firestore_client.batch.return_value = batch
+
+        result = staged_tasks_db.restore_legacy_conversation_items('test-uid', firestore_client=firestore_client)
+
+        assert result == {
+            'restored': 1,
+            'skipped_existing': 1,
+            'has_more': False,
+            'next_cursor': None,
+        }
+        assert batch.commit.call_count == 2
+        assert batch.create.call_count == 2
+        assert batch.delete.call_count == 2
+
     def test_restore_legacy_conversation_items_pages_by_document_id(self):
         """Recovery bounds each request and returns an exclusive continuation cursor."""
         snapshots = []

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -2227,7 +2227,7 @@ class TestLegacyConversationRecovery:
         batch.delete.assert_called_once()
 
     def test_restore_legacy_conversation_items_skips_stale_row_and_continues(self):
-        """A staged-row precondition race preserves the row and does not abort the page."""
+        """A staged-row precondition race refreshes the row and retries the restore."""
         from google.api_core.exceptions import FailedPrecondition
 
         snapshots = []
@@ -2251,7 +2251,80 @@ class TestLegacyConversationRecovery:
         recovery_query.stream.return_value = snapshots
         staged_col.where.return_value = recovery_query
         batch = MagicMock()
-        batch.commit.side_effect = [FailedPrecondition('staged row changed'), None]
+        batch.commit.side_effect = [FailedPrecondition('staged row changed'), None, None]
+        refreshed_snapshot = MagicMock()
+        refreshed_snapshot.id = snapshots[0].id
+        refreshed_snapshot.update_time = object()
+        refreshed_snapshot.exists = True
+        refreshed_snapshot.to_dict.return_value = {
+            'id': refreshed_snapshot.id,
+            'description': 'Updated supplier call',
+            'completed': False,
+            'source': 'conversation_migration',
+        }
+
+        def col_side_effect(collection_name):
+            return action_items_col if collection_name == 'action_items' else staged_col
+
+        firestore_client = MagicMock()
+        firestore_client.collection.return_value.document.return_value.collection.side_effect = col_side_effect
+        firestore_client.batch.return_value = batch
+        staged_col.document.return_value.get.return_value = refreshed_snapshot
+
+        result = staged_tasks_db.restore_legacy_conversation_items('test-uid', firestore_client=firestore_client)
+
+        assert result == {
+            'restored': 2,
+            'skipped_existing': 0,
+            'has_more': False,
+            'next_cursor': None,
+        }
+        assert batch.commit.call_count == 3
+        assert batch.create.call_count == 3
+        assert batch.delete.call_count == 3
+        assert staged_col.document.return_value.get.call_count == 1
+
+    def test_restore_legacy_conversation_items_does_not_acknowledge_repeated_stale_rows(self):
+        """Repeated contention fails the sweep instead of marking the row recovered."""
+        from google.api_core.exceptions import FailedPrecondition
+
+        staged_snapshot = MagicMock()
+        staged_snapshot.id = 'legacy-task'
+        staged_snapshot.update_time = object()
+        staged_snapshot.to_dict.return_value = {
+            'id': 'legacy-task',
+            'description': 'Call supplier',
+            'completed': False,
+            'source': 'conversation_migration',
+        }
+        refreshed_snapshots = []
+        for index in range(staged_tasks_db.LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES):
+            refreshed = MagicMock()
+            refreshed.id = staged_snapshot.id
+            refreshed.update_time = object()
+            refreshed.exists = True
+            refreshed.to_dict.return_value = {
+                'id': staged_snapshot.id,
+                'description': f'Call supplier {index}',
+                'completed': False,
+                'source': 'conversation_migration',
+            }
+            refreshed_snapshots.append(refreshed)
+
+        action_items_col = MagicMock()
+        staged_col = MagicMock()
+        recovery_query = MagicMock()
+        recovery_query.order_by.return_value = recovery_query
+        recovery_query.limit.return_value = recovery_query
+        recovery_query.stream.return_value = [staged_snapshot]
+        staged_col.where.return_value = recovery_query
+        staged_ref = staged_col.document.return_value
+        staged_ref.get.side_effect = refreshed_snapshots
+        batch = MagicMock()
+        batch.commit.side_effect = [
+            FailedPrecondition(f'staged row changed {index}')
+            for index in range(staged_tasks_db.LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES + 1)
+        ]
 
         def col_side_effect(collection_name):
             return action_items_col if collection_name == 'action_items' else staged_col
@@ -2260,17 +2333,11 @@ class TestLegacyConversationRecovery:
         firestore_client.collection.return_value.document.return_value.collection.side_effect = col_side_effect
         firestore_client.batch.return_value = batch
 
-        result = staged_tasks_db.restore_legacy_conversation_items('test-uid', firestore_client=firestore_client)
+        with pytest.raises(FailedPrecondition):
+            staged_tasks_db.restore_legacy_conversation_items('test-uid', firestore_client=firestore_client)
 
-        assert result == {
-            'restored': 1,
-            'skipped_existing': 1,
-            'has_more': False,
-            'next_cursor': None,
-        }
-        assert batch.commit.call_count == 2
-        assert batch.create.call_count == 2
-        assert batch.delete.call_count == 2
+        assert batch.commit.call_count == staged_tasks_db.LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES + 1
+        assert staged_ref.get.call_count == staged_tasks_db.LEGACY_CONVERSATION_RECOVERY_MAX_CONTENTION_RETRIES
 
     def test_restore_legacy_conversation_items_pages_by_document_id(self):
         """Recovery bounds each request and returns an exclusive continuation cursor."""

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -2124,6 +2124,7 @@ class TestLegacyConversationRecovery:
         """Recovery removes only its marker and atomically recreates the original action item."""
         staged_snapshot = MagicMock()
         staged_snapshot.id = 'legacy-task'
+        staged_snapshot.update_time = object()
         staged_snapshot.to_dict.return_value = {
             'id': 'legacy-task',
             'description': 'Call supplier',
@@ -2151,6 +2152,7 @@ class TestLegacyConversationRecovery:
         staged_ref = MagicMock()
         staged_col.document.return_value = staged_ref
         batch = MagicMock()
+        delete_option = object()
 
         def col_side_effect(collection_name):
             return action_items_col if collection_name == 'action_items' else staged_col
@@ -2158,6 +2160,7 @@ class TestLegacyConversationRecovery:
         firestore_client = MagicMock()
         firestore_client.collection.return_value.document.return_value.collection.side_effect = col_side_effect
         firestore_client.batch.return_value = batch
+        firestore_client.write_option.return_value = delete_option
         with patch.object(staged_tasks_db, 'get_firestore_client') as get_firestore_client:
             result = staged_tasks_db.restore_legacy_conversation_items('test-uid', firestore_client=firestore_client)
 
@@ -2177,7 +2180,8 @@ class TestLegacyConversationRecovery:
                 'completed': False,
             },
         )
-        batch.delete.assert_called_once_with(staged_ref)
+        firestore_client.write_option.assert_called_once_with(last_update_time=staged_snapshot.update_time)
+        batch.delete.assert_called_once_with(staged_ref, option=delete_option)
         batch.commit.assert_called_once()
 
     @pytest.mark.parametrize('conflict_error', ['already_exists', 'conflict'])


### PR DESCRIPTION
## Summary

Protect legacy conversation recovery from deleting a staged row that changed after it was read.

The recovery helper creates the restored action item and deletes the marker row in one Firestore batch. Before this change, the delete was unconditional: a concurrent promotion or closure could update the staged row between the query and batch commit, leaving the promoted action item while erasing the newer staged record and its provenance. The delete now carries the streamed snapshot's `update_time` precondition, so a stale batch fails atomically and preserves the newer record.

The recovery path now treats Firestore `FailedPrecondition` as a stale-row contention: it refreshes and retries the row a bounded number of times, then fails the sweep rather than acknowledging arbitrary score or metadata updates. Identity collisions remain skip-counted. The loopback LLM gateway oracle also records its fake-upstream response before writing the body, removing a CI-only event-ordering race. The app-client schema inventory now explicitly classifies the bounded sync recovery-window error discriminator as a non-REST control envelope, so the migration gate remains strict for ordinary response DTOs.

The standalone Firestore emulator harness now installs the metrics dependency required by the production recovery import when it uses its isolated `uv` environment in CI.

## Product invariants affected

None. This is a backend data-integrity fix within the existing legacy recovery contract.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_desktop_migration.py -k restore_legacy_conversation_items` — 7 passed.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_desktop_migration.py` — 114 passed.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_staged_tasks_review_controls.py` — 30 passed.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_app_client_schema_inventory.py` — 10 passed, including the bounded error-discriminator regression.
- The PR merge-ref reproduction of the previously failing schema-inventory file — 9 passed after the gate fix.
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt BACKEND_FAST_UNIT_FAIL_SECONDS=1.0 bash backend/test.sh` — 2 passed for the previously failing CI file.
- The loopback oracle test — 16 passed across 8 repeated runs.
- `npm run test:desktop-beta-admission:emulator` — passed; the real Firestore emulator proved atomic rollback on the fenced delete and successful retry of the refreshed row.
- The isolated `uv` harness import path — passed with pinned Firestore and Prometheus dependencies.
- `make preflight` — passed.
- The bounded pre-push gate — passed (type check: 0 errors; formatting: unchanged).

The focused regressions invoke the production recovery helper with an injected Firestore client and verify both the snapshot update-time write precondition and the stale-row continuation path. I did not run against a live Firestore service.
