### PR TITLE
fix: deduplicate local playback transcripts

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1607
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1610
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds shared-capture silent-mic recovery telemetry so non-Bluetooth CoreAudio rebuild attempts are visible to release-health alongside the existing Bluetooth fallback. Transcription start also resolves the user's explicit microphone choice (UID -> device ID) before building the capture service so a picked Ray-Ban Meta mic survives reconnects (port of BasedHardware/omi#9181)."
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds local transcript duplicate suppression and persistence flushes before stop or rotation so source-aware deduplication cannot leave stale rows."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1610
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1608
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds local transcript duplicate suppression and persistence flushes before stop or rotation so source-aware deduplication cannot leave stale rows."

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -410,6 +410,9 @@ class AppState: ObservableObject {
   }
 
   var currentSessionId: Int64?
+  /// Serializes segment persistence so a local duplicate replacement cannot race
+  /// the original mic segment's upsert in SQLite.
+  var transcriptPersistenceTail: Task<Void, Never>?
   /// True while a bridge-owned hermetic capture session is active (T2 E2E only).
   var automationCaptureTestSessionActive = false
   var currentBackendConversationId: String?

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -6,6 +6,8 @@ import SwiftUI
 @MainActor
 extension AppState {
   func handleBackendSegments(_ segments: [TranscriptionService.BackendSegment]) {
+    var segmentsToPersist = [TranscriptionService.BackendSegment]()
+
     for segment in segments {
       guard !segment.text.isEmpty else { continue }
 
@@ -43,13 +45,37 @@ extension AppState {
         log(
           "Transcript [UPDATE] Speaker \(speakerId) [\(String(format: "%.1f", segment.start))s-\(String(format: "%.1f", segment.end))s]: \(segment.text.prefix(80))"
         )
+        segmentsToPersist.append(segment)
+      } else if sttSession.useLocalSTT {
+        switch LocalTranscriptionDuplicatePolicy.decision(for: newSeg, existing: speakerSegments) {
+        case .accept:
+          appendNewTranscriptSegment(newSeg, segment: segment, to: &segmentsToPersist)
+
+        case .suppressIncoming:
+          log(
+            "Transcript [DEDUP] Suppressed mic playback duplicate [\(String(format: "%.1f", segment.start))s-\(String(format: "%.1f", segment.end))s]"
+          )
+
+        case .replaceExisting(let existingSegmentId):
+          guard let existingIdx = speakerSegments.firstIndex(where: { $0.segmentId == existingSegmentId }) else {
+            appendNewTranscriptSegment(newSeg, segment: segment, to: &segmentsToPersist)
+            continue
+          }
+
+          let oldWords = speakerSegments[existingIdx].text.split(separator: " ").count
+          let newWords = newSeg.text.split(separator: " ").count
+          totalWordCount += newWords - oldWords
+
+          var replacement = newSeg
+          replacement.segmentId = existingSegmentId
+          speakerSegments[existingIdx] = replacement
+          segmentsToPersist.append(segmentWithID(segment, id: existingSegmentId))
+          log(
+            "Transcript [DEDUP] Promoted system-audio copy over mic playback duplicate [\(String(format: "%.1f", segment.start))s-\(String(format: "%.1f", segment.end))s]"
+          )
+        }
       } else {
-        totalWordCount += newSeg.text.split(separator: " ").count
-        speakerSegments.append(newSeg)
-        totalSegmentCount += 1
-        log(
-          "Transcript [ADD] Speaker \(speakerId) [\(String(format: "%.1f", segment.start))s-\(String(format: "%.1f", segment.end))s]: \(segment.text.prefix(80))"
-        )
+        appendNewTranscriptSegment(newSeg, segment: segment, to: &segmentsToPersist)
       }
     }
 
@@ -67,12 +93,56 @@ extension AppState {
     LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
 
     // Persist segments to DB for crash safety (upsert by backend segment ID)
-    if let sessionId = currentSessionId {
-      let segmentsToPersist = segments
-      Task {
-        await persistBackendSegmentsToStorage(segmentsToPersist, sessionId: sessionId)
-      }
+    if let sessionId = currentSessionId, !segmentsToPersist.isEmpty {
+      enqueueTranscriptPersistence(segmentsToPersist, sessionId: sessionId)
     }
+  }
+
+  private func appendNewTranscriptSegment(
+    _ newSegment: SpeakerSegment,
+    segment: TranscriptionService.BackendSegment,
+    to segmentsToPersist: inout [TranscriptionService.BackendSegment]
+  ) {
+    totalWordCount += newSegment.text.split(separator: " ").count
+    speakerSegments.append(newSegment)
+    totalSegmentCount += 1
+    segmentsToPersist.append(segment)
+    log(
+      "Transcript [ADD] Speaker \(newSegment.speaker) [\(String(format: "%.1f", newSegment.start))s-\(String(format: "%.1f", newSegment.end))s]: \(segment.text.prefix(80))"
+    )
+  }
+
+  private func segmentWithID(
+    _ segment: TranscriptionService.BackendSegment,
+    id: String
+  ) -> TranscriptionService.BackendSegment {
+    TranscriptionService.BackendSegment(
+      id: id,
+      text: segment.text,
+      speaker: segment.speaker,
+      speaker_id: segment.speaker_id,
+      is_user: segment.is_user,
+      person_id: segment.person_id,
+      start: segment.start,
+      end: segment.end,
+      translations: segment.translations
+    )
+  }
+
+  private func enqueueTranscriptPersistence(
+    _ segments: [TranscriptionService.BackendSegment],
+    sessionId: Int64
+  ) {
+    let previous = transcriptPersistenceTail
+    transcriptPersistenceTail = Task { @MainActor [weak self] in
+      await previous?.value
+      guard let self else { return }
+      await self.persistBackendSegmentsToStorage(segments, sessionId: sessionId)
+    }
+  }
+
+  func flushTranscriptPersistence() async {
+    await transcriptPersistenceTail?.value
   }
 
   func persistBackendSegmentsToStorage(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -282,6 +282,7 @@ extension AppState {
           if wasLocalSTT {
             await mic?.finish()
             await sys?.finish()
+            await self.flushTranscriptPersistence()
           }
           if let sessionId {
             try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .maxDurationRotation)
@@ -1031,14 +1032,13 @@ extension AppState {
     if sttSession.useLocalSTT {
       await localMicService?.finish()
       await localSystemService?.finish()
+      await flushTranscriptPersistence()
     } else {
       // Close the cloud stream before marking the old local session finished, so no late
       // WebSocket segments can be persisted after the finalization snapshot starts.
       transcriptionService?.stop()
       transcriptionService = nil
     }
-
-    await flushTranscriptPersistence()
 
     // Mark current DB session as finished before stopping
     // (backend will process it; memory_created event may arrive on the new session's WebSocket)
@@ -1106,6 +1106,7 @@ extension AppState {
         if wasLocalSTT {
           await mic?.finish()
           await sys?.finish()
+          await self.flushTranscriptPersistence()
         }
         if let sessionId {
           try? await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .maxDurationRotation)
@@ -1443,9 +1444,7 @@ extension AppState {
       translations: nil
     )
     handleBackendSegments([segment])
-    if let sessionId = currentSessionId {
-      await persistBackendSegmentsToStorage([segment], sessionId: sessionId)
-    }
+    await flushTranscriptPersistence()
     return [
       "injected": trimmed,
       "session_id": currentSessionId.map { "\($0)" } ?? "",
@@ -1516,9 +1515,7 @@ extension AppState {
     }
 
     handleBackendSegments(backendSegments)
-    if let sessionId = currentSessionId {
-      await persistBackendSegmentsToStorage(backendSegments, sessionId: sessionId)
-    }
+    await flushTranscriptPersistence()
     let uniqueSpeakers = Set(speakerLabels).sorted().joined(separator: ",")
     return [
       "injected_count": "\(backendSegments.count)",
@@ -1561,6 +1558,7 @@ extension AppState {
     LiveNotesMonitor.shared.endSession()
 
     var finalizeError: String?
+    await flushTranscriptPersistence()
     if let sessionId {
       do {
         try await TranscriptionStorage.shared.finishSession(id: sessionId, reason: .userStop)

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -866,6 +866,7 @@ extension AppState {
         self.stopAudioCapture()
         await mic?.finish()
         await sys?.finish()
+        await self.flushTranscriptPersistence()
         self.clearTranscriptionState(finalizationReason: .userStop, allowCloudForceProcess: false)
         self.silentMicFallbackInProgress = false
       }
@@ -1036,6 +1037,8 @@ extension AppState {
       transcriptionService?.stop()
       transcriptionService = nil
     }
+
+    await flushTranscriptPersistence()
 
     // Mark current DB session as finished before stopping
     // (backend will process it; memory_created event may arrive on the new session's WebSocket)

--- a/desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Identifies a narrow class of duplicate local-STT segments caused by the same
+/// playback being present in both the system-audio tap and the microphone input.
+///
+/// This deliberately requires exact normalized text and tight timing. Fuzzy text
+/// matching would risk deleting legitimate speech where two people happen to say
+/// similar words at the same time.
+enum LocalTranscriptionDuplicateDecision: Equatable {
+  case accept
+  case suppressIncoming
+  case replaceExisting(segmentId: String)
+}
+
+enum LocalTranscriptionDuplicatePolicy {
+  /// Short acknowledgements such as "yes" or "okay" are too common to use as
+  /// reliable evidence of playback bleed.
+  static let minimumWordCount = 4
+
+  /// The two local recognizers use independent capture clocks. Allow a small
+  /// boundary difference while still requiring the windows to overlap or nearly
+  /// touch.
+  static let maximumTimestampGap: Double = 1.0
+
+  static func decision(
+    for incoming: SpeakerSegment,
+    existing: [SpeakerSegment]
+  ) -> LocalTranscriptionDuplicateDecision {
+    guard let duplicate = existing.first(where: { isDuplicate($0, incoming) }),
+      let segmentId = duplicate.segmentId,
+      !segmentId.isEmpty
+    else {
+      return .accept
+    }
+
+    // Keep one canonical segment. If the mic copy arrived first, promote that
+    // existing row to the system-audio source rather than deleting and reinserting
+    // it. If the system copy arrived first, discard only the later mic copy.
+    return incoming.isUser ? .suppressIncoming : .replaceExisting(segmentId: segmentId)
+  }
+
+  static func isDuplicate(_ lhs: SpeakerSegment, _ rhs: SpeakerSegment) -> Bool {
+    guard lhs.isUser != rhs.isUser,
+      normalizedWords(lhs.text).count >= minimumWordCount,
+      normalizedWords(lhs.text) == normalizedWords(rhs.text)
+    else {
+      return false
+    }
+
+    return timestampRangesAreClose(lhs, rhs)
+  }
+
+  static func normalizedWords(_ text: String) -> [String] {
+    text
+      .lowercased()
+      .split { !$0.isLetter && !$0.isNumber }
+      .map(String.init)
+  }
+
+  private static func timestampRangesAreClose(_ lhs: SpeakerSegment, _ rhs: SpeakerSegment) -> Bool {
+    let overlapStart = max(lhs.start, rhs.start)
+    let overlapEnd = min(lhs.end, rhs.end)
+    if overlapStart <= overlapEnd {
+      return true
+    }
+
+    return min(abs(lhs.start - rhs.end), abs(rhs.start - lhs.end)) <= maximumTimestampGap
+  }
+}

--- a/desktop/macos/Desktop/Tests/LocalTranscriptionDuplicatePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalTranscriptionDuplicatePolicyTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class LocalTranscriptionDuplicatePolicyTests: XCTestCase {
+  private func segment(
+    text: String,
+    isUser: Bool,
+    start: Double = 0,
+    end: Double = 10,
+    id: String? = UUID().uuidString
+  ) -> SpeakerSegment {
+    SpeakerSegment(
+      segmentId: id,
+      speaker: isUser ? 0 : 1,
+      text: text,
+      start: start,
+      end: end,
+      isUser: isUser
+    )
+  }
+
+  func testExactOverlappingPlaybackReturnsSourceAwareDecision() {
+    let mic = segment(text: "This is the video transcript", isUser: true, id: "mic")
+    let system = segment(text: "This is the video transcript.", isUser: false, id: "system")
+
+    XCTAssertEqual(
+      LocalTranscriptionDuplicatePolicy.decision(for: mic, existing: [system]),
+      .suppressIncoming
+    )
+    XCTAssertEqual(
+      LocalTranscriptionDuplicatePolicy.decision(for: system, existing: [mic]),
+      .replaceExisting(segmentId: "mic")
+    )
+  }
+
+  func testIdenticalWordsOutsideTimingWindowAreKept() {
+    let mic = segment(text: "This is the video transcript", isUser: true, start: 0, end: 2)
+    let system = segment(text: "This is the video transcript", isUser: false, start: 4, end: 6)
+
+    XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: mic, existing: [system]), .accept)
+  }
+
+  func testFuzzyTextIsNotSuppressed() {
+    let mic = segment(text: "This is the video transcript", isUser: true)
+    let system = segment(text: "This is a video transcript", isUser: false)
+
+    XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: mic, existing: [system]), .accept)
+  }
+
+  func testShortAcknowledgementIsNotSuppressed() {
+    let mic = segment(text: "Yes okay", isUser: true)
+    let system = segment(text: "Yes, okay", isUser: false)
+
+    XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: mic, existing: [system]), .accept)
+  }
+
+  func testSameSourceSpeechIsNeverSuppressed() {
+    let first = segment(text: "This is the video transcript", isUser: true)
+    let second = segment(text: "This is the video transcript", isUser: true)
+
+    XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: second, existing: [first]), .accept)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260802-local-system-audio-duplicate.json
+++ b/desktop/macos/changelog/unreleased/20260802-local-system-audio-duplicate.json
@@ -1,0 +1,3 @@
+{
+  "change": "Avoid duplicate local transcripts when the same system-audio playback is also heard by the microphone"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -81,18 +81,48 @@ steps:
       ok: true
 
   - id: S2
-    name: Run capture lifecycle with marker transcript
+    name: Start hermetic capture lifecycle
     bridge.action:
       name: capture_test_transcript
       params:
-        phase: lifecycle
-        text: "[[MARKER:capture-lifecycle]] hermetic desktop capture"
+        phase: start
+    expect:
+      result.detail.started: "true"
+
+  - id: S3
+    name: Suppress mic copy of system playback
+    bridge.action:
+      name: capture_test_transcript
+      params:
+        phase: inject_multi
+        segments: '[{"text":"[[MARKER:capture-lifecycle]] system playback phrase","speaker":"SPEAKER_01","speaker_id":1,"is_user":false,"start":0,"end":2},{"text":"[[MARKER:capture-lifecycle]] system playback phrase","speaker":"SPEAKER_00","speaker_id":0,"is_user":true,"start":0.1,"end":2.1}]'
+    expect:
+      result.detail.injected_count: "2"
+      result.detail.segment_count: "1"
+
+  - id: S4
+    name: Promote system copy over mic playback
+    bridge.action:
+      name: capture_test_transcript
+      params:
+        phase: inject_multi
+        segments: '[{"text":"[[MARKER:capture-lifecycle]] mic playback phrase","speaker":"SPEAKER_00","speaker_id":0,"is_user":true,"start":3,"end":5},{"text":"[[MARKER:capture-lifecycle]] mic playback phrase","speaker":"SPEAKER_01","speaker_id":1,"is_user":false,"start":3.1,"end":5.1}]'
+    expect:
+      result.detail.injected_count: "2"
+      result.detail.segment_count: "2"
+
+  - id: S5
+    name: Stop hermetic capture lifecycle
+    bridge.action:
+      name: capture_test_transcript
+      params:
+        phase: stop
     expect:
       result.detail.stopped: "true"
       result.detail.conversation_count_increased: "true"
-      result.detail.segment_count: "1"
+      result.detail.segment_count: "2"
 
-  - id: S3
+  - id: S6
     name: Navigate to Conversations
     bridge.navigate:
       target: conversations
@@ -100,7 +130,7 @@ steps:
     wait:
       state.selectedTabIndex: 1
 
-  - id: S4
+  - id: S7
     name: Reconcile cached list and canonical detail
     bridge.action:
       name: conversation_reconciliation_snapshot
@@ -114,7 +144,7 @@ steps:
       result.detail.cache_revision_matches: "true"
       result.detail.opened_detail: "true"
 
-  - id: S5
+  - id: S8
     name: Assert conversation list reflects new capture
     bridge.action:
       name: conversation_list_snapshot
@@ -124,7 +154,7 @@ steps:
       ok: true
       result.detail.is_transcribing: "false"
 
-  - id: S6
+  - id: S9
     name: Logs clean
     log.expect:
       absent:

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
   - desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+  - desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
   - desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
   - desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
   - desktop/macos/Desktop/Sources/TranscriptionService.swift


### PR DESCRIPTION
## Summary

Fixes duplicate local transcripts when playback from a YouTube video is captured both by the macOS system-audio tap and by the microphone.

The implementation plan was independently reviewed by Sol. The review narrowed the fix to a conservative local-only policy and explicitly rejected fuzzy text matching, cloud-path changes, and a broad acoustic-echo-cancellation migration.

## Root cause

On Apple Silicon, local Parakeet transcription runs separate mic and system-audio services. Both recognize the same playback, but the local service assigns each result a different random segment ID. The existing AppState path therefore appended both segments; it had no source-aware duplicate boundary. The mic path also lacks acoustic echo cancellation, so YouTube speech can legitimately appear in both inputs.

## Changes

- Add an exact normalized-text plus close-timestamp duplicate policy for local STT only.
- Require opposite source labels and at least four words to avoid suppressing ordinary short acknowledgements or legitimate same-source speech.
- Keep one canonical row: suppress a later mic copy, or promote a later system-audio copy in place using the existing segment ID.
- Serialize transcript persistence and flush it before stop/rotation so the replacement cannot race the original SQLite upsert.
- Await the persistence tail in both max-duration local-session rotation handlers; keep the flush barrier limited to local STT rather than implying cloud callback quiescence.
- Make the non-production capture seam drain the same selected persistence queue as production, then exercise both suppression and promotion orderings in the capture lifecycle flow.
- Leave cloud transcription, the Always setting, and the audio capture graph unchanged.
- Add focused regression tests, capture-lifecycle flow coverage, and an unreleased desktop changelog entry.
- Update the existing AppState line-count ratchet with its required justification for the lifecycle guard additions.

## Verification

- `xcrun swift test --package-path desktop/macos/Desktop --filter LocalTranscriptionDuplicatePolicyTests` — 5 passed; full Swift package/test binary compiled successfully.
- `xcrun swift test --package-path desktop/macos/Desktop --filter CanonicalGoalsStoreTests/` — 7 passed locally; the initial PR run's 300-second timeout was isolated to this unrelated suite.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed.
- `python3 desktop/macos/scripts/desktop-flow-lint.py` — passed for all 65 flows and 151 registered actions.
- `OMI_APP_NAME=omi-audio-echo OMI_AUTOMATION_PORT=50919 OMI_ALLOW_ADHOC_SIGN=1 OMI_SKIP_TUNNEL=1 ./run.sh --yolo` — named bundle compiled, ad-hoc signed, installed, launched, and passed the dependency audit.
- Named-bundle capture harness injected overlapping mic/system copies and reduced the live segment count from 2 to 1; the app log recorded `[DEDUP] Promoted system-audio copy over mic playback duplicate`.
- `OMI_PR_BODY_FILE=/tmp/omi-duplicate-transcript-pr-body.md make preflight` — pass after review fixes.

## Product invariants

None affected. This preserves the existing local transcript ownership path and improves capture trust without changing the cloud protocol.

Failure-Class: none
