### PR TITLE
app: survive mic contention in voice memo and speech profile

### DIFF
--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -125,7 +125,10 @@ class SpeechProfileProvider extends ChangeNotifier
         await _initiateWebsocket(codec: codec, sampleRate: 16000, force: true);
 
         // Start phone mic streaming
-        await _initiatePhoneMicStreaming();
+        if (!await _initiatePhoneMicStreaming()) {
+          notifyError('SOCKET_INIT_FAILED');
+          return false;
+        }
       } else {
         // Device mode - use device codec
         device = deviceProvider?.connectedDevice;
@@ -185,33 +188,42 @@ class SpeechProfileProvider extends ChangeNotifier
     _socket?.subscribe(this, this);
   }
 
-  /// Start phone microphone streaming (alternative to BLE device streaming)
-  Future<void> _initiatePhoneMicStreaming() async {
+  /// Start phone microphone streaming (alternative to BLE device streaming).
+  /// Returns false when the mic could not be acquired — contention with a live
+  /// conversation throws a [StateError] — so [initialise] fails visibly instead
+  /// of leaving a recording UI that never receives audio.
+  Future<bool> _initiatePhoneMicStreaming() async {
     Logger.debug('Starting phone mic streaming for speech profile...');
 
     // Request mic permission
     await Permission.microphone.request();
 
-    await ServiceManager.instance().mic.start(
-      onByteReceived: (Uint8List bytes) {
-        if (bytes.isEmpty) return;
+    try {
+      await ServiceManager.instance().mic.start(
+        onByteReceived: (Uint8List bytes) {
+          if (bytes.isEmpty) return;
 
-        // Store audio frames for speech profile upload
-        audioStorage.frames.add(bytes.toList());
+          // Store audio frames for speech profile upload
+          audioStorage.frames.add(bytes.toList());
 
-        // Send to transcription socket
-        if (_socket?.state == SocketServiceState.connected) {
-          _socket?.send(bytes);
-        }
-      },
-      onRecording: () {
-        Logger.debug('Phone mic recording started');
-        updateStartedRecording(true);
-      },
-      onStop: () {
-        Logger.debug('Phone mic recording stopped');
-      },
-    );
+          // Send to transcription socket
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(bytes);
+          }
+        },
+        onRecording: () {
+          Logger.debug('Phone mic recording started');
+          updateStartedRecording(true);
+        },
+        onStop: () {
+          Logger.debug('Phone mic recording stopped');
+        },
+      );
+      return true;
+    } catch (e) {
+      Logger.debug('Speech profile: phone mic start failed: $e');
+      return false;
+    }
   }
 
   /// Stop phone microphone streaming

--- a/app/lib/providers/voice_recorder_provider.dart
+++ b/app/lib/providers/voice_recorder_provider.dart
@@ -60,8 +60,15 @@ class VoiceRecorderProvider extends ChangeNotifier {
 
   final VoiceMessageTranscriber _transcribeVoiceMessage;
 
-  VoiceRecorderProvider({VoiceMessageTranscriber? transcriber})
-      : _transcribeVoiceMessage = transcriber ?? transcribeVoiceMessage;
+  // Injected only by tests — ServiceManager is a singleton initialised from
+  // native plumbing, so the mic is resolved lazily at call time otherwise.
+  final IMicRecorderService? _micOverride;
+
+  VoiceRecorderProvider({VoiceMessageTranscriber? transcriber, IMicRecorderService? mic})
+      : _transcribeVoiceMessage = transcriber ?? transcribeVoiceMessage,
+        _micOverride = mic;
+
+  IMicRecorderService get _mic => _micOverride ?? ServiceManager.instance().mic;
 
   VoiceRecorderState get state => _state;
   String get transcript => _transcript;
@@ -142,64 +149,94 @@ class VoiceRecorderProvider extends ChangeNotifier {
       }
     });
 
-    await ServiceManager.instance().mic.start(
-      onByteReceived: (bytes) {
-        if (_state == VoiceRecorderState.recording) {
-          // Write to disk instead of accumulating in RAM
-          _pcmSink?.add(bytes);
-          _pcmBytesWritten += bytes.length;
+    try {
+      await _mic.start(
+        onByteReceived: (bytes) {
+          if (_state == VoiceRecorderState.recording) {
+            // Write to disk instead of accumulating in RAM
+            _pcmSink?.add(bytes);
+            _pcmBytesWritten += bytes.length;
 
-          // Update audio visualization based on actual audio levels
-          if (bytes.isNotEmpty) {
-            double rms = 0;
-            for (int i = 0; i < bytes.length - 1; i += 2) {
-              int sample = bytes[i] | (bytes[i + 1] << 8);
-              if (sample > 32767) {
-                sample = sample - 65536;
+            // Update audio visualization based on actual audio levels
+            if (bytes.isNotEmpty) {
+              double rms = 0;
+              for (int i = 0; i < bytes.length - 1; i += 2) {
+                int sample = bytes[i] | (bytes[i + 1] << 8);
+                if (sample > 32767) {
+                  sample = sample - 65536;
+                }
+                rms += sample * sample;
               }
-              rms += sample * sample;
-            }
 
-            int sampleCount = bytes.length ~/ 2;
-            if (sampleCount > 0) {
-              rms = math.sqrt(rms / sampleCount) / 32768.0;
-            } else {
-              rms = 0;
-            }
+              int sampleCount = bytes.length ~/ 2;
+              if (sampleCount > 0) {
+                rms = math.sqrt(rms / sampleCount) / 32768.0;
+              } else {
+                rms = 0;
+              }
 
-            // Wider dynamic range so quiet sections stay near zero and loud
-            // peaks reach the full bar height. The 0.5 exponent boosts mid
-            // levels so normal speech has visible amplitude.
-            final level = math.pow(rms, 0.5).toDouble().clamp(0.02, 1.0);
+              // Wider dynamic range so quiet sections stay near zero and loud
+              // peaks reach the full bar height. The 0.5 exponent boosts mid
+              // levels so normal speech has visible amplitude.
+              final level = math.pow(rms, 0.5).toDouble().clamp(0.02, 1.0);
 
-            for (int i = 0; i < _audioLevels.length - 1; i++) {
-              _audioLevels[i] = _audioLevels[i + 1];
+              for (int i = 0; i < _audioLevels.length - 1; i++) {
+                _audioLevels[i] = _audioLevels[i + 1];
+              }
+              _audioLevels[_audioLevels.length - 1] = level;
             }
-            _audioLevels[_audioLevels.length - 1] = level;
           }
-        }
-      },
-      onRecording: () {
-        Logger.debug('VoiceRecorderProvider: Recording started');
-        _state = VoiceRecorderState.recording;
-        // Reset audio levels
-        for (int i = 0; i < _audioLevels.length; i++) {
-          _audioLevels[i] = 0.1;
-        }
-        notifyListeners();
-      },
-      onStop: () {
-        Logger.debug('VoiceRecorderProvider: Recording stopped');
-      },
-      onInitializing: () {
-        Logger.debug('VoiceRecorderProvider: Initializing');
-      },
-    );
+        },
+        onRecording: () {
+          Logger.debug('VoiceRecorderProvider: Recording started');
+          _state = VoiceRecorderState.recording;
+          // Reset audio levels
+          for (int i = 0; i < _audioLevels.length; i++) {
+            _audioLevels[i] = 0.1;
+          }
+          notifyListeners();
+        },
+        onStop: () {
+          Logger.debug('VoiceRecorderProvider: Recording stopped');
+        },
+        onInitializing: () {
+          Logger.debug('VoiceRecorderProvider: Initializing');
+        },
+      );
+    } catch (e) {
+      // Mic contention (a conversation already holds the recorder) or a native
+      // start failure. Never rethrows: this runs from a fire-and-forget tap
+      // handler, so an escaping error is an unhandled async crash.
+      Logger.debug('VoiceRecorderProvider: failed to start recording: $e');
+      await _unwindFailedStart();
+    }
+  }
+
+  /// Undo everything [startRecording] armed before handing the mic over — the
+  /// waveform timer, the open PCM sink and its file — and return to idle so the
+  /// chat bar drops back to the text field instead of wedging in `recording`.
+  Future<void> _unwindFailedStart() async {
+    _waveformTimer?.cancel();
+    _waveformTimer = null;
+    try {
+      await _pcmSink?.close();
+    } catch (e) {
+      Logger.debug('Error closing PCM sink after failed start: $e');
+    }
+    _pcmSink = null;
+    await _cleanupPcmFile();
+    _pcmBytesWritten = 0;
+    _autoSendRequested = false;
+    _state = VoiceRecorderState.idle;
+    for (int i = 0; i < _audioLevels.length; i++) {
+      _audioLevels[i] = 0.1;
+    }
+    notifyListeners();
   }
 
   void stopRecording() {
     _waveformTimer?.cancel();
-    ServiceManager.instance().mic.stop();
+    _mic.stop();
   }
 
   Future<void> processRecording() async {
@@ -503,7 +540,7 @@ class VoiceRecorderProvider extends ChangeNotifier {
     _waveformTimer?.cancel();
     _pcmSink?.close();
     if (_state == VoiceRecorderState.recording) {
-      ServiceManager.instance().mic.stop();
+      _mic.stop();
     }
     super.dispose();
   }

--- a/app/test/unit/voice_recorder_mic_contention_test.dart
+++ b/app/test/unit/voice_recorder_mic_contention_test.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/providers/voice_recorder_provider.dart';
+import 'package:omi/services/services.dart';
+
+/// Mic double that reproduces [ArbitratedMic]'s contention contract: starting a
+/// chat voice memo while a conversation holds the mic throws a [StateError].
+class _ContendedMic implements IMicRecorderService {
+  bool failStart = true;
+  int startCalls = 0;
+  int stopCalls = 0;
+  Function()? _onStop;
+
+  @override
+  Future<void> start({
+    required Function(Uint8List bytes) onByteReceived,
+    Function()? onRecording,
+    Function()? onStop,
+    Function()? onInitializing,
+    Function()? onStalled,
+    Function(bool began)? onInterruption,
+  }) async {
+    startCalls++;
+    if (failStart) {
+      throw StateError('Microphone is busy (held by conversation)');
+    }
+    _onStop = onStop;
+  }
+
+  @override
+  Future<void> startBatch({
+    Function()? onStop,
+    Function(bool began)? onInterruption,
+    Function()? onBatchStalled,
+    Function(String code, String message)? onError,
+  }) async {
+    throw UnsupportedError('batch capture is not used by the voice recorder');
+  }
+
+  @override
+  void stop() {
+    stopCalls++;
+    _onStop?.call();
+    _onStop = null;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  const permissionsChannel = MethodChannel('flutter.baseflow.com/permissions/methods');
+
+  late Directory tempDir;
+
+  Directory recordingsDir() => Directory('${tempDir.path}/voice_recordings');
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    tempDir = Directory.systemTemp.createTempSync('voice_recorder_contention_');
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      pathProviderChannel,
+      (MethodCall call) async {
+        if (call.method == 'getApplicationSupportDirectory') return tempDir.path;
+        if (call.method == 'getTemporaryDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      permissionsChannel,
+      (MethodCall call) async {
+        if (call.method == 'checkPermissionStatus') return 1;
+        if (call.method == 'requestPermissions') {
+          return {for (final permission in call.arguments as List<dynamic>) permission: 1};
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(permissionsChannel, null);
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('VoiceRecorderProvider mic contention', () {
+    test('a busy mic unwinds the half-armed session instead of escaping', () async {
+      final mic = _ContendedMic();
+      final provider = VoiceRecorderProvider(mic: mic);
+      final observed = <VoiceRecorderState>[];
+      provider.addListener(() => observed.add(provider.state));
+
+      // Must not throw: startRecording() is called fire-and-forget from a tap
+      // handler, so an escaping StateError is an unhandled async crash.
+      await provider.startRecording();
+
+      expect(mic.startCalls, 1);
+      expect(provider.state, VoiceRecorderState.idle);
+      expect(provider.isRecording, isFalse);
+      expect(provider.isActive, isFalse);
+
+      // The session was armed, then unwound — and listeners saw both.
+      expect(observed, contains(VoiceRecorderState.recording));
+      expect(observed.last, VoiceRecorderState.idle);
+
+      // The PCM file opened before the failed start is deleted.
+      expect(recordingsDir().listSync(), isEmpty);
+    });
+
+    test('the provider is not wedged — a later start records normally', () async {
+      final mic = _ContendedMic();
+      final provider = VoiceRecorderProvider(mic: mic);
+
+      await provider.startRecording();
+      expect(provider.state, VoiceRecorderState.idle);
+
+      mic.failStart = false;
+      await provider.startRecording();
+
+      expect(mic.startCalls, 2);
+      expect(provider.state, VoiceRecorderState.recording);
+      expect(provider.isRecording, isTrue);
+      expect(recordingsDir().listSync().length, 1);
+
+      provider.close();
+      expect(mic.stopCalls, 1);
+      expect(provider.state, VoiceRecorderState.idle);
+    });
+  });
+}


### PR DESCRIPTION
Fixes a Crashlytics fatal reported from production:

```
Bad state: Microphone is busy (held by conversation)
  at ArbitratedMic.start(mic_arbiter.dart:50)
  at VoiceRecorderProvider.startRecording(voice_recorder_provider.dart:145)
```

## What happened

The `MicArbiter` throw is the intended contract — it stops a chat voice memo from hijacking the recorder out from under a live phone-mic conversation. But neither caller guarded it: `VoiceRecorderProvider.startRecording` arms its session (state=recording, PCM sink open, waveform timer running) **before** awaiting `mic.start`, so contention escaped as an unhandled async crash from a fire-and-forget tap handler and wedged the memo UI. Latent on both platforms since the two-owner arbiter split (#9398); the Android native phone-mic rollout (#9882) made the contention path actually exercised.

## The fix

- **`VoiceRecorderProvider`**: `mic.start` wrapped; on failure a dedicated unwind reverses exactly what was armed (timer, sink, PCM file, counters) and returns to idle — the chat bar drops back to the text field. No rethrow. A minimal `mic` injection seam (same pattern as the existing `transcriber` seam) makes the production flow hermetically testable.
- **`SpeechProfileProvider`**: `_initiatePhoneMicStreaming` now returns `bool`; a mic-start failure surfaces the existing `SOCKET_INIT_FAILED` connection-error dialog instead of being swallowed by the outer catch, mislabeled as a socket failure, and leaving a recording UI that receives no audio.
- **Audit**: the only other `mic.start` / `startBatch` call sites (`capture_controller.dart`) were already guarded; `mic_arbiter.dart` unchanged — the throw stays the contract.

## Verification

- New hermetic regression tests (`test/unit/voice_recorder_mic_contention_test.dart`) run the **real** `startRecording()` flow (path_provider + permission channels mocked) against a fake mic throwing the exact production `StateError`: no escape, clean return to idle, PCM temp file deleted, provider not wedged for the next attempt.
- Regression proof: temporarily replacing the guard with a rethrow makes both tests fail with the production crash string.
- Full app suite **1019/1019**; `analyze_ratchet.sh` passes.
- Not exercised on-device: the live tap-memo-during-conversation path (needs a running phone-mic conversation + chat interaction); the hermetic tests drive the identical provider code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

