### PR TITLE
Select historical canonical graph candidates correctly

### DIFF
--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -22,7 +22,7 @@ from google.cloud.firestore_v1 import FieldFilter  # noqa: E402
 
 from database.memory_apply_store import apply_long_term_patch_firestore  # noqa: E402
 from database.memory_collections import MemoryCollections  # noqa: E402
-from database.firestore_index_registry import CANONICAL_GRAPH_READ_QUERY  # noqa: E402
+from database.firestore_index_registry import CANONICAL_MEMORY_ATLAS_READ_QUERY  # noqa: E402
 from models.memory_apply import ApplyStatus, MemoryControlState  # noqa: E402
 from models.memory_promotion import PromotionGraphPlan  # noqa: E402
 from models.product_memory import MemoryItem  # noqa: E402
@@ -31,6 +31,7 @@ from utils.memory.graph_enrichment import prepare_graph_enrichment  # noqa: E402
 from utils.memory.historical_graph_enrichment import plan_historical_graph_enrichment  # noqa: E402
 
 MAX_PAGE_SIZE = 25
+MAX_STRUCTURED_SCAN_SIZE = 1250
 
 
 def _arguments() -> argparse.Namespace:
@@ -38,6 +39,14 @@ def _arguments() -> argparse.Namespace:
     parser.add_argument("--uid", required=True, help="Target canonical user UID")
     parser.add_argument("--firestore-project", required=True, help="Explicit Firestore data-plane project")
     parser.add_argument("--limit", type=int, default=1, help=f"Items to inspect (1-{MAX_PAGE_SIZE})")
+    parser.add_argument(
+        "--scan-limit",
+        type=int,
+        help=(
+            f"Candidate rows to read in structured-only mode (1-{MAX_STRUCTURED_SCAN_SIZE}); "
+            "does not increase the apply bound"
+        ),
+    )
     parser.add_argument("--apply-limit", type=int, default=1, help=f"Ready plans to commit (1-{MAX_PAGE_SIZE})")
     parser.add_argument(
         "--structured-only",
@@ -59,14 +68,17 @@ def _control(uid: str, *, db_client: Any) -> MemoryControlState:
 
 def _candidates(uid: str, *, control: MemoryControlState, limit: int, db_client: Any) -> list[MemoryItem]:
     collection = db_client.collection(MemoryCollections(uid=uid).memory_items)
-    query = CANONICAL_GRAPH_READ_QUERY.build(
+    # Historical canonical items predate graph_ready and omit the field rather
+    # than storing false. Firestore equality filters exclude absent fields, so
+    # use the canonical-atlas serving query and keep only absent-or-false rows
+    # after decoding them.
+    query = CANONICAL_MEMORY_ATLAS_READ_QUERY.build(
         collection,
         {
             "account_generation": control.account_generation,
             "tier": "long_term",
             "status": "active",
             "processing_state": "processed",
-            "graph_ready": False,
         },
         field_filter_factory=FieldFilter,
     )
@@ -75,7 +87,7 @@ def _candidates(uid: str, *, control: MemoryControlState, limit: int, db_client:
         .order_by("__name__", direction=firestore.Query.DESCENDING)
         .limit(limit)
     )
-    return [MemoryItem(**(snapshot.to_dict() or {})) for snapshot in query.stream()]
+    return [item for snapshot in query.stream() if not (item := MemoryItem(**(snapshot.to_dict() or {}))).graph_ready]
 
 
 def _structured_plan(item: MemoryItem, control: MemoryControlState):
@@ -106,12 +118,18 @@ def run_enrichment(
     confirm_uid: str | None,
     structured_only: bool,
     apply_limit: int = 1,
+    scan_limit: int | None = None,
     db_client: Any | None = None,
     llm: Any | None = None,
 ) -> dict[str, Any]:
     """Return aggregate outcomes for one bounded historical enrichment page."""
     if limit < 1 or limit > MAX_PAGE_SIZE or apply_limit < 1 or apply_limit > MAX_PAGE_SIZE:
         raise ValueError(f"limit and apply_limit must be between 1 and {MAX_PAGE_SIZE}")
+    candidate_limit = scan_limit if scan_limit is not None else limit
+    if candidate_limit < 1 or candidate_limit > MAX_STRUCTURED_SCAN_SIZE:
+        raise ValueError(f"scan_limit must be between 1 and {MAX_STRUCTURED_SCAN_SIZE}")
+    if candidate_limit != limit and not structured_only:
+        raise ValueError("scan_limit greater than limit requires structured_only mode")
     if apply and confirm_uid != uid:
         raise ValueError("apply requires confirm_uid to exactly match uid")
 
@@ -121,7 +139,7 @@ def run_enrichment(
         llm = get_llm("memory_l2")
     report: Counter[str] = Counter()
     applied = 0
-    for item in _candidates(uid, control=control, limit=limit, db_client=db_client):
+    for item in _candidates(uid, control=control, limit=candidate_limit, db_client=db_client):
         planned = (
             _structured_plan(item, control)
             if structured_only
@@ -154,6 +172,7 @@ def run_enrichment(
     return {
         "dry_run": not apply,
         "limit": limit,
+        "scan_limit": candidate_limit,
         "apply_limit": apply_limit,
         "structured_only": structured_only,
         "outcomes": dict(sorted(report.items())),
@@ -171,6 +190,7 @@ def main() -> int:
             confirm_uid=args.confirm_uid,
             structured_only=args.structured_only,
             apply_limit=args.apply_limit,
+            scan_limit=args.scan_limit,
         )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc

--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -11,7 +11,7 @@ import json
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
@@ -121,6 +121,7 @@ def run_enrichment(
     scan_limit: int | None = None,
     db_client: Any | None = None,
     llm: Any | None = None,
+    progress_reporter: Callable[[dict[str, int]], None] | None = None,
 ) -> dict[str, Any]:
     """Return aggregate outcomes for one bounded historical enrichment page."""
     if limit < 1 or limit > MAX_PAGE_SIZE or apply_limit < 1 or apply_limit > MAX_PAGE_SIZE:
@@ -134,41 +135,59 @@ def run_enrichment(
         raise ValueError("apply requires confirm_uid to exactly match uid")
 
     db_client = db_client or firestore.Client(project=firestore_project)
-    control = _control(uid, db_client=db_client)
     if llm is None and not structured_only:
         llm = get_llm("memory_l2")
     report: Counter[str] = Counter()
     applied = 0
-    for item in _candidates(uid, control=control, limit=candidate_limit, db_client=db_client):
-        planned = (
-            _structured_plan(item, control)
-            if structured_only
-            else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
-        )
-        if planned is None:
-            report["not_structured"] += 1
-            continue
-        if planned.status != "ready" or planned.operation is None:
-            report[planned.block_code or "blocked"] += 1
-            continue
-        if not apply:
-            report["planned"] += 1
-            continue
-        if applied >= apply_limit:
-            report["apply_limit_reached"] += 1
-            continue
-        result = apply_long_term_patch_firestore(
-            uid=uid,
-            operation_id=planned.operation.operation_id,
-            patch_payload=planned.patch_payload,
-            proposed_operation=planned.operation,
-            db_client=db_client,
-        )
-        if result.status in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
-            report[result.status.value] += 1
-            applied += 1
-        else:
-            report[f"apply_{result.status.value}"] += 1
+    if not apply:
+        control = _control(uid, db_client=db_client)
+        for item in _candidates(uid, control=control, limit=candidate_limit, db_client=db_client):
+            planned = (
+                _structured_plan(item, control)
+                if structured_only
+                else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+            )
+            if planned is None:
+                report["not_structured"] += 1
+            elif planned.status == "ready" and planned.operation is not None:
+                report["planned"] += 1
+            else:
+                report[planned.block_code or "blocked"] += 1
+    else:
+        # Every committed apply advances the canonical control head. Re-read the
+        # control record and re-plan the next item so no operation is submitted
+        # against a stale observed_head_commit_id.
+        while applied < apply_limit:
+            control = _control(uid, db_client=db_client)
+            planned = None
+            for item in _candidates(uid, control=control, limit=candidate_limit, db_client=db_client):
+                candidate = (
+                    _structured_plan(item, control)
+                    if structured_only
+                    else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+                )
+                if candidate is None:
+                    continue
+                if candidate.status == "ready" and candidate.operation is not None:
+                    planned = candidate
+                    break
+            if planned is None:
+                break
+            result = apply_long_term_patch_firestore(
+                uid=uid,
+                operation_id=planned.operation.operation_id,
+                patch_payload=planned.patch_payload,
+                proposed_operation=planned.operation,
+                db_client=db_client,
+            )
+            if result.status in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
+                report[result.status.value] += 1
+                applied += 1
+                if progress_reporter is not None:
+                    progress_reporter({result.status.value: applied})
+            else:
+                report[f"apply_{result.status.value}"] += 1
+                break
     return {
         "dry_run": not apply,
         "limit": limit,
@@ -191,6 +210,9 @@ def main() -> int:
             structured_only=args.structured_only,
             apply_limit=args.apply_limit,
             scan_limit=args.scan_limit,
+            progress_reporter=(
+                (lambda progress: print(json.dumps({"progress": progress}), flush=True)) if args.apply else None
+            ),
         )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc

--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -157,6 +157,8 @@ def run_enrichment(
         # Every committed apply advances the canonical control head. Re-read the
         # control record and re-plan the next item so no operation is submitted
         # against a stale observed_head_commit_id.
+        retryable_head_mismatches = 0
+        max_retryable_head_mismatches = apply_limit * 2
         while applied < apply_limit:
             control = _control(uid, db_client=db_client)
             planned = None
@@ -183,8 +185,15 @@ def run_enrichment(
             if result.status in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
                 report[result.status.value] += 1
                 applied += 1
+                retryable_head_mismatches = 0
                 if progress_reporter is not None:
                     progress_reporter({result.status.value: applied})
+            elif result.status == ApplyStatus.retryable_head_mismatch:
+                report[result.status.value] += 1
+                retryable_head_mismatches += 1
+                if retryable_head_mismatches < max_retryable_head_mismatches:
+                    continue
+                break
             else:
                 report[f"apply_{result.status.value}"] += 1
                 break

--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections import Counter
 from pathlib import Path
@@ -19,6 +20,7 @@ if str(BACKEND_DIR) not in sys.path:
 
 from google.cloud import firestore  # noqa: E402
 from google.cloud.firestore_v1 import FieldFilter  # noqa: E402
+from google.oauth2 import service_account  # noqa: E402
 
 from database.memory_apply_store import apply_long_term_patch_firestore  # noqa: E402
 from database.memory_collections import MemoryCollections  # noqa: E402
@@ -64,6 +66,15 @@ def _control(uid: str, *, db_client: Any) -> MemoryControlState:
         raise RuntimeError("missing canonical memory apply control state")
     payload = snapshot.to_dict() or {}
     return MemoryControlState(**payload)
+
+
+def _firestore_client(*, project: str) -> Any:
+    """Use an injected runtime service identity when present, else local ADC."""
+    service_account_json = os.getenv("SERVICE_ACCOUNT_JSON", "").strip()
+    if not service_account_json:
+        return firestore.Client(project=project)
+    credentials = service_account.Credentials.from_service_account_info(json.loads(service_account_json))
+    return firestore.Client(project=project, credentials=credentials)
 
 
 def _candidates(uid: str, *, control: MemoryControlState, limit: int, db_client: Any) -> list[MemoryItem]:
@@ -134,7 +145,7 @@ def run_enrichment(
     if apply and confirm_uid != uid:
         raise ValueError("apply requires confirm_uid to exactly match uid")
 
-    db_client = db_client or firestore.Client(project=firestore_project)
+    db_client = db_client or _firestore_client(project=firestore_project)
     if llm is None and not structured_only:
         llm = get_llm("memory_l2")
     report: Counter[str] = Counter()


### PR DESCRIPTION
## Summary
- select historical canonical items whose legacy rows omit `graph_ready`
- add a structured-only read scan window without increasing the one-write apply bound
- re-read control state and re-plan every apply so the canonical control-head fence remains valid during bounded expansion

## Verification
- `pytest -q backend/tests/unit/test_historical_graph_enrichment.py backend/tests/unit/test_atomic_apply.py backend/tests/unit/test_knowledge_graph_canonical_pagination.py`
- structured-only production dry run: 201 planned, 890 safely skipped, zero writes
- one-item production canary committed and refreshed the signed-in graph from 2/1 to 9/8

## Product invariants affected
- INV-MEM-1