### PR TITLE
ci(desktop): stop uploading cold SwiftPM build cache

### DIFF
--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -293,14 +293,16 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         self.assertIn("~/.cache/omi-swift-format", job)
         self.assertIn("~/.cache/omi-swiftlint", job)
 
-    def test_cache_saves_completed_build_state_after_a_test_failure(self):
-        """A retry should reuse SwiftPM's validated incremental build state."""
+    def test_cache_keeps_dependencies_but_not_pr_scoped_build_products(self):
+        """A retry retains dependency downloads without uploading Desktop/.build."""
         job = self.jobs["desktop-swift-verify"]
         self.assertIn("id: swiftpm-cache", job)
         self.assertIn("uses: actions/cache/restore@v6", job)
         self.assertIn("uses: actions/cache/save@v6", job)
         self.assertIn("always()", job)
         self.assertIn("steps.swiftpm-cache.outputs.cache-hit != 'true'", job)
+        self.assertIn("~/Library/Caches/org.swift.swiftpm", job)
+        self.assertNotIn("desktop/macos/Desktop/.build", job)
 
     # --- changed-file gate assertions --------------------------------------
 

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -145,14 +145,17 @@ jobs:
             ~/.cache/omi-swiftlint
           key: ${{ runner.os }}-desktop-swift-tools-xcode164-${{ hashFiles('desktop/macos/scripts/swift-format-wrapper.sh', 'desktop/macos/scripts/swiftlint-wrapper.sh') }}
 
-      - name: Restore SwiftPM build products
+      # A Desktop/.build archive is about 5.3 GB. GitHub scopes those archives
+      # to a PR ref, so they miss for normal new commits and spend over a minute
+      # uploading without reducing a subsequent run. Retain only SwiftPM's
+      # dependency cache, which is small and reusable when the manifest matches.
+      - name: Restore SwiftPM dependency cache
         if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' }}
         id: swiftpm-cache
         uses: actions/cache/restore@v6
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
-            desktop/macos/Desktop/.build
           key: ${{ runner.os }}-desktop-swift-build-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-desktop-swift-build-xcode164-
@@ -198,16 +201,15 @@ jobs:
         working-directory: desktop/macos
         run: ./scripts/run-swift-ci.sh --release-notification-regression
 
-      # SwiftPM validates cached incremental state before using it. Saving after
-      # a failed test command makes the next diagnostic run reuse completed
-      # dependency and module work instead of recompiling the same test bundle.
-      - name: Save SwiftPM build products after test attempt
+      # Preserve resolved dependency downloads after a failed test command, but
+      # do not archive Desktop/.build: its PR-scoped 5.3 GB cache misses in
+      # ordinary new-commit runs and increases billed macOS time on every save.
+      - name: Save SwiftPM dependency cache after test attempt
         if: ${{ always() && !cancelled() && needs.changes.outputs.should_run_tests == 'true' && steps.swiftpm-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v6
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
-            desktop/macos/Desktop/.build
           key: ${{ runner.os }}-desktop-swift-build-xcode164-${{ hashFiles('desktop/macos/Desktop/Package.swift', 'desktop/macos/Desktop/Package.resolved') }}
 
       - name: Require independent macOS phase verdicts


### PR DESCRIPTION
## Summary

- Stop caching `desktop/macos/Desktop/.build` in Desktop Swift CI.
- Keep the smaller SwiftPM dependency cache so package resolution remains warm.
- The removed archive was 5.3 GB, missed across the sampled PR runs because it is ref-scoped, and added 59–84 seconds of macOS upload time per miss.

## Verification

- `python3 .github/scripts/test_desktop_swift_ci_contract.py`
- `black --check --line-length 120 --skip-string-normalization .github/scripts/test_desktop_swift_ci_contract.py`
- `actionlint .github/workflows/desktop-swift-ci.yml`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

