### PR TITLE
fix(desktop): route hermes/openclaw harness modes through AgentRuntimeRouting

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentControlService.swift
@@ -73,7 +73,11 @@ final class AgentControlService {
 
   static func currentHarnessMode() -> String {
     let mode = UserDefaults.standard.string(forKey: "chatBridgeMode") ?? "piMono"
-    return mode == "piMono" ? "piMono" : "acp"
+    // Delegate to AgentRuntimeRouting which knows all harness modes
+    // (piMono, acp, hermes, openclaw). Previously this hardcoded "acp" for
+    // anything that wasn't "piMono", which silently broke the Hermes and
+    // OpenClaw adapters even when selected in Settings.
+    return AgentRuntimeRouting.harnessMode(from: mode)?.rawValue ?? "piMono"
   }
 
   func logDetail(name: String, arguments: [String: Any]) -> String {


### PR DESCRIPTION
## Problem

AgentControlService.currentHarnessMode() hardcoded the return to either "piMono" or "acp", silently discarding "hermes" and "openclaw" even when the user selected them in Settings > Advanced > AI Provider.

When chatBridgeMode was set to "hermes" (via the Settings UI), currentHarnessMode() returned "acp", causing the Node agent to register the generic ACP (Claude Code) adapter instead of the Hermes adapter, binding chat sessions to adapterId "acp" and failing with "Claude sign-in is required" errors.

This made the "Local Hermes Agent via ACP" option in Settings appear non-functional — the preference was written to the database correctly, but the chat engine ignored it.

## Root Cause

```swift
// AgentControlService.swift:74-76 (before)
static func currentHarnessMode() -> String {
    let mode = UserDefaults.standard.string(forKey: "chatBridgeMode") ?? "piMono"
    return mode == "piMono" ? "piMono" : "acp"  // hermes/openclaw discarded
}
```

The function only distinguished between piMono and acp, returning "acp" for everything else — including "hermes" and "openclaw", which are valid BridgeMode values (see ChatProvider.BridgeMode and AgentRuntimeRouting).

## Fix

Delegate to AgentRuntimeRouting.harnessMode(from:) which already knows all production harness modes (piMono, acp, hermes, openclaw) and maps them correctly. The routing helper now also accepts the persisted Claude Code spelling and maps it to ACP.

## Verification

1. Set chatBridgeMode = "hermes" in UserDefaults
2. Built and launched the desktop app
3. Confirmed HARNESS_MODE=hermes in the Node agent environment
4. Sent a chat message — got a response from Hermes (gpt-5.4-mini via ACP)
5. DB shows adapterId "hermes" in adapter_bindings, run.succeeded events
6. Added a regression assertion for the persisted "claudeCode" preference mapping to ACP

## Failure-Class

Failure-Class: none

## Product invariants affected

- INV-CHAT-1

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
