### PR TITLE
feat(desktop): extract knowledge graph from screen OCR locally

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,12 +1,12 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1688,
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3499,
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3554,
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": 1856
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Add full local task retrieval for persistence-time category rebase, so clearing a search before the debounce never loses an off-page pending reorder id.",
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Nullable screenshot capture provenance preserves the canonical-memory device identity and prevents multi-Mac screen activity from overwriting local row IDs.",
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "kgExtracted migration and screenshot query helpers track which OCR rows were promoted into local_kg_nodes so ScreenKnowledgeGraphExtractor does not reprocess the same capture.",
     "desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift": "Search-result rows load a downsampled ImageIO thumbnail instead of the full-resolution screenshot, so a long results list no longer retains full-size images behind a 120x80 view."
   },
   "threshold": 1500

--- a/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
+++ b/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
@@ -362,6 +362,7 @@ enum RuntimeOwnerIdentity {
     // it captured. New-owner mutations remain parked by the fence.
     await FileIndexerService.shared.invalidateCache()
     await OCREmbeddingService.shared.reset()
+    await ScreenKnowledgeGraphExtractor.shared.reset()
     await RewindDatabase.shared.retargetEffectiveOwner(to: nextOwner)
     await TranscriptionStorage.shared.invalidateCache()
     await MemoryStorage.shared.invalidateCache()

--- a/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
+++ b/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
@@ -364,6 +364,11 @@ enum RuntimeOwnerIdentity {
     await OCREmbeddingService.shared.reset()
     await ScreenKnowledgeGraphExtractor.shared.reset()
     await RewindDatabase.shared.retargetEffectiveOwner(to: nextOwner)
+    if nextOwner != nil {
+      Task(priority: .background) {
+        await ScreenKnowledgeGraphExtractor.shared.scheduleBackfillIfNeeded()
+      }
+    }
     await TranscriptionStorage.shared.invalidateCache()
     await MemoryStorage.shared.invalidateCache()
     await ActionItemStorage.shared.invalidateCache()

--- a/desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphRecordBuilder.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphRecordBuilder.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Builds `local_kg_*` records from parsed extraction payloads.
+/// Mirrors the merge semantics of `ChatToolExecutor.executeSaveKnowledgeGraph`.
+enum KnowledgeGraphRecordBuilder {
+  struct ParsedNode {
+    let id: String
+    let label: String
+    let nodeType: String
+    let aliases: [String]
+  }
+
+  struct ParsedEdge {
+    let sourceId: String
+    let targetId: String
+    let label: String
+  }
+
+  static func buildRecords(
+    nodes: [ParsedNode],
+    edges: [ParsedEdge],
+    createdAt: Date = Date()
+  ) -> (nodes: [LocalKGNodeRecord], edges: [LocalKGEdgeRecord]) {
+    var nodeRecords: [LocalKGNodeRecord] = []
+    var edgeRecords: [LocalKGEdgeRecord] = []
+    var seenLabels: [String: String] = [:]
+    var idRemap: [String: String] = [:]
+
+    for node in nodes {
+      let lowerLabel = node.label.lowercased()
+      if let existingId = seenLabels[lowerLabel] {
+        idRemap[node.id] = existingId
+        continue
+      }
+
+      seenLabels[lowerLabel] = node.id
+      idRemap[node.id] = node.id
+
+      var aliasesJson: String?
+      if !node.aliases.isEmpty, let data = try? JSONEncoder().encode(node.aliases) {
+        aliasesJson = String(data: data, encoding: .utf8)
+      }
+
+      nodeRecords.append(
+        LocalKGNodeRecord(
+          nodeId: node.id,
+          label: node.label,
+          nodeType: node.nodeType,
+          aliasesJson: aliasesJson,
+          sourceFileIds: nil,
+          createdAt: createdAt,
+          updatedAt: createdAt
+        ))
+    }
+
+    for edge in edges {
+      let remappedSource = idRemap[edge.sourceId] ?? edge.sourceId
+      let remappedTarget = idRemap[edge.targetId] ?? edge.targetId
+      guard remappedSource != remappedTarget else { continue }
+
+      let edgeId =
+        "\(remappedSource)_\(remappedTarget)_\(edge.label.lowercased().replacingOccurrences(of: " ", with: "_"))"
+      edgeRecords.append(
+        LocalKGEdgeRecord(
+          edgeId: edgeId,
+          sourceNodeId: remappedSource,
+          targetNodeId: remappedTarget,
+          label: edge.label,
+          createdAt: createdAt
+        ))
+    }
+
+    return (nodeRecords, edgeRecords)
+  }
+
+  static func parseExtractionJSON(_ jsonText: String) -> (nodes: [ParsedNode], edges: [ParsedEdge])? {
+    guard let data = jsonText.data(using: .utf8),
+      let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return nil
+    }
+
+    let nodesArray = root["nodes"] as? [[String: Any]] ?? []
+    let edgesArray = root["edges"] as? [[String: Any]] ?? []
+
+    let nodes: [ParsedNode] = nodesArray.compactMap { node in
+      guard let id = node["id"] as? String,
+        let label = node["label"] as? String
+      else { return nil }
+      let nodeType = node["node_type"] as? String ?? "concept"
+      let aliases = node["aliases"] as? [String] ?? []
+      return ParsedNode(id: id, label: label, nodeType: nodeType, aliases: aliases)
+    }
+
+    let edges: [ParsedEdge] = edgesArray.compactMap { edge in
+      guard let sourceId = edge["source_id"] as? String,
+        let targetId = edge["target_id"] as? String,
+        let label = edge["label"] as? String
+      else { return nil }
+      return ParsedEdge(sourceId: sourceId, targetId: targetId, label: label)
+    }
+
+    return (nodes, edges)
+  }
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2554,6 +2554,18 @@ actor RewindDatabase {
 
     RewindAbandonedVideoChunkQuarantine.registerMigration(on: &migrator)
 
+    migrator.registerMigration("addScreenshotKgExtracted") { db in
+      try db.alter(table: "screenshots") { t in
+        t.add(column: "kgExtracted", .boolean).notNull().defaults(to: false)
+      }
+      try db.execute(
+        sql: """
+              CREATE INDEX idx_screenshots_pending_kg_extraction
+              ON screenshots(id)
+              WHERE kgExtracted = 0 AND ocrText IS NOT NULL AND LENGTH(ocrText) >= 20
+          """)
+    }
+
     try migrator.migrate(queue)
   }
 
@@ -2877,6 +2889,49 @@ actor RewindDatabase {
   }
 
   // MARK: - Screenshot Embedding Methods
+
+  /// Screenshots with OCR that have not yet been processed by the screen→KG extractor.
+  func getScreenshotsPendingKGExtraction(limit: Int = 50) throws -> [(
+    id: Int64, ocrText: String, appName: String, windowTitle: String?
+  )] {
+    guard let dbQueue = dbQueue else {
+      throw RewindError.databaseNotInitialized
+    }
+
+    return try dbQueue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+              SELECT id, ocrText, appName, windowTitle FROM screenshots
+              WHERE kgExtracted = 0 AND ocrText IS NOT NULL AND LENGTH(ocrText) >= 20
+              ORDER BY id LIMIT ?
+          """, arguments: [limit]
+      ).compactMap { row in
+        guard let id: Int64 = row["id"],
+          let ocrText: String = row["ocrText"],
+          let appName: String = row["appName"]
+        else { return nil }
+        let windowTitle: String? = row["windowTitle"]
+        return (id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+      }
+    }
+  }
+
+  /// Mark screenshots as processed by the screen→KG extractor.
+  func markScreenshotsKGExtracted(ids: [Int64]) throws {
+    guard !ids.isEmpty else { return }
+    guard let dbQueue = dbQueue else {
+      throw RewindError.databaseNotInitialized
+    }
+
+    try dbQueue.write { db in
+      let placeholders = Array(repeating: "?", count: ids.count).joined(separator: ", ")
+      try db.execute(
+        sql: "UPDATE screenshots SET kgExtracted = 1 WHERE id IN (\(placeholders))",
+        arguments: StatementArguments(ids)
+      )
+    }
+  }
 
   /// Store embedding BLOB for a screenshot
   func updateScreenshotEmbedding(id: Int64, embedding: Data) throws {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2891,7 +2891,7 @@ actor RewindDatabase {
   // MARK: - Screenshot Embedding Methods
 
   /// Screenshots with OCR that have not yet been processed by the screen→KG extractor.
-  func getScreenshotsPendingKGExtraction(limit: Int = 50) throws -> [(
+  func getScreenshotsPendingKGExtraction(limit: Int = 50, afterID: Int64 = 0) throws -> [(
     id: Int64, ocrText: String, appName: String, windowTitle: String?
   )] {
     guard let dbQueue = dbQueue else {
@@ -2903,9 +2903,9 @@ actor RewindDatabase {
         db,
         sql: """
               SELECT id, ocrText, appName, windowTitle FROM screenshots
-              WHERE kgExtracted = 0 AND ocrText IS NOT NULL AND LENGTH(ocrText) >= 20
+              WHERE kgExtracted = 0 AND ocrText IS NOT NULL AND LENGTH(ocrText) >= 20 AND id > ?
               ORDER BY id LIMIT ?
-          """, arguments: [limit]
+          """, arguments: [afterID, limit]
       ).compactMap { row in
         guard let id: Int64 = row["id"],
           let ocrText: String = row["ocrText"],

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
@@ -53,6 +53,9 @@ struct Screenshot: Codable, FetchableRecord, PersistableRecord, Identifiable, Eq
   /// Stable per-installation capture identity used by the canonical memory system
   var clientDeviceId: String?
 
+  /// Whether entities/edges were extracted from this screenshot's OCR into local_kg_*
+  var kgExtracted: Bool
+
   static let databaseTableName = "screenshots"
 
   // MARK: - Storage Type
@@ -80,7 +83,8 @@ struct Screenshot: Codable, FetchableRecord, PersistableRecord, Identifiable, Eq
     adviceJson: String? = nil,
     skippedForBattery: Bool = false,
     deviceName: String? = nil,
-    clientDeviceId: String? = nil
+    clientDeviceId: String? = nil,
+    kgExtracted: Bool = false
   ) {
     self.id = id
     self.timestamp = timestamp
@@ -98,6 +102,7 @@ struct Screenshot: Codable, FetchableRecord, PersistableRecord, Identifiable, Eq
     self.skippedForBattery = skippedForBattery
     self.deviceName = deviceName
     self.clientDeviceId = clientDeviceId
+    self.kgExtracted = kgExtracted
   }
 
   // MARK: - Persistence Callbacks

--- a/desktop/macos/Desktop/Sources/Rewind/Services/OnDeviceScreenKGExtractionBackend.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/OnDeviceScreenKGExtractionBackend.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// On-device screen→KG extraction via Apple Foundation Models when available.
+/// Falls back to `GeminiProxyScreenKGBackend` via `ScreenKGExtractionBackendSelector`.
+///
+/// Privacy: OCR text stays on-device; no image data is ever passed to this backend.
+enum OnDeviceScreenKGExtractionBackend {
+  static var isAvailable: Bool {
+    #if canImport(FoundationModels)
+      if #available(macOS 26.0, *) {
+        return FoundationModelsScreenKGAvailability.isModelAvailable
+      }
+    #endif
+    return false
+  }
+
+  static let shared: any ScreenKGExtractionBackend = {
+    #if canImport(FoundationModels)
+      if #available(macOS 26.0, *) {
+        return FoundationModelsScreenKGBackend()
+      }
+    #endif
+    return UnavailableOnDeviceScreenKGBackend()
+  }()
+}
+
+#if canImport(FoundationModels)
+  import FoundationModels
+
+  @available(macOS 26.0, *)
+  private enum FoundationModelsScreenKGAvailability {
+    static var isModelAvailable: Bool {
+      SystemLanguageModel.default.isAvailable
+    }
+  }
+
+  @available(macOS 26.0, *)
+  private struct FoundationModelsScreenKGBackend: ScreenKGExtractionBackend {
+    let name = "foundation_models"
+
+    func extractEntities(from input: ScreenKGExtractionInput) async throws -> String {
+      let session = LanguageModelSession(instructions: ScreenKGExtractionPrompt.systemPrompt)
+      let prompt = ScreenKGExtractionPrompt.userPrompt(for: input)
+      let response = try await session.respond(to: prompt)
+      let text = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard KnowledgeGraphRecordBuilder.parseExtractionJSON(text) != nil else {
+        throw ScreenKGExtractionError.invalidStructuredOutput
+      }
+      return text
+    }
+  }
+#endif
+
+private struct UnavailableOnDeviceScreenKGBackend: ScreenKGExtractionBackend {
+  let name = "on_device_unavailable"
+
+  func extractEntities(from input: ScreenKGExtractionInput) async throws -> String {
+    throw ScreenKGExtractionError.onDeviceUnavailable
+  }
+}
+
+enum ScreenKGExtractionError: Error {
+  case onDeviceUnavailable
+  case invalidStructuredOutput
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -334,12 +334,18 @@ actor RewindIndexer {
       markFrameEncodedForDedupe(dedupeSignature, timestamp: frame.captureTime)
 
       // Embed OCR text for semantic search (non-blocking)
-      if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
+      if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id,
+        let captureOwnerID = RuntimeOwnerIdentity.currentOwnerId()
+      {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
             id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
           await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
-            id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
+            id: id,
+            ocrText: ocrText,
+            appName: frame.appName,
+            windowTitle: frame.windowTitle,
+            expectedOwnerID: captureOwnerID)
         }
       }
 
@@ -426,12 +432,18 @@ actor RewindIndexer {
       markFrameEncodedForDedupe(dedupeSignature, timestamp: captureTime)
 
       // Embed OCR text for semantic search (non-blocking)
-      if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
+      if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id,
+        let captureOwnerID = RuntimeOwnerIdentity.currentOwnerId()
+      {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
             id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
           await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
-            id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+            id: id,
+            ocrText: ocrText,
+            appName: appName,
+            windowTitle: windowTitle,
+            expectedOwnerID: captureOwnerID)
         }
       }
 
@@ -554,12 +566,18 @@ actor RewindIndexer {
       }
 
       // Embed OCR text for semantic search (non-blocking)
-      if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
+      if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id,
+        let captureOwnerID = RuntimeOwnerIdentity.currentOwnerId()
+      {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
             id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
           await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
-            id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
+            id: id,
+            ocrText: ocrText,
+            appName: frame.appName,
+            windowTitle: frame.windowTitle,
+            expectedOwnerID: captureOwnerID)
         }
       }
 
@@ -705,9 +723,15 @@ actor RewindIndexer {
             let ocrText = ocrResult.fullText
             let appName = screenshot.appName
             let windowTitle = screenshot.windowTitle
-            Task(priority: .utility) {
-              await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
-                id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+            if let captureOwnerID = RuntimeOwnerIdentity.currentOwnerId() {
+              Task(priority: .utility) {
+                await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+                  id: id,
+                  ocrText: ocrText,
+                  appName: appName,
+                  windowTitle: windowTitle,
+                  expectedOwnerID: captureOwnerID)
+              }
             }
           } catch RewindError.screenshotNotFound {
             // Screenshot/video file is permanently missing — clear skippedForBattery so we don't retry forever

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -117,6 +117,11 @@ actor RewindIndexer {
       await OCREmbeddingService.shared.backfillIfNeeded()
     }
 
+    // Backfill screen→KG extraction for screenshots captured before this shipped
+    Task(priority: .background) {
+      await ScreenKnowledgeGraphExtractor.shared.scheduleBackfillIfNeeded()
+    }
+
     // Reduce ocrDataJson float precision for existing rows (one-time migration)
     Task(priority: .background) {
       await RewindDatabase.shared.reduceOCRDataPrecisionIfNeeded()
@@ -333,6 +338,8 @@ actor RewindIndexer {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
             id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
+          await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+            id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
         }
       }
 
@@ -422,6 +429,8 @@ actor RewindIndexer {
       if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
+            id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+          await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
             id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
         }
       }
@@ -548,6 +557,8 @@ actor RewindIndexer {
       if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
+            id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
+          await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
             id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle)
         }
       }

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -701,6 +701,14 @@ actor RewindIndexer {
 
             try await RewindDatabase.shared.updateOCRResult(id: id, ocrResult: ocrResult)
             totalProcessed += 1
+
+            let ocrText = ocrResult.fullText
+            let appName = screenshot.appName
+            let windowTitle = screenshot.windowTitle
+            Task(priority: .utility) {
+              await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+                id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+            }
           } catch RewindError.screenshotNotFound {
             // Screenshot/video file is permanently missing — clear skippedForBattery so we don't retry forever
             try? await RewindDatabase.shared.clearSkippedForBattery(id: id)

--- a/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKGExtractionBackend.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKGExtractionBackend.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+struct ScreenKGExtractionInput: Sendable {
+  let ocrText: String
+  let appName: String
+  let windowTitle: String?
+}
+
+/// Text-only extraction backend. Never accepts image data.
+protocol ScreenKGExtractionBackend: Sendable {
+  var name: String { get }
+  func extractEntities(from input: ScreenKGExtractionInput) async throws -> String
+}
+
+enum ScreenKGExtractionPrompt {
+  static let systemPrompt = """
+    You extract a personal knowledge graph from on-screen OCR text. The user is building a memory \
+    graph of people, organizations, projects, tools, and concepts visible on their screen.
+
+    OUTPUT: JSON only, matching the schema. Each call should add NEW entities and relationships \
+    supported by the text — do not repeat generic UI chrome (Back, Cancel, File, Edit).
+
+    NODE TYPES: person, place, organization, thing, concept
+    - person: named individuals
+    - organization: companies, teams, products-as-orgs
+    - place: locations, cities, venues
+    - thing: apps, documents, repos, files, products
+    - concept: topics, projects, goals, skills
+
+    RULES:
+    - Only include facts directly supported by the OCR text or window title
+    - Use stable snake_case ids (e.g. "acme_corp", "jane_doe")
+    - Edge labels are short verbs/phrases: "works_at", "uses", "discusses", "owns", "member_of"
+    - Prefer quality over quantity: 0-8 nodes and 0-10 edges per screen is typical
+    - Never invent email addresses, phone numbers, or URLs not present in the text
+    - Skip passwords, tokens, credit cards, and other secrets entirely
+    """
+
+  static func userPrompt(for input: ScreenKGExtractionInput) -> String {
+    var prompt = "App: \(input.appName)"
+    if let title = input.windowTitle, !title.isEmpty {
+      prompt += "\nWindow: \(title)"
+    }
+    prompt += "\n\nOCR text:\n\(input.ocrText)"
+    return prompt
+  }
+
+  static var responseSchema: GeminiRequest.GenerationConfig.ResponseSchema {
+    GeminiRequest.GenerationConfig.ResponseSchema(
+      type: "object",
+      properties: [
+        "nodes": .init(
+          type: "array",
+          description: "Entities visible on screen",
+          items: .init(
+            type: "object",
+            properties: [
+              "id": .init(type: "string", description: "Stable snake_case identifier"),
+              "label": .init(type: "string", description: "Human-readable name"),
+              "node_type": .init(
+                type: "string",
+                enum: ["person", "place", "organization", "thing", "concept"],
+                description: "Entity category"),
+              "aliases": .init(
+                type: "array",
+                description: "Alternate names",
+                items: .init(type: "string", properties: nil, required: nil)),
+            ],
+            required: ["id", "label", "node_type"]
+          )),
+        "edges": .init(
+          type: "array",
+          description: "Relationships between entities",
+          items: .init(
+            type: "object",
+            properties: [
+              "source_id": .init(type: "string"),
+              "target_id": .init(type: "string"),
+              "label": .init(type: "string", description: "Relationship verb phrase"),
+            ],
+            required: ["source_id", "target_id", "label"]
+          )),
+      ],
+      required: ["nodes", "edges"]
+    )
+  }
+}
+
+/// Gemini proxy backend — OCR text transits the Omi backend; images are never sent.
+struct GeminiProxyScreenKGBackend: ScreenKGExtractionBackend {
+  let name = "gemini_proxy"
+
+  private let clientFactory: @Sendable () throws -> GeminiClient
+
+  init(
+    clientFactory: @escaping @Sendable () throws -> GeminiClient = {
+      try GeminiClient(model: ModelQoS.Gemini.taskExtraction)
+    }
+  ) {
+    self.clientFactory = clientFactory
+  }
+
+  func extractEntities(from input: ScreenKGExtractionInput) async throws -> String {
+    let client = try clientFactory()
+    return try await client.sendRequest(
+      prompt: ScreenKGExtractionPrompt.userPrompt(for: input),
+      systemPrompt: ScreenKGExtractionPrompt.systemPrompt,
+      responseSchema: ScreenKGExtractionPrompt.responseSchema,
+      thinkingBudget: 0
+    )
+  }
+}
+
+/// Selects on-device extraction when available, otherwise Gemini proxy.
+enum ScreenKGExtractionBackendSelector {
+  static func preferredBackend() -> any ScreenKGExtractionBackend {
+    if OnDeviceScreenKGExtractionBackend.isAvailable {
+      return OnDeviceScreenKGExtractionBackend.shared
+    }
+    return GeminiProxyScreenKGBackend()
+  }
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
@@ -311,20 +311,26 @@ actor ScreenKnowledgeGraphExtractor {
   }
 
   private func processItem(_ item: PendingItem, generation: Int) async {
-    guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+    guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else {
+      requeueIfCurrentGeneration(item, mergeCompleted: item.mergeCompleted, generation: generation)
+      return
+    }
 
     var mergeCompleted = item.mergeCompleted
     do {
       if !mergeCompleted {
         let jsonText = try await extractEntities(item.input)
         guard generation == ownerGeneration else { return }
-        guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+        guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else {
+          requeueIfCurrentGeneration(item, mergeCompleted: false, generation: generation)
+          return
+        }
 
         guard let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) else {
           log(
             "ScreenKnowledgeGraphExtractor: invalid extraction JSON for screenshot \(item.id) — will retry"
           )
-          pendingItems.append(item)
+          requeueIfCurrentGeneration(item, mergeCompleted: false, generation: generation)
           return
         }
 
@@ -335,15 +341,22 @@ actor ScreenKnowledgeGraphExtractor {
             edges: records.edges,
             expectedOwnerID: item.ownerID,
             generation: generation)
+          mergeCompleted = true
           guard generation == ownerGeneration else { return }
-          guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+          guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else {
+            requeueIfCurrentGeneration(item, mergeCompleted: true, generation: generation)
+            return
+          }
           ChatToolExecutor.onKnowledgeGraphUpdated?()
         }
         mergeCompleted = true
       }
 
       guard generation == ownerGeneration else { return }
-      guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+      guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else {
+        requeueIfCurrentGeneration(item, mergeCompleted: mergeCompleted, generation: generation)
+        return
+      }
       try await markExtracted([item.id])
       guard generation == ownerGeneration else { return }
       recentHashes.insert(item.contentHash)
@@ -362,14 +375,23 @@ actor ScreenKnowledgeGraphExtractor {
         return
       }
       log("ScreenKnowledgeGraphExtractor: extraction failed for screenshot \(item.id): \(error.localizedDescription)")
-      pendingItems.append(
-        PendingItem(
-          id: item.id,
-          input: item.input,
-          contentHash: item.contentHash,
-          ownerID: item.ownerID,
-          mergeCompleted: mergeCompleted))
+      requeueIfCurrentGeneration(item, mergeCompleted: mergeCompleted, generation: generation)
     }
+  }
+
+  private func requeueIfCurrentGeneration(
+    _ item: PendingItem,
+    mergeCompleted: Bool,
+    generation: Int
+  ) {
+    guard generation == ownerGeneration else { return }
+    pendingItems.append(
+      PendingItem(
+        id: item.id,
+        input: item.input,
+        contentHash: item.contentHash,
+        ownerID: item.ownerID,
+        mergeCompleted: mergeCompleted))
   }
 
   private func mergeGraph(

--- a/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
@@ -12,6 +12,7 @@ actor ScreenKnowledgeGraphExtractor {
     let id: Int64
     let input: ScreenKGExtractionInput
     let contentHash: String
+    let ownerID: String
   }
 
   private let minTextLength = 20
@@ -35,10 +36,12 @@ actor ScreenKnowledgeGraphExtractor {
     @Sendable (_ limit: Int) async throws -> [(
       id: Int64, ocrText: String, appName: String, windowTitle: String?
     )]
+  typealias OwnerIDProvider = @Sendable () async -> String?
 
   private let extractEntities: ExtractionBackend
   private let markExtracted: KGMarkedWriter
   private let fetchPending: PendingFetcher
+  private let activeOwnerID: OwnerIDProvider
 
   private init() {
     self.extractEntities = { input in
@@ -51,12 +54,14 @@ actor ScreenKnowledgeGraphExtractor {
     self.fetchPending = { limit in
       try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit)
     }
+    self.activeOwnerID = { RuntimeOwnerIdentity.currentOwnerId() }
   }
 
   init(
     extractEntitiesForTesting: @escaping ExtractionBackend,
     markExtractedForTesting: @escaping KGMarkedWriter,
-    fetchPendingForTesting: PendingFetcher? = nil
+    fetchPendingForTesting: PendingFetcher? = nil,
+    activeOwnerIDForTesting: @escaping OwnerIDProvider = { "test-owner" }
   ) {
     self.extractEntities = extractEntitiesForTesting
     self.markExtracted = markExtractedForTesting
@@ -64,6 +69,7 @@ actor ScreenKnowledgeGraphExtractor {
       fetchPendingForTesting ?? { limit in
         try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit)
       }
+    self.activeOwnerID = activeOwnerIDForTesting
   }
 
   var pendingCount: Int { pendingItems.count }
@@ -79,24 +85,58 @@ actor ScreenKnowledgeGraphExtractor {
   }
 
   /// Queue a newly captured screenshot for extraction.
-  func queueScreenshot(id: Int64, ocrText: String, appName: String, windowTitle: String?) async {
-    guard !pausedForProductGate else { return }
+  func queueScreenshot(
+    id: Int64,
+    ocrText: String,
+    appName: String,
+    windowTitle: String?,
+    expectedOwnerID: String? = nil
+  ) async {
     guard ocrText.count >= minTextLength else { return }
+    guard let ownerID = await resolvedOwnerID(expectedOwnerID: expectedOwnerID) else { return }
+    let generation = ownerGeneration
+
+    let wasPausedForProductGate = pausedForProductGate
+    if wasPausedForProductGate {
+      pausedForProductGate = false
+      backfillScheduled = false
+    }
 
     let input = Self.makeInput(ocrText: ocrText, appName: appName, windowTitle: windowTitle)
     let hash = Self.contentHash(ocrText: ocrText, appName: appName, windowTitle: windowTitle)
 
     if recentHashes.contains(hash) {
-      try? await markExtracted([id])
+      guard generation == ownerGeneration else { return }
+      guard await resolvedOwnerID(expectedOwnerID: ownerID) != nil else { return }
+      guard generation == ownerGeneration else { return }
+      do {
+        try await markExtracted([id])
+      } catch {
+        log(
+          "ScreenKnowledgeGraphExtractor: failed to mark duplicate screenshot \(id): \(error.localizedDescription)"
+        )
+        if wasPausedForProductGate {
+          await scheduleBackfillIfNeeded()
+        }
+        return
+      }
+      if wasPausedForProductGate {
+        await scheduleBackfillIfNeeded()
+      }
       return
     }
 
-    pendingItems.append(PendingItem(id: id, input: input, contentHash: hash))
+    guard generation == ownerGeneration else { return }
+    pendingItems.append(PendingItem(id: id, input: input, contentHash: hash, ownerID: ownerID))
 
     if pendingItems.count >= maxPendingItems {
       await flushPendingExtractions()
     } else {
       startFlushTimerIfNeeded()
+    }
+
+    if wasPausedForProductGate {
+      await scheduleBackfillIfNeeded()
     }
   }
 
@@ -111,10 +151,7 @@ actor ScreenKnowledgeGraphExtractor {
     flushTask?.cancel()
     flushTask = nil
     guard !pendingItems.isEmpty else { return }
-    guard !pausedForProductGate else {
-      pendingItems.removeAll()
-      return
-    }
+    guard !pausedForProductGate else { return }
 
     let generation = ownerGeneration
     let batch = Array(pendingItems.prefix(maxItemsPerFlush))
@@ -125,9 +162,14 @@ actor ScreenKnowledgeGraphExtractor {
         return
       }
       guard !pausedForProductGate else {
+        pendingItems.removeAll()
         return
       }
       await processItem(item, generation: generation)
+      if pausedForProductGate {
+        pendingItems.removeAll()
+        return
+      }
     }
 
     if !pendingItems.isEmpty && !pausedForProductGate {
@@ -154,6 +196,16 @@ actor ScreenKnowledgeGraphExtractor {
   }
 
   // MARK: - Private
+
+  private func resolvedOwnerID(expectedOwnerID: String?) async -> String? {
+    guard !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress else { return nil }
+    guard let current = await activeOwnerID() else { return nil }
+    if let expectedOwnerID {
+      guard expectedOwnerID == current else { return nil }
+      return expectedOwnerID
+    }
+    return current
+  }
 
   private func startFlushTimerIfNeeded() {
     guard flushTask == nil else { return }
@@ -188,6 +240,7 @@ actor ScreenKnowledgeGraphExtractor {
         }
 
         if pausedForProductGate { break }
+        if !pendingItems.isEmpty { break }
 
         processedThisLaunch += rows.count
         if processedThisLaunch < maxBackfillItemsPerLaunch {
@@ -200,9 +253,12 @@ actor ScreenKnowledgeGraphExtractor {
   }
 
   private func processItem(_ item: PendingItem, generation: Int) async {
+    guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+
     do {
       let jsonText = try await extractEntities(item.input)
       guard generation == ownerGeneration else { return }
+      guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
 
       guard let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) else {
         log(
@@ -218,18 +274,19 @@ actor ScreenKnowledgeGraphExtractor {
       }
 
       guard generation == ownerGeneration else { return }
+      guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+      try await markExtracted([item.id])
+      guard generation == ownerGeneration else { return }
       recentHashes.insert(item.contentHash)
       if recentHashes.count > maxRecentHashes {
         recentHashes.removeAll(keepingCapacity: true)
       }
-      try await markExtracted([item.id])
       log(
         "ScreenKnowledgeGraphExtractor: extracted from screenshot \(item.id) via \(backendName())")
     } catch {
       guard generation == ownerGeneration else { return }
       if let geminiError = error as? GeminiClient.GeminiClientError, geminiError.isExpectedProductState {
         pausedForProductGate = true
-        pendingItems.removeAll()
         log(
           "ScreenKnowledgeGraphExtractor: pausing — expected product state for screenshot \(item.id): \(error.localizedDescription)"
         )

--- a/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
@@ -1,0 +1,219 @@
+import CryptoKit
+import Foundation
+
+/// Extracts entity nodes and edges from screenshot OCR text into `local_kg_*`.
+///
+/// Runs asynchronously after Rewind capture. Uses OCR text only — never images.
+/// Prefers on-device Foundation Models when available; falls back to Gemini proxy.
+actor ScreenKnowledgeGraphExtractor {
+  static let shared = ScreenKnowledgeGraphExtractor()
+
+  private struct PendingItem {
+    let id: Int64
+    let input: ScreenKGExtractionInput
+    let contentHash: String
+  }
+
+  private let minTextLength = 20
+  private let flushIntervalNanos: UInt64 = 60_000_000_000
+  private let maxPendingItems = 20
+  private let maxItemsPerFlush = 5
+
+  private var pendingItems: [PendingItem] = []
+  private var flushTask: Task<Void, Never>?
+  private var ownerGeneration = 0
+  private var recentHashes: Set<String> = []
+  private let maxRecentHashes = 2_000
+  private var backfillScheduled = false
+
+  typealias ExtractionBackend = @Sendable (ScreenKGExtractionInput) async throws -> String
+  typealias KGMarkedWriter = @Sendable (_ ids: [Int64]) async throws -> Void
+  typealias PendingFetcher =
+    @Sendable (_ limit: Int) async throws -> [(
+      id: Int64, ocrText: String, appName: String, windowTitle: String?
+    )]
+
+  private let extractEntities: ExtractionBackend
+  private let markExtracted: KGMarkedWriter
+  private let fetchPending: PendingFetcher
+
+  private init() {
+    self.extractEntities = { input in
+      let backend = ScreenKGExtractionBackendSelector.preferredBackend()
+      return try await backend.extractEntities(from: input)
+    }
+    self.markExtracted = { ids in
+      try await RewindDatabase.shared.markScreenshotsKGExtracted(ids: ids)
+    }
+    self.fetchPending = { limit in
+      try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit)
+    }
+  }
+
+  init(
+    extractEntitiesForTesting: @escaping ExtractionBackend,
+    markExtractedForTesting: @escaping KGMarkedWriter,
+    fetchPendingForTesting: PendingFetcher? = nil
+  ) {
+    self.extractEntities = extractEntitiesForTesting
+    self.markExtracted = markExtractedForTesting
+    self.fetchPending =
+      fetchPendingForTesting ?? { limit in
+        try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit)
+      }
+  }
+
+  var pendingCount: Int { pendingItems.count }
+
+  func reset() {
+    ownerGeneration &+= 1
+    flushTask?.cancel()
+    flushTask = nil
+    pendingItems = []
+    recentHashes = []
+    backfillScheduled = false
+  }
+
+  /// Queue a newly captured screenshot for extraction.
+  func queueScreenshot(id: Int64, ocrText: String, appName: String, windowTitle: String?) async {
+    guard ocrText.count >= minTextLength else { return }
+
+    let input = Self.makeInput(ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+    let hash = Self.contentHash(input)
+
+    if recentHashes.contains(hash) {
+      try? await markExtracted([id])
+      return
+    }
+
+    pendingItems.append(PendingItem(id: id, input: input, contentHash: hash))
+
+    if pendingItems.count >= maxPendingItems {
+      await flushPendingExtractions()
+    } else {
+      startFlushTimerIfNeeded()
+    }
+  }
+
+  /// One-shot backfill for screenshots captured before the extractor shipped.
+  func scheduleBackfillIfNeeded() {
+    guard !backfillScheduled else { return }
+    backfillScheduled = true
+    Task(priority: .utility) {
+      await self.runBackfillBatch()
+    }
+  }
+
+  func flushPendingExtractions() async {
+    flushTask?.cancel()
+    flushTask = nil
+    guard !pendingItems.isEmpty else { return }
+
+    let generation = ownerGeneration
+    let batch = Array(pendingItems.prefix(maxItemsPerFlush))
+    pendingItems.removeFirst(min(maxItemsPerFlush, pendingItems.count))
+
+    for item in batch {
+      guard generation == ownerGeneration else {
+        return
+      }
+      await processItem(item, generation: generation)
+    }
+
+    if !pendingItems.isEmpty {
+      startFlushTimerIfNeeded()
+    }
+  }
+
+  // MARK: - Formatting
+
+  static func makeInput(ocrText: String, appName: String, windowTitle: String?) -> ScreenKGExtractionInput {
+    let truncated =
+      ocrText.count > 6_000 ? String(ocrText.prefix(6_000)) + "…" : ocrText
+    return ScreenKGExtractionInput(ocrText: truncated, appName: appName, windowTitle: windowTitle)
+  }
+
+  static func contentHash(_ input: ScreenKGExtractionInput) -> String {
+    let key = "[\(input.appName)]\(input.windowTitle ?? "")\n\(input.ocrText)"
+    let digest = SHA256.hash(data: Data(key.utf8))
+    return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+  }
+
+  // MARK: - Private
+
+  private func startFlushTimerIfNeeded() {
+    guard flushTask == nil else { return }
+    flushTask = Task {
+      try? await Task.sleep(nanoseconds: flushIntervalNanos)
+      guard !Task.isCancelled else { return }
+      await self.flushPendingExtractions()
+    }
+  }
+
+  private func runBackfillBatch() async {
+    do {
+      let rows = try await fetchPending(50)
+      for row in rows {
+        await queueScreenshot(
+          id: row.id, ocrText: row.ocrText, appName: row.appName, windowTitle: row.windowTitle)
+      }
+      if !rows.isEmpty {
+        await flushPendingExtractions()
+      }
+    } catch {
+      log("ScreenKnowledgeGraphExtractor: backfill fetch failed: \(error.localizedDescription)")
+    }
+  }
+
+  private func processItem(_ item: PendingItem, generation: Int) async {
+    do {
+      let jsonText = try await extractEntities(item.input)
+      guard generation == ownerGeneration else { return }
+
+      if let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) {
+        let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed.nodes, edges: parsed.edges)
+        if !records.nodes.isEmpty || !records.edges.isEmpty {
+          try await mergeGraph(nodes: records.nodes, edges: records.edges)
+        }
+      }
+
+      guard generation == ownerGeneration else { return }
+      recentHashes.insert(item.contentHash)
+      if recentHashes.count > maxRecentHashes {
+        recentHashes.removeAll(keepingCapacity: true)
+      }
+      try await markExtracted([item.id])
+      log(
+        "ScreenKnowledgeGraphExtractor: extracted from screenshot \(item.id) via \(backendName())")
+    } catch {
+      guard generation == ownerGeneration else { return }
+      if let geminiError = error as? GeminiClient.GeminiClientError, geminiError.isExpectedProductState {
+        log("ScreenKnowledgeGraphExtractor: skipping screenshot \(item.id) — \(error.localizedDescription)")
+        try? await markExtracted([item.id])
+        return
+      }
+      log("ScreenKnowledgeGraphExtractor: extraction failed for screenshot \(item.id): \(error.localizedDescription)")
+      pendingItems.append(item)
+    }
+  }
+
+  private func mergeGraph(nodes: [LocalKGNodeRecord], edges: [LocalKGEdgeRecord]) async throws {
+    guard RuntimeOwnerIdentity.currentOwnerId() != nil,
+      !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
+    else {
+      throw LocalMutationAuthorizationError.revoked
+    }
+
+    try await KnowledgeGraphStorage.shared.mergeGraph(
+      nodes: nodes,
+      edges: edges,
+      authorization: LocalMutationAuthorization {
+        RuntimeOwnerIdentity.currentOwnerId() != nil
+          && !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
+      })
+  }
+
+  private func backendName() -> String {
+    ScreenKGExtractionBackendSelector.preferredBackend().name
+  }
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
@@ -18,6 +18,8 @@ actor ScreenKnowledgeGraphExtractor {
   private let flushIntervalNanos: UInt64 = 60_000_000_000
   private let maxPendingItems = 20
   private let maxItemsPerFlush = 5
+  private let backfillBatchSize = 50
+  private let maxBackfillItemsPerLaunch = 5_000
 
   private var pendingItems: [PendingItem] = []
   private var flushTask: Task<Void, Never>?
@@ -25,6 +27,7 @@ actor ScreenKnowledgeGraphExtractor {
   private var recentHashes: Set<String> = []
   private let maxRecentHashes = 2_000
   private var backfillScheduled = false
+  private var pausedForProductGate = false
 
   typealias ExtractionBackend = @Sendable (ScreenKGExtractionInput) async throws -> String
   typealias KGMarkedWriter = @Sendable (_ ids: [Int64]) async throws -> Void
@@ -72,14 +75,16 @@ actor ScreenKnowledgeGraphExtractor {
     pendingItems = []
     recentHashes = []
     backfillScheduled = false
+    pausedForProductGate = false
   }
 
   /// Queue a newly captured screenshot for extraction.
   func queueScreenshot(id: Int64, ocrText: String, appName: String, windowTitle: String?) async {
+    guard !pausedForProductGate else { return }
     guard ocrText.count >= minTextLength else { return }
 
     let input = Self.makeInput(ocrText: ocrText, appName: appName, windowTitle: windowTitle)
-    let hash = Self.contentHash(input)
+    let hash = Self.contentHash(ocrText: ocrText, appName: appName, windowTitle: windowTitle)
 
     if recentHashes.contains(hash) {
       try? await markExtracted([id])
@@ -95,19 +100,21 @@ actor ScreenKnowledgeGraphExtractor {
     }
   }
 
-  /// One-shot backfill for screenshots captured before the extractor shipped.
-  func scheduleBackfillIfNeeded() {
+  /// Backfill screenshots captured before the extractor shipped (capped per launch).
+  func scheduleBackfillIfNeeded() async {
     guard !backfillScheduled else { return }
     backfillScheduled = true
-    Task(priority: .utility) {
-      await self.runBackfillBatch()
-    }
+    await runBackfillBatch()
   }
 
   func flushPendingExtractions() async {
     flushTask?.cancel()
     flushTask = nil
     guard !pendingItems.isEmpty else { return }
+    guard !pausedForProductGate else {
+      pendingItems.removeAll()
+      return
+    }
 
     let generation = ownerGeneration
     let batch = Array(pendingItems.prefix(maxItemsPerFlush))
@@ -117,10 +124,13 @@ actor ScreenKnowledgeGraphExtractor {
       guard generation == ownerGeneration else {
         return
       }
+      guard !pausedForProductGate else {
+        return
+      }
       await processItem(item, generation: generation)
     }
 
-    if !pendingItems.isEmpty {
+    if !pendingItems.isEmpty && !pausedForProductGate {
       startFlushTimerIfNeeded()
     }
   }
@@ -133,16 +143,21 @@ actor ScreenKnowledgeGraphExtractor {
     return ScreenKGExtractionInput(ocrText: truncated, appName: appName, windowTitle: windowTitle)
   }
 
-  static func contentHash(_ input: ScreenKGExtractionInput) -> String {
-    let key = "[\(input.appName)]\(input.windowTitle ?? "")\n\(input.ocrText)"
+  static func contentHash(ocrText: String, appName: String, windowTitle: String?) -> String {
+    let key = "[\(appName)]\(windowTitle ?? "")\n\(ocrText)"
     let digest = SHA256.hash(data: Data(key.utf8))
     return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+  }
+
+  static func contentHash(_ input: ScreenKGExtractionInput) -> String {
+    contentHash(ocrText: input.ocrText, appName: input.appName, windowTitle: input.windowTitle)
   }
 
   // MARK: - Private
 
   private func startFlushTimerIfNeeded() {
     guard flushTask == nil else { return }
+    guard !pausedForProductGate else { return }
     flushTask = Task {
       try? await Task.sleep(nanoseconds: flushIntervalNanos)
       guard !Task.isCancelled else { return }
@@ -151,14 +166,33 @@ actor ScreenKnowledgeGraphExtractor {
   }
 
   private func runBackfillBatch() async {
+    var processedThisLaunch = 0
+
     do {
-      let rows = try await fetchPending(50)
-      for row in rows {
-        await queueScreenshot(
-          id: row.id, ocrText: row.ocrText, appName: row.appName, windowTitle: row.windowTitle)
-      }
-      if !rows.isEmpty {
-        await flushPendingExtractions()
+      while processedThisLaunch < maxBackfillItemsPerLaunch {
+        if pausedForProductGate { break }
+
+        let rows = try await fetchPending(backfillBatchSize)
+        if rows.isEmpty { break }
+
+        for row in rows {
+          await queueScreenshot(
+            id: row.id, ocrText: row.ocrText, appName: row.appName, windowTitle: row.windowTitle)
+        }
+
+        while !pendingItems.isEmpty {
+          if pausedForProductGate { break }
+          let before = pendingItems.count
+          await flushPendingExtractions()
+          if pendingItems.count >= before { break }
+        }
+
+        if pausedForProductGate { break }
+
+        processedThisLaunch += rows.count
+        if processedThisLaunch < maxBackfillItemsPerLaunch {
+          try? await Task.sleep(nanoseconds: 200_000_000)
+        }
       }
     } catch {
       log("ScreenKnowledgeGraphExtractor: backfill fetch failed: \(error.localizedDescription)")
@@ -170,11 +204,17 @@ actor ScreenKnowledgeGraphExtractor {
       let jsonText = try await extractEntities(item.input)
       guard generation == ownerGeneration else { return }
 
-      if let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) {
-        let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed.nodes, edges: parsed.edges)
-        if !records.nodes.isEmpty || !records.edges.isEmpty {
-          try await mergeGraph(nodes: records.nodes, edges: records.edges)
-        }
+      guard let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) else {
+        log(
+          "ScreenKnowledgeGraphExtractor: invalid extraction JSON for screenshot \(item.id) — will retry"
+        )
+        pendingItems.append(item)
+        return
+      }
+
+      let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed.nodes, edges: parsed.edges)
+      if !records.nodes.isEmpty || !records.edges.isEmpty {
+        try await mergeGraph(nodes: records.nodes, edges: records.edges)
       }
 
       guard generation == ownerGeneration else { return }
@@ -188,8 +228,11 @@ actor ScreenKnowledgeGraphExtractor {
     } catch {
       guard generation == ownerGeneration else { return }
       if let geminiError = error as? GeminiClient.GeminiClientError, geminiError.isExpectedProductState {
-        log("ScreenKnowledgeGraphExtractor: skipping screenshot \(item.id) — \(error.localizedDescription)")
-        try? await markExtracted([item.id])
+        pausedForProductGate = true
+        pendingItems.removeAll()
+        log(
+          "ScreenKnowledgeGraphExtractor: pausing — expected product state for screenshot \(item.id): \(error.localizedDescription)"
+        )
         return
       }
       log("ScreenKnowledgeGraphExtractor: extraction failed for screenshot \(item.id): \(error.localizedDescription)")

--- a/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
@@ -13,6 +13,7 @@ actor ScreenKnowledgeGraphExtractor {
     let input: ScreenKGExtractionInput
     let contentHash: String
     let ownerID: String
+    let mergeCompleted: Bool
   }
 
   private let minTextLength = 20
@@ -33,15 +34,24 @@ actor ScreenKnowledgeGraphExtractor {
   typealias ExtractionBackend = @Sendable (ScreenKGExtractionInput) async throws -> String
   typealias KGMarkedWriter = @Sendable (_ ids: [Int64]) async throws -> Void
   typealias PendingFetcher =
-    @Sendable (_ limit: Int) async throws -> [(
+    @Sendable (_ limit: Int, _ afterID: Int64) async throws -> [(
       id: Int64, ocrText: String, appName: String, windowTitle: String?
     )]
   typealias OwnerIDProvider = @Sendable () async -> String?
+  typealias GraphMerger =
+    @Sendable (
+      _ nodes: [LocalKGNodeRecord],
+      _ edges: [LocalKGEdgeRecord],
+      _ authorization: LocalMutationAuthorization
+    ) async throws -> Void
+  typealias OwnerMatchChecker = @Sendable (_ expectedOwnerID: String) -> Bool
 
   private let extractEntities: ExtractionBackend
   private let markExtracted: KGMarkedWriter
   private let fetchPending: PendingFetcher
   private let activeOwnerID: OwnerIDProvider
+  private let mergeGraphImpl: GraphMerger
+  private let ownerMatches: OwnerMatchChecker
 
   private init() {
     self.extractEntities = { input in
@@ -51,25 +61,46 @@ actor ScreenKnowledgeGraphExtractor {
     self.markExtracted = { ids in
       try await RewindDatabase.shared.markScreenshotsKGExtracted(ids: ids)
     }
-    self.fetchPending = { limit in
-      try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit)
+    self.fetchPending = { limit, afterID in
+      try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit, afterID: afterID)
     }
     self.activeOwnerID = { RuntimeOwnerIdentity.currentOwnerId() }
+    self.mergeGraphImpl = { nodes, edges, authorization in
+      try await KnowledgeGraphStorage.shared.mergeGraph(
+        nodes: nodes, edges: edges, authorization: authorization)
+    }
+    self.ownerMatches = { expectedOwnerID in
+      RuntimeOwnerIdentity.currentOwnerId() == expectedOwnerID
+        && !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
+    }
   }
 
   init(
     extractEntitiesForTesting: @escaping ExtractionBackend,
     markExtractedForTesting: @escaping KGMarkedWriter,
     fetchPendingForTesting: PendingFetcher? = nil,
-    activeOwnerIDForTesting: @escaping OwnerIDProvider = { "test-owner" }
+    activeOwnerIDForTesting: @escaping OwnerIDProvider = { "test-owner" },
+    mergeGraphForTesting: GraphMerger? = nil,
+    ownerMatchesForTesting: OwnerMatchChecker? = nil
   ) {
     self.extractEntities = extractEntitiesForTesting
     self.markExtracted = markExtractedForTesting
     self.fetchPending =
-      fetchPendingForTesting ?? { limit in
-        try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(limit: limit)
+      fetchPendingForTesting ?? { limit, afterID in
+        try await RewindDatabase.shared.getScreenshotsPendingKGExtraction(
+          limit: limit, afterID: afterID)
       }
     self.activeOwnerID = activeOwnerIDForTesting
+    self.mergeGraphImpl =
+      mergeGraphForTesting ?? { nodes, edges, authorization in
+        try await KnowledgeGraphStorage.shared.mergeGraph(
+          nodes: nodes, edges: edges, authorization: authorization)
+      }
+    self.ownerMatches =
+      ownerMatchesForTesting ?? { expectedOwnerID in
+        RuntimeOwnerIdentity.currentOwnerId() == expectedOwnerID
+          && !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
+      }
   }
 
   var pendingCount: Int { pendingItems.count }
@@ -127,7 +158,9 @@ actor ScreenKnowledgeGraphExtractor {
     }
 
     guard generation == ownerGeneration else { return }
-    pendingItems.append(PendingItem(id: id, input: input, contentHash: hash, ownerID: ownerID))
+    pendingItems.append(
+      PendingItem(
+        id: id, input: input, contentHash: hash, ownerID: ownerID, mergeCompleted: false))
 
     if pendingItems.count >= maxPendingItems {
       await flushPendingExtractions()
@@ -219,30 +252,55 @@ actor ScreenKnowledgeGraphExtractor {
 
   private func runBackfillBatch() async {
     var processedThisLaunch = 0
+    var afterID: Int64 = 0
+    let generation = ownerGeneration
 
     do {
       while processedThisLaunch < maxBackfillItemsPerLaunch {
+        guard generation == ownerGeneration else { return }
         if pausedForProductGate { break }
 
-        let rows = try await fetchPending(backfillBatchSize)
+        guard let ownerID = await resolvedOwnerID(expectedOwnerID: nil) else { return }
+        guard generation == ownerGeneration else { return }
+
+        let rows = try await fetchPending(backfillBatchSize, afterID)
+        guard generation == ownerGeneration else { return }
         if rows.isEmpty { break }
 
         for row in rows {
+          guard generation == ownerGeneration else { return }
           await queueScreenshot(
-            id: row.id, ocrText: row.ocrText, appName: row.appName, windowTitle: row.windowTitle)
+            id: row.id,
+            ocrText: row.ocrText,
+            appName: row.appName,
+            windowTitle: row.windowTitle,
+            expectedOwnerID: ownerID)
         }
+        guard generation == ownerGeneration else { return }
 
         while !pendingItems.isEmpty {
+          guard generation == ownerGeneration else { return }
           if pausedForProductGate { break }
           let before = pendingItems.count
           await flushPendingExtractions()
           if pendingItems.count >= before { break }
         }
 
-        if pausedForProductGate { break }
-        if !pendingItems.isEmpty { break }
-
+        if let maxID = rows.map(\.id).max() {
+          afterID = max(afterID, maxID)
+        }
         processedThisLaunch += rows.count
+
+        if pausedForProductGate { break }
+        if !pendingItems.isEmpty {
+          if !pausedForProductGate {
+            startFlushTimerIfNeeded()
+          }
+          if processedThisLaunch >= maxBackfillItemsPerLaunch { break }
+          try? await Task.sleep(nanoseconds: 200_000_000)
+          continue
+        }
+
         if processedThisLaunch < maxBackfillItemsPerLaunch {
           try? await Task.sleep(nanoseconds: 200_000_000)
         }
@@ -255,22 +313,33 @@ actor ScreenKnowledgeGraphExtractor {
   private func processItem(_ item: PendingItem, generation: Int) async {
     guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
 
+    var mergeCompleted = item.mergeCompleted
     do {
-      let jsonText = try await extractEntities(item.input)
-      guard generation == ownerGeneration else { return }
-      guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+      if !mergeCompleted {
+        let jsonText = try await extractEntities(item.input)
+        guard generation == ownerGeneration else { return }
+        guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
 
-      guard let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) else {
-        log(
-          "ScreenKnowledgeGraphExtractor: invalid extraction JSON for screenshot \(item.id) — will retry"
-        )
-        pendingItems.append(item)
-        return
-      }
+        guard let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(jsonText) else {
+          log(
+            "ScreenKnowledgeGraphExtractor: invalid extraction JSON for screenshot \(item.id) — will retry"
+          )
+          pendingItems.append(item)
+          return
+        }
 
-      let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed.nodes, edges: parsed.edges)
-      if !records.nodes.isEmpty || !records.edges.isEmpty {
-        try await mergeGraph(nodes: records.nodes, edges: records.edges)
+        let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed.nodes, edges: parsed.edges)
+        if !records.nodes.isEmpty || !records.edges.isEmpty {
+          try await mergeGraph(
+            nodes: records.nodes,
+            edges: records.edges,
+            expectedOwnerID: item.ownerID,
+            generation: generation)
+          guard generation == ownerGeneration else { return }
+          guard await resolvedOwnerID(expectedOwnerID: item.ownerID) != nil else { return }
+          ChatToolExecutor.onKnowledgeGraphUpdated?()
+        }
+        mergeCompleted = true
       }
 
       guard generation == ownerGeneration else { return }
@@ -293,23 +362,36 @@ actor ScreenKnowledgeGraphExtractor {
         return
       }
       log("ScreenKnowledgeGraphExtractor: extraction failed for screenshot \(item.id): \(error.localizedDescription)")
-      pendingItems.append(item)
+      pendingItems.append(
+        PendingItem(
+          id: item.id,
+          input: item.input,
+          contentHash: item.contentHash,
+          ownerID: item.ownerID,
+          mergeCompleted: mergeCompleted))
     }
   }
 
-  private func mergeGraph(nodes: [LocalKGNodeRecord], edges: [LocalKGEdgeRecord]) async throws {
-    guard RuntimeOwnerIdentity.currentOwnerId() != nil,
-      !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
-    else {
+  private func mergeGraph(
+    nodes: [LocalKGNodeRecord],
+    edges: [LocalKGEdgeRecord],
+    expectedOwnerID: String,
+    generation: Int
+  ) async throws {
+    guard generation == ownerGeneration else {
+      throw LocalMutationAuthorizationError.revoked
+    }
+    guard await resolvedOwnerID(expectedOwnerID: expectedOwnerID) != nil else {
       throw LocalMutationAuthorizationError.revoked
     }
 
-    try await KnowledgeGraphStorage.shared.mergeGraph(
-      nodes: nodes,
-      edges: edges,
-      authorization: LocalMutationAuthorization {
-        RuntimeOwnerIdentity.currentOwnerId() != nil
-          && !RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
+    let expected = expectedOwnerID
+    let matches = ownerMatches
+    try await mergeGraphImpl(
+      nodes,
+      edges,
+      LocalMutationAuthorization {
+        matches(expected)
       })
   }
 

--- a/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
@@ -62,25 +62,29 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
   }
 
   func testQueueSkipsShortOCR() async {
-    await ScreenKnowledgeGraphExtractor.shared.reset()
-    await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in "{\"nodes\":[],\"edges\":[]}" },
+      markExtractedForTesting: { _ in })
+    await extractor.queueScreenshot(
       id: 1, ocrText: "too short", appName: "Notes", windowTitle: nil)
-    let pending = await ScreenKnowledgeGraphExtractor.shared.pendingCount
+    let pending = await extractor.pendingCount
     XCTAssertEqual(pending, 0)
   }
 
   func testResetDropsPendingQueue() async {
-    await ScreenKnowledgeGraphExtractor.shared.reset()
-    await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in "{\"nodes\":[],\"edges\":[]}" },
+      markExtractedForTesting: { _ in })
+    await extractor.queueScreenshot(
       id: 9,
       ocrText: String(repeating: "on-screen entity text ", count: 3),
       appName: "Safari",
       windowTitle: "Docs")
-    var pending = await ScreenKnowledgeGraphExtractor.shared.pendingCount
+    var pending = await extractor.pendingCount
     XCTAssertEqual(pending, 1)
 
-    await ScreenKnowledgeGraphExtractor.shared.reset()
-    pending = await ScreenKnowledgeGraphExtractor.shared.pendingCount
+    await extractor.reset()
+    pending = await extractor.pendingCount
     XCTAssertEqual(pending, 0)
   }
 
@@ -155,6 +159,187 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     XCTAssertEqual(pending, 0)
   }
 
+  func testProductGateResumeAllowsNewScreenshotsAndBackfill() async {
+    let extractCount = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let remaining = LockedBox(
+      [
+        (
+          id: Int64(99),
+          ocrText: String(repeating: "backfill after upgrade ", count: 3),
+          appName: "Notes",
+          windowTitle: nil as String?
+        )
+      ])
+    let shouldGate = LockedBox(true)
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        if await shouldGate.value {
+          throw GeminiClient.GeminiClientError.apiError("trial_expired")
+        }
+        await extractCount.increment()
+        return "{\"nodes\":[],\"edges\":[]}"
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      },
+      fetchPendingForTesting: { limit in
+        await remaining.takePrefix(limit)
+      })
+
+    await extractor.queueScreenshot(
+      id: 7,
+      ocrText: String(repeating: "gated entity payload ", count: 3),
+      appName: "Notes",
+      windowTitle: nil)
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await extractor.pendingCount, 0)
+    XCTAssertTrue(await marked.value.isEmpty)
+
+    await shouldGate.set(false)
+    await extractor.queueScreenshot(
+      id: 8,
+      ocrText: String(repeating: "post upgrade capture ", count: 3),
+      appName: "Notes",
+      windowTitle: nil)
+
+    let ids = await marked.value
+    XCTAssertTrue(ids.contains(8))
+    XCTAssertTrue(ids.contains(99), "live resume must reschedule backfill for gated rows")
+    XCTAssertGreaterThanOrEqual(await extractCount.value, 2)
+  }
+
+  func testStaleExpectedOwnerIsRejected() async {
+    let owner = LockedBox("owner-a")
+    let marked = LockedBox<[Int64]>([])
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in "{\"nodes\":[],\"edges\":[]}" },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      },
+      activeOwnerIDForTesting: { await owner.value })
+
+    await extractor.queueScreenshot(
+      id: 1,
+      ocrText: String(repeating: "owner a screen text ", count: 3),
+      appName: "Mail",
+      windowTitle: nil,
+      expectedOwnerID: "owner-a")
+    XCTAssertEqual(await extractor.pendingCount, 1)
+
+    await owner.set("owner-b")
+    await extractor.queueScreenshot(
+      id: 2,
+      ocrText: String(repeating: "stale owner a screen text ", count: 3),
+      appName: "Mail",
+      windowTitle: nil,
+      expectedOwnerID: "owner-a")
+    XCTAssertEqual(await extractor.pendingCount, 1, "stale capture owner must not enqueue")
+
+    await extractor.flushPendingExtractions()
+    XCTAssertTrue(
+      await marked.value.isEmpty,
+      "pending from previous owner must not mark after owner change without reset")
+  }
+
+  func testMarkFailureDoesNotRecordDedupHash() async {
+    let markShouldFail = LockedBox(true)
+    let extractCount = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let text = String(repeating: "hash ordering payload ", count: 3)
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        await extractCount.increment()
+        return "{\"nodes\":[],\"edges\":[]}"
+      },
+      markExtractedForTesting: { ids in
+        if await markShouldFail.value {
+          throw NSError(domain: "ScreenKGTest", code: 1)
+        }
+        await marked.append(contentsOf: ids)
+      })
+
+    await extractor.queueScreenshot(id: 1, ocrText: text, appName: "Docs", windowTitle: nil)
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await extractCount.value, 1)
+    XCTAssertTrue(await marked.value.isEmpty)
+    XCTAssertEqual(await extractor.pendingCount, 1, "failed mark must re-queue for retry")
+
+    await markShouldFail.set(false)
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await marked.value, [1])
+
+    await extractor.queueScreenshot(id: 2, ocrText: text, appName: "Docs", windowTitle: nil)
+    XCTAssertEqual(await extractCount.value, 1, "hash dedup only after successful mark")
+    XCTAssertEqual(await marked.value, [1, 2])
+  }
+
+  func testBackfillStopsWithoutCountingWhenFlushStalls() async {
+    let fetchCalls = LockedBox(0)
+    let remaining = LockedBox(
+      (1...80).map { id -> (id: Int64, ocrText: String, appName: String, windowTitle: String?) in
+        (
+          id: Int64(id),
+          ocrText: String(repeating: "stall entity \(id) ", count: 3),
+          appName: "App",
+          windowTitle: nil
+        )
+      })
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        "not-json{{{broken"
+      },
+      markExtractedForTesting: { _ in },
+      fetchPendingForTesting: { limit in
+        await fetchCalls.increment()
+        return await remaining.takePrefix(limit)
+      })
+
+    await extractor.scheduleBackfillIfNeeded()
+
+    let calls = await fetchCalls.value
+    XCTAssertEqual(calls, 1, "stalled flush must not keep refetching the same pending rows")
+    XCTAssertEqual(await remaining.value.count, 30)
+  }
+
+  func testResetAllowsBackfillToBeRescheduled() async {
+    let fetchCalls = LockedBox(0)
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in "{\"nodes\":[],\"edges\":[]}" },
+      markExtractedForTesting: { _ in },
+      fetchPendingForTesting: { _ in
+        await fetchCalls.increment()
+        return []
+      })
+
+    await extractor.scheduleBackfillIfNeeded()
+    XCTAssertEqual(await fetchCalls.value, 1)
+
+    await extractor.scheduleBackfillIfNeeded()
+    XCTAssertEqual(await fetchCalls.value, 1, "second schedule is a no-op until reset")
+
+    await extractor.reset()
+    await extractor.scheduleBackfillIfNeeded()
+    XCTAssertEqual(await fetchCalls.value, 2, "reset must allow backfill to run again")
+  }
+
+  func testOwnerRetargetReschedulesScreenKGBackfill() throws {
+    // omi-test-quality: source-inspection -- static contract: owner retarget must
+    // reschedule ScreenKnowledgeGraphExtractor backfill after reset; RuntimeOwnerIdentity
+    // transition has no injectable seam for hermetic scheduling assertions.
+    let source = try XCTUnwrap(
+      String(
+        contentsOfFile: RewindIndexerSourcePath.runtimeOwnerIdentitySwift,
+        encoding: .utf8))
+    XCTAssertTrue(source.contains("ScreenKnowledgeGraphExtractor.shared.reset()"))
+    XCTAssertTrue(
+      source.contains("ScreenKnowledgeGraphExtractor.shared.scheduleBackfillIfNeeded()"),
+      "owner retarget must reschedule KG backfill after reset")
+  }
+
   func testInvalidExtractionJSONDoesNotMarkExtracted() async {
     let marked = LockedBox<[Int64]>([])
     let extractor = ScreenKnowledgeGraphExtractor(
@@ -225,6 +410,9 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     XCTAssertTrue(
       source.contains("ScreenKnowledgeGraphExtractor.shared.queueScreenshot"),
       "battery OCR backfill must queue KG extraction for newly indexed screenshots")
+    XCTAssertTrue(
+      source.contains("expectedOwnerID: captureOwnerID"),
+      "capture paths must fence queueScreenshot with the capture-time owner")
 
     if let updateRange = source.range(of: "updateOCRResult(id: id, ocrResult: ocrResult)"),
       let backfillRange = source.range(of: "func backfillUnindexedScreenshots")
@@ -268,13 +456,19 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
 }
 
 private enum RewindIndexerSourcePath {
-  static var rewindIndexerSwift: String {
-    let thisFile = URL(fileURLWithPath: #filePath)
-    return thisFile
+  static var desktopSourcesRoot: URL {
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()  // Tests/
       .deletingLastPathComponent()  // Desktop/
-      .appendingPathComponent("Sources/Rewind/Services/RewindIndexer.swift")
-      .path
+      .appendingPathComponent("Sources")
+  }
+
+  static var rewindIndexerSwift: String {
+    desktopSourcesRoot.appendingPathComponent("Rewind/Services/RewindIndexer.swift").path
+  }
+
+  static var runtimeOwnerIdentitySwift: String {
+    desktopSourcesRoot.appendingPathComponent("Chat/RuntimeOwnerIdentity.swift").path
   }
 }
 
@@ -282,6 +476,10 @@ private actor LockedBox<T> {
   private(set) var value: T
 
   init(_ value: T) {
+    self.value = value
+  }
+
+  func set(_ value: T) {
     self.value = value
   }
 

--- a/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
+  override func tearDown() async throws {
+    await ScreenKnowledgeGraphExtractor.shared.reset()
+    try await super.tearDown()
+  }
+
+  func testParseExtractionJSONBuildsRecordsWithLabelDedup() {
+    let json = """
+      {
+        "nodes": [
+          {"id": "acme", "label": "Acme Corp", "node_type": "organization"},
+          {"id": "acme_dup", "label": "acme corp", "node_type": "organization"}
+        ],
+        "edges": [
+          {"source_id": "jane", "target_id": "acme_dup", "label": "works_at"}
+        ]
+      }
+      """
+
+    let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(json)
+    XCTAssertNotNil(parsed)
+    let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed!.nodes, edges: parsed!.edges)
+    XCTAssertEqual(records.nodes.count, 1)
+    XCTAssertEqual(records.nodes.first?.nodeId, "acme")
+    XCTAssertEqual(records.edges.first?.sourceNodeId, "jane")
+    XCTAssertEqual(records.edges.first?.targetNodeId, "acme")
+  }
+
+  func testContentHashIsStableForSameInput() {
+    let input = ScreenKnowledgeGraphExtractor.makeInput(
+      ocrText: "Quarterly planning with Jane Doe at Acme",
+      appName: "Slack",
+      windowTitle: "# eng")
+    let a = ScreenKnowledgeGraphExtractor.contentHash(input)
+    let b = ScreenKnowledgeGraphExtractor.contentHash(input)
+    XCTAssertEqual(a, b)
+  }
+
+  func testQueueSkipsShortOCR() async {
+    await ScreenKnowledgeGraphExtractor.shared.reset()
+    await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+      id: 1, ocrText: "too short", appName: "Notes", windowTitle: nil)
+    let pending = await ScreenKnowledgeGraphExtractor.shared.pendingCount
+    XCTAssertEqual(pending, 0)
+  }
+
+  func testResetDropsPendingQueue() async {
+    await ScreenKnowledgeGraphExtractor.shared.reset()
+    await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
+      id: 9,
+      ocrText: String(repeating: "on-screen entity text ", count: 3),
+      appName: "Safari",
+      windowTitle: "Docs")
+    var pending = await ScreenKnowledgeGraphExtractor.shared.pendingCount
+    XCTAssertEqual(pending, 1)
+
+    await ScreenKnowledgeGraphExtractor.shared.reset()
+    pending = await ScreenKnowledgeGraphExtractor.shared.pendingCount
+    XCTAssertEqual(pending, 0)
+  }
+
+  func testFlushMarksExtractedAfterSuccessfulExtraction() async throws {
+    let marked = LockedBox<[Int64]>([])
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        """
+        {"nodes":[],"edges":[]}
+        """
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      })
+
+    await extractor.queueScreenshot(
+      id: 42,
+      ocrText: String(repeating: "Project X roadmap details ", count: 3),
+      appName: "Linear",
+      windowTitle: "ENG")
+    await extractor.flushPendingExtractions()
+
+    let ids = await marked.value
+    XCTAssertEqual(ids, [42])
+  }
+
+  func testDuplicateContentHashMarksWithoutReextracting() async {
+    let extractCount = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let text = String(repeating: "duplicate entity payload ", count: 3)
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        await extractCount.increment()
+        return "{\"nodes\":[],\"edges\":[]}"
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      })
+
+    await extractor.queueScreenshot(id: 1, ocrText: text, appName: "Mail", windowTitle: "Inbox")
+    await extractor.flushPendingExtractions()
+
+    await extractor.queueScreenshot(id: 2, ocrText: text, appName: "Mail", windowTitle: "Inbox")
+
+    let count = await extractCount.value
+    XCTAssertEqual(count, 1)
+    let ids = await marked.value
+    XCTAssertEqual(ids, [1, 2])
+  }
+}
+
+private actor LockedBox<T> {
+  private(set) var value: T
+
+  init(_ value: T) {
+    self.value = value
+  }
+
+  func append(contentsOf elements: [Int64]) where T == [Int64] {
+    value.append(contentsOf: elements)
+  }
+
+  func increment() where T == Int {
+    value += 1
+  }
+}

--- a/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
@@ -317,6 +317,51 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     XCTAssertEqual(await marked.value, [3])
   }
 
+  func testOwnerGuardAfterMergeRequeuesMarkOnlyRetry() async {
+    let owner = LockedBox<String?>("owner-a")
+    let extractCount = LockedBox(0)
+    let mergeCount = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let text = String(repeating: "merged then owner blip ", count: 3)
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        await extractCount.increment()
+        return """
+          {"nodes":[{"id":"n1","label":"Acme","node_type":"organization"}],"edges":[]}
+          """
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      },
+      activeOwnerIDForTesting: { await owner.value },
+      mergeGraphForTesting: { _, _, _ in
+        await mergeCount.increment()
+        await owner.set(nil)
+      },
+      ownerMatchesForTesting: { _ in true })
+
+    await extractor.queueScreenshot(
+      id: 4,
+      ocrText: text,
+      appName: "Docs",
+      windowTitle: nil,
+      expectedOwnerID: "owner-a")
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await extractCount.value, 1)
+    XCTAssertEqual(await mergeCount.value, 1)
+    XCTAssertTrue(await marked.value.isEmpty)
+    XCTAssertEqual(
+      await extractor.pendingCount, 1, "owner guard after merge must re-queue for mark retry")
+
+    await owner.set("owner-a")
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await extractCount.value, 1, "re-queue after merge must not re-extract")
+    XCTAssertEqual(await mergeCount.value, 1, "re-queue after merge must not re-merge")
+    XCTAssertEqual(await marked.value, [4])
+    XCTAssertEqual(await extractor.pendingCount, 0)
+  }
+
   func testBackfillAdvancesPastStalledFlushWindow() async {
     let fetchCalls = LockedBox(0)
     let remaining = LockedBox(

--- a/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
@@ -22,8 +22,11 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
       """
 
     let parsed = KnowledgeGraphRecordBuilder.parseExtractionJSON(json)
-    XCTAssertNotNil(parsed)
-    let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed!.nodes, edges: parsed!.edges)
+    guard let parsed else {
+      XCTFail("expected parsed extraction JSON")
+      return
+    }
+    let records = KnowledgeGraphRecordBuilder.buildRecords(nodes: parsed.nodes, edges: parsed.edges)
     XCTAssertEqual(records.nodes.count, 1)
     XCTAssertEqual(records.nodes.first?.nodeId, "acme")
     XCTAssertEqual(records.edges.first?.sourceNodeId, "jane")

--- a/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
   override func tearDown() async throws {
+    ChatToolExecutor.onKnowledgeGraphUpdated = nil
     await ScreenKnowledgeGraphExtractor.shared.reset()
     try await super.tearDown()
   }
@@ -184,8 +185,8 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
       markExtractedForTesting: { ids in
         await marked.append(contentsOf: ids)
       },
-      fetchPendingForTesting: { limit in
-        await remaining.takePrefix(limit)
+      fetchPendingForTesting: { limit, afterID in
+        await remaining.takePrefix(limit, afterID: afterID)
       })
 
     await extractor.queueScreenshot(
@@ -270,13 +271,53 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     await markShouldFail.set(false)
     await extractor.flushPendingExtractions()
     XCTAssertEqual(await marked.value, [1])
+    XCTAssertEqual(
+      await extractCount.value, 1, "mark-only retry must not re-call the extraction backend")
 
     await extractor.queueScreenshot(id: 2, ocrText: text, appName: "Docs", windowTitle: nil)
     XCTAssertEqual(await extractCount.value, 1, "hash dedup only after successful mark")
     XCTAssertEqual(await marked.value, [1, 2])
   }
 
-  func testBackfillStopsWithoutCountingWhenFlushStalls() async {
+  func testMarkFailureAfterMergeDoesNotReextract() async {
+    let markShouldFail = LockedBox(true)
+    let extractCount = LockedBox(0)
+    let mergeCount = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let text = String(repeating: "merged then mark fails ", count: 3)
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        await extractCount.increment()
+        return """
+          {"nodes":[{"id":"n1","label":"Acme","node_type":"organization"}],"edges":[]}
+          """
+      },
+      markExtractedForTesting: { ids in
+        if await markShouldFail.value {
+          throw NSError(domain: "ScreenKGTest", code: 2)
+        }
+        await marked.append(contentsOf: ids)
+      },
+      mergeGraphForTesting: { _, _, _ in
+        await mergeCount.increment()
+      },
+      ownerMatchesForTesting: { _ in true })
+
+    await extractor.queueScreenshot(id: 3, ocrText: text, appName: "Docs", windowTitle: nil)
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await extractCount.value, 1)
+    XCTAssertEqual(await mergeCount.value, 1)
+    XCTAssertEqual(await extractor.pendingCount, 1)
+
+    await markShouldFail.set(false)
+    await extractor.flushPendingExtractions()
+    XCTAssertEqual(await extractCount.value, 1, "successful merge must not re-extract on mark retry")
+    XCTAssertEqual(await mergeCount.value, 1, "successful merge must not re-merge on mark retry")
+    XCTAssertEqual(await marked.value, [3])
+  }
+
+  func testBackfillAdvancesPastStalledFlushWindow() async {
     let fetchCalls = LockedBox(0)
     let remaining = LockedBox(
       (1...80).map { id -> (id: Int64, ocrText: String, appName: String, windowTitle: String?) in
@@ -293,16 +334,17 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
         "not-json{{{broken"
       },
       markExtractedForTesting: { _ in },
-      fetchPendingForTesting: { limit in
+      fetchPendingForTesting: { limit, afterID in
         await fetchCalls.increment()
-        return await remaining.takePrefix(limit)
+        return await remaining.takePrefix(limit, afterID: afterID)
       })
 
     await extractor.scheduleBackfillIfNeeded()
 
     let calls = await fetchCalls.value
-    XCTAssertEqual(calls, 1, "stalled flush must not keep refetching the same pending rows")
-    XCTAssertEqual(await remaining.value.count, 30)
+    XCTAssertGreaterThanOrEqual(
+      calls, 2, "stalled flush must advance the DB cursor and continue backfill")
+    XCTAssertEqual(await remaining.value.count, 0, "entire pending backlog must be fetched")
   }
 
   func testResetAllowsBackfillToBeRescheduled() async {
@@ -310,7 +352,7 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     let extractor = ScreenKnowledgeGraphExtractor(
       extractEntitiesForTesting: { _ in "{\"nodes\":[],\"edges\":[]}" },
       markExtractedForTesting: { _ in },
-      fetchPendingForTesting: { _ in
+      fetchPendingForTesting: { _, _ in
         await fetchCalls.increment()
         return []
       })
@@ -383,9 +425,9 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
       markExtractedForTesting: { ids in
         await marked.append(contentsOf: ids)
       },
-      fetchPendingForTesting: { limit in
+      fetchPendingForTesting: { limit, afterID in
         await fetchCalls.increment()
-        return await remaining.takePrefix(limit)
+        return await remaining.takePrefix(limit, afterID: afterID)
       })
 
     await extractor.scheduleBackfillIfNeeded()
@@ -453,6 +495,117 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     let ids = await marked.value
     XCTAssertEqual(ids, [1, 2])
   }
+
+  func testResetDuringInFlightMergeDropsStaleWrite() async {
+    let mergeSuspended = AsyncGate()
+    let releaseMerge = AsyncGate()
+    let merges = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let allowedOwner = SyncBox("owner-a")
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        """
+        {"nodes":[{"id":"n1","label":"Secret","node_type":"concept"}],"edges":[]}
+        """
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      },
+      activeOwnerIDForTesting: { allowedOwner.value },
+      mergeGraphForTesting: { _, _, authorization in
+        await mergeSuspended.open()
+        await releaseMerge.wait()
+        try authorization.require()
+        await merges.increment()
+      },
+      ownerMatchesForTesting: { expected in
+        allowedOwner.value == expected
+      })
+
+    await extractor.queueScreenshot(
+      id: 500,
+      ocrText: String(repeating: "previous owner private text ", count: 3),
+      appName: "Notes",
+      windowTitle: nil,
+      expectedOwnerID: "owner-a")
+
+    let flush = Task { await extractor.flushPendingExtractions() }
+    await mergeSuspended.wait()
+    allowedOwner.value = "owner-b"
+    await extractor.reset()
+    await releaseMerge.open()
+    await flush.value
+
+    XCTAssertEqual(await merges.value, 0, "retarget mid-merge must revoke the commit lease")
+    XCTAssertTrue(await marked.value.isEmpty)
+    XCTAssertEqual(await extractor.pendingCount, 0, "stale item must not re-queue after reset")
+  }
+
+  func testResetDuringBackfillDropsStaleRows() async {
+    let fetchSuspended = AsyncGate()
+    let releaseFetch = AsyncGate()
+    let marked = LockedBox<[Int64]>([])
+    let queued = LockedBox(0)
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        await queued.increment()
+        return "{\"nodes\":[],\"edges\":[]}"
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      },
+      fetchPendingForTesting: { _, _ in
+        await fetchSuspended.open()
+        await releaseFetch.wait()
+        return [
+          (
+            id: Int64(77),
+            ocrText: String(repeating: "previous account ocr ", count: 3),
+            appName: "Mail",
+            windowTitle: nil as String?
+          )
+        ]
+      },
+      activeOwnerIDForTesting: { "owner-b" })
+
+    let backfill = Task { await extractor.scheduleBackfillIfNeeded() }
+    await fetchSuspended.wait()
+    await extractor.reset()
+    await releaseFetch.open()
+    await backfill.value
+
+    XCTAssertEqual(await queued.value, 0, "stale backfill rows must not extract after reset")
+    XCTAssertTrue(await marked.value.isEmpty)
+    XCTAssertEqual(await extractor.pendingCount, 0)
+  }
+
+  func testSuccessfulMergeNotifiesKnowledgeGraphUI() async {
+    let updates = SyncBox(0)
+    ChatToolExecutor.onKnowledgeGraphUpdated = {
+      updates.value += 1
+    }
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        """
+        {"nodes":[{"id":"n1","label":"Acme","node_type":"organization"}],"edges":[]}
+        """
+      },
+      markExtractedForTesting: { _ in },
+      mergeGraphForTesting: { _, _, _ in },
+      ownerMatchesForTesting: { _ in true })
+
+    await extractor.queueScreenshot(
+      id: 12,
+      ocrText: String(repeating: "ui refresh payload ", count: 3),
+      appName: "Safari",
+      windowTitle: nil)
+    await extractor.flushPendingExtractions()
+
+    XCTAssertEqual(updates.value, 1, "screen OCR merge must refresh an open knowledge-graph view")
+  }
 }
 
 private enum RewindIndexerSourcePath {
@@ -491,9 +644,52 @@ private actor LockedBox<T> {
     value += 1
   }
 
-  func takePrefix(_ limit: Int) -> T where T == [(id: Int64, ocrText: String, appName: String, windowTitle: String?)] {
+  func takePrefix(_ limit: Int, afterID: Int64) -> T
+  where T == [(id: Int64, ocrText: String, appName: String, windowTitle: String?)] {
+    value = value.filter { $0.id > afterID }
     let batch = Array(value.prefix(limit))
     value.removeFirst(batch.count)
     return batch
+  }
+}
+
+/// One-shot async gate: `wait()` suspends until the first `open()`.
+private actor AsyncGate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func open() {
+    guard !isOpen else { return }
+    isOpen = true
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending { waiter.resume() }
+  }
+
+  func wait() async {
+    if isOpen { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+}
+
+private final class SyncBox<T>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var _value: T
+
+  init(_ value: T) {
+    _value = value
+  }
+
+  var value: T {
+    get {
+      lock.lock()
+      defer { lock.unlock() }
+      return _value
+    }
+    set {
+      lock.lock()
+      defer { lock.unlock() }
+      _value = newValue
+    }
   }
 }

--- a/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenKnowledgeGraphExtractorTests.swift
@@ -43,6 +43,24 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     XCTAssertEqual(a, b)
   }
 
+  func testContentHashUsesFullOCRTextBeyondTruncation() {
+    let prefix = String(repeating: "A", count: 6_000)
+    let left = prefix + "unique-tail-alpha"
+    let right = prefix + "unique-tail-beta"
+    let leftHash = ScreenKnowledgeGraphExtractor.contentHash(
+      ocrText: left, appName: "Pages", windowTitle: "Doc")
+    let rightHash = ScreenKnowledgeGraphExtractor.contentHash(
+      ocrText: right, appName: "Pages", windowTitle: "Doc")
+    XCTAssertNotEqual(leftHash, rightHash)
+
+    // Truncated model inputs share a prefix, but dedup must not collapse them.
+    let leftInput = ScreenKnowledgeGraphExtractor.makeInput(
+      ocrText: left, appName: "Pages", windowTitle: "Doc")
+    let rightInput = ScreenKnowledgeGraphExtractor.makeInput(
+      ocrText: right, appName: "Pages", windowTitle: "Doc")
+    XCTAssertEqual(leftInput.ocrText, rightInput.ocrText)
+  }
+
   func testQueueSkipsShortOCR() async {
     await ScreenKnowledgeGraphExtractor.shared.reset()
     await ScreenKnowledgeGraphExtractor.shared.queueScreenshot(
@@ -113,6 +131,151 @@ final class ScreenKnowledgeGraphExtractorTests: XCTestCase {
     let ids = await marked.value
     XCTAssertEqual(ids, [1, 2])
   }
+
+  func testExpectedProductStateDoesNotMarkExtracted() async {
+    let marked = LockedBox<[Int64]>([])
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        throw GeminiClient.GeminiClientError.apiError("trial_expired")
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      })
+
+    await extractor.queueScreenshot(
+      id: 7,
+      ocrText: String(repeating: "gated entity payload ", count: 3),
+      appName: "Notes",
+      windowTitle: nil)
+    await extractor.flushPendingExtractions()
+
+    let ids = await marked.value
+    XCTAssertTrue(ids.isEmpty)
+    let pending = await extractor.pendingCount
+    XCTAssertEqual(pending, 0)
+  }
+
+  func testInvalidExtractionJSONDoesNotMarkExtracted() async {
+    let marked = LockedBox<[Int64]>([])
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        "not-json{{{broken"
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      })
+
+    await extractor.queueScreenshot(
+      id: 11,
+      ocrText: String(repeating: "parse failure payload ", count: 3),
+      appName: "Safari",
+      windowTitle: "Tab")
+    await extractor.flushPendingExtractions()
+
+    let ids = await marked.value
+    XCTAssertTrue(ids.isEmpty)
+    let pending = await extractor.pendingCount
+    XCTAssertEqual(pending, 1)
+  }
+
+  func testBackfillProcessesMultipleBatches() async {
+    let marked = LockedBox<[Int64]>([])
+    let fetchCalls = LockedBox(0)
+    let remaining = LockedBox(
+      (1...120).map { id -> (id: Int64, ocrText: String, appName: String, windowTitle: String?) in
+        (
+          id: Int64(id),
+          ocrText: String(repeating: "backfill entity \(id) ", count: 3),
+          appName: "App",
+          windowTitle: nil
+        )
+      })
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        "{\"nodes\":[],\"edges\":[]}"
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      },
+      fetchPendingForTesting: { limit in
+        await fetchCalls.increment()
+        return await remaining.takePrefix(limit)
+      })
+
+    await extractor.scheduleBackfillIfNeeded()
+
+    let calls = await fetchCalls.value
+    XCTAssertGreaterThanOrEqual(calls, 3)
+    let ids = await marked.value
+    XCTAssertEqual(ids.count, 120)
+  }
+
+  func testBatteryOCRBackfillQueuesScreenKGExtraction() throws {
+    // omi-test-quality: source-inspection -- static contract: battery OCR backfill must
+    // queue ScreenKnowledgeGraphExtractor after updateOCRResult; RewindIndexer has no
+    // injectable seam for hermetic OCR/storage, so behavioral coverage of that path
+    // cannot run in the Linux/macOS unit host without a full Rewind stack.
+    let source = try XCTUnwrap(
+      String(
+        contentsOfFile: RewindIndexerSourcePath.rewindIndexerSwift,
+        encoding: .utf8))
+    XCTAssertTrue(source.contains("func backfillUnindexedScreenshots"))
+    XCTAssertTrue(source.contains("updateOCRResult(id: id, ocrResult: ocrResult)"))
+    XCTAssertTrue(
+      source.contains("ScreenKnowledgeGraphExtractor.shared.queueScreenshot"),
+      "battery OCR backfill must queue KG extraction for newly indexed screenshots")
+
+    if let updateRange = source.range(of: "updateOCRResult(id: id, ocrResult: ocrResult)"),
+      let backfillRange = source.range(of: "func backfillUnindexedScreenshots")
+    {
+      let afterUpdate = source[updateRange.upperBound...]
+      let queueRange = afterUpdate.range(
+        of: "ScreenKnowledgeGraphExtractor.shared.queueScreenshot")
+      XCTAssertNotNil(queueRange, "queueScreenshot must follow updateOCRResult in OCR backfill")
+      XCTAssertTrue(backfillRange.lowerBound < updateRange.lowerBound)
+    } else {
+      XCTFail("expected updateOCRResult inside backfillUnindexedScreenshots")
+    }
+  }
+
+  func testDistinctLongCapturesAreNotCollapsedByTruncation() async {
+    let extractCount = LockedBox(0)
+    let marked = LockedBox<[Int64]>([])
+    let prefix = String(repeating: "shared-prefix-content ", count: 300)  // > 6000 chars
+    let first = prefix + " FIRST-TAIL-ENTITY-ALPHA"
+    let second = prefix + " SECOND-TAIL-ENTITY-BETA"
+
+    let extractor = ScreenKnowledgeGraphExtractor(
+      extractEntitiesForTesting: { _ in
+        await extractCount.increment()
+        return "{\"nodes\":[],\"edges\":[]}"
+      },
+      markExtractedForTesting: { ids in
+        await marked.append(contentsOf: ids)
+      })
+
+    await extractor.queueScreenshot(id: 1, ocrText: first, appName: "Docs", windowTitle: "Long")
+    await extractor.flushPendingExtractions()
+    await extractor.queueScreenshot(id: 2, ocrText: second, appName: "Docs", windowTitle: "Long")
+    await extractor.flushPendingExtractions()
+
+    let count = await extractCount.value
+    XCTAssertEqual(count, 2)
+    let ids = await marked.value
+    XCTAssertEqual(ids, [1, 2])
+  }
+}
+
+private enum RewindIndexerSourcePath {
+  static var rewindIndexerSwift: String {
+    let thisFile = URL(fileURLWithPath: #filePath)
+    return thisFile
+      .deletingLastPathComponent()  // Tests/
+      .deletingLastPathComponent()  // Desktop/
+      .appendingPathComponent("Sources/Rewind/Services/RewindIndexer.swift")
+      .path
+  }
 }
 
 private actor LockedBox<T> {
@@ -128,5 +291,11 @@ private actor LockedBox<T> {
 
   func increment() where T == Int {
     value += 1
+  }
+
+  func takePrefix(_ limit: Int) -> T where T == [(id: Int64, ocrText: String, appName: String, windowTitle: String?)] {
+    let batch = Array(value.prefix(limit))
+    value.removeFirst(batch.count)
+    return batch
   }
 }

--- a/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
+++ b/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
@@ -1,0 +1,3 @@
+{
+  "change": "Agent sync now transmits knowledge graph data only; screenshots, OCR text, and screen embeddings no longer leave this Mac"
+}

--- a/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
+++ b/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
@@ -1,3 +1,0 @@
-{
-  "change": "Agent sync now transmits knowledge graph data only; screenshots, OCR text, and screen embeddings no longer leave this Mac"
-}

--- a/desktop/macos/changelog/unreleased/20260801-screen-to-kg-extractor.json
+++ b/desktop/macos/changelog/unreleased/20260801-screen-to-kg-extractor.json
@@ -1,0 +1,3 @@
+{
+  "change": "Screen activity is distilled into a local knowledge graph from OCR text without uploading images"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -46,6 +46,11 @@ covers:
   - desktop/macos/Desktop/Sources/Services/QueryTracer.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
   - desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+  - desktop/macos/Desktop/Sources/Rewind/Services/ScreenKnowledgeGraphExtractor.swift
+  - desktop/macos/Desktop/Sources/Rewind/Services/ScreenKGExtractionBackend.swift
+  - desktop/macos/Desktop/Sources/Rewind/Services/OnDeviceScreenKGExtractionBackend.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/KnowledgeGraphRecordBuilder.swift
+  - desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
   - desktop/macos/Desktop/Sources/MeetingDetector.swift
   - desktop/macos/Desktop/Sources/Rewind/Services/PowerMonitor.swift
   - desktop/macos/Desktop/Sources/Bluetooth/BtDevice.swift


### PR DESCRIPTION
## Product invariants affected
- INV-AUTH-1
- INV-CHAT-1

## Summary
- `ScreenKnowledgeGraphExtractor` turns screenshot OCR text into `local_kg_nodes/edges` via on-device Foundation Models or Gemini proxy fallback (text only, never images).

## Test plan
- [ ] `swift test --filter ScreenKnowledgeGraphExtractorTests` in CI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

