### PR TITLE
fix(memory): scan past graph-ready backfill rows

### DIFF
--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -48,7 +48,7 @@ def _arguments() -> argparse.Namespace:
         "--scan-limit",
         type=int,
         help=(
-            f"Candidate rows to read in structured-only mode (1-{MAX_STRUCTURED_SCAN_SIZE}); "
+            f"Candidate rows to read before filtering (1-{MAX_STRUCTURED_SCAN_SIZE}); "
             "does not increase the apply bound"
         ),
     )
@@ -163,8 +163,10 @@ def run_enrichment(
     candidate_limit = scan_limit if scan_limit is not None else limit
     if candidate_limit < 1 or candidate_limit > MAX_STRUCTURED_SCAN_SIZE:
         raise ValueError(f"scan_limit must be between 1 and {MAX_STRUCTURED_SCAN_SIZE}")
-    if candidate_limit != limit and not (structured_only or replan_existing):
-        raise ValueError("scan_limit greater than limit requires structured_only or replan_existing mode")
+    # The serving query orders by recent mutation time. A successful graph
+    # enrichment moves a row to the head of that ordering, so every backfill
+    # mode needs a bounded scan to look past already graph-ready rows without
+    # raising the per-execution write cap.
     if apply and confirm_uid != uid:
         raise ValueError("apply requires confirm_uid to exactly match uid")
 

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
+import pytest
+
 from models.memory_apply import MemoryControlState, memory_content_hash
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
 from utils.memory.graph_enrichment import GraphEnrichmentStatus
 from utils.memory.historical_graph_enrichment import plan_historical_graph_enrichment
 from scripts.enrich_historical_memory_graph import _is_replan_candidate
+from scripts.enrich_historical_memory_graph import run_enrichment
 
 
 class _Response:
@@ -128,3 +131,19 @@ def test_replan_candidates_exclude_current_planner_version():
 
     assert _is_replan_candidate(current) is False
     assert _is_replan_candidate(legacy) is True
+
+
+def test_historical_runner_allows_a_bounded_scan_for_unenriched_candidates():
+    """A recent graph-ready head must not hide older non-graph candidates."""
+    with pytest.raises(AttributeError, match="document"):
+        run_enrichment(
+            uid="u1",
+            firestore_project="test",
+            limit=1,
+            scan_limit=2,
+            apply=False,
+            confirm_uid=None,
+            structured_only=False,
+            db_client=object(),
+            llm=object(),
+        )


### PR DESCRIPTION
## Summary

- Permit bounded candidate scans for normal historical graph backfill.
- Prevent recently graph-ready rows from hiding older eligible un-enriched memories.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Verification

- `pytest -q backend/tests/unit/test_historical_graph_enrichment.py backend/tests/unit/test_atomic_apply.py` (32 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

