### PR TITLE
fix(backend): charge desktop chat quota only after the provider accepts the turn (#11088)

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -5,7 +5,7 @@ import base64
 import json
 import re
 import time
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from types import SimpleNamespace
 from typing import Any, cast
 from uuid import uuid4
@@ -815,6 +815,7 @@ async def _stream(
     uid: str,
     *,
     client: Any | None = None,
+    on_upstream_accepted: Callable[[], Awaitable[None]] | None = None,
 ) -> AsyncIterator[str]:
     stream_id = f'chatcmpl-{uuid4()}'
     created = int(time.time())
@@ -833,6 +834,10 @@ async def _stream(
     try:
         stream_client = client or anthropic_client
         async with stream_client.messages.stream(**payload) as stream:
+            # Quota is charged once the provider accepts the turn, mirroring the
+            # gateway lane: a request the provider rejects costs the user nothing.
+            if on_upstream_accepted is not None:
+                await on_upstream_accepted()
             message_delta_usage: object = None
             next_tool_index = 0
             client_tool_indexes: dict[int, int] = {}
@@ -1228,13 +1233,13 @@ async def chat_completions(
                     'X-Request-Id': request_id,
                 },
             )
-        await _record_chat_quota_question(uid, request_id, x_app_platform)
         return StreamingResponse(
             _stream(
                 payload,
                 public_model,
                 uid,
                 client=get_direct_anthropic_client(byok_api_key=get_byok_key('anthropic')),
+                on_upstream_accepted=lambda: _record_chat_quota_question(uid, request_id, x_app_platform),
             ),
             media_type='text/event-stream',
             headers={
@@ -1243,8 +1248,6 @@ async def chat_completions(
                 'X-Request-Id': request_id,
             },
         )
-    if not gateway_mode:
-        await _record_chat_quota_question(uid, request_id, x_app_platform)
     if gateway_mode:
         usage_token = set_usage_context(uid, 'chat_agent')
         started_at = time.monotonic()
@@ -1306,6 +1309,7 @@ async def chat_completions(
         raise HTTPException(status_code=502, detail='Upstream provider error') from exc
     except Exception as exc:
         raise HTTPException(status_code=502, detail='Upstream provider error') from exc
+    await _record_chat_quota_question(uid, request_id, x_app_platform)
     await _record_usage(uid, usage)
     return JSONResponse(
         _message_response(message, public_model, content_override=content, usage_override=usage),

--- a/backend/tests/unit/test_desktop_chat.py
+++ b/backend/tests/unit/test_desktop_chat.py
@@ -1064,6 +1064,126 @@ async def test_gateway_rejection_does_not_record_quota_question(monkeypatch):
     assert quota_calls == []
 
 
+def _wire_direct_lane(monkeypatch, quota_calls):
+    monkeypatch.setattr(desktop_chat, 'llm_stub_enabled', lambda: False)
+    monkeypatch.setattr(desktop_chat, 'enforce_chat_quota', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(desktop_chat, '_meter_server_request', lambda *_args, **_kwargs: _done())
+    monkeypatch.setattr(desktop_chat, 'should_route_features_through_gateway', lambda: False)
+    monkeypatch.setattr(desktop_chat, 'get_byok_key', lambda _provider: None)
+
+    async def record_quota(*args, **kwargs):
+        quota_calls.append((args, kwargs))
+
+    monkeypatch.setattr(desktop_chat, '_record_chat_quota_question', record_quota)
+
+    async def record_usage(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(desktop_chat, '_record_usage', record_usage)
+    monkeypatch.setattr(desktop_chat, '_record_usage_resilient', record_usage)
+
+
+async def _drain(response):
+    return ''.join([chunk async for chunk in response.body_iterator])
+
+
+@pytest.mark.asyncio
+async def test_direct_stream_rejection_does_not_record_quota_question(monkeypatch):
+    quota_calls = []
+    _wire_direct_lane(monkeypatch, quota_calls)
+
+    class Stream:
+        async def __aenter__(self):
+            raise RuntimeError('upstream rejected the request')
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setattr(
+        desktop_chat,
+        'get_direct_anthropic_client',
+        lambda **_: SimpleNamespace(messages=SimpleNamespace(stream=lambda **_kwargs: Stream())),
+    )
+
+    response = await desktop_chat.chat_completions(
+        {'model': 'omi-sonnet', 'stream': True, 'messages': [{'role': 'user', 'content': 'hello'}]},
+        uid='user-1',
+        x_app_platform='windows',
+        x_omi_chat_contract_version=None,
+        x_omi_request_id='request-1',
+    )
+    body = await _drain(response)
+
+    assert 'Upstream provider error' in body
+    assert quota_calls == []
+
+
+@pytest.mark.asyncio
+async def test_direct_stream_records_one_quota_question_when_upstream_accepts(monkeypatch):
+    quota_calls = []
+    _wire_direct_lane(monkeypatch, quota_calls)
+
+    class Stream:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def get_final_message(self):
+            return SimpleNamespace(
+                content=[SimpleNamespace(type='text', text='hi')], stop_reason='end_turn', usage=None
+            )
+
+        def __aiter__(self):
+            async def events():
+                yield SimpleNamespace(type='content_block_delta', delta=SimpleNamespace(type='text_delta', text='hi'))
+
+            return events()
+
+    monkeypatch.setattr(
+        desktop_chat,
+        'get_direct_anthropic_client',
+        lambda **_: SimpleNamespace(messages=SimpleNamespace(stream=lambda **_kwargs: Stream())),
+    )
+
+    response = await desktop_chat.chat_completions(
+        {'model': 'omi-sonnet', 'stream': True, 'messages': [{'role': 'user', 'content': 'hello'}]},
+        uid='user-1',
+        x_app_platform='windows',
+        x_omi_chat_contract_version=None,
+        x_omi_request_id='request-1',
+    )
+    body = await _drain(response)
+
+    assert 'hi' in body
+    assert [call[0] for call in quota_calls] == [('user-1', 'request-1', 'windows')]
+
+
+@pytest.mark.asyncio
+async def test_direct_json_upstream_error_does_not_record_quota_question(monkeypatch):
+    quota_calls = []
+    _wire_direct_lane(monkeypatch, quota_calls)
+    monkeypatch.setattr(desktop_chat, 'get_direct_anthropic_client', lambda **_: object())
+
+    async def raise_upstream(*_args, **_kwargs):
+        raise RuntimeError('upstream rejected the request')
+
+    monkeypatch.setattr(desktop_chat, '_create_with_pause_turn_continuations', raise_upstream)
+
+    with pytest.raises(desktop_chat.HTTPException) as error:
+        await desktop_chat.chat_completions(
+            {'model': 'omi-sonnet', 'messages': [{'role': 'user', 'content': 'hello'}]},
+            uid='user-1',
+            x_app_platform='windows',
+            x_omi_chat_contract_version=None,
+            x_omi_request_id='request-1',
+        )
+
+    assert error.value.status_code == 502
+    assert quota_calls == []
+
+
 @pytest.mark.asyncio
 async def test_chat_completions_rejects_unknown_explicit_model_before_gateway(monkeypatch):
     monkeypatch.setattr(desktop_chat, 'llm_stub_enabled', lambda: False)


### PR DESCRIPTION
## What changed and why

Reported in #11088: users are charged "chat questions" for work they did not get. The direct (non-gateway) `/v2/chat/completions` lanes recorded a chat quota question *before* calling Anthropic, so a provider rejection or transport failure still consumed one of the user's monthly questions. The gateway lane already charges only after the upstream response is accepted (`test_gateway_rejection_does_not_record_quota_question` locks that in); this makes the direct lanes match.

Streaming lane: charges once the Anthropic stream context opens. JSON lane: charges after the message call returns. A request the provider rejects now costs the user nothing.

This fixes only the "quota consumed by a failed request" defect from #11088. The larger asks in that issue (per-feature quota attribution, background-feature disclosure, an overage hard stop) are product decisions and are not addressed here.

## Product invariants affected

none

## How it was verified

- `ENCRYPTION_SECRET=... .venv/bin/python -m pytest tests/unit/test_desktop_chat.py -q` → 56 passed.
- Guard proof: reverted `routers/desktop_chat.py` to the pre-fix version and re-ran the two new tests — both fail (`Left contains one more item: (('user-1', 'request-1', 'windows'), {})`), and pass with the fix.
- Quota neighbours green: `pytest tests/unit/test_desktop_chat.py tests/unit/test_chat_quota_counting_router.py tests/unit/test_user_usage.py tests/unit/test_desktop_message_quota_router.py -q` → 81 passed.
- Not exercised against live Anthropic/Firestore — the counting boundary is covered by the hermetic router tests above.

## Tests

`backend/tests/unit/test_desktop_chat.py`:
- `test_direct_stream_rejection_does_not_record_quota_question` — regression test for the streaming lane.
- `test_direct_json_upstream_error_does_not_record_quota_question` — regression test for the JSON lane.
- `test_direct_stream_records_one_quota_question_when_upstream_accepts` — the accepted turn still charges exactly once.

## Failure class (fixes)

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

