### PR TITLE
fix(backend): fail closed for unset Sentry webhook secret

### DIFF
--- a/backend/routers/desktop_core.py
+++ b/backend/routers/desktop_core.py
@@ -213,7 +213,9 @@ async def sentry_webhook(request: Request) -> dict[str, str]:
         return {"status": "ok"}
     body = await request.body()
     secret = os.getenv("SENTRY_WEBHOOK_SECRET")
-    if secret and not _sentry_signature_matches(secret, body, request.headers.get("sentry-hook-signature")):
+    if not secret:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+    if not _sentry_signature_matches(secret, body, request.headers.get("sentry-hook-signature")):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     try:
         payload = await request.json()

--- a/backend/tests/unit/test_desktop_core.py
+++ b/backend/tests/unit/test_desktop_core.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import json
 
+import pytest
 import redis
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -140,6 +141,18 @@ def test_sentry_webhook_fails_closed_and_creates_feedback_item(monkeypatch):
     assert body.json() == {"status": "created"}
     assert created[0][0] == "admin"
     assert created[0][1]["metadata"]["sentry_issue_id"] == "42"
+
+
+@pytest.mark.parametrize("secret", [None, ""])
+def test_sentry_webhook_rejects_unsigned_requests_when_secret_is_unconfigured(monkeypatch, secret):
+    if secret is None:
+        monkeypatch.delenv("SENTRY_WEBHOOK_SECRET", raising=False)
+    else:
+        monkeypatch.setenv("SENTRY_WEBHOOK_SECRET", secret)
+
+    response = make_client().post("/v1/webhooks/sentry", json={})
+
+    assert response.status_code == 503
 
 
 def test_sentry_poll_classifies_auth_failure(monkeypatch):


### PR DESCRIPTION
## Summary

- Fail closed with HTTP 503 when `SENTRY_WEBHOOK_SECRET` is absent or empty.
- Retain HMAC validation for configured secrets and the public installation-hook acknowledgement.

## Testing

- `backend/.venv/bin/pytest backend/tests/unit/test_desktop_core.py -q --tb=short` — 10 passed

Closes #11069

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

