### PR TITLE
fix(memory): bound historical graph planner calls

### DIFF
--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -37,6 +37,7 @@ from utils.memory.historical_graph_enrichment import (  # noqa: E402
 
 MAX_PAGE_SIZE = 25
 MAX_STRUCTURED_SCAN_SIZE = 1250
+HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS = 20.0
 
 
 def _arguments() -> argparse.Namespace:
@@ -172,7 +173,10 @@ def run_enrichment(
 
     db_client = db_client or _firestore_client(project=firestore_project)
     if llm is None and not structured_only:
-        llm = get_llm("memory_l2")
+        # A page applies serially and may retry individual records. Keep the
+        # per-item transport deadline below the Cloud Run task budget so one
+        # silent upstream request cannot monopolize the full backfill page.
+        llm = get_llm("memory_l2", request_timeout=HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
     report: Counter[str] = Counter()
     applied = 0
     if not apply:

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -227,6 +227,28 @@ def test_memory_l2_gateway_mode_uses_luna_auto_lane_without_direct_fallback(monk
     assert legacy.calls == []
 
 
+def test_get_llm_forwards_an_explicit_gateway_transport_timeout(monkeypatch):
+    captured = {}
+
+    def fake_gateway(lane_id, streaming=False, options=None, *, feature=None):
+        captured.update(lane_id=lane_id, streaming=streaming, options=options, feature=feature)
+        return FakeChatModel(name="gateway", calls=[])
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, "gateway")
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(clients, "get_or_create_omi_gateway_llm", fake_gateway)
+
+    clients.get_llm("memory_l2", request_timeout=20.0)
+
+    assert captured == {
+        "lane_id": "omi:auto:memory-l2",
+        "streaming": False,
+        "options": {"request_timeout": 20.0},
+        "feature": "memory_l2",
+    }
+
+
 def test_get_llm_feature_gateway_mode_fails_closed_on_transport_failure(monkeypatch):
     legacy = FakeChatModel(name='legacy', calls=[])
 
@@ -248,7 +270,6 @@ def test_get_llm_feature_gateway_mode_fails_closed_on_transport_failure(monkeypa
 
 
 def test_gateway_serving_does_not_fallback_on_gateway_configuration_503():
-    from utils.llm import gateway_serving
 
     request = httpx.Request('POST', 'http://gateway/v1/chat/completions')
     response = httpx.Response(503, request=request)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 import hashlib
 import logging
 import os
@@ -27,7 +28,6 @@ from utils.llm.byok_errors import handle_llm_error
 from utils.llm.model_config import (
     MODEL_QOS_PROFILES,
     _ANTHROPIC_ONLY_FEATURES,
-    _DEFAULT_CONFIG,
     _OPENROUTER_TEMPERATURES,
     _PERPLEXITY_ONLY_FEATURES,
     _PINNED_FEATURES,
@@ -36,12 +36,12 @@ from utils.llm.model_config import (
     _active_profile_name,
     _byok_profile,
     _byok_profile_name,
+    get_default_config,
     get_active_profile,
     get_active_profile_name,
     get_all_configured_features,
     get_byok_profile,
     get_byok_profile_name,
-    get_default_config,
     get_model,
     get_provider,
     get_route_options,
@@ -51,15 +51,15 @@ from utils.llm.model_config import (
     supports_cache_retention,
     supports_prompt_cache,
     _get_model_config,
-)
+)  # noqa: F401 - legacy clients-module QoS re-exports
 from utils.llm.providers import (
-    ChatGoogleGenerativeAI,  # backward-compat re-export (was here pre-refactor)
+    ChatGoogleGenerativeAI,
     GEMINI_OPENAI_BASE_URL,
     get_default_client,
     get_or_create_gemini_llm as _get_or_create_gemini_llm,
     get_or_create_openai_compatible_llm,
     _llm_cache,
-)
+)  # noqa: F401 - legacy clients-module provider re-exports
 
 try:
     from utils.llm.providers import get_or_create_omi_gateway_llm
@@ -450,6 +450,7 @@ def get_llm(
     streaming: bool = False,
     cache_key: Optional[str] = None,
     prompt_cache_options: Optional[dict[str, str]] = None,
+    request_timeout: float | None = None,
 ) -> BaseChatModel:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
@@ -516,9 +517,15 @@ def get_llm(
             else get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
         )
     elif gateway_feature_mode:
-        result = get_or_create_omi_gateway_llm(feature_auto_lane_id(feature), streaming, feature=feature)
+        gateway_options = {"request_timeout": request_timeout} if request_timeout is not None else None
+        result = get_or_create_omi_gateway_llm(
+            feature_auto_lane_id(feature), streaming, gateway_options, feature=feature
+        )
     else:
-        result = get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
+        route_options = get_route_options(feature, model, provider)
+        if request_timeout is not None:
+            route_options = {**route_options, "request_timeout": request_timeout}
+        result = get_default_client(model, provider, streaming, route_options)
 
     result = maybe_wrap_dev_gateway_shadow(
         feature=feature,
@@ -590,13 +597,13 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
 
 
 # Startup logging — log active profile so cost issues are traceable.
-_active_profile = get_active_profile()
-logger.info('Model QoS profile=%s (%d features)', get_active_profile_name(), len(_active_profile))
-for _feat, (_model, _provider) in sorted(_active_profile.items()):
+_active_qos_profile = get_active_profile()
+logger.info('Model QoS profile=%s (%d features)', get_active_profile_name(), len(_active_qos_profile))
+for _feat, (_model, _provider) in sorted(_active_qos_profile.items()):
     logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
 logger.info('BYOK QoS profile=%s', get_byok_profile_name())
 
-_so_gemini = {f for f in _active_profile if is_structured_output_feature(f) and _get_model_config(f)[1] == 'gemini'}
+_so_gemini = {f for f in _active_qos_profile if is_structured_output_feature(f) and _get_model_config(f)[1] == 'gemini'}
 if _so_gemini:
     logger.info('Structured output features on Gemini: %s', ', '.join(sorted(_so_gemini)))
 


### PR DESCRIPTION
## Summary
- Bound historical graph planner gateway calls to 20 seconds so a single silent upstream request cannot consume the Cloud Run page budget.
- Preserve per-item retry/skip behavior and verify the gateway transport receives the explicit timeout.

## Product invariants affected
- INV-MEM-1

Failure-Class: none

## Verification
- pytest -q backend/tests/unit/test_historical_graph_enrichment.py backend/tests/unit/test_llm_gateway_client_config.py backend/tests/unit/test_atomic_apply.py (56 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

