### PR TITLE
fix(desktop): sync only knowledge graph tables, not screen capture

### DIFF
--- a/backend/agent_vm/main.py
+++ b/backend/agent_vm/main.py
@@ -23,15 +23,15 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 
 SYNC_TABLES = frozenset(
     {
-        "screenshots",
         "action_items",
         "transcription_sessions",
         "transcription_segments",
         "memories",
         "staged_tasks",
         "focus_sessions",
-        "observations",
         "live_notes",
+        "local_kg_nodes",
+        "local_kg_edges",
         "ai_user_profiles",
         "task_dedup_log",
     }

--- a/backend/tests/unit/test_agent_vm_protocol.py
+++ b/backend/tests/unit/test_agent_vm_protocol.py
@@ -71,7 +71,7 @@ def test_http_protocol_requires_vm_token(tmp_path: Path) -> None:
         assert client.post("/upload", content=b"x").status_code == 401
         assert client.post("/auth", json={"firebaseToken": "firebase"}).status_code == 401
         assert client.post("/ping").status_code == 401
-        assert client.post("/sync", json={"table": "screenshots", "rows": [{"id": "1"}]}).status_code == 401
+        assert client.post("/sync", json={"table": "local_kg_nodes", "rows": [{"id": "1"}]}).status_code == 401
         assert client.post("/auth?token=test-token", json={}).status_code == 400
         assert client.post("/ping?token=test-token").json() == {"status": "ok"}
 
@@ -157,7 +157,7 @@ def test_execute_sql_serializes_sqlite_rows(tmp_path: Path) -> None:
 def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:
     app, module = load_app(tmp_path)
     connection = sqlite3.connect(module.runtime.db_path)
-    connection.execute("CREATE TABLE screenshots (id TEXT PRIMARY KEY, appName TEXT, ocrText TEXT)")
+    connection.execute("CREATE TABLE local_kg_nodes (id TEXT PRIMARY KEY, nodeId TEXT, label TEXT)")
     connection.commit()
     connection.close()
     assert module.runtime.open_database()
@@ -165,23 +165,23 @@ def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:
         response = client.post(
             "/sync?token=test-token",
             json={
-                "table": "screenshots",
+                "table": "local_kg_nodes",
                 "rows": [
-                    {"id": "one", "appName": "Safari"},
-                    {"id": "two", "appName": "Terminal", "ocrText": "build passed"},
+                    {"id": "one", "nodeId": "node-one"},
+                    {"id": "two", "nodeId": "node-two", "label": "Build passed"},
                     {},
                 ],
             },
         )
         rows = [
-            tuple(row) for row in module.runtime.db.execute("SELECT id, appName, ocrText FROM screenshots ORDER BY id")
+            tuple(row) for row in module.runtime.db.execute("SELECT id, nodeId, label FROM local_kg_nodes ORDER BY id")
         ]
 
     assert response.status_code == 200
-    assert response.json() == {"applied": 2, "table": "screenshots"}
+    assert response.json() == {"applied": 2, "table": "local_kg_nodes"}
     assert rows == [
-        ("one", "Safari", None),
-        ("two", "Terminal", "build passed"),
+        ("one", "node-one", None),
+        ("two", "node-two", "Build passed"),
     ]
 
 

--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -17,8 +17,8 @@ private struct AgentSyncRowsPayload: @unchecked Sendable {
 /// POSTs them to the cloud agent VM's `/sync` endpoint.
 ///
 /// Cursor strategy:
-/// - Append-only tables (screenshots, transcription_segments, …): track `lastSyncedId`
-/// - Mutable tables (action_items, memories, …): track `lastSyncedUpdatedAt`
+/// - Append-only tables (transcription_segments, local_kg_edges, …): track `lastSyncedId`
+/// - Mutable tables (action_items, memories, local_kg_nodes, …): track `lastSyncedUpdatedAt`
 ///
 /// Cursors are persisted in UserDefaults so sync resumes after restart.
 actor AgentSyncService {
@@ -72,11 +72,44 @@ actor AgentSyncService {
     var lastUpdatedAt: String  // ISO-8601
   }
 
-  private struct TableSpec {
+  struct TableSpec {
     let name: String
     let appendOnly: Bool  // true = cursor by id, false = cursor by updatedAt
+    /// Explicit allow-list. When non-empty, only these columns sync.
+    /// When empty, all schema columns sync except those in `excludedColumns`.
+    let includedColumns: [String]
     let excludedColumns: Set<String>
   }
+
+  /// Resolve which columns to include in a sync payload for a table.
+  static func resolveSyncColumns(spec: TableSpec, schemaColumns: [String]) -> [String] {
+    if !spec.includedColumns.isEmpty {
+      let schema = Set(schemaColumns)
+      return spec.includedColumns.filter { schema.contains($0) }
+    }
+    return schemaColumns.filter { !spec.excludedColumns.contains($0) }
+  }
+
+  /// Screen-capture fields that must never appear in agent-VM sync payloads.
+  static let forbiddenSyncFieldNames: Set<String> = [
+    "ocrText", "ocrDataJson", "imagePath", "videoChunkPath", "embedding",
+  ]
+
+  static var syncedTableNames: [String] { tableSpecs.map(\.name) }
+
+  /// Tables with an explicit column allow-list (new columns never sync by default).
+  static var graphSyncTableNames: [String] {
+    tableSpecs.filter { !$0.includedColumns.isEmpty }.map(\.name)
+  }
+
+  static func resolvedColumnsForTable(_ name: String, schemaColumns: [String]) -> [String]? {
+    guard let spec = tableSpecs.first(where: { $0.name == name }) else { return nil }
+    return resolveSyncColumns(spec: spec, schemaColumns: schemaColumns)
+  }
+
+  #if DEBUG
+    static var tableSpecsForTesting: [TableSpec] { tableSpecs }
+  #endif
 
   /// Recovery state belongs to the effective owner, not to a particular loop
   /// task or aggregate sync result. A missing required table has its own
@@ -129,26 +162,35 @@ actor AgentSyncService {
 
   private static let tableSpecs: [TableSpec] = [
     // Mutable (cursor by updatedAt) — sessions before segments (FK dependency)
-    TableSpec(name: "transcription_sessions", appendOnly: false, excludedColumns: []),
+    TableSpec(name: "transcription_sessions", appendOnly: false, includedColumns: [], excludedColumns: []),
     TableSpec(
       name: "action_items", appendOnly: false,
+      includedColumns: [],
       excludedColumns: [
         "agentStatus", "agentSessionName", "agentPrompt", "agentPlan",
         "agentStartedAt", "agentCompletedAt", "agentEditedFilesJson",
         "chatSessionId",
       ]),
-    TableSpec(name: "memories", appendOnly: false, excludedColumns: []),
-    TableSpec(name: "staged_tasks", appendOnly: false, excludedColumns: []),
-    TableSpec(name: "live_notes", appendOnly: false, excludedColumns: []),
+    TableSpec(name: "memories", appendOnly: false, includedColumns: [], excludedColumns: []),
+    TableSpec(name: "staged_tasks", appendOnly: false, includedColumns: [], excludedColumns: []),
+    TableSpec(name: "live_notes", appendOnly: false, includedColumns: [], excludedColumns: []),
     // Append-only (cursor by id) — segments after sessions
+    TableSpec(name: "transcription_segments", appendOnly: true, includedColumns: [], excludedColumns: []),
+    TableSpec(name: "focus_sessions", appendOnly: true, includedColumns: [], excludedColumns: []),
+    // Memory graph — derived facts only; no screenshots/OCR/images (see HANDOFF.md Path 1)
     TableSpec(
-      name: "screenshots", appendOnly: true,
-      excludedColumns: [
-        "ocrDataJson"
-      ]),
-    TableSpec(name: "transcription_segments", appendOnly: true, excludedColumns: []),
-    TableSpec(name: "focus_sessions", appendOnly: true, excludedColumns: []),
-    TableSpec(name: "observations", appendOnly: true, excludedColumns: []),
+      name: "local_kg_nodes", appendOnly: false,
+      includedColumns: [
+        "id", "nodeId", "label", "nodeType", "aliasesJson", "sourceFileIds",
+        "createdAt", "updatedAt",
+      ],
+      excludedColumns: []),
+    TableSpec(
+      name: "local_kg_edges", appendOnly: true,
+      includedColumns: [
+        "id", "edgeId", "sourceNodeId", "targetNodeId", "label", "createdAt",
+      ],
+      excludedColumns: []),
   ]
 
   private let tables = AgentSyncService.tableSpecs
@@ -488,7 +530,7 @@ actor AgentSyncService {
         let fetched: [String] = try await dbPool.read { db in
           let columnInfos = try Row.fetchAll(db, sql: "PRAGMA table_info('\(spec.name)')")
           let allColumns = columnInfos.compactMap { $0["name"] as? String }
-          return allColumns.filter { !spec.excludedColumns.contains($0) }
+          return Self.resolveSyncColumns(spec: spec, schemaColumns: allColumns)
         }
         await RewindDatabase.shared.reportQuerySuccess()
         guard syncGeneration == generation else { return 0 }

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -305,7 +305,7 @@ final class AgentSyncBatchQueryTests: XCTestCase {
 
   func testAppendOnlyTablePagesById() {
     let (sql, args) = AgentSyncService.buildBatchQuery(
-      tableName: "screenshots",
+      tableName: "local_kg_edges",
       selectCols: "\"id\"",
       appendOnly: true,
       lastId: 7,
@@ -316,6 +316,35 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     XCTAssertTrue(sql.contains("WHERE id > ? ORDER BY id ASC"), sql)
     XCTAssertFalse(sql.contains("updatedAt"), sql)
     XCTAssertEqual(args, [.int(7), .int(100)])
+  }
+
+  func testSyncedTablesExcludeScreenCaptureTables() {
+    let synced = Set(AgentSyncService.syncedTableNames)
+    XCTAssertFalse(synced.contains("screenshots"), "screenshots must not sync — OCR/images/embeddings stay local")
+    XCTAssertFalse(synced.contains("observations"), "observations must not sync — screen context stays local")
+    XCTAssertTrue(synced.contains("local_kg_nodes"))
+    XCTAssertTrue(synced.contains("local_kg_edges"))
+  }
+
+  func testGraphTableSpecsUseExplicitAllowList() {
+    XCTAssertEqual(
+      Set(AgentSyncService.graphSyncTableNames),
+      Set(["local_kg_nodes", "local_kg_edges"]))
+  }
+
+  func testResolvedSyncColumnsExcludeForbiddenScreenFields() {
+    let poisonSchema = [
+      "id", "ocrText", "ocrDataJson", "imagePath", "videoChunkPath", "embedding",
+      "updatedAt", "createdAt", "description", "nodeId", "label",
+    ]
+    for table in AgentSyncService.graphSyncTableNames {
+      let resolved = Set(AgentSyncService.resolvedColumnsForTable(table, schemaColumns: poisonSchema) ?? [])
+      for forbidden in AgentSyncService.forbiddenSyncFieldNames {
+        XCTAssertFalse(
+          resolved.contains(forbidden),
+          "Table \(table) must not sync column \(forbidden)")
+      }
+    }
   }
 
   @MainActor
@@ -349,6 +378,146 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     XCTAssertEqual(requestURLs.first?.path, "/auth")
   }
 }
+
+#if DEBUG
+  private final class AgentSyncEgressProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var payloads: [[String: Any]] = []
+
+    func respond(to request: URLRequest) throws -> (Data, URLResponse) {
+      let url = try XCTUnwrap(request.url)
+      switch url.path {
+      case "/auth":
+        return (Data(), response(url, status: 200))
+      case "/sync":
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        lock.withLock { payloads.append(json) }
+        return (Data(), response(url, status: 200))
+      default:
+        return (Data(), response(url, status: 404))
+      }
+    }
+
+    func capturedPayloads() -> [[String: Any]] {
+      lock.withLock { payloads }
+    }
+
+    private func response(_ url: URL, status: Int) -> URLResponse {
+      HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
+        ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+    }
+  }
+
+  /// Integration guard: even when screenshots/observations rows exist locally,
+  /// agent-VM sync must never POST OCR, image paths, or embedding blobs.
+  final class AgentSyncEgressTests: XCTestCase {
+    private var storageFixture: RewindStorageTestIsolation.Fixture?
+    private var authSnapshot: RewindStorageTestIsolation.AuthSnapshot?
+
+    override func setUp() async throws {
+      try await super.setUp()
+      let fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "agent-sync-egress")
+      storageFixture = fixture
+      authSnapshot = await MainActor.run { RewindStorageTestIsolation.captureAuthSnapshot() }
+      await MainActor.run { RewindStorageTestIsolation.signInForTests(userId: fixture.testUserId) }
+      try await insertLocalScreenCaptureRows()
+      try await insertGraphRows()
+    }
+
+    override func tearDown() async throws {
+      if let authSnapshot {
+        await MainActor.run { RewindStorageTestIsolation.restoreAuthSnapshot(authSnapshot) }
+      }
+      await RewindStorageTestIsolation.tearDown(userDir: storageFixture?.userDir)
+      try await super.tearDown()
+    }
+
+    func testSyncPayloadExcludesScreenCaptureFields() async {
+      let probe = AgentSyncEgressProbe()
+      let service = AgentSyncService(
+        networkHooks: AgentSyncService.NetworkHooks(
+          fetchIDToken: { "test-firebase-token" },
+          dataForRequest: { request in try probe.respond(to: request) },
+          reuploadDatabase: { _, _ in true },
+          now: Date.init,
+          tableSyncEnabled: true))
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+      await service.syncOnceForTesting()
+      await service.stop(flushPendingChanges: false)
+
+      let payloads = probe.capturedPayloads()
+      XCTAssertFalse(payloads.isEmpty, "Sync tick should POST at least one table")
+
+      let syncedTables = Set(payloads.compactMap { $0["table"] as? String })
+      XCTAssertFalse(syncedTables.contains("screenshots"))
+      XCTAssertFalse(syncedTables.contains("observations"))
+
+      let forbidden = AgentSyncService.forbiddenSyncFieldNames
+      for payload in payloads {
+        let table = payload["table"] as? String ?? "<unknown>"
+        let rows = payload["rows"] as? [[String: Any]] ?? []
+        for row in rows {
+          for key in row.keys {
+            XCTAssertFalse(
+              forbidden.contains(key),
+              "Sync payload for \(table) must not include forbidden field \(key)")
+          }
+        }
+      }
+    }
+
+    private func insertLocalScreenCaptureRows() async throws {
+      guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+        return XCTFail("Rewind database should be initialized")
+      }
+      let now = Date(timeIntervalSince1970: 1_700_000_000)
+      let fakeEmbedding = Data(repeating: 0xAB, count: 12_288)
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO screenshots (
+              timestamp, appName, windowTitle, imagePath, ocrText, ocrDataJson, isIndexed, embedding
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [
+            now, "Safari", "Secret Page", "/tmp/leak.jpg", "CONFIDENTIAL OCR TEXT",
+            "{\"lines\":[]}", false, fakeEmbedding,
+          ])
+        try db.execute(
+          sql: """
+            INSERT INTO observations (
+              screenshotId, appName, contextSummary, currentActivity, hasTask, createdAt
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [1, "Safari", "Reading docs", "Browsing", false, now])
+      }
+    }
+
+    private func insertGraphRows() async throws {
+      guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+        return XCTFail("Rewind database should be initialized")
+      }
+      let now = Date(timeIntervalSince1970: 1_700_000_000)
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO local_kg_nodes (
+              nodeId, label, nodeType, createdAt, updatedAt
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+          arguments: ["node-1", "Example Entity", "concept", now, now])
+        try db.execute(
+          sql: """
+            INSERT INTO local_kg_edges (
+              edgeId, sourceNodeId, targetNodeId, label, createdAt
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+          arguments: ["edge-1", "node-1", "node-2", "related_to", now])
+      }
+    }
+  }
+#endif
 
 #if DEBUG
   // omi-release-compile: this suite drives AgentSyncService's DEBUG-only

--- a/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
+++ b/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
@@ -1,0 +1,3 @@
+{
+  "change": "Agent sync now transmits knowledge graph data only; screenshots, OCR text, and screen embeddings no longer leave this Mac"
+}


### PR DESCRIPTION
## Product invariants affected
- INV-AUTH-1

## Summary
- Removes `screenshots` and `observations` from AgentSyncService tableSpecs.
- Adds `local_kg_nodes` / `local_kg_edges` with explicit column allow-lists.

## Test plan
- [ ] `swift test --filter AgentSync` in CI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Product invariants affected

- INV-AUTH-1

Failure-Class: none
