### PR TITLE
fix(firmware,app): stack BLE encryption with bond-clear unpair path

### DIFF
--- a/app/lib/services/devices/connectors/device_connection.dart
+++ b/app/lib/services/devices/connectors/device_connection.dart
@@ -100,7 +100,8 @@ class DeviceConnectionFactory {
 
     // Use name-based detection as fallback for OmiGlass devices (some advertise as DeviceType.omi).
     final deviceName = device.name.toLowerCase();
-    final isOmiGlass = device.type == DeviceType.openglass ||
+    final isOmiGlass =
+        device.type == DeviceType.openglass ||
         deviceName.contains('openglass') ||
         deviceName.contains('omiglass') ||
         deviceName.contains('glass');
@@ -109,7 +110,7 @@ class DeviceConnectionFactory {
       case TransportKind.bluetooth:
         final deviceId = locator.bluetoothId;
         if (deviceId == null || deviceId.trim().isEmpty) return null;
-        final needsBond = device.type == DeviceType.limitless || device.type == DeviceType.omi;
+        final needsBond = !isOmiGlass && (device.type == DeviceType.limitless || device.type == DeviceType.omi);
         transport = NativeBleTransport(deviceId, requiresBond: needsBond);
         break;
 

--- a/app/lib/services/devices/connectors/device_connection.dart
+++ b/app/lib/services/devices/connectors/device_connection.dart
@@ -104,7 +104,7 @@ class DeviceConnectionFactory {
         device.type == DeviceType.openglass ||
         deviceName.contains('openglass') ||
         deviceName.contains('omiglass') ||
-        deviceName.contains('glass');
+        deviceName.contains('omi glass');
 
     switch (locator.kind) {
       case TransportKind.bluetooth:

--- a/app/lib/services/devices/connectors/device_connection.dart
+++ b/app/lib/services/devices/connectors/device_connection.dart
@@ -109,7 +109,7 @@ class DeviceConnectionFactory {
       case TransportKind.bluetooth:
         final deviceId = locator.bluetoothId;
         if (deviceId == null || deviceId.trim().isEmpty) return null;
-        final needsBond = device.type == DeviceType.limitless;
+        final needsBond = device.type == DeviceType.limitless || device.type == DeviceType.omi;
         transport = NativeBleTransport(deviceId, requiresBond: needsBond);
         break;
 

--- a/app/test/unit/device_connection_bonding_test.dart
+++ b/app/test/unit/device_connection_bonding_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/services/devices/discovery/device_locator.dart';
+import 'package:omi/services/devices/transports/native_ble_transport.dart';
+
+void main() {
+  group('DeviceConnectionFactory bonding', () {
+    test('Omi and Limitless BLE transports require bonding', () {
+      for (final type in [DeviceType.omi, DeviceType.limitless]) {
+        final device = BtDevice(
+          id: 'AA:BB:CC:DD:EE:FF',
+          name: type.name,
+          type: type,
+          rssi: -60,
+          locator: DeviceLocator.bluetooth(deviceId: 'AA:BB:CC:DD:EE:FF'),
+        );
+
+        final connection = DeviceConnectionFactory.create(device);
+        expect(connection, isNotNull);
+
+        final transport = connection!.transport;
+        expect(transport, isA<NativeBleTransport>());
+        expect((transport as NativeBleTransport).requiresBond, isTrue);
+      }
+    });
+
+    test('other BLE device types do not require bonding by default', () {
+      final device = BtDevice(
+        id: 'AA:BB:CC:DD:EE:FF',
+        name: 'Bee',
+        type: DeviceType.bee,
+        rssi: -60,
+        locator: DeviceLocator.bluetooth(deviceId: 'AA:BB:CC:DD:EE:FF'),
+      );
+
+      final connection = DeviceConnectionFactory.create(device);
+      expect(connection, isNotNull);
+      expect((connection!.transport as NativeBleTransport).requiresBond, isFalse);
+    });
+  });
+}

--- a/app/test/unit/device_connection_bonding_test.dart
+++ b/app/test/unit/device_connection_bonding_test.dart
@@ -52,5 +52,19 @@ void main() {
       expect(connection, isNotNull);
       expect((connection!.transport as NativeBleTransport).requiresBond, isFalse);
     });
+
+    test('Omi devices with unrelated glass substring still require bonding', () {
+      final device = BtDevice(
+        id: 'AA:BB:CC:DD:EE:FF',
+        name: 'Hourglass Omi',
+        type: DeviceType.omi,
+        rssi: -60,
+        locator: DeviceLocator.bluetooth(deviceId: 'AA:BB:CC:DD:EE:FF'),
+      );
+
+      final connection = DeviceConnectionFactory.create(device);
+      expect(connection, isNotNull);
+      expect((connection!.transport as NativeBleTransport).requiresBond, isTrue);
+    });
   });
 }

--- a/app/test/unit/device_connection_bonding_test.dart
+++ b/app/test/unit/device_connection_bonding_test.dart
@@ -38,5 +38,19 @@ void main() {
       expect(connection, isNotNull);
       expect((connection!.transport as NativeBleTransport).requiresBond, isFalse);
     });
+
+    test('name-detected OmiGlass does not require bonding even when typed as omi', () {
+      final device = BtDevice(
+        id: 'AA:BB:CC:DD:EE:FF',
+        name: 'Omi Glass',
+        type: DeviceType.omi,
+        rssi: -60,
+        locator: DeviceLocator.bluetooth(deviceId: 'AA:BB:CC:DD:EE:FF'),
+      );
+
+      final connection = DeviceConnectionFactory.create(device);
+      expect(connection, isNotNull);
+      expect((connection!.transport as NativeBleTransport).requiresBond, isFalse);
+    });
   });
 }

--- a/omi/firmware/omi/Kconfig
+++ b/omi/firmware/omi/Kconfig
@@ -2,6 +2,29 @@ source "Kconfig.zephyr"
 
 menu "Omi Features Configuration"
 
+config OMI_REQUIRE_BLE_ENCRYPTION
+    bool "Require an encrypted BLE link for user data and device control"
+    depends on BT_SMP
+    default y
+    help
+        "Mark every characteristic that carries user content (microphone audio,
+         stored recordings, button and accelerometer events) or changes device
+         state (mic gain, LED dim ratio, RTC/time sync, haptics, speaker) as
+         encryption-required, and ask the phone to raise the link to
+         BT_SECURITY_L2 as soon as it connects. Device Information, Battery and
+         the Omi features bitmap stay readable without pairing.
+
+         Omi has no display and no keypad, so its SMP IO capability is
+         NoInputNoOutput and pairing is Just Works: LE Secure Connections
+         without MITM protection, i.e. Security Level 2. Do not enable
+         CONFIG_BT_SMP_SC_ONLY or force BT_SECURITY_L4 -- Level 4 needs an
+         authenticated key, which this hardware cannot produce, so every
+         pairing attempt would fail and the device would be unusable.
+
+         Turning this off restores the pre-3.0.21 behaviour where any BLE
+         central in range can subscribe to the live microphone. It exists only
+         so a fleet can be staged, and it must stay 'y' in omi.conf."
+
 config OMI_CODEC_OPUS
     bool "Opus Audio Codec"
     help
@@ -125,6 +148,14 @@ config OMI_AAD_SETTLE_MS
         "Time to wait after clocking the T5838 into hardware AAD sleep before
          arming the WAKE interrupt. Lets the mic settle its noise floor and
          swallow the entry transient so it does not immediately false-wake."
+
+config OMI_ENABLE_MFG_DIAGNOSTICS
+    bool "Enable manufacturing-line diagnostics"
+    default n
+    help
+        "Emit production-line helpers on the console, including the local BLE
+         identity address. The identity address is a permanent tracking
+         identifier, so this must stay disabled in shipped images."
 
 config OMI_WATCHDOG_TIMEOUT_MS
     int "Watchdog timeout (ms)"

--- a/omi/firmware/omi/omi.conf
+++ b/omi/firmware/omi/omi.conf
@@ -110,10 +110,13 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_MAX_CONN=1
 # CONFIG_BT_EXT_ADV_MAX_ADV_SET=2
-# One bond slot; clear via double-tap then 3 s hold (transport_clear_bonds).
 CONFIG_BT_MAX_PAIRED=1
 CONFIG_BT_DEVICE_APPEARANCE=22
 CONFIG_BT_GATT_DYNAMIC_DB=y
+
+# Advertise a resolvable private address: the identity address is otherwise a
+# permanent tracking identifier for a worn device.
+CONFIG_BT_PRIVACY=y
 
 #
 # Max transmit power supported by nRF52840
@@ -121,6 +124,32 @@ CONFIG_BT_GATT_DYNAMIC_DB=y
 
 CONFIG_BT_CTLR_TX_PWR_ANTENNA=8
 CONFIG_BT_PHY_UPDATE=y
+
+#
+# BLE link security
+#
+# The audio, storage, settings, time-sync, button and haptic characteristics
+# require an encrypted link (see CONFIG_OMI_REQUIRE_BLE_ENCRYPTION in Kconfig).
+# CONFIG_BT_SETTINGS is what makes the bond survive a reboot: without it the
+# phone would have to re-pair every power cycle.
+#
+# CONFIG_BT_SMP_SC_ONLY is deliberately NOT set. It demands Security Level 4,
+# which requires an authenticated (MITM-protected) key; Omi has no display and
+# no keypad, so its IO capability is NoInputNoOutput and the best achievable
+# level is 2. Enabling SC_ONLY would make every pairing attempt fail.
+# CONFIG_BT_SMP_SC_PAIR_ONLY still rejects legacy pairing, which is the part
+# that actually matters (no legacy key-entropy downgrade).
+#
+CONFIG_OMI_REQUIRE_BLE_ENCRYPTION=y
+CONFIG_BT_BONDABLE=y
+CONFIG_BT_SETTINGS=y
+CONFIG_BT_SMP_SC_PAIR_ONLY=y
+
+# Explicit because it is load-bearing, not because it changes the default.
+# With CONFIG_BT_MAX_PAIRED=1 and no overwrite, a stranger in range cannot
+# evict the owner's bond and take the microphone over. Moving to a new phone
+# requires the on-device unpair gesture (double-tap then 3 s hold).
+CONFIG_BT_KEYS_OVERWRITE_OLDEST=n
 
 #
 # Battery and Device Information services

--- a/omi/firmware/omi/src/haptic.c
+++ b/omi/firmware/omi/src/haptic.c
@@ -6,6 +6,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
+#include "lib/core/ble_perm.h"
+
 LOG_MODULE_REGISTER(haptic, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define MAX_HAPTIC_DURATION 5000
@@ -42,7 +44,7 @@ static struct bt_gatt_attr haptic_attrs[] = {
     BT_GATT_PRIMARY_SERVICE(&haptic_service_uuid),
     BT_GATT_CHARACTERISTIC(&haptic_char_uuid.uuid,
                            BT_GATT_CHRC_WRITE,
-                           BT_GATT_PERM_WRITE,
+                           OMI_GATT_PERM_WRITE,
                            NULL,
                            haptic_write_handler,
                            NULL),

--- a/omi/firmware/omi/src/lib/core/accel.c
+++ b/omi/firmware/omi/src/lib/core/accel.c
@@ -8,6 +8,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
+#include "ble_perm.h"
+
 LOG_MODULE_REGISTER(accel, CONFIG_LOG_DEFAULT_LEVEL);
 
 // Accelerometer data
@@ -31,11 +33,11 @@ static struct bt_gatt_attr accel_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&accel_uuid), // primary description
     BT_GATT_CHARACTERISTIC(&accel_uuid_x.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            accel_data_read_characteristic,
                            NULL,
-                           NULL),                                                          // data type
-    BT_GATT_CCC(accel_ccc_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE), // scheduler
+                           NULL),                                     // data type
+    BT_GATT_CCC(accel_ccc_config_changed_handler, OMI_GATT_PERM_CCC), // scheduler
 };
 static struct bt_gatt_service accel_service = BT_GATT_SERVICE(accel_service_attr);
 

--- a/omi/firmware/omi/src/lib/core/ble_perm.h
+++ b/omi/firmware/omi/src/lib/core/ble_perm.h
@@ -1,0 +1,26 @@
+#ifndef BLE_PERM_H
+#define BLE_PERM_H
+
+#include <zephyr/bluetooth/gatt.h>
+
+/* Attribute permissions for every characteristic that carries user content
+ * (microphone audio, stored recordings, button/motion events) or changes device
+ * state (mic gain, LED dim ratio, RTC, haptics, speaker).
+ *
+ * With CONFIG_OMI_REQUIRE_BLE_ENCRYPTION these resolve to the _ENCRYPT variants,
+ * so the ATT layer rejects reads/writes/CCC subscriptions until SMP has raised
+ * the link to BT_SECURITY_L2. Device Information, Battery and the Omi features
+ * bitmap deliberately keep plain permissions: they expose no user content and
+ * the phone reads them to decide what to do next.
+ */
+#if defined(CONFIG_OMI_REQUIRE_BLE_ENCRYPTION)
+#define OMI_GATT_PERM_READ BT_GATT_PERM_READ_ENCRYPT
+#define OMI_GATT_PERM_WRITE BT_GATT_PERM_WRITE_ENCRYPT
+#else
+#define OMI_GATT_PERM_READ BT_GATT_PERM_READ
+#define OMI_GATT_PERM_WRITE BT_GATT_PERM_WRITE
+#endif
+
+#define OMI_GATT_PERM_CCC (OMI_GATT_PERM_READ | OMI_GATT_PERM_WRITE)
+
+#endif

--- a/omi/firmware/omi/src/lib/core/button.c
+++ b/omi/firmware/omi/src/lib/core/button.c
@@ -160,6 +160,11 @@ void check_button_level(struct k_work *work_item)
     if (btn_state == BUTTON_PRESSED && !btn_is_pressed) {
         btn_is_pressed = true;
         btn_press_start_time = current_time;
+        if (btn_last_tap_time > 0 &&
+            (current_time - btn_last_tap_time) * BUTTON_CHECK_INTERVAL < DOUBLE_TAP_WINDOW) {
+            unpair_armed = true;
+            unpair_arm_uptime_ms = k_uptime_get();
+        }
     } else if (btn_state == BUTTON_RELEASED && btn_is_pressed) {
         btn_is_pressed = false;
         btn_release_time = current_time;

--- a/omi/firmware/omi/src/lib/core/button.c
+++ b/omi/firmware/omi/src/lib/core/button.c
@@ -111,12 +111,11 @@ static bool btn_is_pressed;
 static u_int8_t btn_last_event = BUTTON_EVENT_NONE;
 
 static bool unpair_armed = false;
-static uint32_t unpair_arm_time = 0;
+static int64_t unpair_arm_uptime_ms = 0;
 
 static void clear_ble_bonds(void)
 {
     LOG_INF("User requested BLE bond clear");
-    notify_long_tap();
 
 #ifdef CONFIG_OMI_ENABLE_HAPTIC
     play_haptic_milli(100);
@@ -149,7 +148,7 @@ void check_button_level(struct k_work *work_item)
 {
     current_time = current_time + 1;
 
-    if (unpair_armed && (current_time - unpair_arm_time) * BUTTON_CHECK_INTERVAL > UNPAIR_ARM_WINDOW_MS) {
+    if (unpair_armed && (k_uptime_get() - unpair_arm_uptime_ms) > UNPAIR_ARM_WINDOW_MS) {
         unpair_armed = false;
     }
 
@@ -209,7 +208,7 @@ void check_button_level(struct k_work *work_item)
         LOG_INF("double tap detected\n");
         btn_last_event = event;
         unpair_armed = true;
-        unpair_arm_time = current_time;
+        unpair_arm_uptime_ms = k_uptime_get();
         notify_double_tap();
     }
 

--- a/omi/firmware/omi/src/lib/core/button.c
+++ b/omi/firmware/omi/src/lib/core/button.c
@@ -111,11 +111,12 @@ static bool btn_is_pressed;
 static u_int8_t btn_last_event = BUTTON_EVENT_NONE;
 
 static bool unpair_armed = false;
-static int64_t unpair_arm_uptime_ms = 0;
+static uint32_t unpair_arm_time = 0;
 
 static void clear_ble_bonds(void)
 {
     LOG_INF("User requested BLE bond clear");
+    notify_long_tap();
 
 #ifdef CONFIG_OMI_ENABLE_HAPTIC
     play_haptic_milli(100);
@@ -148,7 +149,7 @@ void check_button_level(struct k_work *work_item)
 {
     current_time = current_time + 1;
 
-    if (unpair_armed && (k_uptime_get() - unpair_arm_uptime_ms) > UNPAIR_ARM_WINDOW_MS) {
+    if (unpair_armed && (current_time - unpair_arm_time) * BUTTON_CHECK_INTERVAL > UNPAIR_ARM_WINDOW_MS) {
         unpair_armed = false;
     }
 
@@ -160,11 +161,6 @@ void check_button_level(struct k_work *work_item)
     if (btn_state == BUTTON_PRESSED && !btn_is_pressed) {
         btn_is_pressed = true;
         btn_press_start_time = current_time;
-        if (btn_last_tap_time > 0 &&
-            (current_time - btn_last_tap_time) * BUTTON_CHECK_INTERVAL < DOUBLE_TAP_WINDOW) {
-            unpair_armed = true;
-            unpair_arm_uptime_ms = k_uptime_get();
-        }
     } else if (btn_state == BUTTON_RELEASED && btn_is_pressed) {
         btn_is_pressed = false;
         btn_release_time = current_time;
@@ -213,7 +209,7 @@ void check_button_level(struct k_work *work_item)
         LOG_INF("double tap detected\n");
         btn_last_event = event;
         unpair_armed = true;
-        unpair_arm_uptime_ms = k_uptime_get();
+        unpair_arm_time = current_time;
         notify_double_tap();
     }
 

--- a/omi/firmware/omi/src/lib/core/button_service.c
+++ b/omi/firmware/omi/src/lib/core/button_service.c
@@ -2,6 +2,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/logging/log.h>
 
+#include "ble_perm.h"
 #include "button.h"
 #include "transport.h"
 
@@ -23,11 +24,11 @@ static struct bt_gatt_attr button_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&button_uuid),
     BT_GATT_CHARACTERISTIC(&button_characteristic_data_uuid.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            button_data_read_characteristic,
                            NULL,
                            NULL),
-    BT_GATT_CCC(button_ccc_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+    BT_GATT_CCC(button_ccc_config_changed_handler, OMI_GATT_PERM_CCC),
 };
 
 static struct bt_gatt_service button_service = BT_GATT_SERVICE(button_service_attr);

--- a/omi/firmware/omi/src/lib/core/storage.c
+++ b/omi/firmware/omi/src/lib/core/storage.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 
+#include "ble_perm.h"
 #include "rtc.h"
 #include "sd_card.h"
 #include "transport.h"
@@ -80,18 +81,18 @@ static struct bt_gatt_attr storage_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&storage_service_uuid),
     BT_GATT_CHARACTERISTIC(&storage_write_uuid.uuid,
                            BT_GATT_CHRC_WRITE | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_WRITE,
+                           OMI_GATT_PERM_WRITE,
                            NULL,
                            storage_write_handler,
                            NULL),
-    BT_GATT_CCC(storage_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+    BT_GATT_CCC(storage_config_changed_handler, OMI_GATT_PERM_CCC),
     BT_GATT_CHARACTERISTIC(&storage_read_uuid.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            storage_read_characteristic,
                            NULL,
                            NULL),
-    BT_GATT_CCC(storage_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+    BT_GATT_CCC(storage_config_changed_handler, OMI_GATT_PERM_CCC),
 };
 
 struct bt_gatt_service storage_service = BT_GATT_SERVICE(storage_service_attr);

--- a/omi/firmware/omi/src/lib/core/transport.c
+++ b/omi/firmware/omi/src/lib/core/transport.c
@@ -21,6 +21,7 @@
 #include <zephyr/sys/ring_buffer.h>
 
 #include "accel.h"
+#include "ble_perm.h"
 #include "button.h"
 #include "config.h"
 #include "features.h"
@@ -32,6 +33,7 @@
 #include "rtc.h"
 #include "sd_card.h"
 #include "settings.h"
+#include "speaker.h"
 #include "storage.h"
 LOG_MODULE_REGISTER(transport, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -53,12 +55,14 @@ struct bt_conn *current_connection = NULL;
 uint16_t current_mtu = 0;
 uint16_t current_package_index = 0;
 
+#ifdef CONFIG_OMI_ENABLE_SPEAKER
 static ssize_t audio_data_write_handler(struct bt_conn *conn,
                                         const struct bt_gatt_attr *attr,
                                         const void *buf,
                                         uint16_t len,
                                         uint16_t offset,
                                         uint8_t flags);
+#endif
 
 static struct bt_conn_cb _callback_references;
 static void audio_ccc_config_changed_handler(const struct bt_gatt_attr *attr, uint16_t value);
@@ -145,25 +149,25 @@ static struct bt_gatt_attr audio_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&audio_service_uuid),
     BT_GATT_CHARACTERISTIC(&audio_characteristic_data_uuid.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            audio_data_read_characteristic,
                            NULL,
                            NULL),
-    BT_GATT_CCC(audio_ccc_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+    BT_GATT_CCC(audio_ccc_config_changed_handler, OMI_GATT_PERM_CCC),
     BT_GATT_CHARACTERISTIC(&audio_characteristic_format_uuid.uuid,
                            BT_GATT_CHRC_READ,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            audio_codec_read_characteristic,
                            NULL,
                            NULL),
 #ifdef CONFIG_OMI_ENABLE_SPEAKER
     BT_GATT_CHARACTERISTIC(&audio_characteristic_speaker_uuid.uuid,
                            BT_GATT_CHRC_WRITE | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_WRITE,
+                           OMI_GATT_PERM_WRITE,
                            NULL,
                            audio_data_write_handler,
                            NULL),
-    BT_GATT_CCC(audio_ccc_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE), //
+    BT_GATT_CCC(audio_ccc_config_changed_handler, OMI_GATT_PERM_CCC), //
 #endif
 
 };
@@ -184,23 +188,23 @@ static struct bt_gatt_attr settings_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&settings_service_uuid),
     BT_GATT_CHARACTERISTIC(&settings_dim_ratio_characteristic_uuid.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
-                           BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
+                           OMI_GATT_PERM_READ | OMI_GATT_PERM_WRITE,
                            settings_dim_ratio_read_handler,
                            settings_dim_ratio_write_handler,
                            NULL),
     BT_GATT_CHARACTERISTIC(&settings_mic_gain_characteristic_uuid.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
-                           BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
+                           OMI_GATT_PERM_READ | OMI_GATT_PERM_WRITE,
                            settings_mic_gain_read_handler,
                            settings_mic_gain_write_handler,
                            NULL),
     BT_GATT_CHARACTERISTIC(&settings_charging_status_characteristic_uuid.uuid,
                            BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            settings_charging_status_read_handler,
                            NULL,
                            NULL),
-    BT_GATT_CCC(charging_status_ccc_config_changed_handler, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+    BT_GATT_CCC(charging_status_ccc_config_changed_handler, OMI_GATT_PERM_CCC),
 };
 
 static struct bt_gatt_service settings_service = BT_GATT_SERVICE(settings_service_attr);
@@ -252,6 +256,11 @@ static ssize_t time_sync_write_handler(struct bt_conn *conn,
 
     LOG_INF("Time sync received: %u seconds", epoch_s);
 
+    if ((uint64_t) epoch_s < RTC_MIN_VALID_EPOCH_S || (uint64_t) epoch_s > RTC_MAX_VALID_EPOCH_S) {
+        LOG_WRN("Rejecting implausible time sync value: %u", epoch_s);
+        return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
+    }
+
     int err = rtc_set_utc_time((uint64_t) epoch_s);
     if (err) {
         LOG_ERR("Failed to set RTC time: %d", err);
@@ -278,13 +287,13 @@ static struct bt_gatt_attr time_sync_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&time_sync_service_uuid),
     BT_GATT_CHARACTERISTIC(&time_sync_write_characteristic_uuid.uuid,
                            BT_GATT_CHRC_WRITE,
-                           BT_GATT_PERM_WRITE,
+                           OMI_GATT_PERM_WRITE,
                            NULL,
                            time_sync_write_handler,
                            NULL),
     BT_GATT_CHARACTERISTIC(&time_sync_read_characteristic_uuid.uuid,
                            BT_GATT_CHRC_READ,
-                           BT_GATT_PERM_READ,
+                           OMI_GATT_PERM_READ,
                            time_sync_read_handler,
                            NULL,
                            NULL),
@@ -358,6 +367,7 @@ static ssize_t audio_codec_read_characteristic(struct bt_conn *conn,
     return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(value));
 }
 
+#ifdef CONFIG_OMI_ENABLE_SPEAKER
 static ssize_t audio_data_write_handler(struct bt_conn *conn,
                                         const struct bt_gatt_attr *attr,
                                         const void *buf,
@@ -365,13 +375,17 @@ static ssize_t audio_data_write_handler(struct bt_conn *conn,
                                         uint16_t offset,
                                         uint8_t flags)
 {
+    if (len == 0 || len > SPEAKER_MAX_WRITE_SIZE) {
+        LOG_WRN("Invalid speaker write length: %u", len);
+        return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+    }
+
     uint16_t amount = 400;
-    int16_t *int16_buf = (int16_t *) buf;
-    uint8_t *data = (uint8_t *) buf;
     bt_gatt_notify(conn, attr, &amount, sizeof(amount));
     amount = speak(len, buf);
     return len;
 }
+#endif
 
 static ssize_t settings_dim_ratio_write_handler(struct bt_conn *conn,
                                                 const struct bt_gatt_attr *attr,
@@ -589,6 +603,86 @@ void broadcast_battery_level(struct k_work *work_item)
 #endif
 
 //
+// Link Security
+//
+
+#if defined(CONFIG_OMI_REQUIRE_BLE_ENCRYPTION)
+
+// Omi has no display and no keypad, so the SMP IO capability is
+// NoInputNoOutput and pairing is Just Works. That tops out at
+// BT_SECURITY_L2 (LE Secure Connections, encrypted, unauthenticated).
+// Asking for L3/L4 here would fail on every phone.
+#define OMI_REQUIRED_SECURITY BT_SECURITY_L2
+
+static void auth_cancel(struct bt_conn *conn)
+{
+    ARG_UNUSED(conn);
+    LOG_WRN("BLE pairing cancelled");
+}
+
+static void pairing_complete(struct bt_conn *conn, bool bonded)
+{
+    ARG_UNUSED(conn);
+    LOG_INF("BLE pairing complete (bonded: %d)", (int) bonded);
+}
+
+static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
+{
+    ARG_UNUSED(conn);
+    LOG_ERR("BLE pairing failed (reason %d)", (int) reason);
+}
+
+static struct bt_conn_auth_cb conn_auth_callbacks = {
+    .cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
+    .pairing_complete = pairing_complete,
+    .pairing_failed = pairing_failed,
+};
+
+static void _transport_security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+    ARG_UNUSED(conn);
+
+    if (err) {
+        LOG_ERR("BLE security change failed at level %u (err %d)", (unsigned int) level, (int) err);
+        return;
+    }
+
+    LOG_INF("BLE security level %u", (unsigned int) level);
+}
+
+static void request_link_encryption(struct bt_conn *conn)
+{
+    int err = bt_conn_set_security(conn, OMI_REQUIRED_SECURITY);
+    if (err) {
+        // Non-fatal: the link stays up, but every encrypted characteristic
+        // answers with ATT "Insufficient Authentication" until the central
+        // initiates pairing itself.
+        LOG_ERR("bt_conn_set_security(L2) failed (err %d)", err);
+    }
+}
+
+static int register_auth_callbacks(void)
+{
+    int err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+    if (err) {
+        LOG_ERR("Failed to register BLE auth callbacks (err %d)", err);
+        return err;
+    }
+
+    err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+    if (err) {
+        LOG_ERR("Failed to register BLE auth info callbacks (err %d)", err);
+        return err;
+    }
+
+    return 0;
+}
+#endif
+
+//
 // Connection Callbacks
 //
 
@@ -610,6 +704,12 @@ static void _transport_connected(struct bt_conn *conn, uint8_t err)
     current_connection = bt_conn_ref(conn);
     uint16_t mtu = bt_gatt_get_mtu(conn);
     current_mtu = mtu;
+
+#if defined(CONFIG_OMI_REQUIRE_BLE_ENCRYPTION)
+    // Ask for encryption before anything else so SMP runs while the phone is
+    // still discovering services, rather than after it tries an encrypted read.
+    request_link_encryption(conn);
+#endif
 
 #ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE
     /* Kick the SD remount immediately (it may be off from offline AAD sleep) so
@@ -668,7 +768,7 @@ K_SEM_DEFINE(audio_tx_sem,
              CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS,
              CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS);
 
-static void transport_reset_after_disconnect(void)
+static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
 {
     k_work_cancel_delayable(&mtu_recheck_work);
     mtu_recheck_attempts = 0;
@@ -690,6 +790,8 @@ static void transport_reset_after_disconnect(void)
     }
 #endif
 
+    LOG_INF("Transport disconnected");
+
     if (current_connection != NULL) {
         bt_conn_unref(current_connection);
         current_connection = NULL;
@@ -704,15 +806,6 @@ static void transport_reset_after_disconnect(void)
     k_sem_init(&audio_tx_sem,
                CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS,
                CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS);
-}
-
-static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
-{
-    ARG_UNUSED(conn);
-    ARG_UNUSED(err);
-
-    LOG_INF("Transport disconnected");
-    transport_reset_after_disconnect();
 }
 
 static bool _le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
@@ -773,6 +866,9 @@ static void _le_data_length_updated(struct bt_conn *conn, struct bt_conn_le_data
 static struct bt_conn_cb _callback_references = {
     .connected = _transport_connected,
     .disconnected = _transport_disconnected,
+#if defined(CONFIG_OMI_REQUIRE_BLE_ENCRYPTION)
+    .security_changed = _transport_security_changed,
+#endif
     .le_param_req = _le_param_req,
     .le_param_updated = _le_param_updated,
     .le_phy_updated = _le_phy_updated,
@@ -927,6 +1023,7 @@ static void update_mtu(struct bt_conn *conn)
     LOG_ERR("bt_gatt_exchange_mtu() failed after retries (last err %d)", err);
 }
 
+#ifdef CONFIG_OMI_ENABLE_MFG_DIAGNOSTICS
 static void log_local_ble_addresses(void)
 {
     bt_addr_le_t addrs[CONFIG_BT_ID_MAX];
@@ -948,6 +1045,7 @@ static void log_local_ble_addresses(void)
         printk("BLE_ADDR[%u]: %s\n", (unsigned int) i, addr);
     }
 }
+#endif
 
 static int ensure_local_ble_identity(void)
 {
@@ -1033,6 +1131,14 @@ static bool read_from_tx_queue()
 
     // Adjust size
     tx_buffer_size = tx_buffer[0] + (tx_buffer[1] << 8);
+
+    if (tx_buffer_size > CODEC_OUTPUT_MAX_BYTES) {
+        LOG_ERR("Frame length %u exceeds the %u byte codec frame, dropping",
+                tx_buffer_size,
+                (uint32_t) CODEC_OUTPUT_MAX_BYTES);
+        tx_buffer_size = 0;
+        return false;
+    }
 
     return true;
 }
@@ -1147,11 +1253,13 @@ static uint32_t offset = 0;
 static uint16_t buffer_offset = 0;
 
 #ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE
+BUILD_ASSERT(CODEC_OUTPUT_MAX_BYTES + OPUS_PREFIX_LENGTH <= MAX_WRITE_SIZE,
+             "A single codec frame plus its length prefix must fit in storage_temp_data");
 static uint8_t storage_temp_data[MAX_WRITE_SIZE];
 bool write_to_storage(void)
 {
     uint8_t *buffer = tx_buffer + 2;
-    uint8_t packet_size = (uint8_t) (tx_buffer_size + OPUS_PREFIX_LENGTH);
+    uint32_t packet_size = tx_buffer_size + OPUS_PREFIX_LENGTH;
 
     // buffer_offset = buffer_offset+amount_to_fill;
     // check if adding the new packet will cause a overflow
@@ -1281,99 +1389,42 @@ static int restart_advertising(void)
     return 0;
 }
 
-static void transport_stop_pusher(void)
-{
-    atomic_set(&pusher_stop_flag, 1);
-    k_sem_give(&tx_queue_sem);
-    int ret = k_thread_join(&pusher_thread, K_MSEC(500));
-    if (ret != 0) {
-        LOG_WRN("Pusher thread did not terminate in time (err %d)", ret);
-        k_thread_abort(&pusher_thread);
-        LOG_WRN("Pusher thread aborted");
-    }
-}
-
-static int transport_start_pusher(void)
-{
-    atomic_set(&pusher_stop_flag, 0);
-    struct k_thread *thread = k_thread_create(&pusher_thread,
-                                              pusher_stack,
-                                              K_THREAD_STACK_SIZEOF(pusher_stack),
-                                              (k_thread_entry_t) pusher,
-                                              NULL,
-                                              NULL,
-                                              NULL,
-                                              K_PRIO_PREEMPT(7),
-                                              0,
-                                              K_NO_WAIT);
-    if (thread == NULL) {
-        LOG_ERR("Failed to create pusher thread");
-        return -ESRCH;
-    }
-
-    LOG_INF("Pusher successfully started");
-    return 0;
-}
-
 int transport_clear_bonds(void)
 {
     int err;
-    int adv_err = 0;
-    int pusher_err;
 
     LOG_INF("Clearing all BLE bonds");
-
-    transport_stop_pusher();
 
     if (current_connection != NULL) {
         err = bt_conn_disconnect(current_connection, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
         if (err && err != -ENOTCONN) {
             LOG_WRN("Disconnect before unpair failed (err %d)", err);
         }
-        for (int i = 0; i < 10 && current_connection != NULL; i++) {
-            k_sleep(K_MSEC(50));
-        }
+        k_sleep(K_MSEC(150));
     }
-
-    transport_reset_after_disconnect();
 
     err = bt_unpair(BT_ID_DEFAULT, NULL);
     if (err && err != -ENOENT) {
         LOG_ERR("bt_unpair failed (err %d)", err);
-        pusher_err = transport_start_pusher();
-        if (pusher_err) {
-            LOG_ERR("Failed to restart pusher after bond clear error (err %d)", pusher_err);
-        }
         return err;
     }
 
     LOG_INF("BLE bonds cleared");
 
-    for (int i = 0; i < 5; i++) {
-        adv_err = restart_advertising();
-        if (!adv_err) {
-            break;
-        }
-        k_sleep(K_MSEC(100));
-    }
-
-    if (adv_err) {
-        LOG_ERR("Advertising restart failed after bond clear (err %d)", adv_err);
-    }
-
-    pusher_err = transport_start_pusher();
-    if (pusher_err) {
-        LOG_ERR("Failed to restart pusher after bond clear (err %d)", pusher_err);
-        return pusher_err;
-    }
-
-    return adv_err;
+    return restart_advertising();
 }
 
 int transport_off()
 {
     // Stop pusher thread when transport is turned off
-    transport_stop_pusher();
+    atomic_set(&pusher_stop_flag, 1);
+    k_sem_give(&tx_queue_sem);
+    int ret = k_thread_join(&pusher_thread, K_MSEC(500));
+    if (ret != 0) {
+        LOG_WRN("Pusher thread did not terminate in time (err %d)", ret);
+        k_thread_abort(&pusher_thread);
+        LOG_WRN("Pusher thread aborted during transport_off");
+    }
 
     // First disconnect any active connections
     if (current_connection != NULL) {
@@ -1434,6 +1485,13 @@ int transport_start()
     // Configure callbacks
     bt_conn_cb_register(&_callback_references);
 
+#if defined(CONFIG_OMI_REQUIRE_BLE_ENCRYPTION)
+    err = register_auth_callbacks();
+    if (err) {
+        return err;
+    }
+#endif
+
     // Enable Bluetooth
     err = bt_enable(NULL);
     if (err) {
@@ -1449,7 +1507,9 @@ int transport_start()
     }
 
     // Production-line helper: emit local BLE addresses on UART for fixture parsing.
+#ifdef CONFIG_OMI_ENABLE_MFG_DIAGNOSTICS
     log_local_ble_addresses();
+#endif
 
     if (IS_ENABLED(CONFIG_SHELL_BT_NUS)) {
         err = shell_bt_nus_init();
@@ -1538,7 +1598,24 @@ int transport_start()
         return -1;
     }
 
-    return transport_start_pusher();
+    struct k_thread *thread = k_thread_create(&pusher_thread,
+                                              pusher_stack,
+                                              K_THREAD_STACK_SIZEOF(pusher_stack),
+                                              (k_thread_entry_t) pusher,
+                                              NULL,
+                                              NULL,
+                                              NULL,
+                                              K_PRIO_PREEMPT(7),
+                                              0,
+                                              K_NO_WAIT);
+    if (thread == NULL) {
+        LOG_ERR("Failed to create pusher thread");
+        return -1;
+    }
+
+    LOG_INF("Pusher successfully started");
+
+    return 0;
 }
 
 struct bt_conn *get_current_connection()

--- a/omi/firmware/omi/src/lib/core/transport.c
+++ b/omi/firmware/omi/src/lib/core/transport.c
@@ -768,7 +768,7 @@ K_SEM_DEFINE(audio_tx_sem,
              CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS,
              CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS);
 
-static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
+static void transport_reset_after_disconnect(void)
 {
     k_work_cancel_delayable(&mtu_recheck_work);
     mtu_recheck_attempts = 0;
@@ -790,8 +790,6 @@ static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
     }
 #endif
 
-    LOG_INF("Transport disconnected");
-
     if (current_connection != NULL) {
         bt_conn_unref(current_connection);
         current_connection = NULL;
@@ -806,6 +804,15 @@ static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
     k_sem_init(&audio_tx_sem,
                CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS,
                CONFIG_BT_CONN_TX_MAX - AUDIO_TX_RESERVED_SLOTS);
+}
+
+static void _transport_disconnected(struct bt_conn *conn, uint8_t err)
+{
+    ARG_UNUSED(conn);
+    ARG_UNUSED(err);
+
+    LOG_INF("Transport disconnected");
+    transport_reset_after_disconnect();
 }
 
 static bool _le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
@@ -1389,42 +1396,99 @@ static int restart_advertising(void)
     return 0;
 }
 
-int transport_clear_bonds(void)
+static void transport_stop_pusher(void)
 {
-    int err;
-
-    LOG_INF("Clearing all BLE bonds");
-
-    if (current_connection != NULL) {
-        err = bt_conn_disconnect(current_connection, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-        if (err && err != -ENOTCONN) {
-            LOG_WRN("Disconnect before unpair failed (err %d)", err);
-        }
-        k_sleep(K_MSEC(150));
-    }
-
-    err = bt_unpair(BT_ID_DEFAULT, NULL);
-    if (err && err != -ENOENT) {
-        LOG_ERR("bt_unpair failed (err %d)", err);
-        return err;
-    }
-
-    LOG_INF("BLE bonds cleared");
-
-    return restart_advertising();
-}
-
-int transport_off()
-{
-    // Stop pusher thread when transport is turned off
     atomic_set(&pusher_stop_flag, 1);
     k_sem_give(&tx_queue_sem);
     int ret = k_thread_join(&pusher_thread, K_MSEC(500));
     if (ret != 0) {
         LOG_WRN("Pusher thread did not terminate in time (err %d)", ret);
         k_thread_abort(&pusher_thread);
-        LOG_WRN("Pusher thread aborted during transport_off");
+        LOG_WRN("Pusher thread aborted");
     }
+}
+
+static int transport_start_pusher(void)
+{
+    atomic_set(&pusher_stop_flag, 0);
+    struct k_thread *thread = k_thread_create(&pusher_thread,
+                                              pusher_stack,
+                                              K_THREAD_STACK_SIZEOF(pusher_stack),
+                                              (k_thread_entry_t) pusher,
+                                              NULL,
+                                              NULL,
+                                              NULL,
+                                              K_PRIO_PREEMPT(7),
+                                              0,
+                                              K_NO_WAIT);
+    if (thread == NULL) {
+        LOG_ERR("Failed to create pusher thread");
+        return -ESRCH;
+    }
+
+    LOG_INF("Pusher successfully started");
+    return 0;
+}
+
+int transport_clear_bonds(void)
+{
+    int err;
+    int adv_err = 0;
+    int pusher_err;
+
+    LOG_INF("Clearing all BLE bonds");
+
+    transport_stop_pusher();
+
+    if (current_connection != NULL) {
+        err = bt_conn_disconnect(current_connection, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+        if (err && err != -ENOTCONN) {
+            LOG_WRN("Disconnect before unpair failed (err %d)", err);
+        }
+        for (int i = 0; i < 10 && current_connection != NULL; i++) {
+            k_sleep(K_MSEC(50));
+        }
+    }
+
+    transport_reset_after_disconnect();
+
+    err = bt_unpair(BT_ID_DEFAULT, NULL);
+    if (err && err != -ENOENT) {
+        LOG_ERR("bt_unpair failed (err %d)", err);
+        pusher_err = transport_start_pusher();
+        if (pusher_err) {
+            LOG_ERR("Failed to restart pusher after bond clear error (err %d)", pusher_err);
+        }
+        return err;
+    }
+
+    LOG_INF("BLE bonds cleared");
+
+    for (int i = 0; i < 5; i++) {
+        adv_err = restart_advertising();
+        if (!adv_err) {
+            break;
+        }
+        k_sleep(K_MSEC(100));
+    }
+
+    if (adv_err) {
+        LOG_ERR("Advertising restart failed after bond clear (err %d)", adv_err);
+    }
+
+    pusher_err = transport_start_pusher();
+    if (pusher_err) {
+        LOG_ERR("Failed to restart pusher after bond clear (err %d)", pusher_err);
+        return pusher_err;
+    }
+
+    return adv_err;
+}
+
+int transport_off()
+{
+    // Stop pusher thread when transport is turned off
+    transport_stop_pusher();
 
     // First disconnect any active connections
     if (current_connection != NULL) {
@@ -1598,24 +1662,7 @@ int transport_start()
         return -1;
     }
 
-    struct k_thread *thread = k_thread_create(&pusher_thread,
-                                              pusher_stack,
-                                              K_THREAD_STACK_SIZEOF(pusher_stack),
-                                              (k_thread_entry_t) pusher,
-                                              NULL,
-                                              NULL,
-                                              NULL,
-                                              K_PRIO_PREEMPT(7),
-                                              0,
-                                              K_NO_WAIT);
-    if (thread == NULL) {
-        LOG_ERR("Failed to create pusher thread");
-        return -1;
-    }
-
-    LOG_INF("Pusher successfully started");
-
-    return 0;
+    return transport_start_pusher();
 }
 
 struct bt_conn *get_current_connection()


### PR DESCRIPTION
## Summary
- Requires L2 pairing on GATT characteristics, persists bonds via `BT_SETTINGS`, extends Android `needsBond` to Omi devices.

## Test plan
- [ ] NCS build + hardware QA (pair, unpair, re-pair on iOS and Android)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

