### PR TITLE
fix(desktop): route Escape in Chat-first shell

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift
@@ -266,6 +266,13 @@ final class ChatFirstShellNavigation: ObservableObject {
     analytics(.routeEntered(route: destination.analyticsRoute, origin: origin))
   }
 
+  @discardableResult
+  func handleEscapeNavigation() -> Bool {
+    guard route != .chat else { return false }
+    selectPrimary(.chat)
+    return true
+  }
+
   func selectMore(_ page: ChatFirstMorePage) {
     invalidateGoalLinkResolutions()
     route = .more(page)

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -98,11 +98,12 @@ struct ChatFirstShell: View {
       else { return }
       promptMaterializationCoordinator.mainWindowDidBecomeForeground()
     }
-    .onExitCommand {
-      guard navigation.route != .chat else { return }
+    .onEscapeKey(priority: .navigation) {
+      guard navigation.route != .chat else { return false }
       OmiMotion.withGated(.easeOut(duration: 0.12)) {
-        navigation.selectPrimary(.chat)
+        _ = navigation.handleEscapeNavigation()
       }
+      return true
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift
@@ -470,6 +470,10 @@ private struct ChatFirstTaskRow: View {
             .focused($titleIsFocused)
             .onSubmit { rename() }
             .onExitCommand { cancelRename() }
+            .onEscapeKey(priority: .editing) {
+              cancelRename()
+              return true
+            }
             .accessibilityLabel("Rename \(task.description)")
             .accessibilityIdentifier("chat-first-tasks-rename-\(task.id)")
             .onAppear {

--- a/desktop/macos/Desktop/Tests/ChatFirstShellTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstShellTests.swift
@@ -91,6 +91,20 @@ final class ChatFirstShellTests: XCTestCase {
     XCTAssertFalse(restored.isFocusedEntityAcknowledged)
   }
 
+  func testEscapeReturnsToChatFromSecondaryRoutesAndRemainsUnhandledOnChat() throws {
+    let suiteName = "ChatFirstShellTests.escape-navigation.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let navigation = ChatFirstShellNavigation(defaults: defaults)
+    navigation.selectPrimary(.tasks)
+
+    XCTAssertTrue(navigation.handleEscapeNavigation())
+    XCTAssertEqual(navigation.route, .chat)
+    XCTAssertFalse(navigation.handleEscapeNavigation())
+    XCTAssertEqual(navigation.route, .chat)
+  }
+
   func testMemoryFocusRequiresTheRequestedMemoryToBeVisibleBeforeAcknowledgement() {
     let focus = ChatFirstPendingFocus.memory(id: "memory-1")
 

--- a/desktop/macos/changelog/unreleased/20260803-chat-first-escape-navigation.json
+++ b/desktop/macos/changelog/unreleased/20260803-chat-first-escape-navigation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Escape navigation from Chat-first pages"
+}


### PR DESCRIPTION
## Summary

Fixes #10698.

Chat-first pages were using SwiftUI's focus-dependent `onExitCommand`, while the
shared window Escape dispatcher was only attached to the legacy shell. Escape
could therefore be swallowed on Chat-first Tasks, Goals, Memories,
Conversations, and More pages.

The Chat-first shell now registers navigation with the shared window-scoped
Escape monitor. Child handlers retain priority, and Escape remains unhandled on
Chat. Navigation behavior is centralized in `ChatFirstShellNavigation` and
covered by a regression test.

## Verification

- `xcrun swift test --package-path Desktop --filter ChatFirstShellTests`
  - 20 tests passed.
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift Desktop/Tests/ChatFirstShellTests.swift`
  - Passed with pinned swift-format 602.0.0.
- `python3 scripts/check_desktop_test_quality.py`
  - Passed; test-quality debt remains at or below baseline.
- `OMI_APP_NAME="omi-10698-escape" ./run.sh --yolo --full --no-wait`
  - Named bundle built, signed, installed, and launched successfully.
  - Interactive route verification was unavailable because the source dev bundle
    was signed out and `agent-swift` is not installed in this environment.

## Invariants

No product invariants are affected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

