### PR TITLE
fix(mcp): reject malformed action-item text arguments

### DIFF
--- a/backend/tests/unit/test_mcp_action_item_writes.py
+++ b/backend/tests/unit/test_mcp_action_item_writes.py
@@ -142,7 +142,7 @@ if not (isinstance(_existing_fp, type) and issubclass(_existing_fp, BaseExceptio
     _api_core_exc.FailedPrecondition = type('FailedPrecondition', (Exception,), {})
 
 if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
-    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10 ** 12))
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
 sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
 sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
 sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)

--- a/backend/tests/unit/test_mcp_action_item_writes.py
+++ b/backend/tests/unit/test_mcp_action_item_writes.py
@@ -142,7 +142,7 @@ if not (isinstance(_existing_fp, type) and issubclass(_existing_fp, BaseExceptio
     _api_core_exc.FailedPrecondition = type('FailedPrecondition', (Exception,), {})
 
 if not isinstance(getattr(sys.modules['database._client'], '__file__', None), str):
-    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
+    sys.modules['database._client'].document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10 ** 12))
 sys.modules['dependencies'].get_uid_from_mcp_api_key = MagicMock(return_value='user-1')
 sys.modules['dependencies'].get_current_user_id = MagicMock(return_value='user-1')
 sys.modules['utils.other.endpoints'].with_rate_limit = MagicMock(side_effect=lambda dependency, _policy: dependency)
@@ -432,6 +432,20 @@ class TestSseDispatch:
     def test_tool_create_bad_due_date_is_invalid_params(self, _mock_db):
         with pytest.raises(sse.ToolExecutionError) as ei:
             sse.execute_tool(UID, 'create_action_item', {'description': 'x', 'due_at': 'whenever'})
+        assert ei.value.code == -32602
+
+    @pytest.mark.parametrize(
+        ('tool_name', 'arguments'),
+        [
+            ('create_action_item', {'description': {'text': 'Email Bob'}}),
+            ('create_action_item', {'description': 'Email Bob', 'due_at': ['2026-07-01']}),
+            ('search_action_items', {'query': {'text': 'Bob'}}),
+        ],
+    )
+    @patch('utils.mcp_action_items.action_items_db')
+    def test_tool_rejects_non_string_text_arguments(self, _mock_db, tool_name, arguments):
+        with pytest.raises(sse.ToolExecutionError) as ei:
+            sse.execute_tool(UID, tool_name, arguments)
         assert ei.value.code == -32602
 
     @patch('utils.mcp_action_items.action_items_db')

--- a/backend/utils/mcp_action_items.py
+++ b/backend/utils/mcp_action_items.py
@@ -58,9 +58,11 @@ def content_idempotency_key(uid: str, description: str) -> str:
     return hashlib.sha256(payload.encode('utf-8')).hexdigest()
 
 
-def _normalize_description(description: Optional[str]) -> str:
+def _normalize_description(description: object) -> str:
     if description is None:
         raise ValueError("description is required")
+    if not isinstance(description, str):
+        raise ValueError("description must be a string")
     text = description.strip()
     if not text:
         raise ValueError("description cannot be empty")
@@ -69,7 +71,7 @@ def _normalize_description(description: Optional[str]) -> str:
     return text
 
 
-def parse_due_at(value: Union[str, datetime, None]) -> Optional[datetime]:
+def parse_due_at(value: object) -> Optional[datetime]:
     """Accept an ISO 8601 datetime, a yyyy-mm-dd date, a datetime, or None.
 
     REST passes a parsed ``datetime``; MCP tools pass a JSON string. Both routes
@@ -77,6 +79,8 @@ def parse_due_at(value: Union[str, datetime, None]) -> Optional[datetime]:
     """
     if value is None or isinstance(value, datetime):
         return value
+    if not isinstance(value, str):
+        raise ValueError("due_at must be a string or datetime")
     text = value.strip()
     if not text:
         return None
@@ -121,10 +125,7 @@ def _reload(uid: str, action_item_id: str) -> Dict[str, Any]:
 
 
 def create_action_item(
-    uid: str,
-    description: Optional[str],
-    due_at: Union[str, datetime, None] = None,
-    completed: bool = False,
+    uid: str, description: Optional[str], due_at: Union[str, datetime, None] = None, completed: bool = False,
 ) -> Dict[str, Any]:
     """Create a task and return its cleaned MCP shape. Content-idempotent on
     (uid, normalized description)."""
@@ -162,10 +163,7 @@ def set_completed(uid: str, action_item_id: str, completed: bool = True) -> Dict
 
 
 def update_action_item(
-    uid: str,
-    action_item_id: str,
-    description: Optional[str] = None,
-    due_at: Union[str, datetime, None] = None,
+    uid: str, action_item_id: str, description: Optional[str] = None, due_at: Union[str, datetime, None] = None,
 ) -> Dict[str, Any]:
     """Update a task's description and/or due date.
 
@@ -220,7 +218,7 @@ def delete_action_item(uid: str, action_item_id: str) -> None:
 
 def search_action_items(uid: str, query: Optional[str], limit: int = 10) -> List[Dict[str, Any]]:
     """Semantic search over the user's tasks, returned in relevance order."""
-    if not query or not query.strip():
+    if not isinstance(query, str) or not query.strip():
         raise ValueError("query is required")
     try:
         limit = int(limit)

--- a/backend/utils/mcp_action_items.py
+++ b/backend/utils/mcp_action_items.py
@@ -125,7 +125,10 @@ def _reload(uid: str, action_item_id: str) -> Dict[str, Any]:
 
 
 def create_action_item(
-    uid: str, description: Optional[str], due_at: Union[str, datetime, None] = None, completed: bool = False,
+    uid: str,
+    description: Optional[str],
+    due_at: Union[str, datetime, None] = None,
+    completed: bool = False,
 ) -> Dict[str, Any]:
     """Create a task and return its cleaned MCP shape. Content-idempotent on
     (uid, normalized description)."""
@@ -163,7 +166,10 @@ def set_completed(uid: str, action_item_id: str, completed: bool = True) -> Dict
 
 
 def update_action_item(
-    uid: str, action_item_id: str, description: Optional[str] = None, due_at: Union[str, datetime, None] = None,
+    uid: str,
+    action_item_id: str,
+    description: Optional[str] = None,
+    due_at: Union[str, datetime, None] = None,
 ) -> Dict[str, Any]:
     """Update a task's description and/or due date.
 


### PR DESCRIPTION
## What

MCP advertises action-item descriptions, due dates, and search queries as strings, but the tool dispatcher does not validate JSON Schema inputs before calling the shared helper. Object- or array-valued arguments therefore reached `.strip()` and raised an uncaught `AttributeError` instead of returning MCP invalid params.

This adds direct type checks at the existing shared action-item boundary. The helper now raises `ValueError`, which both MCP transports already translate into their normal client error (`-32602` for tool calls). A parameterized dispatcher regression test covers malformed description, due date, and query values.

## Scope

No dependency or general-purpose schema validator was added. The existing `mcp_action_items` helper remains the single boundary shared by REST and MCP tool calls.

## Verification

- `backend/.venv/bin/pytest -q backend/tests/unit/test_mcp_action_item_writes.py` — 43 passed
- repository pre-push gate — full backend typecheck passed; 43/43 selected backend tests passed
- `BACKEND_FAST_UNIT_WARN_SECONDS=1.0 BACKEND_FAST_UNIT_FAIL_SECONDS=1.0 bash backend/test.sh` — all changed-path tests passed; one unrelated `test_sync_v2.py` process flaked in the parallel run, then passed 168/168 with the same runner in isolation
- `OMI_PR_BODY_FILE=/tmp/omi-mcp-invalid-params-pr.md make preflight`

The real production dispatcher was exercised through its controllable database seam; a live authenticated MCP server was not required for this input-boundary regression.

## Product invariants affected

none

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

