### PR TITLE
fix(desktop): restore Conversations in legacy Home UI

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 1998,
-    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1885,
+    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1884,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3558,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4463,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3630,

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1778,11 +1778,10 @@ private struct PageContentView: View {
           taskChatCoordinator: viewModelContainer.taskChatCoordinator,
           selectedIndex: $selectedTabIndex)
       case 1:
-        MemoryHubPage(
+        ConversationsDestinationView(
           appState: appState,
           viewModelContainer: viewModelContainer,
-          memoriesViewModel: viewModelContainer.memoriesViewModel,
-          destinationRawValue: $memoryDestinationRawValue
+          memoryDestinationRawValue: $memoryDestinationRawValue
         )
       case 2:
         ChatPage(

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -9,6 +9,11 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
   case conversations
   case brainMap
 
+  enum Presentation: Equatable {
+    case standaloneConversations
+    case memoryHub
+  }
+
   var id: Int { rawValue }
 
   var title: String {
@@ -49,6 +54,19 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
       memoryDestinationRawValue = destination.rawValue
     }
     selectedIndex = item.rawValue
+  }
+
+  /// The legacy sidebar has separate Conversations and Memories destinations.
+  /// The modern top bar uses the same rail index as a Memory hub, so keep that
+  /// shared index from replacing the old standalone Conversations page.
+  static func presentation(
+    for sidebarItem: SidebarNavItem,
+    useLegacyHomeDesign: Bool
+  ) -> Presentation {
+    if useLegacyHomeDesign, sidebarItem == .conversations {
+      return .standaloneConversations
+    }
+    return .memoryHub
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ConversationsDestinationView: View {
+  let appState: AppState
+  let viewModelContainer: ViewModelContainer
+  @Binding var memoryDestinationRawValue: Int
+  @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
+
+  var body: some View {
+    switch MemoryHubDestination.presentation(
+      for: .conversations,
+      useLegacyHomeDesign: useLegacyHomeDesign
+    ) {
+    case .standaloneConversations:
+      ConversationsPageHost(appState: appState)
+    case .memoryHub:
+      MemoryHubPage(
+        appState: appState,
+        viewModelContainer: viewModelContainer,
+        memoriesViewModel: viewModelContainer.memoriesViewModel,
+        destinationRawValue: $memoryDestinationRawValue
+      )
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/MemoryHubSidebarRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryHubSidebarRoutingTests.swift
@@ -30,4 +30,24 @@ final class MemoryHubSidebarRoutingTests: XCTestCase {
     XCTAssertEqual(selectedIndex, SidebarNavItem.tasks.rawValue)
     XCTAssertEqual(memoryDestinationRawValue, MemoryHubDestination.conversations.rawValue)
   }
+
+  func testLegacyHomeDesignKeepsConversationsAsAStandalonePage() {
+    XCTAssertEqual(
+      MemoryHubDestination.presentation(
+        for: .conversations,
+        useLegacyHomeDesign: true
+      ),
+      .standaloneConversations
+    )
+  }
+
+  func testModernHomeDesignUsesTheMemoryHubForTheSharedRailIndex() {
+    XCTAssertEqual(
+      MemoryHubDestination.presentation(
+        for: .conversations,
+        useLegacyHomeDesign: false
+      ),
+      .memoryHub
+    )
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260805-restore-legacy-conversations.json
+++ b/desktop/macos/changelog/unreleased/20260805-restore-legacy-conversations.json
@@ -1,0 +1,3 @@
+{
+  "change": "Restored the Conversations tab in the old Home design"
+}

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -8,6 +8,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
   - desktop/macos/Desktop/Sources/MainWindow/EscapeKeyHandler.swift
 preconditions:
@@ -85,3 +86,10 @@ steps:
     expect:
       text_visible:
         - Home
+
+  - id: S9
+    name: Verify legacy Home Conversations tab
+    do: "In Settings > Advanced, enable Use old Home design, return to Home, and verify the left sidebar shows Conversations as a separate destination from Memories. Click Conversations."
+    expect:
+      text_visible:
+        - Conversations


### PR DESCRIPTION
## Summary

- Restore the standalone Conversations page when the macOS “Use old Home design” setting is enabled.
- Keep the modern shell’s Memory Hub routing unchanged.
- Add regression coverage and a desktop changelog entry.

## Root cause

The navigation simplification changed the shared rail index used by Conversations to render `MemoryHubPage`. A later routing fix correctly preserved the modern hub destination, but the legacy sidebar continued to use that shared page instead of the established standalone `ConversationsPageHost`.

## Invariants

- `INV-NAV-1` — legacy and modern navigation must route to the established full-feature Conversations owner.

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter MemoryHubSidebarRoutingTests` — 4 passed.
- `python3 scripts/check_desktop_test_quality.py` — passed.
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/MainWindow/MemoryHubDestination.swift Desktop/Sources/MainWindow/DesktopHomeView.swift Desktop/Tests/MemoryHubSidebarRoutingTests.swift` — passed.
- `python3 scripts/check-e2e-flow-coverage.py --base origin/main --strict` and `python3 scripts/desktop-flow-lint.py` — passed; the navigation flow now covers the legacy sidebar path.
- Named bundle build/run with `OMI_APP_NAME=omi-conversation-restore` — built, signed ad hoc, installed, and launched successfully; the automation state confirmed `usesLegacyHomeDesign=true` and `showsPrimarySidebar=true`. Authenticated click-through was unavailable because the local Omi Dev seed is signed out.
- `OMI_PR_BODY_FILE=/tmp/omi-restore-legacy-conversations-pr-body.md make preflight` — passed (20 checks).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

