### PR TITLE
fix(desktop): await physical mic teardown before restart

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
@@ -318,17 +318,31 @@ extension SettingsContentView {
   func restartTranscriptionIfNeeded() {
     guard appState.isTranscribing else { return }
 
-    // Stop and restart to apply new language settings
-    appState.stopTranscription()
-
-    // Wait a moment for cleanup, then restart
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-      self.appState.startTranscription()
-    }
+    let capture = appState.audioCaptureService
+    _ = TranscriptionRestartCoordinator.restart(
+      stop: { self.appState.stopTranscription() },
+      waitForPhysicalStop: { await capture?.waitForPhysicalStop() },
+      start: { self.appState.startTranscription() })
   }
 
   // MARK: - Notifications Section
 
+}
+
+@MainActor
+enum TranscriptionRestartCoordinator {
+  @discardableResult
+  static func restart(
+    stop: @escaping @MainActor () -> Void,
+    waitForPhysicalStop: @escaping () async -> Void,
+    start: @escaping @MainActor () -> Void
+  ) -> Task<Void, Never> {
+    stop()
+    return Task { @MainActor in
+      await waitForPhysicalStop()
+      start()
+    }
+  }
 }
 
 /// Multi-select for the languages the user speaks to the VOICE ASSISTANT (push-to-talk).

--- a/desktop/macos/Desktop/Tests/TranscriptionRestartCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionRestartCoordinatorTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class TranscriptionRestartCoordinatorTests: XCTestCase {
+  func testRestartWaitsForPhysicalStopBeforeStartingReplacement() async {
+    var events: [String] = []
+    let (stream, continuation) = AsyncStream<Void>.makeStream()
+
+    let task = TranscriptionRestartCoordinator.restart(
+      stop: { events.append("stop") },
+      waitForPhysicalStop: {
+        for await _ in stream { break }
+      },
+      start: { events.append("start") }
+    )
+
+    XCTAssertEqual(events, ["stop"])
+    continuation.yield(())
+    await task.value
+    XCTAssertEqual(events, ["stop", "start"])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260803-await-mic-teardown.json
+++ b/desktop/macos/changelog/unreleased/20260803-await-mic-teardown.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved microphone switching reliability during transcription"
+}


### PR DESCRIPTION
## Summary

Fixes #10921.

Changing the microphone or transcription language while recording stopped the
old capture and restarted it after a fixed one-second delay. CoreAudio teardown
is asynchronous and can take longer than that, so the replacement IOProc could
start while the old IOProc still owned the device. This is especially visible
when switching Bluetooth microphone routes.

The settings restart path now waits on the existing
`AudioCaptureService.waitForPhysicalStop()` boundary before starting the
replacement transcription session. A small coordinator makes the ordering
deterministic and adds a regression test proving that `start` cannot run before
physical teardown completes.

This PR intentionally does not change preferred-device reconnect handling,
active PTT arbitration, or route reservation; those are separate #10921
failure boundaries.

## Verification

- `xcrun swift test --package-path Desktop --filter TranscriptionRestartCoordinatorTests`
  - 1 test passed.
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift Desktop/Tests/TranscriptionRestartCoordinatorTests.swift`
  - Passed with pinned swift-format 602.0.0.
- `python3 scripts/check_desktop_test_quality.py`
  - Passed; test-quality debt remains at or below baseline.
- `OMI_APP_NAME="omi-10921-teardown" ./run.sh --yolo --full --no-wait`
  - Named bundle built, signed, installed, dependency-audited, and launched.
  - Interactive microphone switching was not exercised because the seeded
    source dev bundle is signed out in this environment; no hardware behavior
    is being claimed from the launch alone.

## Invariants

No product invariants are affected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

