### PR TITLE
fix(agent-vm): make reconciler IAM bindings condition-safe

### DIFF
--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -59,8 +59,13 @@ gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$role" \
   --condition="title=Agent VM reconciler disk scope,description=Boot disk reads for omi-agent instances in the Agent VM zone,expression=resource.type == 'compute.googleapis.com/Disk' && resource.name.startsWith('projects/${project}/zones/${zone}/disks/omi-agent-')"
 gcloud projects add-iam-policy-binding "$project" \
-  --member="serviceAccount:${gsa}" --role="$operations_role"
-gcloud projects add-iam-policy-binding "$project" --member="serviceAccount:${gsa}" --role=roles/datastore.user
+  --member="serviceAccount:${gsa}" --role="$operations_role" --condition=None
+# Project IAM policies containing scoped bindings require unconditional bindings
+# to say so explicitly.  The operations and datastore roles are intentionally
+# unconditioned because neither permission supports the instance resource
+# condition used above.
+gcloud projects add-iam-policy-binding "$project" \
+  --member="serviceAccount:${gsa}" --role=roles/datastore.user --condition=None
 gcloud storage buckets add-iam-policy-binding "gs://${bucket}" --member="serviceAccount:${gsa}" --role=roles/storage.objectViewer
 
 bootstrap="omi-agent-vm-bootstrap@${project}.iam.gserviceaccount.com"

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -160,6 +160,16 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         "--member=serviceAccount:local-development-joan@based-hardware-dev.iam.gserviceaccount.com "
         "--role=roles/iam.serviceAccountUser"
     ) in commands
+    assert (
+        "projects add-iam-policy-binding based-hardware-dev "
+        "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
+        "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerOperations --condition=None"
+    ) in commands
+    assert (
+        "projects add-iam-policy-binding based-hardware-dev "
+        "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
+        "--role=roles/datastore.user --condition=None"
+    ) in commands
 
 
 def test_revoke_script_removes_all_conditional_bindings_and_verifies_absence():


### PR DESCRIPTION
## Summary

- make the Agent VM reconciler's two intentional project-wide role bindings explicit with `--condition=None`
- retain resource-scoped conditions for Compute instance and disk access
- behaviorally verify the exact unconditional IAM commands with fake `gcloud`

## Validation

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py`
- `bash -n backend/scripts/apply-agent-vm-reconciler-iam.sh`
- `git diff --check`

Failure-Class: FC-agent-vm-bootstrap-contract


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

