### PR TITLE
fix(app): avoid synced UI when WALs remain pending (#7240)

### DIFF
--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -398,12 +398,16 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       updatedConversationIds: result.updatedConversationIds,
     );
     if (_isDisposed) return;
+    // Refresh WALs *before* updating the "synced" conversation UI so we don't
+    // label recordings as synced while the reconciler is still leaving some
+    // WALs in an uploaded/pending state (issue #7240).
+    await refreshWals();
     if (conversations.isNotEmpty && !_syncState.isProcessing) {
       // Append to whatever is already shown — jobs reconcile incrementally.
       final merged = [..._syncState.syncedConversations, ...conversations];
-      _updateSyncState(_syncState.toCompleted(conversations: merged));
+      final filtered = filterFullySyncedConversations(conversations: merged, wals: _allWals);
+      _updateSyncState(_syncState.toCompleted(conversations: filtered));
     }
-    await refreshWals();
   }
 
   Future<void> _discoverPendingWals() async {
@@ -676,9 +680,37 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       newConversationIds: result.newConversationIds,
       updatedConversationIds: result.updatedConversationIds,
     );
-    _updateSyncState(_syncState.toCompleted(conversations: conversations));
-    // Refresh WAL list so home screen cloud icon updates (clears synced WALs)
+    // Refresh WAL list so we can filter "synced" conversations to only those
+    // whose WALs have been reconciled to WalStatus.synced.
     await refreshWals();
+    final filtered = filterFullySyncedConversations(conversations: conversations, wals: _allWals);
+    _updateSyncState(_syncState.toCompleted(conversations: filtered));
+  }
+
+  /// Filters "synced" conversation pointers down to only those conversations
+  /// whose associated WALs have been fully reconciled (`WalStatus.synced`).
+  ///
+  /// This prevents UI states like "synced OK" from showing up while some
+  /// recordings are still left in an uploaded/pending state (issue #7240).
+  @visibleForTesting
+  static List<SyncedConversationPointer> filterFullySyncedConversations({
+    required List<SyncedConversationPointer> conversations,
+    required List<Wal> wals,
+  }) {
+    final byConversationId = <String, List<Wal>>{};
+    for (final wal in wals) {
+      final id = wal.conversationId;
+      if (id == null) continue;
+      (byConversationId[id] ??= <Wal>[]).add(wal);
+    }
+
+    bool isFullySynced(SyncedConversationPointer pointer) {
+      final walsForConversation = byConversationId[pointer.conversation.id] ?? const <Wal>[];
+      if (walsForConversation.isEmpty) return true; // No local WALs → nothing pending.
+      return walsForConversation.every((w) => w.status == WalStatus.synced);
+    }
+
+    return conversations.where(isFullySynced).toList();
   }
 
   // Audio playback delegate methods

--- a/app/test/providers/sync_provider_fully_synced_conversations_test.dart
+++ b/app/test/providers/sync_provider_fully_synced_conversations_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/utils/conversation_sync_utils.dart';
+
+ServerConversation _convo(String id) => ServerConversation(
+      id: id,
+      createdAt: DateTime.utc(2026, 7, 18, 12, 0),
+      structured: Structured('Title', 'Overview'),
+      status: ConversationStatus.completed,
+    );
+
+Wal _wal({
+  required String conversationId,
+  required WalStatus status,
+  required int timerStart,
+}) {
+  return Wal(
+    timerStart: timerStart,
+    codec: BleAudioCodec.pcm16,
+    seconds: 60,
+    status: status,
+    device: 'phone',
+    conversationId: conversationId,
+  );
+}
+
+void main() {
+  test('filters out synced conversations that still have uploaded/pending WALs', () {
+    final c1 = _convo('c1');
+    final c2 = _convo('c2');
+
+    final p1 = ConversationSyncUtils.createPointer(c1, SyncedConversationType.newConversation);
+    final p2 = ConversationSyncUtils.createPointer(c2, SyncedConversationType.newConversation);
+
+    final wals = [
+      _wal(conversationId: c1.id, status: WalStatus.uploaded, timerStart: 1000),
+      _wal(conversationId: c2.id, status: WalStatus.synced, timerStart: 2000),
+    ];
+
+    final filtered = SyncProvider.filterFullySyncedConversations(
+      conversations: [p1, p2],
+      wals: wals,
+    );
+
+    expect(filtered.map((p) => p.conversation.id), ['c2']);
+  });
+
+  test('keeps a synced conversation if there are no local WALs yet', () {
+    final c1 = _convo('c1');
+    final p1 = ConversationSyncUtils.createPointer(c1, SyncedConversationType.newConversation);
+
+    final filtered = SyncProvider.filterFullySyncedConversations(
+      conversations: [p1],
+      wals: const [],
+    );
+
+    expect(filtered, [p1]);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #7240 where the app can mark recordings/conversations as *synced* even though some associated WALs are still left in an uploaded/pending state.

## What changed
- `SyncProvider` now refreshes WAL state before updating `syncState.completed.syncedConversations`.
- It filters the “synced conversations” pointers down to only those conversations whose associated WALs are fully `WalStatus.synced`.

## Regression test
- `flutter test test/providers/sync_provider_fully_synced_conversations_test.dart`

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none
