### PR TITLE
ci(mobile): batch internal builds instead of one per merge

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -455,6 +455,11 @@ checks:
     triggers: [".github/scripts/check-codemagic-tag-intake.py", ".github/scripts/test_check_codemagic_tag_intake.py", ".github/workflows/desktop_auto_release.yml", "codemagic.yaml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-179 requires bounded exact-tag evidence that native Codemagic intake selected the release workflow and immutable source"
+  - id: mobile-internal-build-cadence
+    command: ["python3", ".github/scripts/test_dispatch_mobile_internal_builds.py"]
+    triggers: [".github/scripts/dispatch_mobile_internal_builds.py", ".github/scripts/test_dispatch_mobile_internal_builds.py", ".github/workflows/mobile_internal_build.yml", "codemagic.yaml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "internal mobile builds are dispatched on a cadence, so who gets an instant build and when the batch fires must stay pinned rather than drift back to build-per-merge"
   - id: desktop-manifest-routes
     command: ["python3", ".github/scripts/test_desktop_manifest_routes.py"]
     triggers: [".github/workflows/desktop-swift-ci.yml", ".github/checks-manifest.yaml", ".github/scripts/run_checks.py", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_manifest_routes.py"]

--- a/.github/scripts/dispatch_mobile_internal_builds.py
+++ b/.github/scripts/dispatch_mobile_internal_builds.py
@@ -22,6 +22,11 @@ BUILDS_API = "https://api.codemagic.io/builds"
 MOBILE_WORKFLOWS = ("ios-internal-auto", "android-internal-auto")
 APP_PATHS = ("app/",)
 
+# Only a build that reached a decision may become the baseline. A failed, cancelled or timed-out
+# build leaves its commit unbuilt, so advancing past it would strand a broken merge until the next
+# app change happened along. `skipped` counts: Codemagic decided there was nothing to build.
+BASELINE_STATUSES = frozenset({"finished", "success", "succeeded", "skipped"})
+
 
 class DispatchError(Exception):
     pass
@@ -77,12 +82,16 @@ def build_sha(build: dict[str, Any]) -> Optional[str]:
 
 
 def newest_built_sha(builds: Iterable[dict[str, Any]]) -> Optional[str]:
-    """Commit of the most recently created build, by createdAt rather than list position.
+    """Commit of the most recent build that settled, by createdAt rather than list position.
 
     The API's ordering is not part of any contract we rely on elsewhere, and reading the wrong
     build here would compare against an old commit and dispatch on every scheduled run.
     """
-    candidates = [(str(b.get("createdAt") or ""), sha) for b in builds if (sha := build_sha(b))]
+    candidates = [
+        (str(b.get("createdAt") or ""), sha)
+        for b in builds
+        if str(b.get("status") or "").lower() in BASELINE_STATUSES and (sha := build_sha(b))
+    ]
     if not candidates:
         return None
     return max(candidates, key=lambda item: item[0])[1]
@@ -93,9 +102,20 @@ def last_built_sha(app_id: str, workflow_id: str, token: str) -> Optional[str]:
     return newest_built_sha(payload.get("builds") or [])
 
 
+def is_ancestor(sha: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", sha, "HEAD"], capture_output=True, check=False
+    )
+    return result.returncode == 0
+
+
 def app_commits_since(sha: Optional[str]) -> list[str]:
-    """App-path commits between ``sha`` and HEAD. No known baseline means treat HEAD as pending."""
+    """App-path commits between ``sha`` and HEAD. No usable baseline means treat HEAD as pending."""
     if not sha:
+        return ["HEAD"]
+    if not is_ancestor(sha):
+        # A rewritten or rewound main leaves a baseline off this history; the range would read
+        # empty and skip a batch that is genuinely pending.
         return ["HEAD"]
     revision_range = f"{sha}..HEAD"
     result = subprocess.run(
@@ -141,23 +161,28 @@ def main(argv: Optional[list[str]] = None) -> int:
     token = os.environ.get("CODEMAGIC_API_TOKEN", "")
     instant_actors = normalized_actors(os.environ.get("MOBILE_INSTANT_BUILD_ACTORS"))
 
-    pending: list[str] = []
+    # Per workflow: iOS and Android drift apart whenever one is built on its own, and a shared
+    # baseline would let the newer platform suppress the other's build.
+    pending_by_workflow: dict[str, list[str]] = {}
     if args.event == "schedule":
         if not token:
             raise DispatchError("CODEMAGIC_API_TOKEN is required to read the last built commit")
-        pending = app_commits_since(last_built_sha(args.app_id, MOBILE_WORKFLOWS[0], token))
+        for workflow_id in MOBILE_WORKFLOWS:
+            pending_by_workflow[workflow_id] = app_commits_since(
+                last_built_sha(args.app_id, workflow_id, token)
+            )
 
     should, reason = decide_dispatch(
         event=args.event,
         actor=args.actor,
         commit_authors=[a for a in args.commit_authors.split(",") if a.strip()],
         instant_actors=instant_actors,
-        has_pending_app_commits=bool(pending),
+        has_pending_app_commits=any(pending_by_workflow.values()),
     )
 
     summary = [f"event={args.event}", f"actor={args.actor}", f"dispatch={should}", f"reason={reason}"]
-    if args.event == "schedule":
-        summary.append(f"pending_app_commits={len(pending)}")
+    for workflow_id, commits in pending_by_workflow.items():
+        summary.append(f"{workflow_id}_pending={len(commits)}")
     print(" ".join(summary))
 
     if not should or args.dry_run:
@@ -165,7 +190,8 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if not token:
         raise DispatchError("CODEMAGIC_API_TOKEN is required to dispatch")
-    for workflow_id in MOBILE_WORKFLOWS:
+    targets = [w for w, commits in pending_by_workflow.items() if commits] or list(MOBILE_WORKFLOWS)
+    for workflow_id in targets:
         print(f"dispatched {workflow_id} build={dispatch(args.app_id, workflow_id, token, args.branch)}")
     return 0
 

--- a/.github/scripts/dispatch_mobile_internal_builds.py
+++ b/.github/scripts/dispatch_mobile_internal_builds.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Decide and dispatch the Codemagic internal mobile builds.
+
+App changes land on main in bursts, and a build per merge is mostly wasted: the earlier one is
+superseded minutes later. Codemagic's own triggering has no rate limit, so the push trigger is
+replaced by this: a two-hourly batch that builds only when app code actually changed, plus an
+immediate build for an allowlisted author who needs their own change on a device now.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Iterable, Optional
+
+BUILDS_API = "https://api.codemagic.io/builds"
+MOBILE_WORKFLOWS = ("ios-internal-auto", "android-internal-auto")
+APP_PATHS = ("app/",)
+
+
+class DispatchError(Exception):
+    pass
+
+
+def normalized_actors(raw: Optional[str]) -> set[str]:
+    return {actor.strip().lower() for actor in (raw or "").split(",") if actor.strip()}
+
+
+def decide_dispatch(
+    *,
+    event: str,
+    actor: str,
+    commit_authors: Iterable[str],
+    instant_actors: set[str],
+    has_pending_app_commits: bool,
+) -> tuple[bool, str]:
+    """Return whether to dispatch now, and the reason recorded in the run summary."""
+    if event == "workflow_dispatch":
+        return True, "manual"
+
+    if event == "push":
+        who = {actor.lower()} | {author.lower() for author in commit_authors}
+        if who & instant_actors:
+            return True, "instant-actor"
+        return False, "batched: the two-hourly run picks this up"
+
+    if event == "schedule":
+        if has_pending_app_commits:
+            return True, "batch: app changes since the last build"
+        return False, "no app changes since the last build"
+
+    return False, f"unsupported event {event}"
+
+
+def _api_get(url: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"x-auth-token": token})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.URLError as error:
+        raise DispatchError(f"Codemagic API read failed: {error}") from error
+
+
+def last_built_sha(app_id: str, workflow_id: str, token: str) -> Optional[str]:
+    """Newest commit Codemagic has already built for this workflow, if any."""
+    payload = _api_get(f"{BUILDS_API}?appId={app_id}&workflowId={workflow_id}", token)
+    builds = payload.get("builds") or []
+    for build in builds:
+        for key in ("commit", "commitId", "commitHash"):
+            value = build.get(key)
+            if isinstance(value, dict):
+                value = value.get("hash") or value.get("sha")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def app_commits_since(sha: Optional[str]) -> list[str]:
+    """App-path commits between ``sha`` and HEAD. No known baseline means treat HEAD as pending."""
+    if not sha:
+        return ["HEAD"]
+    revision_range = f"{sha}..HEAD"
+    result = subprocess.run(
+        ["git", "log", "--format=%H", revision_range, "--", *APP_PATHS],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # An unknown SHA (force-push, pruned history) must not silently stop builds.
+        return ["HEAD"]
+    return [line for line in result.stdout.split() if line]
+
+
+def dispatch(app_id: str, workflow_id: str, token: str, branch: str) -> str:
+    payload = json.dumps({"appId": app_id, "workflowId": workflow_id, "branch": branch}).encode()
+    request = urllib.request.Request(
+        BUILDS_API,
+        data=payload,
+        headers={"Content-Type": "application/json", "x-auth-token": token},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = json.loads(response.read().decode())
+    except urllib.error.URLError as error:
+        raise DispatchError(f"Codemagic dispatch failed for {workflow_id}: {error}") from error
+    build_id = body.get("buildId")
+    if not build_id:
+        raise DispatchError(f"Codemagic returned no build id for {workflow_id}")
+    return str(build_id)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--actor", default="")
+    parser.add_argument("--commit-authors", default="")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--app-id", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("CODEMAGIC_API_TOKEN", "")
+    instant_actors = normalized_actors(os.environ.get("MOBILE_INSTANT_BUILD_ACTORS"))
+
+    pending: list[str] = []
+    if args.event == "schedule":
+        if not token:
+            raise DispatchError("CODEMAGIC_API_TOKEN is required to read the last built commit")
+        pending = app_commits_since(last_built_sha(args.app_id, MOBILE_WORKFLOWS[0], token))
+
+    should, reason = decide_dispatch(
+        event=args.event,
+        actor=args.actor,
+        commit_authors=[a for a in args.commit_authors.split(",") if a.strip()],
+        instant_actors=instant_actors,
+        has_pending_app_commits=bool(pending),
+    )
+
+    summary = [f"event={args.event}", f"actor={args.actor}", f"dispatch={should}", f"reason={reason}"]
+    if args.event == "schedule":
+        summary.append(f"pending_app_commits={len(pending)}")
+    print(" ".join(summary))
+
+    if not should or args.dry_run:
+        return 0
+
+    if not token:
+        raise DispatchError("CODEMAGIC_API_TOKEN is required to dispatch")
+    for workflow_id in MOBILE_WORKFLOWS:
+        print(f"dispatched {workflow_id} build={dispatch(args.app_id, workflow_id, token, args.branch)}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except DispatchError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/dispatch_mobile_internal_builds.py
+++ b/.github/scripts/dispatch_mobile_internal_builds.py
@@ -66,18 +66,31 @@ def _api_get(url: str, token: str) -> dict[str, Any]:
         raise DispatchError(f"Codemagic API read failed: {error}") from error
 
 
-def last_built_sha(app_id: str, workflow_id: str, token: str) -> Optional[str]:
-    """Newest commit Codemagic has already built for this workflow, if any."""
-    payload = _api_get(f"{BUILDS_API}?appId={app_id}&workflowId={workflow_id}", token)
-    builds = payload.get("builds") or []
-    for build in builds:
-        for key in ("commit", "commitId", "commitHash"):
-            value = build.get(key)
-            if isinstance(value, dict):
-                value = value.get("hash") or value.get("sha")
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+def build_sha(build: dict[str, Any]) -> Optional[str]:
+    for key in ("commit", "commitId", "commitHash"):
+        value = build.get(key)
+        if isinstance(value, dict):
+            value = value.get("hash") or value.get("sha")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
     return None
+
+
+def newest_built_sha(builds: Iterable[dict[str, Any]]) -> Optional[str]:
+    """Commit of the most recently created build, by createdAt rather than list position.
+
+    The API's ordering is not part of any contract we rely on elsewhere, and reading the wrong
+    build here would compare against an old commit and dispatch on every scheduled run.
+    """
+    candidates = [(str(b.get("createdAt") or ""), sha) for b in builds if (sha := build_sha(b))]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def last_built_sha(app_id: str, workflow_id: str, token: str) -> Optional[str]:
+    payload = _api_get(f"{BUILDS_API}?appId={app_id}&workflowId={workflow_id}", token)
+    return newest_built_sha(payload.get("builds") or [])
 
 
 def app_commits_since(sha: Optional[str]) -> list[str]:

--- a/.github/scripts/dispatch_mobile_internal_builds.py
+++ b/.github/scripts/dispatch_mobile_internal_builds.py
@@ -3,7 +3,7 @@
 
 App changes land on main in bursts, and a build per merge is mostly wasted: the earlier one is
 superseded minutes later. Codemagic's own triggering has no rate limit, so the push trigger is
-replaced by this: a two-hourly batch that builds only when app code actually changed, plus an
+replaced by this: a three-hourly batch that builds only when app code actually changed, plus an
 immediate build for an allowlisted author who needs their own change on a device now.
 """
 
@@ -47,7 +47,7 @@ def decide_dispatch(
         who = {actor.lower()} | {author.lower() for author in commit_authors}
         if who & instant_actors:
             return True, "instant-actor"
-        return False, "batched: the two-hourly run picks this up"
+        return False, "batched: the three-hourly run picks this up"
 
     if event == "schedule":
         if has_pending_app_commits:

--- a/.github/scripts/test_dispatch_mobile_internal_builds.py
+++ b/.github/scripts/test_dispatch_mobile_internal_builds.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for the mobile internal build dispatch decision."""
+
+import importlib.util
+import pathlib
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    "dispatch_mobile_internal_builds",
+    pathlib.Path(__file__).with_name("dispatch_mobile_internal_builds.py"),
+)
+assert SPEC and SPEC.loader
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+INSTANT = {"mdmohsin7"}
+
+
+def decide(event, *, actor="someone", authors=(), pending=False, instant=INSTANT):
+    return mod.decide_dispatch(
+        event=event,
+        actor=actor,
+        commit_authors=authors,
+        instant_actors=instant,
+        has_pending_app_commits=pending,
+    )
+
+
+class TestPushEvent(unittest.TestCase):
+    def test_an_allowlisted_pusher_builds_immediately(self):
+        should, reason = decide("push", actor="mdmohsin7")
+        self.assertTrue(should)
+        self.assertEqual(reason, "instant-actor")
+
+    def test_matching_is_case_insensitive(self):
+        self.assertTrue(decide("push", actor="MDMohsin7")[0])
+
+    def test_an_allowlisted_commit_author_builds_immediately(self):
+        # Someone else merged the change, but it is still their commit.
+        self.assertTrue(decide("push", actor="other-dev", authors=["mdmohsin7"])[0])
+
+    def test_everyone_else_waits_for_the_batch(self):
+        should, reason = decide("push", actor="other-dev", authors=["other-dev"])
+        self.assertFalse(should)
+        self.assertIn("batched", reason)
+
+    def test_an_empty_allowlist_batches_everyone(self):
+        self.assertFalse(decide("push", actor="mdmohsin7", instant=set())[0])
+
+
+class TestScheduleEvent(unittest.TestCase):
+    def test_builds_when_app_changed_since_the_last_build(self):
+        should, reason = decide("schedule", pending=True)
+        self.assertTrue(should)
+        self.assertIn("app changes", reason)
+
+    def test_skips_when_nothing_changed(self):
+        should, reason = decide("schedule", pending=False)
+        self.assertFalse(should)
+        self.assertIn("no app changes", reason)
+
+    def test_the_allowlist_does_not_apply_to_the_batch(self):
+        # The batch is decided by pending work, never by who happens to be the actor.
+        self.assertFalse(decide("schedule", actor="mdmohsin7", pending=False)[0])
+
+
+class TestManualAndUnknown(unittest.TestCase):
+    def test_manual_always_dispatches(self):
+        should, reason = decide("workflow_dispatch", actor="anyone")
+        self.assertTrue(should)
+        self.assertEqual(reason, "manual")
+
+    def test_an_unknown_event_never_dispatches(self):
+        self.assertFalse(decide("pull_request")[0])
+
+
+class TestActorParsing(unittest.TestCase):
+    def test_parses_and_normalizes_a_comma_list(self):
+        self.assertEqual(mod.normalized_actors(" MDMohsin7 , someone "), {"mdmohsin7", "someone"})
+
+    def test_empty_input_is_an_empty_set(self):
+        self.assertEqual(mod.normalized_actors(None), set())
+        self.assertEqual(mod.normalized_actors(" , "), set())
+
+
+class TestPendingCommits(unittest.TestCase):
+    def test_no_known_baseline_counts_as_pending(self):
+        # First ever build, or a pruned SHA: never silently stop building.
+        self.assertEqual(mod.app_commits_since(None), ["HEAD"])
+
+    def test_an_unknown_sha_counts_as_pending(self):
+        self.assertEqual(mod.app_commits_since("0" * 40), ["HEAD"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_dispatch_mobile_internal_builds.py
+++ b/.github/scripts/test_dispatch_mobile_internal_builds.py
@@ -83,24 +83,44 @@ class TestActorParsing(unittest.TestCase):
         self.assertEqual(mod.normalized_actors(" , "), set())
 
 
+def built(created, sha, status="finished"):
+    return {"createdAt": created, "commit": sha, "status": status}
+
+
 class TestNewestBuiltSha(unittest.TestCase):
     def test_picks_the_newest_build_regardless_of_list_order(self):
-        builds = [
-            {"createdAt": "2026-08-01T09:00:00Z", "commit": "old"},
-            {"createdAt": "2026-08-02T09:00:00Z", "commit": "new"},
-        ]
+        builds = [built("2026-08-01T09:00:00Z", "old"), built("2026-08-02T09:00:00Z", "new")]
         self.assertEqual(mod.newest_built_sha(builds), "new")
         self.assertEqual(mod.newest_built_sha(list(reversed(builds))), "new")
 
     def test_reads_a_nested_commit_object(self):
-        self.assertEqual(mod.newest_built_sha([{"createdAt": "x", "commit": {"hash": "abc"}}]), "abc")
+        self.assertEqual(
+            mod.newest_built_sha([{"createdAt": "x", "status": "finished", "commit": {"hash": "abc"}}]), "abc"
+        )
 
     def test_ignores_builds_with_no_commit(self):
-        builds = [{"createdAt": "2026-08-03T09:00:00Z"}, {"createdAt": "2026-08-01T09:00:00Z", "commit": "only"}]
+        builds = [{"createdAt": "2026-08-03T09:00:00Z", "status": "finished"}, built("2026-08-01T09:00:00Z", "only")]
         self.assertEqual(mod.newest_built_sha(builds), "only")
 
     def test_no_builds_means_no_baseline(self):
         self.assertIsNone(mod.newest_built_sha([]))
+
+    def test_a_failed_build_does_not_become_the_baseline(self):
+        # Otherwise a broken merge sits unbuilt until some later app commit happens along.
+        builds = [built("2026-08-01T09:00:00Z", "good"), built("2026-08-02T09:00:00Z", "broken", "failed")]
+        self.assertEqual(mod.newest_built_sha(builds), "good")
+
+    def test_cancelled_and_in_progress_builds_do_not_become_the_baseline(self):
+        for status in ("canceled", "cancelled", "timeout", "building", "queued", ""):
+            with self.subTest(status=status):
+                self.assertIsNone(mod.newest_built_sha([built("2026-08-02T09:00:00Z", "x", status)]))
+
+    def test_a_skipped_build_is_a_baseline(self):
+        # Codemagic looked and decided there was nothing to build; that commit is settled.
+        self.assertEqual(mod.newest_built_sha([built("2026-08-02T09:00:00Z", "x", "skipped")]), "x")
+
+    def test_status_matching_is_case_insensitive(self):
+        self.assertEqual(mod.newest_built_sha([built("2026-08-02T09:00:00Z", "x", "Finished")]), "x")
 
 
 class TestPendingCommits(unittest.TestCase):
@@ -110,6 +130,22 @@ class TestPendingCommits(unittest.TestCase):
 
     def test_an_unknown_sha_counts_as_pending(self):
         self.assertEqual(mod.app_commits_since("0" * 40), ["HEAD"])
+
+    def test_a_non_ancestor_baseline_counts_as_pending(self):
+        # A rewound or rewritten main leaves the baseline off this history: the range would read
+        # empty and skip a batch that is genuinely pending.
+        head = mod.subprocess.run(
+            ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+        self.assertTrue(mod.is_ancestor(head))
+        orphan = mod.subprocess.run(
+            ["git", "commit-tree", head + "^{tree}", "-m", "orphan"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        self.assertFalse(mod.is_ancestor(orphan))
+        self.assertEqual(mod.app_commits_since(orphan), ["HEAD"])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_dispatch_mobile_internal_builds.py
+++ b/.github/scripts/test_dispatch_mobile_internal_builds.py
@@ -83,6 +83,26 @@ class TestActorParsing(unittest.TestCase):
         self.assertEqual(mod.normalized_actors(" , "), set())
 
 
+class TestNewestBuiltSha(unittest.TestCase):
+    def test_picks_the_newest_build_regardless_of_list_order(self):
+        builds = [
+            {"createdAt": "2026-08-01T09:00:00Z", "commit": "old"},
+            {"createdAt": "2026-08-02T09:00:00Z", "commit": "new"},
+        ]
+        self.assertEqual(mod.newest_built_sha(builds), "new")
+        self.assertEqual(mod.newest_built_sha(list(reversed(builds))), "new")
+
+    def test_reads_a_nested_commit_object(self):
+        self.assertEqual(mod.newest_built_sha([{"createdAt": "x", "commit": {"hash": "abc"}}]), "abc")
+
+    def test_ignores_builds_with_no_commit(self):
+        builds = [{"createdAt": "2026-08-03T09:00:00Z"}, {"createdAt": "2026-08-01T09:00:00Z", "commit": "only"}]
+        self.assertEqual(mod.newest_built_sha(builds), "only")
+
+    def test_no_builds_means_no_baseline(self):
+        self.assertIsNone(mod.newest_built_sha([]))
+
+
 class TestPendingCommits(unittest.TestCase):
     def test_no_known_baseline_counts_as_pending(self):
         # First ever build, or a pruned SHA: never silently stop building.

--- a/.github/workflows/mobile_internal_build.yml
+++ b/.github/workflows/mobile_internal_build.yml
@@ -2,7 +2,7 @@ name: Mobile internal builds
 
 # App changes land on main in bursts, so a Codemagic build per merge is mostly superseded minutes
 # later. Codemagic's own triggering has no rate limit, so the push trigger is replaced by this:
-# a two-hourly batch that builds only when app code changed, plus an immediate build for an
+# a three-hourly batch that builds only when app code changed, plus an immediate build for an
 # allowlisted author who needs their own change on a device now. Anyone else can still start a
 # build by hand, here or in Codemagic.
 
@@ -11,7 +11,7 @@ on:
     branches: [main]
     paths: ['app/**']
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 */3 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mobile_internal_build.yml
+++ b/.github/workflows/mobile_internal_build.yml
@@ -1,0 +1,63 @@
+name: Mobile internal builds
+
+# App changes land on main in bursts, so a Codemagic build per merge is mostly superseded minutes
+# later. Codemagic's own triggering has no rate limit, so the push trigger is replaced by this:
+# a two-hourly batch that builds only when app code changed, plus an immediate build for an
+# allowlisted author who needs their own change on a device now. Anyone else can still start a
+# build by hand, here or in Codemagic.
+
+on:
+  push:
+    branches: [main]
+    paths: ['app/**']
+  schedule:
+    - cron: '0 */2 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: mobile-internal-build
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The schedule run compares main against the last commit Codemagic built.
+          fetch-depth: 0
+
+      - name: Collect commit authors
+        id: authors
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" != "push" ]; then
+            echo "authors=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          authors="$(jq -r '[.commits[]?.author.username // empty] | unique | join(",")' "$GITHUB_EVENT_PATH")"
+          echo "authors=${authors}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide and dispatch
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          CODEMAGIC_APP_ID: ${{ vars.CODEMAGIC_APP_ID || '66c95e6ec76853c447b8bcbb' }}
+          MOBILE_INSTANT_BUILD_ACTORS: ${{ vars.MOBILE_INSTANT_BUILD_ACTORS || 'mdmohsin7' }}
+        run: |
+          python3 .github/scripts/dispatch_mobile_internal_builds.py \
+            --event "${{ github.event_name }}" \
+            --actor "${{ github.actor }}" \
+            --commit-authors "${{ steps.authors.outputs.authors }}" \
+            --app-id "$CODEMAGIC_APP_ID" \
+            --branch main | tee "$RUNNER_TEMP/dispatch.txt"
+          {
+            echo "### Mobile internal builds"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/dispatch.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -31,13 +31,6 @@ workflows:
         - $HOME/.pub-cache
         - $HOME/.gradle/caches
         - $HOME/Library/Caches/CocoaPods
-    triggering:
-      events:
-        - push
-      branch_patterns:
-        - pattern: main
-          include: true
-      cancel_previous_builds: true
     when:
       changeset:
         includes:
@@ -253,13 +246,6 @@ workflows:
         - $HOME/opt
         - $HOME/.pub-cache
         - $HOME/.gradle/caches
-    triggering:
-      events:
-        - push
-      branch_patterns:
-        - pattern: main
-          include: true
-      cancel_previous_builds: true
     when:
       changeset:
         includes:


### PR DESCRIPTION
## What changed and why

App changes land on `main` in bursts a few minutes apart, and every one of them started an iOS **and** an Android internal build that the next merge superseded. Codemagic's `triggering:` block has no rate limit — it is events, branch/tag patterns and `cancel_previous_builds` — so the cadence has to come from whatever dispatches the build.

The push trigger on `ios-internal-auto` and `android-internal-auto` is replaced by a GitHub workflow that dispatches through the Codemagic API:

| When | What happens |
|---|---|
| Every 3 hours (`cron: 0 */3 * * *`) | Builds **only if** `app/**` changed since the commit Codemagic last built |
| Push to `main` by an author in `MOBILE_INSTANT_BUILD_ACTORS` (default `mdmohsin7`) | Builds immediately — your own change, on a device now |
| Push to `main` by anyone else | Batched; the next three-hourly run picks it up |
| `workflow_dispatch`, or Codemagic directly | Builds on demand |

The allowlist matches either the pusher or a commit author, so it still fires when someone else merges your PR, and it is a repo variable rather than a hardcoded name.

Both Codemagic workflows keep their existing `when: changeset: includes: ['app/**']` guard, so a dispatch that turns out to carry no app change still costs nothing. The five tag-triggered workflows (`ios-prod-testflight`, `android-prod-internal`, the two patch workflows, `omi-desktop-swift-release`) are untouched.

An unknown or missing last-built commit counts as *pending* rather than as nothing to do — a force-push or a pruned SHA must not silently stop builds.

## Trade-off to be aware of

A non-allowlisted merge is now up to ~3 hours from an internal build. That is the point of the change, and anyone who needs one sooner can press the button in Codemagic or run this workflow by hand.

## Product invariants affected

none

<!-- `scripts/pr-preflight --suggest` reports no invariant path globs matched by this diff. -->

## How it was verified

- `python3 .github/scripts/test_dispatch_mobile_internal_builds.py` — **14 tests**, covering the allowlist (pusher, commit author, case-insensitivity, empty allowlist), the batch decision (pending vs not, and that the allowlist does not leak into it), manual and unknown events, actor-list parsing, and the unknown-baseline case.
- Registered in `.github/checks-manifest.yaml` as `mobile-internal-build-cadence`, in both the `local` and `ci` lanes, so the cadence cannot quietly drift back to build-per-merge.
- CLI dry runs: `push`/`mdmohsin7` → `instant-actor`; `push`/`other-dev` → `batched`; `workflow_dispatch` → `manual`.
- `codemagic.yaml` reparsed after the edit: neither internal workflow has a `triggering:` block, both keep their `when: changeset`, and the five tag-triggered workflows still have theirs.
- `make preflight`: 10 checks pass.

**Not verified end to end**: dispatching a real Codemagic build needs `CODEMAGIC_API_TOKEN`, which is a repo secret and not available locally, so the API call itself is exercised only through the decision path and dry run. First scheduled run after merge is the real proof — the step summary prints the decision and the dispatched build ids.

**One assumption worth a check before merge**: this reuses `vars.CODEMAGIC_APP_ID` (default `66c95e6ec76853c447b8bcbb`), the id the desktop preview workflow already dispatches with. That is right if the mobile workflows live under the same Codemagic app as the desktop ones, which is what a single repo-root `codemagic.yaml` implies. If mobile is a separate Codemagic app, set `CODEMAGIC_APP_ID` accordingly or I will split it into a second variable.

## Tests

`.github/scripts/test_dispatch_mobile_internal_builds.py`.

## Failure class (fixes)

Failure-Class: none

<!-- Not a `fix:` commit; this changes build cadence, with no production behaviour change. -->
