### PR TITLE
fix(memory): isolate transient graph planner failures

### DIFF
--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -180,11 +180,19 @@ def run_enrichment(
         for item in _candidates(
             uid, control=control, limit=candidate_limit, db_client=db_client, replan_existing=replan_existing
         ):
-            planned = (
-                _structured_plan(item, control)
-                if structured_only
-                else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
-            )
+            try:
+                planned = (
+                    _structured_plan(item, control)
+                    if structured_only
+                    else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+                )
+            # The planner is an external dependency. A transient transport or
+            # provider failure must not make a bounded page fail closed for all
+            # of a user's remaining historical memories; leave this item
+            # unchanged and let a later page retry it.
+            except Exception:
+                report["planner_error"] += 1
+                continue
             if planned is None:
                 report["not_structured"] += 1
             elif planned.status == "ready" and planned.operation is not None:
@@ -197,17 +205,28 @@ def run_enrichment(
         # against a stale observed_head_commit_id.
         retryable_head_mismatches = 0
         max_retryable_head_mismatches = apply_limit * 2
+        planner_error_memory_ids: set[str] = set()
         while applied < apply_limit:
             control = _control(uid, db_client=db_client)
             planned = None
             for item in _candidates(
                 uid, control=control, limit=candidate_limit, db_client=db_client, replan_existing=replan_existing
             ):
-                candidate = (
-                    _structured_plan(item, control)
-                    if structured_only
-                    else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
-                )
+                if item.memory_id in planner_error_memory_ids:
+                    continue
+                try:
+                    candidate = (
+                        _structured_plan(item, control)
+                        if structured_only
+                        else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+                    )
+                # Do not repeatedly select a temporarily failing item during
+                # one page; continue looking through this bounded scan and
+                # retry it on a later execution.
+                except Exception:
+                    report["planner_error"] += 1
+                    planner_error_memory_ids.add(item.memory_id)
+                    continue
                 if candidate is None:
                     continue
                 if candidate.status == "ready" and candidate.operation is not None:

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
-from models.memory_apply import MemoryControlState, memory_content_hash
+from models.memory_apply import ApplyStatus, MemoryControlState, memory_content_hash
 from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState, MemoryItem
 from utils.memory.graph_enrichment import GraphEnrichmentStatus
 from utils.memory.historical_graph_enrichment import plan_historical_graph_enrichment
+from scripts import enrich_historical_memory_graph as historical_runner
 from scripts.enrich_historical_memory_graph import _is_replan_candidate
 from scripts.enrich_historical_memory_graph import run_enrichment
 
@@ -24,6 +26,11 @@ class _Planner:
 
     def invoke(self, _messages: object) -> _Response:
         return _Response(self.payload)
+
+
+class _FailingPlanner:
+    def invoke(self, _messages: object) -> _Response:
+        raise RuntimeError("transient gateway failure")
 
 
 def _item(**overrides: object) -> MemoryItem:
@@ -147,3 +154,53 @@ def test_historical_runner_allows_a_bounded_scan_for_unenriched_candidates():
             db_client=object(),
             llm=object(),
         )
+
+
+def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+    failing = _item(memory_id="mem_failing")
+    ready = _item(memory_id="mem_ready")
+    planner = _Planner(
+        {
+            "eligible": True,
+            "subject_entity_id": "user",
+            "predicate": "prefers_update_style",
+            "object_label": "concise updates",
+        }
+    )
+
+    monkeypatch.setattr(historical_runner, "_control", lambda *_args, **_kwargs: control)
+    monkeypatch.setattr(
+        historical_runner,
+        "_candidates",
+        lambda *_args, **_kwargs: [failing, ready],
+    )
+
+    def plan(item: MemoryItem, **_kwargs: object):
+        if item.memory_id == failing.memory_id:
+            return plan_historical_graph_enrichment(item=item, control=control, llm=_FailingPlanner())
+        return plan_historical_graph_enrichment(item=item, control=control, llm=planner)
+
+    monkeypatch.setattr(historical_runner, "plan_historical_graph_enrichment", plan)
+    monkeypatch.setattr(
+        historical_runner,
+        "apply_long_term_patch_firestore",
+        lambda **_kwargs: SimpleNamespace(status=ApplyStatus.committed),
+    )
+
+    report = run_enrichment(
+        uid="u1",
+        firestore_project="test",
+        limit=1,
+        scan_limit=2,
+        apply=True,
+        confirm_uid="u1",
+        structured_only=False,
+        apply_limit=1,
+        db_client=object(),
+        llm=object(),
+    )
+
+    assert report["outcomes"] == {"committed": 1, "planner_error": 1}


### PR DESCRIPTION
## Summary
- Count and skip transient per-item historical graph planner failures so one LLM transport error cannot abort a bounded cohort backfill page.
- Continue scanning remaining candidates in the same page and retry failed items in later executions.

## Product invariants affected
- INV-MEM-1

Failure-Class: none

## Verification
- pytest -q backend/tests/unit/test_historical_graph_enrichment.py backend/tests/unit/test_atomic_apply.py (33 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

