### PR TITLE
fix(backend): pass gateway VPC probe lanes as --lane=<lane> so gcloud accepts --args

### DIFF
--- a/backend/scripts/probe-llm-gateway-from-cloud-run.sh
+++ b/backend/scripts/probe-llm-gateway-from-cloud-run.sh
@@ -46,7 +46,9 @@ JOB_NAME="llm-gateway-vpc-probe-${NAME_SUFFIX}"
 SMOKE_ARGS=(scripts/smoke-llm-gateway.py --url "$GATEWAY_URL")
 for lane in "${LANES[@]}"; do
   [[ -n "$lane" ]] || continue
-  SMOKE_ARGS+=(--lane "$lane")
+  # `gcloud run jobs deploy --args` rejects a repeated list element, so pass each
+  # lane as a single `--lane=<lane>` token instead of a repeated `--lane` flag.
+  SMOKE_ARGS+=("--lane=$lane")
 done
 SMOKE_ARGS_CSV="$(IFS=,; echo "${SMOKE_ARGS[*]}")"
 cleanup() {

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -311,7 +311,30 @@ def test_gateway_vpc_probe_workflows_execute_the_production_parser(tmp_path):
     """Exercise each rendered workflow caller through the real probe parser with fake gcloud."""
     calls = tmp_path / 'gcloud-calls.txt'
     fake_gcloud = tmp_path / 'gcloud'
-    fake_gcloud.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$FAKE_GCLOUD_CALLS"\n', encoding='utf-8')
+    # Real gcloud parses --args as a unique list and exits 2 on a repeated element,
+    # so the fake rejects duplicates the same way instead of accepting any payload.
+    fake_gcloud.write_text(
+        '#!/usr/bin/env bash\n'
+        'printf "%s\\n" "$*" >> "$FAKE_GCLOUD_CALLS"\n'
+        'for argument in "$@"; do\n'
+        '  case "$argument" in\n'
+        '    --args=*)\n'
+        '      IFS="," read -r -a items <<< "${argument#--args=}"\n'
+        '      for item in "${items[@]}"; do\n'
+        '        count=0\n'
+        '        for other in "${items[@]}"; do\n'
+        '          [[ "$item" == "$other" ]] && count=$((count + 1))\n'
+        '        done\n'
+        '        if (( count > 1 )); then\n'
+        '          echo "ERROR: argument --args: \\"$item\\" cannot be specified multiple times" >&2\n'
+        '          exit 2\n'
+        '        fi\n'
+        '      done\n'
+        '      ;;\n'
+        '  esac\n'
+        'done\n',
+        encoding='utf-8',
+    )
     fake_gcloud.chmod(0o755)
 
     for workflow_name in VPC_PROBE_WORKFLOWS:


### PR DESCRIPTION
## Bug

Every backend deploy that reaches **Probe LLM Gateway from the Cloud Run VPC** dies:

```
ERROR: (gcloud.run.jobs.deploy) argument --args: "--lane" cannot be specified multiple times
```

Live dev failures on `main`: runs 30794228425 (07:35Z) and 30795565086 (07:57Z) on 2026-08-03. `gcp_backend.yml` (prod) passes the same two lanes to the same script, so a prod backend deploy would fail the same way.

## Root cause

`gcloud run jobs deploy --args` parses its value as a **unique** list and exits 2 on any repeated element. `backend/scripts/probe-llm-gateway-from-cloud-run.sh` serialized the smoke arguments as `scripts/smoke-llm-gateway.py,--url,<url>,--lane,<a>,--lane,<b>`. That was fine while a single lane was probed; 78e6c3e063 ("feat(memory): route maintenance L2 through gateway", 2026-08-02) added the second `--lane`, which made the token `--lane` repeat and broke the deploy input.

`test_gateway_vpc_probe_workflows_execute_the_production_parser` already ran the real script through the rendered workflow steps, but its fake `gcloud` accepted any payload — so CI could not see the constraint the real CLI enforces.

## Fix

- Serialize each lane as one `--lane=<lane>` token, which stays unique inside the `--args` list. `smoke-llm-gateway.py` declares `--lane` with argparse `action='append'`, so the equals form parses to the identical lane list.
- The probe test's fake `gcloud` now rejects duplicate `--args` elements the way real gcloud does, so the regression fails without the script change.

## Verification

Real `gcloud` 569.0.0, invoked against a nonexistent project so nothing is deployed — same flags the workflows pass:

- **before:** `ERROR: (gcloud.run.jobs.deploy) argument --args: "--lane" cannot be specified multiple times` (exact CI failure)
- **after:** `ERROR: (gcloud.run.jobs.deploy) PERMISSION_DENIED: Permission denied on resource project zz-nonexistent-proj-9917` — argument parsing succeeded and the call reached the API

Argparse equivalence: `--lane=omi:auto:public-shared-conversation-chat --lane=omi:auto:memory-l2` -> `['omi:auto:public-shared-conversation-chat', 'omi:auto:memory-l2']`.

Tests: `backend/tests/unit/test_llm_gateway_deploy_contract.py` 13 passed (fails at `test_gateway_vpc_probe_workflows_execute_the_production_parser` without the fix). The changed-file selector's other 14 files pass; `tests/unit/test_sync_two_lane.py` could not be collected locally (missing `google.cloud.firestore` in this environment) and is untouched by this change.

Failure-Class: FC-deploy-input-serialization

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

