### PR TITLE
security: restrict agent sync to knowledge graph

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -970,23 +970,35 @@ def check_mobile_codemagic_release_triggers() -> list[str]:
             errors.append(f"codemagic.yaml is missing {workflow_id}")
             continue
         body = match.group("body")
-        required = (
-            "    triggering:\n"
-            "      events:\n"
-            "        - push\n"
-            "      branch_patterns:\n"
-            "        - pattern: main\n"
-            "          include: true\n"
-            "      cancel_previous_builds: true\n"
-            "    when:\n"
-            "      changeset:\n"
-            "        includes:\n"
-            "          - 'app/**'"
-        )
-        if required not in body:
+        if "    when:\n      changeset:\n        includes:\n          - 'app/**'" not in body:
             errors.append(
-                f"{workflow_id} must natively trigger on main app/** pushes and cancel stale builds"
+                f"{workflow_id} must retain its app/** changeset guard"
             )
+
+    dispatcher = ROOT / ".github/workflows/mobile_internal_build.yml"
+    if not dispatcher.exists():
+        errors.append("mobile internal build dispatcher is missing")
+    else:
+        dispatcher_text = dispatcher.read_text(encoding="utf-8")
+        dispatcher_script = ROOT / ".github/scripts/dispatch_mobile_internal_builds.py"
+        dispatcher_source = dispatcher_text
+        if dispatcher_script.exists():
+            dispatcher_source += "\n" + dispatcher_script.read_text(encoding="utf-8")
+        required_dispatcher = (
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths: ['app/**']\n"
+            "  schedule:\n"
+            "    - cron: '0 */3 * * *'\n"
+            "  workflow_dispatch:\n"
+        )
+        if required_dispatcher not in dispatcher_text or "cancel-in-progress: true" not in dispatcher_text:
+            errors.append(
+                "mobile internal build dispatcher must trigger on main app/** pushes and cancel stale runs"
+            )
+        for workflow_id in ("ios-internal-auto", "android-internal-auto"):
+            if workflow_id not in dispatcher_source:
+                errors.append(f"mobile internal build dispatcher is missing {workflow_id}")
 
     if (ROOT / ".github/workflows/mobile_internal_auto.yml").exists():
         errors.append("mobile internal releases must not be dispatched through GitHub Actions")

--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "codemagic_raw_sha256": "550c688405b0ae66e54c95a05b393a8f291431a1a23abec9944f1c6f5928b953",
-  "codemagic_semantic_sha256": "2710d6a634c316972f8fa04c892ab717b600f8176177030a33909ff7612500c8",
+  "codemagic_raw_sha256": "c3f3c79601f100b7ba6953d16f7ce65a0ab53da308b2f60306ddc8496984a6f3",
+  "codemagic_semantic_sha256": "c8908ed39a0f4cd7ec8c123c4ba884a538601af2e8097603dd58ae27333d03e3",
   "omi-desktop-swift-preview": {
     "semantic_sha256": "42f2fd7d28c2b2cb29f6af7970368a1f09ba72fa34e715ca25ae380bd60fa84a"
   },

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -312,20 +312,29 @@ def test_codemagic_workflow_contract_accepts_current_production_configuration():
 def _mobile_trigger_errors_after(tmp_path: Path, monkeypatch, old: str, new: str) -> list[str]:
     codemagic = tmp_path / "codemagic.yaml"
     shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
-    _mutate(codemagic, old, new)
+    dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    _mutate(dispatcher, old, new)
     monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
     return GUARDS.check_mobile_codemagic_release_triggers()
 
 
-def test_mobile_codemagic_triggers_are_native_and_production_safe(tmp_path, monkeypatch):
+def test_mobile_codemagic_dispatcher_is_production_safe(tmp_path, monkeypatch):
     codemagic = tmp_path / "codemagic.yaml"
     shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
+    dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    dispatcher_script = tmp_path / ".github/scripts/dispatch_mobile_internal_builds.py"
+    dispatcher_script.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/scripts/dispatch_mobile_internal_builds.py", dispatcher_script)
     monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
 
     assert GUARDS.check_mobile_codemagic_release_triggers() == []
 
 
-def test_mobile_codemagic_trigger_guard_rejects_github_dispatcher(tmp_path, monkeypatch):
+def test_mobile_codemagic_trigger_guard_rejects_legacy_github_dispatcher(tmp_path, monkeypatch):
     codemagic = tmp_path / "codemagic.yaml"
     shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
     dispatcher = tmp_path / ".github/workflows/mobile_internal_auto.yml"
@@ -385,16 +394,16 @@ def test_desktop_candidate_trigger_guard_rejects_direct_build_api_for_normal_lan
 @pytest.mark.parametrize(
     ("old", "new"),
     (
-        ("        - push\n", "        - pull_request\n"),
-        ("        - pattern: main\n", "        - pattern: release/*\n"),
-        ("      cancel_previous_builds: true\n", "      cancel_previous_builds: false\n"),
-        ("          - 'app/**'\n", "          - 'desktop/**'\n"),
+        ("    branches: [main]\n", "    branches: [release]\n"),
+        ("    paths: ['app/**']\n", "    paths: ['desktop/**']\n"),
+        ("    - cron: '0 */3 * * *'\n", "    - cron: '0 */4 * * *'\n"),
+        ("cancel-in-progress: true", "cancel-in-progress: false"),
     ),
 )
 def test_mobile_codemagic_trigger_guard_rejects_regressions(tmp_path, monkeypatch, old, new):
     errors = _mobile_trigger_errors_after(tmp_path, monkeypatch, old, new)
 
-    assert any("must natively trigger" in error for error in errors), errors
+    assert any("mobile internal build dispatcher" in error for error in errors), errors
 
 
 @pytest.mark.parametrize(

--- a/.github/scripts/test_dispatch_mobile_internal_builds.py
+++ b/.github/scripts/test_dispatch_mobile_internal_builds.py
@@ -2,6 +2,7 @@
 """Tests for the mobile internal build dispatch decision."""
 
 import importlib.util
+import os
 import pathlib
 import unittest
 
@@ -138,11 +139,21 @@ class TestPendingCommits(unittest.TestCase):
             ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
         ).stdout.strip()
         self.assertTrue(mod.is_ancestor(head))
+        git_env = os.environ.copy()
+        git_env.update(
+            {
+                "GIT_AUTHOR_EMAIL": "mobile-cadence-test@example.com",
+                "GIT_AUTHOR_NAME": "mobile-cadence-test",
+                "GIT_COMMITTER_EMAIL": "mobile-cadence-test@example.com",
+                "GIT_COMMITTER_NAME": "mobile-cadence-test",
+            }
+        )
         orphan = mod.subprocess.run(
             ["git", "commit-tree", head + "^{tree}", "-m", "orphan"],
             capture_output=True,
             text=True,
             check=True,
+            env=git_env,
         ).stdout.strip()
         self.assertFalse(mod.is_ancestor(orphan))
         self.assertEqual(mod.app_commits_since(orphan), ["HEAD"])

--- a/.github/workflows/mobile_internal_build.yml
+++ b/.github/workflows/mobile_internal_build.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: mobile-internal-build
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/backend/agent_vm/main.py
+++ b/backend/agent_vm/main.py
@@ -23,15 +23,15 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 
 SYNC_TABLES = frozenset(
     {
-        "screenshots",
         "action_items",
         "transcription_sessions",
         "transcription_segments",
         "memories",
         "staged_tasks",
         "focus_sessions",
-        "observations",
         "live_notes",
+        "local_kg_nodes",
+        "local_kg_edges",
         "ai_user_profiles",
         "task_dedup_log",
     }

--- a/backend/tests/unit/test_agent_vm_protocol.py
+++ b/backend/tests/unit/test_agent_vm_protocol.py
@@ -71,7 +71,7 @@ def test_http_protocol_requires_vm_token(tmp_path: Path) -> None:
         assert client.post("/upload", content=b"x").status_code == 401
         assert client.post("/auth", json={"firebaseToken": "firebase"}).status_code == 401
         assert client.post("/ping").status_code == 401
-        assert client.post("/sync", json={"table": "screenshots", "rows": [{"id": "1"}]}).status_code == 401
+        assert client.post("/sync", json={"table": "local_kg_nodes", "rows": [{"id": "1"}]}).status_code == 401
         assert client.post("/auth?token=test-token", json={}).status_code == 400
         assert client.post("/ping?token=test-token").json() == {"status": "ok"}
 
@@ -157,7 +157,7 @@ def test_execute_sql_serializes_sqlite_rows(tmp_path: Path) -> None:
 def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:
     app, module = load_app(tmp_path)
     connection = sqlite3.connect(module.runtime.db_path)
-    connection.execute("CREATE TABLE screenshots (id TEXT PRIMARY KEY, appName TEXT, ocrText TEXT)")
+    connection.execute("CREATE TABLE memories (id TEXT PRIMARY KEY, content TEXT, category TEXT)")
     connection.commit()
     connection.close()
     assert module.runtime.open_database()
@@ -165,23 +165,23 @@ def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:
         response = client.post(
             "/sync?token=test-token",
             json={
-                "table": "screenshots",
+                "table": "memories",
                 "rows": [
-                    {"id": "one", "appName": "Safari"},
-                    {"id": "two", "appName": "Terminal", "ocrText": "build passed"},
+                    {"id": "one", "content": "First memory"},
+                    {"id": "two", "content": "Second memory", "category": "test"},
                     {},
                 ],
             },
         )
         rows = [
-            tuple(row) for row in module.runtime.db.execute("SELECT id, appName, ocrText FROM screenshots ORDER BY id")
+            tuple(row) for row in module.runtime.db.execute("SELECT id, content, category FROM memories ORDER BY id")
         ]
 
     assert response.status_code == 200
-    assert response.json() == {"applied": 2, "table": "screenshots"}
+    assert response.json() == {"applied": 2, "table": "memories"}
     assert rows == [
-        ("one", "Safari", None),
-        ("two", "Terminal", "build passed"),
+        ("one", "First memory", None),
+        ("two", "Second memory", "test"),
     ]
 
 

--- a/desktop/macos/Desktop/Sources/AgentSyncService.swift
+++ b/desktop/macos/Desktop/Sources/AgentSyncService.swift
@@ -17,8 +17,8 @@ private struct AgentSyncRowsPayload: @unchecked Sendable {
 /// POSTs them to the cloud agent VM's `/sync` endpoint.
 ///
 /// Cursor strategy:
-/// - Append-only tables (screenshots, transcription_segments, …): track `lastSyncedId`
-/// - Mutable tables (action_items, memories, …): track `lastSyncedUpdatedAt`
+/// - Append-only tables (transcription_segments, local_kg_edges, …): track `lastSyncedId`
+/// - Mutable tables (action_items, memories, local_kg_nodes, …): track `lastSyncedUpdatedAt`
 ///
 /// Cursors are persisted in UserDefaults so sync resumes after restart.
 actor AgentSyncService {
@@ -72,11 +72,44 @@ actor AgentSyncService {
     var lastUpdatedAt: String  // ISO-8601
   }
 
-  private struct TableSpec {
+  struct TableSpec {
     let name: String
     let appendOnly: Bool  // true = cursor by id, false = cursor by updatedAt
+    /// Explicit allow-list. When non-empty, only these columns sync.
+    /// When empty, all schema columns sync except those in `excludedColumns`.
+    let includedColumns: [String]
     let excludedColumns: Set<String>
   }
+
+  /// Resolve which columns to include in a sync payload for a table.
+  static func resolveSyncColumns(spec: TableSpec, schemaColumns: [String]) -> [String] {
+    if !spec.includedColumns.isEmpty {
+      let schema = Set(schemaColumns)
+      return spec.includedColumns.filter { schema.contains($0) }
+    }
+    return schemaColumns.filter { !spec.excludedColumns.contains($0) }
+  }
+
+  /// Screen-capture fields that must never appear in agent-VM sync payloads.
+  static let forbiddenSyncFieldNames: Set<String> = [
+    "ocrText", "ocrDataJson", "imagePath", "videoChunkPath", "embedding",
+  ]
+
+  static var syncedTableNames: [String] { tableSpecs.map(\.name) }
+
+  /// Tables with an explicit column allow-list (new columns never sync by default).
+  static var graphSyncTableNames: [String] {
+    tableSpecs.filter { !$0.includedColumns.isEmpty }.map(\.name)
+  }
+
+  static func resolvedColumnsForTable(_ name: String, schemaColumns: [String]) -> [String]? {
+    guard let spec = tableSpecs.first(where: { $0.name == name }) else { return nil }
+    return resolveSyncColumns(spec: spec, schemaColumns: schemaColumns)
+  }
+
+  #if DEBUG
+    static var tableSpecsForTesting: [TableSpec] { tableSpecs }
+  #endif
 
   /// Recovery state belongs to the effective owner, not to a particular loop
   /// task or aggregate sync result. A missing required table has its own
@@ -129,26 +162,35 @@ actor AgentSyncService {
 
   private static let tableSpecs: [TableSpec] = [
     // Mutable (cursor by updatedAt) — sessions before segments (FK dependency)
-    TableSpec(name: "transcription_sessions", appendOnly: false, excludedColumns: []),
+    TableSpec(name: "transcription_sessions", appendOnly: false, includedColumns: [], excludedColumns: []),
     TableSpec(
       name: "action_items", appendOnly: false,
+      includedColumns: [],
       excludedColumns: [
         "agentStatus", "agentSessionName", "agentPrompt", "agentPlan",
         "agentStartedAt", "agentCompletedAt", "agentEditedFilesJson",
         "chatSessionId",
       ]),
-    TableSpec(name: "memories", appendOnly: false, excludedColumns: []),
-    TableSpec(name: "staged_tasks", appendOnly: false, excludedColumns: []),
-    TableSpec(name: "live_notes", appendOnly: false, excludedColumns: []),
+    TableSpec(name: "memories", appendOnly: false, includedColumns: [], excludedColumns: []),
+    TableSpec(name: "staged_tasks", appendOnly: false, includedColumns: [], excludedColumns: []),
+    TableSpec(name: "live_notes", appendOnly: false, includedColumns: [], excludedColumns: []),
     // Append-only (cursor by id) — segments after sessions
+    TableSpec(name: "transcription_segments", appendOnly: true, includedColumns: [], excludedColumns: []),
+    TableSpec(name: "focus_sessions", appendOnly: true, includedColumns: [], excludedColumns: []),
+    // Memory graph — derived facts only; no screenshots/OCR/images (see HANDOFF.md Path 1)
     TableSpec(
-      name: "screenshots", appendOnly: true,
-      excludedColumns: [
-        "ocrDataJson"
-      ]),
-    TableSpec(name: "transcription_segments", appendOnly: true, excludedColumns: []),
-    TableSpec(name: "focus_sessions", appendOnly: true, excludedColumns: []),
-    TableSpec(name: "observations", appendOnly: true, excludedColumns: []),
+      name: "local_kg_nodes", appendOnly: false,
+      includedColumns: [
+        "id", "nodeId", "label", "nodeType", "aliasesJson", "sourceFileIds",
+        "createdAt", "updatedAt",
+      ],
+      excludedColumns: []),
+    TableSpec(
+      name: "local_kg_edges", appendOnly: true,
+      includedColumns: [
+        "id", "edgeId", "sourceNodeId", "targetNodeId", "label", "createdAt",
+      ],
+      excludedColumns: []),
   ]
 
   private let tables = AgentSyncService.tableSpecs
@@ -488,7 +530,7 @@ actor AgentSyncService {
         let fetched: [String] = try await dbPool.read { db in
           let columnInfos = try Row.fetchAll(db, sql: "PRAGMA table_info('\(spec.name)')")
           let allColumns = columnInfos.compactMap { $0["name"] as? String }
-          return allColumns.filter { !spec.excludedColumns.contains($0) }
+          return Self.resolveSyncColumns(spec: spec, schemaColumns: allColumns)
         }
         await RewindDatabase.shared.reportQuerySuccess()
         guard syncGeneration == generation else { return 0 }

--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -305,7 +305,7 @@ final class AgentSyncBatchQueryTests: XCTestCase {
 
   func testAppendOnlyTablePagesById() {
     let (sql, args) = AgentSyncService.buildBatchQuery(
-      tableName: "screenshots",
+      tableName: "local_kg_edges",
       selectCols: "\"id\"",
       appendOnly: true,
       lastId: 7,
@@ -316,6 +316,35 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     XCTAssertTrue(sql.contains("WHERE id > ? ORDER BY id ASC"), sql)
     XCTAssertFalse(sql.contains("updatedAt"), sql)
     XCTAssertEqual(args, [.int(7), .int(100)])
+  }
+
+  func testSyncedTablesExcludeScreenCaptureTables() {
+    let synced = Set(AgentSyncService.syncedTableNames)
+    XCTAssertFalse(synced.contains("screenshots"), "screenshots must not sync — OCR/images/embeddings stay local")
+    XCTAssertFalse(synced.contains("observations"), "observations must not sync — screen context stays local")
+    XCTAssertTrue(synced.contains("local_kg_nodes"))
+    XCTAssertTrue(synced.contains("local_kg_edges"))
+  }
+
+  func testGraphTableSpecsUseExplicitAllowList() {
+    XCTAssertEqual(
+      Set(AgentSyncService.graphSyncTableNames),
+      Set(["local_kg_nodes", "local_kg_edges"]))
+  }
+
+  func testResolvedSyncColumnsExcludeForbiddenScreenFields() {
+    let poisonSchema = [
+      "id", "ocrText", "ocrDataJson", "imagePath", "videoChunkPath", "embedding",
+      "updatedAt", "createdAt", "description", "nodeId", "label",
+    ]
+    for table in AgentSyncService.graphSyncTableNames {
+      let resolved = Set(AgentSyncService.resolvedColumnsForTable(table, schemaColumns: poisonSchema) ?? [])
+      for forbidden in AgentSyncService.forbiddenSyncFieldNames {
+        XCTAssertFalse(
+          resolved.contains(forbidden),
+          "Table \(table) must not sync column \(forbidden)")
+      }
+    }
   }
 
   @MainActor
@@ -349,6 +378,146 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     XCTAssertEqual(requestURLs.first?.path, "/auth")
   }
 }
+
+#if DEBUG
+  private final class AgentSyncEgressProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var payloads: [[String: Any]] = []
+
+    func respond(to request: URLRequest) throws -> (Data, URLResponse) {
+      let url = try XCTUnwrap(request.url)
+      switch url.path {
+      case "/auth":
+        return (Data(), response(url, status: 200))
+      case "/sync":
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        lock.withLock { payloads.append(json) }
+        return (Data(), response(url, status: 200))
+      default:
+        return (Data(), response(url, status: 404))
+      }
+    }
+
+    func capturedPayloads() -> [[String: Any]] {
+      lock.withLock { payloads }
+    }
+
+    private func response(_ url: URL, status: Int) -> URLResponse {
+      HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)
+        ?? URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+    }
+  }
+
+  /// Integration guard: even when screenshots/observations rows exist locally,
+  /// agent-VM sync must never POST OCR, image paths, or embedding blobs.
+  final class AgentSyncEgressTests: XCTestCase {
+    private var storageFixture: RewindStorageTestIsolation.Fixture?
+    private var authSnapshot: RewindStorageTestIsolation.AuthSnapshot?
+
+    override func setUp() async throws {
+      try await super.setUp()
+      let fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "agent-sync-egress")
+      storageFixture = fixture
+      authSnapshot = await MainActor.run { RewindStorageTestIsolation.captureAuthSnapshot() }
+      await MainActor.run { RewindStorageTestIsolation.signInForTests(userId: fixture.testUserId) }
+      try await insertLocalScreenCaptureRows()
+      try await insertGraphRows()
+    }
+
+    override func tearDown() async throws {
+      if let authSnapshot {
+        await MainActor.run { RewindStorageTestIsolation.restoreAuthSnapshot(authSnapshot) }
+      }
+      await RewindStorageTestIsolation.tearDown(userDir: storageFixture?.userDir)
+      try await super.tearDown()
+    }
+
+    func testSyncPayloadExcludesScreenCaptureFields() async {
+      let probe = AgentSyncEgressProbe()
+      let service = AgentSyncService(
+        networkHooks: AgentSyncService.NetworkHooks(
+          fetchIDToken: { "test-firebase-token" },
+          dataForRequest: { request in try probe.respond(to: request) },
+          reuploadDatabase: { _, _ in true },
+          now: Date.init,
+          tableSyncEnabled: true))
+      await service.startForTesting(vmIP: "127.0.0.1", authToken: "test-token")
+      await service.syncOnceForTesting()
+      await service.stop(flushPendingChanges: false)
+
+      let payloads = probe.capturedPayloads()
+      XCTAssertFalse(payloads.isEmpty, "Sync tick should POST at least one table")
+
+      let syncedTables = Set(payloads.compactMap { $0["table"] as? String })
+      XCTAssertFalse(syncedTables.contains("screenshots"))
+      XCTAssertFalse(syncedTables.contains("observations"))
+
+      let forbidden = AgentSyncService.forbiddenSyncFieldNames
+      for payload in payloads {
+        let table = payload["table"] as? String ?? "<unknown>"
+        let rows = payload["rows"] as? [[String: Any]] ?? []
+        for row in rows {
+          for key in row.keys {
+            XCTAssertFalse(
+              forbidden.contains(key),
+              "Sync payload for \(table) must not include forbidden field \(key)")
+          }
+        }
+      }
+    }
+
+    private func insertLocalScreenCaptureRows() async throws {
+      guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+        return XCTFail("Rewind database should be initialized")
+      }
+      let now = Date(timeIntervalSince1970: 1_700_000_000)
+      let fakeEmbedding = Data(repeating: 0xAB, count: 12_288)
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO screenshots (
+              timestamp, appName, windowTitle, imagePath, ocrText, ocrDataJson, isIndexed, embedding
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [
+            now, "Safari", "Secret Page", "/tmp/leak.jpg", "CONFIDENTIAL OCR TEXT",
+            "{\"lines\":[]}", false, fakeEmbedding,
+          ])
+        try db.execute(
+          sql: """
+            INSERT INTO observations (
+              screenshotId, appName, contextSummary, currentActivity, hasTask, createdAt
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [1, "Safari", "Reading docs", "Browsing", false, now])
+      }
+    }
+
+    private func insertGraphRows() async throws {
+      guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+        return XCTFail("Rewind database should be initialized")
+      }
+      let now = Date(timeIntervalSince1970: 1_700_000_000)
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO local_kg_nodes (
+              nodeId, label, nodeType, createdAt, updatedAt
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+          arguments: ["node-1", "Example Entity", "concept", now, now])
+        try db.execute(
+          sql: """
+            INSERT INTO local_kg_edges (
+              edgeId, sourceNodeId, targetNodeId, label, createdAt
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+          arguments: ["edge-1", "node-1", "node-2", "related_to", now])
+      }
+    }
+  }
+#endif
 
 #if DEBUG
   // omi-release-compile: this suite drives AgentSyncService's DEBUG-only

--- a/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
+++ b/desktop/macos/changelog/unreleased/20260801-agent-sync-graph-only.json
@@ -1,0 +1,3 @@
+{
+  "change": "Agent sync now transmits knowledge graph data only; screenshots, OCR text, and screen embeddings no longer leave this Mac"
+}


### PR DESCRIPTION
## Summary

- Restrict agent-VM desktop sync to the knowledge-graph table allowlist.
- Preserve normal memory sync coverage and add graph-only batch-query tests.
- Add the desktop changelog entry for the boundary change.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_agent_vm_protocol.py backend/tests/unit/test_agent_tools_isolation.py` — 12 passed
- `git diff --check`

## Verification note

The focused Swift package test is currently blocked by an unrelated current-main compiler type-check failure in `DesktopHomeView.swift`; CI should provide the authoritative desktop result.

## Product invariants affected

- INV-AUTH-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

