### PR TITLE
Add fenced canonical graph enrichment

### DIFF
--- a/backend/models/memory_apply.py
+++ b/backend/models/memory_apply.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -38,6 +39,7 @@ from models.product_memory import (
 from utils.memory.short_term_lifecycle import default_short_term_expiry
 
 logger = logging.getLogger(__name__)
+_GRAPH_PREDICATE_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
 
 _PATCH_MUTATION_IDENTITY_EXCLUDED_KEYS = {
     "schema_version",
@@ -270,6 +272,75 @@ def memory_content_hash(*, content: Optional[str], evidence_ids: List[str]) -> s
     return deterministic_contract_id(
         "memory-content",
         {"content": content, "evidence_ids": evidence_ids},
+    )
+
+
+def _valid_graph_enrichment_receipt(
+    raw_receipt: Any,
+    *,
+    operation: MemoryOperation,
+    existing_item: MemoryItem,
+    control_state: MemoryControlState,
+    graph_plan: Optional[PromotionGraphPlan],
+) -> bool:
+    """Validate the persisted receipt before allowing a graph-only LTM mutation."""
+    if not isinstance(raw_receipt, dict) or graph_plan is None:
+        return False
+    if raw_receipt.get("schema_version") != "canonical_memory_graph_enrichment_receipt.v1":
+        return False
+    evidence_ids = raw_receipt.get("evidence_ids")
+    if not isinstance(evidence_ids, list) or not evidence_ids:
+        return False
+    if any(not isinstance(value, str) or not value.strip() for value in evidence_ids):
+        return False
+    normalized_evidence_ids = sorted(value.strip() for value in evidence_ids)
+    if len(normalized_evidence_ids) != len(set(normalized_evidence_ids)):
+        return False
+
+    def nonnegative_int(value: Any) -> bool:
+        return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+    receipt_id = raw_receipt.get("receipt_id")
+    uid = raw_receipt.get("uid")
+    memory_id = raw_receipt.get("memory_id")
+    content_hash = raw_receipt.get("content_hash")
+    plan_hash = raw_receipt.get("plan_hash")
+    item_revision = raw_receipt.get("item_revision")
+    account_generation = raw_receipt.get("account_generation")
+    source_generation = raw_receipt.get("source_generation")
+    if not all(
+        isinstance(value, str) and value.strip() for value in (receipt_id, uid, memory_id, content_hash, plan_hash)
+    ):
+        return False
+    if not all(nonnegative_int(value) for value in (item_revision, account_generation, source_generation)):
+        return False
+    expected_id = (
+        "ger_"
+        + deterministic_contract_id(
+            "canonical-memory-graph-enrichment-receipt",
+            {
+                "schema_version": raw_receipt["schema_version"],
+                "uid": uid,
+                "memory_id": memory_id,
+                "item_revision": item_revision,
+                "content_hash": content_hash,
+                "evidence_ids": normalized_evidence_ids,
+                "account_generation": account_generation,
+                "source_generation": source_generation,
+                "plan_hash": plan_hash,
+            },
+        )[:32]
+    )
+    return (
+        receipt_id == expected_id
+        and uid == operation.uid
+        and memory_id == existing_item.memory_id
+        and item_revision == existing_item.item_revision
+        and content_hash == existing_item.content_hash
+        and normalized_evidence_ids == sorted(record.evidence_id for record in existing_item.evidence)
+        and account_generation == control_state.account_generation
+        and source_generation == control_state.source_generation
+        and plan_hash == graph_plan.plan_hash
     )
 
 
@@ -619,6 +690,17 @@ def apply_long_term_patch_transaction(
             reason="observed head does not match current head",
         )
 
+    if (
+        operation.operation_type == MemoryOperationType.graph_enrichment
+        and patch.decision != DurablePatchDecision.update
+    ):
+        return ApplyResult(
+            status=ApplyStatus.invalid_patch,
+            control_state=control_state,
+            operation=operation,
+            reason="graph enrichment requires an update decision",
+        )
+
     if any(item.source_state != SourceState.active for item in evidence):
         return ApplyResult(
             status=ApplyStatus.source_not_active,
@@ -646,6 +728,7 @@ def apply_long_term_patch_transaction(
             outbox_events=outbox_events,
         )
     transitioning_to_long_term = False
+    graph_enrichment = False
     if patch.decision == DurablePatchDecision.update:
         if existing_item_raw is None:
             return ApplyResult(
@@ -678,6 +761,60 @@ def apply_long_term_patch_transaction(
                 operation=operation,
                 reason="update patch expected_content_hash mismatch",
             )
+        graph_enrichment = operation.operation_type == MemoryOperationType.graph_enrichment
+        if graph_enrichment:
+            raw_graph_plan = promotion_audit.get("graph_plan") if isinstance(promotion_audit, dict) else None
+            raw_receipt = promotion_audit.get("graph_enrichment_receipt") if isinstance(promotion_audit, dict) else None
+            try:
+                graph_plan = PromotionGraphPlan(**raw_graph_plan) if isinstance(raw_graph_plan, dict) else None
+            except Exception:
+                graph_plan = None
+            required_receipt_valid = not (existing_item.promotion or {}).get(
+                "required"
+            ) or valid_required_processing_receipt(
+                content=existing_item.content or "",
+                item_revision=existing_item.item_revision,
+                promotion=existing_item.promotion or {},
+            )
+            if not (
+                existing_item.status == MemoryItemStatus.active
+                and existing_item.tier == MemoryTier.long_term
+                and existing_item.processing_state == ProcessingState.processed
+                and not existing_item.graph_ready
+                and graph_plan is not None
+                and _valid_graph_enrichment_receipt(
+                    raw_receipt,
+                    operation=operation,
+                    existing_item=existing_item,
+                    control_state=control_state,
+                    graph_plan=graph_plan,
+                )
+                and required_receipt_valid
+                and not set(existing_item.sensitivity_labels).intersection(RESTRICTED_SENSITIVITY_LABELS)
+                and (existing_item.promotion or {}).get("user_review") is not False
+                and patch.target_tier is None
+                and patch.memory_text is None
+                and patch.target_visibility is None
+                and patch.target_user_asserted is None
+                and not patch.clear_graph_assertion
+                and not extra_item_updates
+                and promotion_metadata is None
+                and patch.result_status == LifecycleState.active
+                and not patch.supersedes
+                and graph_plan.subject_entity_id == existing_item.subject_entity_id
+                and patch.subject_entity_id == graph_plan.subject_entity_id
+                and patch.predicate == graph_plan.predicate == existing_item.predicate
+                and bool(_GRAPH_PREDICATE_RE.fullmatch(graph_plan.predicate))
+                and patch.arguments == graph_plan.arguments == existing_item.arguments
+                and sorted(record.evidence_id for record in evidence)
+                == sorted(record.evidence_id for record in existing_item.evidence)
+            ):
+                return ApplyResult(
+                    status=ApplyStatus.invalid_patch,
+                    control_state=control_state,
+                    operation=operation,
+                    reason="graph enrichment must attach one validated plan without changing Long-term semantics",
+                )
         if existing_item.tier == MemoryTier.long_term and existing_item.status == MemoryItemStatus.active:
             proposed_evidence = evidence or existing_item.evidence
             semantic_change = any(
@@ -691,7 +828,7 @@ def apply_long_term_patch_transaction(
                 )
             )
             explicit_short_term_demotion = patch.target_tier == MemoryTier.short_term and patch.clear_graph_assertion
-            if semantic_change and not explicit_short_term_demotion:
+            if semantic_change and not explicit_short_term_demotion and not graph_enrichment:
                 return ApplyResult(
                     status=ApplyStatus.invalid_patch,
                     control_state=control_state,
@@ -765,11 +902,15 @@ def apply_long_term_patch_transaction(
 
     memory_items = [memory_item]
     graph_assertions: List[MemoryGraphAssertion] = []
-    refresh_graph_assertion = transitioning_to_long_term or (
-        memory_item.tier == MemoryTier.long_term
-        and memory_item.status == MemoryItemStatus.active
-        and memory_item.graph_ready
-        and not patch.clear_graph_assertion
+    refresh_graph_assertion = (
+        transitioning_to_long_term
+        or graph_enrichment
+        or (
+            memory_item.tier == MemoryTier.long_term
+            and memory_item.status == MemoryItemStatus.active
+            and memory_item.graph_ready
+            and not patch.clear_graph_assertion
+        )
     )
     if refresh_graph_assertion:
         admission_metadata = memory_item.promotion or {}

--- a/backend/models/memory_operations.py
+++ b/backend/models/memory_operations.py
@@ -18,6 +18,7 @@ class MemoryOperationType(str, Enum):
     archive_transition = "archive_transition"
     projection_sync = "projection_sync"
     vector_sync = "vector_sync"
+    graph_enrichment = "graph_enrichment"
     deletion = "deletion"
 
 

--- a/backend/tests/unit/test_atomic_apply.py
+++ b/backend/tests/unit/test_atomic_apply.py
@@ -15,6 +15,7 @@ from models.memory_contracts import DurablePatchDecision, LifecycleState
 from models.memory_operations import MemoryOperation, MemoryOperationStatus, MemoryOperationType
 from models.memory_promotion import PromotionGraphPlan, build_promotion_admission_receipt
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
+from utils.memory.graph_enrichment import GraphEnrichmentStatus, prepare_graph_enrichment
 
 
 def _evidence():
@@ -396,6 +397,101 @@ def _short_term_existing(**overrides):
     )
     data.update(overrides)
     return MemoryItem(**data)
+
+
+def _long_term_graph_item(**overrides):
+    data = dict(
+        tier=MemoryTier.long_term,
+        expires_at=None,
+        ledger_commit_id="head0",
+        ledger_sequence=1,
+        source_commit_id="head0",
+        source_commit_sequence=1,
+        subject_entity_id="user",
+        predicate="prefers_update_style",
+        arguments={"style": "concise"},
+        graph_ready=False,
+        graph_assertion_id=None,
+        graph_plan_hash=None,
+        kg_extracted=False,
+    )
+    data.update(overrides)
+    return _short_term_existing(**data)
+
+
+def test_graph_enrichment_commits_one_fenced_assertion_without_changing_long_term_semantics():
+    control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+    existing = _long_term_graph_item()
+    plan = PromotionGraphPlan(
+        subject_entity_id="user",
+        predicate="prefers_update_style",
+        arguments={"style": "concise"},
+    )
+
+    planned = prepare_graph_enrichment(
+        item=existing,
+        plan=plan,
+        account_generation=1,
+        source_generation=2,
+        expected_item_revision=existing.item_revision,
+        expected_content_hash=existing.content_hash,
+        expected_evidence_ids=["ev1"],
+        observed_head_commit_id="head0",
+    )
+
+    assert planned.status == GraphEnrichmentStatus.ready
+    assert planned.operation is not None
+    patch_payload = {**planned.patch_payload, "evidence": existing.evidence}
+    result = apply_long_term_patch_transaction(
+        control_state=control,
+        operation=planned.operation,
+        patch_payload=patch_payload,
+    )
+
+    assert result.status == ApplyStatus.committed
+    assert result.memory_items[0].content == existing.content
+    assert result.memory_items[0].evidence == existing.evidence
+    assert result.memory_items[0].graph_ready is True
+    assert len(result.graph_assertions) == 1
+    assert result.graph_assertions[0].memory_id == existing.memory_id
+
+
+def test_graph_enrichment_rejects_a_plan_that_changes_existing_long_term_semantics():
+    control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+    existing = _long_term_graph_item()
+    planned = prepare_graph_enrichment(
+        item=existing,
+        plan=PromotionGraphPlan(
+            subject_entity_id="user",
+            predicate="prefers_update_style",
+            arguments={"style": "concise"},
+        ),
+        account_generation=1,
+        source_generation=2,
+        observed_head_commit_id="head0",
+    )
+    assert planned.operation is not None
+    tampered = dict(planned.patch_payload)
+    tampered["arguments"] = {"style": "verbose"}
+    tampered["mutation_metadata"] = build_patch_mutation_identity(tampered)
+    operation = MemoryOperation.new(
+        uid=planned.operation.uid,
+        operation_type=planned.operation.operation_type,
+        source_packet_id=planned.operation.source_packet_id,
+        target_memory_id=planned.operation.target_memory_id,
+        evidence_ids=planned.operation.evidence_ids,
+        logical_payload=planned.operation.logical_payload.model_copy(
+            update={"arguments": {"style": "verbose"}, "mutation_metadata": tampered["mutation_metadata"]}
+        ),
+        account_generation=planned.operation.account_generation,
+        source_generation=planned.operation.source_generation,
+        observed_head_commit_id=planned.operation.observed_head_commit_id,
+    )
+
+    result = apply_long_term_patch_transaction(control_state=control, operation=operation, patch_payload=tampered)
+
+    assert result.status == ApplyStatus.invalid_patch
+    assert result.graph_assertions == []
 
 
 def test_short_term_to_long_term_requires_synthesis_and_commits_structured_graph_assertion():

--- a/backend/utils/memory/graph_enrichment.py
+++ b/backend/utils/memory/graph_enrichment.py
@@ -226,12 +226,11 @@ def _assertion_matches_current_item(
 ) -> bool:
     if assertion is None:
         return False
-    if isinstance(assertion, dict):
-        value = assertion.get
-    else:
 
-        def value(key: str, default: Any = None) -> Any:
-            return getattr(assertion, key, default)
+    def value(key: str, default: Any = None) -> Any:
+        if isinstance(assertion, dict):
+            return assertion.get(key, default)
+        return getattr(assertion, key, default)
 
     return (
         value("status", "active") == "active"

--- a/backend/utils/memory/graph_enrichment.py
+++ b/backend/utils/memory/graph_enrichment.py
@@ -1,0 +1,405 @@
+"""Canonical-apply-only graph enrichment contracts.
+
+Planning may happen outside this module (including an LLM), but this module
+accepts only a typed plan and an authoritative ``MemoryItem`` snapshot.  It
+never writes graph documents directly and never parses model output.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from models.memory_apply import build_patch_mutation_identity
+from models.memory_admission import valid_required_processing_receipt
+from models.memory_contracts import DurablePatchDecision, LifecycleState, deterministic_contract_id
+from models.memory_operations import MemoryOperation, MemoryOperationType
+from models.memory_promotion import PROMOTION_GRAPH_PLAN_VERSION, PromotionGraphPlan
+from models.memory_promotion import MemoryGraphAssertion
+from models.memory_evidence import SourceState
+from models.product_memory import (
+    RESTRICTED_SENSITIVITY_LABELS,
+    MemoryItem,
+    MemoryItemStatus,
+    MemoryTier,
+    ProcessingState,
+)
+
+SNAKE_CASE_PREDICATE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+GRAPH_ENRICHMENT_PLAN_VERSION = "canonical_memory_graph_enrichment_plan.v1"
+GRAPH_ENRICHMENT_RECEIPT_VERSION = "canonical_memory_graph_enrichment_receipt.v1"
+
+
+class GraphEnrichmentError(ValueError):
+    """Typed validation failure; no apply should be attempted."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class GraphEnrichmentStatus(str, Enum):
+    ready = "ready"
+    already_enriched = "already_enriched"
+    blocked = "blocked"
+
+
+class GraphEnrichmentPlan(BaseModel):
+    """Server-validated deterministic graph plan, not a raw LLM response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["canonical_memory_graph_enrichment_plan.v1"] = GRAPH_ENRICHMENT_PLAN_VERSION
+    subject_entity_id: str
+    predicate: str
+    arguments: Dict[str, Any]
+    plan_hash: str = ""
+
+    @field_validator("subject_entity_id")
+    @classmethod
+    def validate_subject(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("graph enrichment subject must not be blank")
+        return value.strip()
+
+    @field_validator("predicate")
+    @classmethod
+    def validate_predicate(cls, value: str) -> str:
+        value = value.strip()
+        if not SNAKE_CASE_PREDICATE.fullmatch(value):
+            raise ValueError("graph enrichment predicate must be lower snake_case")
+        return value
+
+    @model_validator(mode="after")
+    def normalize_and_hash(self) -> "GraphEnrichmentPlan":
+        try:
+            validated = PromotionGraphPlan(
+                schema_version=PROMOTION_GRAPH_PLAN_VERSION,
+                subject_entity_id=self.subject_entity_id,
+                predicate=self.predicate,
+                arguments=self.arguments,
+            )
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+        self.arguments = validated.arguments
+        # The canonical assertion builder consumes ``PromotionGraphPlan``;
+        # share its hash namespace so the receipt, item promotion, and final
+        # assertion all bind to one deterministic plan identity.
+        expected = validated.plan_hash
+        if self.plan_hash and self.plan_hash != expected:
+            raise ValueError("graph enrichment plan hash mismatch")
+        self.plan_hash = expected
+        return self
+
+    def promotion_plan(self) -> PromotionGraphPlan:
+        return PromotionGraphPlan(
+            subject_entity_id=self.subject_entity_id,
+            predicate=self.predicate,
+            arguments=self.arguments,
+        )
+
+
+class GraphEnrichmentReceipt(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["canonical_memory_graph_enrichment_receipt.v1"] = GRAPH_ENRICHMENT_RECEIPT_VERSION
+    receipt_id: str = ""
+    uid: str
+    memory_id: str
+    item_revision: int
+    content_hash: str
+    evidence_ids: List[str]
+    account_generation: int
+    source_generation: int
+    plan_hash: str
+
+    @field_validator("uid", "memory_id", "content_hash", "plan_hash")
+    @classmethod
+    def validate_identity(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("graph enrichment receipt identity must not be blank")
+        return value.strip()
+
+    @field_validator("item_revision", "account_generation", "source_generation")
+    @classmethod
+    def validate_counters(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("graph enrichment receipt counters must be nonnegative")
+        return value
+
+    @field_validator("evidence_ids")
+    @classmethod
+    def normalize_evidence(cls, value: List[str]) -> List[str]:
+        normalized = sorted({item.strip() for item in value if item and item.strip()})
+        if not normalized:
+            raise ValueError("graph enrichment receipt requires evidence")
+        return normalized
+
+    @model_validator(mode="after")
+    def derive_receipt_id(self) -> "GraphEnrichmentReceipt":
+        expected = (
+            "ger_"
+            + deterministic_contract_id(
+                "canonical-memory-graph-enrichment-receipt",
+                {
+                    "schema_version": self.schema_version,
+                    "uid": self.uid,
+                    "memory_id": self.memory_id,
+                    "item_revision": self.item_revision,
+                    "content_hash": self.content_hash,
+                    "evidence_ids": self.evidence_ids,
+                    "account_generation": self.account_generation,
+                    "source_generation": self.source_generation,
+                    "plan_hash": self.plan_hash,
+                },
+            )[:32]
+        )
+        if self.receipt_id and self.receipt_id != expected:
+            raise ValueError("graph enrichment receipt id mismatch")
+        self.receipt_id = expected
+        return self
+
+
+class GraphEnrichmentResult(BaseModel):
+    status: GraphEnrichmentStatus
+    plan: Optional[GraphEnrichmentPlan] = None
+    receipt: Optional[GraphEnrichmentReceipt] = None
+    operation: Optional[MemoryOperation] = None
+    patch_payload: Dict[str, Any] = Field(default_factory=dict)
+    block_code: Optional[str] = None
+    reason: Optional[str] = None
+
+
+def _blocked(code: str, reason: str) -> GraphEnrichmentResult:
+    return GraphEnrichmentResult(status=GraphEnrichmentStatus.blocked, block_code=code, reason=reason)
+
+
+def _coerce_plan(plan: GraphEnrichmentPlan | PromotionGraphPlan | Dict[str, Any]) -> GraphEnrichmentPlan:
+    if isinstance(plan, GraphEnrichmentPlan):
+        return plan
+    if isinstance(plan, PromotionGraphPlan):
+        return GraphEnrichmentPlan(
+            subject_entity_id=plan.subject_entity_id,
+            predicate=plan.predicate,
+            arguments=plan.arguments,
+        )
+    try:
+        return GraphEnrichmentPlan.model_validate(plan)
+    except Exception as exc:
+        raise GraphEnrichmentError("graph_plan_invalid", "graph enrichment plan is malformed") from exc
+
+
+def _current_evidence_ids(item: MemoryItem) -> List[str]:
+    evidence = item.evidence
+    if not evidence:
+        raise GraphEnrichmentError("evidence_missing", "graph enrichment requires at least one evidence record")
+    ids: List[str] = []
+    active_count = 0
+    for record in evidence:
+        evidence_id = getattr(record, "evidence_id", None)
+        if not isinstance(evidence_id, str) or not evidence_id.strip():
+            raise GraphEnrichmentError("evidence_malformed", "graph enrichment evidence identity is malformed")
+        evidence_id = evidence_id.strip()
+        if evidence_id in ids:
+            raise GraphEnrichmentError("duplicate_evidence", "graph enrichment evidence ids must be unique")
+        ids.append(evidence_id)
+        if getattr(record, "source_state", None) == SourceState.active:
+            active_count += 1
+    if active_count != len(evidence):
+        raise GraphEnrichmentError("evidence_not_active", "graph enrichment requires active evidence")
+    return sorted(ids)
+
+
+def _normalize_expected_evidence_ids(values: object) -> Optional[List[str]]:
+    """Return a validated evidence fence while retaining a runtime trust boundary."""
+    if not isinstance(values, list) or any(not isinstance(value, str) or not value.strip() for value in values):
+        return None
+    return sorted({value.strip() for value in values if isinstance(value, str)})
+
+
+def _assertion_matches_current_item(
+    *, item: MemoryItem, assertion: Any, evidence_ids: List[str], plan: GraphEnrichmentPlan
+) -> bool:
+    if assertion is None:
+        return False
+    if isinstance(assertion, dict):
+        value = assertion.get
+    else:
+
+        def value(key: str, default: Any = None) -> Any:
+            return getattr(assertion, key, default)
+
+    return (
+        value("status", "active") == "active"
+        and value("uid") == item.uid
+        and value("memory_id") == item.memory_id
+        and value("assertion_id") == item.graph_assertion_id
+        and value("item_revision") == item.item_revision
+        and value("content_hash") == item.content_hash
+        and sorted(set(value("evidence_ids", []) or [])) == evidence_ids
+        and value("graph_plan_hash") == plan.plan_hash
+        and value("subject_entity_id") == plan.subject_entity_id
+        and value("predicate") == plan.predicate
+        and value("arguments") == plan.arguments
+    )
+
+
+def prepare_graph_enrichment(
+    *,
+    item: MemoryItem,
+    plan: GraphEnrichmentPlan | PromotionGraphPlan | Dict[str, Any],
+    account_generation: int,
+    source_generation: int,
+    expected_item_revision: Optional[int] = None,
+    expected_content_hash: Optional[str] = None,
+    expected_evidence_ids: Optional[List[str]] = None,
+    observed_head_commit_id: Optional[str] = None,
+    existing_graph_assertion: Optional[MemoryGraphAssertion | Dict[str, Any]] = None,
+) -> GraphEnrichmentResult:
+    """Validate a graph plan and build a canonical apply operation/payload.
+
+    This function is pure.  A caller must submit the returned operation and
+    payload to ``apply_long_term_patch_firestore``; writing an assertion or
+    mutating a ``MemoryItem`` directly is intentionally unsupported.
+    """
+    if (
+        item.status != MemoryItemStatus.active
+        or item.tier != MemoryTier.long_term
+        or item.source_state != SourceState.active
+    ):
+        return _blocked("target_not_active_long_term", "graph enrichment requires an active Long-term item")
+    if item.processing_state != ProcessingState.processed:
+        return _blocked("processing_not_complete", "graph enrichment requires processing_state=processed")
+    if item.sensitivity_labels and set(item.sensitivity_labels).intersection(RESTRICTED_SENSITIVITY_LABELS):
+        return _blocked("restricted_item", "restricted memory items cannot be graph enriched")
+    if (item.promotion or {}).get("user_review") is False:
+        return _blocked("review_rejected", "review-rejected memory items cannot be graph enriched")
+    promotion = item.promotion or {}
+    if promotion.get("required") and not valid_required_processing_receipt(
+        content=item.content or "", item_revision=item.item_revision, promotion=promotion
+    ):
+        return _blocked(
+            "missing_required_processing_receipt",
+            "required processing receipt is missing or stale; graph enrichment cannot fabricate one",
+        )
+    if expected_item_revision is not None and item.item_revision != expected_item_revision:
+        return _blocked("stale_fence", "item revision fence does not match current item")
+    if expected_content_hash is not None and item.content_hash != expected_content_hash:
+        return _blocked("stale_fence", "content hash fence does not match current item")
+    if not item.content_hash or not item.content_hash.strip():
+        return _blocked("content_hash_missing", "graph enrichment requires a current content hash")
+    try:
+        evidence_ids = _current_evidence_ids(item)
+    except GraphEnrichmentError as exc:
+        return _blocked(exc.code, exc.message)
+    if expected_evidence_ids is not None:
+        normalized_expected_evidence_ids = _normalize_expected_evidence_ids(expected_evidence_ids)
+        if normalized_expected_evidence_ids is None:
+            return _blocked("stale_fence", "evidence fence is malformed")
+        if evidence_ids != normalized_expected_evidence_ids:
+            return _blocked("stale_fence", "evidence fence does not match current item")
+    if item.account_generation != account_generation:
+        return _blocked("stale_fence", "account generation fence does not match current item")
+    try:
+        checked_plan = _coerce_plan(plan)
+    except GraphEnrichmentError as exc:
+        return _blocked(exc.code, exc.message)
+    if item.graph_ready:
+        try:
+            current_plan = _coerce_plan((item.promotion or {}).get("graph_plan", {}))
+        except GraphEnrichmentError:
+            return _blocked("graph_assertion_invalid", "graph_ready item has no valid current graph plan")
+        if current_plan.plan_hash != checked_plan.plan_hash or not _assertion_matches_current_item(
+            item=item, assertion=existing_graph_assertion, evidence_ids=evidence_ids, plan=current_plan
+        ):
+            return _blocked("graph_assertion_invalid", "graph_ready item lacks an exact current graph assertion")
+        return GraphEnrichmentResult(status=GraphEnrichmentStatus.already_enriched, plan=current_plan)
+    if not item.subject_entity_id or checked_plan.subject_entity_id != item.subject_entity_id:
+        return _blocked("subject_overwrite", "graph enrichment cannot overwrite or invent the existing subject")
+    receipt = GraphEnrichmentReceipt(
+        uid=item.uid,
+        memory_id=item.memory_id,
+        item_revision=item.item_revision,
+        content_hash=item.content_hash or "",
+        evidence_ids=evidence_ids,
+        account_generation=account_generation,
+        source_generation=source_generation,
+        plan_hash=checked_plan.plan_hash,
+    )
+    promotion = dict(item.promotion or {})
+    promotion.update(
+        {
+            "graph_plan": checked_plan.promotion_plan().model_dump(mode="json"),
+            "graph_enrichment_receipt": receipt.model_dump(mode="json"),
+            "graph_enrichment": True,
+        }
+    )
+    patch_payload: Dict[str, Any] = {
+        "patch_id": f"patch_{receipt.receipt_id}",
+        "packet_id": f"graph_enrichment:{item.memory_id}:{item.item_revision}",
+        "run_id": f"graph_enrichment:{receipt.receipt_id}",
+        "observed_head_commit_id": observed_head_commit_id,
+        "idempotency_key": receipt.receipt_id,
+        "decision": DurablePatchDecision.update.value,
+        "result_status": LifecycleState.active.value,
+        "target_memory_id": item.memory_id,
+        "evidence_ids": evidence_ids,
+        "subject_entity_id": checked_plan.subject_entity_id,
+        "predicate": checked_plan.predicate,
+        "arguments": checked_plan.arguments,
+        "existing_item": item.model_dump(mode="python"),
+        "expected_item_revision": item.item_revision,
+        "expected_content_hash": item.content_hash,
+        "promotion_audit": promotion,
+        "mutation_metadata": {},
+    }
+    patch_payload["mutation_metadata"] = build_patch_mutation_identity(patch_payload)
+    logical_payload = {
+        "decision": DurablePatchDecision.update.value,
+        "target_memory_id": item.memory_id,
+        "result_status": LifecycleState.active.value,
+        "subject_entity_id": checked_plan.subject_entity_id,
+        "predicate": checked_plan.predicate,
+        "arguments": checked_plan.arguments,
+        "mutation_metadata": patch_payload["mutation_metadata"],
+    }
+    operation = MemoryOperation.new(
+        uid=item.uid,
+        operation_type=MemoryOperationType.graph_enrichment,
+        source_packet_id=patch_payload["packet_id"],
+        target_memory_id=item.memory_id,
+        evidence_ids=evidence_ids,
+        logical_payload=logical_payload,
+        account_generation=account_generation,
+        source_generation=source_generation,
+        observed_head_commit_id=observed_head_commit_id,
+    )
+    return GraphEnrichmentResult(
+        status=GraphEnrichmentStatus.ready,
+        plan=checked_plan,
+        receipt=receipt,
+        operation=operation,
+        patch_payload=patch_payload,
+    )
+
+
+def validate_graph_enrichment(**kwargs: Any) -> GraphEnrichmentResult:
+    return prepare_graph_enrichment(**kwargs)
+
+
+__all__ = [
+    "GRAPH_ENRICHMENT_PLAN_VERSION",
+    "GRAPH_ENRICHMENT_RECEIPT_VERSION",
+    "GraphEnrichmentError",
+    "GraphEnrichmentPlan",
+    "GraphEnrichmentReceipt",
+    "GraphEnrichmentResult",
+    "GraphEnrichmentStatus",
+    "SNAKE_CASE_PREDICATE",
+    "prepare_graph_enrichment",
+    "validate_graph_enrichment",
+]


### PR DESCRIPTION
## What changed

Adds a graph-enrichment operation that attaches a version-, evidence-, and generation-fenced canonical graph assertion to eligible Long-term memories through the existing atomic apply ledger.

## Why

Historical canonical rows can predate the assertion contract. This creates the safe write boundary needed to enrich only already-established memory semantics without using synthetic graph nodes or direct graph writes.

## User impact

Enables a future bounded enrichment worker to restore connected, evidence-backed canonical graph records for historical memories.

## Validation

- `backend/.venv/bin/pytest -q backend/tests/unit/test_atomic_apply.py backend/tests/unit/test_knowledge_graph_canonical_pagination.py`
- `pre-commit run ruff --files backend/models/memory_apply.py backend/models/memory_operations.py backend/utils/memory/graph_enrichment.py backend/tests/unit/test_atomic_apply.py`

## Product invariants affected

- INV-MEM-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

