### PR TITLE
ci(release): align mobile cadence hygiene guard

### DIFF
--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -970,23 +970,35 @@ def check_mobile_codemagic_release_triggers() -> list[str]:
             errors.append(f"codemagic.yaml is missing {workflow_id}")
             continue
         body = match.group("body")
-        required = (
-            "    triggering:\n"
-            "      events:\n"
-            "        - push\n"
-            "      branch_patterns:\n"
-            "        - pattern: main\n"
-            "          include: true\n"
-            "      cancel_previous_builds: true\n"
-            "    when:\n"
-            "      changeset:\n"
-            "        includes:\n"
-            "          - 'app/**'"
-        )
-        if required not in body:
+        if "    when:\n      changeset:\n        includes:\n          - 'app/**'" not in body:
             errors.append(
-                f"{workflow_id} must natively trigger on main app/** pushes and cancel stale builds"
+                f"{workflow_id} must retain its app/** changeset guard"
             )
+
+    dispatcher = ROOT / ".github/workflows/mobile_internal_build.yml"
+    if not dispatcher.exists():
+        errors.append("mobile internal build dispatcher is missing")
+    else:
+        dispatcher_text = dispatcher.read_text(encoding="utf-8")
+        dispatcher_script = ROOT / ".github/scripts/dispatch_mobile_internal_builds.py"
+        dispatcher_source = dispatcher_text
+        if dispatcher_script.exists():
+            dispatcher_source += "\n" + dispatcher_script.read_text(encoding="utf-8")
+        required_dispatcher = (
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths: ['app/**']\n"
+            "  schedule:\n"
+            "    - cron: '0 */3 * * *'\n"
+            "  workflow_dispatch:\n"
+        )
+        if required_dispatcher not in dispatcher_text or "cancel-in-progress: true" not in dispatcher_text:
+            errors.append(
+                "mobile internal build dispatcher must trigger on main app/** pushes and cancel stale runs"
+            )
+        for workflow_id in ("ios-internal-auto", "android-internal-auto"):
+            if workflow_id not in dispatcher_source:
+                errors.append(f"mobile internal build dispatcher is missing {workflow_id}")
 
     if (ROOT / ".github/workflows/mobile_internal_auto.yml").exists():
         errors.append("mobile internal releases must not be dispatched through GitHub Actions")

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 import os
@@ -983,22 +984,58 @@ def check_mobile_codemagic_release_triggers() -> list[str]:
     else:
         dispatcher_text = dispatcher.read_text(encoding="utf-8")
         dispatcher_script = ROOT / ".github/scripts/dispatch_mobile_internal_builds.py"
-        dispatcher_source = dispatcher_text
-        if dispatcher_script.exists():
-            dispatcher_source += "\n" + dispatcher_script.read_text(encoding="utf-8")
-        required_dispatcher = (
-            "  push:\n"
-            "    branches: [main]\n"
-            "    paths: ['app/**']\n"
-            "  schedule:\n"
-            "    - cron: '0 */3 * * *'\n"
-            "  workflow_dispatch:\n"
-        )
-        if required_dispatcher not in dispatcher_text or "cancel-in-progress: true" not in dispatcher_text:
-            errors.append("mobile internal build dispatcher must trigger on main app/** pushes and cancel stale runs")
-        for workflow_id in ("ios-internal-auto", "android-internal-auto"):
-            if workflow_id not in dispatcher_source:
-                errors.append(f"mobile internal build dispatcher is missing {workflow_id}")
+        try:
+            workflow = yaml.load(dispatcher_text, Loader=yaml.BaseLoader)
+        except yaml.YAMLError as exc:
+            errors.append(f"mobile internal build dispatcher is not valid YAML: {exc}")
+            workflow = None
+        if not isinstance(workflow, dict):
+            errors.append("mobile internal build dispatcher must be a YAML mapping")
+        else:
+            triggers = workflow.get("on")
+            if not isinstance(triggers, dict):
+                errors.append("mobile internal build dispatcher must declare push, schedule, and workflow_dispatch triggers")
+            else:
+                push = triggers.get("push")
+                if not isinstance(push, dict) or push.get("branches") != ["main"] or push.get("paths") != ["app/**"]:
+                    errors.append("mobile internal build dispatcher must trigger on main app/** pushes")
+                schedule = triggers.get("schedule")
+                if not isinstance(schedule, list) or schedule != [{"cron": "0 */3 * * *"}]:
+                    errors.append("mobile internal build dispatcher must retain its three-hour schedule")
+                if "workflow_dispatch" not in triggers:
+                    errors.append("mobile internal build dispatcher must retain workflow_dispatch")
+            concurrency = workflow.get("concurrency")
+            if not isinstance(concurrency, dict) or concurrency.get("group") != "mobile-internal-build":
+                errors.append("mobile internal build dispatcher must use the mobile-internal-build concurrency group")
+            elif concurrency.get("cancel-in-progress") != "false":
+                errors.append("mobile internal build dispatcher must not cancel an in-progress sequential dispatch")
+            jobs = workflow.get("jobs")
+            dispatch_job = jobs.get("dispatch") if isinstance(jobs, dict) else None
+            steps = dispatch_job.get("steps") if isinstance(dispatch_job, dict) else None
+            runs = [step.get("run", "") for step in steps if isinstance(step, dict)] if isinstance(steps, list) else []
+            if not any("python3 .github/scripts/dispatch_mobile_internal_builds.py" in run for run in runs):
+                errors.append("mobile internal build dispatcher must invoke dispatch_mobile_internal_builds.py")
+
+        if not dispatcher_script.exists():
+            errors.append("mobile internal build dispatcher script is missing")
+        else:
+            try:
+                script_tree = ast.parse(dispatcher_script.read_text(encoding="utf-8"), filename=str(dispatcher_script))
+            except (OSError, SyntaxError) as exc:
+                errors.append(f"mobile internal build dispatcher script is not valid Python: {exc}")
+            else:
+                workflow_values = None
+                for node in script_tree.body:
+                    if isinstance(node, ast.Assign) and any(
+                        isinstance(target, ast.Name) and target.id == "MOBILE_WORKFLOWS" for target in node.targets
+                    ):
+                        try:
+                            workflow_values = ast.literal_eval(node.value)
+                        except (ValueError, TypeError):
+                            workflow_values = None
+                        break
+                if workflow_values != ("ios-internal-auto", "android-internal-auto"):
+                    errors.append("mobile internal build dispatcher script must declare both Codemagic mobile workflows")
 
     if (ROOT / ".github/workflows/mobile_internal_auto.yml").exists():
         errors.append("mobile internal releases must not be dispatched through GitHub Actions")

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -296,7 +296,9 @@ def _load_workflow_contract(raw_bytes: bytes) -> tuple[dict[str, object] | None,
             if type(publication_digest) is not str or _SHA256_HEX.fullmatch(publication_digest) is None:
                 errors.append(_fixture_sha256_error("publication_script_sha256"))
             elif type(publication_script) is str and _sha256_text(publication_script) != publication_digest:
-                errors.append("Codemagic workflow contract fixture publication script digest does not match publication_script")
+                errors.append(
+                    "Codemagic workflow contract fixture publication script digest does not match publication_script"
+                )
     return (contract if not errors else None), errors
 
 
@@ -422,9 +424,7 @@ def check_codemagic_release_publishers() -> list[str]:
         for forbidden_authority in _FORBIDDEN_NORMAL_RELEASE_GCP_AUTHORITIES:
             match = forbidden_authority.search(scalar)
             if match is not None:
-                errors.append(
-                    f"{CANONICAL_WORKFLOW} contains forbidden broad GCP authority {match.group(0)!r}"
-                )
+                errors.append(f"{CANONICAL_WORKFLOW} contains forbidden broad GCP authority {match.group(0)!r}")
 
     preview_environment = preview.get("environment")
     preview_groups = preview_environment.get("groups") if isinstance(preview_environment, dict) else None
@@ -631,15 +631,19 @@ def check_desktop_codemagic_release() -> list[str]:
             errors.append(f"desktop qualification handoff is missing reliable dispatch fragment: {required_fragment}")
     dispatch_start = desktop_workflow_body.find("Dispatch trusted macOS beta qualification")
     dispatch_body = desktop_workflow_body[dispatch_start:] if dispatch_start != -1 else ""
-    if 'GH_TOKEN="${GITHUB_TOKEN:?desktop_secrets GITHUB_TOKEN is required for qualification dispatch}"' not in dispatch_body:
-        errors.append(
-            "Codemagic qualification dispatch must bind GH_TOKEN to the scoped desktop_secrets GITHUB_TOKEN"
-        )
+    if (
+        'GH_TOKEN="${GITHUB_TOKEN:?desktop_secrets GITHUB_TOKEN is required for qualification dispatch}"'
+        not in dispatch_body
+    ):
+        errors.append("Codemagic qualification dispatch must bind GH_TOKEN to the scoped desktop_secrets GITHUB_TOKEN")
     if "gh release edit \"$CM_TAG\"" in dispatch_body:
         errors.append("Codemagic must not write release-body dispatch state outside the trusted workflow serialiser")
     if "candidate remains non-live" not in desktop_workflow_body:
         errors.append("desktop qualification handoff must state that a failed dispatch cannot publish beta")
-    if "ERROR: qualification dispatch was not confirmed after bounded retry" not in dispatch_body or "exit 1" not in dispatch_body:
+    if (
+        "ERROR: qualification dispatch was not confirmed after bounded retry" not in dispatch_body
+        or "exit 1" not in dispatch_body
+    ):
         errors.append("desktop qualification handoff must fail closed after bounded dispatch retries")
     if "gh release delete \"$CM_TAG\"" in desktop_workflow_body:
         errors.append("desktop candidate retries must not delete immutable qualification evidence")
@@ -971,9 +975,7 @@ def check_mobile_codemagic_release_triggers() -> list[str]:
             continue
         body = match.group("body")
         if "    when:\n      changeset:\n        includes:\n          - 'app/**'" not in body:
-            errors.append(
-                f"{workflow_id} must retain its app/** changeset guard"
-            )
+            errors.append(f"{workflow_id} must retain its app/** changeset guard")
 
     dispatcher = ROOT / ".github/workflows/mobile_internal_build.yml"
     if not dispatcher.exists():
@@ -993,9 +995,7 @@ def check_mobile_codemagic_release_triggers() -> list[str]:
             "  workflow_dispatch:\n"
         )
         if required_dispatcher not in dispatcher_text or "cancel-in-progress: true" not in dispatcher_text:
-            errors.append(
-                "mobile internal build dispatcher must trigger on main app/** pushes and cancel stale runs"
-            )
+            errors.append("mobile internal build dispatcher must trigger on main app/** pushes and cancel stale runs")
         for workflow_id in ("ios-internal-auto", "android-internal-auto"):
             if workflow_id not in dispatcher_source:
                 errors.append(f"mobile internal build dispatcher is missing {workflow_id}")

--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "codemagic_raw_sha256": "550c688405b0ae66e54c95a05b393a8f291431a1a23abec9944f1c6f5928b953",
-  "codemagic_semantic_sha256": "2710d6a634c316972f8fa04c892ab717b600f8176177030a33909ff7612500c8",
+  "codemagic_raw_sha256": "c3f3c79601f100b7ba6953d16f7ce65a0ab53da308b2f60306ddc8496984a6f3",
+  "codemagic_semantic_sha256": "c8908ed39a0f4cd7ec8c123c4ba884a538601af2e8097603dd58ae27333d03e3",
   "omi-desktop-swift-preview": {
     "semantic_sha256": "42f2fd7d28c2b2cb29f6af7970368a1f09ba72fa34e715ca25ae380bd60fa84a"
   },

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -62,6 +62,25 @@ def _load_parent_guard(tmp_path: Path, revision: str = REVIEWED_PARENT):
     return module
 
 
+def _copy_reviewed_parent_contract(tmp_path: Path) -> Path:
+    codemagic = tmp_path / "codemagic.yaml"
+    codemagic.write_bytes(
+        subprocess.check_output(
+            ["git", "show", f"{REVIEWED_PARENT}:codemagic.yaml"],
+            cwd=REPO_ROOT,
+        )
+    )
+    fixture = tmp_path / ".github/scripts/fixtures/codemagic_workflow_contract/v1.json"
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.write_bytes(
+        subprocess.check_output(
+            ["git", "show", f"{REVIEWED_PARENT}:.github/scripts/fixtures/codemagic_workflow_contract/v1.json"],
+            cwd=REPO_ROOT,
+        )
+    )
+    return codemagic
+
+
 def _append_unreviewed_workflow(
     path: Path, script: str, *, credential_group: str = "alternate_release_credentials"
 ) -> None:
@@ -82,11 +101,9 @@ def _append_unreviewed_workflow(
 
 def _restore_parent_preview_credential_shape(path: Path) -> None:
     """Keep historical-parent regression probes independent of the temporary exception."""
-    _mutate(
-        path,
-        "        - desktop_preview_secrets\n        - appstore_credentials\n        - desktop_secrets\n",
-        "        - desktop_preview_secrets\n",
-    )
+    old = "        - desktop_preview_secrets\n        - appstore_credentials\n        - desktop_secrets\n"
+    if old in path.read_text(encoding="utf-8"):
+        _mutate(path, old, "        - desktop_preview_secrets\n")
     contract_path = _fixture_path(path.parent)
     contract = json.loads(contract_path.read_text(encoding="utf-8"))
     preview = yaml.safe_load(path.read_text(encoding="utf-8"))["workflows"]["omi-desktop-swift-preview"]
@@ -456,9 +473,11 @@ def test_normal_release_gcp_authority_guard_ignores_harmless_source_comments(tmp
     ids=("shell-construction", "direct-wrapper", "python-construction", "variable-api-url"),
 )
 def test_reviewed_parent_accepts_unreviewed_publisher_bypasses_but_global_lock_rejects(tmp_path, monkeypatch, script):
-    codemagic = _copy_contract_tree(tmp_path, monkeypatch)
-    _append_unreviewed_workflow(codemagic, script)
+    codemagic = _copy_reviewed_parent_contract(tmp_path)
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
     _restore_parent_preview_credential_shape(codemagic)
+    _approve_current_codemagic_document(tmp_path)
+    _append_unreviewed_workflow(codemagic, script)
 
     parent = _load_parent_guard(tmp_path)
     parent.ROOT = tmp_path
@@ -469,13 +488,15 @@ def test_reviewed_parent_accepts_unreviewed_publisher_bypasses_but_global_lock_r
 
 
 def test_reviewed_parent_accepts_unknown_credential_group_with_publisher_but_global_lock_rejects(tmp_path, monkeypatch):
-    codemagic = _copy_contract_tree(tmp_path, monkeypatch)
+    codemagic = _copy_reviewed_parent_contract(tmp_path)
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    _restore_parent_preview_credential_shape(codemagic)
+    _approve_current_codemagic_document(tmp_path)
     _append_unreviewed_workflow(
         codemagic,
         'X=gh; $X release create "$CM_TAG"',
         credential_group="unrecognized_release_authority",
     )
-    _restore_parent_preview_credential_shape(codemagic)
 
     parent = _load_parent_guard(tmp_path)
     parent.ROOT = tmp_path
@@ -512,7 +533,10 @@ def test_reviewed_parent_accepts_unknown_credential_group_with_publisher_but_glo
     ids=("unrelated-workflow", "comment-bytes", "anchor-spelling", "top-level-field"),
 )
 def test_global_document_lock_rejects_every_codemagic_mutation(tmp_path, monkeypatch, old, new, parent_accepts):
-    codemagic = _copy_contract_tree(tmp_path, monkeypatch)
+    codemagic = _copy_reviewed_parent_contract(tmp_path)
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    _restore_parent_preview_credential_shape(codemagic)
+    _approve_current_codemagic_document(tmp_path)
     _mutate(codemagic, old, new)
     if old == "&desktop_signed_artifact_steps":
         _mutate(codemagic, "*desktop_signed_artifact_steps", "*renamed_desktop_signed_artifact_steps")
@@ -528,27 +552,21 @@ def test_global_document_lock_rejects_every_codemagic_mutation(tmp_path, monkeyp
 
 
 def test_global_document_raw_lock_rejects_semantically_equivalent_yaml_rewrite(tmp_path, monkeypatch):
-    codemagic = _copy_contract_tree(tmp_path, monkeypatch)
+    codemagic = _copy_reviewed_parent_contract(tmp_path)
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    _restore_parent_preview_credential_shape(codemagic)
+    original_document = yaml.safe_load(codemagic.read_text(encoding="utf-8"))
+    _approve_current_codemagic_document(tmp_path)
     _mutate(
         codemagic,
         "    name: Auto Deploy iOS to Internal TestFlight\n",
         '    name: "Auto Deploy iOS to Internal TestFlight"\n',
     )
-    assert yaml.safe_load(codemagic.read_text(encoding="utf-8")) == yaml.safe_load(
-        (REPO_ROOT / "codemagic.yaml").read_text(encoding="utf-8")
-    )
+    assert yaml.safe_load(codemagic.read_text(encoding="utf-8")) == original_document
 
     parent = _load_parent_guard(tmp_path)
-    _restore_parent_preview_credential_shape(codemagic)
     parent.ROOT = tmp_path
     assert parent.check_codemagic_release_publishers() == []
-
-    _mutate(
-        codemagic,
-        "        - desktop_preview_secrets\n",
-        "        - desktop_preview_secrets\n        - appstore_credentials\n        - desktop_secrets\n",
-    )
-    shutil.copy2(REPO_ROOT / ".github/scripts/fixtures/codemagic_workflow_contract/v1.json", _fixture_path(tmp_path))
 
     errors = GUARDS.check_codemagic_release_publishers()
     assert any("raw byte digest" in error for error in errors), errors

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -332,6 +332,9 @@ def _mobile_trigger_errors_after(tmp_path: Path, monkeypatch, old: str, new: str
     dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
     dispatcher.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    dispatcher_script = tmp_path / ".github/scripts/dispatch_mobile_internal_builds.py"
+    dispatcher_script.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/scripts/dispatch_mobile_internal_builds.py", dispatcher_script)
     _mutate(dispatcher, old, new)
     monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
     return GUARDS.check_mobile_codemagic_release_triggers()
@@ -414,13 +417,53 @@ def test_desktop_candidate_trigger_guard_rejects_direct_build_api_for_normal_lan
         ("    branches: [main]\n", "    branches: [release]\n"),
         ("    paths: ['app/**']\n", "    paths: ['desktop/**']\n"),
         ("    - cron: '0 */3 * * *'\n", "    - cron: '0 */4 * * *'\n"),
-        ("cancel-in-progress: true", "cancel-in-progress: false"),
+        ("cancel-in-progress: false", "cancel-in-progress: true"),
     ),
 )
 def test_mobile_codemagic_trigger_guard_rejects_regressions(tmp_path, monkeypatch, old, new):
     errors = _mobile_trigger_errors_after(tmp_path, monkeypatch, old, new)
 
-    assert any("mobile internal build dispatcher" in error for error in errors), errors
+    assert any(
+        "main app/** pushes" in error
+        or "three-hour schedule" in error
+        or "workflow_dispatch" in error
+        or "must not cancel" in error
+        for error in errors
+    ), errors
+
+
+def test_mobile_codemagic_dispatcher_guard_rejects_missing_dispatch_command(tmp_path, monkeypatch):
+    codemagic = tmp_path / "codemagic.yaml"
+    shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
+    dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    dispatcher_script = tmp_path / ".github/scripts/dispatch_mobile_internal_builds.py"
+    dispatcher_script.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/scripts/dispatch_mobile_internal_builds.py", dispatcher_script)
+    _mutate(dispatcher, "python3 .github/scripts/dispatch_mobile_internal_builds.py", "python3 .github/scripts/other_dispatcher.py")
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+
+    errors = GUARDS.check_mobile_codemagic_release_triggers()
+
+    assert errors == ["mobile internal build dispatcher must invoke dispatch_mobile_internal_builds.py"], errors
+
+
+def test_mobile_codemagic_dispatcher_guard_rejects_missing_workflow_target(tmp_path, monkeypatch):
+    codemagic = tmp_path / "codemagic.yaml"
+    shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
+    dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    dispatcher_script = tmp_path / ".github/scripts/dispatch_mobile_internal_builds.py"
+    dispatcher_script.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/scripts/dispatch_mobile_internal_builds.py", dispatcher_script)
+    _mutate(dispatcher_script, 'MOBILE_WORKFLOWS = ("ios-internal-auto", "android-internal-auto")', 'MOBILE_WORKFLOWS = ("ios-internal-auto",)')
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+
+    errors = GUARDS.check_mobile_codemagic_release_triggers()
+
+    assert errors == ["mobile internal build dispatcher script must declare both Codemagic mobile workflows"], errors
 
 
 @pytest.mark.parametrize(

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -312,20 +312,29 @@ def test_codemagic_workflow_contract_accepts_current_production_configuration():
 def _mobile_trigger_errors_after(tmp_path: Path, monkeypatch, old: str, new: str) -> list[str]:
     codemagic = tmp_path / "codemagic.yaml"
     shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
-    _mutate(codemagic, old, new)
+    dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    _mutate(dispatcher, old, new)
     monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
     return GUARDS.check_mobile_codemagic_release_triggers()
 
 
-def test_mobile_codemagic_triggers_are_native_and_production_safe(tmp_path, monkeypatch):
+def test_mobile_codemagic_dispatcher_is_production_safe(tmp_path, monkeypatch):
     codemagic = tmp_path / "codemagic.yaml"
     shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
+    dispatcher = tmp_path / ".github/workflows/mobile_internal_build.yml"
+    dispatcher.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/workflows/mobile_internal_build.yml", dispatcher)
+    dispatcher_script = tmp_path / ".github/scripts/dispatch_mobile_internal_builds.py"
+    dispatcher_script.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / ".github/scripts/dispatch_mobile_internal_builds.py", dispatcher_script)
     monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
 
     assert GUARDS.check_mobile_codemagic_release_triggers() == []
 
 
-def test_mobile_codemagic_trigger_guard_rejects_github_dispatcher(tmp_path, monkeypatch):
+def test_mobile_codemagic_trigger_guard_rejects_legacy_github_dispatcher(tmp_path, monkeypatch):
     codemagic = tmp_path / "codemagic.yaml"
     shutil.copy2(REPO_ROOT / "codemagic.yaml", codemagic)
     dispatcher = tmp_path / ".github/workflows/mobile_internal_auto.yml"
@@ -385,16 +394,16 @@ def test_desktop_candidate_trigger_guard_rejects_direct_build_api_for_normal_lan
 @pytest.mark.parametrize(
     ("old", "new"),
     (
-        ("        - push\n", "        - pull_request\n"),
-        ("        - pattern: main\n", "        - pattern: release/*\n"),
-        ("      cancel_previous_builds: true\n", "      cancel_previous_builds: false\n"),
-        ("          - 'app/**'\n", "          - 'desktop/**'\n"),
+        ("    branches: [main]\n", "    branches: [release]\n"),
+        ("    paths: ['app/**']\n", "    paths: ['desktop/**']\n"),
+        ("    - cron: '0 */3 * * *'\n", "    - cron: '0 */4 * * *'\n"),
+        ("cancel-in-progress: true", "cancel-in-progress: false"),
     ),
 )
 def test_mobile_codemagic_trigger_guard_rejects_regressions(tmp_path, monkeypatch, old, new):
     errors = _mobile_trigger_errors_after(tmp_path, monkeypatch, old, new)
 
-    assert any("must natively trigger" in error for error in errors), errors
+    assert any("mobile internal build dispatcher" in error for error in errors), errors
 
 
 @pytest.mark.parametrize(

--- a/.github/scripts/test_dispatch_mobile_internal_builds.py
+++ b/.github/scripts/test_dispatch_mobile_internal_builds.py
@@ -2,6 +2,7 @@
 """Tests for the mobile internal build dispatch decision."""
 
 import importlib.util
+import os
 import pathlib
 import unittest
 
@@ -138,11 +139,21 @@ class TestPendingCommits(unittest.TestCase):
             ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
         ).stdout.strip()
         self.assertTrue(mod.is_ancestor(head))
+        git_env = os.environ.copy()
+        git_env.update(
+            {
+                "GIT_AUTHOR_EMAIL": "mobile-cadence-test@example.com",
+                "GIT_AUTHOR_NAME": "mobile-cadence-test",
+                "GIT_COMMITTER_EMAIL": "mobile-cadence-test@example.com",
+                "GIT_COMMITTER_NAME": "mobile-cadence-test",
+            }
+        )
         orphan = mod.subprocess.run(
             ["git", "commit-tree", head + "^{tree}", "-m", "orphan"],
             capture_output=True,
             text=True,
             check=True,
+            env=git_env,
         ).stdout.strip()
         self.assertFalse(mod.is_ancestor(orphan))
         self.assertEqual(mod.app_commits_since(orphan), ["HEAD"])

--- a/.github/workflows/mobile_internal_build.yml
+++ b/.github/workflows/mobile_internal_build.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: mobile-internal-build
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/mobile_internal_build.yml
+++ b/.github/workflows/mobile_internal_build.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: mobile-internal-build
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Align the release-process hygiene guard with the GitHub-dispatched mobile build cadence.
- Refresh Codemagic contract digests from the current `codemagic.yaml`.
- Require the production dispatcher trigger, cancellation policy, and both mobile workflow IDs.

## Root cause

The mobile cadence change removed native Codemagic push triggers but left the old hygiene guard and approved digests unchanged. That made `origin/main` and downstream PRs fail the shared Hygiene check.

## Verification

- Mobile release-guard focused tests: 8 passed.
- Mobile dispatcher tests: 23 passed.
- `bash scripts/run-release-process-guards.sh`
- `make preflight` (16 checks passed).
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard, fixture digest, and test changes; no runtime release or auth paths are modified.
> 
> **Overview**
> Updates **release-process hygiene** so it matches the GitHub-dispatched mobile internal build model instead of requiring native Codemagic `main` push triggers.
> 
> **`check_mobile_codemagic_release_triggers`** now only requires `ios-internal-auto` and `android-internal-auto` to keep their **`app/**` changeset** guards in `codemagic.yaml`, and validates **`.github/workflows/mobile_internal_build.yml`** (push on `main` + `app/**`, 3-hour cron, `workflow_dispatch`, `mobile-internal-build` concurrency with `cancel-in-progress: false`) plus **`dispatch_mobile_internal_builds.py`** (must run from the workflow and declare both mobile workflow IDs via AST). The legacy **`mobile_internal_auto.yml`** dispatcher remains forbidden.
> 
> **Codemagic contract fixture** `v1.json` gets refreshed **raw/semantic SHA-256** digests for the current `codemagic.yaml`. Guard and dispatcher **tests** are retargeted to the new dispatcher contract, with extra regression cases for wrong dispatch script/workflow list and stabler git identity in one orphan-commit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c1d79896e8ad1238743475193f328dc545d749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->