### PR TITLE
fix withhold unverified gmail.readonly scope from the Google consent request

### DIFF
--- a/backend/tests/unit/test_gmail_scope_contract.py
+++ b/backend/tests/unit/test_gmail_scope_contract.py
@@ -21,7 +21,11 @@ def test_google_capabilities_resolve_to_one_provider_with_required_scopes():
         assert resolved is not None
         provider_key, provider = resolved
         assert provider_key == 'google_calendar'
-        assert required_scope in oauth_authorization_query(provider)['scope'].split()
+        # gmail.readonly is a restricted scope pending Google verification, so it is
+        # withheld from the consent request (see consent_pending_scopes) even though
+        # the capability still resolves. Only verified scopes are asked for.
+        if required_scope not in provider.get('consent_pending_scopes', ()):
+            assert required_scope in oauth_authorization_query(provider)['scope'].split()
 
 
 def test_provider_resolution_normalizes_agent_and_callback_keys():

--- a/backend/tests/unit/test_gmail_scope_gating.py
+++ b/backend/tests/unit/test_gmail_scope_gating.py
@@ -51,16 +51,16 @@ def test_granted_scope_check_ignores_merely_requested_scopes():
     assert google_integration_has_scope(None, GMAIL_READONLY_SCOPE) is False
 
 
-def test_connecting_google_requests_the_gmail_scope():
-    # The consent request is built by the integration registry (the inline
-    # AUTH_PROVIDERS table this used to read no longer exists). Assert against the
-    # query actually sent, so a scope that is gated at runtime is provably one the
-    # user was asked for.
+def test_connecting_google_withholds_the_unverified_gmail_scope():
+    # gmail.readonly is a Google restricted scope pending verification, so it is
+    # withheld from the consent request — requesting it shows users the "unverified
+    # app" screen. Calendar is verified and stays requested.
     _, provider = resolve_integration_provider('google_calendar')
     requested = oauth_authorization_query(provider)['scope'].split()
 
-    assert GMAIL_READONLY_SCOPE in GOOGLE_OAUTH_SCOPES
-    assert GMAIL_READONLY_SCOPE in requested
+    assert GMAIL_READONLY_SCOPE not in GOOGLE_OAUTH_SCOPES
+    assert GMAIL_READONLY_SCOPE not in requested
+    assert CALENDAR_SCOPE in requested
 
 
 def test_gmail_is_disconnected_without_a_google_grant(stored_grants):
@@ -111,7 +111,10 @@ def test_gmail_oauth_url_runs_the_google_flow(monkeypatch):
     auth_url = integrations_router.get_oauth_url('gmail', uid='u1').auth_url
 
     params = parse_qs(urlparse(auth_url).query)
-    assert GMAIL_READONLY_SCOPE in params['scope'][0]
+    # Gmail routes through the Google flow, but the unverified gmail.readonly scope is
+    # withheld from the consent request; Calendar is still asked for.
+    assert GMAIL_READONLY_SCOPE not in params['scope'][0]
+    assert CALENDAR_SCOPE in params['scope'][0]
     assert params['redirect_uri'] == ['https://api.example.com/v2/integrations/google-calendar/callback']
     # The callback validates state against the source key, so state must carry it.
     assert '"app_key": "google_calendar"' in next(iter(stored_state.values()))

--- a/backend/utils/integrations_registry.py
+++ b/backend/utils/integrations_registry.py
@@ -22,6 +22,12 @@ INTEGRATION_PROVIDERS: Dict[str, Dict[str, Any]] = {
             'contacts': GOOGLE_CONTACTS_SCOPES,
             'google_contacts': GOOGLE_CONTACTS_SCOPES,
         },
+        # Scopes declared as capabilities (so routing/enforcement stay wired) but
+        # WITHHELD from the consent request until Google approves them. gmail.readonly
+        # is a Google *restricted* scope: requesting it before verification + CASA are
+        # granted makes Google show every user an "unverified app" screen and blocks
+        # sign-in. Remove a scope from this tuple only once verification is granted.
+        'consent_pending_scopes': (GMAIL_READ_SCOPE,),
         'oauth': {
             'client_id_env': 'GOOGLE_CLIENT_ID',
             'client_secret_env': 'GOOGLE_CLIENT_SECRET',
@@ -55,9 +61,19 @@ def oauth_scopes(provider: Dict[str, Any]) -> Tuple[str, ...]:
     checks stored grants against — is derived from this, so the scopes requested
     and the scopes enforced cannot drift apart. Adding a capability here widens
     the consent request, so treat any addition as a user-consent change.
+
+    Scopes listed in `consent_pending_scopes` are excluded: they are declared but
+    not yet approved by Google, so requesting them would trip the "unverified app"
+    screen. They stay resolvable as capabilities but are never sent on the wire.
     """
+    pending = set(provider.get('consent_pending_scopes', ()))
     return tuple(
-        dict.fromkeys(scope for required_scopes in provider['capabilities'].values() for scope in required_scopes)
+        dict.fromkeys(
+            scope
+            for required_scopes in provider['capabilities'].values()
+            for scope in required_scopes
+            if scope not in pending
+        )
     )
 
 


### PR DESCRIPTION
## Problem (production incident)

Users are seeing Google's **"unverified app" screen / blocked Google sign-in**. Google emailed that our OAuth project is requesting unverified restricted scopes — chiefly `https://www.googleapis.com/auth/gmail.readonly`.

This scope was added to the production Google consent request by the merged Gmail integration (#10472). `gmail.readonly` is a Google **restricted** scope and our project has **not** completed the required verification + CASA assessment, so requesting it trips the unverified-app screen for every user hitting the Google connect flow.

## Fix

Withhold the unverified scope from the consent request until Google approves it, without ripping out the Gmail plumbing:

- New `consent_pending_scopes` tuple on the provider in `integrations_registry.py`. `gmail.readonly` stays a declared **capability** (so Gmail routing + the granted-scope enforcement stay wired) but `oauth_scopes()` now excludes any consent-pending scope from the request.
- The Google consent screen now asks only for the **verified** scopes: `calendar` + `contacts.readonly` + `contacts.other.readonly`. No `gmail.readonly`.
- Re-enabling after Google approves is a **one-line** change (drop it from `consent_pending_scopes`).

## Effect

- **Google sign-in / connect flow: unblocked** — new consents no longer request the unverified scope.
- **Google Calendar: unchanged**, keeps working.
- **Gmail in chat**: returns its existing "reconnect Gmail from settings" message instead of data until the scope is verified. (The Gmail UI tile is left as-is; harmless until verification or a later UI change.)
- Users who already granted `gmail.readonly` during the window keep a token carrying it; Google's Security Center may warn them until that token is refreshed/revoked. New consents are clean immediately.

## Requires prod deploy

The consent request is server-side — this only takes effect once the backend is deployed to prod (`gcp_backend.yml`). Not deploying from this PR.

## Tests

No new tests added. Two pre-existing scope tests (`test_gmail_scope_contract.py`, `test_gmail_scope_gating.py`) asserted the scope was requested; their now-inverted assertions were updated to expect it withheld. All green via `test.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/10997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

