### PR TITLE
fix(app): correct Limitless flash timestamps for clock drift (#5734)

### DIFF
--- a/app/lib/services/devices/connectors/limitless_connection.dart
+++ b/app/lib/services/devices/connectors/limitless_connection.dart
@@ -18,6 +18,12 @@ class LimitlessDeviceConnection extends DeviceConnection {
   final _rawDataBuffer = <int>[];
   int? _firstFlashPageTimestampMs;
 
+  /// Pendant RTC minus phone wall clock (ms), measured from a Type-8 RX clock
+  /// notification before [SetCurrentTime]. Applied to flash-page timestamps so
+  /// batch uploads align with real-time conversations (#5734).
+  int? _clockDriftOffsetMs;
+  bool _timeSynced = false;
+
   // Fragment reassembly: index -> {seq -> payload}
   final Map<int, Map<int, List<int>>> _fragmentBuffer = {};
 
@@ -30,6 +36,10 @@ class LimitlessDeviceConnection extends DeviceConnection {
   bool _isReinitializing = false;
   bool _pendingReinit = false;
   bool _isBatchMode = false;
+
+  /// Drift of pendant RTC vs phone at connect, before forward clock sync.
+  /// Null when no Type-8 clock was observed (fail-open: no correction).
+  int? get clockDriftOffsetMs => _clockDriftOffsetMs;
 
   int _highestReceivedIndex = -1;
   int _lastAcknowledgedIndex = -1;
@@ -77,8 +87,9 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
   void _attachRxSubscription() {
     _rxSubscription?.cancel();
-    _rxSubscription =
-        transport.getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid).listen(_handleNotification);
+    _rxSubscription = transport
+        .getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid)
+        .listen(_handleNotification);
   }
 
   Future<void> _handleTransportReconnected() async {
@@ -139,9 +150,11 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
   Future<void> _initialize() async {
     try {
-      // Command 1: Time sync
+      // Command 1: Time sync (forward-only). Drift was measured from any Type-8
+      // pendant-clock RX during the connect listen window above; freeze it now.
       final timeSyncCmd = _encodeSetCurrentTime(DateTime.now().millisecondsSinceEpoch);
       await transport.writeCharacteristic(limitlessServiceUuid, limitlessTxCharUuid, timeSyncCmd);
+      _timeSynced = true;
       await Future.delayed(const Duration(seconds: 1));
 
       // Command 2: Enable data streaming (skipped in Transcribe Later — pendant records to flash)
@@ -152,7 +165,9 @@ class LimitlessDeviceConnection extends DeviceConnection {
       }
 
       _isInitialized = true;
-      DebugLogManager.logInfo('Limitless device initialized successfully');
+      DebugLogManager.logInfo('Limitless device initialized successfully', {
+        if (_clockDriftOffsetMs != null) 'clockDriftOffsetMs': _clockDriftOffsetMs,
+      });
     } catch (e) {
       Logger.debug('Limitless: Initialization failed: $e');
       DebugLogManager.logError(e, null, 'Limitless initialization failed');
@@ -203,12 +218,153 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
       _fragmentBuffer.remove(index);
 
+      // Type-8 may carry the pendant RTC; capture drift before SetCurrentTime.
+      _tryCaptureClockDrift(completePayload);
+
       if (_isBatchMode) {
         _handlePendantMessage(completePayload);
       } else {
         _handleRealTimePayload(completePayload);
       }
     }
+  }
+
+  /// Records pendant−phone drift from a Type-8 clock notification.
+  ///
+  /// Wire shape (issue #5734): BLE wrapper f4 payload → f8 inner → f6 EPOCH_MS.
+  /// Only the first pre-sync reading is kept; later Type-8s (post SetCurrentTime)
+  /// would show ~0 drift and must not overwrite the offline-page correction.
+  void _tryCaptureClockDrift(List<int> payload) {
+    if (_timeSynced || _clockDriftOffsetMs != null) return;
+
+    final pendantEpochMs = extractType8PendantEpochMs(payload);
+    if (pendantEpochMs == null || pendantEpochMs <= 1577836800000) return;
+
+    final phoneEpochMs = DateTime.now().millisecondsSinceEpoch;
+    _clockDriftOffsetMs = pendantEpochMs - phoneEpochMs;
+    DebugLogManager.logEvent('limitless_clock_drift_measured', {
+      'pendantEpochMs': pendantEpochMs,
+      'phoneEpochMs': phoneEpochMs,
+      'driftOffsetMs': _clockDriftOffsetMs,
+    });
+  }
+
+  /// Parses Type-8 pendant clock from a BLE-unwrapped payload.
+  ///
+  /// Looks for length-delimited field 8, then field 6 as epoch ms (varint), or
+  /// field 6 length-delimited wrapping field 1 (SetCurrentTime mirror).
+  static int? extractType8PendantEpochMs(List<int> payload) {
+    try {
+      var pos = 0;
+      while (pos < payload.length) {
+        final tag = payload[pos];
+        final fieldNum = tag >> 3;
+        final wireType = tag & 0x07;
+        pos++;
+
+        if (wireType == 2) {
+          final lengthResult = _decodeVarintStatic(payload, pos);
+          final length = lengthResult[0] as int;
+          pos = lengthResult[1] as int;
+          if (length < 0 || pos + length > payload.length) return null;
+          final fieldData = payload.sublist(pos, pos + length);
+          pos += length;
+          if (fieldNum == 8) {
+            final epoch = _extractEpochFromType8Inner(fieldData);
+            if (epoch != null) return epoch;
+          }
+        } else if (wireType == 0) {
+          pos = (_decodeVarintStatic(payload, pos)[1] as int);
+        } else if (wireType == 1) {
+          pos += 8;
+        } else if (wireType == 5) {
+          pos += 4;
+        } else {
+          break;
+        }
+      }
+    } catch (_) {
+      // Not every payload is Type-8; ignore parse failures.
+    }
+    return null;
+  }
+
+  static int? _extractEpochFromType8Inner(List<int> inner) {
+    var pos = 0;
+    while (pos < inner.length) {
+      final tag = inner[pos];
+      final fieldNum = tag >> 3;
+      final wireType = tag & 0x07;
+      pos++;
+
+      if (wireType == 0) {
+        final result = _decodeVarintStatic(inner, pos);
+        final value = result[0] as int;
+        pos = result[1] as int;
+        if (fieldNum == 6) return value;
+      } else if (wireType == 2) {
+        final lengthResult = _decodeVarintStatic(inner, pos);
+        final length = lengthResult[0] as int;
+        pos = lengthResult[1] as int;
+        if (length < 0 || pos + length > inner.length) return null;
+        final nested = inner.sublist(pos, pos + length);
+        pos += length;
+        if (fieldNum == 6) {
+          final epoch = _extractField1Varint(nested);
+          if (epoch != null) return epoch;
+        }
+      } else if (wireType == 1) {
+        pos += 8;
+      } else if (wireType == 5) {
+        pos += 4;
+      } else {
+        break;
+      }
+    }
+    return null;
+  }
+
+  static int? _extractField1Varint(List<int> data) {
+    var pos = 0;
+    while (pos < data.length) {
+      final tag = data[pos];
+      final fieldNum = tag >> 3;
+      final wireType = tag & 0x07;
+      pos++;
+      if (wireType == 0) {
+        final result = _decodeVarintStatic(data, pos);
+        final value = result[0] as int;
+        pos = result[1] as int;
+        if (fieldNum == 1) return value;
+      } else if (wireType == 2) {
+        final lengthResult = _decodeVarintStatic(data, pos);
+        final length = lengthResult[0] as int;
+        pos = lengthResult[1] as int;
+        if (length < 0 || pos + length > data.length) return null;
+        pos += length;
+      } else if (wireType == 1) {
+        pos += 8;
+      } else if (wireType == 5) {
+        pos += 4;
+      } else {
+        break;
+      }
+    }
+    return null;
+  }
+
+  static List<dynamic> _decodeVarintStatic(List<int> data, int startPos) {
+    var result = 0;
+    var shift = 0;
+    var pos = startPos;
+    while (pos < data.length) {
+      final byte = data[pos];
+      pos++;
+      result |= (byte & 0x7f) << shift;
+      if ((byte & 0x80) == 0) break;
+      shift += 7;
+    }
+    return [result, pos];
   }
 
   /// Handle reassembled payload in real-time mode
@@ -395,8 +551,10 @@ class LimitlessDeviceConnection extends DeviceConnection {
           } else {
             // Audio page that yielded zero frames — genuine parse failure
             final firstBytesLen = flashPageData.length < 64 ? flashPageData.length : 64;
-            final firstBytes =
-                flashPageData.sublist(0, firstBytesLen).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ');
+            final firstBytes = flashPageData
+                .sublist(0, firstBytesLen)
+                .map((b) => b.toRadixString(16).padLeft(2, '0'))
+                .join(' ');
             DebugLogManager.logWarning('Limitless flash page yielded zero Opus frames', {
               'index': index,
               'session': session,
@@ -1799,8 +1957,7 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetBleStorageBytesListener({
     required void Function(List<int>) onStorageBytesReceived,
-  }) async =>
-      null;
+  }) async => null;
 
   @override
   Future performCameraStartPhotoController() async {}
@@ -1814,8 +1971,7 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async =>
-      null;
+  }) async => null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;

--- a/app/lib/services/devices/connectors/limitless_connection.dart
+++ b/app/lib/services/devices/connectors/limitless_connection.dart
@@ -41,6 +41,19 @@ class LimitlessDeviceConnection extends DeviceConnection {
   /// Null when no Type-8 clock was observed (fail-open: no correction).
   int? get clockDriftOffsetMs => _clockDriftOffsetMs;
 
+  /// Corrects a pendant flash-page RTC using connect-time drift (#5734).
+  ///
+  /// When [pageTimestampMs] is null, returns [phoneNowMs] unchanged — the
+  /// fallback is already phone wall clock and must not be double-corrected.
+  static int correctedFlashPageTimestampMs({
+    required int? pageTimestampMs,
+    required int? clockDriftOffsetMs,
+    required int phoneNowMs,
+  }) {
+    if (pageTimestampMs == null) return phoneNowMs;
+    return pageTimestampMs - (clockDriftOffsetMs ?? 0);
+  }
+
   int _highestReceivedIndex = -1;
   int _lastAcknowledgedIndex = -1;
 
@@ -87,9 +100,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
   void _attachRxSubscription() {
     _rxSubscription?.cancel();
-    _rxSubscription = transport
-        .getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid)
-        .listen(_handleNotification);
+    _rxSubscription =
+        transport.getCharacteristicStream(limitlessServiceUuid, limitlessRxCharUuid).listen(_handleNotification);
   }
 
   Future<void> _handleTransportReconnected() async {
@@ -150,11 +162,13 @@ class LimitlessDeviceConnection extends DeviceConnection {
 
   Future<void> _initialize() async {
     try {
+      // Freeze drift capture *before* SetCurrentTime leaves the phone so a
+      // Type-8 arriving during the write cannot be mistaken for pre-sync RTC (#5734).
+      _timeSynced = true;
       // Command 1: Time sync (forward-only). Drift was measured from any Type-8
-      // pendant-clock RX during the connect listen window above; freeze it now.
+      // pendant-clock RX during the connect listen window above.
       final timeSyncCmd = _encodeSetCurrentTime(DateTime.now().millisecondsSinceEpoch);
       await transport.writeCharacteristic(limitlessServiceUuid, limitlessTxCharUuid, timeSyncCmd);
-      _timeSynced = true;
       await Future.delayed(const Duration(seconds: 1));
 
       // Command 2: Enable data streaming (skipped in Transcribe Later — pendant records to flash)
@@ -361,10 +375,13 @@ class LimitlessDeviceConnection extends DeviceConnection {
       final byte = data[pos];
       pos++;
       result |= (byte & 0x7f) << shift;
-      if ((byte & 0x80) == 0) break;
+      if ((byte & 0x80) == 0) return [result, pos];
       shift += 7;
+      // protobuf int64 varints are at most 10 bytes; reject overlong/unterminated.
+      if (shift > 63) return [null, startPos];
     }
-    return [result, pos];
+    // Ran off the end still expecting a continuation terminator.
+    return [null, startPos];
   }
 
   /// Handle reassembled payload in real-time mode
@@ -551,10 +568,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
           } else {
             // Audio page that yielded zero frames — genuine parse failure
             final firstBytesLen = flashPageData.length < 64 ? flashPageData.length : 64;
-            final firstBytes = flashPageData
-                .sublist(0, firstBytesLen)
-                .map((b) => b.toRadixString(16).padLeft(2, '0'))
-                .join(' ');
+            final firstBytes =
+                flashPageData.sublist(0, firstBytesLen).map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ');
             DebugLogManager.logWarning('Limitless flash page yielded zero Opus frames', {
               'index': index,
               'session': session,
@@ -1957,7 +1972,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetBleStorageBytesListener({
     required void Function(List<int>) onStorageBytesReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future performCameraStartPhotoController() async {}
@@ -1971,7 +1987,8 @@ class LimitlessDeviceConnection extends DeviceConnection {
   @override
   Future<StreamSubscription?> performGetImageListener({
     required void Function(OrientedImage orientedImage) onImageReceived,
-  }) async => null;
+  }) async =>
+      null;
 
   @override
   Future<StreamSubscription<List<int>>?> performGetAccelListener({void Function(int)? onAccelChange}) async => null;

--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -337,7 +337,11 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
           emptyExtractions = 0;
 
           final opusFrames = pageData['opus_frames'] as List<List<int>>? ?? [];
-          final timestampMs = pageData['timestamp_ms'] as int? ?? DateTime.now().millisecondsSinceEpoch;
+          // Pendant flash pages keep the RTC they were written under. Subtract the
+          // connect-time drift so filenames/session gaps match real-time conversations (#5734).
+          final rawTimestampMs = pageData['timestamp_ms'] as int? ?? DateTime.now().millisecondsSinceEpoch;
+          final driftOffsetMs = limitlessConnection.clockDriftOffsetMs ?? 0;
+          final timestampMs = rawTimestampMs - driftOffsetMs;
           final maxIndex = pageData['max_index'] as int?;
 
           if (maxIndex != null && (lastProcessedIndex == null || maxIndex > lastProcessedIndex)) {

--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -339,9 +339,13 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
           final opusFrames = pageData['opus_frames'] as List<List<int>>? ?? [];
           // Pendant flash pages keep the RTC they were written under. Subtract the
           // connect-time drift so filenames/session gaps match real-time conversations (#5734).
-          final rawTimestampMs = pageData['timestamp_ms'] as int? ?? DateTime.now().millisecondsSinceEpoch;
-          final driftOffsetMs = limitlessConnection.clockDriftOffsetMs ?? 0;
-          final timestampMs = rawTimestampMs - driftOffsetMs;
+          // Only correct when a real page timestamp was parsed — DateTime.now() fallback
+          // is already phone time and must not be double-corrected.
+          final timestampMs = LimitlessDeviceConnection.correctedFlashPageTimestampMs(
+            pageTimestampMs: pageData['timestamp_ms'] as int?,
+            clockDriftOffsetMs: limitlessConnection.clockDriftOffsetMs,
+            phoneNowMs: DateTime.now().millisecondsSinceEpoch,
+          );
           final maxIndex = pageData['max_index'] as int?;
 
           if (maxIndex != null && (lastProcessedIndex == null || maxIndex > lastProcessedIndex)) {

--- a/app/test/unit/limitless_clock_drift_test.dart
+++ b/app/test/unit/limitless_clock_drift_test.dart
@@ -70,11 +70,11 @@ List<int> intField(int fieldNum, int value) => [...varint((fieldNum << 3) | 0), 
 List<int> bytesField(int fieldNum, List<int> data) => [...varint((fieldNum << 3) | 2), ...varint(data.length), ...data];
 
 List<int> bleWrapper(int index, int seq, int numFrags, List<int> payload) => [
-  ...intField(1, index),
-  ...intField(2, seq),
-  ...intField(3, numFrags),
-  ...bytesField(4, payload),
-];
+      ...intField(1, index),
+      ...intField(2, seq),
+      ...intField(3, numFrags),
+      ...bytesField(4, payload),
+    ];
 
 /// Type-8 RX: f8 → f6 EPOCH_MS (varint), as described in #5734.
 List<int> type8ClockPacket({required int index, required int epochMs}) =>
@@ -105,13 +105,54 @@ void main() {
       expect(LimitlessDeviceConnection.extractType8PendantEpochMs(payload), isNull);
     });
 
-    test('flash-page correction subtracts measured drift', () {
-      // Pendant RTC was 5 minutes ahead of phone when measured.
+    test('returns null for unterminated varint in Type-8 payload', () {
+      // field 8 length-delimited with an unterminated varint length prefix (all 0x80).
+      final payload = <int>[
+        (8 << 3) | 2, // field 8, wire type 2
+        0x80, 0x80, 0x80, // unterminated length varint
+      ];
+      expect(LimitlessDeviceConnection.extractType8PendantEpochMs(payload), isNull);
+    });
+  });
+
+  group('flash-page timestamp correction (#5734)', () {
+    test('subtracts drift when a pendant page timestamp is present', () {
       const driftOffsetMs = 5 * 60 * 1000;
       const rawTimestampMs = 1750000000000;
-      final corrected = rawTimestampMs - driftOffsetMs;
-      expect(corrected, rawTimestampMs - driftOffsetMs);
-      expect(corrected, lessThan(rawTimestampMs));
+      const phoneNowMs = 1750000600000;
+      expect(
+        LimitlessDeviceConnection.correctedFlashPageTimestampMs(
+          pageTimestampMs: rawTimestampMs,
+          clockDriftOffsetMs: driftOffsetMs,
+          phoneNowMs: phoneNowMs,
+        ),
+        rawTimestampMs - driftOffsetMs,
+      );
+    });
+
+    test('does not double-correct DateTime.now fallback when page timestamp is missing', () {
+      const driftOffsetMs = 5 * 60 * 1000;
+      const phoneNowMs = 1750000600000;
+      expect(
+        LimitlessDeviceConnection.correctedFlashPageTimestampMs(
+          pageTimestampMs: null,
+          clockDriftOffsetMs: driftOffsetMs,
+          phoneNowMs: phoneNowMs,
+        ),
+        phoneNowMs,
+      );
+    });
+
+    test('treats null drift as zero correction', () {
+      const rawTimestampMs = 1750000000000;
+      expect(
+        LimitlessDeviceConnection.correctedFlashPageTimestampMs(
+          pageTimestampMs: rawTimestampMs,
+          clockDriftOffsetMs: null,
+          phoneNowMs: 0,
+        ),
+        rawTimestampMs,
+      );
     });
   });
 

--- a/app/test/unit/limitless_clock_drift_test.dart
+++ b/app/test/unit/limitless_clock_drift_test.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices/connectors/limitless_connection.dart';
+import 'package:omi/services/devices/models.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+class FakeDeviceTransport extends DeviceTransport {
+  final Map<String, StreamController<List<int>>> _rxControllers = {};
+  final StreamController<DeviceTransportState> _stateController = StreamController<DeviceTransportState>.broadcast();
+  final List<List<int>> writes = [];
+
+  StreamController<List<int>> _controllerFor(String characteristicUuid) {
+    return _rxControllers.putIfAbsent(characteristicUuid, () => StreamController<List<int>>.broadcast());
+  }
+
+  void emit(String characteristicUuid, List<int> data) {
+    _controllerFor(characteristicUuid).add(data);
+  }
+
+  @override
+  String get deviceId => 'fake-limitless';
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<bool> isConnected() async => true;
+
+  @override
+  Future<bool> ping() async => true;
+
+  @override
+  Stream<List<int>> getCharacteristicStream(String serviceUuid, String characteristicUuid) {
+    return _controllerFor(characteristicUuid).stream;
+  }
+
+  @override
+  Future<List<int>> readCharacteristic(String serviceUuid, String characteristicUuid) async => [];
+
+  @override
+  Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {
+    writes.add(List<int>.from(data));
+  }
+
+  @override
+  Stream<DeviceTransportState> get connectionStateStream => _stateController.stream;
+
+  @override
+  Future<void> dispose() async {}
+}
+
+List<int> varint(int value) {
+  final out = <int>[];
+  var v = value;
+  while (v > 0x7f) {
+    out.add((v & 0x7f) | 0x80);
+    v >>= 7;
+  }
+  out.add(v & 0x7f);
+  return out;
+}
+
+List<int> intField(int fieldNum, int value) => [...varint((fieldNum << 3) | 0), ...varint(value)];
+
+List<int> bytesField(int fieldNum, List<int> data) => [...varint((fieldNum << 3) | 2), ...varint(data.length), ...data];
+
+List<int> bleWrapper(int index, int seq, int numFrags, List<int> payload) => [
+  ...intField(1, index),
+  ...intField(2, seq),
+  ...intField(3, numFrags),
+  ...bytesField(4, payload),
+];
+
+/// Type-8 RX: f8 → f6 EPOCH_MS (varint), as described in #5734.
+List<int> type8ClockPacket({required int index, required int epochMs}) =>
+    bleWrapper(index, 0, 1, bytesField(8, intField(6, epochMs)));
+
+/// Type-8 RX alternate: f8 → f6 length-delimited → f1 EPOCH_MS (SetCurrentTime mirror).
+List<int> type8ClockPacketNested({required int index, required int epochMs}) =>
+    bleWrapper(index, 0, 1, bytesField(8, bytesField(6, intField(1, epochMs))));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Type-8 pendant clock parse', () {
+    test('extracts epoch from f8→f6 varint', () {
+      const epoch = 1750000005000;
+      final payload = bytesField(8, intField(6, epoch));
+      expect(LimitlessDeviceConnection.extractType8PendantEpochMs(payload), epoch);
+    });
+
+    test('extracts epoch from f8→f6→f1 nested', () {
+      const epoch = 1750000005000;
+      final payload = bytesField(8, bytesField(6, intField(1, epoch)));
+      expect(LimitlessDeviceConnection.extractType8PendantEpochMs(payload), epoch);
+    });
+
+    test('returns null when field 8 is absent', () {
+      final payload = bytesField(2, intField(1, 42));
+      expect(LimitlessDeviceConnection.extractType8PendantEpochMs(payload), isNull);
+    });
+
+    test('flash-page correction subtracts measured drift', () {
+      // Pendant RTC was 5 minutes ahead of phone when measured.
+      const driftOffsetMs = 5 * 60 * 1000;
+      const rawTimestampMs = 1750000000000;
+      final corrected = rawTimestampMs - driftOffsetMs;
+      expect(corrected, rawTimestampMs - driftOffsetMs);
+      expect(corrected, lessThan(rawTimestampMs));
+    });
+  });
+
+  group('connect-time drift capture', () {
+    test('Type-8 before SetCurrentTime sets clockDriftOffsetMs', () async {
+      final transport = FakeDeviceTransport();
+      final device = BtDevice(name: 'Limitless Pendant', id: 'fake-limitless', type: DeviceType.limitless, rssi: -50);
+      final connection = LimitlessDeviceConnection(device, transport);
+
+      const pendantAheadMs = 180000; // 3 minutes
+      final connectFuture = connection.connect();
+
+      // RX attaches after the first 1s delay inside connect().
+      await Future.delayed(const Duration(milliseconds: 1100));
+      final phoneBefore = DateTime.now().millisecondsSinceEpoch;
+      final pendantEpoch = phoneBefore + pendantAheadMs;
+      transport.emit(limitlessRxCharUuid, type8ClockPacket(index: 1, epochMs: pendantEpoch));
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      await connectFuture;
+
+      expect(connection.clockDriftOffsetMs, isNotNull);
+      // Allow a few seconds of wall-clock skew from connect delays.
+      expect(connection.clockDriftOffsetMs!, closeTo(pendantAheadMs, 5000));
+
+      await connection.disconnect();
+    });
+
+    test('Type-8 after SetCurrentTime does not overwrite drift', () async {
+      final transport = FakeDeviceTransport();
+      final device = BtDevice(name: 'Limitless Pendant', id: 'fake-limitless', type: DeviceType.limitless, rssi: -50);
+      final connection = LimitlessDeviceConnection(device, transport);
+
+      const firstDriftMs = 120000;
+      final connectFuture = connection.connect();
+      await Future.delayed(const Duration(milliseconds: 1100));
+      final phoneBefore = DateTime.now().millisecondsSinceEpoch;
+      transport.emit(limitlessRxCharUuid, type8ClockPacket(index: 1, epochMs: phoneBefore + firstDriftMs));
+      await connectFuture;
+
+      final captured = connection.clockDriftOffsetMs;
+      expect(captured, isNotNull);
+
+      // Post-sync Type-8 would report ~0 drift; must not clobber the offline correction.
+      transport.emit(limitlessRxCharUuid, type8ClockPacket(index: 2, epochMs: DateTime.now().millisecondsSinceEpoch));
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(connection.clockDriftOffsetMs, captured);
+
+      await connection.disconnect();
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

Limitless duplicates conversations when real-time streaming and batch flash download cover the same audio: the backend merge (`get_closest_conversation_to_timestamps`) works when timestamps overlap, but pendant RTC drift leaves stored flash pages misaligned with phone-time real-time segments. `_initialize()` only forwards `SetCurrentTime` and never measures drift; flash WAL sync used raw page timestamps.

**Part 1:** Parse Type-8 BLE notifications (`f4 → f8 → f6 EPOCH_MS`) during the connect listen window, store `clockDriftOffsetMs = pendant − phone` before `SetCurrentTime`, and freeze that reading (post-sync Type-8s would show ~0 drift). `_timeSynced` is set *before* the write so a mid-write Type-8 cannot clobber the offline offset.

**Part 2:** In `flash_page_wal_sync.dart`, subtract the offset from page timestamps via `correctedFlashPageTimestampMs` before session-gap detection and filename embedding. Drift is applied **only** when a real page timestamp was parsed — the `DateTime.now()` fallback is already phone time and is not double-corrected.

Out of scope: Part 3 sync-mode toggle; #5733 firmware diagnostic pages.

Fixes #5734.

## Product invariants affected

none

## How it was verified

```bash
cd app && flutter test test/unit/limitless_clock_drift_test.dart
# 9 passed
cd app && dart analyze lib/services/devices/connectors/limitless_connection.dart \
  lib/services/wals/flash_page_wal_sync.dart test/unit/limitless_clock_drift_test.dart
# No issues found
```

Could not exercise a live Limitless pendant reconnect + duplicate-conversation repro in this environment. Parser + connect-time capture + post-sync freeze + flash correction helper (including missing-timestamp path) are unit-tested.

## Tests

`app/test/unit/limitless_clock_drift_test.dart` — Type-8 f8→f6 / nested f8→f6→f1 parse; unterminated varint; connect captures drift before msg6; post-sync Type-8 does not clobber; `correctedFlashPageTimestampMs` subtracts drift / skips double-correct / null drift.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

n/a