### PR TITLE
fix(agent-vm): make development bootstrap self-contained

### DIFF
--- a/.github/failure-classes/FC-agent-vm-bootstrap-contract.json
+++ b/.github/failure-classes/FC-agent-vm-bootstrap-contract.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-agent-vm-bootstrap-contract",
+  "violated_contract": "An account-owned Agent VM bootstrap must receive its immutable image, an attached least-privilege metadata identity with the required scopes, and a usable Docker runtime before starting the authenticated container.",
+  "canonical_prevention": "Publish the startup template with allowlisted image and secret-name substitution, create the VM with a dedicated environment service account limited to the Agent VM image repository and secrets, install and start Docker idempotently, and cover the rendered bootstrap and VM request contracts with tests.",
+  "canonical_prevention_artifact": [
+    "backend/agent_vm/startup.sh",
+    "backend/tests/unit/test_agent_vm_startup.py",
+    "backend/routers/desktop_agent_vm.py",
+    "backend/tests/unit/test_desktop_agent_vm.py"
+  ],
+  "evidence_prs": [10391],
+  "scope_hints": [
+    "backend/agent_vm/**",
+    "backend/routers/desktop_agent_vm.py",
+    ".github/workflows/desktop_backend_*.yml"
+  ],
+  "status": "open"
+}

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -184,6 +184,7 @@ jobs:
         env:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           AGENT_GCS_BUCKET: ${{ vars.AGENT_GCS_BUCKET }}
+          AGENT_VM_GEMINI_SECRET_NAME: GEMINI_API_KEY
         run: |
           set -euo pipefail
           if [[ -z "$AGENT_GCS_BUCKET" ]]; then
@@ -195,7 +196,8 @@ jobs:
           python3 backend/scripts/runtime_image_contracts.py smoke \
             --dockerfile backend/agent_vm/Dockerfile --image "$agent_image"
           docker push "$agent_image"
-          AGENT_VM_IMAGE="$agent_image" envsubst < backend/agent_vm/startup.sh \
+          AGENT_VM_IMAGE="$agent_image" AGENT_VM_GEMINI_SECRET_NAME="$AGENT_VM_GEMINI_SECRET_NAME" \
+            envsubst '$AGENT_VM_IMAGE $AGENT_VM_GEMINI_SECRET_NAME' < backend/agent_vm/startup.sh \
             | gcloud storage cp - "gs://$AGENT_GCS_BUCKET/startup.sh"
 
       - name: Deploy desktop-backend to Cloud Run
@@ -219,6 +221,7 @@ jobs:
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.candidate-identity.outputs.source_sha }}
             OMI_DESKTOP_BACKEND_RELEASE_CHANNEL=development
             AGENT_GCS_BUCKET=${{ env.AGENT_GCS_BUCKET }}
+            GCE_SERVICE_ACCOUNT=omi-agent-vm-bootstrap@based-hardware-dev.iam.gserviceaccount.com
           secrets: |
             /secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest
             GEMINI_API_KEY=GEMINI_API_KEY:latest

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -267,6 +267,7 @@ jobs:
       - name: Build and publish Agent VM image
         env:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          AGENT_VM_GEMINI_SECRET_NAME: DESKTOP_GEMINI_API_KEY
         run: |
           set -euo pipefail
           test -n "$AGENT_GCS_BUCKET"
@@ -275,7 +276,8 @@ jobs:
           python3 backend/scripts/runtime_image_contracts.py smoke \
             --dockerfile backend/agent_vm/Dockerfile --image "$agent_image"
           docker push "$agent_image"
-          AGENT_VM_IMAGE="$agent_image" envsubst < backend/agent_vm/startup.sh \
+          AGENT_VM_IMAGE="$agent_image" AGENT_VM_GEMINI_SECRET_NAME="$AGENT_VM_GEMINI_SECRET_NAME" \
+            envsubst '$AGENT_VM_IMAGE $AGENT_VM_GEMINI_SECRET_NAME' < backend/agent_vm/startup.sh \
             | gcloud storage cp - "gs://$AGENT_GCS_BUCKET/startup.sh"
 
       - name: Deploy production candidate at zero traffic
@@ -300,6 +302,7 @@ jobs:
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.admitted-source.outputs.source_sha }}
             OMI_DESKTOP_BACKEND_RELEASE_CHANNEL=production
             AGENT_GCS_BUCKET=${{ env.AGENT_GCS_BUCKET }}
+            GCE_SERVICE_ACCOUNT=omi-agent-vm-bootstrap@based-hardware.iam.gserviceaccount.com
           secrets: |
             /secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest
             GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest

--- a/backend/agent_vm/startup.sh
+++ b/backend/agent_vm/startup.sh
@@ -2,12 +2,52 @@
 set -euo pipefail
 
 image="${AGENT_VM_IMAGE}"
-auth_token="$(curl -fsS -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/attributes/auth-token)"
-anthropic_api_key="$(gcloud secrets versions access latest --secret=DESKTOP_ANTHROPIC_API_KEY)"
-gemini_api_key="$(gcloud secrets versions access latest --secret=GEMINI_API_KEY)"
+
+metadata_get() {
+  curl -fsS -H 'Metadata-Flavor: Google' "$1"
+}
+
+metadata_access_token() {
+  metadata_get "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])'
+}
+
+secret_access() {
+  local secret_name="$1"
+  local project_id
+  local access_token
+  project_id="$(metadata_get 'http://metadata.google.internal/computeMetadata/v1/project/project-id')"
+  access_token="$(metadata_access_token)"
+  curl -fsS \
+    -H "Authorization: Bearer $access_token" \
+    "https://secretmanager.googleapis.com/v1/projects/${project_id}/secrets/${secret_name}/versions/latest:access" \
+    | python3 -c 'import base64, json, sys; print(base64.b64decode(json.load(sys.stdin)["payload"]["data"]).decode())'
+}
+
+auth_token="$(metadata_get 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/auth-token')"
+anthropic_api_key="$(secret_access DESKTOP_ANTHROPIC_API_KEY)"
+gemini_secret_name="${AGENT_VM_GEMINI_SECRET_NAME:-GEMINI_API_KEY}"
+gemini_api_key="$(secret_access "$gemini_secret_name")"
 data_dir="${AGENT_VM_DATA_DIR:-/var/lib/omi-agent}"
 mkdir -p "$data_dir"
-gcloud auth configure-docker gcr.io --quiet
+
+if ! command -v docker >/dev/null 2>&1; then
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+fi
+if ! docker info >/dev/null 2>&1; then
+  if command -v systemctl >/dev/null 2>&1 && systemctl enable --now docker; then
+    :
+  elif command -v service >/dev/null 2>&1; then
+    service docker start
+  else
+    echo 'Docker daemon could not be started' >&2
+    exit 1
+  fi
+fi
+
+registry_token="$(metadata_access_token)"
+printf '%s' "$registry_token" | docker login --username oauth2accesstoken --password-stdin https://gcr.io >/dev/null
 docker pull "$image"
 docker rm -f omi-agent-vm >/dev/null 2>&1 || true
 docker run --detach --name omi-agent-vm --restart unless-stopped --publish 8080:8080 \

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -88,6 +88,13 @@ def _gcs_bucket() -> str:
     return bucket
 
 
+def _service_account() -> str:
+    service_account = os.getenv("GCE_SERVICE_ACCOUNT")
+    if not service_account:
+        raise RuntimeError("GCE_SERVICE_ACCOUNT is not configured")
+    return service_account
+
+
 def _get_vm(uid: str) -> dict[str, Any] | None:
     snapshot = get_firestore_client().collection("users").document(uid).get()
     if not snapshot.exists:
@@ -281,7 +288,9 @@ def _ip(instance: dict[str, Any]) -> str | None:
     return candidate if _is_usable_vm_ip(candidate) else None
 
 
-async def _create_vm(project: str, source_image: str, bucket: str, vm_name: str, auth_token: str) -> str:
+async def _create_vm(
+    project: str, source_image: str, bucket: str, vm_name: str, auth_token: str, service_account: str
+) -> str:
     url = f"https://compute.googleapis.com/compute/v1/projects/{project}/zones/{_ZONE}/instances"
     startup = f"#!/bin/bash\ncurl -sf https://storage.googleapis.com/{bucket}/startup.sh -o /tmp/omi-startup.sh && bash /tmp/omi-startup.sh\n"
     body = {
@@ -296,6 +305,14 @@ async def _create_vm(project: str, source_image: str, bucket: str, vm_name: str,
                     "diskSizeGb": "50",
                     "diskType": f"zones/{_ZONE}/diskTypes/pd-balanced",
                 },
+            }
+        ],
+        "serviceAccounts": [
+            {
+                # This identity is dedicated to VM bootstrap and is limited to
+                # the Agent VM image repository and environment secrets.
+                "email": service_account,
+                "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
             }
         ],
         "networkInterfaces": [
@@ -378,13 +395,13 @@ async def _cleanup_possible_late_vm(uid: str, project: str, vm_name: str, zone: 
 
 
 async def _provision_background(
-    uid: str, project: str, source_image: str, bucket: str, vm_name: str, auth_token: str
+    uid: str, project: str, source_image: str, bucket: str, vm_name: str, auth_token: str, service_account: str
 ) -> None:
     if not await run_blocking(db_executor, _vm_lifecycle_allowed, uid, vm_name, auth_token):
         logger.info("Skipping Agent VM create after deletion/owner transition for uid=%s", uid)
         return
     try:
-        ip = await _create_vm(project, source_image, bucket, vm_name, auth_token)
+        ip = await _create_vm(project, source_image, bucket, vm_name, auth_token, service_account)
     except AgentVmCreateOutcomeUnknown as exc:
         logger.error("Agent VM provisioning failed for uid=%s: %s", uid, exc)
         if not await run_blocking(db_executor, _vm_lifecycle_allowed, uid, vm_name, auth_token):
@@ -454,6 +471,7 @@ async def provision_agent_vm(
         project = _project()
         source_image = _source_image(project)
         bucket = _gcs_bucket()
+        service_account = _service_account()
     except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     generation = uuid.uuid4().hex
@@ -479,7 +497,9 @@ async def provision_agent_vm(
             authToken=str(vm.get("authToken") or ""),
             agentStatus=str(vm.get("status") or "provisioning"),
         )
-    background_tasks.add_task(_provision_background, uid, project, source_image, bucket, vm_name, auth_token)
+    background_tasks.add_task(
+        _provision_background, uid, project, source_image, bucket, vm_name, auth_token, service_account
+    )
     return ProvisionAgentResponse(
         status="provisioning", vmName=vm_name, authToken=auth_token, agentStatus="provisioning"
     )

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -13,8 +13,7 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     for name, body in {
-        "curl": "printf '%s\\n' omi-token\n",
-        "gcloud": "printf 'gcloud %s\\n' \"$*\" >> \"$COMMAND_LOG\"\ncase \"$1 $2\" in\n  'secrets versions') printf '%s\\n' secret-value ;;\nesac\n",
+        "curl": "case \"$*\" in\n  *'/instance/attributes/auth-token'*) printf '%s\\n' omi-token ;;\n  *'/instance/service-accounts/default/token'*) printf '%s\\n' '{\"access_token\":\"metadata-token\"}' ;;\n  *'/project/project-id'*) printf '%s\\n' based-hardware-dev ;;\n  *'secretmanager.googleapis.com'*) printf '%s\\n' '{\"payload\":{\"data\":\"c2VjcmV0LXZhbHVl\"}}' ;;\n  *) exit 1 ;;\nesac\n",
         "docker": "printf 'docker %s\\n' \"$*\" >> \"$COMMAND_LOG\"\n",
     }.items():
         path = bin_dir / name
@@ -24,6 +23,7 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
     environment = {
         **os.environ,
         "AGENT_VM_IMAGE": "gcr.io/project/agent-vm:abcdef0",
+        "AGENT_VM_GEMINI_SECRET_NAME": "GEMINI_API_KEY",
         "AGENT_VM_DATA_DIR": bash_path(tmp_path / "data", cwd=ROOT),
         "COMMAND_LOG": bash_path(log, cwd=ROOT),
         "OMI_TEST_FAKE_BIN": bash_path(bin_dir, cwd=ROOT),
@@ -41,9 +41,8 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
     )
 
     commands = log.read_text(encoding="utf-8")
-    assert "gcloud secrets versions access latest --secret=DESKTOP_ANTHROPIC_API_KEY" in commands
-    assert "gcloud secrets versions access latest --secret=GEMINI_API_KEY" in commands
-    assert "gcloud auth configure-docker gcr.io --quiet" in commands
+    assert "gcloud" not in commands
+    assert "docker login --username oauth2accesstoken --password-stdin https://gcr.io" in commands
     assert "docker pull gcr.io/project/agent-vm:abcdef0" in commands
     assert "--env ANTHROPIC_API_KEY=secret-value" in commands
     assert "--env AUTH_TOKEN=omi-token" in commands
@@ -53,3 +52,15 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
         "--env PLAYWRIGHT_MCP_ARGS=[\"--user-data-dir\", \"/app/chrome-profile\", \"--headless\", \"--no-sandbox\"]"
         in commands
     )
+
+
+def test_startup_publishers_substitute_only_the_image() -> None:
+    workflows = {
+        "desktop_backend_auto_dev.yml": "GCE_SERVICE_ACCOUNT=omi-agent-vm-bootstrap@based-hardware-dev.iam.gserviceaccount.com",
+        "desktop_backend_prod.yml": "GCE_SERVICE_ACCOUNT=omi-agent-vm-bootstrap@based-hardware.iam.gserviceaccount.com",
+    }
+    for workflow, service_account in workflows.items():
+        content = (ROOT.parent / ".github" / "workflows" / workflow).read_text(encoding="utf-8")
+        assert "envsubst '$AGENT_VM_IMAGE $AGENT_VM_GEMINI_SECRET_NAME' < backend/agent_vm/startup.sh" in content
+        assert "envsubst < backend/agent_vm/startup.sh" not in content
+        assert service_account in content

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 from fastapi import BackgroundTasks, HTTPException
 
@@ -47,6 +48,7 @@ async def test_provision_returns_existing_vm_without_scheduling(monkeypatch):
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_source_image", lambda _project: "image")
     monkeypatch.setattr(desktop_agent_vm, "_gcs_bucket", lambda: "bucket")
+    monkeypatch.setattr(desktop_agent_vm, "_service_account", lambda: "service-account")
     monkeypatch.setattr(desktop_agent_vm, "_claim_vm_if_allowed", lambda _uid, _candidate: (vm, False))
     tasks = BackgroundTasks()
 
@@ -73,6 +75,7 @@ async def test_sparse_new_uid_is_persisted_as_provisioning_and_scheduled(monkeyp
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_source_image", lambda _project: "image")
     monkeypatch.setattr(desktop_agent_vm, "_gcs_bucket", lambda: "bucket")
+    monkeypatch.setattr(desktop_agent_vm, "_service_account", lambda: "service-account")
     monkeypatch.setattr(
         desktop_agent_vm,
         "_claim_vm_if_allowed",
@@ -113,7 +116,9 @@ async def test_late_created_vm_cleanup_is_persisted_when_provider_delete_fails(m
         lambda *args: persisted.append(args),
     )
 
-    await desktop_agent_vm._provision_background("uid", "project", "image", "bucket", "omi-agent-uid", "omi-token")
+    await desktop_agent_vm._provision_background(
+        "uid", "project", "image", "bucket", "omi-agent-uid", "omi-token", "service-account"
+    )
 
     assert persisted == [("uid", "omi-agent-uid", "us-central1-a")]
 
@@ -142,7 +147,9 @@ async def test_create_error_after_deletion_admission_still_records_possible_late
         lambda *args: persisted.append(args),
     )
 
-    await desktop_agent_vm._provision_background("uid", "project", "image", "bucket", "omi-agent-uid", "omi-token")
+    await desktop_agent_vm._provision_background(
+        "uid", "project", "image", "bucket", "omi-agent-uid", "omi-token", "service-account"
+    )
 
     assert persisted == [("uid", "omi-agent-uid", "us-central1-a")]
 
@@ -163,7 +170,9 @@ async def test_pre_dispatch_create_error_never_deletes_a_superseding_vm(monkeypa
     monkeypatch.setattr(desktop_agent_vm, "_create_vm", create_vm)
     monkeypatch.setattr(desktop_agent_vm, "_delete_vm", lambda *args: deleted.append(args))
 
-    await desktop_agent_vm._provision_background("uid", "project", "image", "bucket", "old-generation", "old-token")
+    await desktop_agent_vm._provision_background(
+        "uid", "project", "image", "bucket", "old-generation", "old-token", "service-account"
+    )
 
     assert deleted == []
 
@@ -294,6 +303,44 @@ async def test_agent_vm_rejects_paywalled_desktop_user(monkeypatch):
 
     assert error.value.status_code == 402
     assert error.value.detail == "trial_expired"
+
+
+@pytest.mark.asyncio
+async def test_create_vm_attaches_dedicated_service_account_with_cloud_platform_scope(monkeypatch):
+    requests = []
+
+    async def fake_gce_request(method, url, token, body=None):
+        requests.append((method, url, body))
+        return httpx.Response(200, json={"name": "operation"}, request=httpx.Request(method, url))
+
+    async def fake_operation(*args):
+        return None
+
+    async def fake_instance(*args):
+        return "RUNNING", {"networkInterfaces": [{"accessConfigs": [{"natIP": "203.0.113.10"}]}]}
+
+    monkeypatch.setattr(desktop_agent_vm, "_get_access_token", lambda: "gce-token")
+    monkeypatch.setattr(desktop_agent_vm, "_gce_request", fake_gce_request)
+    monkeypatch.setattr(desktop_agent_vm, "_operation", fake_operation)
+    monkeypatch.setattr(desktop_agent_vm, "_instance", fake_instance)
+
+    ip = await desktop_agent_vm._create_vm(
+        "project",
+        "source-image",
+        "bucket",
+        "omi-agent-user",
+        "omi-token",
+        "agent-bootstrap@example.iam.gserviceaccount.com",
+    )
+
+    assert ip == "203.0.113.10"
+    assert requests[0][0] == "POST"
+    assert requests[0][2]["serviceAccounts"] == [
+        {
+            "email": "agent-bootstrap@example.iam.gserviceaccount.com",
+            "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
+        }
+    ]
 
 
 async def _stopped_instance():


### PR DESCRIPTION
## Summary

Follow-up to #10391 after exercising the merged development rollout against the account-owned VM for `david.d.zhang@gmail.com`.

The first live recovery required per-instance manual fixes because the published startup artifact lost its runtime shell variables, VM creation did not attach a metadata service account, and the base image did not contain Docker. This PR makes the bootstrap path self-contained and environment-correct without exposing the project default service account to user workloads.

## Changes

- Restrict `envsubst` in both development and production publishers to the image and environment-specific Gemini secret name, preserving runtime shell variables.
- Attach a dedicated environment service account with the Cloud Platform scope when creating an Agent VM; its IAM is limited to the Agent VM image repository and the two environment secrets.
- Fetch secrets and registry credentials through the metadata access token instead of requiring `gcloud` on the VM.
- Install/start Docker idempotently when the base image does not provide it.
- Bind the dev `GEMINI_API_KEY` and prod `DESKTOP_GEMINI_API_KEY` secret names explicitly.
- Configure the dedicated dev/prod service accounts in the corresponding Cloud Run deploy workflows; both identities and their least-privilege IAM bindings are provisioned.
- Add startup-template, VM request, and failure-class regression coverage.

## Verification

- `backend/.venv/bin/python -m pytest tests/unit/test_agent_vm_startup.py tests/unit/test_desktop_agent_vm.py -q` — 15 passed.
- `bash -n backend/agent_vm/startup.sh` — passed.
- Rendered-template check — image and environment-specific secret name substituted; runtime shell variables preserved.
- `make preflight` — passed all checks before PR metadata validation; the post-commit run correctly required this PR declaration.
- Prior dev evidence on the manually recovered VM: unauthenticated `/health` and `/ping` returned `401`; authenticated `/health` and `/ping` returned `200`; the exact Agent VM image pulled and ran successfully after the manual bootstrap workaround.
- Dedicated service-account IAM was provisioned in `based-hardware-dev` and `based-hardware`: Artifact Registry reader, Secret Manager accessor only for the environment's two Agent VM secrets, and `actAs` granted only to the existing desktop-backend runtime identity.

## Rollout gates

- Merge only after required CI is green and review shows no P1 comments.
- Let the merged change deploy through the development desktop-backend workflow.
- Delete and recreate only the account-owned development VM from the corrected VM request/startup contract, then verify clean startup, exact image identity, service-account metadata credentials, Docker/container readiness, and authenticated/unauthenticated health and ping behavior.
- Do not change production traffic or firewall/NAT state as part of this PR.

## Failure-Class

Failure-Class: new