### PR TITLE
feat(memory): show canonical catalog in atlas

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -5,7 +5,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3558,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4463,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3630,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4427,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4418,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1646,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 6633,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1616

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -5,7 +5,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3558,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4463,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3630,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4418,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4416,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1646,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 6633,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1616

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -832,7 +832,6 @@ final class DesktopAutomationActionRegistry {
         ]
       }
     }
-
     register(
       name: "task_capture_fixture",
       summary: "Evaluate canonical screen-capture policy facts without screenshot bytes",
@@ -3123,14 +3122,15 @@ final class DesktopAutomationActionRegistry {
     ) { params in
       do {
         let graph = try await APIClient.shared.getKnowledgeGraph()
+        let atlas = MemoryAtlasProjection(graph: graph.atlasResponse, userName: nil)
         var detail = [
           "node_count": "\(graph.nodes.count)",
           "edge_count": "\(graph.edges.count)",
+          "catalog_memory_count": "\(graph.catalogNodes?.count ?? 0)",
+          "atlas_mark_count": "\(atlas.snapshot.nodes.count)",
           "is_empty": graph.nodes.isEmpty ? "true" : "false",
         ]
-        // `label` resolves a human-typed name to the ids the inspector needs,
-        // so a cursor-free check can both drive a selection and state what it
-        // expects the panel to show.
+        // A label resolves to the ids and citations the inspector needs.
         if let query = params["label"]?.lowercased(), !query.isEmpty {
           if let match = graph.nodes.first(where: { $0.label.lowercased().contains(query) }) {
             let edges = graph.edges.filter { $0.sourceId == match.id || $0.targetId == match.id }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -236,16 +236,6 @@ struct MemoryAtlasTimeline: Equatable {
   }
 }
 
-struct MemoryAtlasNodePlacement: Identifiable {
-  let node: KnowledgeGraphNode
-  let cluster: MemoryAtlasCluster?
-  let normalizedPosition: CGPoint
-  let degree: Int
-  let clusterRank: Int
-
-  var id: String { node.id }
-}
-
 struct MemoryAtlasEdgePlacement: Identifiable {
   let edge: KnowledgeGraphEdge
   let source: CGPoint
@@ -875,7 +865,13 @@ enum MemoryAtlasRenderPlanner {
     let tierCount = includeBackgroundNodes ? tiers.count : 3
     for tierIndex in 0..<tierCount where result.count < limit {
       let remaining = limit - result.count
-      result.append(contentsOf: fairPrefix(tiers[tierIndex], limit: remaining))
+      result.append(
+        contentsOf: fairPrefix(
+          tiers[tierIndex],
+          limit: remaining,
+          prioritizeCatalog: matchingNodeIDs != nil && tierIndex <= 1
+        )
+      )
     }
     return result
   }
@@ -961,8 +957,9 @@ enum MemoryAtlasLayoutEngine {
     // here would make an unsupported claim about what that memory relates to.
     let catalogNodes = uniqueNodes(from: graph.catalogNodes ?? [])
       .filter { !assertionNodeIDs.contains($0.id) }
-    let edges = uniqueEdges(from: graph.edges)
-
+    let edges = uniqueEdges(from: graph.edges).filter {
+      assertionNodeIDs.contains($0.sourceId) && assertionNodeIDs.contains($0.targetId)
+    }
     guard !nodes.isEmpty || !catalogNodes.isEmpty else {
       return MemoryAtlasSnapshot(nodes: [], edges: [], anchorNodeID: nil, clusterCenters: [:])
     }
@@ -1136,7 +1133,8 @@ enum MemoryAtlasLayoutEngine {
           cluster: nil,
           normalizedPosition: layout.positions[anchor.id] ?? MemoryAtlasCluster.starCenter,
           degree: neighborIDs[anchor.id]?.count ?? 0,
-          clusterRank: 0
+          clusterRank: 0,
+          isCatalog: false
         )
       )
     }
@@ -1159,7 +1157,8 @@ enum MemoryAtlasLayoutEngine {
             cluster: cluster,
             normalizedPosition: layout.positions[node.id] ?? MemoryAtlasCluster.starCenter,
             degree: neighborIDs[node.id]?.count ?? 0,
-            clusterRank: index
+            clusterRank: index,
+            isCatalog: false
           )
         )
       }
@@ -1171,7 +1170,6 @@ enum MemoryAtlasLayoutEngine {
     // selection. Ordering by stable id keeps a refresh from shuffling the map.
     let catalogPositions = MemoryAtlasForceLayout.haloPositions(
       groups: catalogNodes.sorted { $0.id < $1.id }.map { [$0.id] }, area: Self.layoutArea)
-    let catalogRankBase = placements.count
     for (index, node) in catalogNodes.sorted(by: { $0.id < $1.id }).enumerated() {
       placements.append(
         MemoryAtlasNodePlacement(
@@ -1179,7 +1177,8 @@ enum MemoryAtlasLayoutEngine {
           cluster: nil,
           normalizedPosition: catalogPositions[node.id] ?? MemoryAtlasCluster.starCenter,
           degree: 0,
-          clusterRank: catalogRankBase + index
+          clusterRank: index + 1,
+          isCatalog: true
         )
       )
     }
@@ -1391,8 +1390,11 @@ enum MemoryAtlasLayoutEngine {
 
   /// One phrasing for "how big is this map", so the header and the timeline
   /// footer cannot describe the same thing in two different ways.
-  static func countLabel(entities: Int, connections: Int) -> String {
-    "\(entities) entit\(entities == 1 ? "y" : "ies") · \(connections) connection\(connections == 1 ? "" : "s")"
+  static func countLabel(entities: Int, memories: Int? = nil, connections: Int) -> String {
+    let entityLabel = "\(entities) entit\(entities == 1 ? "y" : "ies")"
+    let connectionLabel = "\(connections) connection\(connections == 1 ? "" : "s")"
+    guard let memories else { return "\(entityLabel) · \(connectionLabel)" }
+    return "\(entityLabel) · \(memories) memor\(memories == 1 ? "y" : "ies") · \(connectionLabel)"
   }
 
   /// Whether the account holder's own connections should recede into the
@@ -1978,16 +1980,18 @@ struct CanonicalMemoryAtlasPage: View {
   /// Opens a cited memory on the Memories surface this page came from.
   let onOpenMemory: (String) -> Void
 
-  /// Reads the same memoized snapshot the surface below is drawing, so the two
-  /// cannot drift. Free after the first build — the cache is keyed on graph
-  /// content and the surface has already paid for it.
+  /// Reads the memoized snapshot drawn below, so the counts cannot drift.
   private var headerCountLabel: String {
     if let projection = viewModel.canonicalAtlasProjection {
       return MemoryAtlasLayoutEngine.countLabel(
-        entities: projection.snapshot.nodes.count, connections: projection.snapshot.edges.count)
+        entities: projection.snapshot.nodes.filter { !$0.isCatalog }.count,
+        memories: projection.snapshot.nodes.filter(\.isCatalog).count,
+        connections: projection.snapshot.edges.count)
     }
     return MemoryAtlasLayoutEngine.countLabel(
-      entities: viewModel.graphResponse.atlasNodes.count, connections: viewModel.graphResponse.edges.count)
+      entities: viewModel.graphResponse.atlasNodes.count,
+      memories: viewModel.graphResponse.catalogNodes?.count,
+      connections: viewModel.graphResponse.edges.count)
   }
 
   var body: some View {
@@ -2014,16 +2018,8 @@ struct CanonicalMemoryAtlasPage: View {
 
         Spacer()
 
-        // The map's own counts, not the server response's.
-        //
-        // The header used to report `graphResponse`, which counts things this
-        // page does not draw: a duplicate id, a "The User" node folded into
-        // you, and every extra edge the server emitted for one relationship
-        // ("includes" and "with" between the same two entities). On a real
-        // account that read "1,097 entities · 1,544 connections" directly above
-        // a timeline saying 1,096 and 1,377 — the same map, described twice,
-        // disagreeing. A count nobody can reconcile costs more trust than it
-        // buys completeness, and the drawn map is the one the user can check.
+        // Show the semantic map and the complete canonical-memory catalog as
+        // distinct counts; catalog records are visible but never fake edges.
         Text(headerCountLabel)
           .scaledFont(size: 12)
           .foregroundColor(OmiColors.textTertiary)
@@ -3901,11 +3897,13 @@ private struct CanonicalMemoryAtlasSurface: View {
     if isInspectMode {
       if selected { return 64 }
       if placement.id == snapshot.anchorNodeID { return 50 }
+      if placement.isCatalog { return 34 }
       if placement.clusterRank == 0 { return 42 }
       return 34
     }
     if selected { return compact ? 28 : (isFocusMode ? 50 : 34) }
     if placement.id == snapshot.anchorNodeID { return compact ? 24 : (isFocusMode ? 38 : 29) }
+    if placement.isCatalog { return compact ? 10 : (isFocusMode ? 22 : 13) }
     if placement.clusterRank == 0 { return compact ? 19 : (isFocusMode ? 32 : 23) }
     return compact ? 10 : (isFocusMode ? 22 : 13)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -541,39 +541,6 @@ enum MemoryAtlasZoomPolicy {
   }
 }
 
-enum MemoryAtlasNodeVisualPolicy {
-  /// Deep inspection keeps dots at a stable, usable size. The dynamic maximum
-  /// zoom adds label fidelity; it must not make a node harder to see or target.
-  static func radius(
-    clusterRank: Int,
-    zoom: CGFloat,
-    compact: Bool,
-    isFullyLabelled: Bool,
-    isInspect: Bool,
-    isFocus: Bool,
-    isSmallAtlas: Bool = false
-  ) -> CGFloat {
-    if isFullyLabelled || isInspect {
-      return clusterRank == 0 ? 16 : 12
-    }
-    // A 2.1pt dot is the right mark among thousands of peers and far too timid
-    // when there are two dozen. Scale the mark to the graph, not just the zoom.
-    if isSmallAtlas && !compact && !isFocus {
-      return clusterRank == 0 ? 9 : 6
-    }
-    if isFocus {
-      return clusterRank == 0 ? 10 : 7.2
-    }
-    if clusterRank == 0 {
-      if compact { return 5 }
-      return zoom >= 4.2 ? 8 : 6
-    }
-    if compact { return zoom >= 1.2 ? 2.4 : 2.1 }
-    if zoom >= 4.2 { return 4.8 }
-    return zoom >= 1.45 ? 2.8 : 2.1
-  }
-}
-
 struct MemoryAtlasRenderPlan {
   let visibleNodes: [MemoryAtlasNodePlacement]
   let visibleEdges: [MemoryAtlasEdgePlacement]
@@ -913,38 +880,6 @@ enum MemoryAtlasRenderPlanner {
     return result
   }
 
-  /// Preserve the precomputed per-cluster salience order while avoiding a
-  /// single dense cluster monopolizing a capped detail viewport.
-  private static func fairPrefix(
-    _ candidates: [MemoryAtlasNodePlacement],
-    limit: Int
-  ) -> [MemoryAtlasNodePlacement] {
-    var unclustered: [MemoryAtlasNodePlacement] = []
-    var byCluster: [MemoryAtlasCluster: [MemoryAtlasNodePlacement]] = [:]
-    for placement in candidates {
-      if let cluster = placement.cluster {
-        byCluster[cluster, default: []].append(placement)
-      } else {
-        unclustered.append(placement)
-      }
-    }
-
-    var result = Array(unclustered.prefix(limit))
-    var nextIndexes = [Int](repeating: 0, count: MemoryAtlasCluster.allCases.count)
-    while result.count < limit {
-      var appended = false
-      for (clusterIndex, cluster) in MemoryAtlasCluster.allCases.enumerated() where result.count < limit {
-        let index = nextIndexes[clusterIndex]
-        guard let placements = byCluster[cluster], index < placements.count else { continue }
-        result.append(placements[index])
-        nextIndexes[clusterIndex] = index + 1
-        appended = true
-      }
-      if !appended { break }
-    }
-    return result
-  }
-
   /// Labels admitted without collision, plus the subset drawn above their mark.
   private struct AdmittedLabels {
     var placements: [MemoryAtlasNodePlacement] = []
@@ -1018,9 +953,17 @@ enum MemoryAtlasLayoutEngine {
     // Graph responses are external data. Coalesce duplicate identifiers at the
     // boundary so a malformed server response cannot trap while building a UI.
     let nodes = uniqueNodes(from: graph.atlasNodes)
+    let assertionNodeIDs = Set(nodes.map(\.id))
+    // A canonical memory without a verified relationship is still a real
+    // memory. It belongs in the atlas as a neutral, explicitly unconnected
+    // mark rather than being silently removed from the user's browser. Keep it
+    // out of the semantic layout below: using a type field or an inferred edge
+    // here would make an unsupported claim about what that memory relates to.
+    let catalogNodes = uniqueNodes(from: graph.catalogNodes ?? [])
+      .filter { !assertionNodeIDs.contains($0.id) }
     let edges = uniqueEdges(from: graph.edges)
 
-    guard !nodes.isEmpty else {
+    guard !nodes.isEmpty || !catalogNodes.isEmpty else {
       return MemoryAtlasSnapshot(nodes: [], edges: [], anchorNodeID: nil, clusterCenters: [:])
     }
 
@@ -1220,6 +1163,25 @@ enum MemoryAtlasLayoutEngine {
           )
         )
       }
+    }
+
+    // Catalog records deliberately receive no cluster and no edge. The outer
+    // halo is an honest visual distinction from assertion-backed constellations
+    // while keeping every canonical memory reachable through zoom, search, and
+    // selection. Ordering by stable id keeps a refresh from shuffling the map.
+    let catalogPositions = MemoryAtlasForceLayout.haloPositions(
+      groups: catalogNodes.sorted { $0.id < $1.id }.map { [$0.id] }, area: Self.layoutArea)
+    let catalogRankBase = placements.count
+    for (index, node) in catalogNodes.sorted(by: { $0.id < $1.id }).enumerated() {
+      placements.append(
+        MemoryAtlasNodePlacement(
+          node: node,
+          cluster: nil,
+          normalizedPosition: catalogPositions[node.id] ?? MemoryAtlasCluster.starCenter,
+          degree: 0,
+          clusterRank: catalogRankBase + index
+        )
+      )
     }
 
     let positions = Dictionary(lastWriteWins: placements.map { ($0.id, $0.normalizedPosition) })
@@ -3135,6 +3097,35 @@ private struct CanonicalMemoryAtlasSurface: View {
       if !mutedPath.isEmpty {
         context.fill(mutedPath, with: .color(cluster.color.opacity(0.1)))
       }
+    }
+
+    // Catalog marks are deliberately neutral. They are durable memories, not
+    // concepts or members of a relationship cluster, and their outer placement
+    // is the only spatial statement the atlas makes about them.
+    var catalogPrimaryPath = Path()
+    var catalogMutedPath = Path()
+    for placement in plan.visibleNodes
+    where placement.cluster == nil && placement.id != snapshot.anchorNodeID && placement.id != selectedNodeID {
+      let related = selectedNodeID == nil || plan.relatedNodeIDs.contains(placement.id)
+      let matches = matchingNodeIDs == nil || matchingNodeIDs?.contains(placement.id) == true
+      let radius = nodeRadius(for: placement)
+      let center = point(for: placement.normalizedPosition, in: size)
+      guard
+        paintBounds.intersects(
+          CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2))
+      else { continue }
+      let rect = CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)
+      if related && matches {
+        catalogPrimaryPath.addEllipse(in: rect)
+      } else {
+        catalogMutedPath.addEllipse(in: rect)
+      }
+    }
+    if !catalogPrimaryPath.isEmpty {
+      context.fill(catalogPrimaryPath, with: .color(OmiColors.textTertiary.opacity(0.44)))
+    }
+    if !catalogMutedPath.isEmpty {
+      context.fill(catalogMutedPath, with: .color(OmiColors.textTertiary.opacity(0.09)))
     }
 
     if let anchorNodeID = snapshot.anchorNodeID,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPresentationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPresentationPolicy.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+enum MemoryAtlasNodeVisualPolicy {
+  /// Deep inspection keeps dots at a stable, usable size. The dynamic maximum
+  /// zoom adds label fidelity; it must not make a node harder to see or target.
+  static func radius(
+    clusterRank: Int,
+    zoom: CGFloat,
+    compact: Bool,
+    isFullyLabelled: Bool,
+    isInspect: Bool,
+    isFocus: Bool,
+    isSmallAtlas: Bool = false
+  ) -> CGFloat {
+    if isFullyLabelled || isInspect {
+      return clusterRank == 0 ? 16 : 12
+    }
+    // A 2.1pt dot is the right mark among thousands of peers and far too timid
+    // when there are two dozen. Scale the mark to the graph, not just the zoom.
+    if isSmallAtlas && !compact && !isFocus {
+      return clusterRank == 0 ? 9 : 6
+    }
+    if isFocus {
+      return clusterRank == 0 ? 10 : 7.2
+    }
+    if clusterRank == 0 {
+      if compact { return 5 }
+      return zoom >= 4.2 ? 8 : 6
+    }
+    if compact { return zoom >= 1.2 ? 2.4 : 2.1 }
+    if zoom >= 4.2 { return 4.8 }
+    return zoom >= 1.45 ? 2.8 : 2.1
+  }
+}
+
+extension MemoryAtlasRenderPlanner {
+  /// Preserve the precomputed per-cluster salience order while avoiding a
+  /// single dense cluster monopolizing a capped detail viewport.
+  static func fairPrefix(
+    _ candidates: [MemoryAtlasNodePlacement],
+    limit: Int
+  ) -> [MemoryAtlasNodePlacement] {
+    var unclustered: [MemoryAtlasNodePlacement] = []
+    var byCluster: [MemoryAtlasCluster: [MemoryAtlasNodePlacement]] = [:]
+    for placement in candidates {
+      if let cluster = placement.cluster {
+        byCluster[cluster, default: []].append(placement)
+      } else {
+        unclustered.append(placement)
+      }
+    }
+
+    // The anchor is an unclustered semantic node; catalog records are also
+    // unclustered but are intentionally background material until a search or
+    // selection asks for them. Otherwise a large historical catalog would
+    // crowd all assertion-backed constellations out of an overview.
+    let semanticUnclustered = unclustered.filter { !$0.id.hasPrefix("memory:") }
+    let catalogUnclustered = unclustered.filter { $0.id.hasPrefix("memory:") }
+    var result = Array(semanticUnclustered.prefix(limit))
+    var nextIndexes = [Int](repeating: 0, count: MemoryAtlasCluster.allCases.count)
+    while result.count < limit {
+      var appended = false
+      for (clusterIndex, cluster) in MemoryAtlasCluster.allCases.enumerated() where result.count < limit {
+        let index = nextIndexes[clusterIndex]
+        guard let placements = byCluster[cluster], index < placements.count else { continue }
+        result.append(placements[index])
+        nextIndexes[clusterIndex] = index + 1
+        appended = true
+      }
+      if !appended { break }
+    }
+    if result.count < limit {
+      result.append(contentsOf: catalogUnclustered.prefix(limit - result.count))
+    }
+    return result
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPresentationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPresentationPolicy.swift
@@ -1,5 +1,35 @@
 import SwiftUI
 
+struct MemoryAtlasNodePlacement: Identifiable {
+  let node: KnowledgeGraphNode
+  let cluster: MemoryAtlasCluster?
+  let normalizedPosition: CGPoint
+  let degree: Int
+  let clusterRank: Int
+  /// Presentation-only catalog records represent a canonical memory without
+  /// asserting a semantic entity or relationship. Layout is the authoritative
+  /// source for this classification; no id convention is involved.
+  let isCatalog: Bool
+
+  init(
+    node: KnowledgeGraphNode,
+    cluster: MemoryAtlasCluster?,
+    normalizedPosition: CGPoint,
+    degree: Int,
+    clusterRank: Int,
+    isCatalog: Bool
+  ) {
+    self.node = node
+    self.cluster = cluster
+    self.normalizedPosition = normalizedPosition
+    self.degree = degree
+    self.clusterRank = clusterRank
+    self.isCatalog = isCatalog
+  }
+
+  var id: String { node.id }
+}
+
 enum MemoryAtlasNodeVisualPolicy {
   /// Deep inspection keeps dots at a stable, usable size. The dynamic maximum
   /// zoom adds label fidelity; it must not make a node harder to see or target.
@@ -38,7 +68,8 @@ extension MemoryAtlasRenderPlanner {
   /// single dense cluster monopolizing a capped detail viewport.
   static func fairPrefix(
     _ candidates: [MemoryAtlasNodePlacement],
-    limit: Int
+    limit: Int,
+    prioritizeCatalog: Bool = false
   ) -> [MemoryAtlasNodePlacement] {
     var unclustered: [MemoryAtlasNodePlacement] = []
     var byCluster: [MemoryAtlasCluster: [MemoryAtlasNodePlacement]] = [:]
@@ -54,9 +85,12 @@ extension MemoryAtlasRenderPlanner {
     // unclustered but are intentionally background material until a search or
     // selection asks for them. Otherwise a large historical catalog would
     // crowd all assertion-backed constellations out of an overview.
-    let semanticUnclustered = unclustered.filter { !$0.id.hasPrefix("memory:") }
-    let catalogUnclustered = unclustered.filter { $0.id.hasPrefix("memory:") }
-    var result = Array(semanticUnclustered.prefix(limit))
+    let semanticUnclustered = unclustered.filter { !$0.isCatalog }
+    let catalogUnclustered = unclustered.filter(\.isCatalog)
+    // A search tier is the user explicitly asking to see matching memories.
+    // Admit its catalog matches before semantic background so a broad result
+    // cannot disappear merely because an assertion constellation is denser.
+    var result = Array((prioritizeCatalog ? catalogUnclustered : semanticUnclustered).prefix(limit))
     var nextIndexes = [Int](repeating: 0, count: MemoryAtlasCluster.allCases.count)
     while result.count < limit {
       var appended = false
@@ -68,6 +102,9 @@ extension MemoryAtlasRenderPlanner {
         appended = true
       }
       if !appended { break }
+    }
+    if result.count < limit, prioritizeCatalog {
+      result.append(contentsOf: semanticUnclustered.prefix(limit - result.count))
     }
     if result.count < limit {
       result.append(contentsOf: catalogUnclustered.prefix(limit - result.count))

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSnapshotCache.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSnapshotCache.swift
@@ -98,6 +98,15 @@ final class MemoryAtlasSnapshotCache: @unchecked Sendable {
       hasher.combine(node.createdAt)
       hasher.combine(node.updatedAt)
     }
+    for node in graph.catalogNodes ?? [] {
+      hasher.combine(node.id)
+      hasher.combine(node.label)
+      hasher.combine(node.nodeType)
+      hasher.combine(node.aliases)
+      hasher.combine(node.memoryIds)
+      hasher.combine(node.createdAt)
+      hasher.combine(node.updatedAt)
+    }
     for edge in graph.edges {
       hasher.combine(edge.id)
       hasher.combine(edge.sourceId)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -187,6 +187,10 @@ class MemoryGraphViewModel: ObservableObject {
   private var sessionGeneration = 0
   private let canonicalGraphFetcher: CanonicalGraphFetcher
 
+  private static func hasAtlasContent(_ response: KnowledgeGraphResponse) -> Bool {
+    !response.atlasNodes.isEmpty || !(response.catalogNodes?.isEmpty ?? true)
+  }
+
   init() {
     canonicalGraphFetcher = { authorizationSnapshot in
       try await APIClient.shared.getKnowledgeGraph(
@@ -202,7 +206,7 @@ class MemoryGraphViewModel: ObservableObject {
   ) {
     self.canonicalGraphFetcher = canonicalGraphFetcher
     graphResponse = initialGraphResponse
-    isEmpty = initialGraphResponse.nodes.isEmpty
+    isEmpty = !Self.hasAtlasContent(initialGraphResponse)
     setupCamera()
     setupLighting()
   }
@@ -304,13 +308,13 @@ class MemoryGraphViewModel: ObservableObject {
     }
 
     if hasLoadedCanonicalAtlas,
-      !graphResponse.nodes.isEmpty,
+      Self.hasAtlasContent(graphResponse),
       !PollingConfig.shouldAllowActivationRefresh(lastRefresh: lastLoadedAt)
     {
       return
     }
 
-    let showSpinner = graphResponse.nodes.isEmpty
+    let showSpinner = !Self.hasAtlasContent(graphResponse)
     if showSpinner { isLoading = true }
     defer {
       if showSpinner && generation == sessionGeneration {
@@ -332,7 +336,7 @@ class MemoryGraphViewModel: ObservableObject {
       }
       canonicalAtlasProjection = projection
       graphResponse = response
-      isEmpty = response.atlasNodes.isEmpty
+      isEmpty = !Self.hasAtlasContent(response)
       hasLoadedCanonicalAtlas = true
       lastLoadedAt = Date()
       log("Memory atlas: \(response.atlasNodes.count) nodes, \(response.edges.count) edges")
@@ -388,7 +392,7 @@ class MemoryGraphViewModel: ObservableObject {
           }
           canonicalAtlasProjection = projection
           graphResponse = response
-          isEmpty = response.atlasNodes.isEmpty
+          isEmpty = !Self.hasAtlasContent(response)
           hasLoadedCanonicalAtlas = true
           lastLoadedAt = Date()
           log("Memory atlas: rebuilt graph loaded after \(attempt) poll(s), \(response.atlasNodes.count) nodes")

--- a/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
@@ -265,10 +265,11 @@ final class DesktopAutomationSecondaryActionTests: XCTestCase {
   func testMemoryGraphSnapshotUsesKnowledgeGraphAPI() throws {
     let source = try bridgeSource()
     let body = try actionBody(named: "memory_graph_snapshot", in: source)
-    for key in ["node_count", "edge_count", "is_empty"] {
+    for key in ["node_count", "edge_count", "catalog_memory_count", "atlas_mark_count", "is_empty"] {
       XCTAssertTrue(body.contains("\"\(key)\""), "memory_graph_snapshot should return \(key)")
     }
     XCTAssertTrue(body.contains("getKnowledgeGraph"))
+    XCTAssertTrue(body.contains("MemoryAtlasProjection"))
   }
 
   func testMemoryAtlasHarnessActionsPostBoundedViewportNotifications() throws {

--- a/desktop/macos/Desktop/Tests/KnowledgeGraphPaginationTests.swift
+++ b/desktop/macos/Desktop/Tests/KnowledgeGraphPaginationTests.swift
@@ -450,6 +450,28 @@ final class KnowledgeGraphPaginationTests: XCTestCase {
     XCTAssertTrue(viewModel.isEmpty)
   }
 
+  func testCatalogOnlyCanonicalAtlasIsRenderableAndActivationCached() async throws {
+    let fetches = LockedCounter()
+    let response = KnowledgeGraphResponse(
+      nodes: [],
+      edges: [],
+      catalogNodes: [KnowledgeGraphNode(id: "memory-only", label: "Canonical memory", nodeType: .concept)])
+    let viewModel = MemoryGraphViewModel(
+      canonicalGraphFetcher: { _ in
+        fetches.increment()
+        return response
+      },
+      initialGraphResponse: KnowledgeGraphResponse(nodes: [], edges: []))
+
+    await viewModel.prepareCanonicalAtlas()
+    await viewModel.prepareCanonicalAtlas()
+
+    XCTAssertEqual(fetches.read(), 1, "A catalog-only atlas is a settled atlas, not an empty retry loop")
+    XCTAssertFalse(viewModel.isEmpty)
+    XCTAssertFalse(viewModel.isLoading)
+    XCTAssertEqual(viewModel.canonicalAtlasProjection?.snapshot.nodes.map(\.id), ["memory-only"])
+  }
+
   private func makeClient(urlProtocolClass: URLProtocol.Type) async -> APIClient {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [urlProtocolClass]

--- a/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
@@ -23,24 +23,52 @@ final class MemoryAtlasLayoutTests: XCTestCase {
   func testCatalogNodesEnterAtlasAsNeutralUnconnectedMarks() throws {
     let assertionNodes = [
       KnowledgeGraphNode(id: "david", label: "David", nodeType: .person),
-      KnowledgeGraphNode(id: "omi", label: "Omi", nodeType: .thing),
+      KnowledgeGraphNode(id: "memory:semantic-entity", label: "Omi", nodeType: .thing),
     ]
     let catalogNode = KnowledgeGraphNode(
-      id: "memory:unlinked",
+      id: "canonical-record",
       label: "A durable memory that has no assertion",
       nodeType: .concept)
     let response = KnowledgeGraphResponse(
       nodes: assertionNodes,
-      edges: [KnowledgeGraphEdge(id: "uses", sourceId: "david", targetId: "omi", label: "uses")],
+      edges: [KnowledgeGraphEdge(id: "uses", sourceId: "david", targetId: "memory:semantic-entity", label: "uses")],
       catalogNodes: [catalogNode])
 
     let snapshot = MemoryAtlasLayoutEngine.makeSnapshot(graph: response, userName: "David")
 
-    XCTAssertEqual(response.catalogNodes?.map(\.id), ["memory:unlinked"])
-    XCTAssertEqual(snapshot.nodes.map(\.id), ["david", "omi", catalogNode.id])
+    XCTAssertEqual(response.catalogNodes?.map(\.id), ["canonical-record"])
+    XCTAssertEqual(snapshot.nodes.map(\.id), ["david", "memory:semantic-entity", catalogNode.id])
+    XCTAssertEqual(snapshot.nodeByID["memory:semantic-entity"]?.isCatalog, false)
     XCTAssertEqual(snapshot.nodeByID[catalogNode.id]?.cluster, nil)
     XCTAssertEqual(snapshot.nodeByID[catalogNode.id]?.degree, 0)
+    XCTAssertEqual(snapshot.nodeByID[catalogNode.id]?.isCatalog, true)
+    XCTAssertNotEqual(snapshot.nodeByID[catalogNode.id]?.clusterRank, 0)
     XCTAssertEqual(snapshot.edges.count, 1)
+  }
+
+  func testCatalogSearchMatchesWinTheirTierWithoutIDPrefixCoupling() {
+    let catalogMatch = MemoryAtlasNodePlacement(
+      node: KnowledgeGraphNode(id: "canonical-record", label: "Matching memory", nodeType: .concept),
+      cluster: nil,
+      normalizedPosition: .zero,
+      degree: 0,
+      clusterRank: 1,
+      isCatalog: true)
+    let semantic = (0..<10).map { index in
+      MemoryAtlasNodePlacement(
+        node: KnowledgeGraphNode(id: "entity-\(index)", label: "Matching entity \(index)", nodeType: .concept),
+        cluster: .concept,
+        normalizedPosition: .zero,
+        degree: 1,
+        clusterRank: index,
+        isCatalog: false)
+    }
+
+    let selected = MemoryAtlasRenderPlanner.fairPrefix(
+      semantic + [catalogMatch], limit: 4, prioritizeCatalog: true)
+
+    XCTAssertTrue(selected.contains(where: { $0.id == catalogMatch.id }))
+    XCTAssertEqual(selected.first?.id, catalogMatch.id)
   }
 
   func testProjectionCarriesCatalogNodesIntoTheAtlasPresentation() {
@@ -1224,6 +1252,10 @@ final class MemoryAtlasLayoutTests: XCTestCase {
         entities: snapshot.nodes.count, connections: snapshot.edges.count),
       "2 entities · 1 connection",
       "Three nodes and three edges arrived; two entities and one connection are drawn")
+
+    XCTAssertEqual(
+      MemoryAtlasLayoutEngine.countLabel(entities: 2, memories: 1_093, connections: 1),
+      "2 entities · 1093 memories · 1 connection")
   }
 
   private func placement(label: String, degree: Int) -> MemoryAtlasNodePlacement {
@@ -1232,7 +1264,8 @@ final class MemoryAtlasLayoutTests: XCTestCase {
       cluster: .thing,
       normalizedPosition: .zero,
       degree: degree,
-      clusterRank: 0
+      clusterRank: 0,
+      isCatalog: false
     )
   }
 

--- a/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
@@ -20,7 +20,7 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     XCTAssertEqual(Double(anchor.y), 0.5, accuracy: 1e-9)
   }
 
-  func testCatalogNodesRemainInResponseStateButNeverEnterAtlasProjection() throws {
+  func testCatalogNodesEnterAtlasAsNeutralUnconnectedMarks() throws {
     let assertionNodes = [
       KnowledgeGraphNode(id: "david", label: "David", nodeType: .person),
       KnowledgeGraphNode(id: "omi", label: "Omi", nodeType: .thing),
@@ -37,12 +37,13 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     let snapshot = MemoryAtlasLayoutEngine.makeSnapshot(graph: response, userName: "David")
 
     XCTAssertEqual(response.catalogNodes?.map(\.id), ["memory:unlinked"])
-    XCTAssertEqual(snapshot.nodes.map(\.id), ["david", "omi"])
-    XCTAssertNil(snapshot.nodeByID[catalogNode.id])
+    XCTAssertEqual(snapshot.nodes.map(\.id), ["david", "omi", catalogNode.id])
+    XCTAssertEqual(snapshot.nodeByID[catalogNode.id]?.cluster, nil)
+    XCTAssertEqual(snapshot.nodeByID[catalogNode.id]?.degree, 0)
     XCTAssertEqual(snapshot.edges.count, 1)
   }
 
-  func testProjectionCarriesCatalogNodesWithoutProjectingThem() {
+  func testProjectionCarriesCatalogNodesIntoTheAtlasPresentation() {
     let catalogNode = KnowledgeGraphNode(
       id: "memory:catalog",
       label: "Catalog memory",
@@ -55,7 +56,24 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     let projection = MemoryAtlasProjection(graph: response, userName: nil)
 
     XCTAssertEqual(projection.graph.catalogNodes?.map(\.id), [catalogNode.id])
-    XCTAssertEqual(projection.snapshot.nodes.map(\.id), ["entity"])
+    XCTAssertEqual(projection.snapshot.nodes.map(\.id), ["entity", catalogNode.id])
+    XCTAssertNil(projection.snapshot.nodeByID[catalogNode.id]?.cluster)
+  }
+
+  func testCatalogOnlyAtlasIsStableAndDoesNotCreateEdgesOrClusters() {
+    let catalog = (0..<600).map {
+      KnowledgeGraphNode(id: "memory:\($0)", label: "Canonical memory \($0)", nodeType: .concept)
+    }
+    let response = KnowledgeGraphResponse(nodes: [], edges: [], catalogNodes: catalog)
+
+    let first = MemoryAtlasLayoutEngine.makeSnapshot(graph: response, userName: "David")
+    let second = MemoryAtlasLayoutEngine.makeSnapshot(graph: response, userName: "David")
+
+    XCTAssertEqual(first.nodes.count, catalog.count)
+    XCTAssertTrue(first.nodes.allSatisfy { $0.cluster == nil && $0.degree == 0 })
+    XCTAssertTrue(first.edges.isEmpty)
+    XCTAssertTrue(first.activeClusters.isEmpty)
+    XCTAssertEqual(first.nodes.map(\.normalizedPosition), second.nodes.map(\.normalizedPosition))
   }
 
   /// Type still decides a node's colour and which constellation it counts

--- a/desktop/macos/Desktop/Tests/MemoryAtlasSnapshotCacheTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasSnapshotCacheTests.swift
@@ -53,6 +53,24 @@ final class MemoryAtlasSnapshotCacheTests: XCTestCase {
     XCTAssertEqual(cache.computeCount, 2)
   }
 
+  func testChangingOnlyTheCatalogDoesNotReuseThePreviousAtlas() {
+    let graph = makeGraph(memoryIDsByNode: [:])
+    let first = KnowledgeGraphResponse(
+      nodes: graph.nodes,
+      edges: [],
+      catalogNodes: [KnowledgeGraphNode(id: "memory-a", label: "First", nodeType: .concept)])
+    let second = KnowledgeGraphResponse(
+      nodes: graph.nodes,
+      edges: [],
+      catalogNodes: [KnowledgeGraphNode(id: "memory-b", label: "Second", nodeType: .concept)])
+
+    _ = cache.snapshot(for: first, userName: "David")
+    let refreshed = cache.snapshot(for: second, userName: "David")
+
+    XCTAssertEqual(cache.computeCount, 2)
+    XCTAssertEqual(refreshed.nodes.map(\.id), ["memory-b"])
+  }
+
   private func makeGraph(memoryIDsByNode: [String: [String]]) -> KnowledgeGraphResponse {
     let nodes = memoryIDsByNode.keys.sorted().map { id in
       KnowledgeGraphNode(

--- a/desktop/macos/changelog/unreleased/20260805-canonical-memory-catalog-atlas.json
+++ b/desktop/macos/changelog/unreleased/20260805-canonical-memory-catalog-atlas.json
@@ -1,0 +1,3 @@
+{
+  "change": "Memory Atlas now shows every canonical memory while keeping verified relationship clusters distinct."
+}

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryProvenance.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPresentationPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasTerritoryLabels.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasIslands.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasRenderPlanCache.swift

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -17,6 +17,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasRenderPlanCache.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSnapshotCache.swift
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
 preconditions:


### PR DESCRIPTION
## Summary

- Render canonical catalog-only memories as neutral, unconnected atlas marks.
- Preserve assertion-backed clusters, neighborhoods, and relationship edges as the sole semantic map.
- Keep catalog entries searchable and selectable without letting a large historical catalog crowd the semantic overview.

## Verification

- `xcrun swift test --package-path desktop/macos/Desktop --filter MemoryAtlasLayoutTests`

## Product invariant

- INV-MEM-1: this is a read-only presentation of existing canonical Long-term memories; it does not create a tier, mutate memory authority, or bypass access policy.

Failure-Class: none
