### PR TITLE
fix(app): navigate from FCM background/terminated notification taps (#5126)

### DIFF
--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:isolate';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:awesome_notifications/awesome_notifications.dart';

--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:isolate';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:awesome_notifications/awesome_notifications.dart';
@@ -57,12 +59,13 @@ class NotificationUtil {
     if (receivedAction.payload == null || receivedAction.payload!.isEmpty) {
       return;
     }
-    _handleAppLinkOrDeepLink(receivedAction.payload!);
+    await _handleAppLinkOrDeepLink(receivedAction.payload!);
   }
 
   /// Public entry for FCM background/terminated notification taps (#5126).
   static void handleNavigateTo(String route) {
-    _handleAppLinkOrDeepLink({'navigate_to': route});
+    // Fire-and-forget: waits for navigator readiness before pushing (terminated cold start).
+    unawaited(_handleAppLinkOrDeepLink({'navigate_to': route}));
   }
 
   /// Extract a chat/conversation deep-link from an FCM data map.
@@ -75,19 +78,45 @@ class NotificationUtil {
     return null;
   }
 
-  static void _handleAppLinkOrDeepLink(Map<String, dynamic> payload) async {
+  /// Poll until [read] returns non-null, or [timeout] elapses.
+  ///
+  /// Used so terminated-state FCM taps (`getInitialMessage`) that resolve before
+  /// `runApp` attach the navigator do not silently no-op (#5126; same class of
+  /// race as app_links cold-start in `app_shell` / #4763).
+  @visibleForTesting
+  static Future<T?> waitUntilNonNull<T>(
+    T? Function() read, {
+    Duration timeout = const Duration(seconds: 15),
+    Duration pollInterval = const Duration(milliseconds: 16),
+  }) async {
+    final existing = read();
+    if (existing != null) return existing;
+
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(pollInterval);
+      final value = read();
+      if (value != null) return value;
+    }
+    return null;
+  }
+
+  static Future<void> _handleAppLinkOrDeepLink(Map<String, dynamic> payload) async {
     WidgetsFlutterBinding.ensureInitialized();
 
-    String? navigateTo;
-    if (payload.containsKey('navigate_to')) {
-      navigateTo = payload['navigate_to'];
-    }
-    if (navigateTo == null) {
-      Logger.debug("Navigate To is null");
+    final navigateTo = payload['navigate_to'];
+    if (navigateTo is! String || navigateTo.isEmpty) {
+      Logger.debug('Navigate To is null');
       return;
     }
 
-    globalNavigatorKey.currentState?.pushReplacement(
+    final navigator = await waitUntilNonNull(() => globalNavigatorKey.currentState);
+    if (navigator == null) {
+      Logger.debug('Navigator unavailable; dropping navigate_to=$navigateTo');
+      return;
+    }
+
+    navigator.pushReplacement(
       MaterialPageRoute(builder: (context) => HomePageWrapper(navigateToRoute: navigateTo)),
     );
   }

--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -60,6 +60,21 @@ class NotificationUtil {
     _handleAppLinkOrDeepLink(receivedAction.payload!);
   }
 
+  /// Public entry for FCM background/terminated notification taps (#5126).
+  static void handleNavigateTo(String route) {
+    _handleAppLinkOrDeepLink({'navigate_to': route});
+  }
+
+  /// Extract a chat/conversation deep-link from an FCM data map.
+  /// Returns null when `navigate_to` is missing, empty, or not a String.
+  static String? navigateToFromFcmData(Map<String, dynamic> data) {
+    final navigateTo = data['navigate_to'];
+    if (navigateTo is String && navigateTo.isNotEmpty) {
+      return navigateTo;
+    }
+    return null;
+  }
+
   static void _handleAppLinkOrDeepLink(Map<String, dynamic> payload) async {
     WidgetsFlutterBinding.ensureInitialized();
 

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -12,6 +12,7 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 
 import 'package:omi/backend/http/api/notifications.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/services/notifications.dart' show NotificationUtil;
 import 'package:omi/services/notifications/action_item_notification_handler.dart';
 import 'package:omi/services/notifications/important_conversation_notification_handler.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
@@ -261,6 +262,20 @@ class _FCMNotificationService implements NotificationInterface {
         return;
       }
     });
+
+    void handleNotificationTap(RemoteMessage? message) {
+      if (message == null) return;
+      final navigateTo = NotificationUtil.navigateToFromFcmData(message.data);
+      if (navigateTo != null) {
+        NotificationUtil.handleNavigateTo(navigateTo);
+      }
+    }
+
+    // Background: app is backgrounded and the user taps a push notification (#5126).
+    FirebaseMessaging.onMessageOpenedApp.listen(handleNotificationTap);
+
+    // Terminated: app was killed and opened via notification tap (#5126).
+    FirebaseMessaging.instance.getInitialMessage().then(handleNotificationTap);
   }
 
   final _serverMessageStreamController = StreamController<ServerMessage>.broadcast();

--- a/app/test/unit/notification_fcm_navigate_to_test.dart
+++ b/app/test/unit/notification_fcm_navigate_to_test.dart
@@ -21,4 +21,36 @@ void main() {
       expect(NotificationUtil.navigateToFromFcmData({'navigate_to': true}), isNull);
     });
   });
+
+  group('NotificationUtil.waitUntilNonNull (#5126 cold-start)', () {
+    test('returns immediately when value is already present', () async {
+      final result = await NotificationUtil.waitUntilNonNull(
+        () => 'ready',
+        timeout: const Duration(milliseconds: 50),
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      expect(result, 'ready');
+    });
+
+    test('resolves once the value appears after a delay', () async {
+      String? value;
+      Future<void>.delayed(const Duration(milliseconds: 30), () => value = 'ready');
+
+      final result = await NotificationUtil.waitUntilNonNull(
+        () => value,
+        timeout: const Duration(seconds: 1),
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      expect(result, 'ready');
+    });
+
+    test('returns null when the value never appears before timeout', () async {
+      final result = await NotificationUtil.waitUntilNonNull<String>(
+        () => null,
+        timeout: const Duration(milliseconds: 40),
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      expect(result, isNull);
+    });
+  });
 }

--- a/app/test/unit/notification_fcm_navigate_to_test.dart
+++ b/app/test/unit/notification_fcm_navigate_to_test.dart
@@ -5,20 +5,20 @@ import 'package:omi/services/notifications.dart';
 void main() {
   group('NotificationUtil.navigateToFromFcmData (#5126)', () {
     test('returns navigate_to when it is a non-empty String', () {
-      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': '/chat/omi'}), '/chat/omi');
+      expect(NotificationUtil.navigateToFromFcmData(const {'navigate_to': '/chat/omi'}), '/chat/omi');
     });
 
     test('returns null when navigate_to is missing', () {
-      expect(NotificationUtil.navigateToFromFcmData({'type': 'plugin'}), isNull);
+      expect(NotificationUtil.navigateToFromFcmData(const {'type': 'plugin'}), isNull);
     });
 
     test('returns null when navigate_to is empty', () {
-      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': ''}), isNull);
+      expect(NotificationUtil.navigateToFromFcmData(const {'navigate_to': ''}), isNull);
     });
 
     test('returns null when navigate_to is not a String', () {
-      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': 42}), isNull);
-      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': true}), isNull);
+      expect(NotificationUtil.navigateToFromFcmData(const {'navigate_to': 42}), isNull);
+      expect(NotificationUtil.navigateToFromFcmData(const {'navigate_to': true}), isNull);
     });
   });
 

--- a/app/test/unit/notification_fcm_navigate_to_test.dart
+++ b/app/test/unit/notification_fcm_navigate_to_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/notifications.dart';
+
+void main() {
+  group('NotificationUtil.navigateToFromFcmData (#5126)', () {
+    test('returns navigate_to when it is a non-empty String', () {
+      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': '/chat/omi'}), '/chat/omi');
+    });
+
+    test('returns null when navigate_to is missing', () {
+      expect(NotificationUtil.navigateToFromFcmData({'type': 'plugin'}), isNull);
+    });
+
+    test('returns null when navigate_to is empty', () {
+      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': ''}), isNull);
+    });
+
+    test('returns null when navigate_to is not a String', () {
+      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': 42}), isNull);
+      expect(NotificationUtil.navigateToFromFcmData({'navigate_to': true}), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

Tapping an Omi/plugin chat push from background or terminated state opened the last screen because `listenForMessages()` only handled foreground `onMessage`. Backend already sends `navigate_to` (e.g. `/chat/omi`). Register `onMessageOpenedApp` + `getInitialMessage`, and expose `NotificationUtil.handleNavigateTo`. Fixes #5126.

**Terminated cold-start harden:** `getInitialMessage` can resolve before `runApp` attaches `globalNavigatorKey`, so a bare `currentState?.pushReplacement` silently no-ops. `_handleAppLinkOrDeepLink` now polls via `waitUntilNonNull` until the navigator is ready (same race class as app_links in `app_shell` / #4763), then pushes.

Resurrects closed unmerged [#5127](https://github.com/BasedHardware/omi/pull/5127) with Gemini’s type-safe helper feedback applied.

## Product invariants affected

none

## How it was verified

```bash
cd app && flutter test test/unit/notification_fcm_navigate_to_test.dart
# 7 passed
```

Could not exercise a live FCM tap from background/terminated on a device in this environment; wiring matches FlutterFire’s documented handlers and the prior #5127 approach. Navigator-wait helper is unit-tested for immediate / delayed / timeout cases.

## Tests

`app/test/unit/notification_fcm_navigate_to_test.dart` — `navigateToFromFcmData` accepts non-empty String routes and rejects missing/empty/non-String values; `waitUntilNonNull` covers cold-start readiness polling.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

n/a