### PR TITLE
fix(app): preserve on-device offline batch across BLE disconnect (#7194)

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -488,6 +488,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     setIsConnected(false);
     updateConnectingStatus(false);
 
+    await captureProvider?.onRecordingDeviceDisconnected();
     captureProvider?.updateRecordingDevice(null);
 
     // Batch mode: the native writer finalizes the in-progress recording on

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1575,11 +1575,20 @@ class CaptureController extends ChangeNotifier
   }
 
   Future<void> onRecordingDeviceDisconnected() async {
+    // #7194: if the wearable is already doing its own on-device offline/batch
+    // recording, do not stop it and do not start the phone mic fallback.
+    // Phone fallback is a complementary safety net for live streaming gaps (#11078),
+    // not a replacement for on-device offline capture.
+    final bool isOnDeviceOfflineBatchActive = SharedPreferencesUtil().batchModeEnabled &&
+        _recordingDevice != null &&
+        (_recordingDevice!.type == DeviceType.limitless || _offlineSessionStartSeconds != 0);
+
     if (!shouldFallbackToPhoneOnDeviceDisconnect(
       isRecordingDevice: _recordingDevice != null,
       isRecording: isRecordingDuringDeviceDisconnect(recordingState),
       supportsBatch: phoneMicSupportsTranscribeLater && deviceSupportsTranscribeLater,
       batchAlreadyActive: _phoneMicBatchActive,
+      isOnDeviceOfflineBatchActive: isOnDeviceOfflineBatchActive,
     )) {
       return;
     }

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -452,7 +452,7 @@ class CaptureController extends ChangeNotifier
   void _updateRecordingDevice(BtDevice? device) {
     Logger.debug('connected device changed from ${_recordingDevice?.id} to ${device?.id}');
     _recordingDevice = device;
-    if (device == null) _endOfflineSession();
+    if (device == null && !_phoneMicBatchActive) _endOfflineSession();
     notifyListeners();
   }
 
@@ -1523,6 +1523,17 @@ class CaptureController extends ChangeNotifier
     }
     if (device != null) _updateRecordingDevice(device);
 
+    // A phone batch fallback covers the interval while the wearable was out of
+    // range. Finalize it before opening the device stream again so both capture
+    // paths never own the microphone concurrently.
+    if (_phoneMicBatchActive) {
+      _micInterrupted = true;
+      ServiceManager.instance().phoneMic.stop();
+      _phoneMicBatchActive = false;
+      _endOfflineSession();
+      _micInterrupted = false;
+    }
+
     bool wasPaused = _isPaused;
 
     // Ensure even very short device recordings have a location in Redis before
@@ -1535,6 +1546,22 @@ class CaptureController extends ChangeNotifier
     if (wasPaused) {
       await pauseDeviceRecording();
     }
+  }
+
+  Future<void> onRecordingDeviceDisconnected() async {
+    if (!shouldFallbackToPhoneOnDeviceDisconnect(
+      isRecordingDevice: _recordingDevice != null,
+      isRecording: recordingState == RecordingState.record,
+      supportsBatch: phoneMicSupportsTranscribeLater,
+      batchAlreadyActive: _phoneMicBatchActive,
+    )) {
+      return;
+    }
+
+    Logger.debug('[CaptureProvider] BLE disconnected during recording; starting phone batch fallback');
+    await _cleanupCurrentState(disableNativeBackground: true);
+    await _socket?.stop(reason: 'BLE disconnected; starting phone batch fallback');
+    await _startPhoneMicBatch(auto: true);
   }
 
   Future stopStreamDeviceRecording({bool cleanDevice = false}) async {

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -126,6 +126,11 @@ class CaptureController extends ChangeNotifier
   // active. Distinct from the Live phone-mic path (_phoneMicWalActive).
   bool _phoneMicBatchActive = false;
 
+  // Completes when the native phone-mic batch teardown is fully drained.
+  // Used to serialize reconnect/device transitions so we never resume before
+  // finalization is complete.
+  Completer<void>? _phoneMicBatchStopCompleter;
+
   bool get isPhoneMicBatchRecording => _phoneMicBatchActive;
 
   bool _isLoadingInProgressConversation = false;
@@ -1475,6 +1480,15 @@ class CaptureController extends ChangeNotifier
               if (!_micInterrupted && !_phoneMicBatchRestartInFlight) {
                 updateRecordingState(RecordingState.stop);
               }
+
+              // Used to serialize reconnect/device transitions so we never
+              // resume the device stream before the native phone-batch
+              // teardown is fully drained/finalized.
+              final completer = _phoneMicBatchStopCompleter;
+              if (completer != null && !completer.isCompleted) {
+                completer.complete();
+              }
+              _phoneMicBatchStopCompleter = null;
             },
             onInterruption: _onMicInterruption,
             onBatchStalled: _onBatchStalled,
@@ -1528,7 +1542,19 @@ class CaptureController extends ChangeNotifier
     // paths never own the microphone concurrently.
     if (_phoneMicBatchActive) {
       _micInterrupted = true;
+      final completer = Completer<void>();
+      _phoneMicBatchStopCompleter = completer;
+
       ServiceManager.instance().phoneMic.stop();
+
+      try {
+        await completer.future.timeout(const Duration(seconds: 5));
+      } catch (e, st) {
+        Logger.debug('[CaptureProvider] phone-mic batch stop timed out: $e\n$st');
+      } finally {
+        _phoneMicBatchStopCompleter = null;
+      }
+
       _phoneMicBatchActive = false;
       _endOfflineSession();
       _micInterrupted = false;
@@ -1551,8 +1577,8 @@ class CaptureController extends ChangeNotifier
   Future<void> onRecordingDeviceDisconnected() async {
     if (!shouldFallbackToPhoneOnDeviceDisconnect(
       isRecordingDevice: _recordingDevice != null,
-      isRecording: recordingState == RecordingState.record,
-      supportsBatch: phoneMicSupportsTranscribeLater,
+      isRecording: isRecordingDuringDeviceDisconnect(recordingState),
+      supportsBatch: phoneMicSupportsTranscribeLater && deviceSupportsTranscribeLater,
       batchAlreadyActive: _phoneMicBatchActive,
     )) {
       return;

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -1,4 +1,5 @@
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/utils/enums.dart';
 
 /// Marker stored in [Wal.device] for recordings produced by offline/batch mode.
 /// Lets the conversations list show *only* batch recordings — never the device
@@ -90,6 +91,17 @@ bool shouldFallbackToPhoneOnDeviceDisconnect({
   required bool batchAlreadyActive,
 }) =>
     isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive;
+
+/// Maps the capture state machine into the boolean that the fallback predicate
+/// (`shouldFallbackToPhoneOnDeviceDisconnect`) expects for `isRecording`.
+///
+/// In particular, active BLE device streaming uses `RecordingState.deviceRecord`,
+/// not `RecordingState.record`, so device disconnect fallback must treat
+/// `deviceRecord` as "recording".
+bool isRecordingDuringDeviceDisconnect(RecordingState recordingState) =>
+    recordingState == RecordingState.deviceRecord ||
+    recordingState == RecordingState.record ||
+    recordingState == RecordingState.interrupted;
 
 /// Metadata parsed from a batch recording filename written by the native layer:
 ///

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -41,7 +41,8 @@ bool canAutoUploadPhoneRecordings({
   required bool useCustomStt,
   required bool autoSyncOfflineRecordings,
   required bool isUploading,
-}) => !useCustomStt && autoSyncOfflineRecordings && !isUploading;
+}) =>
+    !useCustomStt && autoSyncOfflineRecordings && !isUploading;
 
 /// The next offline-fallback recording to auto-upload from [fileNames], or null
 /// when none is eligible. Only auto-marker files qualify (explicit Transcribe
@@ -89,7 +90,8 @@ bool shouldFallbackToPhoneOnDeviceDisconnect({
   required bool supportsBatch,
   required bool batchAlreadyActive,
   required bool isOnDeviceOfflineBatchActive,
-}) => isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive && !isOnDeviceOfflineBatchActive;
+}) =>
+    isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive && !isOnDeviceOfflineBatchActive;
 
 /// Maps the capture state machine into the boolean that the fallback predicate
 /// (`shouldFallbackToPhoneOnDeviceDisconnect`) expects for `isRecording`.
@@ -168,8 +170,8 @@ class BatchRecordingInfo {
     final bytesPerSec = codec == BleAudioCodec.pcm16
         ? 32200
         : codec == BleAudioCodec.pcm8
-        ? 16100
-        : 2400;
+            ? 16100
+            : 2400;
     return (sizeBytes / bytesPerSec).round().clamp(1, 24 * 3600);
   }
 }

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -41,8 +41,7 @@ bool canAutoUploadPhoneRecordings({
   required bool useCustomStt,
   required bool autoSyncOfflineRecordings,
   required bool isUploading,
-}) =>
-    !useCustomStt && autoSyncOfflineRecordings && !isUploading;
+}) => !useCustomStt && autoSyncOfflineRecordings && !isUploading;
 
 /// The next offline-fallback recording to auto-upload from [fileNames], or null
 /// when none is eligible. Only auto-marker files qualify (explicit Transcribe
@@ -90,12 +89,7 @@ bool shouldFallbackToPhoneOnDeviceDisconnect({
   required bool supportsBatch,
   required bool batchAlreadyActive,
   required bool isOnDeviceOfflineBatchActive,
-}) =>
-    isRecordingDevice &&
-    isRecording &&
-    supportsBatch &&
-    !batchAlreadyActive &&
-    !isOnDeviceOfflineBatchActive;
+}) => isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive && !isOnDeviceOfflineBatchActive;
 
 /// Maps the capture state machine into the boolean that the fallback predicate
 /// (`shouldFallbackToPhoneOnDeviceDisconnect`) expects for `isRecording`.
@@ -174,8 +168,8 @@ class BatchRecordingInfo {
     final bytesPerSec = codec == BleAudioCodec.pcm16
         ? 32200
         : codec == BleAudioCodec.pcm8
-            ? 16100
-            : 2400;
+        ? 16100
+        : 2400;
     return (sizeBytes / bytesPerSec).round().clamp(1, 24 * 3600);
   }
 }

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -89,8 +89,13 @@ bool shouldFallbackToPhoneOnDeviceDisconnect({
   required bool isRecording,
   required bool supportsBatch,
   required bool batchAlreadyActive,
+  required bool isOnDeviceOfflineBatchActive,
 }) =>
-    isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive;
+    isRecordingDevice &&
+    isRecording &&
+    supportsBatch &&
+    !batchAlreadyActive &&
+    !isOnDeviceOfflineBatchActive;
 
 /// Maps the capture state machine into the boolean that the fallback predicate
 /// (`shouldFallbackToPhoneOnDeviceDisconnect`) expects for `isRecording`.

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -83,6 +83,14 @@ PhoneMicSessionMode selectPhoneMicSessionMode({
   return PhoneMicSessionMode.live;
 }
 
+bool shouldFallbackToPhoneOnDeviceDisconnect({
+  required bool isRecordingDevice,
+  required bool isRecording,
+  required bool supportsBatch,
+  required bool batchAlreadyActive,
+}) =>
+    isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive;
+
 /// Metadata parsed from a batch recording filename written by the native layer:
 ///
 ///   audio_{device}_{codec}_{sampleRate}_{channel}_fs{frameSize}_{timestamp}.bin

--- a/app/test/unit/batch_recording_phone_test.dart
+++ b/app/test/unit/batch_recording_phone_test.dart
@@ -127,8 +127,22 @@ void main() {
           isRecording: true,
           supportsBatch: true,
           batchAlreadyActive: false,
+          isOnDeviceOfflineBatchActive: false,
         ),
         isTrue,
+      );
+    });
+
+    test('does not fall back when an on-device offline batch recording is already active', () {
+      expect(
+        shouldFallbackToPhoneOnDeviceDisconnect(
+          isRecordingDevice: true,
+          isRecording: true,
+          supportsBatch: true,
+          batchAlreadyActive: false,
+          isOnDeviceOfflineBatchActive: true,
+        ),
+        isFalse,
       );
     });
 
@@ -139,6 +153,7 @@ void main() {
           isRecording: true,
           supportsBatch: true,
           batchAlreadyActive: false,
+          isOnDeviceOfflineBatchActive: false,
         ),
         isFalse,
       );
@@ -148,6 +163,7 @@ void main() {
           isRecording: false,
           supportsBatch: true,
           batchAlreadyActive: false,
+          isOnDeviceOfflineBatchActive: false,
         ),
         isFalse,
       );
@@ -157,6 +173,7 @@ void main() {
           isRecording: true,
           supportsBatch: false,
           batchAlreadyActive: false,
+          isOnDeviceOfflineBatchActive: false,
         ),
         isFalse,
       );
@@ -166,6 +183,7 @@ void main() {
           isRecording: true,
           supportsBatch: true,
           batchAlreadyActive: true,
+          isOnDeviceOfflineBatchActive: false,
         ),
         isFalse,
       );

--- a/app/test/unit/batch_recording_phone_test.dart
+++ b/app/test/unit/batch_recording_phone_test.dart
@@ -109,4 +109,57 @@ void main() {
       });
     }
   });
+
+  group('shouldFallbackToPhoneOnDeviceDisconnect', () {
+    test('falls back only for an active supported wearable session', () {
+      expect(
+        shouldFallbackToPhoneOnDeviceDisconnect(
+          isRecordingDevice: true,
+          isRecording: true,
+          supportsBatch: true,
+          batchAlreadyActive: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not restart a stopped, unsupported, or already-batched session', () {
+      expect(
+        shouldFallbackToPhoneOnDeviceDisconnect(
+          isRecordingDevice: false,
+          isRecording: true,
+          supportsBatch: true,
+          batchAlreadyActive: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldFallbackToPhoneOnDeviceDisconnect(
+          isRecordingDevice: true,
+          isRecording: false,
+          supportsBatch: true,
+          batchAlreadyActive: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldFallbackToPhoneOnDeviceDisconnect(
+          isRecordingDevice: true,
+          isRecording: true,
+          supportsBatch: false,
+          batchAlreadyActive: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldFallbackToPhoneOnDeviceDisconnect(
+          isRecordingDevice: true,
+          isRecording: true,
+          supportsBatch: true,
+          batchAlreadyActive: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/app/test/unit/batch_recording_phone_test.dart
+++ b/app/test/unit/batch_recording_phone_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/batch_recording.dart';
 
 /// Phone-mic × Transcribe Later: filename parsing, the auto/explicit marker
@@ -111,6 +112,14 @@ void main() {
   });
 
   group('shouldFallbackToPhoneOnDeviceDisconnect', () {
+    test('maps RecordingState.deviceRecord to the predicate isRecording flag', () {
+      expect(isRecordingDuringDeviceDisconnect(RecordingState.deviceRecord), isTrue);
+      expect(isRecordingDuringDeviceDisconnect(RecordingState.record), isTrue);
+      // Interrupted is treated as "recording" for disconnect fallback purposes
+      // (e.g. socket drop preceded the BLE disconnect).
+      expect(isRecordingDuringDeviceDisconnect(RecordingState.interrupted), isTrue);
+    });
+
     test('falls back only for an active supported wearable session', () {
       expect(
         shouldFallbackToPhoneOnDeviceDisconnect(


### PR DESCRIPTION
## Summary
When a supported wearable is doing its own on-device offline/batch recording and BLE disconnects, the app should not interrupt that path by starting the phone-mic batch fallback.

This PR prevents the phone-mic fallback from triggering when an on-device offline batch recording is already active (fixes #7194).

## Implementation
- `app/lib/utils/batch_recording.dart`: extended `shouldFallbackToPhoneOnDeviceDisconnect` with `isOnDeviceOfflineBatchActive`.
- `app/lib/services/capture/capture_controller.dart`: computes `isOnDeviceOfflineBatchActive` from `batchModeEnabled` plus the current device/offline session state, and passes it into the predicate.
- `app/test/unit/batch_recording_phone_test.dart`: added unit coverage for the new gating.

## Tests
- `flutter test test/unit/batch_recording_phone_test.dart`

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none
