### PR TITLE
test(backend): fix wall-clock flaky inline run-lease tests (Backend Unit Tests red on main)

### DIFF
--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1822,6 +1822,12 @@ class TestAsyncCoordinatorBehavioral:
             pipeline.RUN_LOCK_HEARTBEAT_SECONDS = 0.001
             pipeline.RUN_LOCK_TTL_SECONDS = 0.006
             pipeline.RUN_LOCK_RENEWAL_SAFETY_SECONDS = 0.001
+            # Same explicit deadline as the renew-error case: a 6 ms wall-clock
+            # window can expire before the first renewal is even attempted on a
+            # busy worker, which would assert against the scheduler, not the
+            # fail-closed behavior under test.
+            lease_readings = [0.0, 0.0, 0.001]
+            pipeline.time = types.SimpleNamespace(monotonic=lambda: lease_readings.pop(0) if lease_readings else 0.006)
             renewal_started = asyncio.Event()
 
             async def _hanging_run_blocking(_executor, _fn, *_args, **_kwargs):
@@ -1910,6 +1916,13 @@ class TestAsyncCoordinatorBehavioral:
             pipeline.RUN_LOCK_HEARTBEAT_SECONDS = 0.001
             pipeline.RUN_LOCK_TTL_SECONDS = 0.006
             pipeline.RUN_LOCK_RENEWAL_SAFETY_SECONDS = 0.001
+            # Drive the lease deadline explicitly. A 6 ms wall-clock window can
+            # legitimately expire after one scheduler turn on a busy CI worker,
+            # even though the retry behavior under test is correct. The
+            # coordinator is parked on the capacity gate here, so the lease
+            # heartbeat is the only reader of this clock.
+            lease_readings = [0.0, 0.0, 0.001, 0.001, 0.002]
+            pipeline.time = types.SimpleNamespace(monotonic=lambda: lease_readings.pop(0) if lease_readings else 0.006)
             pipeline.renew_job_run_lock = MagicMock(side_effect=ConnectionError('redis unavailable'))
             pipeline._cleanup_files = MagicMock()
             pipeline.release_sync_content_claim = MagicMock()


### PR DESCRIPTION
## Bug

`Backend Unit Tests` went red on `main` at b9168c502 (run 30884041142):

```
FAILED tests/unit/test_sync_v2.py::TestAsyncCoordinatorBehavioral::test_inline_renew_errors_cancel_before_capacity_admission_without_releasing_retry_material
E   AssertionError: assert 1 >= 2
```

## Root cause

That test (and its sibling `test_inline_lease_renew_timeout_fails_closed_before_token_expiry`) measures a 6 ms inline run-lease window against the real wall clock: `RUN_LOCK_TTL_SECONDS = 0.006`, `RUN_LOCK_HEARTBEAT_SECONDS = 0.001`, `RUN_LOCK_RENEWAL_SAFETY_SECONDS = 0.001`. A single slow scheduler turn — one `asyncio.wait_for(..., timeout=0.001)` that takes 4-5 ms on a busy worker — burns the whole lease before the second renew attempt (or, in the timeout test, before the first renewal is even reached), so the test asserts against the scheduler, not the behavior it names. Nothing in the production lease code (`utils/sync/pipeline.py::_maintain_inline_run_lease`) changed; b9168c502 (#11073) does not touch sync.

## Fix

Both tests now drive the lease deadline from an explicit `monotonic` reading schedule via `pipeline.time`, the pattern already used by the third sibling in this family, `test_inline_lease_renew_errors_fail_closed_before_token_expiry` (added for exactly this reason). The coordinator is parked on the capacity gate in these tests, so the lease heartbeat is the only reader of that clock. Assertions are unchanged — bounded renew retries, lease loss, and retry material left intact (`_cleanup_files` / `release_sync_content_claim` / `release_job_run_lock` never called).

Test-only change; no production code touched.

## Verification

`backend/test.sh` runner (`BACKEND_UNIT_TEST_FILE_LIST=tests/unit/test_sync_v2.py`), macOS, python 3.11:

- **Before:** the CI failure reproduces on this machine unloaded (`assert 1 >= 2`), and 3/3 runs red under 8-way CPU load (both lease tests failing).
- **After:** 9/9 runs green — 6 unloaded, 3 under the same 8-way CPU load — `168 passed` every time.
- `make preflight` (23 checks) passed; bounded pre-push gate passed.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

