### PR TITLE
chore(codeowners): require review for firmware and the app BLE/sync paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,23 @@
+# Review is required from the listed owner before merge. Ordering matters: the last matching
+# pattern wins, so keep the broad entries above the narrow ones.
+
 # Broad production authority remains protected after the retired release-ring deletion.
 /.github/workflows/** @Git-on-my-level
 /backend/charts/backend-secrets/** @Git-on-my-level
+
+# Device firmware. Behaviour here ships to hardware in the field and cannot be rolled back the
+# way a server deploy can.
+/omi/firmware/** @TuEmb
+
+# BLE and offline sync. These carry recording data between the device and the backend, and a
+# change that looks local has repeatedly broken capture or stranded recordings on devices.
+/app/lib/services/devices/** @mdmohsin7
+/app/lib/services/wals/** @mdmohsin7
+/app/lib/services/bridges/** @mdmohsin7
+/app/lib/services/wals.dart @mdmohsin7
+/app/lib/services/devices.dart @mdmohsin7
+/app/lib/providers/sync_provider.dart @mdmohsin7
+/app/lib/providers/device_provider.dart @mdmohsin7
+/app/lib/providers/capture_provider.dart @mdmohsin7
+/app/android/app/src/main/kotlin/com/friend/ios/ble/** @mdmohsin7
+/app/ios/Runner/Ble/** @mdmohsin7


### PR DESCRIPTION
## What changed and why

`main` already runs with `require_code_owner_reviews: true`, so a CODEOWNERS entry here **blocks the merge** rather than only requesting a review. Two areas were unprotected:

**Firmware → @TuEmb.** Behaviour here ships to hardware in the field and cannot be rolled back the way a server deploy can.

**The app's BLE and offline-sync paths → @mdmohsin7.** They carry recording data between the device and the backend, and changes that look local have broken capture or stranded recordings on devices before. The live example is #11016 / #11017, which propose restoring BLE bonding that was deliberately removed after shipping in firmware 3.0.18.

| Path | Owner |
|---|---|
| `/omi/firmware/**` | @TuEmb |
| `/app/lib/services/devices/**`, `/app/lib/services/wals/**`, `/app/lib/services/bridges/**` | @mdmohsin7 |
| `/app/lib/services/wals.dart`, `/app/lib/services/devices.dart` | @mdmohsin7 |
| `/app/lib/providers/{sync,device,capture}_provider.dart` | @mdmohsin7 |
| `/app/android/app/src/main/kotlin/com/friend/ios/ble/**` | @mdmohsin7 |
| `/app/ios/Runner/Ble/**` | @mdmohsin7 |

The native BLE directories matter: they sit outside `app/lib`, so an `app/lib`-only pattern would have left the Kotlin and Swift BLE managers unowned — which is where bonding actually lives.

## Product invariants affected

none

<!-- `scripts/pr-preflight --suggest` reports no invariant path globs matched by this diff. -->

## How it was verified

- Every owned path resolves in the tree; none is a guess. The BLE code is split across `app/lib/services/devices/`, `app/android/.../ble/` and `app/ios/Runner/Ble/`, and all three are covered.
- Both handles resolve to real GitHub users (`TuEmb`, `mdmohsin7`).
- Branch protection on `main` confirmed to have `require_code_owner_reviews: true` and `required_approving_review_count: 1`, so these entries are enforced.
- Existing entries are unchanged and still first, with a note that the last matching pattern wins.

## One consequence to decide before merging

@TuEmb is the sole owner of `/omi/firmware/**`, and GitHub does not count an author's approval of their own PR. His own firmware PRs would therefore have no one able to satisfy the code-owner requirement, and he is not on the branch-protection bypass list — so this would block the person it is meant to empower.

Options:

1. Leave as is, and let an admin bypass merge his firmware PRs.
2. Add a second firmware owner (`/omi/firmware/** @TuEmb @mdmohsin7`). GitHub accepts approval from **any one** listed owner, which unblocks his own PRs but also means a firmware change could be approved without him.
3. Add @TuEmb to the bypass list, leaving the single-owner rule intact for everyone else.

This PR implements option 1 — the literal request. Say which you want and I will adjust.

## Tests

None; CODEOWNERS is configuration. Correctness is path resolution and handle validity, both checked above.

## Failure class (fixes)

Failure-Class: none

<!-- Not a `fix:` commit; this adds review ownership with no production behaviour change. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

