### PR TITLE
fix(backend): restore bunx in the agent-vm image (unblocks desktop-backend deploys)

### DIFF
--- a/.github/failure-classes/FC-image-build-tool-not-copied.json
+++ b/.github/failure-classes/FC-image-build-tool-not-copied.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-image-build-tool-not-copied",
+  "violated_contract": "A multi-stage image stage may only invoke executables it provisions itself; a tool that exists in a donor stage is absent until this stage copies, installs, or links every entry name it invokes.",
+  "canonical_prevention": "Provision each entry name a stage invokes next to the COPY that brings its binary in, including sibling entries the upstream image publishes for the same binary, and keep an executing image build as the check that the stage is self-sufficient.",
+  "evidence_prs": [
+    11043
+  ],
+  "scope_hints": [
+    "backend/**/Dockerfile",
+    "backend/Dockerfile*"
+  ],
+  "status": "open"
+}

--- a/backend/agent_vm/Dockerfile
+++ b/backend/agent_vm/Dockerfile
@@ -19,6 +19,7 @@ ENV BUN_INSTALL=/opt/bun
 ENV PATH="/opt/bun/bin:/opt/venv/bin:$PATH"
 
 COPY --from=bun /usr/local/bin/bun /opt/bun/bin/bun
+RUN ln -s bun /opt/bun/bin/bunx
 RUN bunx playwright@1.59.0-alpha-1770338664000 install --with-deps chromium
 RUN bun add --global @playwright/mcp@0.0.64
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
## Bug

Both desktop-backend deploys are red on `main`. The "Build and publish Agent VM image" step fails:

```
#12 [stage-2 4/7] RUN bunx playwright@1.59.0-alpha-1770338664000 install --with-deps chromium
#12 0.121 /bin/sh: 1: bunx: not found
ERROR: ... exit code: 127
```

## Root cause

`backend/agent_vm/Dockerfile` copies a single file out of the `oven/bun` stage —
`COPY --from=bun /usr/local/bin/bun /opt/bun/bin/bun` — but the next layer invokes `bunx`.
In the upstream bun image `bunx` is a separate entry that resolves to the same binary; it was
never copied, so the final stage has no `bunx` on `PATH`. The layer only started failing in CI
once `AGENT_GCS_BUCKET` was set and the build stopped being skipped.

## Failure class

New: `FC-image-build-tool-not-copied` — a stage may only invoke executables it provisions itself.
No registered class covered it: `FC-runtime-image-boundary` is about the entrypoint module closure of a
*built* image, while this stage never built at all.

## Fix

Symlink `bunx` to `bun` inside the image, exactly as the upstream bun image does. One line, no
behaviour change to the invoked command.

## Tested

Built `backend/agent_vm/Dockerfile` end to end against the real base image (`linux/amd64`):

- build succeeds; the Playwright layer installs chromium-1209, chromium_headless_shell-1209, ffmpeg-1011 and `@playwright/mcp@0.0.64`
- `/opt/bun/bin/bunx -> bun` present in the final image
- container boots and `GET /health` returns `200 {"status":"ok","uptime":1,"databaseReady":false}`
- packaged browser runs: `Google Chrome for Testing 145.0.7632.18`
- `make runtime-image-source-closure` passes (12 registered images)

Reproduced the failure first on the same base image: `which bunx` -> not found.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged
