### PR TITLE
fix(memory): advance canonical graph cohort backfill

### DIFF
--- a/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
+++ b/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
@@ -84,6 +84,18 @@ def test_enabled_cohort_graph_backfill_uses_the_fenced_bounded_runner(monkeypatc
     assert graph_calls[0]["confirm_uid"] == CANONICAL_A
     assert graph_calls[0]["limit"] == cron.DEFAULT_GRAPH_BACKFILL_PAGE_SIZE
     assert graph_calls[0]["apply_limit"] == cron.DEFAULT_GRAPH_BACKFILL_PAGE_SIZE
+    assert graph_calls[0]["scan_limit"] == cron.DEFAULT_GRAPH_BACKFILL_SCAN_SIZE
+
+
+def test_graph_backfill_scan_size_is_independently_bounded(monkeypatch):
+    monkeypatch.setenv(cron.MEMORY_CANONICAL_GRAPH_BACKFILL_SCAN_SIZE_ENV, "0")
+    assert cron.canonical_graph_backfill_scan_size() == 1
+
+    monkeypatch.setenv(cron.MEMORY_CANONICAL_GRAPH_BACKFILL_SCAN_SIZE_ENV, "not-an-integer")
+    assert cron.canonical_graph_backfill_scan_size() == cron.DEFAULT_GRAPH_BACKFILL_SCAN_SIZE
+
+    monkeypatch.setenv(cron.MEMORY_CANONICAL_GRAPH_BACKFILL_SCAN_SIZE_ENV, "999999")
+    assert cron.canonical_graph_backfill_scan_size() == cron.MAX_STRUCTURED_SCAN_SIZE
 
 
 def test_cohort_summary_uses_consolidation_routes_and_promotions(monkeypatch):

--- a/backend/utils/memory/canonical_short_term_maintenance_cron.py
+++ b/backend/utils/memory/canonical_short_term_maintenance_cron.py
@@ -32,14 +32,16 @@ from utils.memory.short_term_promotion import (
     CanonicalShortTermMaintenanceReport,
     run_canonical_short_term_maintenance,
 )
-from scripts.enrich_historical_memory_graph import MAX_PAGE_SIZE, run_enrichment
+from scripts.enrich_historical_memory_graph import MAX_PAGE_SIZE, MAX_STRUCTURED_SCAN_SIZE, run_enrichment
 
 logger = logging.getLogger(__name__)
 
 MEMORY_CANONICAL_MAINTENANCE_ENABLED_ENV = "MEMORY_CANONICAL_MAINTENANCE_ENABLED"
 MEMORY_CANONICAL_GRAPH_BACKFILL_ENABLED_ENV = "MEMORY_CANONICAL_GRAPH_BACKFILL_ENABLED"
 MEMORY_CANONICAL_GRAPH_BACKFILL_PAGE_SIZE_ENV = "MEMORY_CANONICAL_GRAPH_BACKFILL_PAGE_SIZE"
+MEMORY_CANONICAL_GRAPH_BACKFILL_SCAN_SIZE_ENV = "MEMORY_CANONICAL_GRAPH_BACKFILL_SCAN_SIZE"
 DEFAULT_GRAPH_BACKFILL_PAGE_SIZE = 5
+DEFAULT_GRAPH_BACKFILL_SCAN_SIZE = MAX_STRUCTURED_SCAN_SIZE
 
 
 def _required_memory_processor(item: MemoryItem) -> ProcessedRequiredMemory:
@@ -68,6 +70,22 @@ def canonical_graph_backfill_page_size() -> int:
     except ValueError:
         return DEFAULT_GRAPH_BACKFILL_PAGE_SIZE
     return min(MAX_PAGE_SIZE, max(1, value))
+
+
+def canonical_graph_backfill_scan_size() -> int:
+    """Return the bounded candidate window needed to make cohort pages advance.
+
+    Enrichment writes update ``updated_at``.  A scan no larger than the write
+    page therefore re-reads those just-enriched items and never reaches the
+    remaining historical rows.  Keep the larger read window explicit and
+    independently bounded from the per-user apply budget.
+    """
+    raw = os.getenv(MEMORY_CANONICAL_GRAPH_BACKFILL_SCAN_SIZE_ENV, str(DEFAULT_GRAPH_BACKFILL_SCAN_SIZE))
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_GRAPH_BACKFILL_SCAN_SIZE
+    return min(MAX_STRUCTURED_SCAN_SIZE, max(1, value))
 
 
 @dataclass
@@ -258,6 +276,7 @@ def run_canonical_short_term_maintenance_for_cohort(
                 confirm_uid=uid,
                 structured_only=False,
                 apply_limit=canonical_graph_backfill_page_size(),
+                scan_limit=canonical_graph_backfill_scan_size(),
                 db_client=client,
             )
             graph_outcomes = graph_report.get("outcomes", {})


### PR DESCRIPTION
## What changed

- Pass an independently bounded candidate scan window to the canonical cohort graph-enrichment runner.
- Keep the per-user write budget unchanged and add regression coverage for the scan window bounds.

## Why

Enrichment updates `updated_at`; scanning only the write-page size can repeatedly revisit freshly graph-ready rows and fail to reach older historical memories.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Validation

- `PYTHONPATH=$PWD/backend .../.venv/bin/pytest -q backend/tests/unit/test_canonical_short_term_maintenance_cron.py` (12 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

