### PR TITLE
fix(windows): keep the hub goals row on the shared goals cache

### DIFF
--- a/desktop/windows/src/renderer/src/components/home/HomeGoalsChips.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/HomeGoalsChips.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
 
 // Hermetic: stub the data layer so the chip row mounts without a live backend or
 // Firebase. `currentUser` is set so the auth-gated fetch fires on mount.
@@ -15,18 +15,38 @@ vi.mock('../../lib/firebase', () => ({
   }
 }))
 
+import { resetGoalsCache } from '../../lib/goalsCache'
 import { HomeGoalsChips } from './HomeGoalsChips'
 
+// The row only ever renders inside the Home panel, so mount it there — the
+// "returning to Home" refetch below keys on that pathname.
 function renderChips(props: Parameters<typeof HomeGoalsChips>[0] = {}): void {
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={['/home']}>
       <HomeGoalsChips {...props} />
+      <Nav to="/settings" />
+      <Nav to="/home" />
     </MemoryRouter>
+  )
+}
+
+// Home stays MOUNTED while the user is on another tab (MainViews hides it), so a
+// return to Home is a navigation, not a remount. These drive that navigation.
+function Nav({ to }: { to: string }): React.JSX.Element {
+  const navigate = useNavigate()
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      go {to}
+    </button>
   )
 }
 
 beforeEach(() => {
   get.mockReset()
+  // The row now reads the SHARED goals cache (the Goals page's module singleton),
+  // so each case starts from a cold one.
+  resetGoalsCache()
+  localStorage.clear()
 })
 afterEach(() => cleanup())
 
@@ -106,5 +126,62 @@ describe('HomeGoalsChips', () => {
     get.mockRejectedValue(new Error('network'))
     renderChips()
     await waitFor(() => expect(screen.getByText('Set a goal')).not.toBeNull())
+  })
+})
+
+// #10893: the Hub's resting cluster — this row with it — UNMOUNTS whenever the
+// chat or connect panel opens, so closing the panel remounts the row. With a
+// private per-mount fetch that meant every return to the home screen re-flashed
+// the skeleton and re-issued GET /v1/goals/all. The row now reads the same module
+// cache the Goals page writes, so a remount paints the known chips immediately.
+describe('HomeGoalsChips — surviving the Hub panel transitions', () => {
+  it('issues ONE request on mount, not one per trigger', async () => {
+    // Mounting on Home satisfied BOTH the auth-ready fetch and the
+    // returning-to-Home fetch, so every mount asked for the same list twice.
+    get.mockResolvedValue({ data: [{ id: 'g1', title: 'Ship the app' }] })
+    renderChips()
+
+    await screen.findByText('Ship the app')
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('still refetches when Home comes BACK into view', async () => {
+    get.mockResolvedValue({ data: [{ id: 'g1', title: 'Ship the app' }] })
+    renderChips()
+    await screen.findByText('Ship the app')
+    expect(get).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('go /settings'))
+    expect(get).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('go /home'))
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+  })
+
+  it('repaints the known chips on remount — no skeleton, no refetch', async () => {
+    get.mockResolvedValue({ data: [{ id: 'g1', title: 'Ship the app' }] })
+    renderChips()
+    await screen.findByText('Ship the app')
+    cleanup() // the chat panel opened: the resting cluster unmounted
+
+    renderChips() // …and closed again
+    // Synchronously on the very first render, before any effect could fetch.
+    expect(screen.queryByTestId('home-goals-chips-loading')).toBeNull()
+    expect(screen.getByText('Ship the app')).not.toBeNull()
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not serve another account chips from the shared cache', async () => {
+    get.mockResolvedValue({ data: [{ id: 'g1', title: 'Ship the app' }] })
+    renderChips()
+    await screen.findByText('Ship the app')
+    cleanup()
+
+    // Sign-out / account switch wipes the module cache (authTeardown).
+    resetGoalsCache()
+    get.mockReturnValue(new Promise(() => {})) // the new account's fetch is in flight
+    renderChips()
+    expect(screen.queryByText('Ship the app')).toBeNull()
+    expect(screen.getByTestId('home-goals-chips-loading')).not.toBeNull()
   })
 })

--- a/desktop/windows/src/renderer/src/components/home/HomeGoalsChips.tsx
+++ b/desktop/windows/src/renderer/src/components/home/HomeGoalsChips.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { omiApi } from '../../lib/apiClient'
 import { auth, onAuthStateChanged } from '../../lib/firebase'
 import { goalEmoji, DEFAULT_GOAL_EMOJI } from '../../lib/goalEmoji'
 import { isCompleted, progressColor, progressPct } from '../../lib/goalVisuals'
+import { cache as goalsCache, hydrateGoalsFromDisk, writeCache } from '../../lib/goalsCache'
+import { getCacheUid } from '../../lib/persistentCache'
+import type { GoalResponse as Goal } from '../../lib/omiApi.generated'
 import type { HubHomeWidgetsProps } from './hub/hubHomeWidgetsSlot'
 
 // The resting Hub's focused-goals chip row — the compact, single-line surface
@@ -19,20 +22,28 @@ import type { HubHomeWidgetsProps } from './hub/hubHomeWidgetsSlot'
 // This mounts inside the hub cluster above the stat ribbon and MUST stay one line
 // (`shrink-0`) so it never breaks the Hub's no-scroll centering. States are all
 // single-line and roughly the same height, so the row never reflows the cluster.
-type Goal = {
-  id: string
-  title: string
-  target_value?: number | null
-  current_value?: number | null
-  // Done when is_active === false (matches the live backend Goal model).
-  is_active?: boolean
-}
+//
+// The list comes from the SAME module cache the Goals page fills (goalsCache), not
+// a private copy: the Hub's resting cluster — this row with it — unmounts whenever
+// the chat or connect panel opens, so a per-mount fetch meant every return to the
+// home screen re-flashed the skeleton and re-issued GET /v1/goals/all (#10893).
 
 // Mac caps the row at `.prefix(5)` (WhatMattersNowSection.swift:156).
 const MAX_CHIPS = 5
 
+// What the row displays: the active slice of the cached list. `null` (nothing
+// cached yet) stays null so the skeleton is shown only when there is genuinely
+// nothing to paint — never an "empty" claim we can't back.
+function activeGoals(list: Goal[] | null): Goal[] | null {
+  return list ? list.filter((g) => !isCompleted(g)) : null
+}
+
 export function HomeGoalsChips({ onShowAll, onOpenGoal }: HubHomeWidgetsProps): React.JSX.Element {
-  const [goals, setGoals] = useState<Goal[] | null>(null)
+  // Seed from the per-uid cold-start snapshot before the initial state is read,
+  // exactly as the Goals page does, so a fresh launch paints the last-known chips
+  // instead of the skeleton. The revalidating fetch below still runs.
+  hydrateGoalsFromDisk()
+  const [goals, setGoals] = useState<Goal[] | null>(() => activeGoals(goalsCache.goals))
   const { pathname } = useLocation()
   const navigate = useNavigate()
 
@@ -61,12 +72,19 @@ export function HomeGoalsChips({ onShowAll, onOpenGoal }: HubHomeWidgetsProps): 
 
   const fetchGoals = useCallback((): (() => void) => {
     let cancelled = false
+    const originUid = getCacheUid()
     omiApi
       .get('/v1/goals/all')
       .then((res) => {
         const data = res.data as Goal[] | { goals?: Goal[] }
         const list = Array.isArray(data) ? data : (data.goals ?? [])
-        if (!cancelled) setGoals(list.filter((g) => !isCompleted(g)))
+        // Account-switch guard, same as the Goals page's fetchAll: a fetch that
+        // outlived the account must not land under the new uid.
+        if (getCacheUid() === originUid) {
+          writeCache(list)
+          goalsCache.loaded = true
+        }
+        if (!cancelled) setGoals(activeGoals(list))
       })
       .catch(() => {
         // Keep any previously-loaded goals on a transient failure rather than
@@ -79,13 +97,23 @@ export function HomeGoalsChips({ onShowAll, onOpenGoal }: HubHomeWidgetsProps): 
   }, [])
 
   // Primary fetch: as soon as auth is ready (and again if the user changes).
+  // Skipped when the cache already holds an authoritative list — that is what
+  // makes closing the chat panel repaint the row instead of reloading it.
   useEffect(() => {
-    if (!userId) return
+    if (!userId || goalsCache.loaded) return
     return fetchGoals()
   }, [userId, fetchGoals])
 
   // Refetch when returning to Home (pick up goals added/completed elsewhere).
+  // Home stays MOUNTED while the user is on another tab (MainViews hides it), so
+  // coming back is a navigation, not a remount. Its first run IS the mount, where
+  // the effect above already fetched — firing both asked for the same list twice.
+  const navigated = useRef(false)
   useEffect(() => {
+    if (!navigated.current) {
+      navigated.current = true
+      return
+    }
     if (pathname !== '/home') return
     return fetchGoals()
   }, [pathname, fetchGoals])


### PR DESCRIPTION
## What changed and why

Reported in #10893: on Omi Desktop, returning to the home screen from chat is not
smooth. This fixes one reproducible piece of that transition — the hub reloading
data it already had.

The Hub's resting cluster — the focused-goals chip row with it — unmounts whenever
the chat or connect panel opens (`HomeHub.tsx` renders the cluster only in `hub`
mode), so closing the panel **remounts** the row. The row owned a private
per-mount fetch of `/v1/goals/all`, so every return to the home screen dropped its
list, re-rendered the pulsing loading skeleton, and re-issued the request. Mounting
on Home also satisfied **both** of its fetch triggers at once (auth-ready *and*
returning-to-Home), so each mount asked for the same list twice.

The row now reads the module cache the Goals page already writes
(`lib/goalsCache`) instead of keeping a second, divergent copy of the same feed —
the pattern `useHubStats` already documents for the stat ribbon ("never a second,
divergent fetch"). It seeds from that cache, skips its own fetch when the cache is
already authoritative, writes results back under the same account-switch guard
`Goals.tsx#fetchAll` uses, and lets the returning-to-Home trigger skip its own
mount run.

**This does not claim to close #10893.** It removes reload work and a loading flash
from the exact transition the reporter describes, and it is what I could prove on
this hardware. Whether it accounts for the whole perceived stall is unverified — I
have no Windows machine to profile the remaining candidates (the full-bleed
5-layer gradient repaint in `HomeCanvasBackground`, and unmounting a long chat
thread's markdown). Leaving the issue open for that.

## Product invariants affected

none (`scripts/pr-preflight --suggest`: "no locked invariants require naming for
these changes")

## How it was verified

Exercised in the real built app on macOS (`electron-vite build` +
Playwright `_electron`, `OMI_E2E=1 OMI_E2E_FAKE_AUTH=1`), driving the reported
flow: visit Goals → back Home → click the ask bar (chat panel opens) → Esc (back
home), with `GET /v1/goals/all` stubbed and counted, and the goals row sampled
every ~16ms across the return so a flash could not be missed.

| | requests before opening chat | requests after returning home | skeleton frames on return |
|---|---|---|---|
| parent commit (`71305e7820`) | 2 | 3 | 0 * |
| this branch | 1 | 1 | 0 |

\* the harness stubs the response locally, so the pre-fix refetch resolves in under
one sample; the skeleton render itself is what the unit test below pins
synchronously. On a real network that gap is the length of the request.

Also run in `desktop/windows/`:

- `npx vitest run` — 5149 passed, 24 skipped, 0 failed
- `npm run typecheck` (node + web) — clean
- `npx eslint` on both changed files — clean
- `make preflight` — 10 manifest checks pass

## Tests

`HomeGoalsChips.test.tsx` — three regression cases that fail on the parent commit
and pass here:

- `issues ONE request on mount, not one per trigger` (was 2)
- `repaints the known chips on remount — no skeleton, no refetch` (asserts the
  skeleton is absent on the first render after a remount, before any effect runs)
- `does not serve another account chips from the shared cache`

plus `still refetches when Home comes BACK into view`, which locks the behavior the
mount-run skip must not break. The suite's harness now mounts the row at `/home`
(its only real mount point) and resets the shared cache per case.

## Failure class (fixes)

Failure-Class: none

---

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

