### PR TITLE
fix(backend): deduplicate all-time usage reads

### DIFF
--- a/backend/database/firestore_read_metrics.py
+++ b/backend/database/firestore_read_metrics.py
@@ -12,6 +12,7 @@ from prometheus_client import Counter, Histogram
 class FirestoreReadFamily(StrEnum):
     ACTION_ITEMS_LIST = 'action_items_list'
     LISTEN_MONTHLY_USAGE = 'listen_monthly_usage'
+    ALL_TIME_USAGE = 'all_time_usage'
 
 
 class FirestoreReadMode(StrEnum):

--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -311,9 +311,8 @@ def get_yearly_usage_stats(uid: str, date: datetime) -> Dict[str, Any]:
 
 def get_all_time_usage_stats(uid: str) -> Dict[str, Any]:
     """Aggregates all hourly usage stats for a user from Firestore."""
-    user_ref = db.collection('users').document(uid)
-    hourly_usage_collection = user_ref.collection('hourly_usage')
-    return _aggregate_stats(hourly_usage_collection)
+    stats, _ = _read_all_time_usage(uid)
+    return stats
 
 
 def get_hourly_history_for_today(uid: str, date: datetime) -> List[Dict[str, Any]]:
@@ -440,6 +439,47 @@ def get_yearly_history(uid: str) -> List[Dict[str, Any]]:
     return history
 
 
+def _read_all_time_usage(uid: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Read hourly usage once while building both the total and yearly history."""
+    user_ref = db.collection('users').document(uid)
+    hourly_usage_collection = user_ref.collection('hourly_usage')
+    stats: Dict[str, Any] = {
+        'transcription_seconds': 0,
+        'words_transcribed': 0,
+        'insights_gained': 0,
+        'memories_created': 0,
+        'speech_seconds': 0,
+    }
+    yearly_totals: Dict[int, Dict[str, int]] = {}
+    document_count = 0
+    for doc in hourly_usage_collection.stream():
+        document_count += 1
+        data = _typed_doc(doc)
+        for key in stats:
+            stats[key] += data.get(key, 0)
+        year = cast(int, data.get('year', 0))
+        year_stats = yearly_totals.setdefault(
+            year,
+            {
+                'transcription_seconds': 0,
+                'words_transcribed': 0,
+                'insights_gained': 0,
+                'memories_created': 0,
+            },
+        )
+        for key in year_stats:
+            year_stats[key] += data.get(key, 0)
+
+    record_firestore_read(
+        FirestoreReadFamily.ALL_TIME_USAGE,
+        FirestoreReadMode.UNBOUNDED,
+        document_count,
+    )
+    history = [{'date': f"{year}-01-01", **year_stats} for year, year_stats in yearly_totals.items()]
+    history.sort(key=lambda x: cast(str, x['date']))
+    return stats, history
+
+
 def get_current_user_usage(
     uid: str, period: str, tz_name: Optional[str] = None, now: Optional[datetime] = None
 ) -> Dict[str, Any]:
@@ -477,7 +517,8 @@ def get_current_user_usage(
         response['yearly'] = UsageStats(**get_yearly_usage_stats(uid, now)).model_dump()
         response['history'] = get_monthly_history_for_year(uid, now)
     elif period == 'all_time':
-        response['all_time'] = UsageStats(**get_all_time_usage_stats(uid)).model_dump()
-        response['history'] = get_yearly_history(uid)
+        all_time, history = _read_all_time_usage(uid)
+        response['all_time'] = UsageStats(**all_time).model_dump()
+        response['history'] = history
 
     return response

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -231,3 +231,40 @@ def test_usage_endpoint_serves_the_users_local_day_not_the_utc_day(mock_db, monk
     # 600 (7am local, filed under the previous UTC date) + 300 (6pm local, filed under today's
     # UTC date). Serving the UTC day alone finds only the 300.
     assert result['today']['transcription_seconds'] == 900, result['today']
+
+
+def test_all_time_usage_builds_totals_and_history_from_one_stream(mock_db, monkeypatch):
+    query = MagicMock()
+    query.stream.return_value = iter(
+        [
+            _Snap({'year': 2025, 'transcription_seconds': 10, 'speech_seconds': 8}),
+            _Snap({'year': 2026, 'transcription_seconds': 20, 'words_transcribed': 4, 'speech_seconds': 16}),
+        ]
+    )
+    mock_db.collection.return_value.document.return_value.collection.return_value = query
+    record_read = MagicMock()
+    monkeypatch.setattr(user_usage, 'record_firestore_read', record_read)
+
+    result = user_usage.get_current_user_usage('uid', 'all_time')
+
+    assert result['all_time']['transcription_seconds'] == 30
+    assert result['all_time']['words_transcribed'] == 4
+    assert result['all_time']['speech_seconds'] == 24
+    assert result['history'] == [
+        {
+            'date': '2025-01-01',
+            'transcription_seconds': 10,
+            'words_transcribed': 0,
+            'insights_gained': 0,
+            'memories_created': 0,
+        },
+        {
+            'date': '2026-01-01',
+            'transcription_seconds': 20,
+            'words_transcribed': 4,
+            'insights_gained': 0,
+            'memories_created': 0,
+        },
+    ]
+    query.stream.assert_called_once_with()
+    record_read.assert_called_once_with(FirestoreReadFamily.ALL_TIME_USAGE, FirestoreReadMode.UNBOUNDED, 2)


### PR DESCRIPTION
## Summary

Fixes the all-time usage read amplification identified in #10950 and #9889.

`GET /v1/users/me/usage?period=all_time` previously streamed the complete
`hourly_usage` collection once for aggregate totals and a second time for yearly
history. The duplicated unbounded read grew with every user's history and could
amplify Firestore document reads under concurrent usage-page traffic.

The endpoint now builds both response sections from one stream, preserving the
existing totals and history shape. It also records a low-cardinality
`all_time_usage` read family with only boundedness and document-count metrics,
so future Firestore alerts can attribute this query family without logging user
content or identifiers.

This PR does not claim to identify the sole source of the production 10k/s alert;
the alert contains no query attribution. It removes one confirmed duplicate
read path and adds privacy-safe attribution for subsequent measurement.

## Verification

- `python3 -m pytest backend/tests/unit/test_user_usage.py -q`
  - 8 tests passed.
- `python3 -m black --check --line-length 120 --skip-string-normalization backend/database/user_usage.py backend/database/firestore_read_metrics.py backend/tests/unit/test_user_usage.py`
  - Passed.
- `python3 backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils`
  - Passed with zero selected blocking findings.

## Invariants

No product invariants are affected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

