### PR TITLE
fix(ci): preserve reconciler Cloud Run job arguments

### DIFF
--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -100,6 +100,7 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
         "DESKTOP_BACKEND_TRAFFIC_MUTATION_ATTEMPTED=true",
         "failure() && env.DESKTOP_BACKEND_TRAFFIC_MUTATION_ATTEMPTED == 'true'",
         "rollback verification found",
+        "extract_single_cloud_run_traffic_revision.py",
         "Upload desktop backend acceptance evidence",
     )
     for fragment in required:
@@ -143,6 +144,11 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             workflow=workflow,
         )
     )
+    # Static workflow tripwire: deploy-cloudrun's parseFlags splits an unquoted
+    # --args=-m,... token, making Python treat -m as a gcloud flag instead of a
+    # container argument.  The quoted full token preserves the intended argv.
+    if "'--args=-m,jobs.agent_vm_reconciler'" not in text:
+        errors.append(f"{workflow}: Agent VM reconciler Python module argument must remain action-parser-safe")
 
     if production:
         for fragment in (
@@ -252,6 +258,8 @@ def validate_recovery_workflow(text: str) -> list[str]:
         "group: desktop-backend-prod",
         "cancel-in-progress: false",
         "environment: prod",
+        "Checkout recovery controls",
+        "actions/checkout@v7",
         "recover-desktop-backend-prod",
         "serving.knative.dev/service",
         'ready.get("status") != "True"',
@@ -263,6 +271,7 @@ def validate_recovery_workflow(text: str) -> list[str]:
         "recovered-desktop-backend-health.json",
         "jq -e",
         "recovery rollback found",
+        "extract_single_cloud_run_traffic_revision.py",
     ):
         if fragment not in text:
             errors.append(f"desktop_backend_recover_prod.yml: missing recovery guard {fragment!r}")

--- a/.github/scripts/extract_single_cloud_run_traffic_revision.py
+++ b/.github/scripts/extract_single_cloud_run_traffic_revision.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Print the sole 100%-traffic Cloud Run revision from a service document."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def extract_single_serving_revision(service: dict[str, Any]) -> str:
+    traffic = service.get("status", {}).get("traffic", [])
+    if not isinstance(traffic, list):
+        raise ValueError("Cloud Run service status.traffic must be a list")
+    revisions = [
+        entry.get("revisionName")
+        for entry in traffic
+        if isinstance(entry, dict) and entry.get("percent") == 100 and isinstance(entry.get("revisionName"), str)
+    ]
+    if len(revisions) != 1:
+        raise ValueError(f"expected exactly one 100% Cloud Run revision, found {revisions!r}")
+    return revisions[0]
+
+
+def main() -> int:
+    try:
+        service = json.load(sys.stdin)
+        if not isinstance(service, dict):
+            raise ValueError("Cloud Run service document must be an object")
+        print(extract_single_serving_revision(service))
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"Cloud Run traffic revision contract: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -238,6 +238,13 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         errors = POLICY.validate_desktop_release_gates(mutated, self.stable)
         self.assertTrue(any("desktop_qualify_beta.yml" in error for error in errors), errors)
 
+    def test_rejects_an_agent_vm_job_argument_that_deploy_cloudrun_would_split(self) -> None:
+        mutated = self.dev.replace("'--args=-m,jobs.agent_vm_reconciler'", "--args=-m,jobs.agent_vm_reconciler", 1)
+
+        errors = POLICY.validate_deploy_workflow(mutated, production=False)
+
+        self.assertTrue(any("action-parser-safe" in error for error in errors), errors)
+
     def test_rejects_beta_qualification_without_development_python_health(self) -> None:
         mutated = self.qualification.replace(
             "https://api.omiapi.com/v1/health",
@@ -293,6 +300,13 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         errors = POLICY.validate_recovery_workflow(mutated)
         self.assertTrue(any("manual traffic-only" in error for error in errors), errors)
         self.assertTrue(any("Ready" in error or "ready" in error for error in errors), errors)
+
+    def test_recovery_requires_checked_out_controls_for_traffic_verification(self) -> None:
+        mutated = self.recovery.replace("      - name: Checkout recovery controls\n        uses: actions/checkout@v7\n\n", "", 1)
+
+        errors = POLICY.validate_recovery_workflow(mutated)
+
+        self.assertTrue(any("Checkout recovery controls" in error for error in errors), errors)
 
     def test_rejects_workflow_chat_contract_drift(self) -> None:
         mutated = self.dev.replace("CHAT_CONTRACT_VERSION: '1'", "CHAT_CONTRACT_VERSION: '2'")

--- a/.github/scripts/test_extract_single_cloud_run_traffic_revision.py
+++ b/.github/scripts/test_extract_single_cloud_run_traffic_revision.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("extract_single_cloud_run_traffic_revision.py")
+SPEC = importlib.util.spec_from_file_location("cloud_run_traffic_revision", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ExtractSingleCloudRunTrafficRevisionTests(unittest.TestCase):
+    def test_returns_the_unique_serving_revision_despite_zero_traffic_tags(self) -> None:
+        service = {
+            "status": {
+                "traffic": [
+                    {"percent": 0, "revisionName": "candidate", "tag": "candidate"},
+                    {"percent": 100, "revisionName": "stable"},
+                ]
+            }
+        }
+
+        self.assertEqual(MODULE.extract_single_serving_revision(service), "stable")
+
+    def test_rejects_missing_or_ambiguous_serving_revision(self) -> None:
+        for traffic in ([], [{"percent": 50, "revisionName": "one"}, {"percent": 50, "revisionName": "two"}]):
+            with self.subTest(traffic=traffic):
+                with self.assertRaisesRegex(ValueError, "exactly one"):
+                    MODULE.extract_single_serving_revision({"status": {"traffic": traffic}})

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/desktop_backend_auto_dev.yml'
       - '.github/scripts/desktop_backend_candidate_probe.py'
       - '.github/scripts/verify_desktop_backend_image_lineage.py'
+      - '.github/scripts/extract_single_cloud_run_traffic_revision.py'
       - 'backend/scripts/resolve_cloud_run_tagged_url.py'
       - 'backend/scripts/wait_cloud_run_candidate_readiness.py'
       - 'backend/scripts/firebase_release_probe_token.py'
@@ -490,7 +491,7 @@ jobs:
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}@${{ steps.build-image.outputs.digest }}
           flags: >-
             --command=python
-            --args=-m,jobs.agent_vm_reconciler
+            '--args=-m,jobs.agent_vm_reconciler'
             --max-retries=0
             --task-timeout=3600s
             --service-account=agent-vm-reconciler@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
@@ -586,7 +587,7 @@ jobs:
           restored_revision="$(gcloud run services describe "$SERVICE" \
             --project="$PROJECT_ID" \
             --region="$REGION" \
-            --format='value(status.traffic[percent=100].revisionName)')"
+            --format=json | python3 .github/scripts/extract_single_cloud_run_traffic_revision.py)"
           if [[ "$restored_revision" != "$PREVIOUS_REVISION" ]]; then
             echo "ERROR: rollback verification found $restored_revision, expected $PREVIOUS_REVISION." >&2
             exit 1

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -547,7 +547,7 @@ jobs:
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}@${{ steps.build-image.outputs.digest }}
           flags: >-
             --command=python
-            --args=-m,jobs.agent_vm_reconciler
+            '--args=-m,jobs.agent_vm_reconciler'
             --max-retries=0
             --task-timeout=3600s
             --service-account=agent-vm-reconciler@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
@@ -641,7 +641,7 @@ jobs:
           restored_revision="$(gcloud run services describe "$SERVICE" \
             --project="$PROJECT_ID" \
             --region="$REGION" \
-            --format='value(status.traffic[percent=100].revisionName)')"
+            --format=json | python3 .github/scripts/extract_single_cloud_run_traffic_revision.py)"
           if [[ "$restored_revision" != "$PREVIOUS_REVISION" ]]; then
             echo "ERROR: rollback verification found $restored_revision, expected $PREVIOUS_REVISION." >&2
             exit 1

--- a/.github/workflows/desktop_backend_recover_prod.yml
+++ b/.github/workflows/desktop_backend_recover_prod.yml
@@ -31,6 +31,9 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout recovery controls
+        uses: actions/checkout@v7
+
       - name: Google Auth
         uses: google-github-actions/auth@v3
         with:
@@ -130,7 +133,7 @@ jobs:
           serving_revision="$(gcloud run services describe "$SERVICE" \
             --project="$PROJECT_ID" \
             --region="$REGION" \
-            --format='value(status.traffic[percent=100].revisionName)')"
+            --format=json | python3 .github/scripts/extract_single_cloud_run_traffic_revision.py)"
           if [[ "$serving_revision" != "$REVISION" ]]; then
             echo "ERROR: serving revision is $serving_revision, expected $REVISION." >&2
             exit 1
@@ -166,7 +169,7 @@ jobs:
           restored_revision="$(gcloud run services describe "$SERVICE" \
             --project="$PROJECT_ID" \
             --region="$REGION" \
-            --format='value(status.traffic[percent=100].revisionName)')"
+            --format=json | python3 .github/scripts/extract_single_cloud_run_traffic_revision.py)"
           if [[ "$restored_revision" != "$PREVIOUS_REVISION" ]]; then
             echo "ERROR: recovery rollback found $restored_revision, expected $PREVIOUS_REVISION." >&2
             exit 1


### PR DESCRIPTION
## Summary

- Preserve the Agent VM reconciler's Python `-m jobs.agent_vm_reconciler` argument as one Cloud Run deploy argument when `deploy-cloudrun` parses workflow flags.
- Make desktop-backend traffic rollback verification read and require the sole 100%-traffic revision, including the production recovery workflow.

## Failure class

Failure-Class: FC-agent-vm-bootstrap-contract

## Validation

- `python3 .github/scripts/test_extract_single_cloud_run_traffic_revision.py`
- `python3 .github/scripts/test_check_desktop_backend_release_policy.py`
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py -q`
- Parsed all modified workflows with PyYAML and verified the exact `deploy-cloudrun` parser contract for the quoted argument token.

## Rollout

Merging this PR retriggers the development desktop-backend deploy. The existing release pointer remains unchanged until the reconciler Cloud Run Job deploys successfully; no production workflow is dispatched by this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

