### PR TITLE
fix(ci): exempt desktop e2e flow definitions from the changelog gate

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -66,6 +66,11 @@ EXEMPT_DESKTOP_PATH_PREFIXES = (
     # a changelog fragment, and — like tests/ above — the post-merge push run
     # would otherwise redden main. Same directory the swift-format linter skips.
     "desktop/macos/Desktop/Sources/Generated/",
+    # E2E flow definitions and their docs are CI/harness test artifacts that never
+    # ship in the desktop app. Registering a new source file in a flow's `covers:`
+    # is exactly the kind of internal-only edit that reddened main on the merge
+    # push for #11039.
+    "desktop/macos/e2e/",
 )
 
 

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -87,6 +87,9 @@ class ChangelogRequirementTests(unittest.TestCase):
             # Generated Swift is derived from the OpenAPI contract, never a
             # user-facing app note (EXEMPT_DESKTOP_PATH_PREFIXES).
             "desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift",
+            # E2E flow definitions are harness test artifacts; #11039 only added a
+            # `covers:` entry and the post-merge push run reddened main.
+            "desktop/macos/e2e/flows/notifications-settings.yaml",
         ):
             with self.subTest(path=path):
                 self.assertFalse(checker.is_desktop_change_requiring_changelog(path))


### PR DESCRIPTION
## Bug

`Repo Checks` and `Release Eligibility` went red on `main` at d962001223 (#11039). #11039 changed exactly one file — `desktop/macos/e2e/flows/notifications-settings.yaml`, adding a `covers:` entry — and carried the `no-changelog-needed` label, so its PR run was green.

## Root cause

`desktop-changelog-entry` also runs on the post-merge push lane, where there is no PR and the `no-changelog-needed` label cannot be honored. The script already documents this (see the comment above `EXEMPT_DESKTOP_PATH_PREFIXES`, added after #10374/#10387): never-user-facing desktop paths must be exempt **by path**, or a legitimate change to them reddens main with no author able to satisfy the gate. `desktop/macos/e2e/` was missing from that set.

This is `FC-push-gate-internal-path-scope`, and the fix is its documented canonical prevention — extend the exemption set plus its test, in the same two artifacts the class names.

## Fix

- `check-desktop-changelog.py`: add `desktop/macos/e2e/` to `EXEMPT_DESKTOP_PATH_PREFIXES`. E2E flow definitions and their docs are harness test artifacts, exactly like the already-exempt `desktop/macos/tests/` and `Desktop/Tests/`; nothing under `desktop/macos/e2e/` ships in the app.
- `test_desktop_changelog.py`: add the regression case that would have caught this.

Product source (`Desktop/Sources/*.swift`, non-generated) still requires a fragment — that assertion is already in the same test and still passes.

## What I tested

Against the exact invocation that is failing on main right now (base/head = the #11039 merge push):

```
$ python3 .github/scripts/check-desktop-changelog.py --base 275a4886291a --head d962001223d9
# before: exit 1 — "FAIL: desktop changes require an unreleased changelog fragment."
#                  Changed desktop files: desktop/macos/e2e/flows/notifications-settings.yaml
# after:  exit 0 — "No desktop changes require a changelog entry."

$ python3 .github/scripts/test_desktop_changelog.py
Ran 4 tests in 0.003s — OK
```

`make preflight` green on this branch.

Failure-Class: FC-push-gate-internal-path-scope

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

