### PR TITLE
fix(llm-gateway): separate LKG serving from fallback telemetry

### DIFF
--- a/.github/failure-classes/FC-rollout-state-counted-as-failover.json
+++ b/.github/failure-classes/FC-rollout-state-counted-as-failover.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "FC-rollout-state-counted-as-failover",
+  "violated_contract": "A selected serving state is not a failover outcome. Shadow, disabled, zero-percent, and out-of-bucket canary policy may intentionally select the last-known-good route without any provider failure; classifying that ordinary selection as fallback makes healthy rollout exposure indistinguishable from a recovered dependency fault and can drive a false elevated-fallback alert.",
+  "canonical_prevention": "Classify the initially selected route independently as active, canary, or LKG, and set actual fallback only after a bounded eligible failure followed by a successful different provider or route. Preserve a non-none failure reason and bounded from/to route evidence for that success, publish rollout exposure separately, and cover normal active/canary/LKG serving plus recovered and exhausted failover in behavioral tests.",
+  "canonical_prevention_artifact": [
+    "backend/llm_gateway/gateway/executor.py",
+    "backend/tests/unit/test_llm_gateway_executor.py",
+    "backend/tests/unit/test_llm_gateway_openai_compatible.py"
+  ],
+  "evidence_prs": [
+    8427,
+    9462
+  ],
+  "scope_hints": [
+    "backend/llm_gateway/**",
+    "backend/charts/monitoring/**"
+  ],
+  "status": "open"
+}

--- a/backend/charts/llm-gateway/templates/deployment.yaml
+++ b/backend/charts/llm-gateway/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
           command: ["uvicorn"]
           args: ["llm_gateway.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.service.port }}", "--loop", "uvloop"]
           env:
+            - name: OMI_LLM_GATEWAY_BUILD_IDENTITY
+              value: {{ required "image.tag is required" .Values.image.tag | quote }}
             {{- toYaml .Values.env | nindent 12 }}
           ports:
             - name: http

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -8238,7 +8238,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[30m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[30m])), 1e-9)",
+          "expr": "sum(rate(llm_gateway_requests_total{route_serving_class=\"actual_fallback\",fallback_used=\"true\",fallback_reason!=\"none\",outcome=\"success\"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome=~\"success|error\"}[30m])), 1e-9)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -20,7 +20,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(llm_gateway_chat_extraction_requests_total{mode=\"fallback\"}[30m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~\"serving|fallback\"}[30m])), 1e-9)",
+          "expr": "sum(rate(llm_gateway_requests_total{route_serving_class=\"actual_fallback\",fallback_used=\"true\",fallback_reason!=\"none\",outcome=\"success\"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome=~\"success|error\"}[30m])), 1e-9)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,

--- a/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
+++ b/backend/charts/monitoring/dashboards/omi-services/resilience-fallbacks.json
@@ -480,7 +480,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(llm_gateway_requests_total{fallback_used=\"true\"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total[30m])), 1e-9)",
+          "expr": "sum(rate(llm_gateway_requests_total{route_serving_class=\"actual_fallback\",fallback_used=\"true\",fallback_reason!=\"none\",outcome=\"success\"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome=~\"success|error\"}[30m])), 1e-9)",
           "legendFormat": "fallback_used share",
           "range": true,
           "refId": "A"
@@ -750,6 +750,55 @@
         }
       ],
       "title": "Live STT attempt failure rate (failure / accepted)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(llm_gateway_requests_total{route_serving_class=\"lkg\",outcome=\"success\"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome=\"success\"}[30m])), 1e-9)",
+          "legendFormat": "ordinary LKG serving share",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM gateway LKG serving share (rollout exposure)",
       "type": "timeseries"
     }
   ],

--- a/backend/docs/runbooks/llm-gateway-fallback.md
+++ b/backend/docs/runbooks/llm-gateway-fallback.md
@@ -1,12 +1,14 @@
 # LLM Gateway — fallback rate elevated (ticket)
 
-**What it means:** The gateway or one of its upstream routes is unhealthy. A short client transport deadline and per-process circuit send new requests directly to the legacy provider after consecutive gateway transport failures, so this is normally a degraded dependency rather than a total chat outage. A circuit-open event still requires prompt investigation: it can mean the gateway is unreachable from Cloud Run even when its pods look healthy.
+**What it means:** An active/canary gateway route or provider failed with an eligible bounded failure class and a different provider or the LKG route successfully served the request. Ordinary LKG serving because a candidate is shadowed, disabled, outside its canary bucket, or at 0% is rollout exposure, not fallback.
 
-**PromQL:** `sum(rate(llm_gateway_chat_extraction_requests_total{mode="fallback"}[30m])) / clamp_min(sum(rate(llm_gateway_chat_extraction_requests_total{mode=~"serving|fallback"}[30m])), 1e-9)`
+**PromQL:** `sum(rate(llm_gateway_requests_total{route_serving_class="actual_fallback",fallback_used="true",fallback_reason!="none",outcome="success"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome=~"success|error"}[30m])), 1e-9)`
 
-**Client-side signals:** `llm_gateway_chat_extraction_requests_total{mode="fallback"}`, `llm_gateway_circuit_open`, `llm_gateway_client_first_byte_seconds`, and structured `llm_gateway_backend_event` logs with `reason=circuit_open`. The gateway cannot emit a request metric for a TCP black hole it never receives, so inspect client-side fallback/circuit telemetry as the primary signal for reachability failures.
+**Rollout exposure:** `sum(rate(llm_gateway_requests_total{route_serving_class="lkg",outcome="success"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome="success"}[30m])), 1e-9)`. A high share can be intentional while a candidate is shadowed or at 0%; correlate with `llm_gateway_config_info` and route rollout state.
 
-**Alerts:** the deployed LLM Gateway rules page on a client fallback ratio above 5%, any open circuit, zero gateway-serving successes after 10 client attempts, p95 client first-byte latency above 5 seconds, or zero ready production gateway endpoints. The first four are client-visible by design; the fifth is the Kubernetes control-plane corroboration.
+**Client reachability:** `llm_gateway_chat_extraction_requests_total`, `llm_gateway_circuit_open`, `llm_gateway_client_first_byte_seconds`, and structured `llm_gateway_backend_event` logs remain the primary signals for a TCP black hole the gateway cannot observe.
+
+**Alert source:** `backend/charts/monitoring/alerts/resilience.json` tickets above 5% actual-fallback share for 30 minutes. Repository changes do not update live Grafana until the monitoring source is applied through its normal deployment path.
 
 **Owner:** llm-gateway / platform team.
 
@@ -14,6 +16,6 @@
 1. Confirm the current Cloud Run revisions are still `OMI_LLM_GATEWAY_FEATURE_MODE=direct` unless a deliberately gated promotion has occurred.
 2. Run the same evidence chain used by promotion: `verify-llm-gateway-serving.py` for deployment/Service/EndpointSlice/Ingress/ILB attachment, followed by the Cloud Run VPC probe. Do not treat a reserved IP as proof of reachability.
 3. Inspect `llm_gateway_circuit_open`, client fallback ratio, `llm_gateway_client_first_byte_seconds` p95, and `llm_gateway_backend_event` reasons. If the circuit is open, keep/direct-route while repairing the data plane.
-4. Then inspect gateway `llm_gateway_requests_total{fallback_used="true"}` by route/model lane and upstream provider status.
+4. Inspect `llm_gateway_requests_total` by `route_serving_class`, `fallback_reason`, and bounded from/to route artifact labels. Treat `route_serving_class="lkg"` as rollout exposure unless a separate error signal is present.
 
 **Severity:** Ticket — investigate during business hours unless user-facing chat error rates also rise.

--- a/backend/docs/runbooks/resilience-dashboards.md
+++ b/backend/docs/runbooks/resilience-dashboards.md
@@ -20,7 +20,8 @@ Cross-platform view of backend Prometheus fallbacks, desktop PostHog heals, and 
 | Sync enqueue uncertainty share | `sum(rate(omi_sync_dispatch_attempts_total{mode="enqueue_uncertain"}[10m])) / clamp_min(sum(rate(omi_sync_dispatch_attempts_total[10m])), 1e-9)` | Dashboard only until Cloud Run scrape — see [sync-dispatch-fallback.md](./sync-dispatch-fallback.md) |
 | Pusher degraded sessions & ratio | `pusher_sessions_degraded`, `pusher_active_ws_connections`, ratio | **PAGE** — see [pusher-degraded.md](./pusher-degraded.md) |
 | Real-traffic journey outcomes | `omi_journey_*`, `omi_capture_finalization_reconciliations_total`, `listen_finalization_durable_jobs`, `listen_finalization_oldest_nonterminal_age_seconds` | Traffic-gated product alerts plus separate scrape-source health — see [real-traffic-journeys.md](./real-traffic-journeys.md) |
-| LLM gateway fallback rate | `sum(rate(llm_gateway_requests_total{fallback_used="true"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total[30m])), 1e-9)` | **Ticket** — see [llm-gateway-fallback.md](./llm-gateway-fallback.md) |
+| LLM gateway actual fallback rate | `sum(rate(llm_gateway_requests_total{route_serving_class="actual_fallback",fallback_used="true",fallback_reason!="none",outcome="success"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome=~"success|error"}[30m])), 1e-9)` | **Ticket** — see [llm-gateway-fallback.md](./llm-gateway-fallback.md) |
+| LLM gateway ordinary LKG serving share | `sum(rate(llm_gateway_requests_total{route_serving_class="lkg",outcome="success"}[30m])) / clamp_min(sum(rate(llm_gateway_requests_total{outcome="success"}[30m])), 1e-9)` | Dashboard-only rollout exposure |
 
 The dashboard text panel repeats paging policy: page only on exhausted outcomes, sync enqueue uncertainty, and pusher degraded ratio. Successful `outcome=recovered` heals are dashboard-only.
 

--- a/backend/llm_gateway/config/README.md
+++ b/backend/llm_gateway/config/README.md
@@ -43,6 +43,13 @@ only in response headers and structured logs, never as Prometheus labels. Pre-ro
 `llm_gateway_request_rejections_total{api_surface,error_class}`; service authentication failures use
 `llm_gateway_auth_rejections_total{reason}`.
 
+`route_serving_class` is a closed `active|canary|lkg|actual_fallback` contract. `fallback_used=true` requires a
+prior eligible provider failure and a subsequent successful provider/route; merely selecting LKG for shadow,
+disabled, 0%, or an out-of-bucket canary request is `route_serving_class="lkg"` with `fallback_used="false"`.
+Bounded from/to route artifact labels and a non-`none` `fallback_reason` identify real failover without request or
+user identifiers. `llm_gateway_config_info` separately publishes the immutable image tag plus active/LKG route
+artifact IDs and SHA-256 content digests, avoiding build/config identity labels on the high-volume request counter.
+
 ## Usage accounting ledger
 
 Every managed and BYOK provider attempt that reaches a gateway provider is scheduled for best-effort delivery to the

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -251,6 +251,7 @@ async def _execute_route(
     refs = [route.primary, *route.fallbacks]
     last_error: GatewayError | None = None
     current_fallback_reason = fallback_reason
+    failed_provider_refs: list[ProviderRef] = []
 
     for index, provider_ref in enumerate(refs):
         provider = provider_registry.provider_for(provider_ref.provider)
@@ -281,22 +282,37 @@ async def _execute_route(
                         'provider request failed',
                         failure_class=FailureClass.INVALID_CONFIG,
                     )
+                # A within-route provider fallback qualifies as actual failover
+                # only when the succeeding ref differs (provider or model) from
+                # every failed ref.  An identical provider+model retry is a retry,
+                # not a failover — it violates the PR contract that actual
+                # fallback requires a *subsequent provider/route* success.
+                # Cross-route fallback (fallback_reason passed from the caller,
+                # e.g. active→LKG) is always actual regardless of ref identity.
+                distinct_within_route = any(
+                    failed.provider != provider_ref.provider or failed.model != provider_ref.model
+                    for failed in failed_provider_refs
+                )
+                actual_fallback = current_fallback_reason is not None and (
+                    fallback_reason is not None or distinct_within_route
+                )
                 return _executor_result(
                     response,
                     resolved_route=resolved_route,
                     route=route,
                     provider_ref=provider_ref,
-                    fallback_used=current_fallback_reason is not None,
-                    fallback_reason=current_fallback_reason,
+                    fallback_used=actual_fallback,
+                    fallback_reason=current_fallback_reason if actual_fallback else None,
                     fallback_from_route_artifact_id=(
                         fallback_from_route_artifact_id
                         if fallback_from_route_artifact_id is not None
-                        else route.route_artifact_id if current_fallback_reason is not None else None
+                        else route.route_artifact_id if actual_fallback else None
                     ),
                     used_lkg=is_lkg,
                 )
 
         last_error = error
+        failed_provider_refs.append(provider_ref)
         if index == len(refs) - 1 or not _can_try_next_provider(route, error.failure_class):
             raise error
         current_fallback_reason = error.failure_class

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -29,7 +29,14 @@ from llm_gateway.gateway.providers import (
 )
 from llm_gateway.gateway.output_budget import OutputBudgetDecision, apply_output_budget
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, select_lkg_route_for_failure
-from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutStage, RouteArtifact
+from llm_gateway.gateway.schemas import (
+    CredentialMode,
+    FailureClass,
+    ProviderRef,
+    RolloutStage,
+    RouteArtifact,
+    RouteServingClass,
+)
 from llm_gateway.gateway.validator import ValidatedChatCompletionRequest
 from utils.log_sanitizer import sanitize
 
@@ -53,7 +60,10 @@ class ExecutorResult:
     selected_model: str
     fallback_used: bool
     fallback_reason: FailureClass | None
+    fallback_from_route_artifact_id: str | None
+    fallback_to_route_artifact_id: str | None
     used_lkg: bool
+    route_serving_class: RouteServingClass
     output_budget: OutputBudgetDecision
     provider_accounting: ProviderResponseMetadata
 
@@ -93,7 +103,7 @@ async def execute_chat_completion(
     attempt_trace: AttemptTrace | None = None,
 ) -> ExecutorResult:
     serving_route = _select_serving_route(resolved_route)
-    serving_is_lkg = serving_route is resolved_route.last_known_good_route
+    serving_is_lkg = selected_route_is_lkg(resolved_route)
     _validate_credential_mode(serving_route, credential_context)
     deadline_monotonic = monotonic() + serving_route.timeouts.request_ms / 1000.0
 
@@ -107,6 +117,7 @@ async def execute_chat_completion(
             provider_registry,
             is_lkg=serving_is_lkg,
             fallback_reason=None,
+            fallback_from_route_artifact_id=None,
             attempt_trace=attempt_trace,
             deadline_monotonic=deadline_monotonic,
         )
@@ -128,6 +139,7 @@ async def execute_chat_completion(
                 provider_registry,
                 is_lkg=True,
                 fallback_reason=first_failure,
+                fallback_from_route_artifact_id=serving_route.route_artifact_id,
                 attempt_trace=attempt_trace,
                 deadline_monotonic=deadline_monotonic,
             )
@@ -158,6 +170,18 @@ def selected_serving_route_artifact_id(resolved_route: ResolvedRoute) -> str:
 
 def selected_serving_route(resolved_route: ResolvedRoute) -> RouteArtifact:
     return _select_serving_route(resolved_route)
+
+
+def selected_route_serving_class(resolved_route: ResolvedRoute) -> RouteServingClass:
+    if selected_route_is_lkg(resolved_route):
+        return RouteServingClass.LKG
+    if resolved_route.active_route.rollout.stage == RolloutStage.CANARY:
+        return RouteServingClass.CANARY
+    return RouteServingClass.ACTIVE
+
+
+def selected_route_is_lkg(resolved_route: ResolvedRoute) -> bool:
+    return not _is_route_eligible_to_serve(resolved_route.active_route, resolved_route.validated_request)
 
 
 def provider_request_for(resolved_route: ResolvedRoute, provider_ref: ProviderRef) -> dict[str, Any]:
@@ -220,6 +244,7 @@ async def _execute_route(
     *,
     is_lkg: bool,
     fallback_reason: FailureClass | None,
+    fallback_from_route_artifact_id: str | None,
     attempt_trace: AttemptTrace | None,
     deadline_monotonic: float,
 ) -> ExecutorResult:
@@ -261,8 +286,13 @@ async def _execute_route(
                     resolved_route=resolved_route,
                     route=route,
                     provider_ref=provider_ref,
-                    fallback_used=index > 0 or is_lkg,
+                    fallback_used=current_fallback_reason is not None,
                     fallback_reason=current_fallback_reason,
+                    fallback_from_route_artifact_id=(
+                        fallback_from_route_artifact_id
+                        if fallback_from_route_artifact_id is not None
+                        else route.route_artifact_id if current_fallback_reason is not None else None
+                    ),
                     used_lkg=is_lkg,
                 )
 
@@ -494,6 +524,7 @@ def _executor_result(
     provider_ref: ProviderRef,
     fallback_used: bool,
     fallback_reason: FailureClass | None,
+    fallback_from_route_artifact_id: str | None,
     used_lkg: bool,
 ) -> ExecutorResult:
     response = dict(provider_response.response)
@@ -506,7 +537,12 @@ def _executor_result(
         selected_model=provider_ref.model,
         fallback_used=fallback_used,
         fallback_reason=fallback_reason,
+        fallback_from_route_artifact_id=fallback_from_route_artifact_id,
+        fallback_to_route_artifact_id=route.route_artifact_id if fallback_used else None,
         used_lkg=used_lkg,
+        route_serving_class=(
+            RouteServingClass.ACTUAL_FALLBACK if fallback_used else selected_route_serving_class(resolved_route)
+        ),
         output_budget=output_budget_for(resolved_route, route),
         provider_accounting=provider_response.accounting,
     )

--- a/backend/llm_gateway/gateway/metrics.py
+++ b/backend/llm_gateway/gateway/metrics.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from typing import Protocol
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 from llm_gateway.gateway.accounting import AccountingEvent
+from llm_gateway.gateway.config_loader import GatewayConfig
 from llm_gateway.gateway.errors import GatewayError
 from llm_gateway.gateway.output_budget import OutputBudgetDecision, output_budget_bucket
-from llm_gateway.gateway.schemas import FailureClass, ProviderRejection
+from llm_gateway.gateway.schemas import FailureClass, ProviderRejection, RouteServingClass
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +29,12 @@ _REQUEST_LABELS = [
     'api_surface',
     'streaming',
     'phase',
+    'route_serving_class',
     'used_lkg',
     'fallback_used',
     'fallback_reason',
+    'fallback_from_route_artifact_id',
+    'fallback_to_route_artifact_id',
     'outcome',
     'error_class',
     'provider_rejection',
@@ -77,6 +82,12 @@ ACCOUNTING_EVENTS_TOTAL = Counter(
     ['api_surface', 'provider', 'payer', 'usage_status', 'cost_status', 'delivery'],
 )
 
+GATEWAY_CONFIG_INFO = Gauge(
+    'llm_gateway_config_info',
+    'Immutable gateway build and route/config artifact identity',
+    ['build_identity', 'lane_id', 'route_role', 'route_artifact_id', 'artifact_digest'],
+)
+
 
 class ExecutorResultLike(Protocol):
     @property
@@ -98,7 +109,16 @@ class ExecutorResultLike(Protocol):
     def fallback_reason(self) -> FailureClass | None: ...
 
     @property
+    def fallback_from_route_artifact_id(self) -> str | None: ...
+
+    @property
+    def fallback_to_route_artifact_id(self) -> str | None: ...
+
+    @property
     def used_lkg(self) -> bool: ...
+
+    @property
+    def route_serving_class(self) -> RouteServingClass: ...
 
     @property
     def output_budget(self) -> OutputBudgetDecision: ...
@@ -121,9 +141,12 @@ def observe_success(
         provider=result.selected_provider,
         model=result.selected_model,
         credential_source=credential_source,
+        route_serving_class=result.route_serving_class,
         used_lkg=result.used_lkg,
         fallback_used=result.fallback_used,
         fallback_reason=result.fallback_reason,
+        fallback_from_route_artifact_id=result.fallback_from_route_artifact_id,
+        fallback_to_route_artifact_id=result.fallback_to_route_artifact_id,
         outcome='success',
         error_class='none',
         request_id=request_id,
@@ -147,6 +170,8 @@ def observe_error(
     request_id: str,
     api_surface: str = 'openai_chat_completions',
     streaming: bool = False,
+    used_lkg: bool = False,
+    route_serving_class: RouteServingClass | str = RouteServingClass.ACTIVE,
 ) -> None:
     observe_route_result(
         started_at,
@@ -155,9 +180,12 @@ def observe_error(
         provider=error.provider,
         model=error.model,
         credential_source=credential_source,
-        used_lkg=False,
+        route_serving_class=route_serving_class,
+        used_lkg=used_lkg,
         fallback_used=False,
         fallback_reason=error.failure_class,
+        fallback_from_route_artifact_id=None,
+        fallback_to_route_artifact_id=None,
         outcome='error',
         error_class=error.code.value,
         provider_rejection=error.provider_rejection,
@@ -176,9 +204,12 @@ def observe_route_result(
     provider: str,
     model: str,
     credential_source: str,
+    route_serving_class: RouteServingClass | str = RouteServingClass.ACTIVE,
     used_lkg: bool,
     fallback_used: bool,
     fallback_reason: FailureClass | str | None,
+    fallback_from_route_artifact_id: str | None = None,
+    fallback_to_route_artifact_id: str | None = None,
     outcome: str,
     error_class: str,
     request_id: str,
@@ -201,9 +232,12 @@ def observe_route_result(
         'api_surface': _bounded(api_surface),
         'streaming': _bool_label(streaming),
         'phase': _bounded(phase),
+        'route_serving_class': _route_serving_class_label(route_serving_class),
         'used_lkg': _bool_label(used_lkg),
         'fallback_used': _bool_label(fallback_used),
         'fallback_reason': _enum_label(fallback_reason, default='none'),
+        'fallback_from_route_artifact_id': _optional_identity_label(fallback_from_route_artifact_id),
+        'fallback_to_route_artifact_id': _optional_identity_label(fallback_to_route_artifact_id),
         'outcome': _bounded(outcome),
         'error_class': _bounded(error_class),
         'provider_rejection': _provider_rejection_label(provider_rejection),
@@ -223,7 +257,8 @@ def observe_route_result(
     terminal_log = logger.warning if outcome == 'error' else logger.info
     terminal_log(
         'llm_gateway_terminal request_id=%s surface=%s streaming=%s phase=%s lane=%s route=%s provider=%s '
-        'model=%s credential_source=%s outcome=%s error_class=%s failure_class=%s fallback_used=%s '
+        'model=%s credential_source=%s outcome=%s error_class=%s route_serving_class=%s failure_class=%s '
+        'fallback_used=%s fallback_from=%s fallback_to=%s '
         'provider_rejection=%s '
         'budget_source=%s output_budget=%s completion_size=%s finish_reason=%s ttfb_seconds=%s',
         request_id,
@@ -237,8 +272,11 @@ def observe_route_result(
         labels['credential_source'],
         labels['outcome'],
         labels['error_class'],
+        labels['route_serving_class'],
         labels['fallback_reason'],
         labels['fallback_used'],
+        labels['fallback_from_route_artifact_id'],
+        labels['fallback_to_route_artifact_id'],
         labels['provider_rejection'],
         labels['budget_source'],
         labels['output_budget'],
@@ -277,6 +315,22 @@ def observe_accounting_event(event: AccountingEvent, *, delivery: str) -> None:
     ).inc()
 
 
+def observe_gateway_config_identity(config: GatewayConfig, *, build_identity: str) -> None:
+    """Publish one bounded info series per lane pointer, never per request."""
+    build_label = _build_identity_label(build_identity)
+    GATEWAY_CONFIG_INFO.clear()
+    for lane_id, lane in sorted(config.lanes.items()):
+        for route_role, route_id in (('active', lane.active_route), ('lkg', lane.last_known_good)):
+            route = config.route_artifacts[route_id]
+            GATEWAY_CONFIG_INFO.labels(
+                build_identity=build_label,
+                lane_id=_bounded(lane_id),
+                route_role=route_role,
+                route_artifact_id=_bounded(route.route_artifact_id),
+                artifact_digest=_artifact_digest_label(route.artifact_digest or route.content_digest),
+            ).set(1)
+
+
 def report_observation_failure(*, api_surface: str, request_id: str) -> None:
     """Rate-limit a payload-free warning when best-effort telemetry itself fails."""
     global _last_observation_warning_at
@@ -304,6 +358,28 @@ def _enum_label(value: object, *, default: str = 'unknown') -> str:
     if raw_value is None:
         return default
     return _bounded(str(raw_value))
+
+
+def _route_serving_class_label(value: object) -> str:
+    raw_value = getattr(value, 'value', value)
+    try:
+        return RouteServingClass(str(raw_value)).value
+    except ValueError:
+        return 'unknown'
+
+
+def _optional_identity_label(value: str | None) -> str:
+    return 'none' if value is None else _bounded(value)
+
+
+def _build_identity_label(value: str) -> str:
+    normalized = value.strip().lower()
+    return normalized if re.fullmatch(r'[0-9a-f]{7,64}', normalized) else 'unknown'
+
+
+def _artifact_digest_label(value: str) -> str:
+    normalized = value.strip().lower()
+    return normalized if re.fullmatch(r'sha256:[0-9a-f]{64}', normalized) else 'unknown'
 
 
 def _provider_rejection_label(value: object) -> str:

--- a/backend/llm_gateway/gateway/resolver.py
+++ b/backend/llm_gateway/gateway/resolver.py
@@ -83,7 +83,10 @@ def resolve_lane(config: GatewayConfig, model: str) -> LaneConfig:
 def select_lkg_route_for_failure(
     resolved_route: ResolvedRoute, failure_class: FailureClass | str
 ) -> RouteArtifact | None:
-    if is_lkg_eligible(resolved_route.active_route, failure_class):
+    if (
+        resolved_route.active_route.route_artifact_id != resolved_route.last_known_good_route.route_artifact_id
+        and is_lkg_eligible(resolved_route.active_route, failure_class)
+    ):
         return resolved_route.last_known_good_route
     return None
 

--- a/backend/llm_gateway/gateway/schemas.py
+++ b/backend/llm_gateway/gateway/schemas.py
@@ -39,6 +39,15 @@ class RolloutStage(str, Enum):
     ACTIVE = 'active'
 
 
+class RouteServingClass(str, Enum):
+    """Bounded classification of why the terminal provider served the request."""
+
+    ACTIVE = 'active'
+    CANARY = 'canary'
+    LKG = 'lkg'
+    ACTUAL_FALLBACK = 'actual_fallback'
+
+
 class FailureClass(str, Enum):
     TIMEOUT_BEFORE_OUTPUT = 'timeout_before_output'
     PROVIDER_429_OMI_PAID = 'provider_429_omi_paid'

--- a/backend/llm_gateway/main.py
+++ b/backend/llm_gateway/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 
@@ -8,15 +9,20 @@ from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
 from llm_gateway.gateway.request_context import REQUEST_ID_HEADER, request_id_for, resolve_request_id
+from llm_gateway.gateway.metrics import observe_gateway_config_identity
 from llm_gateway.gateway.accounting_sink import drain_accounting_persistence_tasks
 from llm_gateway.routers import anthropic_messages, health, metrics, openai_compatible
-from llm_gateway.routers.dependencies import close_provider_registry
+from llm_gateway.routers.dependencies import close_provider_registry, get_gateway_config
 
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    observe_gateway_config_identity(
+        get_gateway_config(),
+        build_identity=os.getenv('OMI_LLM_GATEWAY_BUILD_IDENTITY', ''),
+    )
     try:
         yield
     finally:

--- a/backend/llm_gateway/routers/anthropic_messages.py
+++ b/backend/llm_gateway/routers/anthropic_messages.py
@@ -32,7 +32,7 @@ from llm_gateway.gateway.metrics import (
     time_request,
 )
 from llm_gateway.gateway.request_context import request_id_for
-from llm_gateway.gateway.schemas import RouteArtifact, Surface
+from llm_gateway.gateway.schemas import RouteArtifact, RouteServingClass, Surface
 from llm_gateway.gateway.sse import SSEEventDecoder
 from llm_gateway.routers.dependencies import get_gateway_config
 
@@ -616,6 +616,7 @@ def _observe_message_terminal(
             provider=context.provider,
             model=context.model,
             credential_source=context.credential_source,
+            route_serving_class=RouteServingClass.ACTIVE,
             used_lkg=False,
             fallback_used=False,
             fallback_reason=None,

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -552,11 +552,17 @@ async def _stream_with_terminal_metrics(
         if terminal_observed:
             return
         terminal_observed = True
+        # Per the PR behavioral contract, actual fallback requires a subsequent
+        # successful provider/route.  Only stamp the actual-fallback labels when
+        # the terminal outcome is success; an error or cancellation means the
+        # failover did not complete, so dashboards and ad-hoc queries must not
+        # count it as a completed failover.
+        completed_fallback = prepared.fallback_used and outcome == 'success'
         trace.record(
             provider=prepared.provider,
             configured_model=prepared.model,
             route_artifact_id=route.route_artifact_id,
-            fallback_reason=prepared.fallback_reason,
+            fallback_reason=prepared.fallback_reason if completed_fallback else None,
             retry_ordinal=1,
             outcome=outcome,
             error_class=error_class,
@@ -579,14 +585,14 @@ async def _stream_with_terminal_metrics(
                 credential_source=credentials.source.value,
                 route_serving_class=(
                     RouteServingClass.ACTUAL_FALLBACK
-                    if prepared.fallback_used
+                    if completed_fallback
                     else selected_route_serving_class(resolved_route)
                 ),
                 used_lkg=selected_route_is_lkg(resolved_route),
-                fallback_used=prepared.fallback_used,
-                fallback_reason=prepared.fallback_reason,
-                fallback_from_route_artifact_id=route.route_artifact_id if prepared.fallback_used else None,
-                fallback_to_route_artifact_id=route.route_artifact_id if prepared.fallback_used else None,
+                fallback_used=completed_fallback,
+                fallback_reason=prepared.fallback_reason if completed_fallback else None,
+                fallback_from_route_artifact_id=route.route_artifact_id if completed_fallback else None,
+                fallback_to_route_artifact_id=route.route_artifact_id if completed_fallback else None,
                 outcome=outcome,
                 error_class=error_class,
                 request_id=request_id,

--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -43,6 +43,8 @@ from llm_gateway.gateway.executor import (
     provider_request_for,
     selected_serving_route,
     selected_serving_route_artifact_id,
+    selected_route_is_lkg,
+    selected_route_serving_class,
 )
 from llm_gateway.gateway.metrics import (
     observe_error,
@@ -56,7 +58,7 @@ from llm_gateway.gateway.output_budget import OutputBudgetDecision, completion_s
 from llm_gateway.gateway.providers import ProviderFailure
 from llm_gateway.gateway.request_context import request_id_for
 from llm_gateway.gateway.resolver import ResolvedRoute, is_lkg_eligible, resolve_chat_completion_route
-from llm_gateway.gateway.schemas import FailureClass, RouteArtifact
+from llm_gateway.gateway.schemas import FailureClass, RouteArtifact, RouteServingClass
 from llm_gateway.gateway.sse import SSEEventDecoder
 from llm_gateway.routers.dependencies import get_gateway_config, get_provider_registry
 
@@ -139,8 +141,9 @@ async def create_chat_completion(
                     provider='none',
                     model='none',
                     credential_source=credential_source,
-                    used_lkg=route is resolved_route.last_known_good_route,
-                    fallback_used=route is resolved_route.last_known_good_route,
+                    route_serving_class=selected_route_serving_class(resolved_route),
+                    used_lkg=selected_route_is_lkg(resolved_route),
+                    fallback_used=False,
                     fallback_reason=None,
                     outcome='cancelled',
                     error_class='client_cancelled',
@@ -166,6 +169,8 @@ async def create_chat_completion(
                     credential_source=credential_source,
                     request_id=request_id,
                     streaming=is_streaming,
+                    used_lkg=selected_route_is_lkg(resolved_route),
+                    route_serving_class=selected_route_serving_class(resolved_route),
                 ),
                 request_id=request_id,
                 api_surface='openai_chat_completions',
@@ -194,8 +199,9 @@ async def create_chat_completion(
                     provider='none',
                     model='none',
                     credential_source=credential_source,
-                    used_lkg=route is resolved_route.last_known_good_route,
-                    fallback_used=route is resolved_route.last_known_good_route,
+                    route_serving_class=selected_route_serving_class(resolved_route),
+                    used_lkg=selected_route_is_lkg(resolved_route),
+                    fallback_used=False,
                     fallback_reason=None,
                     outcome='error',
                     error_class='unexpected_internal',
@@ -458,7 +464,7 @@ async def _prepared_streaming_iterator(
 ) -> _PreparedStream:
     last_error: GatewayError | None = None
     first_failure: str | None = None
-    for index, provider_ref in enumerate([route.primary, *route.fallbacks]):
+    for provider_ref in [route.primary, *route.fallbacks]:
         provider = provider_registry.provider_for(provider_ref.provider)
         if provider is None:
             raise GatewayInvalidRouteConfigError(f'provider is not supported for this route: {provider_ref.provider}')
@@ -484,7 +490,7 @@ async def _prepared_streaming_iterator(
                 stream=stream,
                 provider=provider_ref.provider,
                 model=provider_ref.model,
-                fallback_used=index > 0 or route is resolved_route.last_known_good_route,
+                fallback_used=first_failure is not None,
                 fallback_reason=first_failure,
                 cache_requested=cache_requested_for_openai_request(provider_request),
             )
@@ -509,7 +515,7 @@ async def _prepared_streaming_iterator(
             stream=stream,
             provider=provider_ref.provider,
             model=provider_ref.model,
-            fallback_used=index > 0 or route is resolved_route.last_known_good_route,
+            fallback_used=first_failure is not None,
             fallback_reason=first_failure,
             cache_requested=cache_requested_for_openai_request(provider_request),
         )
@@ -571,9 +577,16 @@ async def _stream_with_terminal_metrics(
                 provider=prepared.provider,
                 model=prepared.model,
                 credential_source=credentials.source.value,
-                used_lkg=route is resolved_route.last_known_good_route,
+                route_serving_class=(
+                    RouteServingClass.ACTUAL_FALLBACK
+                    if prepared.fallback_used
+                    else selected_route_serving_class(resolved_route)
+                ),
+                used_lkg=selected_route_is_lkg(resolved_route),
                 fallback_used=prepared.fallback_used,
                 fallback_reason=prepared.fallback_reason,
+                fallback_from_route_artifact_id=route.route_artifact_id if prepared.fallback_used else None,
+                fallback_to_route_artifact_id=route.route_artifact_id if prepared.fallback_used else None,
                 outcome=outcome,
                 error_class=error_class,
                 request_id=request_id,

--- a/backend/tests/unit/test_journey_observability.py
+++ b/backend/tests/unit/test_journey_observability.py
@@ -176,6 +176,7 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
     assert 'Live STT attempt failure rate (failure / accepted)' in panel_titles
     assert 'Journey acceptance-to-terminal latency (p95)' in panel_titles
     assert 'Capture finalization durable projection and nonterminal work' in panel_titles
+    assert 'LLM gateway LKG serving share (rollout exposure)' in panel_titles
     live_stt_panel = next(
         panel for panel in dashboard['panels'] if panel['title'].startswith('Live STT attempt failure')
     )
@@ -197,3 +198,6 @@ def test_idle_metrics_and_monitoring_contract_distinguish_traffic_from_a_missing
     assert 'max(listen_finalization_durable_jobs{state="accepted"})' in dead_emission_rule['data'][0]['model']['expr']
     assert 'max by (state)' in dead_emission_rule['data'][1]['model']['expr']
     assert dead_emission_rule['data'][2]['model']['expression'] == '$A >= 5 && $B == 0'
+    lkg_panel = next(panel for panel in dashboard['panels'] if panel['id'] == 11)
+    assert 'route_serving_class="lkg"' in lkg_panel['targets'][0]['expr']
+    assert 'fallback_used' not in lkg_panel['targets'][0]['expr']

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -136,6 +136,10 @@ def test_llm_gateway_anthropic_secret_and_authenticated_readiness_probe_contract
         assert '${OMI_LLM_GATEWAY_SERVICE_TOKEN}' in probe_command
         assert 'X-Omi-Service-Caller: backend' in probe_command
 
+    deployment = (BACKEND_ROOT / 'charts/llm-gateway/templates/deployment.yaml').read_text(encoding='utf-8')
+    assert 'name: OMI_LLM_GATEWAY_BUILD_IDENTITY' in deployment
+    assert 'value: {{ required "image.tag is required" .Values.image.tag | quote }}' in deployment
+
 
 def test_prod_gateway_wiring_promotes_cloud_run_only_after_verified_endpoint_injection():
     manifest = _load_yaml('deploy/runtime_env.yaml')

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -24,7 +24,14 @@ from llm_gateway.gateway.executor import (
 )
 from llm_gateway.gateway.providers import FakeChatCompletionProvider, ProviderFailure, fake_success_response
 from llm_gateway.gateway.resolver import resolve_chat_completion_route
-from llm_gateway.gateway.schemas import CredentialMode, FailureClass, ProviderRef, RolloutPolicy, RolloutStage
+from llm_gateway.gateway.schemas import (
+    CredentialMode,
+    FailureClass,
+    ProviderRef,
+    RolloutPolicy,
+    RolloutStage,
+    RouteServingClass,
+)
 
 LANE_ID = 'omi:auto:chat-structured'
 CHAT_AGENT_LANE_ID = 'omi:auto:chat-agent'
@@ -51,7 +58,11 @@ async def test_executor_success_uses_active_primary_and_exposes_lane_model():
     assert result.selected_provider == 'openai'
     assert result.selected_model == 'gpt-5.6-luna'
     assert not result.fallback_used
+    assert result.fallback_reason is None
+    assert result.fallback_from_route_artifact_id is None
+    assert result.fallback_to_route_artifact_id is None
     assert not result.used_lkg
+    assert result.route_serving_class == RouteServingClass.ACTIVE
     assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
     assert provider.calls[0].request['stream'] is False
 
@@ -299,7 +310,10 @@ async def test_executor_uses_active_route_fallback_for_policy_allowed_failures(f
     assert result.selected_model == 'gpt-4o-mini'
     assert result.fallback_used
     assert result.fallback_reason == failure_class
+    assert result.fallback_from_route_artifact_id == ACTIVE_ROUTE
+    assert result.fallback_to_route_artifact_id == ACTIVE_ROUTE
     assert not result.used_lkg
+    assert result.route_serving_class == RouteServingClass.ACTUAL_FALLBACK
     assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-4o-mini']
 
 
@@ -355,7 +369,10 @@ async def test_executor_uses_lkg_only_when_active_route_policy_allows():
     assert result.selected_model == 'gpt-5.6-luna'
     assert result.fallback_used
     assert result.fallback_reason == FailureClass.TIMEOUT_BEFORE_OUTPUT
+    assert result.fallback_from_route_artifact_id == ACTIVE_ROUTE
+    assert result.fallback_to_route_artifact_id == LKG_ROUTE
     assert result.used_lkg
+    assert result.route_serving_class == RouteServingClass.ACTUAL_FALLBACK
     assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-5.6-luna']
 
 
@@ -383,6 +400,28 @@ async def test_executor_does_not_use_lkg_when_active_route_policy_rejects_failur
 
     assert exc_info.value.failure_class == FailureClass.TIMEOUT_BEFORE_OUTPUT
     assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_executor_remains_error_when_active_and_lkg_routes_both_fail():
+    config = config_with_active_route(active_route_with_fallbacks([]))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider(
+        [
+            ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT),
+            ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID),
+        ]
+    )
+
+    with pytest.raises(GatewayProviderFailureError) as exc_info:
+        await execute_chat_completion(
+            resolved,
+            omi_credentials(),
+            ProviderRegistry({'openai': provider}),
+        )
+
+    assert exc_info.value.failure_class == FailureClass.PROVIDER_5XX_OMI_PAID
+    assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-5.6-luna']
 
 
 @pytest.mark.asyncio
@@ -487,6 +526,11 @@ async def test_shadow_active_route_serves_lkg_not_active():
     assert result.selected_route_artifact_id == LKG_ROUTE
     assert result.selected_model == 'gpt-5.6-luna'
     assert result.used_lkg
+    assert not result.fallback_used
+    assert result.fallback_reason is None
+    assert result.fallback_from_route_artifact_id is None
+    assert result.fallback_to_route_artifact_id is None
+    assert result.route_serving_class == RouteServingClass.LKG
     assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
     assert selected_serving_route_artifact_id(resolved) == LKG_ROUTE
 
@@ -600,6 +644,8 @@ async def test_canary_route_at_100_percent_serves_active():
 
     assert result.selected_route_artifact_id == ACTIVE_ROUTE
     assert not result.used_lkg
+    assert not result.fallback_used
+    assert result.route_serving_class == RouteServingClass.CANARY
 
 
 def valid_request(**overrides):

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -318,6 +318,37 @@ async def test_executor_uses_active_route_fallback_for_policy_allowed_failures(f
 
 
 @pytest.mark.asyncio
+async def test_executor_identical_provider_model_retry_is_not_actual_fallback():
+    """A within-route fallback to the same provider+model is a retry, not a
+    distinct provider/route failover, and must not be classified as
+    ACTUAL_FALLBACK — per the PR behavioral contract that actual fallback
+    requires a *subsequent provider/route* success."""
+    identical_ref = ProviderRef(provider='openai', model='gpt-5.6-luna')
+    config = config_with_active_route(active_route_with_fallbacks([identical_ref]))
+    resolved = resolve_chat_completion_route(config, valid_request())
+    provider = FakeChatCompletionProvider(
+        [
+            ProviderFailure(FailureClass.TIMEOUT_BEFORE_OUTPUT),
+            fake_success_response(identical_ref, content='{"answer":"retry"}'),
+        ]
+    )
+
+    result = await execute_chat_completion(
+        resolved,
+        omi_credentials(),
+        ProviderRegistry({'openai': provider}),
+    )
+
+    assert result.selected_model == 'gpt-5.6-luna'
+    assert not result.fallback_used
+    assert result.fallback_reason is None
+    assert result.fallback_from_route_artifact_id is None
+    assert result.fallback_to_route_artifact_id is None
+    assert result.route_serving_class == RouteServingClass.ACTIVE
+    assert [call.model for call in provider.calls] == ['gpt-5.6-luna', 'gpt-5.6-luna']
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'failure_class,error_type',
     [

--- a/backend/tests/unit/test_llm_gateway_metrics.py
+++ b/backend/tests/unit/test_llm_gateway_metrics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from llm_gateway.gateway import metrics
+from llm_gateway.gateway.config_loader import load_gateway_config
 from llm_gateway.gateway.errors import GatewayProviderRequestRejectedError
 from llm_gateway.gateway.schemas import ProviderRejection
 
@@ -18,14 +19,23 @@ class _MetricChild:
     def observe(self, value):
         self.parent.observations.append((self.labels, value))
 
+    def set(self, value):
+        self.parent.values.append((self.labels, value))
+
 
 class _Metric:
     def __init__(self):
         self.increments: list[dict[str, str]] = []
         self.observations: list[tuple[dict[str, str], float]] = []
+        self.values: list[tuple[dict[str, str], float]] = []
 
     def labels(self, **labels):
         return _MetricChild(self, labels)
+
+    def clear(self):
+        self.increments.clear()
+        self.observations.clear()
+        self.values.clear()
 
 
 def test_stream_terminal_metric_exposes_bounded_surface_phase_and_byok_source(monkeypatch):
@@ -63,6 +73,7 @@ def test_stream_terminal_metric_exposes_bounded_surface_phase_and_byok_source(mo
     assert labels['api_surface'] == 'anthropic_messages'
     assert labels['streaming'] == 'true'
     assert labels['phase'] == 'midstream'
+    assert labels['route_serving_class'] == 'active'
     assert labels['credential_source'] == 'service_forwarded_byok'
     assert labels['budget_source'] == 'route_default'
     assert labels['output_budget'] == 'le_128'
@@ -125,9 +136,36 @@ def test_terminal_errors_are_warning_logs_with_only_bounded_failure_fields(monke
         'surface=openai_chat_completions streaming=false phase=before_output '
         'lane=omi:auto:conv-structure route=route.conv_structure.model_config.001 '
         'provider=none model=none credential_source=service_forwarded_byok outcome=error '
-        'error_class=credential_failure failure_class=byok_auth fallback_used=false provider_rejection=none '
+        'error_class=credential_failure route_serving_class=active failure_class=byok_auth '
+        'fallback_used=false fallback_from=none fallback_to=none provider_rejection=none '
         'budget_source=none output_budget=none completion_size=unknown finish_reason=unknown ttfb_seconds=none'
     ]
+
+
+def test_config_info_separates_immutable_build_and_bounded_route_identity(monkeypatch):
+    info = _Metric()
+    monkeypatch.setattr(metrics, 'GATEWAY_CONFIG_INFO', info)
+
+    config = load_gateway_config(prod_mode=True)
+    metrics.observe_gateway_config_identity(config, build_identity='deadbee')
+
+    assert len(info.values) == len(config.lanes) * 2
+    for labels, value in info.values:
+        assert value == 1
+        assert labels['build_identity'] == 'deadbee'
+        assert labels['route_role'] in {'active', 'lkg'}
+        assert labels['route_artifact_id'].startswith('route.')
+        assert labels['artifact_digest'].startswith('sha256:')
+        assert set(labels) == {
+            'build_identity',
+            'lane_id',
+            'route_role',
+            'route_artifact_id',
+            'artifact_digest',
+        }
+
+    metrics.observe_gateway_config_identity(config, build_identity='customer/request/secret')
+    assert {labels['build_identity'] for labels, _ in info.values} == {'unknown'}
 
 
 def test_provider_rejection_terminal_identifies_route_target_and_bounds_rejection(monkeypatch, caplog):

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -634,6 +634,10 @@ def test_streaming_success_requires_done_marker_and_records_byok_source(monkeypa
     assert recorded[0]['phase'] == 'terminal_marker'
     assert recorded[0]['credential_source'] == 'service_forwarded_byok'
     assert recorded[0]['streaming'] is True
+    assert recorded[0]['used_lkg'] is True
+    assert recorded[0]['fallback_used'] is False
+    assert recorded[0]['fallback_reason'] is None
+    assert recorded[0]['route_serving_class'].value == 'lkg'
     assert recorded[0]['ttfb_seconds'] is not None
     assert recorded[0]['budget_source'] == 'none'
     assert recorded[0]['output_budget'] == 'none'

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -746,6 +746,91 @@ async def test_streaming_consumer_abandonment_records_cancelled_exactly_once(mon
     assert recorded[0]['error_class'] == 'consumer_abandoned_stream'
 
 
+@pytest.mark.asyncio
+async def test_streaming_fallback_that_fails_midstream_is_not_actual_fallback(monkeypatch):
+    """When a fallback stream is opened (prepared.fallback_used=True) but that
+    stream later fails before [DONE], the terminal metric must not classify the
+    request as ACTUAL_FALLBACK — the PR contract requires a *subsequent
+    successful* provider/route."""
+    recorded: list[dict] = []
+    monkeypatch.setattr(openai_compatible, 'observe_route_result', lambda *_args, **kwargs: recorded.append(kwargs))
+    config = _streaming_enabled_gateway_config()
+    resolved = resolve_chat_completion_route(config, valid_request(stream=True))
+    route = openai_compatible.selected_serving_route(resolved)
+
+    async def failing_stream():
+        raise ProviderFailure(FailureClass.PROVIDER_5XX_OMI_PAID)
+        yield b''
+
+    prepared = openai_compatible._PreparedStream(
+        first_chunk=b'data: {"choices":[]}\n\n',
+        stream=failing_stream(),
+        provider='openai',
+        model='gpt-4o-mini',
+        fallback_used=True,
+        fallback_reason='timeout_before_output',
+    )
+    stream = openai_compatible._stream_with_terminal_metrics(
+        prepared,
+        resolved_route=resolved,
+        credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+        route=route,
+        started_at=openai_compatible.time_request(),
+        request_id='a1b2c3d4-fallback-fail-test-000000000001',
+    )
+
+    assert await anext(stream) == b'data: {"choices":[]}\n\n'
+    with pytest.raises(ProviderFailure):
+        await anext(stream)
+
+    assert len(recorded) == 1
+    assert recorded[0]['outcome'] == 'error'
+    assert recorded[0]['error_class'] == 'provider_5xx_omi_paid_midstream'
+    assert recorded[0]['fallback_used'] is False
+    assert recorded[0]['fallback_reason'] is None
+    assert recorded[0]['route_serving_class'] != openai_compatible.RouteServingClass.ACTUAL_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_streaming_successful_fallback_is_classified_as_actual_fallback(monkeypatch):
+    """When a fallback stream opens and completes successfully ([DONE]), the
+    terminal metric SHOULD classify it as ACTUAL_FALLBACK."""
+    recorded: list[dict] = []
+    monkeypatch.setattr(openai_compatible, 'observe_route_result', lambda *_args, **kwargs: recorded.append(kwargs))
+    config = _streaming_enabled_gateway_config()
+    resolved = resolve_chat_completion_route(config, valid_request(stream=True))
+    route = openai_compatible.selected_serving_route(resolved)
+
+    async def done_stream():
+        yield b'data: [DONE]\n\n'
+
+    prepared = openai_compatible._PreparedStream(
+        first_chunk=b'data: {"choices":[]}\n\n',
+        stream=done_stream(),
+        provider='openai',
+        model='gpt-4o-mini',
+        fallback_used=True,
+        fallback_reason='timeout_before_output',
+    )
+    stream = openai_compatible._stream_with_terminal_metrics(
+        prepared,
+        resolved_route=resolved,
+        credentials=build_omi_managed_credential_context(ServiceCaller(name='backend')),
+        route=route,
+        started_at=openai_compatible.time_request(),
+        request_id='b2c3d4e5-fallback-ok-test-0000000000002',
+    )
+
+    collected = [chunk async for chunk in stream]
+    assert b'data: [DONE]\n\n' in collected
+
+    assert len(recorded) == 1
+    assert recorded[0]['outcome'] == 'success'
+    assert recorded[0]['fallback_used'] is True
+    assert recorded[0]['fallback_reason'] == 'timeout_before_output'
+    assert recorded[0]['route_serving_class'] == openai_compatible.RouteServingClass.ACTUAL_FALLBACK
+
+
 def _streaming_enabled_gateway_config():
     config = load_gateway_config(prod_mode=True)
     lane = config.lanes[LANE_ID]

--- a/backend/tests/unit/test_llm_gateway_resolver.py
+++ b/backend/tests/unit/test_llm_gateway_resolver.py
@@ -98,6 +98,20 @@ def test_lkg_is_selected_only_for_active_route_policy_allowed_failure():
     assert selected.route_artifact_id == LKG_ROUTE
 
 
+def test_same_artifact_pointer_is_not_a_distinct_lkg_failover():
+    base = load_gateway_config(prod_mode=True)
+    lanes = dict(base.lanes)
+    lanes[LANE_ID] = lanes[LANE_ID].model_copy(update={'last_known_good': ACTIVE_ROUTE})
+    config = GatewayConfig(
+        lanes=lanes,
+        route_artifacts=base.route_artifacts,
+        feature_bundles=base.feature_bundles,
+    )
+    resolved = resolve_chat_completion_route(config, valid_request())
+
+    assert select_lkg_route_for_failure(resolved, FailureClass.TIMEOUT_BEFORE_OUTPUT) is None
+
+
 @pytest.mark.parametrize(
     'failure_class',
     [

--- a/backend/tests/unit/test_llm_gateway_service.py
+++ b/backend/tests/unit/test_llm_gateway_service.py
@@ -78,3 +78,29 @@ async def test_lifespan_runs_registry_cleanup_when_image_cleanup_fails(monkeypat
         pass
 
     assert set(calls) == {'accounting', 'image', 'registry'}
+
+
+@pytest.mark.asyncio
+async def test_lifespan_publishes_deployment_and_config_identity(monkeypatch):
+    observed = []
+    config = object()
+
+    async def noop_cleanup():
+        return None
+
+    monkeypatch.setenv('OMI_LLM_GATEWAY_BUILD_IDENTITY', 'deadbee')
+    monkeypatch.setattr(main, 'get_gateway_config', lambda: config)
+    monkeypatch.setattr(
+        main,
+        'observe_gateway_config_identity',
+        lambda loaded_config, *, build_identity: observed.append((loaded_config, build_identity)),
+    )
+    monkeypatch.setattr(main, 'drain_accounting_persistence_tasks', noop_cleanup)
+    monkeypatch.setattr(main.openai_compatible, 'close_image_generation_client', noop_cleanup)
+    monkeypatch.setattr(main.anthropic_messages, 'close_anthropic_messages_client', noop_cleanup)
+    monkeypatch.setattr(main, 'close_provider_registry', noop_cleanup)
+
+    async with main.lifespan(app):
+        pass
+
+    assert observed == [(config, 'deadbee')]

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -227,6 +227,18 @@ def test_llm_gateway_alerts_cover_client_black_holes_and_ready_endpoints():
     assert "kube_endpoint_address_available" in endpoint_rule["data"][0]["model"]["expr"]
 
 
+def test_llm_gateway_fallback_ticket_counts_only_successful_actual_failover():
+    for rules in _all_rule_exports().values():
+        expression = rules["bfobs1llmgfb01"]["data"][0]["model"]["expr"]
+        assert 'llm_gateway_requests_total' in expression
+        assert 'route_serving_class="actual_fallback"' in expression
+        assert 'fallback_used="true"' in expression
+        assert 'fallback_reason!="none"' in expression
+        assert 'outcome="success"' in expression
+        assert 'used_lkg' not in expression
+        assert 'llm_gateway_chat_extraction_requests_total' not in expression
+
+
 def test_live_transcription_alert_is_traffic_gated_and_ignores_idle_no_data():
     """The real-traffic alert must not page before any live sessions exist."""
     for rules in _all_rule_exports().values():


### PR DESCRIPTION
Closes 6df70049-2e32-473f-ab7f-1fa207ad5068

## Summary

- classify ordinary active, canary, and LKG serving separately from successful actual failover
- require a prior eligible failure and a subsequent provider/route success before emitting `fallback_used=true`, with bounded reason and from/to route evidence
- publish immutable image plus route-artifact/digest identity through a separate low-cardinality info metric
- update the repo-owned fallback ticket query and dashboard, adding a distinct ordinary-LKG rollout-exposure panel

No deployment, traffic, rollout, credential, or live Grafana mutation is included.

## Existing-work inventory

- #8427 introduced the executor classification and #9462 propagated it into terminal metrics; #9286 introduced the shared fallback observability surfaces this patch corrects.
- Draft #10934 changes gateway catalog/config resolution but does not change fallback telemetry; this focused repair intentionally keeps its only resolver change to the same-artifact no-failover guard.
- No open PR or issue was found for `fallback_used` telemetry semantics.

## Behavioral contract

- active route success: `route_serving_class=active`, no fallback
- canary success: `route_serving_class=canary`, no fallback
- shadow/disabled/0% or out-of-bucket serving: `route_serving_class=lkg`, no fallback
- eligible provider/active-route failure followed by success: `route_serving_class=actual_fallback`, non-`none` reason, bounded from/to route artifacts
- no successful failover: request remains an error

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_llm_gateway_executor.py backend/tests/unit/test_llm_gateway_resolver.py backend/tests/unit/test_llm_gateway_metrics.py backend/tests/unit/test_llm_gateway_service.py backend/tests/unit/test_llm_gateway_deploy_contract.py backend/tests/unit/test_llm_gateway_openai_compatible.py backend/tests/unit/test_monitoring_alert_rule_contract.py backend/tests/unit/test_journey_observability.py` — 123 passed
- `python3 -m json.tool` on the split alert source, combined alert export, and resilience dashboard — passed
- `helm template test backend/charts/llm-gateway -f backend/charts/llm-gateway/dev_omi_llm_gateway_values.yaml --set-string image.tag=deadbee` — passed
- HTTP/TestClient streaming route exercised the checked-in shadow/0% selection and observed `used_lkg=true`, `fallback_used=false`, `route_serving_class=lkg`
- `git diff --check` — passed

## Product invariants affected

none

## Failure class

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

