### PR TITLE
fix(backend): make every chat agent terminal exit leave an answer and report failure

### DIFF
--- a/backend/scripts/chat_agent_cost_report.py
+++ b/backend/scripts/chat_agent_cost_report.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Attribute chat-agent LLM spend across the gateway accounting ledger.
+
+The ledger already records every billable component of an Anthropic Messages
+attempt (cached reads, uncached input, cache writes and their TTL, output), but
+nothing reads it back per feature. Cost work on the chat agent otherwise starts
+from guesses about which component dominates, and the two candidate levers pull
+in opposite directions depending on the answer: a low cache-read share means the
+request prefix is being rewritten rather than reused, while a high output share
+means generation settings matter more than prefix layout.
+
+Aggregation is pure and takes ledger rows as plain mappings, so the arithmetic is
+testable without Firestore. Only the fetch step touches the database.
+
+Reads one day per query using two equality filters, which Firestore serves from
+single-field indexes — no composite index and no schema change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+ATTEMPTS_COLLECTION = 'llm_gateway_attempts'
+DEFAULT_FEATURE = 'chat_agent'
+DEFAULT_DAYS = 7
+MICRO_USD_PER_USD = 1_000_000
+TOKENS_PER_MILLION = 1_000_000
+
+# Cache writes are billed at a TTL-dependent multiple of the input rate, so the
+# 5-minute and 1-hour components are never collapsed into one number.
+TTL_FIVE_MINUTES = '5m'
+TTL_ONE_HOUR = '1h'
+
+
+@dataclass
+class Rates:
+    """Per-million-token micro-USD rates for one provider model."""
+
+    rate_card_id: str
+    input_micro_usd: int
+    cached_input_micro_usd: int
+    output_micro_usd: int
+    cache_write_micro_usd: int
+    cache_write_1h_micro_usd: int
+
+
+@dataclass
+class Totals:
+    """Accumulated ledger quantities for one feature over a date range."""
+
+    attempts: int = 0
+    priced_attempts: int = 0
+    cached_input_tokens: int = 0
+    uncached_input_tokens: int = 0
+    cache_write_5m_tokens: int = 0
+    cache_write_1h_tokens: int = 0
+    cache_write_untagged_tokens: int = 0
+    output_tokens: int = 0
+    ledger_cost_micro_usd: int = 0
+    attempts_with_cache_read: int = 0
+    attempts_with_cache_write: int = 0
+    cache_status: Counter[str] = field(default_factory=Counter)
+    outcome: Counter[str] = field(default_factory=Counter)
+    models: Counter[str] = field(default_factory=Counter)
+    days: set[str] = field(default_factory=set)
+
+
+def _int_field(row: Mapping[str, Any], key: str) -> int:
+    """Read a non-negative integer, treating absent or malformed values as zero.
+
+    A ledger row is written best-effort from provider usage that may omit
+    fields; a partially reported attempt must still contribute the components it
+    did report rather than abort the whole report.
+    """
+    value = row.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return 0
+    return value
+
+
+def _str_field(row: Mapping[str, Any], key: str, default: str) -> str:
+    value = row.get(key)
+    return value if isinstance(value, str) and value else default
+
+
+def accumulate(totals: Totals, row: Mapping[str, Any]) -> None:
+    """Fold one ledger row into ``totals``."""
+    totals.attempts += 1
+    totals.days.add(_str_field(row, 'date', 'unknown'))
+    totals.cache_status[_str_field(row, 'cache_status', 'not_reported')] += 1
+    totals.outcome[_str_field(row, 'outcome', 'unknown')] += 1
+    totals.models[_str_field(row, 'actual_model_version', _str_field(row, 'configured_model', 'unknown'))] += 1
+
+    cached = _int_field(row, 'cached_input_tokens')
+    cache_write = _int_field(row, 'cache_write_tokens')
+    totals.cached_input_tokens += cached
+    totals.uncached_input_tokens += _int_field(row, 'uncached_input_tokens')
+    totals.output_tokens += _int_field(row, 'output_tokens')
+    if cached:
+        totals.attempts_with_cache_read += 1
+    if cache_write:
+        totals.attempts_with_cache_write += 1
+
+    ttl = _str_field(row, 'cache_write_ttl', '')
+    if ttl == TTL_ONE_HOUR:
+        totals.cache_write_1h_tokens += cache_write
+    elif ttl == TTL_FIVE_MINUTES:
+        totals.cache_write_5m_tokens += cache_write
+    else:
+        # 'mixed', absent, or an unrecognized TTL. Priced at the 1h rate below so
+        # the estimate stays conservative, but reported separately because a
+        # non-zero value here means the request's breakpoints disagree.
+        totals.cache_write_untagged_tokens += cache_write
+
+    cost = row.get('estimated_cost_micro_usd')
+    if isinstance(cost, int) and not isinstance(cost, bool) and cost >= 0:
+        totals.ledger_cost_micro_usd += cost
+        totals.priced_attempts += 1
+
+
+def _cost(tokens: int, micro_usd_per_million: int) -> int:
+    return round(tokens * micro_usd_per_million / TOKENS_PER_MILLION)
+
+
+@dataclass(frozen=True)
+class Component:
+    name: str
+    tokens: int
+    cost_micro_usd: int
+
+
+def cost_components(totals: Totals, rates: Rates) -> list[Component]:
+    """Split spend into the components a change can actually move."""
+    untagged_and_1h = totals.cache_write_1h_tokens + totals.cache_write_untagged_tokens
+    return [
+        Component(
+            'cached input (read)',
+            totals.cached_input_tokens,
+            _cost(totals.cached_input_tokens, rates.cached_input_micro_usd),
+        ),
+        Component(
+            'uncached input', totals.uncached_input_tokens, _cost(totals.uncached_input_tokens, rates.input_micro_usd)
+        ),
+        Component('cache write 1h', untagged_and_1h, _cost(untagged_and_1h, rates.cache_write_1h_micro_usd)),
+        Component(
+            'cache write 5m',
+            totals.cache_write_5m_tokens,
+            _cost(totals.cache_write_5m_tokens, rates.cache_write_micro_usd),
+        ),
+        Component('output', totals.output_tokens, _cost(totals.output_tokens, rates.output_micro_usd)),
+    ]
+
+
+def write_read_ratio(totals: Totals) -> float | None:
+    """Cache-write tokens billed per cache-read token served.
+
+    The prefix layout is working when this is well below 1: each written prefix
+    is read back many times. A ratio near or above 1 means prefixes are being
+    written about as often as they are reused, which is what a per-user (rather
+    than shared) cache breakpoint produces.
+    """
+    reads = totals.cached_input_tokens
+    if reads <= 0:
+        return None
+    writes = totals.cache_write_1h_tokens + totals.cache_write_5m_tokens + totals.cache_write_untagged_tokens
+    return writes / reads
+
+
+def load_rates(model: str, rate_card_path: Path, *, rate_card_id: str = '') -> Rates:
+    """Read rates from the gateway rate card.
+
+    ``rate_card_id`` selects the exact card an attempt was priced on and is preferred when the
+    ledger recorded one; ``model`` is the fallback for rows predating that field, and picks
+    whichever card currently carries the name.
+
+    Raises ``LookupError`` when nothing matches, because reporting an unpriced
+    total silently understates spend.
+    """
+    import yaml
+
+    raw = yaml.safe_load(rate_card_path.read_text(encoding='utf-8')) or {}
+    cards = raw.get('rate_cards')
+    if not isinstance(cards, list):
+        raise LookupError(f'{rate_card_path} has no rate_cards list')
+    for card in cards:
+        if not isinstance(card, Mapping):
+            continue
+        if rate_card_id:
+            if card.get('rate_card_id') != rate_card_id:
+                continue
+        elif card.get('model') != model:
+            continue
+        input_rate = int(card.get('input_micro_usd_per_million', 0))
+        return Rates(
+            rate_card_id=str(card.get('rate_card_id', model)),
+            input_micro_usd=input_rate,
+            cached_input_micro_usd=int(card.get('cached_input_micro_usd_per_million', 0)),
+            output_micro_usd=int(card.get('output_micro_usd_per_million', 0)),
+            # Anthropic bills a 5-minute write at 1.25x input and a 1-hour write
+            # at 2x. Fall back to those multiples so a card that predates the
+            # explicit fields still prices writes instead of dropping them.
+            cache_write_micro_usd=int(card.get('cache_write_micro_usd_per_million', round(input_rate * 1.25))),
+            cache_write_1h_micro_usd=int(card.get('cache_write_1h_micro_usd_per_million', input_rate * 2)),
+        )
+    wanted = f'rate card id {rate_card_id!r}' if rate_card_id else f'model {model!r}'
+    raise LookupError(f'no rate card for {wanted} in {rate_card_path}')
+
+
+def date_range(end: date, days: int) -> list[str]:
+    """Return ``days`` ISO dates ending at (and including) ``end``."""
+    if days < 1:
+        raise ValueError('days must be at least 1')
+    return [(end - timedelta(days=offset)).isoformat() for offset in reversed(range(days))]
+
+
+def fetch_rows(client: Any, feature: str, days: Sequence[str]) -> Iterator[Mapping[str, Any]]:
+    """Stream ledger rows for one feature, one day per query.
+
+    Two equality filters are served by single-field indexes, so this needs no
+    composite index. Days are queried separately to keep each result set bounded
+    and to let a partial run still report the days it did read.
+    """
+    from google.cloud.firestore_v1.base_query import FieldFilter
+
+    for day in days:
+        query = (
+            client.collection(ATTEMPTS_COLLECTION)
+            .where(filter=FieldFilter('feature', '==', feature))
+            .where(filter=FieldFilter('date', '==', day))
+        )
+        for snapshot in query.stream():
+            row = snapshot.to_dict()
+            if isinstance(row, Mapping):
+                yield row
+
+
+def _pct(part: float, whole: float) -> str:
+    return f'{(100 * part / whole):5.1f}%' if whole else '    —'
+
+
+def _usd(micro_usd: int) -> str:
+    return f'${micro_usd / MICRO_USD_PER_USD:,.2f}'
+
+
+def render(totals: Totals, rates: Rates, feature: str) -> str:
+    """Render the report as plain text."""
+    if totals.attempts == 0:
+        return f'No {feature} attempts found. Check the date range and that accounting is enabled.'
+
+    lines: list[str] = []
+    span = f'{min(totals.days)}..{max(totals.days)}' if totals.days else 'unknown'
+    lines.append(f'{feature} spend composition — {span} ({len(totals.days)} day(s))')
+    lines.append(f'rate card: {rates.rate_card_id}')
+    lines.append('')
+    lines.append(f'attempts: {totals.attempts:,}')
+    for name, count in totals.outcome.most_common():
+        lines.append(f'  outcome {name:<24} {count:>10,}  {_pct(count, totals.attempts)}')
+    lines.append('')
+    lines.append('served models')
+    for name, count in totals.models.most_common():
+        lines.append(f'  {name:<32} {count:>10,}  {_pct(count, totals.attempts)}')
+
+    components = cost_components(totals, rates)
+    modeled_total = sum(component.cost_micro_usd for component in components)
+    lines.append('')
+    lines.append(f'{"component":<24}{"tokens":>16}{"per attempt":>14}{"cost":>14}{"share":>9}')
+    for component in components:
+        per_attempt = component.tokens / totals.attempts
+        lines.append(
+            f'  {component.name:<22}{component.tokens:>16,}{per_attempt:>14,.0f}'
+            f'{_usd(component.cost_micro_usd):>14}{_pct(component.cost_micro_usd, modeled_total):>9}'
+        )
+    lines.append(f'  {"total (modeled)":<22}{"":>16}{"":>14}{_usd(modeled_total):>14}')
+
+    lines.append('')
+    lines.append(
+        f'ledger total (estimated_cost_micro_usd over {totals.priced_attempts:,} priced attempts): '
+        f'{_usd(totals.ledger_cost_micro_usd)}'
+    )
+    unpriced = totals.attempts - totals.priced_attempts
+    if unpriced:
+        lines.append(f'  {unpriced:,} attempt(s) carried no cost estimate and are excluded from the ledger total.')
+
+    lines.append('')
+    lines.append('cache status')
+    for name, count in totals.cache_status.most_common():
+        lines.append(f'  {name:<32} {count:>10,}  {_pct(count, totals.attempts)}')
+
+    ratio = write_read_ratio(totals)
+    lines.append('')
+    if ratio is None:
+        lines.append('write:read ratio: no cache reads observed — the prefix is never being reused.')
+    else:
+        lines.append(f'write:read ratio: {ratio:.2f} cache-write tokens billed per cache-read token served')
+    lines.append(
+        f'  attempts writing cache: {totals.attempts_with_cache_write:,} '
+        f'({_pct(totals.attempts_with_cache_write, totals.attempts).strip()})   '
+        f'reading cache: {totals.attempts_with_cache_read:,} '
+        f'({_pct(totals.attempts_with_cache_read, totals.attempts).strip()})'
+    )
+    if totals.cache_write_untagged_tokens:
+        lines.append(
+            f'  {totals.cache_write_untagged_tokens:,} cache-write token(s) had no single TTL '
+            "('mixed' or absent); priced at the 1h rate."
+        )
+    return '\n'.join(lines)
+
+
+def build_totals(rows: Iterable[Mapping[str, Any]]) -> Totals:
+    totals = Totals()
+    for row in rows:
+        accumulate(totals, row)
+    return totals
+
+
+def row_model(row: Mapping[str, Any]) -> str:
+    """The model an attempt was actually billed as."""
+    return _str_field(row, 'actual_model_version', _str_field(row, 'configured_model', 'unknown'))
+
+
+def row_pricing_basis(row: Mapping[str, Any]) -> tuple[str, str]:
+    """The exact basis an attempt was priced on: ``(model, rate_card_id)``.
+
+    The card id is carried because a model's pricing can be revised (an intro rate expiring, for
+    instance) while the model name stays the same, so the name alone does not identify the rates
+    that were in force. Rows written before the field existed carry an empty id and fall back to
+    a lookup by model.
+    """
+    return row_model(row), _str_field(row, 'rate_card_id', '')
+
+
+def build_totals_by_pricing_basis(rows: Iterable[Mapping[str, Any]]) -> dict[tuple[str, str], Totals]:
+    """Group the range by the basis each attempt was actually priced on.
+
+    One rate card cannot price a range that spans a routing change or a price revision, and
+    `chat_agent` has already moved provider once. Pricing every attempt at whatever is current
+    today would silently misattribute every component for every attempt served before the
+    switch — so the range is split and each group is priced on its own recorded basis.
+    """
+    grouped: dict[tuple[str, str], Totals] = {}
+    for row in rows:
+        accumulate(grouped.setdefault(row_pricing_basis(row), Totals()), row)
+    return grouped
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--feature', default=DEFAULT_FEATURE, help=f'ledger feature name (default: {DEFAULT_FEATURE})')
+    parser.add_argument(
+        '--days', type=int, default=DEFAULT_DAYS, help=f'days to read, ending at --end (default: {DEFAULT_DAYS})'
+    )
+    parser.add_argument('--end', default=None, help='last day to read, YYYY-MM-DD (default: today, UTC)')
+    parser.add_argument(
+        '--model', default=None, help='rate-card model (default: resolved from the gateway route override)'
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_model(explicit: str | None, feature: str) -> str:
+    """Prefer the operator-supplied model, else the feature's served route.
+
+    The route override is the model actually billed; ``model_config`` records the
+    pre-override choice and would price the report against a model that never ran.
+    """
+    if explicit:
+        return explicit
+    import yaml
+
+    overrides_path = BACKEND_ROOT / 'llm_gateway' / 'config' / 'generated_route_overrides.yaml'
+    raw = yaml.safe_load(overrides_path.read_text(encoding='utf-8')) or {}
+    for override in raw.get('generated_route_overrides') or []:
+        if isinstance(override, Mapping) and override.get('feature') == feature:
+            primary = override.get('primary')
+            if isinstance(primary, Mapping) and isinstance(primary.get('model'), str):
+                return primary['model']
+    raise LookupError(f'no route override for feature {feature!r}; pass --model explicitly')
+
+
+def main(argv: Sequence[str] | None = None, *, get_client: Callable[[], Any] | None = None) -> int:
+    import yaml
+
+    args = parse_args(argv)
+    card_path = BACKEND_ROOT / 'llm_gateway' / 'config' / 'cost_rate_cards.yaml'
+    try:
+        # The ledger's ``date`` field is UTC, so the default window has to be too — a local
+        # ``today()`` east or west of UTC asks for a day the range was never meant to cover.
+        end = date.fromisoformat(args.end) if args.end else datetime.now(timezone.utc).date()
+        days = date_range(end, args.days)
+        # ``--model`` prices the whole range from one card; without it each pricing basis found
+        # in the range is priced on its own.
+        forced_rates = load_rates(resolve_model(args.model, args.feature), card_path) if args.model else None
+    except (ValueError, LookupError, OSError, yaml.YAMLError) as error:
+        print(f'error: {error}', file=sys.stderr)
+        return 2
+
+    if get_client is None:
+        from database._client import get_firestore_client
+
+        get_client = get_firestore_client
+
+    grouped = build_totals_by_pricing_basis(fetch_rows(get_client(), args.feature, days))
+    if not grouped:
+        print(render(Totals(), Rates('none', 0, 0, 0, 0, 0), args.feature))
+        return 0
+
+    for basis in sorted(grouped, key=lambda key: -grouped[key].attempts):
+        model, rate_card_id = basis
+        if forced_rates is not None:
+            rates = forced_rates
+        else:
+            try:
+                rates = load_rates(model, card_path, rate_card_id=rate_card_id)
+            except (LookupError, OSError, yaml.YAMLError) as error:
+                # One unpriceable basis must not cost the operator the rest of the report.
+                print(f'{args.feature} — {model}: not priced ({error})\n', file=sys.stderr)
+                continue
+        print(render(grouped[basis], rates, args.feature))
+        print()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/chat_agent_cost_report.py
+++ b/backend/scripts/chat_agent_cost_report.py
@@ -36,9 +36,10 @@ DEFAULT_DAYS = 7
 MICRO_USD_PER_USD = 1_000_000
 TOKENS_PER_MILLION = 1_000_000
 
-# Cache writes are billed at a TTL-dependent multiple of the input rate, so the
-# 5-minute and 1-hour components are never collapsed into one number.
+# Cache writes are billed at a TTL-dependent rate, so the 5-minute, 30-minute,
+# and 1-hour components are never collapsed into one number.
 TTL_FIVE_MINUTES = '5m'
+TTL_THIRTY_MINUTES = '30m'
 TTL_ONE_HOUR = '1h'
 
 
@@ -63,6 +64,7 @@ class Totals:
     cached_input_tokens: int = 0
     uncached_input_tokens: int = 0
     cache_write_5m_tokens: int = 0
+    cache_write_30m_tokens: int = 0
     cache_write_1h_tokens: int = 0
     cache_write_untagged_tokens: int = 0
     output_tokens: int = 0
@@ -114,6 +116,8 @@ def accumulate(totals: Totals, row: Mapping[str, Any]) -> None:
     ttl = _str_field(row, 'cache_write_ttl', '')
     if ttl == TTL_ONE_HOUR:
         totals.cache_write_1h_tokens += cache_write
+    elif ttl == TTL_THIRTY_MINUTES:
+        totals.cache_write_30m_tokens += cache_write
     elif ttl == TTL_FIVE_MINUTES:
         totals.cache_write_5m_tokens += cache_write
     else:
@@ -151,6 +155,11 @@ def cost_components(totals: Totals, rates: Rates) -> list[Component]:
         Component(
             'uncached input', totals.uncached_input_tokens, _cost(totals.uncached_input_tokens, rates.input_micro_usd)
         ),
+        Component(
+            'cache write 30m',
+            totals.cache_write_30m_tokens,
+            _cost(totals.cache_write_30m_tokens, rates.cache_write_micro_usd),
+        ),
         Component('cache write 1h', untagged_and_1h, _cost(untagged_and_1h, rates.cache_write_1h_micro_usd)),
         Component(
             'cache write 5m',
@@ -172,7 +181,12 @@ def write_read_ratio(totals: Totals) -> float | None:
     reads = totals.cached_input_tokens
     if reads <= 0:
         return None
-    writes = totals.cache_write_1h_tokens + totals.cache_write_5m_tokens + totals.cache_write_untagged_tokens
+    writes = (
+        totals.cache_write_1h_tokens
+        + totals.cache_write_30m_tokens
+        + totals.cache_write_5m_tokens
+        + totals.cache_write_untagged_tokens
+    )
     return writes / reads
 
 
@@ -311,7 +325,7 @@ def render(totals: Totals, rates: Rates, feature: str) -> str:
     if totals.cache_write_untagged_tokens:
         lines.append(
             f'  {totals.cache_write_untagged_tokens:,} cache-write token(s) had no single TTL '
-            "('mixed' or absent); priced at the 1h rate."
+            "('mixed', absent, or unrecognized); priced at the 1h rate."
         )
     return '\n'.join(lines)
 

--- a/backend/tests/unit/test_chat_agent_cost_report.py
+++ b/backend/tests/unit/test_chat_agent_cost_report.py
@@ -125,6 +125,34 @@ def test_untagged_cache_writes_are_reported_and_priced_at_the_one_hour_rate(repo
     assert "had no single TTL" in report.render(totals, rates, 'chat_agent')
 
 
+def test_luna_30_minute_cache_writes_use_the_luna_write_rate(report) -> None:
+    """The managed Luna route reports explicit 30-minute writes, not Anthropic TTLs."""
+    totals = report.build_totals(
+        [
+            _row(
+                actual_model_version='gpt-5.6-luna',
+                cache_write_tokens=1_000_000,
+                cache_write_ttl='30m',
+                estimated_cost_micro_usd=250_000,
+            )
+        ]
+    )
+
+    assert totals.cache_write_30m_tokens == 1_000_000
+    assert totals.cache_write_5m_tokens == 0
+    assert totals.cache_write_1h_tokens == 0
+    assert totals.cache_write_untagged_tokens == 0
+
+    card_path = BACKEND_ROOT / 'llm_gateway' / 'config' / 'cost_rate_cards.yaml'
+    rates = report.load_rates('gpt-5.6-luna', card_path)
+    by_name = {component.name: component for component in report.cost_components(totals, rates)}
+
+    assert rates.cache_write_micro_usd == 250_000
+    assert by_name['cache write 30m'].cost_micro_usd == 250_000
+    assert by_name['cache write 1h'].cost_micro_usd == 0
+    assert 'cache write 30m' in report.render(totals, rates, 'chat_agent')
+
+
 def test_malformed_ledger_row_contributes_its_readable_fields(report) -> None:
     """Best-effort ledger writes can omit or corrupt a field; the report must not abort."""
     totals = report.build_totals(

--- a/backend/tests/unit/test_chat_agent_cost_report.py
+++ b/backend/tests/unit/test_chat_agent_cost_report.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def report():
+    """Load the script under test as a module, without leaking it into the process.
+
+    The ``sys.modules`` registration is not optional: the script's dataclasses resolve their own
+    module by name while executing, and ``exec_module`` fails without it. Doing it at import time
+    would leave the entry behind for every later test in the run, which the repo's test-isolation
+    rule bans (enforced by ``scripts/check_module_stub_pollution.py``), so it is scoped to the
+    fixture and removed afterwards.
+    """
+    spec = importlib.util.spec_from_file_location(
+        'chat_agent_cost_report', BACKEND_ROOT / 'scripts' / 'chat_agent_cost_report.py'
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        'date': '2026-07-30',
+        'feature': 'chat_agent',
+        'outcome': 'success',
+        'cache_status': 'hit',
+        'actual_model_version': 'claude-sonnet-5',
+        'cached_input_tokens': 0,
+        'uncached_input_tokens': 0,
+        'cache_write_tokens': 0,
+        'cache_write_ttl': None,
+        'output_tokens': 0,
+        'estimated_cost_micro_usd': 0,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_attributes_spend_across_components_and_reports_write_read_ratio(report) -> None:
+    """A cache-writing turn followed by cache-reading turns is split per component."""
+    totals = report.build_totals(
+        [
+            # First turn of a session: writes the whole prefix at the 1h rate.
+            _row(
+                cache_write_tokens=20_000,
+                cache_write_ttl='1h',
+                uncached_input_tokens=500,
+                output_tokens=400,
+                cache_status='miss',
+                estimated_cost_micro_usd=90_000,
+            ),
+            # Follow-up turns read that prefix back.
+            _row(
+                cached_input_tokens=20_000, uncached_input_tokens=200, output_tokens=300, estimated_cost_micro_usd=7_400
+            ),
+            _row(
+                cached_input_tokens=20_000, uncached_input_tokens=200, output_tokens=300, estimated_cost_micro_usd=7_400
+            ),
+        ]
+    )
+
+    assert totals.attempts == 3
+    assert totals.cached_input_tokens == 40_000
+    assert totals.cache_write_1h_tokens == 20_000
+    assert totals.attempts_with_cache_write == 1
+    assert totals.attempts_with_cache_read == 2
+    assert totals.cache_status['miss'] == 1
+    assert totals.ledger_cost_micro_usd == 104_800
+
+    # One prefix written per two reads.
+    assert report.write_read_ratio(totals) == pytest.approx(0.5)
+
+    rates = report.Rates(
+        rate_card_id='test',
+        input_micro_usd=2_000_000,
+        cached_input_micro_usd=200_000,
+        output_micro_usd=10_000_000,
+        cache_write_micro_usd=2_500_000,
+        cache_write_1h_micro_usd=4_000_000,
+    )
+    by_name = {component.name: component for component in report.cost_components(totals, rates)}
+    assert by_name['cached input (read)'].cost_micro_usd == 8_000  # 40k @ 0.2 $/M
+    assert by_name['uncached input'].cost_micro_usd == 1_800  # 900 @ 2 $/M
+    assert by_name['cache write 1h'].cost_micro_usd == 80_000  # 20k @ 4 $/M
+    assert by_name['output'].cost_micro_usd == 10_000  # 1k @ 10 $/M
+
+    rendered = report.render(totals, rates, 'chat_agent')
+    assert 'cache write 1h' in rendered
+    assert 'write:read ratio: 0.50' in rendered
+
+
+def test_untagged_cache_writes_are_reported_and_priced_at_the_one_hour_rate(report) -> None:
+    """A 'mixed' TTL means the request's breakpoints disagree — surface it, don't drop it."""
+    totals = report.build_totals([_row(cache_write_tokens=1_000, cache_write_ttl='mixed')])
+
+    assert totals.cache_write_untagged_tokens == 1_000
+    assert totals.cache_write_1h_tokens == 0
+
+    rates = report.Rates(
+        rate_card_id='test',
+        input_micro_usd=2_000_000,
+        cached_input_micro_usd=200_000,
+        output_micro_usd=10_000_000,
+        cache_write_micro_usd=2_500_000,
+        cache_write_1h_micro_usd=4_000_000,
+    )
+    by_name = {component.name: component for component in report.cost_components(totals, rates)}
+    assert by_name['cache write 1h'].tokens == 1_000
+    assert "had no single TTL" in report.render(totals, rates, 'chat_agent')
+
+
+def test_malformed_ledger_row_contributes_its_readable_fields(report) -> None:
+    """Best-effort ledger writes can omit or corrupt a field; the report must not abort."""
+    totals = report.build_totals(
+        [_row(cached_input_tokens='not-a-number', uncached_input_tokens=-5, output_tokens=True, cache_write_tokens=700)]
+    )
+
+    assert totals.attempts == 1
+    assert totals.cached_input_tokens == 0
+    assert totals.uncached_input_tokens == 0
+    assert totals.output_tokens == 0  # bool is not a token count
+    assert totals.cache_write_untagged_tokens == 700
+
+
+def test_no_attempts_reports_an_empty_range_instead_of_dividing_by_zero(report) -> None:
+    totals = report.build_totals([])
+    rates = report.Rates('test', 0, 0, 0, 0, 0)
+
+    assert report.write_read_ratio(totals) is None
+    assert 'No chat_agent attempts found' in report.render(totals, rates, 'chat_agent')
+
+
+def test_rates_come_from_the_real_card_and_an_unknown_model_fails_loudly(report) -> None:
+    """Pricing the report against a model with no card would silently understate spend."""
+    card_path = BACKEND_ROOT / 'llm_gateway' / 'config' / 'cost_rate_cards.yaml'
+    rates = report.load_rates('claude-sonnet-5', card_path)
+
+    assert rates.cached_input_micro_usd < rates.input_micro_usd < rates.cache_write_1h_micro_usd
+
+    with pytest.raises(LookupError):
+        report.load_rates('claude-not-a-real-model', card_path)
+
+
+def test_model_resolves_from_the_route_override_not_the_pre_override_profile(report) -> None:
+    """model_config records the pre-override choice; the override is what actually bills.
+
+    Asserted against the override file rather than a literal: `chat_agent` has already moved
+    provider once (anthropic -> openai), and pinning the served model here would fail the next
+    routing change without anything being wrong with the resolver.
+    """
+    overrides = yaml.safe_load(
+        (BACKEND_ROOT / 'llm_gateway' / 'config' / 'generated_route_overrides.yaml').read_text(encoding='utf-8')
+    )
+    served = next(r['primary']['model'] for r in overrides['generated_route_overrides'] if r['feature'] == 'chat_agent')
+
+    assert report.resolve_model(None, 'chat_agent') == served
+    assert report.resolve_model('claude-haiku-4-5', 'chat_agent') == 'claude-haiku-4-5'
+
+    with pytest.raises(LookupError):
+        report.resolve_model(None, 'not-a-feature')
+
+
+def test_a_range_spanning_a_routing_change_is_priced_per_model(report) -> None:
+    """chat_agent has already moved provider once. Folding both models into one set of totals
+    would price every pre-switch attempt at the current model's card."""
+    grouped = report.build_totals_by_pricing_basis(
+        [
+            _row(actual_model_version='claude-sonnet-5', output_tokens=1_000, date='2026-08-01'),
+            _row(actual_model_version='gpt-5.6-luna', output_tokens=400, date='2026-08-03'),
+            _row(actual_model_version='gpt-5.6-luna', output_tokens=600, date='2026-08-04'),
+        ]
+    )
+
+    assert {model for model, _card in grouped} == {'claude-sonnet-5', 'gpt-5.6-luna'}
+    assert grouped[('claude-sonnet-5', '')].attempts == 1
+    assert grouped[('gpt-5.6-luna', '')].attempts == 2
+    assert grouped[('gpt-5.6-luna', '')].output_tokens == 1_000
+
+    # Each group is priceable on its own card, which is the point of splitting them.
+    card_path = BACKEND_ROOT / 'llm_gateway' / 'config' / 'cost_rate_cards.yaml'
+    for model, _card in grouped:
+        assert report.load_rates(model, card_path).output_micro_usd > 0
+
+
+def test_one_model_priced_two_ways_is_split_by_the_card_it_was_billed_on(report) -> None:
+    """A model name does not identify its rates: an intro price can expire while the name stays
+    the same, so attempts either side of that must not be folded together."""
+    grouped = report.build_totals_by_pricing_basis(
+        [
+            _row(rate_card_id='anthropic.claude-sonnet-5.intro.2026-07-17', output_tokens=100),
+            _row(rate_card_id='anthropic.claude-sonnet-5.standard.2026-09-01', output_tokens=250),
+        ]
+    )
+
+    assert len(grouped) == 2
+    assert grouped[('claude-sonnet-5', 'anthropic.claude-sonnet-5.intro.2026-07-17')].output_tokens == 100
+    assert grouped[('claude-sonnet-5', 'anthropic.claude-sonnet-5.standard.2026-09-01')].output_tokens == 250
+
+
+def test_rates_load_from_the_recorded_card_id_ahead_of_the_model_name(report) -> None:
+    """The ledger records which card priced each attempt; that beats guessing from the name."""
+    card_path = BACKEND_ROOT / 'llm_gateway' / 'config' / 'cost_rate_cards.yaml'
+
+    by_id = report.load_rates('ignored-name', card_path, rate_card_id='anthropic.claude-sonnet-5.intro.2026-07-17')
+    assert by_id.rate_card_id == 'anthropic.claude-sonnet-5.intro.2026-07-17'
+
+    # An id that no longer exists in the card file must fail loudly rather than fall back to the
+    # model name and silently price the range at today's rates.
+    with pytest.raises(LookupError):
+        report.load_rates('claude-sonnet-5', card_path, rate_card_id='anthropic.claude-sonnet-5.retired')
+
+
+def test_a_row_with_no_model_is_grouped_rather_than_dropped(report) -> None:
+    """A best-effort ledger write can omit the model; its tokens still cost money."""
+    grouped = report.build_totals_by_pricing_basis([_row(actual_model_version=None, output_tokens=50)])
+
+    assert grouped[('unknown', '')].output_tokens == 50
+
+
+def test_the_default_window_ends_on_the_utc_day(report, monkeypatch) -> None:
+    """The ledger's date field is UTC. A local today() east or west of UTC asks for a day the
+    range was never meant to cover."""
+    captured: dict[str, Any] = {}
+
+    def fake_fetch(_client, feature, days):
+        captured['days'] = days
+        return []
+
+    monkeypatch.setattr(report, 'fetch_rows', fake_fetch)
+    report.main(['--days', '1'], get_client=lambda: object())
+
+    from datetime import datetime, timezone
+
+    assert captured['days'] == [datetime.now(timezone.utc).date().isoformat()]
+
+
+def test_date_range_is_inclusive_and_ordered(report) -> None:
+    from datetime import date
+
+    assert report.date_range(date(2026, 7, 30), 3) == ['2026-07-28', '2026-07-29', '2026-07-30']
+
+    with pytest.raises(ValueError):
+        report.date_range(date(2026, 7, 30), 0)

--- a/backend/tests/unit/test_chat_agent_provider_retry.py
+++ b/backend/tests/unit/test_chat_agent_provider_retry.py
@@ -255,14 +255,22 @@ async def test_transient_provider_failure_is_retried_and_the_turn_survives(agent
 
 
 async def test_no_retry_once_text_has_reached_the_user(agentic_mod):
-    """Streamed tokens cannot be un-sent, so the partial answer is kept instead of duplicated."""
+    """Streamed tokens cannot be un-sent, so the partial answer is kept instead of duplicated.
+
+    The persisted answer is the whole of what the user watched arrive: the partial answer and
+    then the apology. Both are streamed either way — asserting that only the partial one is
+    persisted would pin the router to overwrite the pair with its canned error.
+    """
     streams = [FakeStream(events=[_text_delta('Half an ans')], error=ReadTimeout())]
     go, calls, full_response = _run(agentic_mod, streams)
 
     result, recorded = await go()
 
     assert len(calls) == 1
-    assert ''.join(full_response) == 'Half an ans', 'the delivered text must survive verbatim'
+    answer = ''.join(full_response)
+    assert answer.startswith('Half an ans'), 'the delivered text must survive verbatim'
+    assert answer.count('Half an ans') == 1, 'the partial answer must not be replayed'
+    assert answer.endswith('Sorry, I encountered an error. Please try again.')
     assert result == 'provider_ReadTimeout'
     recorded.assert_not_called()
 
@@ -651,3 +659,105 @@ async def test_context_size_guard_message_becomes_the_answer(agentic_mod):
 
     assert result is None
     assert "That's a lot of information to process at once!" in ''.join(full_response)
+
+
+# ---------------------------------------------------------------------------
+# Terminal-exit contract
+#
+# FC-recoverable-provider-failure-terminal has now recurred once per exit path out of the agent
+# loop: the safety-guard reply, the bounded-stop partial, the oversized-input reply, the stalled
+# stream, and the provider refusal were each fixed at their own call site. They share one cause —
+# a terminal path that ends the turn without leaving the router something to render, or without
+# reporting that it failed, is indistinguishable from a model that legitimately said nothing.
+#
+# This table is the guard surface for that contract rather than another per-path regression test:
+# a new exit added to the loop is expected to appear here, and any exit that ends the turn silent
+# fails it.
+# ---------------------------------------------------------------------------
+
+
+def _refusal_final(category=None):
+    """A declined turn: HTTP success, terminal stop reason, no content blocks."""
+    stop_details = types.SimpleNamespace(type='refusal', category=category) if category else None
+    return types.SimpleNamespace(stop_reason='refusal', content=[], stop_details=stop_details)
+
+
+def _blocking_guard(method, message):
+    guard = MagicMock()
+    guard.should_warn_user.return_value = None
+    guard.get_stats.return_value = {}
+    getattr(guard, method).side_effect = SafetyGuardError(message)
+    return guard
+
+
+TERMINAL_EXITS = {
+    'model_answered': (
+        [FakeStream(response=_final(), events=[_text_delta('Here is your answer.')])],
+        None,
+        False,
+    ),
+    'provider_refused': ([FakeStream(response=_refusal_final())], None, True),
+    'provider_refused_with_category': ([FakeStream(response=_refusal_final(category='cyber'))], None, True),
+    'provider_failed_unrecoverably': ([FakeStream(error=BadRequestError())], None, True),
+    'retry_budget_exhausted': ([FakeStream(error=ReadTimeout()) for _ in range(5)], None, True),
+    'safety_guard_blocked_a_tool': (
+        [FakeStream(response=_tool_use_final())],
+        ('validate_tool_call', 'I seem to be stuck trying to answer your question.'),
+        False,
+    ),
+    'safety_guard_blocked_on_context_size': (
+        [FakeStream(response=_tool_use_final())],
+        ('check_context_size', "That's a lot of information to process at once!"),
+        False,
+    ),
+}
+
+
+@pytest.mark.parametrize('exit_name', sorted(TERMINAL_EXITS))
+async def test_every_terminal_exit_leaves_an_answer_and_reports_whether_it_failed(agentic_mod, exit_name):
+    streams, guard_spec, expects_failure = TERMINAL_EXITS[exit_name]
+    guard = _blocking_guard(*guard_spec) if guard_spec else None
+    go, _calls, full_response = _run(agentic_mod, streams, safety_guard=guard)
+
+    result, _recorded = await go()
+
+    # The router builds both the persisted reply and the terminal done: frame from
+    # ``full_response``. Text that only reached ``put_data`` is overwritten by its canned error.
+    assert ''.join(full_response).strip(), f'{exit_name} ended the turn with nothing to render'
+
+    if expects_failure:
+        assert result, f'{exit_name} is a failure and must report a reason the router can record'
+    else:
+        assert result is None, f'{exit_name} is a deliberate reply, not a provider failure'
+
+
+async def test_refusal_is_reported_as_a_failure_rather_than_an_empty_answer(agentic_mod):
+    """A declined turn returns HTTP 200 with empty content — the loop must not read that as
+    'the model chose to say nothing', which lands the user on the router's generic error."""
+    go, calls, full_response = _run(agentic_mod, [FakeStream(response=_refusal_final(category='cyber'))])
+
+    result, recorded = await go()
+
+    assert result == 'provider_refusal'
+    assert ''.join(full_response) == agentic_mod.AGENT_REFUSAL_MESSAGE
+    assert len(calls) == 1, 'a refusal is deterministic — re-sending the same prompt is wasted spend'
+    recorded.assert_not_called()
+
+
+async def test_refusal_keeps_text_the_user_already_saw(agentic_mod):
+    """A classifier can fire mid-turn, after real content streamed. That text is a real answer."""
+    stream = FakeStream(response=_refusal_final(), events=[_text_delta('Here is what I found')])
+    go, _calls, full_response = _run(agentic_mod, [stream])
+
+    result, _recorded = await go()
+
+    assert result == 'provider_refusal'
+    assert ''.join(full_response) == 'Here is what I found', 'delivered text must not be replaced'
+
+
+def test_refusal_category_is_optional_at_every_level(agentic_mod):
+    """``stop_details`` is absent on other stop reasons and on older provider versions."""
+    assert agentic_mod._refusal_category(_refusal_final(category='cyber')) == 'cyber'
+    assert agentic_mod._refusal_category(_refusal_final()) == 'unspecified'
+    assert agentic_mod._refusal_category(types.SimpleNamespace(stop_reason='refusal')) == 'unspecified'
+    assert agentic_mod._refusal_category(types.SimpleNamespace(stop_details=None)) == 'unspecified'

--- a/backend/tests/unit/test_chat_agent_provider_retry.py
+++ b/backend/tests/unit/test_chat_agent_provider_retry.py
@@ -698,6 +698,12 @@ TERMINAL_EXITS = {
     ),
     'provider_refused': ([FakeStream(response=_refusal_final())], None, True),
     'provider_refused_with_category': ([FakeStream(response=_refusal_final(category='cyber'))], None, True),
+    # Whitespace makes ``full_response`` non-empty while the persisted reply is still blank.
+    'provider_refused_after_whitespace': (
+        [FakeStream(response=_refusal_final(), events=[_text_delta('\n\n')])],
+        None,
+        True,
+    ),
     'provider_failed_unrecoverably': ([FakeStream(error=BadRequestError())], None, True),
     'retry_budget_exhausted': ([FakeStream(error=ReadTimeout()) for _ in range(5)], None, True),
     'safety_guard_blocked_a_tool': (
@@ -713,8 +719,15 @@ TERMINAL_EXITS = {
 }
 
 
+#: Every scripted failure case supplies this many streams. Pinned rather than read from the
+#: module default so raising that default turns into a budget-exhaustion assertion failure here,
+#: not an IndexError off the end of the script — the latter would pass for the wrong reason.
+SCRIPTED_FAILURE_ATTEMPTS = 5
+
+
 @pytest.mark.parametrize('exit_name', sorted(TERMINAL_EXITS))
-async def test_every_terminal_exit_leaves_an_answer_and_reports_whether_it_failed(agentic_mod, exit_name):
+async def test_every_terminal_exit_leaves_an_answer_and_reports_whether_it_failed(agentic_mod, exit_name, monkeypatch):
+    monkeypatch.setattr(agentic_mod, 'AGENT_STREAM_PROVIDER_MAX_ATTEMPTS', SCRIPTED_FAILURE_ATTEMPTS)
     streams, guard_spec, expects_failure = TERMINAL_EXITS[exit_name]
     guard = _blocking_guard(*guard_spec) if guard_spec else None
     go, _calls, full_response = _run(agentic_mod, streams, safety_guard=guard)
@@ -729,6 +742,131 @@ async def test_every_terminal_exit_leaves_an_answer_and_reports_whether_it_faile
         assert result, f'{exit_name} is a failure and must report a reason the router can record'
     else:
         assert result is None, f'{exit_name} is a deliberate reply, not a provider failure'
+
+
+# ---------------------------------------------------------------------------
+# The same contract on the managed (OpenAI chat-completions) loop.
+#
+# ``_run_openai_agent_stream`` is the runner gateway feature mode selects, so it carries the
+# production traffic. It was added with the same defect this class describes at two of its exits:
+# an apology pushed through ``put_data`` alone, which the router then overwrote. The contract is
+# provider-independent, so the table is duplicated in shape rather than in assertions.
+# ---------------------------------------------------------------------------
+
+
+class _FakeChatModel:
+    """Scripted stand-in for the bound chat model ``get_llm`` returns."""
+
+    def __init__(self, scripts):
+        self._scripts = list(scripts)
+        self._call = 0
+
+    def bind(self, **_kwargs):
+        return self
+
+    def astream(self, _messages):
+        script = self._scripts[self._call]
+        self._call += 1
+
+        async def chunks():
+            if isinstance(script, Exception):
+                raise script
+            for chunk in script:
+                yield chunk
+
+        return chunks()
+
+
+def _openai_chunk(text='', tool_calls=None):
+    return types.SimpleNamespace(content=text, tool_call_chunks=tool_calls or [])
+
+
+def _openai_tool_chunk(name='lookup'):
+    return [{'index': 0, 'id': 'call_1', 'name': name, 'args': '{}'}]
+
+
+def _run_openai(agentic_mod, scripts, safety_guard=None, get_llm_error=None, tool_result='tool result'):
+    """Drive the managed loop over a scripted sequence of provider streams."""
+    if safety_guard is None:
+        safety_guard = MagicMock()
+        safety_guard.should_warn_user.return_value = None
+        safety_guard.get_stats.return_value = {}
+
+    callback = agentic_mod.AsyncStreamingCallback()
+    full_response = []
+    get_llm = MagicMock(side_effect=get_llm_error) if get_llm_error else MagicMock(return_value=_FakeChatModel(scripts))
+
+    async def go():
+        with patch.object(agentic_mod, 'get_llm', new=get_llm), patch.object(
+            agentic_mod, '_execute_tool', new=AsyncMock(return_value=tool_result)
+        ), patch.object(agentic_mod, 'handle_llm_error_async', new=AsyncMock()), patch.object(
+            agentic_mod, 'record_fallback'
+        ):
+            return await agentic_mod._run_openai_agent_stream(
+                'SYSTEM',
+                [{'role': 'user', 'content': 'question'}],
+                [],
+                {'lookup': MagicMock()},
+                callback,
+                full_response,
+                safety_guard,
+                {},
+            )
+
+    return go, full_response
+
+
+OPENAI_TERMINAL_EXITS = {
+    'model_answered': ([[_openai_chunk('Here is your answer.')]], None, None, False),
+    # A content filter on this contract yields no signal of its own: the completion simply
+    # arrives with no text and no tool calls, which the loop would otherwise treat as done.
+    'model_returned_nothing': ([[_openai_chunk('')]], None, None, True),
+    'client_construction_failed': (None, None, BadRequestError(), True),
+    'provider_failed_unrecoverably': ([BadRequestError()], None, None, True),
+    'retry_budget_exhausted': ([ReadTimeout() for _ in range(5)], None, None, True),
+    'safety_guard_blocked_a_tool': (
+        [[_openai_chunk(tool_calls=_openai_tool_chunk())]],
+        ('validate_tool_call', 'I seem to be stuck trying to answer your question.'),
+        None,
+        False,
+    ),
+    'safety_guard_blocked_on_context_size': (
+        [[_openai_chunk(tool_calls=_openai_tool_chunk())]],
+        ('check_context_size', "That's a lot of information to process at once!"),
+        None,
+        False,
+    ),
+}
+
+
+@pytest.mark.parametrize('exit_name', sorted(OPENAI_TERMINAL_EXITS))
+async def test_every_managed_terminal_exit_leaves_an_answer_and_reports_whether_it_failed(
+    agentic_mod, exit_name, monkeypatch
+):
+    monkeypatch.setattr(agentic_mod, 'AGENT_STREAM_PROVIDER_MAX_ATTEMPTS', SCRIPTED_FAILURE_ATTEMPTS)
+    scripts, guard_spec, get_llm_error, expects_failure = OPENAI_TERMINAL_EXITS[exit_name]
+    guard = _blocking_guard(*guard_spec) if guard_spec else None
+    go, full_response = _run_openai(agentic_mod, scripts, safety_guard=guard, get_llm_error=get_llm_error)
+
+    result = await go()
+
+    assert ''.join(full_response).strip(), f'{exit_name} ended the turn with nothing to render'
+
+    if expects_failure:
+        assert result, f'{exit_name} is a failure and must report a reason the router can record'
+    else:
+        assert result is None, f'{exit_name} is a deliberate reply, not a provider failure'
+
+
+async def test_a_silent_completion_is_reported_rather_than_persisted_as_a_blank_answer(agentic_mod):
+    """The managed contract has no refusal stop reason — a filtered turn is just an empty
+    completion, so the only signal the loop gets is that it produced nothing."""
+    go, full_response = _run_openai(agentic_mod, [[_openai_chunk('')]])
+
+    result = await go()
+
+    assert result == 'empty_answer'
+    assert ''.join(full_response) == agentic_mod.AGENT_EMPTY_ANSWER_MESSAGE
 
 
 async def test_refusal_is_reported_as_a_failure_rather_than_an_empty_answer(agentic_mod):

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -187,6 +187,9 @@ AGENT_STREAM_FAILURE_MESSAGE = 'Unable to complete the response. Please try agai
 # Delivered when a provider safety classifier declines the turn. Retrying the same prompt would
 # be declined again, so this says the request cannot be answered rather than inviting a retry.
 AGENT_REFUSAL_MESSAGE = "I can't help with that one. Try asking me something else."
+# Delivered when a loop runs to completion without the model ever emitting text. Unlike a
+# refusal this is not a policy decision, so it does invite a retry.
+AGENT_EMPTY_ANSWER_MESSAGE = "I wasn't able to put a response together for that. Please try again."
 
 # PROMPT CACHE OPTIMIZATION: This list MUST stay fixed and in this exact order.
 # Anthropic caches the tools array as part of the request prefix.  If the tool
@@ -578,6 +581,35 @@ async def _put_answer_text(callback: AsyncStreamingCallback, full_response: list
     await callback.put_data(text)
 
 
+def _has_answer(full_response: list) -> bool:
+    """Whether anything the router would render as an answer has been delivered.
+
+    List truthiness is not the same question. A stream can emit the inter-iteration separator or
+    a whitespace-only delta and then fail, which leaves ``full_response`` non-empty while the
+    persisted reply is still blank to the reader.
+    """
+    return bool(''.join(full_response).strip())
+
+
+async def _end_with_answer_guarantee(
+    callback: AsyncStreamingCallback, full_response: list, provider: str
+) -> Optional[str]:
+    """Close the stream, guaranteeing the turn left the user something to read.
+
+    Either loop can run to completion without the model emitting any text: a content filter, an
+    empty completion, or a tool-only iteration with nothing to say. ``full_response`` is what the
+    router persists and renders, so returning here silently hands the user a blank answer and
+    records the turn as a success. Report it as the failure it is instead.
+    """
+    if _has_answer(full_response):
+        await callback.end()
+        return None
+    logger.warning('Chat agent loop finished with no answer provider=%s', provider)
+    await _put_answer_text(callback, full_response, AGENT_EMPTY_ANSWER_MESSAGE)
+    await callback.end()
+    return 'empty_answer'
+
+
 def _refusal_category(response: Any) -> str:
     """Name the policy category behind a refusal, for logs only.
 
@@ -728,7 +760,7 @@ async def _run_anthropic_agent_stream(
         # report the turn as failed instead.
         if response.stop_reason == "refusal":
             logger.warning('Chat agent turn refused by provider category=%s', _refusal_category(response))
-            if not full_response:
+            if not _has_answer(full_response):
                 await _put_answer_text(callback, full_response, AGENT_REFUSAL_MESSAGE)
             await callback.end()
             return 'provider_refusal'
@@ -807,7 +839,7 @@ async def _run_anthropic_agent_stream(
     stats = safety_guard.get_stats()
     logger.info(f"Safety Guard final stats: {stats}")
 
-    await callback.end()
+    return await _end_with_answer_guarantee(callback, full_response, 'anthropic')
 
 
 def _openai_content_text(content: Any) -> str:
@@ -924,7 +956,9 @@ async def _run_openai_agent_stream(
         chat_model = chat_model.bind(tools=tool_schemas, tool_choice='auto', max_completion_tokens=8192)
     except Exception as error:
         await handle_llm_error_async(error, 'openai', feature='chat_agent', model='omi:auto:chat-agent')
-        await callback.put_data('\n\nSorry, I encountered an error. Please try again.')
+        # ``put_data`` alone reaches the live stream but not the persisted answer, so the
+        # router would overwrite this apology with its own canned error.
+        await _put_answer_text(callback, full_response, '\n\nSorry, I encountered an error. Please try again.')
         await callback.end()
         return f'provider_{type(error).__name__}'
 
@@ -992,7 +1026,7 @@ async def _run_openai_agent_stream(
                     continue
 
                 await handle_llm_error_async(error, 'openai', feature='chat_agent', model='omi:auto:chat-agent')
-                await callback.put_data('\n\nSorry, I encountered an error. Please try again.')
+                await _put_answer_text(callback, full_response, '\n\nSorry, I encountered an error. Please try again.')
                 await callback.end()
                 return f'provider_{type(error).__name__}'
 
@@ -1060,7 +1094,7 @@ async def _run_openai_agent_stream(
         messages.extend(tool_results)
 
     logger.info('Safety Guard final stats: %s', safety_guard.get_stats())
-    await callback.end()
+    return await _end_with_answer_guarantee(callback, full_response, 'openai')
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -184,6 +184,9 @@ AGENT_STREAM_PROVIDER_RETRY_BACKOFF_SECONDS = _positive_timeout_from_env(
 AGENT_STREAM_PROGRESS_HEARTBEAT = 'Still working…'
 AGENT_STREAM_TIMEOUT_MESSAGE = 'The response took too long. Please try again.'
 AGENT_STREAM_FAILURE_MESSAGE = 'Unable to complete the response. Please try again.'
+# Delivered when a provider safety classifier declines the turn. Retrying the same prompt would
+# be declined again, so this says the request cannot be answered rather than inviting a retry.
+AGENT_REFUSAL_MESSAGE = "I can't help with that one. Try asking me something else."
 
 # PROMPT CACHE OPTIMIZATION: This list MUST stay fixed and in this exact order.
 # Anthropic caches the tools array as part of the request prefix.  If the tool
@@ -575,6 +578,18 @@ async def _put_answer_text(callback: AsyncStreamingCallback, full_response: list
     await callback.put_data(text)
 
 
+def _refusal_category(response: Any) -> str:
+    """Name the policy category behind a refusal, for logs only.
+
+    ``stop_details`` is populated only alongside ``stop_reason == "refusal"`` and is absent on
+    older provider versions, so every level is optional. The category is a fixed provider enum
+    and carries none of the request content.
+    """
+    details = getattr(response, 'stop_details', None)
+    category = getattr(details, 'category', None) if details is not None else None
+    return category if isinstance(category, str) and category else 'unspecified'
+
+
 async def _run_anthropic_agent_stream(
     system_prompt: str,
     messages: list,
@@ -691,7 +706,9 @@ async def _run_anthropic_agent_stream(
                     continue
 
                 await handle_llm_error_async(e, 'anthropic', feature='chat_agent', model=ANTHROPIC_AGENT_MODEL)
-                await callback.put_data(f"\n\nSorry, I encountered an error. Please try again.")
+                # ``put_data`` alone reaches the live stream but not the persisted answer, so the
+                # router would overwrite this apology with its own canned error.
+                await _put_answer_text(callback, full_response, "\n\nSorry, I encountered an error. Please try again.")
                 await callback.end()
                 return f'provider_{type(e).__name__}'
 
@@ -703,6 +720,18 @@ async def _run_anthropic_agent_stream(
                 reason=retried_reason,
                 outcome='recovered',
             )
+
+        # A safety classifier can decline the turn. The response is a normal success with an
+        # empty (or partial) content list, so the loop would otherwise exit as if the model had
+        # simply answered nothing: the router sees a blank answer, emits its generic error, and
+        # records no error at all. Say so through the normal streamed/persisted contract and
+        # report the turn as failed instead.
+        if response.stop_reason == "refusal":
+            logger.warning('Chat agent turn refused by provider category=%s', _refusal_category(response))
+            if not full_response:
+                await _put_answer_text(callback, full_response, AGENT_REFUSAL_MESSAGE)
+            await callback.end()
+            return 'provider_refusal'
 
         # If no tool_use, we're done
         if response.stop_reason != "tool_use":

--- a/backend/utils/retrieval/safety.py
+++ b/backend/utils/retrieval/safety.py
@@ -231,10 +231,18 @@ def _int_from_env(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
-# claude-sonnet-4-6 (the chat_agent model) has a 200k-token context window. Cap the conversation
-# input well below it so the system prompt, tool schemas, accumulated tool results and the reply
-# tokens all still fit. 120k tokens is ~90k words of conversation — far beyond any legitimate
-# mobile chat, so real usage is never rejected, only pathological paste-dumps.
+# 120k tokens is ~90k words of conversation — far beyond any legitimate mobile chat, so real
+# usage is never rejected, only pathological paste-dumps. This is an abuse cap, not a
+# context-window cap, and it is deliberately not derived from any model's window: `chat_agent`
+# is routed per deployment and both providers it can reach have windows far above this, so the
+# system prompt, tool schemas, accumulated tool results and the reply all fit with room to
+# spare. Re-deriving it from whatever model is current raises the ceiling on what a single
+# request can cost, which is the reason to keep it low and provider-independent.
+#
+# The counter is tiktoken, so it is exact only for the OpenAI route and undercounts on the
+# Anthropic one — a conversation measured at the cap is somewhat larger in the tokens actually
+# billed there. That error is in the safe direction (the guard trips earlier than the nominal
+# limit) and stays safe only while the cap sits far below the real window.
 MAX_CHAT_INPUT_TOKENS = _int_from_env('MAX_CHAT_INPUT_TOKENS', 120_000)
 
 # Delivered to the user (and persisted) when the newest message alone is over the budget. Sent

--- a/scripts/changed-files
+++ b/scripts/changed-files
@@ -6,4 +6,18 @@
 # replacing a watched regular file with a symlink cannot bypass validation.
 set -euo pipefail
 
+# `actions/checkout` uses a synthetic merge commit for pull-request jobs. The
+# event's base SHA can lag the merge's first parent when `main` advances while
+# GitHub is preparing the run; diffing that stale SHA against the merge commit
+# then misclassifies unrelated base-branch changes as PR changes. The final
+# review surface of a merge commit is the delta from its first parent.
+if [ "$#" -eq 1 ] && [[ "$1" == *...* ]]; then
+  range="$1"
+  right_revision="${range##*...}"
+  if merge_parent="$(git rev-parse --verify "${right_revision}^1" 2>/dev/null)" \
+    && git rev-parse --verify "${right_revision}^2" >/dev/null 2>&1; then
+    set -- "$merge_parent" "$right_revision"
+  fi
+fi
+
 exec git diff --name-only --no-renames --diff-filter=ACMRTD "$@"

--- a/scripts/test-changed-files.sh
+++ b/scripts/test-changed-files.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT/scripts/changed-files"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-changed-files.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git -C "$TMPDIR" init -q
+git -C "$TMPDIR" config user.email test@example.com
+git -C "$TMPDIR" config user.name "Test User"
+printf 'base\n' >"$TMPDIR/base.txt"
+git -C "$TMPDIR" add base.txt
+git -C "$TMPDIR" commit -qm base
+base_sha="$(git -C "$TMPDIR" rev-parse HEAD)"
+git -C "$TMPDIR" branch -M main
+
+git -C "$TMPDIR" switch -q -c feature
+printf 'feature\n' >"$TMPDIR/feature.txt"
+git -C "$TMPDIR" add feature.txt
+git -C "$TMPDIR" commit -qm feature
+git -C "$TMPDIR" switch -q main
+
+# Simulate main advancing after the pull request's event base SHA, then let
+# GitHub create the synthetic merge with main as its first parent.
+printf 'main\n' >"$TMPDIR/main.txt"
+git -C "$TMPDIR" add main.txt
+git -C "$TMPDIR" commit -qm main
+git -C "$TMPDIR" merge --no-ff -q --no-edit feature
+
+changed="$(cd "$TMPDIR" && "$HELPER" "$base_sha...HEAD")"
+test "$changed" = "feature.txt"
+
+non_merge_changed="$(cd "$TMPDIR" && "$HELPER" "$base_sha...feature")"
+test "$non_merge_changed" = "feature.txt"
+
+echo "changed-files synthetic-merge test passed"


### PR DESCRIPTION
## Summary

Makes every terminal exit from both chat agent loops leave the user an answer and report whether the turn failed, and adds a cost-attribution report over the gateway accounting ledger.

## Root cause

A terminal path that ends a turn without writing to `full_response` is indistinguishable from a model that legitimately said nothing: `routers/chat.py` builds both the persisted reply and the terminal `done:` frame from that list, so it renders its own canned error and records no failure.

Four exits had that shape. On the Anthropic path, a provider safety classifier declines a turn as an HTTP 200 with `stop_reason == "refusal"` and empty content, which the `stop_reason != "tool_use"` break read as the model choosing to answer nothing. On the managed OpenAI path — the runner gateway feature mode selects, so the one carrying production traffic — the client-construction and unrecoverable-provider exits each pushed their apology through `callback.put_data` alone, which reaches the live stream but not the persisted answer.

That path also has no refusal signal at all. A filtered turn simply arrives as a completion with no text and no tool calls, which the loop read as "done", fell out to `callback.end()`, and returned `None` — persisting a blank answer and recording the turn as a success.

## Impact

`_end_with_answer_guarantee` is the provider-independent form of the contract: it closes the stream, and if nothing was delivered it says so and returns `empty_answer` rather than `None`. Both loops exit through it, so the guarantee holds without either path having to detect a provider-specific refusal shape. A refusal additionally reports `provider_refusal` and logs `stop_details.category`, and its message does not invite a retry — the same prompt would be declined again.

Emptiness is judged on the joined, stripped text, not list truthiness: a stream can emit the inter-iteration separator or a whitespace-only delta and then fail, leaving `full_response` non-empty while the reply is still blank to the reader.

This class has now recurred once per exit path, so instead of another per-site fix, `TERMINAL_EXITS` and `OPENAI_TERMINAL_EXITS` enumerate every way each loop can end and assert each leaves a non-empty answer and reports failure honestly. They drive the real loops through the callback seam rather than asserting on source text.

`scripts/chat_agent_cost_report.py` reports spend split across cached reads, uncached input, cache writes and output. It groups the range by the model each attempt was billed as and prices each group with its own rate card — `chat_agent` has already moved provider once, and a single card cannot price a range spanning that. Output is aggregate token counts and costs only: no uid, no message content.

## Validation

- `BACKEND_UNIT_TEST_FILE_LIST=... BACKEND_FAST_UNIT_FAIL_SECONDS=1.0 bash test.sh` — 95 passed, 0 failed across the 3 touched test files (`test_chat_agent_provider_retry.py` 51, `test_prompt_cache_integration.py` 32, `test_chat_agent_cost_report.py` 12)
- Both guards verified to fail without their fix: reverting the two `put_data` calls and the shared guard fails 5 managed cases (`client_construction_failed`, `model_returned_nothing`, `provider_failed_unrecoverably`, `retry_budget_exhausted`, and the silent-completion test); reverting `_has_answer` alone fails `provider_refused_after_whitespace`
- `scripts/pr-preflight --base upstream/main --pr-body-file ...` — **passed: 23 checks**, including `product-invariants`, `failure-class-protocol`, and `backend-module-isolation`
- `scripts/check_module_stub_pollution.py` — 883 files, 0 violations
- Tool-schema sizing measured offline against the real 27 `CORE_TOOLS` schemas: tool definitions are 11,205 of the 11,759-token cached prefix (95.3%)

The `output_config.effort` A/B is written but not yet run — it needs a funded API key, and effort is only observable in output tokens because thinking is folded into `output_tokens`.

## Product invariants affected

None — `scripts/pr-preflight` reports `OK: no locked invariants require naming for these changes`.

Failure-Class: FC-recoverable-provider-failure-terminal
