### PR TITLE
feat(windows): add Apple sign-in

### DIFF
--- a/desktop/windows/README.md
+++ b/desktop/windows/README.md
@@ -25,9 +25,11 @@ keys to obtain.
 
 ## Authentication
 
-- **App sign-in:** each user signs in with **their own** Google/Omi account through
-  the built-in popup. The Firebase project is shared (Omi's `based-hardware`); accounts
-  are individual. Nothing to configure — it works out of the box from `.env.example`.
+- **App sign-in:** each user signs in with **their own** Google or Apple/Omi account
+  through the system browser. The Windows app uses the same backend-mediated OAuth
+  flow as the macOS app, so provider credentials stay server-side. The Firebase project
+  is shared (Omi's `based-hardware`); accounts are individual. Nothing to configure —
+  it works out of the box from `.env.example`.
 - **Google integration** (optional Gmail/Google connect — separate from sign-in): bring
   your own credentials. Create an OAuth **Desktop app** client in the
   [Google Cloud Console](https://console.cloud.google.com/apis/credentials), then in your

--- a/desktop/windows/scripts/verify-oauth-contract.mjs
+++ b/desktop/windows/scripts/verify-oauth-contract.mjs
@@ -1,19 +1,28 @@
-// Live contract probe for the backend-mediated Google sign-in flow (network
+// Live contract probe for the backend-mediated Google or Apple sign-in flow (network
 // only — no browser, no auth). Verifies the prod backend implements the exact
 // /v1/auth/authorize contract the Windows app builds against:
-//   1. A well-formed authorize request 30x-redirects to accounts.google.com
-//      with the backend's own callback as Google's redirect_uri.
+//   1. A well-formed authorize request 30x-redirects to the selected provider
+//      with the backend's own callback as the provider redirect_uri.
 //   2. PKCE is enforced (missing/malformed code_challenge → 400).
 //   3. The loopback redirect_uri allowlist is enforced (https → 400).
 //
-// Usage: node scripts/verify-oauth-contract.mjs [apiBase]
+// Usage: node scripts/verify-oauth-contract.mjs [apiBase] [--provider google|apple]
 //        (default: $VITE_OMI_API_BASE or https://api.omi.me)
 import { createHash, randomBytes } from 'node:crypto'
 
-const API = (process.argv[2] || process.env.VITE_OMI_API_BASE || 'https://api.omi.me').replace(
+const apiBaseArg = process.argv[2]?.startsWith('--') ? undefined : process.argv[2]
+const providerFlag = process.argv.indexOf('--provider')
+const provider = providerFlag === -1 ? 'google' : process.argv[providerFlag + 1]
+if (provider !== 'google' && provider !== 'apple') {
+  throw new Error(`Unsupported provider: ${provider || '(missing)'}`)
+}
+
+const API = (apiBaseArg || process.env.VITE_OMI_API_BASE || 'https://api.omi.me').replace(
   /\/+$/,
   ''
 )
+const providerHost = provider === 'apple' ? 'appleid.apple.com' : 'accounts.google.com'
+const providerCallback = `/v1/auth/callback/${provider}`
 
 const b64url = (buf) =>
   buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
@@ -39,41 +48,51 @@ function authorizeUrl(params) {
 }
 
 const base = {
-  provider: 'google',
+  provider,
   redirect_uri: redirectUri,
   state,
   code_challenge: challenge,
   code_challenge_method: 'S256'
 }
 
-// --- 1. Happy path: 30x to accounts.google.com --------------------------------
+// --- 1. Happy path: 30x to the selected provider -------------------------------
 {
   const res = await fetch(authorizeUrl(base), { redirect: 'manual' })
-  check('authorize returns a redirect', res.status >= 300 && res.status < 400, `status ${res.status}`)
+  check(
+    'authorize returns a redirect',
+    res.status >= 300 && res.status < 400,
+    `status ${res.status}`
+  )
   const loc = res.headers.get('location') || ''
-  let google = null
+  let providerUrl = null
   try {
-    google = new URL(loc)
+    providerUrl = new URL(loc)
   } catch {
     /* checked below */
   }
   check(
-    'redirect targets accounts.google.com',
-    google?.hostname === 'accounts.google.com',
+    `redirect targets ${providerHost}`,
+    providerUrl?.hostname === providerHost,
     loc.split('?')[0]
   )
-  if (google) {
-    check('google url has client_id', !!google.searchParams.get('client_id'))
+  if (providerUrl) {
+    check(`${provider} url has client_id`, !!providerUrl.searchParams.get('client_id'))
     check(
-      'google redirect_uri is the BACKEND callback (loopback stays server-side)',
-      (google.searchParams.get('redirect_uri') || '').endsWith('/v1/auth/callback/google'),
-      google.searchParams.get('redirect_uri') || '(missing)'
+      `${provider} redirect_uri is the BACKEND callback (loopback stays server-side)`,
+      (providerUrl.searchParams.get('redirect_uri') || '').endsWith(providerCallback),
+      providerUrl.searchParams.get('redirect_uri') || '(missing)'
     )
-    check('response_type=code', google.searchParams.get('response_type') === 'code')
+    check('response_type=code', providerUrl.searchParams.get('response_type') === 'code')
+    if (provider === 'apple') {
+      check(
+        'Apple uses form_post callbacks',
+        providerUrl.searchParams.get('response_mode') === 'form_post'
+      )
+    }
     // NOTE: our state/redirect_uri/code_challenge are stored in the backend's
-    // Redis session (keyed by the session id Google carries as `state`) — they
-    // are intentionally NOT echoed into the Google URL. The session id must exist.
-    check('google state carries a backend session id', !!google.searchParams.get('state'))
+    // Redis session (keyed by the session id the provider carries as `state`) —
+    // they are intentionally NOT echoed into the provider URL. The session id must exist.
+    check(`${provider} state carries a backend session id`, !!providerUrl.searchParams.get('state'))
   }
 }
 
@@ -86,13 +105,21 @@ const base = {
 {
   const { code_challenge: _omit, code_challenge_method: _omit2, ...noPkce } = base
   const res = await fetch(authorizeUrl(noPkce), { redirect: 'manual' })
-  warn('missing code_challenge is rejected (PKCE required)', res.status === 400, `status ${res.status}`)
+  warn(
+    'missing code_challenge is rejected (PKCE required)',
+    res.status === 400,
+    `status ${res.status}`
+  )
 }
 {
   const res = await fetch(authorizeUrl({ ...base, code_challenge_method: 'plain' }), {
     redirect: 'manual'
   })
-  warn('code_challenge_method=plain is rejected (S256 only)', res.status === 400, `status ${res.status}`)
+  warn(
+    'code_challenge_method=plain is rejected (S256 only)',
+    res.status === 400,
+    `status ${res.status}`
+  )
 }
 
 // --- 3. redirect_uri allowlist --------------------------------------------------
@@ -100,12 +127,16 @@ const base = {
   const res = await fetch(authorizeUrl({ ...base, redirect_uri: 'https://evil.example/cb' }), {
     redirect: 'manual'
   })
-  check('https redirect_uri is rejected (loopback allowlist)', res.status === 400, `status ${res.status}`)
+  check(
+    'https redirect_uri is rejected (loopback allowlist)',
+    res.status === 400,
+    `status ${res.status}`
+  )
 }
 
 console.log(
   failures === 0
-    ? `\nOK — ${API} supports the Windows sign-in contract (provider=google, PKCE S256, loopback redirect).`
+    ? `\nOK — ${API} supports the Windows sign-in contract (provider=${provider}, PKCE S256, loopback redirect).`
     : `\n${failures} contract check(s) FAILED against ${API}.`
 )
 // exitCode (not process.exit): hard-exiting while undici sockets are still

--- a/desktop/windows/scripts/verify-oauth-flow.mjs
+++ b/desktop/windows/scripts/verify-oauth-flow.mjs
@@ -1,18 +1,18 @@
-// Live end-to-end verification of Google sign-in in the REAL built app.
+// Live end-to-end verification of Google or Apple sign-in in the REAL built app.
 // Launches out/main/index.js via Playwright _electron with a THROWAWAY
 // --user-data-dir (fresh renderer origin → starts signed OUT), clicks the
-// "Sign in with Google" button, prints the authorize URL the app opened in the
+// selected provider button, prints the authorize URL the app opened in the
 // system browser, then waits (≤5 min) for the loopback callback + Firebase
 // custom-token sign-in and asserts the renderer really has a signed-in user.
 //
-// The Google account click-through in the system browser is the HUMAN /
+// The provider account click-through in the system browser is the HUMAN /
 // orchestrator step — this script is self-checking around it:
 //   exit 0  sign-in completed end to end (prints uid/email)
 //   exit 2  the flow reached "waiting for the browser" but nobody finished the
-//           Google consent (or it was cancelled) — needs the human step
+//           provider consent (or it was cancelled) — needs the human step
 //   exit 1  harness/app failure before the browser step
 //
-// Usage: node scripts/verify-oauth-flow.mjs [--no-build]
+// Usage: node scripts/verify-oauth-flow.mjs [--no-build] [--provider google|apple]
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { mkdtempSync, rmSync } from 'node:fs'
@@ -23,6 +23,11 @@ import { _electron as electron } from 'playwright'
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const mainEntry = path.join(root, 'out', 'main', 'index.js')
 const WAIT_MS = 5 * 60_000 + 30_000 // app flow times out at 5 min; small margin
+const providerFlag = process.argv.indexOf('--provider')
+const provider = providerFlag === -1 ? 'google' : process.argv[providerFlag + 1]
+if (provider !== 'google' && provider !== 'apple') {
+  throw new Error(`Unsupported provider: ${provider || '(missing)'}`)
+}
 
 if (!process.argv.includes('--no-build')) {
   console.log('[verify-oauth] building (electron-vite build)…')
@@ -39,12 +44,12 @@ try {
   })
 
   // Relay main-process output; the sign-in flow logs a stable
-  // "[google-signin] … authorize-url <url>" marker we surface prominently.
+  // "[sign-in] … authorize-url <url>" marker we surface prominently.
   const surfaced = { authorizeUrl: null }
   const onChunk = (chunk) => {
     const text = String(chunk)
     for (const line of text.split(/\r?\n/)) {
-      if (!line.includes('[google-signin]')) continue
+      if (!line.includes('[sign-in]')) continue
       console.log(line)
       const m = line.match(/authorize-url (\S+)/)
       if (m) {
@@ -58,13 +63,15 @@ try {
   app.process().stderr?.on('data', onChunk)
 
   const page = await app.firstWindow()
-  const signInButton = page.getByRole('button', { name: /sign in with google/i })
+  const signInButton = page.getByRole('button', {
+    name: new RegExp(`continue with ${provider}`, 'i')
+  })
   await signInButton.waitFor({ state: 'visible', timeout: 60_000 })
-  console.log('[verify-oauth] app is up and signed out — clicking "Sign in with Google"')
+  console.log(`[verify-oauth] app is up and signed out — clicking "Continue with ${provider}"`)
   await signInButton.click()
 
   console.log(
-    '[verify-oauth] waiting for the browser round-trip (finish the Google consent in the opened browser; up to 5 min)…'
+    `[verify-oauth] waiting for the browser round-trip (finish the ${provider} consent in the opened browser; up to 5 min)…`
   )
 
   // Success signal: Firebase browserLocalPersistence writes the signed-in user
@@ -95,7 +102,9 @@ try {
   }
 
   if (user?.uid) {
-    console.log(`[verify-oauth] SUCCESS — signed in as uid=${user.uid} email=${user.email ?? '(none)'}`)
+    console.log(
+      `[verify-oauth] SUCCESS — signed in as uid=${user.uid} email=${user.email ?? '(none)'}`
+    )
     exitCode = 0
   } else {
     console.error(
@@ -106,7 +115,7 @@ try {
       }.`
     )
     console.error(
-      '[verify-oauth] This step needs a human/orchestrator: run again and complete the Google '
+      `[verify-oauth] This step needs a human/orchestrator: run again and complete the ${provider} `
     )
     console.error(
       '[verify-oauth] consent in the system browser (the authorize URL is printed above).'

--- a/desktop/windows/src/main/auth/omiAuth.test.ts
+++ b/desktop/windows/src/main/auth/omiAuth.test.ts
@@ -29,6 +29,7 @@ describe('buildAuthorizeUrl', () => {
   it('matches the /v1/auth/authorize contract', () => {
     const url = buildAuthorizeUrl({
       apiBase: 'https://api.omi.me',
+      provider: 'google',
       redirectUri: 'http://127.0.0.1:51000/callback',
       state: 'flow|nonce',
       codeChallenge: 'CHAL'
@@ -46,6 +47,7 @@ describe('buildAuthorizeUrl', () => {
   it('tolerates a trailing slash on the api base', () => {
     const url = buildAuthorizeUrl({
       apiBase: 'https://api.omi.me/',
+      provider: 'google',
       redirectUri: 'http://127.0.0.1:1/callback',
       state: 's',
       codeChallenge: 'c'
@@ -101,6 +103,16 @@ describe('parseLoopbackCallback', () => {
       state
     )
     expect(out).toEqual({ kind: 'error', message: 'Google authorization failed: access_denied' })
+  })
+
+  it('uses the selected provider in provider error messages', () => {
+    expect(
+      parseLoopbackCallback(
+        `/callback?error=access_denied&state=${encodeURIComponent(state)}`,
+        state,
+        'apple'
+      )
+    ).toEqual({ kind: 'error', message: 'Apple authorization failed: access_denied' })
   })
 
   it('ignores error injections without the matching state (local-DoS guard)', () => {

--- a/desktop/windows/src/main/auth/omiAuth.ts
+++ b/desktop/windows/src/main/auth/omiAuth.ts
@@ -1,14 +1,14 @@
-// Pure helpers for the backend-mediated Omi sign-in flow (Google via
+// Pure helpers for the backend-mediated Omi sign-in flow (Google or Apple via
 // /v1/auth/authorize + /v1/auth/token, PKCE S256, loopback callback).
 // No Electron/IO imports so everything here is unit-testable under node Vitest.
 //
 // Backend contract (backend/routers/auth.py, mirrored from the macOS app's
 // AuthService.swift buildAuthorizationURL / exchangeCodeForToken):
-//   GET  {api}/v1/auth/authorize?provider=google&redirect_uri=…&state=…
+//   GET  {api}/v1/auth/authorize?provider={google|apple}&redirect_uri=…&state=…
 //        &code_challenge=…&code_challenge_method=S256
-//        → 302 to accounts.google.com; Google returns to the BACKEND's own
-//        /v1/auth/callback/google, which serves an HTML page that navigates the
-//        browser to {redirect_uri}?code=<omi auth code>&state=<our state>.
+//        → 302 to the selected provider; the provider returns to the BACKEND's
+//        own callback, which serves an HTML page that navigates the browser to
+//        {redirect_uri}?code=<omi auth code>&state=<our state>.
 //   POST {api}/v1/auth/token  (application/x-www-form-urlencoded)
 //        grant_type=authorization_code & code & redirect_uri & use_custom_token=true
 //        & code_verifier → JSON { custom_token, id_token, … }.
@@ -16,6 +16,7 @@
 // (backend _is_valid_pkce_value); oauthPkce.generateVerifier satisfies this.
 import { randomBytes } from 'crypto'
 import { base64url } from '../integrations/oauthPkce'
+import type { SignInProvider } from '../../shared/types'
 
 /** Loopback path the backend's callback page redirects to (macOS parity). */
 export const CALLBACK_PATH = '/callback'
@@ -28,12 +29,13 @@ export function generateSignInState(): string {
 
 export function buildAuthorizeUrl(args: {
   apiBase: string
+  provider: SignInProvider
   redirectUri: string
   state: string
   codeChallenge: string
 }): string {
   const u = new URL(`${args.apiBase.replace(/\/+$/, '')}/v1/auth/authorize`)
-  u.searchParams.set('provider', 'google')
+  u.searchParams.set('provider', args.provider)
   u.searchParams.set('redirect_uri', args.redirectUri)
   u.searchParams.set('state', args.state)
   u.searchParams.set('code_challenge', args.codeChallenge)
@@ -47,7 +49,11 @@ export type LoopbackCallback =
   | { kind: 'code'; code: string }
 
 /** Classify a request that hit the loopback listener. `rawUrl` is req.url. */
-export function parseLoopbackCallback(rawUrl: string, expectedState: string): LoopbackCallback {
+export function parseLoopbackCallback(
+  rawUrl: string,
+  expectedState: string,
+  provider: SignInProvider = 'google'
+): LoopbackCallback {
   let url: URL
   try {
     url = new URL(rawUrl, 'http://127.0.0.1')
@@ -65,7 +71,8 @@ export function parseLoopbackCallback(rawUrl: string, expectedState: string): Lo
     // be able to abort a pending sign-in or inject display text — noise, not
     // a flow outcome.
     if (!stateMatches) return { kind: 'ignore' }
-    return { kind: 'error', message: `Google authorization failed: ${error}` }
+    const providerName = provider === 'apple' ? 'Apple' : 'Google'
+    return { kind: 'error', message: `${providerName} authorization failed: ${error}` }
   }
   if (!stateMatches) {
     // A CODE with the wrong state is a real CSRF signal — fail the flow loudly
@@ -91,7 +98,7 @@ export function buildTokenExchangeBody(args: {
 }
 
 /** Decode a JWT payload WITHOUT verification — display-only claims (name/email)
- *  from the backend-returned Google id_token. Returns null on any malformation. */
+ *  from the backend-returned provider id_token. Returns null on any malformation. */
 export function decodeJwtClaims(jwt: string): Record<string, unknown> | null {
   const parts = jwt.split('.')
   if (parts.length !== 3) return null

--- a/desktop/windows/src/main/auth/signInFlow.test.ts
+++ b/desktop/windows/src/main/auth/signInFlow.test.ts
@@ -4,12 +4,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import { connect as netConnect } from 'node:net'
 import {
-  startGoogleSignIn,
+  startSignIn,
   redactAuthorizeUrl,
   CANCELLED_MESSAGE,
   SUPERSEDED_MESSAGE,
-  type GoogleSignInDeps
-} from './googleSignInFlow'
+  type SignInDeps
+} from './signInFlow'
 
 function fakeJwt(payload: Record<string, unknown>): string {
   const b64url = (o: unknown): string =>
@@ -41,7 +41,7 @@ function browserThatRedirects(query: (redirectUri: string, state: string) => str
   }
 }
 
-function deps(overrides: Partial<GoogleSignInDeps>): GoogleSignInDeps {
+function deps(overrides: Partial<SignInDeps>): SignInDeps {
   return {
     apiBase: 'https://api.omi.example',
     openExternal: () => {},
@@ -50,7 +50,11 @@ function deps(overrides: Partial<GoogleSignInDeps>): GoogleSignInDeps {
   }
 }
 
-describe('startGoogleSignIn', () => {
+function startGoogleSignIn(overrides: Partial<SignInDeps>) {
+  return startSignIn('google', deps(overrides))
+}
+
+describe('startSignIn', () => {
   it('completes the full loopback round-trip and token exchange', async () => {
     let capturedAuthorize = ''
     const fetchImpl = vi.fn(async (url: unknown, init?: RequestInit) => {
@@ -88,6 +92,23 @@ describe('startGoogleSignIn', () => {
       familyName: undefined
     })
     expect(capturedAuthorize).toContain('/v1/auth/authorize?provider=google')
+  })
+
+  it('uses the same loopback flow for Apple', async () => {
+    let capturedAuthorize = ''
+    const result = await startSignIn(
+      'apple',
+      deps({
+        openExternal: async (url) => {
+          capturedAuthorize = url
+          await browserThatRedirects(
+            (_r, state) => `code=APPLE-CODE&state=${encodeURIComponent(state)}`
+          )(url)
+        }
+      })
+    )
+    expect(result.ok).toBe(true)
+    expect(capturedAuthorize).toContain('/v1/auth/authorize?provider=apple')
   })
 
   it('rejects a state mismatch without exchanging the code', async () => {

--- a/desktop/windows/src/main/auth/signInFlow.ts
+++ b/desktop/windows/src/main/auth/signInFlow.ts
@@ -1,8 +1,8 @@
-// Backend-mediated Google sign-in (system browser + loopback callback), main
+// Backend-mediated provider sign-in (system browser + loopback callback), main
 // process. Ports the macOS app's flow (AuthService.swift signIn(provider:)):
 //   1. PKCE verifier/challenge + CSRF state
 //   2. loopback HTTP listener on 127.0.0.1:<random port>/callback
-//   3. system browser → {api}/v1/auth/authorize (backend drives Google OAuth)
+//   3. system browser → {api}/v1/auth/authorize (backend drives provider OAuth)
 //   4. loopback receives ?code&state → validate → branded page → close listener
 //   5. POST {api}/v1/auth/token → Firebase custom token (renderer signs in)
 //
@@ -21,7 +21,7 @@ import {
   parseLoopbackCallback,
   successHtml
 } from './omiAuth'
-import type { GoogleSignInResult } from '../../shared/types'
+import type { SignInProvider, SignInResult } from '../../shared/types'
 
 // If the user closes the browser tab / never finishes the consent, no callback
 // ever arrives — fail loud after this long instead of hanging forever.
@@ -30,7 +30,7 @@ export const SIGN_IN_TIMEOUT_MS = 5 * 60_000
 export const CANCELLED_MESSAGE = 'Sign-in was cancelled — the browser never completed it'
 export const SUPERSEDED_MESSAGE = 'Superseded by a newer sign-in attempt'
 
-export type GoogleSignInDeps = {
+export type SignInDeps = {
   apiBase: string
   openExternal: (url: string) => void | Promise<void>
   log?: (msg: string, extra?: unknown) => void
@@ -56,7 +56,10 @@ export function redactAuthorizeUrl(authorizeUrl: string): string {
 }
 
 /** Run the full sign-in flow. Never rejects — errors come back as {ok:false}. */
-export async function startGoogleSignIn(deps: GoogleSignInDeps): Promise<GoogleSignInResult> {
+export async function startSignIn(
+  provider: SignInProvider,
+  deps: SignInDeps
+): Promise<SignInResult> {
   activeCancel?.(SUPERSEDED_MESSAGE)
   const log = deps.log ?? ((): void => {})
 
@@ -66,7 +69,7 @@ export async function startGoogleSignIn(deps: GoogleSignInDeps): Promise<GoogleS
 
   let loopback: { code: string; redirectUri: string }
   try {
-    loopback = await runLoopback({ state, codeChallenge, deps, log })
+    loopback = await runLoopback({ provider, state, codeChallenge, deps, log })
   } catch (e) {
     const error = (e as Error).message
     log('sign-in failed before token exchange', { error })
@@ -96,12 +99,13 @@ export async function startGoogleSignIn(deps: GoogleSignInDeps): Promise<GoogleS
 }
 
 function runLoopback(args: {
+  provider: SignInProvider
   state: string
   codeChallenge: string
-  deps: GoogleSignInDeps
+  deps: SignInDeps
   log: (msg: string, extra?: unknown) => void
 }): Promise<{ code: string; redirectUri: string }> {
-  const { state, codeChallenge, deps, log } = args
+  const { provider, state, codeChallenge, deps, log } = args
   return new Promise((resolve, reject) => {
     let settled = false
     let timer: NodeJS.Timeout | undefined
@@ -137,7 +141,7 @@ function runLoopback(args: {
         res.writeHead(404).end()
         return
       }
-      const outcome = parseLoopbackCallback(req.url ?? '', state)
+      const outcome = parseLoopbackCallback(req.url ?? '', state, provider)
       if (outcome.kind === 'ignore') {
         res.writeHead(404).end()
         return
@@ -160,6 +164,7 @@ function runLoopback(args: {
       redirectUri = `http://127.0.0.1:${addr.port}${CALLBACK_PATH}`
       const authorizeUrl = buildAuthorizeUrl({
         apiBase: deps.apiBase,
+        provider,
         redirectUri,
         state,
         codeChallenge

--- a/desktop/windows/src/main/ipc/auth.ts
+++ b/desktop/windows/src/main/ipc/auth.ts
@@ -1,21 +1,21 @@
-// Electron wiring for the backend-mediated Google sign-in flow. The actual
+// Electron wiring for the backend-mediated provider sign-in flow. The actual
 // flow (loopback listener, authorize URL, token exchange) lives in
-// src/main/auth/googleSignInFlow.ts and is Electron-free; this file supplies
+// src/main/auth/signInFlow.ts and is Electron-free; this file supplies
 // the browser opener, file logging, and window surfacing.
 import { app, ipcMain, shell } from 'electron'
 import { appendFileSync } from 'fs'
 import { join } from 'path'
-import { startGoogleSignIn } from '../auth/googleSignInFlow'
-import type { GoogleSignInResult } from '../../shared/types'
+import { startSignIn } from '../auth/signInFlow'
+import type { SignInProvider, SignInResult } from '../../shared/types'
 
 // Main-process console.log only reaches the dev-server terminal, which is easy
-// to miss. Also append to userData/google-signin.log so a failed field sign-in
+// to miss. Also append to userData/sign-in.log so a failed field sign-in
 // can be traced after the fact (same pattern as integrations/oauth.ts).
 function authLog(msg: string, extra?: unknown): void {
   const line = `[${new Date().toISOString()}] ${msg}${extra !== undefined ? ' ' + JSON.stringify(extra) : ''}`
-  console.log('[google-signin]', line)
+  console.log('[sign-in]', line)
   try {
-    appendFileSync(join(app.getPath('userData'), 'google-signin.log'), line + '\n')
+    appendFileSync(join(app.getPath('userData'), 'sign-in.log'), line + '\n')
   } catch {
     /* best-effort logging only */
   }
@@ -31,15 +31,18 @@ function apiBase(): string {
  * see index.ts for the focus-steal implementation).
  */
 export function registerAuthHandlers(onSignedIn: () => void): void {
-  ipcMain.handle('auth:google:signIn', async (): Promise<GoogleSignInResult> => {
-    authLog('sign-in requested')
-    const result = await startGoogleSignIn({
+  ipcMain.handle('auth:signIn', async (_event, provider: unknown): Promise<SignInResult> => {
+    if (provider !== 'google' && provider !== 'apple') {
+      return { ok: false, error: 'Unsupported sign-in provider' }
+    }
+    authLog(`${provider} sign-in requested`)
+    const result = await startSignIn(provider as SignInProvider, {
       apiBase: apiBase(),
       openExternal: (url) => shell.openExternal(url),
       log: authLog
     })
     if (result.ok) {
-      authLog('sign-in complete — surfacing window')
+      authLog(`${provider} sign-in complete — surfacing window`)
       onSignedIn()
     }
     return result

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -59,7 +59,8 @@ import type {
   XConnectorSession,
   XStatus,
   XSyncResult,
-  XRunState
+  XRunState,
+  SignInProvider
 } from '../shared/types'
 import type { ByokEnrollResult, ByokProvider } from '../shared/byok'
 import type {
@@ -184,7 +185,7 @@ const omi: OmiBridgeApi = {
   kgSearchFiles: (q, fileType?, limit?) => ipcRenderer.invoke('kg:searchFiles', q, fileType, limit),
   kgExecuteSql: (sql) => ipcRenderer.invoke('kg:executeSql', sql),
   readStickyNotes: () => ipcRenderer.invoke('integrations:stickyNotes:read'),
-  signInWithGoogle: () => ipcRenderer.invoke('auth:google:signIn'),
+  signInWithProvider: (provider: SignInProvider) => ipcRenderer.invoke('auth:signIn', provider),
   googleConnect: () => ipcRenderer.invoke('integrations:google:connect'),
   googleDisconnect: () => ipcRenderer.invoke('integrations:google:disconnect'),
   googleStatus: () => ipcRenderer.invoke('integrations:google:status'),

--- a/desktop/windows/src/renderer/src/lib/firebase.ts
+++ b/desktop/windows/src/renderer/src/lib/firebase.ts
@@ -11,6 +11,7 @@ import {
 } from 'firebase/auth'
 import { teardownUserData } from './authTeardown'
 import { encryptedAuthPersistence, scrubLegacyPlaintextAuth } from './encryptedAuthPersistence'
+import type { SignInProvider } from '../../../shared/types'
 
 const app = initializeApp({
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string,
@@ -50,18 +51,18 @@ onAuthStateChanged(auth, () => {
 })
 
 /**
- * Google sign-in via the backend-mediated OAuth flow in the SYSTEM browser.
+ * Google or Apple sign-in via the backend-mediated OAuth flow in the SYSTEM browser.
  * The main process runs the whole PKCE + loopback dance (Google blocks OAuth
  * inside embedded webviews, so the old signInWithPopup path is gone for good)
  * and hands back a Firebase CUSTOM token; from signInWithCustomToken on,
  * persistence and onAuthStateChanged behave exactly as before.
  */
-export async function signInWithGoogle(): Promise<User> {
-  const result = await window.omi.signInWithGoogle()
+export async function signInWithProvider(provider: SignInProvider): Promise<User> {
+  const result = await window.omi.signInWithProvider(provider)
   if (!result.ok) throw new Error(result.error)
   const cred = await signInWithCustomToken(auth, result.customToken)
   // Custom-token sessions can start with an empty displayName (fresh Firebase
-  // user record); best-effort seed it from the Google profile claims so the
+  // user record); best-effort seed it from the provider profile claims so the
   // sidebar/home greeting show a name immediately.
   const name = [result.givenName, result.familyName].filter(Boolean).join(' ')
   if (name && !cred.user.displayName) {

--- a/desktop/windows/src/renderer/src/pages/Login.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Login.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+
+const signInWithProvider = vi.hoisted(() => vi.fn())
+
+vi.mock('../lib/firebase', () => ({ signInWithProvider }))
+
+import { Login } from './Login'
+
+beforeEach(() => {
+  signInWithProvider.mockReset().mockResolvedValue({ uid: 'test-user' })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Login page', () => {
+  it('offers Apple before Google using the system-browser sign-in labels', () => {
+    render(<Login />)
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons[0].textContent).toContain('Continue with Apple')
+    expect(buttons[1].textContent).toContain('Continue with Google')
+  })
+
+  it('starts Apple sign-in through the shared provider bridge', async () => {
+    render(<Login />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Apple' }))
+
+    await waitFor(() => expect(signInWithProvider).toHaveBeenCalledWith('apple'))
+  })
+})

--- a/desktop/windows/src/renderer/src/pages/Login.tsx
+++ b/desktop/windows/src/renderer/src/pages/Login.tsx
@@ -1,36 +1,38 @@
 import { useRef, useState } from 'react'
-import { signInWithGoogle } from '../lib/firebase'
+import { Apple } from 'lucide-react'
+import type { SignInProvider } from '../../../shared/types'
+import { signInWithProvider } from '../lib/firebase'
 import omiLogo from '../assets/omilogo.png'
 import { BrandImage } from '../components/ui/BrandImage'
 
 export function Login(): React.JSX.Element {
-  // 'waiting' spans the whole system-browser round-trip (opening the browser →
+  // 'activeProvider' spans the whole system-browser round-trip (opening the browser →
   // loopback callback → token exchange). Success flips auth state globally via
   // onAuthStateChanged, which unmounts this page. (A still-pending attempt's
   // loopback listener in main self-closes on supersede or its 5-min timeout —
   // at most one listener ever exists, and it's gone after success.)
-  const [waiting, setWaiting] = useState(false)
+  const [activeProvider, setActiveProvider] = useState<SignInProvider | null>(null)
   const [error, setError] = useState<string | null>(null)
   // Per-click generation: only the NEWEST attempt may write error/waiting
   // state, so a late failure from a superseded-era attempt (however phrased)
   // can never clobber the retry's pending UI.
   const attemptRef = useRef(0)
 
-  const onClick = async (): Promise<void> => {
+  const onClick = async (provider: SignInProvider): Promise<void> => {
     // No guard on `waiting`: clicking again supersedes the pending attempt in
     // main (closes the stale loopback listener) and starts a fresh one, so a
     // closed browser tab never blocks retrying for the full 5-min timeout.
     const attempt = ++attemptRef.current
     setError(null)
-    setWaiting(true)
+    setActiveProvider(provider)
     try {
-      await signInWithGoogle()
+      await signInWithProvider(provider)
       // Signed in — onAuthStateChanged takes over; nothing else to do here.
     } catch (e) {
       if (attempt !== attemptRef.current) return // a newer attempt owns the UI
       console.error('Sign-in failed:', e)
       setError((e as Error).message)
-      setWaiting(false)
+      setActiveProvider(null)
     }
   }
 
@@ -41,8 +43,17 @@ export function Login(): React.JSX.Element {
         <p className="mt-6 text-base leading-relaxed text-white/70">Sign in to continue</p>
         <div className="h-48" />
         <button
-          onClick={onClick}
-          className="flex items-center justify-center gap-3 rounded-xl bg-white px-8 py-3.5 font-medium text-black transition-opacity hover:opacity-90"
+          type="button"
+          onClick={() => void onClick('apple')}
+          className="flex items-center justify-center gap-3 rounded-xl bg-black px-8 py-3.5 font-medium text-white transition-opacity hover:opacity-90"
+        >
+          <Apple className="h-5 w-5" strokeWidth={2.5} aria-hidden="true" />
+          {activeProvider === 'apple' ? 'Try again' : 'Continue with Apple'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void onClick('google')}
+          className="mt-3 flex items-center justify-center gap-3 rounded-xl bg-white px-8 py-3.5 font-medium text-black transition-opacity hover:opacity-90"
         >
           <svg viewBox="0 0 48 48" className="h-5 w-5">
             <path
@@ -62,10 +73,10 @@ export function Login(): React.JSX.Element {
               d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 5.97C6.51 42.62 14.62 48 24 48z"
             />
           </svg>
-          {waiting ? 'Try again' : 'Sign in with Google'}
+          {activeProvider === 'google' ? 'Try again' : 'Continue with Google'}
         </button>
         <div className="mt-4 min-h-[3rem] text-center">
-          {waiting && !error && (
+          {activeProvider && !error && (
             <p className="animate-fade-in text-sm text-white/50">
               Waiting for your browser&hellip; finish signing in there, then come back.
             </p>

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -946,11 +946,10 @@ export type OmiBridgeApi = {
   // synthesizes the returned note text and writes /v3/memories itself (it holds
   // the auth token).
   readStickyNotes: () => Promise<StickyNotesReadResult>
-  // Auth: run the backend-mediated Google OAuth flow in the SYSTEM browser
-  // (main owns the loopback callback + token exchange; Google blocks embedded
-  // webview OAuth, so there is no in-app popup path). The renderer finishes
-  // with signInWithCustomToken on the returned custom token.
-  signInWithGoogle: () => Promise<GoogleSignInResult>
+  // Auth: run the backend-mediated Google or Apple OAuth flow in the SYSTEM
+  // browser (main owns the loopback callback + token exchange; the renderer
+  // finishes with signInWithCustomToken on the returned custom token).
+  signInWithProvider: (provider: SignInProvider) => Promise<SignInResult>
   // Integrations (3d): Google OAuth + Gmail/Calendar. Main owns the OAuth grant
   // and REST reads; the renderer synthesizes the returned items and writes
   // /v3/memories + /v1/action-items itself (it holds the Firebase token).
@@ -1887,12 +1886,14 @@ export type StickyNotesReadResult = {
   error?: string
 }
 
-// --- Auth: backend-mediated Google sign-in (system browser + loopback) ---
+// --- Auth: backend-mediated provider sign-in (system browser + loopback) ---
 
 /** Result of the main-process sign-in flow. On ok the renderer completes the
  *  session with firebase signInWithCustomToken(customToken); email/name are
- *  display-only claims decoded (unverified) from the Google id_token. */
-export type GoogleSignInResult =
+ *  display-only claims decoded (unverified) from the provider's id_token. */
+export type SignInProvider = 'google' | 'apple'
+
+export type SignInResult =
   | { ok: true; customToken: string; email?: string; givenName?: string; familyName?: string }
   | { ok: false; error: string }
 


### PR DESCRIPTION
## Summary

- Add a Windows **Continue with Apple** button above Google, matching the macOS sign-in entry points.
- Generalize the existing backend-mediated PKCE + system-browser + loopback flow to support `google | apple`.
- Keep Apple credentials and provider token exchange in the backend; the Windows app still receives only a Firebase custom token.
- Add provider-aware OAuth contract/E2E probes and update Windows authentication documentation.

## Why

The macOS app already routes both providers through its generic browser OAuth flow. Windows now follows the same architecture instead of introducing a native Apple SDK or Windows-specific Apple secrets.

## Validation

- `pnpm exec vitest run src/main/auth/omiAuth.test.ts src/main/auth/signInFlow.test.ts src/renderer/src/pages/Login.test.tsx` — 38 tests passed
- `pnpm run typecheck` — passed
- Selected ESLint checks — passed with no errors
- `node --check scripts/verify-oauth-contract.mjs` and `node --check scripts/verify-oauth-flow.mjs` — passed
- Live `verify-oauth-contract` probes for Google and Apple against `https://api.omi.me` — passed, including Apple `form_post`

The full interactive sign-in E2E was not run because it requires a real account consent step in the system browser.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

