### PR TITLE
fix(backend): stop the gateway VPC probe from repeating --lane in gcloud --args

### DIFF
--- a/backend/scripts/probe-llm-gateway-from-cloud-run.sh
+++ b/backend/scripts/probe-llm-gateway-from-cloud-run.sh
@@ -44,9 +44,14 @@ fi
 
 JOB_NAME="llm-gateway-vpc-probe-${NAME_SUFFIX}"
 SMOKE_ARGS=(scripts/smoke-llm-gateway.py --url "$GATEWAY_URL")
+# gcloud's --args parser rejects any element that repeats, so each lane must be
+# one `--lane=<lane>` element rather than a `--lane` + value pair.
+SEEN_LANES=""
 for lane in "${LANES[@]}"; do
   [[ -n "$lane" ]] || continue
-  SMOKE_ARGS+=(--lane "$lane")
+  case " $SEEN_LANES " in *" $lane "*) continue ;; esac
+  SEEN_LANES="$SEEN_LANES $lane"
+  SMOKE_ARGS+=("--lane=$lane")
 done
 SMOKE_ARGS_CSV="$(IFS=,; echo "${SMOKE_ARGS[*]}")"
 cleanup() {

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -344,6 +344,20 @@ def test_gateway_vpc_probe_workflows_execute_the_production_parser(tmp_path):
     assert any(call.startswith('run jobs execute llm-gateway-vpc-probe-42-1 ') for call in recorded_calls)
     assert any(call.startswith('run jobs delete llm-gateway-vpc-probe-42-1 ') for call in recorded_calls)
 
+    # gcloud rejects `--args` lists that repeat an element ("<value>" cannot be
+    # specified multiple times), which is how a second probe lane broke every
+    # backend deploy at the VPC probe step.
+    for call in recorded_calls:
+        if not call.startswith('run jobs deploy '):
+            continue
+        smoke_args = next(
+            (token[len('--args=') :] for token in call.split(' ') if token.startswith('--args=')),
+            None,
+        )
+        assert smoke_args is not None, call
+        elements = smoke_args.split(',')
+        assert len(elements) == len(set(elements)), f'duplicate --args element: {smoke_args}'
+
 
 def test_gateway_vpc_probe_rejects_equals_style_arguments():
     result = subprocess.run(


### PR DESCRIPTION
## Bug

Every backend deploy dies at **"Probe LLM Gateway from the Cloud Run VPC"**:

```
ERROR: (gcloud.run.jobs.deploy) argument --args: "--lane" cannot be specified multiple times
```

Live on `main`. `Auto Deploy Backend to Development` failed this way on 2026-08-03 at
07:35Z (run 30794228425, `812e3aca`) and 07:57Z (run 30795565086, `a689d3c0`); the last
run whose probe step actually passed was 06:22Z on `deab4a57`, before the second lane
landed. `gcp_backend.yml` (prod) passes the same two lanes, so prod deploys hit it too.

## Root cause

`backend/scripts/probe-llm-gateway-from-cloud-run.sh` rendered each smoke lane as **two**
`--args` elements — `--lane` then the value — and joined them into the comma-separated
`--args` list. gcloud's `--args` parser rejects any element that repeats, so the moment
#11046 added `--lane omi:auto:memory-l2` alongside `--lane omi:auto:public-shared-conversation-chat`,
the literal token `--lane` appeared twice and gcloud refused to parse the command. This is
not lane-specific: `--args="a,b,a"` fails the same way.

## Fix

Emit each lane as one `--lane=<lane>` element, and skip a lane already added, so no
`--args` element can collide. `scripts/smoke-llm-gateway.py` takes `--lane` through
argparse `action='append'`, which accepts the `=` form unchanged — no caller or workflow
edit needed.

## What I tested

- **Real gcloud 569.0.0, the exact CI invocation** (both lanes, same flags as
  `gcp_backend_auto_dev.yml`): pre-fix it dies at argument parsing with the CI error;
  post-fix it parses and reaches the API (`PERMISSION_DENIED` against a throwaway
  project, i.e. past the parser). Also confirmed the parser rejects any duplicate
  element, flag-shaped or not.
- `python scripts/smoke-llm-gateway.py --url ... --lane=a --lane=b` parses both lanes.
- **Regression guard** added to `test_gateway_vpc_probe_workflows_execute_the_production_parser`:
  the rendered `--args` list must contain no duplicate element. The existing harness stubs
  gcloud with a script that echoes whatever it is given, which is exactly why this shipped
  green. The new assertion fails on the old script and passes on the new one.
- `pytest tests/unit/test_llm_gateway_deploy_contract.py tests/unit/test_workflow_contracts.py tests/unit/test_llm_gateway_config.py` → 54 passed.

Failure-Class: FC-deploy-input-serialization

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

