### PR TITLE
fix(agent-vm): gate readiness on runtime bootstrap

### DIFF
--- a/backend/agent_vm/startup.sh
+++ b/backend/agent_vm/startup.sh
@@ -26,7 +26,7 @@ secret_access() {
 
 auth_token="$(metadata_get 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/auth-token')"
 anthropic_api_key="$(secret_access DESKTOP_ANTHROPIC_API_KEY)"
-gemini_secret_name="${AGENT_VM_GEMINI_SECRET_NAME:-GEMINI_API_KEY}"
+gemini_secret_name="${AGENT_VM_GEMINI_SECRET_NAME}"
 gemini_api_key="$(secret_access "$gemini_secret_name")"
 data_dir="${AGENT_VM_DATA_DIR:-/var/lib/omi-agent}"
 mkdir -p "$data_dir"

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -3,6 +3,7 @@ import hashlib
 import ipaddress
 import logging
 import os
+import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -24,6 +25,9 @@ from utils.subscription import is_trial_paywalled
 logger = logging.getLogger(__name__)
 router = APIRouter()
 _ZONE = "us-central1-a"
+_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+_READY_TIMEOUT_SECONDS = 300
+_READY_POLL_SECONDS = 5
 
 
 class AccountDeletionAccessBlocked(RuntimeError):
@@ -270,6 +274,26 @@ async def _instance(project: str, zone: str, vm_name: str) -> tuple[str, dict[st
     return str(instance.get("status", "UNKNOWN")), instance
 
 
+async def _wait_for_vm_ready(ip: str, auth_token: str) -> None:
+    deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
+    url = f"http://{ip}:8080/health"
+    headers = {"Authorization": f"Bearer {auth_token}"}
+    async with httpx.AsyncClient(timeout=10) as client:
+        while time.monotonic() < deadline:
+            try:
+                unauthenticated = await client.get(url)
+                if unauthenticated.status_code != 401:
+                    await asyncio.sleep(_READY_POLL_SECONDS)
+                    continue
+                response = await client.get(url, headers=headers)
+                if response.status_code == 200 and response.json().get("status") == "ok":
+                    return
+            except (httpx.HTTPError, ValueError):
+                pass
+            await asyncio.sleep(_READY_POLL_SECONDS)
+    raise RuntimeError("Agent VM did not become healthy before the readiness timeout")
+
+
 def _is_usable_vm_ip(value: Any) -> bool:
     if not isinstance(value, str) or not value or value == "unknown":
         return False
@@ -312,7 +336,7 @@ async def _create_vm(
                 # This identity is dedicated to VM bootstrap and is limited to
                 # the Agent VM image repository and environment secrets.
                 "email": service_account,
-                "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
+                "scopes": [_CLOUD_PLATFORM_SCOPE],
             }
         ],
         "networkInterfaces": [
@@ -345,7 +369,31 @@ async def _create_vm(
     ip = _ip(instance)
     if ip is None:
         raise AgentVmCreateOutcomeUnknown("GCE created VM has no usable IP address")
+    await _wait_for_vm_ready(ip, auth_token)
     return ip
+
+
+async def _set_service_account(project: str, vm_name: str, zone: str, service_account: str) -> None:
+    token = await run_blocking(db_executor, _get_access_token)
+    url = f"https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{vm_name}/setServiceAccount"
+    body = {"email": service_account, "scopes": [_CLOUD_PLATFORM_SCOPE]}
+    response = await _gce_request("POST", url, token, body)
+    response.raise_for_status()
+    operation = response.json().get("name")
+    if not operation:
+        raise RuntimeError("GCE set-service-account response omitted operation name")
+    await _operation(project, zone, operation)
+
+
+async def _stop_vm(project: str, vm_name: str, zone: str) -> None:
+    token = await run_blocking(db_executor, _get_access_token)
+    url = f"https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{vm_name}/stop"
+    response = await _gce_request("POST", url, token)
+    response.raise_for_status()
+    operation = response.json().get("name")
+    if not operation:
+        raise RuntimeError("GCE stop response omitted operation name")
+    await _operation(project, zone, operation)
 
 
 async def _start_vm(project: str, vm_name: str, zone: str) -> str:
@@ -424,29 +472,33 @@ async def _provision_background(
         await _cleanup_possible_late_vm(uid, project, vm_name, _ZONE)
 
 
-async def _restart_background(uid: str, project: str, vm: dict[str, Any]) -> None:
+async def _restart_background(uid: str, project: str, vm: dict[str, Any], service_account: str) -> None:
     vm_name = str(vm["vmName"])
     zone = str(vm.get("zone") or _ZONE)
     auth_token = str(vm.get("authToken") or "")
     try:
+        await _set_service_account(project, vm_name, zone, service_account)
         ip = await _start_vm(project, vm_name, zone)
+        await _wait_for_vm_ready(ip, auth_token)
         await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "ready", ip, zone)
     except Exception as exc:
         logger.error("Agent VM restart failed for uid=%s: %s", uid, exc)
         await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "error", None, zone)
 
 
-async def _recover_background(uid: str, vm: dict[str, Any], ip: str) -> None:
-    await run_blocking(
-        db_executor,
-        _set_vm_if_current,
-        uid,
-        str(vm["vmName"]),
-        str(vm.get("authToken") or ""),
-        "ready",
-        ip,
-        str(vm.get("zone") or _ZONE),
-    )
+async def _rebootstrap_background(uid: str, project: str, vm: dict[str, Any], service_account: str) -> None:
+    vm_name = str(vm["vmName"])
+    zone = str(vm.get("zone") or _ZONE)
+    auth_token = str(vm.get("authToken") or "")
+    try:
+        await _stop_vm(project, vm_name, zone)
+        await _set_service_account(project, vm_name, zone, service_account)
+        ip = await _start_vm(project, vm_name, zone)
+        await _wait_for_vm_ready(ip, auth_token)
+        await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "ready", ip, zone)
+    except Exception as exc:
+        logger.error("Agent VM rebootstrap failed for uid=%s: %s", uid, exc)
+        await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "error", None, zone)
 
 
 def _response(vm: dict[str, Any]) -> AgentVmResponse:
@@ -546,7 +598,22 @@ async def get_agent_status(
         )
         if not updated:
             return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        background_tasks.add_task(_restart_background, uid, project, vm)
+        try:
+            service_account = _service_account()
+        except RuntimeError as exc:
+            logger.error("Agent VM restart blocked for uid=%s: %s", uid, exc)
+            await run_blocking(
+                db_executor,
+                _set_vm_if_current,
+                uid,
+                str(vm["vmName"]),
+                str(vm.get("authToken") or ""),
+                "error",
+                None,
+                str(vm.get("zone") or _ZONE),
+            )
+            return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
+        background_tasks.add_task(_restart_background, uid, project, vm, service_account)
         return _response(pending)
     if (
         gce_status == "RUNNING"
@@ -572,6 +639,21 @@ async def get_agent_status(
                 auth_token,
             )
             return None if deleted else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        background_tasks.add_task(_recover_background, uid, vm, instance_ip)
+        try:
+            service_account = _service_account()
+        except RuntimeError as exc:
+            logger.error("Agent VM recovery blocked for uid=%s: %s", uid, exc)
+            await run_blocking(
+                db_executor,
+                _set_vm_if_current,
+                uid,
+                str(vm["vmName"]),
+                str(vm.get("authToken") or ""),
+                "error",
+                None,
+                str(vm.get("zone") or _ZONE),
+            )
+            return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
+        background_tasks.add_task(_rebootstrap_background, uid, project, vm, service_account)
         return _response(pending)
     return _response(vm)

--- a/backend/scripts/apply-agent-vm-bootstrap-iam.sh
+++ b/backend/scripts/apply-agent-vm-bootstrap-iam.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Provision the narrow runtime permission used by Agent VM self-stop.
+#
+# Refuse by default. Apply only after reviewing the target projects:
+#   AGENT_VM_BOOTSTRAP_IAM_APPLY=1 bash backend/scripts/apply-agent-vm-bootstrap-iam.sh
+set -euo pipefail
+
+if [[ "${AGENT_VM_BOOTSTRAP_IAM_APPLY:-}" != "1" ]]; then
+  echo "REFUSED: set AGENT_VM_BOOTSTRAP_IAM_APPLY=1 to mutate Agent VM IAM." >&2
+  exit 1
+fi
+
+ROLE_ID="omiAgentVmSelfStop"
+ROLE_TITLE="Omi Agent VM self-stop"
+ROLE_PERMISSIONS="compute.instances.stop"
+ZONE="us-central1-a"
+
+for project in based-hardware-dev based-hardware; do
+  service_account="omi-agent-vm-bootstrap@${project}.iam.gserviceaccount.com"
+  role="projects/${project}/roles/${ROLE_ID}"
+  condition_title="Agent VM prefix self-stop"
+  condition_description="Allow the bootstrap identity to stop only Agent VMs in ${ZONE}."
+  condition_expression="resource.type == 'compute.googleapis.com/Instance' && resource.name.startsWith('projects/${project}/zones/${ZONE}/instances/omi-agent-')"
+
+  if gcloud iam roles describe "${ROLE_ID}" --project="${project}" >/dev/null 2>&1; then
+    gcloud iam roles update "${ROLE_ID}" \
+      --project="${project}" \
+      --title="${ROLE_TITLE}" \
+      --permissions="${ROLE_PERMISSIONS}" \
+      --stage=GA >/dev/null
+  else
+    gcloud iam roles create "${ROLE_ID}" \
+      --project="${project}" \
+      --title="${ROLE_TITLE}" \
+      --permissions="${ROLE_PERMISSIONS}" \
+      --stage=GA >/dev/null
+  fi
+
+  gcloud projects remove-iam-policy-binding "${project}" \
+    --member="serviceAccount:${service_account}" \
+    --role="${role}" \
+    --condition=None >/dev/null 2>&1 || true
+  gcloud projects add-iam-policy-binding "${project}" \
+    --member="serviceAccount:${service_account}" \
+    --role="${role}" \
+    --condition="title=${condition_title},description=${condition_description},expression=${condition_expression}" >/dev/null
+  echo "Configured conditional ${role} for ${service_account} in ${project}."
+done

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -54,13 +54,37 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
     )
 
 
-def test_startup_publishers_substitute_only_the_image() -> None:
+def test_startup_publishers_render_image_and_secret_name_without_shell_defaults() -> None:
     workflows = {
         "desktop_backend_auto_dev.yml": "GCE_SERVICE_ACCOUNT=omi-agent-vm-bootstrap@based-hardware-dev.iam.gserviceaccount.com",
         "desktop_backend_prod.yml": "GCE_SERVICE_ACCOUNT=omi-agent-vm-bootstrap@based-hardware.iam.gserviceaccount.com",
     }
-    for workflow, service_account in workflows.items():
-        content = (ROOT.parent / ".github" / "workflows" / workflow).read_text(encoding="utf-8")
+    publisher_paths = sorted(
+        path
+        for path in (ROOT.parent / ".github" / "workflows").glob("desktop_backend_*.yml")
+        if "backend/agent_vm/startup.sh" in path.read_text(encoding="utf-8")
+    )
+    assert {path.name for path in publisher_paths} == set(workflows)
+    for path in publisher_paths:
+        workflow = path.name
+        service_account = workflows[workflow]
+        content = path.read_text(encoding="utf-8")
         assert "envsubst '$AGENT_VM_IMAGE $AGENT_VM_GEMINI_SECRET_NAME' < backend/agent_vm/startup.sh" in content
         assert "envsubst < backend/agent_vm/startup.sh" not in content
         assert service_account in content
+
+    rendered = subprocess.run(
+        ["envsubst", "$AGENT_VM_IMAGE $AGENT_VM_GEMINI_SECRET_NAME"],
+        input=STARTUP.read_bytes(),
+        env={
+            **os.environ,
+            "AGENT_VM_IMAGE": "gcr.io/project/agent-vm:abcdef0",
+            "AGENT_VM_GEMINI_SECRET_NAME": "DESKTOP_GEMINI_API_KEY",
+        },
+        capture_output=True,
+        check=True,
+    ).stdout.decode("utf-8")
+    assert 'image="gcr.io/project/agent-vm:abcdef0"' in rendered
+    assert 'gemini_secret_name="DESKTOP_GEMINI_API_KEY"' in rendered
+    assert "${AGENT_VM_GEMINI_SECRET_NAME}" not in rendered
+    assert '${AGENT_VM_DATA_DIR:-/var/lib/omi-agent}' in rendered

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -209,6 +209,7 @@ async def test_status_restarts_stopped_vm_and_returns_provisioning(monkeypatch):
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", lambda *args: _stopped_instance())
+    monkeypatch.setattr(desktop_agent_vm, "_service_account", lambda: "service-account")
     monkeypatch.setattr(desktop_agent_vm, "_set_vm_if_current", lambda *args: writes.append(args) or True)
     tasks = BackgroundTasks()
 
@@ -323,6 +324,7 @@ async def test_create_vm_attaches_dedicated_service_account_with_cloud_platform_
     monkeypatch.setattr(desktop_agent_vm, "_gce_request", fake_gce_request)
     monkeypatch.setattr(desktop_agent_vm, "_operation", fake_operation)
     monkeypatch.setattr(desktop_agent_vm, "_instance", fake_instance)
+    monkeypatch.setattr(desktop_agent_vm, "_wait_for_vm_ready", lambda *_args: _async_result(None))
 
     ip = await desktop_agent_vm._create_vm(
         "project",
@@ -341,6 +343,99 @@ async def test_create_vm_attaches_dedicated_service_account_with_cloud_platform_
             "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_restart_sets_bootstrap_identity_and_waits_for_health(monkeypatch):
+    calls = []
+
+    async def set_service_account(*args):
+        calls.append(("service-account", args))
+
+    async def start_vm(*args):
+        calls.append(("start", args))
+        return "203.0.113.10"
+
+    async def wait_for_ready(*args):
+        calls.append(("health", args))
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_set_service_account", set_service_account)
+    monkeypatch.setattr(desktop_agent_vm, "_start_vm", start_vm)
+    monkeypatch.setattr(desktop_agent_vm, "_wait_for_vm_ready", wait_for_ready)
+    monkeypatch.setattr(desktop_agent_vm, "_set_vm_if_current", lambda *args: calls.append(("ready", args)))
+
+    await desktop_agent_vm._restart_background(
+        "uid",
+        "project",
+        {"vmName": "omi-agent-user", "zone": "zone", "authToken": "omi-token"},
+        "agent-bootstrap@example.iam.gserviceaccount.com",
+    )
+
+    assert [name for name, _ in calls] == ["service-account", "start", "health", "ready"]
+
+
+@pytest.mark.asyncio
+async def test_rebootstrap_stops_legacy_running_vm_before_identity_migration(monkeypatch):
+    calls = []
+
+    async def stop_vm(*args):
+        calls.append(("stop", args))
+
+    async def set_service_account(*args):
+        calls.append(("service-account", args))
+
+    async def start_vm(*args):
+        calls.append(("start", args))
+        return "203.0.113.10"
+
+    async def wait_for_ready(*args):
+        calls.append(("health", args))
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_stop_vm", stop_vm)
+    monkeypatch.setattr(desktop_agent_vm, "_set_service_account", set_service_account)
+    monkeypatch.setattr(desktop_agent_vm, "_start_vm", start_vm)
+    monkeypatch.setattr(desktop_agent_vm, "_wait_for_vm_ready", wait_for_ready)
+    monkeypatch.setattr(desktop_agent_vm, "_set_vm_if_current", lambda *args: calls.append(("ready", args)))
+
+    await desktop_agent_vm._rebootstrap_background(
+        "uid",
+        "project",
+        {"vmName": "omi-agent-user", "zone": "zone", "authToken": "omi-token"},
+        "agent-bootstrap@example.iam.gserviceaccount.com",
+    )
+
+    assert [name for name, _ in calls] == ["stop", "service-account", "start", "health", "ready"]
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_requires_unauthenticated_rejection(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, _url, headers=None):
+            calls.append(headers)
+            if headers is None:
+                return httpx.Response(401)
+            return httpx.Response(200, json={"status": "ok"})
+
+    monkeypatch.setattr(desktop_agent_vm.httpx, "AsyncClient", lambda **_kwargs: FakeClient())
+    await desktop_agent_vm._wait_for_vm_ready("203.0.113.10", "omi-token")
+
+    assert calls == [None, {"Authorization": "Bearer omi-token"}]
 
 
 async def _stopped_instance():


### PR DESCRIPTION
## Summary

Follow-up to #11111 after verifying its merged development deployment artifact. The first corrected artifact still preserved the `${AGENT_VM_GEMINI_SECRET_NAME:-GEMINI_API_KEY}` shell expression, which `envsubst` does not render; the deployed artifact therefore did not prove the environment-specific Gemini secret contract.

This PR closes that runtime gap and the remaining review findings before another account-owned development VM test.

## Changes

- Use a plain environment-specific Gemini secret placeholder so the dev/prod publishers render the actual secret name into `startup.sh`; add behavioral render coverage.
- Keep Agent VM Firestore state `provisioning` until an unauthenticated `/health` request is rejected and authenticated `/health` succeeds, including legacy running-VM rebootstrap.
- Stop legacy running VMs, attach the dedicated bootstrap service account, and start them again before publishing `ready`.
- Add a refuse-by-default IAM script for a conditional custom `compute.instances.stop` role restricted to `omi-agent-*` instances in the Agent VM zone.

## Verification

- `bash -n backend/agent_vm/startup.sh backend/scripts/apply-agent-vm-bootstrap-iam.sh` — passed.
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_agent_vm_startup.py backend/tests/unit/test_desktop_agent_vm.py -q` — 18 passed.
- Rendered the deployed development startup artifact from the merged revision and confirmed the remaining secret-placeholder defect before stopping VM retest.

## Rollout gates

- Merge only with current-head CI green and no unresolved P1 review comments.
- Apply `backend/scripts/apply-agent-vm-bootstrap-iam.sh` in dev and prod after review; it refuses to mutate IAM without `AGENT_VM_BOOTSTRAP_IAM_APPLY=1` and replaces any prior unconditioned binding with the Agent VM prefix condition.
- Let the merged change deploy to development.
- Delete and recreate only the account-owned development VM for `david.d.zhang@gmail.com`, then verify the rendered secret name, dedicated service account, Docker/container readiness, authenticated/unauthenticated health and ping behavior, and no default service-account attachment.
- Do not change production traffic or firewall/NAT state.

## Failure-Class

Failure-Class: FC-agent-vm-bootstrap-contract
