### PR TITLE
feat(memory): persist historical graph backfill progress

### DIFF
--- a/backend/database/memory_collections.py
+++ b/backend/database/memory_collections.py
@@ -40,6 +40,10 @@ class MemoryCollections:
         return f"{self.user_root}/memory_control/legacy_canonical_backfill"
 
     @property
+    def historical_graph_enrichment_cursor(self) -> str:
+        return f"{self.user_root}/memory_control/historical_graph_enrichment"
+
+    @property
     def memory_apply_control_state(self) -> str:
         return f"{self.user_root}/memory_state/apply_control"
 

--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -12,8 +12,10 @@ import os
 import signal
 import sys
 from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
@@ -43,6 +45,125 @@ HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS = 20.0
 
 class HistoricalGraphPlannerTimeout(TimeoutError):
     """The planner did not return within its process-level deadline."""
+
+
+@dataclass(frozen=True)
+class HistoricalGraphEnrichmentCursor:
+    """Server-owned progress fence for one user's rotating graph sweep."""
+
+    generation: int = 0
+    resume_after_updated_at: datetime | None = None
+    resume_after_memory_id: str | None = None
+
+
+@dataclass(frozen=True)
+class HistoricalGraphCandidatePage:
+    """One keyset page plus the cursor boundary for each examined item."""
+
+    items: list[MemoryItem]
+    last_scanned: MemoryItem | None
+    exhausted: bool
+
+
+class HistoricalGraphCursorStore(Protocol):
+    def read(
+        self, uid: str, *, control: MemoryControlState, replan_existing: bool
+    ) -> HistoricalGraphEnrichmentCursor: ...
+
+    def advance(
+        self,
+        uid: str,
+        *,
+        control: MemoryControlState,
+        replan_existing: bool,
+        expected_generation: int,
+        resume_after: MemoryItem | None,
+    ) -> bool: ...
+
+
+def _cursor_mode_matches(payload: dict[str, Any], *, control: MemoryControlState, replan_existing: bool) -> bool:
+    return (
+        payload.get("account_generation") == control.account_generation
+        and payload.get("planner_version") == HISTORICAL_GRAPH_PLANNER_VERSION
+        and payload.get("replan_existing") is replan_existing
+    )
+
+
+class FirestoreHistoricalGraphCursorStore:
+    """Persist a CAS-fenced per-user keyset cursor under ``memory_control``."""
+
+    def __init__(self, db_client: Any):
+        self._db_client = db_client
+
+    def _ref(self, uid: str) -> Any:
+        return self._db_client.document(MemoryCollections(uid=uid).historical_graph_enrichment_cursor)
+
+    def read(self, uid: str, *, control: MemoryControlState, replan_existing: bool) -> HistoricalGraphEnrichmentCursor:
+        snapshot = self._ref(uid).get()
+        if not getattr(snapshot, "exists", False):
+            return HistoricalGraphEnrichmentCursor()
+        payload = snapshot.to_dict() or {}
+        generation = int(payload.get("generation", 0))
+        if not _cursor_mode_matches(payload, control=control, replan_existing=replan_existing):
+            return HistoricalGraphEnrichmentCursor(generation=generation)
+        updated_at = payload.get("resume_after_updated_at")
+        memory_id = payload.get("resume_after_memory_id")
+        if not isinstance(updated_at, datetime) or not isinstance(memory_id, str):
+            return HistoricalGraphEnrichmentCursor(generation=generation)
+        return HistoricalGraphEnrichmentCursor(generation, updated_at, memory_id)
+
+    def advance(
+        self,
+        uid: str,
+        *,
+        control: MemoryControlState,
+        replan_existing: bool,
+        expected_generation: int,
+        resume_after: MemoryItem | None,
+    ) -> bool:
+        ref = self._ref(uid)
+        transaction = self._db_client.transaction()
+        transactional = firestore.transactional(_advance_historical_graph_cursor_txn)
+        return transactional(
+            transaction,
+            ref,
+            control,
+            replan_existing,
+            expected_generation,
+            resume_after,
+            datetime.now(timezone.utc),
+        )
+
+
+def _advance_historical_graph_cursor_txn(
+    transaction: Any,
+    ref: Any,
+    control: MemoryControlState,
+    replan_existing: bool,
+    expected_generation: int,
+    resume_after: MemoryItem | None,
+    now: datetime,
+) -> bool:
+    """Advance only the reader generation that examined this page.
+
+    A losing writer cannot overwrite a newer boundary. ``resume_after=None`` is
+    the durable tail-wrap marker: the next invocation starts from the head.
+    """
+    snapshot = ref.get(transaction=transaction)
+    payload = (snapshot.to_dict() or {}) if getattr(snapshot, "exists", False) else {}
+    if int(payload.get("generation", 0)) != expected_generation:
+        return False
+    update: dict[str, Any] = {
+        "account_generation": control.account_generation,
+        "planner_version": HISTORICAL_GRAPH_PLANNER_VERSION,
+        "replan_existing": replan_existing,
+        "generation": expected_generation + 1,
+        "updated_at": now,
+        "resume_after_updated_at": resume_after.updated_at if resume_after is not None else None,
+        "resume_after_memory_id": resume_after.memory_id if resume_after is not None else None,
+    }
+    transaction.set(ref, update)
+    return True
 
 
 def _plan_with_deadline(*, item: MemoryItem, control: MemoryControlState, llm: Any):
@@ -121,9 +242,15 @@ def _is_replan_candidate(item: MemoryItem) -> bool:
     )
 
 
-def _candidates(
-    uid: str, *, control: MemoryControlState, limit: int, db_client: Any, replan_existing: bool = False
-) -> list[MemoryItem]:
+def _candidate_page(
+    uid: str,
+    *,
+    control: MemoryControlState,
+    cursor: HistoricalGraphEnrichmentCursor,
+    limit: int,
+    db_client: Any,
+    replan_existing: bool = False,
+) -> HistoricalGraphCandidatePage:
     collection = db_client.collection(MemoryCollections(uid=uid).memory_items)
     # Historical canonical items predate graph_ready and omit the field rather
     # than storing false. Firestore equality filters exclude absent fields, so
@@ -139,15 +266,37 @@ def _candidates(
         },
         field_filter_factory=FieldFilter,
     )
-    query = (
-        query.order_by("updated_at", direction=firestore.Query.DESCENDING)
-        .order_by("__name__", direction=firestore.Query.DESCENDING)
-        .limit(limit)
+    query = query.order_by("updated_at", direction=firestore.Query.DESCENDING).order_by(
+        "__name__", direction=firestore.Query.DESCENDING
     )
-    items = [MemoryItem(**(snapshot.to_dict() or {})) for snapshot in query.stream()]
+    if cursor.resume_after_updated_at is not None and cursor.resume_after_memory_id is not None:
+        query = query.start_after([cursor.resume_after_updated_at, collection.document(cursor.resume_after_memory_id)])
+    snapshots = list(query.limit(limit).stream())
+    scanned_items = [MemoryItem(**(snapshot.to_dict() or {})) for snapshot in snapshots]
+    items = list(scanned_items)
     if replan_existing:
-        return [item for item in items if _is_replan_candidate(item)]
-    return [item for item in items if not item.graph_ready]
+        items = [item for item in items if _is_replan_candidate(item)]
+    else:
+        items = [item for item in items if not item.graph_ready]
+    return HistoricalGraphCandidatePage(
+        items=items,
+        last_scanned=scanned_items[-1] if scanned_items else None,
+        exhausted=len(snapshots) < limit,
+    )
+
+
+def _candidates(
+    uid: str, *, control: MemoryControlState, limit: int, db_client: Any, replan_existing: bool = False
+) -> list[MemoryItem]:
+    """Compatibility helper for callers that do not persist historical progress."""
+    return _candidate_page(
+        uid,
+        control=control,
+        cursor=HistoricalGraphEnrichmentCursor(),
+        limit=limit,
+        db_client=db_client,
+        replan_existing=replan_existing,
+    ).items
 
 
 def _structured_plan(item: MemoryItem, control: MemoryControlState):
@@ -183,6 +332,7 @@ def run_enrichment(
     db_client: Any | None = None,
     llm: Any | None = None,
     progress_reporter: Callable[[dict[str, int]], None] | None = None,
+    cursor_store: HistoricalGraphCursorStore | None = None,
 ) -> dict[str, Any]:
     """Return aggregate outcomes for one bounded historical enrichment page."""
     if limit < 1 or limit > MAX_PAGE_SIZE or apply_limit < 1 or apply_limit > MAX_PAGE_SIZE:
@@ -230,40 +380,47 @@ def run_enrichment(
             else:
                 report[planned.block_code or "blocked"] += 1
     else:
+        initial_control = _control(uid, db_client=db_client)
+        cursor_store = cursor_store or FirestoreHistoricalGraphCursorStore(db_client)
+        cursor = cursor_store.read(uid, control=initial_control, replan_existing=replan_existing)
+        page = _candidate_page(
+            uid,
+            control=initial_control,
+            cursor=cursor,
+            limit=candidate_limit,
+            db_client=db_client,
+            replan_existing=replan_existing,
+        )
         # Every committed apply advances the canonical control head. Re-read the
-        # control record and re-plan the next item so no operation is submitted
+        # control record before every candidate so no operation is submitted
         # against a stale observed_head_commit_id.
         retryable_head_mismatches = 0
         max_retryable_head_mismatches = apply_limit * 2
-        planner_error_memory_ids: set[str] = set()
-        while applied < apply_limit:
-            control = _control(uid, db_client=db_client)
-            planned = None
-            for item in _candidates(
-                uid, control=control, limit=candidate_limit, db_client=db_client, replan_existing=replan_existing
-            ):
-                if item.memory_id in planner_error_memory_ids:
-                    continue
-                try:
-                    candidate = (
-                        _structured_plan(item, control)
-                        if structured_only
-                        else _plan_with_deadline(item=item, control=control, llm=llm)
-                    )
-                # Do not repeatedly select a temporarily failing item during
-                # one page; continue looking through this bounded scan and
-                # retry it on a later execution.
-                except Exception:
-                    report["planner_error"] += 1
-                    planner_error_memory_ids.add(item.memory_id)
-                    continue
-                if candidate is None:
-                    continue
-                if candidate.status == "ready" and candidate.operation is not None:
-                    planned = candidate
-                    break
-            if planned is None:
+        last_examined: MemoryItem | None = None
+        completed_page = True
+        for item in page.items:
+            if applied >= apply_limit:
                 break
+            control = _control(uid, db_client=db_client)
+            last_examined = item
+            try:
+                planned = (
+                    _structured_plan(item, control)
+                    if structured_only
+                    else _plan_with_deadline(item=item, control=control, llm=llm)
+                )
+            # A failed planner is still an examined row. Advancing past it lets
+            # a later candidate in this page make progress; a subsequent full
+            # cursor rotation retries the failure without starving older rows.
+            except Exception:
+                report["planner_error"] += 1
+                continue
+            if planned is None:
+                report["not_structured"] += 1
+                continue
+            if planned.status != "ready" or planned.operation is None:
+                report[planned.block_code or "blocked"] += 1
+                continue
             result = apply_long_term_patch_firestore(
                 uid=uid,
                 operation_id=planned.operation.operation_id,
@@ -282,10 +439,39 @@ def run_enrichment(
                 retryable_head_mismatches += 1
                 if retryable_head_mismatches < max_retryable_head_mismatches:
                     continue
+                completed_page = False
                 break
             else:
                 report[f"apply_{result.status.value}"] += 1
+                completed_page = False
                 break
+        else:
+            # An all-filtered scan still needs to move past its stable prefix.
+            last_examined = page.last_scanned
+
+        if completed_page:
+            reached_scanned_tail = (
+                last_examined is not None
+                and page.last_scanned is not None
+                and last_examined.memory_id == page.last_scanned.memory_id
+                and last_examined.updated_at == page.last_scanned.updated_at
+            )
+            if page.exhausted and (page.last_scanned is None or reached_scanned_tail):
+                # We examined the tail: persist a null boundary so the next
+                # invocation wraps to the newest rows and retries failures.
+                resume_after = None
+            else:
+                resume_after = last_examined
+            if cursor_store.advance(
+                uid,
+                control=initial_control,
+                replan_existing=replan_existing,
+                expected_generation=cursor.generation,
+                resume_after=resume_after,
+            ):
+                report["cursor_advanced"] += 1
+            else:
+                report["cursor_conflict"] += 1
     return {
         "dry_run": not apply,
         "limit": limit,

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -34,6 +34,56 @@ class _FailingPlanner:
         raise RuntimeError("transient gateway failure")
 
 
+class _CursorStore:
+    def __init__(self):
+        self.cursor = historical_runner.HistoricalGraphEnrichmentCursor()
+        self.advances: list[tuple[int, str | None]] = []
+
+    def read(self, _uid: str, **_kwargs: object):
+        return self.cursor
+
+    def advance(self, _uid: str, *, expected_generation: int, resume_after: MemoryItem | None, **_kwargs: object):
+        if expected_generation != self.cursor.generation:
+            return False
+        self.advances.append((expected_generation, resume_after.memory_id if resume_after is not None else None))
+        self.cursor = historical_runner.HistoricalGraphEnrichmentCursor(
+            generation=expected_generation + 1,
+            resume_after_updated_at=resume_after.updated_at if resume_after is not None else None,
+            resume_after_memory_id=resume_after.memory_id if resume_after is not None else None,
+        )
+        return True
+
+
+class _CursorSnapshot:
+    def __init__(self, payload: dict[str, object] | None):
+        self.exists = payload is not None
+        self._payload = payload
+
+    def to_dict(self):
+        return self._payload
+
+
+class _CursorRef:
+    def __init__(self, payload: dict[str, object] | None):
+        self.payload = payload
+
+    def get(self, *, transaction: object | None = None):
+        return _CursorSnapshot(self.payload)
+
+
+class _CursorTransaction:
+    def set(self, ref: _CursorRef, payload: dict[str, object]):
+        ref.payload = payload
+
+
+class _CursorDb:
+    def __init__(self, ref: _CursorRef):
+        self.ref = ref
+
+    def document(self, _path: str):
+        return self.ref
+
+
 def _item(**overrides: object) -> MemoryItem:
     now = datetime.now(timezone.utc)
     payload: dict[str, object] = {
@@ -163,6 +213,7 @@ def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_c
     control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
     failing = _item(memory_id="mem_failing")
     ready = _item(memory_id="mem_ready")
+    cursor_store = _CursorStore()
     planner = _Planner(
         {
             "eligible": True,
@@ -175,8 +226,10 @@ def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_c
     monkeypatch.setattr(historical_runner, "_control", lambda *_args, **_kwargs: control)
     monkeypatch.setattr(
         historical_runner,
-        "_candidates",
-        lambda *_args, **_kwargs: [failing, ready],
+        "_candidate_page",
+        lambda *_args, **_kwargs: historical_runner.HistoricalGraphCandidatePage(
+            items=[failing, ready], last_scanned=ready, exhausted=False
+        ),
     )
 
     def plan(item: MemoryItem, **_kwargs: object):
@@ -202,9 +255,107 @@ def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_c
         apply_limit=1,
         db_client=object(),
         llm=object(),
+        cursor_store=cursor_store,
     )
 
-    assert report["outcomes"] == {"committed": 1, "planner_error": 1}
+    assert report["outcomes"] == {"committed": 1, "cursor_advanced": 1, "planner_error": 1}
+    assert cursor_store.advances == [(0, "mem_ready")]
+
+
+def test_historical_runner_rotates_cursor_past_a_bounded_scan_window(monkeypatch: pytest.MonkeyPatch):
+    control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+    pages = {
+        None: _item(memory_id="mem_head"),
+        "mem_head": _item(memory_id="mem_middle"),
+        "mem_middle": _item(memory_id="mem_tail"),
+    }
+    seen: list[str] = []
+    cursor_store = _CursorStore()
+
+    monkeypatch.setattr(historical_runner, "_control", lambda *_args, **_kwargs: control)
+
+    def candidate_page(*_args: object, cursor: historical_runner.HistoricalGraphEnrichmentCursor, **_kwargs: object):
+        item = pages[cursor.resume_after_memory_id]
+        return historical_runner.HistoricalGraphCandidatePage(
+            items=[item], last_scanned=item, exhausted=item.memory_id == "mem_tail"
+        )
+
+    monkeypatch.setattr(historical_runner, "_candidate_page", candidate_page)
+    monkeypatch.setattr(
+        historical_runner,
+        "_plan_with_deadline",
+        lambda *, item, **_kwargs: (
+            seen.append(item.memory_id)
+            or SimpleNamespace(
+                status=GraphEnrichmentStatus.ready,
+                operation=SimpleNamespace(operation_id=item.memory_id),
+                patch_payload={},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        historical_runner,
+        "apply_long_term_patch_firestore",
+        lambda **_kwargs: SimpleNamespace(status=ApplyStatus.committed),
+    )
+
+    for _ in range(3):
+        run_enrichment(
+            uid="u1",
+            firestore_project="test",
+            limit=1,
+            scan_limit=1,
+            apply=True,
+            confirm_uid="u1",
+            structured_only=False,
+            db_client=object(),
+            llm=object(),
+            cursor_store=cursor_store,
+        )
+
+    assert seen == ["mem_head", "mem_middle", "mem_tail"]
+    assert cursor_store.advances == [(0, "mem_head"), (1, "mem_middle"), (2, None)]
+
+
+def test_historical_graph_cursor_cas_rejects_a_stale_writer():
+    control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+    ref = _CursorRef({"generation": 2, "resume_after_memory_id": "newer"})
+    transaction = _CursorTransaction()
+
+    stale = historical_runner._advance_historical_graph_cursor_txn(
+        transaction, ref, control, False, 1, _item(memory_id="stale"), datetime.now(timezone.utc)
+    )
+    current = historical_runner._advance_historical_graph_cursor_txn(
+        transaction, ref, control, False, 2, _item(memory_id="current"), datetime.now(timezone.utc)
+    )
+
+    assert stale is False
+    assert current is True
+    assert ref.payload is not None
+    assert ref.payload["generation"] == 3
+    assert ref.payload["resume_after_memory_id"] == "current"
+
+
+def test_historical_graph_cursor_resets_boundary_when_the_account_generation_changes():
+    item = _item(memory_id="old_boundary")
+    ref = _CursorRef(
+        {
+            "generation": 4,
+            "account_generation": 1,
+            "planner_version": historical_runner.HISTORICAL_GRAPH_PLANNER_VERSION,
+            "replan_existing": False,
+            "resume_after_updated_at": item.updated_at,
+            "resume_after_memory_id": item.memory_id,
+        }
+    )
+
+    cursor = historical_runner.FirestoreHistoricalGraphCursorStore(_CursorDb(ref)).read(
+        "u1",
+        control=MemoryControlState(uid="u1", head_commit_id="head0", account_generation=2, source_generation=2),
+        replan_existing=False,
+    )
+
+    assert cursor == historical_runner.HistoricalGraphEnrichmentCursor(generation=4)
 
 
 def test_historical_planner_deadline_interrupts_a_stuck_sync_call(monkeypatch: pytest.MonkeyPatch):

--- a/backend/tests/unit/test_inv_mem_1_guard.py
+++ b/backend/tests/unit/test_inv_mem_1_guard.py
@@ -54,6 +54,9 @@ _ALLOWED_MEMORY_COLLECTIONS_PROPERTIES = frozenset(
         "memory_control_state",
         # Migration checkpoint under memory_control (not a product-memory tier store).
         "legacy_canonical_backfill_checkpoint",
+        # Operational graph-enrichment sweep cursor under memory_control; it
+        # stores no product-memory records or source content.
+        "historical_graph_enrichment_cursor",
         "memory_apply_control_state",
         "memory_lineage",
         "memory_evidence",


### PR DESCRIPTION
## What changed

- Persist a CAS-fenced, rotating historical graph-enrichment cursor for each canonical user.
- Resume bounded scans after the last examined row and wrap safely after the tail.
- Keep graph mutations on the canonical apply ledger while recording only operational checkpoint metadata.

## Why

Without a durable keyset cursor, a stable recent prefix or a backlog beyond one bounded scan can prevent older canonical memories from ever reaching graph enrichment.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Validation

- `PYTHONPATH=$PWD/backend .../.venv/bin/pytest -q backend/tests/unit/test_historical_graph_enrichment.py` (10 passed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

