### PR TITLE
fix(app): stall watchdog for zombie Listening on BLE live capture (#6977)

### DIFF
--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -91,8 +91,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 (SharedPreferencesUtil().batchModeEnabled && provider.havingRecordingDevice)) {
               return;
             }
-            final isCaptureActive =
-                provider.recordingState == RecordingState.record ||
+            final isCaptureActive = provider.recordingState == RecordingState.record ||
                 provider.recordingState == RecordingState.systemAudioRecord ||
                 provider.recordingState == RecordingState.deviceRecord ||
                 provider.recordingState == RecordingState.initialising ||
@@ -191,8 +190,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     bool isHavingDesireDevice = SharedPreferencesUtil().btDevice.id.isNotEmpty;
     bool isHavingRecordingDevice = captureProvider.havingRecordingDevice;
 
-    bool isUsingPhoneMic =
-        captureProvider.recordingState == RecordingState.record ||
+    bool isUsingPhoneMic = captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.initialising ||
         captureProvider.recordingState == RecordingState.pause ||
         captureProvider.recordingState == RecordingState.interrupted;
@@ -200,8 +198,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     // Check if any recording is active (phone mic, system audio, or device recording).
     // `interrupted` is included so the in-session UI stays visible while the
     // pipeline is transiently broken (e.g., iOS audio session interruption).
-    bool isAnyRecordingActive =
-        captureProvider.recordingState == RecordingState.record ||
+    bool isAnyRecordingActive = captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.systemAudioRecord ||
         captureProvider.recordingState == RecordingState.deviceRecord ||
         captureProvider.recordingState == RecordingState.initialising ||
@@ -342,8 +339,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
   }
 
   Widget _buildUnifiedRecordingUI(CaptureProvider provider, Widget? header) {
-    bool isDeviceRecording =
-        provider.havingRecordingDevice &&
+    bool isDeviceRecording = provider.havingRecordingDevice &&
         (provider.recordingState == RecordingState.deviceRecord || provider.recordingState == RecordingState.pause);
 
     // Offline/batch mode: device or phone-mic audio is saved locally with no live
@@ -355,8 +351,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
 
     // A phone-mic batch session reports RecordingState.record too; exclude it here so
     // the Live "Listening" card never renders for it (it is handled above).
-    bool isPhoneRecording =
-        !provider.isPhoneMicBatchRecording &&
+    bool isPhoneRecording = !provider.isPhoneMicBatchRecording &&
         (provider.recordingState == RecordingState.record ||
             provider.recordingState == RecordingState.systemAudioRecord ||
             provider.recordingState == RecordingState.initialising ||
@@ -384,14 +379,14 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     String statusText = isAudioInterrupted
         ? context.l10n.paused
         : isPaused
-        ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
-        : hasTerminalTranscriptionFailure
-        ? context.l10n.transcriptionUnavailable
-        : provider.isTranscriptStalled
-        ? context.l10n.transcriptionPausedReconnecting
-        : hasPhotos
-        ? 'Capturing'
-        : context.l10n.listening;
+            ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
+            : hasTerminalTranscriptionFailure
+                ? context.l10n.transcriptionUnavailable
+                : provider.isTranscriptStalled
+                    ? context.l10n.transcriptionPausedReconnecting
+                    : hasPhotos
+                        ? 'Capturing'
+                        : context.l10n.listening;
 
     // When recording is active, show the unified UI design
     if (isDeviceRecording || isPhoneRecording) {
@@ -505,22 +500,22 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 decoration: BoxDecoration(
                   color: isPaused
                       ? isDeviceRecording
-                            ? const Color(0xFFFE5D50)
-                            : const Color(0xFF7C3AED)
+                          ? const Color(0xFFFE5D50)
+                          : const Color(0xFF7C3AED)
                       : isDeviceRecording
-                      ? const Color(0xFF35343B)
-                      : const Color(0xFFFF9500),
+                          ? const Color(0xFF35343B)
+                          : const Color(0xFFFF9500),
                   shape: BoxShape.circle,
                 ),
                 child: Center(
                   child: FaIcon(
                     isPaused
                         ? isDeviceRecording
-                              ? FontAwesomeIcons.microphoneSlash
-                              : FontAwesomeIcons.play
+                            ? FontAwesomeIcons.microphoneSlash
+                            : FontAwesomeIcons.play
                         : isDeviceRecording
-                        ? FontAwesomeIcons.microphone
-                        : FontAwesomeIcons.pause,
+                            ? FontAwesomeIcons.microphone
+                            : FontAwesomeIcons.pause,
                     color: Colors.white,
                     size: 12,
                   ),
@@ -608,8 +603,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                       storageFull
                           ? context.l10n.paused
                           : muted
-                          ? context.l10n.muted
-                          : context.l10n.recording,
+                              ? context.l10n.muted
+                              : context.l10n.recording,
                       style: const TextStyle(color: Color(0xFFC9CBCF), fontSize: 14, fontWeight: FontWeight.w500),
                     ),
                   ],
@@ -633,8 +628,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
             isPendant
                 ? (prefs.pendantDraining ? context.l10n.pendantSyncingRecordings : context.l10n.pendantRecordingNote)
                 : storageFull
-                ? context.l10n.transcribeLaterStorageFull
-                : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
+                    ? context.l10n.transcribeLaterStorageFull
+                    : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
             style: TextStyle(color: Colors.grey.shade400, fontSize: 13, height: 1.35),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -91,7 +91,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 (SharedPreferencesUtil().batchModeEnabled && provider.havingRecordingDevice)) {
               return;
             }
-            final isCaptureActive = provider.recordingState == RecordingState.record ||
+            final isCaptureActive =
+                provider.recordingState == RecordingState.record ||
                 provider.recordingState == RecordingState.systemAudioRecord ||
                 provider.recordingState == RecordingState.deviceRecord ||
                 provider.recordingState == RecordingState.initialising ||
@@ -190,7 +191,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     bool isHavingDesireDevice = SharedPreferencesUtil().btDevice.id.isNotEmpty;
     bool isHavingRecordingDevice = captureProvider.havingRecordingDevice;
 
-    bool isUsingPhoneMic = captureProvider.recordingState == RecordingState.record ||
+    bool isUsingPhoneMic =
+        captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.initialising ||
         captureProvider.recordingState == RecordingState.pause ||
         captureProvider.recordingState == RecordingState.interrupted;
@@ -198,7 +200,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     // Check if any recording is active (phone mic, system audio, or device recording).
     // `interrupted` is included so the in-session UI stays visible while the
     // pipeline is transiently broken (e.g., iOS audio session interruption).
-    bool isAnyRecordingActive = captureProvider.recordingState == RecordingState.record ||
+    bool isAnyRecordingActive =
+        captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.systemAudioRecord ||
         captureProvider.recordingState == RecordingState.deviceRecord ||
         captureProvider.recordingState == RecordingState.initialising ||
@@ -285,6 +288,11 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
         // explicitly said live STT is unavailable. Do not claim "Listening".
         stateText = context.l10n.transcriptionUnavailable;
         statusIndicator = const PausedStatusIndicator();
+      } else if (captureProvider.isTranscriptStalled) {
+        // #6977: do not leave the UI in indefinite "Listening" when transcript
+        // progress has stalled despite an apparently-connected socket.
+        stateText = context.l10n.transcriptionPausedReconnecting;
+        statusIndicator = const PausedStatusIndicator();
       } else {
         // Show "Listening" for all active recording states — WAL ensures audio is
         // saved locally regardless of transcription connection status.
@@ -334,7 +342,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
   }
 
   Widget _buildUnifiedRecordingUI(CaptureProvider provider, Widget? header) {
-    bool isDeviceRecording = provider.havingRecordingDevice &&
+    bool isDeviceRecording =
+        provider.havingRecordingDevice &&
         (provider.recordingState == RecordingState.deviceRecord || provider.recordingState == RecordingState.pause);
 
     // Offline/batch mode: device or phone-mic audio is saved locally with no live
@@ -346,7 +355,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
 
     // A phone-mic batch session reports RecordingState.record too; exclude it here so
     // the Live "Listening" card never renders for it (it is handled above).
-    bool isPhoneRecording = !provider.isPhoneMicBatchRecording &&
+    bool isPhoneRecording =
+        !provider.isPhoneMicBatchRecording &&
         (provider.recordingState == RecordingState.record ||
             provider.recordingState == RecordingState.systemAudioRecord ||
             provider.recordingState == RecordingState.initialising ||
@@ -369,15 +379,19 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     bool hasPhotos = provider.photos.isNotEmpty;
     // Show "Listening" for all active recording states — WAL ensures audio is
     // saved locally regardless of transcription connection status.
+    // Pause / mute / audio-interrupt outrank stall so an explicit user action
+    // never briefly shows "reconnecting" (cubic #6977).
     String statusText = isAudioInterrupted
         ? context.l10n.paused
         : isPaused
-            ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
-            : hasTerminalTranscriptionFailure
-                ? context.l10n.transcriptionUnavailable
-                : hasPhotos
-                    ? 'Capturing'
-                    : context.l10n.listening;
+        ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
+        : hasTerminalTranscriptionFailure
+        ? context.l10n.transcriptionUnavailable
+        : provider.isTranscriptStalled
+        ? context.l10n.transcriptionPausedReconnecting
+        : hasPhotos
+        ? 'Capturing'
+        : context.l10n.listening;
 
     // When recording is active, show the unified UI design
     if (isDeviceRecording || isPhoneRecording) {
@@ -491,22 +505,22 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 decoration: BoxDecoration(
                   color: isPaused
                       ? isDeviceRecording
-                          ? const Color(0xFFFE5D50)
-                          : const Color(0xFF7C3AED)
+                            ? const Color(0xFFFE5D50)
+                            : const Color(0xFF7C3AED)
                       : isDeviceRecording
-                          ? const Color(0xFF35343B)
-                          : const Color(0xFFFF9500),
+                      ? const Color(0xFF35343B)
+                      : const Color(0xFFFF9500),
                   shape: BoxShape.circle,
                 ),
                 child: Center(
                   child: FaIcon(
                     isPaused
                         ? isDeviceRecording
-                            ? FontAwesomeIcons.microphoneSlash
-                            : FontAwesomeIcons.play
+                              ? FontAwesomeIcons.microphoneSlash
+                              : FontAwesomeIcons.play
                         : isDeviceRecording
-                            ? FontAwesomeIcons.microphone
-                            : FontAwesomeIcons.pause,
+                        ? FontAwesomeIcons.microphone
+                        : FontAwesomeIcons.pause,
                     color: Colors.white,
                     size: 12,
                   ),
@@ -594,8 +608,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                       storageFull
                           ? context.l10n.paused
                           : muted
-                              ? context.l10n.muted
-                              : context.l10n.recording,
+                          ? context.l10n.muted
+                          : context.l10n.recording,
                       style: const TextStyle(color: Color(0xFFC9CBCF), fontSize: 14, fontWeight: FontWeight.w500),
                     ),
                   ],
@@ -619,8 +633,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
             isPendant
                 ? (prefs.pendantDraining ? context.l10n.pendantSyncingRecordings : context.l10n.pendantRecordingNote)
                 : storageFull
-                    ? context.l10n.transcribeLaterStorageFull
-                    : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
+                ? context.l10n.transcribeLaterStorageFull
+                : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
             style: TextStyle(color: Colors.grey.shade400, fontSize: 13, height: 1.35),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -165,7 +165,7 @@ class CaptureController extends ChangeNotifier
   }
 
   CaptureController({CaptureExternalActions? externalActions})
-    : externalActions = externalActions ?? const NoopCaptureExternalActions() {
+      : externalActions = externalActions ?? const NoopCaptureExternalActions() {
     // Restore a persisted device mute so it survives an app kill/restart. When
     // the device reconnects, streamDeviceRecording() reads _isPaused as
     // `wasPaused` and re-applies the mute instead of silently resuming.
@@ -226,30 +226,30 @@ class CaptureController extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().phoneMic.start(
-      onByteReceived: (bytes) {
-        final frames = _activeSource?.processBytes(bytes) ?? [];
-        for (final frame in frames) {
-          _wal.getSyncs().phone.onFrameCaptured(frame);
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(frame.payload);
-            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-          }
-        }
-      },
-      onRecording: () {
-        updateRecordingState(RecordingState.record);
-      },
-      onStop: () {
-        if (!_micInterrupted) {
-          updateRecordingState(RecordingState.stop);
-        }
-      },
-      onInitializing: () {
-        updateRecordingState(RecordingState.initialising);
-      },
-      onStalled: _onMicStalled,
-      onInterruption: _onMicInterruption,
-    );
+          onByteReceived: (bytes) {
+            final frames = _activeSource?.processBytes(bytes) ?? [];
+            for (final frame in frames) {
+              _wal.getSyncs().phone.onFrameCaptured(frame);
+              if (_socket?.state == SocketServiceState.connected) {
+                _socket?.send(frame.payload);
+                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+              }
+            }
+          },
+          onRecording: () {
+            updateRecordingState(RecordingState.record);
+          },
+          onStop: () {
+            if (!_micInterrupted) {
+              updateRecordingState(RecordingState.stop);
+            }
+          },
+          onInitializing: () {
+            updateRecordingState(RecordingState.initialising);
+          },
+          onStalled: _onMicStalled,
+          onInterruption: _onMicInterruption,
+        );
   }
 
   void _onMicStalled() {
@@ -668,9 +668,8 @@ class CaptureController extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    String language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -684,13 +683,13 @@ class CaptureController extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-      codec: codec,
-      sampleRate: sampleRate,
-      language: language,
-      force: force,
-      source: source,
-      customSttConfig: effectiveConfig,
-    );
+          codec: codec,
+          sampleRate: sampleRate,
+          language: language,
+          force: force,
+          source: source,
+          customSttConfig: effectiveConfig,
+        );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -807,24 +806,20 @@ class CaptureController extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error resuming device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              resumeDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error resuming device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error pausing device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              pauseDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error pausing device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -920,8 +915,7 @@ class CaptureController extends ChangeNotifier
         // .bin files, so the Dart WAL writer must stay off to avoid double-writes.
         // #6977: keep phone WAL always-on for supported BLE device audio so a
         // stale "connected" socket cannot drop the middle of a session.
-        var checkWalSupported =
-            !SharedPreferencesUtil().batchModeEnabled &&
+        var checkWalSupported = !SharedPreferencesUtil().batchModeEnabled &&
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported();
         if (checkWalSupported != _isWalSupported) {
@@ -1034,9 +1028,8 @@ class CaptureController extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    var language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1405,33 +1398,33 @@ class CaptureController extends ChangeNotifier
     // record
     try {
       await ServiceManager.instance().phoneMic.start(
-        onByteReceived: (bytes) {
-          // Process through AudioSource for frame splitting and sync key generation
-          final frames = _activeSource?.processBytes(bytes) ?? [];
+            onByteReceived: (bytes) {
+              // Process through AudioSource for frame splitting and sync key generation
+              final frames = _activeSource?.processBytes(bytes) ?? [];
 
-          for (final frame in frames) {
-            _wal.getSyncs().phone.onFrameCaptured(frame);
+              for (final frame in frames) {
+                _wal.getSyncs().phone.onFrameCaptured(frame);
 
-            if (_socket?.state == SocketServiceState.connected) {
-              _socket?.send(frame.payload);
-              _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-            }
-          }
-        },
-        onRecording: () {
-          updateRecordingState(RecordingState.record);
-        },
-        onStop: () {
-          if (!_micInterrupted) {
-            updateRecordingState(RecordingState.stop);
-          }
-        },
-        onInitializing: () {
-          updateRecordingState(RecordingState.initialising);
-        },
-        onStalled: _onMicStalled,
-        onInterruption: _onMicInterruption,
-      );
+                if (_socket?.state == SocketServiceState.connected) {
+                  _socket?.send(frame.payload);
+                  _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+                }
+              }
+            },
+            onRecording: () {
+              updateRecordingState(RecordingState.record);
+            },
+            onStop: () {
+              if (!_micInterrupted) {
+                updateRecordingState(RecordingState.stop);
+              }
+            },
+            onInitializing: () {
+              updateRecordingState(RecordingState.initialising);
+            },
+            onStalled: _onMicStalled,
+            onInterruption: _onMicInterruption,
+          );
     } catch (e, st) {
       // Typed native failures (permission_denied, engine_start_failed, ...) or
       // mic contention — fail visibly instead of recording silence.
@@ -1548,8 +1541,7 @@ class CaptureController extends ChangeNotifier
   }
 
   void _evaluateTranscriptStall() {
-    final monitoringActive =
-        _transcriptServiceReady &&
+    final monitoringActive = _transcriptServiceReady &&
         recordingState == RecordingState.deviceRecord &&
         !_isPaused &&
         _terminalTranscriptionFailure == null &&

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -697,6 +697,13 @@ class CaptureController extends ChangeNotifier
     }
     _socket?.subscribe(this, this);
     _transcriptServiceReady = true;
+    // Start the stall watchdog here — not only from onConnected(). PureSocket
+    // calls onConnected() synchronously inside connect(), before this subscribe
+    // runs, so the listener map is empty on first connect and a watchdog started
+    // only from onConnected never arms for a fresh BLE session (#6977 / cubic).
+    if (recordingState == RecordingState.deviceRecord) {
+      _startTranscriptStallWatchdog();
+    }
     if (_sessionStartSeconds == 0) {
       _sessionStartSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     }
@@ -1640,7 +1647,19 @@ class CaptureController extends ChangeNotifier
   void onClosed([int? closeCode]) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
-    _clearTranscriptStallState();
+
+    // Watchdog-triggered restart: keep isTranscriptStalled true so the UI stays
+    // on "reconnecting" until onConnected / real transcript progress clears it.
+    // Full clear here would flash Listening between stop() and the next socket.
+    if (shouldPreserveTranscriptStallAcrossSocketClose(
+      stallRestartInFlight: _transcriptStallRestartInFlight,
+    )) {
+      _lastTranscriptProgressAt = null;
+      _secondsSinceLastTranscriptProgress = 0;
+      _stopTranscriptStallWatchdog();
+    } else {
+      _clearTranscriptStallState();
+    }
 
     if (closeCode == 4002) {
       externalActions.markAsOutOfCreditsAndRefresh();

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1725,7 +1725,11 @@ class CaptureController extends ChangeNotifier
     _transcriptServiceReady = true;
     _transcriptStalled = false;
     _transcriptStallRestartInFlight = false;
-    _lastTranscriptProgressAt = DateTime.now();
+    // Do NOT seed _lastTranscriptProgressAt here — a fresh socket connection is
+    // not transcript progress. Seeding it let shouldMarkFramesSyncedAfterSocketSend
+    // mark WAL frames "synced" for ~10s after every reconnect purely because the
+    // socket opened, before any transcription had actually happened; leave it
+    // null (cleared by onClosed/onError) until real progress arrives.
     _secondsSinceLastTranscriptProgress = 0;
     _startTranscriptStallWatchdog();
     // Restart mic on reconnect if interrupted (skip during active call).
@@ -2306,6 +2310,9 @@ class CaptureController extends ChangeNotifier
     await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
     await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
     _isPaused = true;
+    // Clear immediately — otherwise a stale "reconnecting" state can outlive
+    // the pause by up to one watchdog tick and outrank the Paused/Muted text.
+    _clearTranscriptStallState(keepWatchdog: true);
     // Persist so the mute survives an app kill/restart, not just a reconnect.
     SharedPreferencesUtil().deviceMuted = true;
     updateRecordingState(RecordingState.pause);

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -43,6 +43,7 @@ import 'package:omi/services/wals.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/batch_recording.dart';
 import 'package:omi/utils/enums.dart';
+import 'package:omi/utils/transcript_stall.dart';
 import 'package:omi/utils/image/image_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/services/battery_widget_service.dart';
@@ -135,6 +136,16 @@ class CaptureController extends ChangeNotifier
   double get bleReceiveRateKbps => _metrics.bleReceiveRateKbps;
   double get wsSendRateKbps => _metrics.wsSendRateKbps;
 
+  // Live transcript stall watchdog (#6977): avoid zombie "Listening" when the
+  // socket still looks connected but transcript progress has stopped.
+  Timer? _transcriptStallWatchdogTimer;
+  DateTime? _lastTranscriptProgressAt;
+  bool _transcriptStalled = false;
+  bool _transcriptStallRestartInFlight = false;
+  int _secondsSinceLastTranscriptProgress = 0;
+
+  bool get isTranscriptStalled => _transcriptStalled;
+
   /// Call this in initState of a widget that needs BLE/WS metrics
   void addMetricsListener() {
     _metrics.addMetricsListener();
@@ -154,7 +165,7 @@ class CaptureController extends ChangeNotifier
   }
 
   CaptureController({CaptureExternalActions? externalActions})
-      : externalActions = externalActions ?? const NoopCaptureExternalActions() {
+    : externalActions = externalActions ?? const NoopCaptureExternalActions() {
     // Restore a persisted device mute so it survives an app kill/restart. When
     // the device reconnects, streamDeviceRecording() reads _isPaused as
     // `wasPaused` and re-applies the mute instead of silently resuming.
@@ -215,30 +226,30 @@ class CaptureController extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().phoneMic.start(
-          onByteReceived: (bytes) {
-            final frames = _activeSource?.processBytes(bytes) ?? [];
-            for (final frame in frames) {
-              _wal.getSyncs().phone.onFrameCaptured(frame);
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
-                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-              }
-            }
-          },
-          onRecording: () {
-            updateRecordingState(RecordingState.record);
-          },
-          onStop: () {
-            if (!_micInterrupted) {
-              updateRecordingState(RecordingState.stop);
-            }
-          },
-          onInitializing: () {
-            updateRecordingState(RecordingState.initialising);
-          },
-          onStalled: _onMicStalled,
-          onInterruption: _onMicInterruption,
-        );
+      onByteReceived: (bytes) {
+        final frames = _activeSource?.processBytes(bytes) ?? [];
+        for (final frame in frames) {
+          _wal.getSyncs().phone.onFrameCaptured(frame);
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(frame.payload);
+            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+          }
+        }
+      },
+      onRecording: () {
+        updateRecordingState(RecordingState.record);
+      },
+      onStop: () {
+        if (!_micInterrupted) {
+          updateRecordingState(RecordingState.stop);
+        }
+      },
+      onInitializing: () {
+        updateRecordingState(RecordingState.initialising);
+      },
+      onStalled: _onMicStalled,
+      onInterruption: _onMicInterruption,
+    );
   }
 
   void _onMicStalled() {
@@ -476,6 +487,7 @@ class CaptureController extends ChangeNotifier
     segments = [];
     photos = [];
     hasTranscripts = false;
+    _clearTranscriptStallState();
     suggestionsBySegmentId = {};
     _conversation = null;
     taggingSegmentIds = [];
@@ -656,8 +668,9 @@ class CaptureController extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -671,13 +684,13 @@ class CaptureController extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-          codec: codec,
-          sampleRate: sampleRate,
-          language: language,
-          force: force,
-          source: source,
-          customSttConfig: effectiveConfig,
-        );
+      codec: codec,
+      sampleRate: sampleRate,
+      language: language,
+      force: force,
+      source: source,
+      customSttConfig: effectiveConfig,
+    );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -794,20 +807,24 @@ class CaptureController extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error resuming device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              resumeDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error resuming device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error pausing device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              pauseDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error pausing device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -901,10 +918,12 @@ class CaptureController extends ChangeNotifier
 
         // Local storage syncs. In batch mode the native layer owns writing the
         // .bin files, so the Dart WAL writer must stay off to avoid double-writes.
-        var checkWalSupported = !SharedPreferencesUtil().batchModeEnabled &&
+        // #6977: keep phone WAL always-on for supported BLE device audio so a
+        // stale "connected" socket cannot drop the middle of a session.
+        var checkWalSupported =
+            !SharedPreferencesUtil().batchModeEnabled &&
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
-            codec.isOpusSupported() &&
-            (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
+            codec.isOpusSupported();
         if (checkWalSupported != _isWalSupported) {
           setIsWalSupported(checkWalSupported);
         }
@@ -925,8 +944,14 @@ class CaptureController extends ChangeNotifier
           // Track bytes sent to websocket
           _metrics.addSocketBytes(socketPayload.length);
 
-          // Mark frames as synced
-          if (_isWalSupported) {
+          // #6977: websocket send is a fast path, not durability. Only mark
+          // frames synced while transcript progress is recent.
+          if (shouldMarkFramesSyncedAfterSocketSend(
+            walSupported: _isWalSupported,
+            transcriptServiceReady: _transcriptServiceReady,
+            lastTranscriptProgressAt: _lastTranscriptProgressAt,
+            now: DateTime.now(),
+          )) {
             for (final frame in frames) {
               _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
             }
@@ -1009,8 +1034,9 @@ class CaptureController extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1326,6 +1352,7 @@ class CaptureController extends ChangeNotifier
     _connectionStateListener?.cancel();
     _metrics.dispose();
     _autoSyncFallbackTimer?.cancel();
+    _stopTranscriptStallWatchdog();
     _peopleRefreshFuture = null; // Clear in-flight tracker
     BleBridge.instance.removeBatchRecordingFinalizedListener(_onOfflineRecordingFinalized);
 
@@ -1378,33 +1405,33 @@ class CaptureController extends ChangeNotifier
     // record
     try {
       await ServiceManager.instance().phoneMic.start(
-            onByteReceived: (bytes) {
-              // Process through AudioSource for frame splitting and sync key generation
-              final frames = _activeSource?.processBytes(bytes) ?? [];
+        onByteReceived: (bytes) {
+          // Process through AudioSource for frame splitting and sync key generation
+          final frames = _activeSource?.processBytes(bytes) ?? [];
 
-              for (final frame in frames) {
-                _wal.getSyncs().phone.onFrameCaptured(frame);
+          for (final frame in frames) {
+            _wal.getSyncs().phone.onFrameCaptured(frame);
 
-                if (_socket?.state == SocketServiceState.connected) {
-                  _socket?.send(frame.payload);
-                  _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-                }
-              }
-            },
-            onRecording: () {
-              updateRecordingState(RecordingState.record);
-            },
-            onStop: () {
-              if (!_micInterrupted) {
-                updateRecordingState(RecordingState.stop);
-              }
-            },
-            onInitializing: () {
-              updateRecordingState(RecordingState.initialising);
-            },
-            onStalled: _onMicStalled,
-            onInterruption: _onMicInterruption,
-          );
+            if (_socket?.state == SocketServiceState.connected) {
+              _socket?.send(frame.payload);
+              _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+            }
+          }
+        },
+        onRecording: () {
+          updateRecordingState(RecordingState.record);
+        },
+        onStop: () {
+          if (!_micInterrupted) {
+            updateRecordingState(RecordingState.stop);
+          }
+        },
+        onInitializing: () {
+          updateRecordingState(RecordingState.initialising);
+        },
+        onStalled: _onMicStalled,
+        onInterruption: _onMicInterruption,
+      );
     } catch (e, st) {
       // Typed native failures (permission_denied, engine_start_failed, ...) or
       // mic contention — fail visibly instead of recording silence.
@@ -1500,6 +1527,66 @@ class CaptureController extends ChangeNotifier
     }
   }
 
+  void _startTranscriptStallWatchdog() {
+    _transcriptStallWatchdogTimer?.cancel();
+    _transcriptStallWatchdogTimer = Timer.periodic(kTranscriptStallWatchdogTick, (_) {
+      _evaluateTranscriptStall();
+    });
+  }
+
+  void _stopTranscriptStallWatchdog() {
+    _transcriptStallWatchdogTimer?.cancel();
+    _transcriptStallWatchdogTimer = null;
+  }
+
+  void _clearTranscriptStallState({bool keepWatchdog = false}) {
+    _transcriptStalled = false;
+    _transcriptStallRestartInFlight = false;
+    _lastTranscriptProgressAt = null;
+    _secondsSinceLastTranscriptProgress = 0;
+    if (!keepWatchdog) _stopTranscriptStallWatchdog();
+  }
+
+  void _evaluateTranscriptStall() {
+    final monitoringActive =
+        _transcriptServiceReady &&
+        recordingState == RecordingState.deviceRecord &&
+        !_isPaused &&
+        _terminalTranscriptionFailure == null &&
+        segments.isNotEmpty &&
+        _lastTranscriptProgressAt != null;
+
+    _secondsSinceLastTranscriptProgress = nextSecondsSinceTranscriptProgress(
+      monitoringActive: monitoringActive,
+      previousSeconds: _secondsSinceLastTranscriptProgress,
+    );
+
+    final stalled = shouldReportTranscriptStall(
+      transcriptServiceReady: _transcriptServiceReady,
+      isDeviceRecording: recordingState == RecordingState.deviceRecord,
+      isPaused: _isPaused,
+      hasTerminalTranscriptionFailure: _terminalTranscriptionFailure != null,
+      hasTranscriptSegments: segments.isNotEmpty,
+      hasSeenTranscriptProgress: _lastTranscriptProgressAt != null,
+      secondsSinceLastTranscriptProgress: _secondsSinceLastTranscriptProgress,
+    );
+
+    if (stalled) {
+      if (!_transcriptStalled) {
+        _transcriptStalled = true;
+        notifyListeners();
+      }
+      if (!_transcriptStallRestartInFlight) {
+        _transcriptStallRestartInFlight = true;
+        unawaited(_socket?.stop(reason: 'transcript stalled watchdog — restarting'));
+      }
+    } else if (_transcriptStalled) {
+      _transcriptStalled = false;
+      _transcriptStallRestartInFlight = false;
+      notifyListeners();
+    }
+  }
+
   /// Batch liveness watchdog escalation: the native progress feed went silent, so
   /// tear the session down and start a fresh one. Never routes through the Live
   /// restart path (_restartPhoneMicRecording), which assumes a socket/WAL.
@@ -1561,6 +1648,7 @@ class CaptureController extends ChangeNotifier
   void onClosed([int? closeCode]) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
+    _clearTranscriptStallState();
 
     if (closeCode == 4002) {
       externalActions.markAsOutOfCreditsAndRefresh();
@@ -1634,6 +1722,7 @@ class CaptureController extends ChangeNotifier
   void onError(Object err) {
     _transcriptionServiceStatuses = [];
     _transcriptServiceReady = false;
+    _clearTranscriptStallState();
 
     notifyListeners();
     _startKeepAliveServices();
@@ -1642,6 +1731,11 @@ class CaptureController extends ChangeNotifier
   @override
   void onConnected() {
     _transcriptServiceReady = true;
+    _transcriptStalled = false;
+    _transcriptStallRestartInFlight = false;
+    _lastTranscriptProgressAt = DateTime.now();
+    _secondsSinceLastTranscriptProgress = 0;
+    _startTranscriptStallWatchdog();
     // Restart mic on reconnect if interrupted (skip during active call).
     if (recordingState == RecordingState.interrupted && !_micInterrupted) {
       if (_activeSource is PhoneMicSource) {
@@ -1995,6 +2089,12 @@ class CaptureController extends ChangeNotifier
         Logger.debug("Adding ${remainSegments.length} new translated segments");
       }
 
+      // Transcript progressed: clear stall so the UI can return to "Listening".
+      _lastTranscriptProgressAt = DateTime.now();
+      _secondsSinceLastTranscriptProgress = 0;
+      _transcriptStalled = false;
+      _transcriptStallRestartInFlight = false;
+
       _segmentsPhotosVersion++;
       notifyListeners();
     } catch (e) {
@@ -2150,6 +2250,12 @@ class CaptureController extends ChangeNotifier
         _peopleRefreshFuture = null;
       });
     }
+
+    // Live transcript progress clears the #6977 stall watchdog.
+    _lastTranscriptProgressAt = DateTime.now();
+    _secondsSinceLastTranscriptProgress = 0;
+    _transcriptStalled = false;
+    _transcriptStallRestartInFlight = false;
 
     _segmentsPhotosVersion++; // Bump version so Selector rebuilds
     hasTranscripts = true;

--- a/app/lib/utils/transcript_stall.dart
+++ b/app/lib/utils/transcript_stall.dart
@@ -1,7 +1,6 @@
-/// Live transcript stall helpers for BLE device capture (#6977).
-///
-/// Pure predicates so the "zombie Listening" contract can be unit-tested
-/// without spinning up CaptureController / sockets.
+// Live transcript stall helpers for BLE device capture (#6977).
+// Pure predicates so the "zombie Listening" contract can be unit-tested
+// without spinning up CaptureController / sockets.
 
 /// Default: surface a stall warning after this much silence in transcript progress.
 const Duration kTranscriptStallWarningAfter = Duration(seconds: 15);

--- a/app/lib/utils/transcript_stall.dart
+++ b/app/lib/utils/transcript_stall.dart
@@ -62,3 +62,12 @@ bool shouldMarkFramesSyncedAfterSocketSend({
   if (last == null) return false;
   return now.difference(last) <= grace;
 }
+
+/// Keep "reconnecting" visible across an intentional watchdog socket restart.
+///
+/// When the watchdog calls `stop()`, `onClosed` fires immediately. Clearing the
+/// stall flag there would flash Listening again before reconnect completes.
+bool shouldPreserveTranscriptStallAcrossSocketClose({
+  required bool stallRestartInFlight,
+}) =>
+    stallRestartInFlight;

--- a/app/lib/utils/transcript_stall.dart
+++ b/app/lib/utils/transcript_stall.dart
@@ -1,0 +1,57 @@
+/// Live transcript stall helpers for BLE device capture (#6977).
+///
+/// Pure predicates so the "zombie Listening" contract can be unit-tested
+/// without spinning up CaptureController / sockets.
+
+/// Default: surface a stall warning after this much silence in transcript progress.
+const Duration kTranscriptStallWarningAfter = Duration(seconds: 15);
+
+/// WAL frames may be marked synced after a local socket send only while transcript
+/// progress has advanced within this grace window.
+const Duration kFrameSyncedGraceAfterTranscriptProgress = Duration(seconds: 10);
+
+const Duration kTranscriptStallWatchdogTick = Duration(seconds: 5);
+
+/// Whether the capture UI should leave the indefinite "Listening" state.
+bool shouldReportTranscriptStall({
+  required bool transcriptServiceReady,
+  required bool isDeviceRecording,
+  required bool isPaused,
+  required bool hasTerminalTranscriptionFailure,
+  required bool hasTranscriptSegments,
+  required bool hasSeenTranscriptProgress,
+  required int secondsSinceLastTranscriptProgress,
+  Duration stallAfter = kTranscriptStallWarningAfter,
+}) {
+  if (!transcriptServiceReady) return false;
+  if (!isDeviceRecording) return false;
+  if (isPaused) return false;
+  if (hasTerminalTranscriptionFailure) return false;
+  if (!hasTranscriptSegments) return false;
+  if (!hasSeenTranscriptProgress) return false;
+  return secondsSinceLastTranscriptProgress >= stallAfter.inSeconds;
+}
+
+/// Seconds of stall silence after one watchdog tick (or 0 when monitoring is inactive).
+int nextSecondsSinceTranscriptProgress({
+  required bool monitoringActive,
+  required int previousSeconds,
+  Duration tick = kTranscriptStallWatchdogTick,
+}) {
+  if (!monitoringActive) return 0;
+  return previousSeconds + tick.inSeconds;
+}
+
+/// Whether a successful local websocket send is durable enough to mark WAL frames synced.
+bool shouldMarkFramesSyncedAfterSocketSend({
+  required bool walSupported,
+  required bool transcriptServiceReady,
+  required DateTime? lastTranscriptProgressAt,
+  required DateTime now,
+  Duration grace = kFrameSyncedGraceAfterTranscriptProgress,
+}) {
+  if (!walSupported || !transcriptServiceReady) return false;
+  final last = lastTranscriptProgressAt;
+  if (last == null) return false;
+  return now.difference(last) <= grace;
+}

--- a/app/lib/utils/transcript_stall.dart
+++ b/app/lib/utils/transcript_stall.dart
@@ -3,7 +3,15 @@
 // without spinning up CaptureController / sockets.
 
 /// Default: surface a stall warning after this much silence in transcript progress.
-const Duration kTranscriptStallWarningAfter = Duration(seconds: 15);
+///
+/// This is silence in *transcript output*, not audio input — a person pausing
+/// mid-conversation, listening rather than speaking, or a quiet room are all
+/// completely normal and can easily exceed 15s without any transcript segment
+/// arriving. 15s made the watchdog restart healthy sockets during ordinary
+/// pauses (cubic review on #6977). Raised well past typical conversational
+/// pause lengths while staying far short of "the session went dead for
+/// minutes" territory this watchdog exists to catch.
+const Duration kTranscriptStallWarningAfter = Duration(seconds: 45);
 
 /// WAL frames may be marked synced after a local socket send only while transcript
 /// progress has advanced within this grace window.

--- a/app/test/unit/transcript_stall_test.dart
+++ b/app/test/unit/transcript_stall_test.dart
@@ -13,13 +13,13 @@ void main() {
           hasTerminalTranscriptionFailure: false,
           hasTranscriptSegments: true,
           hasSeenTranscriptProgress: true,
-          secondsSinceLastTranscriptProgress: 15,
+          secondsSinceLastTranscriptProgress: 45,
         ),
         isTrue,
       );
     });
 
-    test('does not report stall before the warning threshold', () {
+    test('does not report stall before the warning threshold, including normal conversational pauses', () {
       expect(
         shouldReportTranscriptStall(
           transcriptServiceReady: true,
@@ -28,7 +28,21 @@ void main() {
           hasTerminalTranscriptionFailure: false,
           hasTranscriptSegments: true,
           hasSeenTranscriptProgress: true,
-          secondsSinceLastTranscriptProgress: 10,
+          secondsSinceLastTranscriptProgress: 20,
+        ),
+        isFalse,
+      );
+      // A silent listener or a quiet room easily exceeds the old 15s threshold —
+      // this must not be reported as a stall (cubic review on #6977).
+      expect(
+        shouldReportTranscriptStall(
+          transcriptServiceReady: true,
+          isDeviceRecording: true,
+          isPaused: false,
+          hasTerminalTranscriptionFailure: false,
+          hasTranscriptSegments: true,
+          hasSeenTranscriptProgress: true,
+          secondsSinceLastTranscriptProgress: 30,
         ),
         isFalse,
       );

--- a/app/test/unit/transcript_stall_test.dart
+++ b/app/test/unit/transcript_stall_test.dart
@@ -140,4 +140,11 @@ void main() {
       expect(nextSecondsSinceTranscriptProgress(monitoringActive: false, previousSeconds: 10), 0);
     });
   });
+
+  group('shouldPreserveTranscriptStallAcrossSocketClose (#6977)', () {
+    test('preserves stall UI only for intentional watchdog restarts', () {
+      expect(shouldPreserveTranscriptStallAcrossSocketClose(stallRestartInFlight: true), isTrue);
+      expect(shouldPreserveTranscriptStallAcrossSocketClose(stallRestartInFlight: false), isFalse);
+    });
+  });
 }

--- a/app/test/unit/transcript_stall_test.dart
+++ b/app/test/unit/transcript_stall_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/transcript_stall.dart';
+
+void main() {
+  group('shouldReportTranscriptStall (#6977)', () {
+    test('reports stall only after sustained silence during live device capture', () {
+      expect(
+        shouldReportTranscriptStall(
+          transcriptServiceReady: true,
+          isDeviceRecording: true,
+          isPaused: false,
+          hasTerminalTranscriptionFailure: false,
+          hasTranscriptSegments: true,
+          hasSeenTranscriptProgress: true,
+          secondsSinceLastTranscriptProgress: 15,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not report stall before the warning threshold', () {
+      expect(
+        shouldReportTranscriptStall(
+          transcriptServiceReady: true,
+          isDeviceRecording: true,
+          isPaused: false,
+          hasTerminalTranscriptionFailure: false,
+          hasTranscriptSegments: true,
+          hasSeenTranscriptProgress: true,
+          secondsSinceLastTranscriptProgress: 10,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not report stall when paused, not ready, or no prior progress', () {
+      expect(
+        shouldReportTranscriptStall(
+          transcriptServiceReady: true,
+          isDeviceRecording: true,
+          isPaused: true,
+          hasTerminalTranscriptionFailure: false,
+          hasTranscriptSegments: true,
+          hasSeenTranscriptProgress: true,
+          secondsSinceLastTranscriptProgress: 30,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReportTranscriptStall(
+          transcriptServiceReady: false,
+          isDeviceRecording: true,
+          isPaused: false,
+          hasTerminalTranscriptionFailure: false,
+          hasTranscriptSegments: true,
+          hasSeenTranscriptProgress: true,
+          secondsSinceLastTranscriptProgress: 30,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReportTranscriptStall(
+          transcriptServiceReady: true,
+          isDeviceRecording: true,
+          isPaused: false,
+          hasTerminalTranscriptionFailure: false,
+          hasTranscriptSegments: true,
+          hasSeenTranscriptProgress: false,
+          secondsSinceLastTranscriptProgress: 30,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldMarkFramesSyncedAfterSocketSend (#6977)', () {
+    final now = DateTime.utc(2026, 8, 5, 12);
+
+    test('allows synced marks only while transcript progress is recent', () {
+      expect(
+        shouldMarkFramesSyncedAfterSocketSend(
+          walSupported: true,
+          transcriptServiceReady: true,
+          lastTranscriptProgressAt: now.subtract(const Duration(seconds: 5)),
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldMarkFramesSyncedAfterSocketSend(
+          walSupported: true,
+          transcriptServiceReady: true,
+          lastTranscriptProgressAt: now.subtract(const Duration(seconds: 20)),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('never marks synced when WAL or transcript service is inactive', () {
+      expect(
+        shouldMarkFramesSyncedAfterSocketSend(
+          walSupported: false,
+          transcriptServiceReady: true,
+          lastTranscriptProgressAt: now,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldMarkFramesSyncedAfterSocketSend(
+          walSupported: true,
+          transcriptServiceReady: false,
+          lastTranscriptProgressAt: now,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('nextSecondsSinceTranscriptProgress', () {
+    test('accumulates ticks while monitoring and resets when inactive', () {
+      expect(nextSecondsSinceTranscriptProgress(monitoringActive: true, previousSeconds: 10), 15);
+      expect(nextSecondsSinceTranscriptProgress(monitoringActive: false, previousSeconds: 10), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes [#6977](https://github.com/BasedHardware/omi/issues/6977): BLE live capture can look permanently **Listening** while transcript progress stalls and audio mid-session is lost when the socket still appears connected.
- Keep phone WAL always-on for supported BLE device audio (no longer gated on socket disconnected / unlimited storage).
- Only `markFrameSynced` after a local websocket send while transcript progress is recent.
- Add a transcript-stall watchdog: after sustained silence, flip UI to reconnecting and stop the socket so reconnect can recover; clear stall on new segments / connect / close.
- Pure helpers + unit tests in `app/test/unit/transcript_stall_test.dart`.

## Test plan
- [x] `flutter test test/unit/transcript_stall_test.dart`
- [ ] Manual: start BLE live capture, confirm Listening while segments arrive
- [ ] Manual: force transcript silence with socket still connected → status becomes reconnecting (not indefinite Listening) and socket restarts
- [ ] Manual: after reconnect + new segments, status returns to Listening
- [ ] Manual: pause / mute does not falsely trip the stall watchdog
- [ ] Confirm mid-session audio remains in phone WAL when the live socket was stale

## Invariants

No product invariants are affected.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


