### PR TITLE
feat(memory): automate canonical cohort staging lifecycle

### DIFF
--- a/backend/tests/unit/test_canonical_cohort_lifecycle.py
+++ b/backend/tests/unit/test_canonical_cohort_lifecycle.py
@@ -1,0 +1,164 @@
+from types import SimpleNamespace
+
+import pytest
+
+from database.memory_collections import MemoryCollections
+from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore, StrictFirestoreDocument
+from utils.memory import canonical_cohort_lifecycle as lifecycle
+
+
+class _Db(StrictFirestore):
+    def __init__(self, docs=None):
+        super().__init__({tuple(path.split("/")): payload for path, payload in (docs or {}).items()})
+
+    def document(self, path):
+        return StrictFirestoreDocument(self, tuple(path.split("/")))
+
+    def payload(self, path):
+        return self.rows[tuple(path.split("/"))]
+
+
+def _path(uid):
+    return MemoryCollections(uid=uid).memory_control_state
+
+
+def test_lifecycle_advances_only_exact_inert_control_and_runs_bounded_apply(monkeypatch):
+    uid = "cohort-a"
+    db = _Db({_path(uid): lifecycle._inert_control_payload(uid)})
+    onboarding = SimpleNamespace(created_uids=(), preserved_uids=(uid,))
+    page = SimpleNamespace(summary=SimpleNamespace(read_ready_count=1))
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: onboarding)
+    calls = []
+    monkeypatch.setattr(
+        lifecycle,
+        "run_canonical_legacy_backfill_page",
+        lambda **kwargs: calls.append(kwargs) or page,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "FirestoreCheckpointStore",
+        lambda _db: SimpleNamespace(read=lambda _uid: SimpleNamespace(state="not_started")),
+    )
+
+    report = lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert report.write_enrolled_uids == (uid,)
+    assert report.preserved_uids == ()
+    assert db.payload(_path(uid)) == lifecycle._write_control_payload(uid)
+    assert calls[0]["db_client"] is db
+    assert calls[0]["config"].dry_run is False
+
+
+def test_lifecycle_preserves_existing_write_or_read_state(monkeypatch):
+    uid = "cohort-a"
+    existing = lifecycle._write_control_payload(uid)
+    existing["mode"] = "read"
+    db = _Db({_path(uid): existing})
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: SimpleNamespace())
+    monkeypatch.setattr(
+        lifecycle,
+        "run_canonical_legacy_backfill_page",
+        lambda **_kwargs: SimpleNamespace(summary=SimpleNamespace(read_ready_count=0)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "FirestoreCheckpointStore",
+        lambda _db: SimpleNamespace(read=lambda _uid: SimpleNamespace(state="not_started")),
+    )
+
+    report = lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert report.write_enrolled_uids == ()
+    assert report.preserved_uids == (uid,)
+    assert db.transactions[-1].sets == []
+
+
+def test_lifecycle_fails_closed_for_non_scheduler_owned_off_state(monkeypatch):
+    uid = "cohort-a"
+    malformed = lifecycle._inert_control_payload(uid)
+    malformed["grants"] = {"omi_chat": {"default_memory": True, "archive": False}}
+    db = _Db({_path(uid): malformed})
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match="unsupported_canonical_rollout_state"):
+        lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert db.transactions[-1].sets == []
+
+
+def test_terminal_backfill_reconciles_only_the_scheduler_owned_write_generation(monkeypatch):
+    uid = "cohort-a"
+    db = _Db({_path(uid): lifecycle._write_control_payload(uid)})
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: SimpleNamespace())
+    monkeypatch.setattr(
+        lifecycle,
+        "run_canonical_legacy_backfill_page",
+        lambda **_kwargs: SimpleNamespace(summary=SimpleNamespace(read_ready_count=1)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "FirestoreCheckpointStore",
+        lambda _db: SimpleNamespace(read=lambda _uid: SimpleNamespace(state=lifecycle.MigrationState.read_ready)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "read_memory_v3_trusted_account_generation",
+        lambda **kwargs: SimpleNamespace(require_account_generation=lambda: 1),
+    )
+
+    report = lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert report.backfill_ready_uids == (uid,)
+    assert report.generation_reconciled_uids == (uid,)
+    assert db.payload(_path(uid))["account_generation"] == 1
+
+
+def test_terminal_backfill_reconciles_a_newer_trusted_head_after_a_prior_scheduler_generation(monkeypatch):
+    uid = "cohort-a"
+    db = _Db({_path(uid): lifecycle._write_control_payload(uid, account_generation=1)})
+    seen_transactions = []
+    monkeypatch.setattr(
+        lifecycle,
+        "read_memory_v3_trusted_account_generation",
+        lambda **kwargs: seen_transactions.append(kwargs["transaction"])
+        or SimpleNamespace(require_account_generation=lambda: 2),
+    )
+
+    reconciled = lifecycle._reconcile_terminal_backfill_generation(uid=uid, db_client=db)
+
+    assert reconciled is True
+    assert len(seen_transactions) == 1
+    assert db.payload(_path(uid)) == lifecycle._write_control_payload(uid, account_generation=2)
+
+
+def test_terminal_backfill_never_updates_a_read_control_generation(monkeypatch):
+    uid = "cohort-a"
+    control = lifecycle._write_control_payload(uid)
+    control.update({"mode": "read", "account_generation": 0, "fallback_projection_ready": True})
+    db = _Db({_path(uid): control})
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: SimpleNamespace())
+    monkeypatch.setattr(
+        lifecycle,
+        "run_canonical_legacy_backfill_page",
+        lambda **_kwargs: SimpleNamespace(summary=SimpleNamespace(read_ready_count=1)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "FirestoreCheckpointStore",
+        lambda _db: SimpleNamespace(read=lambda _uid: SimpleNamespace(state=lifecycle.MigrationState.read_ready)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "read_memory_v3_trusted_account_generation",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("manual/read controls must not load a trusted head")),
+    )
+
+    report = lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert report.generation_reconciled_uids == ()
+    assert db.payload(_path(uid))["account_generation"] == 0

--- a/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
+++ b/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -30,6 +31,16 @@ CANONICAL_B = "uid-canonical-b"
 def _enable_for(monkeypatch, *uids: str) -> None:
     monkeypatch.setenv(cron.MEMORY_CANONICAL_MAINTENANCE_ENABLED_ENV, "true")
     monkeypatch.setattr(cron, "list_canonical_cohort_uids", lambda: list(uids))
+    monkeypatch.setattr(
+        cron,
+        "run_canonical_cohort_lifecycle",
+        lambda **_kwargs: SimpleNamespace(
+            write_enrolled_uids=(),
+            backfill=SimpleNamespace(summary=SimpleNamespace(read_ready_count=0)),
+            backfill_ready_uids=tuple(uids),
+            generation_reconciled_uids=(),
+        ),
+    )
 
 
 def test_disabled_cohort_runner_returns_empty_summary_without_running_maintenance(
@@ -50,6 +61,51 @@ def test_disabled_cohort_runner_returns_empty_summary_without_running_maintenanc
     assert summary == cron.CanonicalShortTermMaintenanceCronSummary(run_id="cron-disabled")
     list_uids.assert_not_called()
     run_maintenance.assert_not_called()
+
+
+def test_enabled_cohort_runs_lifecycle_before_maintenance(monkeypatch):
+    _enable_for(monkeypatch, CANONICAL_A)
+    lifecycle_report = SimpleNamespace(
+        write_enrolled_uids=(CANONICAL_A,),
+        backfill=SimpleNamespace(summary=SimpleNamespace(read_ready_count=1)),
+        backfill_ready_uids=(CANONICAL_A,),
+        generation_reconciled_uids=(CANONICAL_A,),
+    )
+    lifecycle_calls = []
+    monkeypatch.setattr(
+        cron,
+        "run_canonical_cohort_lifecycle",
+        lambda **kwargs: lifecycle_calls.append(kwargs) or lifecycle_report,
+    )
+    monkeypatch.setattr(
+        cron,
+        "run_canonical_short_term_maintenance",
+        lambda uid, **_kwargs: MaintenanceReport(uid=uid),
+    )
+    client = object()
+
+    summary = cron.run_canonical_short_term_maintenance_for_cohort(
+        db_client=client,
+        now=NOW,
+        run_id="cron-lifecycle",
+    )
+
+    assert lifecycle_calls == [{"db_client": client}]
+    assert summary.lifecycle_write_enrolled_total == 1
+    assert summary.lifecycle_backfill_read_ready_total == 1
+    assert summary.lifecycle_generation_reconciled_total == 1
+
+
+def test_lifecycle_failure_blocks_graph_staging_but_not_per_user_maintenance(monkeypatch):
+    _enable_for(monkeypatch, CANONICAL_A)
+    maintenance = MagicMock(side_effect=lambda uid, **_kwargs: MaintenanceReport(uid=uid))
+    monkeypatch.setattr(cron, "run_canonical_cohort_lifecycle", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError()))
+    monkeypatch.setattr(cron, "run_canonical_short_term_maintenance", maintenance)
+
+    summary = cron.run_canonical_short_term_maintenance_for_cohort(now=NOW, run_id="cron-lifecycle-failure")
+
+    assert summary.errors == ["canonical_cohort_lifecycle:RuntimeError"]
+    maintenance.assert_called_once()
 
 
 def test_enabled_cohort_graph_backfill_uses_the_fenced_bounded_runner(monkeypatch):
@@ -85,6 +141,33 @@ def test_enabled_cohort_graph_backfill_uses_the_fenced_bounded_runner(monkeypatc
     assert graph_calls[0]["limit"] == cron.DEFAULT_GRAPH_BACKFILL_PAGE_SIZE
     assert graph_calls[0]["apply_limit"] == cron.DEFAULT_GRAPH_BACKFILL_PAGE_SIZE
     assert graph_calls[0]["scan_limit"] == cron.DEFAULT_GRAPH_BACKFILL_SCAN_SIZE
+
+
+def test_graph_backfill_is_withheld_until_lifecycle_reports_readiness(monkeypatch):
+    _enable_for(monkeypatch, CANONICAL_A)
+    monkeypatch.setenv(cron.MEMORY_CANONICAL_GRAPH_BACKFILL_ENABLED_ENV, "true")
+    monkeypatch.setattr(
+        cron,
+        "run_canonical_cohort_lifecycle",
+        lambda **_kwargs: SimpleNamespace(
+            write_enrolled_uids=(),
+            backfill=SimpleNamespace(summary=SimpleNamespace(read_ready_count=0)),
+            backfill_ready_uids=(),
+            generation_reconciled_uids=(),
+        ),
+    )
+    monkeypatch.setattr(
+        cron,
+        "run_canonical_short_term_maintenance",
+        lambda uid, **_kwargs: MaintenanceReport(uid=uid),
+    )
+    graph_calls = []
+    monkeypatch.setattr(cron, "run_enrichment", lambda **kwargs: graph_calls.append(kwargs) or {"outcomes": {}})
+
+    summary = cron.run_canonical_short_term_maintenance_for_cohort(db_client=object(), now=NOW, run_id="cron-not-ready")
+
+    assert graph_calls == []
+    assert summary.graph_enriched_total == 0
 
 
 def test_graph_backfill_scan_size_is_bounded_to_the_current_page_multiple(monkeypatch):

--- a/backend/tests/unit/test_v3_account_generation_source.py
+++ b/backend/tests/unit/test_v3_account_generation_source.py
@@ -76,6 +76,15 @@ def test_trusted_account_generation_reads_independent_memory_state_head_path():
     assert db.document_reads == ["users/u1/memory_state/head"]
 
 
+def test_trusted_account_generation_can_join_the_callers_firestore_transaction():
+    db = _FakeDb({"users/u1/memory_state/head": _head_doc(account_generation=8)})
+    transaction = object()
+
+    result = read_memory_v3_trusted_account_generation(uid="u1", db_client=db, transaction=transaction)
+
+    assert result.account_generation == 8
+
+
 @pytest.mark.parametrize(
     "docs, reason",
     [

--- a/backend/utils/memory/canonical_cohort_lifecycle.py
+++ b/backend/utils/memory/canonical_cohort_lifecycle.py
@@ -1,0 +1,243 @@
+"""Scheduler-owned enrollment and bounded staging for canonical-memory cohorts.
+
+LIFECYCLE: permanent
+
+The code-owned cohort selector is the only entitlement input.  This coordinator
+turns the exact inert state created by canonical onboarding into the existing
+write-stage control document, then delegates historical rows to the bounded,
+checkpointed backfill owner.  It intentionally never opens global read gates or
+marks a user projection-ready: read cutover needs its own trusted generation and
+compatibility-projection proof.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from google.cloud.firestore_v1 import transactional as _firestore_transactional
+
+from config.memory_rollout import MemoryRolloutMode
+from database.memory_collections import MemoryCollections
+from scripts.enroll_canonical_memory_user import build_user_control_state
+from utils.memory.canonical_legacy_backfill import (
+    CanonicalLegacyBackfillConfig,
+    CanonicalLegacyBackfillPage,
+    run_canonical_legacy_backfill_page,
+)
+from utils.memory.bulk_legacy_backfill import FirestoreCheckpointStore, MigrationState
+from utils.memory.canonical_memory_onboarding import (
+    ONBOARDING_ACCOUNT_GENERATION,
+    CanonicalMemoryOnboardingReport,
+    reconcile_canonical_memory_onboarding,
+)
+from utils.memory.memory_system import list_canonical_cohort_uids
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.limited_rollout_config import build_whitelisted_user_control_state
+
+
+@dataclass(frozen=True)
+class CanonicalCohortLifecycleReport:
+    onboarding: CanonicalMemoryOnboardingReport
+    write_enrolled_uids: tuple[str, ...]
+    preserved_uids: tuple[str, ...]
+    backfill_ready_uids: tuple[str, ...]
+    generation_reconciled_uids: tuple[str, ...]
+    backfill: CanonicalLegacyBackfillPage
+
+
+def _inert_control_payload(uid: str) -> dict[str, Any]:
+    return build_whitelisted_user_control_state(
+        uid=uid,
+        account_generation=ONBOARDING_ACCOUNT_GENERATION,
+        mode=MemoryRolloutMode.off,
+        projection_ready=False,
+        default_memory_grant=False,
+        archive_grant=False,
+    )
+
+
+def _write_control_payload(
+    uid: str,
+    *,
+    account_generation: int = ONBOARDING_ACCOUNT_GENERATION,
+) -> dict[str, Any]:
+    """Build the existing write-stage contract without read access."""
+    return build_user_control_state(
+        uid=uid,
+        stage="write",
+        account_generation=account_generation,
+        default_memory_grant=False,
+        archive_grant=False,
+    )
+
+
+def _is_existing_write_or_read_control(*, uid: str, payload: dict[str, Any]) -> bool:
+    expected = _write_control_payload(uid)
+    if payload.get("uid") != uid or payload.get("schema_version") != expected["schema_version"]:
+        return False
+    if payload.get("mode") not in {"write", "read"}:
+        return False
+    if payload.get("persistent_memory_writes_started") is not True or payload.get("writes_blocked") is not False:
+        return False
+    gates = payload.get("stage_gates")
+    return isinstance(gates, dict) and gates.get("shadow") == "passed" and gates.get("write") == "passed"
+
+
+def _is_scheduler_owned_write_control(*, uid: str, payload: dict[str, Any]) -> bool:
+    account_generation = payload.get("account_generation")
+    return (
+        not isinstance(account_generation, bool)
+        and isinstance(account_generation, int)
+        and account_generation >= 0
+        and payload == _write_control_payload(uid, account_generation=account_generation)
+    )
+
+
+def _enroll_inert_user_for_writes_transaction(
+    transaction: Any,
+    control_ref: Any,
+    *,
+    uid: str,
+) -> bool:
+    snapshot = control_ref.get(transaction=transaction)
+    if getattr(snapshot, "exists", False) is not True:
+        raise RuntimeError("missing_onboarded_control_state")
+    payload = snapshot.to_dict()
+    if not isinstance(payload, dict):
+        raise RuntimeError("malformed_onboarded_control_state")
+    if payload == _inert_control_payload(uid):
+        transaction.set(control_ref, _write_control_payload(uid))
+        return True
+    if _is_existing_write_or_read_control(uid=uid, payload=payload):
+        return False
+    raise RuntimeError("unsupported_canonical_rollout_state")
+
+
+def _enroll_inert_user_for_writes(*, uid: str, db_client: Any) -> bool:
+    """Advance only the exact scheduler-created inert control state.
+
+    A pre-existing rollout document is not an activation request.  Matching the
+    complete inert payload makes the scheduler idempotent and ensures a manual,
+    malformed, or already-progressed state is never silently overwritten.
+    """
+    control_ref = db_client.document(MemoryCollections(uid=uid).memory_control_state)
+    if hasattr(db_client, "transaction"):
+        transaction = db_client.transaction()
+        if transaction.__class__.__module__.startswith("google.cloud.firestore"):
+            wrapped = _firestore_transactional(_enroll_inert_user_for_writes_transaction)
+            return wrapped(transaction, control_ref, uid=uid)
+        return _enroll_inert_user_for_writes_transaction(transaction, control_ref, uid=uid)
+
+    # Lightweight hermetic fakes without transactions use the same validation
+    # contract. Production Firestore always takes the transactional branch.
+    snapshot = control_ref.get()
+    if getattr(snapshot, "exists", False) is not True:
+        raise RuntimeError("missing_onboarded_control_state")
+    payload = snapshot.to_dict()
+    if not isinstance(payload, dict):
+        raise RuntimeError("malformed_onboarded_control_state")
+    if payload == _inert_control_payload(uid):
+        control_ref.set(_write_control_payload(uid))
+        return True
+    if _is_existing_write_or_read_control(uid=uid, payload=payload):
+        return False
+    raise RuntimeError("unsupported_canonical_rollout_state")
+
+
+def _reconcile_terminal_backfill_generation_transaction(
+    transaction: Any,
+    control_ref: Any,
+    *,
+    uid: str,
+    db_client: Any,
+) -> bool:
+    snapshot = control_ref.get(transaction=transaction)
+    if getattr(snapshot, "exists", False) is not True:
+        raise RuntimeError("missing_write_control_after_backfill")
+    payload = snapshot.to_dict()
+    if not isinstance(payload, dict):
+        raise RuntimeError("malformed_write_control_after_backfill")
+    if not _is_scheduler_owned_write_control(uid=uid, payload=payload):
+        # Read controls and manual write controls need their own explicit
+        # rollout ceremony.  Updating either here could reopen a stale read.
+        return False
+    # The trusted state head and control write are in the same transaction. If
+    # either changes, Firestore retries the callback instead of committing a
+    # stale generation into the scheduler-owned control state. Read ownership
+    # first so manual/read controls never depend on a scheduler-only head.
+    trusted = read_memory_v3_trusted_account_generation(
+        uid=uid,
+        db_client=db_client,
+        transaction=transaction,
+    )
+    account_generation = trusted.require_account_generation()
+    transaction.set(control_ref, _write_control_payload(uid, account_generation=account_generation))
+    return True
+
+
+def _reconcile_terminal_backfill_generation(*, uid: str, db_client: Any) -> bool:
+    """Fence the scheduler-owned write control to the trusted post-backfill head."""
+    control_ref = db_client.document(MemoryCollections(uid=uid).memory_control_state)
+    if hasattr(db_client, "transaction"):
+        transaction = db_client.transaction()
+        if transaction.__class__.__module__.startswith("google.cloud.firestore"):
+            wrapped = _firestore_transactional(_reconcile_terminal_backfill_generation_transaction)
+            return wrapped(transaction, control_ref, uid=uid, db_client=db_client)
+        return _reconcile_terminal_backfill_generation_transaction(
+            transaction,
+            control_ref,
+            uid=uid,
+            db_client=db_client,
+        )
+
+    trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=db_client)
+    account_generation = trusted.require_account_generation()
+    snapshot = control_ref.get()
+    if getattr(snapshot, "exists", False) is not True:
+        raise RuntimeError("missing_write_control_after_backfill")
+    payload = snapshot.to_dict()
+    if not isinstance(payload, dict):
+        raise RuntimeError("malformed_write_control_after_backfill")
+    if not _is_scheduler_owned_write_control(uid=uid, payload=payload):
+        return False
+    control_ref.set(_write_control_payload(uid, account_generation=account_generation))
+    return True
+
+
+def run_canonical_cohort_lifecycle(*, db_client: Any) -> CanonicalCohortLifecycleReport:
+    """Onboard, safely enroll, and stage one bounded page for the code cohort."""
+    onboarding = reconcile_canonical_memory_onboarding(db_client)
+    write_enrolled: list[str] = []
+    preserved: list[str] = []
+    for uid in list_canonical_cohort_uids():
+        if _enroll_inert_user_for_writes(uid=uid, db_client=db_client):
+            write_enrolled.append(uid)
+        else:
+            preserved.append(uid)
+
+    backfill = run_canonical_legacy_backfill_page(
+        config=CanonicalLegacyBackfillConfig(dry_run=False),
+        db_client=db_client,
+    )
+    checkpoint_store = FirestoreCheckpointStore(db_client)
+    backfill_ready = tuple(
+        uid for uid in list_canonical_cohort_uids() if checkpoint_store.read(uid).state == MigrationState.read_ready
+    )
+    generation_reconciled = tuple(
+        uid for uid in backfill_ready if _reconcile_terminal_backfill_generation(uid=uid, db_client=db_client)
+    )
+    return CanonicalCohortLifecycleReport(
+        onboarding=onboarding,
+        write_enrolled_uids=tuple(write_enrolled),
+        preserved_uids=tuple(preserved),
+        backfill_ready_uids=backfill_ready,
+        generation_reconciled_uids=generation_reconciled,
+        backfill=backfill,
+    )
+
+
+__all__ = [
+    "CanonicalCohortLifecycleReport",
+    "run_canonical_cohort_lifecycle",
+]

--- a/backend/utils/memory/canonical_short_term_maintenance_cron.py
+++ b/backend/utils/memory/canonical_short_term_maintenance_cron.py
@@ -27,6 +27,7 @@ from utils.memory.canonical_required_processing import (
     ProcessedRequiredMemory,
     invoke_required_memory_processor,
 )
+from utils.memory.canonical_cohort_lifecycle import run_canonical_cohort_lifecycle
 from utils.memory.memory_system import list_canonical_cohort_uids
 from utils.memory.short_term_promotion import (
     CanonicalShortTermMaintenanceReport,
@@ -111,6 +112,9 @@ class CanonicalShortTermMaintenanceCronSummary:
     outbox_ack_failures_total: int = 0
     graph_enriched_total: int = 0
     graph_enrichment_blocked_total: int = 0
+    lifecycle_write_enrolled_total: int = 0
+    lifecycle_backfill_read_ready_total: int = 0
+    lifecycle_generation_reconciled_total: int = 0
     errors: list[str] = field(default_factory=_empty_errors)
 
 
@@ -164,8 +168,19 @@ def run_canonical_short_term_maintenance_for_cohort(
 
     client = db_client if db_client is not None else default_db_client
     uids = list_canonical_cohort_uids()
-
     summary = CanonicalShortTermMaintenanceCronSummary(run_id=effective_run_id, user_count=len(uids))
+    lifecycle_backfill_ready_uids: tuple[str, ...] = ()
+    try:
+        lifecycle = run_canonical_cohort_lifecycle(db_client=client)
+    except Exception as exc:
+        message = f"canonical_cohort_lifecycle:{type(exc).__name__}"
+        logger.warning("canonical_short_term_maintenance_cron: %s", message)
+        summary.errors.append(message)
+    else:
+        summary.lifecycle_write_enrolled_total = len(lifecycle.write_enrolled_uids)
+        summary.lifecycle_backfill_read_ready_total = lifecycle.backfill.summary.read_ready_count
+        summary.lifecycle_generation_reconciled_total = len(lifecycle.generation_reconciled_uids)
+        lifecycle_backfill_ready_uids = lifecycle.backfill_ready_uids
     logger.info(
         "canonical_short_term_maintenance_cron: start run_id=%s user_count=%d",
         effective_run_id,
@@ -272,7 +287,7 @@ def run_canonical_short_term_maintenance_for_cohort(
             skipped,
         )
 
-        if not canonical_graph_backfill_enabled():
+        if not canonical_graph_backfill_enabled() or uid not in lifecycle_backfill_ready_uids:
             continue
         try:
             graph_page_size = canonical_graph_backfill_page_size()

--- a/backend/utils/memory/v3/account_generation_source.py
+++ b/backend/utils/memory/v3/account_generation_source.py
@@ -65,7 +65,12 @@ def _fail(*, uid: str, source_path: str, reason: V3AccountGenerationFailureReaso
     return V3TrustedAccountGenerationResult(uid=uid, source_path=source_path, read_error_reason=reason)
 
 
-def read_memory_v3_trusted_account_generation(*, uid: str, db_client: Any) -> V3TrustedAccountGenerationResult:
+def read_memory_v3_trusted_account_generation(
+    *,
+    uid: str,
+    db_client: Any,
+    transaction: Any | None = None,
+) -> V3TrustedAccountGenerationResult:
     """Read and validate the independent account-generation state-head source.
 
     Future `/v3` GET wiring must feed this returned generation into projection
@@ -76,7 +81,9 @@ def read_memory_v3_trusted_account_generation(*, uid: str, db_client: Any) -> V3
 
     source_path = MemoryCollections(uid=uid).memory_state_head
     try:
-        data = _snapshot_data(db_client.document(source_path).get())
+        document = db_client.document(source_path)
+        snapshot = document.get(transaction=transaction) if transaction is not None else document.get()
+        data = _snapshot_data(snapshot)
     except Exception:
         return _fail(uid=uid, source_path=source_path, reason=V3AccountGenerationFailureReason.READ_FAILED)
 

--- a/docs/doc/developer/backend/canonical_memory_architecture.md
+++ b/docs/doc/developer/backend/canonical_memory_architecture.md
@@ -93,8 +93,14 @@ Primary seams:
 
 ## 2. Maintenance: normalize, enforce TTL, route once
 
-The enabled `memory-maintenance-job` runs
-`run_canonical_short_term_maintenance` once per canonical cohort user:
+The enabled `memory-maintenance-job` first reconciles code-whitelisted users
+into its exact inert control state, advances only that scheduler-owned state to
+the guarded write stage, and resumes one bounded legacy-backfill page. It never
+opens a global read gate, grants default memory access, or marks a projection
+ready. Only after a user's terminal backfill checkpoint does it reconcile the
+write control to the trusted state-head generation and allow that user's graph
+enrichment. It then runs `run_canonical_short_term_maintenance` once per canonical
+cohort user:
 
 1. `memory_outbox_worker.py` drains already-committed work before any
    Short-term row is parsed.

--- a/docs/runbooks/canonical-legacy-backfill.md
+++ b/docs/runbooks/canonical-legacy-backfill.md
@@ -38,6 +38,14 @@ change `MEMORY_MODE`, add the UID to `CANONICAL_MEMORY_USERS`, grant default
 memory reads, or open the global read gate. Those remain explicit later rollout
 actions.
 
+For a code-whitelisted user on an enabled maintenance deployment, the scheduler
+owns the same bounded progression: it creates only the known inert onboarding
+state, advances only that exact state to write, and invokes this checkpointed
+page. At terminal staging it reconciles only a scheduler-owned write control to
+the trusted state-head generation and permits graph enrichment for that user.
+Existing write/read controls are preserved; malformed or manually altered
+controls fail closed. The scheduler does not perform the later read cutover.
+
 ### 1. Prepare an explicit UID file
 
 Use either repeatable `--uid` flags or a UTF-8 newline-delimited/JSON UID file:

--- a/docs/runbooks/canonical-memory-rollout-flags.md
+++ b/docs/runbooks/canonical-memory-rollout-flags.md
@@ -13,7 +13,8 @@ an unentitled user canonical.
 | `MEMORY_MODE` | Request paths and maintenance job | Declares deployment readiness: `off` is the dark contract and `read` is the ready contract. Request routing does not read this env. The checked-in deploy contract uses only `off` and `read`; internal persisted rollout state still understands `shadow` and `write` for convergence and rollback. |
 | `MEMORY_ENABLED_USERS` | Request paths and maintenance job | Duplicated, redacted rollout inventory used by deploy validation. In `read` mode it must be non-empty and identical on request paths and the maintenance job. It does not grant product entitlement or enumerate maintenance users. |
 | `MEMORY_V3_GET_ENABLED` | Request paths | Declares that the v3 GET proof has passed. Request routing does not read this env; code entitlement plus persisted control/head/grant/projection state decide the route. The job carries the same value as readiness metadata but does not serve GET. |
-| `MEMORY_CANONICAL_MAINTENANCE_ENABLED` | Maintenance job only | Master switch for normalization, TTL settlement, consolidation, and the projection outbox. It must be false on request-path services. Cloud Scheduler owns cadence. |
+| `MEMORY_CANONICAL_MAINTENANCE_ENABLED` | Maintenance job only | Master switch for canonical onboarding, guarded write enrollment, bounded legacy staging, normalization, TTL settlement, consolidation, and the projection outbox. It must be false on request-path services. Cloud Scheduler owns cadence. |
+| `MEMORY_CANONICAL_GRAPH_BACKFILL_ENABLED` | Maintenance job only | Separately enables the bounded historical graph-enrichment page after a cohort user's staging checkpoint is read-ready. It defaults to false and must be enabled only with maintenance; it never grants entitlement or opens reads. |
 | `MEMORY_CANONICAL_CONSOLIDATION_ENABLED` | Maintenance job only | Independently disables the L2 consolidation/model step while leaving required processing, TTL settlement, and outbox repair available. This is an incident/cost switch, not a rollout stage. |
 
 `MEMORY_TYPESENSE_COLLECTION`, `TYPESENSE_HOST_PORT`, `PINECONE_INDEX_NAME`,
@@ -53,7 +54,14 @@ resources separately before any approved production activation.
    code cohort is the product-path selection; the env inventory does not keep
    that user dark.
 2. **Backfill or stage.** Before deploying a new entitlement, run the
-   single-user inventory with `--dry-run` and review counts. If staging a
+   single-user inventory with `--dry-run` and review counts. Once the code
+   entitlement is deployed and the maintenance switch is on, the scheduled
+   lifecycle creates only its exact inert control record, advances it to the
+   guarded write stage, and resumes one bounded checkpointed staging page per
+   run. At the terminal checkpoint it reconciles only its scheduler-owned write
+   control to the independently trusted state-head generation, then permits
+   graph enrichment for that user. It never opens read gates or grants default
+   memory reads. If staging a
    non-cohort UID, use only the CLI's explicit one-user admin-override ceremony.
    Apply only the approved bucket and never delete legacy data.
 3. **Start maintenance.** In a coordinated activation, deploy the code cohort


### PR DESCRIPTION
## What changed

Make the maintenance job own the safe automatic lifecycle for a code-whitelisted canonical-memory user: inert onboarding, transactional exact-state write enrollment, and one bounded checkpointed legacy staging page per run. At a terminal checkpoint it reconciles only scheduler-owned write state to the independent trusted head generation and permits graph enrichment for that user. Existing progressed controls are preserved; malformed controls fail closed. The job does not open read gates or claim projection readiness.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_canonical_cohort_lifecycle.py backend/tests/unit/test_canonical_short_term_maintenance_cron.py backend/tests/unit/test_canonical_memory_onboarding.py backend/tests/unit/test_canonical_legacy_backfill.py` (36 passed)
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_workflow_contracts.py` (24 passed)
- `backend/.venv/bin/python backend/scripts/scan_async_blockers.py --dirs backend/utils`
- `make preflight` with this PR body


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

