### PR TITLE
feat(memory): add governed bulk legacy backfill automation

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -4,7 +4,7 @@
     "backend/utils/conversations/process_conversation.py": 1971,
     "backend/utils/memory/canonical_consolidation.py": 1935,
     "backend/utils/memory/canonical_memory_adapter.py": 2012,
-    "backend/utils/memory/legacy_backfill.py": 1723,
+    "backend/utils/memory/legacy_backfill.py": 1753,
     "backend/utils/memory_ingestion/pipeline.py": 1711,
     "backend/utils/other/storage.py": 1587,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
@@ -16,7 +16,8 @@
     "backend/utils/memory/canonical_consolidation.py": "Candidate selection, bounded retry leases, atomic promotion planning, and batch-level duplicate-supersede rejection remain one canonical long-term admission authority; extracting them would permit competing admission state machines (FC-split-mutation-authority).",
     "backend/utils/memory/canonical_memory_adapter.py": "Canonical conversation replacement coordinates source-generation fencing, bounded lineage discovery, and atomic replacement application; splitting this state machine would duplicate lifecycle authority (FC-split-mutation-authority).",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873); the deletion purge path additionally records bounded storage wipe counters for telemetry.",
-    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator."
+    "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator.",
+    "backend/utils/memory/legacy_backfill.py": "Public inventory wrappers for bulk backfill without exposing private helpers; keep one backfill module."
   },
   "threshold": 1500
 }

--- a/backend/database/memory_collections.py
+++ b/backend/database/memory_collections.py
@@ -36,6 +36,10 @@ class MemoryCollections:
         return f"{self.user_root}/memory_control/state"
 
     @property
+    def legacy_canonical_backfill_checkpoint(self) -> str:
+        return f"{self.user_root}/memory_control/legacy_canonical_backfill"
+
+    @property
     def memory_apply_control_state(self) -> str:
         return f"{self.user_root}/memory_state/apply_control"
 

--- a/backend/scripts/bulk_backfill_legacy_memories.py
+++ b/backend/scripts/bulk_backfill_legacy_memories.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Inventory or apply a governed multi-user legacy-memory migration.
+
+LIFECYCLE: permanent
+
+Dry-run is the default. Apply mode is deliberately write-only: it enrolls
+control docs at ``stage=write`` and stages canonical admission candidates, but
+never edits the code-owned cohort, enables canonical reads, invokes L2, or
+promotes memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from google.cloud import firestore
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from database.google_credentials import prepare_google_credentials
+from scripts.enroll_canonical_memory_user import apply_documents, build_rollout_documents
+from utils.memory.bulk_legacy_backfill import (
+    BulkMigrationConfig,
+    FirestoreCheckpointStore,
+    read_global_pause,
+    run_bulk_migration,
+)
+from utils.memory.legacy_backfill import backfill_user, backfill_user_bucketed
+from utils.memory.legacy_backfill_inventory import inventory_legacy_user
+
+APPLY_CONFIRMATION = "bulk-canonical-memory-backfill"
+WRITABLE_BUCKET_CHOICES = ("manual_required_promotion", "reviewed_long_term")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inventory or apply governed legacy-to-canonical memory migration for multiple UIDs"
+    )
+    parser.add_argument("--uid", action="append", default=[], help="Firebase UID; repeat for multiple users")
+    parser.add_argument(
+        "--uid-file",
+        type=Path,
+        help="UTF-8 newline-delimited UIDs or a JSON array of UID strings",
+    )
+    parser.add_argument("--firestore-project", required=True, help="Explicit Firestore data-plane project")
+    parser.add_argument("--apply", action="store_true", help="Apply enrollment and staging writes")
+    parser.add_argument(
+        "--confirm-apply",
+        help=f"Required with --apply; must be exactly {APPLY_CONFIRMATION!r}",
+    )
+    parser.add_argument(
+        "--confirm-user-count",
+        type=int,
+        help="Required with --apply; must equal the deduplicated input UID count",
+    )
+    parser.add_argument(
+        "--allow-existing-update",
+        action="store_true",
+        help="Acknowledge merge-updating existing differing enrollment control docs",
+    )
+    parser.add_argument(
+        "--allow-admin-override",
+        action="store_true",
+        help="Stage UIDs outside CANONICAL_MEMORY_USERS (requires the second override acknowledgement)",
+    )
+    parser.add_argument(
+        "--i-understand-uids-not-whitelisted",
+        action="store_true",
+        help="Second acknowledgement required with --allow-admin-override",
+    )
+    parser.add_argument("--account-generation", type=int, default=1)
+    parser.add_argument("--owner", default="memory_platform")
+    parser.add_argument("--operator-context", default=None)
+    parser.add_argument("--batch-size", type=int, default=50)
+    parser.add_argument("--max-users-per-run", type=int, default=10)
+    parser.add_argument("--max-admitted-rows-per-user", type=int, default=100)
+    parser.add_argument("--max-estimated-tokens-per-run", type=int, default=100_000)
+    parser.add_argument("--wall-clock-seconds", type=float)
+    parser.add_argument("--concurrency-limit", type=int, default=1)
+    parser.add_argument(
+        "--process-bucket",
+        action="append",
+        choices=WRITABLE_BUCKET_CHOICES,
+        default=[],
+        help="Optionally upgrade a reviewed writable bucket after staging; repeatable",
+    )
+    return parser
+
+
+def _read_uid_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    stripped = text.strip()
+    if not stripped:
+        return []
+    if stripped.startswith("["):
+        payload = json.loads(stripped)
+        if not isinstance(payload, list) or not all(isinstance(uid, str) for uid in payload):
+            raise ValueError("--uid-file JSON must be an array of strings")
+        return payload
+    return [line.strip() for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def _deduplicate_uids(uids: list[str]) -> list[str]:
+    return list(dict.fromkeys(uid.strip() for uid in uids if uid.strip()))
+
+
+def _load_uids(args: argparse.Namespace) -> list[str]:
+    uids = list(args.uid)
+    if args.uid_file is not None:
+        uids.extend(_read_uid_file(args.uid_file))
+    return _deduplicate_uids(uids)
+
+
+def _validate_apply_flags(args: argparse.Namespace, uids: list[str]) -> None:
+    if not uids:
+        raise ValueError("at least one --uid or --uid-file entry is required")
+    if not args.apply:
+        return
+    if args.confirm_apply != APPLY_CONFIRMATION:
+        raise ValueError(f"--confirm-apply must be exactly {APPLY_CONFIRMATION!r}")
+    if args.confirm_user_count != len(uids):
+        raise ValueError("--confirm-user-count must equal the deduplicated input UID count")
+    if args.allow_admin_override != args.i_understand_uids_not_whitelisted:
+        raise ValueError("--allow-admin-override and --i-understand-uids-not-whitelisted must be supplied together")
+
+
+def _load_firestore_client(*, firestore_project: str) -> Any:
+    prepare_google_credentials()
+    return firestore.Client(project=firestore_project)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        uids = _load_uids(args)
+        _validate_apply_flags(args, uids)
+        config = BulkMigrationConfig(
+            dry_run=not args.apply,
+            max_users_per_run=args.max_users_per_run,
+            max_admitted_rows_per_user=args.max_admitted_rows_per_user,
+            max_estimated_tokens_per_run=args.max_estimated_tokens_per_run,
+            wall_clock_seconds=args.wall_clock_seconds,
+            concurrency_limit=args.concurrency_limit,
+            process_buckets=tuple(args.process_bucket),
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+
+    db_client = _load_firestore_client(firestore_project=args.firestore_project)
+    operator_context = args.operator_context or getpass.getuser()
+
+    def inventory_fn(uid: str):
+        return inventory_legacy_user(uid, db_client=db_client)
+
+    def enroll_fn(uid: str) -> None:
+        # Global read/write gates are rollout-wide controls, not per-user bulk
+        # enrollment state. Leave them untouched; only the user-owned control
+        # document is safe to apply repeatedly across a cohort.
+        documents = [
+            document
+            for document in build_rollout_documents(
+                uid=uid,
+                stage="write",
+                account_generation=args.account_generation,
+                owner=args.owner,
+            )
+            if document.path.startswith(f"users/{uid}/")
+        ]
+        apply_documents(db_client, documents, allow_existing_update=args.allow_existing_update)
+
+    def backfill_fn(uid: str, max_rows: int, resume: bool, stop_requested):
+        return backfill_user(
+            uid,
+            dry_run=False,
+            batch_size=args.batch_size,
+            resume=resume,
+            max_rows=max_rows,
+            continue_on_error=True,
+            stop_requested=stop_requested,
+            allow_admin_override=args.allow_admin_override,
+            acknowledge_non_canonical_uid=args.i_understand_uids_not_whitelisted,
+            operator_context=operator_context,
+            db_client=db_client,
+        )
+
+    def bucket_process_fn(uid: str, bucket: str, max_rows: int, stop_requested):
+        del max_rows, stop_requested  # orchestrator admits only buckets that fit the remaining row budget
+        return backfill_user_bucketed(
+            uid,
+            bucket=bucket,
+            dry_run=False,
+            allow_admin_override=args.allow_admin_override,
+            acknowledge_non_canonical_uid=args.i_understand_uids_not_whitelisted,
+            operator_context=operator_context,
+            db_client=db_client,
+        )
+
+    summary = run_bulk_migration(
+        uids,
+        config=config,
+        inventory_fn=inventory_fn,
+        pause_fn=lambda: read_global_pause(db_client),
+        checkpoint_store=FirestoreCheckpointStore(db_client) if args.apply else None,
+        enroll_fn=enroll_fn if args.apply else None,
+        backfill_fn=backfill_fn if args.apply else None,
+        bucket_process_fn=bucket_process_fn if args.apply else None,
+    )
+    payload = summary.to_dict()
+    payload["artifact"] = "bulk_legacy_canonical_memory_migration"
+    payload["firestore_project"] = args.firestore_project
+    payload["cohort_patch_suggestion"] = {
+        "config": "backend/config/canonical_memory_cohort.py",
+        "uids": uids,
+        "applied": False,
+    }
+    payload["ownership"] = {
+        "staging": "this CLI",
+        "l2_and_promotion": "memory-maintenance-job",
+        "read_flip": "explicit later operator action",
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+    return 1 if summary.failed_user_count else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -119,12 +119,25 @@
     {
       "id": "legacy_memory_backfill",
       "risk": "high",
-      "sources": ["backend/utils/memory/legacy_backfill.py", "backend/scripts/backfill_legacy_memories.py"],
-      "tests": ["tests/unit/test_ws_c_backfill.py"],
+      "sources": [
+        "backend/utils/memory/legacy_backfill.py",
+        "backend/utils/memory/legacy_backfill_bulk_support.py",
+        "backend/utils/memory/legacy_backfill_inventory.py",
+        "backend/utils/memory/bulk_legacy_backfill.py",
+        "backend/scripts/backfill_legacy_memories.py",
+        "backend/scripts/bulk_backfill_legacy_memories.py"
+      ],
+      "tests": [
+        "tests/unit/test_ws_c_backfill.py",
+        "tests/unit/test_bulk_legacy_backfill.py",
+        "tests/unit/test_bulk_backfill_legacy_memories_cli.py"
+      ],
       "checks": ["no_large_tuple_results"],
       "invariants": [
         "completed checkpoints recognize required-processing and quarantined pending-admission destinations without derived side effects",
         "partial checkpoints resume idempotently",
+        "bulk runs stop at user, row, token, pause, and wall-clock governors without enabling reads",
+        "bulk inventory and structured summaries never return raw memory content",
         "legacy/domain timestamps are preserved while rows await required processing",
         "unreviewed bulk legacy rows remain hidden pending-admission candidates",
         "legacy rows never reach long-term, vector, keyword, or KG without processing admission"

--- a/backend/tests/unit/test_bulk_backfill_legacy_memories_cli.py
+++ b/backend/tests/unit/test_bulk_backfill_legacy_memories_cli.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = BACKEND_DIR / "scripts" / "bulk_backfill_legacy_memories.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("bulk_backfill_legacy_memories", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script()
+
+
+class _Snapshot:
+    exists = False
+
+    def to_dict(self):
+        return None
+
+
+class _Document:
+    def __init__(self, db, path):
+        self._db = db
+        self._path = path
+
+    def get(self):
+        self._db.reads.append(self._path)
+        return _Snapshot()
+
+    def set(self, payload, merge=False):
+        self._db.writes.append((self._path, payload, merge))
+
+
+class _Db:
+    def __init__(self):
+        self.reads = []
+        self.writes = []
+
+    def document(self, path):
+        return _Document(self, path)
+
+
+def test_dry_run_cli_uses_offline_fake_and_emits_redacted_json(script, monkeypatch, capsys):
+    db = _Db()
+    secret_content = "the user's raw secret memory"
+    monkeypatch.setattr(script, "_load_firestore_client", lambda **_: db)
+    monkeypatch.setattr(
+        script,
+        "inventory_legacy_user",
+        lambda uid, **_: LegacyBackfillInventoryReport(
+            uid=uid,
+            source_count=3,
+            bucket_counts={"manual_required_promotion": 2, "hold_sensitive": 1},
+            admitted_candidate_count=2,
+            content_character_count=len(secret_content),
+            estimated_tokens=8,
+            admitted_candidate_estimated_tokens=6,
+        ),
+    )
+
+    exit_code = script.main(
+        [
+            "--uid",
+            "uid-a",
+            "--firestore-project",
+            "offline-test-project",
+            "--max-users-per-run",
+            "1",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert exit_code == 0
+    assert payload["dry_run"] is True
+    assert payload["users"][0]["actions"] == [
+        "would_enroll_write_only",
+        "would_stage_all_for_admission",
+    ]
+    assert secret_content not in output
+    assert db.writes == []
+    assert db.reads == ["memory_control/legacy_canonical_backfill_pause"]
+
+
+def test_apply_cli_requires_both_bulk_confirmations(script, capsys):
+    try:
+        script.main(
+            [
+                "--uid",
+                "uid-a",
+                "--firestore-project",
+                "offline-test-project",
+                "--apply",
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("unsafe apply flags unexpectedly accepted")
+
+    assert "--confirm-apply must be exactly" in capsys.readouterr().err

--- a/backend/tests/unit/test_bulk_legacy_backfill.py
+++ b/backend/tests/unit/test_bulk_legacy_backfill.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import Barrier, Lock
+
+import pytest
+
+from utils.memory.bulk_legacy_backfill import (
+    BulkMigrationConfig,
+    MigrationCheckpoint,
+    MigrationState,
+    PauseDecision,
+    read_global_pause,
+    run_bulk_migration,
+    validate_checkpoint_transition,
+)
+from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
+
+
+@dataclass(frozen=True)
+class _BackfillReport:
+    written_count: int = 1
+    skipped_already_present: int = 0
+    skipped_both_store_duplicate: int = 0
+    destination_count: int = 1
+    intended_count: int = 1
+    legacy_rows_touched: int = 1
+    completed: bool = True
+    verified: bool = True
+    cohort_gated: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+class _CheckpointStore:
+    def __init__(self):
+        self.checkpoints: dict[str, MigrationCheckpoint] = {}
+        self.lock = Lock()
+
+    def read(self, uid: str) -> MigrationCheckpoint:
+        with self.lock:
+            return self.checkpoints.get(uid, MigrationCheckpoint(uid=uid))
+
+    def write(self, checkpoint: MigrationCheckpoint) -> None:
+        with self.lock:
+            current = self.checkpoints.get(checkpoint.uid, MigrationCheckpoint(uid=checkpoint.uid))
+            validate_checkpoint_transition(current.state, checkpoint.state)
+            self.checkpoints[checkpoint.uid] = checkpoint
+
+
+def _inventory(uid: str, *, candidates: int = 2, tokens: int = 20) -> LegacyBackfillInventoryReport:
+    return LegacyBackfillInventoryReport(
+        uid=uid,
+        source_count=candidates + 1,
+        bucket_counts={"manual_required_promotion": candidates, "hold_sensitive": 1},
+        admitted_candidate_count=candidates,
+        content_character_count=tokens * 6,
+        estimated_tokens=tokens + 10,
+        admitted_candidate_estimated_tokens=tokens,
+    )
+
+
+def test_checkpoint_state_machine_rejects_regressions_and_read_ready_mutation():
+    validate_checkpoint_transition(MigrationState.not_started, MigrationState.inventory_done)
+    validate_checkpoint_transition(MigrationState.processing, MigrationState.staged)
+    validate_checkpoint_transition(MigrationState.staged, MigrationState.processing)
+    validate_checkpoint_transition(MigrationState.failed, MigrationState.processing)
+
+    with pytest.raises(ValueError, match="inventory_done -> not_started"):
+        validate_checkpoint_transition(MigrationState.inventory_done, MigrationState.not_started)
+    with pytest.raises(ValueError, match="read_ready -> processing"):
+        validate_checkpoint_transition(MigrationState.read_ready, MigrationState.processing)
+
+
+def test_malformed_checkpoint_counts_fail_closed_to_zero():
+    checkpoint = MigrationCheckpoint.from_payload(
+        "uid-a",
+        {
+            "state": "unexpected",
+            "source_count": "not-a-number",
+            "bucket_counts": {"hold_sensitive": "bad"},
+        },
+    )
+
+    assert checkpoint.state == MigrationState.failed
+    assert checkpoint.source_count == 0
+    assert checkpoint.bucket_counts == {"hold_sensitive": 0}
+
+
+def test_dry_run_token_governor_stops_before_over_budget_user_without_callbacks():
+    callback_calls: list[str] = []
+    inventories = {"uid-a": _inventory("uid-a", tokens=60), "uid-b": _inventory("uid-b", tokens=60)}
+
+    def unused_backfill(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        callback_calls.append(f"backfill:{uid}")
+        return _BackfillReport()
+
+    summary = run_bulk_migration(
+        ["uid-a", "uid-b"],
+        config=BulkMigrationConfig(max_estimated_tokens_per_run=100),
+        inventory_fn=inventories.__getitem__,
+        enroll_fn=lambda uid: callback_calls.append(f"enroll:{uid}"),
+        backfill_fn=unused_backfill,
+    )
+
+    assert summary.dry_run is True
+    assert summary.stopped_reason == "max_estimated_tokens_per_run"
+    assert summary.selected_user_count == 1
+    assert summary.estimated_tokens == 60
+    assert [user.state for user in summary.users] == [MigrationState.inventory_done, MigrationState.paused]
+    assert callback_calls == []
+
+
+def test_user_governor_limits_inventory_to_configured_count():
+    inventoried: list[str] = []
+
+    def inventory(uid: str) -> LegacyBackfillInventoryReport:
+        inventoried.append(uid)
+        return _inventory(uid)
+
+    summary = run_bulk_migration(
+        ["uid-a", "uid-b", "uid-c"],
+        config=BulkMigrationConfig(max_users_per_run=2),
+        inventory_fn=inventory,
+    )
+
+    assert summary.stopped_reason == "max_users_per_run"
+    assert summary.selected_user_count == 2
+    assert inventoried == ["uid-a", "uid-b"]
+
+
+def test_global_pause_env_and_read_failure_both_fail_closed():
+    assert read_global_pause(object(), env={"MEMORY_BULK_BACKFILL_PAUSED": "true"}) == PauseDecision(
+        True, "paused_by_env"
+    )
+
+    class _FailingDb:
+        def document(self, path):
+            raise RuntimeError("unavailable")
+
+    assert read_global_pause(_FailingDb(), env={}) == PauseDecision(True, "pause_check_failed")
+
+
+def test_apply_is_idempotent_across_multiple_uids_and_skips_read_ready_reentry():
+    store = _CheckpointStore()
+    calls: list[str] = []
+
+    def enroll(uid: str) -> None:
+        calls.append(f"enroll:{uid}")
+
+    def backfill(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        calls.append(f"backfill:{uid}:{cap}:{resume}")
+        return _BackfillReport(written_count=2, intended_count=2, legacy_rows_touched=2)
+
+    config = BulkMigrationConfig(
+        dry_run=False,
+        max_admitted_rows_per_user=5,
+        concurrency_limit=2,
+    )
+    first = run_bulk_migration(
+        ["uid-a", "uid-b", "uid-a"],
+        config=config,
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=enroll,
+        backfill_fn=backfill,
+    )
+    calls_after_first = list(calls)
+    second = run_bulk_migration(
+        ["uid-a", "uid-b"],
+        config=config,
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=enroll,
+        backfill_fn=backfill,
+    )
+
+    assert first.read_ready_count == 2
+    assert second.read_ready_count == 2
+    assert calls == calls_after_first
+    assert all(checkpoint.state == MigrationState.read_ready for checkpoint in store.checkpoints.values())
+
+
+def test_row_cap_pauses_cleanly_and_resume_reaches_read_ready():
+    store = _CheckpointStore()
+    reports = iter(
+        [
+            _BackfillReport(written_count=1, intended_count=1, completed=False, verified=False),
+            _BackfillReport(written_count=1, intended_count=1, completed=True, verified=True),
+        ]
+    )
+
+    def backfill(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        assert cap == 1
+        return next(reports)
+
+    config = BulkMigrationConfig(dry_run=False, max_admitted_rows_per_user=1)
+    first = run_bulk_migration(
+        ["uid-a"],
+        config=config,
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=backfill,
+    )
+    second = run_bulk_migration(
+        ["uid-a"],
+        config=config,
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=backfill,
+    )
+
+    assert first.stopped_reason is None
+    assert first.paused_user_count == 1
+    assert first.users[0].error_codes == ("max_admitted_rows_per_user",)
+    assert second.read_ready_count == 1
+    assert store.checkpoints["uid-a"].state == MigrationState.read_ready
+
+
+def test_pause_is_checked_between_enrollment_and_staging():
+    store = _CheckpointStore()
+    decisions = iter([PauseDecision(False), PauseDecision(False), PauseDecision(True, "paused_by_firestore")])
+    backfill_calls: list[str] = []
+
+    def unused_backfill(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        backfill_calls.append(uid)
+        return _BackfillReport()
+
+    summary = run_bulk_migration(
+        ["uid-a"],
+        config=BulkMigrationConfig(dry_run=False),
+        inventory_fn=lambda uid: _inventory(uid),
+        pause_fn=lambda: next(decisions),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=unused_backfill,
+    )
+
+    assert summary.paused_user_count == 1
+    assert summary.users[0].error_codes == ("paused_by_firestore",)
+    assert store.checkpoints["uid-a"].state == MigrationState.paused
+    assert store.checkpoints["uid-a"].resume_state == MigrationState.enrolled
+    assert backfill_calls == []
+
+
+def test_wall_clock_stop_is_forwarded_to_row_worker_and_checkpoints_pause():
+    store = _CheckpointStore()
+    clock_values = iter([0.0, 0.0, 0.0, 0.0, 2.0, 2.0])
+
+    def backfill(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        assert stop() is True
+        return _BackfillReport(written_count=0, intended_count=0, completed=False, verified=False)
+
+    summary = run_bulk_migration(
+        ["uid-a"],
+        config=BulkMigrationConfig(dry_run=False, wall_clock_seconds=1.0),
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=backfill,
+        monotonic_fn=lambda: next(clock_values),
+    )
+
+    assert summary.paused_user_count == 1
+    assert summary.users[0].error_codes == ("wall_clock_seconds",)
+    assert store.checkpoints["uid-a"].last_error_code == "wall_clock_seconds"
+
+
+def test_requested_bucket_processing_waits_for_row_budget_then_resumes():
+    store = _CheckpointStore()
+    stage_reports = iter(
+        [
+            _BackfillReport(written_count=2, destination_count=2, intended_count=2),
+            _BackfillReport(written_count=0, destination_count=2, intended_count=0),
+        ]
+    )
+    bucket_calls: list[str] = []
+
+    def stage(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        return next(stage_reports)
+
+    def process_bucket(uid: str, bucket: str, cap: int, stop) -> _BackfillReport:
+        bucket_calls.append(f"{uid}:{bucket}:{cap}")
+        return _BackfillReport(
+            written_count=0,
+            destination_count=2,
+            intended_count=2,
+            legacy_rows_touched=2,
+        )
+
+    config = BulkMigrationConfig(
+        dry_run=False,
+        max_admitted_rows_per_user=2,
+        process_buckets=("manual_required_promotion",),
+    )
+    first = run_bulk_migration(
+        ["uid-a"],
+        config=config,
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=stage,
+        bucket_process_fn=process_bucket,
+    )
+    second = run_bulk_migration(
+        ["uid-a"],
+        config=config,
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=stage,
+        bucket_process_fn=process_bucket,
+    )
+
+    assert first.paused_user_count == 1
+    assert "bucket_processing_deferred_row_cap" in first.users[0].actions
+    assert bucket_calls == ["uid-a:manual_required_promotion:2"]
+    assert second.read_ready_count == 1
+
+
+def test_checkpoint_worker_failure_isolated_from_other_uids():
+    class _FailOneStore(_CheckpointStore):
+        def write(self, checkpoint: MigrationCheckpoint) -> None:
+            if checkpoint.uid == "uid-a":
+                raise RuntimeError("checkpoint unavailable")
+            super().write(checkpoint)
+
+    store = _FailOneStore()
+    summary = run_bulk_migration(
+        ["uid-a", "uid-b"],
+        config=BulkMigrationConfig(dry_run=False, concurrency_limit=2),
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=lambda uid, cap, resume, stop: _BackfillReport(),
+    )
+
+    assert summary.failed_user_count == 1
+    assert summary.read_ready_count == 1
+    assert summary.users[0].error_codes == ("checkpoint_or_worker_failed",)
+    assert summary.users[1].state == MigrationState.read_ready
+
+
+def test_apply_user_concurrency_never_exceeds_configured_limit():
+    store = _CheckpointStore()
+    first_wave = Barrier(2)
+    counters = {"active": 0, "maximum": 0}
+    counter_lock = Lock()
+
+    def backfill(uid: str, cap: int, resume: bool, stop) -> _BackfillReport:
+        with counter_lock:
+            counters["active"] += 1
+            counters["maximum"] = max(counters["maximum"], counters["active"])
+        if uid in {"uid-a", "uid-b"}:
+            first_wave.wait(timeout=2)
+        with counter_lock:
+            counters["active"] -= 1
+        return _BackfillReport()
+
+    summary = run_bulk_migration(
+        ["uid-a", "uid-b", "uid-c"],
+        config=BulkMigrationConfig(dry_run=False, max_users_per_run=3, concurrency_limit=2),
+        inventory_fn=lambda uid: _inventory(uid),
+        checkpoint_store=store,
+        enroll_fn=lambda uid: None,
+        backfill_fn=backfill,
+    )
+
+    assert summary.read_ready_count == 3
+    assert counters["maximum"] == 2

--- a/backend/tests/unit/test_inv_mem_1_guard.py
+++ b/backend/tests/unit/test_inv_mem_1_guard.py
@@ -52,6 +52,8 @@ _ALLOWED_MEMORY_COLLECTIONS_PROPERTIES = frozenset(
         "memory_source_replacements",
         "memory_outbox",
         "memory_control_state",
+        # Migration checkpoint under memory_control (not a product-memory tier store).
+        "legacy_canonical_backfill_checkpoint",
         "memory_apply_control_state",
         "memory_lineage",
         "memory_evidence",

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -50,6 +50,9 @@ def _ws_c_import_isolation():
     module_globals["apply_legacy_backfill_remediation_archives"] = apply_legacy_backfill_remediation_archives
     module_globals["build_legacy_backfill_remediation_plan"] = build_legacy_backfill_remediation_plan
     module_globals["classify_legacy_backfill_bucket"] = classify_legacy_backfill_bucket
+    from utils.memory.legacy_backfill_inventory import inventory_legacy_user
+
+    module_globals["inventory_legacy_user"] = inventory_legacy_user
     module_globals["is_active_legacy_row"] = is_active_legacy_row
     module_globals["legacy_backfill_memory_id"] = legacy_backfill_memory_id
     module_globals["reconcile_backfill_counts"] = reconcile_backfill_counts
@@ -491,6 +494,100 @@ def test_dry_run_writes_nothing(_trusted_account):
     assert not any(path.startswith(f"users/{LEGACY_UID}/memory_items/") for path in db.docs)
     assert get_non_filtered_fn(LEGACY_UID, limit=10, offset=0) == rows
     assert active_snapshot == rows
+
+
+def test_bulk_inventory_is_read_only_and_never_returns_content(_trusted_account):
+    rows = [
+        _legacy_row(legacy_id="leg-manual", content="User keeps a private launch checklist"),
+        _legacy_row(legacy_id="leg-sensitive", content="User secret token must never be logged"),
+    ]
+    rows[0]["manually_added"] = True
+    get_non_filtered_fn, active_snapshot = _make_non_filtered_store(rows)
+    db = _PromotionFakeDb({})
+
+    report = inventory_legacy_user(
+        LEGACY_UID,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+    )
+
+    assert report.source_count == 2
+    assert report.bucket_counts[LegacyBackfillBucket.manual_required_promotion.value] == 1
+    assert report.bucket_counts[LegacyBackfillBucket.hold_sensitive.value] == 1
+    assert report.admitted_candidate_count == 1
+    assert report.estimated_tokens > 0
+    serialized = json.dumps(report.__dict__)
+    assert rows[0]["content"] not in serialized
+    assert rows[1]["content"] not in serialized
+    assert db.docs == {}
+    assert active_snapshot == rows
+
+
+def test_capped_backfill_resumes_until_complete(_trusted_account):
+    rows = [
+        _legacy_row(legacy_id=f"leg-cap-{index}", content=f"Capped fact {index}", conversation_id=f"conv-{index}")
+        for index in range(3)
+    ]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+    _seed_legacy_evidence(db, rows)
+
+    first = backfill_user(
+        LEGACY_UID,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+        max_rows=1,
+    )
+    second = backfill_user(
+        LEGACY_UID,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+        max_rows=1,
+    )
+    third = backfill_user(
+        LEGACY_UID,
+        db_client=db,
+        get_non_filtered_memories_fn=get_non_filtered_fn,
+        max_rows=1,
+    )
+
+    assert [first.resumed_from_index, second.resumed_from_index, third.resumed_from_index] == [0, 1, 2]
+    assert first.completed is False
+    assert second.completed is False
+    assert third.completed is True
+    assert third.verified is True
+
+
+def test_continue_on_error_refreshes_control_and_retries_row(_trusted_account):
+    rows = [
+        _legacy_row(legacy_id="leg-retry-1", content="Retry one", conversation_id="conv-retry-1"),
+        _legacy_row(legacy_id="leg-retry-2", content="Retry two", conversation_id="conv-retry-2"),
+    ]
+    get_non_filtered_fn, _ = _make_non_filtered_store(rows)
+    db = _canonical_db_with_control(LEGACY_UID)
+    _seed_legacy_evidence(db, rows)
+    real_apply = backfill_user.__globals__["apply_long_term_patch_firestore"]
+    calls = {"count": 0}
+
+    def _fail_once(**kwargs):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise RuntimeError("simulated recoverable head mismatch")
+        return real_apply(**kwargs)
+
+    with patch("utils.memory.legacy_backfill.apply_long_term_patch_firestore", side_effect=_fail_once):
+        report = backfill_user(
+            LEGACY_UID,
+            db_client=db,
+            get_non_filtered_memories_fn=get_non_filtered_fn,
+            continue_on_error=True,
+        )
+
+    assert calls["count"] == 3
+    assert report.errors == []
+    assert report.completed is True
+    assert report.written_count == 2
+    assert report.verified is True
 
 
 def test_bucket_classifier_holds_noise_and_sensitive_rows():

--- a/backend/utils/memory/bulk_legacy_backfill.py
+++ b/backend/utils/memory/bulk_legacy_backfill.py
@@ -1,0 +1,735 @@
+"""Governed multi-user legacy-to-canonical memory migration orchestration.
+
+LIFECYCLE: permanent
+
+This module coordinates existing enrollment and backfill primitives. It never
+reads or returns raw memory content, never mutates legacy memory rows, and never
+changes the code-owned canonical cohort or a user's read mode. Canonical L2
+processing and promotion remain owned by ``memory-maintenance-job``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Dict, Iterable, Optional, Protocol, Sequence
+
+from database.memory_collections import MemoryCollections
+from utils.executors import db_executor
+from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
+
+GLOBAL_PAUSE_PATH = "memory_control/legacy_canonical_backfill_pause"
+PAUSE_ENV = "MEMORY_BULK_BACKFILL_PAUSED"
+WRITABLE_BUCKETS = frozenset({"manual_required_promotion", "reviewed_long_term"})
+
+
+def _nonnegative_int(value: object) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+class BackfillReport(Protocol):
+    @property
+    def written_count(self) -> int: ...
+
+    @property
+    def skipped_already_present(self) -> int: ...
+
+    @property
+    def skipped_both_store_duplicate(self) -> int: ...
+
+    @property
+    def destination_count(self) -> int: ...
+
+    @property
+    def intended_count(self) -> int: ...
+
+    @property
+    def legacy_rows_touched(self) -> int: ...
+
+    @property
+    def completed(self) -> bool: ...
+
+    @property
+    def verified(self) -> bool: ...
+
+    @property
+    def cohort_gated(self) -> bool: ...
+
+    @property
+    def errors(self) -> list[str]: ...
+
+
+class MigrationState(str, Enum):
+    not_started = "not_started"
+    inventory_done = "inventory_done"
+    enrolled = "enrolled"
+    staged = "staged"
+    processing = "processing"
+    read_ready = "read_ready"
+    failed = "failed"
+    paused = "paused"
+
+
+_FORWARD_TRANSITIONS: Dict[MigrationState, frozenset[MigrationState]] = {
+    MigrationState.not_started: frozenset(
+        {MigrationState.inventory_done, MigrationState.paused, MigrationState.failed}
+    ),
+    MigrationState.inventory_done: frozenset({MigrationState.enrolled, MigrationState.paused, MigrationState.failed}),
+    MigrationState.enrolled: frozenset(
+        {MigrationState.processing, MigrationState.staged, MigrationState.paused, MigrationState.failed}
+    ),
+    MigrationState.processing: frozenset(
+        {MigrationState.staged, MigrationState.read_ready, MigrationState.paused, MigrationState.failed}
+    ),
+    MigrationState.staged: frozenset(
+        {MigrationState.processing, MigrationState.read_ready, MigrationState.paused, MigrationState.failed}
+    ),
+    MigrationState.read_ready: frozenset(),
+    MigrationState.failed: frozenset(
+        {
+            MigrationState.inventory_done,
+            MigrationState.enrolled,
+            MigrationState.processing,
+            MigrationState.staged,
+            MigrationState.paused,
+        }
+    ),
+    MigrationState.paused: frozenset(
+        {
+            MigrationState.inventory_done,
+            MigrationState.enrolled,
+            MigrationState.processing,
+            MigrationState.staged,
+            MigrationState.failed,
+        }
+    ),
+}
+
+
+def validate_checkpoint_transition(current: MigrationState, target: MigrationState) -> None:
+    """Reject checkpoint regressions while allowing idempotent re-entry."""
+    if current == target:
+        return
+    if target not in _FORWARD_TRANSITIONS[current]:
+        raise ValueError(f"invalid bulk memory migration transition: {current.value} -> {target.value}")
+
+
+@dataclass(frozen=True)
+class MigrationCheckpoint:
+    uid: str
+    state: MigrationState = MigrationState.not_started
+    resume_state: Optional[MigrationState] = None
+    source_count: int = 0
+    bucket_counts: Dict[str, int] = field(default_factory=dict)
+    admitted_candidate_count: int = 0
+    admitted_candidate_estimated_tokens: int = 0
+    staged_count: int = 0
+    error_count: int = 0
+    last_error_code: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+    @classmethod
+    def from_payload(cls, uid: str, payload: object) -> "MigrationCheckpoint":
+        if not isinstance(payload, dict):
+            return cls(uid=uid)
+        try:
+            state = MigrationState(str(payload.get("state", MigrationState.not_started.value)))
+        except ValueError:
+            state = MigrationState.failed
+        raw_resume = payload.get("resume_state")
+        try:
+            resume_state = MigrationState(str(raw_resume)) if raw_resume else None
+        except ValueError:
+            resume_state = None
+        raw_buckets = payload.get("bucket_counts")
+        bucket_counts = (
+            {str(key): _nonnegative_int(value) for key, value in raw_buckets.items()}
+            if isinstance(raw_buckets, dict)
+            else {}
+        )
+        return cls(
+            uid=uid,
+            state=state,
+            resume_state=resume_state,
+            source_count=_nonnegative_int(payload.get("source_count", 0)),
+            bucket_counts=bucket_counts,
+            admitted_candidate_count=_nonnegative_int(payload.get("admitted_candidate_count", 0)),
+            admitted_candidate_estimated_tokens=_nonnegative_int(payload.get("admitted_candidate_estimated_tokens", 0)),
+            staged_count=_nonnegative_int(payload.get("staged_count", 0)),
+            error_count=_nonnegative_int(payload.get("error_count", 0)),
+            last_error_code=(str(payload["last_error_code"]) if payload.get("last_error_code") is not None else None),
+            updated_at=payload.get("updated_at") if isinstance(payload.get("updated_at"), datetime) else None,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "uid": self.uid,
+            "state": self.state.value,
+            "resume_state": self.resume_state.value if self.resume_state is not None else None,
+            "source_count": self.source_count,
+            "bucket_counts": dict(self.bucket_counts),
+            "admitted_candidate_count": self.admitted_candidate_count,
+            "admitted_candidate_estimated_tokens": self.admitted_candidate_estimated_tokens,
+            "staged_count": self.staged_count,
+            "error_count": self.error_count,
+            "last_error_code": self.last_error_code,
+            "updated_at": self.updated_at or datetime.now(timezone.utc),
+        }
+
+
+class CheckpointStore(Protocol):
+    def read(self, uid: str) -> MigrationCheckpoint: ...
+
+    def write(self, checkpoint: MigrationCheckpoint) -> None: ...
+
+
+class FirestoreCheckpointStore:
+    """Server-owned checkpoint store under each user's ``memory_control``."""
+
+    def __init__(self, db_client: Any):
+        self._db_client = db_client
+
+    def read(self, uid: str) -> MigrationCheckpoint:
+        snapshot = self._db_client.document(MemoryCollections(uid).legacy_canonical_backfill_checkpoint).get()
+        payload = snapshot.to_dict() if getattr(snapshot, "exists", False) else None
+        return MigrationCheckpoint.from_payload(uid, payload)
+
+    def write(self, checkpoint: MigrationCheckpoint) -> None:
+        current = self.read(checkpoint.uid)
+        validate_checkpoint_transition(current.state, checkpoint.state)
+        self._db_client.document(MemoryCollections(checkpoint.uid).legacy_canonical_backfill_checkpoint).set(
+            checkpoint.to_payload(), merge=True
+        )
+
+
+@dataclass(frozen=True)
+class PauseDecision:
+    paused: bool
+    reason: Optional[str] = None
+
+
+def read_global_pause(db_client: Any, *, env: Optional[dict[str, str]] = None) -> PauseDecision:
+    """Fail closed when the environment or Firestore pause control cannot be cleared."""
+    values = os.environ if env is None else env
+    if str(values.get(PAUSE_ENV, "")).strip().lower() in {"1", "true", "yes", "on"}:
+        return PauseDecision(True, "paused_by_env")
+    try:
+        snapshot = db_client.document(GLOBAL_PAUSE_PATH).get()
+        payload = snapshot.to_dict() if getattr(snapshot, "exists", False) else None
+    except Exception:
+        return PauseDecision(True, "pause_check_failed")
+    if isinstance(payload, dict) and payload.get("paused") is True:
+        return PauseDecision(True, "paused_by_firestore")
+    return PauseDecision(False)
+
+
+@dataclass(frozen=True)
+class BulkMigrationConfig:
+    dry_run: bool = True
+    max_users_per_run: int = 10
+    max_admitted_rows_per_user: int = 100
+    max_estimated_tokens_per_run: int = 100_000
+    wall_clock_seconds: Optional[float] = None
+    concurrency_limit: int = 1
+    process_buckets: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.max_users_per_run <= 0:
+            raise ValueError("max_users_per_run must be positive")
+        if self.max_admitted_rows_per_user <= 0:
+            raise ValueError("max_admitted_rows_per_user must be positive")
+        if self.max_estimated_tokens_per_run <= 0:
+            raise ValueError("max_estimated_tokens_per_run must be positive")
+        if self.wall_clock_seconds is not None and self.wall_clock_seconds <= 0:
+            raise ValueError("wall_clock_seconds must be positive")
+        if self.concurrency_limit <= 0:
+            raise ValueError("concurrency_limit must be positive")
+        unknown = set(self.process_buckets) - WRITABLE_BUCKETS
+        if unknown:
+            raise ValueError("unsupported writable bucket(s): " + ", ".join(sorted(unknown)))
+
+
+@dataclass(frozen=True)
+class BulkUserResult:
+    uid: str
+    state: MigrationState
+    inventory: LegacyBackfillInventoryReport
+    actions: tuple[str, ...]
+    staged_count: int = 0
+    error_codes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uid": self.uid,
+            "state": self.state.value,
+            "inventory": asdict(self.inventory),
+            "actions": list(self.actions),
+            "staged_count": self.staged_count,
+            "error_codes": list(self.error_codes),
+        }
+
+
+@dataclass(frozen=True)
+class BulkRunSummary:
+    dry_run: bool
+    requested_user_count: int
+    selected_user_count: int
+    processed_user_count: int
+    read_ready_count: int
+    failed_user_count: int
+    paused_user_count: int
+    admitted_candidate_count: int
+    estimated_tokens: int
+    stopped_reason: Optional[str]
+    users: tuple[BulkUserResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["users"] = [user.to_dict() for user in self.users]
+        return payload
+
+
+InventoryFn = Callable[[str], LegacyBackfillInventoryReport]
+EnrollFn = Callable[[str], None]
+StopFn = Callable[[], bool]
+BackfillFn = Callable[[str, int, bool, StopFn], BackfillReport]
+BucketProcessFn = Callable[[str, str, int, StopFn], BackfillReport]
+PauseFn = Callable[[], PauseDecision]
+
+
+def _deduplicate_uids(uids: Iterable[str]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for raw_uid in uids:
+        uid = raw_uid.strip()
+        if not uid or uid in seen:
+            continue
+        ordered.append(uid)
+        seen.add(uid)
+    return ordered
+
+
+def _checkpoint_from_inventory(
+    inventory: LegacyBackfillInventoryReport,
+    *,
+    state: MigrationState,
+    resume_state: Optional[MigrationState] = None,
+    staged_count: int = 0,
+    error_count: int = 0,
+    last_error_code: Optional[str] = None,
+) -> MigrationCheckpoint:
+    return MigrationCheckpoint(
+        uid=inventory.uid,
+        state=state,
+        resume_state=resume_state,
+        source_count=inventory.source_count,
+        bucket_counts=dict(inventory.bucket_counts),
+        admitted_candidate_count=inventory.admitted_candidate_count,
+        admitted_candidate_estimated_tokens=inventory.admitted_candidate_estimated_tokens,
+        staged_count=staged_count,
+        error_count=error_count,
+        last_error_code=last_error_code,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def _paused_result(
+    inventory: LegacyBackfillInventoryReport,
+    *,
+    reason: str,
+    actions: Sequence[str],
+    staged_count: int = 0,
+) -> BulkUserResult:
+    return BulkUserResult(
+        uid=inventory.uid,
+        state=MigrationState.paused,
+        inventory=inventory,
+        actions=tuple(actions),
+        staged_count=staged_count,
+        error_codes=(reason,),
+    )
+
+
+def _apply_user(
+    inventory: LegacyBackfillInventoryReport,
+    *,
+    config: BulkMigrationConfig,
+    checkpoint_store: CheckpointStore,
+    pause_fn: PauseFn,
+    enroll_fn: EnrollFn,
+    backfill_fn: BackfillFn,
+    bucket_process_fn: Optional[BucketProcessFn],
+    stop_fn: StopFn,
+) -> BulkUserResult:
+    current = checkpoint_store.read(inventory.uid)
+    if current.state == MigrationState.read_ready:
+        return BulkUserResult(
+            uid=inventory.uid,
+            state=MigrationState.read_ready,
+            inventory=inventory,
+            actions=("already_read_ready",),
+            staged_count=current.staged_count,
+        )
+
+    resume_state = (
+        current.resume_state if current.state in {MigrationState.failed, MigrationState.paused} else current.state
+    )
+    resume_state = resume_state or MigrationState.not_started
+    actions: list[str] = []
+
+    if resume_state == MigrationState.not_started:
+        checkpoint_store.write(_checkpoint_from_inventory(inventory, state=MigrationState.inventory_done))
+        resume_state = MigrationState.inventory_done
+        actions.append("inventory_checkpointed")
+
+    pause = pause_fn()
+    if pause.paused:
+        reason = pause.reason or "paused"
+        checkpoint_store.write(
+            _checkpoint_from_inventory(
+                inventory,
+                state=MigrationState.paused,
+                resume_state=resume_state,
+                staged_count=current.staged_count,
+                last_error_code=reason,
+            )
+        )
+        return _paused_result(inventory, reason=reason, actions=actions + ["paused_before_enroll_or_stage"])
+
+    if resume_state == MigrationState.inventory_done:
+        try:
+            enroll_fn(inventory.uid)
+        except Exception:
+            checkpoint_store.write(
+                _checkpoint_from_inventory(
+                    inventory,
+                    state=MigrationState.failed,
+                    resume_state=MigrationState.inventory_done,
+                    error_count=current.error_count + 1,
+                    last_error_code="enrollment_failed",
+                )
+            )
+            return BulkUserResult(
+                uid=inventory.uid,
+                state=MigrationState.failed,
+                inventory=inventory,
+                actions=tuple(actions + ["enrollment_failed"]),
+                error_codes=("enrollment_failed",),
+            )
+        checkpoint_store.write(_checkpoint_from_inventory(inventory, state=MigrationState.enrolled))
+        resume_state = MigrationState.enrolled
+        actions.append("enrolled_write_only")
+
+    pause = pause_fn()
+    if pause.paused:
+        reason = pause.reason or "paused"
+        checkpoint_store.write(
+            _checkpoint_from_inventory(
+                inventory,
+                state=MigrationState.paused,
+                resume_state=resume_state,
+                staged_count=current.staged_count,
+                last_error_code=reason,
+            )
+        )
+        return _paused_result(inventory, reason=reason, actions=actions + ["paused_before_stage"])
+
+    checkpoint_store.write(_checkpoint_from_inventory(inventory, state=MigrationState.processing))
+    resume = current.state != MigrationState.failed
+    try:
+        report = backfill_fn(inventory.uid, config.max_admitted_rows_per_user, resume, stop_fn)
+    except Exception:
+        checkpoint_store.write(
+            _checkpoint_from_inventory(
+                inventory,
+                state=MigrationState.failed,
+                resume_state=MigrationState.processing,
+                error_count=current.error_count + 1,
+                last_error_code="backfill_failed",
+            )
+        )
+        return BulkUserResult(
+            uid=inventory.uid,
+            state=MigrationState.failed,
+            inventory=inventory,
+            actions=tuple(actions + ["stage_failed"]),
+            error_codes=("backfill_failed",),
+        )
+
+    staged_count = report.destination_count
+    actions.append("stage_all_for_admission")
+    if report.cohort_gated:
+        error_code = "cohort_gated"
+    elif report.errors:
+        error_code = "row_errors"
+    else:
+        error_code = None
+    if error_code is not None:
+        checkpoint_store.write(
+            _checkpoint_from_inventory(
+                inventory,
+                state=MigrationState.failed,
+                resume_state=MigrationState.processing,
+                staged_count=staged_count,
+                error_count=current.error_count + max(1, len(report.errors)),
+                last_error_code=error_code,
+            )
+        )
+        return BulkUserResult(
+            uid=inventory.uid,
+            state=MigrationState.failed,
+            inventory=inventory,
+            actions=tuple(actions),
+            staged_count=staged_count,
+            error_codes=(error_code,),
+        )
+
+    checkpoint_store.write(
+        _checkpoint_from_inventory(inventory, state=MigrationState.staged, staged_count=staged_count)
+    )
+    if not report.completed or not report.verified:
+        pause_reason = "wall_clock_seconds" if stop_fn() else "max_admitted_rows_per_user"
+        checkpoint_store.write(
+            _checkpoint_from_inventory(
+                inventory,
+                state=MigrationState.paused,
+                resume_state=MigrationState.staged,
+                staged_count=staged_count,
+                last_error_code=pause_reason,
+            )
+        )
+        return _paused_result(
+            inventory,
+            reason=pause_reason,
+            actions=actions + ["resume_required"],
+            staged_count=staged_count,
+        )
+
+    remaining_rows = max(0, config.max_admitted_rows_per_user - report.intended_count)
+    required_bucket_rows = sum(inventory.bucket_counts.get(bucket, 0) for bucket in config.process_buckets)
+    if required_bucket_rows > remaining_rows:
+        checkpoint_store.write(
+            _checkpoint_from_inventory(
+                inventory,
+                state=MigrationState.paused,
+                resume_state=MigrationState.staged,
+                staged_count=staged_count,
+                last_error_code="max_admitted_rows_per_user",
+            )
+        )
+        return _paused_result(
+            inventory,
+            reason="max_admitted_rows_per_user",
+            actions=actions + ["bucket_processing_deferred_row_cap", "resume_required"],
+            staged_count=staged_count,
+        )
+    for bucket in config.process_buckets:
+        if bucket_process_fn is None or remaining_rows == 0:
+            break
+        bucket_report = bucket_process_fn(inventory.uid, bucket, remaining_rows, stop_fn)
+        actions.append(f"processed_bucket:{bucket}")
+        consumed = max(bucket_report.legacy_rows_touched, bucket_report.intended_count)
+        remaining_rows = max(0, remaining_rows - consumed)
+        if bucket_report.errors or bucket_report.cohort_gated:
+            checkpoint_store.write(
+                _checkpoint_from_inventory(
+                    inventory,
+                    state=MigrationState.failed,
+                    resume_state=MigrationState.staged,
+                    staged_count=staged_count,
+                    error_count=current.error_count + max(1, len(bucket_report.errors)),
+                    last_error_code="bucket_processing_failed",
+                )
+            )
+            return BulkUserResult(
+                uid=inventory.uid,
+                state=MigrationState.failed,
+                inventory=inventory,
+                actions=tuple(actions),
+                staged_count=staged_count,
+                error_codes=("bucket_processing_failed",),
+            )
+
+    checkpoint_store.write(
+        _checkpoint_from_inventory(inventory, state=MigrationState.read_ready, staged_count=staged_count)
+    )
+    actions.append("checkpoint_read_ready")
+    return BulkUserResult(
+        uid=inventory.uid,
+        state=MigrationState.read_ready,
+        inventory=inventory,
+        actions=tuple(actions),
+        staged_count=staged_count,
+    )
+
+
+def run_bulk_migration(
+    uids: Iterable[str],
+    *,
+    config: BulkMigrationConfig,
+    inventory_fn: InventoryFn,
+    pause_fn: Optional[PauseFn] = None,
+    checkpoint_store: Optional[CheckpointStore] = None,
+    enroll_fn: Optional[EnrollFn] = None,
+    backfill_fn: Optional[BackfillFn] = None,
+    bucket_process_fn: Optional[BucketProcessFn] = None,
+    monotonic_fn: Callable[[], float] = time.monotonic,
+) -> BulkRunSummary:
+    """Inventory and optionally enroll/stage a bounded set of users.
+
+    The planning pass is sequential so pause, wall-clock, and token governors
+    make deterministic admission decisions. Apply work is bounded by
+    ``concurrency_limit`` and each user remains isolated from failures in peers.
+    """
+    requested_uids = _deduplicate_uids(uids)
+    selected_uids = requested_uids[: config.max_users_per_run]
+    stopped_reason = "max_users_per_run" if len(requested_uids) > len(selected_uids) else None
+    started_at = monotonic_fn()
+    pause_check = pause_fn or (lambda: PauseDecision(False))
+
+    def wall_clock_exhausted() -> bool:
+        return config.wall_clock_seconds is not None and monotonic_fn() - started_at >= config.wall_clock_seconds
+
+    def governed_pause_check() -> PauseDecision:
+        if wall_clock_exhausted():
+            return PauseDecision(True, "wall_clock_seconds")
+        return pause_check()
+
+    planned: list[LegacyBackfillInventoryReport] = []
+    results: list[BulkUserResult] = []
+    estimated_tokens = 0
+
+    for uid in selected_uids:
+        pause = governed_pause_check()
+        if pause.paused:
+            stopped_reason = pause.reason or "paused"
+            break
+        try:
+            inventory = inventory_fn(uid)
+        except Exception:
+            empty_inventory = LegacyBackfillInventoryReport(
+                uid=uid,
+                source_count=0,
+                bucket_counts={},
+                admitted_candidate_count=0,
+                content_character_count=0,
+                estimated_tokens=0,
+                admitted_candidate_estimated_tokens=0,
+            )
+            results.append(
+                BulkUserResult(
+                    uid=uid,
+                    state=MigrationState.failed,
+                    inventory=empty_inventory,
+                    actions=("inventory_failed",),
+                    error_codes=("inventory_failed",),
+                )
+            )
+            continue
+        governed_tokens = inventory.admitted_candidate_estimated_tokens
+        if inventory.admitted_candidate_count > config.max_admitted_rows_per_user:
+            governed_tokens = (
+                inventory.admitted_candidate_estimated_tokens * config.max_admitted_rows_per_user
+                + inventory.admitted_candidate_count
+                - 1
+            ) // inventory.admitted_candidate_count
+        projected_tokens = estimated_tokens + governed_tokens
+        if projected_tokens > config.max_estimated_tokens_per_run:
+            stopped_reason = "max_estimated_tokens_per_run"
+            results.append(
+                _paused_result(
+                    inventory,
+                    reason="max_estimated_tokens_per_run",
+                    actions=("inventory_only", "not_selected_for_apply"),
+                )
+            )
+            break
+        estimated_tokens = projected_tokens
+        planned.append(inventory)
+
+    if config.dry_run:
+        for inventory in planned:
+            actions = ["would_enroll_write_only", "would_stage_all_for_admission"]
+            actions.extend(f"would_process_bucket:{bucket}" for bucket in config.process_buckets)
+            results.append(
+                BulkUserResult(
+                    uid=inventory.uid,
+                    state=MigrationState.inventory_done,
+                    inventory=inventory,
+                    actions=tuple(actions),
+                )
+            )
+    else:
+        if checkpoint_store is None or enroll_fn is None or backfill_fn is None:
+            raise ValueError("apply mode requires checkpoint_store, enroll_fn, and backfill_fn")
+
+        def apply_one(inventory: LegacyBackfillInventoryReport) -> BulkUserResult:
+            return _apply_user(
+                inventory,
+                config=config,
+                checkpoint_store=checkpoint_store,
+                pause_fn=governed_pause_check,
+                enroll_fn=enroll_fn,
+                backfill_fn=backfill_fn,
+                bucket_process_fn=bucket_process_fn,
+                stop_fn=wall_clock_exhausted,
+            )
+
+        # Submit only one bounded wave at a time so the CLI never exceeds its
+        # configured user concurrency while reusing the process-wide DB pool.
+        # The caller thread is the coordinator; each worker performs only this
+        # user's synchronous Firestore leaf operations.
+        for start_index in range(0, len(planned), config.concurrency_limit):
+            batch = planned[start_index : start_index + config.concurrency_limit]
+            futures = [db_executor.submit(apply_one, inventory) for inventory in batch]
+            for inventory, future in zip(batch, futures):
+                try:
+                    results.append(future.result())
+                except Exception:
+                    results.append(
+                        BulkUserResult(
+                            uid=inventory.uid,
+                            state=MigrationState.failed,
+                            inventory=inventory,
+                            actions=("worker_failed",),
+                            error_codes=("checkpoint_or_worker_failed",),
+                        )
+                    )
+
+    ordered_results = tuple(sorted(results, key=lambda result: requested_uids.index(result.uid)))
+    return BulkRunSummary(
+        dry_run=config.dry_run,
+        requested_user_count=len(requested_uids),
+        selected_user_count=len(planned),
+        processed_user_count=len(ordered_results),
+        read_ready_count=sum(result.state == MigrationState.read_ready for result in ordered_results),
+        failed_user_count=sum(result.state == MigrationState.failed for result in ordered_results),
+        paused_user_count=sum(result.state == MigrationState.paused for result in ordered_results),
+        admitted_candidate_count=sum(result.inventory.admitted_candidate_count for result in ordered_results),
+        estimated_tokens=estimated_tokens,
+        stopped_reason=stopped_reason,
+        users=ordered_results,
+    )
+
+
+__all__ = [
+    "BulkMigrationConfig",
+    "BulkRunSummary",
+    "BulkUserResult",
+    "FirestoreCheckpointStore",
+    "GLOBAL_PAUSE_PATH",
+    "LegacyBackfillInventoryReport",
+    "MigrationCheckpoint",
+    "MigrationState",
+    "PAUSE_ENV",
+    "PauseDecision",
+    "read_global_pause",
+    "run_bulk_migration",
+    "validate_checkpoint_transition",
+]

--- a/backend/utils/memory/bulk_legacy_backfill.py
+++ b/backend/utils/memory/bulk_legacy_backfill.py
@@ -27,10 +27,18 @@ WRITABLE_BUCKETS = frozenset({"manual_required_promotion", "reviewed_long_term"}
 
 
 def _nonnegative_int(value: object) -> int:
-    try:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, float):
         return max(0, int(value))
-    except (TypeError, ValueError):
-        return 0
+    if isinstance(value, str):
+        try:
+            return max(0, int(value.strip()))
+        except ValueError:
+            return 0
+    return 0
 
 
 class BackfillReport(Protocol):

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -116,6 +116,11 @@ def _row_content(row: LegacyRow) -> str:
     return _row_str(row, "content").strip()
 
 
+def row_content(row: LegacyRow) -> str:
+    """Public content accessor for inventory/orchestrators (no new behavior)."""
+    return _row_content(row)
+
+
 def _legacy_source_attribution(
     payload: Payload,
     *,
@@ -811,6 +816,15 @@ def _bucket_counts_and_samples(
     return counts, {bucket: sample_rows for bucket, sample_rows in samples.items() if sample_rows}
 
 
+def bucket_counts_and_samples(
+    rows: Sequence[LegacyRow],
+    *,
+    sample_size: int = 5,
+) -> tuple[Dict[str, int], BucketSampleMap]:
+    """Public inventory helper; wraps the internal classifier tally."""
+    return _bucket_counts_and_samples(rows, sample_size=sample_size)
+
+
 def _fetch_active_legacy_memories(
     uid: str,
     *,
@@ -824,6 +838,22 @@ def _fetch_active_legacy_memories(
         db_client=db_client,
         reader=get_non_filtered_memories_fn,
         is_active=is_active_legacy_row,
+        scan_page_size=scan_page_size,
+    )
+
+
+def fetch_active_legacy_memories(
+    uid: str,
+    *,
+    db_client: Any,
+    get_non_filtered_memories_fn: LegacyReader,
+    scan_page_size: int = LEGACY_SCAN_PAGE_SIZE,
+) -> List[LegacyRow]:
+    """Public read-only active legacy scan for inventory/orchestrators."""
+    return _fetch_active_legacy_memories(
+        uid,
+        db_client=db_client,
+        get_non_filtered_memories_fn=get_non_filtered_memories_fn,
         scan_page_size=scan_page_size,
     )
 

--- a/backend/utils/memory/legacy_backfill.py
+++ b/backend/utils/memory/legacy_backfill.py
@@ -33,6 +33,7 @@ from models.memory_contracts import DurablePatchDecision, LifecycleState, determ
 from models.memory_operations import MemoryOperation, MemoryOperationType
 from models.product_memory import MemoryItemStatus, MemoryLayer, ProcessingState, MemoryItem
 from utils.memory.canonical_memory_adapter import extraction_memory_id
+from utils.memory.legacy_backfill_bulk_support import apply_with_control_refresh, fetch_active_legacy_rows
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items
 from utils.memory.required_promotion import (
@@ -817,33 +818,14 @@ def _fetch_active_legacy_memories(
     get_non_filtered_memories_fn: LegacyReader,
     scan_page_size: int = LEGACY_SCAN_PAGE_SIZE,
 ) -> List[LegacyRow]:
-    """Read-only scan of active legacy memories (never writes).
-
-    Paginates over the raw Firestore page from ``get_non_filtered_memories`` so
-    ``len(page) < page_size`` reliably signals end-of-data even when many rows in
-    a page are inactive and filtered out here.
-    """
-    all_rows: List[LegacyRow] = []
-    offset = 0
-    page_size = scan_page_size
-    while True:
-        try:
-            page: List[LegacyRow] = get_non_filtered_memories_fn(
-                uid, limit=page_size, offset=offset, firestore_client=db_client
-            )
-        except TypeError as exc:
-            if "firestore_client" not in str(exc):
-                raise
-            page = get_non_filtered_memories_fn(uid, limit=page_size, offset=offset)
-        if not page:
-            break
-        for row in page:
-            if is_active_legacy_row(row):
-                all_rows.append(row)
-        if len(page) < page_size:
-            break
-        offset += page_size
-    return sorted(all_rows, key=lambda row: _row_str(row, "id"))
+    """Read-only raw-page scan; active filtering never mutates legacy rows."""
+    return fetch_active_legacy_rows(
+        uid,
+        db_client=db_client,
+        reader=get_non_filtered_memories_fn,
+        is_active=is_active_legacy_row,
+        scan_page_size=scan_page_size,
+    )
 
 
 def _read_control_state(uid: str, *, db_client: Any, create_if_missing: bool = True) -> MemoryControlState:
@@ -1538,6 +1520,9 @@ def backfill_user(
     dry_run: bool = False,
     batch_size: int = DEFAULT_BATCH_SIZE,
     resume: bool = True,
+    max_rows: Optional[int] = None,
+    continue_on_error: bool = False,
+    stop_requested: Optional[Callable[[], bool]] = None,
     allow_admin_override: bool = False,
     acknowledge_non_canonical_uid: bool = False,
     operator_context: Optional[str] = None,
@@ -1580,7 +1565,10 @@ def backfill_user(
         start_index = 0
         if resume and control.legacy_backfill_source_fingerprint == fingerprint:
             start_index = min(control.legacy_backfill_processed_count, len(admissible_rows))
-        intended_count = max(0, len(admissible_rows) - start_index)
+        end_index = len(admissible_rows)
+        if max_rows is not None:
+            end_index = min(end_index, start_index + max(0, max_rows))
+        intended_count = max(0, end_index - start_index)
         _, destination_count, verified, discrepancy = reconcile_backfill_counts(uid, admissible_rows, db_client=client)
         return BackfillReport(
             uid=uid,
@@ -1614,7 +1602,10 @@ def backfill_user(
         )
         start_index = 0
 
-    intended_count = max(0, len(admissible_rows) - start_index)
+    end_index = len(admissible_rows)
+    if max_rows is not None:
+        end_index = min(end_index, start_index + max(0, max_rows))
+    intended_count = max(0, end_index - start_index)
     written_count = 0
     skipped_already_present = 0
     skipped_both_store_duplicate = 0
@@ -1626,7 +1617,9 @@ def backfill_user(
     materialized_semantic_keys: set[str] = set()
 
     processed_index = start_index
-    while processed_index < len(admissible_rows):
+    while processed_index < end_index:
+        if stop_requested is not None and stop_requested():
+            break
         legacy_row = admissible_rows[processed_index]
         semantic_key = semantic_materialization_key(uid=uid, legacy_row=legacy_row)
         if semantic_key is not None and semantic_key in materialized_semantic_keys:
@@ -1641,15 +1634,21 @@ def backfill_user(
             )
             _persist_control_state(control, db_client=client)
             continue
-        try:
-            row_result = _apply_one_legacy_row(
+        attempt = apply_with_control_refresh(
+            control=control,
+            apply_fn=lambda latest: _apply_one_legacy_row(
                 uid=uid,
                 legacy_row=legacy_row,
                 index=processed_index,
-                control=control,
+                control=latest,
                 run_id=effective_run_id,
                 db_client=client,
-            )
+            ),
+            refresh_control=lambda: _read_control_state(uid, db_client=client, create_if_missing=False),
+            retry_once=continue_on_error,
+        )
+        control, row_result, row_error = attempt.control, attempt.result, attempt.error
+        if row_result is not None:
             control = row_result.control
             if row_result.written:
                 written_count += 1
@@ -1665,12 +1664,13 @@ def backfill_user(
                 keyword_sync_failures += 1
             if row_result.kg_extraction_failed:
                 kg_extraction_failures += 1
-        except Exception as exc:
+        elif row_error is not None:
             safe_uid = sanitize_pii(uid)
             safe_legacy_id = sanitize_pii(_row_str(legacy_row, "id", "unknown"))
-            logger.exception("legacy backfill failed for %s row %s", safe_uid, safe_legacy_id)
-            errors.append(f"{safe_legacy_id}: {sanitize(exc)}")
-            break
+            logger.error("legacy backfill failed for %s row %s", safe_uid, safe_legacy_id)
+            errors.append(f"{safe_legacy_id}: {sanitize(row_error)}")
+            if not continue_on_error:
+                break
 
         processed_index += 1
         control = control.model_copy(

--- a/backend/utils/memory/legacy_backfill_bulk_support.py
+++ b/backend/utils/memory/legacy_backfill_bulk_support.py
@@ -1,0 +1,87 @@
+"""Small dependency-free contracts shared by bulk legacy backfill modules.
+
+LIFECYCLE: permanent
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
+
+ControlT = TypeVar("ControlT")
+ResultT = TypeVar("ResultT")
+
+
+@dataclass(frozen=True)
+class LegacyBackfillInventoryReport:
+    """Content-free legacy inventory for bulk migration planning."""
+
+    uid: str
+    source_count: int
+    bucket_counts: Dict[str, int]
+    admitted_candidate_count: int
+    content_character_count: int
+    estimated_tokens: int
+    admitted_candidate_estimated_tokens: int
+
+
+@dataclass(frozen=True)
+class RefreshedApplyAttempt(Generic[ControlT, ResultT]):
+    control: ControlT
+    result: Optional[ResultT]
+    error: Optional[Exception]
+
+
+def apply_with_control_refresh(
+    *,
+    control: ControlT,
+    apply_fn: Callable[[ControlT], ResultT],
+    refresh_control: Callable[[], ControlT],
+    retry_once: bool,
+) -> RefreshedApplyAttempt[ControlT, ResultT]:
+    """Retry one deterministic row mutation after refreshing its control head."""
+    attempts = 2 if retry_once else 1
+    current_control = control
+    for attempt in range(attempts):
+        try:
+            return RefreshedApplyAttempt(current_control, apply_fn(current_control), None)
+        except Exception as exc:
+            if attempt + 1 == attempts:
+                return RefreshedApplyAttempt(current_control, None, exc)
+            current_control = refresh_control()
+    raise AssertionError("unreachable apply retry state")
+
+
+def fetch_active_legacy_rows(
+    uid: str,
+    *,
+    db_client: Any,
+    reader: Callable[..., List[Dict[str, Any]]],
+    is_active: Callable[[Dict[str, Any]], bool],
+    scan_page_size: int,
+) -> List[Dict[str, Any]]:
+    """Page a raw legacy reader before applying its in-process active filter."""
+    rows: List[Dict[str, Any]] = []
+    offset = 0
+    while True:
+        try:
+            page = reader(uid, limit=scan_page_size, offset=offset, firestore_client=db_client)
+        except TypeError as exc:
+            if "firestore_client" not in str(exc):
+                raise
+            page = reader(uid, limit=scan_page_size, offset=offset)
+        if not page:
+            break
+        rows.extend(row for row in page if is_active(row))
+        if len(page) < scan_page_size:
+            break
+        offset += scan_page_size
+    return sorted(rows, key=lambda row: str(row.get("id") or ""))
+
+
+__all__ = [
+    "LegacyBackfillInventoryReport",
+    "RefreshedApplyAttempt",
+    "apply_with_control_refresh",
+    "fetch_active_legacy_rows",
+]

--- a/backend/utils/memory/legacy_backfill_inventory.py
+++ b/backend/utils/memory/legacy_backfill_inventory.py
@@ -11,10 +11,10 @@ from database._client import db as default_db_client
 from database.memories import get_non_filtered_memories
 from utils.memory.legacy_backfill import (
     LegacyReader,
-    _bucket_counts_and_samples,
-    _fetch_active_legacy_memories,
-    _row_content,
+    bucket_counts_and_samples,
+    fetch_active_legacy_memories,
     is_legacy_backfill_admissible,
+    row_content,
 )
 from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
 
@@ -27,16 +27,16 @@ def inventory_legacy_user(
 ) -> LegacyBackfillInventoryReport:
     """Return counts and token proxies without logging or returning memory content."""
     client: Any = db_client if db_client is not None else default_db_client
-    legacy_rows = _fetch_active_legacy_memories(
+    legacy_rows = fetch_active_legacy_memories(
         uid,
         db_client=client,
         get_non_filtered_memories_fn=get_non_filtered_memories_fn,
     )
-    eligible_rows = [row for row in legacy_rows if _row_content(row)]
-    bucket_counts, _ = _bucket_counts_and_samples(eligible_rows, sample_size=0)
+    eligible_rows = [row for row in legacy_rows if row_content(row)]
+    bucket_counts, _ = bucket_counts_and_samples(eligible_rows, sample_size=0)
     admitted_rows = [row for row in eligible_rows if is_legacy_backfill_admissible(row)]
-    content_character_count = sum(len(_row_content(row)) for row in eligible_rows)
-    admitted_character_count = sum(len(_row_content(row)) for row in admitted_rows)
+    content_character_count = sum(len(row_content(row)) for row in eligible_rows)
+    admitted_character_count = sum(len(row_content(row)) for row in admitted_rows)
     return LegacyBackfillInventoryReport(
         uid=uid,
         source_count=len(eligible_rows),

--- a/backend/utils/memory/legacy_backfill_inventory.py
+++ b/backend/utils/memory/legacy_backfill_inventory.py
@@ -1,0 +1,51 @@
+"""Read-only, content-free inventory for bulk legacy-memory planning.
+
+LIFECYCLE: permanent
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database._client import db as default_db_client
+from database.memories import get_non_filtered_memories
+from utils.memory.legacy_backfill import (
+    LegacyReader,
+    _bucket_counts_and_samples,
+    _fetch_active_legacy_memories,
+    _row_content,
+    is_legacy_backfill_admissible,
+)
+from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
+
+
+def inventory_legacy_user(
+    uid: str,
+    *,
+    db_client: Any = None,
+    get_non_filtered_memories_fn: LegacyReader = get_non_filtered_memories,
+) -> LegacyBackfillInventoryReport:
+    """Return counts and token proxies without logging or returning memory content."""
+    client: Any = db_client if db_client is not None else default_db_client
+    legacy_rows = _fetch_active_legacy_memories(
+        uid,
+        db_client=client,
+        get_non_filtered_memories_fn=get_non_filtered_memories_fn,
+    )
+    eligible_rows = [row for row in legacy_rows if _row_content(row)]
+    bucket_counts, _ = _bucket_counts_and_samples(eligible_rows, sample_size=0)
+    admitted_rows = [row for row in eligible_rows if is_legacy_backfill_admissible(row)]
+    content_character_count = sum(len(_row_content(row)) for row in eligible_rows)
+    admitted_character_count = sum(len(_row_content(row)) for row in admitted_rows)
+    return LegacyBackfillInventoryReport(
+        uid=uid,
+        source_count=len(eligible_rows),
+        bucket_counts=bucket_counts,
+        admitted_candidate_count=len(admitted_rows),
+        content_character_count=content_character_count,
+        estimated_tokens=(content_character_count + 3) // 4,
+        admitted_candidate_estimated_tokens=(admitted_character_count + 3) // 4,
+    )
+
+
+__all__ = ["inventory_legacy_user"]

--- a/docs/runbooks/canonical-legacy-backfill.md
+++ b/docs/runbooks/canonical-legacy-backfill.md
@@ -17,9 +17,137 @@ For first-user dogfood, start with the **bucketed** inventory. The `stage-all-fo
 - **Bucketed dogfood** — bucketed runs preserve legacy timestamps, stage only manual or positively reviewed rows for required processing, and hold unreviewed profile/noisy/sensitive rows out of durable memory.
 - **Reversible** — remove `uid` from `CANONICAL_MEMORY_USERS` and redeploy to return them to legacy reads; legacy rows remain intact.
 
-## Preconditions
+## Bulk automation
 
-1. **Target uid chosen** — first production dogfood user only; no bulk/cron.
+Use `scripts/bulk_backfill_legacy_memories.py` for governed inventory and
+write-only enrollment/staging across an explicit UID list. The command defaults
+to dry-run and emits only counts, bucket totals, and character/token proxies. It
+never returns memory text or bucket samples.
+
+The bulk worker stores its server-owned checkpoint at
+`users/{uid}/memory_control/legacy_canonical_backfill`. States progress through
+`not_started`, `inventory_done`, `enrolled`, `processing`, `staged`, and
+`read_ready`; a governor or operator pause uses `paused`, while isolated failures
+use `failed`. Re-entry is idempotent. A capped run resumes from the existing
+single-user apply checkpoint, and a failed run restarts deterministic staging so
+successful rows are skipped and failed rows can be retried.
+
+`read_ready` means enrollment and staging reconciled for that UID. It does not
+change `MEMORY_MODE`, add the UID to `CANONICAL_MEMORY_USERS`, grant default
+memory reads, or open the global read gate. Those remain explicit later rollout
+actions.
+
+### 1. Prepare an explicit UID file
+
+Use either repeatable `--uid` flags or a UTF-8 newline-delimited/JSON UID file:
+
+```text
+# cohort-uids.txt
+uid-canary-a
+uid-canary-b
+```
+
+Do not put email addresses, names, or memory content in this file. The bulk
+command does not query all users or silently expand the cohort.
+
+### 2. Inventory dry-run
+
+Point `--firestore-project` at the data-plane project. For local testing, start
+the Firestore emulator, export `FIRESTORE_EMULATOR_HOST`, and use a disposable
+project name with seeded fake users.
+
+```bash
+cd backend
+python scripts/bulk_backfill_legacy_memories.py \
+  --uid-file cohort-uids.txt \
+  --firestore-project based-hardware \
+  --max-users-per-run 10 \
+  --max-admitted-rows-per-user 100 \
+  --max-estimated-tokens-per-run 100000 \
+  --concurrency-limit 1
+```
+
+Review `source_count`, `bucket_counts`, `admitted_candidate_count`, and
+`admitted_candidate_estimated_tokens`. `actions` contains would-be enrollment
+and staging operations. Dry-run writes no enrollment or migration checkpoint
+documents.
+
+### 3. Canary apply
+
+Start with one UID and conservative caps. Apply mode requires both a fixed
+confirmation phrase and the exact deduplicated input count. A UID outside the
+code-owned cohort additionally requires both admin-override flags; the command
+prints a cohort patch suggestion but never edits the cohort.
+
+```bash
+python scripts/bulk_backfill_legacy_memories.py \
+  --uid uid-canary-a \
+  --firestore-project based-hardware \
+  --apply \
+  --confirm-apply bulk-canonical-memory-backfill \
+  --confirm-user-count 1 \
+  --allow-admin-override \
+  --i-understand-uids-not-whitelisted \
+  --max-users-per-run 1 \
+  --max-admitted-rows-per-user 25 \
+  --max-estimated-tokens-per-run 25000 \
+  --wall-clock-seconds 600 \
+  --concurrency-limit 1
+```
+
+If existing enrollment documents differ, inspect them first and rerun only with
+`--allow-existing-update` after confirming the requested write-stage payload.
+The worker always enrolls at `stage=write`; it has no read-stage flag.
+Bulk enrollment writes only the per-user `memory_control/state` document. It
+does not rewrite rollout-wide global read or write-convergence gates and does
+not fabricate `memory_state/head` or compatibility projection data.
+
+The default `stage-all-for-admission` path is Firestore-only. Optional reviewed
+bucket upgrades remain capped by the same per-user row budget:
+
+```bash
+python scripts/bulk_backfill_legacy_memories.py \
+  --uid uid-canary-a \
+  --firestore-project based-hardware \
+  --apply \
+  --confirm-apply bulk-canonical-memory-backfill \
+  --confirm-user-count 1 \
+  --allow-admin-override \
+  --i-understand-uids-not-whitelisted \
+  --process-bucket manual_required_promotion \
+  --max-users-per-run 1 \
+  --max-admitted-rows-per-user 25 \
+  --max-estimated-tokens-per-run 25000
+```
+
+This CLI does not invoke an LLM. Required `memory_l2` processing and promotion
+remain exclusively owned by `memory-maintenance-job`, which processes admitted
+rows under its own bounds. Never run L2 over `pending_admission`,
+`hold_noise`, or `hold_sensitive` rows.
+
+### Pause and resume
+
+Set `MEMORY_BULK_BACKFILL_PAUSED=true` on the maintenance shell for an immediate
+local pause, or set the server-owned Firestore document
+`memory_control/legacy_canonical_backfill_pause` to `{"paused": true}`. The
+worker checks pause before inventory and again before each enrollment/staging
+boundary. A pause-control read error fails closed.
+
+Clear the pause flag and rerun the exact command to resume. Do not delete or
+manually advance checkpoint documents. Row, token, user, and wall-clock limits
+stop cleanly; increase a cap only after reviewing the prior structured summary.
+
+### Rollback
+
+Before a read flip, rollback is simply: pause bulk work and do not add the UID to
+the code-owned cohort. If a later rollout already selected the UID, remove it
+from `backend/config/canonical_memory_cohort.py` and redeploy through the normal
+reviewed path. Canonical staged rows and checkpoints remain for idempotent
+resume; legacy memories remain untouched and must not be deleted or rewritten.
+
+## Single-user preconditions
+
+1. **Target uid chosen** — use this section for one-off dogfood; use the governed bulk command above for cohorts.
 2. **Backend env** — `GOOGLE_APPLICATION_CREDENTIALS` (or emulator) points at the intended project.
 3. **Cohort whitelist** — add uid to `CANONICAL_MEMORY_USERS` in `backend/utils/memory/memory_system.py` **before** backfill, then deploy:
    ```python


### PR DESCRIPTION
## Summary

- add a content-free multi-UID inventory and governed bulk migration orchestrator
- add server-owned per-UID checkpoints, pause/resume, bounded concurrency, and hard user/row/token/wall-clock stops
- keep enrollment write-only and stage legacy rows through the existing deterministic `stage-all-for-admission` path
- preserve single-user behavior while adding capped resume and one control-refresh retry for recoverable row failures
- document dry-run, canary apply, pause/resume, rollback, and the maintenance ownership boundary

## Safety and rollout boundary

- legacy `users/{uid}/memories` remains read-only; reports and fixtures contain no raw memory content
- dry-run is the default; apply requires a fixed confirmation phrase plus the exact deduplicated UID count
- non-cohort staging keeps the existing double admin override acknowledgement
- bulk enrollment writes only per-user `memory_control/state`; it does not rewrite rollout-wide gates, edit `CANONICAL_MEMORY_USERS`, flip `MEMORY_MODE`, enable reads, deploy, or run live Firestore bulk writes
- `read_ready` is a migration checkpoint, not a read flip
- L2 and promotion remain exclusively owned by `memory-maintenance-job`; the CLI never invokes an LLM or processes hold buckets

## Product invariants

- `INV-MEM-1`: canonical staging continues to use the existing three-tier vocabulary and single `memory_items` store
- `INV-MEM-3`: enrolled canonical read-mode remains fail-closed; this worker does not introduce a legacy fallback or change read routing

Failure-Class: none

## Verification

- `pytest -q tests/unit/test_bulk_legacy_backfill.py` — 12 passed
- `pytest -q tests/unit/test_bulk_backfill_legacy_memories_cli.py` — 2 passed with an offline Firestore fake and no writes
- `pytest -q tests/unit/test_ws_c_backfill.py` — 36 passed
- `pytest -q tests/unit/test_enroll_canonical_memory_user.py` — 7 passed
- `pytest -q tests/unit/test_workflow_contracts.py` — 24 passed
- `python backend/scripts/bulk_backfill_legacy_memories.py --help` — exit 0
- `make preflight` — passed

No live dev/prod Firestore apply, deployment, cohort expansion, or read-mode flip was performed.

## Canary dry-run

```bash
cd backend
python scripts/bulk_backfill_legacy_memories.py \
  --uid CANARY_UID \
  --firestore-project based-hardware \
  --max-users-per-run 1 \
  --max-admitted-rows-per-user 25 \
  --max-estimated-tokens-per-run 25000 \
  --wall-clock-seconds 600 \
  --concurrency-limit 1
```

Apply remains a separate operator-approved step documented in `docs/runbooks/canonical-legacy-backfill.md`.

## Residual risks

- the offline-fake CLI path is exercised, but no live credentials or Firestore emulator were used in this PR session
- operators must supply the correct data-plane project and account generation, then review existing control docs before acknowledging updates
- the change is review-sized because the state machine/governor and safety/error paths have dedicated hermetic coverage; production-source growth stays below the repository advisory threshold and the frozen legacy module remains at its prior line-count baseline


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

