### PR TITLE
Restore canonical memory graph boundary

### DIFF
--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -88,6 +88,7 @@ class CanonicalKnowledgeGraphResponse(BaseModel):
     edges: List[Dict[str, Any]]
     has_more: bool
     next_cursor: Optional[str] = None
+    catalog_nodes: List[Dict[str, Any]] = []
 
 
 class RebuildResponse(BaseModel):
@@ -145,6 +146,7 @@ def get_canonical_knowledge_graph(
         edges=page.edges,
         has_more=page.has_more,
         next_cursor=page.next_cursor,
+        catalog_nodes=getattr(page, 'catalog_nodes', []),
     )
 
 

--- a/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
@@ -315,24 +315,28 @@ def test_canonical_graph_filters_stale_ineligible_and_restricted_assertions(monk
     assert "stale-generation" not in {memory_id for refs in db.assertion_ref_pages for memory_id in refs}
 
 
-def test_canonical_graph_includes_unlinked_canonical_memory_as_an_atlas_node(monkeypatch):
+def test_canonical_graph_separates_unlinked_canonical_memory_from_assertion_graph(monkeypatch):
     monkeypatch.setenv("MEMORY_V3_CURSOR_SECRET", "canonical-graph-test-secret")
-    item, _assertion = _assertion_and_item("unlinked", 1, graph_ready=False)
-    item._payload["content"] = "A durable canonical memory that has no inferred relationship yet."
-    db = _FakeDB([item], {})
+    linked_item, linked_assertion = _assertion_and_item("linked", 1, updated_at=NOW.replace(minute=1))
+    unlinked_updated_at = NOW.replace(minute=2)
+    unlinked_item, _unlinked_assertion = _assertion_and_item("unlinked", 2, updated_at=unlinked_updated_at)
+    unlinked_item._payload["content"] = "A durable canonical memory that has no inferred relationship yet."
+    db = _FakeDB([linked_item, unlinked_item], {"linked": linked_assertion})
 
     page = kg.get_canonical_knowledge_graph(UID, db_client=db, limit=10)
 
-    assert page.edges == []
-    assert page.nodes == [
+    assert page.nodes
+    assert _page_memory_ids(page) == {"linked"}
+    assert all(not node["id"].startswith("memory:") for node in page.nodes)
+    assert page.catalog_nodes == [
         {
             "id": "memory:unlinked",
             "label": "A durable canonical memory that has no inferred relationship yet.",
             "node_type": "concept",
             "aliases": [],
             "memory_ids": ["unlinked"],
-            "created_at": NOW,
-            "updated_at": NOW,
+            "created_at": unlinked_updated_at,
+            "updated_at": unlinked_updated_at,
         }
     ]
 
@@ -419,6 +423,7 @@ def test_canonical_route_is_additive_and_legacy_route_response_is_unchanged(monk
     canonical_payload = {
         "nodes": [{"id": "canonical-node"}],
         "edges": [],
+        "catalog_nodes": [{"id": "memory:catalog-only"}],
         "has_more": True,
         "next_cursor": "v3.opaque.signed",
     }

--- a/backend/utils/memory/canonical_graph.py
+++ b/backend/utils/memory/canonical_graph.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -54,6 +54,7 @@ class CanonicalKnowledgeGraphPage:
     edges: List[Dict[str, Any]]
     has_more: bool
     next_cursor: Optional[str]
+    catalog_nodes: List[Dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -356,8 +357,8 @@ def _read_canonical_graph_page_once(
             secret=secret,
         )
 
-    accepted_items: List[Dict[str, Any]] = []
     accepted_assertions: List[MemoryGraphAssertion] = []
+    catalog_nodes: List[Dict[str, Any]] = []
     visible_memory_ids: set[str] = set()
     pending_snapshots: List[Any] = []
     pending_window_has_more = False
@@ -398,7 +399,6 @@ def _read_canonical_graph_page_once(
                 last_consumed_snapshot = snapshot
 
             if eligible_batch:
-                accepted_items.extend(eligible_batch)
                 memory_ids = [cast(str, item['memory_id']) for item in eligible_batch]
                 loaded_assertions = kg_db.load_fenced_assertions_for_memory_items(
                     uid,
@@ -406,12 +406,18 @@ def _read_canonical_graph_page_once(
                     account_generation=revision.account_generation,
                     db_client=client,
                 )
+                assertion_memory_ids = {assertion.memory_id for assertion in loaded_assertions}
                 for assertion in loaded_assertions:
                     accepted_assertions.append(assertion)
                     visible_memory_ids.add(assertion.memory_id)
                 for item in eligible_batch:
-                    if _canonical_memory_catalog_node(item) is not None:
-                        visible_memory_ids.add(cast(str, item['memory_id']))
+                    memory_id = cast(str, item['memory_id'])
+                    if memory_id in assertion_memory_ids:
+                        continue
+                    catalog_node = _canonical_memory_catalog_node(item)
+                    if catalog_node is not None:
+                        catalog_nodes.append(catalog_node)
+                        visible_memory_ids.add(memory_id)
 
             if len(visible_memory_ids) >= limit:
                 break
@@ -474,12 +480,12 @@ def _read_canonical_graph_page_once(
         {'nodes': [], 'edges': []},
         accepted_assertions,
     )
-    catalog_nodes = [node for item in accepted_items if (node := _canonical_memory_catalog_node(item)) is not None]
     return CanonicalKnowledgeGraphPage(
-        nodes=[*merged['nodes'], *catalog_nodes],
+        nodes=merged['nodes'],
         edges=merged['edges'],
         has_more=has_more,
         next_cursor=next_cursor,
+        catalog_nodes=catalog_nodes,
     )
 
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -1017,7 +1017,7 @@ enum MemoryAtlasLayoutEngine {
   ) -> MemoryAtlasSnapshot {
     // Graph responses are external data. Coalesce duplicate identifiers at the
     // boundary so a malformed server response cannot trap while building a UI.
-    let nodes = uniqueNodes(from: graph.nodes)
+    let nodes = uniqueNodes(from: graph.atlasNodes)
     let edges = uniqueEdges(from: graph.edges)
 
     guard !nodes.isEmpty else {
@@ -2025,7 +2025,7 @@ struct CanonicalMemoryAtlasPage: View {
         entities: projection.snapshot.nodes.count, connections: projection.snapshot.edges.count)
     }
     return MemoryAtlasLayoutEngine.countLabel(
-      entities: viewModel.graphResponse.nodes.count, connections: viewModel.graphResponse.edges.count)
+      entities: viewModel.graphResponse.atlasNodes.count, connections: viewModel.graphResponse.edges.count)
   }
 
   var body: some View {
@@ -2089,7 +2089,7 @@ struct CanonicalMemoryAtlasPage: View {
     .task { await viewModel.prepareCanonicalAtlas() }
     .onAppear {
       memoryAtlasLogger.info(
-        "Atlas page opened nodes=\(viewModel.graphResponse.nodes.count, privacy: .public) edges=\(viewModel.graphResponse.edges.count, privacy: .public)"
+        "Atlas page opened nodes=\(viewModel.graphResponse.atlasNodes.count, privacy: .public) edges=\(viewModel.graphResponse.edges.count, privacy: .public)"
       )
     }
   }
@@ -2126,7 +2126,7 @@ struct CanonicalMemoryAtlasTabView: View {
     .task { await viewModel.prepareCanonicalAtlas() }
     .onAppear {
       memoryAtlasLogger.info(
-        "Atlas tab opened nodes=\(viewModel.graphResponse.nodes.count, privacy: .public) edges=\(viewModel.graphResponse.edges.count, privacy: .public)"
+        "Atlas tab opened nodes=\(viewModel.graphResponse.atlasNodes.count, privacy: .public) edges=\(viewModel.graphResponse.edges.count, privacy: .public)"
       )
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -325,17 +325,17 @@ class MemoryGraphViewModel: ObservableObject {
       }
       let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
       let projection = await Task.detached(priority: .userInitiated) {
-        MemoryAtlasProjection(graph: response, userName: givenName.isEmpty ? nil : givenName)
+        MemoryAtlasProjection(graph: response.atlasResponse, userName: givenName.isEmpty ? nil : givenName)
       }.value
       guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
         return
       }
       canonicalAtlasProjection = projection
       graphResponse = response
-      isEmpty = response.nodes.isEmpty
+      isEmpty = response.atlasNodes.isEmpty
       hasLoadedCanonicalAtlas = true
       lastLoadedAt = Date()
-      log("Memory atlas: \(response.nodes.count) nodes, \(response.edges.count) edges")
+      log("Memory atlas: \(response.atlasNodes.count) nodes, \(response.edges.count) edges")
     } catch {
       log("Failed to load memory atlas: \(error.localizedDescription)")
     }
@@ -378,20 +378,20 @@ class MemoryGraphViewModel: ObservableObject {
           return false
         }
 
-        if !response.nodes.isEmpty {
+        if !response.atlasNodes.isEmpty || !(response.catalogNodes?.isEmpty ?? true) {
           let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
           let projection = await Task.detached(priority: .userInitiated) {
-            MemoryAtlasProjection(graph: response, userName: givenName.isEmpty ? nil : givenName)
+            MemoryAtlasProjection(graph: response.atlasResponse, userName: givenName.isEmpty ? nil : givenName)
           }.value
           guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
             return false
           }
           canonicalAtlasProjection = projection
           graphResponse = response
-          isEmpty = false
+          isEmpty = response.atlasNodes.isEmpty
           hasLoadedCanonicalAtlas = true
           lastLoadedAt = Date()
-          log("Memory atlas: rebuilt graph loaded after \(attempt) poll(s), \(response.nodes.count) nodes")
+          log("Memory atlas: rebuilt graph loaded after \(attempt) poll(s), \(response.atlasNodes.count) nodes")
           return true
         }
       }

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+KnowledgeGraph.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+KnowledgeGraph.swift
@@ -119,6 +119,10 @@ struct KnowledgeGraphResponse: Codable, Equatable, Sendable {
   let nextCursor: String?
   let eligibleItemCount: Int?
   let processedItemCount: Int?
+  /// Optional additive catalog records. These are durable memory nodes, not
+  /// assertion-backed graph nodes, and are intentionally excluded from atlas
+  /// layout and counts.
+  let catalogNodes: [KnowledgeGraphNode]?
 
   enum CodingKeys: String, CodingKey {
     case nodes, edges
@@ -126,6 +130,7 @@ struct KnowledgeGraphResponse: Codable, Equatable, Sendable {
     case nextCursor = "next_cursor"
     case eligibleItemCount = "eligible_item_count"
     case processedItemCount = "processed_item_count"
+    case catalogNodes = "catalog_nodes"
   }
 
   init(
@@ -134,7 +139,8 @@ struct KnowledgeGraphResponse: Codable, Equatable, Sendable {
     hasMore: Bool = false,
     nextCursor: String? = nil,
     eligibleItemCount: Int? = nil,
-    processedItemCount: Int? = nil
+    processedItemCount: Int? = nil,
+    catalogNodes: [KnowledgeGraphNode]? = nil
   ) {
     self.nodes = nodes
     self.edges = edges
@@ -142,6 +148,7 @@ struct KnowledgeGraphResponse: Codable, Equatable, Sendable {
     self.nextCursor = nextCursor
     self.eligibleItemCount = eligibleItemCount
     self.processedItemCount = processedItemCount
+    self.catalogNodes = catalogNodes
   }
 
   init(from decoder: Decoder) throws {
@@ -152,6 +159,30 @@ struct KnowledgeGraphResponse: Codable, Equatable, Sendable {
     nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor)
     eligibleItemCount = try container.decodeIfPresent(Int.self, forKey: .eligibleItemCount)
     processedItemCount = try container.decodeIfPresent(Int.self, forKey: .processedItemCount)
+    catalogNodes = try container.decodeIfPresent([KnowledgeGraphNode].self, forKey: .catalogNodes)
+  }
+
+  /// Nodes that are safe for the atlas to lay out. The canonical endpoint's
+  /// `nodes` field is assertion-backed; older canonical payloads that predate
+  /// `catalog_nodes` may still have isolated catalog nodes folded into it, so
+  /// those are excluded by their stable `memory:` id prefix.
+  var atlasNodes: [KnowledgeGraphNode] {
+    if catalogNodes != nil { return nodes }
+    return nodes.filter { !$0.id.hasPrefix("memory:") }
+  }
+
+  /// A graph-shaped view for projection caches. It retains the catalog on the
+  /// response model while ensuring node consumers receive assertion-backed
+  /// nodes only.
+  var atlasResponse: KnowledgeGraphResponse {
+    KnowledgeGraphResponse(
+      nodes: atlasNodes,
+      edges: edges,
+      hasMore: hasMore,
+      nextCursor: nextCursor,
+      eligibleItemCount: eligibleItemCount,
+      processedItemCount: processedItemCount,
+      catalogNodes: catalogNodes)
   }
 
   /// Deterministically unions pages and removes edges whose endpoints were not
@@ -172,6 +203,7 @@ typealias KnowledgeGraphPageResponse = KnowledgeGraphResponse
 struct KnowledgeGraphAccumulator: Sendable {
   private var nodesByID: [String: KnowledgeGraphNode] = [:]
   private var edgesByID: [String: KnowledgeGraphEdge] = [:]
+  private var catalogNodesByID: [String: KnowledgeGraphNode]?
   private var eligibleItemCount: Int?
   private var processedItemCount: Int?
 
@@ -189,6 +221,17 @@ struct KnowledgeGraphAccumulator: Sendable {
         edgesByID[edge.id] = Self.merge(existing, edge)
       } else {
         edgesByID[edge.id] = edge
+      }
+    }
+
+    if let catalogNodes = page.catalogNodes {
+      if catalogNodesByID == nil { catalogNodesByID = [:] }
+      for node in catalogNodes {
+        if let existing = catalogNodesByID?[node.id] {
+          catalogNodesByID?[node.id] = Self.merge(existing, node)
+        } else {
+          catalogNodesByID?[node.id] = node
+        }
       }
     }
 
@@ -224,7 +267,8 @@ struct KnowledgeGraphAccumulator: Sendable {
       nodes: nodes,
       edges: edges,
       eligibleItemCount: eligibleItemCount,
-      processedItemCount: processedItemCount)
+      processedItemCount: processedItemCount,
+      catalogNodes: catalogNodesByID?.values.sorted { $0.id < $1.id })
   }
 
   private static func merge(_ lhs: KnowledgeGraphNode, _ rhs: KnowledgeGraphNode) -> KnowledgeGraphNode {

--- a/desktop/macos/Desktop/Tests/KnowledgeGraphPaginationTests.swift
+++ b/desktop/macos/Desktop/Tests/KnowledgeGraphPaginationTests.swift
@@ -181,7 +181,8 @@ final class KnowledgeGraphPaginationTests: XCTestCase {
           edges: [],
           hasMore: true,
           nextCursor: "cursor-1",
-          processedItemCount: 200)
+          processedItemCount: 200,
+          catalogNodes: [nodeData(id: "memory:catalog-a", label: "Unlinked memory")])
       ),
       (
         200,
@@ -190,7 +191,8 @@ final class KnowledgeGraphPaginationTests: XCTestCase {
           edges: [],
           hasMore: false,
           eligibleItemCount: 201,
-          processedItemCount: 201)
+          processedItemCount: 201,
+          catalogNodes: [nodeData(id: "memory:catalog-b", label: "Another memory")])
       ),
     ])
     let client = await makeClient(urlProtocolClass: KnowledgeGraphURLStub.self)
@@ -203,6 +205,7 @@ final class KnowledgeGraphPaginationTests: XCTestCase {
     XCTAssertNil(graph.nextCursor)
     XCTAssertEqual(graph.eligibleItemCount, 201)
     XCTAssertEqual(graph.processedItemCount, 201)
+    XCTAssertEqual(graph.catalogNodes?.map(\.id), ["memory:catalog-a", "memory:catalog-b"])
 
     let requests = KnowledgeGraphURLStub.requests()
     XCTAssertEqual(requests.count, 2)
@@ -212,6 +215,20 @@ final class KnowledgeGraphPaginationTests: XCTestCase {
     XCTAssertNil(queryItems(in: requests[0].url)["cursor"])
     XCTAssertEqual(queryItems(in: requests[1].url)["limit"], "200")
     XCTAssertEqual(queryItems(in: requests[1].url)["cursor"], "cursor-1")
+  }
+
+  func testLegacyPayloadDecodesWithoutCatalogNodesAndPreservesAtlasFallback() throws {
+    let legacy = try JSONSerialization.data(
+      withJSONObject: [
+        "nodes": [nodeData(id: "entity-a"), nodeData(id: "memory:catalog-old", label: "Old catalog")],
+        "edges": [],
+      ])
+
+    let response = try OmiHTTPTransport.makeDecoder().decode(KnowledgeGraphResponse.self, from: legacy)
+
+    XCTAssertNil(response.catalogNodes)
+    XCTAssertEqual(response.nodes.map(\.id), ["entity-a", "memory:catalog-old"])
+    XCTAssertEqual(response.atlasNodes.map(\.id), ["entity-a"])
   }
 
   func testDuplicateNodesEdgesAndMemoryCitationsMergeDeterministicallyAndCleanDanglingEdges() {
@@ -508,7 +525,8 @@ private func pageData(
   hasMore: Bool = false,
   nextCursor: String? = nil,
   eligibleItemCount: Int? = nil,
-  processedItemCount: Int? = nil
+  processedItemCount: Int? = nil,
+  catalogNodes: [[String: Any]]? = nil
 ) -> Data {
   var object: [String: Any] = [
     "nodes": nodes,
@@ -518,5 +536,6 @@ private func pageData(
   if let nextCursor { object["next_cursor"] = nextCursor }
   if let eligibleItemCount { object["eligible_item_count"] = eligibleItemCount }
   if let processedItemCount { object["processed_item_count"] = processedItemCount }
+  if let catalogNodes { object["catalog_nodes"] = catalogNodes }
   return (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
 }

--- a/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
@@ -20,6 +20,44 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     XCTAssertEqual(Double(anchor.y), 0.5, accuracy: 1e-9)
   }
 
+  func testCatalogNodesRemainInResponseStateButNeverEnterAtlasProjection() throws {
+    let assertionNodes = [
+      KnowledgeGraphNode(id: "david", label: "David", nodeType: .person),
+      KnowledgeGraphNode(id: "omi", label: "Omi", nodeType: .thing),
+    ]
+    let catalogNode = KnowledgeGraphNode(
+      id: "memory:unlinked",
+      label: "A durable memory that has no assertion",
+      nodeType: .concept)
+    let response = KnowledgeGraphResponse(
+      nodes: assertionNodes,
+      edges: [KnowledgeGraphEdge(id: "uses", sourceId: "david", targetId: "omi", label: "uses")],
+      catalogNodes: [catalogNode])
+
+    let snapshot = MemoryAtlasLayoutEngine.makeSnapshot(graph: response, userName: "David")
+
+    XCTAssertEqual(response.catalogNodes?.map(\.id), ["memory:unlinked"])
+    XCTAssertEqual(snapshot.nodes.map(\.id), ["david", "omi"])
+    XCTAssertNil(snapshot.nodeByID[catalogNode.id])
+    XCTAssertEqual(snapshot.edges.count, 1)
+  }
+
+  func testProjectionCarriesCatalogNodesWithoutProjectingThem() {
+    let catalogNode = KnowledgeGraphNode(
+      id: "memory:catalog",
+      label: "Catalog memory",
+      nodeType: .concept)
+    let response = KnowledgeGraphResponse(
+      nodes: [KnowledgeGraphNode(id: "entity", label: "Entity", nodeType: .concept)],
+      edges: [],
+      catalogNodes: [catalogNode])
+
+    let projection = MemoryAtlasProjection(graph: response, userName: nil)
+
+    XCTAssertEqual(projection.graph.catalogNodes?.map(\.id), [catalogNode.id])
+    XCTAssertEqual(projection.snapshot.nodes.map(\.id), ["entity"])
+  }
+
   /// Type still decides a node's colour and which constellation it counts
   /// toward. It no longer decides where the node goes — relatedness does — so
   /// the caption follows the entities instead of marking a fixed petal.

--- a/desktop/macos/changelog/unreleased/20260804-canonical-memory-graph-boundary.json
+++ b/desktop/macos/changelog/unreleased/20260804-canonical-memory-graph-boundary.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Memory atlas so unlinked canonical memories are kept out of the relationship map instead of appearing as disconnected dots"
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -866,6 +866,7 @@ export type CandidateStatus = "pending" | "accepted" | "rejected" | "expired";
 export type CandidateSubjectKind = "task" | "workstream";
 
 export interface CanonicalKnowledgeGraphResponse {
+  catalog_nodes?: Array<Record<string, unknown>>;
   edges: Array<Record<string, unknown>>;
   has_more: boolean;
   next_cursor?: string | null;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -5580,6 +5580,15 @@
       },
       "CanonicalKnowledgeGraphResponse": {
         "properties": {
+          "catalog_nodes": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Catalog Nodes",
+            "type": "array"
+          },
           "edges": {
             "items": {
               "additionalProperties": true,

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -866,6 +866,7 @@ export type CandidateStatus = "pending" | "accepted" | "rejected" | "expired";
 export type CandidateSubjectKind = "task" | "workstream";
 
 export interface CanonicalKnowledgeGraphResponse {
+  catalog_nodes?: Array<Record<string, unknown>>;
   edges: Array<Record<string, unknown>>;
   has_more: boolean;
   next_cursor?: string | null;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -866,6 +866,7 @@ export type CandidateStatus = "pending" | "accepted" | "rejected" | "expired";
 export type CandidateSubjectKind = "task" | "workstream";
 
 export interface CanonicalKnowledgeGraphResponse {
+  catalog_nodes?: Array<Record<string, unknown>>;
   edges: Array<Record<string, unknown>>;
   has_more: boolean;
   next_cursor?: string | null;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -866,6 +866,7 @@ export type CandidateStatus = "pending" | "accepted" | "rejected" | "expired";
 export type CandidateSubjectKind = "task" | "workstream";
 
 export interface CanonicalKnowledgeGraphResponse {
+  catalog_nodes?: Array<Record<string, unknown>>;
   edges: Array<Record<string, unknown>>;
   has_more: boolean;
   next_cursor?: string | null;


### PR DESCRIPTION
## Summary

Separates canonical memory catalog records from assertion-backed graph entities in the canonical graph response and desktop atlas.

## Root cause

The prior synthetic `memory:` nodes made every canonical memory render as a graph node although historical items did not have graph assertions. With only one real edge, the atlas correctly laid out a dense field of isolates.

## Impact

The atlas now renders only evidence-fenced assertion-backed entities and edges. Catalog memories remain available in the paginated response for the catalog experience rather than being dropped.

## Validation

- `backend/.venv/bin/pytest -q backend/tests/unit/test_knowledge_graph_canonical_pagination.py`
- `xcrun swift test --package-path desktop/macos/Desktop --filter 'KnowledgeGraphPaginationTests|MemoryAtlasLayoutTests'`
- `make preflight`

## Product invariants affected

- INV-MEM-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

