### PR TITLE
revert(app): remove the automatic phone-mic fallback on BLE disconnect

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -488,7 +488,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     setIsConnected(false);
     updateConnectingStatus(false);
 
-    await captureProvider?.onRecordingDeviceDisconnected();
     captureProvider?.updateRecordingDevice(null);
 
     // Batch mode: the native writer finalizes the in-progress recording on

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -126,11 +126,6 @@ class CaptureController extends ChangeNotifier
   // active. Distinct from the Live phone-mic path (_phoneMicWalActive).
   bool _phoneMicBatchActive = false;
 
-  // Completes when the native phone-mic batch teardown is fully drained.
-  // Used to serialize reconnect/device transitions so we never resume before
-  // finalization is complete.
-  Completer<void>? _phoneMicBatchStopCompleter;
-
   bool get isPhoneMicBatchRecording => _phoneMicBatchActive;
 
   bool _isLoadingInProgressConversation = false;
@@ -457,7 +452,7 @@ class CaptureController extends ChangeNotifier
   void _updateRecordingDevice(BtDevice? device) {
     Logger.debug('connected device changed from ${_recordingDevice?.id} to ${device?.id}');
     _recordingDevice = device;
-    if (device == null && !_phoneMicBatchActive) _endOfflineSession();
+    if (device == null) _endOfflineSession();
     notifyListeners();
   }
 
@@ -1480,15 +1475,6 @@ class CaptureController extends ChangeNotifier
               if (!_micInterrupted && !_phoneMicBatchRestartInFlight) {
                 updateRecordingState(RecordingState.stop);
               }
-
-              // Used to serialize reconnect/device transitions so we never
-              // resume the device stream before the native phone-batch
-              // teardown is fully drained/finalized.
-              final completer = _phoneMicBatchStopCompleter;
-              if (completer != null && !completer.isCompleted) {
-                completer.complete();
-              }
-              _phoneMicBatchStopCompleter = null;
             },
             onInterruption: _onMicInterruption,
             onBatchStalled: _onBatchStalled,
@@ -1537,29 +1523,6 @@ class CaptureController extends ChangeNotifier
     }
     if (device != null) _updateRecordingDevice(device);
 
-    // A phone batch fallback covers the interval while the wearable was out of
-    // range. Finalize it before opening the device stream again so both capture
-    // paths never own the microphone concurrently.
-    if (_phoneMicBatchActive) {
-      _micInterrupted = true;
-      final completer = Completer<void>();
-      _phoneMicBatchStopCompleter = completer;
-
-      ServiceManager.instance().phoneMic.stop();
-
-      try {
-        await completer.future.timeout(const Duration(seconds: 5));
-      } catch (e, st) {
-        Logger.debug('[CaptureProvider] phone-mic batch stop timed out: $e\n$st');
-      } finally {
-        _phoneMicBatchStopCompleter = null;
-      }
-
-      _phoneMicBatchActive = false;
-      _endOfflineSession();
-      _micInterrupted = false;
-    }
-
     bool wasPaused = _isPaused;
 
     // Ensure even very short device recordings have a location in Redis before
@@ -1572,31 +1535,6 @@ class CaptureController extends ChangeNotifier
     if (wasPaused) {
       await pauseDeviceRecording();
     }
-  }
-
-  Future<void> onRecordingDeviceDisconnected() async {
-    // #7194: if the wearable is already doing its own on-device offline/batch
-    // recording, do not stop it and do not start the phone mic fallback.
-    // Phone fallback is a complementary safety net for live streaming gaps (#11078),
-    // not a replacement for on-device offline capture.
-    final bool isOnDeviceOfflineBatchActive = SharedPreferencesUtil().batchModeEnabled &&
-        _recordingDevice != null &&
-        (_recordingDevice!.type == DeviceType.limitless || _offlineSessionStartSeconds != 0);
-
-    if (!shouldFallbackToPhoneOnDeviceDisconnect(
-      isRecordingDevice: _recordingDevice != null,
-      isRecording: isRecordingDuringDeviceDisconnect(recordingState),
-      supportsBatch: phoneMicSupportsTranscribeLater && deviceSupportsTranscribeLater,
-      batchAlreadyActive: _phoneMicBatchActive,
-      isOnDeviceOfflineBatchActive: isOnDeviceOfflineBatchActive,
-    )) {
-      return;
-    }
-
-    Logger.debug('[CaptureProvider] BLE disconnected during recording; starting phone batch fallback');
-    await _cleanupCurrentState(disableNativeBackground: true);
-    await _socket?.stop(reason: 'BLE disconnected; starting phone batch fallback');
-    await _startPhoneMicBatch(auto: true);
   }
 
   Future stopStreamDeviceRecording({bool cleanDevice = false}) async {

--- a/app/lib/utils/batch_recording.dart
+++ b/app/lib/utils/batch_recording.dart
@@ -1,5 +1,4 @@
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
-import 'package:omi/utils/enums.dart';
 
 /// Marker stored in [Wal.device] for recordings produced by offline/batch mode.
 /// Lets the conversations list show *only* batch recordings — never the device
@@ -83,26 +82,6 @@ PhoneMicSessionMode selectPhoneMicSessionMode({
   if (!hasNetwork) return PhoneMicSessionMode.batchAuto;
   return PhoneMicSessionMode.live;
 }
-
-bool shouldFallbackToPhoneOnDeviceDisconnect({
-  required bool isRecordingDevice,
-  required bool isRecording,
-  required bool supportsBatch,
-  required bool batchAlreadyActive,
-  required bool isOnDeviceOfflineBatchActive,
-}) =>
-    isRecordingDevice && isRecording && supportsBatch && !batchAlreadyActive && !isOnDeviceOfflineBatchActive;
-
-/// Maps the capture state machine into the boolean that the fallback predicate
-/// (`shouldFallbackToPhoneOnDeviceDisconnect`) expects for `isRecording`.
-///
-/// In particular, active BLE device streaming uses `RecordingState.deviceRecord`,
-/// not `RecordingState.record`, so device disconnect fallback must treat
-/// `deviceRecord` as "recording".
-bool isRecordingDuringDeviceDisconnect(RecordingState recordingState) =>
-    recordingState == RecordingState.deviceRecord ||
-    recordingState == RecordingState.record ||
-    recordingState == RecordingState.interrupted;
 
 /// Metadata parsed from a batch recording filename written by the native layer:
 ///

--- a/app/test/unit/batch_recording_phone_test.dart
+++ b/app/test/unit/batch_recording_phone_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
-import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/batch_recording.dart';
 
 /// Phone-mic × Transcribe Later: filename parsing, the auto/explicit marker
@@ -109,84 +108,5 @@ void main() {
         );
       });
     }
-  });
-
-  group('shouldFallbackToPhoneOnDeviceDisconnect', () {
-    test('maps RecordingState.deviceRecord to the predicate isRecording flag', () {
-      expect(isRecordingDuringDeviceDisconnect(RecordingState.deviceRecord), isTrue);
-      expect(isRecordingDuringDeviceDisconnect(RecordingState.record), isTrue);
-      // Interrupted is treated as "recording" for disconnect fallback purposes
-      // (e.g. socket drop preceded the BLE disconnect).
-      expect(isRecordingDuringDeviceDisconnect(RecordingState.interrupted), isTrue);
-    });
-
-    test('falls back only for an active supported wearable session', () {
-      expect(
-        shouldFallbackToPhoneOnDeviceDisconnect(
-          isRecordingDevice: true,
-          isRecording: true,
-          supportsBatch: true,
-          batchAlreadyActive: false,
-          isOnDeviceOfflineBatchActive: false,
-        ),
-        isTrue,
-      );
-    });
-
-    test('does not fall back when an on-device offline batch recording is already active', () {
-      expect(
-        shouldFallbackToPhoneOnDeviceDisconnect(
-          isRecordingDevice: true,
-          isRecording: true,
-          supportsBatch: true,
-          batchAlreadyActive: false,
-          isOnDeviceOfflineBatchActive: true,
-        ),
-        isFalse,
-      );
-    });
-
-    test('does not restart a stopped, unsupported, or already-batched session', () {
-      expect(
-        shouldFallbackToPhoneOnDeviceDisconnect(
-          isRecordingDevice: false,
-          isRecording: true,
-          supportsBatch: true,
-          batchAlreadyActive: false,
-          isOnDeviceOfflineBatchActive: false,
-        ),
-        isFalse,
-      );
-      expect(
-        shouldFallbackToPhoneOnDeviceDisconnect(
-          isRecordingDevice: true,
-          isRecording: false,
-          supportsBatch: true,
-          batchAlreadyActive: false,
-          isOnDeviceOfflineBatchActive: false,
-        ),
-        isFalse,
-      );
-      expect(
-        shouldFallbackToPhoneOnDeviceDisconnect(
-          isRecordingDevice: true,
-          isRecording: true,
-          supportsBatch: false,
-          batchAlreadyActive: false,
-          isOnDeviceOfflineBatchActive: false,
-        ),
-        isFalse,
-      );
-      expect(
-        shouldFallbackToPhoneOnDeviceDisconnect(
-          isRecordingDevice: true,
-          isRecording: true,
-          supportsBatch: true,
-          batchAlreadyActive: true,
-          isOnDeviceOfflineBatchActive: false,
-        ),
-        isFalse,
-      );
-    });
   });
 }


### PR DESCRIPTION
## Summary

Reverts #11084 (`75e4e1789d`), which added `CaptureController.onRecordingDeviceDisconnected()` and the `DeviceProvider` hook that starts a **phone-mic batch recording whenever the wearable disconnects mid-session**.

## Why

**This behaviour was already reviewed and rejected.** #11066 proposed the same phone-side fallback and received `CHANGES_REQUESTED` from the app maintainer:

> The tagged issue actually means recording on the device offline when not connected to bluetooth. Right now it does record offline but it breaks sometimes. This PR is not the right fix for this

#11066 was closed, and #11078 was opened specifically so a phone-side fallback could be scoped on its own merits. **#11078 is still open and unapproved.**

**The PR description did not match its diff.** #11084 is titled "preserve on-device offline batch across BLE disconnect" and its body states it "prevents the phone-mic fallback from triggering". Before #11084 there was no such fallback to prevent: `onRecordingDeviceDisconnected` did not exist and nothing called it, and `_startPhoneMicBatch` was reachable only from user-initiated paths. The PR introduced the feature together with a guard for it; the Implementation section listed neither the new method nor the `device_provider.dart` call site.

**The guard does not cover Omi hardware.** It reads:

```dart
final bool isOnDeviceOfflineBatchActive = SharedPreferencesUtil().batchModeEnabled &&
    _recordingDevice != null &&
    (_recordingDevice!.type == DeviceType.limitless || _offlineSessionStartSeconds != 0);
```

It consults `batchModeEnabled`, but ring-buffer capture is keyed on firmware (`WalSyncs.isRingBufferFirmware`, 3.0.20+) and is independent of that pref. With batch mode off, an Omi on 3.0.20+ keeps writing to its on-device ring while the phone starts its own mic batch — the same interval is captured twice and syncs as duplicate conversations, plus an unrequested mic activation and the battery cost.

#11084 did address the technical review notes from #11066 (`deviceRecord` state, awaited stop hand-off, `deviceSupportsTranscribeLater`). The product objection was not addressed.

## Scope

Revert only. #11064 and #11085 from the same batch are left in place — #11064 is a genuine sort fix, and #11085 needs a real fix rather than a revert (its `filterFullySyncedConversations` never releases a WAL retired to `WalStatus.outsideRecoveryWindow` by #10995, so those conversations stay filtered out of the synced list; tracked separately).

#7194 remains open on its actual subject: on-device offline recording that works but is flaky across disconnects.

## Verification

```
flutter analyze lib/services/capture/capture_controller.dart lib/utils/batch_recording.dart \
  lib/providers/device_provider.dart test/unit/batch_recording_phone_test.dart
  -> 1 info (unnecessary_import at device_provider.dart:4), confirmed pre-existing on main; 0 new

flutter test test/unit/batch_recording_phone_test.dart test/providers/capture_provider_test.dart \
  test/providers/sync_provider_fully_synced_conversations_test.dart \
  test/unit/synced_conversation_pointer_order_test.dart
  -> 89 tests, all passed

grep shouldFallbackToPhoneOnDeviceDisconnect | onRecordingDeviceDisconnected |
     isRecordingDuringDeviceDisconnect | _phoneMicBatchStopCompleter
  -> no matches remain under app/

make preflight -> 11 checks passed
```

Clean revert: no later commit touched `capture_controller.dart`, `batch_recording.dart`, `device_provider.dart`, or `batch_recording_phone_test.dart` between #11084 and `84e4c1828b`.

## Product invariants affected

none

## Failure class (fixes)

No `fix:` commits; no declaration required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

