### PR TITLE
fix(desktop): size the local Swift per-suite budget to the slowest healthy suite (#11011)

### DIFF
--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -15,7 +15,12 @@ PACKAGE_PATH="${OMI_SWIFT_TEST_PACKAGE_PATH:-Desktop}"
 # diagnosis (`OMI_SWIFT_TEST_SUITE_WORKERS=1`).
 WORKERS="${OMI_SWIFT_TEST_SUITE_WORKERS:-${SWIFT_TEST_SUITE_WORKERS:-4}}"
 PREBUILD="${OMI_SWIFT_TEST_PREBUILD:-1}"
-SUITE_TIMEOUT_SECONDS="${OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS:-120}"
+# The per-suite budget must clear the slowest legitimate suite, not the median
+# one: MemoryAtlasPerformanceHarnessTests runs 19 tests whose XCTest `measure`
+# blocks take ~245s in isolation, so a 120s local default reported it FAILED on
+# a clean main while CI (300s, see .github/workflows/desktop-swift-ci.yml) was
+# green. Keep this in sync with that workflow — the check below proves it.
+SUITE_TIMEOUT_SECONDS="${OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS:-300}"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -170,7 +175,7 @@ for suite in "${suites[@]}"; do
   fi
 done
 
-echo "Ran $suite_count Swift suites in isolation with $WORKERS worker(s)."
+echo "Ran $suite_count Swift suites in isolation with $WORKERS worker(s), ${SUITE_TIMEOUT_SECONDS}s per-suite budget."
 
 if [ -n "$failed_suites" ]; then
   echo "FAILED Swift suites:$failed_suites"

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -151,8 +151,18 @@ unset OMI_SWIFT_TEST_SUITE_WORKERS SWIFT_TEST_SUITE_WORKERS
 if "$RUNNER" >"$TMPDIR/default-runner.out" 2>"$TMPDIR/default-runner.err"; then
   fail "default runner unexpectedly succeeded despite AlphaTests failure"
 fi
-if ! grep -q "Ran 6 Swift suites in isolation with 4 worker(s)." "$TMPDIR/default-runner.out"; then
+if ! grep -q "Ran 6 Swift suites in isolation with 4 worker(s)," "$TMPDIR/default-runner.out"; then
   fail "runner did not default local suite execution to four workers"
+fi
+
+# ...and the same per-suite budget as CI. A smaller local default is not a
+# harmless local nicety: the slowest legitimate suite needs ~245s, so a 120s
+# default reported the documented local runner FAILED on a clean main.
+ci_workflow="$(cd "$MACOS_DIR/../.." && pwd)/.github/workflows/desktop-swift-ci.yml"
+ci_budget="$(sed -n 's/^[[:space:]]*OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS:[[:space:]]*"\{0,1\}\([0-9][0-9]*\)"\{0,1\}[[:space:]]*$/\1/p' "$ci_workflow" | head -1)"
+[ -n "$ci_budget" ] || fail "could not read OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS from $ci_workflow"
+if ! grep -q "worker(s), ${ci_budget}s per-suite budget." "$TMPDIR/default-runner.out"; then
+  fail "runner default per-suite budget does not match CI's ${ci_budget}s"
 fi
 
 export OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS=1


### PR DESCRIPTION
Fixes #11011

## Bug

`desktop/macos/test.sh` — the documented local desktop test runner — reports `FAILED Swift suites: MemoryAtlasPerformanceHarnessTests` and exits 1 on an unmodified `main`, while the same suites are green in CI.

## Root cause

`swift-test-suites.sh` defaults the per-suite watchdog to **120s**; `.github/workflows/desktop-swift-ci.yml` overrides it to **300s**. `MemoryAtlasPerformanceHarnessTests` is a healthy, passing suite whose 19 tests run XCTest `measure` blocks (5 iterations each) and take **~245s** in isolation. The suite is not hanging, and the runner already excludes SwiftPM build-lock wait from the budget — the budget is simply below the worst-case cost of the healthy work it bounds, and only CI's override hid it.

## Fix

- Default `OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS` to 300, matching CI.
- Report the active budget in the runner's summary line.
- `tests/test-swift-test-suites.sh` now reads `desktop-swift-ci.yml` and asserts the runner's default budget equals CI's, so the local and CI budgets cannot silently drift apart again.

## What I tested

On clean `origin/main` c10eb9a3608f (M-series MacBook, Xcode default toolchain):

- `swift test --package-path Desktop --filter MemoryAtlasPerformanceHarnessTests` → `Executed 19 tests, with 0 failures (0 unexpected) in 244.804 seconds` — the suite is healthy, just long.
- Before the fix, `scripts/swift-test-suites.sh` (default budget): `suite timed out after 120s`, `FAILED Swift suites: MemoryAtlasPerformanceHarnessTests`, exit 1.
- After the fix, `scripts/swift-test-suites.sh` with **no env override**: `Ran 458 Swift suites in isolation with 4 worker(s), 300s per-suite budget.`, exit 0 — all 458 suites green.
- `tests/test-swift-test-suites.sh` passes; restoring the 120s default makes it fail with `FAIL: runner default per-suite budget does not match CI's 300s` (guard proven red-before / green-after).
- All 41 `desktop/macos/tests/test-*.sh` pass, plus `scripts/check-e2e-flow-coverage.py --strict`.
- `desktop/shared-rust` `cargo test --workspace`: 7 passed, 0 failed.

Not covered: this changes only the local test-runner budget, so there is no app behavior to exercise in a running build. CI keeps its own explicit 300s value and is unaffected by the default.

Failure-Class: FC-gate-timeout-below-cold-cost

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

