### PR TITLE
fix(desktop): repair transcript speaker assignment

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
+from collections.abc import Mapping
 from typing import Dict, List, Literal, Optional
+import uuid
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -212,6 +214,25 @@ class Conversation(BaseModel):
     client_platform: Optional[str] = None
 
     def __init__(self, **data):
+        raw_segments = data.get('transcript_segments')
+        conversation_id = data.get('id')
+        if isinstance(raw_segments, list) and conversation_id:
+            normalized_segments = []
+            for index, raw_segment in enumerate(raw_segments):
+                if isinstance(raw_segment, Mapping):
+                    segment = dict(raw_segment)
+                    if not segment.get('id'):
+                        segment['id'] = str(
+                            uuid.uuid5(
+                                uuid.NAMESPACE_URL,
+                                f'omi/conversations/{conversation_id}/transcript-segments/{index}',
+                            )
+                        )
+                    normalized_segments.append(segment)
+                else:
+                    normalized_segments.append(raw_segment)
+            data['transcript_segments'] = normalized_segments
+
         super().__init__(**data)
         # Update plugins_results based on apps_results
         self.plugins_results = [PluginResult(plugin_id=app.app_id, content=app.content) for app in self.apps_results]

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -361,11 +361,49 @@ def _ensure_aware(value: datetime) -> datetime:
 # comma-separated filter into an unhandled 500. ConversationStatus and the source set are both
 # tiny, so a cap of 20 can never reject a request a real client would send.
 MAX_IN_FILTER_VALUES = 20
+LEGACY_SEGMENT_INDEX_PREFIX = '#index:'
 
 
 def _reject_oversized_filter(values: List[str], field_name: str) -> None:
     if len(values) > MAX_IN_FILTER_VALUES:
         raise HTTPException(status_code=400, detail=f"{field_name} accepts at most {MAX_IN_FILTER_VALUES} values")
+
+
+def _resolve_bulk_segment_indices(conversation: Conversation, requested_ids: List[str]) -> List[int]:
+    """Resolve assignment targets before mutating any transcript segment.
+
+    Desktop sends positional targets for legacy transcripts that were stored without
+    segment IDs. Exact IDs remain the preferred wire contract; positional targets are
+    only accepted for completed conversations because an in-progress transcript can
+    still be reordered or merged.
+    """
+    segments = conversation.transcript_segments
+    segment_indices_by_id = {segment.id: index for index, segment in enumerate(segments)}
+    resolved_indices: List[int] = []
+    unresolved_ids: List[str] = []
+    allow_legacy_indices = conversation.status == ConversationStatus.completed
+
+    for requested_id in requested_ids:
+        segment_index = segment_indices_by_id.get(requested_id)
+        if segment_index is None and allow_legacy_indices and requested_id.startswith(LEGACY_SEGMENT_INDEX_PREFIX):
+            raw_index = requested_id[len(LEGACY_SEGMENT_INDEX_PREFIX) :]
+            if raw_index.isascii() and raw_index.isdecimal():
+                candidate_index = int(raw_index)
+                if candidate_index < len(segments):
+                    segment_index = candidate_index
+
+        if segment_index is None:
+            unresolved_ids.append(requested_id)
+        elif segment_index not in resolved_indices:
+            resolved_indices.append(segment_index)
+
+    if unresolved_ids:
+        raise HTTPException(
+            status_code=409,
+            detail=f'Unable to resolve transcript segment assignment target(s): {", ".join(unresolved_ids)}',
+        )
+
+    return resolved_indices
 
 
 @router.get(
@@ -1083,23 +1121,24 @@ def assign_segments_bulk(
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
     conversation = deserialize_conversation(conversation)
 
+    if data.assign_type not in {'is_user', 'person_id'}:
+        raise HTTPException(status_code=400, detail="Invalid assign type")
+
     value = data.value
     if value == 'null':
         value = None
 
-    segment_map = {segment.id: segment for segment in conversation.transcript_segments}
+    segment_indices = _resolve_bulk_segment_indices(conversation, data.segment_ids)
+    resolved_segment_ids = [conversation.transcript_segments[index].id for index in segment_indices]
 
-    for segment_id in data.segment_ids:
-        if segment_id in segment_map:
-            segment = segment_map[segment_id]
-            if data.assign_type == 'is_user':
-                segment.is_user = bool(value) if value is not None else False
-                segment.person_id = None
-            elif data.assign_type == 'person_id':
-                segment.is_user = False
-                segment.person_id = value
-            else:
-                raise HTTPException(status_code=400, detail="Invalid assign type")
+    for index in segment_indices:
+        segment = conversation.transcript_segments[index]
+        if data.assign_type == 'is_user':
+            segment.is_user = bool(value) if value is not None else False
+            segment.person_id = None
+        else:
+            segment.is_user = False
+            segment.person_id = value
 
     conversations_db.update_conversation_segments(
         uid, conversation_id, [segment.model_dump() for segment in conversation.transcript_segments]
@@ -1112,7 +1151,7 @@ def assign_segments_bulk(
             uid=uid,
             person_id=value,
             conversation_id=conversation_id,
-            segment_ids=data.segment_ids,
+            segment_ids=resolved_segment_ids,
         )
 
     return conversation

--- a/backend/tests/unit/test_conversation_events_bounds.py
+++ b/backend/tests/unit/test_conversation_events_bounds.py
@@ -237,17 +237,18 @@ def test_valid_index_still_updates(router):
 class _FakeSegment:
     """Minimal transcript segment: assignable (.is_user / .person_id) and model_dump-able."""
 
-    def __init__(self):
+    def __init__(self, segment_id=None):
+        self.id = segment_id
         self.is_user = False
         self.person_id = None
 
     def model_dump(self):
-        return {"is_user": self.is_user, "person_id": self.person_id}
+        return {"id": self.id, "is_user": self.is_user, "person_id": self.person_id}
 
 
-def _fake_conversation_with_segments(count):
-    segments = [_FakeSegment() for _ in range(count)]
-    return SimpleNamespace(transcript_segments=segments), segments
+def _fake_conversation_with_segments(count, status=None, with_ids=False):
+    segments = [_FakeSegment(f"segment-{index}" if with_ids else None) for index in range(count)]
+    return SimpleNamespace(transcript_segments=segments, status=status), segments
 
 
 def _segment_assign_handler(conv):
@@ -306,3 +307,84 @@ def test_segment_assign_valid_index_still_updates(router):
     assert segments[1].is_user is True
     assert segments[0].is_user is False  # untouched
     assert result is convo
+
+
+def test_bulk_assign_resolves_legacy_positional_target_and_persists_canonical_id(router):
+    """The desktop's #index fallback must resolve to the same segment the backend persists."""
+    convo, segments = _fake_conversation_with_segments(
+        2,
+        status=router.conv.ConversationStatus.completed,
+        with_ids=True,
+    )
+    background_tasks = router.conv.BackgroundTasks()
+    data = router.conv.BulkAssignSegmentsRequest(
+        segment_ids=["#index:0"],
+        assign_type="person_id",
+        value="person-9",
+    )
+
+    with patch.object(router.conv, "_get_valid_conversation_by_id", return_value={"id": "c1"}), patch.object(
+        router.conv, "deserialize_conversation", return_value=convo
+    ), patch.object(router.conv.conversations_db, "update_conversation_segments"):
+        result = router.conv.assign_segments_bulk("c1", data, background_tasks, uid="u1")
+
+    assert result is convo
+    assert segments[0].person_id == "person-9"
+    assert segments[0].is_user is False
+    assert segments[1].person_id is None
+    assert len(background_tasks.tasks) == 1
+    assert background_tasks.tasks[0].kwargs["segment_ids"] == ["segment-0"]
+
+
+def test_bulk_assign_exact_id_still_supports_user_assignment(router):
+    """Already-shipped clients using persisted IDs retain the existing assignment path."""
+    convo, segments = _fake_conversation_with_segments(
+        2,
+        status=router.conv.ConversationStatus.completed,
+        with_ids=True,
+    )
+    segments[0].person_id = "old-person"
+    background_tasks = router.conv.BackgroundTasks()
+    data = router.conv.BulkAssignSegmentsRequest(
+        segment_ids=["segment-0"],
+        assign_type="is_user",
+        value="true",
+    )
+
+    with patch.object(router.conv, "_get_valid_conversation_by_id", return_value={"id": "c1"}), patch.object(
+        router.conv, "deserialize_conversation", return_value=convo
+    ), patch.object(router.conv.conversations_db, "update_conversation_segments"):
+        router.conv.assign_segments_bulk("c1", data, background_tasks, uid="u1")
+
+    assert segments[0].is_user is True
+    assert segments[0].person_id is None
+    assert segments[1].is_user is False
+    assert background_tasks.tasks == []
+
+
+def test_bulk_assign_rejects_unresolved_target_without_partial_mutation(router):
+    """A stale or malformed target must fail closed instead of reporting a silent no-op."""
+    convo, segments = _fake_conversation_with_segments(
+        2,
+        status=router.conv.ConversationStatus.completed,
+        with_ids=True,
+    )
+    segments[0].person_id = "old-person"
+    background_tasks = router.conv.BackgroundTasks()
+    data = router.conv.BulkAssignSegmentsRequest(
+        segment_ids=["segment-0", "#index:99"],
+        assign_type="person_id",
+        value="person-9",
+    )
+    update = MagicMock()
+
+    with patch.object(router.conv, "_get_valid_conversation_by_id", return_value={"id": "c1"}), patch.object(
+        router.conv, "deserialize_conversation", return_value=convo
+    ), patch.object(router.conv.conversations_db, "update_conversation_segments", update):
+        with pytest.raises(HTTPException) as exc:
+            router.conv.assign_segments_bulk("c1", data, background_tasks, uid="u1")
+
+    assert exc.value.status_code == 409
+    assert segments[0].person_id == "old-person"
+    assert update.call_count == 0
+    assert background_tasks.tasks == []

--- a/backend/tests/unit/test_conversation_model_split.py
+++ b/backend/tests/unit/test_conversation_model_split.py
@@ -215,6 +215,46 @@ class TestSerializationRoundTrip:
         assert eic2.text == "test content"
         assert eic2.text_source == ExternalIntegrationConversationSource.message
 
+    def test_legacy_transcript_segment_ids_are_deterministic_per_conversation(self):
+        from models.conversation import Conversation
+        from models.structured import Structured
+
+        now = datetime.now(timezone.utc)
+        raw_segments = [
+            {
+                "text": "legacy",
+                "speaker": "SPEAKER_00",
+                "is_user": False,
+                "start": 0.0,
+                "end": 1.0,
+            },
+            {
+                "id": "explicit-segment-id",
+                "text": "explicit",
+                "speaker": "SPEAKER_01",
+                "is_user": False,
+                "start": 1.0,
+                "end": 2.0,
+            },
+        ]
+        fields = {
+            "id": "conversation-with-legacy-segments",
+            "created_at": now,
+            "started_at": now,
+            "finished_at": now,
+            "structured": Structured(),
+            "transcript_segments": raw_segments,
+        }
+
+        first = Conversation(**fields)
+        second = Conversation(**fields)
+
+        assert first.transcript_segments[0].id == second.transcript_segments[0].id
+        assert first.transcript_segments[0].id
+        assert first.transcript_segments[0].id != first.transcript_segments[1].id
+        assert first.transcript_segments[1].id == "explicit-segment-id"
+        assert "id" not in raw_segments[0]
+
 
 class TestHelperMethods:
     """Helper methods on moved models must work correctly."""

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/NameSpeakerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/NameSpeakerSheet.swift
@@ -6,8 +6,8 @@ struct NameSpeakerSheet: View {
   let segment: TranscriptSegment
   let allSegments: [TranscriptSegment]
   let people: [Person]
-  let onSave: (_ personId: String?, _ isUser: Bool, _ segmentIndices: [Int]) -> Void
-  let onCreatePerson: (_ name: String) async -> Person?
+  let onSave: (_ personId: String?, _ isUser: Bool, _ segmentIndices: [Int]) async -> Bool
+  let onCreatePerson: ((_ name: String) async -> Person?)?
   let onDismiss: () -> Void
 
   @State private var selectedPersonId: String? = nil
@@ -18,6 +18,7 @@ struct NameSpeakerSheet: View {
   @State private var tagAllFromSpeaker: Bool = true
   @State private var isSaving: Bool = false
   @State private var isCreating: Bool = false
+  @State private var saveError: String? = nil
 
   /// Segments from the same speaker in this conversation
   private var sameSpeakerSegments: [TranscriptSegment] {
@@ -81,6 +82,14 @@ struct NameSpeakerSheet: View {
       Divider()
         .background(OmiColors.border)
 
+      if let saveError {
+        Text(saveError)
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(OmiColors.error)
+          .padding(.horizontal, OmiSpacing.xl)
+          .padding(.bottom, OmiSpacing.sm)
+      }
+
       // Action buttons
       HStack {
         Spacer()
@@ -92,7 +101,9 @@ struct NameSpeakerSheet: View {
         .padding(.horizontal, OmiSpacing.lg)
         .padding(.vertical, OmiSpacing.sm)
 
-        Button(action: save) {
+        Button {
+          Task { await save() }
+        } label: {
           if isSaving {
             ProgressView()
               .scaleEffect(0.6)
@@ -179,12 +190,14 @@ struct NameSpeakerSheet: View {
           }
         }
 
-        // "+ Add Person" chip
-        personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
-          isAddingNewPerson = true
-          isUserSelected = false
-          selectedPersonId = nil
-          duplicateWarning = nil
+        if onCreatePerson != nil {
+          // "+ Add Person" chip
+          personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
+            isAddingNewPerson = true
+            isUserSelected = false
+            selectedPersonId = nil
+            duplicateWarning = nil
+          }
         }
       }
 
@@ -283,7 +296,7 @@ struct NameSpeakerSheet: View {
 
   private func createAndSelect() async {
     let trimmed = newPersonName.trimmingCharacters(in: .whitespaces)
-    guard !trimmed.isEmpty, duplicateWarning == nil else { return }
+    guard !trimmed.isEmpty, duplicateWarning == nil, let onCreatePerson else { return }
 
     isCreating = true
     if let person = await onCreatePerson(trimmed) {
@@ -294,10 +307,20 @@ struct NameSpeakerSheet: View {
     isCreating = false
   }
 
-  private func save() {
+  private func save() async {
+    guard !isSaving else { return }
+
     isSaving = true
+    saveError = nil
     let segmentIndices = tagAllFromSpeaker ? sameSpeakerIndices : [tappedSegmentIndex]
-    onSave(selectedPersonId, isUserSelected, segmentIndices)
+    let succeeded = await onSave(selectedPersonId, isUserSelected, segmentIndices)
+    isSaving = false
+
+    if succeeded {
+      onDismiss()
+    } else {
+      saveError = "Couldn't assign this speaker. Try again."
+    }
   }
 
   private func personChip(label: String, isSelected: Bool, isAction: Bool = false, action: @escaping () -> Void)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -267,34 +267,31 @@ struct ConversationDetailView: View {
         allSegments: displayConversation.transcriptSegments,
         people: people,
         onSave: { personId, isUser, segmentIndices in
-          Task {
-            let assignment = Self.assignmentMetadata(
-              for: segmentIndices,
-              in: displayConversation.transcriptSegments
-            )
-            let success =
-              await onAssignSpeaker?(
-                conversation.id,
-                assignment.targets,
-                personId,
-                isUser
-              ) ?? false
-            if success {
-              await persistSpeakerAssignment(
-                conversationId: conversation.id,
-                backendSegmentIds: assignment.backendIds,
-                fallbackSegmentOrders: assignment.fallbackOrders,
-                isUser: isUser,
-                personId: personId
-              )
-              updateDisplayedConversation(segmentIndices: segmentIndices, isUser: isUser, personId: personId)
-            }
-            selectedSegmentForNaming = nil
-          }
+          guard let onAssignSpeaker else { return false }
+
+          let assignment = Self.assignmentMetadata(
+            for: segmentIndices,
+            in: displayConversation.transcriptSegments
+          )
+          let success = await onAssignSpeaker(
+            conversation.id,
+            assignment.targets,
+            personId,
+            isUser
+          )
+          guard success else { return false }
+
+          await persistSpeakerAssignment(
+            conversationId: conversation.id,
+            backendSegmentIds: assignment.backendIds,
+            fallbackSegmentOrders: assignment.fallbackOrders,
+            isUser: isUser,
+            personId: personId
+          )
+          updateDisplayedConversation(segmentIndices: segmentIndices, isUser: isUser, personId: personId)
+          return true
         },
-        onCreatePerson: { name in
-          await onCreatePerson?(name)
-        },
+        onCreatePerson: onCreatePerson,
         onDismiss: {
           selectedSegmentForNaming = nil
         }
@@ -757,7 +754,7 @@ struct ConversationDetailView: View {
         segment: segment,
         isUser: segment.isUser,
         personName: segment.personId.flatMap { peopleDict[$0]?.name },
-        onSpeakerTapped: segment.isUser
+        onSpeakerTapped: segment.isUser || onAssignSpeaker == nil
           ? nil
           : {
             selectedSegmentForNaming = segment

--- a/desktop/macos/changelog/unreleased/20260802-speaker-assignment.json
+++ b/desktop/macos/changelog/unreleased/20260802-speaker-assignment.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed naming transcript speakers so assignments persist for legacy conversations and failed saves can be retried"
+}


### PR DESCRIPTION
## Summary

Fix desktop transcript speaker assignment for legacy conversations whose transcript segments do not have stored backend IDs.

- Derive deterministic segment IDs from conversation ID and transcript position at the backend conversation boundary, preserving explicit IDs.
- Resolve exact IDs and strict `#index:<n>` fallbacks atomically before mutation; reject unresolved targets with 409 and pass canonical IDs to speaker-sample extraction.
- Keep the Name Speaker sheet open with a retryable error when assignment fails, hide Add Person when unsupported, and remove the editor affordance from unwired detail surfaces.

## Root cause

Legacy segments were given fresh random UUIDs every time the backend deserialized a conversation. The ID returned by GET could therefore differ from the ID used while handling PATCH, and the bulk endpoint silently ignored unmatched targets. The desktop's existing positional fallback was also not implemented by the backend. Person creation could succeed independently, making the failure appear to be only the assignment.

## Verification

- `backend/.venv/bin/python -m pytest -q tests/unit/test_conversation_model_split.py tests/unit/test_conversation_events_bounds.py` — 59 passed.
- `xcrun swift build -c debug --package-path Desktop` — passed.
- `xcrun swift test --package-path Desktop --filter TranscriptSpeakerAssignmentTests` — 19 passed.
- `python3 scripts/check_desktop_test_quality.py` — passed.
- `backend/test.sh` — runner completed but reported five unrelated failures in `test_byok_fingerprint_pepper_migration.py`, `test_pusher_runtime_protocol.py`, `test_sync_v2.py`, `test_verify_backend_release_vector.py`, and `test_ws_b_short_term_lifecycle.py`; the focused backend tests above passed.
- `xcrun swift test --package-path Desktop` — 3,731 tests ran with 2 skips and 1 unexpected failure in `MemoryAtlasEvidenceNavigationTests.testOpeningAMemoryThatIsNotOnThisDeviceReportsFailure`, amid SQLite/Core Data/XPC environment errors; the focused speaker-assignment suite above passed.
- `OMI_PR_BODY_FILE=/tmp/omi-speaker-assignment-pr-body.md make preflight` — passed.
- Named ad-hoc bundle packaged, signed, installed, and launched as `omi-speaker-assignment-qa`; manual assignment was not exercised because the isolated bundle had no signed-in test identity.

## Product invariants

No locked product invariants are affected.

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

