### PR TITLE
fix(desktop): make delayed-owner-token sync guard deterministic (#11119)

### DIFF
--- a/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift
@@ -9,6 +9,8 @@ private actor AgentSyncDelayedTokenGate {
   private var firstFetchStarted = false
   private var firstFetchWaiters: [CheckedContinuation<Void, Never>] = []
   private var firstFetchContinuation: CheckedContinuation<Void, Never>?
+  private var firstFetchCancelled = false
+  private var firstFetchCancelWaiters: [CheckedContinuation<Void, Never>] = []
   private var requests: [URLRequest] = []
   private var requestWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -37,6 +39,26 @@ private actor AgentSyncDelayedTokenGate {
   func releaseFirstFetch() {
     firstFetchContinuation?.resume()
     firstFetchContinuation = nil
+  }
+
+  /// `stop()` bumps the sync generation and only then cancels the sync task, so
+  /// the cancellation of the task that owns the first fetch is the observable
+  /// proof that the owner boundary has already moved. Waiting on it before
+  /// releasing the delayed token is what makes "the token resumes *after* the
+  /// handoff" a fact rather than a scheduling coincidence.
+  func noteFirstFetchCancelled() {
+    guard !firstFetchCancelled else { return }
+    firstFetchCancelled = true
+    let waiters = firstFetchCancelWaiters
+    firstFetchCancelWaiters.removeAll()
+    waiters.forEach { $0.resume() }
+  }
+
+  func waitUntilFirstFetchCancelled() async {
+    guard !firstFetchCancelled else { return }
+    await withCheckedContinuation { continuation in
+      firstFetchCancelWaiters.append(continuation)
+    }
   }
 
   func respond(to request: URLRequest) -> (Data, URLResponse) {
@@ -339,7 +361,13 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     let gate = AgentSyncDelayedTokenGate()
     let service = AgentSyncService(
       networkHooks: AgentSyncService.NetworkHooks(
-        fetchIDToken: { await gate.fetchToken() },
+        fetchIDToken: {
+          await withTaskCancellationHandler {
+            await gate.fetchToken()
+          } onCancel: {
+            Task { await gate.noteFirstFetchCancelled() }
+          }
+        },
         dataForRequest: { request in await gate.respond(to: request) },
         reuploadDatabase: { _, _ in true },
         now: Date.init,
@@ -348,12 +376,12 @@ final class AgentSyncBatchQueryTests: XCTestCase {
     await service.start(vmIP: "owner-a-vm", authToken: "owner-a-auth")
     await gate.waitUntilFirstFetchStarts()
     let stopOwnerA = Task { await service.stop(flushPendingChanges: false) }
+    await gate.waitUntilFirstFetchCancelled()
     await gate.releaseFirstFetch()
     await stopOwnerA.value
     await service.start(vmIP: "owner-b-vm", authToken: "owner-b-auth")
 
     await gate.waitForRequest()
-    await Task.yield()
     await service.stop(flushPendingChanges: false)
 
     let requestURLs = await gate.requestURLs()


### PR DESCRIPTION
Fixes #11119.

## Bug

`AgentSyncBatchQueryTests.testDelayedOwnerATokenCannotResumeIntoOwnerBVM` fails intermittently on `main` (~30% in CI), blocking `Desktop Swift Static & Test Contracts` and the dependent `Desktop Swift Build & Tests` with no PR content involved. Measured on a clean `origin/main` checkout in isolation: **19 of 20 runs fail**, always at the same assertion:

```
AgentSyncBatchQueryTests.swift:361: XCTAssertEqual failed:
("Optional("owner-a-vm")") is not equal to ("Optional("owner-b-vm")")
```

## Root cause

The harness, not `AgentSyncService`. The test spawned the owner-A `stop()` into a detached `Task` and then released owner A's suspended token fetch immediately, with nothing ordering the two:

```swift
let stopOwnerA = Task { await service.stop(flushPendingChanges: false) }
await gate.releaseFirstFetch()   // may win the race against stop()
```

`stop()` bumps `syncGeneration` before it suspends on `await task?.value`, and `refreshFirebaseToken` re-checks the generation only *after* its `fetchIDToken()` await. When the release won the race, owner A resumed while its generation was still current, passed `isCurrent(...)`, and issued a real request to `owner-a-vm`. `waitForRequest()` then returned on owner A's request rather than owner B's — so the assertion read `owner-a-vm` as the first (and only) recorded URL. Failing runs took ~2.7s, passing runs ~0.005s: scheduler-dependent, exactly as the issue diagnosed.

## Fix (test-only — `AgentSyncService` is untouched)

The owner boundary already has an observable: `stop()` cancels the sync task *after* bumping the generation, so cancellation of the task that owns the first fetch proves the handoff happened. The gate records that cancellation via `withTaskCancellationHandler`, and the test waits on it before releasing the delayed token — which is what "delayed" was always supposed to mean. The trailing bare `Task.yield()` is dropped: `waitForRequest()` is now reached only with owner B's request pending, so it blocks until that request is recorded instead of returning on owner A's leak. No polling, no sleeps, no new production surface.

## What I tested

macOS 26.5.2 / Xcode 26.2, `xcrun swift test --package-path Desktop --filter AgentSyncBatchQueryTests/testDelayedOwnerATokenCannotResumeIntoOwnerBVM`:

| Tree | Result |
|---|---|
| clean `origin/main` @ `342290651f` | **19/20 FAIL** (failures ~2.7s, passes ~0.005s) |
| this branch | **30/30 PASS**, every run ~0.007s |

The guard still has teeth — this is a determinism fix, not a weakened assertion: deleting the post-await `guard isCurrent(generation:ownerID:vmIP:)` from `refreshFirebaseToken` makes the test fail **5/5** with the original `owner-a-vm != owner-b-vm` message, then restored. Also `xcrun swift test --package-path Desktop --filter AgentSync`: 16/16 pass.

Product invariants: none affected.

Failure-Class: none

Test-harness sequencing defect; no production contract changed and no production behavior fixed, so there is no semantic failure class to declare or open.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

