### PR TITLE
fix(app): run bounded cloud sync grace when screen locks (#7221)

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -89,6 +89,7 @@ final class QuickActionsIconPatcher: NSObject {
   private var phoneMicController: PhoneMicController?
   private var notificationTitleOnKill: String?
   private var notificationBodyOnKill: String?
+  private var syncBackgroundTaskId: UIBackgroundTaskIdentifier = .invalid
 
   var session: WCSession?
     var flutterWatchAPI: WatchRecorderFlutterAPI?
@@ -217,6 +218,16 @@ final class QuickActionsIconPatcher: NSObject {
     // Create WiFi Network plugin for device AP connection
     _ = WifiNetworkPlugin(messenger: controller!.binaryMessenger)
 
+    // Bounded sync grace after screen lock (#7221) — keeps Flutter alive briefly
+    // for phone-disk upload + reconcile without BLE device drains.
+    let syncBackgroundChannel = FlutterMethodChannel(
+      name: "com.omi/sync_background_task",
+      binaryMessenger: controller!.binaryMessenger
+    )
+    syncBackgroundChannel.setMethodCallHandler { [weak self] (call, result) in
+      self?.handleSyncBackgroundTaskCall(call, result: result)
+    }
+
     // Battery widget channel — writes Omi device battery to the shared App Group
     // so the WidgetKit extension can read it.
     let batteryWidgetChannel = FlutterMethodChannel(name: "com.omi.battery_widget", binaryMessenger: controller!.binaryMessenger)
@@ -284,6 +295,28 @@ final class QuickActionsIconPatcher: NSObject {
       default:
         result(FlutterMethodNotImplemented)
     }
+  }
+
+  private func handleSyncBackgroundTaskCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "begin":
+      endSyncBackgroundTaskIfNeeded()
+      syncBackgroundTaskId = UIApplication.shared.beginBackgroundTask(withName: "omi.sync.cloudGrace") { [weak self] in
+        self?.endSyncBackgroundTaskIfNeeded()
+      }
+      result(nil)
+    case "end":
+      endSyncBackgroundTaskIfNeeded()
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func endSyncBackgroundTaskIfNeeded() {
+    guard syncBackgroundTaskId != .invalid else { return }
+    UIApplication.shared.endBackgroundTask(syncBackgroundTaskId)
+    syncBackgroundTaskId = .invalid
   }
 
   private func handleSetNotificationOnKillService(call: FlutterMethodCall) {

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -13,15 +13,14 @@ import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/utils/audio_player_utils.dart';
 import 'package:omi/utils/conversation_sync_utils.dart';
+import 'package:omi/utils/sync_continuation_policy.dart';
 import 'package:omi/utils/waveform_utils.dart';
 
 enum WalStatusFilter { pending, synced, corrupted }
 
 enum WalDisplayFilter { all, pending, synced }
 
-List<SyncedConversationPointer> sortSyncedConversationPointers(
-  Iterable<SyncedConversationPointer> pointers,
-) {
+List<SyncedConversationPointer> sortSyncedConversationPointers(Iterable<SyncedConversationPointer> pointers) {
   final sorted = List<SyncedConversationPointer>.from(pointers);
   sorted.sort((a, b) {
     final aDate = a.conversation.startedAt ?? a.conversation.createdAt;
@@ -214,10 +213,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// exhausted), the file is unreadable, or the server permanently refused it
   /// for being too old. Surfaced explicitly so a failure is never mistaken for
   /// a recording that simply hasn't synced yet.
-  int get needsAttentionWalsCount => _countWhere((s) =>
-      s == WalSyncDisplayState.failed ||
-      s == WalSyncDisplayState.corrupted ||
-      s == WalSyncDisplayState.outsideRecoveryWindow);
+  int get needsAttentionWalsCount => _countWhere(
+    (s) =>
+        s == WalSyncDisplayState.failed ||
+        s == WalSyncDisplayState.corrupted ||
+        s == WalSyncDisplayState.outsideRecoveryWindow,
+  );
 
   int get retryingWalsCount => _countWhere((s) => s == WalSyncDisplayState.retrying);
 
@@ -337,12 +338,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
     @visibleForTesting Future<void> Function()? startRecovery,
     @visibleForTesting Future<void> Function(WakeTrigger trigger)? wakeTransfer,
-  })  : _walServiceOverride = walService,
-        _uploadGate = uploadGate ?? SyncUploadGate.instance,
-        _startBackgroundSync = startBackgroundSync,
-        _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
-        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
-        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
+  }) : _walServiceOverride = walService,
+       _uploadGate = uploadGate ?? SyncUploadGate.instance,
+       _startBackgroundSync = startBackgroundSync,
+       _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
+       _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
+       _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _rateLimitWasActive = SyncRateLimiter.instance.isLimited;
@@ -388,6 +389,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         discover: _discoverPendingWals,
         refreshPending: refreshWals,
         drain: _drainEligibleWals,
+        cloudGraceDrain: _drainCloudGraceWals,
         autoUploadEnabled: () =>
             !SharedPreferencesUtil().useCustomStt && SharedPreferencesUtil().autoSyncOfflineRecordings,
         connectivityChanges: ConnectivityService().onConnectionChange,
@@ -447,6 +449,36 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     final result = await _performSync(
       operation: () => _walService.getSyncs().syncAll(progress: this),
       context: 'coordinated recording transfer',
+      rethrowOnError: true,
+    );
+    await refreshWals();
+    return RecordingTransferDrainResult(
+      attempted: true,
+      failed: (result?.localUploadFailures ?? 0) > 0,
+      needsReconciliation: uploadedWals.isNotEmpty,
+    );
+  }
+
+  /// Bounded phone-disk uploads only — used by the screen-lock grace wake (#7221).
+  Future<RecordingTransferDrainResult> _drainCloudGraceWals() async {
+    if (_isDisposed || _syncState.isProcessing) return const RecordingTransferDrainResult.contended();
+    if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) {
+      return const RecordingTransferDrainResult.contended();
+    }
+
+    final phoneMiss = missingWals.where((w) => w.storage == WalStorage.disk || w.storage == WalStorage.mem).toList();
+    if (phoneMiss.isEmpty) return const RecordingTransferDrainResult.skipped();
+
+    await _uploadGate.prepareToUpload();
+    if (_isDisposed) return const RecordingTransferDrainResult.contended();
+
+    _updateSyncState(_syncState.toIdle());
+    _totalWalsToProcess = phoneMiss.length;
+    _walsProcessedCount = 0;
+    final result = await _performSync(
+      operation: () =>
+          _walService.getSyncs().syncLocalUploadsOnly(progress: this, maxBatches: kScreenLockedCloudGraceMaxBatches),
+      context: 'screen-lock cloud grace upload',
       rethrowOnError: true,
     );
     await refreshWals();

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -214,11 +214,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// for being too old. Surfaced explicitly so a failure is never mistaken for
   /// a recording that simply hasn't synced yet.
   int get needsAttentionWalsCount => _countWhere(
-    (s) =>
-        s == WalSyncDisplayState.failed ||
-        s == WalSyncDisplayState.corrupted ||
-        s == WalSyncDisplayState.outsideRecoveryWindow,
-  );
+        (s) =>
+            s == WalSyncDisplayState.failed ||
+            s == WalSyncDisplayState.corrupted ||
+            s == WalSyncDisplayState.outsideRecoveryWindow,
+      );
 
   int get retryingWalsCount => _countWhere((s) => s == WalSyncDisplayState.retrying);
 
@@ -338,12 +338,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
     @visibleForTesting Future<void> Function()? startRecovery,
     @visibleForTesting Future<void> Function(WakeTrigger trigger)? wakeTransfer,
-  }) : _walServiceOverride = walService,
-       _uploadGate = uploadGate ?? SyncUploadGate.instance,
-       _startBackgroundSync = startBackgroundSync,
-       _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
-       _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
-       _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
+  })  : _walServiceOverride = walService,
+        _uploadGate = uploadGate ?? SyncUploadGate.instance,
+        _startBackgroundSync = startBackgroundSync,
+        _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
+        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
+        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _rateLimitWasActive = SyncRateLimiter.instance.isLimited;

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -548,8 +548,9 @@ class LocalWalSyncImpl implements LocalWalSync {
   /// retryable Pending action.
   @override
   Future<void> deleteAllCorruptedWals() async {
-    final corruptedWals =
-        _wals.where((w) => w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow).toList();
+    final corruptedWals = _wals
+        .where((w) => w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow)
+        .toList();
     for (final wal in corruptedWals) {
       await _deleteWal(wal);
     }
@@ -574,13 +575,17 @@ class LocalWalSyncImpl implements LocalWalSync {
   }
 
   @override
-  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) =>
-      _syncAll(progress: progress, liveCaptureOnly: false);
+  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress, int? maxBatches}) =>
+      _syncAll(progress: progress, liveCaptureOnly: false, maxBatches: maxBatches);
 
-  Future<SyncLocalFilesResponse?> syncLiveCaptureOnly({IWalSyncProgressListener? progress}) =>
-      _syncAll(progress: progress, liveCaptureOnly: true);
+  Future<SyncLocalFilesResponse?> syncLiveCaptureOnly({IWalSyncProgressListener? progress, int? maxBatches}) =>
+      _syncAll(progress: progress, liveCaptureOnly: true, maxBatches: maxBatches);
 
-  Future<SyncLocalFilesResponse?> _syncAll({IWalSyncProgressListener? progress, required bool liveCaptureOnly}) async {
+  Future<SyncLocalFilesResponse?> _syncAll({
+    IWalSyncProgressListener? progress,
+    required bool liveCaptureOnly,
+    int? maxBatches,
+  }) async {
     await _flush();
     _isCancelled = false;
     _accumulatedResponse = null;
@@ -634,11 +639,16 @@ class LocalWalSyncImpl implements LocalWalSync {
           .toList();
       final pending = candidates.where((wal) => !liveCaptureOnly || isLiveCaptureWal(wal, batchNowSeconds)).toList();
       if (pending.isEmpty) break;
+      if (maxBatches != null && batchesCompleted >= maxBatches) {
+        Logger.debug('LocalWalSync: stopping after $maxBatches batch(es) (screen-lock grace)');
+        break;
+      }
       final batch = nextSyncUploadBatch(pending, batchNowSeconds);
       if (batch.isEmpty) break;
       attemptedWalIds.addAll(batch.map((wal) => wal.id));
       final batchConversationId = batch.first.conversationId;
-      final claimLiveCapture = !unclaimableConversationIds.contains(batchConversationId) &&
+      final claimLiveCapture =
+          !unclaimableConversationIds.contains(batchConversationId) &&
           canClaimLiveCapture(
             batch,
             candidates.where((wal) => wal.conversationId == batchConversationId).toList(),

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -548,9 +548,8 @@ class LocalWalSyncImpl implements LocalWalSync {
   /// retryable Pending action.
   @override
   Future<void> deleteAllCorruptedWals() async {
-    final corruptedWals = _wals
-        .where((w) => w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow)
-        .toList();
+    final corruptedWals =
+        _wals.where((w) => w.status == WalStatus.corrupted || w.status == WalStatus.outsideRecoveryWindow).toList();
     for (final wal in corruptedWals) {
       await _deleteWal(wal);
     }
@@ -618,6 +617,10 @@ class LocalWalSyncImpl implements LocalWalSync {
 
     int batchesCompleted = 0;
     int batchesFailed = 0;
+    // Every selected batch consumes the grace budget — including upload failures
+    // and recovery-window rejections — so a transient outage cannot walk the
+    // whole backlog during a screen-lock pass (#7221 / cubic P1).
+    int batchesAttempted = 0;
     int corruptedCount = 0;
     int filesUploaded = 0;
     final totalFilesToUpload = wals.length;
@@ -639,16 +642,16 @@ class LocalWalSyncImpl implements LocalWalSync {
           .toList();
       final pending = candidates.where((wal) => !liveCaptureOnly || isLiveCaptureWal(wal, batchNowSeconds)).toList();
       if (pending.isEmpty) break;
-      if (maxBatches != null && batchesCompleted >= maxBatches) {
-        Logger.debug('LocalWalSync: stopping after $maxBatches batch(es) (screen-lock grace)');
+      if (maxBatches != null && batchesAttempted >= maxBatches) {
+        Logger.debug('LocalWalSync: stopping after $maxBatches batch attempt(s) (screen-lock grace)');
         break;
       }
       final batch = nextSyncUploadBatch(pending, batchNowSeconds);
       if (batch.isEmpty) break;
+      batchesAttempted++;
       attemptedWalIds.addAll(batch.map((wal) => wal.id));
       final batchConversationId = batch.first.conversationId;
-      final claimLiveCapture =
-          !unclaimableConversationIds.contains(batchConversationId) &&
+      final claimLiveCapture = !unclaimableConversationIds.contains(batchConversationId) &&
           canClaimLiveCapture(
             batch,
             candidates.where((wal) => wal.conversationId == batchConversationId).toList(),

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -2,11 +2,22 @@ import 'dart:async';
 
 import 'package:omi/utils/logger.dart';
 
-/// The event that made another foreground recording-transfer pass worthwhile.
+/// The event that made another recording-transfer pass worthwhile.
 ///
 /// All recording recovery paths use this closed set so a wake can be audited
 /// without introducing a second recovery owner.
-enum WakeTrigger { startup, foregrounded, connectivityRestored, deviceConnected, cooldownElapsed, userRetry }
+enum WakeTrigger {
+  startup,
+  foregrounded,
+  connectivityRestored,
+  deviceConnected,
+  cooldownElapsed,
+  userRetry,
+
+  /// Bounded cloud upload + reconcile while the OS still grants background time
+  /// after screen lock (#7221). Never starts BLE device drains.
+  screenLockedGrace,
+}
 
 /// Result reported by the production drain seam.
 ///
@@ -23,17 +34,17 @@ class RecordingTransferDrainResult {
 
   /// Nothing eligible to drain (empty backlog). Not a retry signal.
   const RecordingTransferDrainResult.skipped()
-      : attempted = false,
-        failed = false,
-        needsReconciliation = false,
-        contended = false;
+    : attempted = false,
+      failed = false,
+      needsReconciliation = false,
+      contended = false;
 
   /// Drain could not run because another sync owned the seam. Retry later.
   const RecordingTransferDrainResult.contended()
-      : attempted = false,
-        failed = false,
-        needsReconciliation = false,
-        contended = true;
+    : attempted = false,
+      failed = false,
+      needsReconciliation = false,
+      contended = true;
 
   final bool attempted;
   final bool failed;
@@ -57,28 +68,31 @@ class RecordingTransferCoordinator {
     required RecordingTransferPass refreshPending,
     required RecordingTransferDrain drain,
     required bool Function() autoUploadEnabled,
+    RecordingTransferDrain? cloudGraceDrain,
     Stream<bool>? connectivityChanges,
     bool initiallyConnected = true,
     DateTime Function()? clock,
     RecordingTransferCooldownScheduler? scheduleCooldown,
-  })  : _reconcile = reconcile,
-        _discover = discover,
-        _refreshPending = refreshPending,
-        _drain = drain,
-        _autoUploadEnabled = autoUploadEnabled,
-        _clock = clock ?? DateTime.now,
-        _scheduleCooldown = scheduleCooldown {
+  }) : _reconcile = reconcile,
+       _discover = discover,
+       _refreshPending = refreshPending,
+       _drain = drain,
+       _cloudGraceDrain = cloudGraceDrain,
+       _autoUploadEnabled = autoUploadEnabled,
+       _clock = clock ?? DateTime.now,
+       _scheduleCooldown = scheduleCooldown {
     _configured = true;
     _listenToConnectivity(connectivityChanges, initiallyConnected);
   }
 
   RecordingTransferCoordinator._singleton()
-      : _reconcile = _noop,
-        _discover = _noop,
-        _refreshPending = _noop,
-        _drain = _skippedDrain,
-        _autoUploadEnabled = _disabled,
-        _clock = DateTime.now;
+    : _reconcile = _noop,
+      _discover = _noop,
+      _refreshPending = _noop,
+      _drain = _skippedDrain,
+      _cloudGraceDrain = null,
+      _autoUploadEnabled = _disabled,
+      _clock = DateTime.now;
 
   static final RecordingTransferCoordinator instance = RecordingTransferCoordinator._singleton();
 
@@ -97,6 +111,7 @@ class RecordingTransferCoordinator {
   RecordingTransferPass _discover;
   RecordingTransferPass _refreshPending;
   RecordingTransferDrain _drain;
+  RecordingTransferDrain? _cloudGraceDrain;
   bool Function() _autoUploadEnabled;
   final DateTime Function() _clock;
   RecordingTransferCooldownScheduler? _scheduleCooldown;
@@ -127,11 +142,13 @@ class RecordingTransferCoordinator {
     required bool Function() autoUploadEnabled,
     required Stream<bool> connectivityChanges,
     required bool initiallyConnected,
+    RecordingTransferDrain? cloudGraceDrain,
   }) {
     _reconcile = reconcile;
     _discover = discover;
     _refreshPending = refreshPending;
     _drain = drain;
+    _cloudGraceDrain = cloudGraceDrain;
     _autoUploadEnabled = autoUploadEnabled;
     _configured = true;
     _listenToConnectivity(connectivityChanges, initiallyConnected);
@@ -170,10 +187,11 @@ class RecordingTransferCoordinator {
   /// Coalesces concurrent events into a single extra serial pass. Five wakes
   /// during one pass therefore run at most two passes and never parallel drains.
   Future<void> wake(WakeTrigger trigger) {
-    // Recovery is foreground-only. Persisted WAL state is recovered by the
-    // foreground wake, so background connectivity/device callbacks must not
-    // start discovery or a whole-WAL drain.
-    if (!_foreground) return Future.value();
+    // Recovery is foreground-only except for the bounded screen-lock cloud
+    // grace pass (#7221). Connectivity/device callbacks must not start BLE
+    // discovery or a whole-WAL drain while backgrounded.
+    final allowWhileBackgrounded = trigger == WakeTrigger.screenLockedGrace;
+    if (!_foreground && !allowWhileBackgrounded) return Future.value();
 
     if (!_configured) {
       _wakeBeforeConfigured = _preferWake(_wakeBeforeConfigured, trigger);
@@ -201,10 +219,16 @@ class RecordingTransferCoordinator {
   }
 
   WakeTrigger _preferWake(WakeTrigger? existing, WakeTrigger incoming) {
-    if (existing == WakeTrigger.userRetry || incoming != WakeTrigger.userRetry) {
-      return existing ?? incoming;
+    if (existing == null) return incoming;
+    // userRetry always wins so an explicit Sync tap is not coalesced away.
+    if (existing == WakeTrigger.userRetry || incoming == WakeTrigger.userRetry) {
+      return WakeTrigger.userRetry;
     }
-    return incoming;
+    // Prefer screen-lock cloud grace over quieter background wakes (#7221).
+    if (existing == WakeTrigger.screenLockedGrace || incoming == WakeTrigger.screenLockedGrace) {
+      return WakeTrigger.screenLockedGrace;
+    }
+    return existing;
   }
 
   Future<void> _run(WakeTrigger firstWake) async {
@@ -217,13 +241,16 @@ class RecordingTransferCoordinator {
   }
 
   Future<void> _runPass(WakeTrigger trigger) async {
+    final cloudGrace = trigger == WakeTrigger.screenLockedGrace;
     try {
       // Uploaded jobs are resolved before a whole-WAL drain can offer any
       // retryable bytes. `syncAll` only uploads `miss`, preserving job ids.
       // Reconciling only resolves work already on the server, so a failure here
       // must not stop new recordings from uploading — it is retried instead.
       var reconcileFailed = !await _tryReconcile();
-      await _discover();
+      if (!cloudGrace) {
+        await _discover();
+      }
       await _refreshPending();
 
       final mayUpload = trigger == WakeTrigger.userRetry || _autoUploadEnabled();
@@ -232,7 +259,8 @@ class RecordingTransferCoordinator {
         return;
       }
 
-      final result = await _drain();
+      final drain = cloudGrace ? (_cloudGraceDrain ?? _skippedDrain) : _drain;
+      final result = await drain();
       await _refreshPending();
 
       // Partial upload success still leaves `uploaded` WALs that need the

--- a/app/lib/services/wals/recording_transfer_coordinator.dart
+++ b/app/lib/services/wals/recording_transfer_coordinator.dart
@@ -34,17 +34,17 @@ class RecordingTransferDrainResult {
 
   /// Nothing eligible to drain (empty backlog). Not a retry signal.
   const RecordingTransferDrainResult.skipped()
-    : attempted = false,
-      failed = false,
-      needsReconciliation = false,
-      contended = false;
+      : attempted = false,
+        failed = false,
+        needsReconciliation = false,
+        contended = false;
 
   /// Drain could not run because another sync owned the seam. Retry later.
   const RecordingTransferDrainResult.contended()
-    : attempted = false,
-      failed = false,
-      needsReconciliation = false,
-      contended = true;
+      : attempted = false,
+        failed = false,
+        needsReconciliation = false,
+        contended = true;
 
   final bool attempted;
   final bool failed;
@@ -73,26 +73,26 @@ class RecordingTransferCoordinator {
     bool initiallyConnected = true,
     DateTime Function()? clock,
     RecordingTransferCooldownScheduler? scheduleCooldown,
-  }) : _reconcile = reconcile,
-       _discover = discover,
-       _refreshPending = refreshPending,
-       _drain = drain,
-       _cloudGraceDrain = cloudGraceDrain,
-       _autoUploadEnabled = autoUploadEnabled,
-       _clock = clock ?? DateTime.now,
-       _scheduleCooldown = scheduleCooldown {
+  })  : _reconcile = reconcile,
+        _discover = discover,
+        _refreshPending = refreshPending,
+        _drain = drain,
+        _cloudGraceDrain = cloudGraceDrain,
+        _autoUploadEnabled = autoUploadEnabled,
+        _clock = clock ?? DateTime.now,
+        _scheduleCooldown = scheduleCooldown {
     _configured = true;
     _listenToConnectivity(connectivityChanges, initiallyConnected);
   }
 
   RecordingTransferCoordinator._singleton()
-    : _reconcile = _noop,
-      _discover = _noop,
-      _refreshPending = _noop,
-      _drain = _skippedDrain,
-      _cloudGraceDrain = null,
-      _autoUploadEnabled = _disabled,
-      _clock = DateTime.now;
+      : _reconcile = _noop,
+        _discover = _noop,
+        _refreshPending = _noop,
+        _drain = _skippedDrain,
+        _cloudGraceDrain = null,
+        _autoUploadEnabled = _disabled,
+        _clock = DateTime.now;
 
   static final RecordingTransferCoordinator instance = RecordingTransferCoordinator._singleton();
 
@@ -223,6 +223,12 @@ class RecordingTransferCoordinator {
     // userRetry always wins so an explicit Sync tap is not coalesced away.
     if (existing == WakeTrigger.userRetry || incoming == WakeTrigger.userRetry) {
       return WakeTrigger.userRetry;
+    }
+    // Full transfer wakes beat screen-lock grace so unlock/reconnect still run
+    // BLE discovery + drain instead of another cloud-only pass (#7221 / cubic P2).
+    bool isFullTransferWake(WakeTrigger t) => t == WakeTrigger.foregrounded || t == WakeTrigger.deviceConnected;
+    if (isFullTransferWake(existing) || isFullTransferWake(incoming)) {
+      return isFullTransferWake(existing) ? existing : incoming;
     }
     // Prefer screen-lock cloud grace over quieter background wakes (#7221).
     if (existing == WakeTrigger.screenLockedGrace || incoming == WakeTrigger.screenLockedGrace) {

--- a/app/lib/services/wals/sync_background_task.dart
+++ b/app/lib/services/wals/sync_background_task.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'package:omi/utils/logger.dart';
+
+/// iOS `beginBackgroundTask` bridge for the screen-lock sync grace (#7221).
+///
+/// No-ops on non-iOS. Failures are swallowed — grace still attempts work under
+/// whatever suspension budget Flutter retains.
+class SyncBackgroundTask {
+  SyncBackgroundTask._();
+
+  static const MethodChannel _channel = MethodChannel('com.omi/sync_background_task');
+
+  static Future<void> begin() async {
+    if (!Platform.isIOS) return;
+    try {
+      await _channel.invokeMethod<void>('begin');
+    } catch (e) {
+      Logger.debug('SyncBackgroundTask.begin failed: $e');
+    }
+  }
+
+  static Future<void> end() async {
+    if (!Platform.isIOS) return;
+    try {
+      await _channel.invokeMethod<void>('end');
+    } catch (e) {
+      Logger.debug('SyncBackgroundTask.end failed: $e');
+    }
+  }
+}

--- a/app/lib/services/wals/sync_reconciler.dart
+++ b/app/lib/services/wals/sync_reconciler.dart
@@ -3,8 +3,11 @@ import 'dart:async';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/wals/local_wal_sync.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
+import 'package:omi/services/wals/sync_background_task.dart';
 import 'package:omi/services/wals/wal.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/sync_continuation_policy.dart';
+import 'package:omi/backend/preferences.dart';
 
 /// Called with the conversation ids surfaced by a reconcile pass so the
 /// presentation layer can fetch + show them. Provided by the provider so this
@@ -106,13 +109,43 @@ class SyncReconciler {
     unawaited(RecordingTransferCoordinator.instance.wake(WakeTrigger.foregrounded));
   }
 
-  /// App backgrounded — stop the timer. State is persisted; a later
-  /// foreground/startup poke resumes. (No OS background execution by design.)
+  /// App backgrounded — stop the timer, then optionally run one bounded cloud
+  /// grace pass while the OS still grants execution time (#7221).
   void onBackground() {
     _foreground = false;
     _timer?.cancel();
     _timer = null;
     RecordingTransferCoordinator.instance.setForeground(false);
+    unawaited(_maybeStartScreenLockedGrace());
+  }
+
+  Future<void> _maybeStartScreenLockedGrace() async {
+    final phone = _phone;
+    if (phone == null) return;
+    try {
+      final wals = await phone.getAllWals();
+      final hasMissLocal = wals.any(
+        (w) => w.status == WalStatus.miss && (w.storage == WalStorage.disk || w.storage == WalStorage.mem),
+      );
+      final hasUploaded = wals.any((w) => w.status == WalStatus.uploaded);
+      final autoUpload = !SharedPreferencesUtil().useCustomStt && SharedPreferencesUtil().autoSyncOfflineRecordings;
+      final action = decideScreenLockedSyncContinuation(
+        autoUploadEnabled: autoUpload,
+        hasMissLocalWals: hasMissLocal,
+        hasUploadedWals: hasUploaded,
+      );
+      if (action != SyncContinuationAction.runCloudGracePass) return;
+
+      await SyncBackgroundTask.begin();
+      try {
+        await RecordingTransferCoordinator.instance.wake(WakeTrigger.screenLockedGrace);
+      } finally {
+        await SyncBackgroundTask.end();
+      }
+    } catch (e) {
+      Logger.debug('SyncReconciler: screen-lock grace failed: $e');
+      await SyncBackgroundTask.end();
+    }
   }
 
   void dispose() {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -246,6 +246,13 @@ class WalSyncs implements IWalSync {
     await _ringSync.stop();
   }
 
+  /// Phone-disk uploads only — no BLE device drain phases (#7221 screen-lock grace).
+  Future<SyncLocalFilesResponse?> syncLocalUploadsOnly({IWalSyncProgressListener? progress, int? maxBatches}) async {
+    _isCancelled = false;
+    progress?.onWalSyncedProgress(0.0, phase: SyncPhase.uploadingToCloud);
+    return _phoneSync.syncAll(progress: progress, maxBatches: maxBatches);
+  }
+
   @override
   Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async {
     _isCancelled = false;

--- a/app/lib/utils/sync_continuation_policy.dart
+++ b/app/lib/utils/sync_continuation_policy.dart
@@ -1,0 +1,44 @@
+/// Screen-lock sync continuation policy (#7221).
+///
+/// [RecordingTransferCoordinator] is foreground-only by design (#9763). When the
+/// user locks the screen with a large upload/reconcile backlog, Flutter is
+/// suspended within seconds and overnight drain stalls (~5% of 1000+ files).
+///
+/// This policy decides whether a **bounded cloud-only grace pass** should run
+/// while iOS still grants background execution time. BLE device drains stay
+/// deferred — they need an active Flutter BLE loop and fight platform limits.
+library;
+
+/// What to do when the app leaves the foreground with pending sync work.
+enum SyncContinuationAction {
+  /// Wait for the next foreground/startup wake (default #9763 contract).
+  deferToForeground,
+
+  /// Run one cloud upload + server-reconcile pass; skip BLE device drains.
+  runCloudGracePass,
+}
+
+/// Max local-upload batches for one screen-locked grace pass.
+///
+/// Each batch is at most 5 WALs (`local_wal_sync`). Three batches ≈ 15 files —
+/// enough to make overnight progress under `beginBackgroundTask` without
+/// attempting a full 1000+ backlog in one suspended window.
+const int kScreenLockedCloudGraceMaxBatches = 3;
+
+/// Whether locking the screen should start a cloud-only grace wake.
+///
+/// [hasMissLocalWals] — phone-disk WALs still `miss` (bytes ready to upload).
+/// [hasUploadedWals] — WALs waiting on server job reconcile ("processing").
+/// [autoUploadEnabled] — user auto-sync preference (userRetry is foreground-only).
+SyncContinuationAction decideScreenLockedSyncContinuation({
+  required bool autoUploadEnabled,
+  required bool hasMissLocalWals,
+  required bool hasUploadedWals,
+}) {
+  // Uploaded jobs must keep moving or the Sync UI stays at "processing 0%".
+  if (hasUploadedWals) return SyncContinuationAction.runCloudGracePass;
+  if (autoUploadEnabled && hasMissLocalWals) {
+    return SyncContinuationAction.runCloudGracePass;
+  }
+  return SyncContinuationAction.deferToForeground;
+}

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -130,6 +130,34 @@ void main() {
       expect(harness.drainPasses, 1);
     });
 
+    test('screen-lock grace runs cloud drain while backgrounded without BLE discover (#7221)', () async {
+      final harness = _TransferHarness(cloudGraceDrain: true);
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.screenLockedGrace);
+      await _settle();
+
+      expect(harness.reconcilePasses, greaterThanOrEqualTo(1));
+      expect(harness.discoveryPasses, 0);
+      expect(harness.cloudGraceDrainPasses, 1);
+      expect(harness.drainPasses, 0);
+    });
+
+    test('screen-lock grace is a no-op when no cloud grace drain is configured', () async {
+      final harness = _TransferHarness();
+      addTearDown(harness.dispose);
+
+      harness.coordinator.setForeground(false);
+      await harness.coordinator.wake(WakeTrigger.screenLockedGrace);
+      await _settle();
+
+      expect(harness.reconcilePasses, greaterThanOrEqualTo(1));
+      expect(harness.drainPasses, 0);
+      expect(harness.cloudGraceDrainPasses, 0);
+      expect(harness.discoveryPasses, 0);
+    });
+
     test('startup resumes a pending backlog once without loss or duplication', () async {
       final sharedBacklog = <String>['pending-wal'];
       final drainedWalIds = <String>[];
@@ -208,15 +236,20 @@ class _ScheduledCooldown {
 }
 
 class _TransferHarness {
-  _TransferHarness({bool autoUploadEnabled = true, List<String>? backlog, List<String>? drainedWalIds})
-      : _autoUploadEnabled = autoUploadEnabled,
-        backlog = backlog ?? <String>['wal-1'],
-        drainedWalIds = drainedWalIds ?? <String>[] {
+  _TransferHarness({
+    bool autoUploadEnabled = true,
+    List<String>? backlog,
+    List<String>? drainedWalIds,
+    bool cloudGraceDrain = false,
+  }) : _autoUploadEnabled = autoUploadEnabled,
+       backlog = backlog ?? <String>['wal-1'],
+       drainedWalIds = drainedWalIds ?? <String>[] {
     coordinator = RecordingTransferCoordinator(
       reconcile: _reconcile,
       discover: _discover,
       refreshPending: _refreshPending,
       drain: _drain,
+      cloudGraceDrain: cloudGraceDrain ? _cloudGraceDrain : null,
       autoUploadEnabled: () => _autoUploadEnabled,
       connectivityChanges: connectivity.stream,
       initiallyConnected: true,
@@ -245,6 +278,7 @@ class _TransferHarness {
   int discoveryPasses = 0;
   int pendingRefreshes = 0;
   int drainPasses = 0;
+  int cloudGraceDrainPasses = 0;
   int _concurrentDrains = 0;
   int maximumConcurrentDrains = 0;
 
@@ -296,6 +330,15 @@ class _TransferHarness {
     } finally {
       _concurrentDrains--;
     }
+  }
+
+  Future<RecordingTransferDrainResult> _cloudGraceDrain() async {
+    cloudGraceDrainPasses++;
+    if (backlog.isEmpty) return const RecordingTransferDrainResult.skipped();
+    // Bounded grace: clear at most one backlog item to mirror maxBatches=1 in tests.
+    drainedWalIds.add(backlog.removeAt(0));
+    walState = 'uploaded';
+    return const RecordingTransferDrainResult(attempted: true, failed: false, needsReconciliation: false);
   }
 
   Future<void> dispose() async {

--- a/app/test/services/wals/recording_transfer_coordinator_test.dart
+++ b/app/test/services/wals/recording_transfer_coordinator_test.dart
@@ -158,6 +158,56 @@ void main() {
       expect(harness.discoveryPasses, 0);
     });
 
+    test('pending foregrounded wake beats screen-lock grace so unlock still discovers (#7221)', () async {
+      final harness = _TransferHarness(cloudGraceDrain: true);
+      addTearDown(harness.dispose);
+      final reconcileGate = Completer<void>();
+      harness.reconcileGate = reconcileGate;
+
+      harness.coordinator.setForeground(true);
+      final firstWake = harness.coordinator.wake(WakeTrigger.startup);
+      await _settle();
+      expect(harness.reconcilePasses, 1);
+
+      // While the first pass is gated, queue grace then unlock/foreground.
+      harness.coordinator.setForeground(false);
+      harness.coordinator.wake(WakeTrigger.screenLockedGrace);
+      harness.coordinator.setForeground(true);
+      harness.coordinator.wake(WakeTrigger.foregrounded);
+
+      reconcileGate.complete();
+      await firstWake;
+      await _settle();
+
+      // Second pass must be the full foreground transfer (BLE discover + drain),
+      // not another cloud-only grace pass.
+      expect(harness.discoveryPasses, greaterThanOrEqualTo(1));
+      expect(harness.drainPasses, greaterThanOrEqualTo(1));
+    });
+
+    test('pending deviceConnected wake beats screen-lock grace (#7221)', () async {
+      final harness = _TransferHarness(cloudGraceDrain: true);
+      addTearDown(harness.dispose);
+      final reconcileGate = Completer<void>();
+      harness.reconcileGate = reconcileGate;
+
+      harness.coordinator.setForeground(true);
+      final firstWake = harness.coordinator.wake(WakeTrigger.startup);
+      await _settle();
+
+      harness.coordinator.setForeground(false);
+      harness.coordinator.wake(WakeTrigger.screenLockedGrace);
+      harness.coordinator.setForeground(true);
+      harness.coordinator.wake(WakeTrigger.deviceConnected);
+
+      reconcileGate.complete();
+      await firstWake;
+      await _settle();
+
+      expect(harness.discoveryPasses, greaterThanOrEqualTo(1));
+      expect(harness.drainPasses, greaterThanOrEqualTo(1));
+    });
+
     test('startup resumes a pending backlog once without loss or duplication', () async {
       final sharedBacklog = <String>['pending-wal'];
       final drainedWalIds = <String>[];
@@ -241,9 +291,9 @@ class _TransferHarness {
     List<String>? backlog,
     List<String>? drainedWalIds,
     bool cloudGraceDrain = false,
-  }) : _autoUploadEnabled = autoUploadEnabled,
-       backlog = backlog ?? <String>['wal-1'],
-       drainedWalIds = drainedWalIds ?? <String>[] {
+  })  : _autoUploadEnabled = autoUploadEnabled,
+        backlog = backlog ?? <String>['wal-1'],
+        drainedWalIds = drainedWalIds ?? <String>[] {
     coordinator = RecordingTransferCoordinator(
       reconcile: _reconcile,
       discover: _discover,

--- a/app/test/unit/sync_continuation_policy_test.dart
+++ b/app/test/unit/sync_continuation_policy_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/sync_continuation_policy.dart';
+
+void main() {
+  group('decideScreenLockedSyncContinuation (#7221)', () {
+    test('defers when there is no cloud work', () {
+      expect(
+        decideScreenLockedSyncContinuation(autoUploadEnabled: true, hasMissLocalWals: false, hasUploadedWals: false),
+        SyncContinuationAction.deferToForeground,
+      );
+    });
+
+    test('runs grace when miss WALs are ready and auto-upload is on', () {
+      expect(
+        decideScreenLockedSyncContinuation(autoUploadEnabled: true, hasMissLocalWals: true, hasUploadedWals: false),
+        SyncContinuationAction.runCloudGracePass,
+      );
+    });
+
+    test('does not upload miss WALs when auto-upload is off', () {
+      expect(
+        decideScreenLockedSyncContinuation(autoUploadEnabled: false, hasMissLocalWals: true, hasUploadedWals: false),
+        SyncContinuationAction.deferToForeground,
+      );
+    });
+
+    test('always reconciles uploaded WALs even when auto-upload is off', () {
+      expect(
+        decideScreenLockedSyncContinuation(autoUploadEnabled: false, hasMissLocalWals: false, hasUploadedWals: true),
+        SyncContinuationAction.runCloudGracePass,
+      );
+    });
+
+    test('grace max batches stays bounded for iOS background time', () {
+      expect(kScreenLockedCloudGraceMaxBatches, greaterThan(0));
+      expect(kScreenLockedCloudGraceMaxBatches, lessThanOrEqualTo(5));
+    });
+  });
+}

--- a/app/test/unit/wal_upload_resilience_test.dart
+++ b/app/test/unit/wal_upload_resilience_test.dart
@@ -474,4 +474,45 @@ void main() {
       );
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Screen-lock grace maxBatches must count every attempt (#7221 / cubic P1).
+  // -------------------------------------------------------------------------
+
+  group('maxBatches bounds attempts including failures', () {
+    test('failed uploads still consume the maxBatches budget', () async {
+      var uploadAttempts = 0;
+      sync = LocalWalSyncImpl(
+        listener,
+        uploadGate: SyncUploadGate(
+          limiter: SyncRateLimiter.instance,
+          uploader: (files, {onUploadProgress, conversationId, claimLiveCapture = false}) async {
+            uploadAttempts++;
+            throw StateError('deterministic grace-pass failure');
+          },
+          fairUseStatusLoader: () async => {'stage': 'none'},
+        ),
+      );
+
+      // Distinct conversationIds → one WAL per batch so attempt count is visible.
+      final wals = <Wal>[];
+      for (var i = 0; i < 5; i++) {
+        final filename = 'grace_fail_$i.bin';
+        await File('${tempDir.path}/$filename').writeAsBytes([0xAA, 0xBB]);
+        wals.add(_makeWal(timerStart: 9000 + i, filePath: filename)..conversationId = 'conv-$i');
+      }
+      sync.testWals = wals;
+
+      final result = await sync.syncAll(maxBatches: 3);
+
+      expect(uploadAttempts, 3, reason: 'grace budget must stop after 3 attempts even when every upload fails');
+      expect(result?.localUploadFailures, 3);
+      expect(wals.where((w) => w.status == WalStatus.miss).length, 5, reason: 'failures leave WALs retryable');
+      expect(
+        wals.where((w) => !w.isSyncing).length,
+        5,
+        reason: 'isSyncing cleared on every attempted WAL',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
When the screen locks, Flutter hits `paused` and `#9763`'s foreground-only `RecordingTransferCoordinator` stops all upload/reconcile work. That matches [#7221](https://github.com/BasedHardware/omi/issues/7221): overnight with the app "open" on fiber Wi-Fi still only drains ~5% of a 1000+ file backlog, and "processing on server" freezes at 0%.

## Implementation
- Pure `decideScreenLockedSyncContinuation` policy (`app/lib/utils/sync_continuation_policy.dart`).
- New `WakeTrigger.screenLockedGrace`: while backgrounded, runs **reconcile + bounded phone-disk uploads only** (max 3 batches / ~15 WALs). Skips BLE device discovery/drain.
- `SyncReconciler.onBackground` starts that grace when miss/uploaded work exists; iOS `beginBackgroundTask` via `com.omi/sync_background_task`.
- `WalSyncs.syncLocalUploadsOnly` + `LocalWalSyncImpl.maxBatches` for the bounded pass.

Out of scope: overnight BGProcessingTask for full 1000+ drain, BLE flash download in background, server job pipeline stalls.

## Tests
- `flutter test test/unit/sync_continuation_policy_test.dart`
- `flutter test test/services/wals/recording_transfer_coordinator_test.dart`

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

