### PR TITLE
ci(desktop): cover the floating bar notification preview policy flow

### DIFF
--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/PostHogManager.swift
 preconditions:


### PR DESCRIPTION
## Bug

`Desktop Swift CI` is **red on `main`** since 275a488629 (#10956). Every push to `main` since that merge fails the `Desktop Swift Static & Test Contracts` job, which in turn fails `Desktop Swift Build & Tests` — the lane that gates desktop release candidates.

## Root cause

#10956 extracted the in-bar-preview / system-banner decision out of `NotificationService` into a new file, `desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift`, but never added it to any e2e flow's `covers:` list. `desktop-e2e-flow-coverage` runs `--strict` on `main` pushes:

```
Covered: 5
Uncovered: 1
  UNCOVERED desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
Manifest checks failed: desktop-e2e-flow-coverage
```

Everything else in the run was green (`LAUNCHER_OUTCOME: success`, `TEST_OUTCOME: success`, `NOTIFICATION_OUTCOME: success`) — the manifest gap is the whole failure.

## Fix

One line: add the policy file to `notifications-settings.yaml`'s `covers:`. That is the honest owner — the policy is called from `NotificationService.deliver` (`shouldShowInBarPreview` / `shouldDeliverSystemBanner`), and `NotificationService.swift` is already covered by that same flow. It mirrors the existing convention of listing extracted pure-policy types on the flow that drives them (e.g. `FloatingBarLaunchPolicy.swift` under `floating-bar-functional.yaml`).

## What I tested

Reproduced and then fixed the exact check CI ran, at the same base CI used:

```
$ python3 desktop/macos/scripts/check-e2e-flow-coverage.py --strict \
    --base e28f753be6b212b20482719ee325fc62b6e975f2
# on main:        FAIL — Covered: 5, Uncovered: 1 (FloatingBarNotificationPreviewPolicy.swift)
# with this fix:  PASS — Covered: 6, Uncovered: 0
#   COVERED .../FloatingBarNotificationPreviewPolicy.swift -> notifications-settings (notifications-settings.yaml)
```

`make preflight` passes on this branch except `desktop-changelog-entry`, which is satisfied by the `no-changelog-needed` label (internal-only change — no user-facing behavior changes).

Labeled `no-changelog-needed`: this touches only a CI coverage manifest, no product code.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

