### PR TITLE
fix(backend): pass profile name into summarization-app transcripts (#5319)

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "backend/utils/apps.py": 1652,
-    "backend/utils/conversations/process_conversation.py": 1971,
+    "backend/utils/conversations/process_conversation.py": 1970,
     "backend/utils/memory/canonical_consolidation.py": 1935,
     "backend/utils/memory/canonical_memory_adapter.py": 2037,
     "backend/utils/memory/legacy_backfill.py": 1758,

--- a/backend/tests/unit/test_summary_transcript_user_name.py
+++ b/backend/tests/unit/test_summary_transcript_user_name.py
@@ -1,0 +1,36 @@
+"""#5319 — LLM transcript rendering must use the configured profile name."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.conversations.transcript_for_llm import conversation_transcript_for_llm
+
+
+def test_conversation_transcript_for_llm_passes_configured_name(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "utils.conversations.transcript_for_llm.get_user_name",
+        lambda uid, use_default=False: "Stephen",
+    )
+    conversation = MagicMock()
+    conversation.get_transcript.return_value = "Stephen: Hello.\n\nSpeaker 1: Hi."
+    people = [MagicMock()]
+
+    rendered = conversation_transcript_for_llm("uid-1", conversation, people)
+
+    conversation.get_transcript.assert_called_once_with(False, people=people, user_name="Stephen")
+    assert rendered.startswith("Stephen:")
+
+
+def test_conversation_transcript_for_llm_forwards_missing_name(monkeypatch: pytest.MonkeyPatch):
+    """When no profile name exists, forward None so segments_as_string keeps its 'User' fallback."""
+    monkeypatch.setattr(
+        "utils.conversations.transcript_for_llm.get_user_name",
+        lambda uid, use_default=False: None,
+    )
+    conversation = MagicMock()
+    conversation.get_transcript.return_value = "User: Hello."
+
+    conversation_transcript_for_llm("uid-1", conversation, people=None, include_timestamps=True)
+
+    conversation.get_transcript.assert_called_once_with(True, people=None, user_name=None)

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 import database._client as db_client_module
 from database import redis_db
 from database.auth import get_user_name
+from utils.conversations.transcript_for_llm import conversation_transcript_for_llm
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.notifications as notification_db
@@ -259,8 +260,7 @@ def _get_structured(
             raise HTTPException(status_code=400, detail=f'Invalid conversation source: {ext_conv.text_source}')
 
         main_conv = cast(Union[Conversation, CreateConversation], conversation)
-        user_name = get_user_name(uid, use_default=False)
-        transcript_text = main_conv.get_transcript(False, people=people, user_name=user_name)  # type: ignore[reportArgumentType]  # conversation.py reverted to main; people/user_name may be Optional
+        transcript_text = conversation_transcript_for_llm(uid, main_conv, people)
 
         # For re-processing, we don't discard, just re-structure.
         if force_process:
@@ -490,9 +490,8 @@ def _trigger_apps(
 
     def execute_app(app: App) -> None:
         with track_usage(uid, Features.CONVERSATION_APPS):
-            result = get_app_result(
-                conversation.get_transcript(False, people=people), conversation.photos, app, language_code=language_code  # type: ignore[reportArgumentType]  # conversation.py reverted to main; people/user_name may be Optional
-            ).strip()
+            transcript = conversation_transcript_for_llm(uid, conversation, people)
+            result = get_app_result(transcript, conversation.photos, app, language_code=language_code).strip()
         conversation.apps_results.append(AppResult(app_id=app.id, content=result))
         if not is_reprocess:
             record_app_usage(uid, app.id, UsageHistoryType.memory_created_prompt, conversation_id=conversation.id)

--- a/backend/utils/conversations/transcript_for_llm.py
+++ b/backend/utils/conversations/transcript_for_llm.py
@@ -1,0 +1,32 @@
+"""Render conversation transcripts for LLM prompts with the configured user name.
+
+#5319: ``TranscriptSegment.segments_as_string`` defaults missing ``user_name`` to
+``"User"``. Callers that feed transcripts into summary / summarization-app LLMs
+must pass the profile name from ``get_user_name`` so the model never sees the
+generic label when the user has configured one.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Protocol
+
+from database.auth import get_user_name
+from models.other import Person
+
+
+class _TranscriptSource(Protocol):
+    def get_transcript(
+        self, include_timestamps: bool, people: Optional[List[Person]] = None, user_name: Optional[str] = None
+    ) -> str: ...
+
+
+def conversation_transcript_for_llm(
+    uid: str,
+    conversation: _TranscriptSource,
+    people: Optional[List[Person]] = None,
+    *,
+    include_timestamps: bool = False,
+) -> str:
+    """Build a transcript string for LLM prompts using the user's configured name."""
+    user_name = get_user_name(uid, use_default=False)
+    return conversation.get_transcript(include_timestamps, people=people, user_name=user_name)


### PR DESCRIPTION
## What changed and why

#7751 already fixed structured summary generation (`_get_structured`) so the transcript uses `get_user_name`. Summarization apps in `_trigger_apps` still called `get_transcript` without `user_name`, so app-generated summaries could still say **"User"**. Shared `conversation_transcript_for_llm` wires both surfaces. Fixes #5319.

## Product invariants affected

none

## How it was verified

```bash
cd backend && python3 -m pytest \
  tests/unit/test_summary_transcript_user_name.py \
  tests/unit/test_transcript_segment.py::test_segments_as_string_uses_configured_user_name \
  tests/unit/test_transcript_segment.py::test_segments_as_string_defaults_to_user_when_name_missing -q
# 4 passed
```

## Tests

- `test_summary_transcript_user_name.py` — helper forwards configured name / None
- Existing #5319 `segments_as_string` tests still green

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

n/a

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

