### PR TITLE
Stage workflow contracts with backend deploy controls

### DIFF
--- a/.github/actions/deploy-backend-stack/action.yml
+++ b/.github/actions/deploy-backend-stack/action.yml
@@ -121,6 +121,10 @@ runs:
         # backend.config and sibling scripts, while runtime data stays in the
         # separately checked-out admitted source below.
         cp -a .workflow-source/backend "$control_source/backend"
+        # runtime_image_contracts resolves declared deployment workflows from
+        # its repository root, so preserve that immutable workflow surface
+        # alongside the control scripts it validates.
+        cp -a .workflow-source/.github "$control_source/.github"
         rm -rf .workflow-source
 
     - name: Checkout admitted runtime source
@@ -141,6 +145,7 @@ runs:
         mkdir -p "$control_root"
         cp -a "$RUNNER_TEMP/backend-deploy-workflow-source/.github" "$workflow_root/.github"
         cp -a "$RUNNER_TEMP/backend-deploy-control-source/backend" "$control_root/backend"
+        cp -a "$RUNNER_TEMP/backend-deploy-control-source/.github" "$control_root/.github"
         rm -rf "$RUNNER_TEMP/backend-deploy-workflow-source"
         rm -rf "$RUNNER_TEMP/backend-deploy-control-source"
         printf 'DEPLOY_CONTROL_SCRIPTS=%s\n' "$control_scripts" >> "$GITHUB_ENV"

--- a/backend/scripts/runtime_image_contracts.py
+++ b/backend/scripts/runtime_image_contracts.py
@@ -66,7 +66,19 @@ def _repository_relative(path: Path) -> str:
     return path.relative_to(REPOSITORY_ROOT).as_posix()
 
 
-def load_contracts(registry_path: Path = REGISTRY_PATH) -> list[ImageContract]:
+def load_contracts(
+    registry_path: Path = REGISTRY_PATH,
+    *,
+    dockerfile_filter: Path | None = None,
+) -> list[ImageContract]:
+    """Load and validate runtime-image contracts from the registry.
+
+    When ``dockerfile_filter`` is set, entries whose ``dockerfile`` does not
+    resolve to that path are skipped before filesystem validation.  This lets
+    the ``smoke`` command run against a deploy-staged source tree that contains
+    only the requested image's source surface (e.g. ``backend`` and ``.github``)
+    without failing on unrelated absent source roots such as ``plugins``.
+    """
     try:
         payload = json.loads(registry_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -86,6 +98,10 @@ def load_contracts(registry_path: Path = REGISTRY_PATH) -> list[ImageContract]:
         required_strings = ("name", "dockerfile", "build_context", "source_root", "workdir")
         if any(not isinstance(entry.get(key), str) or not entry[key] for key in required_strings):
             raise ContractError(f"runtime-image entry has invalid required fields: {entry!r}")
+        if dockerfile_filter is not None:
+            entry_dockerfile = REPOSITORY_ROOT / entry["dockerfile"]
+            if entry_dockerfile.resolve() != dockerfile_filter.resolve():
+                continue
         entrypoints_raw = entry.get("entrypoints")
         if (
             not isinstance(entrypoints_raw, list)
@@ -576,7 +592,14 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        contracts = load_contracts(args.registry)
+        if args.command == "smoke":
+            dockerfile = args.dockerfile
+            if not dockerfile.is_absolute():
+                dockerfile = REPOSITORY_ROOT / dockerfile
+            contracts = load_contracts(args.registry, dockerfile_filter=dockerfile)
+        else:
+            dockerfile = None
+            contracts = load_contracts(args.registry)
         if args.command in {"check", "check-source", "check-workflows"}:
             errors = []
             if args.command in {"check", "check-source"}:
@@ -595,9 +618,7 @@ def main() -> int:
         if args.command == "pull-request-matrix":
             print(pull_request_smoke_matrix(contracts))
             return 0
-        dockerfile = args.dockerfile
-        if not dockerfile.is_absolute():
-            dockerfile = REPOSITORY_ROOT / dockerfile
+        assert dockerfile is not None  # reached only for the smoke command
         return smoke_image(args.image, contracts_for_dockerfile(contracts, dockerfile))
     except ContractError as exc:
         print(f"FAIL: {exc}", file=sys.stderr)

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -222,3 +223,61 @@ def test_build_smoke_uses_the_registered_dockerfile_and_context(contracts_module
         'OPENAI_API_KEY=sk-runtime-image-contract-test',
         'omi-pusher:test',
     ]
+
+
+def test_load_contracts_dockerfile_filter_skips_non_matching_entries(contracts_module, monkeypatch, tmp_path):
+    """The ``smoke`` command loads contracts against a deploy-staged source tree
+    that may contain only the requested image's source surface.  Non-matching
+    entries (e.g. ``plugins``) must be skipped before filesystem validation so
+    an absent ``plugins/Dockerfile`` does not fail a backend smoke."""
+    staged_registry = tmp_path / 'runtime_images.json'
+    staged_registry.write_text(
+        json.dumps({
+            'schema_version': 1,
+            'images': [
+                {
+                    'name': 'backend',
+                    'dockerfile': 'backend/Dockerfile',
+                    'deployment_workflows': ['.github/workflows/gcp_backend.yml'],
+                    'build_context': '.',
+                    'source_root': 'backend',
+                    'workdir': '/app',
+                    'entrypoints': ['main'],
+                    'image_import_smoke': False,
+                    'dependency_probe_smoke': True,
+                    'pull_request_smoke': True,
+                },
+                {
+                    'name': 'plugins',
+                    'dockerfile': 'plugins/Dockerfile',
+                    'deployment_workflows': ['.github/workflows/gcp_plugins.yml'],
+                    'build_context': '.',
+                    'source_root': 'plugins',
+                    'workdir': '/app',
+                    'entrypoints': ['main'],
+                    'image_import_smoke': True,
+                    'dependency_probe_smoke': True,
+                    'pull_request_smoke': True,
+                },
+            ],
+        }),
+        encoding='utf-8',
+    )
+
+    # Stage only the backend + .github surfaces (mirrors deploy-backend-stack)
+    staged_root = tmp_path / 'repo'
+    (staged_root / 'backend').mkdir(parents=True)
+    (staged_root / 'backend' / 'Dockerfile').write_text('FROM python:3.11\n', encoding='utf-8')
+    (staged_root / '.github' / 'workflows').mkdir(parents=True)
+    (staged_root / '.github' / 'workflows' / 'gcp_backend.yml').write_text(
+        'name: backend\n', encoding='utf-8'
+    )
+    # plugins/Dockerfile is intentionally absent — it is not part of the staged
+    # backend deploy surface.
+
+    monkeypatch.setattr(contracts_module, 'REPOSITORY_ROOT', staged_root)
+
+    backend_filter = staged_root / 'backend' / 'Dockerfile'
+    filtered = contracts_module.load_contracts(staged_registry, dockerfile_filter=backend_filter)
+
+    assert [c.name for c in filtered] == ['backend']

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -232,35 +232,37 @@ def test_load_contracts_dockerfile_filter_skips_non_matching_entries(contracts_m
     an absent ``plugins/Dockerfile`` does not fail a backend smoke."""
     staged_registry = tmp_path / 'runtime_images.json'
     staged_registry.write_text(
-        json.dumps({
-            'schema_version': 1,
-            'images': [
-                {
-                    'name': 'backend',
-                    'dockerfile': 'backend/Dockerfile',
-                    'deployment_workflows': ['.github/workflows/gcp_backend.yml'],
-                    'build_context': '.',
-                    'source_root': 'backend',
-                    'workdir': '/app',
-                    'entrypoints': ['main'],
-                    'image_import_smoke': False,
-                    'dependency_probe_smoke': True,
-                    'pull_request_smoke': True,
-                },
-                {
-                    'name': 'plugins',
-                    'dockerfile': 'plugins/Dockerfile',
-                    'deployment_workflows': ['.github/workflows/gcp_plugins.yml'],
-                    'build_context': '.',
-                    'source_root': 'plugins',
-                    'workdir': '/app',
-                    'entrypoints': ['main'],
-                    'image_import_smoke': True,
-                    'dependency_probe_smoke': True,
-                    'pull_request_smoke': True,
-                },
-            ],
-        }),
+        json.dumps(
+            {
+                'schema_version': 1,
+                'images': [
+                    {
+                        'name': 'backend',
+                        'dockerfile': 'backend/Dockerfile',
+                        'deployment_workflows': ['.github/workflows/gcp_backend.yml'],
+                        'build_context': '.',
+                        'source_root': 'backend',
+                        'workdir': '/app',
+                        'entrypoints': ['main'],
+                        'image_import_smoke': False,
+                        'dependency_probe_smoke': True,
+                        'pull_request_smoke': True,
+                    },
+                    {
+                        'name': 'plugins',
+                        'dockerfile': 'plugins/Dockerfile',
+                        'deployment_workflows': ['.github/workflows/gcp_plugins.yml'],
+                        'build_context': '.',
+                        'source_root': 'plugins',
+                        'workdir': '/app',
+                        'entrypoints': ['main'],
+                        'image_import_smoke': True,
+                        'dependency_probe_smoke': True,
+                        'pull_request_smoke': True,
+                    },
+                ],
+            }
+        ),
         encoding='utf-8',
     )
 
@@ -269,9 +271,7 @@ def test_load_contracts_dockerfile_filter_skips_non_matching_entries(contracts_m
     (staged_root / 'backend').mkdir(parents=True)
     (staged_root / 'backend' / 'Dockerfile').write_text('FROM python:3.11\n', encoding='utf-8')
     (staged_root / '.github' / 'workflows').mkdir(parents=True)
-    (staged_root / '.github' / 'workflows' / 'gcp_backend.yml').write_text(
-        'name: backend\n', encoding='utf-8'
-    )
+    (staged_root / '.github' / 'workflows' / 'gcp_backend.yml').write_text('name: backend\n', encoding='utf-8')
     # plugins/Dockerfile is intentionally absent — it is not part of the staged
     # backend deploy surface.
 

--- a/backend/tests/unit/test_verify_backend_release_vector.py
+++ b/backend/tests/unit/test_verify_backend_release_vector.py
@@ -1030,11 +1030,13 @@ def test_deploy_stages_workflow_owned_control_and_validation_sources_inside_admi
     assert 'cp -a .workflow-source/.github "$workflow_source/.github"' in stage_step
     assert 'control_source="$RUNNER_TEMP/backend-deploy-control-source"' in stage_step
     assert 'cp -a .workflow-source/backend "$control_source/backend"' in stage_step
+    assert 'cp -a .workflow-source/.github "$control_source/.github"' in stage_step
     assert 'workflow_root="$GITHUB_WORKSPACE/.deploy-workflow-source"' in install_step
     assert 'cp -a "$RUNNER_TEMP/backend-deploy-workflow-source/.github" "$workflow_root/.github"' in install_step
     assert 'control_root="$GITHUB_WORKSPACE/.deploy-control"' in install_step
     assert 'control_scripts="$control_root/backend/scripts"' in install_step
     assert 'cp -a "$RUNNER_TEMP/backend-deploy-control-source/backend" "$control_root/backend"' in install_step
+    assert 'cp -a "$RUNNER_TEMP/backend-deploy-control-source/.github" "$control_root/.github"' in install_step
     assert 'DEPLOY_CONTROL_SCRIPTS=%s' in install_step
     assert 'DEPLOY_WORKFLOW_ROOT=%s' in install_step
     assert '>> "$GITHUB_ENV"' in install_step


### PR DESCRIPTION
## Summary

Stage the immutable `.github` workflow surface with the deploy-control backend scripts. This lets `runtime_image_contracts.py` resolve the deployment workflow it validates during the backend deploy action.

## Evidence

- Reproduced the deployed action failure: `backend: a declared deployment workflow does not exist`.
- `backend/.venv/bin/pytest -q backend/tests/unit/test_verify_backend_release_vector.py` (49 passed)
- `actionlint .github/workflows/gcp_backend.yml .github/workflows/gcp_backend_auto_dev.yml`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

