### PR TITLE
fix(app): auto-retry BLE connect after timeout + resume kick (#6721)

### DIFF
--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -47,6 +47,13 @@ final class OmiBleManager: NSObject {
     /// Periodic check for CoreBluetooth peripherals stuck in `.connecting`.
     private var connectingWatchdogTimer: Timer?
 
+    /// UUIDs the connecting watchdog just canceled and is about to re-issue.
+    /// `didFailToConnect`/`didDisconnectPeripheral` check this so a delegate
+    /// callback triggered by the watchdog's own cancel doesn't *also* schedule
+    /// its own retry — otherwise the same peripheral gets two overlapping
+    /// `connect()` calls for one stall.
+    private var watchdogPendingReissue: Set<String> = []
+
     /// Tracks peripherals that have connected at least once (for reconnection counting).
     private var everConnected: Set<String> = []
 
@@ -136,9 +143,7 @@ final class OmiBleManager: NSObject {
                 NSLog("[OmiBle] connectPeripheral: \(uuid) already connected, skipping")
                 return
             }
-            connectAttemptStartTimes[uuid] = Date()
-            startConnectingWatchdogIfNeeded()
-            centralManager.connect(peripheral, options: nil)
+            issueConnect(peripheral, uuid: uuid)
             return
         }
 
@@ -148,10 +153,18 @@ final class OmiBleManager: NSObject {
         if let peripheral = retrieved.first {
             peripheral.delegate = self
             peripherals[uuid] = peripheral
-            connectAttemptStartTimes[uuid] = Date()
-            startConnectingWatchdogIfNeeded()
-            centralManager.connect(peripheral, options: nil)
+            issueConnect(peripheral, uuid: uuid)
         }
+    }
+
+    /// Single funnel for every `centralManager.connect` issuance (#6610 review:
+    /// a connect issued outside this path is invisible to the watchdog and can
+    /// stall in `.connecting` forever with nothing left to recover it).
+    private func issueConnect(_ peripheral: CBPeripheral, uuid: String) {
+        connectAttemptStartTimes[uuid] = Date()
+        startConnectingWatchdogIfNeeded()
+        peripheral.delegate = self
+        centralManager.connect(peripheral, options: nil)
     }
 
     /// CoreBluetooth can leave a peripheral in `.connecting` after backgrounding
@@ -164,28 +177,41 @@ final class OmiBleManager: NSObject {
         }
     }
 
+    /// Threshold mirrors `kBleConnectingWatchdogAfter` in
+    /// `app/lib/utils/ble_connect_retry.dart` (`shouldKickStuckConnectingAttempt`
+    /// documents/tests the same contract in Dart). Keep both in sync — there is
+    /// no shared source of truth across the platform channel.
     private func kickStuckConnectingPeripherals() {
         let threshold: TimeInterval = 65
         for (uuid, peripheral) in peripherals {
             guard peripheral.state == .connecting else { continue }
-            guard !manuallyDisconnected.contains(uuid) else { continue }
+            // A manual disconnect may leave no delegate callback to clear this
+            // entry (cancelPeripheralConnection during .connecting doesn't
+            // always fire one) — drop it here so the timer can still stop.
+            if manuallyDisconnected.contains(uuid) {
+                connectAttemptStartTimes.removeValue(forKey: uuid)
+                continue
+            }
             guard let started = connectAttemptStartTimes[uuid] else { continue }
             let elapsed = Date().timeIntervalSince(started)
             guard elapsed >= threshold else { continue }
 
             NSLog("[OmiBle] connecting watchdog: canceling stuck connect for \(uuid) after \(Int(elapsed))s")
             connectAttemptStartTimes.removeValue(forKey: uuid)
+            // Mark before canceling: CoreBluetooth can route this cancel through
+            // didFailToConnect, whose own retry logic must not fire a second,
+            // overlapping connect for the same stall (see didFailToConnect).
+            watchdogPendingReissue.insert(uuid)
             centralManager.cancelPeripheralConnection(peripheral)
 
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
                 guard let self = self else { return }
+                self.watchdogPendingReissue.remove(uuid)
                 guard !self.manuallyDisconnected.contains(uuid) else { return }
                 guard let peripheral = self.peripherals[uuid] else { return }
                 if peripheral.state == .connected { return }
                 NSLog("[OmiBle] connecting watchdog: re-issuing connect for \(uuid)")
-                self.connectAttemptStartTimes[uuid] = Date()
-                peripheral.delegate = self
-                self.centralManager.connect(peripheral, options: nil)
+                self.issueConnect(peripheral, uuid: uuid)
             }
         }
 
@@ -231,8 +257,7 @@ final class OmiBleManager: NSObject {
             // silently waiting in congested RF. connect() is idempotent on iOS.
             if peripheral.state == .connected { continue }
             NSLog("[OmiBle] Re-issuing connect on foreground for \(uuid), state=\(peripheral.state.rawValue)")
-            peripheral.delegate = self
-            centralManager.connect(peripheral, options: nil)
+            issueConnect(peripheral, uuid: uuid)
         }
     }
 
@@ -617,7 +642,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
                 // Re-establish connection if not already connected
                 if peripheral.state != .connected {
-                    central.connect(peripheral, options: nil)
+                    issueConnect(peripheral, uuid: uuid)
                 } else {
                     peripheral.discoverServices(nil)
                 }
@@ -656,6 +681,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         everConnected.insert(uuid)
         connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
         connectAttemptStartTimes.removeValue(forKey: uuid)
+        watchdogPendingReissue.remove(uuid)
 
         peripheral.delegate = self
         peripheral.discoverServices(nil)
@@ -684,12 +710,18 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
+        // The connecting watchdog's own cancel can route here on some iOS
+        // versions. Its re-issue (200ms after cancel, see kickStuckConnectingPeripherals)
+        // is the only retry for this stall — scheduling a second one here would
+        // issue two overlapping connect() calls for the same peripheral.
+        let watchdogOwnsRetry = watchdogPendingReissue.remove(uuid) != nil
+
         // Retry previously-connected peripherals — otherwise a failed connect silently
         // drops the user. iOS queues this at the chipset level; it's free while waiting.
-        if !isManual, !pairingLost, everConnected.contains(uuid) {
+        if !isManual, !pairingLost, everConnected.contains(uuid), !watchdogOwnsRetry {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
                 guard let self = self else { return }
-                self.centralManager.connect(peripheral, options: nil)
+                self.issueConnect(peripheral, uuid: uuid)
             }
         }
     }
@@ -724,12 +756,16 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
+        // See didFailToConnect: don't double-issue a connect for a stall the
+        // watchdog is already re-issuing itself.
+        let watchdogOwnsRetry = watchdogPendingReissue.remove(uuid) != nil
+
         // Auto-reconnect unless manually disconnected
-        if !isManual, !pairingLost {
+        if !isManual, !pairingLost, !watchdogOwnsRetry {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
                 guard let self = self else { return }
                 // iOS handles this at the BLE chipset level — zero CPU/radio cost while waiting
-                self.centralManager.connect(peripheral, options: nil)
+                self.issueConnect(peripheral, uuid: uuid)
             }
         }
     }

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -40,6 +40,13 @@ final class OmiBleManager: NSObject {
     /// Connection start time per peripheral UUID.
     private var connectionStartTimes: [String: Int64] = [:]
 
+    /// When `connectPeripheral` was last issued per UUID. Used by the connecting
+    /// watchdog (#6610) to cancel + re-issue connects stuck in `.connecting`.
+    private var connectAttemptStartTimes: [String: Date] = [:]
+
+    /// Periodic check for CoreBluetooth peripherals stuck in `.connecting`.
+    private var connectingWatchdogTimer: Timer?
+
     /// Tracks peripherals that have connected at least once (for reconnection counting).
     private var everConnected: Set<String> = []
 
@@ -129,6 +136,8 @@ final class OmiBleManager: NSObject {
                 NSLog("[OmiBle] connectPeripheral: \(uuid) already connected, skipping")
                 return
             }
+            connectAttemptStartTimes[uuid] = Date()
+            startConnectingWatchdogIfNeeded()
             centralManager.connect(peripheral, options: nil)
             return
         }
@@ -139,7 +148,51 @@ final class OmiBleManager: NSObject {
         if let peripheral = retrieved.first {
             peripheral.delegate = self
             peripherals[uuid] = peripheral
+            connectAttemptStartTimes[uuid] = Date()
+            startConnectingWatchdogIfNeeded()
             centralManager.connect(peripheral, options: nil)
+        }
+    }
+
+    /// CoreBluetooth can leave a peripheral in `.connecting` after backgrounding
+    /// without firing disconnect/fail callbacks (#6610). Cancel and re-issue connect
+    /// so Dart's soft-retry path and native auto-reconnect can recover.
+    private func startConnectingWatchdogIfNeeded() {
+        guard connectingWatchdogTimer == nil else { return }
+        connectingWatchdogTimer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
+            self?.kickStuckConnectingPeripherals()
+        }
+    }
+
+    private func kickStuckConnectingPeripherals() {
+        let threshold: TimeInterval = 65
+        for (uuid, peripheral) in peripherals {
+            guard peripheral.state == .connecting else { continue }
+            guard !manuallyDisconnected.contains(uuid) else { continue }
+            guard let started = connectAttemptStartTimes[uuid] else { continue }
+            let elapsed = Date().timeIntervalSince(started)
+            guard elapsed >= threshold else { continue }
+
+            NSLog("[OmiBle] connecting watchdog: canceling stuck connect for \(uuid) after \(Int(elapsed))s")
+            connectAttemptStartTimes.removeValue(forKey: uuid)
+            centralManager.cancelPeripheralConnection(peripheral)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
+                guard let self = self else { return }
+                guard !self.manuallyDisconnected.contains(uuid) else { return }
+                guard let peripheral = self.peripherals[uuid] else { return }
+                if peripheral.state == .connected { return }
+                NSLog("[OmiBle] connecting watchdog: re-issuing connect for \(uuid)")
+                self.connectAttemptStartTimes[uuid] = Date()
+                peripheral.delegate = self
+                self.centralManager.connect(peripheral, options: nil)
+            }
+        }
+
+        if connectAttemptStartTimes.isEmpty,
+           peripherals.values.allSatisfy({ $0.state != .connecting }) {
+            connectingWatchdogTimer?.invalidate()
+            connectingWatchdogTimer = nil
         }
     }
 
@@ -602,6 +655,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         }
         everConnected.insert(uuid)
         connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
+        connectAttemptStartTimes.removeValue(forKey: uuid)
 
         peripheral.delegate = self
         peripheral.discoverServices(nil)
@@ -612,6 +666,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         let isManual = manuallyDisconnected.contains(uuid)
         let pairingLost = (error as? CBError)?.code == .peerRemovedPairingInformation
         NSLog("[OmiBle] didFailToConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
+        connectAttemptStartTimes.removeValue(forKey: uuid)
         cleanupPeripheral(uuid)
 
         if !isManual {
@@ -644,6 +699,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         let isManual = manuallyDisconnected.contains(uuid)
         let pairingLost = (error as? CBError)?.code == .peerRemovedPairingInformation
         NSLog("[OmiBle] didDisconnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
+        connectAttemptStartTimes.removeValue(forKey: uuid)
         cleanupPeripheral(uuid)
 
         // Finalize the in-progress batch recording so it's saved + ingestable right away

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -48,11 +48,14 @@ final class OmiBleManager: NSObject {
     private var connectingWatchdogTimer: Timer?
 
     /// UUIDs the connecting watchdog just canceled and is about to re-issue.
-    /// `didFailToConnect`/`didDisconnectPeripheral` check this so a delegate
-    /// callback triggered by the watchdog's own cancel doesn't *also* schedule
-    /// its own retry — otherwise the same peripheral gets two overlapping
-    /// `connect()` calls for one stall.
+    /// Exactly one of (watchdog asyncAfter, didFail/didDisconnect) may
+    /// `remove` the UUID and become the sole owner of the reconnect.
     private var watchdogPendingReissue: Set<String> = []
+
+    /// Monotonic connect-attempt generation per UUID. Soft-failure retries
+    /// capture the generation at failure time and bail if a newer
+    /// `issueConnect` (e.g. watchdog re-issue) has already superseded them.
+    private var connectAttemptGeneration: [String: Int] = [:]
 
     /// Tracks peripherals that have connected at least once (for reconnection counting).
     private var everConnected: Set<String> = []
@@ -161,10 +164,25 @@ final class OmiBleManager: NSObject {
     /// a connect issued outside this path is invisible to the watchdog and can
     /// stall in `.connecting` forever with nothing left to recover it).
     private func issueConnect(_ peripheral: CBPeripheral, uuid: String) {
+        connectAttemptGeneration[uuid, default: 0] += 1
         connectAttemptStartTimes[uuid] = Date()
         startConnectingWatchdogIfNeeded()
         peripheral.delegate = self
         centralManager.connect(peripheral, options: nil)
+    }
+
+    /// Single delayed reconnect after fail/disconnect. Rechecks manual
+    /// disconnect and connect-generation so a tap-disconnect or a newer
+    /// `issueConnect` cannot race a stale 200ms retry (#6721 cubic).
+    private func scheduleFailureReconnect(peripheral: CBPeripheral, uuid: String, generation: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
+            guard let self = self else { return }
+            guard !self.manuallyDisconnected.contains(uuid) else { return }
+            guard (self.connectAttemptGeneration[uuid] ?? 0) == generation else { return }
+            let target = self.peripherals[uuid] ?? peripheral
+            if target.state == .connected { return }
+            self.issueConnect(target, uuid: uuid)
+        }
     }
 
     /// CoreBluetooth can leave a peripheral in `.connecting` after backgrounding
@@ -199,15 +217,19 @@ final class OmiBleManager: NSObject {
             NSLog("[OmiBle] connecting watchdog: canceling stuck connect for \(uuid) after \(Int(elapsed))s")
             connectAttemptStartTimes.removeValue(forKey: uuid)
             // Mark before canceling: CoreBluetooth can route this cancel through
-            // didFailToConnect, whose own retry logic must not fire a second,
-            // overlapping connect for the same stall (see didFailToConnect).
+            // didFailToConnect / didDisconnect. Exactly one of this asyncAfter
+            // or that delegate path may consume the flag and re-issue connect.
+            let generation = connectAttemptGeneration[uuid] ?? 0
             watchdogPendingReissue.insert(uuid)
             centralManager.cancelPeripheralConnection(peripheral)
 
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
                 guard let self = self else { return }
-                self.watchdogPendingReissue.remove(uuid)
+                // Atomic ownership: if the fail/disconnect delegate already
+                // removed this UUID, it owns the single reconnect.
+                guard self.watchdogPendingReissue.remove(uuid) != nil else { return }
                 guard !self.manuallyDisconnected.contains(uuid) else { return }
+                guard (self.connectAttemptGeneration[uuid] ?? 0) == generation else { return }
                 guard let peripheral = self.peripherals[uuid] else { return }
                 if peripheral.state == .connected { return }
                 NSLog("[OmiBle] connecting watchdog: re-issuing connect for \(uuid)")
@@ -691,6 +713,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         let uuid = peripheralUuidString(peripheral)
         let isManual = manuallyDisconnected.contains(uuid)
         let pairingLost = (error as? CBError)?.code == .peerRemovedPairingInformation
+        let failedGeneration = connectAttemptGeneration[uuid] ?? 0
         NSLog("[OmiBle] didFailToConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
         connectAttemptStartTimes.removeValue(forKey: uuid)
         cleanupPeripheral(uuid)
@@ -710,19 +733,13 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
-        // The connecting watchdog's own cancel can route here on some iOS
-        // versions. Its re-issue (200ms after cancel, see kickStuckConnectingPeripherals)
-        // is the only retry for this stall — scheduling a second one here would
-        // issue two overlapping connect() calls for the same peripheral.
-        let watchdogOwnsRetry = watchdogPendingReissue.remove(uuid) != nil
+        // Claiming the watchdog flag transfers sole reconnect ownership to this
+        // path (the watchdog asyncAfter will no-op). Generation + manual checks
+        // inside scheduleFailureReconnect stop late/duplicate connects.
+        let claimedWatchdogRetry = watchdogPendingReissue.remove(uuid) != nil
 
-        // Retry previously-connected peripherals — otherwise a failed connect silently
-        // drops the user. iOS queues this at the chipset level; it's free while waiting.
-        if !isManual, !pairingLost, everConnected.contains(uuid), !watchdogOwnsRetry {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
-                guard let self = self else { return }
-                self.issueConnect(peripheral, uuid: uuid)
-            }
+        if !isManual, !pairingLost, claimedWatchdogRetry || everConnected.contains(uuid) {
+            scheduleFailureReconnect(peripheral: peripheral, uuid: uuid, generation: failedGeneration)
         }
     }
 
@@ -730,6 +747,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         let uuid = peripheralUuidString(peripheral)
         let isManual = manuallyDisconnected.contains(uuid)
         let pairingLost = (error as? CBError)?.code == .peerRemovedPairingInformation
+        let failedGeneration = connectAttemptGeneration[uuid] ?? 0
         NSLog("[OmiBle] didDisconnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
         connectAttemptStartTimes.removeValue(forKey: uuid)
         cleanupPeripheral(uuid)
@@ -756,17 +774,12 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
-        // See didFailToConnect: don't double-issue a connect for a stall the
-        // watchdog is already re-issuing itself.
-        let watchdogOwnsRetry = watchdogPendingReissue.remove(uuid) != nil
+        let claimedWatchdogRetry = watchdogPendingReissue.remove(uuid) != nil
 
-        // Auto-reconnect unless manually disconnected
-        if !isManual, !pairingLost, !watchdogOwnsRetry {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
-                guard let self = self else { return }
-                // iOS handles this at the BLE chipset level — zero CPU/radio cost while waiting
-                self.issueConnect(peripheral, uuid: uuid)
-            }
+        // Auto-reconnect unless manually disconnected. Claiming the watchdog
+        // flag means this path owns the single re-issue for that stall.
+        if !isManual, !pairingLost, claimedWatchdogRetry || everConnected.contains(uuid) {
+            scheduleFailureReconnect(peripheral: peripheral, uuid: uuid, generation: failedGeneration)
         }
     }
 }

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -870,8 +870,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                              ? Colors.orange.withValues(alpha: 0.15)
-                              : const Color(0xFF1F1F25),
+                                  ? Colors.orange.withValues(alpha: 0.15)
+                                  : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -880,8 +880,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                              ? Colors.orangeAccent
-                              : Colors.white70,
+                                  ? Colors.orangeAccent
+                                  : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -57,6 +57,8 @@ import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/services/integrations/apple_reminders_sync_service.dart';
 import 'package:omi/services/quick_actions_service.dart';
+import 'package:omi/services/services.dart';
+import 'package:omi/utils/ble_connect_retry.dart';
 import 'package:omi/utils/device.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/services/announcement_service.dart';
@@ -196,6 +198,19 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         captureProvider.refreshInProgressConversations();
         // Pick up any batch recordings the native layer wrote while backgrounded/closed.
         Provider.of<LocalRecordingsProvider>(context, listen: false).refresh();
+
+        // #6721: Dart-side reconnect after device-ready timeout / stalled native
+        // retries — native iOS also kicks stale peripherals on foreground.
+        final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
+        final pairedId = SharedPreferencesUtil().btDevice.id;
+        if (shouldAttemptBleReconnectOnResume(
+          hasPairedDevice: pairedId.isNotEmpty,
+          isConnected: deviceProvider.isConnected,
+          isConnecting: deviceProvider.isConnecting,
+          userDisconnected: ServiceManager.instance().device.suppressesAutoReconnect,
+        )) {
+          unawaited(deviceProvider.initiateConnection('AppResumed', boundDeviceOnly: true));
+        }
       }
 
       // Ensure agent VM is running and restart keepalive
@@ -855,8 +870,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                                  ? Colors.orange.withValues(alpha: 0.15)
-                                  : const Color(0xFF1F1F25),
+                              ? Colors.orange.withValues(alpha: 0.15)
+                              : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -865,8 +880,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                                  ? Colors.orangeAccent
-                                  : Colors.white70,
+                              ? Colors.orangeAccent
+                              : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -95,7 +95,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void Function(BtDevice device, int fileCount, int totalBytes)? onOfflineDataDetected;
 
   DeviceProvider({BleDiagnosticsLoader? bleDiagnosticsLoader})
-      : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
+    : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
     ServiceManager.instance().device.subscribe(this, this);
     BleBridge.instance.pairingLostCallback = _showPairingLostDialog;
   }
@@ -350,8 +350,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Throttle notifyListeners to reduce battery drain from excessive UI rebuilds
     // Only notify when: first reading, >=5% change, 15min elapsed, or crosses 20% threshold
     final delta = (_lastNotifiedBatteryLevel - value).abs();
-    final elapsed =
-        _lastBatteryNotifyTime == null ? const Duration(minutes: 999) : currentTime.difference(_lastBatteryNotifyTime!);
+    final elapsed = _lastBatteryNotifyTime == null
+        ? const Duration(minutes: 999)
+        : currentTime.difference(_lastBatteryNotifyTime!);
     final crossedLowBatteryThreshold =
         (value < 20 && _lastNotifiedBatteryLevel >= 20) || (value >= 20 && _lastNotifiedBatteryLevel < 20);
     final shouldNotify =
@@ -390,8 +391,8 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Known device — use ensureConnection which creates the NativeBleTransport,
     // then connects natively. If native is already connected, it just re-notifies Dart.
     // force: true ensures we retry even if a previous attempt left a stale connection.
-    // softRetry: true reuses the existing transport so a device-ready timeout (#6610)
-    // does not dispose BleBridge registration / cancel native reconnect.
+    // softRetry: true reuses the existing transport so a device-ready timeout
+    // (#6721 / #6610) does not dispose BleBridge registration / cancel native reconnect.
     try {
       await ServiceManager.instance().device.ensureConnection(pairedDeviceId, force: true, softRetry: true);
     } catch (e) {

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -95,7 +95,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void Function(BtDevice device, int fileCount, int totalBytes)? onOfflineDataDetected;
 
   DeviceProvider({BleDiagnosticsLoader? bleDiagnosticsLoader})
-      : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
+    : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
     ServiceManager.instance().device.subscribe(this, this);
     BleBridge.instance.pairingLostCallback = _showPairingLostDialog;
   }
@@ -350,8 +350,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Throttle notifyListeners to reduce battery drain from excessive UI rebuilds
     // Only notify when: first reading, >=5% change, 15min elapsed, or crosses 20% threshold
     final delta = (_lastNotifiedBatteryLevel - value).abs();
-    final elapsed =
-        _lastBatteryNotifyTime == null ? const Duration(minutes: 999) : currentTime.difference(_lastBatteryNotifyTime!);
+    final elapsed = _lastBatteryNotifyTime == null
+        ? const Duration(minutes: 999)
+        : currentTime.difference(_lastBatteryNotifyTime!);
     final crossedLowBatteryThreshold =
         (value < 20 && _lastNotifiedBatteryLevel >= 20) || (value >= 20 && _lastNotifiedBatteryLevel < 20);
     final shouldNotify =
@@ -390,11 +391,12 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Known device — use ensureConnection which creates the NativeBleTransport,
     // then connects natively. If native is already connected, it just re-notifies Dart.
     // force: true ensures we retry even if a previous attempt left a stale connection.
+    // softRetry: true reuses the existing transport so a device-ready timeout (#6610)
+    // does not dispose BleBridge registration / cancel native reconnect.
     try {
-      await ServiceManager.instance().device.ensureConnection(pairedDeviceId, force: true);
+      await ServiceManager.instance().device.ensureConnection(pairedDeviceId, force: true, softRetry: true);
     } catch (e) {
-      // Timeout or transport failure — native keeps trying in the background.
-      // NativeBleTransport's BleBridge registration persists, so auto-reconnect still works.
+      // Timeout or transport failure — DeviceService schedules backoff soft-retries.
       Logger.debug('initiateConnection ($caller): ensureConnection failed: $e');
     }
   }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -95,7 +95,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void Function(BtDevice device, int fileCount, int totalBytes)? onOfflineDataDetected;
 
   DeviceProvider({BleDiagnosticsLoader? bleDiagnosticsLoader})
-    : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
+      : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
     ServiceManager.instance().device.subscribe(this, this);
     BleBridge.instance.pairingLostCallback = _showPairingLostDialog;
   }
@@ -350,9 +350,8 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Throttle notifyListeners to reduce battery drain from excessive UI rebuilds
     // Only notify when: first reading, >=5% change, 15min elapsed, or crosses 20% threshold
     final delta = (_lastNotifiedBatteryLevel - value).abs();
-    final elapsed = _lastBatteryNotifyTime == null
-        ? const Duration(minutes: 999)
-        : currentTime.difference(_lastBatteryNotifyTime!);
+    final elapsed =
+        _lastBatteryNotifyTime == null ? const Duration(minutes: 999) : currentTime.difference(_lastBatteryNotifyTime!);
     final crossedLowBatteryThreshold =
         (value < 20 && _lastNotifiedBatteryLevel >= 20) || (value >= 20 && _lastNotifiedBatteryLevel < 20);
     final shouldNotify =

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -10,6 +10,7 @@ import 'package:omi/services/devices/discovery/rayban_meta_discoverer.dart';
 import 'package:omi/services/devices/discovery/device_discoverer.dart';
 import 'package:omi/services/devices/discovery/native_bluetooth_discoverer.dart';
 import 'package:omi/services/devices/errors.dart';
+import 'package:omi/utils/ble_connect_retry.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/mutex.dart';
@@ -35,10 +36,7 @@ class OmiFeatures {
 abstract class IDeviceServiceSubsciption {
   void onDevices(List<BtDevice> devices);
   void onStatusChanged(DeviceServiceStatus status);
-  void onDeviceConnectionStateChanged(
-    String deviceId,
-    DeviceConnectionState state,
-  );
+  void onDeviceConnectionStateChanged(String deviceId, DeviceConnectionState state);
 }
 
 class DeviceService {
@@ -59,6 +57,13 @@ class DeviceService {
   DeviceServiceStatus get status => _status;
 
   DateTime? _firstConnectedAt;
+
+  // #6610: after device-ready timeout / connect failure, soft-retry with backoff
+  // without disposing the transport (native auto-reconnect must stay alive).
+  Timer? _bleConnectRetryTimer;
+  int _bleConnectRetryAttempt = 0;
+  String? _bleConnectRetryDeviceId;
+  bool _userDisconnectedBle = false;
 
   Future<void> discover({String? desirableDeviceId, int timeout = 5}) async {
     Logger.debug("Device discovering...");
@@ -103,51 +108,87 @@ class DeviceService {
     }
   }
 
-  Future<void> _connectToDevice(String id) async {
-    // Clean up existing connection — disconnect if active, then dispose transport
-    if (_connection != null) {
-      if (_connection!.status == DeviceConnectionState.connected) {
-        await _connection!.disconnect();
-      }
-      await _connection!.transport.dispose();
-    }
-    _connection = null;
+  Future<void> _connectToDevice(String id, {required bool softRetry}) async {
+    final reuseExisting =
+        softRetry &&
+        shouldSoftRetryExistingConnection(existingDeviceId: _connection?.device.id, targetDeviceId: id, force: true);
 
-    var device = _devices.firstWhereOrNull((f) => f.id == id);
-    Logger.debug(
-      '[DeviceService] device lookup result: ${device?.name ?? "NULL"} (locator: ${device?.locator?.kind})',
-    );
-
-    // If device not in discovered list, try to get it from SharedPreferences
-    // This allows background reconnection without scanning
-    if (device == null) {
-      Logger.debug(
-        '[DeviceService] Device not in discovered list, checking stored device',
-      );
-      device = _getStoredDevice(id);
-      if (device != null) {
-        Logger.debug('[DeviceService] Using stored device: ${device.name}');
-        if (!_devices.any((d) => d.id == device!.id)) {
-          _devices.add(device);
+    if (!reuseExisting) {
+      // Clean up existing connection — disconnect if active, then dispose transport
+      if (_connection != null) {
+        if (_connection!.status == DeviceConnectionState.connected) {
+          await _connection!.disconnect();
         }
-      } else {
-        Logger.debug(
-          '[DeviceService] No stored device available for $id, returning',
-        );
-        return;
+        await _connection!.transport.dispose();
       }
+      _connection = null;
+
+      var device = _devices.firstWhereOrNull((f) => f.id == id);
+      Logger.debug(
+        '[DeviceService] device lookup result: ${device?.name ?? "NULL"} (locator: ${device?.locator?.kind})',
+      );
+
+      // If device not in discovered list, try to get it from SharedPreferences
+      // This allows background reconnection without scanning
+      if (device == null) {
+        Logger.debug('[DeviceService] Device not in discovered list, checking stored device');
+        device = _getStoredDevice(id);
+        if (device != null) {
+          Logger.debug('[DeviceService] Using stored device: ${device.name}');
+          if (!_devices.any((d) => d.id == device!.id)) {
+            _devices.add(device);
+          }
+        } else {
+          Logger.debug('[DeviceService] No stored device available for $id, returning');
+          return;
+        }
+      }
+
+      _connection = DeviceConnectionFactory.create(device);
+    } else {
+      Logger.debug('[DeviceService] soft-retrying existing transport for $id');
     }
 
-    _connection = DeviceConnectionFactory.create(device);
     if (_connection != null) {
-      await _connection!.connect(
-        onConnectionStateChanged: onDeviceConnectionStateChanged,
-      );
+      await _connection!.connect(onConnectionStateChanged: onDeviceConnectionStateChanged);
     } else {
-      Logger.debug(
-        '[DeviceService] Failed to create device connection for ${device.id}',
-      );
+      Logger.debug('[DeviceService] Failed to create device connection for $id');
     }
+  }
+
+  void _cancelBleConnectRetry() {
+    _bleConnectRetryTimer?.cancel();
+    _bleConnectRetryTimer = null;
+    _bleConnectRetryDeviceId = null;
+  }
+
+  void _resetBleConnectRetryState() {
+    _cancelBleConnectRetry();
+    _bleConnectRetryAttempt = 0;
+  }
+
+  void _scheduleBleConnectRetry(String deviceId) {
+    final pairedId = SharedPreferencesUtil().btDevice.id;
+    final should = shouldScheduleBleConnectRetry(
+      serviceReady: _status == DeviceServiceStatus.ready || _status == DeviceServiceStatus.scanning,
+      hasPairedDevice: pairedId.isNotEmpty && pairedId == deviceId,
+      userDisconnected: _userDisconnectedBle,
+      alreadyConnected: _connection?.device.id == deviceId && _connection?.status == DeviceConnectionState.connected,
+      retryAlreadyScheduled: _bleConnectRetryTimer?.isActive == true,
+    );
+    if (!should) return;
+
+    final delay = nextBleConnectRetryDelay(_bleConnectRetryAttempt);
+    _bleConnectRetryAttempt += 1;
+    _bleConnectRetryDeviceId = deviceId;
+    Logger.debug(
+      '[DeviceService] scheduling BLE soft-retry #$_bleConnectRetryAttempt for $deviceId in ${delay.inSeconds}s',
+    );
+    _bleConnectRetryTimer?.cancel();
+    _bleConnectRetryTimer = Timer(delay, () {
+      _bleConnectRetryTimer = null;
+      unawaited(ensureConnection(deviceId, force: true, softRetry: true));
+    });
   }
 
   void subscribe(IDeviceServiceSubsciption subscription, Object context) {
@@ -165,11 +206,13 @@ class DeviceService {
 
   void start() {
     _status = DeviceServiceStatus.ready;
-
-    // TODO: Start watchdog to discover automatically, re-connect automatically
+    // Auto-reconnect after connect/device-ready failures is handled by
+    // _scheduleBleConnectRetry (#6610). Native owns in-session BLE reconnect.
   }
 
   void stop() {
+    _userDisconnectedBle = true;
+    _cancelBleConnectRetry();
     _status = DeviceServiceStatus.stop;
     onStatusChanged(_status);
 
@@ -188,15 +231,13 @@ class DeviceService {
     }
   }
 
-  void onDeviceConnectionStateChanged(
-    String deviceId,
-    DeviceConnectionState state,
-  ) {
+  void onDeviceConnectionStateChanged(String deviceId, DeviceConnectionState state) {
     Logger.debug("device connection state changed...$deviceId...$state");
-    DebugLogManager.logEvent('device_connection_state', {
-      'device_id': deviceId,
-      'state': state.name,
-    });
+    DebugLogManager.logEvent('device_connection_state', {'device_id': deviceId, 'state': state.name});
+    if (state == DeviceConnectionState.connected) {
+      _userDisconnectedBle = false;
+      _resetBleConnectRetryState();
+    }
     for (var s in _subscriptions.values) {
       s.onDeviceConnectionStateChanged(deviceId, state);
     }
@@ -210,18 +251,16 @@ class DeviceService {
 
   final Mutex _mutex = Mutex();
 
-  Future<DeviceConnection?> ensureConnection(
-    String deviceId, {
-    bool force = false,
-  }) async {
+  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false, bool softRetry = false}) async {
     await _mutex.acquire();
     try {
       Logger.debug(
-        "ensureConnection ${_connection?.device.id} ${_connection?.status} $force",
+        "ensureConnection ${_connection?.device.id} ${_connection?.status} force=$force softRetry=$softRetry",
       );
 
       // Connected to this device — return it
       if (_connection?.device.id == deviceId && _connection?.status == DeviceConnectionState.connected) {
+        _resetBleConnectRetryState();
         return _connection;
       }
 
@@ -235,15 +274,27 @@ class DeviceService {
       // No connection or different device — only connect on force (user-initiated)
       if (!force) return null;
 
+      // App/user asked to reconnect — clear manual-disconnect suppression.
+      _userDisconnectedBle = false;
+
       try {
-        await _connectToDevice(deviceId);
+        await _connectToDevice(deviceId, softRetry: softRetry);
       } on DeviceConnectionException catch (e) {
         Logger.debug(e.cause);
+        _scheduleBleConnectRetry(deviceId);
         return null;
       }
 
-      _firstConnectedAt ??= DateTime.now();
-      return _connection;
+      if (_connection?.status == DeviceConnectionState.connected) {
+        _firstConnectedAt ??= DateTime.now();
+        _resetBleConnectRetryState();
+        return _connection;
+      }
+
+      // Connect returned without throwing but never reached connected (e.g. no
+      // stored device). Schedule a soft retry while the device stays paired.
+      _scheduleBleConnectRetry(deviceId);
+      return null;
     } finally {
       _mutex.release();
     }
@@ -267,6 +318,8 @@ class DeviceService {
   }
 
   Future<void> disconnectDevice() async {
+    _userDisconnectedBle = true;
+    _cancelBleConnectRetry();
     if (_connection != null) {
       Logger.debug("DeviceService: Disconnecting device...");
       await _connection?.disconnect();
@@ -276,6 +329,8 @@ class DeviceService {
 
   Future<void> forgetDevice(String deviceId) async {
     Logger.debug("DeviceService: Forgetting device $deviceId");
+    _userDisconnectedBle = true;
+    _cancelBleConnectRetry();
     if (_connection != null) {
       if (_connection!.status == DeviceConnectionState.connected) {
         try {
@@ -288,9 +343,7 @@ class DeviceService {
       try {
         await _connection!.transport.dispose();
       } catch (e) {
-        Logger.debug(
-          "DeviceService: transport dispose during forget failed: $e",
-        );
+        Logger.debug("DeviceService: transport dispose during forget failed: $e");
       }
       _connection = null;
     }

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -56,10 +56,13 @@ class DeviceService {
 
   DeviceServiceStatus get status => _status;
 
+  /// True after an explicit disconnect/forget until a successful connect.
+  bool get suppressesAutoReconnect => _userDisconnectedBle;
+
   DateTime? _firstConnectedAt;
 
-  // #6610: after device-ready timeout / connect failure, soft-retry with backoff
-  // without disposing the transport (native auto-reconnect must stay alive).
+  // #6721 / #6610: after device-ready timeout / connect failure, soft-retry with
+  // backoff without disposing the transport (native auto-reconnect must stay alive).
   Timer? _bleConnectRetryTimer;
   int _bleConnectRetryAttempt = 0;
   String? _bleConnectRetryDeviceId;
@@ -109,7 +112,8 @@ class DeviceService {
   }
 
   Future<void> _connectToDevice(String id, {required bool softRetry}) async {
-    final reuseExisting = softRetry &&
+    final reuseExisting =
+        softRetry &&
         shouldSoftRetryExistingConnection(existingDeviceId: _connection?.device.id, targetDeviceId: id, force: true);
 
     if (!reuseExisting) {

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -211,7 +211,7 @@ class DeviceService {
 
   void stop() {
     _userDisconnectedBle = true;
-    _cancelBleConnectRetry();
+    _resetBleConnectRetryState();
     _status = DeviceServiceStatus.stop;
     onStatusChanged(_status);
 
@@ -256,6 +256,20 @@ class DeviceService {
       Logger.debug(
         "ensureConnection ${_connection?.device.id} ${_connection?.status} force=$force softRetry=$softRetry",
       );
+
+      // A force-connect to a different device supersedes any pending soft-retry
+      // for the old one. Without this, a stale retry timer can fire later and
+      // tear down + replace the connection this call is about to establish.
+      if (shouldInvalidatePendingRetryForDifferentTarget(
+        pendingRetryDeviceId: _bleConnectRetryDeviceId,
+        targetDeviceId: deviceId,
+        force: force,
+      )) {
+        Logger.debug(
+          '[DeviceService] invalidating stale soft-retry for $_bleConnectRetryDeviceId (now targeting $deviceId)',
+        );
+        _resetBleConnectRetryState();
+      }
 
       // Connected to this device — return it
       if (_connection?.device.id == deviceId && _connection?.status == DeviceConnectionState.connected) {
@@ -318,7 +332,7 @@ class DeviceService {
 
   Future<void> disconnectDevice() async {
     _userDisconnectedBle = true;
-    _cancelBleConnectRetry();
+    _resetBleConnectRetryState();
     if (_connection != null) {
       Logger.debug("DeviceService: Disconnecting device...");
       await _connection?.disconnect();
@@ -329,7 +343,7 @@ class DeviceService {
   Future<void> forgetDevice(String deviceId) async {
     Logger.debug("DeviceService: Forgetting device $deviceId");
     _userDisconnectedBle = true;
-    _cancelBleConnectRetry();
+    _resetBleConnectRetryState();
     if (_connection != null) {
       if (_connection!.status == DeviceConnectionState.connected) {
         try {

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -109,8 +109,7 @@ class DeviceService {
   }
 
   Future<void> _connectToDevice(String id, {required bool softRetry}) async {
-    final reuseExisting =
-        softRetry &&
+    final reuseExisting = softRetry &&
         shouldSoftRetryExistingConnection(existingDeviceId: _connection?.device.id, targetDeviceId: id, force: true);
 
     if (!reuseExisting) {

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -66,6 +66,9 @@ class DeviceService {
   Timer? _bleConnectRetryTimer;
   int _bleConnectRetryAttempt = 0;
   String? _bleConnectRetryDeviceId;
+
+  /// Bumped on cancel/reset so an already-queued soft-retry exits after mutex.
+  int _bleConnectRetryGeneration = 0;
   bool _userDisconnectedBle = false;
 
   Future<void> discover({String? desirableDeviceId, int timeout = 5}) async {
@@ -112,8 +115,7 @@ class DeviceService {
   }
 
   Future<void> _connectToDevice(String id, {required bool softRetry}) async {
-    final reuseExisting =
-        softRetry &&
+    final reuseExisting = softRetry &&
         shouldSoftRetryExistingConnection(existingDeviceId: _connection?.device.id, targetDeviceId: id, force: true);
 
     if (!reuseExisting) {
@@ -163,6 +165,7 @@ class DeviceService {
     _bleConnectRetryTimer?.cancel();
     _bleConnectRetryTimer = null;
     _bleConnectRetryDeviceId = null;
+    _bleConnectRetryGeneration += 1;
   }
 
   void _resetBleConnectRetryState() {
@@ -184,13 +187,14 @@ class DeviceService {
     final delay = nextBleConnectRetryDelay(_bleConnectRetryAttempt);
     _bleConnectRetryAttempt += 1;
     _bleConnectRetryDeviceId = deviceId;
+    final generation = _bleConnectRetryGeneration;
     Logger.debug(
       '[DeviceService] scheduling BLE soft-retry #$_bleConnectRetryAttempt for $deviceId in ${delay.inSeconds}s',
     );
     _bleConnectRetryTimer?.cancel();
     _bleConnectRetryTimer = Timer(delay, () {
       _bleConnectRetryTimer = null;
-      unawaited(ensureConnection(deviceId, force: true, softRetry: true));
+      unawaited(ensureConnection(deviceId, force: true, softRetry: true, softRetryGeneration: generation));
     });
   }
 
@@ -254,12 +258,33 @@ class DeviceService {
 
   final Mutex _mutex = Mutex();
 
-  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false, bool softRetry = false}) async {
+  Future<DeviceConnection?> ensureConnection(
+    String deviceId, {
+    bool force = false,
+    bool softRetry = false,
+    int? softRetryGeneration,
+  }) async {
     await _mutex.acquire();
     try {
       Logger.debug(
         "ensureConnection ${_connection?.device.id} ${_connection?.status} force=$force softRetry=$softRetry",
       );
+
+      // A retry that was queued before invalidate/reset must not run after a
+      // force-connect to another device (or any cancel) won the mutex race.
+      if (softRetry &&
+          softRetryGeneration != null &&
+          !shouldProceedWithScheduledSoftRetry(
+            scheduledGeneration: softRetryGeneration,
+            currentGeneration: _bleConnectRetryGeneration,
+          )) {
+        Logger.debug(
+          '[DeviceService] dropping superseded soft-retry for $deviceId (gen $softRetryGeneration → $_bleConnectRetryGeneration)',
+        );
+        return _connection?.device.id == deviceId && _connection?.status == DeviceConnectionState.connected
+            ? _connection
+            : null;
+      }
 
       // A force-connect to a different device supersedes any pending soft-retry
       // for the old one. Without this, a stale retry timer can fire later and

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/utils/ble_connect_retry.dart';
 import 'package:omi/utils/logger.dart';
 import 'device_transport.dart';
 
@@ -63,8 +64,10 @@ class NativeBleTransport extends DeviceTransport {
 
     try {
       _services = await _deviceReadyCompleter!.future.timeout(
-        const Duration(seconds: 60),
-        onTimeout: () => throw TimeoutException('Device ready timeout after 60s'),
+        kBleDeviceReadyTimeout,
+        onTimeout: () => throw TimeoutException(
+          'Device ready timeout after ${kBleDeviceReadyTimeout.inSeconds}s',
+        ),
       );
       _deviceReadyCompleter = null;
       _updateState(DeviceTransportState.connected);

--- a/app/lib/utils/ble_connect_retry.dart
+++ b/app/lib/utils/ble_connect_retry.dart
@@ -2,6 +2,7 @@
 ///
 /// Pure predicates/delays so the "connecting → timeout → disconnected → retry"
 /// contract can be unit-tested without CoreBluetooth or NativeBleTransport.
+library;
 
 /// Matches [NativeBleTransport.connect] device-ready wait.
 const Duration kBleDeviceReadyTimeout = Duration(seconds: 60);

--- a/app/lib/utils/ble_connect_retry.dart
+++ b/app/lib/utils/ble_connect_retry.dart
@@ -1,4 +1,4 @@
-/// BLE connect retry helpers for post-timeout auto-reconnect (#6610).
+/// BLE connect retry helpers for post-timeout auto-reconnect (#6721 / #6610).
 ///
 /// Pure predicates/delays so the "connecting → timeout → disconnected → retry"
 /// contract can be unit-tested without CoreBluetooth or NativeBleTransport.
@@ -76,4 +76,22 @@ bool shouldInvalidatePendingRetryForDifferentTarget({
   if (!force) return false;
   if (pendingRetryDeviceId == null) return false;
   return pendingRetryDeviceId != targetDeviceId;
+}
+
+/// Whether bringing the app to the foreground should kick a BLE reconnect (#6721).
+///
+/// Native iOS already calls `reconnectStalePeripherals` on foreground; Dart still
+/// needs an `initiateConnection` when the 60s device-ready timeout left the
+/// transport disconnected with no pending soft-retry.
+bool shouldAttemptBleReconnectOnResume({
+  required bool hasPairedDevice,
+  required bool isConnected,
+  required bool isConnecting,
+  required bool userDisconnected,
+}) {
+  if (!hasPairedDevice) return false;
+  if (userDisconnected) return false;
+  if (isConnected) return false;
+  if (isConnecting) return false;
+  return true;
 }

--- a/app/lib/utils/ble_connect_retry.dart
+++ b/app/lib/utils/ble_connect_retry.dart
@@ -78,6 +78,19 @@ bool shouldInvalidatePendingRetryForDifferentTarget({
   return pendingRetryDeviceId != targetDeviceId;
 }
 
+/// Whether a soft-retry that was queued with [scheduledGeneration] should still
+/// run after acquiring the device-service mutex.
+///
+/// Canceling / resetting the retry counter bumps the live generation so an
+/// already-queued Timer callback (or a callback waiting on the mutex behind a
+/// force-connect to another device) exits instead of switching sessions.
+bool shouldProceedWithScheduledSoftRetry({
+  required int scheduledGeneration,
+  required int currentGeneration,
+}) {
+  return scheduledGeneration == currentGeneration;
+}
+
 /// Whether bringing the app to the foreground should kick a BLE reconnect (#6721).
 ///
 /// Native iOS already calls `reconnectStalePeripherals` on foreground; Dart still

--- a/app/lib/utils/ble_connect_retry.dart
+++ b/app/lib/utils/ble_connect_retry.dart
@@ -1,0 +1,61 @@
+/// BLE connect retry helpers for post-timeout auto-reconnect (#6610).
+///
+/// Pure predicates/delays so the "connecting → timeout → disconnected → retry"
+/// contract can be unit-tested without CoreBluetooth or NativeBleTransport.
+
+/// Matches [NativeBleTransport.connect] device-ready wait.
+const Duration kBleDeviceReadyTimeout = Duration(seconds: 60);
+
+/// Backoff after a failed Dart-side connect / device-ready timeout.
+/// Caps at 60s so background stalls keep retrying without hammering radio.
+const List<int> kBleConnectRetryBackoffSeconds = [2, 5, 10, 30, 60];
+
+/// Native/CoreBluetooth can sit in `.connecting` without firing disconnect.
+/// Kick the attempt slightly after the Dart timeout window.
+const Duration kBleConnectingWatchdogAfter = Duration(seconds: 65);
+
+Duration nextBleConnectRetryDelay(int attempt) {
+  if (attempt < 0) attempt = 0;
+  final idx = attempt >= kBleConnectRetryBackoffSeconds.length ? kBleConnectRetryBackoffSeconds.length - 1 : attempt;
+  return Duration(seconds: kBleConnectRetryBackoffSeconds[idx]);
+}
+
+/// Whether DeviceService should schedule another soft reconnect after a failure.
+bool shouldScheduleBleConnectRetry({
+  required bool serviceReady,
+  required bool hasPairedDevice,
+  required bool userDisconnected,
+  required bool alreadyConnected,
+  required bool retryAlreadyScheduled,
+}) {
+  if (!serviceReady) return false;
+  if (!hasPairedDevice) return false;
+  if (userDisconnected) return false;
+  if (alreadyConnected) return false;
+  if (retryAlreadyScheduled) return false;
+  return true;
+}
+
+/// Soft retry reuses an existing transport for the same device so native
+/// auto-reconnect / BleBridge registration is not torn down.
+bool shouldSoftRetryExistingConnection({
+  required String? existingDeviceId,
+  required String targetDeviceId,
+  required bool force,
+}) {
+  if (!force) return false;
+  if (existingDeviceId == null || existingDeviceId.isEmpty) return false;
+  return existingDeviceId == targetDeviceId;
+}
+
+/// Whether an iOS connecting watchdog should cancel + re-issue connect.
+bool shouldKickStuckConnectingAttempt({
+  required bool isConnecting,
+  required bool manuallyDisconnected,
+  required Duration elapsed,
+  Duration threshold = kBleConnectingWatchdogAfter,
+}) {
+  if (!isConnecting) return false;
+  if (manuallyDisconnected) return false;
+  return elapsed >= threshold;
+}

--- a/app/lib/utils/ble_connect_retry.dart
+++ b/app/lib/utils/ble_connect_retry.dart
@@ -59,3 +59,20 @@ bool shouldKickStuckConnectingAttempt({
   if (manuallyDisconnected) return false;
   return elapsed >= threshold;
 }
+
+/// Whether a force-connect to [targetDeviceId] should invalidate a pending
+/// soft-retry timer tracked for [pendingRetryDeviceId].
+///
+/// Without this, a retry scheduled for a device the user has since moved away
+/// from can still fire later, target the old device id with `force: true`,
+/// and tear down + replace a connection the user explicitly established to a
+/// *different* device in the meantime — see #6610 review discussion.
+bool shouldInvalidatePendingRetryForDifferentTarget({
+  required String? pendingRetryDeviceId,
+  required String targetDeviceId,
+  required bool force,
+}) {
+  if (!force) return false;
+  if (pendingRetryDeviceId == null) return false;
+  return pendingRetryDeviceId != targetDeviceId;
+}

--- a/app/test/unit/ble_connect_retry_test.dart
+++ b/app/test/unit/ble_connect_retry_test.dart
@@ -80,6 +80,49 @@ void main() {
     });
   });
 
+  group('shouldInvalidatePendingRetryForDifferentTarget (#6610 review)', () {
+    test('invalidates a pending retry when force-connecting to a different device', () {
+      expect(
+        shouldInvalidatePendingRetryForDifferentTarget(
+          pendingRetryDeviceId: 'old-device',
+          targetDeviceId: 'new-device',
+          force: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not invalidate when there is no pending retry', () {
+      expect(
+        shouldInvalidatePendingRetryForDifferentTarget(
+          pendingRetryDeviceId: null,
+          targetDeviceId: 'new-device',
+          force: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not invalidate the retry\'s own device or a non-forced call', () {
+      expect(
+        shouldInvalidatePendingRetryForDifferentTarget(
+          pendingRetryDeviceId: 'same-device',
+          targetDeviceId: 'same-device',
+          force: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldInvalidatePendingRetryForDifferentTarget(
+          pendingRetryDeviceId: 'old-device',
+          targetDeviceId: 'new-device',
+          force: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('shouldKickStuckConnectingAttempt', () {
     test('kicks only after sustained .connecting without manual disconnect', () {
       expect(

--- a/app/test/unit/ble_connect_retry_test.dart
+++ b/app/test/unit/ble_connect_retry_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/ble_connect_retry.dart';
+
+void main() {
+  group('nextBleConnectRetryDelay (#6610)', () {
+    test('uses escalating backoff then caps at 60s', () {
+      expect(nextBleConnectRetryDelay(0), const Duration(seconds: 2));
+      expect(nextBleConnectRetryDelay(1), const Duration(seconds: 5));
+      expect(nextBleConnectRetryDelay(2), const Duration(seconds: 10));
+      expect(nextBleConnectRetryDelay(3), const Duration(seconds: 30));
+      expect(nextBleConnectRetryDelay(4), const Duration(seconds: 60));
+      expect(nextBleConnectRetryDelay(9), const Duration(seconds: 60));
+    });
+  });
+
+  group('shouldScheduleBleConnectRetry (#6610)', () {
+    test('schedules after connecting → timeout → disconnected when paired', () {
+      expect(
+        shouldScheduleBleConnectRetry(
+          serviceReady: true,
+          hasPairedDevice: true,
+          userDisconnected: false,
+          alreadyConnected: false,
+          retryAlreadyScheduled: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not schedule when user disconnected, already connected, or unpaired', () {
+      expect(
+        shouldScheduleBleConnectRetry(
+          serviceReady: true,
+          hasPairedDevice: true,
+          userDisconnected: true,
+          alreadyConnected: false,
+          retryAlreadyScheduled: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldScheduleBleConnectRetry(
+          serviceReady: true,
+          hasPairedDevice: true,
+          userDisconnected: false,
+          alreadyConnected: true,
+          retryAlreadyScheduled: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldScheduleBleConnectRetry(
+          serviceReady: true,
+          hasPairedDevice: false,
+          userDisconnected: false,
+          alreadyConnected: false,
+          retryAlreadyScheduled: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldScheduleBleConnectRetry(
+          serviceReady: true,
+          hasPairedDevice: true,
+          userDisconnected: false,
+          alreadyConnected: false,
+          retryAlreadyScheduled: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldSoftRetryExistingConnection', () {
+    test('reuses transport for the same device on force retry', () {
+      expect(shouldSoftRetryExistingConnection(existingDeviceId: 'abc', targetDeviceId: 'abc', force: true), isTrue);
+      expect(shouldSoftRetryExistingConnection(existingDeviceId: 'abc', targetDeviceId: 'abc', force: false), isFalse);
+      expect(shouldSoftRetryExistingConnection(existingDeviceId: 'abc', targetDeviceId: 'xyz', force: true), isFalse);
+    });
+  });
+
+  group('shouldKickStuckConnectingAttempt', () {
+    test('kicks only after sustained .connecting without manual disconnect', () {
+      expect(
+        shouldKickStuckConnectingAttempt(
+          isConnecting: true,
+          manuallyDisconnected: false,
+          elapsed: const Duration(seconds: 65),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldKickStuckConnectingAttempt(
+          isConnecting: true,
+          manuallyDisconnected: false,
+          elapsed: const Duration(seconds: 30),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldKickStuckConnectingAttempt(
+          isConnecting: true,
+          manuallyDisconnected: true,
+          elapsed: const Duration(seconds: 90),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/app/test/unit/ble_connect_retry_test.dart
+++ b/app/test/unit/ble_connect_retry_test.dart
@@ -151,4 +151,57 @@ void main() {
       );
     });
   });
+
+  group('shouldAttemptBleReconnectOnResume (#6721)', () {
+    test('kicks reconnect when paired but disconnected and not manually stopped', () {
+      expect(
+        shouldAttemptBleReconnectOnResume(
+          hasPairedDevice: true,
+          isConnected: false,
+          isConnecting: false,
+          userDisconnected: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('skips when already connected, connecting, unpaired, or user disconnected', () {
+      expect(
+        shouldAttemptBleReconnectOnResume(
+          hasPairedDevice: true,
+          isConnected: true,
+          isConnecting: false,
+          userDisconnected: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAttemptBleReconnectOnResume(
+          hasPairedDevice: true,
+          isConnected: false,
+          isConnecting: true,
+          userDisconnected: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAttemptBleReconnectOnResume(
+          hasPairedDevice: false,
+          isConnected: false,
+          isConnecting: false,
+          userDisconnected: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAttemptBleReconnectOnResume(
+          hasPairedDevice: true,
+          isConnected: false,
+          isConnecting: false,
+          userDisconnected: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/app/test/unit/ble_connect_retry_test.dart
+++ b/app/test/unit/ble_connect_retry_test.dart
@@ -123,6 +123,14 @@ void main() {
     });
   });
 
+  group('shouldProceedWithScheduledSoftRetry (#6721 cubic)', () {
+    test('proceeds only when the scheduled generation is still current', () {
+      expect(shouldProceedWithScheduledSoftRetry(scheduledGeneration: 3, currentGeneration: 3), isTrue);
+      expect(shouldProceedWithScheduledSoftRetry(scheduledGeneration: 3, currentGeneration: 4), isFalse);
+      expect(shouldProceedWithScheduledSoftRetry(scheduledGeneration: 0, currentGeneration: 1), isFalse);
+    });
+  });
+
   group('shouldKickStuckConnectingAttempt', () {
     test('kicks only after sustained .connecting without manual disconnect', () {
       expect(


### PR DESCRIPTION
## Summary
[#6721](https://github.com/BasedHardware/omi/issues/6721): after an unexpected BLE disconnect, the app sometimes stays disconnected for hours until force-quit / re-pair / power-cycle. The documented iOS sub-path ([#6610](https://github.com/BasedHardware/omi/issues/6610)) is a 60s Dart `deviceReady` timeout with **no soft-retry**, plus no resume hook.

This resurrects the closed [#11097](https://github.com/BasedHardware/omi/pull/11097) fix (retargeted to #6721) and adds the missing app-resume kick.

## Implementation
- Soft reconnect with backoff (`2s → 5s → 10s → 30s → 60s`) **without disposing** `NativeBleTransport` after connect / device-ready failure.
- Manual disconnect / forget suppresses retries; success resets the counter.
- Invalidate stale soft-retries when force-connecting to a different device.
- iOS connecting watchdog (≥65s) cancel + re-issue `connect` for peripherals stuck in `.connecting`.
- On `AppLifecycleState.resumed`, call `initiateConnection` when paired but disconnected (unless user disconnected).
- Pure helpers + unit tests: `ble_connect_retry.dart`.

## Tests
- `flutter test test/unit/ble_connect_retry_test.dart`

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

