### PR TITLE
feat(memory): catalog every canonical atlas item

### DIFF
--- a/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
@@ -315,9 +315,10 @@ def test_canonical_graph_filters_stale_ineligible_and_restricted_assertions(monk
     assert "stale-generation" not in {memory_id for refs in db.assertion_ref_pages for memory_id in refs}
 
 
-def test_canonical_graph_separates_unlinked_canonical_memory_from_assertion_graph(monkeypatch):
+def test_canonical_graph_returns_every_canonical_memory_as_a_catalog_record(monkeypatch):
     monkeypatch.setenv("MEMORY_V3_CURSOR_SECRET", "canonical-graph-test-secret")
     linked_item, linked_assertion = _assertion_and_item("linked", 1, updated_at=NOW.replace(minute=1))
+    linked_item._payload["content"] = "A durable canonical memory with a verified relationship."
     unlinked_updated_at = NOW.replace(minute=2)
     unlinked_item, _unlinked_assertion = _assertion_and_item("unlinked", 2, updated_at=unlinked_updated_at)
     unlinked_item._payload["content"] = "A durable canonical memory that has no inferred relationship yet."
@@ -337,7 +338,16 @@ def test_canonical_graph_separates_unlinked_canonical_memory_from_assertion_grap
             "memory_ids": ["unlinked"],
             "created_at": unlinked_updated_at,
             "updated_at": unlinked_updated_at,
-        }
+        },
+        {
+            "id": "memory:linked",
+            "label": "A durable canonical memory with a verified relationship.",
+            "node_type": "concept",
+            "aliases": [],
+            "memory_ids": ["linked"],
+            "created_at": NOW.replace(minute=1),
+            "updated_at": NOW.replace(minute=1),
+        },
     ]
 
 

--- a/backend/utils/memory/canonical_graph.py
+++ b/backend/utils/memory/canonical_graph.py
@@ -309,12 +309,11 @@ def _build_canonical_graph_items_query(
 
 
 def _canonical_memory_catalog_node(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Represent a durable canonical memory without inventing a relationship.
+    """Represent every durable canonical memory without inventing a relationship.
 
-    Historical rows may predate the graph-assertion contract.  They remain
-    authoritative memory facts, so the atlas includes them as isolated memory
-    nodes while assertion-backed relationships stay exclusively in the fenced
-    graph records below.
+    The catalog is the one-to-one memory browser. Assertion-backed entities and
+    relationships remain exclusively in the fenced graph records below, so the
+    atlas never needs to infer a relationship merely to show a memory.
     """
     content = item.get('content')
     memory_id = item.get('memory_id')
@@ -406,14 +405,11 @@ def _read_canonical_graph_page_once(
                     account_generation=revision.account_generation,
                     db_client=client,
                 )
-                assertion_memory_ids = {assertion.memory_id for assertion in loaded_assertions}
                 for assertion in loaded_assertions:
                     accepted_assertions.append(assertion)
                     visible_memory_ids.add(assertion.memory_id)
                 for item in eligible_batch:
                     memory_id = cast(str, item['memory_id'])
-                    if memory_id in assertion_memory_ids:
-                        continue
                     catalog_node = _canonical_memory_catalog_node(item)
                     if catalog_node is not None:
                         catalog_nodes.append(catalog_node)


### PR DESCRIPTION
## Summary

- Return one neutral catalog record for every eligible canonical memory, including memories that also contribute verified graph entities.
- Preserve assertion-backed nodes and edges as the only semantic relationship layer.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_knowledge_graph_canonical_pagination.py`

## Product invariant

- INV-MEM-1: the response remains a read-only projection of the existing canonical Long-term collection; no memory authority or access policy changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

