### PR TITLE
fix(agent-vm): centralize recovery authority

### DIFF
--- a/.github/failure-classes/FC-split-mutation-authority.json
+++ b/.github/failure-classes/FC-split-mutation-authority.json
@@ -5,7 +5,8 @@
   "canonical_prevention": "Converge writes and lifecycle transitions behind the canonical repository or coordinator instead of synchronizing competing owners.",
   "canonical_prevention_artifact": [
     "desktop/macos/agent/tests/convergence-authority-ratchet.test.ts",
-    "backend/tests/unit/test_canonical_maintenance_ordering.py"
+    "backend/tests/unit/test_canonical_maintenance_ordering.py",
+    "backend/tests/unit/test_agent_vm_reconciler_authority.py"
   ],
   "evidence_prs": [9365, 9597],
   "scope_hints": ["desktop/macos/**", "backend/**"],

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -2,7 +2,7 @@
 agent-proxy — WebSocket proxy that bridges the mobile app to a user's agent VM.
 
 Auth: Firebase ID token in Authorization header (Bearer <token>) during WS upgrade.
-Flow: validate token → fetch VM from Firestore → if stopped, restart → connect to VM WS → bidirectional pump.
+Flow: validate token → fetch VM from Firestore → request reconciliation when unavailable → connect to VM WS → bidirectional pump.
 History: fetches last 10 agent messages from Firestore and prepends to prompt.
 """
 
@@ -19,8 +19,6 @@ from datetime import datetime, timezone
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, cast
 
 import firebase_admin
-import google.auth
-import google.auth.transport.requests
 import httpx
 import websockets
 from cryptography.hazmat.primitives import hashes
@@ -28,8 +26,8 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from firebase_admin import auth, credentials, firestore
-from google.cloud.firestore import DELETE_FIELD, ArrayUnion, transactional
-from google.cloud.firestore_v1 import Increment, Query
+from google.cloud.firestore import ArrayUnion, transactional
+from google.cloud.firestore_v1 import Query
 from utils.executors import (
     critical_executor,
     db_executor,
@@ -44,6 +42,7 @@ from services.agent_vm_lifecycle import (
     heartbeat_session_lease,
     reconcile_requested,
     release_session_lease,
+    request_vm_start,
 )
 
 logger = logging.getLogger(__name__)
@@ -51,7 +50,6 @@ logger = logging.getLogger(__name__)
 from resilience import circuit_open, classify_error  # noqa: E402
 
 HISTORY_LIMIT = 10
-GCE_PROJECT = "based-hardware"
 # Legacy placeholder that earlier builds persisted as agentVm.ip when the GCE
 # IP poll timed out. Never written any more; still read so already-poisoned
 # records heal on the next connect instead of resetting a healthy VM forever.
@@ -171,117 +169,6 @@ async def _require_account_deletion_access_async(uid: str) -> None:
     await run_blocking(db_executor, _require_account_deletion_access, uid)
 
 
-def _refresh_vm(uid: str) -> Optional[Dict[str, Any]]:
-    """Re-read the VM info from Firestore (called after restart to get new IP)."""
-    doc = _get_firestore_db().collection('users').document(uid).get()
-    if doc.exists:
-        return cast(Optional[Dict[str, Any]], _typed_doc(doc).get('agentVm'))
-    return None
-
-
-# --------------- GCE helpers ---------------
-
-
-class VmNotFoundError(Exception):
-    """The GCE instance backing the user's agentVm record no longer exists."""
-
-
-def _get_gce_access_token() -> str:
-    """Get a GCE access token via Application Default Credentials."""
-    creds, _ = google.auth.default(scopes=['https://www.googleapis.com/auth/cloud-platform'])  # type: ignore[reportUnknownMemberType]
-    creds.refresh(google.auth.transport.requests.Request())
-    return cast(str, creds.token)
-
-
-async def _check_gce_status(vm_name: str, zone: str) -> str:
-    """Check the actual GCE instance status.
-
-    A 404 is reported as `NOT_FOUND` rather than folded into `UNKNOWN`: the
-    instance is gone (the agent-vm reaper deletes aged TERMINATED VMs), which
-    is unrecoverable here and needs the stale Firestore record cleared, while
-    `UNKNOWN` means "could not tell" and must leave the record alone.
-    """
-    token = await run_blocking(critical_executor, _get_gce_access_token)
-    url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
-        if resp.status_code == 404:
-            return "NOT_FOUND"
-        if resp.status_code != 200:
-            return "UNKNOWN"
-        return resp.json().get("status", "UNKNOWN")
-
-
-async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
-    """Start a stopped/terminated GCE VM and return the new IP."""
-
-    t0 = time.monotonic()
-    token = await run_blocking(critical_executor, _get_gce_access_token)
-    instance_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
-    start_url = (
-        f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}/start"
-    )
-
-    async with httpx.AsyncClient(timeout=180) as client:
-        instance_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
-        if instance_resp.status_code == 404:
-            raise VmNotFoundError(vm_name)
-        already_running = instance_resp.status_code == 200 and instance_resp.json().get("status") == "RUNNING"
-        if already_running:
-            logger.info(f"[vm-start] {vm_name} is already RUNNING; resolving its external IP")
-        else:
-            resp = await client.post(start_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
-            if resp.status_code not in (200, 204):
-                raise Exception(f"GCE start failed: {resp.status_code} {resp.text}")
-            t_start = time.monotonic() - t0
-            logger.info(f"[vm-start] {vm_name} start API call: {t_start:.1f}s")
-
-            op_name = resp.json().get("name")
-            if not op_name:
-                raise Exception("Missing operation name in GCE start response")
-
-            op_url = (
-                f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
-            )
-            for i in range(24):
-                await asyncio.sleep(5)
-                token = await run_blocking(critical_executor, _get_gce_access_token)
-                status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {token}"})
-                status = status_resp.json()
-                if status.get("status") == "DONE":
-                    if "error" in status:
-                        raise Exception(f"GCE start operation failed: {status['error']}")
-                    t_op = time.monotonic() - t0
-                    logger.info(f"[vm-start] {vm_name} operation done after {i + 1} polls: {t_op:.1f}s")
-                    break
-
-        # Poll for a valid external IP (may take a few seconds after operation completes)
-        ip = None
-        for attempt in range(6):
-            token = await run_blocking(critical_executor, _get_gce_access_token)
-            inst_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
-            instance = inst_resp.json()
-            try:
-                candidate = instance["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
-                if candidate and candidate != "unknown":
-                    ip = candidate
-                    t_ip = time.monotonic() - t0
-                    logger.info(f"[vm-start] {vm_name} got IP {ip} on attempt {attempt + 1}: {t_ip:.1f}s total")
-                    break
-            except (KeyError, IndexError):
-                pass
-            if attempt < 5:
-                logger.info(f"[vm-start] {vm_name} no IP yet, retrying ({attempt + 1}/6)...")
-                await asyncio.sleep(3)
-
-        if not ip:
-            t_fail = time.monotonic() - t0
-            logger.error(f"[vm-start] {vm_name} failed to get IP after 6 attempts: {t_fail:.1f}s")
-            raise RuntimeError(f"VM {vm_name} started but never reported an external IP")
-
-        return ip
-
-
 def _is_usable_vm_ip(ip: Any) -> bool:
     """True when `ip` is an address the proxy can actually dial.
 
@@ -289,142 +176,6 @@ def _is_usable_vm_ip(ip: Any) -> bool:
     `if ip:` reader on the connect path while resolving to nothing.
     """
     return isinstance(ip, str) and bool(ip) and ip != UNRESOLVED_VM_IP
-
-
-def _update_firestore_vm(
-    uid: str,
-    expected_vm_name: str,
-    expected_auth_token: str,
-    ip: str | None,
-    status: str,
-    *,
-    restart_failed: bool = False,
-    restart_succeeded: bool = False,
-) -> bool:
-    """Update the user's agentVm fields in Firestore (incl. circuit-breaker state).
-
-    `agentVm.ip` is the address every later connect dials, so this writer is
-    the one place that decides what may become that address. A placeholder
-    must never be persisted: it is truthy, so it passes the `status == "ready"
-    and vm_ip` fast path, fails the health probe, and sends `_ensure_vm_running`
-    down the `health_failed` branch — which finds GCE reporting RUNNING and
-    hard-resets a healthy VM, then writes the same placeholder back. Nothing
-    else repairs the field, so the user is stuck in that loop permanently.
-    """
-    if status == "ready" and not _is_usable_vm_ip(ip):
-        raise ValueError(f"refusing to persist ready agentVm without usable ip for uid={uid}")
-
-    update: Dict[str, Any] = {"agentVm.status": status}
-    if ip is not None:
-        if not _is_usable_vm_ip(ip):
-            raise ValueError(f"refusing to persist unusable agentVm.ip for uid={uid}")
-        update["agentVm.ip"] = ip
-    if restart_failed:
-        update["agentVm.restartFailures"] = Increment(1)
-        update["agentVm.lastRestartFailureAt"] = time.time()
-    if restart_succeeded:
-        update["agentVm.restartFailures"] = 0
-    client = _get_firestore_db()
-    return _update_firestore_vm_if_allowed_txn(
-        client.transaction(),
-        client.collection('account_deletions').document(uid),
-        client.collection('users').document(uid),
-        expected_vm_name,
-        expected_auth_token,
-        update,
-    )
-
-
-@transactional
-def _update_firestore_vm_if_allowed_txn(
-    transaction: Any,
-    deletion_ref: Any,
-    user_ref: Any,
-    expected_vm_name: str,
-    expected_auth_token: str,
-    update: Dict[str, Any],
-) -> bool:
-    deletion = deletion_ref.get(transaction=transaction)
-    raw_status = (deletion.to_dict() or {}).get('wipe_status') if deletion.exists else None
-    status = normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
-    if account_deletion_blocks_access(status):
-        raise AccountDeletionAccessBlocked(status or 'unknown')
-    user = user_ref.get(transaction=transaction)
-    current = (user.to_dict() or {}).get('agentVm') if user.exists else None
-    if not isinstance(current, dict):
-        return False
-    if current.get('vmName') != expected_vm_name or current.get('authToken') != expected_auth_token:
-        return False
-    transaction.update(user_ref, update)
-    return True
-
-
-def _clear_agent_vm(uid: str, expected_vm_name: str, expected_auth_token: str) -> bool:
-    """Delete the user's agentVm record once its GCE instance is gone.
-
-    The reaper deletes aged TERMINATED `omi-agent-*` instances but leaves the
-    Firestore record saying `ready` with the old IP, and nothing here can
-    recreate an instance. Keeping the record makes every later connect dial a
-    dead address and makes the desktop provision endpoint report `exists`, so
-    the user's agent stays broken forever. Clearing it is what lets a client
-    provision a new VM — the same repair `GET /v2/agent/status` already does.
-    """
-    client = _get_firestore_db()
-    return _clear_agent_vm_if_allowed_txn(
-        client.transaction(),
-        client.collection('account_deletions').document(uid),
-        client.collection('users').document(uid),
-        expected_vm_name,
-        expected_auth_token,
-    )
-
-
-@transactional
-def _clear_agent_vm_if_allowed_txn(
-    transaction: Any,
-    deletion_ref: Any,
-    user_ref: Any,
-    expected_vm_name: str,
-    expected_auth_token: str,
-) -> bool:
-    deletion = deletion_ref.get(transaction=transaction)
-    raw_status = (deletion.to_dict() or {}).get('wipe_status') if deletion.exists else None
-    status = normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
-    if account_deletion_blocks_access(status):
-        raise AccountDeletionAccessBlocked(status or 'unknown')
-    user = user_ref.get(transaction=transaction)
-    current = (user.to_dict() or {}).get('agentVm') if user.exists else None
-    if not isinstance(current, dict):
-        return False
-    if current.get('vmName') != expected_vm_name or current.get('authToken') != expected_auth_token:
-        return False
-    transaction.update(user_ref, {"agentVm": DELETE_FIELD})
-    return True
-
-
-async def _reset_vm(vm_name: str, zone: str) -> None:
-    """Hard-reset a RUNNING VM whose agent process is unresponsive."""
-    token = await run_blocking(critical_executor, _get_gce_access_token)
-    reset_url = (
-        f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}/reset"
-    )
-    async with httpx.AsyncClient(timeout=60) as client:
-        resp = await client.post(reset_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
-        if resp.status_code not in (200, 204):
-            raise Exception(f"GCE reset failed: {resp.status_code} {resp.text}")
-        logger.info(f"[agent-proxy] VM {vm_name} reset initiated")
-        # Wait for the operation to complete
-        op_name = resp.json().get("name")
-        if op_name:
-            op_url = (
-                f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
-            )
-            for _ in range(12):
-                await asyncio.sleep(5)
-                t = await run_blocking(critical_executor, _get_gce_access_token)
-                status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {t}"})
-                if status_resp.json().get("status") == "DONE":
-                    break
 
 
 def _vm_unavailable_event(uid: str) -> Dict[str, Any]:
@@ -445,11 +196,9 @@ def _vm_unavailable_event(uid: str) -> Dict[str, Any]:
 
 
 async def _ensure_vm_running(uid: str, vm: Dict[str, Any], health_failed: bool = False) -> Optional[Dict[str, Any]]:
-    """If VM is stopped, restart it and return updated VM info. Returns None on failure."""
+    """Ask the reconciler to restore an unavailable VM without mutating GCE here."""
     vm_name = cast(str, vm.get("vmName"))
     vm_auth_token = cast(str, vm.get("authToken", ""))
-    zone = cast(str, vm.get("zone", "us-central1-a"))
-    fs_status = cast(str, vm.get("status", ""))
 
     if circuit_open(vm, time.time()):
         # 3 consecutive restart failures within the cooldown: stop hammering
@@ -460,77 +209,16 @@ async def _ensure_vm_running(uid: str, vm: Dict[str, Any], health_failed: bool =
         )
         return None
 
-    # A record whose stored IP is the legacy placeholder can never be repaired by
-    # the reset branch below — it writes the same value back. Fall through to a
-    # full restart so `_start_vm_and_wait` resolves a real address.
-    if fs_status == "ready" and _is_usable_vm_ip(vm.get("ip")):
-        # Verify it's actually running
-        try:
-            gce_status = await _check_gce_status(vm_name, zone)
-        except Exception:
-            return vm  # Can't check, assume it's fine
-
-        if gce_status == "NOT_FOUND":
-            # Instance reaped: neither restart nor reset can bring it back, and
-            # leaving the record makes the caller wait out the full health
-            # timeout before failing. Clear it so a client can provision anew.
-            logger.warning(f"[agent-proxy] VM {vm_name} no longer exists in GCE — clearing stale agentVm record")
-            await run_blocking(db_executor, _clear_agent_vm, uid, vm_name, vm_auth_token)
-            return None
-
-        if gce_status == "RUNNING":
-            if health_failed:
-                # VM is RUNNING but agent process is dead — hard reset
-                logger.info(f"[agent-proxy] VM {vm_name} is RUNNING but unhealthy, resetting...")
-                await run_blocking(db_executor, _update_firestore_vm, uid, vm_name, vm_auth_token, None, "provisioning")
-                try:
-                    await _reset_vm(vm_name, zone)
-                    await run_blocking(
-                        db_executor,
-                        lambda: _update_firestore_vm(
-                            uid,
-                            vm_name,
-                            vm_auth_token,
-                            vm.get("ip"),
-                            "ready",
-                            restart_succeeded=True,
-                        ),
-                    )
-                    return await run_blocking(db_executor, _refresh_vm, uid)
-                except Exception:
-                    logger.error(f"[agent-proxy] Failed to reset VM {vm_name}", exc_info=True)
-                    await run_blocking(
-                        db_executor,
-                        lambda: _update_firestore_vm(uid, vm_name, vm_auth_token, None, "error", restart_failed=True),
-                    )
-                    return None
-            return vm
-        if gce_status not in ("TERMINATED", "STOPPED"):
-            return vm  # STAGING, etc. — let it be
-
-    # VM needs restart
-    logger.info(f"[agent-proxy] VM {vm_name} needs restart, starting...")
-    await run_blocking(db_executor, _update_firestore_vm, uid, vm_name, vm_auth_token, None, "provisioning")
-
-    try:
-        ip = await _start_vm_and_wait(vm_name, zone)
-        await run_blocking(
-            db_executor,
-            lambda: _update_firestore_vm(uid, vm_name, vm_auth_token, ip, "ready", restart_succeeded=True),
-        )
-        logger.info(f"[agent-proxy] VM {vm_name} restarted, ip={ip}")
-        return await run_blocking(db_executor, _refresh_vm, uid)
-    except VmNotFoundError:
-        logger.warning(f"[agent-proxy] VM {vm_name} no longer exists in GCE — clearing stale agentVm record")
-        await run_blocking(db_executor, _clear_agent_vm, uid, vm_name, vm_auth_token)
+    requested = await run_blocking(db_executor, request_vm_start, uid, vm_name, vm_auth_token)
+    if not requested:
         return None
-    except Exception:
-        logger.error(f"[agent-proxy] Failed to restart VM {vm_name}", exc_info=True)
-        await run_blocking(
-            db_executor,
-            lambda: _update_firestore_vm(uid, vm_name, vm_auth_token, None, "error", restart_failed=True),
-        )
-        return None
+    logger.info(
+        "[agent-proxy] queued reconciler repair for uid=%s vm=%s health_failed=%s",
+        uid,
+        vm_name,
+        health_failed,
+    )
+    return {**vm, "status": "updating", "ip": None}
 
 
 async def _wait_for_vm_healthy(vm_ip: str, auth_token: str, timeout: float = 120) -> bool:
@@ -645,6 +333,20 @@ async def _prepare_vm_for_session(
             candidate_vm, deletion_blocked = await _ensure_vm_running_or_close(websocket, uid, vm, health_failed=True)
             if deletion_blocked or lease_lost.is_set():
                 return None
+            if candidate_vm is not None and candidate_vm.get("status") == "updating":
+                await _send_startup_event(
+                    websocket,
+                    uid,
+                    {
+                        "type": "error",
+                        "code": "agent_vm_draining",
+                        "state": "updating",
+                        "retryable": True,
+                        "message": "Your agent is being updated. Please retry shortly.",
+                    },
+                )
+                await _close_client(websocket, uid, 1013, "Agent VM is updating")
+                return None
             if (
                 candidate_vm is None
                 or candidate_vm.get("status") != "ready"
@@ -674,6 +376,20 @@ async def _prepare_vm_for_session(
         await _send_startup_event(websocket, uid, {"type": "status", "message": "Starting your agent VM..."})
         candidate_vm, deletion_blocked = await _ensure_vm_running_or_close(websocket, uid, vm)
         if deletion_blocked or lease_lost.is_set():
+            return None
+        if candidate_vm is not None and candidate_vm.get("status") == "updating":
+            await _send_startup_event(
+                websocket,
+                uid,
+                {
+                    "type": "error",
+                    "code": "agent_vm_draining",
+                    "state": "updating",
+                    "retryable": True,
+                    "message": "Your agent is being updated. Please retry shortly.",
+                },
+            )
+            await _close_client(websocket, uid, 1013, "Agent VM is updating")
             return None
         if (
             candidate_vm is None
@@ -970,6 +686,13 @@ async def agent_ws(websocket: WebSocket):
     # sessions to finish.  The lease is re-read after readiness because a drain
     # can begin while a stopped VM is being started.
     if reconcile_requested(vm):
+        # An idle-stop lease uses the same drain fence. Preserve this user's
+        # demand before rejecting the socket so the reconciler starts the VM
+        # after the stop operation releases its lease.
+        try:
+            await _ensure_vm_running(uid, vm)
+        except Exception:
+            logger.warning("[agent-proxy] uid=%s could not queue reconciler demand while draining", uid, exc_info=True)
         await websocket.accept()
         await _send_startup_event(
             websocket,
@@ -1092,6 +815,10 @@ async def agent_ws(websocket: WebSocket):
             )
             if not lease_claimed:
                 lease_lost.set()
+                # A conflicting idle-stop/reconcile lease denied admission.
+                # Register demand instead of leaving the owner stopped after
+                # that lease completes.
+                await _ensure_vm_running(uid, vm)
                 await _send_startup_event(
                     websocket,
                     uid,

--- a/backend/agent_vm/startup.sh
+++ b/backend/agent_vm/startup.sh
@@ -51,10 +51,20 @@ if ! docker info >/dev/null 2>&1; then
   fi
 fi
 
+# Agent VM base images before the immutable-container rollout boot a legacy
+# host-level Node service on port 8080. Retire only that known service before
+# taking over the listener with the release-pinned container below. The guard
+# keeps fresh images (which have no legacy unit) idempotent.
+if systemctl cat omi-agent.service >/dev/null 2>&1; then
+  systemctl disable --now omi-agent.service || true
+fi
+
 registry_token="$(metadata_access_token)"
 printf '%s' "$registry_token" | docker login --username oauth2accesstoken --password-stdin https://gcr.io >/dev/null
 docker pull "$image"
-docker rm -f omi-agent-vm >/dev/null 2>&1 || true
+if docker container inspect omi-agent-vm >/dev/null 2>&1; then
+  docker rm -f omi-agent-vm >/dev/null
+fi
 backend_env=()
 if [[ -n "$backend_url" ]]; then
   backend_env=(--env "BACKEND_URL=$backend_url")

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -24,6 +24,7 @@ from typing import Any, Mapping, Sequence
 
 import firebase_admin
 from google.cloud import storage
+from google.cloud.firestore import DELETE_FIELD
 from google.cloud.firestore_v1.base_query import FieldFilter
 
 from database._client import get_firestore_client
@@ -263,6 +264,21 @@ def _select_rollout_owners(
     return selected
 
 
+def _select_reconcile_owners(
+    owners: Sequence[tuple[str, dict[str, Any]]], release_id: str, target_percent: int
+) -> list[tuple[str, dict[str, Any]]]:
+    """Add user-demanded repairs to the rollout cohort without duplicating owners."""
+    selected = _select_rollout_owners(owners, release_id, target_percent)
+    selected_uids = {uid for uid, _ in selected}
+    selected.extend((uid, vm) for uid, vm in owners if uid not in selected_uids and _start_requested(vm))
+    return selected
+
+
+def _start_requested(vm: Mapping[str, Any]) -> bool:
+    reconcile = vm.get("reconcile")
+    return isinstance(reconcile, Mapping) and bool(reconcile.get("startRequested"))
+
+
 def _canonical_image_ref(value: str) -> str:
     marker = "/compute/v1/"
     return value.split(marker, 1)[1] if marker in value else value.lstrip("/")
@@ -308,6 +324,8 @@ async def _update_reconcile(
     fields: Mapping[str, Any],
     *,
     vm_fields: Mapping[str, Any] | None = None,
+    consume_start_request_at: float | None = None,
+    force_consume_start_request: bool = False,
 ) -> bool:
     return await asyncio.to_thread(
         update_vm_reconcile,
@@ -317,6 +335,8 @@ async def _update_reconcile(
         owner,
         fields,
         vm_fields=vm_fields,
+        consume_start_request_at=consume_start_request_at,
+        force_consume_start_request=force_consume_start_request,
     )
 
 
@@ -348,6 +368,9 @@ async def reconcile_one(
         return ReconcileResult(uid, "drift" if reasons else "ready", ",".join(sorted(set(reasons))))
     reconcile_raw = vm.get("reconcile")
     reconcile_state = reconcile_raw if isinstance(reconcile_raw, Mapping) else {}
+    start_requested = bool(reconcile_state.get("startRequested"))
+    start_requested_at = reconcile_state.get("startRequestedAt") if start_requested else None
+    observed_start_request_at = float(start_requested_at) if isinstance(start_requested_at, (int, float)) else None
     if reconcile_state.get("state") == "quarantined" and reconcile_state.get("releaseId") == release.release_id:
         return ReconcileResult(uid, "quarantined", str(reconcile_state.get("lastError") or "operator action required"))
     if not await asyncio.to_thread(claim_vm_lease, uid, vm_name, auth_token, owner, release.release_id):
@@ -363,6 +386,7 @@ async def reconcile_one(
                 auth_token,
                 owner,
                 {"state": "missing", "lastError": "GCE instance not found", **clear_vm_reconcile_lease_fields()},
+                consume_start_request_at=observed_start_request_at,
             ):
                 return ReconcileResult(uid, "stale", "owner lease lost while recording missing VM")
             return ReconcileResult(uid, "missing", "GCE instance not found")
@@ -382,6 +406,7 @@ async def reconcile_one(
                     "observedBootImage": actual,
                     **clear_vm_reconcile_lease_fields(),
                 },
+                consume_start_request_at=observed_start_request_at,
             ):
                 return ReconcileResult(uid, "stale", "owner lease lost while recording boot-image drift")
             return ReconcileResult(
@@ -422,7 +447,7 @@ async def reconcile_one(
                 return ReconcileResult(uid, "deferred", f"{active} active session(s)")
 
         status = str(instance.get("status") or "UNKNOWN")
-        if not reasons and status in {"TERMINATED", "STOPPED"}:
+        if not reasons and status in {"TERMINATED", "STOPPED"} and not start_requested:
             if not await _update_reconcile(
                 uid,
                 vm_name,
@@ -440,6 +465,7 @@ async def reconcile_one(
                     **clear_vm_reconcile_lease_fields(),
                 },
                 vm_fields={"status": "stopped"},
+                consume_start_request_at=observed_start_request_at,
             ):
                 return ReconcileResult(uid, "stale", "owner lease lost while recording stopped VM")
             return ReconcileResult(uid, "ready", "stopped; idle self-stop preserved")
@@ -498,6 +524,7 @@ async def reconcile_one(
                 "privateIp": private_ip,
                 **({"ip": public_ip} if public_ip else {}),
             },
+            consume_start_request_at=observed_start_request_at,
         ):
             return ReconcileResult(uid, "stale", "owner lease lost before final CAS")
         return ReconcileResult(uid, "ready", release.release_id)
@@ -523,8 +550,15 @@ async def reconcile_one(
                 "retryCount": retry_count,
                 "lastError": type(exc).__name__,
                 "retryAt": retry_at,
-                **clear_vm_reconcile_lease_fields(),
+                # A demand start is the retry's eligibility signal. Retain it
+                # until terminal quarantine so the scheduled reconciler can
+                # honor retryAt without requiring another client request.
+                "lease": DELETE_FIELD,
+                "drainRequested": DELETE_FIELD,
+                "drainRequestedAt": DELETE_FIELD,
             },
+            consume_start_request_at=observed_start_request_at if retry_state == "quarantined" else None,
+            force_consume_start_request=retry_state == "quarantined",
         ):
             return ReconcileResult(uid, "stale", "owner lease lost while recording failure")
         return ReconcileResult(uid, retry_state, type(exc).__name__)
@@ -566,7 +600,8 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
             )
             target_percent, max_concurrency = _rollout_spec(raw_manifest, phase)
             owners = await asyncio.to_thread(_owners)
-            selected = _select_rollout_owners(owners, release.release_id, target_percent)
+            rollout_selected = _select_rollout_owners(owners, release.release_id, target_percent)
+            selected = _select_reconcile_owners(owners, release.release_id, target_percent)
             semaphore = asyncio.Semaphore(max_concurrency)
 
             async def one(uid: str, vm: dict[str, Any]) -> ReconcileResult:
@@ -585,7 +620,11 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
         for result in results:
             counts[result.state] = counts.get(result.state, 0) + 1
         if not dry_run:
-            await asyncio.to_thread(_advance_rollout, environment, release.release_id, phase, results, len(selected))
+            rollout_uids = {uid for uid, _ in rollout_selected}
+            rollout_results = [result for result in results if result.uid in rollout_uids]
+            await asyncio.to_thread(
+                _advance_rollout, environment, release.release_id, phase, rollout_results, len(rollout_selected)
+            )
         logger.info("Agent VM reconciliation complete: %s", counts)
         return results
     finally:

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -5,23 +5,21 @@ Endpoints:
 - GET  /v1/agent/tools         — returns tool definitions (name, description, parameters)
 - POST /v1/agent/execute-tool  — executes a named tool and returns the result
 - GET  /v1/agent/vm-status     — returns basic VM status from Firestore
-- POST /v1/agent/vm-ensure     — checks VM status, restarts if stopped, returns current state
+- POST /v1/agent/vm-ensure     — requests reconciliation for an unavailable VM, returns current state
 - POST /v1/agent/keepalive     — pings the VM to reset its idle auto-stop timer
 """
 
-import asyncio
 import logging
 from typing import Any
 
 from utils.executors import db_executor, run_blocking
 
-import google.auth
-import google.auth.transport.requests
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel
 
 from database.users import get_agent_vm
+from services.agent_vm_lifecycle import reconcile_requested, request_vm_start
 from utils.other.endpoints import get_current_user_uid, with_rate_limit
 from utils.retrieval.agentic import agent_config_context, CORE_TOOLS
 from utils.retrieval.tool_result_boundaries import preserve_chat_memory_tool_result_boundary
@@ -34,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-GCE_PROJECT = "based-hardware"
 # Legacy placeholder that earlier builds persisted as agentVm.ip when the GCE
 # IP poll timed out. Never written any more; still read so already-poisoned
 # records are re-provisioned instead of being reported ready.
@@ -61,104 +58,6 @@ class AgentToolsResponse(BaseModel):
     tools: list[AgentToolSchema]
 
 
-# --------------- GCE helpers ---------------
-
-
-def _get_gce_access_token() -> str:
-    """Get a GCE access token via Application Default Credentials."""
-    creds, _ = google.auth.default(scopes=['https://www.googleapis.com/auth/cloud-platform'])
-    creds.refresh(google.auth.transport.requests.Request())
-    return creds.token
-
-
-async def _check_gce_status(vm_name: str, zone: str) -> str:
-    """Check the actual GCE instance status (RUNNING, TERMINATED, STOPPED, etc.).
-
-    A 404 is reported as `NOT_FOUND`, not folded into `UNKNOWN`: the instance is
-    gone (the agent-vm reaper deletes aged TERMINATED VMs) and the stale record
-    must be cleared, whereas `UNKNOWN` means "could not tell" and must leave it.
-    """
-    token = await run_blocking(db_executor, _get_gce_access_token)
-    url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
-        if resp.status_code == 404:
-            return "NOT_FOUND"
-        if resp.status_code != 200:
-            logger.error(f"[gce] Failed to get instance status: {resp.status_code} {sanitize(resp.text)}")
-            return "UNKNOWN"
-        return resp.json().get("status", "UNKNOWN")
-
-
-async def _start_vm_and_wait(vm_name: str, zone: str) -> str:
-    """Start a stopped/terminated GCE VM and wait for it to get an IP. Returns the new IP."""
-    import time
-
-    t0 = time.monotonic()
-    token = await run_blocking(db_executor, _get_gce_access_token)
-    instance_url = f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}"
-    start_url = (
-        f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/instances/{vm_name}/start"
-    )
-
-    async with httpx.AsyncClient(timeout=180) as client:
-        instance_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
-        already_running = instance_resp.status_code == 200 and instance_resp.json().get("status") == "RUNNING"
-        if already_running:
-            logger.info(f"[vm-start] {vm_name} is already RUNNING; resolving its external IP")
-        else:
-            resp = await client.post(start_url, headers={"Authorization": f"Bearer {token}"}, content=b"")
-            if resp.status_code not in (200, 204):
-                raise Exception(f"GCE start failed: {resp.status_code} {sanitize(resp.text)}")
-            t_start = time.monotonic() - t0
-            logger.info(f"[vm-start] {vm_name} start API call: {t_start:.1f}s")
-
-            op_name = resp.json().get("name")
-            if not op_name:
-                raise Exception("Missing operation name in GCE start response")
-
-            op_url = (
-                f"https://compute.googleapis.com/compute/v1/projects/{GCE_PROJECT}/zones/{zone}/operations/{op_name}"
-            )
-            for i in range(24):
-                await asyncio.sleep(5)
-                token = await run_blocking(db_executor, _get_gce_access_token)
-                status_resp = await client.get(op_url, headers={"Authorization": f"Bearer {token}"})
-                status = status_resp.json()
-                if status.get("status") == "DONE":
-                    if "error" in status:
-                        raise Exception(f"GCE start operation failed: {status['error']}")
-                    t_op = time.monotonic() - t0
-                    logger.info(f"[vm-start] {vm_name} operation done after {i + 1} polls: {t_op:.1f}s")
-                    break
-
-        # Poll for a valid external IP (may take a few seconds after operation completes)
-        ip = None
-        for attempt in range(6):
-            token = await run_blocking(db_executor, _get_gce_access_token)
-            inst_resp = await client.get(instance_url, headers={"Authorization": f"Bearer {token}"})
-            instance = inst_resp.json()
-            try:
-                candidate = instance["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
-                if candidate and candidate != "unknown":
-                    ip = candidate
-                    t_ip = time.monotonic() - t0
-                    logger.info(f"[vm-start] {vm_name} got IP {ip} on attempt {attempt + 1}: {t_ip:.1f}s total")
-                    break
-            except (KeyError, IndexError):
-                pass
-            if attempt < 5:
-                logger.info(f"[vm-start] {vm_name} no IP yet, retrying ({attempt + 1}/6)...")
-                await asyncio.sleep(3)
-
-        if not ip:
-            t_fail = time.monotonic() - t0
-            logger.error(f"[vm-start] {vm_name} failed to get IP after 6 attempts: {t_fail:.1f}s")
-            raise RuntimeError(f"VM {vm_name} started but never reported an external IP")
-
-        return ip
-
-
 def _is_usable_vm_ip(ip) -> bool:
     """True when `ip` is an address a caller can actually dial.
 
@@ -166,51 +65,6 @@ def _is_usable_vm_ip(ip) -> bool:
     `if ip:` reader while resolving to nothing.
     """
     return isinstance(ip, str) and bool(ip) and ip != UNRESOLVED_VM_IP
-
-
-def _update_firestore_vm(uid: str, ip: str | None, status: str):
-    """Update the user's agentVm fields in Firestore.
-
-    `agentVm.ip` is the address every later connect dials, so this writer
-    decides what may become that address. A placeholder must never be
-    persisted: it is truthy, so it passes each `if ip:` reader, fails every
-    health probe, and leaves the record permanently unrepairable.
-    """
-    from database.users import db as firestore_db
-
-    if status == "ready" and not _is_usable_vm_ip(ip):
-        raise ValueError(f"refusing to persist ready agentVm without usable ip for uid={uid}")
-
-    update = {"agentVm.status": status}
-    if ip is not None:
-        if not _is_usable_vm_ip(ip):
-            raise ValueError(f"refusing to persist unusable agentVm.ip for uid={uid}")
-        update["agentVm.ip"] = ip
-    firestore_db.collection('users').document(uid).update(update)
-
-
-def _clear_agent_vm(uid: str):
-    """Delete the user's agentVm record once its GCE instance is gone.
-
-    Nothing can restart a deleted instance, and while the record is present the
-    provision endpoint reports `exists`, so keeping it leaves the user's agent
-    permanently broken. Clearing it is what lets a replacement be provisioned.
-    """
-    from google.cloud import firestore
-    from database.users import db as firestore_db
-
-    firestore_db.collection('users').document(uid).update({"agentVm": firestore.DELETE_FIELD})
-
-
-async def _restart_vm_background(uid: str, vm_name: str, zone: str):
-    """Background task: start stopped VM, update Firestore with new IP when ready."""
-    try:
-        ip = await _start_vm_and_wait(vm_name, zone)
-        await run_blocking(db_executor, _update_firestore_vm, uid, ip, "ready")
-        logger.info(f"[vm-ensure] VM {vm_name} restarted, ip={ip}")
-    except Exception as e:
-        logger.error(f"[vm-ensure] Failed to restart VM {vm_name}: {e}")
-        await run_blocking(db_executor, _update_firestore_vm, uid, None, "error")
 
 
 # --------------- endpoints ---------------
@@ -231,55 +85,25 @@ def get_vm_status(uid: str = Depends(get_current_user_uid)):
 
 @router.post("/v1/agent/vm-ensure", response_model=AgentVmInfo)
 async def ensure_vm(background_tasks: BackgroundTasks, uid: str = Depends(get_current_user_uid)):
-    """Check VM status; if stopped/terminated, restart it in the background."""
+    """Queue a fenced reconciliation when the persisted VM is unavailable."""
+    del background_tasks
     vm = await run_blocking(db_executor, get_agent_vm, uid)
     if not vm:
         return {"has_vm": False}
 
-    vm_name = vm.get("vmName")
-    zone = vm.get("zone", "us-central1-a")
-    fs_status = vm.get("status", "")
-
-    # If Firestore already says provisioning, don't double-start
-    if fs_status == "provisioning":
-        return {"has_vm": True, "status": "provisioning"}
-
-    # Check actual GCE status for ready/error/stopped VMs
-    if fs_status in ("ready", "error", "stopped"):
-        try:
-            gce_status = await _check_gce_status(vm_name, zone)
-        except Exception as e:
-            logger.error(f"[vm-ensure] GCE status check failed: {e}")
-            return {"has_vm": True, "status": fs_status}
-
-        if gce_status == "NOT_FOUND":
-            # The instance was deleted (reaper), so no restart can recover it and
-            # reporting the stored status sends the client at a dead address for a
-            # full health timeout. Clear the record so a new VM can be provisioned.
-            logger.warning(f"[vm-ensure] VM {vm_name} no longer exists in GCE — clearing stale agentVm record")
-            await run_blocking(db_executor, _clear_agent_vm, uid)
-            return {"has_vm": False}
-
-        if gce_status in ("TERMINATED", "STOPPED"):
-            logger.info(f"[vm-ensure] VM {vm_name} is {gce_status}, restarting...")
-            await run_blocking(db_executor, _update_firestore_vm, uid, None, "provisioning")
-            background_tasks.add_task(_restart_vm_background, uid, vm_name, zone)
-            return {"has_vm": True, "status": "provisioning"}
-
-        if gce_status == "RUNNING":
-            # A record still holding the legacy placeholder has no dialable
-            # address, so reporting it ready would strand the caller. Restart
-            # instead: that is the only path that resolves a real IP.
-            if not _is_usable_vm_ip(vm.get("ip")):
-                logger.info(f"[vm-ensure] VM {vm_name} is RUNNING but has no usable IP, restarting...")
-                await run_blocking(db_executor, _update_firestore_vm, uid, None, "provisioning")
-                background_tasks.add_task(_restart_vm_background, uid, vm_name, zone)
-                return {"has_vm": True, "status": "provisioning"}
-            if fs_status != "ready":
-                await run_blocking(db_executor, _update_firestore_vm, uid, vm.get("ip"), "ready")
-                return {"has_vm": True, "status": "ready"}
-
-    return {"has_vm": True, "status": fs_status}
+    if reconcile_requested(vm):
+        return {"has_vm": True, "status": "updating"}
+    # Firestore's IP/status is a cache, not provider availability evidence.
+    # Every client ensure records demand; only the reconciler observes GCE and
+    # decides whether a healthy VM needs work.
+    requested = await run_blocking(
+        db_executor,
+        request_vm_start,
+        uid,
+        str(vm.get("vmName") or ""),
+        str(vm.get("authToken") or ""),
+    )
+    return {"has_vm": True, "status": "updating" if requested else str(vm.get("status") or "unknown")}
 
 
 @router.post("/v1/agent/keepalive", response_model=AgentKeepaliveResponse)

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -22,7 +22,14 @@ from pydantic import BaseModel, ConfigDict, Field
 from database import users as users_db
 from database._client import get_firestore_client
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
-from services.agent_vm_lifecycle import startup_wrapper
+from services.agent_vm_lifecycle import (
+    claim_vm_lease,
+    clear_vm_reconcile_lease_fields,
+    reconcile_requested,
+    request_vm_start,
+    startup_wrapper,
+    update_vm_reconcile,
+)
 from utils.executors import db_executor, run_blocking
 from utils.other.endpoints import get_current_user_uid
 from utils.subscription import is_trial_paywalled
@@ -91,11 +98,10 @@ def _project() -> str:
 
 
 def _source_image(project: str) -> str:
-    return (
-        os.getenv("GCE_SOURCE_IMAGE")
-        or os.getenv("AGENT_VM_BOOT_IMAGE")
-        or f"projects/{project}/global/images/family/omi-agent"
-    )
+    source_image = os.getenv("AGENT_VM_BOOT_IMAGE", "").strip()
+    if not re.fullmatch(rf"projects/{re.escape(project)}/global/images/[^/]+", source_image):
+        raise RuntimeError("AGENT_VM_BOOT_IMAGE must name an exact immutable image in the configured GCE project")
+    return source_image
 
 
 def _gcs_bucket() -> str:
@@ -112,26 +118,29 @@ def _service_account() -> str:
     return service_account
 
 
-def _agent_vm_startup_uri(bucket: str) -> str:
-    return os.getenv("AGENT_VM_STARTUP_URI") or f"https://storage.googleapis.com/{bucket}/startup.sh"
-
-
 def _agent_vm_startup_metadata(bucket: str) -> dict[str, str]:
-    startup_uri = _agent_vm_startup_uri(bucket)
-    startup_sha256 = os.getenv("AGENT_VM_STARTUP_SHA256")
+    del bucket
+    startup_uri = os.getenv("AGENT_VM_STARTUP_URI", "").strip()
+    startup_sha256 = os.getenv("AGENT_VM_STARTUP_SHA256", "").strip()
+    release_id = os.getenv("AGENT_VM_RELEASE_ID", "").strip()
+    image_digest = os.getenv("AGENT_VM_IMAGE_DIGEST", "").strip()
+    boot_image = os.getenv("AGENT_VM_BOOT_IMAGE", "").strip()
+    if (
+        not startup_uri.startswith("https://storage.googleapis.com/")
+        or not re.fullmatch(r"[0-9a-f]{64}", startup_sha256)
+        or not re.fullmatch(r"[0-9a-f]{40}", release_id)
+        or not re.fullmatch(r".+@sha256:[0-9a-f]{64}", image_digest)
+        or not re.fullmatch(r"projects/[^/]+/global/images/[^/]+", boot_image)
+    ):
+        raise RuntimeError("Agent VM provisioning requires a complete immutable release contract")
     metadata = {
         "startup-script": startup_wrapper(startup_uri, startup_sha256),
         "omi-agent-reconciler-schema": "1",
+        "omi-agent-release": release_id,
+        "omi-agent-image-digest": image_digest,
+        "omi-agent-startup-sha256": startup_sha256,
+        "omi-agent-boot-image": boot_image,
     }
-    for key, env_name in (
-        ("omi-agent-release", "AGENT_VM_RELEASE_ID"),
-        ("omi-agent-image-digest", "AGENT_VM_IMAGE_DIGEST"),
-        ("omi-agent-startup-sha256", "AGENT_VM_STARTUP_SHA256"),
-        ("omi-agent-boot-image", "AGENT_VM_BOOT_IMAGE"),
-    ):
-        value = os.getenv(env_name)
-        if value:
-            metadata[key] = value
     return metadata
 
 
@@ -141,6 +150,22 @@ def _get_vm(uid: str) -> dict[str, Any] | None:
         return None
     vm = snapshot.to_dict().get("agentVm")
     return vm if isinstance(vm, dict) and vm.get("vmName") else None
+
+
+def _reconcile_lease_active(vm: dict[str, Any], now: float | None = None) -> bool:
+    reconcile = vm.get("reconcile")
+    lease = reconcile.get("lease") if isinstance(reconcile, dict) else None
+    if not isinstance(lease, dict):
+        return False
+    return float(lease.get("expiresAt", 0) or 0) > (time.time() if now is None else now)
+
+
+def _reconcile_in_progress(vm: dict[str, Any], now: float | None = None) -> bool:
+    return reconcile_requested(vm) or _reconcile_lease_active(vm, now)
+
+
+def _updating_vm(vm: dict[str, Any]) -> dict[str, Any]:
+    return {**vm, "status": "updating", "ip": None}
 
 
 def _validate_ready_vm_ip(status: str, ip: str | None) -> None:
@@ -412,18 +437,6 @@ async def _create_vm(
     return ip
 
 
-async def _set_service_account(project: str, vm_name: str, zone: str, service_account: str) -> None:
-    token = await run_blocking(db_executor, _get_access_token)
-    url = f"https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{vm_name}/setServiceAccount"
-    body = {"email": service_account, "scopes": [_CLOUD_PLATFORM_SCOPE]}
-    response = await _gce_request("POST", url, token, body)
-    response.raise_for_status()
-    operation = response.json().get("name")
-    if not operation:
-        raise RuntimeError("GCE set-service-account response omitted operation name")
-    await _operation(project, zone, operation)
-
-
 async def _stop_vm(project: str, vm_name: str, zone: str) -> None:
     token = await run_blocking(db_executor, _get_access_token)
     url = f"https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{vm_name}/stop"
@@ -433,24 +446,6 @@ async def _stop_vm(project: str, vm_name: str, zone: str) -> None:
     if not operation:
         raise RuntimeError("GCE stop response omitted operation name")
     await _operation(project, zone, operation)
-
-
-async def _start_vm(project: str, vm_name: str, zone: str) -> str:
-    token = await run_blocking(db_executor, _get_access_token)
-    url = f"https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{vm_name}/start"
-    response = await _gce_request("POST", url, token)
-    response.raise_for_status()
-    operation = response.json().get("name")
-    if not operation:
-        raise RuntimeError("GCE start response omitted operation name")
-    await _operation(project, zone, operation)
-    _, instance = await _instance(project, zone, vm_name)
-    if instance is None:
-        raise RuntimeError("GCE restarted VM is unavailable")
-    ip = _ip(instance)
-    if ip is None:
-        raise RuntimeError("GCE restarted VM has no usable IP address")
-    return ip
 
 
 async def _delete_vm(project: str, vm_name: str, zone: str) -> None:
@@ -571,14 +566,37 @@ async def stop_self(request: Request) -> dict[str, str]:
     auth_token = str(vm.get("authToken") or "")
     if not auth_token or not await run_blocking(db_executor, _vm_lifecycle_allowed, uid, vm_name, auth_token):
         raise HTTPException(status_code=409, detail="Agent VM owner is no longer active")
-    status, instance = await _instance(project, zone, vm_name)
-    if instance is None:
-        raise HTTPException(status_code=404, detail="Agent VM instance not found")
-    if str(instance.get("id") or "") != instance_id or str(instance.get("name") or "") != vm_name:
-        raise HTTPException(status_code=403, detail="Agent VM runtime identity does not match the live instance")
-    if status == "RUNNING":
-        await _stop_vm(project, vm_name, zone)
-    return {"status": "stopping", "vmName": vm_name}
+    if _reconcile_in_progress(vm):
+        return {"status": "updating", "vmName": vm_name}
+    stop_owner = f"idle-stop:{uuid.uuid4().hex}"
+    claimed = await run_blocking(db_executor, claim_vm_lease, uid, vm_name, auth_token, stop_owner)
+    if not claimed:
+        return {"status": "updating", "vmName": vm_name}
+    persisted_stopped = False
+    try:
+        status, instance = await _instance(project, zone, vm_name)
+        if instance is None:
+            raise HTTPException(status_code=404, detail="Agent VM instance not found")
+        if str(instance.get("id") or "") != instance_id or str(instance.get("name") or "") != vm_name:
+            raise HTTPException(status_code=403, detail="Agent VM runtime identity does not match the live instance")
+        if status == "RUNNING":
+            await _stop_vm(project, vm_name, zone)
+            persisted_stopped = True
+            return {"status": "stopping", "vmName": vm_name}
+        if status in {"STOPPED", "TERMINATED"}:
+            persisted_stopped = True
+        return {"status": "stopped", "vmName": vm_name}
+    finally:
+        await run_blocking(
+            db_executor,
+            update_vm_reconcile,
+            uid,
+            vm_name,
+            auth_token,
+            stop_owner,
+            {"state": "ready", **clear_vm_reconcile_lease_fields()},
+            {"status": "stopped"} if persisted_stopped else None,
+        )
 
 
 async def _delete_late_vm_or_record(uid: str, project: str, vm_name: str, zone: str) -> None:
@@ -627,35 +645,6 @@ async def _provision_background(
         await _cleanup_possible_late_vm(uid, project, vm_name, _ZONE)
 
 
-async def _restart_background(uid: str, project: str, vm: dict[str, Any], service_account: str) -> None:
-    vm_name = str(vm["vmName"])
-    zone = str(vm.get("zone") or _ZONE)
-    auth_token = str(vm.get("authToken") or "")
-    try:
-        await _set_service_account(project, vm_name, zone, service_account)
-        ip = await _start_vm(project, vm_name, zone)
-        await _wait_for_vm_ready(ip, auth_token)
-        await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "ready", ip, zone)
-    except Exception as exc:
-        logger.error("Agent VM restart failed for uid=%s: %s", uid, exc)
-        await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "error", None, zone)
-
-
-async def _rebootstrap_background(uid: str, project: str, vm: dict[str, Any], service_account: str) -> None:
-    vm_name = str(vm["vmName"])
-    zone = str(vm.get("zone") or _ZONE)
-    auth_token = str(vm.get("authToken") or "")
-    try:
-        await _stop_vm(project, vm_name, zone)
-        await _set_service_account(project, vm_name, zone, service_account)
-        ip = await _start_vm(project, vm_name, zone)
-        await _wait_for_vm_ready(ip, auth_token)
-        await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "ready", ip, zone)
-    except Exception as exc:
-        logger.error("Agent VM rebootstrap failed for uid=%s: %s", uid, exc)
-        await run_blocking(db_executor, _set_vm_if_current, uid, vm_name, auth_token, "error", None, zone)
-
-
 def _response(vm: dict[str, Any]) -> AgentVmResponse:
     return AgentVmResponse(
         vmName=str(vm["vmName"]),
@@ -697,6 +686,14 @@ async def provision_agent_vm(
     except AccountDeletionAccessBlocked as exc:
         raise HTTPException(status_code=403, detail="account_deletion_in_progress") from exc
     if not claimed:
+        if _reconcile_in_progress(vm):
+            return ProvisionAgentResponse(
+                status="exists",
+                vmName=str(vm["vmName"]),
+                ip=None,
+                authToken=str(vm.get("authToken") or ""),
+                agentStatus="updating",
+            )
         return ProvisionAgentResponse(
             status="exists",
             vmName=str(vm["vmName"]),
@@ -721,6 +718,8 @@ async def get_agent_status(
     vm = await run_blocking(db_executor, _get_vm, uid)
     if not vm:
         return None
+    if _reconcile_lease_active(vm):
+        return _response(_updating_vm(vm))
     status = str(vm.get("status") or "provisioning")
     if status not in {"ready", "error", "stopped"}:
         return _response(vm)
@@ -740,75 +739,47 @@ async def get_agent_status(
         )
         return None if deleted else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
     if gce_status in {"TERMINATED", "STOPPED"}:
-        pending = {**vm, "status": "provisioning", "ip": None}
-        updated = await run_blocking(
+        requested = await run_blocking(
             db_executor,
-            _set_vm_if_current,
+            request_vm_start,
             uid,
             str(vm["vmName"]),
             str(vm.get("authToken") or ""),
-            "provisioning",
-            None,
-            str(vm.get("zone") or _ZONE),
         )
-        if not updated:
+        if not requested:
             return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        try:
-            service_account = _service_account()
-        except RuntimeError as exc:
-            logger.error("Agent VM restart blocked for uid=%s: %s", uid, exc)
-            await run_blocking(
-                db_executor,
-                _set_vm_if_current,
-                uid,
-                str(vm["vmName"]),
-                str(vm.get("authToken") or ""),
-                "error",
-                None,
-                str(vm.get("zone") or _ZONE),
-            )
-            return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        background_tasks.add_task(_restart_background, uid, project, vm, service_account)
-        return _response(pending)
+        return _response(_updating_vm(vm))
     if (
         gce_status == "RUNNING"
         and instance is not None
         and (status in {"error", "stopped"} or not _is_usable_vm_ip(vm.get("ip")))
     ):
-        pending = {**vm, "status": "provisioning", "ip": None}
         instance_ip = _ip(instance)
         if instance_ip is None:
-            vm_name = str(vm["vmName"])
-            auth_token = str(vm.get("authToken") or "")
-            zone = str(vm.get("zone") or _ZONE)
             logger.warning(
-                "Deleting unusable running Agent VM without an external IP for uid=%s",
+                "Deferring running Agent VM without an external IP to the reconciler for uid=%s",
                 uid,
             )
-            await _delete_vm(project, vm_name, zone)
-            deleted = await run_blocking(
+            requested = await run_blocking(
                 db_executor,
-                _delete_vm_if_current,
-                uid,
-                vm_name,
-                auth_token,
-            )
-            return None if deleted else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        try:
-            service_account = _service_account()
-        except RuntimeError as exc:
-            logger.error("Agent VM recovery blocked for uid=%s: %s", uid, exc)
-            await run_blocking(
-                db_executor,
-                _set_vm_if_current,
+                request_vm_start,
                 uid,
                 str(vm["vmName"]),
                 str(vm.get("authToken") or ""),
-                "error",
-                None,
-                str(vm.get("zone") or _ZONE),
             )
-            return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        background_tasks.add_task(_rebootstrap_background, uid, project, vm, service_account)
-        return _response(pending)
+            return (
+                _response(_updating_vm(vm))
+                if requested
+                else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
+            )
+        requested = await run_blocking(
+            db_executor,
+            request_vm_start,
+            uid,
+            str(vm["vmName"]),
+            str(vm.get("authToken") or ""),
+        )
+        return (
+            _response(_updating_vm(vm)) if requested else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
+        )
     return _response(vm)

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -236,11 +236,20 @@ def rollout_selected(uid: str, release_id: str, target_percent: int) -> bool:
     return bucket < target_percent
 
 
-def reconcile_requested(vm: Mapping[str, Any]) -> bool:
+def reconcile_requested(vm: Mapping[str, Any], now: float | None = None) -> bool:
     reconcile = vm.get("reconcile")
     if not isinstance(reconcile, Mapping):
         return False
-    return bool(reconcile.get("drainRequested")) or reconcile.get("state") in {"draining", "deferred"}
+    lease = reconcile.get("lease")
+    lease_active = isinstance(lease, Mapping) and float(lease.get("expiresAt", 0) or 0) > (
+        time.time() if now is None else now
+    )
+    return (
+        bool(reconcile.get("startRequested"))
+        or bool(reconcile.get("drainRequested"))
+        or reconcile.get("state") in {"draining", "deferred"}
+        or lease_active
+    )
 
 
 @transactional
@@ -325,7 +334,7 @@ def _claim_vm_lease_txn(
     vm_name: str,
     auth_token: str,
     owner: str,
-    release_id: str,
+    release_id: str | None,
     now: float,
     ttl: int,
 ) -> bool:
@@ -340,8 +349,8 @@ def _claim_vm_lease_txn(
         return False
     reconcile_raw = vm.get("reconcile")
     reconcile: dict[str, Any] = reconcile_raw if isinstance(reconcile_raw, dict) else {}
-    release_changed = bool(release_id) and reconcile.get("releaseId") != release_id
-    same_release = not release_changed
+    release_changed = release_id is not None and reconcile.get("releaseId") != release_id
+    same_release = release_id is None or not release_changed
     if reconcile.get("state") == "quarantined" and same_release:
         return False
     if float(reconcile.get("retryAt", 0) or 0) > now and same_release:
@@ -353,9 +362,10 @@ def _claim_vm_lease_txn(
     update: dict[str, Any] = {
         "agentVm.reconcile.lease": {"owner": owner, "claimedAt": now, "expiresAt": now + ttl},
         "agentVm.reconcile.state": "claimed",
-        "agentVm.reconcile.releaseId": release_id,
         "agentVm.reconcile.schemaVersion": RECONCILER_SCHEMA_VERSION,
     }
+    if release_id is not None:
+        update["agentVm.reconcile.releaseId"] = release_id
     if release_changed:
         update.update(
             {
@@ -370,7 +380,7 @@ def _claim_vm_lease_txn(
 
 
 def claim_vm_lease(
-    uid: str, vm_name: str, auth_token: str, owner: str, release_id: str = "", now: float | None = None
+    uid: str, vm_name: str, auth_token: str, owner: str, release_id: str | None = None, now: float | None = None
 ) -> bool:
     now = time.time() if now is None else now
     client = get_firestore_client()
@@ -416,6 +426,10 @@ def _renew_vm_lease_txn(
     lease: dict[str, Any] = lease_raw if isinstance(lease_raw, dict) else {}
     if lease.get("owner") != owner or float(lease.get("expiresAt", 0) or 0) <= now:
         return False
+    reconcile_raw = vm.get("reconcile")
+    reconcile = reconcile_raw if isinstance(reconcile_raw, dict) else {}
+    if reconcile.get("state") == "quarantined":
+        return False
     transaction.update(
         user_ref, {"agentVm.reconcile.lease.expiresAt": now + ttl, "agentVm.reconcile.lease.heartbeatAt": now}
     )
@@ -450,6 +464,8 @@ def _update_vm_reconcile_txn(
     fields: Mapping[str, Any],
     vm_fields: Mapping[str, Any] | None = None,
     now: float | None = None,
+    consume_start_request_at: float | None = None,
+    force_consume_start_request: bool = False,
 ) -> bool:
     now = time.time() if now is None else now
     deletion = deletion_ref.get(transaction=transaction)
@@ -468,12 +484,42 @@ def _update_vm_reconcile_txn(
     if lease.get("owner") != owner or float(lease.get("expiresAt", 0) or 0) <= now:
         return False
     update: dict[str, Any] = {}
-    for key, value in fields.items():
+    reconciled_fields = _reconcile_update_fields(
+        fields, reconcile, consume_start_request_at, force_consume_start_request
+    )
+    for key, value in reconciled_fields.items():
         update[f"agentVm.reconcile.{key}"] = value
     for key, value in (vm_fields or {}).items():
         update[f"agentVm.{key}"] = value
     transaction.update(user_ref, update)
     return True
+
+
+def _reconcile_update_fields(
+    fields: Mapping[str, Any],
+    reconcile: Mapping[str, Any],
+    consume_start_request_at: float | None,
+    force_consume_start_request: bool = False,
+) -> dict[str, Any]:
+    """Do not erase a start request that arrived after a worker's observation."""
+    result = dict(fields)
+    requested_at = reconcile.get("startRequestedAt")
+    current_request_at = float(requested_at) if isinstance(requested_at, (int, float)) else None
+    clears_start_request = (
+        result.get("startRequested") is DELETE_FIELD or result.get("startRequestedAt") is DELETE_FIELD
+    )
+    if (
+        not force_consume_start_request
+        and clears_start_request
+        and (
+            consume_start_request_at is None
+            or current_request_at is None
+            or current_request_at > consume_start_request_at
+        )
+    ):
+        result.pop("startRequested", None)
+        result.pop("startRequestedAt", None)
+    return result
 
 
 def update_vm_reconcile(
@@ -484,6 +530,8 @@ def update_vm_reconcile(
     fields: Mapping[str, Any],
     vm_fields: Mapping[str, Any] | None = None,
     now: float | None = None,
+    consume_start_request_at: float | None = None,
+    force_consume_start_request: bool = False,
 ) -> bool:
     client = get_firestore_client()
     return bool(
@@ -497,6 +545,8 @@ def update_vm_reconcile(
             fields,
             vm_fields,
             now,
+            consume_start_request_at,
+            force_consume_start_request,
         )
     )
 
@@ -504,9 +554,54 @@ def update_vm_reconcile(
 def clear_vm_reconcile_lease_fields() -> dict[str, Any]:
     return {
         "lease": DELETE_FIELD,
+        "startRequested": DELETE_FIELD,
+        "startRequestedAt": DELETE_FIELD,
         "drainRequested": DELETE_FIELD,
         "drainRequestedAt": DELETE_FIELD,
     }
+
+
+@transactional
+def _request_vm_start_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    expected_vm_name: str,
+    expected_auth_token: str,
+    now: float,
+) -> bool:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    status = normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    if account_deletion_blocks_access(status):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    if not isinstance(vm, dict) or vm.get("vmName") != expected_vm_name or vm.get("authToken") != expected_auth_token:
+        return False
+    transaction.update(
+        user_ref,
+        {
+            "agentVm.reconcile.startRequested": True,
+            "agentVm.reconcile.startRequestedAt": now,
+        },
+    )
+    return True
+
+
+def request_vm_start(uid: str, vm_name: str, auth_token: str, now: float | None = None) -> bool:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    return bool(
+        _request_vm_start_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            client.collection("users").document(uid),
+            vm_name,
+            auth_token,
+            now,
+        )
+    )
 
 
 @transactional
@@ -530,7 +625,7 @@ def _claim_session_lease_txn(
     vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
     if not isinstance(vm, dict) or vm.get("vmName") != vm_name or vm.get("authToken") != auth_token:
         return False
-    if reconcile_requested(vm):
+    if reconcile_requested(vm, now):
         return False
     transaction.set(
         lease_ref,
@@ -810,6 +905,7 @@ __all__ = [
     "reconcile_requested",
     "release_manifest_bytes",
     "release_reconciler_run_lease",
+    "request_vm_start",
     "renew_reconciler_run_lease",
     "renew_vm_lease",
     "release_session_lease",

--- a/backend/tests/unit/test_agent_proxy_async_boundaries.py
+++ b/backend/tests/unit/test_agent_proxy_async_boundaries.py
@@ -5,7 +5,7 @@ import json
 import threading
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import firebase_admin
 import pytest
@@ -175,47 +175,6 @@ class _IdleVMProtocol:
 
 
 @pytest.mark.asyncio
-async def test_gce_status_refreshes_credentials_off_the_event_loop(agent_proxy, monkeypatch):
-    event_loop_thread = threading.get_ident()
-    credential_thread = None
-    client = _AsyncClient()
-    executor_calls = []
-    shared_run_blocking = agent_proxy.run_blocking
-
-    def refresh_credentials():
-        nonlocal credential_thread
-        credential_thread = threading.get_ident()
-        return "test-token"
-
-    async def tracking_run_blocking(executor, func, *args, **kwargs):
-        executor_calls.append(executor)
-        return await shared_run_blocking(executor, func, *args, **kwargs)
-
-    monkeypatch.setattr(agent_proxy, "_get_gce_access_token", refresh_credentials)
-    monkeypatch.setattr(agent_proxy, "run_blocking", tracking_run_blocking)
-    monkeypatch.setattr(agent_proxy.httpx, "AsyncClient", lambda: client)
-
-    status = await agent_proxy._check_gce_status("omi-agent-test", "us-central1-a")
-
-    assert status == "RUNNING"
-    assert credential_thread is not None
-    assert credential_thread != event_loop_thread
-    assert executor_calls == [agent_proxy.critical_executor]
-    assert client.headers == {"Authorization": "Bearer test-token"}
-
-
-@pytest.mark.asyncio
-async def test_gce_credential_refresh_failure_still_propagates(agent_proxy, monkeypatch):
-    def refresh_credentials():
-        raise RuntimeError("credential refresh failed")
-
-    monkeypatch.setattr(agent_proxy, "_get_gce_access_token", refresh_credentials)
-
-    with pytest.raises(RuntimeError, match="credential refresh failed"):
-        await agent_proxy._check_gce_status("omi-agent-test", "us-central1-a")
-
-
-@pytest.mark.asyncio
 async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy, monkeypatch):
     phone_ws = _AgentWebSocket()
     vm_ws = _VMProtocol()
@@ -264,9 +223,9 @@ async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy
 
 
 @pytest.mark.asyncio
-async def test_session_admission_is_transactional_before_vm_lifecycle_mutation(agent_proxy, monkeypatch):
+async def test_session_admission_queues_recovery_when_a_lifecycle_lease_wins(agent_proxy, monkeypatch):
     websocket = _AgentWebSocket()
-    ensure_running = MagicMock()
+    ensure_running = AsyncMock(return_value={})
 
     async def direct_run_blocking(_executor, func, *args, **kwargs):
         return func(*args, **kwargs)
@@ -288,7 +247,67 @@ async def test_session_admission_is_transactional_before_vm_lifecycle_mutation(a
 
     await agent_proxy.agent_ws(websocket)
 
-    ensure_running.assert_not_called()
+    ensure_running.assert_awaited_once()
+    assert json.loads(websocket.sent[-1])["code"] == "agent_vm_draining"
+    assert websocket.closed == [(1013, "Agent VM is draining")]
+
+
+@pytest.mark.asyncio
+async def test_existing_reconciler_lease_queues_recovery_before_rejecting_socket(agent_proxy, monkeypatch):
+    websocket = _AgentWebSocket()
+    ensure_running = AsyncMock(return_value={})
+
+    async def direct_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
+    monkeypatch.setattr(agent_proxy, "_verify_id_token", lambda _token: {"uid": "user-1"})
+    monkeypatch.setattr(agent_proxy, "_get_account_deletion_status", lambda _uid: None)
+    monkeypatch.setattr(
+        agent_proxy,
+        "_get_user_context",
+        lambda _uid: (
+            {"vmName": "omi-agent-user", "status": "running", "ip": "10.0.0.5", "authToken": "vm-token"},
+            "standard",
+        ),
+    )
+    monkeypatch.setattr(agent_proxy, "reconcile_requested", lambda _vm: True)
+    monkeypatch.setattr(agent_proxy, "_ensure_vm_running", ensure_running)
+
+    await agent_proxy.agent_ws(websocket)
+
+    ensure_running.assert_awaited_once()
+    assert json.loads(websocket.sent[-1])["code"] == "agent_vm_draining"
+    assert websocket.closed == [(1013, "Agent VM is draining")]
+
+
+@pytest.mark.asyncio
+async def test_existing_reconciler_lease_still_returns_typed_error_when_demand_write_fails(agent_proxy, monkeypatch):
+    websocket = _AgentWebSocket()
+
+    async def direct_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    async def unavailable(_uid, _vm):
+        raise RuntimeError("firestore unavailable")
+
+    monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
+    monkeypatch.setattr(agent_proxy, "_verify_id_token", lambda _token: {"uid": "user-1"})
+    monkeypatch.setattr(agent_proxy, "_get_account_deletion_status", lambda _uid: None)
+    monkeypatch.setattr(
+        agent_proxy,
+        "_get_user_context",
+        lambda _uid: (
+            {"vmName": "omi-agent-user", "status": "running", "ip": "10.0.0.5", "authToken": "vm-token"},
+            "standard",
+        ),
+    )
+    monkeypatch.setattr(agent_proxy, "reconcile_requested", lambda _vm: True)
+    monkeypatch.setattr(agent_proxy, "_ensure_vm_running", unavailable)
+
+    await agent_proxy.agent_ws(websocket)
+
+    assert websocket.accepted is True
     assert json.loads(websocket.sent[-1])["code"] == "agent_vm_draining"
     assert websocket.closed == [(1013, "Agent VM is draining")]
 
@@ -600,28 +619,9 @@ def test_agent_proxy_image_packages_the_shared_executor_boundary():
     assert dockerfile.index(package_copy) < dockerfile.index(entrypoint_copy)
 
 
-def test_static_all_async_gce_refreshes_use_the_critical_executor():
-    tree = ast.parse((AGENT_PROXY_DIR / "main.py").read_text(encoding="utf-8"))
-    direct_refresh_calls = []
-    wrapped_refresh_calls = []
-
-    for function in (node for node in tree.body if isinstance(node, ast.AsyncFunctionDef)):
-        for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
-            if isinstance(call.func, ast.Name) and call.func.id == "_get_gce_access_token":
-                direct_refresh_calls.append(call)
-            if not isinstance(call.func, ast.Name) or call.func.id != "run_blocking" or len(call.args) < 2:
-                continue
-            executor, target = call.args[:2]
-            if (
-                isinstance(executor, ast.Name)
-                and executor.id == "critical_executor"
-                and isinstance(target, ast.Name)
-                and target.id == "_get_gce_access_token"
-            ):
-                wrapped_refresh_calls.append(call)
-
-    assert direct_refresh_calls == []
-    assert len(wrapped_refresh_calls) == 6
+def test_agent_proxy_has_no_direct_compute_control_plane_path():
+    source = (AGENT_PROXY_DIR / "main.py").read_text(encoding="utf-8")
+    assert "compute.googleapis.com" not in source
 
 
 def test_static_agent_proxy_uses_managed_blocking_and_named_lifetime_tasks():
@@ -635,14 +635,7 @@ def test_static_agent_proxy_uses_managed_blocking_and_named_lifetime_tasks():
         assert any(keyword.arg == "name" for keyword in call.keywords)
 
 
-def test_unresolved_vm_ip_is_never_persisted_as_a_dialable_address(agent_proxy):
-    """The placeholder is truthy, so persisting it passed every `if ip:` reader.
-
-    A stored placeholder satisfied the `status == "ready" and vm_ip` fast path,
-    failed the health probe, and drove `_ensure_vm_running(health_failed=True)`
-    into hard-resetting a healthy VM — which wrote the same placeholder back.
-    No writer repaired the field, so the user never recovered.
-    """
+def test_unresolved_vm_ip_is_not_treated_as_dialable(agent_proxy):
     assert not agent_proxy._is_usable_vm_ip(agent_proxy.UNRESOLVED_VM_IP)
     assert not agent_proxy._is_usable_vm_ip("")
     assert not agent_proxy._is_usable_vm_ip(None)
@@ -651,60 +644,9 @@ def test_unresolved_vm_ip_is_never_persisted_as_a_dialable_address(agent_proxy):
     # The placeholder is truthy — this is the property that made it dangerous.
     assert bool(agent_proxy.UNRESOLVED_VM_IP)
 
-    with pytest.raises(ValueError):
-        agent_proxy._update_firestore_vm("uid-1", "vm-1", "token-1", agent_proxy.UNRESOLVED_VM_IP, "ready")
-    with pytest.raises(ValueError):
-        agent_proxy._update_firestore_vm("uid-1", "vm-1", "token-1", None, "ready")
-
-
-@pytest.mark.asyncio
-async def test_running_vm_resolves_ip_without_starting_again(agent_proxy, monkeypatch):
-    class Response:
-        status_code = 200
-
-        def json(self):
-            return {
-                "status": "RUNNING",
-                "networkInterfaces": [{"accessConfigs": [{"natIP": "34.121.9.4"}]}],
-            }
-
-    class Client:
-        def __init__(self):
-            self.post_calls = 0
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, _exc_type, _exc, _traceback):
-            return False
-
-        async def get(self, _url, *, headers):
-            assert headers == {"Authorization": "Bearer test-token"}
-            return Response()
-
-        async def post(self, *_args, **_kwargs):
-            self.post_calls += 1
-            return Response()
-
-    client = Client()
-
-    async def direct_run_blocking(_executor, func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(agent_proxy, "_get_gce_access_token", lambda: "test-token")
-    monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
-    monkeypatch.setattr(agent_proxy.httpx, "AsyncClient", lambda **_kwargs: client)
-
-    assert await agent_proxy._start_vm_and_wait("omi-agent-test", "us-central1-a") == "34.121.9.4"
-    assert client.post_calls == 0
-
 
 def test_agent_proxy_never_assigns_the_unresolved_ip_placeholder():
-    """`_start_vm_and_wait` must raise rather than return a sentinel address.
-
-    Both callers already route an exception to `status: "error"`, so raising
-    reuses the existing failure path instead of inventing a second one.
-    """
+    """Only the named legacy sentinel may use the string ``unknown``."""
     source = (AGENT_PROXY_DIR / "main.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
 

--- a/backend/tests/unit/test_agent_vm_async.py
+++ b/backend/tests/unit/test_agent_vm_async.py
@@ -1,16 +1,4 @@
-"""The agent-VM endpoints must not block the event loop on Firestore writes.
-
-``ensure_vm`` (``POST /v1/agent/vm-ensure``) and its background task
-``_restart_vm_background`` are ``async`` and ``await`` the GCE lifecycle calls, but they
-wrote the user's ``agentVm`` status to Firestore by calling the synchronous
-``_update_firestore_vm`` directly on the event loop. The Firestore sync SDK blocks the loop
-(``database.*`` is exactly the class the async-blocker lint does not catch), and ``ensure_vm``
-already offloads its read via ``run_blocking`` one line up, so the writes were the
-inconsistent part.
-
-They must be offloaded with ``await run_blocking(db_executor, _update_firestore_vm, ...)``.
-These AST checks assert the offload stays in place.
-"""
+"""The Agent VM tools route must only enqueue reconciler intent off the event loop."""
 
 import ast
 from pathlib import Path
@@ -18,8 +6,8 @@ from pathlib import Path
 BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
 AGENT_ROUTER = BACKEND_DIR / "routers" / "agent_tools.py"
 
-_HANDLERS = {"ensure_vm", "_restart_vm_background"}
-_BLOCKING = {"_update_firestore_vm"}
+_HANDLERS = {"ensure_vm"}
+_BLOCKING = {"request_vm_start"}
 
 
 def _func_nodes():
@@ -53,24 +41,22 @@ def _offloaded_via_run_blocking(node):
     return offloaded
 
 
-class TestAgentVmOffloadsFirestoreWrites:
-    def test_firestore_write_is_not_called_directly_in_the_async_functions(self):
+class TestAgentVmQueuesReconcilerIntent:
+    def test_reconciler_intent_is_not_called_directly_in_the_async_handler(self):
         for node in _func_nodes():
             leaked = _BLOCKING & _direct_calls(node)
             assert not leaked, (
-                f"{node.name} writes Firestore directly on the event loop via {sorted(leaked)}. "
-                f"Offload with await run_blocking(db_executor, _update_firestore_vm, ...)."
+                f"{node.name} calls the reconciler intent directly via {sorted(leaked)}. "
+                f"Offload with await run_blocking(db_executor, request_vm_start, ...)."
             )
 
-    def test_firestore_write_is_offloaded_via_run_blocking(self):
+    def test_reconciler_intent_is_offloaded_via_run_blocking(self):
         offloaded = set()
         for node in _func_nodes():
             offloaded |= _offloaded_via_run_blocking(node)
         missing = _BLOCKING - offloaded
-        assert not missing, f"_update_firestore_vm is not offloaded via run_blocking: {sorted(missing)}"
+        assert not missing, f"request_vm_start is not offloaded via run_blocking: {sorted(missing)}"
 
     def test_functions_are_async(self):
-        # Plain def would run in FastAPI's threadpool (background tasks excepted); this fix
-        # matters because these are async and await the GCE lifecycle calls.
         for node in _func_nodes():
             assert isinstance(node, ast.AsyncFunctionDef)

--- a/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
+++ b/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
@@ -1,15 +1,4 @@
-"""A reaped agent VM must clear its Firestore record instead of stranding the user.
-
-``scripts/agent_vm_reaper.py`` deletes aged TERMINATED ``omi-agent-*`` instances but leaves
-``users/{uid}.agentVm`` saying ``ready`` with the deleted VM's IP. Both Python readers folded
-the GCE ``404`` into ``UNKNOWN``: ``_ensure_vm_running`` returned the stale record ("STAGING,
-etc. — let it be") so ``agent-proxy`` dialed a dead address and waited out the full 120s
-health timeout before answering "Agent VM is not responding", and ``POST /v1/agent/vm-ensure``
-reported ``ready``. Nothing repaired the record and the desktop provision endpoint reports
-``exists`` while it is present, so the user's agent chat stayed broken on every later attempt
-(20 distinct users in prod over 2026-07-25..26). Only a 404 may clear the record — ``UNKNOWN``
-means "could not tell" and must leave a live VM's record alone.
-"""
+"""Unavailable Agent VMs are fenced and handed to the fleet reconciler."""
 
 import asyncio
 import importlib
@@ -51,101 +40,22 @@ def agent_proxy(monkeypatch) -> ModuleType:
     return module
 
 
-class _FakeUserDoc:
-    def __init__(self):
-        self.updates = []
+class TestAgentProxyRequestsReconciliation:
+    async def test_unavailable_vm_is_fenced_and_deferred_to_the_reconciler(self, agent_proxy, monkeypatch):
+        requests = []
 
-    def update(self, payload):
-        self.updates.append(payload)
+        async def direct_run_blocking(_executor, function, *args, **kwargs):
+            return function(*args, **kwargs)
 
-    def get(self, transaction=None):
-        del transaction
-        return types.SimpleNamespace(exists=True, to_dict=lambda: {"agentVm": {**READY_VM, "authToken": ""}})
+        monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
+        monkeypatch.setattr(agent_proxy, "request_vm_start", lambda *args: requests.append(args) or True)
 
+        result = await agent_proxy._ensure_vm_running(
+            "uid-reaped", {**READY_VM, "authToken": "token"}, health_failed=True
+        )
 
-def _stub_gce(agent_proxy, monkeypatch, instance_status_code: int, user_doc: _FakeUserDoc):
-    """Point the module's GCE + Firestore seams at a fake instance and user document."""
-
-    class Response:
-        status_code = instance_status_code
-
-        def json(self):
-            return {"status": "RUNNING", "networkInterfaces": [{"accessConfigs": [{"natIP": "34.9.9.9"}]}]}
-
-    class Client:
-        def __init__(self):
-            self.post_calls = 0
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, _exc_type, _exc, _traceback):
-            return False
-
-        async def get(self, _url, *, headers=None):
-            return Response()
-
-        async def post(self, *_args, **_kwargs):
-            self.post_calls += 1
-            return Response()
-
-    client = Client()
-
-    async def direct_run_blocking(_executor, func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    deletion_doc = MagicMock()
-    deletion_doc.get.return_value = types.SimpleNamespace(exists=False, to_dict=lambda: {})
-    transaction = MagicMock()
-    transaction.update.side_effect = lambda doc, payload: doc.update(payload)
-    db = MagicMock()
-    db.transaction.return_value = transaction
-    db.collection.side_effect = lambda name: types.SimpleNamespace(
-        document=lambda _uid: deletion_doc if name == "account_deletions" else user_doc
-    )
-
-    monkeypatch.setattr(agent_proxy, "_get_gce_access_token", lambda: "test-token")
-    monkeypatch.setattr(agent_proxy, "run_blocking", direct_run_blocking)
-    monkeypatch.setattr(agent_proxy, "httpx", types.SimpleNamespace(AsyncClient=lambda **_kwargs: client))
-    monkeypatch.setattr(agent_proxy, "_get_firestore_db", lambda: db)
-    return client
-
-
-class TestAgentProxyClearsReapedRecord:
-    async def test_deleted_instance_clears_the_record_and_fails_fast(self, agent_proxy, monkeypatch):
-        user_doc = _FakeUserDoc()
-        client = _stub_gce(agent_proxy, monkeypatch, 404, user_doc)
-
-        result = await agent_proxy._ensure_vm_running("uid-reaped", dict(READY_VM), health_failed=True)
-
-        assert result is None, "a deleted instance must not be reported as usable"
-        assert user_doc.updates == [{"agentVm": agent_proxy.DELETE_FIELD}]
-        assert client.post_calls == 0, "no reset/start may be attempted against a deleted instance"
-
-    async def test_unknown_status_leaves_the_record_alone(self, agent_proxy, monkeypatch):
-        user_doc = _FakeUserDoc()
-        _stub_gce(agent_proxy, monkeypatch, 500, user_doc)
-
-        result = await agent_proxy._ensure_vm_running("uid-transient", dict(READY_VM), health_failed=False)
-
-        assert result == READY_VM, "an unreadable GCE status must leave the record untouched"
-        assert user_doc.updates == []
-
-    async def test_restart_path_clears_the_record_when_the_instance_is_gone(self, agent_proxy, monkeypatch):
-        user_doc = _FakeUserDoc()
-        _stub_gce(agent_proxy, monkeypatch, 404, user_doc)
-        errored_vm = dict(READY_VM, status="error")
-
-        result = await agent_proxy._ensure_vm_running("uid-errored", errored_vm)
-
-        assert result is None
-        assert {"agentVm": agent_proxy.DELETE_FIELD} in user_doc.updates
-
-    async def test_start_vm_and_wait_raises_vm_not_found_on_404(self, agent_proxy, monkeypatch):
-        _stub_gce(agent_proxy, monkeypatch, 404, _FakeUserDoc())
-
-        with pytest.raises(agent_proxy.VmNotFoundError):
-            await agent_proxy._start_vm_and_wait("omi-agent-reaped", "us-central1-a")
+        assert result == {**READY_VM, "authToken": "token", "status": "updating", "ip": None}
+        assert requests == [("uid-reaped", "omi-agent-reaped", "token")]
 
 
 @pytest.fixture
@@ -159,39 +69,27 @@ def agent_tools(monkeypatch):
     return importlib.import_module('routers.agent_tools')
 
 
-class TestVmEnsureClearsReapedRecord:
-    def test_deleted_instance_reports_no_vm_and_clears_the_record(self, agent_tools, monkeypatch):
-        from database.users import get_agent_vm
-
-        get_agent_vm.return_value = dict(READY_VM)
-        cleared = []
-
-        async def not_found(_vm_name, _zone):
-            return "NOT_FOUND"
-
-        monkeypatch.setattr(agent_tools, "_check_gce_status", not_found)
-        monkeypatch.setattr(agent_tools, "_clear_agent_vm", cleared.append)
+class TestVmEnsureRequestsReconciliation:
+    def test_stopped_vm_queues_a_fenced_reconciler_request(self, agent_tools, monkeypatch):
+        requests = []
+        monkeypatch.setattr(
+            agent_tools, "get_agent_vm", lambda _uid: {**READY_VM, "status": "stopped", "authToken": "token"}
+        )
+        monkeypatch.setattr(agent_tools, "request_vm_start", lambda *args: requests.append(args) or True)
         background = MagicMock()
 
         response = asyncio.run(agent_tools.ensure_vm(background, uid="uid-reaped"))
 
-        assert response == {"has_vm": False}
-        assert cleared == ["uid-reaped"]
+        assert response == {"has_vm": True, "status": "updating"}
+        assert requests == [("uid-reaped", "omi-agent-reaped", "token")]
         background.add_task.assert_not_called()
 
-    def test_unknown_status_keeps_the_record(self, agent_tools, monkeypatch):
-        from database.users import get_agent_vm
-
-        get_agent_vm.return_value = dict(READY_VM)
-        cleared = []
-
-        async def unknown(_vm_name, _zone):
-            return "UNKNOWN"
-
-        monkeypatch.setattr(agent_tools, "_check_gce_status", unknown)
-        monkeypatch.setattr(agent_tools, "_clear_agent_vm", cleared.append)
+    def test_ready_vm_with_a_cached_ip_queues_reconciliation_demand(self, agent_tools, monkeypatch):
+        requests = []
+        monkeypatch.setattr(agent_tools, "get_agent_vm", lambda _uid: {**READY_VM, "authToken": "token"})
+        monkeypatch.setattr(agent_tools, "request_vm_start", lambda *args: requests.append(args) or True)
 
         response = asyncio.run(agent_tools.ensure_vm(MagicMock(), uid="uid-transient"))
 
-        assert response == {"has_vm": True, "status": "ready"}
-        assert cleared == []
+        assert response == {"has_vm": True, "status": "updating"}
+        assert requests == [("uid-transient", "omi-agent-reaped", "token")]

--- a/backend/tests/unit/test_agent_vm_reconciler_authority.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_authority.py
@@ -1,0 +1,49 @@
+"""User-facing Agent VM paths may request, but never bypass, reconciliation."""
+
+import ast
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _function(path: Path, name: str) -> ast.AsyncFunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    matches = [node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    return {call.func.id for call in ast.walk(node) if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)}
+
+
+def _run_blocking_targets(node: ast.AST) -> set[str]:
+    targets = set()
+    for call in ast.walk(node):
+        if not (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "run_blocking"
+            and len(call.args) >= 2
+        ):
+            continue
+        target = call.args[1]
+        if isinstance(target, ast.Name):
+            targets.add(target.id)
+    return targets
+
+
+def test_proxy_and_tools_have_no_direct_compute_control_plane_path():
+    for relative_path in ("agent-proxy/main.py", "routers/agent_tools.py"):
+        source = (BACKEND_DIR / relative_path).read_text(encoding="utf-8")
+        assert "compute.googleapis.com" not in source
+        assert "request_vm_start" in source
+
+
+def test_desktop_status_requests_reconciliation_without_direct_power_mutation():
+    status = _function(BACKEND_DIR / "routers/desktop_agent_vm.py", "get_agent_status")
+    calls = _called_names(status)
+    blocking_targets = _run_blocking_targets(status)
+
+    assert "request_vm_start" in blocking_targets
+    assert not {"_start_vm", "_stop_vm", "_set_service_account", "_delete_vm"} & calls

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 import jobs.agent_vm_reconciler as reconciler
+import services.agent_vm_lifecycle as lifecycle
 from services.agent_vm_lifecycle import AgentVmRelease
 
 RELEASE = AgentVmRelease.from_mapping(
@@ -85,6 +86,76 @@ def test_reconcile_preserves_a_healthy_stopped_vm(monkeypatch):
     assert "idle self-stop preserved" in result.detail
     assert FakeApi.starts == 0
     assert updates[-1]["vm_fields"] == {"status": "stopped"}
+
+
+def test_reconcile_starts_a_current_vm_only_after_fenced_start_request(monkeypatch):
+    class StartRequestedApi:
+        starts = 0
+        waits: list[tuple[str, str, AgentVmRelease]] = []
+
+        def __init__(self, _project: str, _zone: str) -> None:
+            self.instance = {
+                "status": "STOPPED",
+                "metadata": {},
+                "serviceAccounts": [],
+                "disks": [{"boot": True, "source": "projects/project/zones/us-central1-a/disks/omi-agent-user"}],
+                "networkInterfaces": [{"networkIP": "10.128.0.9", "accessConfigs": [{"natIP": "34.1.2.3"}]}],
+            }
+
+        async def get_instance(self, _vm_name: str) -> dict[str, Any] | None:
+            return self.instance
+
+        async def request(self, _method: str, _url: str) -> Any:
+            class Response:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict[str, str]:
+                    return {"sourceImage": "projects/project/global/images/omi-agent-20260805"}
+
+            return Response()
+
+        async def start(self, _vm_name: str) -> None:
+            type(self).starts += 1
+            self.instance["status"] = "RUNNING"
+
+        def private_instance_ip(self, _instance: dict[str, Any]) -> str:
+            return "10.128.0.9"
+
+        def instance_ip(self, _instance: dict[str, Any]) -> str:
+            return "34.1.2.3"
+
+        async def wait_for_runtime(self, private_ip: str, auth_token: str, release: AgentVmRelease) -> None:
+            type(self).waits.append((private_ip, auth_token, release))
+
+    updates: list[dict[str, Any]] = []
+    StartRequestedApi.starts = 0
+    StartRequestedApi.waits = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", StartRequestedApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "renew_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: [])
+    monkeypatch.setattr(
+        reconciler, "update_vm_reconcile", lambda *args, **kwargs: updates.append((args, kwargs)) or True
+    )
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {"vmName": "omi-agent-user", "authToken": "token", "reconcile": {"startRequested": True}},
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "ready"
+    assert StartRequestedApi.starts == 1
+    assert StartRequestedApi.waits == [("10.128.0.9", "token", RELEASE)]
+    assert updates[-1][0][4]["state"] == "ready"
+    assert updates[-1][1]["vm_fields"] == {"status": "ready", "privateIp": "10.128.0.9", "ip": "34.1.2.3"}
 
 
 def test_boot_image_drift_requires_operator_recreate_without_mutating_vm(monkeypatch):
@@ -215,6 +286,33 @@ def test_small_fleet_selects_one_deterministic_sentinel(monkeypatch):
     assert first == second
 
 
+def test_start_requests_bypass_the_release_cohort_without_displacing_it(monkeypatch):
+    owners = [
+        ("cohort", {"vmName": "cohort"}),
+        ("demand", {"vmName": "demand", "reconcile": {"startRequested": True}}),
+    ]
+    monkeypatch.setattr(reconciler, "rollout_selected", lambda uid, *_args: uid == "cohort")
+
+    assert reconciler._select_reconcile_owners(owners, RELEASE.release_id, 1) == owners
+
+
+def test_terminal_reconcile_write_preserves_a_newer_start_request():
+    terminal_fields = lifecycle.clear_vm_reconcile_lease_fields()
+
+    preserved = lifecycle._reconcile_update_fields(terminal_fields, {"startRequestedAt": 20.0}, 10.0)
+    consumed = lifecycle._reconcile_update_fields(terminal_fields, {"startRequestedAt": 10.0}, 10.0)
+
+    assert "startRequested" not in preserved
+    assert "startRequestedAt" not in preserved
+    assert consumed["startRequested"] is lifecycle.DELETE_FIELD
+    assert consumed["startRequestedAt"] is lifecycle.DELETE_FIELD
+
+
+def test_active_lifecycle_lease_blocks_new_session_admission():
+    assert lifecycle.reconcile_requested({"reconcile": {"lease": {"expiresAt": 101}}}, now=100)
+    assert not lifecycle.reconcile_requested({"reconcile": {"lease": {"expiresAt": 100}}}, now=100)
+
+
 def test_recognized_rollout_phase_honors_manifest_and_environment_overrides(monkeypatch):
     assert reconciler._rollout_spec(
         {"rollout": {"phase": "sentinel", "targetPercent": 7, "maxConcurrency": 3}}, "sentinel"
@@ -330,6 +428,39 @@ def test_new_release_starts_quarantined_vm_with_a_fresh_retry_budget(monkeypatch
 
     assert result.state == "retry"
     assert calls[-1][0][4]["retryCount"] == 1
+
+
+def test_demanded_retry_retains_start_request_until_terminal_quarantine(monkeypatch):
+    class FailingApi:
+        def __init__(self, _project: str, _zone: str) -> None:
+            pass
+
+        async def get_instance(self, _vm_name: str) -> dict[str, Any] | None:
+            raise RuntimeError("provider unavailable")
+
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", FailingApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *args, **kwargs: calls.append((args, kwargs)) or True)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "reconcile": {"releaseId": RELEASE.release_id, "startRequested": True, "startRequestedAt": 10.0},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "retry"
+    fields, kwargs = calls[-1][0][4], calls[-1][1]
+    assert "startRequested" not in fields
+    assert kwargs["consume_start_request_at"] is None
 
 
 def test_same_release_quarantine_remains_visible_without_reclaim(monkeypatch):

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -15,6 +15,7 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
     for name, body in {
         "curl": "case \"$*\" in\n  *'/instance/attributes/auth-token'*) printf '%s\\n' omi-token ;;\n  *'/instance/service-accounts/default/token'*) printf '%s\\n' '{\"access_token\":\"metadata-token\"}' ;;\n  *'/project/project-id'*) printf '%s\\n' based-hardware-dev ;;\n  *'secretmanager.googleapis.com'*) printf '%s\\n' '{\"payload\":{\"data\":\"c2VjcmV0LXZhbHVl\"}}' ;;\n  *) exit 1 ;;\nesac\n",
         "docker": "printf 'docker %s\\n' \"$*\" >> \"$COMMAND_LOG\"\n",
+        "systemctl": "printf 'systemctl %s\\n' \"$*\" >> \"$COMMAND_LOG\"\ncase \"$1\" in\n  cat) exit 0 ;;\n  disable) exit 0 ;;\n  *) exit 1 ;;\nesac\n",
     }.items():
         path = bin_dir / name
         path.write_text(f"#!/bin/bash\n{body}", encoding="utf-8")
@@ -46,8 +47,12 @@ def test_startup_runs_the_published_python_runtime_with_instance_credentials(tmp
 
     commands = log.read_text(encoding="utf-8")
     assert "gcloud" not in commands
+    assert "systemctl cat omi-agent.service" in commands
+    assert "systemctl disable --now omi-agent.service" in commands
     assert "docker login --username oauth2accesstoken --password-stdin https://gcr.io" in commands
     assert "docker pull gcr.io/project/agent-vm:abcdef0" in commands
+    assert commands.index("docker container inspect omi-agent-vm") < commands.index("docker rm -f omi-agent-vm")
+    assert commands.index("docker rm -f omi-agent-vm") < commands.index("docker run --detach")
     assert "--env ANTHROPIC_API_KEY=secret-value" in commands
     assert "--env AUTH_TOKEN=omi-token" in commands
     assert "--env GEMINI_API_KEY=secret-value" in commands

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from pathlib import Path
 
 import httpx
@@ -191,7 +192,7 @@ def test_instance_address_parser_never_returns_unknown_placeholder():
 
 
 @pytest.mark.asyncio
-async def test_status_restarts_stopped_vm_and_returns_provisioning(monkeypatch):
+async def test_status_requests_reconciler_start_for_stopped_vm(monkeypatch):
     vm = {
         "vmName": "omi-agent-user",
         "zone": "us-central1-a",
@@ -200,7 +201,7 @@ async def test_status_restarts_stopped_vm_and_returns_provisioning(monkeypatch):
         "status": "ready",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    writes = []
+    requests = []
 
     async def run_blocking(_, function, *args):
         return function(*args)
@@ -209,16 +210,69 @@ async def test_status_restarts_stopped_vm_and_returns_provisioning(monkeypatch):
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", lambda *args: _stopped_instance())
-    monkeypatch.setattr(desktop_agent_vm, "_service_account", lambda: "service-account")
-    monkeypatch.setattr(desktop_agent_vm, "_set_vm_if_current", lambda *args: writes.append(args) or True)
+    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
     tasks = BackgroundTasks()
 
     response = await desktop_agent_vm.get_agent_status(tasks, "user")
 
-    assert response.status == "provisioning"
+    assert response.status == "updating"
     assert response.ip is None
-    assert writes[0][3] == "provisioning"
-    assert len(tasks.tasks) == 1
+    assert requests == [("user", "omi-agent-user", "omi-token")]
+    assert not tasks.tasks
+
+
+@pytest.mark.asyncio
+async def test_status_does_not_restart_a_vm_while_the_reconciler_lease_is_active(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-user",
+        "zone": "us-central1-a",
+        "ip": "1.2.3.4",
+        "authToken": "omi-token",
+        "status": "ready",
+        "createdAt": "2026-07-26T00:00:00Z",
+        "reconcile": {"lease": {"owner": "reconciler", "expiresAt": time.time() + 60}},
+    }
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_instance", lambda *_args: pytest.fail("status must not inspect GCE"))
+
+    tasks = BackgroundTasks()
+    response = await desktop_agent_vm.get_agent_status(tasks, "user")
+
+    assert response.status == "updating"
+    assert response.ip is None
+    assert not tasks.tasks
+
+
+@pytest.mark.asyncio
+async def test_provision_reports_updating_without_overriding_a_reconciler_request(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-user",
+        "authToken": "omi-token",
+        "status": "ready",
+        "reconcile": {"startRequested": True},
+    }
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_claim_vm_if_allowed", lambda *_args: (vm, False))
+    monkeypatch.setattr(desktop_agent_vm, "_agent_disabled", lambda: False)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setattr(desktop_agent_vm, "_source_image", lambda _project: "image")
+    monkeypatch.setattr(desktop_agent_vm, "_gcs_bucket", lambda: "bucket")
+    monkeypatch.setattr(desktop_agent_vm, "_service_account", lambda: "service-account")
+
+    response = await desktop_agent_vm.provision_agent_vm(BackgroundTasks(), "user")
+
+    assert response.status == "exists"
+    assert response.agent_status == "updating"
+    assert response.ip is None
 
 
 @pytest.mark.asyncio
@@ -252,7 +306,7 @@ async def test_status_clears_stale_gce_pointer_with_current_vm_fence(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_status_deletes_running_vm_without_usable_ip_and_cas_clears_pointer(monkeypatch):
+async def test_status_defers_running_vm_without_usable_ip_to_reconciler(monkeypatch):
     vm = {
         "vmName": "omi-agent-unreachable",
         "zone": "us-central1-a",
@@ -261,8 +315,7 @@ async def test_status_deletes_running_vm_without_usable_ip_and_cas_clears_pointe
         "status": "error",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    gce_deletes = []
-    pointer_clears = []
+    requests = []
 
     async def run_blocking(_, function, *args):
         return function(*args)
@@ -270,25 +323,17 @@ async def test_status_deletes_running_vm_without_usable_ip_and_cas_clears_pointe
     async def running_without_ip(*_args):
         return "RUNNING", {"networkInterfaces": []}
 
-    async def delete_vm(*args):
-        gce_deletes.append(args)
-
     monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", running_without_ip)
-    monkeypatch.setattr(desktop_agent_vm, "_delete_vm", delete_vm)
-    monkeypatch.setattr(
-        desktop_agent_vm,
-        "_delete_vm_if_current",
-        lambda *args: pointer_clears.append(args) or True,
-    )
+    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
-    assert response is None
-    assert gce_deletes == [("project", "omi-agent-unreachable", "us-central1-a")]
-    assert pointer_clears == [("uid", "omi-agent-unreachable", "current-token")]
+    assert response.status == "updating"
+    assert response.ip is None
+    assert requests == [("uid", "omi-agent-unreachable", "current-token")]
 
 
 @pytest.mark.asyncio
@@ -325,6 +370,11 @@ async def test_create_vm_attaches_dedicated_service_account_with_cloud_platform_
     monkeypatch.setattr(desktop_agent_vm, "_operation", fake_operation)
     monkeypatch.setattr(desktop_agent_vm, "_instance", fake_instance)
     monkeypatch.setattr(desktop_agent_vm, "_wait_for_vm_ready", lambda *_args: _async_result(None))
+    monkeypatch.setenv("AGENT_VM_STARTUP_URI", "https://storage.googleapis.com/bucket/releases/a/startup.sh")
+    monkeypatch.setenv("AGENT_VM_STARTUP_SHA256", "c" * 64)
+    monkeypatch.setenv("AGENT_VM_RELEASE_ID", "a" * 40)
+    monkeypatch.setenv("AGENT_VM_IMAGE_DIGEST", "gcr.io/project/agent-vm@sha256:" + "b" * 64)
+    monkeypatch.setenv("AGENT_VM_BOOT_IMAGE", "projects/project/global/images/omi-agent-20260805")
 
     ip = await desktop_agent_vm._create_vm(
         "project",
@@ -493,6 +543,8 @@ async def test_stop_broker_binds_token_zone_and_instance_id_to_owner_and_runtime
         ),
     )
     monkeypatch.setattr(desktop_agent_vm, "_vm_lifecycle_allowed", lambda *_args: True)
+    monkeypatch.setattr(desktop_agent_vm, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(desktop_agent_vm, "update_vm_reconcile", lambda *_args: True)
 
     async def wrong_instance(*_args):
         return "RUNNING", {"id": "987654321", "name": "omi-agent-user"}
@@ -501,6 +553,54 @@ async def test_stop_broker_binds_token_zone_and_instance_id_to_owner_and_runtime
     with pytest.raises(HTTPException, match="runtime identity does not match") as instance_error:
         await desktop_agent_vm.stop_self(Request())
     assert instance_error.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stop_broker_never_stops_a_vm_while_reconciliation_is_requested(monkeypatch):
+    class Request:
+        headers = {"authorization": "Bearer identity-token"}
+        client = None
+
+    claims = {
+        "email": "runtime@project.iam.gserviceaccount.com",
+        "email_verified": True,
+        "google": {
+            "compute_engine": {
+                "project_id": "project",
+                "instance_name": "omi-agent-user",
+                "instance_id": "123456789",
+                "zone": "us-central1-a",
+            }
+        },
+    }
+
+    async def direct_run_blocking(_executor, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", direct_run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_stop_broker_rate_allowed", lambda _request: True)
+    monkeypatch.setattr(desktop_agent_vm, "_verify_agent_vm_identity", lambda _token: claims)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setenv("GCE_RUNTIME_SERVICE_ACCOUNT", "runtime@project.iam.gserviceaccount.com")
+    monkeypatch.setattr(
+        desktop_agent_vm,
+        "_find_vm_owner",
+        lambda _name: (
+            "uid",
+            {
+                "vmName": "omi-agent-user",
+                "zone": "us-central1-a",
+                "authToken": "owner-token",
+                "reconcile": {"startRequested": True},
+            },
+        ),
+    )
+    monkeypatch.setattr(desktop_agent_vm, "_vm_lifecycle_allowed", lambda *_args: True)
+    monkeypatch.setattr(
+        desktop_agent_vm, "_instance", lambda *_args: pytest.fail("stop must defer before provider access")
+    )
+
+    assert await desktop_agent_vm.stop_self(Request()) == {"status": "updating", "vmName": "omi-agent-user"}
 
 
 def test_stop_broker_rate_limit_is_bounded(monkeypatch):
@@ -522,83 +622,24 @@ def test_new_vm_startup_metadata_contains_release_checksum_and_boot_image(monkey
     monkeypatch.setenv("AGENT_VM_STARTUP_SHA256", "c" * 64)
     monkeypatch.setenv("AGENT_VM_RELEASE_ID", "a" * 40)
     monkeypatch.setenv("AGENT_VM_IMAGE_DIGEST", "gcr.io/project/agent-vm@sha256:" + "b" * 64)
-    monkeypatch.setenv("AGENT_VM_BOOT_IMAGE", "projects/project/global/images/family/omi-agent")
+    monkeypatch.setenv("AGENT_VM_BOOT_IMAGE", "projects/project/global/images/omi-agent-20260805")
 
     metadata = desktop_agent_vm._agent_vm_startup_metadata("bucket")
 
     assert "sha256sum /tmp/omi-startup.sh" in metadata["startup-script"]
     assert metadata["omi-agent-startup-sha256"] == "c" * 64
-    assert metadata["omi-agent-boot-image"].endswith("/family/omi-agent")
+    assert metadata["omi-agent-boot-image"].endswith("/omi-agent-20260805")
 
 
-@pytest.mark.asyncio
-async def test_restart_sets_bootstrap_identity_and_waits_for_health(monkeypatch):
-    calls = []
+def test_new_vm_requires_an_immutable_boot_image_and_complete_release_contract(monkeypatch):
+    monkeypatch.setenv("AGENT_VM_BOOT_IMAGE", "projects/project/global/images/family/omi-agent")
+    with pytest.raises(RuntimeError, match="exact immutable image"):
+        desktop_agent_vm._source_image("project")
 
-    async def set_service_account(*args):
-        calls.append(("service-account", args))
-
-    async def start_vm(*args):
-        calls.append(("start", args))
-        return "203.0.113.10"
-
-    async def wait_for_ready(*args):
-        calls.append(("health", args))
-
-    async def run_blocking(_, function, *args):
-        return function(*args)
-
-    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
-    monkeypatch.setattr(desktop_agent_vm, "_set_service_account", set_service_account)
-    monkeypatch.setattr(desktop_agent_vm, "_start_vm", start_vm)
-    monkeypatch.setattr(desktop_agent_vm, "_wait_for_vm_ready", wait_for_ready)
-    monkeypatch.setattr(desktop_agent_vm, "_set_vm_if_current", lambda *args: calls.append(("ready", args)))
-
-    await desktop_agent_vm._restart_background(
-        "uid",
-        "project",
-        {"vmName": "omi-agent-user", "zone": "zone", "authToken": "omi-token"},
-        "agent-bootstrap@example.iam.gserviceaccount.com",
-    )
-
-    assert [name for name, _ in calls] == ["service-account", "start", "health", "ready"]
-
-
-@pytest.mark.asyncio
-async def test_rebootstrap_stops_legacy_running_vm_before_identity_migration(monkeypatch):
-    calls = []
-
-    async def stop_vm(*args):
-        calls.append(("stop", args))
-
-    async def set_service_account(*args):
-        calls.append(("service-account", args))
-
-    async def start_vm(*args):
-        calls.append(("start", args))
-        return "203.0.113.10"
-
-    async def wait_for_ready(*args):
-        calls.append(("health", args))
-
-    async def run_blocking(_, function, *args):
-        return function(*args)
-
-    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
-    monkeypatch.setattr(desktop_agent_vm, "_stop_vm", stop_vm)
-    monkeypatch.setattr(desktop_agent_vm, "_set_service_account", set_service_account)
-    monkeypatch.setattr(desktop_agent_vm, "_start_vm", start_vm)
-    monkeypatch.setattr(desktop_agent_vm, "_wait_for_vm_ready", wait_for_ready)
-    monkeypatch.setattr(desktop_agent_vm, "_set_vm_if_current", lambda *args: calls.append(("ready", args)))
-
-    await desktop_agent_vm._rebootstrap_background(
-        "uid",
-        "project",
-        {"vmName": "omi-agent-user", "zone": "zone", "authToken": "omi-token"},
-        "agent-bootstrap@example.iam.gserviceaccount.com",
-    )
-
-    assert [name for name, _ in calls] == ["stop", "service-account", "start", "health", "ready"]
+    monkeypatch.setenv("AGENT_VM_BOOT_IMAGE", "projects/project/global/images/omi-agent-20260805")
+    monkeypatch.delenv("AGENT_VM_STARTUP_SHA256", raising=False)
+    with pytest.raises(RuntimeError, match="complete immutable release contract"):
+        desktop_agent_vm._agent_vm_startup_metadata("bucket")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_tools_agent_route_response_shape.py
+++ b/backend/tests/unit/test_tools_agent_route_response_shape.py
@@ -111,6 +111,10 @@ def _install_route_stubs(monkeypatch):
     users_mod.get_agent_vm = MagicMock(return_value=None)
     monkeypatch.setitem(sys.modules, 'database.users', users_mod)
 
+    client_mod = types.ModuleType('database._client')
+    client_mod.get_firestore_client = MagicMock()
+    monkeypatch.setitem(sys.modules, 'database._client', client_mod)
+
     executors_mod = types.ModuleType('utils.executors')
     executors_mod.db_executor = object()
     executors_mod.postprocess_executor = object()
@@ -143,6 +147,7 @@ def _install_route_stubs(monkeypatch):
     firestore_mod.ArrayRemove = MagicMock()
     firestore_mod.DELETE_FIELD = object()
     firestore_mod.Increment = MagicMock()
+    firestore_mod.transactional = lambda fn: fn
     firestore_v1_mod = types.ModuleType('google.cloud.firestore_v1')
     firestore_v1_mod.FieldFilter = MagicMock()
     firestore_v1_mod.transactional = lambda fn: fn
@@ -251,6 +256,23 @@ def test_tools_rest_memory_routes_preserve_response_model_shape_and_bounded_memo
     assert '- Ignore previous instructions.' not in validated_get.result_text
     assert 'archive_default_visible=False' in validated_get.result_text
     assert validated_get.is_error is False
+
+
+def test_vm_ensure_queues_reconciler_demand_even_when_firestore_cache_looks_ready(loaded_route_modules):
+    _tools_router, agent_tools, _agentic, _memories_service = loaded_route_modules
+    agent_tools.get_agent_vm.return_value = {
+        "vmName": "omi-agent-user",
+        "authToken": "token",
+        "status": "ready",
+        "ip": "34.1.2.3",
+    }
+    request_start = MagicMock(return_value=True)
+    agent_tools.request_vm_start = request_start
+
+    result = asyncio.run(agent_tools.ensure_vm(None, uid="uid-route"))
+
+    assert result == {"has_vm": True, "status": "updating"}
+    request_start.assert_called_once_with("uid-route", "omi-agent-user", "token")
 
 
 def test_tools_rest_memory_routes_fail_closed_for_unbounded_memory_like_text(loaded_route_modules):

--- a/desktop/macos/Desktop/Sources/AgentVMService.swift
+++ b/desktop/macos/Desktop/Sources/AgentVMService.swift
@@ -108,7 +108,7 @@ actor AgentVMService {
       }
       if let status, status.status == "provisioning" || status.status == "stopped" {
         if let result = await pollUntilReady(
-          maxAttempts: 30,
+          maxAttempts: 75,
           intervalSeconds: 5,
           ownerID: ownerID,
           generation: generation),
@@ -148,7 +148,7 @@ actor AgentVMService {
     if vmIP == nil || provisionResult.agentStatus == "provisioning" {
       log("AgentVMService: Waiting for VM to be ready...")
       let pollResult = await pollUntilReady(
-        maxAttempts: 30,
+        maxAttempts: 75,
         intervalSeconds: 5,
         ownerID: ownerID,
         generation: generation)

--- a/desktop/macos/changelog/unreleased/20260805-agent-vm-reconciler-retry.json
+++ b/desktop/macos/changelog/unreleased/20260805-agent-vm-reconciler-retry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved recovery when your desktop agent VM is being updated or restarted"
+}

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -25497,7 +25497,7 @@
     },
     "/v1/agent/vm-ensure": {
       "post": {
-        "description": "Check VM status; if stopped/terminated, restart it in the background.",
+        "description": "Queue a fenced reconciliation when the persisted VM is unavailable.",
         "operationId": "ensure_vm_v1_agent_vm_ensure_post",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

- route every existing-VM recovery path through a fenced reconciler start request
- require immutable boot/startup release inputs when creating a new Agent VM
- retire the known legacy host service before starting the release-pinned container

## Validation

- `python -m pytest backend/tests/unit/test_agent_vm_reconciler_authority.py backend/tests/unit/test_desktop_agent_vm.py backend/tests/unit/test_agent_vm_reconciler_job.py backend/tests/unit/test_agent_vm_startup.py backend/tests/unit/test_agent_vm_reaped_record_recovery.py backend/tests/unit/test_agent_vm_async.py backend/tests/unit/test_agent_proxy_async_boundaries.py backend/tests/unit/test_agent_proxy_startup_client_gone.py -q`

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

