### PR TITLE
fix(agent-vm): isolate dev control-plane projects

### DIFF
--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -19,6 +19,22 @@ def _ordered(text: str, fragments: tuple[str, ...], *, workflow: str) -> list[st
     return []
 
 
+def _step_block(text: str, name: str) -> str | None:
+    """Return one workflow step so its runtime contract cannot be borrowed by another."""
+    start = text.find(f"      - name: {name}\n")
+    if start < 0:
+        return None
+    # Steps are allowed to be unnamed (for example ``- uses:``), so stopping
+    # only at the next named step would let a later peer step satisfy this
+    # step's deployment contract. A step starts at this same indentation level
+    # regardless of which mapping key appears after the dash.
+    lines = text[start:].splitlines(keepends=True)
+    for index, line in enumerate(lines[1:], start=1):
+        if line.startswith("      - "):
+            return "".join(lines[:index])
+    return "".join(lines)
+
+
 def _validate_production_python_runtime(text: str, *, workflow: str) -> list[str]:
     errors: list[str] = []
     retired_desktop_context = "./desktop/macos/" + "Backend" + "-Rust"
@@ -185,7 +201,9 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             "DEVELOPMENT_DESKTOP_BACKEND_URL: https://desktop-backend-dt5lrfkkoa-uc.a.run.app",
             'revision_suffix="${image_tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
             "GOOGLE_APPLICATION_CREDENTIALS=/secrets/firebase/service-account.json",
+            "FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
             "FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
+            "GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}",
             "/secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest",
             "FIREBASE_API_KEY=FIREBASE_API_KEY:latest",
             "${{ secrets.GCP_SERVICE_ACCOUNT }}",
@@ -209,6 +227,27 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             )
         if "FIREBASE_AUTH_PROJECT_ID: based-hardware-dev" in text or "FIREBASE_PROJECT_ID=based-hardware-dev" in text:
             errors.append(f"{workflow}: development serving must retain the production Firebase project")
+        dev_runtime_steps = (
+            "Deploy desktop-backend to Cloud Run",
+            "Deploy Agent VM reconciler Cloud Run Job",
+        )
+        dev_runtime_env = (
+            "FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
+            "FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
+            "GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}",
+            "GCE_PROJECT_ID=${{ vars.GCP_PROJECT_ID }}",
+        )
+        for step in dev_runtime_steps:
+            block = _step_block(text, step)
+            if block is None:
+                errors.append(f"{workflow}: missing development runtime step {step!r}")
+                continue
+            for env_var in dev_runtime_env:
+                # Match complete YAML assignment lines. A comment or an
+                # unrelated value containing the text must never satisfy a
+                # required runtime project binding.
+                if not any(line.strip() == env_var for line in block.splitlines()):
+                    errors.append(f"{workflow}: {step} missing isolated development runtime env {env_var!r}")
     return errors
 
 

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -276,6 +276,47 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         errors = POLICY.validate_deploy_workflow(mutated, production=False)
         self.assertTrue(any("production Firebase project" in error for error in errors), errors)
 
+    def test_requires_isolated_runtime_env_for_each_development_deployment(self) -> None:
+        for step in ("Deploy desktop-backend to Cloud Run", "Deploy Agent VM reconciler Cloud Run Job"):
+            with self.subTest(step=step):
+                start = self.dev.index(f"      - name: {step}\n")
+                end = self.dev.find("\n      - name: ", start + 1)
+                block = self.dev[start:] if end < 0 else self.dev[start:end]
+                mutated_block = block.replace(
+                    "GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}",
+                    "GOOGLE_CLOUD_PROJECT=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
+                    1,
+                )
+                mutated = self.dev[:start] + mutated_block + self.dev[start + len(block):]
+                errors = POLICY.validate_deploy_workflow(mutated, production=False)
+                self.assertTrue(any(step in error and "GOOGLE_CLOUD_PROJECT" in error for error in errors), errors)
+
+                mutated_block = block.replace("GCE_PROJECT_ID=${{ vars.GCP_PROJECT_ID }}", "", 1)
+                mutated = self.dev[:start] + mutated_block + self.dev[start + len(block):]
+                errors = POLICY.validate_deploy_workflow(mutated, production=False)
+                self.assertTrue(any(step in error and "GCE_PROJECT_ID" in error for error in errors), errors)
+
+                for env_var in (
+                    "FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
+                    "FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
+                    "GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}",
+                    "GCE_PROJECT_ID=${{ vars.GCP_PROJECT_ID }}",
+                ):
+                    with self.subTest(step=step, env_var=env_var):
+                        commented_block = block.replace(env_var, f"# {env_var}", 1)
+                        mutated = self.dev[:start] + commented_block + self.dev[start + len(block):]
+                        errors = POLICY.validate_deploy_workflow(mutated, production=False)
+                        self.assertTrue(any(step in error and env_var in error for error in errors), errors)
+
+                        unnamed_peer = (
+                            "\n      - uses: actions/checkout@v4\n"
+                            "        env_vars: |\n"
+                            f"          {env_var}\n"
+                        )
+                        mutated = self.dev[:start] + commented_block + unnamed_peer + self.dev[start + len(block):]
+                        errors = POLICY.validate_deploy_workflow(mutated, production=False)
+                        self.assertTrue(any(step in error and env_var in error for error in errors), errors)
+
     def test_rejects_baked_credentials_or_python_contract_version_drift(self) -> None:
         errors = POLICY.validate_contract_sources(
             dockerfile=self.dockerfile + "\nCOPY google-credentials.json /app/google-credentials.json\n",

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -264,7 +264,9 @@ jobs:
             --tag=${{ env.CANDIDATE_TAG }}
             --remove-env-vars=OMI_DESKTOP_RELEASE_TAG,OMI_DESKTOP_RELEASE_SHA,OMI_DESKTOP_RELEASE_CHANNEL
           env_vars: |
+            FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
             FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
+            GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}
             GOOGLE_APPLICATION_CREDENTIALS=/secrets/firebase/service-account.json
             BASE_API_URL=${{ steps.desktop-base-api-url.outputs.base_api_url }}
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.candidate-identity.outputs.source_sha }}
@@ -499,8 +501,9 @@ jobs:
             --subnet=default
             --vpc-egress=private-ranges-only
           env_vars: |
+            FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
             FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
-            GOOGLE_CLOUD_PROJECT=${{ env.FIREBASE_AUTH_PROJECT_ID }}
+            GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}
             GCE_PROJECT_ID=${{ vars.GCP_PROJECT_ID }}
             AGENT_VM_ENVIRONMENT=development
             AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc

--- a/backend/desktop_backend.py
+++ b/backend/desktop_backend.py
@@ -19,14 +19,18 @@ from routers import (
     desktop_screen_crisp,
     desktop_tts_updates,
 )
-from utils.env_loader import load_backend_env
+from utils.env_loader import firebase_admin_options, load_backend_env
 from utils.http_client import close_all_clients
 
 
-@asynccontextmanager
-async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-    load_backend_env()
-    prepare_google_credentials()
+def _initialize_firebase_admin() -> None:
+    """Initialize token verification without selecting the Google data project.
+
+    Development serves production Firebase identities but runs its Cloud Run
+    workload (Firestore and Agent VM control) in the development GCP project.
+    ``firebase_admin_options`` therefore pins only Firebase Admin's token
+    audience; ADC continues to use ``GOOGLE_CLOUD_PROJECT`` independently.
+    """
     auth_emulator_host = os.environ.get("FIREBASE_AUTH_EMULATOR_HOST", "").strip()
     if auth_emulator_host:
         for adc_key in ("GOOGLE_APPLICATION_CREDENTIALS", "SERVICE_ACCOUNT_JSON"):
@@ -38,9 +42,16 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     elif service_account_json := os.environ.get("SERVICE_ACCOUNT_JSON"):
         service_account_info = json.loads(service_account_json)
         credentials = firebase_admin.credentials.Certificate(service_account_info)
-        firebase_admin.initialize_app(credentials)
+        firebase_admin.initialize_app(credentials, options=firebase_admin_options())
     else:
-        firebase_admin.initialize_app()
+        firebase_admin.initialize_app(options=firebase_admin_options())
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    load_backend_env()
+    prepare_google_credentials()
+    _initialize_firebase_admin()
     try:
         yield
     finally:

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -46,6 +46,7 @@ from services.agent_vm_lifecycle import (
     update_vm_reconcile,
     validate_release_manifest,
 )
+from utils.env_loader import firebase_admin_options
 from utils.observability.fallback import record_fallback
 
 logging.basicConfig(level=logging.INFO)
@@ -79,9 +80,12 @@ def _init_firebase() -> None:
         pass
     service_account_json = os.getenv("SERVICE_ACCOUNT_JSON")
     if service_account_json:
-        firebase_admin.initialize_app(firebase_admin.credentials.Certificate(json.loads(service_account_json)))
+        firebase_admin.initialize_app(
+            firebase_admin.credentials.Certificate(json.loads(service_account_json)),
+            options=firebase_admin_options(),
+        )
     else:
-        firebase_admin.initialize_app()
+        firebase_admin.initialize_app(options=firebase_admin_options())
 
 
 def _read_gcs_uri(uri: str) -> bytes:
@@ -530,9 +534,9 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
     _init_firebase()
     release, raw_manifest = load_active_release()
     environment = os.getenv("AGENT_VM_ENVIRONMENT", release.environment)
-    project = os.getenv("GCE_PROJECT_ID") or os.getenv("FIREBASE_PROJECT_ID") or os.getenv("GCP_PROJECT_ID")
+    project = os.getenv("GCE_PROJECT_ID")
     if not project:
-        raise RuntimeError("GCE_PROJECT_ID, FIREBASE_PROJECT_ID, or GCP_PROJECT_ID is required")
+        raise RuntimeError("GCE_PROJECT_ID is required for Agent VM reconciliation")
     owner = f"{os.getenv('K_REVISION', 'local')}:{uuid.uuid4().hex}"
     if not dry_run and not await asyncio.to_thread(claim_reconciler_run_lease, environment, owner):
         logger.info("Agent VM reconciler skipped: another run owns the %s lease", environment)

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -84,9 +84,9 @@ def _now() -> str:
 
 
 def _project() -> str:
-    project = os.getenv("GCE_PROJECT_ID") or os.getenv("FIREBASE_PROJECT_ID") or os.getenv("GCP_PROJECT_ID")
+    project = os.getenv("GCE_PROJECT_ID")
     if not project:
-        raise RuntimeError("GCE project is not configured")
+        raise RuntimeError("GCE_PROJECT_ID is required for Agent VM control")
     return project
 
 

--- a/backend/tests/unit/test_agent_vm_firebase_project_split.py
+++ b/backend/tests/unit/test_agent_vm_firebase_project_split.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import firebase_admin
+import pytest
+
+import desktop_backend
+import jobs.agent_vm_reconciler as reconciler
+from routers import desktop_agent_vm
+
+
+def test_desktop_backend_initializes_production_auth_separately_from_google_cloud_project(monkeypatch) -> None:
+    initialize = MagicMock()
+    monkeypatch.setattr(firebase_admin, "initialize_app", initialize)
+    monkeypatch.delenv("FIREBASE_AUTH_EMULATOR_HOST", raising=False)
+    monkeypatch.delenv("SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.setenv("FIREBASE_AUTH_PROJECT_ID", "based-hardware")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware-dev")
+
+    desktop_backend._initialize_firebase_admin()
+
+    initialize.assert_called_once_with(options={"projectId": "based-hardware"})
+
+
+def test_reconciler_initializes_production_auth_separately_from_google_cloud_project(monkeypatch) -> None:
+    initialize = MagicMock()
+    monkeypatch.setattr(firebase_admin, "get_app", MagicMock(side_effect=ValueError()))
+    monkeypatch.setattr(firebase_admin, "initialize_app", initialize)
+    monkeypatch.delenv("SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.setenv("FIREBASE_AUTH_PROJECT_ID", "based-hardware")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware-dev")
+
+    reconciler._init_firebase()
+
+    initialize.assert_called_once_with(options={"projectId": "based-hardware"})
+
+
+def test_agent_vm_control_requires_an_explicit_gce_project(monkeypatch) -> None:
+    monkeypatch.delenv("GCE_PROJECT_ID", raising=False)
+    monkeypatch.setenv("FIREBASE_PROJECT_ID", "based-hardware")
+
+    with pytest.raises(RuntimeError, match="GCE_PROJECT_ID"):
+        desktop_agent_vm._project()
+
+
+@pytest.mark.asyncio
+async def test_reconciler_requires_an_explicit_gce_project(monkeypatch) -> None:
+    monkeypatch.setattr(reconciler, "_init_firebase", lambda: None)
+    monkeypatch.setattr(reconciler, "load_active_release", lambda: (MagicMock(environment="development"), {}))
+    monkeypatch.delenv("GCE_PROJECT_ID", raising=False)
+    monkeypatch.setenv("FIREBASE_PROJECT_ID", "based-hardware")
+
+    with pytest.raises(RuntimeError, match="GCE_PROJECT_ID"):
+        await reconciler.run_reconciler(dry_run=True)


### PR DESCRIPTION
## Summary

- separate Firebase ID-token audience selection from the Google Cloud runtime project in the development desktop backend and Agent VM reconciler;
- bind both development runtime deployments independently to `based-hardware-dev` for Firestore and GCE, while retaining `based-hardware` only for Firebase authentication;
- make Agent VM control require `GCE_PROJECT_ID` and mutation-test the deployment policy so either runtime block fails closed if its project binding drifts.

## Root cause

The development reconciler inherited `GOOGLE_CLOUD_PROJECT=based-hardware` from the Firebase Auth configuration. Its dev-only service account therefore attempted to access production Firestore and correctly received `403 PermissionDenied`.

## Validation

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_agent_vm_firebase_project_split.py backend/tests/unit/test_agent_vm_reconciler_job.py backend/tests/unit/test_desktop_agent_vm.py backend/tests/unit/test_env_loader.py .github/scripts/test_check_desktop_backend_release_policy.py`
  - `87 passed`
- `python3 .github/scripts/check-desktop-backend-release-policy.py`
- guarded managed pre-push suite

Failure-Class: FC-firestore-readiness-project-mismatch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

