### PR TITLE
fix(memory): retain blank canonical catalog records

### DIFF
--- a/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_pagination.py
@@ -351,6 +351,29 @@ def test_canonical_graph_returns_every_canonical_memory_as_a_catalog_record(monk
     ]
 
 
+def test_blank_canonical_content_remains_a_neutral_catalog_record(monkeypatch):
+    monkeypatch.setenv("MEMORY_V3_CURSOR_SECRET", "canonical-graph-test-secret")
+    blank_updated_at = NOW.replace(minute=3)
+    blank_item, _blank_assertion = _assertion_and_item("blank", 1, updated_at=blank_updated_at)
+    blank_item._payload["content"] = " \n\t "
+    db = _FakeDB([blank_item], {})
+
+    page = kg.get_canonical_knowledge_graph(UID, db_client=db, limit=10)
+
+    assert page.nodes == []
+    assert page.catalog_nodes == [
+        {
+            "id": "memory:blank",
+            "label": "Untitled canonical memory",
+            "node_type": "concept",
+            "aliases": [],
+            "memory_ids": ["blank"],
+            "created_at": blank_updated_at,
+            "updated_at": blank_updated_at,
+        }
+    ]
+
+
 def test_assertion_loader_rechecks_account_generation_before_fetch():
     stale_item, stale_assertion = _assertion_and_item("stale-generation", 1, account_generation=3)
     db = _fake_db_for([(stale_item, stale_assertion)])

--- a/backend/utils/memory/canonical_graph.py
+++ b/backend/utils/memory/canonical_graph.py
@@ -318,14 +318,15 @@ def _canonical_memory_catalog_node(item: Dict[str, Any]) -> Optional[Dict[str, A
     content = item.get('content')
     memory_id = item.get('memory_id')
     updated_at = item.get('updated_at')
-    if (
-        not isinstance(content, str)
-        or not content.strip()
-        or not isinstance(memory_id, str)
-        or not isinstance(updated_at, datetime)
-    ):
+    if not isinstance(content, str) or not isinstance(memory_id, str) or not isinstance(updated_at, datetime):
         return None
     label = ' '.join(content.split())
+    # Eligibility, authority, and access are decided before presentation. A
+    # historical item with blank source text is still a canonical memory; do
+    # not erase it from the user's one-to-one browser merely because it has no
+    # safe text to display. The fallback makes no semantic claim or edge.
+    if not label:
+        label = 'Untitled canonical memory'
     return {
         'id': f'memory:{memory_id}',
         'label': label[:240],


### PR DESCRIPTION
## Summary

- Retain active canonical memories with blank source text as neutral catalog records.
- Label those records `Untitled canonical memory`; do not infer entities or relationships.

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_knowledge_graph_canonical_pagination.py`

## Product invariants affected

- INV-MEM-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

