### PR TITLE
test(desktop): lock macOS stable-never-beta appcast contract (#9528)

### DIFF
--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -111,6 +111,7 @@
       "checks": [],
       "invariants": [
         "stable never resolves or downloads a beta release",
+        "appcast never exposes an untagged item when only beta resolves (#9528)",
         "validated pointer LKG precedes exact-channel legacy fallback",
         "immutable manifests are registered before atomic pointer promotion",
         "beta visibility requires exact-tag T2 qualification evidence"

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -805,6 +805,74 @@ class TestAppcastEndpoint:
                 resp = await client.get("/v2/desktop/appcast.xml")
         assert resp.headers.get("cache-control") == "max-age=300"
 
+    @pytest.mark.asyncio
+    async def test_appcast_never_exposes_implicit_stable_item_when_only_beta_resolves(self):
+        """#9528: legacy Sparkle treats untagged items as stable-default.
+
+        A beta-only resolved feed must tag every <item> with sparkle:channel=beta
+        so no untagged item can be mistaken for stable.
+        """
+        mock_releases = [
+            {
+                "channel": "beta",
+                "release": {
+                    "published_at": "2026-03-01T00:00:00Z",
+                    "body": "",
+                    "assets": [_zip_asset("https://example.com/Omi-beta.zip")],
+                },
+                "version_info": {"version": "2.0.0+200", "build": "200"},
+                "metadata": {"edSignature": "beta-sig"},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/appcast.xml")
+        assert resp.status_code == 200
+        assert resp.text.count("<item>") == 1
+        assert resp.text.count("<sparkle:channel>beta</sparkle:channel>") == 1
+        # No untagged item that legacy clients could treat as stable-default.
+        assert resp.text.count("<item>") == resp.text.count("<sparkle:channel>beta</sparkle:channel>")
+
+    @pytest.mark.asyncio
+    async def test_appcast_stable_item_is_untagged_and_beta_item_is_explicit(self):
+        """#9528: stable must be the implicit Sparkle default; beta must be tagged."""
+        mock_releases = [
+            {
+                "channel": "stable",
+                "release": {
+                    "published_at": "2026-03-01T00:00:00Z",
+                    "body": "",
+                    "assets": [_zip_asset("https://example.com/Omi-stable.zip")],
+                },
+                "version_info": {"version": "1.0.0+100", "build": "100"},
+                "metadata": {"edSignature": "stable-sig"},
+            },
+            {
+                "channel": "beta",
+                "release": {
+                    "published_at": "2026-03-02T00:00:00Z",
+                    "body": "",
+                    "assets": [_zip_asset("https://example.com/Omi-beta.zip")],
+                },
+                "version_info": {"version": "1.1.0+110", "build": "110"},
+                "metadata": {"edSignature": "beta-sig"},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/appcast.xml")
+        assert resp.status_code == 200
+        assert resp.text.count("<item>") == 2
+        assert resp.text.count("<sparkle:channel>beta</sparkle:channel>") == 1
+        assert "https://example.com/Omi-stable.zip" in resp.text
+        assert "https://example.com/Omi-beta.zip" in resp.text
+
+        items = resp.text.split("<item>")[1:]
+        stable_item = next(item for item in items if "Omi-stable.zip" in item)
+        beta_item = next(item for item in items if "Omi-beta.zip" in item)
+        assert "<sparkle:channel>" not in stable_item.split("</item>")[0]
+        assert "<sparkle:channel>beta</sparkle:channel>" in beta_item.split("</item>")[0]
+
 
 # --- Download endpoint ---
 


### PR DESCRIPTION
## Summary
- Day-1 slice of [#9528](https://github.com/BasedHardware/omi/issues/9528): lock the macOS **stable-never-beta** appcast invariant in CI (resolver already enforces this on main).
- New appcast tests: beta-only feeds must not emit an untagged item (legacy Sparkle stable-default); dual-channel feeds keep stable untagged and beta explicitly tagged.
- Adds the invariant to `workflow_contracts.json` for the desktop update promotion contract.
- **Out of scope** (multi-week #9528 program): pointer seeding, GCS repair installer, compatibility bridge deploy, post-relaunch completion telemetry.

## Test plan
- [x] `pytest tests/unit/test_desktop_updates.py::TestAppcastEndpoint::test_appcast_never_exposes_implicit_stable_item_when_only_beta_resolves`
- [x] `pytest tests/unit/test_desktop_updates.py::TestAppcastEndpoint::test_appcast_stable_item_is_untagged_and_beta_item_is_explicit`
- [ ] Confirm existing `test_stable_never_falls_back_to_beta` download tests still pass in CI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

