### PR TITLE
harden(listen): expose parity capture lifecycle telemetry

### DIFF
--- a/backend/routers/listen/parity_capture.py
+++ b/backend/routers/listen/parity_capture.py
@@ -14,6 +14,8 @@ from testing.parity_pack_v0.capture import CaptureInvocation, CaptureTap
 from testing.parity_pack_v0.schema import CassetteIdentity
 from testing.parity_pack_v0.whitelist import CaptureWhitelist
 
+from .parity_telemetry import record_parity_capture_event
+
 logger = logging.getLogger(__name__)
 
 # Cassettes are a local diagnostic aid, never an unbounded in-memory recording.
@@ -41,6 +43,19 @@ def _capture_root(environ: Mapping[str, str]) -> Path | None:
     return None
 
 
+def _allowlist_decision_reason(whitelist: CaptureWhitelist, principal_id: str | None) -> str:
+    """Classify the existing gate without retaining or emitting its principal."""
+    if whitelist.allows(principal_id):
+        return 'allowed'
+    if not whitelist.enabled:
+        return 'capture_disabled'
+    if whitelist.environment != 'dev':
+        return 'stage_not_dev'
+    if not principal_id:
+        return 'principal_missing'
+    return 'allowlist_miss'
+
+
 class ListenParityCapture:
     """Small listener-side adapter around the pack's generic ``CaptureTap``.
 
@@ -49,8 +64,17 @@ class ListenParityCapture:
     serialized into that local root; logs contain no principal or payload data.
     """
 
-    def __init__(self, invocation: CaptureInvocation | None) -> None:
+    def __init__(
+        self,
+        invocation: CaptureInvocation | None,
+        *,
+        environ: Mapping[str, str] | None = None,
+    ) -> None:
         self._invocation = invocation
+        # Production reads the process environment lazily instead of retaining a
+        # per-session copy that could include unrelated credentials. Tests may
+        # inject only the narrow capture settings they exercise.
+        self._environ = None if environ is None else dict(environ)
         self._event_count = 0
         self._audio_bytes = 0
         self._limit_reached = False
@@ -67,9 +91,21 @@ class ListenParityCapture:
         environ: Mapping[str, str] | None = None,
     ) -> "ListenParityCapture":
         env = os.environ if environ is None else environ
+        record_parity_capture_event('listen', 'accepted', 'none', environ=env)
+        whitelist = CaptureWhitelist.from_environ(dict(env))
+        decision_reason = _allowlist_decision_reason(whitelist, principal_id)
+        record_parity_capture_event(
+            'allowlist',
+            'accepted' if decision_reason == 'allowed' else 'rejected',
+            decision_reason,
+            environ=env,
+        )
+        if decision_reason != 'allowed':
+            return cls(None, environ=environ)
         root = _capture_root(env)
         if root is None:
-            return cls(None)
+            record_parity_capture_event('initialize', 'failed', 'root_invalid', environ=env)
+            return cls(None, environ=environ)
         identity = CassetteIdentity(
             anon_session=_anonymous_id(principal_id, session_id),
             provider_lane="stt",
@@ -79,14 +115,17 @@ class ListenParityCapture:
             parent_event_anon=_anonymous_id(session_id, "listen-stt"),
         )
         try:
-            invocation = CaptureTap(root, CaptureWhitelist.from_environ(dict(env))).start(
-                principal_id, identity, request
-            )
-            return cls(invocation)
+            invocation = CaptureTap(root, whitelist).start(principal_id, identity, request)
+            if invocation is None:
+                record_parity_capture_event('initialize', 'failed', 'internal', environ=env)
+                return cls(None, environ=environ)
+            record_parity_capture_event('initialize', 'succeeded', 'none', environ=env)
+            return cls(invocation, environ=environ)
         except Exception as error:
             # Capture must never make an otherwise valid listen session unavailable.
             logger.warning("Parity pack capture initialization failed error_type=%s", type(error).__name__)
-            return cls(None)
+            record_parity_capture_event('initialize', 'failed', 'internal', environ=env)
+            return cls(None, environ=environ)
 
     @property
     def enabled(self) -> bool:
@@ -140,12 +179,15 @@ class ListenParityCapture:
             path = self._invocation.persist()
         except Exception as error:
             logger.warning("Parity pack capture persist failed error_type=%s", type(error).__name__)
+            record_parity_capture_event('persist', 'failed', 'internal', environ=self._environ)
             return
+        record_parity_capture_event('persist', 'succeeded', 'none', environ=self._environ)
         # Durable export is best-effort and must never affect listen availability.
         try:
             from .parity_pack_export import ensure_reconcile_loop, export_cassette_file
 
-            ensure_reconcile_loop()
-            export_cassette_file(path)
+            ensure_reconcile_loop(environ=self._environ)
+            export_cassette_file(path, environ=self._environ)
         except Exception as error:
             logger.warning("Parity pack capture export failed error_type=%s", type(error).__name__)
+            record_parity_capture_event('export', 'failed', 'internal', environ=self._environ)

--- a/backend/routers/listen/parity_pack_export.py
+++ b/backend/routers/listen/parity_pack_export.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import Mapping
 from urllib.parse import urlparse
 
+from .parity_telemetry import record_parity_capture_event
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_EXPORT_INTERVAL_SECONDS = 3600
@@ -111,31 +113,29 @@ def export_cassette_file(local_path: Path, *, environ: Mapping[str, str] | None 
     env = os.environ if environ is None else environ
     target = resolve_export_target(env)
     if target is None:
+        record_parity_capture_event('export', 'skipped', 'target_unconfigured', environ=env)
         return False
     root_value = (env.get("OMI_PARITY_PACK_ROOT") or "").strip()
     if not root_value:
+        record_parity_capture_event('export', 'skipped', 'root_unconfigured', environ=env)
         return False
     root = Path(root_value)
     path = Path(local_path)
     if not path.is_file():
+        record_parity_capture_event('export', 'failed', 'local_file_missing', environ=env)
         return False
     bucket_name, prefix = target
     object_name = _object_name(prefix, path, root)
+    record_parity_capture_event('export', 'attempted', 'configured', environ=env)
     try:
         client = _storage_client()
         blob = client.bucket(bucket_name).blob(object_name)
         blob.upload_from_filename(str(path), content_type="application/json")
-        logger.info(
-            "Parity pack cassette exported bucket=%s object=%s",
-            bucket_name,
-            object_name,
-        )
+        record_parity_capture_event('export', 'succeeded', 'none', environ=env)
         return True
-    except Exception as error:
-        logger.warning(
-            "Parity pack cassette export failed error_type=%s",
-            type(error).__name__,
-        )
+    except Exception:
+        logger.warning("Parity pack cassette export failed reason_class=upload_error")
+        record_parity_capture_event('export', 'failed', 'upload_error', environ=env)
         _record_export_failure(reason="other")
         return False
 

--- a/backend/routers/listen/parity_telemetry.py
+++ b/backend/routers/listen/parity_telemetry.py
@@ -1,0 +1,98 @@
+"""Privacy-safe, fail-open telemetry for dev parity-pack capture."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL = Counter(
+    'omi_parity_pack_capture_events_total',
+    'Dev-only parity-pack capture lifecycle events by closed stage, outcome, and reason class',
+    ['stage', 'outcome', 'reason_class'],
+)
+
+_STAGES = frozenset({'listen', 'allowlist', 'initialize', 'persist', 'export'})
+_OUTCOMES = frozenset({'accepted', 'rejected', 'succeeded', 'failed', 'attempted', 'skipped'})
+_REASON_CLASSES = frozenset(
+    {
+        'none',
+        'allowed',
+        'capture_disabled',
+        'stage_not_dev',
+        'principal_missing',
+        'allowlist_miss',
+        'root_invalid',
+        'configured',
+        'target_unconfigured',
+        'root_unconfigured',
+        'local_file_missing',
+        'upload_error',
+        'internal',
+        'other',
+    }
+)
+
+# Export the complete expected lifecycle even before dev traffic arrives. This
+# distinguishes a healthy, idle listen scrape target from an absent family.
+for _stage, _outcome, _reason_class in (
+    ('listen', 'accepted', 'none'),
+    ('allowlist', 'accepted', 'allowed'),
+    ('allowlist', 'rejected', 'capture_disabled'),
+    ('allowlist', 'rejected', 'stage_not_dev'),
+    ('allowlist', 'rejected', 'principal_missing'),
+    ('allowlist', 'rejected', 'allowlist_miss'),
+    ('initialize', 'succeeded', 'none'),
+    ('initialize', 'failed', 'root_invalid'),
+    ('initialize', 'failed', 'internal'),
+    ('persist', 'succeeded', 'none'),
+    ('persist', 'failed', 'internal'),
+    ('export', 'attempted', 'configured'),
+    ('export', 'succeeded', 'none'),
+    ('export', 'failed', 'local_file_missing'),
+    ('export', 'failed', 'upload_error'),
+    ('export', 'failed', 'internal'),
+    ('export', 'skipped', 'target_unconfigured'),
+    ('export', 'skipped', 'root_unconfigured'),
+):
+    OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL.labels(
+        stage=_stage,
+        outcome=_outcome,
+        reason_class=_reason_class,
+    )
+
+
+def record_parity_capture_event(
+    stage: str,
+    outcome: str,
+    reason_class: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Emit one bounded dev-only counter/log event without principal or payload data."""
+    env = os.environ if environ is None else environ
+    if env.get('OMI_ENV_STAGE', '').strip().lower() != 'dev':
+        return
+
+    safe_stage = stage if stage in _STAGES else 'other'
+    safe_outcome = outcome if outcome in _OUTCOMES else 'other'
+    safe_reason = reason_class if reason_class in _REASON_CLASSES else 'other'
+    try:
+        OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL.labels(
+            stage=safe_stage,
+            outcome=safe_outcome,
+            reason_class=safe_reason,
+        ).inc()
+        logger.info(
+            'parity_pack_capture_event stage=%s outcome=%s reason_class=%s',
+            safe_stage,
+            safe_outcome,
+            safe_reason,
+        )
+    except Exception:
+        # Observability must never affect a listen session or cassette export.
+        pass

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -84,6 +84,14 @@ npm run test:parity-pack-v0
 Never promote cassettes to production storage or commit them to the repository.
 The emptyDir scratch is still lost on pod restart before a successful export.
 
+Dev listen capture exposes the zero-initialized
+`omi_parity_pack_capture_events_total{stage,outcome,reason_class}` counter and a
+matching `parity_pack_capture_event` log marker. The closed labels distinguish
+accepted listens, allowlist decisions, capture initialization, cassette
+persistence, and GCS export attempt/success/failure. These events never include
+principal or session identifiers, payloads, credentials, or cassette object
+paths; non-dev runtimes do not increment or log them.
+
 ## Replay players
 
 `STTCassettePlayer` and `LLMCassettePlayer` are callback-oriented loopback

--- a/backend/tests/unit/test_listen_parity_capture.py
+++ b/backend/tests/unit/test_listen_parity_capture.py
@@ -1,8 +1,22 @@
 """Focused coverage for the dev-only live listen parity-pack seam."""
 
 import json
+import logging
 
 from routers.listen.parity_capture import ListenParityCapture
+from routers.listen.parity_telemetry import record_parity_capture_event
+
+
+class _TelemetryCounter:
+    def __init__(self):
+        self.events = []
+
+    def labels(self, **labels):
+        self.events.append(labels)
+        return self
+
+    def inc(self):
+        return None
 
 
 def _capture_env(root):
@@ -65,6 +79,74 @@ def test_listen_capture_whitelist_miss_writes_no_cassette_bytes(tmp_path):
     capture.observe_inbound_stt([{'text': 'must-not-persist'}])
     capture.persist()
     assert not (tmp_path / 'cassettes').exists()
+
+
+def test_listen_capture_emits_bounded_lifecycle_telemetry_without_principal(tmp_path, monkeypatch, caplog):
+    from routers.listen import parity_telemetry
+
+    counter = _TelemetryCounter()
+    monkeypatch.setattr(parity_telemetry, 'OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL', counter)
+    caplog.set_level(logging.INFO, logger='routers.listen.parity_telemetry')
+    env = _capture_env(tmp_path)
+
+    capture = ListenParityCapture.from_environ(
+        principal_id='allowed-firebase-uid',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=env,
+    )
+    capture.persist()
+
+    assert counter.events == [
+        {'stage': 'listen', 'outcome': 'accepted', 'reason_class': 'none'},
+        {'stage': 'allowlist', 'outcome': 'accepted', 'reason_class': 'allowed'},
+        {'stage': 'initialize', 'outcome': 'succeeded', 'reason_class': 'none'},
+        {'stage': 'persist', 'outcome': 'succeeded', 'reason_class': 'none'},
+        {'stage': 'export', 'outcome': 'skipped', 'reason_class': 'target_unconfigured'},
+    ]
+    assert 'allowed-firebase-uid' not in caplog.text
+    assert 'runtime-session' not in caplog.text
+
+
+def test_listen_capture_telemetry_distinguishes_allowlist_reject_and_invalid_root(tmp_path, monkeypatch):
+    from routers.listen import parity_telemetry
+
+    counter = _TelemetryCounter()
+    monkeypatch.setattr(parity_telemetry, 'OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL', counter)
+    env = _capture_env(tmp_path)
+    ListenParityCapture.from_environ(
+        principal_id='not-allowlisted',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=env,
+    )
+    invalid_root = dict(env, OMI_PARITY_PACK_ROOT='relative')
+    ListenParityCapture.from_environ(
+        principal_id='allowed-firebase-uid',
+        session_id='runtime-session',
+        provider='parakeet',
+        model='parakeet_streaming',
+        request=_request(),
+        environ=invalid_root,
+    )
+
+    assert {'stage': 'allowlist', 'outcome': 'rejected', 'reason_class': 'allowlist_miss'} in counter.events
+    assert {'stage': 'initialize', 'outcome': 'failed', 'reason_class': 'root_invalid'} in counter.events
+
+
+def test_parity_capture_telemetry_is_dev_only_and_normalizes_unknown_labels(monkeypatch):
+    from routers.listen import parity_telemetry
+
+    counter = _TelemetryCounter()
+    monkeypatch.setattr(parity_telemetry, 'OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL', counter)
+    record_parity_capture_event('user-stage', 'user-outcome', 'user-reason', environ={'OMI_ENV_STAGE': 'prod'})
+    record_parity_capture_event('user-stage', 'user-outcome', 'user-reason', environ={'OMI_ENV_STAGE': 'dev'})
+
+    assert counter.events == [{'stage': 'other', 'outcome': 'other', 'reason_class': 'other'}]
 
 
 def test_listen_capture_requires_a_restricted_absolute_root(tmp_path):
@@ -156,8 +238,9 @@ def test_export_target_resolves_uri_and_bucket_prefix():
     assert resolve_export_target({}) is None
 
 
-def test_export_cassette_file_uploads_under_prefix(tmp_path, monkeypatch):
+def test_export_cassette_file_uploads_under_prefix_without_logging_object_path(tmp_path, monkeypatch, caplog):
     from routers.listen import parity_pack_export as export_mod
+    from routers.listen import parity_telemetry
 
     cassette_dir = tmp_path / 'cassettes'
     cassette_dir.mkdir()
@@ -181,8 +264,12 @@ def test_export_cassette_file_uploads_under_prefix(tmp_path, monkeypatch):
             uploaded['bucket'] = name
             return FakeBucket()
 
+    counter = _TelemetryCounter()
+    monkeypatch.setattr(parity_telemetry, 'OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL', counter)
     monkeypatch.setattr(export_mod, '_storage_client', lambda: FakeClient())
+    caplog.set_level(logging.INFO)
     env = {
+        'OMI_ENV_STAGE': 'dev',
         'OMI_PARITY_PACK_ROOT': str(tmp_path),
         'OMI_PARITY_PACK_GCS_URI': 'gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0',
     }
@@ -190,3 +277,46 @@ def test_export_cassette_file_uploads_under_prefix(tmp_path, monkeypatch):
     assert uploaded['bucket'] == 'based-hardware-dev-omi-parity-pack-v0'
     assert uploaded['object'] == 'parity-pack/v0/cassettes/abc.json'
     assert uploaded['filename'] == str(cassette)
+    assert 'abc.json' not in caplog.text
+    assert counter.events == [
+        {'stage': 'export', 'outcome': 'attempted', 'reason_class': 'configured'},
+        {'stage': 'export', 'outcome': 'succeeded', 'reason_class': 'none'},
+    ]
+
+
+def test_export_cassette_file_emits_attempt_and_bounded_failure(tmp_path, monkeypatch, caplog):
+    from routers.listen import parity_pack_export as export_mod
+    from routers.listen import parity_telemetry
+
+    class FakeBlob:
+        def upload_from_filename(self, *_args, **_kwargs):
+            raise PermissionError('private detail must not be emitted')
+
+    class FakeBucket:
+        def blob(self, _name):
+            return FakeBlob()
+
+    class FakeClient:
+        def bucket(self, _name):
+            return FakeBucket()
+
+    counter = _TelemetryCounter()
+    monkeypatch.setattr(parity_telemetry, 'OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL', counter)
+    monkeypatch.setattr(export_mod, '_storage_client', lambda: FakeClient())
+    monkeypatch.setattr(export_mod, '_record_export_failure', lambda **_kwargs: None)
+    caplog.set_level(logging.INFO)
+    cassette_dir = tmp_path / 'cassettes'
+    cassette_dir.mkdir()
+    cassette = cassette_dir / 'abc.json'
+    cassette.write_text('{"ok":true}\n', encoding='utf-8')
+    env = dict(
+        _capture_env(tmp_path),
+        OMI_PARITY_PACK_GCS_URI='gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0',
+    )
+
+    assert export_mod.export_cassette_file(cassette, environ=env) is False
+    assert counter.events == [
+        {'stage': 'export', 'outcome': 'attempted', 'reason_class': 'configured'},
+        {'stage': 'export', 'outcome': 'failed', 'reason_class': 'upload_error'},
+    ]
+    assert 'private detail' not in caplog.text


### PR DESCRIPTION
## What changed and why

Dev replay capture was unverifiable because the listener emitted failure-only logs: silence could not distinguish no qualifying traffic, an allowlist rejection, an uninitialized capture, a persist failure, or export state. This adds a dev-only, zero-initialized bounded lifecycle counter plus matching searchable log markers for listen acceptance, allowlist decisions, initialization, persistence, and export attempt/success/failure, while removing cassette-specific GCS paths from export logs.

Closes SCA-289

The observability gap is the proven verification blocker (high confidence); the actual live capture/export outcome remains unknown until this is deployed and exercised with allowlisted dev traffic. Counter-evidence against a rollout or bucket-provisioning failure includes the successful dev parity-bucket/Helm rollout, the expected capture gates on the running workload, and zero observed pod restarts.

## Product invariants affected

none

## How it was verified

- `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/unit/test_listen_parity_capture.py -q` — 11 passed.
- `npm run test:parity-pack-v0` — 16 passed.
- `.venv/bin/python -m pyright routers/listen/parity_capture.py routers/listen/parity_pack_export.py routers/listen/parity_telemetry.py tests/unit/test_listen_parity_capture.py --pythonpath .venv/bin/python` (from `backend/`) — 0 errors; existing third-party/test typing warnings only.
- `scripts/pr-preflight --pr-body-file ../pr-body.md` — all 23 selected committed-diff checks passed.

The real `/v4/listen` path was not exercised locally because this workspace has no configured GCP identity/Firebase/STT credentials, and the task does not authorize deploy, traffic, bucket reads, or production writes. The listener/persist/export seam was exercised synthetically with a fake GCS client, including upload success and privacy-safe failure behavior.

## Tests

`backend/tests/unit/test_listen_parity_capture.py` now covers the full accepted lifecycle, allowlist rejection versus invalid-root diagnosis, dev-only bounded labels, GCS attempt/success, upload failure, and the absence of principal/session/object-path/private-error data in telemetry.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

