### PR TITLE
fix(listen): expose parity capture lifecycle boundaries

### DIFF
--- a/backend/routers/listen/parity_capture.py
+++ b/backend/routers/listen/parity_capture.py
@@ -14,7 +14,7 @@ from testing.parity_pack_v0.capture import CaptureInvocation, CaptureTap
 from testing.parity_pack_v0.schema import CassetteIdentity
 from testing.parity_pack_v0.whitelist import CaptureWhitelist
 
-from .parity_telemetry import record_parity_capture_event
+from .parity_telemetry import record_parity_capture_event, record_parity_capture_lifecycle
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,11 @@ class ListenParityCapture:
         env = os.environ if environ is None else environ
         record_parity_capture_event('listen', 'accepted', 'none', environ=env)
         whitelist = CaptureWhitelist.from_environ(dict(env))
+        record_parity_capture_lifecycle(
+            'enabled',
+            'enabled' if whitelist.enabled else 'disabled',
+            environ=env,
+        )
         decision_reason = _allowlist_decision_reason(whitelist, principal_id)
         record_parity_capture_event(
             'allowlist',
@@ -100,11 +105,22 @@ class ListenParityCapture:
             decision_reason,
             environ=env,
         )
+        record_parity_capture_lifecycle(
+            'admitted',
+            'allowed' if decision_reason == 'allowed' else 'rejected',
+            environ=env,
+        )
         if decision_reason != 'allowed':
             return cls(None, environ=environ)
         root = _capture_root(env)
         if root is None:
             record_parity_capture_event('initialize', 'failed', 'root_invalid', environ=env)
+            record_parity_capture_lifecycle(
+                'bootstrap',
+                'failed',
+                error_type='ConfigurationError',
+                environ=env,
+            )
             return cls(None, environ=environ)
         identity = CassetteIdentity(
             anon_session=_anonymous_id(principal_id, session_id),
@@ -118,13 +134,26 @@ class ListenParityCapture:
             invocation = CaptureTap(root, whitelist).start(principal_id, identity, request)
             if invocation is None:
                 record_parity_capture_event('initialize', 'failed', 'internal', environ=env)
+                record_parity_capture_lifecycle(
+                    'bootstrap',
+                    'failed',
+                    error_type='CaptureStartError',
+                    environ=env,
+                )
                 return cls(None, environ=environ)
             record_parity_capture_event('initialize', 'succeeded', 'none', environ=env)
+            record_parity_capture_lifecycle('bootstrap', 'succeeded', environ=env)
             return cls(invocation, environ=environ)
         except Exception as error:
             # Capture must never make an otherwise valid listen session unavailable.
             logger.warning("Parity pack capture initialization failed error_type=%s", type(error).__name__)
             record_parity_capture_event('initialize', 'failed', 'internal', environ=env)
+            record_parity_capture_lifecycle(
+                'bootstrap',
+                'failed',
+                error_type=type(error).__name__,
+                environ=env,
+            )
             return cls(None, environ=environ)
 
     @property
@@ -169,19 +198,34 @@ class ListenParityCapture:
             invocation.observe(direction, payload)
             self._event_count += 1
             self._audio_bytes += audio_bytes
+            record_parity_capture_lifecycle('observe', 'succeeded', environ=self._environ)
         except Exception as error:
             logger.warning("Parity pack capture observe failed error_type=%s", type(error).__name__)
+            record_parity_capture_lifecycle(
+                'observe',
+                'failed',
+                error_type=type(error).__name__,
+                environ=self._environ,
+            )
 
     def persist(self) -> None:
         if self._invocation is None:
             return
+        record_parity_capture_lifecycle('persist', 'attempted', environ=self._environ)
         try:
             path = self._invocation.persist()
         except Exception as error:
             logger.warning("Parity pack capture persist failed error_type=%s", type(error).__name__)
             record_parity_capture_event('persist', 'failed', 'internal', environ=self._environ)
+            record_parity_capture_lifecycle(
+                'persist',
+                'failed',
+                error_type=type(error).__name__,
+                environ=self._environ,
+            )
             return
         record_parity_capture_event('persist', 'succeeded', 'none', environ=self._environ)
+        record_parity_capture_lifecycle('persist', 'succeeded', environ=self._environ)
         # Durable export is best-effort and must never affect listen availability.
         try:
             from .parity_pack_export import ensure_reconcile_loop, export_cassette_file

--- a/backend/routers/listen/parity_pack_export.py
+++ b/backend/routers/listen/parity_pack_export.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Mapping
 from urllib.parse import urlparse
 
-from .parity_telemetry import record_parity_capture_event
+from .parity_telemetry import record_parity_capture_event, record_parity_capture_lifecycle
 
 logger = logging.getLogger(__name__)
 
@@ -114,28 +114,57 @@ def export_cassette_file(local_path: Path, *, environ: Mapping[str, str] | None 
     target = resolve_export_target(env)
     if target is None:
         record_parity_capture_event('export', 'skipped', 'target_unconfigured', environ=env)
+        record_parity_capture_lifecycle(
+            'export',
+            'skipped',
+            error_type='ConfigurationError',
+            environ=env,
+        )
         return False
     root_value = (env.get("OMI_PARITY_PACK_ROOT") or "").strip()
     if not root_value:
         record_parity_capture_event('export', 'skipped', 'root_unconfigured', environ=env)
+        record_parity_capture_lifecycle(
+            'export',
+            'skipped',
+            error_type='ConfigurationError',
+            environ=env,
+        )
         return False
     root = Path(root_value)
     path = Path(local_path)
     if not path.is_file():
         record_parity_capture_event('export', 'failed', 'local_file_missing', environ=env)
+        record_parity_capture_lifecycle(
+            'export',
+            'failed',
+            error_type='FileNotFoundError',
+            environ=env,
+        )
         return False
     bucket_name, prefix = target
     object_name = _object_name(prefix, path, root)
     record_parity_capture_event('export', 'attempted', 'configured', environ=env)
+    record_parity_capture_lifecycle('export', 'attempted', environ=env)
     try:
         client = _storage_client()
         blob = client.bucket(bucket_name).blob(object_name)
         blob.upload_from_filename(str(path), content_type="application/json")
         record_parity_capture_event('export', 'succeeded', 'none', environ=env)
+        record_parity_capture_lifecycle('export', 'succeeded', environ=env)
         return True
-    except Exception:
-        logger.warning("Parity pack cassette export failed reason_class=upload_error")
+    except Exception as error:
+        logger.warning(
+            "Parity pack cassette export failed reason_class=upload_error error_type=%s",
+            type(error).__name__,
+        )
         record_parity_capture_event('export', 'failed', 'upload_error', environ=env)
+        record_parity_capture_lifecycle(
+            'export',
+            'failed',
+            error_type=type(error).__name__,
+            environ=env,
+        )
         _record_export_failure(reason="other")
         return False
 

--- a/backend/routers/listen/parity_telemetry.py
+++ b/backend/routers/listen/parity_telemetry.py
@@ -36,6 +36,10 @@ _REASON_CLASSES = frozenset(
         'other',
     }
 )
+_LIFECYCLE_BOUNDARIES = frozenset({'enabled', 'admitted', 'bootstrap', 'observe', 'persist', 'export'})
+_LIFECYCLE_RESULTS = frozenset(
+    {'enabled', 'disabled', 'allowed', 'rejected', 'attempted', 'succeeded', 'failed', 'skipped'}
+)
 
 # Export the complete expected lifecycle even before dev traffic arrives. This
 # distinguishes a healthy, idle listen scrape target from an absent family.
@@ -95,4 +99,39 @@ def record_parity_capture_event(
         )
     except Exception:
         # Observability must never affect a listen session or cassette export.
+        pass
+
+
+def record_parity_capture_lifecycle(
+    boundary: str,
+    result: str,
+    *,
+    error_type: str = 'none',
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Log one bounded capture lifecycle marker independently of Prometheus.
+
+    The configured-capture gate intentionally does not require a valid dev
+    stage. Otherwise the diagnostic intended to expose a stage rejection would
+    be suppressed by that same rejection. No request or capture identity is
+    accepted by this interface.
+    """
+    env = os.environ if environ is None else environ
+    if env.get('OMI_PARITY_PACK_CAPTURE', '').strip().lower() not in {'1', 'true', 'yes'}:
+        return
+
+    safe_boundary = boundary if boundary in _LIFECYCLE_BOUNDARIES else 'bootstrap'
+    safe_result = result if result in _LIFECYCLE_RESULTS else 'failed'
+    safe_error_type = error_type or 'none'
+    if len(safe_error_type) > 64 or not safe_error_type.isascii() or not safe_error_type.replace('_', '').isalnum():
+        safe_error_type = 'other'
+    try:
+        logger.info(
+            'listen_parity_capture_lifecycle boundary=%s result=%s error_type=%s',
+            safe_boundary,
+            safe_result,
+            safe_error_type,
+        )
+    except Exception:
+        # Diagnostics must never affect a listen session or cassette export.
         pass

--- a/backend/tests/unit/test_listen_parity_capture.py
+++ b/backend/tests/unit/test_listen_parity_capture.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from routers.listen.parity_capture import ListenParityCapture
-from routers.listen.parity_telemetry import record_parity_capture_event
+from routers.listen.parity_telemetry import record_parity_capture_event, record_parity_capture_lifecycle
 
 
 class _TelemetryCounter:
@@ -147,6 +147,28 @@ def test_parity_capture_telemetry_is_dev_only_and_normalizes_unknown_labels(monk
     record_parity_capture_event('user-stage', 'user-outcome', 'user-reason', environ={'OMI_ENV_STAGE': 'dev'})
 
     assert counter.events == [{'stage': 'other', 'outcome': 'other', 'reason_class': 'other'}]
+
+
+def test_parity_capture_lifecycle_log_does_not_require_prometheus_or_valid_dev_stage(monkeypatch, caplog):
+    class BrokenCounter:
+        def labels(self, **_labels):
+            raise RuntimeError('metrics unavailable')
+
+    import routers.listen.parity_telemetry as parity_telemetry
+
+    monkeypatch.setattr(parity_telemetry, 'OMI_PARITY_PACK_CAPTURE_EVENTS_TOTAL', BrokenCounter())
+    caplog.set_level(logging.INFO)
+    record_parity_capture_lifecycle(
+        'admitted',
+        'rejected',
+        error_type='ConfigurationError',
+        environ={'OMI_PARITY_PACK_CAPTURE': '1'},
+    )
+
+    assert (
+        'listen_parity_capture_lifecycle boundary=admitted result=rejected error_type=ConfigurationError' in caplog.text
+    )
+    assert 'metrics unavailable' not in caplog.text
 
 
 def test_listen_capture_requires_a_restricted_absolute_root(tmp_path):
@@ -319,4 +341,6 @@ def test_export_cassette_file_emits_attempt_and_bounded_failure(tmp_path, monkey
         {'stage': 'export', 'outcome': 'attempted', 'reason_class': 'configured'},
         {'stage': 'export', 'outcome': 'failed', 'reason_class': 'upload_error'},
     ]
+    assert 'listen_parity_capture_lifecycle boundary=export result=attempted error_type=none' in caplog.text
+    assert 'listen_parity_capture_lifecycle boundary=export result=failed error_type=PermissionError' in caplog.text
     assert 'private detail' not in caplog.text

--- a/backend/tests/unit/test_listen_parity_runtime.py
+++ b/backend/tests/unit/test_listen_parity_runtime.py
@@ -193,7 +193,7 @@ async def test_listen_runtime_persists_and_exports_capture_exactly_once_after_cl
     monkeypatch.setenv('OMI_PARITY_PACK_GCS_URI', _GCS_URI)
     monkeypatch.setenv('SERVICE_ACCOUNT_JSON', _CREDENTIAL)
 
-    exported = []
+    uploaded = []
     reconcile_calls = []
     persist_calls = []
     original_persist = ListenParityCapture.persist
@@ -203,13 +203,28 @@ async def test_listen_runtime_persists_and_exports_capture_exactly_once_after_cl
         persist_calls.append(capture)
         return original_persist(capture)
 
-    def fake_export(path, *, environ=None):
-        exported.append((path, export_module.resolve_export_target(environ)))
-        return True
+    class FakeBlob:
+        def __init__(self, bucket, object_name):
+            self.bucket = bucket
+            self.object_name = object_name
+
+        def upload_from_filename(self, filename, content_type=None):
+            uploaded.append((self.bucket, self.object_name, filename, content_type))
+
+    class FakeBucket:
+        def __init__(self, name):
+            self.name = name
+
+        def blob(self, object_name):
+            return FakeBlob(self.name, object_name)
+
+    class FakeClient:
+        def bucket(self, name):
+            return FakeBucket(name)
 
     monkeypatch.setattr(ListenParityCapture, 'persist', persist_once)
     monkeypatch.setattr(export_module, 'ensure_reconcile_loop', lambda *, environ=None: reconcile_calls.append(environ))
-    monkeypatch.setattr(export_module, 'export_cassette_file', fake_export)
+    monkeypatch.setattr(export_module, '_storage_client', lambda: FakeClient())
 
     websocket = _FakeWebSocket(audio=_AUDIO)
     runtime = ListenSessionRuntime(ListenRequest(websocket=websocket, uid=_PRINCIPAL, codec='pcm16', sample_rate=16000))
@@ -245,10 +260,33 @@ async def test_listen_runtime_persists_and_exports_capture_exactly_once_after_cl
     assert Counter(event['direction'] for event in cassette['events']) == Counter(
         {'client': 1, 'inbound': 1, 'outbound': 1}
     )
-    assert len(exported) == 1
-    assert exported[0][0] == cassette_files[0]
-    assert exported[0][1] == ('runtime-capture-bucket', 'parity-pack/v0')
+    assert uploaded == [
+        (
+            'runtime-capture-bucket',
+            f'parity-pack/v0/cassettes/{cassette_files[0].name}',
+            str(cassette_files[0]),
+            'application/json',
+        )
+    ]
     assert reconcile_calls == [None]
+
+    lifecycle_messages = Counter(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith('listen_parity_capture_lifecycle ')
+    )
+    assert lifecycle_messages == Counter(
+        {
+            'listen_parity_capture_lifecycle boundary=enabled result=enabled error_type=none': 1,
+            'listen_parity_capture_lifecycle boundary=admitted result=allowed error_type=none': 1,
+            'listen_parity_capture_lifecycle boundary=bootstrap result=succeeded error_type=none': 1,
+            'listen_parity_capture_lifecycle boundary=observe result=succeeded error_type=none': 3,
+            'listen_parity_capture_lifecycle boundary=persist result=attempted error_type=none': 1,
+            'listen_parity_capture_lifecycle boundary=persist result=succeeded error_type=none': 1,
+            'listen_parity_capture_lifecycle boundary=export result=attempted error_type=none': 1,
+            'listen_parity_capture_lifecycle boundary=export result=succeeded error_type=none': 1,
+        }
+    )
 
     for sensitive in (
         _PRINCIPAL,


### PR DESCRIPTION
## What changed and why

PR #11101 is merged and live in dev, but multiple confirmed allowlisted listen
sessions on its exact revision produced no object and no capture lifecycle log.
The fresh-main production-shaped runtime seam still writes and exports a
cassette, so this change does not invent another capture-path fix.

The proven defect is the diagnostic boundary: the existing operator log is
emitted inside the Prometheus counter helper and is suppressed unless
`OMI_ENV_STAGE=dev`. That makes the exact stage/admission failure the telemetry
is intended to expose capable of suppressing its own evidence. Existing events
also do not cover runtime bootstrap or callback observation.

Add a separate, fail-open lifecycle logger gated only by explicit parity
capture enablement. It emits bounded `boundary`, `result`, and `error_type`
values for enabled, admitted, bootstrap, observe, persist, and export. It never
accepts or logs a UID, session ID, transcript, audio, credentials, or paths.
Prometheus behavior remains unchanged.

Strengthen the hermetic runtime regression to traverse the real exporter code
with only the GCS client faked, and require the complete safe marker multiset on
both normal teardown and a prior cleanup failure. This PR is tracked by
SCA-292. It does not deploy or change IAM, RBAC, Helm, traffic, or production.

## Reproduction

On fresh `origin/main` at `cd3dd886ceee0fc23e1047b7d250caee93648005`:

- The existing production-shaped test passed (2 passed), confirming bootstrap,
  client/outbound/inbound callbacks, teardown, `storage_executor`, cassette
  write, and fake export.
- After adding the lifecycle contract first, the same two runtime cases went
  RED because the observed lifecycle marker multiset was empty (`Counter()`).
- After the implementation, the runtime and adversarial capture tests went
  GREEN.

The empty live GCS prefix remains unexplained by local capture behavior. This
PR makes the next dev smoke identify the last completed boundary without
repeating blind traffic.

## Product invariants affected

none

## Verification

- `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/unit/test_listen_parity_runtime.py -q` — baseline 2 passed; RED run 2 failed on the missing lifecycle multiset.
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/unit/test_listen_parity_runtime.py backend/tests/unit/test_listen_parity_capture.py -q` — 14 passed.
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/unit/test_listen_parity_runtime.py backend/tests/unit/test_listen_parity_capture.py backend/tests/unit/test_listen_runtime_regressions.py backend/tests/unit/test_listen_persistence.py backend/tests/unit/test_listen_account_deletion_fence.py backend/tests/unit/test_backend_listen_helm_defaults.py -q` — 45 passed.
- `PYTHON=.venv/bin/python bash test-preflight.sh` from `backend/` — 18 checks passed, 0 failed; optional provider/integration warnings only.
- `scripts/pr-preflight --pr-body-file pr-body.md` — all 23 selected checks passed in 536.62s.
- `OMI_PR_BODY_FILE=pr-body.md make preflight` — all 23 selected checks passed on rebased head `c4bc9e7739e742015f11c49a4f1dba01f8c03887` against `origin/main` `cd7334a8875cbf3e150a5ac7a433f8d90d5ed894` in 473.99s.

## Failure class (fixes)

Failure-Class: none

This is a bounded diagnostic-surface correction after the production behavior
contract stayed green; it does not change capture admission, persistence, or
export semantics.

## Remaining dev gate

After review, merge, and a separately authorized dev rollout, run one confirmed
allowlisted listen session on the exact serving revision. Read the bounded
lifecycle markers to identify the last completed boundary, then verify a new
cassette under the configured dev prefix. GCS read access is now available;
pod exec remains RBAC-denied and is not required by this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

