### PR TITLE
feat(memory): add bounded canonical legacy backfill

### DIFF
--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -124,13 +124,15 @@
         "backend/utils/memory/legacy_backfill_bulk_support.py",
         "backend/utils/memory/legacy_backfill_inventory.py",
         "backend/utils/memory/bulk_legacy_backfill.py",
+        "backend/utils/memory/canonical_legacy_backfill.py",
         "backend/scripts/backfill_legacy_memories.py",
         "backend/scripts/bulk_backfill_legacy_memories.py"
       ],
       "tests": [
         "tests/unit/test_ws_c_backfill.py",
         "tests/unit/test_bulk_legacy_backfill.py",
-        "tests/unit/test_bulk_backfill_legacy_memories_cli.py"
+        "tests/unit/test_bulk_backfill_legacy_memories_cli.py",
+        "tests/unit/test_canonical_legacy_backfill.py"
       ],
       "checks": ["no_large_tuple_results"],
       "invariants": [

--- a/backend/tests/unit/test_canonical_legacy_backfill.py
+++ b/backend/tests/unit/test_canonical_legacy_backfill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 
@@ -94,6 +95,10 @@ def _seed_rollout_control(db: _Db, uid: str, *, stage: str = "write", writes_blo
     db.documents[MemoryCollections(uid).memory_control_state] = payload
 
 
+def _allow_canonical_writes(monkeypatch) -> None:
+    monkeypatch.setattr(backfill, "canonical_write_decision", lambda *args, **kwargs: SimpleNamespace(enabled=True))
+
+
 @pytest.fixture(autouse=True)
 def _canonical_test_cohort(monkeypatch):
     set_canonical_cohort(monkeypatch, "already-done", "cohort-a", "cohort-b")
@@ -127,9 +132,7 @@ def test_default_config_does_not_stage_or_write(monkeypatch):
 def test_enrollment_hook_rejects_non_cohort_uid():
     """A non-cohort uid must never reach terminal read_ready via this seam."""
     with pytest.raises(ValueError, match="non-cohort"):
-        backfill._cohort_enrollment_hook(
-            "intruder", canonical_uids=frozenset({"cohort-a"}), db_client=_Db()
-        )
+        backfill._cohort_enrollment_hook("intruder", canonical_uids=frozenset({"cohort-a"}), db_client=_Db())
 
 
 def test_helper_does_not_import_terminal_graph_or_cron_owners():
@@ -144,6 +147,7 @@ def test_page_uses_only_whitelisted_users_and_skips_durable_completions(monkeypa
     db = _Db()
     _seed_checkpoint(db, "already-done", MigrationState.read_ready)
     _seed_rollout_control(db, "cohort-a")
+    _allow_canonical_writes(monkeypatch)
     monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["already-done", "cohort-a", "cohort-b"])
     monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
     calls: list[str] = []
@@ -172,6 +176,7 @@ def test_page_uses_only_whitelisted_users_and_skips_durable_completions(monkeypa
 def test_second_page_call_resumes_and_is_idempotent(monkeypatch):
     db = _Db()
     _seed_rollout_control(db, "cohort-a")
+    _allow_canonical_writes(monkeypatch)
     monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
     monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
     calls: list[str] = []
@@ -200,6 +205,7 @@ def test_second_page_call_resumes_and_is_idempotent(monkeypatch):
 def test_row_page_is_forwarded_and_only_durable_checkpoints_are_written(monkeypatch):
     db = _Db()
     _seed_rollout_control(db, "cohort-a")
+    _allow_canonical_writes(monkeypatch)
     monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
     monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
     stage_kwargs: list[dict] = []
@@ -264,7 +270,7 @@ def test_page_fails_closed_without_write_stage_enrollment_control(monkeypatch, c
     monkeypatch.setattr(backfill, "backfill_user", stage)
 
     page = backfill.run_canonical_legacy_backfill_page(
-        config=backfill.CanonicalLegacyBackfillConfig(page_size=1),
+        config=backfill.CanonicalLegacyBackfillConfig(page_size=1, dry_run=False),
         db_client=db,
     )
 

--- a/backend/tests/unit/test_canonical_legacy_backfill.py
+++ b/backend/tests/unit/test_canonical_legacy_backfill.py
@@ -10,6 +10,7 @@ from utils.memory import canonical_legacy_backfill as backfill
 from utils.memory.bulk_legacy_backfill import MigrationCheckpoint, MigrationState
 from utils.memory.legacy_backfill import BackfillReport
 from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
+from tests.unit.canonical_cohort_test_helpers import set_canonical_cohort
 
 
 @dataclass
@@ -86,6 +87,18 @@ def _seed_checkpoint(db: _Db, uid: str, state: MigrationState) -> None:
     ).to_payload()
 
 
+def _seed_rollout_control(db: _Db, uid: str, *, stage: str = "write", writes_blocked: bool | None = None) -> None:
+    payload = backfill.build_user_control_state(uid=uid, stage=stage, account_generation=1)
+    if writes_blocked is not None:
+        payload["writes_blocked"] = writes_blocked
+    db.documents[MemoryCollections(uid).memory_control_state] = payload
+
+
+@pytest.fixture(autouse=True)
+def _canonical_test_cohort(monkeypatch):
+    set_canonical_cohort(monkeypatch, "already-done", "cohort-a", "cohort-b")
+
+
 def test_config_rejects_unbounded_pages():
     with pytest.raises(ValueError, match="page_size"):
         backfill.CanonicalLegacyBackfillConfig(page_size=backfill.MAX_COHORT_PAGE_SIZE + 1)
@@ -114,12 +127,9 @@ def test_default_config_does_not_stage_or_write(monkeypatch):
 def test_enrollment_hook_rejects_non_cohort_uid():
     """A non-cohort uid must never reach terminal read_ready via this seam."""
     with pytest.raises(ValueError, match="non-cohort"):
-        backfill._cohort_enrollment_hook("intruder", canonical_uids=frozenset({"cohort-a"}))
-
-
-def test_enrollment_hook_accepts_cohort_uid():
-    """A whitelisted uid advances through the checkpoint normally."""
-    backfill._cohort_enrollment_hook("cohort-a", canonical_uids=frozenset({"cohort-a"}))
+        backfill._cohort_enrollment_hook(
+            "intruder", canonical_uids=frozenset({"cohort-a"}), db_client=_Db()
+        )
 
 
 def test_helper_does_not_import_terminal_graph_or_cron_owners():
@@ -133,6 +143,7 @@ def test_helper_does_not_import_terminal_graph_or_cron_owners():
 def test_page_uses_only_whitelisted_users_and_skips_durable_completions(monkeypatch):
     db = _Db()
     _seed_checkpoint(db, "already-done", MigrationState.read_ready)
+    _seed_rollout_control(db, "cohort-a")
     monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["already-done", "cohort-a", "cohort-b"])
     monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
     calls: list[str] = []
@@ -160,6 +171,7 @@ def test_page_uses_only_whitelisted_users_and_skips_durable_completions(monkeypa
 
 def test_second_page_call_resumes_and_is_idempotent(monkeypatch):
     db = _Db()
+    _seed_rollout_control(db, "cohort-a")
     monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
     monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
     calls: list[str] = []
@@ -187,6 +199,7 @@ def test_second_page_call_resumes_and_is_idempotent(monkeypatch):
 
 def test_row_page_is_forwarded_and_only_durable_checkpoints_are_written(monkeypatch):
     db = _Db()
+    _seed_rollout_control(db, "cohort-a")
     monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
     monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
     stage_kwargs: list[dict] = []
@@ -231,3 +244,33 @@ def test_dry_run_inventories_page_without_durable_writes(monkeypatch):
     assert page.summary.dry_run is True
     assert page.summary.users[0].actions == ("would_enroll_write_only", "would_stage_all_for_admission")
     assert db.writes == []
+
+
+@pytest.mark.parametrize("control_state", ["missing", "off", "write_blocked"])
+def test_page_fails_closed_without_write_stage_enrollment_control(monkeypatch, control_state):
+    db = _Db()
+    if control_state == "off":
+        _seed_rollout_control(db, "cohort-a", stage="off")
+    elif control_state == "write_blocked":
+        _seed_rollout_control(db, "cohort-a", writes_blocked=True)
+    monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
+    monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
+    calls: list[str] = []
+
+    def stage(uid: str, **kwargs):
+        calls.append(uid)
+        return _backfill_report(uid, **kwargs)
+
+    monkeypatch.setattr(backfill, "backfill_user", stage)
+
+    page = backfill.run_canonical_legacy_backfill_page(
+        config=backfill.CanonicalLegacyBackfillConfig(page_size=1),
+        db_client=db,
+    )
+
+    assert page.summary.read_ready_count == 0
+    assert page.summary.failed_user_count == 1
+    assert calls == []
+    assert page.remaining_user_count == 1
+    checkpoint_path = MemoryCollections("cohort-a").legacy_canonical_backfill_checkpoint
+    assert checkpoint_path not in db.documents

--- a/backend/tests/unit/test_canonical_legacy_backfill.py
+++ b/backend/tests/unit/test_canonical_legacy_backfill.py
@@ -93,6 +93,35 @@ def test_config_rejects_unbounded_pages():
         backfill.CanonicalLegacyBackfillConfig(max_rows_per_user=backfill.MAX_ROWS_PER_USER + 1)
 
 
+def test_config_defaults_to_dry_run():
+    """The default config must be fail-safe: no durable writes without opt-in."""
+    assert backfill.CanonicalLegacyBackfillConfig().dry_run is True
+
+
+def test_default_config_does_not_stage_or_write(monkeypatch):
+    """An unparameterized page run inventories only and writes no checkpoints."""
+    db = _Db()
+    monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
+    monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
+    monkeypatch.setattr(backfill, "backfill_user", lambda *a, **k: pytest.fail("dry-run must not stage"))
+
+    page = backfill.run_canonical_legacy_backfill_page(db_client=db)
+
+    assert page.summary.dry_run is True
+    assert db.writes == []
+
+
+def test_enrollment_hook_rejects_non_cohort_uid():
+    """A non-cohort uid must never reach terminal read_ready via this seam."""
+    with pytest.raises(ValueError, match="non-cohort"):
+        backfill._cohort_enrollment_hook("intruder", canonical_uids=frozenset({"cohort-a"}))
+
+
+def test_enrollment_hook_accepts_cohort_uid():
+    """A whitelisted uid advances through the checkpoint normally."""
+    backfill._cohort_enrollment_hook("cohort-a", canonical_uids=frozenset({"cohort-a"}))
+
+
 def test_helper_does_not_import_terminal_graph_or_cron_owners():
     source = inspect.getsource(backfill)
 
@@ -115,7 +144,7 @@ def test_page_uses_only_whitelisted_users_and_skips_durable_completions(monkeypa
     monkeypatch.setattr(backfill, "backfill_user", stage)
 
     page = backfill.run_canonical_legacy_backfill_page(
-        config=backfill.CanonicalLegacyBackfillConfig(page_size=1),
+        config=backfill.CanonicalLegacyBackfillConfig(page_size=1, dry_run=False),
         db_client=db,
     )
 
@@ -140,7 +169,7 @@ def test_second_page_call_resumes_and_is_idempotent(monkeypatch):
         return _backfill_report(uid, **kwargs)
 
     monkeypatch.setattr(backfill, "backfill_user", stage)
-    config = backfill.CanonicalLegacyBackfillConfig(page_size=1)
+    config = backfill.CanonicalLegacyBackfillConfig(page_size=1, dry_run=False)
 
     first = backfill.run_canonical_legacy_backfill_page(config=config, db_client=db)
     calls_after_first = list(calls)
@@ -169,7 +198,7 @@ def test_row_page_is_forwarded_and_only_durable_checkpoints_are_written(monkeypa
     monkeypatch.setattr(backfill, "backfill_user", stage)
 
     page = backfill.run_canonical_legacy_backfill_page(
-        config=backfill.CanonicalLegacyBackfillConfig(page_size=1, max_rows_per_user=7),
+        config=backfill.CanonicalLegacyBackfillConfig(page_size=1, max_rows_per_user=7, dry_run=False),
         db_client=db,
     )
 

--- a/backend/tests/unit/test_canonical_legacy_backfill.py
+++ b/backend/tests/unit/test_canonical_legacy_backfill.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+
+import pytest
+
+from database.memory_collections import MemoryCollections
+from utils.memory import canonical_legacy_backfill as backfill
+from utils.memory.bulk_legacy_backfill import MigrationCheckpoint, MigrationState
+from utils.memory.legacy_backfill import BackfillReport
+from utils.memory.legacy_backfill_bulk_support import LegacyBackfillInventoryReport
+
+
+@dataclass
+class _Snapshot:
+    payload: dict | None
+
+    @property
+    def exists(self) -> bool:
+        return self.payload is not None
+
+    def to_dict(self):
+        return self.payload
+
+
+class _Document:
+    def __init__(self, db: "_Db", path: str):
+        self._db = db
+        self._path = path
+
+    def get(self):
+        self._db.reads.append(self._path)
+        return _Snapshot(self._db.documents.get(self._path))
+
+    def set(self, payload, merge: bool = False):
+        self._db.writes.append((self._path, payload, merge))
+        if merge and self._path in self._db.documents:
+            self._db.documents[self._path] = {**self._db.documents[self._path], **payload}
+        else:
+            self._db.documents[self._path] = dict(payload)
+
+
+class _Db:
+    def __init__(self):
+        self.documents: dict[str, dict] = {}
+        self.reads: list[str] = []
+        self.writes: list[tuple[str, dict, bool]] = []
+
+    def document(self, path: str):
+        return _Document(self, path)
+
+
+def _inventory(uid: str, *, candidates: int = 1) -> LegacyBackfillInventoryReport:
+    return LegacyBackfillInventoryReport(
+        uid=uid,
+        source_count=candidates,
+        bucket_counts={"manual_required_promotion": candidates},
+        admitted_candidate_count=candidates,
+        content_character_count=candidates * 10,
+        estimated_tokens=candidates * 3,
+        admitted_candidate_estimated_tokens=candidates * 3,
+    )
+
+
+def _backfill_report(uid: str, **kwargs) -> BackfillReport:
+    return BackfillReport(
+        uid=uid,
+        dry_run=False,
+        source_count=1,
+        intended_count=1,
+        written_count=1,
+        skipped_already_present=0,
+        skipped_both_store_duplicate=0,
+        skipped_semantic_duplicate=0,
+        destination_count=1,
+        verified=True,
+        completed=True,
+    )
+
+
+def _seed_checkpoint(db: _Db, uid: str, state: MigrationState) -> None:
+    db.documents[MemoryCollections(uid).legacy_canonical_backfill_checkpoint] = MigrationCheckpoint(
+        uid=uid,
+        state=state,
+    ).to_payload()
+
+
+def test_config_rejects_unbounded_pages():
+    with pytest.raises(ValueError, match="page_size"):
+        backfill.CanonicalLegacyBackfillConfig(page_size=backfill.MAX_COHORT_PAGE_SIZE + 1)
+    with pytest.raises(ValueError, match="max_rows_per_user"):
+        backfill.CanonicalLegacyBackfillConfig(max_rows_per_user=backfill.MAX_ROWS_PER_USER + 1)
+
+
+def test_helper_does_not_import_terminal_graph_or_cron_owners():
+    source = inspect.getsource(backfill)
+
+    assert "canonical_short_term_maintenance_cron" not in source
+    assert "canonical_kg_promotion" not in source
+    assert "run_enrichment" not in source
+
+
+def test_page_uses_only_whitelisted_users_and_skips_durable_completions(monkeypatch):
+    db = _Db()
+    _seed_checkpoint(db, "already-done", MigrationState.read_ready)
+    monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["already-done", "cohort-a", "cohort-b"])
+    monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
+    calls: list[str] = []
+
+    def stage(uid: str, **kwargs):
+        calls.append(uid)
+        return _backfill_report(uid, **kwargs)
+
+    monkeypatch.setattr(backfill, "backfill_user", stage)
+
+    page = backfill.run_canonical_legacy_backfill_page(
+        config=backfill.CanonicalLegacyBackfillConfig(page_size=1),
+        db_client=db,
+    )
+
+    assert page.cohort_user_count == 3
+    assert page.pending_user_count == 2
+    assert page.selected_uids == ("cohort-a",)
+    assert calls == ["cohort-a"]
+    assert page.summary.read_ready_count == 1
+    assert page.remaining_user_count == 1
+    assert page.has_more is True
+    assert "already-done" not in calls
+
+
+def test_second_page_call_resumes_and_is_idempotent(monkeypatch):
+    db = _Db()
+    monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
+    monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
+    calls: list[str] = []
+
+    def stage(uid: str, **kwargs):
+        calls.append(uid)
+        return _backfill_report(uid, **kwargs)
+
+    monkeypatch.setattr(backfill, "backfill_user", stage)
+    config = backfill.CanonicalLegacyBackfillConfig(page_size=1)
+
+    first = backfill.run_canonical_legacy_backfill_page(config=config, db_client=db)
+    calls_after_first = list(calls)
+    second = backfill.run_canonical_legacy_backfill_page(config=config, db_client=db)
+
+    assert first.summary.read_ready_count == 1
+    assert first.remaining_user_count == 0
+    assert second.selected_uids == ()
+    assert second.summary.processed_user_count == 0
+    assert second.remaining_user_count == 0
+    assert calls == calls_after_first == ["cohort-a"]
+    checkpoint_path = MemoryCollections("cohort-a").legacy_canonical_backfill_checkpoint
+    assert db.documents[checkpoint_path]["state"] == MigrationState.read_ready.value
+
+
+def test_row_page_is_forwarded_and_only_durable_checkpoints_are_written(monkeypatch):
+    db = _Db()
+    monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
+    monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
+    stage_kwargs: list[dict] = []
+
+    def stage(uid: str, **kwargs):
+        stage_kwargs.append(kwargs)
+        return _backfill_report(uid, **kwargs)
+
+    monkeypatch.setattr(backfill, "backfill_user", stage)
+
+    page = backfill.run_canonical_legacy_backfill_page(
+        config=backfill.CanonicalLegacyBackfillConfig(page_size=1, max_rows_per_user=7),
+        db_client=db,
+    )
+
+    assert page.summary.read_ready_count == 1
+    assert len(stage_kwargs) == 1
+    assert stage_kwargs[0]["dry_run"] is False
+    assert stage_kwargs[0]["batch_size"] == 7
+    assert stage_kwargs[0]["resume"] is True
+    assert stage_kwargs[0]["max_rows"] == 7
+    assert stage_kwargs[0]["continue_on_error"] is True
+    assert callable(stage_kwargs[0]["stop_requested"])
+    assert stage_kwargs[0]["db_client"] is db
+    written_paths = {path for path, _, _ in db.writes}
+    assert written_paths == {MemoryCollections("cohort-a").legacy_canonical_backfill_checkpoint}
+    assert not any("memory_graph_assertions" in path for path in written_paths)
+
+
+def test_dry_run_inventories_page_without_durable_writes(monkeypatch):
+    db = _Db()
+    monkeypatch.setattr(backfill, "list_canonical_cohort_uids", lambda: ["cohort-a"])
+    monkeypatch.setattr(backfill, "inventory_legacy_user", lambda uid, **_: _inventory(uid))
+    stage = lambda *args, **kwargs: pytest.fail("dry-run must not stage canonical candidates")
+    monkeypatch.setattr(backfill, "backfill_user", stage)
+
+    page = backfill.run_canonical_legacy_backfill_page(
+        config=backfill.CanonicalLegacyBackfillConfig(dry_run=True),
+        db_client=db,
+    )
+
+    assert page.summary.dry_run is True
+    assert page.summary.users[0].actions == ("would_enroll_write_only", "would_stage_all_for_admission")
+    assert db.writes == []

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -64,6 +64,7 @@ def test_workflow_contract_sources_select_adjacent_tests(selector_and_all_tests)
     }
     selected_cases = {
         "backend/utils/memory/legacy_backfill.py": "tests/unit/test_ws_c_backfill.py",
+        "backend/utils/memory/canonical_legacy_backfill.py": "tests/unit/test_canonical_legacy_backfill.py",
         "backend/utils/memory/canonical_memory_adapter.py": "testing/e2e/test_canonical_memory_pipeline.py",
         "backend/routers/conversations.py": "tests/unit/test_conversation_lifecycle_contract.py",
         "backend/services/users/account_deletion.py": "tests/services/users/test_account_deletion.py",

--- a/backend/utils/memory/canonical_legacy_backfill.py
+++ b/backend/utils/memory/canonical_legacy_backfill.py
@@ -162,9 +162,7 @@ def run_canonical_legacy_backfill_page(
         inventory_fn=lambda uid: inventory_legacy_user(uid, db_client=client),
         pause_fn=lambda: read_global_pause(client),
         checkpoint_store=None if config.dry_run else checkpoint_store,
-        enroll_fn=None
-        if config.dry_run
-        else partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids)),
+        enroll_fn=None if config.dry_run else partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids)),
         backfill_fn=None if config.dry_run else backfill_fn,
     )
 

--- a/backend/utils/memory/canonical_legacy_backfill.py
+++ b/backend/utils/memory/canonical_legacy_backfill.py
@@ -167,6 +167,7 @@ def run_canonical_legacy_backfill_page(
     checkpoint_store = FirestoreCheckpointStore(client)
     cohort_uids, pending_uids = _cohort_uids_with_pending_checkpoints(checkpoint_store)
     selected_uids = tuple(pending_uids[: config.page_size])
+    enrollment_hook = partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids), db_client=client)
     bulk_config = BulkMigrationConfig(
         dry_run=config.dry_run,
         max_users_per_run=config.page_size,
@@ -179,7 +180,7 @@ def run_canonical_legacy_backfill_page(
 
     def inventory_fn(uid: str):
         if not config.dry_run:
-            _cohort_enrollment_hook(uid, db_client=client)
+            enrollment_hook(uid)
         return inventory_legacy_user(uid, db_client=client)
 
     def backfill_fn(
@@ -188,7 +189,7 @@ def run_canonical_legacy_backfill_page(
         resume: bool,
         stop_requested: Callable[[], bool],
     ) -> BackfillReport:
-        _cohort_enrollment_hook(uid, db_client=client)
+        enrollment_hook(uid)
         return backfill_user(
             uid,
             dry_run=False,
@@ -206,9 +207,7 @@ def run_canonical_legacy_backfill_page(
         inventory_fn=inventory_fn,
         pause_fn=lambda: read_global_pause(client),
         checkpoint_store=None if config.dry_run else checkpoint_store,
-        enroll_fn=None
-        if config.dry_run
-        else partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids), db_client=client),
+        enroll_fn=None if config.dry_run else enrollment_hook,
         backfill_fn=None if config.dry_run else backfill_fn,
     )
 

--- a/backend/utils/memory/canonical_legacy_backfill.py
+++ b/backend/utils/memory/canonical_legacy_backfill.py
@@ -5,7 +5,8 @@ LIFECYCLE: permanent
 This is an orchestration seam for a future maintenance owner. It selects only
 users returned by ``list_canonical_cohort_uids()``, stages at most one bounded
 page of legacy rows per user, and resumes from the existing durable bulk
-checkpoint. It does not change rollout documents or read grants. Terminal
+checkpoint. It verifies the existing per-user write-stage enrollment control
+but does not change rollout documents, global gates, or read grants. Terminal
 processing and any later promotion remain owned by the canonical maintenance
 pipeline.
 """
@@ -18,6 +19,8 @@ from functools import partial
 from typing import Any, Optional
 
 from database._client import get_firestore_client
+from database.memory_collections import MemoryCollections
+from scripts.enroll_canonical_memory_user import build_user_control_state
 from utils.memory.bulk_legacy_backfill import (
     BulkMigrationConfig,
     BulkRunSummary,
@@ -26,6 +29,7 @@ from utils.memory.bulk_legacy_backfill import (
     read_global_pause,
     run_bulk_migration,
 )
+from utils.memory.canonical_activation import canonical_write_decision
 from utils.memory.legacy_backfill import BackfillReport, backfill_user
 from utils.memory.legacy_backfill_inventory import inventory_legacy_user
 from utils.memory.memory_system import list_canonical_cohort_uids
@@ -95,8 +99,9 @@ def _cohort_enrollment_hook(
     uid: str,
     *,
     canonical_uids: frozenset[str],
+    db_client: Any,
 ) -> None:
-    """Assert the uid is code-enrolled before advancing its checkpoint.
+    """Verify whitelist and existing write enrollment before staging.
 
     The bulk state machine treats ``enroll_fn`` as a side effect that makes a
     user write-ready; once it returns, the checkpoint advances through
@@ -111,6 +116,39 @@ def _cohort_enrollment_hook(
             f"refusing to advance checkpoint for non-cohort uid {uid!r}: "
             "canonical legacy backfill is not the enrollment owner"
         )
+    path = MemoryCollections(uid=uid).memory_control_state
+    snapshot = db_client.document(path).get()
+    if not getattr(snapshot, "exists", False):
+        raise RuntimeError("missing_write_stage_enrollment_control")
+    payload = snapshot.to_dict()
+    if not isinstance(payload, dict):
+        raise RuntimeError("malformed_write_stage_enrollment_control")
+
+    account_generation = payload.get("account_generation")
+    if isinstance(account_generation, bool) or not isinstance(account_generation, int) or account_generation < 0:
+        raise RuntimeError("malformed_write_stage_enrollment_control")
+
+    expected = build_user_control_state(
+        uid=uid,
+        stage="write",
+        account_generation=account_generation,
+    )
+    if payload.get("uid") != expected["uid"] or payload.get("schema_version") != expected["schema_version"]:
+        raise RuntimeError("malformed_write_stage_enrollment_control")
+    if payload.get("mode") not in {"write", "read"}:
+        raise RuntimeError("write_stage_enrollment_control_not_ready")
+    for field in ("persistent_memory_writes_started", "writes_blocked"):
+        if payload.get(field) != expected[field]:
+            raise RuntimeError("write_stage_enrollment_control_not_ready")
+    stage_gates = payload.get("stage_gates")
+    if not isinstance(stage_gates, dict) or any(
+        stage_gates.get(gate) != expected["stage_gates"][gate] for gate in ("shadow", "write")
+    ):
+        raise RuntimeError("write_stage_enrollment_control_not_ready")
+
+    decision = canonical_write_decision(uid, db_client=db_client)
+    if not decision.enabled:
+        raise RuntimeError(f"write_stage_enrollment_control_not_ready:{decision.reason}")
 
 
 def run_canonical_legacy_backfill_page(
@@ -139,12 +177,18 @@ def run_canonical_legacy_backfill_page(
         process_buckets=(),
     )
 
+    def inventory_fn(uid: str):
+        if not config.dry_run:
+            _cohort_enrollment_hook(uid, db_client=client)
+        return inventory_legacy_user(uid, db_client=client)
+
     def backfill_fn(
         uid: str,
         max_rows: int,
         resume: bool,
         stop_requested: Callable[[], bool],
     ) -> BackfillReport:
+        _cohort_enrollment_hook(uid, db_client=client)
         return backfill_user(
             uid,
             dry_run=False,
@@ -159,10 +203,12 @@ def run_canonical_legacy_backfill_page(
     summary = run_bulk_migration(
         selected_uids,
         config=bulk_config,
-        inventory_fn=lambda uid: inventory_legacy_user(uid, db_client=client),
+        inventory_fn=inventory_fn,
         pause_fn=lambda: read_global_pause(client),
         checkpoint_store=None if config.dry_run else checkpoint_store,
-        enroll_fn=None if config.dry_run else partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids)),
+        enroll_fn=None
+        if config.dry_run
+        else partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids), db_client=client),
         backfill_fn=None if config.dry_run else backfill_fn,
     )
 

--- a/backend/utils/memory/canonical_legacy_backfill.py
+++ b/backend/utils/memory/canonical_legacy_backfill.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from functools import partial
 from typing import Any, Optional
 
 from database._client import get_firestore_client
@@ -43,7 +44,7 @@ class CanonicalLegacyBackfillConfig:
     max_rows_per_user: int = DEFAULT_MAX_ROWS_PER_USER
     max_estimated_tokens_per_run: int = 100_000
     wall_clock_seconds: Optional[float] = None
-    dry_run: bool = False
+    dry_run: bool = True
 
     def __post_init__(self) -> None:
         if self.page_size <= 0 or self.page_size > MAX_COHORT_PAGE_SIZE:
@@ -90,9 +91,26 @@ def _pending_uids(cohort_uids: tuple[str, ...], checkpoint_store: FirestoreCheck
     return [uid for uid in cohort_uids if checkpoint_store.read(uid).state != MigrationState.read_ready]
 
 
-def _cohort_enrollment_hook(uid: str) -> None:
-    """Satisfy the bulk state machine without writing rollout documents."""
-    del uid
+def _cohort_enrollment_hook(
+    uid: str,
+    *,
+    canonical_uids: frozenset[str],
+) -> None:
+    """Assert the uid is code-enrolled before advancing its checkpoint.
+
+    The bulk state machine treats ``enroll_fn`` as a side effect that makes a
+    user write-ready; once it returns, the checkpoint advances through
+    ``enrolled`` toward the terminal ``read_ready`` state. Because this seam is
+    not the enrollment owner, it must only advance users the cohort whitelist
+    has already enrolled. Passing ``enroll_fn`` to ``run_bulk_migration`` without
+    this guard would let a non-enrolled uid reach ``read_ready``, permanently
+    blocking the real enrollment owner until the checkpoint is manually repaired.
+    """
+    if uid not in canonical_uids:
+        raise ValueError(
+            f"refusing to advance checkpoint for non-cohort uid {uid!r}: "
+            "canonical legacy backfill is not the enrollment owner"
+        )
 
 
 def run_canonical_legacy_backfill_page(
@@ -144,7 +162,9 @@ def run_canonical_legacy_backfill_page(
         inventory_fn=lambda uid: inventory_legacy_user(uid, db_client=client),
         pause_fn=lambda: read_global_pause(client),
         checkpoint_store=None if config.dry_run else checkpoint_store,
-        enroll_fn=None if config.dry_run else _cohort_enrollment_hook,
+        enroll_fn=None
+        if config.dry_run
+        else partial(_cohort_enrollment_hook, canonical_uids=frozenset(cohort_uids)),
         backfill_fn=None if config.dry_run else backfill_fn,
     )
 

--- a/backend/utils/memory/canonical_legacy_backfill.py
+++ b/backend/utils/memory/canonical_legacy_backfill.py
@@ -1,0 +1,169 @@
+"""Bounded legacy-to-canonical staging for the code-owned memory cohort.
+
+LIFECYCLE: permanent
+
+This is an orchestration seam for a future maintenance owner. It selects only
+users returned by ``list_canonical_cohort_uids()``, stages at most one bounded
+page of legacy rows per user, and resumes from the existing durable bulk
+checkpoint. It does not change rollout documents or read grants. Terminal
+processing and any later promotion remain owned by the canonical maintenance
+pipeline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+from database._client import get_firestore_client
+from utils.memory.bulk_legacy_backfill import (
+    BulkMigrationConfig,
+    BulkRunSummary,
+    FirestoreCheckpointStore,
+    MigrationState,
+    read_global_pause,
+    run_bulk_migration,
+)
+from utils.memory.legacy_backfill import BackfillReport, backfill_user
+from utils.memory.legacy_backfill_inventory import inventory_legacy_user
+from utils.memory.memory_system import list_canonical_cohort_uids
+
+DEFAULT_COHORT_PAGE_SIZE = 10
+MAX_COHORT_PAGE_SIZE = 100
+DEFAULT_MAX_ROWS_PER_USER = 100
+MAX_ROWS_PER_USER = 100
+
+
+@dataclass(frozen=True)
+class CanonicalLegacyBackfillConfig:
+    """One bounded apply/inventory page for canonical legacy backfill."""
+
+    page_size: int = DEFAULT_COHORT_PAGE_SIZE
+    max_rows_per_user: int = DEFAULT_MAX_ROWS_PER_USER
+    max_estimated_tokens_per_run: int = 100_000
+    wall_clock_seconds: Optional[float] = None
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        if self.page_size <= 0 or self.page_size > MAX_COHORT_PAGE_SIZE:
+            raise ValueError(f"page_size must be between 1 and {MAX_COHORT_PAGE_SIZE}")
+        if self.max_rows_per_user <= 0 or self.max_rows_per_user > MAX_ROWS_PER_USER:
+            raise ValueError(f"max_rows_per_user must be between 1 and {MAX_ROWS_PER_USER}")
+        if self.max_estimated_tokens_per_run <= 0:
+            raise ValueError("max_estimated_tokens_per_run must be positive")
+        if self.wall_clock_seconds is not None and self.wall_clock_seconds <= 0:
+            raise ValueError("wall_clock_seconds must be positive")
+
+
+@dataclass(frozen=True)
+class CanonicalLegacyBackfillPage:
+    """Content-free result for one bounded cohort operation."""
+
+    cohort_user_count: int
+    pending_user_count: int
+    selected_uids: tuple[str, ...]
+    remaining_user_count: int
+    summary: BulkRunSummary
+
+    @property
+    def has_more(self) -> bool:
+        return self.remaining_user_count > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["selected_uids"] = list(self.selected_uids)
+        payload["summary"] = self.summary.to_dict()
+        return payload
+
+
+def _cohort_uids_with_pending_checkpoints(
+    checkpoint_store: FirestoreCheckpointStore,
+) -> tuple[tuple[str, ...], list[str]]:
+    """Return the current whitelist and users not durably marked complete."""
+    cohort_uids = tuple(list_canonical_cohort_uids())
+    pending_uids = _pending_uids(cohort_uids, checkpoint_store)
+    return cohort_uids, pending_uids
+
+
+def _pending_uids(cohort_uids: tuple[str, ...], checkpoint_store: FirestoreCheckpointStore) -> list[str]:
+    return [uid for uid in cohort_uids if checkpoint_store.read(uid).state != MigrationState.read_ready]
+
+
+def _cohort_enrollment_hook(uid: str) -> None:
+    """Satisfy the bulk state machine without writing rollout documents."""
+    del uid
+
+
+def run_canonical_legacy_backfill_page(
+    *,
+    config: CanonicalLegacyBackfillConfig = CanonicalLegacyBackfillConfig(),
+    db_client: Any = None,
+) -> CanonicalLegacyBackfillPage:
+    """Stage one resumable page for the currently whitelisted canonical users.
+
+    Repeated calls are safe: completed users are skipped by their durable
+    checkpoint, while paused users resume through the existing per-user legacy
+    checkpoint. The operation never accepts a caller-supplied UID list, so an
+    admin override cannot widen its cohort.
+    """
+    client = db_client if db_client is not None else get_firestore_client()
+    checkpoint_store = FirestoreCheckpointStore(client)
+    cohort_uids, pending_uids = _cohort_uids_with_pending_checkpoints(checkpoint_store)
+    selected_uids = tuple(pending_uids[: config.page_size])
+    bulk_config = BulkMigrationConfig(
+        dry_run=config.dry_run,
+        max_users_per_run=config.page_size,
+        max_admitted_rows_per_user=config.max_rows_per_user,
+        max_estimated_tokens_per_run=config.max_estimated_tokens_per_run,
+        wall_clock_seconds=config.wall_clock_seconds,
+        concurrency_limit=1,
+        process_buckets=(),
+    )
+
+    def backfill_fn(
+        uid: str,
+        max_rows: int,
+        resume: bool,
+        stop_requested: Callable[[], bool],
+    ) -> BackfillReport:
+        return backfill_user(
+            uid,
+            dry_run=False,
+            batch_size=max_rows,
+            resume=resume,
+            max_rows=max_rows,
+            continue_on_error=True,
+            stop_requested=stop_requested,
+            db_client=client,
+        )
+
+    summary = run_bulk_migration(
+        selected_uids,
+        config=bulk_config,
+        inventory_fn=lambda uid: inventory_legacy_user(uid, db_client=client),
+        pause_fn=lambda: read_global_pause(client),
+        checkpoint_store=None if config.dry_run else checkpoint_store,
+        enroll_fn=None if config.dry_run else _cohort_enrollment_hook,
+        backfill_fn=None if config.dry_run else backfill_fn,
+    )
+
+    pending_after = _pending_uids(cohort_uids, checkpoint_store)
+    return CanonicalLegacyBackfillPage(
+        cohort_user_count=len(cohort_uids),
+        pending_user_count=len(pending_uids),
+        selected_uids=selected_uids,
+        remaining_user_count=len(pending_after),
+        summary=summary,
+    )
+
+
+__all__ = [
+    "CanonicalLegacyBackfillConfig",
+    "CanonicalLegacyBackfillPage",
+    "DEFAULT_COHORT_PAGE_SIZE",
+    "DEFAULT_MAX_ROWS_PER_USER",
+    "MAX_COHORT_PAGE_SIZE",
+    "MAX_ROWS_PER_USER",
+    "run_canonical_legacy_backfill_page",
+]


### PR DESCRIPTION
## What changed

Add a whitelist-only, checkpointed, bounded legacy-to-canonical staging page.
It uses the existing migration state machine, resumes safely after interruption,
and deliberately leaves enrollment, promotion, and graph assertions to their
respective canonical owners.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_canonical_legacy_backfill.py`
- `make preflight` with this PR body


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

