### PR TITLE
fix(app): fall back to phone capture after BLE disconnect

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -23,6 +23,7 @@ import 'package:omi/services/services.dart';
 import 'package:omi/services/battery_widget_service.dart';
 import 'package:omi/services/wals/wal_syncs.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
+import 'package:omi/utils/batch_recording.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/firmware_update_build_policy.dart';
 import 'package:omi/utils/firmware_update_check_session.dart';
@@ -488,8 +489,28 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     setIsConnected(false);
     updateConnectingStatus(false);
 
-    await captureProvider?.onRecordingDeviceDisconnected();
-    captureProvider?.updateRecordingDevice(null);
+    // Capture before the awaited fallback so a reconnect that installs a new
+    // recording device is not cleared by this stale disconnect continuation.
+    final disconnectedRecordingDeviceId = captureProvider?.recordingDevice?.id;
+    try {
+      await captureProvider?.onRecordingDeviceDisconnected();
+    } catch (e, st) {
+      // Fallback startup/teardown must not abort the rest of disconnect cleanup.
+      Logger.error('onRecordingDeviceDisconnected failed during device disconnect: $e\n$st');
+    }
+
+    final currentRecordingDeviceId = captureProvider?.recordingDevice?.id;
+    if (shouldClearRecordingDeviceAfterDisconnectFallback(
+      disconnectedDeviceId: disconnectedRecordingDeviceId,
+      currentRecordingDeviceId: currentRecordingDeviceId,
+    )) {
+      captureProvider?.updateRecordingDevice(null);
+    } else {
+      Logger.debug(
+        'Skipping updateRecordingDevice(null) after disconnect — reconnect already set '
+        '${currentRecordingDeviceId ?? "unknown"} (was $disconnectedRecordingDeviceId)',
+      );
+    }
 
     // Batch mode: the native writer finalizes the in-progress recording on
     // disconnect (.bin.part -> .bin). Rescan shortly after the rename completes

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -131,6 +131,10 @@ class CaptureController extends ChangeNotifier
   // finalization is complete.
   Completer<void>? _phoneMicBatchStopCompleter;
 
+  /// Bumped to cancel an in-flight BLE-disconnect → phone-batch fallback when
+  /// reconnect / user-stop wins the race across the fallback's awaits.
+  int _disconnectPhoneFallbackEpoch = 0;
+
   bool get isPhoneMicBatchRecording => _phoneMicBatchActive;
 
   bool _isLoadingInProgressConversation = false;
@@ -1532,6 +1536,9 @@ class CaptureController extends ChangeNotifier
 
   Future streamDeviceRecording({BtDevice? device}) async {
     Logger.debug("streamDeviceRecording $device");
+    // Cancel any in-flight disconnect→phone-batch fallback before we claim the
+    // mic for the wearable again.
+    _disconnectPhoneFallbackEpoch++;
     if (deviceOnboardingProvider == null && SharedPreferencesUtil().batchModeSuspendedForOnboarding) {
       await restoreBatchModeAfterOnboarding();
     }
@@ -1593,13 +1600,35 @@ class CaptureController extends ChangeNotifier
       return;
     }
 
+    final disconnectedDeviceId = _recordingDevice?.id;
+    final startedEpoch = ++_disconnectPhoneFallbackEpoch;
+
+    bool stillCurrent() => shouldContinueDisconnectPhoneFallback(
+          startedEpoch: startedEpoch,
+          currentEpoch: _disconnectPhoneFallbackEpoch,
+          disconnectedDeviceId: disconnectedDeviceId,
+          currentRecordingDeviceId: _recordingDevice?.id,
+          userStopped: recordingState == RecordingState.stop,
+        );
+
     Logger.debug('[CaptureProvider] BLE disconnected during recording; starting phone batch fallback');
     await _cleanupCurrentState(disableNativeBackground: true);
+    if (!stillCurrent()) {
+      Logger.debug('[CaptureProvider] aborting phone batch fallback after cleanup (stale disconnect)');
+      return;
+    }
+
     await _socket?.stop(reason: 'BLE disconnected; starting phone batch fallback');
+    if (!stillCurrent()) {
+      Logger.debug('[CaptureProvider] aborting phone batch fallback after socket stop (stale disconnect)');
+      return;
+    }
+
     await _startPhoneMicBatch(auto: true);
   }
 
   Future stopStreamDeviceRecording({bool cleanDevice = false}) async {
+    _disconnectPhoneFallbackEpoch++;
     await _cleanupCurrentState(disableNativeBackground: true);
     if (cleanDevice) {
       _updateRecordingDevice(null);

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -104,6 +104,32 @@ bool isRecordingDuringDeviceDisconnect(RecordingState recordingState) =>
     recordingState == RecordingState.record ||
     recordingState == RecordingState.interrupted;
 
+/// Whether an in-flight BLE-disconnect phone-fallback should keep going after
+/// an await. A bumped epoch cancels the attempt (reconnect/stop). A different
+/// recording-device id means reconnect already installed a new device.
+bool shouldContinueDisconnectPhoneFallback({
+  required int startedEpoch,
+  required int currentEpoch,
+  required String? disconnectedDeviceId,
+  required String? currentRecordingDeviceId,
+  required bool userStopped,
+}) {
+  if (startedEpoch != currentEpoch) return false;
+  if (userStopped) return false;
+  if (currentRecordingDeviceId != null && currentRecordingDeviceId != disconnectedDeviceId) {
+    return false;
+  }
+  return true;
+}
+
+/// After `onRecordingDeviceDisconnected` returns, only clear the capture
+/// recording device when reconnect has not already installed a different one.
+bool shouldClearRecordingDeviceAfterDisconnectFallback({
+  required String? disconnectedDeviceId,
+  required String? currentRecordingDeviceId,
+}) =>
+    currentRecordingDeviceId == null || currentRecordingDeviceId == disconnectedDeviceId;
+
 /// Metadata parsed from a batch recording filename written by the native layer:
 ///
 ///   audio_{device}_{codec}_{sampleRate}_{channel}_fs{frameSize}_{timestamp}.bin

--- a/app/test/unit/batch_recording_phone_test.dart
+++ b/app/test/unit/batch_recording_phone_test.dart
@@ -189,4 +189,86 @@ void main() {
       );
     });
   });
+
+  group('disconnect fallback revalidation', () {
+    test('continues only while epoch and device id still match', () {
+      expect(
+        shouldContinueDisconnectPhoneFallback(
+          startedEpoch: 3,
+          currentEpoch: 3,
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: 'dev-a',
+          userStopped: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldContinueDisconnectPhoneFallback(
+          startedEpoch: 3,
+          currentEpoch: 3,
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: null,
+          userStopped: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('aborts when epoch bumps, user stops, or reconnect installs another device', () {
+      expect(
+        shouldContinueDisconnectPhoneFallback(
+          startedEpoch: 3,
+          currentEpoch: 4,
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: 'dev-a',
+          userStopped: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldContinueDisconnectPhoneFallback(
+          startedEpoch: 3,
+          currentEpoch: 3,
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: 'dev-a',
+          userStopped: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldContinueDisconnectPhoneFallback(
+          startedEpoch: 3,
+          currentEpoch: 3,
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: 'dev-b',
+          userStopped: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('clears recording device only when reconnect has not replaced it', () {
+      expect(
+        shouldClearRecordingDeviceAfterDisconnectFallback(
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: 'dev-a',
+        ),
+        isTrue,
+      );
+      expect(
+        shouldClearRecordingDeviceAfterDisconnectFallback(
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: null,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldClearRecordingDeviceAfterDisconnectFallback(
+          disconnectedDeviceId: 'dev-a',
+          currentRecordingDeviceId: 'dev-b',
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## What changed and why

**Context:** the original phone-mic BLE-disconnect fallback for #11078 already
landed on `main` via #11084 (shared history). This PR rebases cleanly and closes
the disconnect/reconnect race @Git-on-my-level flagged on #11086.

When `onRecordingDeviceDisconnected()` awaits mic permission / docs path /
`startBatch()`, a fast wearable reconnect can install a new recording device
and then be cleared by the stale disconnect continuation — or the fallback can
still start `omibatchphoneauto` after the session is no longer current.

## Fix

- Capture-controller epoch cancels in-flight disconnect→phone-batch fallback on
  `streamDeviceRecording` / `stopStreamDeviceRecording`.
- Recheck epoch + recording-device id after each await before starting batch.
- `device_provider` only calls `updateRecordingDevice(null)` when reconnect has
  not already replaced the disconnected device.
- Fallback errors are caught so the rest of disconnect cleanup always runs.

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/batch_recording_phone_test.dart` (24 passed)

## Tests

- `app/test/unit/batch_recording_phone_test.dart` — revalidation helpers for
  epoch/device-id abort and conditional `updateRecordingDevice(null)`

## Failure class (fixes)

Failure-Class: none
