### PR TITLE
feat(memory): reconcile canonical user onboarding

### DIFF
--- a/backend/tests/unit/test_canonical_memory_onboarding.py
+++ b/backend/tests/unit/test_canonical_memory_onboarding.py
@@ -1,0 +1,156 @@
+from copy import deepcopy
+
+import pytest
+from google.api_core.exceptions import AlreadyExists
+
+from database.memory_collections import MemoryCollections
+from utils.memory.canonical_memory_onboarding import (
+    CanonicalMemoryOnboardingValidationError,
+    reconcile_canonical_memory_onboarding,
+)
+from utils.memory.v3.limited_rollout_config import build_whitelisted_user_control_state
+
+
+class _Snapshot:
+    def __init__(self, payload):
+        self._payload = deepcopy(payload)
+        self.exists = payload is not None
+
+    def to_dict(self):
+        return deepcopy(self._payload)
+
+
+class _Document:
+    def __init__(self, db, path):
+        self.db = db
+        self.path = path
+        self.create_calls = []
+
+    def get(self):
+        self.db.read_paths.append(self.path)
+        return _Snapshot(self.db.docs.get(self.path))
+
+    def create(self, payload):
+        self.create_calls.append(deepcopy(payload))
+        self.db.create_paths.append(self.path)
+        if self.path in self.db.docs:
+            raise AlreadyExists('document already exists')
+        self.db.docs[self.path] = deepcopy(payload)
+
+
+class _Db:
+    def __init__(self, docs=None):
+        self.docs = deepcopy(docs or {})
+        self.read_paths = []
+        self.create_paths = []
+        self.documents = {}
+
+    def document(self, path):
+        self.documents.setdefault(path, _Document(self, path))
+        return self.documents[path]
+
+
+def _path(uid):
+    return MemoryCollections(uid=uid).memory_control_state
+
+
+def test_reconciler_uses_code_cohort_and_creates_only_inert_control_state(monkeypatch):
+    monkeypatch.setattr(
+        'utils.memory.canonical_memory_onboarding.list_canonical_cohort_uids',
+        lambda: ['uid-b', 'uid-a'],
+    )
+    db = _Db()
+
+    report = reconcile_canonical_memory_onboarding(db)
+
+    assert report.created_uids == ('uid-a', 'uid-b')
+    assert report.preserved_uids == ()
+    assert db.create_paths == [_path('uid-a'), _path('uid-b')]
+    assert set(db.docs) == {_path('uid-a'), _path('uid-b')}
+    for uid in ('uid-a', 'uid-b'):
+        state = db.docs[_path(uid)]
+        assert state == build_whitelisted_user_control_state(uid=uid, account_generation=0)
+        assert state['mode'] == 'off'
+        assert state['fallback_projection_ready'] is False
+        assert state['writes_blocked'] is True
+        assert state['grants']['omi_chat'] == {'default_memory': False, 'archive': False}
+    assert not any('memory_state/head' in path for path in db.read_paths + db.create_paths)
+    assert not any('v3_compatibility_projection' in path for path in db.read_paths + db.create_paths)
+
+
+def test_reconciler_is_idempotent_and_preserves_existing_rollout_history(monkeypatch):
+    monkeypatch.setattr(
+        'utils.memory.canonical_memory_onboarding.list_canonical_cohort_uids',
+        lambda: ['uid-a'],
+    )
+    db = _Db()
+    first = reconcile_canonical_memory_onboarding(db)
+    original = deepcopy(db.docs[_path('uid-a')])
+
+    second = reconcile_canonical_memory_onboarding(db)
+
+    assert first.created_uids == ('uid-a',)
+    assert second.created_uids == ()
+    assert second.preserved_uids == ('uid-a',)
+    assert db.docs[_path('uid-a')] == original
+    assert db.documents[_path('uid-a')].create_calls == [original]
+
+    existing = build_whitelisted_user_control_state(uid='uid-a', account_generation=9)
+    existing.update(
+        {
+            'mode': 'read',
+            'mode_epoch': 4,
+            'cutover_epoch': 4,
+            'fallback_projection_ready': True,
+            'persistent_memory_writes_started': True,
+            'writes_blocked': False,
+            'stage_gates': {'shadow': 'passed', 'write': 'passed', 'read': 'passed'},
+            'grants': {'omi_chat': {'default_memory': True, 'archive': False}},
+        }
+    )
+    db = _Db({_path('uid-a'): existing})
+
+    report = reconcile_canonical_memory_onboarding(db)
+
+    assert report.preserved_uids == ('uid-a',)
+    assert db.docs[_path('uid-a')] == existing
+    assert db.documents[_path('uid-a')].create_calls == []
+
+
+def test_reconciler_does_not_overwrite_malformed_existing_state(monkeypatch):
+    monkeypatch.setattr(
+        'utils.memory.canonical_memory_onboarding.list_canonical_cohort_uids',
+        lambda: ['uid-a'],
+    )
+    malformed = {'uid': 'uid-a', 'schema_version': 99, 'mode': 'read'}
+    db = _Db({_path('uid-a'): malformed})
+
+    with pytest.raises(CanonicalMemoryOnboardingValidationError, match='unsupported_rollout_schema'):
+        reconcile_canonical_memory_onboarding(db)
+
+    assert db.docs[_path('uid-a')] == malformed
+    assert db.documents[_path('uid-a')].create_calls == []
+
+
+def test_reconciler_wins_no_race_and_validates_the_concurrent_existing_state(monkeypatch):
+    monkeypatch.setattr(
+        'utils.memory.canonical_memory_onboarding.list_canonical_cohort_uids',
+        lambda: ['uid-a'],
+    )
+    existing = build_whitelisted_user_control_state(uid='uid-a', account_generation=3)
+    db = _Db()
+    document = db.document(_path('uid-a'))
+
+    original_create = document.create
+
+    def concurrent_create(payload):
+        db.docs[_path('uid-a')] = deepcopy(existing)
+        return original_create(payload)
+
+    document.create = concurrent_create
+
+    report = reconcile_canonical_memory_onboarding(db)
+
+    assert report.created_uids == ()
+    assert report.preserved_uids == ('uid-a',)
+    assert db.docs[_path('uid-a')] == existing

--- a/backend/utils/memory/canonical_memory_onboarding.py
+++ b/backend/utils/memory/canonical_memory_onboarding.py
@@ -1,0 +1,160 @@
+"""Idempotent onboarding for code-whitelisted canonical-memory users.
+
+The canonical cohort is code-owned, while the per-user rollout document is
+durable Firestore state.  This module reconciles that boundary without
+activating a user: a missing document is created with the existing inert
+enrollment builder, and an existing document is validated and left untouched.
+It intentionally does not create or inspect memory heads, projections, items,
+or global rollout gates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from google.api_core.exceptions import AlreadyExists, Conflict
+
+from config.memory_rollout import MemoryRolloutMode
+from database.memory_collections import MemoryCollections
+from utils.memory.default_read_rollout import (
+    DEFAULT_READ_ROLLOUT_SCHEMA_VERSION,
+    normalize_default_read_rollout_decision,
+)
+from utils.memory.memory_system import list_canonical_cohort_uids
+from utils.memory.v3.limited_rollout_config import build_whitelisted_user_control_state
+
+ONBOARDING_ACCOUNT_GENERATION = 0
+OnboardingAction = Literal['created', 'preserved']
+
+
+class CanonicalMemoryOnboardingValidationError(RuntimeError):
+    """An existing canonical-memory control document cannot be trusted."""
+
+    def __init__(self, *, uid: str, reason: str):
+        self.uid = uid
+        self.reason = reason
+        super().__init__(f'canonical memory onboarding validation failed for uid={uid}: {reason}')
+
+
+@dataclass(frozen=True)
+class CanonicalMemoryOnboardingUserResult:
+    uid: str
+    action: OnboardingAction
+    control_state_path: str
+
+
+@dataclass(frozen=True)
+class CanonicalMemoryOnboardingReport:
+    users: tuple[CanonicalMemoryOnboardingUserResult, ...]
+
+    @property
+    def created_uids(self) -> tuple[str, ...]:
+        return tuple(user.uid for user in self.users if user.action == 'created')
+
+    @property
+    def preserved_uids(self) -> tuple[str, ...]:
+        return tuple(user.uid for user in self.users if user.action == 'preserved')
+
+
+def _control_state_path(uid: str) -> str:
+    return MemoryCollections(uid=uid).memory_control_state
+
+
+def _validate_existing_control_state(*, uid: str, path: str, payload: object) -> None:
+    """Validate through the existing rollout reader/model contract.
+
+    The normalized decision constructs ``MemoryRolloutState`` and checks the
+    persisted UID and schema.  It deliberately does not require the state to be
+    activated or projection-ready; those are separate rollout decisions.
+    """
+
+    decision = normalize_default_read_rollout_decision(
+        uid=uid,
+        source_path=path,
+        consumer='omi_chat',
+        data=payload,
+    )
+    if decision.reason != 'ok':
+        raise CanonicalMemoryOnboardingValidationError(uid=uid, reason=decision.reason)
+
+
+def _safe_onboarding_payload(uid: str) -> dict[str, Any]:
+    """Build the inert state with the canonical enrollment policy.
+
+    Generation zero is an explicit unknown-generation fence.  It permits a
+    scheduler to establish durable rollout state without claiming a trusted
+    account head that this reconciler neither reads nor creates.
+    """
+
+    payload = build_whitelisted_user_control_state(
+        uid=uid,
+        account_generation=ONBOARDING_ACCOUNT_GENERATION,
+        mode=MemoryRolloutMode.off,
+        projection_ready=False,
+        default_memory_grant=False,
+        archive_grant=False,
+    )
+    if payload.get('schema_version') != DEFAULT_READ_ROLLOUT_SCHEMA_VERSION:
+        raise RuntimeError('canonical enrollment builder returned an unsupported rollout schema')
+    return payload
+
+
+def _existing_snapshot_payload(*, uid: str, snapshot: Any) -> object:
+    if getattr(snapshot, 'exists', False) is not True:
+        raise CanonicalMemoryOnboardingValidationError(uid=uid, reason='control_state_disappeared_after_create_race')
+    try:
+        return snapshot.to_dict()
+    except Exception:
+        raise CanonicalMemoryOnboardingValidationError(uid=uid, reason='control_state_read_failed') from None
+
+
+def _reconcile_user(db_client: Any, *, uid: str) -> CanonicalMemoryOnboardingUserResult:
+    if not uid.strip():
+        raise ValueError('canonical cohort contains a blank uid')
+
+    path = _control_state_path(uid)
+    control_ref = db_client.document(path)
+    snapshot = control_ref.get()
+    if getattr(snapshot, 'exists', False) is True:
+        payload = _existing_snapshot_payload(uid=uid, snapshot=snapshot)
+        _validate_existing_control_state(uid=uid, path=path, payload=payload)
+        return CanonicalMemoryOnboardingUserResult(uid=uid, action='preserved', control_state_path=path)
+
+    payload = _safe_onboarding_payload(uid)
+    try:
+        # Firestore create is an atomic exists=false compare-and-create.  Never
+        # use merge/set here: a concurrent rollout writer must win unchanged.
+        control_ref.create(payload)
+    except (AlreadyExists, Conflict):
+        raced_snapshot = control_ref.get()
+        raced_payload = _existing_snapshot_payload(uid=uid, snapshot=raced_snapshot)
+        _validate_existing_control_state(uid=uid, path=path, payload=raced_payload)
+        return CanonicalMemoryOnboardingUserResult(uid=uid, action='preserved', control_state_path=path)
+
+    return CanonicalMemoryOnboardingUserResult(uid=uid, action='created', control_state_path=path)
+
+
+def reconcile_canonical_memory_onboarding(
+    db_client: Any,
+) -> CanonicalMemoryOnboardingReport:
+    """Ensure inert control state exists for every canonical cohort UID.
+
+    Membership always comes from ``list_canonical_cohort_uids()`` so a scheduler
+    cannot accidentally create state for a UID outside the code-owned selector.
+    """
+
+    uids = list_canonical_cohort_uids()
+    if any(not uid.strip() for uid in uids):
+        raise ValueError('canonical cohort contains a blank uid')
+    results = tuple(_reconcile_user(db_client, uid=uid) for uid in sorted(set(uids)))
+    return CanonicalMemoryOnboardingReport(users=results)
+
+
+__all__ = [
+    'CanonicalMemoryOnboardingReport',
+    'CanonicalMemoryOnboardingUserResult',
+    'CanonicalMemoryOnboardingValidationError',
+    'ONBOARDING_ACCOUNT_GENERATION',
+    'reconcile_canonical_memory_onboarding',
+]


### PR DESCRIPTION
## What changed

Add an idempotent reconciliation primitive for the code-owned canonical-memory
cohort. It creates only an inert per-user rollout control document through the
existing enrollment policy, validates and preserves existing control state, and
never fabricates memory heads, projections, or activation grants.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_canonical_memory_onboarding.py`
- `make preflight` with this PR body


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

