### PR TITLE
fix(memory): interrupt stuck historical graph planners

### DIFF
--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import sys
 from collections import Counter
 from pathlib import Path
@@ -38,6 +39,31 @@ from utils.memory.historical_graph_enrichment import (  # noqa: E402
 MAX_PAGE_SIZE = 25
 MAX_STRUCTURED_SCAN_SIZE = 1250
 HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS = 20.0
+
+
+class HistoricalGraphPlannerTimeout(TimeoutError):
+    """The planner did not return within its process-level deadline."""
+
+
+def _plan_with_deadline(*, item: MemoryItem, control: MemoryControlState, llm: Any):
+    """Enforce the planner deadline even if a provider client ignores its timeout.
+
+    Cloud Run runs this synchronous script in its main thread on POSIX.  The
+    signal interrupts a stuck socket/read and is handled by the existing
+    per-item error path, so the page can continue to another candidate.
+    """
+    previous_handler = signal.getsignal(signal.SIGALRM)
+
+    def _expired(_signum, _frame):
+        raise HistoricalGraphPlannerTimeout("historical graph planner deadline exceeded")
+
+    signal.signal(signal.SIGALRM, _expired)
+    signal.setitimer(signal.ITIMER_REAL, HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
+    try:
+        return plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 def _arguments() -> argparse.Namespace:
@@ -188,7 +214,7 @@ def run_enrichment(
                 planned = (
                     _structured_plan(item, control)
                     if structured_only
-                    else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+                    else _plan_with_deadline(item=item, control=control, llm=llm)
                 )
             # The planner is an external dependency. A transient transport or
             # provider failure must not make a bounded page fail closed for all
@@ -222,7 +248,7 @@ def run_enrichment(
                     candidate = (
                         _structured_plan(item, control)
                         if structured_only
-                        else plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+                        else _plan_with_deadline(item=item, control=control, llm=llm)
                     )
                 # Do not repeatedly select a temporarily failing item during
                 # one page; continue looking through this bounded scan and

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -204,3 +205,19 @@ def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_c
     )
 
     assert report["outcomes"] == {"committed": 1, "planner_error": 1}
+
+
+def test_historical_planner_deadline_interrupts_a_stuck_sync_call(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(historical_runner, "HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        historical_runner,
+        "plan_historical_graph_enrichment",
+        lambda **_kwargs: time.sleep(1),
+    )
+
+    with pytest.raises(historical_runner.HistoricalGraphPlannerTimeout):
+        historical_runner._plan_with_deadline(
+            item=_item(),
+            control=MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2),
+            llm=object(),
+        )


### PR DESCRIPTION
## What changed

- Add a POSIX process-level deadline around each historical graph planner invocation.
- Keep the existing per-item retry path, so a timed-out candidate is skipped for the current page and retried later.

## Why

The gateway transport timeout did not interrupt one synchronous planner call in a live canary, causing a page to run until Cloud Run's task deadline.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Validation

- `pytest -q backend/tests/unit/test_historical_graph_enrichment.py` (7 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

