### PR TITLE
SCA-294: instrument hosted MCP retrieval analytics

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2391,
     "backend/routers/chat.py": 1634,
     "backend/routers/developer.py": 2282,
-    "backend/routers/mcp_sse.py": 1945,
+    "backend/routers/mcp_sse.py": 1968,
     "backend/routers/sync.py": 2053,
     "backend/routers/users.py": 2086
   },
@@ -11,7 +11,7 @@
     "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract. +5 keeps deleted-source rejection at the anonymous owner-migration admission boundary so a fresh UID cannot claim state from a fenced owner (SCA-280).",
     "backend/routers/chat.py": "The HTTP and streaming PTT routes own the raw-audio and final-transcript boundaries; dev-only allowlisted capture therefore starts and persists at those two route seams while serialization, bounds, redaction, and export stay in testing.parity_pack_v0.live_capture.",
     "backend/routers/developer.py": "Developer memory create and batch routes must record their accepted write result at the authoritative API boundary; the shared dev-only allowlisted serializer/exporter lives in testing.parity_pack_v0.live_capture.",
-    "backend/routers/mcp_sse.py": "The MCP SSE tool handler owns the successful memory-write response boundary; its one shared dev-only allowlisted capture call records accepted memory without duplicating serialization or export logic. +24 fences legacy-key, OAuth, and authorization-code issuance at the route's credential admission seams while offloading request validation, Firebase, and Firestore work to their owned executors (SCA-280). +42 keeps hosted MCP tool-call analytics at the authoritative execution boundary while the shared helper owns privacy filtering, PostHog delivery, and connector-ready operation mapping (SCA-294).",
+    "backend/routers/mcp_sse.py": "The MCP SSE tool handler owns the successful memory-write response boundary; its one shared dev-only allowlisted capture call records accepted memory without duplicating serialization or export logic. +24 fences legacy-key, OAuth, and authorization-code issuance at the route's credential admission seams while offloading request validation, Firebase, and Firestore work to their owned executors (SCA-280). +42 keeps hosted MCP tool-call analytics at the authoritative execution boundary while the shared helper owns privacy filtering, PostHog delivery, and connector-ready operation mapping (SCA-294). +23 records every execution outcome and preserves authorization semantics independently of JSON-RPC error codes (SCA-294).",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "Account-deletion outcome telemetry at the users router boundary for PostHog ownership repair; repaired non-empty webhook URLs must also clear the persisted disabled state and failure health at the owning save boundary (#7519)."
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2391,
     "backend/routers/chat.py": 1634,
     "backend/routers/developer.py": 2282,
-    "backend/routers/mcp_sse.py": 1903,
+    "backend/routers/mcp_sse.py": 1945,
     "backend/routers/sync.py": 2053,
     "backend/routers/users.py": 2086
   },
@@ -11,7 +11,7 @@
     "backend/routers/apps.py": "POST /v1/apps/enable reads is_setup_completed through _setup_completed_from_response so a developer-controlled body that is non-JSON or not an object returns the intended 400 instead of a 500 (46 prod occurrences Jul 21-28); the guard stays in the route that owns the enable response contract. +5 keeps deleted-source rejection at the anonymous owner-migration admission boundary so a fresh UID cannot claim state from a fenced owner (SCA-280).",
     "backend/routers/chat.py": "The HTTP and streaming PTT routes own the raw-audio and final-transcript boundaries; dev-only allowlisted capture therefore starts and persists at those two route seams while serialization, bounds, redaction, and export stay in testing.parity_pack_v0.live_capture.",
     "backend/routers/developer.py": "Developer memory create and batch routes must record their accepted write result at the authoritative API boundary; the shared dev-only allowlisted serializer/exporter lives in testing.parity_pack_v0.live_capture.",
-    "backend/routers/mcp_sse.py": "The MCP SSE tool handler owns the successful memory-write response boundary; its one shared dev-only allowlisted capture call records accepted memory without duplicating serialization or export logic. +24 fences legacy-key, OAuth, and authorization-code issuance at the route's credential admission seams while offloading request validation, Firebase, and Firestore work to their owned executors (SCA-280).",
+    "backend/routers/mcp_sse.py": "The MCP SSE tool handler owns the successful memory-write response boundary; its one shared dev-only allowlisted capture call records accepted memory without duplicating serialization or export logic. +24 fences legacy-key, OAuth, and authorization-code issuance at the route's credential admission seams while offloading request validation, Firebase, and Firestore work to their owned executors (SCA-280). +42 keeps hosted MCP tool-call analytics at the authoritative execution boundary while the shared helper owns privacy filtering, PostHog delivery, and connector-ready operation mapping (SCA-294).",
     "backend/routers/sync.py": "Fresh Sync's daily ceiling remains beside the existing fresh-admission gates, before staged audio or durable worker work is created. Lifecycle-fenced workers are terminalized at this Cloud Tasks boundary so released WAL clients do not retry an owner they no longer own; +2 for the queued-dispatch-lost stale finalization path (#10033).",
     "backend/routers/users.py": "Account-deletion outcome telemetry at the users router boundary for PostHog ownership repair; repaired non-empty webhook URLs must also clear the persisted disabled state and failure health at the owning save boundary (#7519)."
   },

--- a/backend/docs/mcp-analytics.md
+++ b/backend/docs/mcp-analytics.md
@@ -1,0 +1,23 @@
+# Hosted MCP analytics
+
+The hosted Streamable HTTP `tools/call` boundary emits one fail-open PostHog
+event named `MCP Tool Call` per attempted tool call. It is the source for MCP
+adoption and retrieval dashboards; do not rename its properties without a
+dashboard migration.
+
+| Property | Values / meaning |
+| --- | --- |
+| `tool` | Allowlisted MCP tool name, otherwise `unknown`. |
+| `operation` | Closed retrieval grouping such as `memory_search`, `memory_list`, `conversation_get`, or the connector-ready `memory_conversation_search` / `memory_conversation_fetch`. |
+| `client` | `chatgpt`, `claude`, `other_registered`, `api_key`, or `unknown`; never the raw OAuth client ID. |
+| `transport` | `hosted_oauth`, `api_key`, or `unknown`. |
+| `outcome` | `success` or `error`. |
+| `authorization_outcome` | `allowed`, `denied`, or `not_applicable`. |
+| `error_category` | `none`, `authorization_denied`, `validation`, `unknown_tool`, or `internal`. |
+| `duration_ms` | Tool execution duration, capped at 60,000 ms; use it for p50/p95. |
+| `result_count` | Top-level result cardinality, capped at 1,000. |
+
+PostHog's distinct ID is the server-side user ID so unique-user counts are
+available. Event properties intentionally exclude tool arguments, query text,
+memory and conversation content/IDs, OAuth/API-key credentials, raw client IDs,
+email, and IP address.

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -754,10 +754,16 @@ def openai_apps_challenge():
 class ToolExecutionError(Exception):
     """Exception raised when a tool execution fails."""
 
-    def __init__(self, message: str, code: int = -32000):
+    def __init__(self, message: str, code: int = -32000, *, analytics_authorization_denied: bool = False):
         self.message = message
         self.code = code
+        self.analytics_authorization_denied = analytics_authorization_denied
         super().__init__(self.message)
+
+
+def _authorization_denied_error(message: str) -> ToolExecutionError:
+    """Preserve a product-authorization denial separately from its MCP code."""
+    return ToolExecutionError(message, code=-32009, analytics_authorization_denied=True)
 
 
 def _raise_tool_error_from_http(exc: HTTPException) -> NoReturn:
@@ -765,7 +771,9 @@ def _raise_tool_error_from_http(exc: HTTPException) -> NoReturn:
         raise ToolExecutionError("Memory not found", code=-32001) from exc
     if exc.status_code == 402:
         raise ToolExecutionError("A paid plan is required to access this memory.", code=-32002) from exc
-    if exc.status_code in {403, 409, 503}:
+    if exc.status_code == 403:
+        raise _authorization_denied_error(str(exc.detail)) from exc
+    if exc.status_code in {409, 503}:
         raise ToolExecutionError(str(exc.detail), code=-32009) from exc
     raise ToolExecutionError(str(exc.detail)) from exc
 
@@ -848,10 +856,10 @@ def execute_tool(
                 raise ToolExecutionError(f"Invalid memory category: '{cat}'", code=-32602)
 
         if auth_context is None:
-            raise ToolExecutionError("Missing MCP API app/key identity for memory read authorization", code=-32009)
+            raise _authorization_denied_error("Missing MCP API app/key identity for memory read authorization")
         app_key_grant = authorize_memory_external_default_memory_read(auth_context, db_client=db)
         if not app_key_grant.allowed:
-            raise ToolExecutionError(str(app_key_grant.observability), code=-32009)
+            raise _authorization_denied_error(str(app_key_grant.observability))
 
         if memory_system == MemorySystem.CANONICAL:
             filtered = collect_filtered_memories(
@@ -892,7 +900,7 @@ def execute_tool(
         if not mcp_legacy_read_authorized(memory_list_results):
             denied = mcp_denied_read_payload(memory_list_results)
             if denied is not None:
-                raise ToolExecutionError(str(denied), code=-32009)
+                raise _authorization_denied_error(str(denied))
             return {"memories": []}
 
         result = collect_filtered_memories(
@@ -922,10 +930,10 @@ def execute_tool(
             raise ToolExecutionError("Content is required")
 
         if auth_context is None:
-            raise ToolExecutionError("Missing MCP API app/key identity for memory write authorization", code=-32009)
+            raise _authorization_denied_error("Missing MCP API app/key identity for memory write authorization")
         write_grant = authorize_memory_external_default_memory_write(auth_context, db_client=db)
         if not write_grant.allowed:
-            raise ToolExecutionError(str(write_grant.observability), code=-32009)
+            raise _authorization_denied_error(str(write_grant.observability))
         try:
             write_context = resolve_external_memory_write_context(
                 user_id,
@@ -974,10 +982,10 @@ def execute_tool(
             raise ToolExecutionError("memory_id is required")
 
         if auth_context is None:
-            raise ToolExecutionError("Missing MCP API app/key identity for memory write authorization", code=-32009)
+            raise _authorization_denied_error("Missing MCP API app/key identity for memory write authorization")
         write_grant = authorize_memory_external_default_memory_write(auth_context, db_client=db)
         if not write_grant.allowed:
-            raise ToolExecutionError(str(write_grant.observability), code=-32009)
+            raise _authorization_denied_error(str(write_grant.observability))
 
         try:
             MemoryService(db_client=db).delete_external_memory(
@@ -999,10 +1007,10 @@ def execute_tool(
             raise ToolExecutionError("memory_id and content are required")
 
         if auth_context is None:
-            raise ToolExecutionError("Missing MCP API app/key identity for memory write authorization", code=-32009)
+            raise _authorization_denied_error("Missing MCP API app/key identity for memory write authorization")
         write_grant = authorize_memory_external_default_memory_write(auth_context, db_client=db)
         if not write_grant.allowed:
-            raise ToolExecutionError(str(write_grant.observability), code=-32009)
+            raise _authorization_denied_error(str(write_grant.observability))
 
         if not content.strip():
             raise ToolExecutionError("content must not be empty", code=-32602)
@@ -1099,10 +1107,10 @@ def execute_tool(
         fetch_limit = min(limit * 3, 60)
 
         if auth_context is None:
-            raise ToolExecutionError("Missing MCP API app/key identity for memory read authorization", code=-32009)
+            raise _authorization_denied_error("Missing MCP API app/key identity for memory read authorization")
         app_key_grant = authorize_memory_external_default_memory_read(auth_context, db_client=db)
         if not app_key_grant.allowed:
-            raise ToolExecutionError(str(app_key_grant.observability), code=-32009)
+            raise _authorization_denied_error(str(app_key_grant.observability))
 
         if memory_system == MemorySystem.CANONICAL:
             memory_service = MemoryService(db_client=db)
@@ -1121,7 +1129,7 @@ def execute_tool(
         if not mcp_legacy_read_authorized(vector_search_results):
             denied = mcp_denied_read_payload(vector_search_results)
             if denied is not None:
-                raise ToolExecutionError(str(denied), code=-32009)
+                raise _authorization_denied_error(str(denied))
             return {"memories": []}
 
         matches = vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=fetch_limit)
@@ -1476,8 +1484,10 @@ def handle_mcp_message(
                 auth_type=mcp_auth_context.auth_type,
                 client_id=mcp_auth_context.client_id,
                 outcome="error",
-                authorization_outcome=authorization_outcome_for_code(e.code),
-                error_category=error_category_for_code(e.code),
+                authorization_outcome=authorization_outcome_for_code(
+                    e.code, authorization_denied=e.analytics_authorization_denied
+                ),
+                error_category=error_category_for_code(e.code, authorization_denied=e.analytics_authorization_denied),
                 duration_ms=(time.monotonic() - started_at) * 1_000,
                 result_count=0,
             )
@@ -1493,6 +1503,19 @@ def handle_mcp_message(
                     }
                 }
             return error, None
+        except Exception:
+            schedule_mcp_tool_call(
+                uid=mcp_auth_context.uid,
+                tool_name=tool_name,
+                auth_type=mcp_auth_context.auth_type,
+                client_id=mcp_auth_context.client_id,
+                outcome="error",
+                authorization_outcome="not_applicable",
+                error_category="internal",
+                duration_ms=(time.monotonic() - started_at) * 1_000,
+                result_count=0,
+            )
+            raise
 
         schedule_mcp_tool_call(
             uid=mcp_auth_context.uid,

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, Any, Dict, List, Tuple, NoReturn, cast
@@ -84,6 +85,12 @@ from utils.mcp_memories import (
     search_default_mcp_memories_vector,
 )
 from utils.mcp_scopes import MCP_FULL_ACCESS_SCOPES
+from utils.mcp_analytics import (
+    authorization_outcome_for_code,
+    error_category_for_code,
+    result_count_for_tool_result,
+    schedule_mcp_tool_call,
+)
 from utils.observability.api_keys import record_api_key_repairs
 from utils.other.endpoints import enforce_account_deletion_http_access
 
@@ -1442,15 +1449,38 @@ def handle_mcp_message(
         raw_arguments: object = params.get("arguments", {})
         arguments: Dict[str, Any] = cast(Dict[str, Any], raw_arguments) if isinstance(raw_arguments, dict) else {}
 
-        if not tool_name:
+        if not isinstance(tool_name, str) or not tool_name:
+            schedule_mcp_tool_call(
+                uid=auth_context.uid,
+                tool_name=tool_name,
+                auth_type=auth_context.auth_type,
+                client_id=auth_context.client_id,
+                outcome="error",
+                authorization_outcome="not_applicable",
+                error_category="validation",
+                duration_ms=0,
+                result_count=0,
+            )
             return create_mcp_error(msg_id, -32602, "Tool name is required"), None
 
+        started_at = time.monotonic()
         try:
             mcp_auth_context = auth_context
             _require_tool_scope(mcp_auth_context, tool_name)
             auth_context = mcp_auth_context.memory_context
             result = execute_tool(mcp_auth_context.uid, tool_name, arguments, auth_context=auth_context)
         except ToolExecutionError as e:
+            schedule_mcp_tool_call(
+                uid=mcp_auth_context.uid,
+                tool_name=tool_name,
+                auth_type=mcp_auth_context.auth_type,
+                client_id=mcp_auth_context.client_id,
+                outcome="error",
+                authorization_outcome=authorization_outcome_for_code(e.code),
+                error_category=error_category_for_code(e.code),
+                duration_ms=(time.monotonic() - started_at) * 1_000,
+                result_count=0,
+            )
             error = create_mcp_error(msg_id, e.code, e.message)
             if e.code == -32003:
                 required_scope = TOOL_REQUIRED_SCOPE.get(tool_name)
@@ -1463,6 +1493,18 @@ def handle_mcp_message(
                     }
                 }
             return error, None
+
+        schedule_mcp_tool_call(
+            uid=mcp_auth_context.uid,
+            tool_name=tool_name,
+            auth_type=mcp_auth_context.auth_type,
+            client_id=mcp_auth_context.client_id,
+            outcome="success",
+            authorization_outcome="allowed",
+            error_category="none",
+            duration_ms=(time.monotonic() - started_at) * 1_000,
+            result_count=result_count_for_tool_result(tool_name, result),
+        )
 
         return (
             create_mcp_response(

--- a/backend/tests/unit/test_mcp_tool_analytics.py
+++ b/backend/tests/unit/test_mcp_tool_analytics.py
@@ -1,0 +1,153 @@
+"""Behavioral contract for privacy-safe hosted MCP tool telemetry."""
+
+from unittest.mock import patch
+
+from routers import mcp_sse
+from utils import mcp_analytics
+
+
+def _auth(*, scopes=None, client_id="omi-chatgpt-prod"):
+    return mcp_sse.MCPAuthContext(
+        uid="uid-test-123",
+        auth_type="oauth",
+        scopes=scopes or ["memories.read", "conversations.read"],
+        client_id=client_id,
+    )
+
+
+def test_memory_retrieval_event_has_only_bounded_allowlisted_properties(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        mcp_analytics,
+        "emit_posthog_event",
+        lambda distinct_id, event, properties: captured.append((distinct_id, event, properties)),
+    )
+
+    mcp_analytics.emit_mcp_tool_call(
+        uid="uid-test-123",
+        tool_name="search_memories",
+        auth_type="oauth",
+        client_id="omi-chatgpt-prod",
+        outcome="success",
+        authorization_outcome="allowed",
+        error_category="none",
+        duration_ms=88.9,
+        result_count=2,
+    )
+
+    assert captured == [
+        (
+            "uid-test-123",
+            "MCP Tool Call",
+            {
+                "tool": "search_memories",
+                "operation": "memory_search",
+                "client": "chatgpt",
+                "transport": "hosted_oauth",
+                "outcome": "success",
+                "authorization_outcome": "allowed",
+                "error_category": "none",
+                "duration_ms": 88,
+                "result_count": 2,
+            },
+        )
+    ]
+    properties = captured[0][2]
+    forbidden = {"query", "content", "memory", "conversation", "token", "uid", "email", "ip", "client_id"}
+    assert forbidden.isdisjoint(properties)
+
+
+def test_conversation_retrieval_records_only_cardinality_at_tool_boundary(monkeypatch):
+    events = []
+    monkeypatch.setattr(mcp_sse, "schedule_mcp_tool_call", lambda **event: events.append(event))
+
+    with patch.object(mcp_sse, "execute_tool", return_value={"conversations": [{"transcript": "private"}]}):
+        response, _ = mcp_sse.handle_mcp_message(
+            _auth(),
+            {
+                "id": 7,
+                "method": "tools/call",
+                "params": {"name": "get_conversations", "arguments": {"query": "secret query"}},
+            },
+        )
+
+    assert response["result"]["content"]
+    assert events == [
+        {
+            "uid": "uid-test-123",
+            "tool_name": "get_conversations",
+            "auth_type": "oauth",
+            "client_id": "omi-chatgpt-prod",
+            "outcome": "success",
+            "authorization_outcome": "allowed",
+            "error_category": "none",
+            "duration_ms": events[0]["duration_ms"],
+            "result_count": 1,
+        }
+    ]
+    assert 0 <= events[0]["duration_ms"] <= 60_000
+    assert "secret query" not in str(events[0])
+    assert "private" not in str(events[0])
+
+
+def test_authorization_and_validation_errors_emit_bounded_categories(monkeypatch):
+    events = []
+    monkeypatch.setattr(mcp_sse, "schedule_mcp_tool_call", lambda **event: events.append(event))
+
+    denied, _ = mcp_sse.handle_mcp_message(
+        _auth(scopes=["memories.read"]),
+        {"id": 1, "method": "tools/call", "params": {"name": "get_conversations", "arguments": {}}},
+    )
+    invalid, _ = mcp_sse.handle_mcp_message(
+        _auth(),
+        {"id": 2, "method": "tools/call", "params": {"arguments": {"query": "do not capture"}}},
+    )
+
+    assert denied["error"]["code"] == -32003
+    assert invalid["error"]["code"] == -32602
+    assert events[0]["authorization_outcome"] == "denied"
+    assert events[0]["error_category"] == "authorization_denied"
+    assert events[0]["result_count"] == 0
+    assert events[1]["authorization_outcome"] == "not_applicable"
+    assert events[1]["error_category"] == "validation"
+    assert "do not capture" not in str(events)
+
+
+def test_analytics_submission_failure_does_not_change_tool_response(monkeypatch):
+    def _raising_submit(*_args, **_kwargs):
+        raise RuntimeError("PostHog unavailable")
+
+    monkeypatch.setattr(mcp_analytics, "submit_with_context", _raising_submit)
+
+    with patch.object(mcp_sse, "execute_tool", return_value={"memories": []}):
+        response, _ = mcp_sse.handle_mcp_message(
+            _auth(),
+            {"id": 3, "method": "tools/call", "params": {"name": "get_memories", "arguments": {}}},
+        )
+
+    assert response["result"]["content"]
+
+
+def test_connector_tool_names_share_the_stable_event_contract(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        mcp_analytics,
+        "emit_posthog_event",
+        lambda distinct_id, event, properties: captured.append((distinct_id, event, properties)),
+    )
+
+    for tool_name, operation in (("search", "memory_conversation_search"), ("fetch", "memory_conversation_fetch")):
+        mcp_analytics.emit_mcp_tool_call(
+            uid="uid-test-123",
+            tool_name=tool_name,
+            auth_type="oauth",
+            client_id="omi-claude-prod",
+            outcome="success",
+            authorization_outcome="allowed",
+            error_category="none",
+            duration_ms=1,
+            result_count=1,
+        )
+        assert captured[-1][1] == "MCP Tool Call"
+        assert captured[-1][2]["operation"] == operation
+        assert captured[-1][2]["client"] == "claude"

--- a/backend/tests/unit/test_mcp_tool_analytics.py
+++ b/backend/tests/unit/test_mcp_tool_analytics.py
@@ -228,7 +228,12 @@ def test_not_found_and_paid_plan_errors_are_validation_not_internal(monkeypatch)
     for i, code in enumerate((-32001, -32002)):
         with patch.object(mcp_sse, "execute_tool", side_effect=mcp_sse.ToolExecutionError("expected", code=code)):
             mcp_sse.handle_mcp_message(
-                _auth(), {"id": 10 + i, "method": "tools/call", "params": {"name": "get_conversation_by_id", "arguments": {}}}
+                _auth(),
+                {
+                    "id": 10 + i,
+                    "method": "tools/call",
+                    "params": {"name": "get_conversation_by_id", "arguments": {}},
+                },
             )
 
     assert [event["error_category"] for event in events] == ["validation", "validation"]

--- a/backend/tests/unit/test_mcp_tool_analytics.py
+++ b/backend/tests/unit/test_mcp_tool_analytics.py
@@ -221,6 +221,53 @@ def test_unexpected_tool_errors_are_recorded_and_propagated(monkeypatch):
     assert "private failure" not in str(events)
 
 
+def test_not_found_and_paid_plan_errors_are_validation_not_internal(monkeypatch):
+    events = []
+    monkeypatch.setattr(mcp_sse, "schedule_mcp_tool_call", lambda **event: events.append(event))
+
+    for i, code in enumerate((-32001, -32002)):
+        with patch.object(mcp_sse, "execute_tool", side_effect=mcp_sse.ToolExecutionError("expected", code=code)):
+            mcp_sse.handle_mcp_message(
+                _auth(), {"id": 10 + i, "method": "tools/call", "params": {"name": "get_conversation_by_id", "arguments": {}}}
+            )
+
+    assert [event["error_category"] for event in events] == ["validation", "validation"]
+    assert [event["authorization_outcome"] for event in events] == ["not_applicable", "not_applicable"]
+
+
+def test_read_tools_have_named_operations(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        mcp_analytics,
+        "emit_posthog_event",
+        lambda distinct_id, event, properties: captured.append(properties),
+    )
+
+    for tool_name in (
+        "get_screen_activity",
+        "get_daily_summaries",
+        "get_action_items",
+        "search_action_items",
+        "get_goals",
+        "get_chat_messages",
+        "get_people",
+        "search_x_posts",
+        "get_x_posts",
+    ):
+        mcp_analytics.emit_mcp_tool_call(
+            uid="uid-test-123",
+            tool_name=tool_name,
+            auth_type="oauth",
+            client_id="omi-chatgpt-prod",
+            outcome="success",
+            authorization_outcome="allowed",
+            error_category="none",
+            duration_ms=1,
+            result_count=0,
+        )
+        assert captured[-1]["operation"] != "other", tool_name
+
+
 def test_screen_activity_summary_result_count_uses_screenshot_total():
     assert (
         mcp_analytics.result_count_for_tool_result(

--- a/backend/tests/unit/test_mcp_tool_analytics.py
+++ b/backend/tests/unit/test_mcp_tool_analytics.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from routers import mcp_sse
 from utils import mcp_analytics
 
@@ -151,3 +153,69 @@ def test_connector_tool_names_share_the_stable_event_contract(monkeypatch):
         assert captured[-1][1] == "MCP Tool Call"
         assert captured[-1][2]["operation"] == operation
         assert captured[-1][2]["client"] == "claude"
+
+
+def test_profile_result_count_ignores_data_source_metadata_and_empty_profiles():
+    assert (
+        mcp_analytics.result_count_for_tool_result(
+            "get_user_profile", {"profile_text": "private", "data_sources_used": ["a", "b"]}
+        )
+        == 1
+    )
+    assert (
+        mcp_analytics.result_count_for_tool_result(
+            "get_user_profile", {"profile": None, "message": "No profile has been generated"}
+        )
+        == 0
+    )
+    assert (
+        mcp_analytics.result_count_for_tool_result(
+            "get_memories", {"metadata": ["not a result"], "memories": [{"id": "one"}, {"id": "two"}]}
+        )
+        == 2
+    )
+
+
+def test_tool_execution_error_analytics_preserves_error_semantics(monkeypatch):
+    events = []
+    monkeypatch.setattr(mcp_sse, "schedule_mcp_tool_call", lambda **event: events.append(event))
+
+    with patch.object(mcp_sse, "execute_tool", side_effect=mcp_sse.ToolExecutionError("query is required")):
+        invalid, _ = mcp_sse.handle_mcp_message(
+            _auth(), {"id": 4, "method": "tools/call", "params": {"name": "search_memories", "arguments": {}}}
+        )
+    with patch.object(
+        mcp_sse, "execute_tool", side_effect=mcp_sse.ToolExecutionError("index unavailable", code=-32009)
+    ):
+        unavailable, _ = mcp_sse.handle_mcp_message(
+            _auth(), {"id": 5, "method": "tools/call", "params": {"name": "search_memories", "arguments": {}}}
+        )
+    with patch.object(mcp_sse, "execute_tool", side_effect=mcp_sse._authorization_denied_error("access denied")):
+        denied, _ = mcp_sse.handle_mcp_message(
+            _auth(), {"id": 6, "method": "tools/call", "params": {"name": "search_memories", "arguments": {}}}
+        )
+
+    assert invalid["error"]["code"] == -32000
+    assert unavailable["error"]["code"] == -32009
+    assert denied["error"]["code"] == -32009
+    assert [(event["authorization_outcome"], event["error_category"]) for event in events] == [
+        ("not_applicable", "validation"),
+        ("not_applicable", "internal"),
+        ("denied", "authorization_denied"),
+    ]
+
+
+def test_unexpected_tool_errors_are_recorded_and_propagated(monkeypatch):
+    events = []
+    monkeypatch.setattr(mcp_sse, "schedule_mcp_tool_call", lambda **event: events.append(event))
+
+    with patch.object(mcp_sse, "execute_tool", side_effect=RuntimeError("private failure")):
+        with pytest.raises(RuntimeError, match="private failure"):
+            mcp_sse.handle_mcp_message(
+                _auth(), {"id": 7, "method": "tools/call", "params": {"name": "get_memories", "arguments": {}}}
+            )
+
+    assert events[0]["outcome"] == "error"
+    assert events[0]["authorization_outcome"] == "not_applicable"
+    assert events[0]["error_category"] == "internal"
+    assert "private failure" not in str(events)

--- a/backend/tests/unit/test_mcp_tool_analytics.py
+++ b/backend/tests/unit/test_mcp_tool_analytics.py
@@ -219,3 +219,17 @@ def test_unexpected_tool_errors_are_recorded_and_propagated(monkeypatch):
     assert events[0]["authorization_outcome"] == "not_applicable"
     assert events[0]["error_category"] == "internal"
     assert "private failure" not in str(events)
+
+
+def test_screen_activity_summary_result_count_uses_screenshot_total():
+    assert (
+        mcp_analytics.result_count_for_tool_result(
+            "get_screen_activity", {"apps": {"Safari": {"count": 3}}, "total_screenshots": 7}
+        )
+        == 7
+    )
+    # Non-summary (row list) path still counts the screen_activity list.
+    assert (
+        mcp_analytics.result_count_for_tool_result("get_screen_activity", {"screen_activity": [{"id": 1}, {"id": 2}]})
+        == 2
+    )

--- a/backend/utils/mcp_analytics.py
+++ b/backend/utils/mcp_analytics.py
@@ -13,7 +13,7 @@ import logging
 import os
 from typing import Any, Mapping, Optional
 
-from utils.executors import db_executor, submit_with_context
+from utils.executors import postprocess_executor, submit_with_context
 from utils.integration_telemetry import emit_posthog_event
 
 logger = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ def schedule_mcp_tool_call(
     """Queue optional analytics without delaying or changing the MCP response."""
     try:
         submit_with_context(
-            db_executor,
+            postprocess_executor,
             emit_mcp_tool_call,
             uid=uid,
             tool_name=tool_name,
@@ -168,6 +168,11 @@ def result_count_for_tool_result(tool_name: object, result: Mapping[str, Any]) -
         # ``data_sources_used`` is metadata, not a collection of profiles. A
         # missing profile is represented by ``{"profile": None, ...}``.
         return 1 if result.get("profile_text") else 0
+    if tool_name == "get_screen_activity":
+        # Summary mode returns ``{"apps": {...}, "total_screenshots": N}`` instead
+        # of the ``screen_activity`` row list; count its bounded screenshot total.
+        if "total_screenshots" in result:
+            return _bounded_int(result.get("total_screenshots"), maximum=1_000)
     list_key = _RESULT_LIST_KEY_BY_TOOL.get(_normalize_tool(tool_name))
     if list_key is not None:
         value = result.get(list_key)

--- a/backend/utils/mcp_analytics.py
+++ b/backend/utils/mcp_analytics.py
@@ -45,6 +45,15 @@ _TOOL_OPERATIONS = {
     "get_conversations": "conversation_list",
     "get_conversation_by_id": "conversation_get",
     "search_conversations": "conversation_search",
+    "get_daily_summaries": "daily_summary_list",
+    "search_x_posts": "x_post_search",
+    "get_x_posts": "x_post_list",
+    "get_action_items": "action_item_list",
+    "search_action_items": "action_item_search",
+    "get_goals": "goal_list",
+    "get_chat_messages": "chat_message_list",
+    "get_people": "people_list",
+    "get_screen_activity": "screen_activity_get",
     # Kept here for the connector branch: once search/fetch reaches this
     # boundary it automatically uses the same event contract.
     "search": "memory_conversation_search",
@@ -186,7 +195,10 @@ def result_count_for_tool_result(tool_name: object, result: Mapping[str, Any]) -
 def error_category_for_code(code: int, *, authorization_denied: bool = False) -> str:
     if authorization_denied or code == -32003:
         return "authorization_denied"
-    if code in {-32602, -32000}:
+    if code in {-32602, -32000, -32001, -32002}:
+        # -32001 (not found) and -32002 (paid-plan/locked) are expected
+        # client/product-gating outcomes, not backend failures; classifying
+        # them as validation keeps the internal-error bucket meaningful.
         return "validation"
     if code == -32601:
         return "unknown_tool"

--- a/backend/utils/mcp_analytics.py
+++ b/backend/utils/mcp_analytics.py
@@ -1,0 +1,212 @@
+"""Privacy-safe product telemetry for hosted MCP tool calls.
+
+``MCP Tool Call`` is the stable PostHog event contract for the hosted
+Streamable HTTP MCP tool boundary. Its properties deliberately contain only
+closed enums and bounded numeric values. In particular, they never contain
+tool arguments, result content, OAuth/API-key credentials, user identifiers,
+client IDs, IP addresses, or exception text.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Mapping, Optional
+
+from utils.executors import db_executor, submit_with_context
+from utils.integration_telemetry import emit_posthog_event
+
+logger = logging.getLogger(__name__)
+
+MCP_TOOL_CALL = "MCP Tool Call"
+
+_CHATGPT_CLIENT_IDS = frozenset(
+    client_id
+    for client_id in {
+        "omi-chatgpt-prod",
+        "omi-chatgpt-dev",
+        os.getenv("MCP_OAUTH_CHATGPT_CLIENT_ID", ""),
+    }
+    if client_id
+)
+_CLAUDE_CLIENT_IDS = frozenset(
+    client_id
+    for client_id in {
+        "omi-claude-prod",
+        os.getenv("MCP_OAUTH_CLAUDE_CLIENT_ID", ""),
+    }
+    if client_id
+)
+
+_TOOL_OPERATIONS = {
+    "get_user_profile": "memory_get",
+    "get_memories": "memory_list",
+    "search_memories": "memory_search",
+    "get_conversations": "conversation_list",
+    "get_conversation_by_id": "conversation_get",
+    "search_conversations": "conversation_search",
+    # Kept here for the connector branch: once search/fetch reaches this
+    # boundary it automatically uses the same event contract.
+    "search": "memory_conversation_search",
+    "fetch": "memory_conversation_fetch",
+}
+_KNOWN_TOOLS = frozenset(
+    {
+        "get_user_profile",
+        "get_memories",
+        "search_memories",
+        "create_memory",
+        "edit_memory",
+        "delete_memory",
+        "get_conversations",
+        "search_conversations",
+        "get_conversation_by_id",
+        "get_daily_summaries",
+        "search_x_posts",
+        "get_x_posts",
+        "get_action_items",
+        "search_action_items",
+        "create_action_item",
+        "complete_action_item",
+        "update_action_item",
+        "delete_action_item",
+        "get_goals",
+        "get_chat_messages",
+        "get_people",
+        "get_screen_activity",
+        "search",
+        "fetch",
+    }
+)
+
+
+def schedule_mcp_tool_call(
+    *,
+    uid: str,
+    tool_name: object,
+    auth_type: object,
+    client_id: Optional[str],
+    outcome: str,
+    authorization_outcome: str,
+    error_category: str,
+    duration_ms: float,
+    result_count: int,
+) -> None:
+    """Queue optional analytics without delaying or changing the MCP response."""
+    try:
+        submit_with_context(
+            db_executor,
+            emit_mcp_tool_call,
+            uid=uid,
+            tool_name=tool_name,
+            auth_type=auth_type,
+            client_id=client_id,
+            outcome=outcome,
+            authorization_outcome=authorization_outcome,
+            error_category=error_category,
+            duration_ms=duration_ms,
+            result_count=result_count,
+        )
+    except Exception as exc:  # noqa: BLE001 - optional telemetry must fail open
+        logger.warning("mcp analytics scheduling failed error=%s", type(exc).__name__)
+
+
+def emit_mcp_tool_call(
+    *,
+    uid: str,
+    tool_name: object,
+    auth_type: object,
+    client_id: Optional[str],
+    outcome: str,
+    authorization_outcome: str,
+    error_category: str,
+    duration_ms: float,
+    result_count: int,
+) -> None:
+    """Emit the shared PostHog event using only bounded, allowlisted values."""
+    properties = {
+        "tool": _normalize_tool(tool_name),
+        "operation": _normalize_operation(tool_name),
+        "client": _normalize_client(auth_type, client_id),
+        "transport": _normalize_transport(auth_type),
+        "outcome": outcome if outcome in {"success", "error"} else "error",
+        "authorization_outcome": (
+            authorization_outcome
+            if authorization_outcome in {"allowed", "denied", "not_applicable"}
+            else "not_applicable"
+        ),
+        "error_category": (
+            error_category
+            if error_category in {"none", "authorization_denied", "validation", "unknown_tool", "internal"}
+            else "internal"
+        ),
+        "duration_ms": _bounded_int(duration_ms, maximum=60_000),
+        "result_count": _bounded_int(result_count, maximum=1_000),
+    }
+    # The shared helper owns the PostHog client and catches capture failures.
+    emit_posthog_event(uid, MCP_TOOL_CALL, properties)
+
+
+def result_count_for_tool_result(tool_name: object, result: Mapping[str, Any]) -> int:
+    """Return only a capped top-level result cardinality, never result contents."""
+    for value in result.values():
+        if isinstance(value, list):
+            return _bounded_int(len(value), maximum=1_000)
+    operation = _normalize_operation(tool_name)
+    if operation.endswith("_get") or operation.endswith("_fetch"):
+        return 1 if result else 0
+    return 0
+
+
+def error_category_for_code(code: int) -> str:
+    if code in {-32003, -32009}:
+        return "authorization_denied"
+    if code == -32602:
+        return "validation"
+    if code == -32601:
+        return "unknown_tool"
+    return "internal"
+
+
+def authorization_outcome_for_code(code: int) -> str:
+    return "denied" if code in {-32003, -32009} else "not_applicable"
+
+
+def _normalize_tool(tool_name: object) -> str:
+    return tool_name if isinstance(tool_name, str) and tool_name in _KNOWN_TOOLS else "unknown"
+
+
+def _normalize_operation(tool_name: object) -> str:
+    normalized_tool = _normalize_tool(tool_name)
+    return _TOOL_OPERATIONS.get(normalized_tool, "other")
+
+
+def _normalize_client(auth_type: object, client_id: Optional[str]) -> str:
+    if auth_type == "legacy_mcp_key":
+        return "api_key"
+    if auth_type != "oauth":
+        return "unknown"
+    if client_id in _CHATGPT_CLIENT_IDS:
+        return "chatgpt"
+    if client_id in _CLAUDE_CLIENT_IDS:
+        return "claude"
+    # OAuth token validation means this is a registered client. Do not publish
+    # its raw client ID as an analytics dimension.
+    return "other_registered"
+
+
+def _normalize_transport(auth_type: object) -> str:
+    if auth_type == "oauth":
+        return "hosted_oauth"
+    if auth_type == "legacy_mcp_key":
+        return "api_key"
+    return "unknown"
+
+
+def _bounded_int(value: object, *, maximum: int) -> int:
+    if not isinstance(value, (int, float, str)):
+        return 0
+    try:
+        return max(0, min(int(value), maximum))
+    except (TypeError, ValueError, OverflowError):
+        return 0

--- a/backend/utils/mcp_analytics.py
+++ b/backend/utils/mcp_analytics.py
@@ -50,6 +50,21 @@ _TOOL_OPERATIONS = {
     "search": "memory_conversation_search",
     "fetch": "memory_conversation_fetch",
 }
+_RESULT_LIST_KEY_BY_TOOL = {
+    "get_memories": "memories",
+    "search_memories": "memories",
+    "get_conversations": "conversations",
+    "search_conversations": "conversations",
+    "search_x_posts": "posts",
+    "get_x_posts": "posts",
+    "get_action_items": "action_items",
+    "search_action_items": "action_items",
+    "get_goals": "goals",
+    "get_chat_messages": "messages",
+    "get_people": "people",
+    "get_screen_activity": "screen_activity",
+    "get_daily_summaries": "daily_summaries",
+}
 _KNOWN_TOOLS = frozenset(
     {
         "get_user_profile",
@@ -149,27 +164,32 @@ def emit_mcp_tool_call(
 
 def result_count_for_tool_result(tool_name: object, result: Mapping[str, Any]) -> int:
     """Return only a capped top-level result cardinality, never result contents."""
-    for value in result.values():
-        if isinstance(value, list):
-            return _bounded_int(len(value), maximum=1_000)
+    if tool_name == "get_user_profile":
+        # ``data_sources_used`` is metadata, not a collection of profiles. A
+        # missing profile is represented by ``{"profile": None, ...}``.
+        return 1 if result.get("profile_text") else 0
+    list_key = _RESULT_LIST_KEY_BY_TOOL.get(_normalize_tool(tool_name))
+    if list_key is not None:
+        value = result.get(list_key)
+        return _bounded_int(len(value), maximum=1_000) if isinstance(value, list) else 0
     operation = _normalize_operation(tool_name)
     if operation.endswith("_get") or operation.endswith("_fetch"):
         return 1 if result else 0
     return 0
 
 
-def error_category_for_code(code: int) -> str:
-    if code in {-32003, -32009}:
+def error_category_for_code(code: int, *, authorization_denied: bool = False) -> str:
+    if authorization_denied or code == -32003:
         return "authorization_denied"
-    if code == -32602:
+    if code in {-32602, -32000}:
         return "validation"
     if code == -32601:
         return "unknown_tool"
     return "internal"
 
 
-def authorization_outcome_for_code(code: int) -> str:
-    return "denied" if code in {-32003, -32009} else "not_applicable"
+def authorization_outcome_for_code(code: int, *, authorization_denied: bool = False) -> str:
+    return "denied" if authorization_denied or code == -32003 else "not_applicable"
 
 
 def _normalize_tool(tool_name: object) -> str:


### PR DESCRIPTION
## Summary

- Adds the privacy-safe `MCP Tool Call` PostHog event at the hosted Streamable HTTP `tools/call` execution boundary.
- Records allowlisted tool/operation, normalized client and transport, success/error and authorization outcome, bounded latency, and result cardinality only.
- Reuses the shared fail-open PostHog helper; analytics submission or capture failures cannot affect an MCP response.
- Documents the stable event contract in `backend/docs/mcp-analytics.md`. Connector `search`/`fetch` operation mappings are included for when PR #8492 is merged; that open PR is not included or superseded here.
- Incorporates focused review feedback: records unexpected failures, separates authorization metadata from shared `-32009` codes, and makes profile/list result cardinality explicit.

## Privacy

Event properties never include query text, memory/conversation content or IDs, OAuth/API-key credentials, raw OAuth client IDs, email, or IP address. The PostHog distinct ID remains the server-side UID for unique-user measurement, consistent with the shared telemetry helper.

## Verification

- Head SHA: `b74766364408aaaf7b2d8f0133cb7e2dd8a591a7`.
- `cd backend && .venv/bin/python -m pytest tests/unit/test_mcp_tool_analytics.py -q` — 8 passed.
- `cd backend && .venv/bin/python -m pytest tests/unit/test_mcp_tool_analytics.py tests/unit/test_mcp_data_endpoints.py -k 'sse_tool_call_returns_mcp_auth_challenge_when_scope_missing or sse_post_tools_list_accepts_missing_session_id or sse_tools_list_filters_by_oauth_scopes' -q` — 3 passed before the review follow-up.
- Offline ASGI `POST /v1/mcp/sse` `tools/call` probe with local auth/data seams — 200.
- `backend/.venv/bin/python backend/scripts/scan_async_blockers.py --dirs backend/routers backend/utils` — 0 selected findings.
- `make preflight` — passed 24 selected checks after the review follow-up.

Live Claude/ChatGPT OAuth clients were not exercised; no deployment or production PostHog read was performed.

Closes SCA-294

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
