### PR TITLE
fix(app): resume phone mic after other-app audio on iPadOS (#4706)

### DIFF
--- a/app/ios/Runner/PhoneMic/PhoneMicCaptureEngine.swift
+++ b/app/ios/Runner/PhoneMic/PhoneMicCaptureEngine.swift
@@ -79,6 +79,11 @@ final class PhoneMicCaptureEngine {
         try engine.start()
     }
 
+    /// True while CoreAudio reports the owned engine is running. Used by the
+    /// controller to detect silent engine death (#4706) without tearing down
+    /// a healthy capture on every foreground.
+    var isRunning: Bool { engine.isRunning }
+
     func teardown() {
         if tapInstalled {
             engine.inputNode.removeTap(onBus: 0)

--- a/app/ios/Runner/PhoneMic/PhoneMicController.swift
+++ b/app/ios/Runner/PhoneMic/PhoneMicController.swift
@@ -324,15 +324,31 @@ final class PhoneMicController {
         case .interruptionEnded(let shouldResume):
             guard state == .interrupted else { return }
             NSLog("[PhoneMic] interruption ended shouldResume=%d", shouldResume ? 1 : 0)
-            // Without shouldResume we stay interrupted: the recording intent
-            // persists and the ticker/call-observer keep probing.
-            if shouldResume {
-                attemptResume()
-            }
+            // Always probe once. Other-app audio (YouTube / Stage Manager, #4706)
+            // often ends without shouldResume; waiting only for the 3s ticker left
+            // sessions stuck until the user force-stopped. Failures stay silent —
+            // the ticker keeps probing if bring-up is still blocked.
+            attemptResume()
 
-        case .allCallsEnded, .appBecameActive:
+        case .allCallsEnded:
             guard state == .interrupted else { return }
             attemptResume()
+
+        case .appBecameActive:
+            switch state {
+            case .interrupted:
+                attemptResume()
+            case .running:
+                // #4706: with .mixWithOthers, competing audio can stop the engine
+                // without an interruption notification. Foreground return must
+                // heal a zombie "still Listening" session.
+                if engine?.isRunning != true {
+                    NSLog("[PhoneMic] app active with dead engine, rebuilding")
+                    beginRebuild()
+                }
+            default:
+                break
+            }
 
         case .routeChanged(let reason):
             guard state == .running else { return }

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -91,7 +91,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 (SharedPreferencesUtil().batchModeEnabled && provider.havingRecordingDevice)) {
               return;
             }
-            final isCaptureActive = provider.recordingState == RecordingState.record ||
+            final isCaptureActive =
+                provider.recordingState == RecordingState.record ||
                 provider.recordingState == RecordingState.systemAudioRecord ||
                 provider.recordingState == RecordingState.deviceRecord ||
                 provider.recordingState == RecordingState.initialising ||
@@ -190,7 +191,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     bool isHavingDesireDevice = SharedPreferencesUtil().btDevice.id.isNotEmpty;
     bool isHavingRecordingDevice = captureProvider.havingRecordingDevice;
 
-    bool isUsingPhoneMic = captureProvider.recordingState == RecordingState.record ||
+    bool isUsingPhoneMic =
+        captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.initialising ||
         captureProvider.recordingState == RecordingState.pause ||
         captureProvider.recordingState == RecordingState.interrupted;
@@ -198,7 +200,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     // Check if any recording is active (phone mic, system audio, or device recording).
     // `interrupted` is included so the in-session UI stays visible while the
     // pipeline is transiently broken (e.g., iOS audio session interruption).
-    bool isAnyRecordingActive = captureProvider.recordingState == RecordingState.record ||
+    bool isAnyRecordingActive =
+        captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.systemAudioRecord ||
         captureProvider.recordingState == RecordingState.deviceRecord ||
         captureProvider.recordingState == RecordingState.initialising ||
@@ -334,7 +337,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
   }
 
   Widget _buildUnifiedRecordingUI(CaptureProvider provider, Widget? header) {
-    bool isDeviceRecording = provider.havingRecordingDevice &&
+    bool isDeviceRecording =
+        provider.havingRecordingDevice &&
         (provider.recordingState == RecordingState.deviceRecord || provider.recordingState == RecordingState.pause);
 
     // Offline/batch mode: device or phone-mic audio is saved locally with no live
@@ -346,7 +350,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
 
     // A phone-mic batch session reports RecordingState.record too; exclude it here so
     // the Live "Listening" card never renders for it (it is handled above).
-    bool isPhoneRecording = !provider.isPhoneMicBatchRecording &&
+    bool isPhoneRecording =
+        !provider.isPhoneMicBatchRecording &&
         (provider.recordingState == RecordingState.record ||
             provider.recordingState == RecordingState.systemAudioRecord ||
             provider.recordingState == RecordingState.initialising ||
@@ -354,13 +359,14 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
             _isPhoneMicPaused);
 
     // Determine pause state based on recording type.
-    // Call-active interruption is treated as paused for button/dot display.
-    bool isCallInterrupted = provider.recordingState == RecordingState.interrupted && provider.isCallActive;
+    // Any audio-session interruption (call, other-app audio, system alert) is
+    // treated as paused so the UI does not claim "Listening" while mute (#4706).
+    bool isAudioInterrupted = provider.recordingState == RecordingState.interrupted;
     bool isPaused = false;
     if (isDeviceRecording) {
       isPaused = provider.isPaused && provider.recordingState == RecordingState.pause;
     } else if (isPhoneRecording) {
-      isPaused = _isPhoneMicPaused || provider.isPaused || isCallInterrupted;
+      isPaused = _isPhoneMicPaused || provider.isPaused || isAudioInterrupted;
     }
     final hasTerminalTranscriptionFailure = provider.terminalTranscriptionFailure != null;
 
@@ -368,15 +374,15 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     bool hasPhotos = provider.photos.isNotEmpty;
     // Show "Listening" for all active recording states — WAL ensures audio is
     // saved locally regardless of transcription connection status.
-    String statusText = provider.recordingState == RecordingState.interrupted && provider.isCallActive
+    String statusText = isAudioInterrupted
         ? context.l10n.paused
         : isPaused
-            ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
-            : hasTerminalTranscriptionFailure
-                ? context.l10n.transcriptionUnavailable
-                : hasPhotos
-                    ? 'Capturing'
-                    : context.l10n.listening;
+        ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
+        : hasTerminalTranscriptionFailure
+        ? context.l10n.transcriptionUnavailable
+        : hasPhotos
+        ? 'Capturing'
+        : context.l10n.listening;
 
     // When recording is active, show the unified UI design
     if (isDeviceRecording || isPhoneRecording) {
@@ -490,22 +496,22 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 decoration: BoxDecoration(
                   color: isPaused
                       ? isDeviceRecording
-                          ? const Color(0xFFFE5D50)
-                          : const Color(0xFF7C3AED)
+                            ? const Color(0xFFFE5D50)
+                            : const Color(0xFF7C3AED)
                       : isDeviceRecording
-                          ? const Color(0xFF35343B)
-                          : const Color(0xFFFF9500),
+                      ? const Color(0xFF35343B)
+                      : const Color(0xFFFF9500),
                   shape: BoxShape.circle,
                 ),
                 child: Center(
                   child: FaIcon(
                     isPaused
                         ? isDeviceRecording
-                            ? FontAwesomeIcons.microphoneSlash
-                            : FontAwesomeIcons.play
+                              ? FontAwesomeIcons.microphoneSlash
+                              : FontAwesomeIcons.play
                         : isDeviceRecording
-                            ? FontAwesomeIcons.microphone
-                            : FontAwesomeIcons.pause,
+                        ? FontAwesomeIcons.microphone
+                        : FontAwesomeIcons.pause,
                     color: Colors.white,
                     size: 12,
                   ),
@@ -593,8 +599,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                       storageFull
                           ? context.l10n.paused
                           : muted
-                              ? context.l10n.muted
-                              : context.l10n.recording,
+                          ? context.l10n.muted
+                          : context.l10n.recording,
                       style: const TextStyle(color: Color(0xFFC9CBCF), fontSize: 14, fontWeight: FontWeight.w500),
                     ),
                   ],
@@ -618,8 +624,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
             isPendant
                 ? (prefs.pendantDraining ? context.l10n.pendantSyncingRecordings : context.l10n.pendantRecordingNote)
                 : storageFull
-                    ? context.l10n.transcribeLaterStorageFull
-                    : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
+                ? context.l10n.transcribeLaterStorageFull
+                : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
             style: TextStyle(color: Colors.grey.shade400, fontSize: 13, height: 1.35),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -91,8 +91,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 (SharedPreferencesUtil().batchModeEnabled && provider.havingRecordingDevice)) {
               return;
             }
-            final isCaptureActive =
-                provider.recordingState == RecordingState.record ||
+            final isCaptureActive = provider.recordingState == RecordingState.record ||
                 provider.recordingState == RecordingState.systemAudioRecord ||
                 provider.recordingState == RecordingState.deviceRecord ||
                 provider.recordingState == RecordingState.initialising ||
@@ -191,8 +190,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     bool isHavingDesireDevice = SharedPreferencesUtil().btDevice.id.isNotEmpty;
     bool isHavingRecordingDevice = captureProvider.havingRecordingDevice;
 
-    bool isUsingPhoneMic =
-        captureProvider.recordingState == RecordingState.record ||
+    bool isUsingPhoneMic = captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.initialising ||
         captureProvider.recordingState == RecordingState.pause ||
         captureProvider.recordingState == RecordingState.interrupted;
@@ -200,8 +198,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     // Check if any recording is active (phone mic, system audio, or device recording).
     // `interrupted` is included so the in-session UI stays visible while the
     // pipeline is transiently broken (e.g., iOS audio session interruption).
-    bool isAnyRecordingActive =
-        captureProvider.recordingState == RecordingState.record ||
+    bool isAnyRecordingActive = captureProvider.recordingState == RecordingState.record ||
         captureProvider.recordingState == RecordingState.systemAudioRecord ||
         captureProvider.recordingState == RecordingState.deviceRecord ||
         captureProvider.recordingState == RecordingState.initialising ||
@@ -337,8 +334,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
   }
 
   Widget _buildUnifiedRecordingUI(CaptureProvider provider, Widget? header) {
-    bool isDeviceRecording =
-        provider.havingRecordingDevice &&
+    bool isDeviceRecording = provider.havingRecordingDevice &&
         (provider.recordingState == RecordingState.deviceRecord || provider.recordingState == RecordingState.pause);
 
     // Offline/batch mode: device or phone-mic audio is saved locally with no live
@@ -350,8 +346,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
 
     // A phone-mic batch session reports RecordingState.record too; exclude it here so
     // the Live "Listening" card never renders for it (it is handled above).
-    bool isPhoneRecording =
-        !provider.isPhoneMicBatchRecording &&
+    bool isPhoneRecording = !provider.isPhoneMicBatchRecording &&
         (provider.recordingState == RecordingState.record ||
             provider.recordingState == RecordingState.systemAudioRecord ||
             provider.recordingState == RecordingState.initialising ||
@@ -377,12 +372,12 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     String statusText = isAudioInterrupted
         ? context.l10n.paused
         : isPaused
-        ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
-        : hasTerminalTranscriptionFailure
-        ? context.l10n.transcriptionUnavailable
-        : hasPhotos
-        ? 'Capturing'
-        : context.l10n.listening;
+            ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
+            : hasTerminalTranscriptionFailure
+                ? context.l10n.transcriptionUnavailable
+                : hasPhotos
+                    ? 'Capturing'
+                    : context.l10n.listening;
 
     // When recording is active, show the unified UI design
     if (isDeviceRecording || isPhoneRecording) {
@@ -496,22 +491,22 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                 decoration: BoxDecoration(
                   color: isPaused
                       ? isDeviceRecording
-                            ? const Color(0xFFFE5D50)
-                            : const Color(0xFF7C3AED)
+                          ? const Color(0xFFFE5D50)
+                          : const Color(0xFF7C3AED)
                       : isDeviceRecording
-                      ? const Color(0xFF35343B)
-                      : const Color(0xFFFF9500),
+                          ? const Color(0xFF35343B)
+                          : const Color(0xFFFF9500),
                   shape: BoxShape.circle,
                 ),
                 child: Center(
                   child: FaIcon(
                     isPaused
                         ? isDeviceRecording
-                              ? FontAwesomeIcons.microphoneSlash
-                              : FontAwesomeIcons.play
+                            ? FontAwesomeIcons.microphoneSlash
+                            : FontAwesomeIcons.play
                         : isDeviceRecording
-                        ? FontAwesomeIcons.microphone
-                        : FontAwesomeIcons.pause,
+                            ? FontAwesomeIcons.microphone
+                            : FontAwesomeIcons.pause,
                     color: Colors.white,
                     size: 12,
                   ),
@@ -599,8 +594,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
                       storageFull
                           ? context.l10n.paused
                           : muted
-                          ? context.l10n.muted
-                          : context.l10n.recording,
+                              ? context.l10n.muted
+                              : context.l10n.recording,
                       style: const TextStyle(color: Color(0xFFC9CBCF), fontSize: 14, fontWeight: FontWeight.w500),
                     ),
                   ],
@@ -624,8 +619,8 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
             isPendant
                 ? (prefs.pendantDraining ? context.l10n.pendantSyncingRecordings : context.l10n.pendantRecordingNote)
                 : storageFull
-                ? context.l10n.transcribeLaterStorageFull
-                : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
+                    ? context.l10n.transcribeLaterStorageFull
+                    : (muted ? context.l10n.transcribeLaterPaused : context.l10n.transcribeLaterNote),
             style: TextStyle(color: Colors.grey.shade400, fontSize: 13, height: 1.35),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -194,6 +194,9 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         Provider.of<ConversationProvider>(context, listen: false).refreshConversations();
         final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
         captureProvider.refreshInProgressConversations();
+        // Heal phone-mic sessions that went silent while another app played
+        // audio (Stage Manager / YouTube) without an AVAudioSession interrupt.
+        captureProvider.onAppResumed();
         // Pick up any batch recordings the native layer wrote while backgrounded/closed.
         Provider.of<LocalRecordingsProvider>(context, listen: false).refresh();
       }
@@ -855,8 +858,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                                  ? Colors.orange.withValues(alpha: 0.15)
-                                  : const Color(0xFF1F1F25),
+                              ? Colors.orange.withValues(alpha: 0.15)
+                              : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -865,8 +868,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                                  ? Colors.orangeAccent
-                                  : Colors.white70,
+                              ? Colors.orangeAccent
+                              : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -858,8 +858,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                              ? Colors.orange.withValues(alpha: 0.15)
-                              : const Color(0xFF1F1F25),
+                                  ? Colors.orange.withValues(alpha: 0.15)
+                                  : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -868,8 +868,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                              ? Colors.orangeAccent
-                              : Colors.white70,
+                                  ? Colors.orangeAccent
+                                  : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -154,7 +154,7 @@ class CaptureController extends ChangeNotifier
   }
 
   CaptureController({CaptureExternalActions? externalActions})
-    : externalActions = externalActions ?? const NoopCaptureExternalActions() {
+      : externalActions = externalActions ?? const NoopCaptureExternalActions() {
     // Restore a persisted device mute so it survives an app kill/restart. When
     // the device reconnects, streamDeviceRecording() reads _isPaused as
     // `wasPaused` and re-applies the mute instead of silently resuming.
@@ -215,30 +215,30 @@ class CaptureController extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().phoneMic.start(
-      onByteReceived: (bytes) {
-        final frames = _activeSource?.processBytes(bytes) ?? [];
-        for (final frame in frames) {
-          _wal.getSyncs().phone.onFrameCaptured(frame);
-          if (_socket?.state == SocketServiceState.connected) {
-            _socket?.send(frame.payload);
-            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-          }
-        }
-      },
-      onRecording: () {
-        updateRecordingState(RecordingState.record);
-      },
-      onStop: () {
-        if (!_micInterrupted) {
-          updateRecordingState(RecordingState.stop);
-        }
-      },
-      onInitializing: () {
-        updateRecordingState(RecordingState.initialising);
-      },
-      onStalled: _onMicStalled,
-      onInterruption: _onMicInterruption,
-    );
+          onByteReceived: (bytes) {
+            final frames = _activeSource?.processBytes(bytes) ?? [];
+            for (final frame in frames) {
+              _wal.getSyncs().phone.onFrameCaptured(frame);
+              if (_socket?.state == SocketServiceState.connected) {
+                _socket?.send(frame.payload);
+                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+              }
+            }
+          },
+          onRecording: () {
+            updateRecordingState(RecordingState.record);
+          },
+          onStop: () {
+            if (!_micInterrupted) {
+              updateRecordingState(RecordingState.stop);
+            }
+          },
+          onInitializing: () {
+            updateRecordingState(RecordingState.initialising);
+          },
+          onStalled: _onMicStalled,
+          onInterruption: _onMicInterruption,
+        );
   }
 
   void _onMicStalled() {
@@ -254,11 +254,14 @@ class CaptureController extends ChangeNotifier
     }
   }
 
-  /// Foreground return hook for phone-mic capture (#4706). Native also rebuilds
-  /// a dead engine on `didBecomeActive`; this covers the Dart timer-suspension
-  /// case where frames stopped without an interruption notification.
+  /// Foreground return hook for phone-mic capture (#4706).
+  ///
+  /// Native `appBecameActive` owns dead-engine rebuild. Dart only soft-rearms
+  /// the stall clock so suspended timers don't false-trigger stop→start (which
+  /// would race native recovery and restart a healthy session).
   void onAppResumed() {
     if (_activeSource is! PhoneMicSource && !_phoneMicBatchActive) return;
+    if (_micInterrupted || _phoneMicRestartInFlight) return;
     ServiceManager.instance().phoneMic.probeStallAfterForeground();
   }
 
@@ -653,9 +656,8 @@ class CaptureController extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    String language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -669,13 +671,13 @@ class CaptureController extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-      codec: codec,
-      sampleRate: sampleRate,
-      language: language,
-      force: force,
-      source: source,
-      customSttConfig: effectiveConfig,
-    );
+          codec: codec,
+          sampleRate: sampleRate,
+          language: language,
+          force: force,
+          source: source,
+          customSttConfig: effectiveConfig,
+        );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -792,24 +794,20 @@ class CaptureController extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error resuming device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              resumeDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error resuming device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording()
-                  .then((_) {
-                    _isProcessingButtonEvent = false;
-                  })
-                  .catchError((e) {
-                    Logger.debug("Error pausing device recording: $e");
-                    _isProcessingButtonEvent = false;
-                  });
+              pauseDeviceRecording().then((_) {
+                _isProcessingButtonEvent = false;
+              }).catchError((e) {
+                Logger.debug("Error pausing device recording: $e");
+                _isProcessingButtonEvent = false;
+              });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -903,8 +901,7 @@ class CaptureController extends ChangeNotifier
 
         // Local storage syncs. In batch mode the native layer owns writing the
         // .bin files, so the Dart WAL writer must stay off to avoid double-writes.
-        var checkWalSupported =
-            !SharedPreferencesUtil().batchModeEnabled &&
+        var checkWalSupported = !SharedPreferencesUtil().batchModeEnabled &&
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported() &&
             (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
@@ -1012,9 +1009,8 @@ class CaptureController extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
-        ? SharedPreferencesUtil().userPrimaryLanguage
-        : "multi";
+    var language =
+        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1382,33 +1378,33 @@ class CaptureController extends ChangeNotifier
     // record
     try {
       await ServiceManager.instance().phoneMic.start(
-        onByteReceived: (bytes) {
-          // Process through AudioSource for frame splitting and sync key generation
-          final frames = _activeSource?.processBytes(bytes) ?? [];
+            onByteReceived: (bytes) {
+              // Process through AudioSource for frame splitting and sync key generation
+              final frames = _activeSource?.processBytes(bytes) ?? [];
 
-          for (final frame in frames) {
-            _wal.getSyncs().phone.onFrameCaptured(frame);
+              for (final frame in frames) {
+                _wal.getSyncs().phone.onFrameCaptured(frame);
 
-            if (_socket?.state == SocketServiceState.connected) {
-              _socket?.send(frame.payload);
-              _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-            }
-          }
-        },
-        onRecording: () {
-          updateRecordingState(RecordingState.record);
-        },
-        onStop: () {
-          if (!_micInterrupted) {
-            updateRecordingState(RecordingState.stop);
-          }
-        },
-        onInitializing: () {
-          updateRecordingState(RecordingState.initialising);
-        },
-        onStalled: _onMicStalled,
-        onInterruption: _onMicInterruption,
-      );
+                if (_socket?.state == SocketServiceState.connected) {
+                  _socket?.send(frame.payload);
+                  _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+                }
+              }
+            },
+            onRecording: () {
+              updateRecordingState(RecordingState.record);
+            },
+            onStop: () {
+              if (!_micInterrupted) {
+                updateRecordingState(RecordingState.stop);
+              }
+            },
+            onInitializing: () {
+              updateRecordingState(RecordingState.initialising);
+            },
+            onStalled: _onMicStalled,
+            onInterruption: _onMicInterruption,
+          );
     } catch (e, st) {
       // Typed native failures (permission_denied, engine_start_failed, ...) or
       // mic contention — fail visibly instead of recording silence.
@@ -1486,15 +1482,15 @@ class CaptureController extends ChangeNotifier
     updateRecordingState(RecordingState.record);
     try {
       await ServiceManager.instance().phoneMic.startBatch(
-        onStop: () {
-          if (!_micInterrupted && !_phoneMicBatchRestartInFlight) {
-            updateRecordingState(RecordingState.stop);
-          }
-        },
-        onInterruption: _onMicInterruption,
-        onBatchStalled: _onBatchStalled,
-        onError: _onBatchCaptureError,
-      );
+            onStop: () {
+              if (!_micInterrupted && !_phoneMicBatchRestartInFlight) {
+                updateRecordingState(RecordingState.stop);
+              }
+            },
+            onInterruption: _onMicInterruption,
+            onBatchStalled: _onBatchStalled,
+            onError: _onBatchCaptureError,
+          );
     } catch (e, st) {
       // No socket to clean in batch — fail visibly instead of recording nothing.
       Logger.error('[CaptureProvider] phone mic batch start failed: $e\n$st');

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -154,7 +154,7 @@ class CaptureController extends ChangeNotifier
   }
 
   CaptureController({CaptureExternalActions? externalActions})
-      : externalActions = externalActions ?? const NoopCaptureExternalActions() {
+    : externalActions = externalActions ?? const NoopCaptureExternalActions() {
     // Restore a persisted device mute so it survives an app kill/restart. When
     // the device reconnects, streamDeviceRecording() reads _isPaused as
     // `wasPaused` and re-applies the mute instead of silently resuming.
@@ -215,30 +215,30 @@ class CaptureController extends ChangeNotifier
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
     await ServiceManager.instance().phoneMic.start(
-          onByteReceived: (bytes) {
-            final frames = _activeSource?.processBytes(bytes) ?? [];
-            for (final frame in frames) {
-              _wal.getSyncs().phone.onFrameCaptured(frame);
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
-                _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-              }
-            }
-          },
-          onRecording: () {
-            updateRecordingState(RecordingState.record);
-          },
-          onStop: () {
-            if (!_micInterrupted) {
-              updateRecordingState(RecordingState.stop);
-            }
-          },
-          onInitializing: () {
-            updateRecordingState(RecordingState.initialising);
-          },
-          onStalled: _onMicStalled,
-          onInterruption: _onMicInterruption,
-        );
+      onByteReceived: (bytes) {
+        final frames = _activeSource?.processBytes(bytes) ?? [];
+        for (final frame in frames) {
+          _wal.getSyncs().phone.onFrameCaptured(frame);
+          if (_socket?.state == SocketServiceState.connected) {
+            _socket?.send(frame.payload);
+            _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+          }
+        }
+      },
+      onRecording: () {
+        updateRecordingState(RecordingState.record);
+      },
+      onStop: () {
+        if (!_micInterrupted) {
+          updateRecordingState(RecordingState.stop);
+        }
+      },
+      onInitializing: () {
+        updateRecordingState(RecordingState.initialising);
+      },
+      onStalled: _onMicStalled,
+      onInterruption: _onMicInterruption,
+    );
   }
 
   void _onMicStalled() {
@@ -252,6 +252,14 @@ class CaptureController extends ChangeNotifier
     if (recordingState == RecordingState.interrupted) {
       _restartPhoneMicRecording();
     }
+  }
+
+  /// Foreground return hook for phone-mic capture (#4706). Native also rebuilds
+  /// a dead engine on `didBecomeActive`; this covers the Dart timer-suspension
+  /// case where frames stopped without an interruption notification.
+  void onAppResumed() {
+    if (_activeSource is! PhoneMicSource && !_phoneMicBatchActive) return;
+    ServiceManager.instance().phoneMic.probeStallAfterForeground();
   }
 
   void updateExternalActions(CaptureExternalActions? actions) {
@@ -645,8 +653,9 @@ class CaptureController extends ChangeNotifier
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');
 
     // Get language and custom STT config
-    String language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    String language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
 
     Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
@@ -660,13 +669,13 @@ class CaptureController extends ChangeNotifier
 
     // Connect to the transcript socket
     _socket = await ServiceManager.instance().socket.conversation(
-          codec: codec,
-          sampleRate: sampleRate,
-          language: language,
-          force: force,
-          source: source,
-          customSttConfig: effectiveConfig,
-        );
+      codec: codec,
+      sampleRate: sampleRate,
+      language: language,
+      force: force,
+      source: source,
+      customSttConfig: effectiveConfig,
+    );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");
@@ -783,20 +792,24 @@ class CaptureController extends ChangeNotifier
             _isProcessingButtonEvent = true;
             if (_isPaused) {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'unmute');
-              resumeDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error resuming device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              resumeDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error resuming device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             } else {
               PlatformManager.instance.analytics.omiDoubleTap(feature: 'mute');
-              pauseDeviceRecording().then((_) {
-                _isProcessingButtonEvent = false;
-              }).catchError((e) {
-                Logger.debug("Error pausing device recording: $e");
-                _isProcessingButtonEvent = false;
-              });
+              pauseDeviceRecording()
+                  .then((_) {
+                    _isProcessingButtonEvent = false;
+                  })
+                  .catchError((e) {
+                    Logger.debug("Error pausing device recording: $e");
+                    _isProcessingButtonEvent = false;
+                  });
             }
           } else if (doubleTapAction == 2) {
             // Star ongoing conversation (doesn't end it)
@@ -890,7 +903,8 @@ class CaptureController extends ChangeNotifier
 
         // Local storage syncs. In batch mode the native layer owns writing the
         // .bin files, so the Dart WAL writer must stay off to avoid double-writes.
-        var checkWalSupported = !SharedPreferencesUtil().batchModeEnabled &&
+        var checkWalSupported =
+            !SharedPreferencesUtil().batchModeEnabled &&
             (_recordingDevice?.type == DeviceType.omi || _recordingDevice?.type == DeviceType.openglass) &&
             codec.isOpusSupported() &&
             (_socket?.state != SocketServiceState.connected || SharedPreferencesUtil().unlimitedLocalStorageEnabled);
@@ -998,8 +1012,9 @@ class CaptureController extends ChangeNotifier
       return;
     }
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
-    var language =
-        SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
+    var language = SharedPreferencesUtil().hasSetPrimaryLanguage
+        ? SharedPreferencesUtil().userPrimaryLanguage
+        : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
     final sttConfigId = customSttConfig.sttConfigId;
 
@@ -1367,33 +1382,33 @@ class CaptureController extends ChangeNotifier
     // record
     try {
       await ServiceManager.instance().phoneMic.start(
-            onByteReceived: (bytes) {
-              // Process through AudioSource for frame splitting and sync key generation
-              final frames = _activeSource?.processBytes(bytes) ?? [];
+        onByteReceived: (bytes) {
+          // Process through AudioSource for frame splitting and sync key generation
+          final frames = _activeSource?.processBytes(bytes) ?? [];
 
-              for (final frame in frames) {
-                _wal.getSyncs().phone.onFrameCaptured(frame);
+          for (final frame in frames) {
+            _wal.getSyncs().phone.onFrameCaptured(frame);
 
-                if (_socket?.state == SocketServiceState.connected) {
-                  _socket?.send(frame.payload);
-                  _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-                }
-              }
-            },
-            onRecording: () {
-              updateRecordingState(RecordingState.record);
-            },
-            onStop: () {
-              if (!_micInterrupted) {
-                updateRecordingState(RecordingState.stop);
-              }
-            },
-            onInitializing: () {
-              updateRecordingState(RecordingState.initialising);
-            },
-            onStalled: _onMicStalled,
-            onInterruption: _onMicInterruption,
-          );
+            if (_socket?.state == SocketServiceState.connected) {
+              _socket?.send(frame.payload);
+              _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+            }
+          }
+        },
+        onRecording: () {
+          updateRecordingState(RecordingState.record);
+        },
+        onStop: () {
+          if (!_micInterrupted) {
+            updateRecordingState(RecordingState.stop);
+          }
+        },
+        onInitializing: () {
+          updateRecordingState(RecordingState.initialising);
+        },
+        onStalled: _onMicStalled,
+        onInterruption: _onMicInterruption,
+      );
     } catch (e, st) {
       // Typed native failures (permission_denied, engine_start_failed, ...) or
       // mic contention — fail visibly instead of recording silence.
@@ -1471,15 +1486,15 @@ class CaptureController extends ChangeNotifier
     updateRecordingState(RecordingState.record);
     try {
       await ServiceManager.instance().phoneMic.startBatch(
-            onStop: () {
-              if (!_micInterrupted && !_phoneMicBatchRestartInFlight) {
-                updateRecordingState(RecordingState.stop);
-              }
-            },
-            onInterruption: _onMicInterruption,
-            onBatchStalled: _onBatchStalled,
-            onError: _onBatchCaptureError,
-          );
+        onStop: () {
+          if (!_micInterrupted && !_phoneMicBatchRestartInFlight) {
+            updateRecordingState(RecordingState.stop);
+          }
+        },
+        onInterruption: _onMicInterruption,
+        onBatchStalled: _onBatchStalled,
+        onError: _onBatchCaptureError,
+      );
     } catch (e, st) {
       // No socket to clean in batch — fail visibly instead of recording nothing.
       Logger.error('[CaptureProvider] phone mic batch start failed: $e\n$st');

--- a/app/lib/services/mic/mic_arbiter.dart
+++ b/app/lib/services/mic/mic_arbiter.dart
@@ -30,9 +30,9 @@ class ArbitratedMic implements IMicRecorderService {
   final String _owner;
 
   ArbitratedMic({required IMicRecorderService inner, required MicArbiter arbiter, required String owner})
-    : _inner = inner,
-      _arbiter = arbiter,
-      _owner = owner;
+      : _inner = inner,
+        _arbiter = arbiter,
+        _owner = owner;
 
   @override
   Future<void> start({

--- a/app/lib/services/mic/mic_arbiter.dart
+++ b/app/lib/services/mic/mic_arbiter.dart
@@ -30,9 +30,9 @@ class ArbitratedMic implements IMicRecorderService {
   final String _owner;
 
   ArbitratedMic({required IMicRecorderService inner, required MicArbiter arbiter, required String owner})
-      : _inner = inner,
-        _arbiter = arbiter,
-        _owner = owner;
+    : _inner = inner,
+      _arbiter = arbiter,
+      _owner = owner;
 
   @override
   Future<void> start({
@@ -96,5 +96,10 @@ class ArbitratedMic implements IMicRecorderService {
   void stop() {
     _inner.stop();
     _arbiter.release(_owner);
+  }
+
+  @override
+  void probeStallAfterForeground() {
+    _inner.probeStallAfterForeground();
   }
 }

--- a/app/lib/services/mic/native_mic_recorder_service.dart
+++ b/app/lib/services/mic/native_mic_recorder_service.dart
@@ -61,8 +61,8 @@ class NativeMicRecorderService implements IMicRecorderService, PhoneMicFlutterAp
     PhoneMicHostApi? hostApi,
     bool registerFlutterApi = true,
     DateTime Function() now = DateTime.now,
-  })  : _hostApi = hostApi ?? PhoneMicHostApi(),
-        _now = now {
+  }) : _hostApi = hostApi ?? PhoneMicHostApi(),
+       _now = now {
     if (registerFlutterApi) {
       PhoneMicFlutterApi.setUp(this);
     }
@@ -288,6 +288,27 @@ class NativeMicRecorderService implements IMicRecorderService, PhoneMicFlutterAp
     _batchStallTimer = null;
     _lastBatchProgressAt = null;
     _batchStallReported = false;
+  }
+
+  /// Called when the Flutter app returns to foreground. Timers may have been
+  /// suspended while another window played audio (#4706); if frames/progress
+  /// already exceeded the stall threshold, fire the callback immediately.
+  @override
+  void probeStallAfterForeground() {
+    if (!_sessionActive) return;
+    if (_batchMode) {
+      if (_batchStallReported || _lastBatchProgressAt == null) return;
+      if (_now().difference(_lastBatchProgressAt!) >= _batchStallThreshold) {
+        _batchStallReported = true;
+        _onBatchStalled?.call();
+      }
+      return;
+    }
+    if (_stallReported || _lastByteAt == null || _interrupted) return;
+    if (_now().difference(_lastByteAt!) >= _stallThreshold) {
+      _stallReported = true;
+      _onStalled?.call();
+    }
   }
 
   void _clearCallbacks() {

--- a/app/lib/services/mic/native_mic_recorder_service.dart
+++ b/app/lib/services/mic/native_mic_recorder_service.dart
@@ -61,8 +61,8 @@ class NativeMicRecorderService implements IMicRecorderService, PhoneMicFlutterAp
     PhoneMicHostApi? hostApi,
     bool registerFlutterApi = true,
     DateTime Function() now = DateTime.now,
-  }) : _hostApi = hostApi ?? PhoneMicHostApi(),
-       _now = now {
+  })  : _hostApi = hostApi ?? PhoneMicHostApi(),
+        _now = now {
     if (registerFlutterApi) {
       PhoneMicFlutterApi.setUp(this);
     }
@@ -290,25 +290,22 @@ class NativeMicRecorderService implements IMicRecorderService, PhoneMicFlutterAp
     _batchStallReported = false;
   }
 
-  /// Called when the Flutter app returns to foreground. Timers may have been
-  /// suspended while another window played audio (#4706); if frames/progress
-  /// already exceeded the stall threshold, fire the callback immediately.
+  /// Soft-rearm liveness after the app returns to foreground (#4706).
+  ///
+  /// Wall-clock silence from timer suspension / screen lock must not force an
+  /// immediate Dart stop→start (that races the native `appBecameActive` rebuild
+  /// and also false-positives a healthy session). Reset the stall clock so the
+  /// periodic watchdog owns escalation only if frames still don't arrive.
   @override
   void probeStallAfterForeground() {
-    if (!_sessionActive) return;
+    if (!_sessionActive || _interrupted) return;
     if (_batchMode) {
-      if (_batchStallReported || _lastBatchProgressAt == null) return;
-      if (_now().difference(_lastBatchProgressAt!) >= _batchStallThreshold) {
-        _batchStallReported = true;
-        _onBatchStalled?.call();
-      }
+      _lastBatchProgressAt = _now();
+      _batchStallReported = false;
       return;
     }
-    if (_stallReported || _lastByteAt == null || _interrupted) return;
-    if (_now().difference(_lastByteAt!) >= _stallThreshold) {
-      _stallReported = true;
-      _onStalled?.call();
-    }
+    _lastByteAt = _now();
+    _stallReported = false;
   }
 
   void _clearCallbacks() {

--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -287,10 +287,10 @@ abstract class IMicRecorderService {
 
   void stop();
 
-  /// Re-check frame/progress liveness after the app returns to foreground.
-  /// iOS may suspend Dart timers while Stage Manager / multi-window lets
-  /// another app steal the mic without an AVAudioSession interruption (#4706).
-  /// No-op on flutter_sound stacks; [NativeMicRecorderService] trips stall.
+  /// Soft-rearm frame/progress liveness after the app returns to foreground.
+  /// iOS may suspend Dart timers while Stage Manager lets another app steal
+  /// the mic (#4706). Must not immediately escalate — that races native rebuild
+  /// and false-restarts healthy sessions. No-op on flutter_sound stacks.
   void probeStallAfterForeground();
 }
 

--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -286,6 +286,12 @@ abstract class IMicRecorderService {
   });
 
   void stop();
+
+  /// Re-check frame/progress liveness after the app returns to foreground.
+  /// iOS may suspend Dart timers while Stage Manager / multi-window lets
+  /// another app steal the mic without an AVAudioSession interruption (#4706).
+  /// No-op on flutter_sound stacks; [NativeMicRecorderService] trips stall.
+  void probeStallAfterForeground();
 }
 
 class MicRecorderBackgroundService implements IMicRecorderService {
@@ -331,6 +337,9 @@ class MicRecorderBackgroundService implements IMicRecorderService {
   void stop() {
     _runner.stopRecorder();
   }
+
+  @override
+  void probeStallAfterForeground() {}
 }
 
 class MicRecorderService implements IMicRecorderService {
@@ -460,4 +469,7 @@ class MicRecorderService implements IMicRecorderService {
     _onRecording = null;
     _onStalled = null;
   }
+
+  @override
+  void probeStallAfterForeground() {}
 }

--- a/app/test/unit/mic_arbiter_test.dart
+++ b/app/test/unit/mic_arbiter_test.dart
@@ -50,6 +50,9 @@ class FakeMic implements IMicRecorderService {
     capturedOnStop?.call();
     capturedOnStop = null;
   }
+
+  @override
+  void probeStallAfterForeground() {}
 }
 
 void main() {

--- a/app/test/unit/native_mic_recorder_service_test.dart
+++ b/app/test/unit/native_mic_recorder_service_test.dart
@@ -53,20 +53,20 @@ void main() {
   });
 
   Future<void> startService() => service.start(
-    onByteReceived: cb.bytes.add,
-    onRecording: () => cb.recording++,
-    onStop: () => cb.stops++,
-    onInitializing: () => cb.initializing++,
-    onStalled: () => cb.stalls++,
-    onInterruption: cb.interruptions.add,
-  );
+        onByteReceived: cb.bytes.add,
+        onRecording: () => cb.recording++,
+        onStop: () => cb.stops++,
+        onInitializing: () => cb.initializing++,
+        onStalled: () => cb.stalls++,
+        onInterruption: cb.interruptions.add,
+      );
 
   Future<void> startBatchService() => service.startBatch(
-    onStop: () => cb.stops++,
-    onInterruption: cb.interruptions.add,
-    onBatchStalled: () => cb.batchStalls++,
-    onError: (code, message) => cb.errors.add(code),
-  );
+        onStop: () => cb.stops++,
+        onInterruption: cb.interruptions.add,
+        onBatchStalled: () => cb.batchStalls++,
+        onError: (code, message) => cb.errors.add(code),
+      );
 
   test('start calls host api and maps state events to callbacks', () async {
     await startService();
@@ -194,10 +194,14 @@ void main() {
     });
   });
 
-  test('probeStallAfterForeground trips stall when timers were suspended (#4706)', () {
+  test('probeStallAfterForeground soft-rearms grace instead of immediate stall (#4706)', () {
     fakeAsync((async) {
       var now = DateTime(2026, 1, 1);
       service = NativeMicRecorderService(hostApi: host, registerFlutterApi: false, now: () => now);
+      void elapse(Duration d) {
+        now = now.add(d);
+        async.elapse(d);
+      }
 
       startService();
       async.flushMicrotasks();
@@ -206,16 +210,16 @@ void main() {
       service.onStateChanged(PhoneMicCaptureState.running, id);
       service.onAudioFrame(Uint8List.fromList([1]), id);
 
-      // Advance wall clock without elapsing timers — models iOS suspending
-      // Dart timers while another Stage Manager window plays audio.
+      // Wall-clock silence without timer ticks (suspended while backgrounded).
       now = now.add(const Duration(seconds: 5));
       expect(cb.stalls, 0);
 
+      // Soft re-arm must not escalate — avoids racing native rebuild / false restart.
       service.probeStallAfterForeground();
-      expect(cb.stalls, 1);
+      expect(cb.stalls, 0);
 
-      // Idempotent until a new frame arrives.
-      service.probeStallAfterForeground();
+      // Genuine post-resume silence still trips the periodic watchdog.
+      elapse(const Duration(seconds: 4));
       expect(cb.stalls, 1);
 
       service.stop();
@@ -226,6 +230,10 @@ void main() {
     fakeAsync((async) {
       var now = DateTime(2026, 1, 1);
       service = NativeMicRecorderService(hostApi: host, registerFlutterApi: false, now: () => now);
+      void elapse(Duration d) {
+        now = now.add(d);
+        async.elapse(d);
+      }
 
       startService();
       async.flushMicrotasks();
@@ -235,8 +243,8 @@ void main() {
       service.onAudioFrame(Uint8List.fromList([1]), id);
       service.onStateChanged(PhoneMicCaptureState.interrupted, id);
 
-      now = now.add(const Duration(seconds: 10));
       service.probeStallAfterForeground();
+      elapse(const Duration(seconds: 10));
       expect(cb.stalls, 0);
 
       service.stop();

--- a/app/test/unit/native_mic_recorder_service_test.dart
+++ b/app/test/unit/native_mic_recorder_service_test.dart
@@ -53,20 +53,20 @@ void main() {
   });
 
   Future<void> startService() => service.start(
-        onByteReceived: cb.bytes.add,
-        onRecording: () => cb.recording++,
-        onStop: () => cb.stops++,
-        onInitializing: () => cb.initializing++,
-        onStalled: () => cb.stalls++,
-        onInterruption: cb.interruptions.add,
-      );
+    onByteReceived: cb.bytes.add,
+    onRecording: () => cb.recording++,
+    onStop: () => cb.stops++,
+    onInitializing: () => cb.initializing++,
+    onStalled: () => cb.stalls++,
+    onInterruption: cb.interruptions.add,
+  );
 
   Future<void> startBatchService() => service.startBatch(
-        onStop: () => cb.stops++,
-        onInterruption: cb.interruptions.add,
-        onBatchStalled: () => cb.batchStalls++,
-        onError: (code, message) => cb.errors.add(code),
-      );
+    onStop: () => cb.stops++,
+    onInterruption: cb.interruptions.add,
+    onBatchStalled: () => cb.batchStalls++,
+    onError: (code, message) => cb.errors.add(code),
+  );
 
   test('start calls host api and maps state events to callbacks', () async {
     await startService();
@@ -189,6 +189,55 @@ void main() {
       service.onStateChanged(PhoneMicCaptureState.interrupted, id);
       elapse(const Duration(seconds: 30));
       expect(cb.stalls, 2);
+
+      service.stop();
+    });
+  });
+
+  test('probeStallAfterForeground trips stall when timers were suspended (#4706)', () {
+    fakeAsync((async) {
+      var now = DateTime(2026, 1, 1);
+      service = NativeMicRecorderService(hostApi: host, registerFlutterApi: false, now: () => now);
+
+      startService();
+      async.flushMicrotasks();
+      final id = host.lastStartSessionId;
+      service.onStateChanged(PhoneMicCaptureState.starting, id);
+      service.onStateChanged(PhoneMicCaptureState.running, id);
+      service.onAudioFrame(Uint8List.fromList([1]), id);
+
+      // Advance wall clock without elapsing timers — models iOS suspending
+      // Dart timers while another Stage Manager window plays audio.
+      now = now.add(const Duration(seconds: 5));
+      expect(cb.stalls, 0);
+
+      service.probeStallAfterForeground();
+      expect(cb.stalls, 1);
+
+      // Idempotent until a new frame arrives.
+      service.probeStallAfterForeground();
+      expect(cb.stalls, 1);
+
+      service.stop();
+    });
+  });
+
+  test('probeStallAfterForeground is a no-op while interrupted', () {
+    fakeAsync((async) {
+      var now = DateTime(2026, 1, 1);
+      service = NativeMicRecorderService(hostApi: host, registerFlutterApi: false, now: () => now);
+
+      startService();
+      async.flushMicrotasks();
+      final id = host.lastStartSessionId;
+      service.onStateChanged(PhoneMicCaptureState.starting, id);
+      service.onStateChanged(PhoneMicCaptureState.running, id);
+      service.onAudioFrame(Uint8List.fromList([1]), id);
+      service.onStateChanged(PhoneMicCaptureState.interrupted, id);
+
+      now = now.add(const Duration(seconds: 10));
+      service.probeStallAfterForeground();
+      expect(cb.stalls, 0);
 
       service.stop();
     });

--- a/app/test/unit/voice_recorder_mic_contention_test.dart
+++ b/app/test/unit/voice_recorder_mic_contention_test.dart
@@ -48,6 +48,9 @@ class _ContendedMic implements IMicRecorderService {
     _onStop?.call();
     _onStop = null;
   }
+
+  @override
+  void probeStallAfterForeground() {}
 }
 
 void main() {

--- a/app/test/widgets/transcription_paused_warning_test.dart
+++ b/app/test/widgets/transcription_paused_warning_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -133,6 +134,22 @@ void main() {
 
       expect(find.text(pausedText), findsWidgets);
       expect(find.text(listeningText), findsNothing);
+      // Phone-mic paused affordance: orange status dot + play (resume) control.
+      expect(
+        find.byWidgetPredicate((w) {
+          if (w is! Container) return false;
+          final d = w.decoration;
+          return d is BoxDecoration &&
+              d.color == const Color(0xFFFF9500) &&
+              d.shape == BoxShape.circle &&
+              w.constraints?.maxWidth == 6;
+        }),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.play.codePoint),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows Listening during phone mic recording when transcription is down', (tester) async {

--- a/app/test/widgets/transcription_paused_warning_test.dart
+++ b/app/test/widgets/transcription_paused_warning_test.dart
@@ -117,6 +117,24 @@ void main() {
       expect(find.text(AppLocalizations.of(context).listening), findsWidgets);
     });
 
+    testWidgets('shows Paused for non-call audio interruption (#4706)', (tester) async {
+      final captureProvider = CaptureProvider();
+      addTearDown(captureProvider.dispose);
+      // recordingState=interrupted without micInterrupted → isCallActive is false
+      // (other-app audio / silent stall path, not an active phone call).
+      captureProvider.updateRecordingState(RecordingState.interrupted);
+      expect(captureProvider.isCallActive, isFalse);
+
+      await pumpCaptureWidget(tester, captureProvider);
+
+      final context = tester.element(find.byType(ConversationCaptureWidget));
+      final pausedText = AppLocalizations.of(context).paused;
+      final listeningText = AppLocalizations.of(context).listening;
+
+      expect(find.text(pausedText), findsWidgets);
+      expect(find.text(listeningText), findsNothing);
+    });
+
     testWidgets('shows Listening during phone mic recording when transcription is down', (tester) async {
       final captureProvider = CaptureProvider();
       addTearDown(captureProvider.dispose);


### PR DESCRIPTION
## What changed and why

On iPadOS (Stage Manager / windowed apps), playing YouTube (or other audio) while Omi phone-mic records can stop mic frames without an AVAudioSession interruption. The UI stayed on “Listening”, Dart stall timers may not fire while suspended, and `appBecameActive` only resumed if already `.interrupted`. Fixes #4706.

- **Native:** on `appBecameActive` while `.running`, rebuild if the engine is dead; on `interruptionEnded`, always `attemptResume()` once (other-app audio often ends without `shouldResume`).
- **Dart:** `probeStallAfterForeground()` soft-rearms the stall clock from home lifecycle resume (does **not** immediately stop→start — native owns dead-engine rebuild; the periodic watchdog escalates only if frames still don’t arrive).
- **UI:** any `RecordingState.interrupted` shows Paused (not only call-active).

## Product invariants affected

none

## How it was verified

```bash
cd app && flutter test \
  test/unit/native_mic_recorder_service_test.dart \
  test/unit/mic_arbiter_test.dart \
  test/unit/voice_recorder_mic_contention_test.dart \
  test/widgets/transcription_paused_warning_test.dart
```

Could not reproduce on a physical iPad in this environment. Native dead-engine rebuild is covered by the existing PhoneMic control path + unit tests for the Dart timer-suspension gap.

## Tests

- `app/test/unit/native_mic_recorder_service_test.dart` — soft-rearm / watchdog foreground-stall cases
- `app/test/widgets/transcription_paused_warning_test.dart` — non-call interrupted → Paused + paused affordance
- mic test doubles stub `probeStallAfterForeground`

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

n/a