### PR TITLE
Show unlinked canonical memories in Brain Map

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -304,6 +304,26 @@ CANONICAL_GRAPH_READ_QUERY = FirestoreQuerySpec(
     ),
 )
 
+CANONICAL_MEMORY_ATLAS_READ_QUERY = FirestoreQuerySpec(
+    identifier='memory_items_canonical_atlas_read',
+    collection_group='memory_items',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('account_generation', '==', 'account_generation'),
+        FirestoreQueryFilter('tier', '==', 'tier'),
+        FirestoreQueryFilter('status', '==', 'status'),
+        FirestoreQueryFilter('processing_state', '==', 'processing_state'),
+    ),
+    index_fields=(
+        _asc('account_generation'),
+        _asc('tier'),
+        _asc('status'),
+        _asc('processing_state'),
+        _desc('updated_at'),
+        _desc('__name__'),
+    ),
+)
+
 CONVERSATION_SOURCE_MEMORY_QUERY = FirestoreQuerySpec(
     identifier='memory_items_by_conversation_source',
     collection_group='memory_items',

--- a/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
@@ -315,6 +315,28 @@ def test_canonical_graph_filters_stale_ineligible_and_restricted_assertions(monk
     assert "stale-generation" not in {memory_id for refs in db.assertion_ref_pages for memory_id in refs}
 
 
+def test_canonical_graph_includes_unlinked_canonical_memory_as_an_atlas_node(monkeypatch):
+    monkeypatch.setenv("MEMORY_V3_CURSOR_SECRET", "canonical-graph-test-secret")
+    item, _assertion = _assertion_and_item("unlinked", 1, graph_ready=False)
+    item._payload["content"] = "A durable canonical memory that has no inferred relationship yet."
+    db = _FakeDB([item], {})
+
+    page = kg.get_canonical_knowledge_graph(UID, db_client=db, limit=10)
+
+    assert page.edges == []
+    assert page.nodes == [
+        {
+            "id": "memory:unlinked",
+            "label": "A durable canonical memory that has no inferred relationship yet.",
+            "node_type": "concept",
+            "aliases": [],
+            "memory_ids": ["unlinked"],
+            "created_at": NOW,
+            "updated_at": NOW,
+        }
+    ]
+
+
 def test_assertion_loader_rechecks_account_generation_before_fetch():
     stale_item, stale_assertion = _assertion_and_item("stale-generation", 1, account_generation=3)
     db = _fake_db_for([(stale_item, stale_assertion)])

--- a/backend/utils/memory/canonical_graph.py
+++ b/backend/utils/memory/canonical_graph.py
@@ -12,9 +12,10 @@ from google.cloud.firestore_v1 import FieldFilter
 
 from database import knowledge_graph as kg_db
 from database._client import get_firestore_client
-from database.firestore_index_registry import CANONICAL_GRAPH_READ_QUERY
+from database.firestore_index_registry import CANONICAL_MEMORY_ATLAS_READ_QUERY
 from database.memory_collections import MemoryCollections
 from models.memory_promotion import MemoryGraphAssertion
+from models.product_memory import RESTRICTED_SENSITIVITY_LABELS
 from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
 from utils.memory.v3.cursor import (
     V3CursorContext,
@@ -29,7 +30,7 @@ DEFAULT_CANONICAL_GRAPH_PAGE_LIMIT = 200
 MAX_CANONICAL_GRAPH_PAGE_LIMIT = 500
 CANONICAL_GRAPH_CURSOR_SOURCE = 'canonical_memory_graph'
 CANONICAL_GRAPH_CURSOR_READ_MODE = 'canonical_graph'
-CANONICAL_GRAPH_CURSOR_FILTER = 'canonical_graph_v1:updated_at_desc:memory_id_desc'
+CANONICAL_GRAPH_CURSOR_FILTER = 'canonical_graph_v2:updated_at_desc:memory_id_desc'
 CANONICAL_GRAPH_CURSOR_TTL_SECONDS = 600
 KNOWLEDGE_GRAPH_DOCUMENT_ORDER = '__name__'
 CANONICAL_GRAPH_REVISION_READ_RETRIES = 2
@@ -216,6 +217,12 @@ def _canonical_graph_query_item_is_eligible(
     account_generation: int,
 ) -> bool:
     item_account_generation = item.get('account_generation')
+    promotion = item.get('promotion')
+    sensitivity_labels = item.get('sensitivity_labels')
+    if not isinstance(promotion, dict) or not isinstance(sensitivity_labels, list):
+        return False
+    if any(not isinstance(label, str) for label in sensitivity_labels):
+        return False
     return (
         item.get('uid') == uid
         and isinstance(item.get('memory_id'), str)
@@ -225,7 +232,9 @@ def _canonical_graph_query_item_is_eligible(
         and _enum_value(item.get('status')) == 'active'
         and _enum_value(item.get('tier')) == 'long_term'
         and _enum_value(item.get('processing_state')) == 'processed'
-        and item.get('graph_ready') is True
+        and _enum_value(item.get('source_state')) == 'active'
+        and not set(sensitivity_labels).intersection(RESTRICTED_SENSITIVITY_LABELS)
+        and promotion.get('user_review') is not False
     )
 
 
@@ -274,14 +283,13 @@ def _build_canonical_graph_items_query(
     cursor_boundary: Optional[Tuple[datetime, str]],
 ):
     items_ref = client.collection(MemoryCollections(uid=uid).memory_items)
-    query = CANONICAL_GRAPH_READ_QUERY.build(
+    query = CANONICAL_MEMORY_ATLAS_READ_QUERY.build(
         items_ref,
         {
             'account_generation': revision.account_generation,
             'tier': 'long_term',
             'status': 'active',
             'processing_state': 'processed',
-            'graph_ready': True,
         },
         field_filter_factory=FieldFilter,
     )
@@ -297,6 +305,36 @@ def _build_canonical_graph_items_query(
             }
         )
     return query
+
+
+def _canonical_memory_catalog_node(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Represent a durable canonical memory without inventing a relationship.
+
+    Historical rows may predate the graph-assertion contract.  They remain
+    authoritative memory facts, so the atlas includes them as isolated memory
+    nodes while assertion-backed relationships stay exclusively in the fenced
+    graph records below.
+    """
+    content = item.get('content')
+    memory_id = item.get('memory_id')
+    updated_at = item.get('updated_at')
+    if (
+        not isinstance(content, str)
+        or not content.strip()
+        or not isinstance(memory_id, str)
+        or not isinstance(updated_at, datetime)
+    ):
+        return None
+    label = ' '.join(content.split())
+    return {
+        'id': f'memory:{memory_id}',
+        'label': label[:240],
+        'node_type': 'concept',
+        'aliases': [],
+        'memory_ids': [memory_id],
+        'created_at': item.get('captured_at') or updated_at,
+        'updated_at': updated_at,
+    }
 
 
 def _read_canonical_graph_page_once(
@@ -318,14 +356,16 @@ def _read_canonical_graph_page_once(
             secret=secret,
         )
 
+    accepted_items: List[Dict[str, Any]] = []
     accepted_assertions: List[MemoryGraphAssertion] = []
+    visible_memory_ids: set[str] = set()
     pending_snapshots: List[Any] = []
     pending_window_has_more = False
     last_consumed_snapshot: Any = None
     query_boundary = cursor_boundary
 
     while True:
-        while len(accepted_assertions) < limit:
+        while len(visible_memory_ids) < limit:
             if not pending_snapshots:
                 query = _build_canonical_graph_items_query(
                     client,
@@ -352,12 +392,13 @@ def _read_canonical_graph_page_once(
                 )
                 if item is not None:
                     eligible_batch.append(item)
-                if len(accepted_assertions) + len(eligible_batch) >= limit or not pending_snapshots:
+                if len(visible_memory_ids) + len(eligible_batch) >= limit or not pending_snapshots:
                     break
                 snapshot = pending_snapshots.pop(0)
                 last_consumed_snapshot = snapshot
 
             if eligible_batch:
+                accepted_items.extend(eligible_batch)
                 memory_ids = [cast(str, item['memory_id']) for item in eligible_batch]
                 loaded_assertions = kg_db.load_fenced_assertions_for_memory_items(
                     uid,
@@ -367,10 +408,12 @@ def _read_canonical_graph_page_once(
                 )
                 for assertion in loaded_assertions:
                     accepted_assertions.append(assertion)
-                    if len(accepted_assertions) >= limit:
-                        break
+                    visible_memory_ids.add(assertion.memory_id)
+                for item in eligible_batch:
+                    if _canonical_memory_catalog_node(item) is not None:
+                        visible_memory_ids.add(cast(str, item['memory_id']))
 
-            if len(accepted_assertions) >= limit:
+            if len(visible_memory_ids) >= limit:
                 break
             if not pending_snapshots and not pending_window_has_more:
                 break
@@ -398,7 +441,7 @@ def _read_canonical_graph_page_once(
         else:
             has_more = False
 
-        if accepted_assertions or not has_more:
+        if visible_memory_ids or not has_more:
             break
         if last_consumed_snapshot is None:
             break
@@ -431,8 +474,9 @@ def _read_canonical_graph_page_once(
         {'nodes': [], 'edges': []},
         accepted_assertions,
     )
+    catalog_nodes = [node for item in accepted_items if (node := _canonical_memory_catalog_node(item)) is not None]
     return CanonicalKnowledgeGraphPage(
-        nodes=merged['nodes'],
+        nodes=[*merged['nodes'], *catalog_nodes],
         edges=merged['edges'],
         has_more=has_more,
         next_cursor=next_cursor,


### PR DESCRIPTION
Show every eligible Long-term canonical memory in the canonical atlas, including historical items that predate assertion-backed relationship extraction.

Relationship edges remain sourced only from revision-fenced graph assertions. Unlinked facts render as isolated memory nodes; no relationships are inferred or fabricated.

Adds the matching Firestore composite index and a pagination regression test.

Verified: `pytest -q backend/tests/unit/test_knowledge_graph_canonical_pagination.py backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py` (19 passed).

## Product invariants affected

- INV-MEM-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

