### PR TITLE
fix(memory): bound historical graph planner candidates

### DIFF
--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -398,7 +398,12 @@ def run_enrichment(
         max_retryable_head_mismatches = apply_limit * 2
         last_examined: MemoryItem | None = None
         completed_page = True
-        for item in page.items:
+        # ``scan_limit`` lets the cursor skip a run of already-enriched rows,
+        # while ``limit`` remains the hard external-planner budget.  Without
+        # this slice a sparse eligible page can invoke the model for every row
+        # in the scan window while still seeking only ``apply_limit`` commits.
+        # That turns a 25-item bounded job into up to 1,250 model calls.
+        for item in page.items[:limit]:
             if applied >= apply_limit:
                 break
             control = _control(uid, db_client=db_client)
@@ -445,7 +450,7 @@ def run_enrichment(
                 report[f"apply_{result.status.value}"] += 1
                 completed_page = False
                 break
-        else:
+        if last_examined is None:
             # An all-filtered scan still needs to move past its stable prefix.
             last_examined = page.last_scanned
 

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -300,12 +300,12 @@ def test_historical_runner_allows_a_bounded_scan_for_unenriched_candidates():
         )
 
 
-def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_candidate(
+def test_historical_runner_holds_the_external_planner_to_the_item_limit_even_with_a_larger_scan(
     monkeypatch: pytest.MonkeyPatch,
 ):
     control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
     failing = _item(memory_id="mem_failing")
-    ready = _item(memory_id="mem_ready")
+    later = _item(memory_id="mem_later")
     cursor_store = _CursorStore()
     planner = _Planner(
         {
@@ -323,7 +323,7 @@ def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_c
         historical_runner,
         "_candidate_page",
         lambda *_args, **_kwargs: historical_runner.HistoricalGraphCandidatePage(
-            items=[failing, ready], last_scanned=ready, exhausted=False
+            items=[failing, later], last_scanned=later, exhausted=False
         ),
     )
 
@@ -353,8 +353,8 @@ def test_historical_runner_skips_a_transient_planner_error_and_commits_a_later_c
         cursor_store=cursor_store,
     )
 
-    assert report["outcomes"] == {"committed": 1, "cursor_advanced": 1, "planner_error": 1}
-    assert cursor_store.advances == [(0, "mem_ready")]
+    assert report["outcomes"] == {"cursor_advanced": 1, "planner_error": 1}
+    assert cursor_store.advances == [(0, "mem_failing")]
 
 
 def test_historical_runner_rotates_cursor_past_a_bounded_scan_window(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## What changed

Bound historical graph enrichment correctly: `scan_limit` may look past an already graph-ready prefix, but `limit` is now the hard maximum number of candidates sent to the external planner. Cursor advancement records the last candidate actually examined, preserving bounded retries without skipping unexamined historical rows.

## Product invariants affected

- INV-MEM-1

Failure-Class: none

## Verification

- `/Volumes/Ephemeral/scratch/worktrees/omi-canonical-cohort-lifecycle-v2/backend/.venv/bin/python -m pytest -q backend/tests/unit/test_historical_graph_enrichment.py` (20 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

