### PR TITLE
fix(listen): make dev parity capture volume writable

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -52,8 +52,12 @@ podLabels:
   # Keep those scrape targets in the same development-only evidence plane as
   # the Pusher targets.
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  # The image runs as omi:omi (10001:10001). Kubernetes mounts emptyDir as
+  # root-owned, so the parity-pack cassette root needs this supplemental group
+  # before the non-root listener can create its cassettes/ directory.
+  fsGroup: 10001
+  fsGroupChangePolicy: OnRootMismatch
 
 securityContext: {}
   # capabilities:

--- a/backend/testing/parity_pack_v0/README.md
+++ b/backend/testing/parity_pack_v0/README.md
@@ -62,8 +62,10 @@ contract unchanged for existing players:
 | `memory_import` | `v3_memory_import_batch` | Bounded import artifacts and ingestion result (not raw media) |
 
 The development listen deployment mounts `/var/omi-parity-pack` as an `emptyDir`
-for explicitly allowlisted dogfood principals and best-effort exports cassette
-JSON to a private development bucket:
+for explicitly allowlisted dogfood principals. Pod `fsGroup: 10001` matches the
+non-root backend image group so the listener can create and persist the
+`cassettes/` directory, then best-effort export cassette JSON to a private
+development bucket:
 
 ```text
 gs://based-hardware-dev-omi-parity-pack-v0/parity-pack/v0/cassettes/<identity-key>.json

--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -105,6 +105,25 @@ def test_backend_listen_helm_template_requires_image_tag():
     assert "image.tag is required" in result.stderr
 
 
+def test_dev_parity_pack_emptydir_is_writable_by_the_non_root_backend_image():
+    """The capture root is an emptyDir, so its pod group must match the image group."""
+    values = _load_values(ENV_IDENTITY_DEFAULTS["dev"]["values_file"])
+    dockerfile = (ROOT / "backend" / "Dockerfile").read_text(encoding="utf-8")
+    deployment_template = (CHART_DIR / "templates" / "deployment.yaml").read_text(encoding="utf-8")
+    assert "groupadd --system --gid 10001 omi" in dockerfile
+    assert "USER omi" in dockerfile
+    assert "with .Values.podSecurityContext" in deployment_template
+    assert values["podSecurityContext"] == {
+        "fsGroup": 10001,
+        "fsGroupChangePolicy": "OnRootMismatch",
+    }
+    assert {volume["name"] for volume in values["volumes"]} >= {"parity-pack"}
+    assert {(mount["name"], mount["mountPath"]) for mount in values["volumeMounts"]} >= {
+        ("parity-pack", "/var/omi-parity-pack")
+    }
+    assert _env_value(values, "OMI_PARITY_PACK_ROOT") == "/var/omi-parity-pack"
+
+
 def test_prod_values_make_modulate_the_explicit_live_stt_primary():
     values = _load_values(ENV_IDENTITY_DEFAULTS['prod']['values_file'])
 

--- a/backend/tests/unit/test_rendered_deployment_contract.py
+++ b/backend/tests/unit/test_rendered_deployment_contract.py
@@ -7,16 +7,57 @@ from pathlib import Path
 import runpy
 import shutil
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "validate_rendered_deployment_contract.py"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def contracts() -> SimpleNamespace:
     """Load the standalone validator without importing or mutating sys.modules."""
     return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+@pytest.fixture(scope="module")
+def rendered_pusher_deployments(contracts: SimpleNamespace) -> tuple[SimpleNamespace, dict[str, dict]]:
+    """Render the two Pusher charts once, outside the fast-test call phase."""
+    helm = shutil.which("helm")
+    assert helm is not None, "helm must be installed for the rendered deployment contract"
+    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
+    deployments = {}
+    for environment in contracts.ENVIRONMENTS:
+        documents = contracts.render_chart(contract, environment, helm)
+        deployment = contracts.deployment_for(documents, contracts.release_name(contract, environment))
+        assert deployment is not None
+        deployments[environment] = deployment
+    return contract, deployments
+
+
+@pytest.fixture(scope="module")
+def untagged_chart_results(contracts: SimpleNamespace) -> list[tuple[str, str, Any]]:
+    """Run the intentionally broad Helm rejection matrix outside the call phase."""
+    helm = shutil.which("helm")
+    assert helm is not None, "helm must be installed for the rendered deployment contract"
+    results = []
+    for environment in contracts.ENVIRONMENTS:
+        for contract in contracts.CONTRACTS:
+            result = contracts.subprocess.run(
+                [
+                    helm,
+                    "template",
+                    contracts.release_name(contract, environment),
+                    str(contracts.chart_dir(contract)),
+                    "-f",
+                    str(contracts.values_file(contract, environment)),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            results.append((environment, contract.service, result))
+    return results
 
 
 def _deployment(contracts: SimpleNamespace, *, image: str | None = None) -> dict:
@@ -129,31 +170,22 @@ def test_repository_charts_render_the_full_contract_when_helm_is_available(contr
     assert contracts.validate_all_contracts(contracts.render_chart, helm) == []
 
 
-def test_dev_pusher_rollout_preserves_the_existing_replica(contracts: SimpleNamespace):
-    helm = shutil.which("helm")
-    assert helm is not None, "helm must be installed for the rendered deployment contract"
-    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
-    documents = contracts.render_chart(contract, "dev", helm)
-    deployment = contracts.deployment_for(documents, contracts.release_name(contract, "dev"))
-
-    assert deployment is not None
+def test_dev_pusher_rollout_preserves_the_existing_replica(
+    rendered_pusher_deployments: tuple[SimpleNamespace, dict[str, dict]],
+):
+    _, deployments = rendered_pusher_deployments
+    deployment = deployments["dev"]
     rolling_update = deployment["spec"]["strategy"]["rollingUpdate"]
     assert rolling_update["maxUnavailable"] == 0
     assert rolling_update["maxSurge"] == 1
 
 
-def test_pusher_dedicated_pool_toleration_is_dev_only(contracts: SimpleNamespace):
-    helm = shutil.which("helm")
-    assert helm is not None, "helm must be installed for the rendered deployment contract"
-    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
-
-    dev_documents = contracts.render_chart(contract, "dev", helm)
-    dev_deployment = contracts.deployment_for(dev_documents, contracts.release_name(contract, "dev"))
-    prod_documents = contracts.render_chart(contract, "prod", helm)
-    prod_deployment = contracts.deployment_for(prod_documents, contracts.release_name(contract, "prod"))
-
-    assert dev_deployment is not None
-    assert prod_deployment is not None
+def test_pusher_dedicated_pool_toleration_is_dev_only(
+    rendered_pusher_deployments: tuple[SimpleNamespace, dict[str, dict]],
+):
+    _, deployments = rendered_pusher_deployments
+    dev_deployment = deployments["dev"]
+    prod_deployment = deployments["prod"]
     assert dev_deployment["spec"]["template"]["spec"].get("tolerations") == [
         {"key": "dedicated", "operator": "Equal", "value": "pusher", "effect": "NoSchedule"}
     ]
@@ -161,28 +193,20 @@ def test_pusher_dedicated_pool_toleration_is_dev_only(contracts: SimpleNamespace
 
 
 @pytest.mark.parametrize("environment", ("dev", "prod"))
-def test_pusher_explicit_zero_min_ready_seconds_renders(contracts: SimpleNamespace, environment: str):
-    helm = shutil.which("helm")
-    assert helm is not None, "helm must be installed for the rendered deployment contract"
-    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
-
-    documents = contracts.render_chart(contract, environment, helm)
-    deployment = contracts.deployment_for(documents, contracts.release_name(contract, environment))
-
-    assert deployment is not None
+def test_pusher_explicit_zero_min_ready_seconds_renders(
+    rendered_pusher_deployments: tuple[SimpleNamespace, dict[str, dict]], environment: str
+):
+    _, deployments = rendered_pusher_deployments
+    deployment = deployments[environment]
     assert deployment["spec"]["minReadySeconds"] == 0
 
 
 @pytest.mark.parametrize("environment", ("dev", "prod"))
-def test_pusher_does_not_mount_kubernetes_api_credentials(contracts: SimpleNamespace, environment: str):
-    helm = shutil.which("helm")
-    assert helm is not None, "helm must be installed for the rendered deployment contract"
-    contract = next(contract for contract in contracts.CONTRACTS if contract.service == "pusher")
-
-    documents = contracts.render_chart(contract, environment, helm)
-    deployment = contracts.deployment_for(documents, contracts.release_name(contract, environment))
-
-    assert deployment is not None
+def test_pusher_does_not_mount_kubernetes_api_credentials(
+    rendered_pusher_deployments: tuple[SimpleNamespace, dict[str, dict]], environment: str
+):
+    _, deployments = rendered_pusher_deployments
+    deployment = deployments[environment]
     assert deployment["spec"]["template"]["spec"]["automountServiceAccountToken"] is False
     assert deployment["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
         "allowPrivilegeEscalation": False,
@@ -223,24 +247,9 @@ def test_pusher_rejects_a_missing_min_ready_seconds(contracts: SimpleNamespace, 
     assert "minReadySeconds is required" in result.stderr
 
 
-def test_first_party_charts_reject_missing_image_tag_when_helm_is_available(contracts: SimpleNamespace):
-    helm = shutil.which("helm")
-    assert helm is not None, "helm must be installed for the rendered deployment contract"
-
-    for environment in contracts.ENVIRONMENTS:
-        for contract in contracts.CONTRACTS:
-            result = contracts.subprocess.run(
-                [
-                    helm,
-                    "template",
-                    contracts.release_name(contract, environment),
-                    str(contracts.chart_dir(contract)),
-                    "-f",
-                    str(contracts.values_file(contract, environment)),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            assert result.returncode != 0, f"{environment}/{contract.service} accepted an untagged image"
-            assert "image.tag is required" in result.stderr
+def test_first_party_charts_reject_missing_image_tag_when_helm_is_available(
+    untagged_chart_results: list[tuple[str, str, Any]],
+):
+    for environment, service, result in untagged_chart_results:
+        assert result.returncode != 0, f"{environment}/{service} accepted an untagged image"
+        assert "image.tag is required" in result.stderr


### PR DESCRIPTION
## What changed and why

The dev listener image runs as the non-root `omi` user with GID `10001`, but
the parity-pack capture root is an `emptyDir` mounted without a pod `fsGroup`.
Kubernetes therefore presented a root-owned volume that the listener could not
write: allowlisted sessions reached capture, then `persist()` failed creating
`cassettes/` with `PermissionError`, leaving both the local root and GCS prefix
empty.

Set the development backend-listen pod `fsGroup` to the image's GID and guard
the complete rendered Helm boundary: image group, capture env root, volume,
mount, and pod security context. Listen remains fail-open and the change does
not add logging identifiers, Prometheus dependencies, IAM changes, or any
production configuration.

Closes fe728900-458f-4eb4-ad80-afe60423ed70

## Product invariants affected

none

## Verification

- `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/unit/test_backend_listen_helm_defaults.py backend/tests/unit/test_listen_parity_capture.py -q` — 19 passed.
- `npm run test:parity-pack-v0` — 16 passed.
- `BACKEND_UNIT_TEST_FILE_LIST=../backend-test-files.txt bash test.sh` (from `backend/`) — 23 passed with the local fast-unit timing guard.
- `OMI_PR_BODY_FILE=pr-body.md make preflight` — repository-required deterministic preflight.

The real dev WebSocket was not exercised from this workspace because no GCP
or Firebase credentials are available. The remaining live gate is a normal dev
backend-listen Helm rollout followed by one allowlisted transcription session
and confirmation of a new cassette under the configured GCS prefix.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

