### PR TITLE
Fix migration type checks

### DIFF
--- a/backend/models/memory_migration.py
+++ b/backend/models/memory_migration.py
@@ -195,7 +195,7 @@ class MigrationVerificationCertificate(BaseModel):
 class CanonicalMigrationJob(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal[MIGRATION_SCHEMA_VERSION] = MIGRATION_SCHEMA_VERSION
+    schema_version: Literal["canonical_memory_migration.v2"] = MIGRATION_SCHEMA_VERSION
     uid: str
     job_id: str
     migration_type: str = "legacy_to_canonical"

--- a/backend/utils/memory/bulk_legacy_backfill.py
+++ b/backend/utils/memory/bulk_legacy_backfill.py
@@ -15,7 +15,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, Optional, Protocol, Sequence
+from typing import Any, Callable, Dict, Iterable, Optional, Protocol, Sequence, cast
 
 from database.memory_collections import MemoryCollections
 from utils.executors import db_executor
@@ -601,14 +601,15 @@ def _apply_user(
             uid=inventory.uid,
             state=MigrationState.failed,
             inventory=inventory,
-            actions=actions + ["bucket_processing_unavailable"],
+            actions=tuple(actions + ["bucket_processing_unavailable"]),
             staged_count=staged_count,
             error_codes=("bucket_processing_unavailable",),
         )
+    bucket_processor = cast(BucketProcessFn, bucket_process_fn)
     for bucket in config.process_buckets:
         if remaining_rows == 0:
             break
-        bucket_report = bucket_process_fn(inventory.uid, bucket, remaining_rows, stop_fn)
+        bucket_report = bucket_processor(inventory.uid, bucket, remaining_rows, stop_fn)
         actions.append(f"processed_bucket:{bucket}")
         consumed = max(bucket_report.legacy_rows_touched, bucket_report.intended_count)
         remaining_rows = max(0, remaining_rows - consumed)

--- a/backend/utils/memory/graph_enrichment.py
+++ b/backend/utils/memory/graph_enrichment.py
@@ -215,6 +215,13 @@ def _current_evidence_ids(item: MemoryItem) -> List[str]:
     return sorted(ids)
 
 
+def _normalize_expected_evidence_ids(values: object) -> Optional[List[str]]:
+    """Return a validated evidence fence while retaining a runtime trust boundary."""
+    if not isinstance(values, list) or any(not isinstance(value, str) or not value.strip() for value in values):
+        return None
+    return sorted({value.strip() for value in values if isinstance(value, str)})
+
+
 def _assertion_matches_current_item(
     *, item: MemoryItem, assertion: Any, evidence_ids: List[str], plan: GraphEnrichmentPlan
 ) -> bool:
@@ -290,14 +297,9 @@ def prepare_graph_enrichment(
     except GraphEnrichmentError as exc:
         return _blocked(exc.code, exc.message)
     if expected_evidence_ids is not None:
-        raw_expected_evidence_ids: object = expected_evidence_ids
-        if not isinstance(raw_expected_evidence_ids, list) or any(
-            not isinstance(value, str) or not value.strip() for value in raw_expected_evidence_ids
-        ):
+        normalized_expected_evidence_ids = _normalize_expected_evidence_ids(expected_evidence_ids)
+        if normalized_expected_evidence_ids is None:
             return _blocked(MigrationBlockCode.stale_fence.value, "evidence fence is malformed")
-        normalized_expected_evidence_ids = sorted(
-            {value.strip() for value in raw_expected_evidence_ids if isinstance(value, str)}
-        )
         if evidence_ids != normalized_expected_evidence_ids:
             return _blocked(MigrationBlockCode.stale_fence.value, "evidence fence does not match current item")
     if item.account_generation != account_generation:

--- a/backend/utils/memory/graph_enrichment.py
+++ b/backend/utils/memory/graph_enrichment.py
@@ -290,11 +290,14 @@ def prepare_graph_enrichment(
     except GraphEnrichmentError as exc:
         return _blocked(exc.code, exc.message)
     if expected_evidence_ids is not None:
-        if not isinstance(expected_evidence_ids, list) or any(
-            not isinstance(value, str) or not value.strip() for value in expected_evidence_ids
+        raw_expected_evidence_ids: object = expected_evidence_ids
+        if not isinstance(raw_expected_evidence_ids, list) or any(
+            not isinstance(value, str) or not value.strip() for value in raw_expected_evidence_ids
         ):
             return _blocked(MigrationBlockCode.stale_fence.value, "evidence fence is malformed")
-        normalized_expected_evidence_ids = sorted({value.strip() for value in expected_evidence_ids})
+        normalized_expected_evidence_ids = sorted(
+            {value.strip() for value in raw_expected_evidence_ids if isinstance(value, str)}
+        )
         if evidence_ids != normalized_expected_evidence_ids:
             return _blocked(MigrationBlockCode.stale_fence.value, "evidence fence does not match current item")
     if item.account_generation != account_generation:


### PR DESCRIPTION
Unblocks the Backend unit suite for #11068.

- use a literal schema-version annotation accepted by pyright
- preserve runtime validation for malformed evidence fences
- narrow the optional bucket processor after its explicit availability guard

Verified: `pytest -q backend/tests/unit/test_canonical_memory_migration.py backend/tests/unit/test_bulk_legacy_backfill.py backend/tests/unit/test_atomic_apply.py` (54 passed).

## Product invariants affected

- INV-MEM-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

