### PR TITLE
fix(desktop): await physical mic teardown

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -214,8 +214,8 @@ class AppState: ObservableObject {
   /// continue into the WAL while the transport reconnects, so this stays
   /// visible until the backend is ready or the active session is reset.
   @Published var transcriptionServiceError: String?
-  /// Monotonically increasing counter — incremented each time a new recording starts.
-  /// Used to detect if a new recording began during the post-stop force-process delay.
+  /// Monotonically increasing counter — incremented for each recording start or stop request.
+  /// Used to prevent asynchronous work from mutating a newer recording decision.
   var recordingGeneration: UInt64 = 0
   @Published var isSavingConversation = false
   // currentTranscript is internal-only (not observed by views), so no @Published needed

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -455,6 +455,22 @@ extension AppState {
       }
     }
   }
+
+  /// Stop the active session and wait until its microphone IOProc is physically gone.
+  /// Settings uses this boundary before reopening capture with changed preferences.
+  func prepareTranscriptionRestartAfterSettingsChange() async -> Bool {
+    guard isTranscribing else { return false }
+
+    let stoppedGeneration = recordingGeneration
+    let stoppedCapture = audioCaptureService
+    let stopCompletion = stopTranscription()
+    await stopCompletion?.value
+    await stoppedCapture?.waitForPhysicalStop()
+
+    // A user may have toggled listening while teardown was in flight. Never let
+    // this older settings change reopen capture over that newer decision.
+    return recordingGeneration == stoppedGeneration && !isTranscribing
+  }
 }
 
 // MARK: - System Event Notification Names

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -461,15 +461,15 @@ extension AppState {
   func prepareTranscriptionRestartAfterSettingsChange() async -> Bool {
     guard isTranscribing else { return false }
 
-    let stoppedGeneration = recordingGeneration
     let stoppedCapture = audioCaptureService
     let stopCompletion = stopTranscription()
+    let restartGeneration = recordingGeneration
     await stopCompletion?.value
     await stoppedCapture?.waitForPhysicalStop()
 
     // A user may have toggled listening while teardown was in flight. Never let
     // this older settings change reopen capture over that newer decision.
-    return recordingGeneration == stoppedGeneration && !isTranscribing
+    return recordingGeneration == restartGeneration && !isTranscribing
   }
 }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -853,9 +853,9 @@ extension AppState {
   /// The Python backend handles conversation lifecycle automatically when the WebSocket closes.
   /// When `/v4/listen` has announced the backend conversation id, finalize that exact conversation
   /// instead of relying on the user's current in-progress pointer.
-  func stopTranscription() {
-    // On-device path: there is no backend WebSocket/conversation, so skip the cloud
-    // force-process/reconciliation entirely. Stop capture, then AWAIT both Parakeet instances'
+  @discardableResult
+  func stopTranscription() -> Task<Void, Never>? {
+    // On-device path: stop capture, then AWAIT both Parakeet instances'
     // final tail flushes (delivered to the still-current session) BEFORE clearing state, so the
     // last words persist to the right conversation instead of racing the async drain.
     if sttSession.useLocalSTT {
@@ -863,7 +863,7 @@ extension AppState {
       let sys = localSystemService
       localMicService = nil
       localSystemService = nil
-      Task { @MainActor in
+      return Task { @MainActor in
         self.stopAudioCapture()
         await mic?.finish()
         await sys?.finish()
@@ -871,7 +871,6 @@ extension AppState {
         self.clearTranscriptionState(finalizationReason: .userStop, allowCloudForceProcess: false)
         self.silentMicFallbackInProgress = false
       }
-      return
     }
 
     // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil).
@@ -920,6 +919,7 @@ extension AppState {
 
       await loadConversations()
     }
+    return nil
   }
 
   /// On-device Parakeet failed to load — fall back to cloud STT instead of silently recording a

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -855,9 +855,9 @@ extension AppState {
   /// instead of relying on the user's current in-progress pointer.
   @discardableResult
   func stopTranscription() -> Task<Void, Never>? {
-    // On-device path: stop capture, then AWAIT both Parakeet instances'
-    // final tail flushes (delivered to the still-current session) BEFORE clearing state, so the
-    // last words persist to the right conversation instead of racing the async drain.
+    recordingGeneration &+= 1
+    // On-device path: await both Parakeet tail flushes before clearing state so the
+    // last words persist to the current conversation.
     if sttSession.useLocalSTT {
       let mic = localMicService
       let sys = localSystemService

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
@@ -316,14 +316,10 @@ extension SettingsContentView {
 
   /// Restart transcription if currently running to apply new settings
   func restartTranscriptionIfNeeded() {
-    guard appState.isTranscribing else { return }
-
-    // Stop and restart to apply new language settings
-    appState.stopTranscription()
-
-    // Wait a moment for cleanup, then restart
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-      self.appState.startTranscription()
+    Task { @MainActor in
+      if await appState.prepareTranscriptionRestartAfterSettingsChange() {
+        appState.startTranscription()
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Tests/TranscriptionSettingsRestartTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionSettingsRestartTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+private final class SuspendedPhysicalStopCapture: AudioCaptureService, @unchecked Sendable {
+  private let lock = NSLock()
+  private var events: [String] = []
+  private let waitStarted = TestAsyncGate()
+  private let mayFinish = TestAsyncGate()
+
+  override func stopCapture() {
+    lock.withLock { events.append("stop") }
+  }
+
+  override func waitForPhysicalStop() async {
+    lock.withLock { events.append("wait") }
+    await waitStarted.open()
+    await mayFinish.wait()
+  }
+
+  func waitUntilPhysicalStopIsAwaited() async {
+    await waitStarted.wait()
+  }
+
+  func finishPhysicalStop() async {
+    await mayFinish.open()
+  }
+
+  func recordedEvents() -> [String] {
+    lock.withLock { events }
+  }
+}
+
+@MainActor
+final class TranscriptionSettingsRestartTests: XCTestCase {
+  func testSettingsRestartWaitsForPhysicalMicStopBeforeStartingAgain() async {
+    let state = AppState()
+    let capture = SuspendedPhysicalStopCapture()
+    state.audioCaptureService = capture
+    state.isTranscribing = true
+    state.sttSession.activeMode = .local
+    var events: [String] = []
+
+    let restart = Task { @MainActor in
+      if await state.prepareTranscriptionRestartAfterSettingsChange() {
+        events.append("start")
+      }
+    }
+
+    await capture.waitUntilPhysicalStopIsAwaited()
+    XCTAssertEqual(capture.recordedEvents(), ["stop", "wait"])
+    XCTAssertTrue(events.isEmpty)
+
+    await capture.finishPhysicalStop()
+    await restart.value
+
+    XCTAssertEqual(events, ["start"])
+  }
+
+  func testSettingsRestartDoesNotReopenAfterANewerRecordingStarts() async {
+    let state = AppState()
+    let capture = SuspendedPhysicalStopCapture()
+    state.audioCaptureService = capture
+    state.isTranscribing = true
+    state.sttSession.activeMode = .local
+    var restarted = false
+
+    let restart = Task { @MainActor in
+      if await state.prepareTranscriptionRestartAfterSettingsChange() {
+        restarted = true
+      }
+    }
+
+    await capture.waitUntilPhysicalStopIsAwaited()
+    state.recordingGeneration += 1
+    await capture.finishPhysicalStop()
+    await restart.value
+
+    XCTAssertFalse(restarted)
+  }
+}

--- a/desktop/macos/Desktop/Tests/TranscriptionSettingsRestartTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionSettingsRestartTests.swift
@@ -58,7 +58,7 @@ final class TranscriptionSettingsRestartTests: XCTestCase {
     XCTAssertEqual(events, ["start"])
   }
 
-  func testSettingsRestartDoesNotReopenAfterANewerRecordingStarts() async {
+  func testSettingsRestartDoesNotReopenAfterUserStopsAgainDuringTeardown() async {
     let state = AppState()
     let capture = SuspendedPhysicalStopCapture()
     state.audioCaptureService = capture
@@ -73,7 +73,8 @@ final class TranscriptionSettingsRestartTests: XCTestCase {
     }
 
     await capture.waitUntilPhysicalStopIsAwaited()
-    state.recordingGeneration += 1
+    let userStop = state.stopTranscription()
+    await userStop?.value
     await capture.finishPhysicalStop()
     await restart.value
 

--- a/desktop/macos/changelog/unreleased/20260802-microphone-settings-restart.json
+++ b/desktop/macos/changelog/unreleased/20260802-microphone-settings-restart.json
@@ -1,0 +1,1 @@
+{"change":"Prevented live microphone changes from racing the previous capture while it shuts down"}


### PR DESCRIPTION
## What changed and why

Fixes the live microphone-switch teardown race tracked in #10921.

Settings previously stopped transcription and guessed that CoreAudio teardown would finish within one second. `AudioCaptureService.stopCapture()` deliberately performs `AudioDeviceStop` and IOProc destruction asynchronously, so a slow Bluetooth teardown could still own the device when the replacement capture opened.

- Expose the existing local-transcription stop task as a completion seam.
- Await both logical transcription shutdown and `waitForPhysicalStop()` before reopening capture.
- Advance and reuse `recordingGeneration` for both start and stop decisions, preventing an older settings restart from overriding a newer user action.
- Remove the fixed one-second timer.

No new capture owner, dependency, compatibility path, or polling loop is introduced.

## Product invariants affected

none

## How it was verified

- `xcrun swiftc -frontend -parse <changed Swift files>` — passed.
- Homebrew `swift-format 603.0.0 format --configuration desktop/macos/Desktop/.swift-format` over all changed Swift files — no diff. This is a cross-check only; CI remains authoritative for the repository-pinned 602.0.0 formatter.
- `python3 .github/scripts/run_checks.py --lane local --base origin/main --head HEAD --skip-pr-body-checks` — all checks through `desktop-main-actor-xctest-hooks` passed; the runner then stopped at `desktop-swift-format-lint` because this machine has Command Line Tools only and `xcrun --sdk macosx --show-sdk-platform-path` cannot resolve a full Xcode platform SDK.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed.
- `python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict --base origin/main` — 3/3 changed production Swift files covered.
- `python3 .github/scripts/desktop-changelog.py validate` — passed.

Not locally verified: Swift compilation, XCTest execution, pinned Swift formatting/SwiftLint, named-bundle launch, or physical Bluetooth microphone switching. This PR is draft until the macOS CI lanes pass and the live hardware path is exercised.

## Tests

`TranscriptionSettingsRestartTests` drives the production restart boundary through a suspended fake physical stop on the default on-device STT path. It proves the replacement cannot start before teardown completes and, through a real second `stopTranscription()` call, that a user stop during teardown cancels the stale restart.

## Failure class (fixes)

Failure-Class: none

## New guards

No repository check or ratchet is added. The focused behavioral regression test would have caught this instance.
