### PR TITLE
fix(backend): return actionable 429 for BYOK rate limits

### DIFF
--- a/backend/llm_gateway/routers/openai_compatible.py
+++ b/backend/llm_gateway/routers/openai_compatible.py
@@ -252,14 +252,18 @@ def _resolve_credentials(request: Request, caller: ServiceAuthDependency) -> Cre
 
 
 def _error_response(exc: GatewayError) -> JSONResponse:
-    content: dict[str, object] = {
-        'error': {
-            'message': exc.message,
-            'type': _error_type_for_code(exc.code, exc.failure_class),
-            'param': exc.param,
-            'code': exc.code.value,
-        }
+    error: dict[str, object] = {
+        'message': exc.message,
+        'type': _error_type_for_code(exc.code, exc.failure_class),
+        'param': exc.param,
+        'code': exc.code.value,
     }
+    if exc.failure_class is not None:
+        # This is a bounded gateway-owned classifier, never an upstream body.
+        # Backend composition boundaries need it to preserve intentional
+        # credential policy without conflating distinct throttling failures.
+        error['failure_class'] = exc.failure_class.value
+    content: dict[str, object] = {'error': error}
     return JSONResponse(
         status_code=_status_code_for_error(exc),
         content=content,

--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -295,6 +295,10 @@ conv_folder_stub.FolderAssignment = MagicMock()
 conv_folder_stub.assign_conversation_to_folder = MagicMock()
 conv_folder_stub.build_folders_context = MagicMock(return_value="")
 
+# Stub utils.llm.gateway_error_contract (conversation_processing imports from it)
+gateway_error_contract_stub = _stub_module("utils.llm.gateway_error_contract")
+gateway_error_contract_stub.is_byok_rate_limit_gateway_error = MagicMock(return_value=False)
+
 # Load models first
 _stub_package("models")
 sys.modules["models"].__path__ = [str(BACKEND_DIR / "models")]

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -123,6 +123,10 @@ conversation_folder_stub.FolderAssignment = MagicMock()
 conversation_folder_stub.assign_conversation_to_folder = MagicMock(return_value=(None, 0.0, "test stub"))
 conversation_folder_stub.build_folders_context = MagicMock(return_value="")
 
+# Stub utils.llm.gateway_error_contract (conversation_processing imports from it)
+gateway_error_contract_stub = _stub_module("utils.llm.gateway_error_contract")
+gateway_error_contract_stub.is_byok_rate_limit_gateway_error = MagicMock(return_value=False)
+
 # Real models (pure pydantic) resolve from the models package directory.
 _stub_package("models")
 sys.modules["models"].__path__ = [str(BACKEND_DIR / "models")]

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -2,9 +2,11 @@ import os
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 import pytest
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
@@ -332,6 +334,48 @@ def test_client_session_id_claim_is_released_when_processing_fails(monkeypatch):
     else:
         raise AssertionError('expected processing failure')
 
+    delete.assert_called_once_with('uid1', expected_id)
+
+
+def test_from_segments_returns_byok_rate_limit_and_releases_idempotent_claim(monkeypatch):
+    """Typed processing errors retain the existing idempotent cleanup path."""
+    expected_id = developer._from_segments_conversation_id('uid1', 'byok-rate-limited-session')
+    delete = MagicMock()
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock(return_value=None))
+    monkeypatch.setattr(developer.lifecycle_service, 'create_processing_conversation', MagicMock(return_value=True))
+    monkeypatch.setattr(conversations_db, 'delete_conversation', delete)
+    monkeypatch.setattr(
+        developer,
+        'process_conversation',
+        MagicMock(
+            side_effect=HTTPException(
+                status_code=429,
+                detail={
+                    'code': 'byok_rate_limit',
+                    'message': 'The configured provider account is rate limited. Please retry later or check its limits.',
+                },
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        developer,
+        'resolve_client_device_from_request',
+        lambda _request: SimpleNamespace(client_device_id=None, platform=None),
+    )
+
+    app = FastAPI()
+    app.include_router(developer.router)
+    response = TestClient(app).post(
+        '/v1/conversations/from-segments',
+        json=_request(client_session_id='byok-rate-limited-session').model_dump(mode='json'),
+    )
+
+    assert response.status_code == 429
+    assert response.json()['detail']['code'] == 'byok_rate_limit'
+    assert (
+        response.json()['detail']['message']
+        == 'The configured provider account is rate limited. Please retry later or check its limits.'
+    )
     delete.assert_called_once_with('uid1', expected_id)
 
 

--- a/backend/tests/unit/test_kg_user_type_mismatch.py
+++ b/backend/tests/unit/test_kg_user_type_mismatch.py
@@ -195,6 +195,9 @@ def _build_fakes() -> dict[str, ModuleType]:
         TRENDS="trends",
     )
 
+    gateway_error_contract = add("utils.llm.gateway_error_contract")
+    gateway_error_contract.conversation_processing_http_exception = lambda error: error
+
     utils_notifications = add("utils.notifications")
     for attr in ["send_notification", "send_important_conversation_message", "send_action_item_data_message"]:
         setattr(utils_notifications, attr, MagicMock())

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -5,6 +5,7 @@ import json
 
 from fastapi.testclient import TestClient
 import httpx
+import openai
 import pytest
 from starlette.requests import Request
 
@@ -19,6 +20,7 @@ from llm_gateway.main import app
 from llm_gateway.routers import dependencies, openai_compatible
 from models.structured_extraction import ActionItemsExtraction, ConversationStructureExtraction
 from utils.llm.gateway_client import _chat_structured_payload
+from utils.llm.gateway_error_contract import is_byok_rate_limit_gateway_error
 
 LANE_ID = 'omi:auto:chat-structured'
 
@@ -157,8 +159,19 @@ def test_byok_throttling_is_not_reported_as_a_credential_rejection(monkeypatch, 
         app.dependency_overrides.clear()
 
     assert response.status_code == 429
-    assert response.json()['error']['type'] == 'rate_limit_error'
-    assert response.json()['error']['message'] == f'provider request failed: {failure_class.value}'
+    error = response.json()['error']
+    assert error['type'] == 'rate_limit_error'
+    assert error['message'] == f'provider request failed: {failure_class.value}'
+    assert error['failure_class'] == failure_class.value
+    # BYOK throttling is terminal: the gateway must not use an Omi-paid or LKG fallback.
+    assert len(provider.calls) == 1
+
+    sdk_error = openai.RateLimitError(
+        'safe gateway error',
+        response=httpx.Response(429, request=httpx.Request('POST', 'http://gateway.test/v1/chat/completions')),
+        body={'error': error},
+    )
+    assert is_byok_rate_limit_gateway_error(sdk_error) is (failure_class == FailureClass.BYOK_RATE_LIMIT)
 
 
 def test_byok_auth_failure_still_reports_a_credential_rejection(monkeypatch):

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -166,12 +166,13 @@ def test_byok_throttling_is_not_reported_as_a_credential_rejection(monkeypatch, 
     # BYOK throttling is terminal: the gateway must not use an Omi-paid or LKG fallback.
     assert len(provider.calls) == 1
 
-    sdk_error = openai.RateLimitError(
-        'safe gateway error',
-        response=httpx.Response(429, request=httpx.Request('POST', 'http://gateway.test/v1/chat/completions')),
-        body={'error': error},
-    )
-    assert is_byok_rate_limit_gateway_error(sdk_error) is (failure_class == FailureClass.BYOK_RATE_LIMIT)
+    for body in (error, {'error': error}):
+        sdk_error = openai.RateLimitError(
+            'safe gateway error',
+            response=httpx.Response(429, request=httpx.Request('POST', 'http://gateway.test/v1/chat/completions')),
+            body=body,
+        )
+        assert is_byok_rate_limit_gateway_error(sdk_error) is (failure_class == FailureClass.BYOK_RATE_LIMIT)
 
 
 def test_byok_auth_failure_still_reports_a_credential_rejection(monkeypatch):

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -21,8 +21,11 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
+from fastapi import HTTPException
 import pytest
 
+from llm_gateway.gateway.errors import GatewayCredentialFailureError, GatewayProviderFailureError
+from llm_gateway.gateway.schemas import FailureClass
 from models.conversation import Conversation, CreateConversation
 from models.conversation_enums import ConversationSource, ConversationStatus
 from models.structured import Structured
@@ -613,6 +616,67 @@ def test_track_usage_context_resets_on_exception():
             raise RuntimeError("boom")
 
     assert usage_tracker.get_current_context() is None
+
+
+def test_byok_rate_limit_reaches_conversation_composition_as_safe_actionable_429(monkeypatch, caplog):
+    """The composition boundary must retain the gateway's typed BYOK outcome."""
+    sensitive_provider_body = 'provider-body-with-api-key-and-transcript'
+    conversation = MagicMock()
+    conversation.source = ConversationSource.phone
+    conversation.get_transcript.return_value = 'a conversation transcript'
+    conversation.photos = []
+    conversation.external_data = None
+    conversation.started_at = datetime(2026, 8, 4, tzinfo=timezone.utc)
+    conversation.finished_at = datetime(2026, 8, 4, 0, 1, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(process_conversation, 'should_discard_conversation', MagicMock(return_value=False))
+    monkeypatch.setattr(
+        process_conversation,
+        'get_transcript_structure',
+        MagicMock(
+            side_effect=GatewayCredentialFailureError(
+                sensitive_provider_body,
+                failure_class=FailureClass.BYOK_RATE_LIMIT,
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        process_conversation._get_structured('uid', 'en', conversation)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail == {
+        'code': 'byok_rate_limit',
+        'message': 'The configured provider account is rate limited. Please retry later or check its limits.',
+    }
+    assert sensitive_provider_body not in str(exc_info.value.detail)
+    assert sensitive_provider_body not in caplog.text
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        GatewayCredentialFailureError('byok quota', failure_class=FailureClass.BYOK_QUOTA),
+        GatewayProviderFailureError('omi paid quota', failure_class=FailureClass.PROVIDER_429_OMI_PAID),
+    ],
+)
+def test_non_byok_rate_limit_failures_keep_generic_processing_error(monkeypatch, error):
+    conversation = MagicMock()
+    conversation.source = ConversationSource.phone
+    conversation.get_transcript.return_value = 'a conversation transcript'
+    conversation.photos = []
+    conversation.external_data = None
+    conversation.started_at = datetime(2026, 8, 4, tzinfo=timezone.utc)
+    conversation.finished_at = datetime(2026, 8, 4, 0, 1, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(process_conversation, 'should_discard_conversation', MagicMock(return_value=False))
+    monkeypatch.setattr(process_conversation, 'get_transcript_structure', MagicMock(side_effect=error))
+
+    with pytest.raises(HTTPException) as exc_info:
+        process_conversation._get_structured('uid', 'en', conversation)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == 'Error processing conversation, please try again later'
 
 
 def test_no_umbrella_conversation_processing_tracking():

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -718,6 +718,48 @@ def test_non_byok_rate_limit_failures_keep_generic_processing_error(monkeypatch,
     assert str(error) not in caplog.text
 
 
+def test_byok_rate_limit_in_action_item_extraction_reaches_composition_boundary(monkeypatch):
+    """A BYOK rate-limit during action-item extraction must not be swallowed by extract_action_items's catch-all.
+
+    extract_action_items catches every exception and returns [] by default. A typed
+    BYOK rate-limit must escape so the composition boundary (_get_structured) maps
+    it to the actionable 429 contract instead of persisting an incomplete conversation.
+    """
+    conversation = MagicMock()
+    conversation.source = ConversationSource.phone
+    conversation.get_transcript.return_value = 'a conversation transcript'
+    conversation.photos = []
+    conversation.external_data = None
+    conversation.started_at = datetime(2026, 8, 4, tzinfo=timezone.utc)
+    conversation.finished_at = datetime(2026, 8, 4, 0, 1, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(process_conversation, 'should_discard_conversation', MagicMock(return_value=False))
+    monkeypatch.setattr(
+        process_conversation,
+        'get_transcript_structure',
+        MagicMock(return_value=Structured(emoji='🧠', title='Test', overview='Overview', action_items=[])),
+    )
+    monkeypatch.setattr(
+        process_conversation,
+        'extract_action_items',
+        MagicMock(
+            side_effect=GatewayCredentialFailureError(
+                'rate limited',
+                failure_class=FailureClass.BYOK_RATE_LIMIT,
+            )
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        process_conversation._get_structured('uid', 'en', conversation)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail == {
+        'code': 'byok_rate_limit',
+        'message': 'The configured provider account is rate limited. Please retry later or check its limits.',
+    }
+
+
 def test_no_umbrella_conversation_processing_tracking():
     """Verify _get_structured no longer wraps everything in CONVERSATION_PROCESSING."""
     import sys

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -22,6 +22,8 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 from fastapi import HTTPException
+import httpx
+import openai
 import pytest
 
 from llm_gateway.gateway.errors import GatewayCredentialFailureError, GatewayProviderFailureError
@@ -653,14 +655,49 @@ def test_byok_rate_limit_reaches_conversation_composition_as_safe_actionable_429
     assert sensitive_provider_body not in caplog.text
 
 
+def test_unwrapped_openai_byok_rate_limit_reaches_conversation_composition(monkeypatch, caplog):
+    """The production SDK shape must preserve the actionable BYOK response."""
+    sensitive_provider_body = 'provider-body-with-api-key-and-transcript'
+    conversation = MagicMock()
+    conversation.source = ConversationSource.phone
+    conversation.get_transcript.return_value = 'a conversation transcript'
+    conversation.photos = []
+    conversation.external_data = None
+    conversation.started_at = datetime(2026, 8, 4, tzinfo=timezone.utc)
+    conversation.finished_at = datetime(2026, 8, 4, 0, 1, tzinfo=timezone.utc)
+
+    sdk_error = openai.RateLimitError(
+        sensitive_provider_body,
+        response=httpx.Response(429, request=httpx.Request('POST', 'http://gateway.test/v1/chat/completions')),
+        body={
+            'code': 'credential_failure',
+            'failure_class': 'byok_rate_limit',
+            'message': sensitive_provider_body,
+        },
+    )
+    monkeypatch.setattr(process_conversation, 'should_discard_conversation', MagicMock(return_value=False))
+    monkeypatch.setattr(process_conversation, 'get_transcript_structure', MagicMock(side_effect=sdk_error))
+
+    with pytest.raises(HTTPException) as exc_info:
+        process_conversation._get_structured('uid', 'en', conversation)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail == {
+        'code': 'byok_rate_limit',
+        'message': 'The configured provider account is rate limited. Please retry later or check its limits.',
+    }
+    assert sensitive_provider_body not in str(exc_info.value.detail)
+    assert sensitive_provider_body not in caplog.text
+
+
 @pytest.mark.parametrize(
     'error',
     [
-        GatewayCredentialFailureError('byok quota', failure_class=FailureClass.BYOK_QUOTA),
-        GatewayProviderFailureError('omi paid quota', failure_class=FailureClass.PROVIDER_429_OMI_PAID),
+        GatewayCredentialFailureError('provider-body-with-api-key', failure_class=FailureClass.BYOK_QUOTA),
+        GatewayProviderFailureError('provider-body-with-transcript', failure_class=FailureClass.PROVIDER_429_OMI_PAID),
     ],
 )
-def test_non_byok_rate_limit_failures_keep_generic_processing_error(monkeypatch, error):
+def test_non_byok_rate_limit_failures_keep_generic_processing_error(monkeypatch, caplog, error):
     conversation = MagicMock()
     conversation.source = ConversationSource.phone
     conversation.get_transcript.return_value = 'a conversation transcript'
@@ -677,6 +714,8 @@ def test_non_byok_rate_limit_failures_keep_generic_processing_error(monkeypatch,
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == 'Error processing conversation, please try again later'
+    assert type(error).__name__ in caplog.text
+    assert str(error) not in caplog.text
 
 
 def test_no_umbrella_conversation_processing_tracking():

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -73,6 +73,7 @@ from utils.llm.conversation_processing import (
     get_reprocess_transcript_structure,
     extract_action_items,
 )
+from utils.llm.gateway_error_contract import conversation_processing_http_exception
 from utils.llm.conversation_folder import assign_conversation_to_folder
 from utils.analytics import record_usage
 from utils.llm.usage_tracker import track_usage, Features
@@ -325,8 +326,7 @@ def _get_structured(
             )
         return structured, False
     except Exception as e:
-        logger.error(e)
-        raise HTTPException(status_code=500, detail="Error processing conversation, please try again later")
+        raise conversation_processing_http_exception(e) from e
 
 
 def _get_conversation_obj(

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -22,6 +22,7 @@ from models.structured import ActionItem, Event, Structured
 from models.structured_extraction import ActionItemsExtraction, StructuredExtraction
 from .clients import get_llm, get_llm_gateway_chat_structured, parser
 from .discard_parser import DiscardConversation, LenientDiscardParser
+from .gateway_error_contract import is_byok_rate_limit_gateway_error
 from utils.byok import has_byok_keys
 from utils.llm.gateway_client import record_chat_extraction_gateway_result
 from utils.llm.gateway_observability import record_gateway_shadow_comparison
@@ -1043,6 +1044,11 @@ def extract_action_items(
         return action_items
 
     except Exception as e:
+        # BYOK rate-limit failures are actionable and must reach the composition
+        # boundary (process_conversation._get_structured) so the user gets the
+        # typed 429/retry contract instead of a silently incomplete conversation.
+        if is_byok_rate_limit_gateway_error(e):
+            raise
         logger.error(f'Error extracting action items: {e}')
         return []
 

--- a/backend/utils/llm/gateway_error_contract.py
+++ b/backend/utils/llm/gateway_error_contract.py
@@ -1,0 +1,70 @@
+"""Privacy-safe gateway failure details consumed at backend composition boundaries."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from enum import Enum
+
+from fastapi import HTTPException
+
+BYOK_RATE_LIMIT_FAILURE_CLASS = 'byok_rate_limit'
+GATEWAY_CREDENTIAL_FAILURE_CODE = 'credential_failure'
+BYOK_RATE_LIMIT_ERROR_DETAIL = {
+    'code': BYOK_RATE_LIMIT_FAILURE_CLASS,
+    'message': 'The configured provider account is rate limited. Please retry later or check its limits.',
+}
+GENERIC_CONVERSATION_PROCESSING_ERROR_DETAIL = 'Error processing conversation, please try again later'
+
+logger = logging.getLogger(__name__)
+
+
+def is_byok_rate_limit_gateway_error(error: BaseException) -> bool:
+    """Return whether ``error`` is the gateway's typed BYOK rate-limit failure.
+
+    Gateway code may be raised directly in in-process tests, while production
+    callers receive the gateway's OpenAI-compatible error envelope through the
+    SDK. Require both the credential error code and the explicit failure class
+    so generic provider 429s and other BYOK credential failures remain distinct.
+    """
+    if (
+        _string_value(getattr(error, 'code', None)) == GATEWAY_CREDENTIAL_FAILURE_CODE
+        and _string_value(getattr(error, 'failure_class', None)) == BYOK_RATE_LIMIT_FAILURE_CLASS
+    ):
+        return True
+
+    if getattr(error, 'status_code', None) != 429:
+        return False
+
+    body = getattr(error, 'body', None)
+    if not isinstance(body, Mapping):
+        return False
+    gateway_error = body.get('error')
+    if not isinstance(gateway_error, Mapping):
+        return False
+    return (
+        _string_value(gateway_error.get('code')) == GATEWAY_CREDENTIAL_FAILURE_CODE
+        and _string_value(gateway_error.get('failure_class')) == BYOK_RATE_LIMIT_FAILURE_CLASS
+    )
+
+
+def _string_value(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Enum) and isinstance(value.value, str):
+        return value.value
+    return None
+
+
+def conversation_processing_http_exception(error: BaseException) -> HTTPException:
+    """Map a processing failure to the existing safe HTTP contract.
+
+    The caller is the authoritative conversation composition boundary. Logging
+    the BYOK case by its bounded class avoids leaking provider error bodies,
+    while every other exception retains the existing generic response and log.
+    """
+    if is_byok_rate_limit_gateway_error(error):
+        logger.warning('Conversation processing halted because the configured BYOK provider is rate limited')
+        return HTTPException(status_code=429, detail=BYOK_RATE_LIMIT_ERROR_DETAIL)
+    logger.error(error)
+    return HTTPException(status_code=500, detail=GENERIC_CONVERSATION_PROCESSING_ERROR_DETAIL)

--- a/backend/utils/llm/gateway_error_contract.py
+++ b/backend/utils/llm/gateway_error_contract.py
@@ -23,9 +23,10 @@ def is_byok_rate_limit_gateway_error(error: BaseException) -> bool:
     """Return whether ``error`` is the gateway's typed BYOK rate-limit failure.
 
     Gateway code may be raised directly in in-process tests, while production
-    callers receive the gateway's OpenAI-compatible error envelope through the
-    SDK. Require both the credential error code and the explicit failure class
-    so generic provider 429s and other BYOK credential failures remain distinct.
+    callers receive either the gateway's OpenAI-compatible error envelope or
+    its unwrapped ``error`` member through the SDK. Require both the credential
+    error code and the explicit failure class so generic provider 429s and other
+    BYOK credential failures remain distinct.
     """
     if (
         _string_value(getattr(error, 'code', None)) == GATEWAY_CREDENTIAL_FAILURE_CODE
@@ -39,7 +40,7 @@ def is_byok_rate_limit_gateway_error(error: BaseException) -> bool:
     body = getattr(error, 'body', None)
     if not isinstance(body, Mapping):
         return False
-    gateway_error = body.get('error')
+    gateway_error = body.get('error', body)
     if not isinstance(gateway_error, Mapping):
         return False
     return (
@@ -61,10 +62,11 @@ def conversation_processing_http_exception(error: BaseException) -> HTTPExceptio
 
     The caller is the authoritative conversation composition boundary. Logging
     the BYOK case by its bounded class avoids leaking provider error bodies,
-    while every other exception retains the existing generic response and log.
+    while every other exception retains the existing generic response and a
+    privacy-safe log entry.
     """
     if is_byok_rate_limit_gateway_error(error):
         logger.warning('Conversation processing halted because the configured BYOK provider is rate limited')
         return HTTPException(status_code=429, detail=BYOK_RATE_LIMIT_ERROR_DETAIL)
-    logger.error(error)
+    logger.error('Conversation processing failed: %s', type(error).__name__)
     return HTTPException(status_code=500, detail=GENERIC_CONVERSATION_PROCESSING_ERROR_DETAIL)


### PR DESCRIPTION
Closes SCA-295

## Summary

- Preserve the gateway's typed `byok_rate_limit` classification in its safe OpenAI-compatible error envelope.
- Translate only that credential failure at the conversation-processing composition boundary into HTTP 429 with the stable `detail.code=byok_rate_limit` contract.
- Keep BYOK no-fallback behavior and idempotent `/v1/conversations/from-segments` cleanup unchanged; BYOK quota and Omi-paid provider 429s retain the existing generic processing error behavior.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_llm_gateway_openai_compatible.py backend/tests/unit/test_process_conversation_usage_context.py backend/tests/unit/test_developer_from_segments_idempotency.py` — 70 passed.
- `black --check --line-length 120 --skip-string-normalization ...` — passed.
- `backend/.venv/bin/python backend/scripts/scan_async_blockers.py --dirs backend/utils/conversations backend/utils/llm backend/llm_gateway` — passed, 0 selected findings.
- The focused TestClient `/v1/conversations/from-segments` path returned 429 with the bounded BYOK rate-limit contract and released its idempotent processing claim.

## Product invariants affected

None.

Failure-Class: FC-recoverable-provider-failure-terminal


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

