### PR TITLE
fix(desktop-windows): pause hidden conversation refreshes

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-chat-panel-background-refresh.json
+++ b/desktop/windows/changelog/unreleased/2026-08-chat-panel-background-refresh.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reduced chat freezes by pausing conversation refresh work while that page is hidden"
+}

--- a/desktop/windows/src/main/whatsNew.ts
+++ b/desktop/windows/src/main/whatsNew.ts
@@ -3,23 +3,27 @@
 // when it INCREASED (a real update, not a fresh install) — surface the changes in
 // the shared acrylic toast window, then record the version so it never nags again.
 //
-// Changelog source: the fragment(s) under changelog/unreleased/ (same schema as
-// desktop/macos/changelog/unreleased/*.json). For this pass a single fragment is
-// imported directly; the fragment→per-version consolidation script + CI check
-// (desktop-changelog.py's Windows equivalent) is a deferred follow-up — see
-// changelog/README.md.
+// Changelog source: fragments under changelog/unreleased/ (same schema as
+// desktop/macos/changelog/unreleased/*.json). Until the Windows fragment
+// consolidation script lands, import the notes we intend to surface this build.
 import { app } from 'electron'
 import { getAppSettings, setAppSettings } from './appSettings'
-import fragment from '../../changelog/unreleased/2026-07-phase-8-windows-redesign.json'
+import phase8Fragment from '../../changelog/unreleased/2026-07-phase-8-windows-redesign.json'
+import chatRefreshFragment from '../../changelog/unreleased/2026-08-chat-panel-background-refresh.json'
 import type { WhatsNewPayload } from '../shared/types'
 
 // Fragment schema: { "changes": string[] } or { "change": string }.
-const raw = fragment as unknown as { changes?: string[]; change?: string }
-const CHANGES: string[] = Array.isArray(raw.changes)
-  ? raw.changes
-  : typeof raw.change === 'string'
-    ? [raw.change]
-    : []
+function changesFromFragment(fragment: unknown): string[] {
+  const raw = fragment as { changes?: string[]; change?: string }
+  if (Array.isArray(raw.changes)) return raw.changes
+  if (typeof raw.change === 'string') return [raw.change]
+  return []
+}
+
+const CHANGES: string[] = [
+  ...changesFromFragment(phase8Fragment),
+  ...changesFromFragment(chatRefreshFragment),
+]
 
 /** Decide whether to show the what's-new toast this launch, advancing the stored
  *  marker as a side effect so it fires at most once per version. Returns the

--- a/desktop/windows/src/renderer/src/lib/conversations/conversationsPanelActivity.test.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/conversationsPanelActivity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isConversationsPanelActive } from './conversationsPanelActivity'
+
+describe('isConversationsPanelActive', () => {
+  it.each(['/home', '/tasks', '/settings', '/conversations/abc123', '/conversations/live'])(
+    'returns false for inactive route %s',
+    (pathname) => {
+      expect(isConversationsPanelActive(pathname)).toBe(false)
+    }
+  )
+
+  it('returns true only for the conversations panel route', () => {
+    expect(isConversationsPanelActive('/conversations')).toBe(true)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/conversations/conversationsPanelActivity.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/conversationsPanelActivity.ts
@@ -1,0 +1,3 @@
+export function isConversationsPanelActive(pathname: string): boolean {
+  return pathname === '/conversations'
+}

--- a/desktop/windows/src/renderer/src/lib/conversations/conversationsPanelActivity.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/conversationsPanelActivity.ts
@@ -1,3 +1,6 @@
+/** Must stay in sync with `CONVERSATIONS_PATH` usage in `routes/manifest.ts`. */
+export const CONVERSATIONS_PATH = '/conversations'
+
 export function isConversationsPanelActive(pathname: string): boolean {
-  return pathname === '/conversations'
+  return pathname === CONVERSATIONS_PATH
 }

--- a/desktop/windows/src/renderer/src/pages/Conversations.tsx
+++ b/desktop/windows/src/renderer/src/pages/Conversations.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import {
   GanttChartSquare,
   Mic,
@@ -40,6 +40,7 @@ import {
   NO_DATE_RANGE
 } from '../lib/conversations/filtering'
 import { fetchFolders, loadCachedFolders } from '../lib/conversations/folders'
+import { isConversationsPanelActive } from '../lib/conversations/conversationsPanelActivity'
 import {
   removeRows,
   restoreRows,
@@ -133,6 +134,8 @@ function ConversationSkeleton(): React.JSX.Element {
 }
 
 export function Conversations(): React.JSX.Element {
+  const { pathname } = useLocation()
+  const panelIsActive = isConversationsPanelActive(pathname)
   const navigate = useNavigate()
   // Seed the shared cache from the per-uid cold-start snapshot before the initial
   // state is read, so the list paints last-known rows immediately on app restart
@@ -297,6 +300,7 @@ export function Conversations(): React.JSX.Element {
 
   // Load folders: cached first (instant paint), then reconcile from the backend.
   useEffect(() => {
+    if (!panelIsActive) return
     void loadCachedFolders()
       .then((f) => {
         if (f.length) setFolders(f)
@@ -305,13 +309,14 @@ export function Conversations(): React.JSX.Element {
     void fetchFolders()
       .then(setFolders)
       .catch(() => {})
-  }, [])
+  }, [panelIsActive])
 
   // (Re)fetch when the folder/date filter changes. Skip the fetch only on the very
   // first mount when the default view is already warm in the shared cache (instant
   // paint from the useState seed); every filter change after that fetches fresh.
   const didInitRef = useRef(false)
   useEffect(() => {
+    if (!panelIsActive) return
     const firstMount = !didInitRef.current
     didInitRef.current = true
     const defaultView = isDefaultView(folderFilter, dateRange)
@@ -330,20 +335,22 @@ export function Conversations(): React.JSX.Element {
     const haveSnapshot = firstMount && defaultView && (conversationsCache.rows?.length ?? 0) > 0
     void loadAll(!haveSnapshot)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- folder/date read once for the first-mount check; loadAll owns the fetch + its own deps
-  }, [loadAll])
+  }, [loadAll, panelIsActive])
 
   // The continuous-recording host (and session-end) request a cloud re-fetch when
   // the backend publishes a new conversation; re-run the full fetch in place.
   useEffect(() => {
+    if (!panelIsActive) return
     return subscribeCloudRefresh(() => {
       void loadAll()
     })
-  }, [loadAll])
+  }, [loadAll, panelIsActive])
 
   // Live refresh: when the local store changes (e.g. an Omi chat is being saved as
   // it streams), re-read local conversations and merge with the already-loaded
   // cloud rows — no extra cloud fetch — so the list updates in real time.
   useEffect(() => {
+    if (!panelIsActive) return
     return subscribeConversations(() => {
       // The account this refresh belongs to (teardown fires this same channel via
       // invalidateConversationsCache, so guard it too — otherwise a switch would
@@ -370,7 +377,7 @@ export function Conversations(): React.JSX.Element {
         })
         .catch((e) => console.error('Live local refresh failed:', e))
     })
-  }, [folderFilter, dateRange])
+  }, [folderFilter, dateRange, panelIsActive])
 
   // Legacy local-only recordings eligible for backfill; recomputed only when the
   // local set actually changes.

--- a/desktop/windows/src/renderer/src/pages/Conversations.tsx
+++ b/desktop/windows/src/renderer/src/pages/Conversations.tsx
@@ -298,6 +298,14 @@ export function Conversations(): React.JSX.Element {
     [folderFilter, dateRange]
   )
 
+  // Leaving the panel must invalidate in-flight loadAll commits so a fetch that
+  // started while visible cannot publish/setState after the route is hidden.
+  useEffect(() => {
+    if (!panelIsActive) {
+      loadGenRef.current += 1
+    }
+  }, [panelIsActive])
+
   // Load folders: cached first (instant paint), then reconcile from the backend.
   useEffect(() => {
     if (!panelIsActive) return
@@ -351,7 +359,8 @@ export function Conversations(): React.JSX.Element {
   // cloud rows — no extra cloud fetch — so the list updates in real time.
   useEffect(() => {
     if (!panelIsActive) return
-    return subscribeConversations(() => {
+    let cancelled = false
+    const unsubscribe = subscribeConversations(() => {
       // The account this refresh belongs to (teardown fires this same channel via
       // invalidateConversationsCache, so guard it too — otherwise a switch would
       // merge A's still-in-state cloud rows and persist them under B).
@@ -359,7 +368,7 @@ export function Conversations(): React.JSX.Element {
       window.omi
         .listLocalConversations()
         .then((freshLocals) => {
-          if (getCacheUid() !== originUid) return
+          if (cancelled || getCacheUid() !== originUid) return
           setLocals(freshLocals)
           setRows((prev) => {
             const cloud = prev.filter((r) => r.source === 'cloud' && !r.pending)
@@ -377,6 +386,10 @@ export function Conversations(): React.JSX.Element {
         })
         .catch((e) => console.error('Live local refresh failed:', e))
     })
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
   }, [folderFilter, dateRange, panelIsActive])
 
   // Legacy local-only recordings eligible for backfill; recomputed only when the

--- a/desktop/windows/src/renderer/src/routes/manifest.ts
+++ b/desktop/windows/src/renderer/src/routes/manifest.ts
@@ -14,6 +14,7 @@ import { Rewind } from '../pages/Rewind'
 import { Insights } from '../pages/Insights'
 import { LiveConversation } from '../pages/LiveConversation'
 import { KnowledgeGraph } from '../pages/KnowledgeGraph'
+import { CONVERSATIONS_PATH } from '../lib/conversations/conversationsPanelActivity'
 
 // Single source of truth for the app's page routing. Both MainViews (what renders
 // in the content area) and Sidebar (the nav rail) are driven off this array, so a
@@ -79,6 +80,10 @@ const AppsPanel = memo(Apps)
 const RewindPanel = memo(Rewind)
 const InsightsPanel = memo(Insights)
 
+// Shared path constants — keep panel activity predicates and the manifest in sync.
+export const HOME_PATH = '/home'
+export { CONVERSATIONS_PATH }
+
 export const routeManifest: RouteEntry[] = [
   // Redirects: legacy/blank routes fold into Home (Home merges the old Chat and
   // Record screens).
@@ -131,7 +136,7 @@ export const routeManifest: RouteEntry[] = [
   {
     id: 'conversations',
     kind: 'panel',
-    path: '/conversations',
+    path: CONVERSATIONS_PATH,
     Component: ConversationsPanel,
     nav: { label: 'Conversations', Icon: GanttChartSquare, order: 1 },
     shortcut: '2',
@@ -182,9 +187,6 @@ export const routeManifest: RouteEntry[] = [
     escapeToHome: true
   }
 ]
-
-// Home is the one page with no PageChromeBar and no Esc-to-home (it IS home).
-export const HOME_PATH = '/home'
 
 export type ResolveResult =
   | { entry: RouteEntry; params: Record<string, string> }


### PR DESCRIPTION
## Summary

Fixes #10892 and #10893.

The Windows shell keeps panels mounted and hidden for instant navigation. The
Conversations panel was still running local-store refreshes, folder fetches, and
cloud revalidation while hidden. Chat persistence broadcasts could therefore
make a hidden panel synchronously enumerate the local SQLite conversation table
while the user was sending a chat message or returning from Chat to Home.

The panel now gates those effects on the active `/conversations` route. It still
loads and refreshes normally when visible, while Home and Chat no longer trigger
conversation-page database work in the background. The route policy has a
regression test covering panel, home, detail, and live routes.

The Chat-to-Home investigation found no separate blocking cleanup path: Home
chat is an internal stage change, and the hidden Conversations refresh is the
shared, verifiable contributor to both reported freezes. This PR does not claim
to eliminate every possible Windows renderer/main-process stall.

## Verification

- `PATH="$HOME/.nvm/versions/node/v22.23.1/bin:$PATH" pnpm exec vitest run src/renderer/src/lib/conversations src/renderer/src/components/conversations src/renderer/src/components/layout/MainViews.test.tsx`
  - 13 files, 102 tests passed.
- `PATH="$HOME/.nvm/versions/node/v22.23.1/bin:$PATH" pnpm run typecheck:web`
  - Passed.
- `PATH="$HOME/.nvm/versions/node/v22.23.1/bin:$PATH" pnpm exec prettier --check src/renderer/src/pages/Conversations.tsx src/renderer/src/lib/conversations/conversationsPanelActivity.ts src/renderer/src/lib/conversations/conversationsPanelActivity.test.ts`
  - Passed for all changed TypeScript files.

## Invariants

No product invariants are affected.

Failure-Class: none
