### PR TITLE
Desktop: add responsiveness performance gates

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/AuthService.swift": 2812,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4469,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4461,
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1515,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1575,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1559

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ChatFirst.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ChatFirst.swift
@@ -27,12 +27,12 @@ enum DesktopAutomationNavigationResponseMode: Equatable {
 
   static func snapshot<T: Sendable>(
     waitForVisibility: Bool?,
-    cached: @Sendable () async -> T,
+    cached: @Sendable () async throws -> T,
     mounted: @Sendable () async throws -> T
   ) async throws -> T {
     switch resolve(waitForVisibility: waitForVisibility) {
     case .routeAcknowledged:
-      return await cached()
+      return try await cached()
     case .mountedVisible:
       return try await mounted()
     }
@@ -56,7 +56,7 @@ extension DesktopAutomationBridge {
         // the shell cannot route: callers can otherwise treat a no-op as an
         // accepted navigation. Reject unknown targets before returning cached.
         try self.validateKnownNavigationTarget(payload)
-        return await self.cachedAutomationSnapshot()
+        return await cachedAutomationSnapshot()
       },
       mounted: { try await waitForNavigationTarget(payload) }
     )

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ChatFirst.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ChatFirst.swift
@@ -51,9 +51,28 @@ extension DesktopAutomationBridge {
   ) async throws -> DesktopAutomationSnapshot {
     try await DesktopAutomationNavigationResponseMode.snapshot(
       waitForVisibility: payload.waitForVisibility,
-      cached: { await cachedAutomationSnapshot() },
+      cached: {
+        // The fast acknowledgement path must not report success for a target
+        // the shell cannot route: callers can otherwise treat a no-op as an
+        // accepted navigation. Reject unknown targets before returning cached.
+        try self.validateKnownNavigationTarget(payload)
+        return await self.cachedAutomationSnapshot()
+      },
       mounted: { try await waitForNavigationTarget(payload) }
     )
+  }
+
+  /// Confirms the target resolves to a known chat-first or legacy destination
+  /// so the acknowledgement path cannot mask an unknown route as success.
+  private func validateKnownNavigationTarget(
+    _ payload: DesktopAutomationNavigationRequest
+  ) throws {
+    let isKnown =
+      ChatFirstRoute.automationVisibilityDestination(named: payload.target) != nil
+      || legacyAutomationDestinationTitle(named: payload.target) != nil
+    guard isKnown else {
+      throw DesktopAutomationActionError.invalidParams("unknown_navigation_target")
+    }
   }
 
   func waitForNavigationTarget(

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ChatFirst.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ChatFirst.swift
@@ -1,8 +1,61 @@
 import Foundation
 
+struct DesktopAutomationNavigationRequest: Codable {
+  let target: String
+  let settingsSection: String?
+  let highlightedSettingId: String?
+  let activateApp: Bool?
+  let settleMs: Int?
+  /// When true (the compatibility default), `/navigate` waits until the
+  /// destination's mounted view reports visibility. Non-production
+  /// responsiveness probes can set false to measure command acknowledgement
+  /// separately from potentially expensive destination loading.
+  let waitForVisibility: Bool?
+}
+
+/// Selects whether `/navigate` measures command acknowledgement or waits for
+/// the destination view to mount. The default remains the historical mounted
+/// visibility contract; responsiveness probes explicitly opt into the faster
+/// acknowledgement phase and then wait on state independently.
+enum DesktopAutomationNavigationResponseMode: Equatable {
+  case routeAcknowledged
+  case mountedVisible
+
+  static func resolve(waitForVisibility: Bool?) -> Self {
+    waitForVisibility == false ? .routeAcknowledged : .mountedVisible
+  }
+
+  static func snapshot<T: Sendable>(
+    waitForVisibility: Bool?,
+    cached: @Sendable () async -> T,
+    mounted: @Sendable () async throws -> T
+  ) async throws -> T {
+    switch resolve(waitForVisibility: waitForVisibility) {
+    case .routeAcknowledged:
+      return await cached()
+    case .mountedVisible:
+      return try await mounted()
+    }
+  }
+}
+
 /// Cohort-shell visibility proof for the non-production automation bridge.
 /// The bridge reports success only after the target route has actually mounted.
 extension DesktopAutomationBridge {
+  /// `dispatchNavigation` posts on MainActor, and the root navigation reducer
+  /// projects its typed route before returning. Keep this acknowledgement
+  /// distinct from mounted-view visibility so probes do not treat a heavy
+  /// destination finishing its load as first input feedback.
+  func navigationSnapshot(
+    for payload: DesktopAutomationNavigationRequest
+  ) async throws -> DesktopAutomationSnapshot {
+    try await DesktopAutomationNavigationResponseMode.snapshot(
+      waitForVisibility: payload.waitForVisibility,
+      cached: { await cachedAutomationSnapshot() },
+      mounted: { try await waitForNavigationTarget(payload) }
+    )
+  }
+
   func waitForNavigationTarget(
     _ payload: DesktopAutomationNavigationRequest
   ) async throws -> DesktopAutomationSnapshot {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -162,14 +162,6 @@ struct DesktopAutomationSnapshot: Codable, Sendable {
   var snapshotStale: Bool = false
 }
 
-struct DesktopAutomationNavigationRequest: Codable {
-  let target: String
-  let settingsSection: String?
-  let highlightedSettingId: String?
-  let activateApp: Bool?
-  let settleMs: Int?
-}
-
 struct DesktopAutomationOpenConversationRequest: Codable {
   let conversationId: String
   let showTranscript: Bool?
@@ -583,7 +575,7 @@ private func liveAutomationSnapshotFromMainActor() async -> DesktopAutomationSna
   }
 }
 
-private func cachedAutomationSnapshot() async -> DesktopAutomationSnapshot {
+func cachedAutomationSnapshot() async -> DesktopAutomationSnapshot {
   var snapshot = DesktopAutomationStateStore.shared.current()
   snapshot.updatedAt = ISO8601DateFormatter().string(from: Date())
   return snapshot
@@ -3981,7 +3973,7 @@ final class DesktopAutomationBridge: @unchecked Sendable {
         let payload = try JSONDecoder().decode(
           DesktopAutomationNavigationRequest.self, from: request.body)
         try await dispatchNavigation(payload)
-        let snapshot = try await waitForNavigationTarget(payload)
+        let snapshot = try await navigationSnapshot(for: payload)
         try await sleepForAutomationSettle(payload.settleMs)
         return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
       } catch {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -106,6 +106,20 @@ enum ChatTranscriptWindow {
     Array(messages.suffix(maximumVisibleMessageCount))
   }
 
+  /// Duplicate detection only needs to inspect rows this surface can render.
+  /// Keeping the windowing at this boundary gives streaming body evaluations a
+  /// deterministic O(visible-window) work budget even when the journal grows.
+  static func visibleDuplicateIDs(in messages: [ChatMessage]) -> Set<String> {
+    duplicateIDs(inVisibleWindow: recentMessages(in: messages))
+  }
+
+  /// Deduplicates a window that the caller has already bounded. Keeping this
+  /// overload separate avoids copying the suffix twice when the transcript
+  /// body shares one visible snapshot with the lifecycle projection.
+  static func duplicateIDs(inVisibleWindow messages: [ChatMessage]) -> Set<String> {
+    ChatMessageDeduplicator.duplicateIDs(in: messages)
+  }
+
   static func allowsLoadingEarlier(for messages: [ChatMessage]) -> Bool {
     messages.count < maximumVisibleMessageCount
   }
@@ -163,12 +177,6 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// surface. Home uses zero because its ask bar fills the chat column.
   var timelineTrailingInset: CGFloat = ChatComposerLayout.pageMargin
   @ViewBuilder var welcomeContent: () -> WelcomeContent
-
-  /// IDs of messages that are near-duplicates of an earlier message in the same session.
-  /// Computed once per messages change to avoid O(n^2) per render.
-  private var duplicateMessageIds: Set<String> {
-    ChatMessageDeduplicator.duplicateIDs(in: messages)
-  }
 
   // MARK: - Scroll State
 
@@ -615,8 +623,12 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     } else if messages.isEmpty {
       welcomeContent()
     } else {
-      let dupeIds = duplicateMessageIds
-      let displayMessages = AgentLifecycleDisplayProjection.project(visibleTranscriptMessages)
+      // Streamed tokens re-evaluate this body. Take one bounded snapshot and
+      // share it with both projections so each token avoids another suffix
+      // copy and never scans history that cannot be rendered.
+      let visibleMessages = visibleTranscriptMessages
+      let dupeIds = ChatTranscriptWindow.duplicateIDs(inVisibleWindow: visibleMessages)
+      let displayMessages = AgentLifecycleDisplayProjection.project(visibleMessages)
       let finalAssistantMessageID = ChatOmiMarkPlacement.finalAssistantMessageID(in: displayMessages)
       ForEach(Array(displayMessages.enumerated()), id: \.element.id) { index, message in
         ChatBubble(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -34,9 +34,11 @@ extension SettingsContentView {
             Text("Notification Previews")
               .scaledFont(size: OmiType.subheading, weight: .semibold)
               .foregroundColor(OmiColors.textPrimary)
-            Text("Show assistant notifications under the Floating Bar. When off, notifications use macOS banners instead.")
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(OmiColors.textSecondary)
+            Text(
+              "Show assistant notifications under the Floating Bar. When off, notifications use macOS banners instead."
+            )
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(OmiColors.textSecondary)
           }
           Spacer()
           Toggle("", isOn: $shortcutSettings.floatingBarNotificationPreviewsEnabled)

--- a/desktop/macos/Desktop/Tests/ChatMessageDeduplicatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageDeduplicatorTests.swift
@@ -40,4 +40,30 @@ final class ChatMessageDeduplicatorTests: XCTestCase {
     let messages = [msg("1", "short repeated"), msg("2", "short repeated")]
     XCTAssertTrue(ChatMessageDeduplicator.duplicateIDs(in: messages).isEmpty)
   }
+
+  func testVisibleDuplicateWorkIsBoundedToRecentTranscriptWindow() {
+    let repeatedBody = sharedOpening + " repeated history body"
+    let oldMessages = (0..<(ChatTranscriptWindow.maximumVisibleMessageCount * 20)).map { index in
+      msg("old-\(index)", repeatedBody)
+    }
+    let visibleMessages = (0..<(ChatTranscriptWindow.maximumVisibleMessageCount - 1)).map { index in
+      msg("visible-\(index)", "visible \(index)")
+    }
+    let visibleDuplicate = msg(
+      "visible-duplicate",
+      sharedOpening + " visible duplicate body"
+    )
+    let visibleDuplicateCopy = msg(
+      "visible-duplicate-copy",
+      sharedOpening + " visible duplicate body"
+    )
+
+    let duplicates = ChatTranscriptWindow.visibleDuplicateIDs(
+      in: oldMessages + visibleMessages + [visibleDuplicate, visibleDuplicateCopy]
+    )
+
+    // The transcript renderer only displays the recent window, so streaming
+    // body updates must not spend work deduplicating rows that cannot appear.
+    XCTAssertEqual(duplicates, ["visible-duplicate-copy"])
+  }
 }

--- a/desktop/macos/Desktop/Tests/DesktopAutomationBridgeRouteTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationBridgeRouteTests.swift
@@ -80,6 +80,25 @@ final class DesktopAutomationBridgeRouteTests: XCTestCase {
     XCTAssertEqual(mountedCalls, 1)
   }
 
+  func testNavigationAcknowledgementRejectsUnknownTarget() async throws {
+    let unknownPayload = DesktopAutomationNavigationRequest(
+      target: "nonexistent-destination",
+      settingsSection: nil,
+      highlightedSettingId: nil,
+      activateApp: nil,
+      settleMs: nil,
+      waitForVisibility: false
+    )
+    do {
+      _ = try await DesktopAutomationBridge.shared.navigationSnapshot(for: unknownPayload)
+      XCTFail("unknown target must not return a cached acknowledgement")
+    } catch DesktopAutomationActionError.invalidParams(let message) {
+      XCTAssertEqual(message, "unknown_navigation_target")
+    } catch {
+      XCTFail("unknown target must be rejected with invalidParams, got: \(error)")
+    }
+  }
+
   func testUnauthenticatedHealthReportsBackendAndRuntimeProtocolIdentity() async throws {
     let response = await DesktopAutomationBridge.shared.response(
       for: DesktopAutomationHTTPRequest(

--- a/desktop/macos/Desktop/Tests/DesktopAutomationBridgeRouteTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationBridgeRouteTests.swift
@@ -17,6 +17,14 @@ private struct AutomationErrorEnvelope: Decodable {
   let error: String?
 }
 
+private actor NavigationWaitCallCounter {
+  private(set) var mountedCalls = 0
+
+  func recordMountedCall() {
+    mountedCalls += 1
+  }
+}
+
 @MainActor
 private final class StubPresentationCoordinator: DesktopAutomationPresentationCoordinating {
   private(set) var calls: [(target: DesktopAutomationPresentationTarget, gate: DesktopAutomationPresentationGate)] = []
@@ -40,6 +48,38 @@ private final class StubPresentationCoordinator: DesktopAutomationPresentationCo
 
 @MainActor
 final class DesktopAutomationBridgeRouteTests: XCTestCase {
+  func testNavigationAcknowledgementReturnsCachedRouteWithoutMountedWait() async throws {
+    let calls = NavigationWaitCallCounter()
+    let response = try await DesktopAutomationNavigationResponseMode.snapshot(
+      waitForVisibility: false,
+      cached: { "route-acknowledged" },
+      mounted: {
+        await calls.recordMountedCall()
+        return "mounted"
+      }
+    )
+
+    XCTAssertEqual(response, "route-acknowledged")
+    let mountedCalls = await calls.mountedCalls
+    XCTAssertEqual(mountedCalls, 0)
+  }
+
+  func testNavigationAcknowledgementDefaultsToMountedVisibilityWait() async throws {
+    let calls = NavigationWaitCallCounter()
+    let response = try await DesktopAutomationNavigationResponseMode.snapshot(
+      waitForVisibility: nil,
+      cached: { "route-acknowledged" },
+      mounted: {
+        await calls.recordMountedCall()
+        return "mounted"
+      }
+    )
+
+    XCTAssertEqual(response, "mounted")
+    let mountedCalls = await calls.mountedCalls
+    XCTAssertEqual(mountedCalls, 1)
+  }
+
   func testUnauthenticatedHealthReportsBackendAndRuntimeProtocolIdentity() async throws {
     let response = await DesktopAutomationBridge.shared.response(
       for: DesktopAutomationHTTPRequest(

--- a/desktop/macos/changelog/unreleased/20260803-chat-transcript-responsiveness.json
+++ b/desktop/macos/changelog/unreleased/20260803-chat-transcript-responsiveness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat transcript responsiveness during long streaming conversations and added safeguards that catch slow navigation and Ask Omi feedback"
+}

--- a/desktop/macos/e2e/flows/ask-omi-open-benchmark.yaml
+++ b/desktop/macos/e2e/flows/ask-omi-open-benchmark.yaml
@@ -1,7 +1,7 @@
-version: 1
+version: 2
 name: ask-omi-open-benchmark
 tier: 3
-description: Repeated cursor-free Ask Omi open timing for the floating pill.
+description: Repeated cursor-free Ask Omi input-feedback gate for the floating pill (100 ms maximum to open and focus).
 app: non-prod
 preconditions:
   - automation_bridge_ready
@@ -17,8 +17,12 @@ steps:
     bridge.action:
       name: open_ask_omi
       reset: true
+    expect:
+      result.detail.elapsedMs:
+        max: 100
     wait:
       state.askOmiOpen: true
+      state.askOmiFocused: true
 
   - id: S3
     name: Close Ask Omi 1
@@ -30,8 +34,12 @@ steps:
     bridge.action:
       name: open_ask_omi
       reset: true
+    expect:
+      result.detail.elapsedMs:
+        max: 100
     wait:
       state.askOmiOpen: true
+      state.askOmiFocused: true
 
   - id: S5
     name: Close Ask Omi 2
@@ -43,8 +51,12 @@ steps:
     bridge.action:
       name: open_ask_omi
       reset: true
+    expect:
+      result.detail.elapsedMs:
+        max: 100
     wait:
       state.askOmiOpen: true
+      state.askOmiFocused: true
 
   - id: S7
     name: Capture Ask Omi Visual
@@ -56,6 +68,7 @@ steps:
     name: Assert Ask Omi State
     state.expect:
       state.askOmiOpen: true
+      state.askOmiFocused: true
 
   - id: S9
     name: Assert Logs Are Clean

--- a/desktop/macos/e2e/flows/desktop-responsiveness-benchmark.yaml
+++ b/desktop/macos/e2e/flows/desktop-responsiveness-benchmark.yaml
@@ -1,10 +1,11 @@
-version: 1
+version: 2
 name: desktop-responsiveness-benchmark
 tier: 3
-description: Fast cursor-free timing for common desktop navigation interactions.
+description: Cursor-free input-to-route-ack gate for common desktop navigation interactions (100 ms maximum per route); default bridge navigation retains its mounted-visibility contract.
 app: non-prod
 preconditions:
   - automation_bridge_ready
+  - chat_first_cohort_named_bundle
 
 steps:
   - id: S1
@@ -12,72 +13,154 @@ steps:
     bridge.navigate:
       target: dashboard
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: more.dashboard
+  - id: S1a
+    name: Dashboard acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S2
     name: Conversations
     bridge.navigate:
       target: conversations
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 1
+      state.chatFirstRoute: conversations
+  - id: S2a
+    name: Conversations acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S3
     name: Chat
     bridge.navigate:
       target: chat
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 2
+      state.chatFirstRoute: chat
+  - id: S3a
+    name: Chat acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S4
     name: Memories
     bridge.navigate:
       target: memories
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 3
+      state.chatFirstRoute: memories
+  - id: S4a
+    name: Memories acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S5
     name: Tasks
     bridge.navigate:
       target: tasks
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 4
+      state.chatFirstRoute: tasks
+  - id: S5a
+    name: Tasks acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S6
     name: Rewind
     bridge.navigate:
       target: rewind
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 7
+      state.chatFirstRoute: more.rewind
+  - id: S6a
+    name: Rewind acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S7
     name: Apps
     bridge.navigate:
       target: apps
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 8
+      state.chatFirstRoute: more.apps
+  - id: S7a
+    name: Apps acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S8
     name: Settings
     bridge.navigate:
       target: settings
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 9
+      state.chatFirstRoute: more.settings
+  - id: S8a
+    name: Settings acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
 
   - id: S9
     name: Return to Dashboard
     bridge.navigate:
       target: dashboard
       activateApp: false
+      waitForVisibility: false
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: more.dashboard
+  - id: S9a
+    name: Return to Dashboard acknowledges input within 100 ms
+    trace.expect:
+      latest: true
+      trace.path: /navigate
+      trace.statusCode: 200
+      trace.durationMs:
+        max: 100
+
 
   - id: S10
     name: Assert Logs Are Clean

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -588,12 +588,13 @@ def assert_trace(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -
     if latest:
         # State waits commonly issue a follow-up /state request. Select the
         # newest trace for the exercised route rather than accidentally
-        # asserting on that bookkeeping request. Duration predicates are not
-        # selectors: they remain the threshold being tested.
+        # asserting on that bookkeeping request. Select by route identity only
+        # (path + method); status and duration remain assertion predicates so a
+        # failed latest response can never be hidden by an earlier success.
         selector = {
             key: value
             for key, value in expectations.items()
-            if key in {"trace.path", "trace.method", "trace.statusCode"}
+            if key in {"trace.path", "trace.method"}
             and not isinstance(value, dict)
         }
         matching = [trace for trace in traces if expectation_matches({"trace": trace}, selector)]

--- a/desktop/macos/scripts/omi-harness
+++ b/desktop/macos/scripts/omi-harness
@@ -576,12 +576,33 @@ def assert_log(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -> 
 def assert_trace(ctx: HarnessContext, spec: dict[str, typing.Any], path: Path) -> tuple[bool, str | None]:
     traces = recent_traces(ctx)
     write_json(path, traces)
-    expectations = spec.get("equals") or spec
+    # A responsiveness assertion must apply to the route just exercised, not
+    # a faster matching route left over from an earlier loop iteration.
+    # `latest` is intentionally a harness-only selector, never a trace field.
+    latest = spec.get("latest", False)
+    if not isinstance(latest, bool):
+        return False, "trace.expect latest must be a boolean"
+    expectations = spec.get("equals") or {key: value for key, value in spec.items() if key != "latest"}
     if not isinstance(expectations, dict):
         return False, "trace.expect requires a mapping"
-    if any(expectation_matches({"trace": trace}, expectations) for trace in traces):
+    if latest:
+        # State waits commonly issue a follow-up /state request. Select the
+        # newest trace for the exercised route rather than accidentally
+        # asserting on that bookkeeping request. Duration predicates are not
+        # selectors: they remain the threshold being tested.
+        selector = {
+            key: value
+            for key, value in expectations.items()
+            if key in {"trace.path", "trace.method", "trace.statusCode"}
+            and not isinstance(value, dict)
+        }
+        matching = [trace for trace in traces if expectation_matches({"trace": trace}, selector)]
+        candidates = matching[-1:] if matching else traces[-1:]
+    else:
+        candidates = traces
+    if any(expectation_matches({"trace": trace}, expectations) for trace in candidates):
         return True, None
-    reasons = [expectation_mismatches({"trace": trace}, expectations) for trace in traces]
+    reasons = [expectation_mismatches({"trace": trace}, expectations) for trace in candidates]
     return False, f"no trace matched: expectations={expectations}, mismatches={reasons}"
 
 

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -114,6 +114,30 @@ with tempfile.TemporaryDirectory() as directory:
         trace_context, {"latest": True, "trace.path": "/navigate", "trace.durationMs": {"max": 100}}, trace_artifact
     )
     assert ok, error
+module.recent_traces = lambda _ctx: [
+    {"path": "/navigate", "method": "POST", "statusCode": 200, "durationMs": 12},
+    {"path": "/navigate", "method": "POST", "statusCode": 500, "durationMs": 8},
+    {"path": "/state", "method": "GET", "statusCode": 200, "durationMs": 4},
+]
+with tempfile.TemporaryDirectory() as directory:
+    trace_artifact = Path(directory) / "traces.json"
+    # The latest /navigate returned 500. The selector must NOT filter it out,
+    # so statusCode: 200 must fail on the newest matching route trace.
+    ok, error = module.assert_trace(
+        trace_context,
+        {"latest": True, "trace.path": "/navigate", "trace.method": "POST", "trace.statusCode": 200, "trace.durationMs": {"max": 100}},
+        trace_artifact,
+    )
+    assert not ok, "latest failed trace must not be hidden by an earlier success"
+    # Duration alone should also fail because the latest trace is the 500 (8ms),
+    # not the earlier 200 (12ms) — the selector must pick the newest by identity.
+    ok, error = module.assert_trace(
+        trace_context,
+        {"latest": True, "trace.path": "/navigate", "trace.method": "POST", "trace.durationMs": {"max": 100}},
+        trace_artifact,
+    )
+    assert ok, error
+
 module.recent_traces = original_recent_traces
 
 mismatch = module.expectation_mismatches(

--- a/desktop/macos/tests/test-omi-harness.sh
+++ b/desktop/macos/tests/test-omi-harness.sh
@@ -77,6 +77,45 @@ assert not module.expectation_matches(
     {"result.error_message": {"contains": "HTTP 500"}},
 )
 
+trace_context = module.HarnessContext(
+    base_url="http://127.0.0.1:59999",
+    flow_path=Path("flow.yaml"),
+    run_dir=Path("runs"),
+    steps_dir=Path("runs/steps"),
+    lane="bridge",
+    log_path=Path("/private/tmp/omi/harness-test.log"),
+    log_start=0,
+    bundle_id=None,
+    process_match=None,
+)
+original_recent_traces = module.recent_traces
+module.recent_traces = lambda _ctx: [
+    {"path": "/navigate", "durationMs": 12},
+    {"path": "/navigate", "durationMs": 145},
+    {"path": "/state", "durationMs": 4},
+]
+with tempfile.TemporaryDirectory() as directory:
+    trace_artifact = Path(directory) / "traces.json"
+    ok, error = module.assert_trace(
+        trace_context, {"latest": True, "trace.path": "/navigate", "trace.durationMs": {"max": 100}}, trace_artifact
+    )
+    assert not ok and "145" in error, error
+    ok, error = module.assert_trace(
+        trace_context, {"trace.path": "/navigate", "trace.durationMs": {"max": 100}}, trace_artifact
+    )
+    assert ok, error
+module.recent_traces = lambda _ctx: [
+    {"path": "/navigate", "durationMs": 12},
+    {"path": "/state", "durationMs": 4},
+]
+with tempfile.TemporaryDirectory() as directory:
+    trace_artifact = Path(directory) / "traces.json"
+    ok, error = module.assert_trace(
+        trace_context, {"latest": True, "trace.path": "/navigate", "trace.durationMs": {"max": 100}}, trace_artifact
+    )
+    assert ok, error
+module.recent_traces = original_recent_traces
+
 mismatch = module.expectation_mismatches(
     {"result": {"count": "1"}}, {"result.count": {"minimum": 1}}
 )["result.count"]


### PR DESCRIPTION
## Summary

- Add repeatable non-production responsiveness gates for Chat-first navigation and Ask Omi, with per-interaction 100 ms acknowledgement or open-and-focus budgets
- Preserve the existing mounted-visibility `/navigate` contract by default while allowing the benchmark to measure acknowledgement separately
- Bound transcript duplicate detection to the 500 rows that can render, avoiding unbounded history work on streamed-token body updates

## Why

Long chat histories were scanned again during SwiftUI transcript updates, and the desktop harness could not reliably distinguish navigation acknowledgement from destination mounting. This made input-latency evidence incomplete and let follow-up `/state` bookkeeping obscure the measured route trace.

## Validation

- `bash desktop/macos/tests/test-omi-harness.sh`
- `python3 desktop/macos/scripts/check_desktop_test_quality.py`
- `/Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python desktop/macos/scripts/desktop-flow-lint.py`
- `xcrun swift test --package-path Desktop --filter 'ChatMessageDeduplicatorTests|DesktopAutomationBridgeRouteTests'`
- `OMI_APP_NAME=omi-ui-responsiveness ./run.sh --yolo --fast-only --no-wait`
- Live named-bundle runs: navigation 5/5 and Ask Omi 5/5 passed on `com.omi.omi-ui-responsiveness` (automation port 47831)
- `make preflight`

## UX review

Independent Sol review approved the final diff. It confirmed no interaction or accessibility regression from visible-window deduplication and verified the acknowledgement-vs-mounted semantics and Ask Omi end-to-end focus gate.

## Product invariants affected

- INV-CHAT-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
