### PR TITLE
feat(backend): merge agent-VM synced local KG into Firestore

### DIFF
--- a/backend/agent_vm/main.py
+++ b/backend/agent_vm/main.py
@@ -334,8 +334,15 @@ async def promote_local_kg_to_backend(table: str, rows: list[dict[str, Any]]) ->
             response.raise_for_status()
             body = response.json()
             return body if isinstance(body, dict) else None
-    except httpx.HTTPError:
-        return None
+    except httpx.HTTPStatusError as exc:
+        if exc.response is not None and exc.response.status_code == 409:
+            return None
+        raise HTTPException(
+            status_code=502,
+            detail=f"Knowledge graph promotion failed: HTTP {exc.response.status_code}",
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail=f"Knowledge graph promotion failed: {exc}") from exc
 
 
 async def execute_backend_tool(name: str, params: dict[str, Any]) -> str:

--- a/backend/agent_vm/main.py
+++ b/backend/agent_vm/main.py
@@ -320,8 +320,13 @@ LOCAL_KG_SYNC_TABLES = frozenset({"local_kg_nodes", "local_kg_edges"})
 
 
 async def promote_local_kg_to_backend(table: str, rows: list[dict[str, Any]]) -> dict[str, Any] | None:
-    if table not in LOCAL_KG_SYNC_TABLES or not runtime.firebase_token:
+    if table not in LOCAL_KG_SYNC_TABLES:
         return None
+    if not runtime.firebase_token:
+        raise HTTPException(
+            status_code=503,
+            detail="Knowledge graph promotion unavailable: Firebase token not set",
+        )
     headers = {"Authorization": f"Bearer {runtime.firebase_token}"}
     payload = {"table": table, "rows": rows}
     try:

--- a/backend/agent_vm/main.py
+++ b/backend/agent_vm/main.py
@@ -316,6 +316,28 @@ async def fetch_backend_tools() -> list[dict[str, Any]]:
     return data if isinstance(data, list) else data.get("tools", [])
 
 
+LOCAL_KG_SYNC_TABLES = frozenset({"local_kg_nodes", "local_kg_edges"})
+
+
+async def promote_local_kg_to_backend(table: str, rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if table not in LOCAL_KG_SYNC_TABLES or not runtime.firebase_token:
+        return None
+    headers = {"Authorization": f"Bearer {runtime.firebase_token}"}
+    payload = {"table": table, "rows": rows}
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                f"{runtime.backend_url}/v1/knowledge-graph/sync",
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
+            body = response.json()
+            return body if isinstance(body, dict) else None
+    except httpx.HTTPError:
+        return None
+
+
 async def execute_backend_tool(name: str, params: dict[str, Any]) -> str:
     if not runtime.firebase_token:
         return "Error: Firebase token is not set"
@@ -725,8 +747,12 @@ async def sync(request: Request) -> dict[str, Any]:
         applied = run_sync(table, rows)
     except (ValueError, sqlite3.Error) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    promotion = await promote_local_kg_to_backend(table, rows)
     runtime.last_activity_at = time.monotonic()
-    return {"applied": applied, "table": table}
+    response: dict[str, Any] = {"applied": applied, "table": table}
+    if promotion is not None:
+        response["promotion"] = promotion
+    return response
 
 
 @app.websocket("/ws")

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -877,10 +877,13 @@ def enforce_knowledge_graph_caps(uid: str, *, db_client: Any = None) -> Dict[str
     return {"nodes_evicted": nodes_evicted, "edges_evicted": edges_evicted}
 
 
-def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Dict[str, Any]], *, db_client: Any = None) -> Dict[str, Any]:
+def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Any], *, db_client: Any = None) -> Dict[str, Any]:
     merged = 0
     skipped = 0
     for row in rows:
+        if not isinstance(row, dict):
+            skipped += 1
+            continue
         node_data = _local_kg_node_to_firestore(row)
         if node_data is None:
             skipped += 1
@@ -891,10 +894,13 @@ def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Dict[str, Any]], *, db_
     return {"table": "local_kg_nodes", "merged": merged, "skipped": skipped, **eviction}
 
 
-def merge_synced_local_kg_edges(uid: str, rows: Iterable[Dict[str, Any]], *, db_client: Any = None) -> Dict[str, Any]:
+def merge_synced_local_kg_edges(uid: str, rows: Iterable[Any], *, db_client: Any = None) -> Dict[str, Any]:
     merged = 0
     skipped = 0
     for row in rows:
+        if not isinstance(row, dict):
+            skipped += 1
+            continue
         edge_data = _local_kg_edge_to_firestore(row)
         if edge_data is None:
             skipped += 1

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -178,10 +178,17 @@ def get_knowledge_node(uid: str, node_id: str, *, db_client: Any = None) -> Opti
     return _typed_doc(doc)
 
 
-def upsert_knowledge_node(uid: str, node_data: Dict[str, Any], *, db_client: Any = None) -> Dict[str, Any]:
+def upsert_knowledge_node(
+    uid: str,
+    node_data: Dict[str, Any],
+    *,
+    db_client: Any = None,
+    resolve_absent_id_by_label: bool = True,
+) -> Dict[str, Any]:
     client = _firestore_client(db_client)
     user_ref = client.collection(users_collection).document(uid)
     nodes_ref = user_ref.collection(knowledge_nodes_collection)
+    now = datetime.now(timezone.utc)
 
     node_id = node_data.get('id')
     if not node_id:
@@ -196,7 +203,7 @@ def upsert_knowledge_node(uid: str, node_data: Dict[str, Any], *, db_client: Any
     node_ref = nodes_ref.document(node_id)
     existing = node_ref.get()
 
-    if not existing.exists:
+    if not existing.exists and resolve_absent_id_by_label:
         existing_node_by_label = find_node_by_label_or_alias(uid, node_data.get('label', ''), db_client=client)
         if existing_node_by_label:
             node_id = existing_node_by_label['id']
@@ -216,13 +223,13 @@ def upsert_knowledge_node(uid: str, node_data: Dict[str, Any], *, db_client: Any
 
         node_data['memory_ids'] = merged_memory_ids
         node_data['aliases'] = merged_aliases
-        node_data['updated_at'] = datetime.now(timezone.utc)
-        node_data['created_at'] = existing_data.get('created_at', datetime.now(timezone.utc))
+        node_data['updated_at'] = node_data.get('updated_at') or now
+        node_data['created_at'] = existing_data.get('created_at', node_data.get('created_at') or now)
         node_data['label_lower'] = node_data.get('label', '').lower()
         node_data['aliases_lower'] = [a.lower() for a in node_data.get('aliases', [])]
     else:
-        node_data['created_at'] = datetime.now(timezone.utc)
-        node_data['updated_at'] = datetime.now(timezone.utc)
+        node_data['created_at'] = node_data.get('created_at') or now
+        node_data['updated_at'] = node_data.get('updated_at') or now
         node_data['label_lower'] = node_data.get('label', '').lower()
         node_data['aliases_lower'] = [a.lower() for a in node_data.get('aliases', [])]
 
@@ -271,6 +278,7 @@ def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any], *, db_client: Any
     client = _firestore_client(db_client)
     user_ref = client.collection(users_collection).document(uid)
     edges_ref = user_ref.collection(knowledge_edges_collection)
+    now = datetime.now(timezone.utc)
 
     edge_id = edge_data.get('id')
     if not edge_id:
@@ -288,9 +296,9 @@ def upsert_knowledge_edge(uid: str, edge_data: Dict[str, Any], *, db_client: Any
         merged_memory_ids = list(existing_memory_ids | new_memory_ids)
 
         edge_data['memory_ids'] = merged_memory_ids
-        edge_data['created_at'] = existing_data.get('created_at', datetime.now(timezone.utc))
+        edge_data['created_at'] = existing_data.get('created_at', edge_data.get('created_at') or now)
     else:
-        edge_data['created_at'] = datetime.now(timezone.utc)
+        edge_data['created_at'] = edge_data.get('created_at') or now
 
     edge_ref.set(edge_data)
     return edge_data
@@ -888,7 +896,7 @@ def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Any], *, db_client: Any
         if node_data is None:
             skipped += 1
             continue
-        upsert_knowledge_node(uid, node_data, db_client=db_client)
+        upsert_knowledge_node(uid, node_data, db_client=db_client, resolve_absent_id_by_label=False)
         merged += 1
     eviction = enforce_knowledge_graph_caps(uid, db_client=db_client)
     return {"table": "local_kg_nodes", "merged": merged, "skipped": skipped, **eviction}

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -779,19 +779,6 @@ def _parse_aliases_json(value: Any) -> List[str]:
     return []
 
 
-def _node_sort_timestamp(node: Dict[str, Any]) -> datetime:
-    for field in ("updated_at", "created_at"):
-        parsed = _parse_sync_timestamp(node.get(field))
-        if parsed is not None:
-            return parsed
-    return datetime.min.replace(tzinfo=timezone.utc)
-
-
-def _edge_sort_timestamp(edge: Dict[str, Any]) -> datetime:
-    parsed = _parse_sync_timestamp(edge.get("created_at"))
-    return parsed if parsed is not None else datetime.min.replace(tzinfo=timezone.utc)
-
-
 def _local_kg_node_to_firestore(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     node_id = row.get("nodeId") or row.get("node_id")
     label = row.get("label")
@@ -844,11 +831,26 @@ def _local_kg_edge_to_firestore(row: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return edge_data
 
 
-def enforce_knowledge_graph_caps(uid: str, *, db_client: Any = None) -> Dict[str, int]:
-    """Evict oldest nodes/edges when Firestore collections exceed public GET caps.
+def _knowledge_graph_endpoint_ids_exist(
+    uid: str,
+    source_id: str,
+    target_id: str,
+    *,
+    db_client: Any = None,
+) -> bool:
+    client = _firestore_client(db_client)
+    nodes_ref = client.collection(users_collection).document(uid).collection(knowledge_nodes_collection)
+    if source_id == target_id:
+        return bool(nodes_ref.document(source_id).get().exists)
+    snapshots = client.get_all([nodes_ref.document(source_id), nodes_ref.document(target_id)])
+    return all(bool(snapshot.exists) for snapshot in snapshots)
 
-    Eviction uses document timestamps only (updated_at for nodes, created_at for edges).
-    Local synced graph rows carry no confidence score, so oldest-first is the stable rule.
+
+def enforce_knowledge_graph_caps(uid: str, *, db_client: Any = None) -> Dict[str, int]:
+    """Evict excess nodes/edges beyond the public GET caps.
+
+    Keep the same document-id prefix GET returns (order_by('__name__').limit(cap)),
+    then drop dangling edges whose endpoints are no longer present.
     """
     client = _firestore_client(db_client)
     user_ref = client.collection(users_collection).document(uid)
@@ -859,8 +861,8 @@ def enforce_knowledge_graph_caps(uid: str, *, db_client: Any = None) -> Dict[str
 
     node_docs = list(nodes_ref.stream())
     if len(node_docs) > MAX_KNOWLEDGE_GRAPH_NODES:
-        sorted_nodes = sorted(node_docs, key=lambda doc: _node_sort_timestamp(_typed_doc(doc)))
-        for doc in sorted_nodes[: len(node_docs) - MAX_KNOWLEDGE_GRAPH_NODES]:
+        sorted_nodes = sorted(node_docs, key=lambda doc: cast(str, doc.id))
+        for doc in sorted_nodes[MAX_KNOWLEDGE_GRAPH_NODES:]:
             doc.reference.delete()
             nodes_evicted += 1
 
@@ -877,8 +879,8 @@ def enforce_knowledge_graph_caps(uid: str, *, db_client: Any = None) -> Dict[str
 
     edge_docs = list(edges_ref.stream())
     if len(edge_docs) > MAX_KNOWLEDGE_GRAPH_EDGES:
-        sorted_edges = sorted(edge_docs, key=lambda doc: _edge_sort_timestamp(_typed_doc(doc)))
-        for doc in sorted_edges[: len(edge_docs) - MAX_KNOWLEDGE_GRAPH_EDGES]:
+        sorted_edges = sorted(edge_docs, key=lambda doc: cast(str, doc.id))
+        for doc in sorted_edges[MAX_KNOWLEDGE_GRAPH_EDGES:]:
             doc.reference.delete()
             edges_evicted += 1
 
@@ -911,6 +913,11 @@ def merge_synced_local_kg_edges(uid: str, rows: Iterable[Any], *, db_client: Any
             continue
         edge_data = _local_kg_edge_to_firestore(row)
         if edge_data is None:
+            skipped += 1
+            continue
+        source_id = cast(str, edge_data["source_id"])
+        target_id = cast(str, edge_data["target_id"])
+        if not _knowledge_graph_endpoint_ids_exist(uid, source_id, target_id, db_client=db_client):
             skipped += 1
             continue
         upsert_knowledge_edge(uid, edge_data, db_client=db_client)

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict, cast
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, TypedDict, cast
+import json
 import uuid
 
 from google.cloud.firestore_v1 import FieldFilter
@@ -742,6 +743,175 @@ def get_knowledge_graph(uid: str, *, db_client: Any = None) -> Dict[str, Any]:
         'node_limit': MAX_KNOWLEDGE_GRAPH_NODES,
         'edge_limit': MAX_KNOWLEDGE_GRAPH_EDGES,
     }
+
+
+def _parse_sync_timestamp(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value.strip():
+        normalized = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def _parse_aliases_json(value: Any) -> List[str]:
+    if isinstance(value, list):
+        return sorted({item.strip() for item in cast(List[Any], value) if isinstance(item, str) and item.strip()})
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return sorted({item.strip() for item in parsed if isinstance(item, str) and item.strip()})
+    return []
+
+
+def _node_sort_timestamp(node: Dict[str, Any]) -> datetime:
+    for field in ("updated_at", "created_at"):
+        parsed = _parse_sync_timestamp(node.get(field))
+        if parsed is not None:
+            return parsed
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _edge_sort_timestamp(edge: Dict[str, Any]) -> datetime:
+    parsed = _parse_sync_timestamp(edge.get("created_at"))
+    return parsed if parsed is not None else datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _local_kg_node_to_firestore(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    node_id = row.get("nodeId") or row.get("node_id")
+    label = row.get("label")
+    if not isinstance(node_id, str) or not node_id.strip() or not isinstance(label, str) or not label.strip():
+        return None
+    node_type = row.get("nodeType") or row.get("node_type") or "concept"
+    aliases = _parse_aliases_json(row.get("aliasesJson") if "aliasesJson" in row else row.get("aliases_json"))
+    node_data: Dict[str, Any] = {
+        "id": node_id.strip(),
+        "label": label.strip(),
+        "node_type": node_type if isinstance(node_type, str) and node_type.strip() else "concept",
+        "aliases": aliases,
+        "memory_ids": [],
+    }
+    created_at = _parse_sync_timestamp(row.get("createdAt") if "createdAt" in row else row.get("created_at"))
+    updated_at = _parse_sync_timestamp(row.get("updatedAt") if "updatedAt" in row else row.get("updated_at"))
+    if created_at is not None:
+        node_data["created_at"] = created_at
+    if updated_at is not None:
+        node_data["updated_at"] = updated_at
+    return node_data
+
+
+def _local_kg_edge_to_firestore(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    edge_id = row.get("edgeId") or row.get("edge_id")
+    source_id = row.get("sourceNodeId") or row.get("source_node_id")
+    target_id = row.get("targetNodeId") or row.get("target_node_id")
+    label = row.get("label")
+    if not all(isinstance(value, str) and value.strip() for value in (edge_id, source_id, target_id, label)):
+        return None
+    edge_data: Dict[str, Any] = {
+        "id": edge_id.strip(),
+        "source_id": source_id.strip(),
+        "target_id": target_id.strip(),
+        "label": label.strip(),
+        "memory_ids": [],
+    }
+    created_at = _parse_sync_timestamp(row.get("createdAt") if "createdAt" in row else row.get("created_at"))
+    if created_at is not None:
+        edge_data["created_at"] = created_at
+    return edge_data
+
+
+def enforce_knowledge_graph_caps(uid: str, *, db_client: Any = None) -> Dict[str, int]:
+    """Evict oldest nodes/edges when Firestore collections exceed public GET caps.
+
+    Eviction uses document timestamps only (updated_at for nodes, created_at for edges).
+    Local synced graph rows carry no confidence score, so oldest-first is the stable rule.
+    """
+    client = _firestore_client(db_client)
+    user_ref = client.collection(users_collection).document(uid)
+    nodes_ref = user_ref.collection(knowledge_nodes_collection)
+    edges_ref = user_ref.collection(knowledge_edges_collection)
+    nodes_evicted = 0
+    edges_evicted = 0
+
+    node_docs = list(nodes_ref.stream())
+    if len(node_docs) > MAX_KNOWLEDGE_GRAPH_NODES:
+        sorted_nodes = sorted(node_docs, key=lambda doc: _node_sort_timestamp(_typed_doc(doc)))
+        for doc in sorted_nodes[: len(node_docs) - MAX_KNOWLEDGE_GRAPH_NODES]:
+            doc.reference.delete()
+            nodes_evicted += 1
+
+    surviving_node_ids = {cast(str, doc.id) for doc in nodes_ref.stream()}
+
+    edge_docs = list(edges_ref.stream())
+    for doc in edge_docs:
+        edge = _typed_doc(doc)
+        source_id = edge.get("source_id")
+        target_id = edge.get("target_id")
+        if source_id not in surviving_node_ids or target_id not in surviving_node_ids:
+            doc.reference.delete()
+            edges_evicted += 1
+
+    edge_docs = list(edges_ref.stream())
+    if len(edge_docs) > MAX_KNOWLEDGE_GRAPH_EDGES:
+        sorted_edges = sorted(edge_docs, key=lambda doc: _edge_sort_timestamp(_typed_doc(doc)))
+        for doc in sorted_edges[: len(edge_docs) - MAX_KNOWLEDGE_GRAPH_EDGES]:
+            doc.reference.delete()
+            edges_evicted += 1
+
+    return {"nodes_evicted": nodes_evicted, "edges_evicted": edges_evicted}
+
+
+def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Dict[str, Any]], *, db_client: Any = None) -> Dict[str, Any]:
+    merged = 0
+    skipped = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            skipped += 1
+            continue
+        node_data = _local_kg_node_to_firestore(row)
+        if node_data is None:
+            skipped += 1
+            continue
+        upsert_knowledge_node(uid, node_data, db_client=db_client)
+        merged += 1
+    eviction = enforce_knowledge_graph_caps(uid, db_client=db_client)
+    return {"table": "local_kg_nodes", "merged": merged, "skipped": skipped, **eviction}
+
+
+def merge_synced_local_kg_edges(uid: str, rows: Iterable[Dict[str, Any]], *, db_client: Any = None) -> Dict[str, Any]:
+    merged = 0
+    skipped = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            skipped += 1
+            continue
+        edge_data = _local_kg_edge_to_firestore(row)
+        if edge_data is None:
+            skipped += 1
+            continue
+        upsert_knowledge_edge(uid, edge_data, db_client=db_client)
+        merged += 1
+    eviction = enforce_knowledge_graph_caps(uid, db_client=db_client)
+    return {"table": "local_kg_edges", "merged": merged, "skipped": skipped, **eviction}
+
+
+def merge_synced_local_kg(
+    uid: str,
+    table: Literal["local_kg_nodes", "local_kg_edges"],
+    rows: Iterable[Dict[str, Any]],
+    *,
+    db_client: Any = None,
+) -> Dict[str, Any]:
+    if table == "local_kg_nodes":
+        return merge_synced_local_kg_nodes(uid, rows, db_client=db_client)
+    return merge_synced_local_kg_edges(uid, rows, db_client=db_client)
 
 
 def delete_knowledge_graph(uid: str, *, db_client: Any = None) -> None:

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -32,6 +32,14 @@ def _firestore_client(db_client: Any = None) -> Any:
     return db_client if db_client is not None else db
 
 
+def _as_utc(value: datetime) -> datetime:
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+class MissingKnowledgeGraphEndpointsError(ValueError):
+    """Raised when synced edges reference node ids that are not in Firestore yet."""
+
+
 def delete_memory_graph_assertion(uid: str, memory_id: str, *, db_client: Any = None) -> None:
     """Delete one derived assertion after its authoritative memory is fenced."""
     if not uid.strip() or not memory_id.strip():
@@ -223,7 +231,19 @@ def upsert_knowledge_node(
 
         node_data['memory_ids'] = merged_memory_ids
         node_data['aliases'] = merged_aliases
-        node_data['updated_at'] = node_data.get('updated_at') or now
+        incoming_updated = node_data.get('updated_at')
+        existing_updated = existing_data.get('updated_at')
+        if incoming_updated is not None:
+            if (
+                isinstance(incoming_updated, datetime)
+                and isinstance(existing_updated, datetime)
+                and _as_utc(existing_updated) > _as_utc(incoming_updated)
+            ):
+                node_data['updated_at'] = existing_updated
+            else:
+                node_data['updated_at'] = incoming_updated
+        else:
+            node_data['updated_at'] = now
         node_data['created_at'] = existing_data.get('created_at', node_data.get('created_at') or now)
         node_data['label_lower'] = node_data.get('label', '').lower()
         node_data['aliases_lower'] = [a.lower() for a in node_data.get('aliases', [])]
@@ -907,6 +927,7 @@ def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Any], *, db_client: Any
 def merge_synced_local_kg_edges(uid: str, rows: Iterable[Any], *, db_client: Any = None) -> Dict[str, Any]:
     merged = 0
     skipped = 0
+    missing_endpoints = 0
     for row in rows:
         if not isinstance(row, dict):
             skipped += 1
@@ -918,10 +939,14 @@ def merge_synced_local_kg_edges(uid: str, rows: Iterable[Any], *, db_client: Any
         source_id = cast(str, edge_data["source_id"])
         target_id = cast(str, edge_data["target_id"])
         if not _knowledge_graph_endpoint_ids_exist(uid, source_id, target_id, db_client=db_client):
-            skipped += 1
+            missing_endpoints += 1
             continue
         upsert_knowledge_edge(uid, edge_data, db_client=db_client)
         merged += 1
+    if missing_endpoints:
+        raise MissingKnowledgeGraphEndpointsError(
+            f"{missing_endpoints} local_kg edge(s) reference missing endpoint nodes"
+        )
     eviction = enforce_knowledge_graph_caps(uid, db_client=db_client)
     return {"table": "local_kg_edges", "merged": merged, "skipped": skipped, **eviction}
 

--- a/backend/database/knowledge_graph.py
+++ b/backend/database/knowledge_graph.py
@@ -812,7 +812,16 @@ def _local_kg_edge_to_firestore(row: Dict[str, Any]) -> Optional[Dict[str, Any]]
     source_id = row.get("sourceNodeId") or row.get("source_node_id")
     target_id = row.get("targetNodeId") or row.get("target_node_id")
     label = row.get("label")
-    if not all(isinstance(value, str) and value.strip() for value in (edge_id, source_id, target_id, label)):
+    if (
+        not isinstance(edge_id, str)
+        or not edge_id.strip()
+        or not isinstance(source_id, str)
+        or not source_id.strip()
+        or not isinstance(target_id, str)
+        or not target_id.strip()
+        or not isinstance(label, str)
+        or not label.strip()
+    ):
         return None
     edge_data: Dict[str, Any] = {
         "id": edge_id.strip(),
@@ -872,9 +881,6 @@ def merge_synced_local_kg_nodes(uid: str, rows: Iterable[Dict[str, Any]], *, db_
     merged = 0
     skipped = 0
     for row in rows:
-        if not isinstance(row, dict):
-            skipped += 1
-            continue
         node_data = _local_kg_node_to_firestore(row)
         if node_data is None:
             skipped += 1
@@ -889,9 +895,6 @@ def merge_synced_local_kg_edges(uid: str, rows: Iterable[Dict[str, Any]], *, db_
     merged = 0
     skipped = 0
     for row in rows:
-        if not isinstance(row, dict):
-            skipped += 1
-            continue
         edge_data = _local_kg_edge_to_firestore(row)
         if edge_data is None:
             skipped += 1

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -71,6 +71,10 @@ routes:
     policy: *desktop_migration_policy
   - route_type: http
     method: POST
+    path: /v1/knowledge-graph/sync
+    policy: *desktop_migration_policy
+  - route_type: http
+    method: POST
     path: /v1/screen-activity/sync
     policy: *desktop_migration_policy
   - route_type: http

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -154,5 +154,6 @@ def sync_local_knowledge_graph(
     uid: str = Depends(auth.get_current_user_uid),
 ):
     """Merge agent-VM synced local_kg_* rows into the user's Firestore graph projection."""
+    _require_legacy_graph_mutation(uid)
     result = kg_db.merge_synced_local_kg(uid, payload.table, payload.rows, db_client=firestore_db)
     return LocalKgSyncResponse(**result)

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -155,5 +155,8 @@ def sync_local_knowledge_graph(
 ):
     """Merge agent-VM synced local_kg_* rows into the user's Firestore graph projection."""
     _require_legacy_graph_mutation(uid)
-    result = kg_db.merge_synced_local_kg(uid, payload.table, payload.rows, db_client=firestore_db)
+    try:
+        result = kg_db.merge_synced_local_kg(uid, payload.table, payload.rows, db_client=firestore_db)
+    except kg_db.MissingKnowledgeGraphEndpointsError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
     return LocalKgSyncResponse(**result)

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -2,8 +2,8 @@ import importlib
 import sys
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
-from pydantic import BaseModel
-from typing import List, Dict, Any, Callable, cast
+from pydantic import BaseModel, Field
+from typing import List, Dict, Any, Callable, Literal, cast
 
 from database import knowledge_graph as kg_db
 from database import memories as memories_db
@@ -87,6 +87,19 @@ class DeleteKnowledgeGraphResponse(BaseModel):
     status: str
 
 
+class LocalKgSyncRequest(BaseModel):
+    table: Literal["local_kg_nodes", "local_kg_edges"]
+    rows: List[Dict[str, Any]] = Field(min_length=1)
+
+
+class LocalKgSyncResponse(BaseModel):
+    table: str
+    merged: int
+    skipped: int
+    nodes_evicted: int
+    edges_evicted: int
+
+
 @router.get('/v1/knowledge-graph', tags=['knowledge_graph'], response_model=KnowledgeGraphResponse)
 def get_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
     graph = get_knowledge_graph_payload(uid)
@@ -133,3 +146,13 @@ def delete_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
     _require_legacy_graph_mutation(uid)
     kg_db.delete_knowledge_graph(uid)
     return {"status": "deleted"}
+
+
+@router.post('/v1/knowledge-graph/sync', tags=['knowledge_graph'], response_model=LocalKgSyncResponse)
+def sync_local_knowledge_graph(
+    payload: LocalKgSyncRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Merge agent-VM synced local_kg_* rows into the user's Firestore graph projection."""
+    result = kg_db.merge_synced_local_kg(uid, payload.table, payload.rows, db_client=firestore_db)
+    return LocalKgSyncResponse(**result)

--- a/backend/tests/unit/test_agent_vm_kg_promotion.py
+++ b/backend/tests/unit/test_agent_vm_kg_promotion.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import json
 import sqlite3
 import sys
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -125,7 +125,7 @@ def test_promote_local_kg_skips_without_firebase_token(tmp_path) -> None:
     assert result is None
 
 
-def test_promote_local_kg_returns_none_on_backend_error(tmp_path, monkeypatch) -> None:
+def test_promote_local_kg_raises_on_backend_error(tmp_path, monkeypatch) -> None:
     _, module = load_app(tmp_path)
     module.runtime.firebase_token = "firebase-token"
 
@@ -138,6 +138,85 @@ def test_promote_local_kg_returns_none_on_backend_error(tmp_path, monkeypatch) -
 
         async def post(self, *_args, **_kwargs):
             raise module.httpx.HTTPError("backend unavailable")
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_: Client())
+    with pytest.raises(module.HTTPException) as error:
+        asyncio.run(
+            module.promote_local_kg_to_backend(
+                "local_kg_nodes",
+                [{"nodeId": "n1", "label": "Test"}],
+            )
+        )
+    assert error.value.status_code == 502
+
+
+def test_sync_fails_when_local_kg_promotion_fails(tmp_path, monkeypatch) -> None:
+    app, module = load_app(tmp_path)
+    connection = sqlite3.connect(module.runtime.db_path)
+    connection.execute(
+        "CREATE TABLE local_kg_edges (id INTEGER PRIMARY KEY, edgeId TEXT, sourceNodeId TEXT, targetNodeId TEXT, label TEXT, createdAt TEXT)"
+    )
+    connection.commit()
+    connection.close()
+    assert module.runtime.open_database()
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            raise module.httpx.ConnectError("backend unavailable")
+
+    module.runtime.firebase_token = "firebase-token"
+    module.runtime.backend_url = "https://api.test"
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_: Client())
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/sync?token=test-token",
+            json={
+                "table": "local_kg_edges",
+                "rows": [
+                    {
+                        "edgeId": "edge-1",
+                        "sourceNodeId": "a",
+                        "targetNodeId": "b",
+                        "label": "knows",
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 502
+
+
+def test_promote_local_kg_skips_canonical_conflict(tmp_path, monkeypatch) -> None:
+    _, module = load_app(tmp_path)
+    module.runtime.firebase_token = "firebase-token"
+    module.runtime.backend_url = "https://api.test"
+
+    class Response:
+        status_code = 409
+
+        def raise_for_status(self):
+            raise module.httpx.HTTPStatusError(
+                "conflict",
+                request=module.httpx.Request("POST", "https://api.test/v1/knowledge-graph/sync"),
+                response=module.httpx.Response(409),
+            )
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            return Response()
 
     monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_: Client())
     result = asyncio.run(

--- a/backend/tests/unit/test_agent_vm_kg_promotion.py
+++ b/backend/tests/unit/test_agent_vm_kg_promotion.py
@@ -81,7 +81,7 @@ def test_sync_promotes_local_kg_nodes_to_backend(tmp_path, monkeypatch) -> None:
     assert captured["json"] == {"table": "local_kg_nodes", "rows": rows}
 
 
-def test_sync_omits_promotion_without_firebase_token(tmp_path) -> None:
+def test_sync_fails_without_firebase_token(tmp_path) -> None:
     app, module = load_app(tmp_path)
     connection = sqlite3.connect(module.runtime.db_path)
     connection.execute(
@@ -108,21 +108,21 @@ def test_sync_omits_promotion_without_firebase_token(tmp_path) -> None:
             },
         )
 
-    assert response.status_code == 200
-    assert response.json()["applied"] == 1
-    assert "promotion" not in response.json()
+    assert response.status_code == 503
+    assert "Firebase token not set" in response.json()["detail"]
 
 
-def test_promote_local_kg_skips_without_firebase_token(tmp_path) -> None:
+def test_promote_local_kg_fails_without_firebase_token(tmp_path) -> None:
     _, module = load_app(tmp_path)
     module.runtime.firebase_token = None
-    result = asyncio.run(
-        module.promote_local_kg_to_backend(
-            "local_kg_nodes",
-            [{"nodeId": "n1", "label": "Test"}],
+    with pytest.raises(module.HTTPException) as error:
+        asyncio.run(
+            module.promote_local_kg_to_backend(
+                "local_kg_nodes",
+                [{"nodeId": "n1", "label": "Test"}],
+            )
         )
-    )
-    assert result is None
+    assert error.value.status_code == 503
 
 
 def test_promote_local_kg_raises_on_backend_error(tmp_path, monkeypatch) -> None:

--- a/backend/tests/unit/test_agent_vm_kg_promotion.py
+++ b/backend/tests/unit/test_agent_vm_kg_promotion.py
@@ -1,0 +1,149 @@
+"""Agent VM promotes local_kg_* sync batches to backend knowledge graph."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVICE = ROOT / "agent_vm"
+
+
+def load_app(tmp_path: Path):
+    import os
+
+    os.environ["AUTH_TOKEN"] = "test-token"
+    os.environ["DB_PATH"] = str(tmp_path / "omi.db")
+    sys.path.insert(0, str(SERVICE))
+    sys.modules.pop("main", None)
+    module = importlib.import_module("main")
+    return module.app, module
+
+
+def test_sync_promotes_local_kg_nodes_to_backend(tmp_path, monkeypatch) -> None:
+    app, module = load_app(tmp_path)
+    connection = sqlite3.connect(module.runtime.db_path)
+    connection.execute(
+        "CREATE TABLE local_kg_nodes (id INTEGER PRIMARY KEY, nodeId TEXT, label TEXT, nodeType TEXT, aliasesJson TEXT, createdAt TEXT, updatedAt TEXT)"
+    )
+    connection.commit()
+    connection.close()
+    assert module.runtime.open_database()
+
+    captured: dict[str, object] = {}
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "table": "local_kg_nodes",
+                "merged": 1,
+                "skipped": 0,
+                "nodes_evicted": 0,
+                "edges_evicted": 0,
+            }
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            captured.update(kwargs)
+            return Response()
+
+    module.runtime.firebase_token = "firebase-token"
+    module.runtime.backend_url = "https://api.test"
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_: Client())
+
+    rows = [{"nodeId": "node-1", "label": "Omi", "nodeType": "org", "aliasesJson": "[]"}]
+    with TestClient(app) as client:
+        response = client.post("/sync?token=test-token", json={"table": "local_kg_nodes", "rows": rows})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied"] == 1
+    assert body["table"] == "local_kg_nodes"
+    assert body["promotion"]["merged"] == 1
+    assert captured["url"] == "https://api.test/v1/knowledge-graph/sync"
+    assert captured["headers"] == {"Authorization": "Bearer firebase-token"}
+    assert captured["json"] == {"table": "local_kg_nodes", "rows": rows}
+
+
+def test_sync_omits_promotion_without_firebase_token(tmp_path) -> None:
+    app, module = load_app(tmp_path)
+    connection = sqlite3.connect(module.runtime.db_path)
+    connection.execute(
+        "CREATE TABLE local_kg_edges (id INTEGER PRIMARY KEY, edgeId TEXT, sourceNodeId TEXT, targetNodeId TEXT, label TEXT, createdAt TEXT)"
+    )
+    connection.commit()
+    connection.close()
+    assert module.runtime.open_database()
+    module.runtime.firebase_token = None
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/sync?token=test-token",
+            json={
+                "table": "local_kg_edges",
+                "rows": [
+                    {
+                        "edgeId": "edge-1",
+                        "sourceNodeId": "a",
+                        "targetNodeId": "b",
+                        "label": "knows",
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["applied"] == 1
+    assert "promotion" not in response.json()
+
+
+def test_promote_local_kg_skips_without_firebase_token(tmp_path) -> None:
+    _, module = load_app(tmp_path)
+    module.runtime.firebase_token = None
+    result = asyncio.run(
+        module.promote_local_kg_to_backend(
+            "local_kg_nodes",
+            [{"nodeId": "n1", "label": "Test"}],
+        )
+    )
+    assert result is None
+
+
+def test_promote_local_kg_returns_none_on_backend_error(tmp_path, monkeypatch) -> None:
+    _, module = load_app(tmp_path)
+    module.runtime.firebase_token = "firebase-token"
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            raise module.httpx.HTTPError("backend unavailable")
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_: Client())
+    result = asyncio.run(
+        module.promote_local_kg_to_backend(
+            "local_kg_nodes",
+            [{"nodeId": "n1", "label": "Test"}],
+        )
+    )
+    assert result is None

--- a/backend/tests/unit/test_agent_vm_protocol.py
+++ b/backend/tests/unit/test_agent_vm_protocol.py
@@ -71,7 +71,7 @@ def test_http_protocol_requires_vm_token(tmp_path: Path) -> None:
         assert client.post("/upload", content=b"x").status_code == 401
         assert client.post("/auth", json={"firebaseToken": "firebase"}).status_code == 401
         assert client.post("/ping").status_code == 401
-        assert client.post("/sync", json={"table": "screenshots", "rows": [{"id": "1"}]}).status_code == 401
+        assert client.post("/sync", json={"table": "local_kg_nodes", "rows": [{"id": "1"}]}).status_code == 401
         assert client.post("/auth?token=test-token", json={}).status_code == 400
         assert client.post("/ping?token=test-token").json() == {"status": "ok"}
 
@@ -157,7 +157,7 @@ def test_execute_sql_serializes_sqlite_rows(tmp_path: Path) -> None:
 def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:
     app, module = load_app(tmp_path)
     connection = sqlite3.connect(module.runtime.db_path)
-    connection.execute("CREATE TABLE screenshots (id TEXT PRIMARY KEY, appName TEXT, ocrText TEXT)")
+    connection.execute("CREATE TABLE action_items (id TEXT PRIMARY KEY, title TEXT, status TEXT)")
     connection.commit()
     connection.close()
     assert module.runtime.open_database()
@@ -165,23 +165,23 @@ def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:
         response = client.post(
             "/sync?token=test-token",
             json={
-                "table": "screenshots",
+                "table": "action_items",
                 "rows": [
-                    {"id": "one", "appName": "Safari"},
-                    {"id": "two", "appName": "Terminal", "ocrText": "build passed"},
+                    {"id": "one", "title": "First task"},
+                    {"id": "two", "title": "Second task", "status": "done"},
                     {},
                 ],
             },
         )
         rows = [
-            tuple(row) for row in module.runtime.db.execute("SELECT id, appName, ocrText FROM screenshots ORDER BY id")
+            tuple(row) for row in module.runtime.db.execute("SELECT id, title, status FROM action_items ORDER BY id")
         ]
 
     assert response.status_code == 200
-    assert response.json() == {"applied": 2, "table": "screenshots"}
+    assert response.json() == {"applied": 2, "table": "action_items"}
     assert rows == [
-        ("one", "Safari", None),
-        ("two", "Terminal", "build passed"),
+        ("one", "First task", None),
+        ("two", "Second task", "done"),
     ]
 
 

--- a/backend/tests/unit/test_kg_sync_server_merge.py
+++ b/backend/tests/unit/test_kg_sync_server_merge.py
@@ -1,0 +1,281 @@
+"""Server-side merge of agent-VM local_kg_* sync into Firestore knowledge graph."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+
+from database import knowledge_graph as kg_db
+from routers import knowledge_graph as kg_router
+
+UID = "uid-kg-sync-merge"
+BASE = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+
+class _Snapshot:
+    def __init__(self, db: "_FakeDb", path: str, *, exists: bool):
+        self._db = db
+        self._path = path
+        self.id = path.rsplit("/", 1)[-1]
+        self.reference = _DocRef(db, path)
+        self.exists = exists
+
+    def to_dict(self):
+        return self._db.docs.get(self._path)
+
+
+class _DocRef:
+    def __init__(self, db: "_FakeDb", path: str):
+        self._db = db
+        self.path = path
+        self.id = path.rsplit("/", 1)[-1]
+
+    def get(self):
+        return _Snapshot(self._db, self.path, exists=self.path in self._db.docs)
+
+    def set(self, data: dict[str, Any], merge: bool = False):
+        if merge and self.path in self._db.docs:
+            existing = dict(self._db.docs[self.path])
+            existing.update(data)
+            self._db.docs[self.path] = existing
+        else:
+            self._db.docs[self.path] = dict(data)
+
+    def delete(self):
+        self._db.docs.pop(self.path, None)
+
+    def collection(self, name: str):
+        return _CollectionRef(self._db, f"{self.path}/{name}")
+
+
+class _CollectionRef:
+    def __init__(self, db: "_FakeDb", path: str):
+        self._db = db
+        self.path = path
+        self._limit: int | None = None
+
+    def document(self, doc_id: str):
+        return _DocRef(self._db, f"{self.path}/{doc_id}")
+
+    def limit(self, count: int):
+        self._limit = count
+        return self
+
+    def order_by(self, _field_path: str, *_args, **_kwargs):
+        return self
+
+    def where(self, *_args, **_kwargs):
+        return self
+
+    def stream(self):
+        prefix = f"{self.path}/"
+        depth = self.path.count("/")
+        emitted = 0
+        for path in sorted(self._db.docs):
+            if path.startswith(prefix) and path.count("/") == depth + 1:
+                yield _Snapshot(self._db, path, exists=True)
+                emitted += 1
+                if self._limit is not None and emitted >= self._limit:
+                    break
+
+
+class _FakeDb:
+    def __init__(self, docs: dict[str, Any] | None = None):
+        self.docs = dict(docs or {})
+
+    def collection(self, name: str):
+        return _CollectionRef(self, name)
+
+    def get_all(self, refs):
+        return [ref.get() for ref in refs]
+
+
+def _node_doc(node_id: str, *, label: str, updated_at: datetime) -> dict[str, Any]:
+    return {
+        "id": node_id,
+        "label": label,
+        "node_type": "concept",
+        "aliases": [],
+        "memory_ids": [],
+        "created_at": updated_at - timedelta(days=1),
+        "updated_at": updated_at,
+        "label_lower": label.lower(),
+        "aliases_lower": [],
+    }
+
+
+def _edge_doc(edge_id: str, *, source_id: str, target_id: str, created_at: datetime) -> dict[str, Any]:
+    return {
+        "id": edge_id,
+        "source_id": source_id,
+        "target_id": target_id,
+        "label": "related_to",
+        "memory_ids": [],
+        "created_at": created_at,
+    }
+
+
+def test_local_kg_node_row_maps_and_merges_aliases(monkeypatch):
+    db = _FakeDb()
+    row = {
+        "nodeId": "node-a",
+        "label": "Omi",
+        "nodeType": "org",
+        "aliasesJson": '["Based Hardware"]',
+        "createdAt": "2026-07-01T12:00:00Z",
+        "updatedAt": "2026-07-02T12:00:00Z",
+    }
+    result = kg_db.merge_synced_local_kg_nodes(UID, [row], db_client=db)
+
+    stored = db.docs[f"users/{UID}/knowledge_nodes/node-a"]
+    assert result == {
+        "table": "local_kg_nodes",
+        "merged": 1,
+        "skipped": 0,
+        "nodes_evicted": 0,
+        "edges_evicted": 0,
+    }
+    assert stored["label"] == "Omi"
+    assert stored["node_type"] == "org"
+    assert stored["aliases"] == ["Based Hardware"]
+
+    updated = {
+        **row,
+        "aliasesJson": '["Based Hardware", "Omi Inc"]',
+        "updatedAt": "2026-07-03T12:00:00Z",
+    }
+    kg_db.merge_synced_local_kg_nodes(UID, [updated], db_client=db)
+    merged = db.docs[f"users/{UID}/knowledge_nodes/node-a"]
+    assert merged["aliases"] == ["Based Hardware", "Omi Inc"]
+
+
+def test_local_kg_edge_row_upserts_by_edge_id():
+    db = _FakeDb(
+        {
+            f"users/{UID}/knowledge_nodes/node-a": _node_doc("node-a", label="A", updated_at=BASE),
+            f"users/{UID}/knowledge_nodes/node-b": _node_doc("node-b", label="B", updated_at=BASE),
+        }
+    )
+    row = {
+        "edgeId": "edge-1",
+        "sourceNodeId": "node-a",
+        "targetNodeId": "node-b",
+        "label": "works_at",
+        "createdAt": "2026-07-01T12:00:00Z",
+    }
+    result = kg_db.merge_synced_local_kg_edges(UID, [row], db_client=db)
+    stored = db.docs[f"users/{UID}/knowledge_edges/edge-1"]
+
+    assert result["merged"] == 1
+    assert stored["source_id"] == "node-a"
+    assert stored["target_id"] == "node-b"
+    assert stored["label"] == "works_at"
+
+
+def test_enforce_caps_evicts_oldest_nodes_and_dangling_edges():
+    docs: dict[str, Any] = {}
+    for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_NODES):
+        node_id = f"old-{index:03d}"
+        docs[f"users/{UID}/knowledge_nodes/{node_id}"] = _node_doc(
+            node_id,
+            label=node_id,
+            updated_at=BASE + timedelta(hours=index),
+        )
+    docs[f"users/{UID}/knowledge_nodes/fresh-node"] = _node_doc(
+        "fresh-node",
+        label="Fresh",
+        updated_at=BASE + timedelta(days=30),
+    )
+    docs[f"users/{UID}/knowledge_edges/stale-edge"] = _edge_doc(
+        "stale-edge",
+        source_id="old-000",
+        target_id="fresh-node",
+        created_at=BASE,
+    )
+    docs[f"users/{UID}/knowledge_edges/keep-edge"] = _edge_doc(
+        "keep-edge",
+        source_id="fresh-node",
+        target_id="old-001",
+        created_at=BASE + timedelta(days=30),
+    )
+    db = _FakeDb(docs)
+
+    eviction = kg_db.enforce_knowledge_graph_caps(UID, db_client=db)
+
+    assert eviction["nodes_evicted"] == 1
+    assert eviction["edges_evicted"] == 1
+    assert f"users/{UID}/knowledge_nodes/old-000" not in db.docs
+    assert f"users/{UID}/knowledge_nodes/fresh-node" in db.docs
+    assert f"users/{UID}/knowledge_edges/stale-edge" not in db.docs
+    assert f"users/{UID}/knowledge_edges/keep-edge" in db.docs
+
+
+def test_enforce_caps_evicts_oldest_edges_when_over_limit():
+    docs: dict[str, Any] = {}
+    for index in range(2):
+        node_id = f"node-{index}"
+        docs[f"users/{UID}/knowledge_nodes/{node_id}"] = _node_doc(
+            node_id,
+            label=node_id,
+            updated_at=BASE,
+        )
+    for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_EDGES + 1):
+        edge_id = f"edge-{index:04d}"
+        docs[f"users/{UID}/knowledge_edges/{edge_id}"] = _edge_doc(
+            edge_id,
+            source_id="node-0",
+            target_id="node-1",
+            created_at=BASE + timedelta(minutes=index),
+        )
+    db = _FakeDb(docs)
+
+    eviction = kg_db.enforce_knowledge_graph_caps(UID, db_client=db)
+
+    assert eviction["edges_evicted"] == 1
+    assert f"users/{UID}/knowledge_edges/edge-0000" not in db.docs
+    remaining_edges = [path for path in db.docs if path.startswith(f"users/{UID}/knowledge_edges/")]
+    assert len(remaining_edges) == kg_db.MAX_KNOWLEDGE_GRAPH_EDGES
+
+
+def test_sync_route_delegates_to_merge(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_merge(uid, table, rows, *, db_client=None):
+        captured["uid"] = uid
+        captured["table"] = table
+        captured["rows"] = rows
+        captured["db_client"] = db_client
+        return {
+            "table": table,
+            "merged": len(rows),
+            "skipped": 0,
+            "nodes_evicted": 0,
+            "edges_evicted": 0,
+        }
+
+    monkeypatch.setattr(kg_router.kg_db, "merge_synced_local_kg", fake_merge)
+    monkeypatch.setattr(kg_router, "firestore_db", object())
+
+    rows = [{"nodeId": "n1", "label": "Test"}]
+    response = kg_router.sync_local_knowledge_graph(
+        payload=kg_router.LocalKgSyncRequest(table="local_kg_nodes", rows=rows),
+        uid=UID,
+    )
+
+    assert captured == {"uid": UID, "table": "local_kg_nodes", "rows": rows, "db_client": kg_router.firestore_db}
+    assert response.merged == 1
+    assert response.table == "local_kg_nodes"
+
+
+def test_invalid_local_kg_rows_are_skipped():
+    db = _FakeDb()
+    result = kg_db.merge_synced_local_kg_nodes(
+        UID,
+        [{"nodeId": "", "label": "Bad"}, {"label": "Missing id"}, "not-a-row"],
+        db_client=db,
+    )
+    assert result["merged"] == 0
+    assert result["skipped"] == 3
+    assert db.docs == {}

--- a/backend/tests/unit/test_kg_sync_server_merge.py
+++ b/backend/tests/unit/test_kg_sync_server_merge.py
@@ -140,6 +140,8 @@ def test_local_kg_node_row_maps_and_merges_aliases(monkeypatch):
     assert stored["label"] == "Omi"
     assert stored["node_type"] == "org"
     assert stored["aliases"] == ["Based Hardware"]
+    assert stored["created_at"] == datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    assert stored["updated_at"] == datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc)
 
     updated = {
         **row,
@@ -257,6 +259,7 @@ def test_sync_route_delegates_to_merge(monkeypatch):
 
     monkeypatch.setattr(kg_router.kg_db, "merge_synced_local_kg", fake_merge)
     monkeypatch.setattr(kg_router, "firestore_db", object())
+    monkeypatch.setattr(kg_router, "_require_legacy_graph_mutation", lambda _uid: None)
 
     rows = [{"nodeId": "n1", "label": "Test"}]
     response = kg_router.sync_local_knowledge_graph(
@@ -279,3 +282,78 @@ def test_invalid_local_kg_rows_are_skipped():
     assert result["merged"] == 0
     assert result["skipped"] == 3
     assert db.docs == {}
+
+
+def test_merge_preserves_stable_node_id_despite_label_collision():
+    db = _FakeDb(
+        {
+            f"users/{UID}/knowledge_nodes/existing-omi": _node_doc(
+                "existing-omi",
+                label="Omi",
+                updated_at=BASE,
+            )
+        }
+    )
+    row = {
+        "nodeId": "local-omi",
+        "label": "Omi",
+        "nodeType": "org",
+        "aliasesJson": "[]",
+        "createdAt": "2026-07-01T12:00:00Z",
+        "updatedAt": "2026-07-02T12:00:00Z",
+    }
+    kg_db.merge_synced_local_kg_nodes(UID, [row], db_client=db)
+
+    assert f"users/{UID}/knowledge_nodes/local-omi" in db.docs
+    assert db.docs[f"users/{UID}/knowledge_nodes/local-omi"]["id"] == "local-omi"
+    assert f"users/{UID}/knowledge_nodes/existing-omi" in db.docs
+
+    edge_row = {
+        "edgeId": "edge-local",
+        "sourceNodeId": "local-omi",
+        "targetNodeId": "existing-omi",
+        "label": "related_to",
+        "createdAt": "2026-07-01T12:00:00Z",
+    }
+    result = kg_db.merge_synced_local_kg_edges(UID, [edge_row], db_client=db)
+    assert result["merged"] == 1
+    assert result["edges_evicted"] == 0
+    assert f"users/{UID}/knowledge_edges/edge-local" in db.docs
+
+
+def test_merge_preserves_synced_timestamps_for_eviction():
+    db = _FakeDb()
+    old_ts = "2026-01-01T00:00:00Z"
+    new_ts = "2026-07-01T12:00:00Z"
+    keep_rows = [
+        {
+            "nodeId": f"keep-{index:03d}",
+            "label": f"keep-{index:03d}",
+            "nodeType": "concept",
+            "aliasesJson": "[]",
+            "createdAt": new_ts,
+            "updatedAt": new_ts,
+        }
+        for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_NODES)
+    ]
+    kg_db.merge_synced_local_kg_nodes(UID, keep_rows, db_client=db)
+    kg_db.merge_synced_local_kg_nodes(
+        UID,
+        [
+            {
+                "nodeId": "stale-local",
+                "label": "Stale",
+                "nodeType": "concept",
+                "aliasesJson": "[]",
+                "createdAt": old_ts,
+                "updatedAt": old_ts,
+            }
+        ],
+        db_client=db,
+    )
+
+    assert f"users/{UID}/knowledge_nodes/stale-local" not in db.docs
+    assert f"users/{UID}/knowledge_nodes/keep-000" in db.docs
+    keep = db.docs[f"users/{UID}/knowledge_nodes/keep-000"]
+    assert keep["updated_at"] == datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    assert keep["created_at"] == datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)

--- a/backend/tests/unit/test_kg_sync_server_merge.py
+++ b/backend/tests/unit/test_kg_sync_server_merge.py
@@ -366,7 +366,7 @@ def test_merge_evicts_by_document_name_not_timestamp():
     assert keep["created_at"] == datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
 
 
-def test_merge_skips_edges_when_endpoints_missing():
+def test_merge_fails_edges_when_endpoints_missing():
     db = _FakeDb(
         {
             f"users/{UID}/knowledge_nodes/node-a": _node_doc("node-a", label="A", updated_at=BASE),
@@ -379,13 +379,46 @@ def test_merge_skips_edges_when_endpoints_missing():
         "label": "related_to",
         "createdAt": "2026-07-01T12:00:00Z",
     }
-    result = kg_db.merge_synced_local_kg_edges(UID, [row], db_client=db)
-
-    assert result == {
-        "table": "local_kg_edges",
-        "merged": 0,
-        "skipped": 1,
-        "nodes_evicted": 0,
-        "edges_evicted": 0,
-    }
+    with pytest.raises(kg_db.MissingKnowledgeGraphEndpointsError):
+        kg_db.merge_synced_local_kg_edges(UID, [row], db_client=db)
     assert f"users/{UID}/knowledge_edges/edge-missing-target" not in db.docs
+
+
+def test_sync_route_returns_422_when_edge_endpoints_missing(monkeypatch):
+    monkeypatch.setattr(kg_router, "_require_legacy_graph_mutation", lambda _uid: None)
+
+    def fake_merge(uid, table, rows, *, db_client=None):
+        raise kg_db.MissingKnowledgeGraphEndpointsError("1 local_kg edge(s) reference missing endpoint nodes")
+
+    monkeypatch.setattr(kg_router.kg_db, "merge_synced_local_kg", fake_merge)
+    with pytest.raises(kg_router.HTTPException) as error:
+        kg_router.sync_local_knowledge_graph(
+            payload=kg_router.LocalKgSyncRequest(
+                table="local_kg_edges",
+                rows=[{"edgeId": "e1", "sourceNodeId": "a", "targetNodeId": "b", "label": "related_to"}],
+            ),
+            uid=UID,
+        )
+    assert error.value.status_code == 422
+
+
+def test_merge_keeps_fresher_cloud_updated_at():
+    newer = BASE + timedelta(days=2)
+    older = BASE
+    db = _FakeDb(
+        {
+            f"users/{UID}/knowledge_nodes/node-a": _node_doc("node-a", label="Omi", updated_at=newer),
+        }
+    )
+    row = {
+        "nodeId": "node-a",
+        "label": "Omi",
+        "nodeType": "org",
+        "aliasesJson": '["Based Hardware"]',
+        "createdAt": "2026-07-01T12:00:00Z",
+        "updatedAt": older.isoformat().replace("+00:00", "Z"),
+    }
+    kg_db.merge_synced_local_kg_nodes(UID, [row], db_client=db)
+    stored = db.docs[f"users/{UID}/knowledge_nodes/node-a"]
+    assert stored["updated_at"] == newer
+    assert sorted(stored["aliases"]) == ["Based Hardware"]

--- a/backend/tests/unit/test_kg_sync_server_merge.py
+++ b/backend/tests/unit/test_kg_sync_server_merge.py
@@ -176,30 +176,30 @@ def test_local_kg_edge_row_upserts_by_edge_id():
     assert stored["label"] == "works_at"
 
 
-def test_enforce_caps_evicts_oldest_nodes_and_dangling_edges():
+def test_enforce_caps_evicts_nodes_beyond_get_name_prefix_and_dangling_edges():
     docs: dict[str, Any] = {}
     for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_NODES):
-        node_id = f"old-{index:03d}"
+        node_id = f"keep-{index:03d}"
         docs[f"users/{UID}/knowledge_nodes/{node_id}"] = _node_doc(
             node_id,
             label=node_id,
             updated_at=BASE + timedelta(hours=index),
         )
-    docs[f"users/{UID}/knowledge_nodes/fresh-node"] = _node_doc(
-        "fresh-node",
-        label="Fresh",
+    docs[f"users/{UID}/knowledge_nodes/zzz-excess"] = _node_doc(
+        "zzz-excess",
+        label="Excess",
         updated_at=BASE + timedelta(days=30),
     )
     docs[f"users/{UID}/knowledge_edges/stale-edge"] = _edge_doc(
         "stale-edge",
-        source_id="old-000",
-        target_id="fresh-node",
+        source_id="zzz-excess",
+        target_id="keep-001",
         created_at=BASE,
     )
     docs[f"users/{UID}/knowledge_edges/keep-edge"] = _edge_doc(
         "keep-edge",
-        source_id="fresh-node",
-        target_id="old-001",
+        source_id="keep-000",
+        target_id="keep-001",
         created_at=BASE + timedelta(days=30),
     )
     db = _FakeDb(docs)
@@ -208,13 +208,13 @@ def test_enforce_caps_evicts_oldest_nodes_and_dangling_edges():
 
     assert eviction["nodes_evicted"] == 1
     assert eviction["edges_evicted"] == 1
-    assert f"users/{UID}/knowledge_nodes/old-000" not in db.docs
-    assert f"users/{UID}/knowledge_nodes/fresh-node" in db.docs
+    assert f"users/{UID}/knowledge_nodes/zzz-excess" not in db.docs
+    assert f"users/{UID}/knowledge_nodes/keep-000" in db.docs
     assert f"users/{UID}/knowledge_edges/stale-edge" not in db.docs
     assert f"users/{UID}/knowledge_edges/keep-edge" in db.docs
 
 
-def test_enforce_caps_evicts_oldest_edges_when_over_limit():
+def test_enforce_caps_evicts_edges_beyond_get_name_prefix():
     docs: dict[str, Any] = {}
     for index in range(2):
         node_id = f"node-{index}"
@@ -223,7 +223,7 @@ def test_enforce_caps_evicts_oldest_edges_when_over_limit():
             label=node_id,
             updated_at=BASE,
         )
-    for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_EDGES + 1):
+    for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_EDGES):
         edge_id = f"edge-{index:04d}"
         docs[f"users/{UID}/knowledge_edges/{edge_id}"] = _edge_doc(
             edge_id,
@@ -231,14 +231,21 @@ def test_enforce_caps_evicts_oldest_edges_when_over_limit():
             target_id="node-1",
             created_at=BASE + timedelta(minutes=index),
         )
+    docs[f"users/{UID}/knowledge_edges/zzz-excess"] = _edge_doc(
+        "zzz-excess",
+        source_id="node-0",
+        target_id="node-1",
+        created_at=BASE + timedelta(days=30),
+    )
     db = _FakeDb(docs)
 
     eviction = kg_db.enforce_knowledge_graph_caps(UID, db_client=db)
 
     assert eviction["edges_evicted"] == 1
-    assert f"users/{UID}/knowledge_edges/edge-0000" not in db.docs
+    assert f"users/{UID}/knowledge_edges/zzz-excess" not in db.docs
     remaining_edges = [path for path in db.docs if path.startswith(f"users/{UID}/knowledge_edges/")]
     assert len(remaining_edges) == kg_db.MAX_KNOWLEDGE_GRAPH_EDGES
+    assert f"users/{UID}/knowledge_edges/edge-0000" in db.docs
 
 
 def test_sync_route_delegates_to_merge(monkeypatch):
@@ -321,7 +328,7 @@ def test_merge_preserves_stable_node_id_despite_label_collision():
     assert f"users/{UID}/knowledge_edges/edge-local" in db.docs
 
 
-def test_merge_preserves_synced_timestamps_for_eviction():
+def test_merge_evicts_by_document_name_not_timestamp():
     db = _FakeDb()
     old_ts = "2026-01-01T00:00:00Z"
     new_ts = "2026-07-01T12:00:00Z"
@@ -331,8 +338,8 @@ def test_merge_preserves_synced_timestamps_for_eviction():
             "label": f"keep-{index:03d}",
             "nodeType": "concept",
             "aliasesJson": "[]",
-            "createdAt": new_ts,
-            "updatedAt": new_ts,
+            "createdAt": old_ts,
+            "updatedAt": old_ts,
         }
         for index in range(kg_db.MAX_KNOWLEDGE_GRAPH_NODES)
     ]
@@ -341,19 +348,44 @@ def test_merge_preserves_synced_timestamps_for_eviction():
         UID,
         [
             {
-                "nodeId": "stale-local",
-                "label": "Stale",
+                "nodeId": "zzz-excess",
+                "label": "Excess",
                 "nodeType": "concept",
                 "aliasesJson": "[]",
-                "createdAt": old_ts,
-                "updatedAt": old_ts,
+                "createdAt": new_ts,
+                "updatedAt": new_ts,
             }
         ],
         db_client=db,
     )
 
-    assert f"users/{UID}/knowledge_nodes/stale-local" not in db.docs
+    assert f"users/{UID}/knowledge_nodes/zzz-excess" not in db.docs
     assert f"users/{UID}/knowledge_nodes/keep-000" in db.docs
     keep = db.docs[f"users/{UID}/knowledge_nodes/keep-000"]
-    assert keep["updated_at"] == datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
-    assert keep["created_at"] == datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    assert keep["updated_at"] == datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    assert keep["created_at"] == datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_merge_skips_edges_when_endpoints_missing():
+    db = _FakeDb(
+        {
+            f"users/{UID}/knowledge_nodes/node-a": _node_doc("node-a", label="A", updated_at=BASE),
+        }
+    )
+    row = {
+        "edgeId": "edge-missing-target",
+        "sourceNodeId": "node-a",
+        "targetNodeId": "node-missing",
+        "label": "related_to",
+        "createdAt": "2026-07-01T12:00:00Z",
+    }
+    result = kg_db.merge_synced_local_kg_edges(UID, [row], db_client=db)
+
+    assert result == {
+        "table": "local_kg_edges",
+        "merged": 0,
+        "skipped": 1,
+        "nodes_evicted": 0,
+        "edges_evicted": 0,
+    }
+    assert f"users/{UID}/knowledge_edges/edge-missing-target" not in db.docs

--- a/backend/tests/unit/test_kg_sync_server_merge.py
+++ b/backend/tests/unit/test_kg_sync_server_merge.py
@@ -148,7 +148,7 @@ def test_local_kg_node_row_maps_and_merges_aliases(monkeypatch):
     }
     kg_db.merge_synced_local_kg_nodes(UID, [updated], db_client=db)
     merged = db.docs[f"users/{UID}/knowledge_nodes/node-a"]
-    assert merged["aliases"] == ["Based Hardware", "Omi Inc"]
+    assert sorted(merged["aliases"]) == ["Based Hardware", "Omi Inc"]
 
 
 def test_local_kg_edge_row_upserts_by_edge_id():

--- a/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
@@ -22,6 +22,29 @@ def test_canonical_delete_route_returns_conflict_without_deleting_projection(mon
     assert delete_calls == []
 
 
+def test_canonical_sync_route_returns_conflict_without_merging(monkeypatch):
+    merge_calls: list[tuple] = []
+    monkeypatch.setattr(kg_router, "pin_memory_system", lambda *_args, **_kwargs: MemorySystem.CANONICAL)
+    monkeypatch.setattr(
+        kg_router.kg_db,
+        "merge_synced_local_kg",
+        lambda *args, **kwargs: merge_calls.append((args, kwargs)) or {},
+    )
+
+    with pytest.raises(HTTPException) as error:
+        kg_router.sync_local_knowledge_graph(
+            payload=kg_router.LocalKgSyncRequest(
+                table="local_kg_nodes",
+                rows=[{"nodeId": "n1", "label": "Test"}],
+            ),
+            uid=UID,
+        )
+
+    assert error.value.status_code == 409
+    assert error.value.detail == kg_router.CANONICAL_GRAPH_MUTATION_CONFLICT
+    assert merge_calls == []
+
+
 def test_canonical_rebuild_route_returns_conflict_without_deleting_or_scheduling(monkeypatch):
     delete_calls: list[str] = []
     user_name_calls: list[str] = []

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -9523,6 +9523,32 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func syncLocalKnowledgeGraphV1KnowledgeGraphSyncPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/knowledge-graph/sync"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func getActionItemsV1McpActionItemsGet(client: OmiApiClient, completed: Bool? = nil, dueStartDate: String? = nil, dueEndDate: String? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> [OmiAnyCodable] {
     let _path = "/v1/mcp/action-items"
     guard var components = URLComponents(string: client.baseURL + _path) else {
@@ -14472,5 +14498,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 388 Swift client methods generated.
+  // Total: 389 Swift client methods generated.
 }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2051,6 +2051,19 @@ export interface LlmUsageResponse {
   top_features?: Array<LlmUsageFeatureResponse>;
 }
 
+export interface LocalKgSyncRequest {
+  rows: Array<Record<string, unknown>>;
+  table: "local_kg_nodes" | "local_kg_edges";
+}
+
+export interface LocalKgSyncResponse {
+  edges_evicted: number;
+  merged: number;
+  nodes_evicted: number;
+  skipped: number;
+  table: string;
+}
+
 export interface LocationContextConsentResponse {
   disclosed_providers?: Array<unknown>;
   enabled: boolean;
@@ -4033,6 +4046,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocalKgSyncRequest": LocalKgSyncRequest;
+  "LocalKgSyncResponse": LocalKgSyncResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
@@ -6245,6 +6260,16 @@ export interface OmiApiPaths {
       operationId: "rebuild_graph_v1_knowledge_graph_rebuild_post";
       responses: {
         "200": RebuildResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/knowledge-graph/sync": {
+    post: {
+      operationId: "sync_local_knowledge_graph_v1_knowledge_graph_sync_post";
+      responses: {
+        "200": LocalKgSyncResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -12061,6 +12086,27 @@ export async function rebuild_graph_v1_knowledge_graph_rebuild_post(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function sync_local_knowledge_graph_v1_knowledge_graph_sync_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocalKgSyncRequest, init?: OmiApiClientInit): Promise<LocalKgSyncResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/knowledge-graph/sync`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_action_items_v1_mcp_action_items_get(query: { completed?: boolean | null, due_start_date?: string | null, due_end_date?: string | null, limit?: number, offset?: number }, init?: OmiApiClientInit): Promise<Array<SimpleActionItem>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/mcp/action-items`;
@@ -15822,4 +15868,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 388 client methods generated.
+// Total: 389 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -12600,6 +12600,66 @@
         "title": "LlmUsageResponse",
         "type": "object"
       },
+      "LocalKgSyncRequest": {
+        "properties": {
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "minItems": 1,
+            "title": "Rows",
+            "type": "array"
+          },
+          "table": {
+            "enum": [
+              "local_kg_nodes",
+              "local_kg_edges"
+            ],
+            "title": "Table",
+            "type": "string"
+          }
+        },
+        "required": [
+          "table",
+          "rows"
+        ],
+        "title": "LocalKgSyncRequest",
+        "type": "object"
+      },
+      "LocalKgSyncResponse": {
+        "properties": {
+          "edges_evicted": {
+            "title": "Edges Evicted",
+            "type": "integer"
+          },
+          "merged": {
+            "title": "Merged",
+            "type": "integer"
+          },
+          "nodes_evicted": {
+            "title": "Nodes Evicted",
+            "type": "integer"
+          },
+          "skipped": {
+            "title": "Skipped",
+            "type": "integer"
+          },
+          "table": {
+            "title": "Table",
+            "type": "string"
+          }
+        },
+        "required": [
+          "table",
+          "merged",
+          "skipped",
+          "nodes_evicted",
+          "edges_evicted"
+        ],
+        "title": "LocalKgSyncResponse",
+        "type": "object"
+      },
       "LocationContextConsentResponse": {
         "properties": {
           "disclosed_providers": {
@@ -40065,6 +40125,94 @@
           }
         ],
         "summary": "Rebuild Graph",
+        "tags": [
+          "knowledge_graph"
+        ]
+      }
+    },
+    "/v1/knowledge-graph/sync": {
+      "post": {
+        "description": "Merge agent-VM synced local_kg_* rows into the user's Firestore graph projection.",
+        "operationId": "sync_local_knowledge_graph_v1_knowledge_graph_sync_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocalKgSyncRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalKgSyncResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Sync Local Knowledge Graph",
         "tags": [
           "knowledge_graph"
         ]

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2051,6 +2051,19 @@ export interface LlmUsageResponse {
   top_features?: Array<LlmUsageFeatureResponse>;
 }
 
+export interface LocalKgSyncRequest {
+  rows: Array<Record<string, unknown>>;
+  table: "local_kg_nodes" | "local_kg_edges";
+}
+
+export interface LocalKgSyncResponse {
+  edges_evicted: number;
+  merged: number;
+  nodes_evicted: number;
+  skipped: number;
+  table: string;
+}
+
 export interface LocationContextConsentResponse {
   disclosed_providers?: Array<unknown>;
   enabled: boolean;
@@ -4033,6 +4046,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocalKgSyncRequest": LocalKgSyncRequest;
+  "LocalKgSyncResponse": LocalKgSyncResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
@@ -6245,6 +6260,16 @@ export interface OmiApiPaths {
       operationId: "rebuild_graph_v1_knowledge_graph_rebuild_post";
       responses: {
         "200": RebuildResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/knowledge-graph/sync": {
+    post: {
+      operationId: "sync_local_knowledge_graph_v1_knowledge_graph_sync_post";
+      responses: {
+        "200": LocalKgSyncResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -12061,6 +12086,27 @@ export async function rebuild_graph_v1_knowledge_graph_rebuild_post(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function sync_local_knowledge_graph_v1_knowledge_graph_sync_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocalKgSyncRequest, init?: OmiApiClientInit): Promise<LocalKgSyncResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/knowledge-graph/sync`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_action_items_v1_mcp_action_items_get(query: { completed?: boolean | null, due_start_date?: string | null, due_end_date?: string | null, limit?: number, offset?: number }, init?: OmiApiClientInit): Promise<Array<SimpleActionItem>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/mcp/action-items`;
@@ -15822,4 +15868,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 388 client methods generated.
+// Total: 389 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2051,6 +2051,19 @@ export interface LlmUsageResponse {
   top_features?: Array<LlmUsageFeatureResponse>;
 }
 
+export interface LocalKgSyncRequest {
+  rows: Array<Record<string, unknown>>;
+  table: "local_kg_nodes" | "local_kg_edges";
+}
+
+export interface LocalKgSyncResponse {
+  edges_evicted: number;
+  merged: number;
+  nodes_evicted: number;
+  skipped: number;
+  table: string;
+}
+
 export interface LocationContextConsentResponse {
   disclosed_providers?: Array<unknown>;
   enabled: boolean;
@@ -4033,6 +4046,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocalKgSyncRequest": LocalKgSyncRequest;
+  "LocalKgSyncResponse": LocalKgSyncResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
@@ -6245,6 +6260,16 @@ export interface OmiApiPaths {
       operationId: "rebuild_graph_v1_knowledge_graph_rebuild_post";
       responses: {
         "200": RebuildResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/knowledge-graph/sync": {
+    post: {
+      operationId: "sync_local_knowledge_graph_v1_knowledge_graph_sync_post";
+      responses: {
+        "200": LocalKgSyncResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -12061,6 +12086,27 @@ export async function rebuild_graph_v1_knowledge_graph_rebuild_post(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function sync_local_knowledge_graph_v1_knowledge_graph_sync_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocalKgSyncRequest, init?: OmiApiClientInit): Promise<LocalKgSyncResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/knowledge-graph/sync`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_action_items_v1_mcp_action_items_get(query: { completed?: boolean | null, due_start_date?: string | null, due_end_date?: string | null, limit?: number, offset?: number }, init?: OmiApiClientInit): Promise<Array<SimpleActionItem>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/mcp/action-items`;
@@ -15822,4 +15868,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 388 client methods generated.
+// Total: 389 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2051,6 +2051,19 @@ export interface LlmUsageResponse {
   top_features?: Array<LlmUsageFeatureResponse>;
 }
 
+export interface LocalKgSyncRequest {
+  rows: Array<Record<string, unknown>>;
+  table: "local_kg_nodes" | "local_kg_edges";
+}
+
+export interface LocalKgSyncResponse {
+  edges_evicted: number;
+  merged: number;
+  nodes_evicted: number;
+  skipped: number;
+  table: string;
+}
+
 export interface LocationContextConsentResponse {
   disclosed_providers?: Array<unknown>;
   enabled: boolean;
@@ -4033,6 +4046,8 @@ export interface OmiApiSchemas {
   "LlmUsageFeatureResponse": LlmUsageFeatureResponse;
   "LlmUsageRecordResponse": LlmUsageRecordResponse;
   "LlmUsageResponse": LlmUsageResponse;
+  "LocalKgSyncRequest": LocalKgSyncRequest;
+  "LocalKgSyncResponse": LocalKgSyncResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
   "McpAddServerResponse": McpAddServerResponse;
@@ -6245,6 +6260,16 @@ export interface OmiApiPaths {
       operationId: "rebuild_graph_v1_knowledge_graph_rebuild_post";
       responses: {
         "200": RebuildResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/knowledge-graph/sync": {
+    post: {
+      operationId: "sync_local_knowledge_graph_v1_knowledge_graph_sync_post";
+      responses: {
+        "200": LocalKgSyncResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -12061,6 +12086,27 @@ export async function rebuild_graph_v1_knowledge_graph_rebuild_post(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function sync_local_knowledge_graph_v1_knowledge_graph_sync_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: LocalKgSyncRequest, init?: OmiApiClientInit): Promise<LocalKgSyncResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/knowledge-graph/sync`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_action_items_v1_mcp_action_items_get(query: { completed?: boolean | null, due_start_date?: string | null, due_end_date?: string | null, limit?: number, offset?: number }, init?: OmiApiClientInit): Promise<Array<SimpleActionItem>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/mcp/action-items`;
@@ -15822,4 +15868,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 388 client methods generated.
+// Total: 389 client methods generated.


### PR DESCRIPTION
## Product invariants affected
- INV-AUTH-1

## Summary
- Promotes `local_kg_nodes/edges` from agent VM sync into Firestore `knowledge_nodes`/`knowledge_edges` with oldest-first cap eviction.

## Test plan
- [x] `pytest tests/unit/test_kg_sync_server_merge.py tests/unit/test_agent_vm_kg_promotion.py`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Product invariants affected

- INV-AUTH-1

Failure-Class: none
