### PR TITLE
fix(app): order offline sync results by recording time

### DIFF
--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -19,6 +19,18 @@ enum WalStatusFilter { pending, synced, corrupted }
 
 enum WalDisplayFilter { all, pending, synced }
 
+List<SyncedConversationPointer> sortSyncedConversationPointers(
+  Iterable<SyncedConversationPointer> pointers,
+) {
+  final sorted = List<SyncedConversationPointer>.from(pointers);
+  sorted.sort((a, b) {
+    final aDate = a.conversation.startedAt ?? a.conversation.createdAt;
+    final bDate = b.conversation.startedAt ?? b.conversation.createdAt;
+    return bDate.compareTo(aDate);
+  });
+  return sorted;
+}
+
 class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSyncProgressListener {
   // Services
   final AudioPlayerUtils _audioPlayerUtils = AudioPlayerUtils.instance;
@@ -290,9 +302,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   double get walsSyncedProgress => _syncState.progress;
   double? get syncSpeedKBps => _syncState.speedKBps;
   List<SyncedConversationPointer> get syncedConversationsPointers {
-    final sorted = List<SyncedConversationPointer>.from(_syncState.syncedConversations);
-    sorted.sort((a, b) => (b.conversation.createdAt).compareTo(a.conversation.createdAt));
-    return sorted;
+    return sortSyncedConversationPointers(_syncState.syncedConversations);
   }
 
   String? get syncError => _syncState.errorMessage;

--- a/app/test/unit/synced_conversation_pointer_order_test.dart
+++ b/app/test/unit/synced_conversation_pointer_order_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/providers/sync_provider.dart';
+
+ServerConversation _conversation({
+  required DateTime createdAt,
+  DateTime? startedAt,
+  required String id,
+}) {
+  return ServerConversation(
+    id: id,
+    createdAt: createdAt,
+    startedAt: startedAt,
+    structured: Structured('Title', 'Overview'),
+  );
+}
+
+SyncedConversationPointer _pointer(ServerConversation conversation, int index) {
+  return SyncedConversationPointer(
+    type: SyncedConversationType.newConversation,
+    index: index,
+    key: conversation.startedAt ?? conversation.createdAt,
+    conversation: conversation,
+  );
+}
+
+void main() {
+  test(
+    'offline sync results sort by recording time instead of upload time',
+    () {
+      final olderRecordingUploadedToday = _conversation(
+        id: 'day-1',
+        startedAt: DateTime.utc(2026, 3, 1, 20),
+        createdAt: DateTime.utc(2026, 3, 2, 9),
+      );
+      final currentRecording = _conversation(
+        id: 'day-2',
+        startedAt: DateTime.utc(2026, 3, 2, 8),
+        createdAt: DateTime.utc(2026, 3, 2, 8, 5),
+      );
+
+      final sorted = sortSyncedConversationPointers([
+        _pointer(olderRecordingUploadedToday, 0),
+        _pointer(currentRecording, 1),
+      ]);
+
+      expect(sorted.map((pointer) => pointer.conversation.id), [
+        'day-2',
+        'day-1',
+      ]);
+    },
+  );
+
+  test('falls back to creation time when recording time is unavailable', () {
+    final older = _conversation(
+      id: 'older',
+      createdAt: DateTime.utc(2026, 3, 1),
+    );
+    final newer = _conversation(
+      id: 'newer',
+      createdAt: DateTime.utc(2026, 3, 2),
+    );
+
+    final sorted = sortSyncedConversationPointers([
+      _pointer(older, 0),
+      _pointer(newer, 1),
+    ]);
+
+    expect(sorted.map((pointer) => pointer.conversation.id), [
+      'newer',
+      'older',
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #5859.

The main Conversations stream already orders and groups by recording time
(`startedAt ?? createdAt`). The post-offline-sync processed-conversations list
still sorted its pointers by upload/creation time, so an older recording uploaded
the next morning could appear above a newer conversation.

The shared sync-pointer ordering now uses recording time with a creation-time
fallback, keeping the post-sync list consistent with the main conversation stream.

## Verification

- `flutter test test/unit/synced_conversation_pointer_order_test.dart`
  - 2 tests passed.
- Regression coverage includes an older recording uploaded after a newer
  recording and a missing-`startedAt` fallback.

## Invariants

No product invariants are affected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

