### PR TITLE
fix(backend): re-enable webhook when URL is repaired

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -5,7 +5,7 @@
     "backend/routers/developer.py": 2282,
     "backend/routers/mcp_sse.py": 1879,
     "backend/routers/sync.py": 2053,
-    "backend/routers/users.py": 2088
+    "backend/routers/users.py": 2086
   },
   "raise_justifications": {
     "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract.",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -5,7 +5,7 @@
     "backend/routers/developer.py": 2282,
     "backend/routers/mcp_sse.py": 1879,
     "backend/routers/sync.py": 2053,
-    "backend/routers/users.py": 2083
+    "backend/routers/users.py": 2088
   },
   "raise_justifications": {
     "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract.",
@@ -13,7 +13,7 @@
     "backend/routers/developer.py": "Developer memory create and batch routes must record their accepted write result at the authoritative API boundary; the shared dev-only allowlisted serializer/exporter lives in testing.parity_pack_v0.live_capture.",
     "backend/routers/mcp_sse.py": "The MCP SSE tool handler owns the successful memory-write response boundary; its one shared dev-only allowlisted capture call records accepted memory without duplicating serialization or export logic.",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
-    "backend/routers/users.py": "Account-deletion outcome telemetry at the users router boundary for PostHog ownership repair."
+    "backend/routers/users.py": "Account-deletion outcome telemetry at the users router boundary for PostHog ownership repair; repaired non-empty webhook URLs must also clear the persisted disabled state and failure health at the owning save boundary (#7519)."
   },
   "threshold": 1500
 }

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -482,6 +482,11 @@ def set_user_webhook_endpoint(
     url = data.url
     if url == '' or url == ',':
         disable_user_webhook_db(uid, wtype)
+    else:
+        set_user_webhook_db(uid, wtype, url)
+        enable_user_webhook_db(uid, wtype)
+        record_dev_webhook_success(uid, wtype)
+        return {'status': 'ok'}
     set_user_webhook_db(uid, wtype, url)
     return {'status': 'ok'}
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -480,14 +480,12 @@ def set_user_webhook_endpoint(
     wtype: WebhookType, data: SetUserWebhookUrlRequest, uid: str = Depends(auth.get_current_user_uid)
 ):
     url = data.url
+    set_user_webhook_db(uid, wtype, url)
     if url == '' or url == ',':
         disable_user_webhook_db(uid, wtype)
     else:
-        set_user_webhook_db(uid, wtype, url)
         enable_user_webhook_db(uid, wtype)
         record_dev_webhook_success(uid, wtype)
-        return {'status': 'ok'}
-    set_user_webhook_db(uid, wtype, url)
     return {'status': 'ok'}
 
 

--- a/backend/testing/e2e/test_webhooks.py
+++ b/backend/testing/e2e/test_webhooks.py
@@ -22,6 +22,11 @@ def _enable_realtime_webhook(client, auth_headers):
     assert enabled.status_code == 200, enabled.text
 
 
+def _disable_realtime_webhook(client, auth_headers):
+    disabled = client.post("/v1/users/developer/webhook/realtime_transcript/disable", headers=auth_headers)
+    assert disabled.status_code == 200, disabled.text
+
+
 def _health(fake_redis, uid="123", wtype="realtime_transcript"):
     return {k.decode(): v.decode() for k, v in fake_redis.hgetall(f"dev_webhook_health:{uid}:{wtype}").items()}
 
@@ -74,6 +79,7 @@ def test_realtime_webhook_config_roundtrip_and_delivery_capture(client, auth_hea
 
 def test_realtime_webhook_does_not_call_provider_when_disabled(client, auth_headers, monkeypatch, fake_redis):
     _configure_realtime_webhook(client, auth_headers)
+    _disable_realtime_webhook(client, auth_headers)
     requests = []
 
     async def handler(request):

--- a/backend/testing/e2e/test_webhooks.py
+++ b/backend/testing/e2e/test_webhooks.py
@@ -89,7 +89,8 @@ def test_realtime_webhook_does_not_call_provider_when_disabled(client, auth_head
     _run_realtime_delivery(monkeypatch, handler)
 
     assert requests == []
-    assert _health(fake_redis) == {}
+    assert _health(fake_redis)["disabled"] == "0"
+    assert _health(fake_redis)["last_status"] == "200"
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_users_webhook_url_validation.py
+++ b/backend/tests/unit/test_users_webhook_url_validation.py
@@ -122,12 +122,36 @@ def test_missing_url_returns_422():
 
 
 def test_valid_url_sets():
-    with patch.object(users_mod, 'set_user_webhook_db') as setdb, patch.object(users_mod, 'disable_user_webhook_db'):
+    with (
+        patch.object(users_mod, 'set_user_webhook_db') as setdb,
+        patch.object(users_mod, 'disable_user_webhook_db'),
+        patch.object(users_mod, 'enable_user_webhook_db') as enable,
+        patch.object(users_mod, 'record_dev_webhook_success') as reset_health,
+    ):
         result = users_mod.set_user_webhook_endpoint(
             wtype='audio_bytes', data=SetUserWebhookUrlRequest(url='http://x'), uid='u1'
         )
     assert result['status'] == 'ok'
     setdb.assert_called_once()
+    enable.assert_called_once_with('u1', 'audio_bytes')
+    reset_health.assert_called_once_with('u1', 'audio_bytes')
+
+
+def test_empty_url_disables_without_resetting_health():
+    with (
+        patch.object(users_mod, 'set_user_webhook_db') as setdb,
+        patch.object(users_mod, 'disable_user_webhook_db') as disable,
+        patch.object(users_mod, 'enable_user_webhook_db') as enable,
+        patch.object(users_mod, 'record_dev_webhook_success') as reset_health,
+    ):
+        result = users_mod.set_user_webhook_endpoint(
+            wtype='audio_bytes', data=SetUserWebhookUrlRequest(url=''), uid='u1'
+        )
+    assert result['status'] == 'ok'
+    disable.assert_called_once_with('u1', 'audio_bytes')
+    setdb.assert_called_once_with('u1', 'audio_bytes', '')
+    enable.assert_not_called()
+    reset_health.assert_not_called()
 
 
 def test_get_missing_webhook_url_validates_as_nullable_response():

--- a/backend/tests/unit/test_users_webhook_url_validation.py
+++ b/backend/tests/unit/test_users_webhook_url_validation.py
@@ -124,7 +124,7 @@ def test_missing_url_returns_422():
 def test_valid_url_sets():
     with (
         patch.object(users_mod, 'set_user_webhook_db') as setdb,
-        patch.object(users_mod, 'disable_user_webhook_db'),
+        patch.object(users_mod, 'disable_user_webhook_db') as disable,
         patch.object(users_mod, 'enable_user_webhook_db') as enable,
         patch.object(users_mod, 'record_dev_webhook_success') as reset_health,
     ):
@@ -135,6 +135,7 @@ def test_valid_url_sets():
     setdb.assert_called_once()
     enable.assert_called_once_with('u1', 'audio_bytes')
     reset_health.assert_called_once_with('u1', 'audio_bytes')
+    disable.assert_not_called()
 
 
 def test_empty_url_disables_without_resetting_health():


### PR DESCRIPTION
## Summary

Fixes #7519.

Developer webhooks are auto-disabled after consecutive delivery failures. The
URL-save endpoint stored a replacement non-empty URL but left the persistent
disabled flag and failure health state untouched. Users could therefore repair
their endpoint and save it successfully while audio webhook delivery remained
silently disabled.

Saving a non-empty URL now enables that webhook and resets its failure health.
Empty URL saves retain the explicit disable behavior. The regression tests cover
auto-disable recovery through URL save and ensure clearing a URL does not
implicitly re-enable the webhook.

## Verification

- `python3 -m pytest backend/tests/unit/test_users_webhook_url_validation.py -q`
  - 4 tests passed.
- `python3 -m black --check --line-length 120 --skip-string-normalization backend/routers/users.py backend/tests/unit/test_users_webhook_url_validation.py`
  - Passed.
- `python3 backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils`
  - Passed with zero selected blocking findings.
- The broader `test_webhook_auto_disable.py` suite was attempted but this bare
  environment lacks `pytest-asyncio` and `fakeredis`; its synchronous URL tests
  pass. CI uses the repository's pinned backend environment.

## Invariants

No product invariants are affected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

