### PR TITLE
fix(agent-vm): grant reconciler deployer actAs

### DIFF
--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -9,8 +9,13 @@ fi
 
 project="${AGENT_VM_RECONCILER_PROJECT:-}"
 bucket="${AGENT_VM_RECONCILER_BUCKET:-}"
-if [[ -z "$project" || -z "$bucket" ]]; then
-  echo "AGENT_VM_RECONCILER_PROJECT and AGENT_VM_RECONCILER_BUCKET are required." >&2
+deployer="${AGENT_VM_RECONCILER_DEPLOYER:-}"
+if [[ -z "$project" || -z "$bucket" || -z "$deployer" ]]; then
+  echo "AGENT_VM_RECONCILER_PROJECT, AGENT_VM_RECONCILER_BUCKET, and AGENT_VM_RECONCILER_DEPLOYER are required." >&2
+  exit 2
+fi
+if [[ "$deployer" != *@*.iam.gserviceaccount.com ]]; then
+  echo "AGENT_VM_RECONCILER_DEPLOYER must be a full Google service-account email." >&2
   exit 2
 fi
 
@@ -27,6 +32,11 @@ zone="us-central1-a"
 if ! gcloud iam service-accounts describe "$gsa" --project="$project" >/dev/null 2>&1; then
   gcloud iam service-accounts create "$gsa_name" --project="$project" --display-name="Omi Agent VM reconciler"
 fi
+# The CI deploy identity needs actAs only on this dedicated runtime identity to
+# attach it to the Cloud Run Job. Do not grant Service Account User at project
+# scope: that would let the deployer impersonate unrelated service accounts.
+gcloud iam service-accounts add-iam-policy-binding "$gsa" --project="$project" \
+  --member="serviceAccount:${deployer}" --role=roles/iam.serviceAccountUser
 if gcloud iam roles describe "$role_id" --project="$project" >/dev/null 2>&1; then
   gcloud iam roles update "$role_id" --project="$project" --title="Omi Agent VM reconciler" --permissions="$permissions" --stage=GA
 else

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -14,7 +14,7 @@ if [[ -z "$project" || -z "$bucket" || -z "$deployer" ]]; then
   echo "AGENT_VM_RECONCILER_PROJECT, AGENT_VM_RECONCILER_BUCKET, and AGENT_VM_RECONCILER_DEPLOYER are required." >&2
   exit 2
 fi
-if [[ "$deployer" != *@*.iam.gserviceaccount.com ]]; then
+if [[ ! "$deployer" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$ ]]; then
   echo "AGENT_VM_RECONCILER_DEPLOYER must be a full Google service-account email." >&2
   exit 2
 fi

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -110,6 +110,7 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         "AGENT_VM_RECONCILER_IAM_APPLY": "1",
         "AGENT_VM_RECONCILER_PROJECT": "based-hardware-dev",
         "AGENT_VM_RECONCILER_BUCKET": "based-hardware-dev-agent",
+        "AGENT_VM_RECONCILER_DEPLOYER": "",
     }
 
     missing_deployer = subprocess.run(
@@ -123,6 +124,21 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert missing_deployer.returncode == 2
     assert "AGENT_VM_RECONCILER_DEPLOYER" in missing_deployer.stderr
     assert not command_log.exists(), "the missing-input guard must run before any gcloud mutation"
+
+    malformed_deployer = subprocess.run(
+        ["bash", "backend/scripts/apply-agent-vm-reconciler-iam.sh"],
+        cwd=REPO_DIR,
+        env={
+            **base_env,
+            "AGENT_VM_RECONCILER_DEPLOYER": "not-an-email",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert malformed_deployer.returncode == 2
+    assert "AGENT_VM_RECONCILER_DEPLOYER must be a full Google service-account email." in malformed_deployer.stderr
+    assert not command_log.exists(), "invalid deployer input must be rejected before any gcloud mutation"
 
     completed = subprocess.run(
         ["bash", "backend/scripts/apply-agent-vm-reconciler-iam.sh"],

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -1,5 +1,7 @@
 import importlib.util
+import os
 from pathlib import Path
+import subprocess
 
 import pytest
 
@@ -73,7 +75,7 @@ def test_scheduler_apply_resumes_existing_trigger_then_validates_exact_contract(
     assert "--scheduler-service-account \"$scheduler_sa\"" in script
 
 
-def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped():
+def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(tmp_path):
     script = _read("backend/scripts/apply-agent-vm-reconciler-iam.sh")
 
     assert 'AGENT_VM_RECONCILER_IAM_APPLY:-}' in script
@@ -89,6 +91,59 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped()
     assert "instances/omi-agent-" in script
     assert "roles/storage.objectViewer" in script
     assert "roles/iam.serviceAccountUser" in script
+    assert 'AGENT_VM_RECONCILER_DEPLOYER:-}' in script
+    assert "AGENT_VM_RECONCILER_DEPLOYER must be a full Google service-account email." in script
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "gcloud.log"
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n" "printf '%s\\n' \"$*\" >> \"$FAKE_GCLOUD_LOG\"\n",
+        encoding="utf-8",
+    )
+    fake_gcloud.chmod(0o755)
+    base_env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_GCLOUD_LOG": str(command_log),
+        "AGENT_VM_RECONCILER_IAM_APPLY": "1",
+        "AGENT_VM_RECONCILER_PROJECT": "based-hardware-dev",
+        "AGENT_VM_RECONCILER_BUCKET": "based-hardware-dev-agent",
+    }
+
+    missing_deployer = subprocess.run(
+        ["bash", "backend/scripts/apply-agent-vm-reconciler-iam.sh"],
+        cwd=REPO_DIR,
+        env=base_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert missing_deployer.returncode == 2
+    assert "AGENT_VM_RECONCILER_DEPLOYER" in missing_deployer.stderr
+    assert not command_log.exists(), "the missing-input guard must run before any gcloud mutation"
+
+    completed = subprocess.run(
+        ["bash", "backend/scripts/apply-agent-vm-reconciler-iam.sh"],
+        cwd=REPO_DIR,
+        env={
+            **base_env,
+            "AGENT_VM_RECONCILER_DEPLOYER": "local-development-joan@based-hardware-dev.iam.gserviceaccount.com",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    commands = command_log.read_text(encoding="utf-8")
+    assert (
+        "iam service-accounts add-iam-policy-binding "
+        "agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
+        "--project=based-hardware-dev "
+        "--member=serviceAccount:local-development-joan@based-hardware-dev.iam.gserviceaccount.com "
+        "--role=roles/iam.serviceAccountUser"
+    ) in commands
 
 
 def test_revoke_script_removes_all_conditional_bindings_and_verifies_absence():

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -41,9 +41,23 @@ path with the exact image reference before the fleet can converge.
 
 ## Installation order
 
-Deploy Agent Proxy with session leases first. Deploy the desktop backend and
-provision the dedicated job identity, deploy the job, then install the
-Scheduler trigger using the refuse-by-default helpers:
+Deploy Agent Proxy with session leases first. Before the desktop-backend
+deployment, provision the dedicated job identity and grant the environment's
+CI deploy service account permission to attach exactly that identity to the
+Cloud Run Job. The helper refuses to infer the deployer or grant project-wide
+Service Account User:
+
+```bash
+AGENT_VM_RECONCILER_IAM_APPLY=1 \
+AGENT_VM_RECONCILER_PROJECT=based-hardware-dev \
+AGENT_VM_RECONCILER_BUCKET=based-hardware-dev-agent \
+AGENT_VM_RECONCILER_DEPLOYER=local-development-joan@based-hardware-dev.iam.gserviceaccount.com \
+bash backend/scripts/apply-agent-vm-reconciler-iam.sh
+```
+
+Use the corresponding CI deploy service account and bucket in each environment.
+Then deploy the desktop backend (which creates or updates the Job), and install
+the Scheduler trigger only after the Agent Proxy lease check succeeds:
 
 ```bash
 AGENT_VM_RECONCILER_SCHEDULER_APPLY=1 \
@@ -59,8 +73,11 @@ when absent and grants it `roles/run.invoker` on the named Cloud Run Job. The
 job identity is provisioned per environment with
 `backend/scripts/apply-agent-vm-reconciler-iam.sh`; it receives Firestore
 read/write, bucket object-read, and condition-scoped Agent VM Compute lifecycle
-permissions. The reconciler job uses its attached identity and Application
-Default Credentials; it does not mount the desktop backend's Firebase key.
+permissions. The CI deploy identity receives `roles/iam.serviceAccountUser`
+only on that reconciler identity, so it can deploy the Job without being able
+to attach unrelated service accounts. The reconciler job uses its attached
+identity and Application Default Credentials; it does not mount the desktop
+backend's Firebase key.
 Validate the installed trigger with
 `backend/scripts/validate_agent_vm_reconciler_scheduler.py` before the first
 live execution.


### PR DESCRIPTION
## Summary

- grant the explicitly supplied CI deploy service account `actAs` only on the dedicated Agent VM reconciler runtime identity
- refuse the IAM bootstrap before any `gcloud` invocation when that deployer identity is missing or malformed
- document the required installation order and validate the exact IAM binding behaviorally

Failure-Class: FC-agent-vm-bootstrap-contract

## Validation

- `python -m pytest backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py -q`
- `bash -n backend/scripts/apply-agent-vm-reconciler-iam.sh`
- `git diff --check`

## Dev rollout

After this merges, authenticate locally and run the refuse-by-default helper only for `based-hardware-dev`, using the deploy identity reported by the failed dev deployment. Re-run the automatic development deployment; do not change production IAM or deploy production.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

