### PR TITLE
fix(monitoring): disable invalid managed GKE alerts

### DIFF
--- a/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
@@ -1,3 +1,18 @@
+## GKE manages the Kubernetes control plane; these customer-cluster scrape
+## targets do not exist and their default "down" alerts would page forever.
+kubeProxy:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+
+defaultRules:
+  disabled:
+    KubeProxyDown: true
+    KubeSchedulerDown: true
+    KubeControllerManagerDown: true
+
 grafana:
   enabled: true
   serviceAccount:

--- a/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
@@ -1,17 +1,14 @@
 ## GKE manages the Kubernetes control plane; these customer-cluster scrape
 ## targets do not exist and their default "down" alerts would page forever.
+## Component `enabled: false` already gates the whole PrometheusRule group in
+## kube-prometheus-stack, so no separate `defaultRules.disabled` entries —
+## flipping enabled back on must restore the alert automatically.
 kubeProxy:
   enabled: false
 kubeScheduler:
   enabled: false
 kubeControllerManager:
   enabled: false
-
-defaultRules:
-  disabled:
-    KubeProxyDown: true
-    KubeSchedulerDown: true
-    KubeControllerManagerDown: true
 
 grafana:
   enabled: true

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -102,16 +102,21 @@ def test_split_alert_exports_preserve_error_count_no_data_contract():
 
 
 def test_managed_gke_disables_unavailable_control_plane_scrapes_and_alerts():
-    """Managed GKE must not page on control-plane targets it cannot expose."""
+    """Managed GKE must not page on control-plane targets it cannot expose.
+
+    kube-prometheus-stack gates each control-plane PrometheusRule group on the
+    component ``enabled`` flag, so ``enabled: false`` alone suppresses the
+    ``*Down`` alerts. Do not also set ``defaultRules.disabled`` — that would
+    keep the alert off after a future self-managed control-plane re-enable.
+    """
     values = yaml.safe_load(PROD_STACK_VALUES.read_text(encoding="utf-8"))
 
     for component in ("kubeProxy", "kubeScheduler", "kubeControllerManager"):
         assert values[component]["enabled"] is False
 
-    disabled = values["defaultRules"]["disabled"]
-    assert disabled["KubeProxyDown"] is True
-    assert disabled["KubeSchedulerDown"] is True
-    assert disabled["KubeControllerManagerDown"] is True
+    disabled = (values.get("defaultRules") or {}).get("disabled") or {}
+    for alert in ("KubeProxyDown", "KubeSchedulerDown", "KubeControllerManagerDown"):
+        assert alert not in disabled
 
 
 def test_combined_alert_export_matches_every_split_source_rule():

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -3,9 +3,12 @@
 import json
 from pathlib import Path
 
+import yaml
+
 REPO = Path(__file__).resolve().parents[3]
 MONITORING = REPO / "backend/charts/monitoring"
 ALERT_SOURCES = MONITORING / "alerts"
+PROD_STACK_VALUES = MONITORING / "kube-prometheus-stack/prod_omi_monitoring_values.yaml"
 ERROR_COUNT_RULES = {
     "cew4j7ruiik1sd",  # Backend 4XX
     "cew4jcnpa68sga",  # Backend 5XX
@@ -96,6 +99,19 @@ def test_split_alert_exports_preserve_error_count_no_data_contract():
     assert ERROR_COUNT_RULES <= split.keys()
     for uid in ERROR_COUNT_RULES:
         assert combined[uid]["noDataState"] == split[uid]["noDataState"] == "OK"
+
+
+def test_managed_gke_disables_unavailable_control_plane_scrapes_and_alerts():
+    """Managed GKE must not page on control-plane targets it cannot expose."""
+    values = yaml.safe_load(PROD_STACK_VALUES.read_text(encoding="utf-8"))
+
+    for component in ("kubeProxy", "kubeScheduler", "kubeControllerManager"):
+        assert values[component]["enabled"] is False
+
+    disabled = values["defaultRules"]["disabled"]
+    assert disabled["KubeProxyDown"] is True
+    assert disabled["KubeSchedulerDown"] is True
+    assert disabled["KubeControllerManagerDown"] is True
 
 
 def test_combined_alert_export_matches_every_split_source_rule():


### PR DESCRIPTION
## Summary

Fixes #9138.

The production kube-prometheus-stack values enabled scrapes for kube-proxy,
kube-scheduler, and kube-controller-manager. Those control-plane targets are
managed by GKE and are not exposed to this customer cluster, so the default
`*Down` rules became permanently false-positive after their 15-minute window.

The production values now set those three component scrapes to `enabled: false`.
In kube-prometheus-stack that alone gates the corresponding PrometheusRule
groups, so the invalid pages stop without a separate `defaultRules.disabled`
block (which would silently keep the alerts off if the components are later
re-enabled on a self-managed control plane). Application alerts, `TargetDown`,
and `PrometheusRuleFailures` are unchanged.

## Verification

- `python3 -m pytest backend/tests/unit/test_monitoring_alert_rule_contract.py backend/tests/unit/test_logging_config.py -q`
- `helm template prod backend/charts/deepgram-self-hosted/nova-3/charts/kube-prometheus-stack -f backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml`
  - Rendered successfully; all three control-plane `*Down` alert rules rendered zero times.

## Risk

This intentionally stops collecting these managed control-plane metrics in the
production chart. If the monitoring deployment moves to a self-managed control
plane, flip the three `enabled` flags (and the alerts return with them).

## Invariants

No product invariants are affected.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


