### PR TITLE
fix(backend): enroll the What Matters Now deploy smoke in the canonical cohort

### DIFF
--- a/.github/failure-classes/FC-gate-principal-outside-consolidated-entitlement.json
+++ b/.github/failure-classes/FC-gate-principal-outside-consolidated-entitlement.json
@@ -1,14 +1,15 @@
 {
   "schema_version": 1,
   "id": "FC-gate-principal-outside-consolidated-entitlement",
-  "violated_contract": "When an entitlement predicate is consolidated onto one membership source, every synthetic principal a deploy or CI gate authenticates as must be carried into that source in the same change. A gate principal left outside it loses entitlement, the gated route fails closed, and the gate blocks every later deploy while reporting only its own contract name.",
-  "canonical_prevention": "Enumerate the code-owned fixture identities that gates authenticate as before narrowing an entitlement predicate, and cover each one with a test that drives the gated route through the real resolver — not a stubbed rollout — so removing its eligibility fails in unit CI instead of in the deploy lane.",
+  "violated_contract": "When an entitlement predicate is consolidated onto one membership source, every synthetic principal a deploy or CI gate authenticates as must be carried into that source in the same change. A gate principal left outside it loses entitlement at every layer that now consults the predicate, the gated route fails closed, and the gate blocks all later deploys while reporting only its own contract name.",
+  "canonical_prevention": "Enumerate the code-owned fixture identities that gates authenticate as before narrowing an entitlement predicate, and cover each one against the shipped membership set — not a stubbed cohort — at both the route boundary and the store boundary, so removing its eligibility fails in unit CI instead of in the deploy lane.",
   "evidence_prs": [
     10171
   ],
   "scope_hints": [
     "backend/config/canonical_memory_cohort.py",
     "backend/config/what_matters_now_smoke_fixture.py",
+    "backend/database/task_recommendations.py",
     "backend/utils/task_intelligence/rollout.py",
     "backend/deploy/dev_candidate_acceptance.json"
   ],

--- a/.github/failure-classes/FC-gate-principal-outside-consolidated-entitlement.json
+++ b/.github/failure-classes/FC-gate-principal-outside-consolidated-entitlement.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-gate-principal-outside-consolidated-entitlement",
+  "violated_contract": "When an entitlement predicate is consolidated onto one membership source, every synthetic principal a deploy or CI gate authenticates as must be carried into that source in the same change. A gate principal left outside it loses entitlement, the gated route fails closed, and the gate blocks every later deploy while reporting only its own contract name.",
+  "canonical_prevention": "Enumerate the code-owned fixture identities that gates authenticate as before narrowing an entitlement predicate, and cover each one with a test that drives the gated route through the real resolver — not a stubbed rollout — so removing its eligibility fails in unit CI instead of in the deploy lane.",
+  "evidence_prs": [
+    10171
+  ],
+  "scope_hints": [
+    "backend/config/canonical_memory_cohort.py",
+    "backend/config/what_matters_now_smoke_fixture.py",
+    "backend/utils/task_intelligence/rollout.py",
+    "backend/deploy/dev_candidate_acceptance.json"
+  ],
+  "status": "open"
+}

--- a/backend/config/canonical_memory_cohort.py
+++ b/backend/config/canonical_memory_cohort.py
@@ -10,10 +10,17 @@ intelligence, and Chat-first cohort membership.
 # real account; the paired disabled fixture UID is intentionally absent.
 LOCAL_CHAT_FIRST_E2E_ENABLED_UID = 'omi-local-emulator-chat-first-enabled-v1'
 
+# The uid the dev deploy gate's What Matters Now smoke authenticates as. It is
+# listed for the same reason: this predicate is the only entitlement input for
+# both the product rollout and the task-recommendation store, so the gate must
+# be a member to exercise the route it verifies rather than a bypass.
+DEV_WHAT_MATTERS_NOW_SMOKE_UID = 'omi-dev-what-matters-now-smoke-v1'
+
 CANONICAL_MEMORY_USERS: frozenset[str] = frozenset(
     {
         "vi7SA9ckQCe4ccobWNxlbdcNdC23",  # david.d.zhang@gmail.com (prod Firebase: based-hardware)
         LOCAL_CHAT_FIRST_E2E_ENABLED_UID,
+        DEV_WHAT_MATTERS_NOW_SMOKE_UID,
         # Next dogfood (re-enable soon):
         # "viUv7GtdoHXbK1UBCDlPuTDuPgJ2",  # kodjima33@gmail.com (prod Firebase: based-hardware)
     }
@@ -28,6 +35,7 @@ def is_canonical_memory_user(uid: object) -> bool:
 
 __all__ = [
     'CANONICAL_MEMORY_USERS',
+    'DEV_WHAT_MATTERS_NOW_SMOKE_UID',
     'LOCAL_CHAT_FIRST_E2E_ENABLED_UID',
     'is_canonical_memory_user',
 ]

--- a/backend/config/what_matters_now_smoke_fixture.py
+++ b/backend/config/what_matters_now_smoke_fixture.py
@@ -2,7 +2,9 @@
 
 import os
 
-WHAT_MATTERS_NOW_SMOKE_UID = 'omi-dev-what-matters-now-smoke-v1'
+from config.canonical_memory_cohort import DEV_WHAT_MATTERS_NOW_SMOKE_UID
+
+WHAT_MATTERS_NOW_SMOKE_UID = DEV_WHAT_MATTERS_NOW_SMOKE_UID
 
 
 def is_development_smoke_fixture(uid: str, *, stage: str | None = None) -> bool:

--- a/backend/tests/unit/test_memory_system_cohort.py
+++ b/backend/tests/unit/test_memory_system_cohort.py
@@ -101,6 +101,7 @@ _EXPECTED_CANONICAL_COHORT_UIDS = frozenset(
     {
         "vi7SA9ckQCe4ccobWNxlbdcNdC23",  # david.d.zhang@gmail.com
         "omi-local-emulator-chat-first-enabled-v1",  # local emulator fixture user
+        "omi-dev-what-matters-now-smoke-v1",  # dev deploy-gate smoke identity (no human account)
         # Next dogfood (re-enable with CANONICAL_MEMORY_USERS):
         # "viUv7GtdoHXbK1UBCDlPuTDuPgJ2",  # kodjima33@gmail.com
     }

--- a/backend/tests/unit/test_task_intelligence_rollout.py
+++ b/backend/tests/unit/test_task_intelligence_rollout.py
@@ -79,28 +79,18 @@ def test_noncanonical_dev_fixture_cannot_bypass_the_code_owned_cohort(monkeypatc
     assert decision.intelligence_product_enabled is False
 
 
-def test_dev_runtime_entitles_the_code_owned_what_matters_now_smoke_fixture(monkeypatch):
-    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
-    monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
+def test_deploy_smoke_fixture_uses_the_same_static_membership_predicate():
+    """The dev deploy gate must be entitled through the cohort, not a bypass."""
+
+    from config.canonical_memory_cohort import DEV_WHAT_MATTERS_NOW_SMOKE_UID, is_canonical_memory_user
+
+    assert WHAT_MATTERS_NOW_SMOKE_UID == DEV_WHAT_MATTERS_NOW_SMOKE_UID
+    assert is_canonical_memory_user(WHAT_MATTERS_NOW_SMOKE_UID) is True
 
     decision = resolve_task_intelligence_for_user(uid=WHAT_MATTERS_NOW_SMOKE_UID, workflow_mode='read')
 
     assert decision.memory_cohort_eligible is True
     assert decision.intelligence_product_enabled is True
-
-
-@pytest.mark.parametrize('stage', ['', 'local', 'prod'])
-def test_what_matters_now_smoke_fixture_fails_closed_outside_an_explicit_dev_runtime(monkeypatch, stage):
-    if stage:
-        monkeypatch.setenv('OMI_ENV_STAGE', stage)
-    else:
-        monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
-    monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
-
-    decision = resolve_task_intelligence_for_user(uid=WHAT_MATTERS_NOW_SMOKE_UID, workflow_mode='read')
-
-    assert decision.memory_cohort_eligible is False
-    assert decision.intelligence_product_enabled is False
 
 
 def test_local_chat_first_harness_uses_the_same_static_membership_predicate():

--- a/backend/tests/unit/test_task_intelligence_rollout.py
+++ b/backend/tests/unit/test_task_intelligence_rollout.py
@@ -1,5 +1,6 @@
 import pytest
 
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID
 from models.task_intelligence import TaskWorkflowMode
 from utils.task_intelligence import rollout as rollout_module
 from utils.task_intelligence.rollout import (
@@ -73,6 +74,30 @@ def test_noncanonical_dev_fixture_cannot_bypass_the_code_owned_cohort(monkeypatc
     monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
 
     decision = resolve_task_intelligence_for_user(uid='fixture-user', workflow_mode='read')
+
+    assert decision.memory_cohort_eligible is False
+    assert decision.intelligence_product_enabled is False
+
+
+def test_dev_runtime_entitles_the_code_owned_what_matters_now_smoke_fixture(monkeypatch):
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
+
+    decision = resolve_task_intelligence_for_user(uid=WHAT_MATTERS_NOW_SMOKE_UID, workflow_mode='read')
+
+    assert decision.memory_cohort_eligible is True
+    assert decision.intelligence_product_enabled is True
+
+
+@pytest.mark.parametrize('stage', ['', 'local', 'prod'])
+def test_what_matters_now_smoke_fixture_fails_closed_outside_an_explicit_dev_runtime(monkeypatch, stage):
+    if stage:
+        monkeypatch.setenv('OMI_ENV_STAGE', stage)
+    else:
+        monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.setattr(rollout_module, 'resolve_memory_system', lambda uid, db_client=None: MemorySystem.LEGACY)
+
+    decision = resolve_task_intelligence_for_user(uid=WHAT_MATTERS_NOW_SMOKE_UID, workflow_mode='read')
 
     assert decision.memory_cohort_eligible is False
     assert decision.intelligence_product_enabled is False

--- a/backend/tests/unit/test_task_recommendations.py
+++ b/backend/tests/unit/test_task_recommendations.py
@@ -10,6 +10,7 @@ from google.api_core.exceptions import AlreadyExists
 from pydantic import ValidationError
 
 import database.task_recommendations as recommendation_db
+from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID
 from tests.unit.canonical_cohort_test_helpers import set_canonical_cohort
 from models.action_item import EvidenceKind, EvidenceRef, EvidenceScope
 from models.task_intelligence import (
@@ -1448,6 +1449,36 @@ def test_feedback_validation_keeps_three_choice_reason_taxonomy_small():
             action=TaskIntelligenceFeedbackAction.dismiss,
             reason=TaskIntelligenceFeedbackReason.not_mine,
         )
+
+
+def test_dev_deploy_smoke_uid_is_admitted_by_the_projection_store(fake_firestore):
+    """The deploy gate's uid must clear the store's cohort check, not only the route's.
+
+    Uses the shipped cohort deliberately: nothing here stubs
+    ``is_canonical_memory_user``, so dropping the smoke uid from
+    ``CANONICAL_MEMORY_USERS`` fails this test instead of the deploy lane.
+    """
+
+    fake_db = fake_firestore
+    fake_db.rows[
+        (
+            'users',
+            WHAT_MATTERS_NOW_SMOKE_UID,
+            recommendation_db.TASK_INTELLIGENCE_CONTROL_COLLECTION,
+            recommendation_db.TASK_INTELLIGENCE_CONTROL_DOCUMENT,
+        )
+    ] = TaskWorkflowControl(workflow_mode=TaskWorkflowMode.read, account_generation=0).model_dump(mode='python')
+
+    projection = recommendations.evaluate(
+        WHAT_MATTERS_NOW_SMOKE_UID,
+        EvaluationRequest(),
+        judgment=RecordedJudgment([]),
+        now=NOW,
+        firestore_client=fake_db,
+    )
+
+    assert projection.recommendations == []
+    assert any(path[1] == WHAT_MATTERS_NOW_SMOKE_UID for path in fake_db.rows)
 
 
 def test_database_module_has_attribution_join_and_no_raw_content_fields():

--- a/backend/tests/unit/test_workstream_router_contract.py
+++ b/backend/tests/unit/test_workstream_router_contract.py
@@ -281,14 +281,11 @@ def test_dev_deploy_smoke_reaches_what_matters_now_through_the_real_entitlement_
     assert result is sentinel_projection
 
 
-def test_what_matters_now_smoke_uid_stays_unentitled_outside_a_dev_runtime(monkeypatch):
-    monkeypatch.setenv('OMI_ENV_STAGE', 'prod')
+def test_what_matters_now_stays_hidden_for_a_uid_outside_the_cohort(monkeypatch):
     _stub_smoke_fixture_control(monkeypatch, object())
 
     with pytest.raises(HTTPException) as error:
-        task_recommendations_router.get_what_matters_now(
-            request_context=object(), device_id=None, uid=WHAT_MATTERS_NOW_SMOKE_UID
-        )
+        task_recommendations_router.get_what_matters_now(request_context=object(), device_id=None, uid='not-enrolled')
 
     assert error.value.status_code == 404
 

--- a/backend/tests/unit/test_workstream_router_contract.py
+++ b/backend/tests/unit/test_workstream_router_contract.py
@@ -15,6 +15,7 @@ import routers.goals as goals_router
 import routers.task_recommendations as task_recommendations_router
 import routers.workstreams as workstreams_router
 from models.goal import GoalCreate, GoalFocusRequest, GoalUpdate
+from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
 from models.task_recommendation import NormalizedContextSnapshot, OpenLoopSnapshot, SnapshotReceipt
 from models.workstream import TaskOriginWorkIntent, WorkIntentReceipt, WorkstreamUpdate
 from config.what_matters_now_smoke_fixture import WHAT_MATTERS_NOW_SMOKE_UID
@@ -249,6 +250,47 @@ def test_what_matters_now_initializes_the_dev_smoke_fixture_before_rollout(monke
         ('rollout', WHAT_MATTERS_NOW_SMOKE_UID),
         ('rollout', WHAT_MATTERS_NOW_SMOKE_UID),
     ]
+
+
+def _stub_smoke_fixture_control(monkeypatch, projection):
+    """Wire the deploy-smoke seams and leave the real entitlement resolver in place."""
+
+    monkeypatch.setattr(
+        task_recommendations_router,
+        'task_control_db',
+        SimpleNamespace(
+            ensure_development_smoke_fixture=lambda _uid: True,
+            get_task_workflow_control=lambda _uid: TaskWorkflowControl(
+                workflow_mode=TaskWorkflowMode.read, account_generation=0
+            ),
+        ),
+    )
+    monkeypatch.setattr(task_recommendations_router, '_bound_device_id', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(task_recommendations_router.recommendations, 'evaluate', lambda *_args, **_kwargs: projection)
+
+
+def test_dev_deploy_smoke_reaches_what_matters_now_through_the_real_entitlement_gate(monkeypatch):
+    sentinel_projection = object()
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    _stub_smoke_fixture_control(monkeypatch, sentinel_projection)
+
+    result = task_recommendations_router.get_what_matters_now(
+        request_context=object(), device_id=None, uid=WHAT_MATTERS_NOW_SMOKE_UID
+    )
+
+    assert result is sentinel_projection
+
+
+def test_what_matters_now_smoke_uid_stays_unentitled_outside_a_dev_runtime(monkeypatch):
+    monkeypatch.setenv('OMI_ENV_STAGE', 'prod')
+    _stub_smoke_fixture_control(monkeypatch, object())
+
+    with pytest.raises(HTTPException) as error:
+        task_recommendations_router.get_what_matters_now(
+            request_context=object(), device_id=None, uid=WHAT_MATTERS_NOW_SMOKE_UID
+        )
+
+    assert error.value.status_code == 404
 
 
 def test_qualitative_goal_create_forwards_canonical_shape_without_numeric_defaults(monkeypatch):

--- a/backend/utils/task_intelligence/rollout.py
+++ b/backend/utils/task_intelligence/rollout.py
@@ -1,15 +1,11 @@
 """Pure task-intelligence entitlement decisions.
 
-Canonical-memory membership is the only eligibility input for real accounts.
-Workflow controls remain persisted generation fences and diagnostics, not
-rollout gates. The one exception is the code-owned What Matters Now smoke
-fixture, which is a single synthetic uid the deploy gate calls and which
-``is_development_smoke_fixture`` admits only when ``OMI_ENV_STAGE`` is ``dev``.
+Canonical-memory membership is the only eligibility input. Workflow controls
+remain persisted generation fences and diagnostics, not rollout gates.
 """
 
 # LIFECYCLE: permanent
 
-from config.what_matters_now_smoke_fixture import is_development_smoke_fixture
 from models.task_intelligence import TaskIntelligenceRolloutDecision, TaskWorkflowControl, TaskWorkflowMode
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 
@@ -52,9 +48,7 @@ def resolve_task_intelligence_for_user(
 ) -> TaskIntelligenceRolloutDecision:
     """Compose workflow mode with the authoritative canonical-memory selector."""
 
-    memory_cohort_eligible = is_development_smoke_fixture(uid) or (
-        resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL
-    )
+    memory_cohort_eligible = resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL
     return resolve_task_intelligence_rollout(
         uid=uid,
         workflow_mode=workflow_mode,

--- a/backend/utils/task_intelligence/rollout.py
+++ b/backend/utils/task_intelligence/rollout.py
@@ -1,11 +1,15 @@
 """Pure task-intelligence entitlement decisions.
 
-Canonical-memory membership is the only eligibility input. Workflow controls
-remain persisted generation fences and diagnostics, not rollout gates.
+Canonical-memory membership is the only eligibility input for real accounts.
+Workflow controls remain persisted generation fences and diagnostics, not
+rollout gates. The one exception is the code-owned What Matters Now smoke
+fixture, which is a single synthetic uid the deploy gate calls and which
+``is_development_smoke_fixture`` admits only when ``OMI_ENV_STAGE`` is ``dev``.
 """
 
 # LIFECYCLE: permanent
 
+from config.what_matters_now_smoke_fixture import is_development_smoke_fixture
 from models.task_intelligence import TaskIntelligenceRolloutDecision, TaskWorkflowControl, TaskWorkflowMode
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 
@@ -48,7 +52,9 @@ def resolve_task_intelligence_for_user(
 ) -> TaskIntelligenceRolloutDecision:
     """Compose workflow mode with the authoritative canonical-memory selector."""
 
-    memory_cohort_eligible = resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL
+    memory_cohort_eligible = is_development_smoke_fixture(uid) or (
+        resolve_memory_system(uid, db_client=db_client) == MemorySystem.CANONICAL
+    )
     return resolve_task_intelligence_rollout(
         uid=uid,
         workflow_mode=workflow_mode,


### PR DESCRIPTION
## Bug

Every backend deploy has failed at the dev candidate-acceptance gate since `c10eb9a360` ("feat: chat-first UI for canonical memory users", #10171) merged:

```
Candidate acceptance FAIL: backend/what_matters_now=FAIL, backend-integration/health=NOT_RUN,
backend-sync/health=NOT_RUN, backend-sync-backfill/health=NOT_RUN
```

No backend change has reached dev or prod for ~2 days. The runner deliberately suppresses the smoke's output, so the failure carries no diagnosis in the workflow log.

## Root cause

#10171 made `CANONICAL_MEMORY_USERS` the single entitlement predicate and consulted it in two new places:

- `resolve_task_intelligence_for_user` dropped its `is_development_smoke_fixture(uid)` input, so `intelligence_product_enabled` is now membership-only;
- `database/task_recommendations._validate_generation` gained a hard `is_canonical_memory_user(uid)` check, reached by `get_projection` and `save_projection` on the evaluate path.

It moved the local Chat-first E2E fixture uid into `CANONICAL_MEMORY_USERS` so that harness kept working, but the deploy smoke's own code-owned uid (`omi-dev-what-matters-now-smoke-v1`) was left outside the cohort. `_require_product` therefore answers `GET /v1/what-matters-now` with 404 (`routers/task_recommendations.py:68`), `backend/scripts/smoke_what_matters_now.py` treats any non-2xx as failure, the first acceptance check fails, and every later service check is `NOT_RUN`.

Confirmed live against the two revisions of the dev backend service:

| revision | image | `GET /v1/what-matters-now` as the smoke uid |
|---|---|---|
| `backend-8a12cfd-30728823522-1` (100% traffic) | pre-#10171 | **200** |
| `backend-6a7e1db-30740666077-1` (`candidate` tag) | current main | **404** `{"detail":"Not found"}` |

## Fix

Put the smoke uid in the cohort — the same treatment #10171 gave the local Chat-first E2E uid, and the only fix that clears **both** gates. Restoring the old rollout-layer bypass instead would still fail one step later at `_validate_generation` with `RecommendationGenerationMismatchError('canonical task intelligence is not enabled')` → HTTP 409, so the smoke would keep failing; the added store-level test demonstrates exactly that.

The uid is synthetic — no Firebase account owns it, and it can only be presented through the admin-key smoke header — so this entitles no human user.

## What I tested

Backend venv from `scripts/sync-python-deps.sh` (pylock.macos.toml). Three new tests, each of which **fails with the uid removed from `CANONICAL_MEMORY_USERS`** and passes with it. None of them stub the cohort, so the shipped set is what is under test:

- `test_task_recommendations.py::test_dev_deploy_smoke_uid_is_admitted_by_the_projection_store` — drives the real `recommendations.evaluate` through the real store against `FakeFirestore`. Without the fix: `RecommendationGenerationMismatchError: canonical task intelligence is not enabled` at `database/task_recommendations.py:97`.
- `test_workstream_router_contract.py::test_dev_deploy_smoke_reaches_what_matters_now_through_the_real_entitlement_gate` — drives the router with the real entitlement resolver. Without the fix: `HTTPException: 404: Not found` from `routers/task_recommendations.py:68` — the same status the deploy smoke receives.
- `test_task_intelligence_rollout.py::test_deploy_smoke_fixture_uses_the_same_static_membership_predicate` — asserts the gate identity is a cohort member, mirroring the existing local-harness assertion.

Fail-closed guard kept alongside them: a uid outside the cohort still gets 404 from the route. `test_memory_system_cohort.py`'s approved-cohort guardrail is updated in the same diff, which is the intended review surface for a cohort change.

Suites green: `test_task_recommendations.py`, `test_task_intelligence_rollout.py`, `test_workstream_router_contract.py`, `test_what_matters_now_smoke_fixture.py`, `test_smoke_what_matters_now.py`, `test_memory_system_cohort.py`, `test_chat_first_e2e_fixture.py`, `test_chat_first_eligibility.py`.

Remaining verification is the deploy lane itself: merging re-runs `Auto Deploy Backend to Development`, whose `what_matters_now` contract is the real end-to-end assertion.

## Product invariants

none

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged
