### PR TITLE
Fix canonical atlas owner anchor and catalog cloud

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -6,7 +6,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4463,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3630,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4416,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1646,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1624,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 6633,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1616
   },

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -972,26 +972,28 @@ enum MemoryAtlasLayoutEngine {
 
     let normalizedUserName = userName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
-    // Entities that stand in for the account holder rather than naming them.
     let selfSynonyms: Set<String> = ["user", "me", "myself", "i", "the user"]
+    func isSelfNode(_ node: KnowledgeGraphNode) -> Bool {
+      node.id == "user" || selfSynonyms.contains(node.label.lowercased())
+        || node.aliases.contains { selfSynonyms.contains($0.lowercased()) }
+    }
 
+    // Never select the highest-degree person over the account holder.
     let rawAnchor =
       nodes.first {
-        $0.nodeType == .person && normalizedUserName != nil && $0.label.lowercased() == normalizedUserName
-      } ?? nodes.filter { $0.nodeType == .person }.max {
+        normalizedUserName != nil && $0.label.lowercased() == normalizedUserName
+      } ?? nodes.first(where: { $0.id == "user" })
+      ?? nodes.first(where: isSelfNode)
+      ?? nodes.filter { $0.nodeType == .person }.max {
         (degree[$0.id] ?? 0) < (degree[$1.id] ?? 0)
       }
       ?? nodes.max {
         (degree[$0.id] ?? 0) < (degree[$1.id] ?? 0)
       }
 
-    // The center of your own map should say your name. The extractor writes a
-    // generic "The User" whenever no memory happens to name you, and collapsing
-    // the synonyms onto that node still left the anchor labelled "The User" —
-    // the one dot the user can identify on sight was the one not identified.
-    // The generic label survives as an alias so search still finds it.
+    // Keep a generic account-holder label searchable, but show the owner name.
     let anchor = rawAnchor.map { node -> KnowledgeGraphNode in
-      guard let userName, !userName.isEmpty, selfSynonyms.contains(node.label.lowercased())
+      guard let userName, !userName.isEmpty, isSelfNode(node)
       else { return node }
       return KnowledgeGraphNode(
         id: node.id,
@@ -1004,11 +1006,7 @@ enum MemoryAtlasLayoutEngine {
       )
     }
 
-    // Collapse every entity that stands in for the account holder — a generic
-    // "User"/"Me" node, or a second person node sharing the user's name — into
-    // the single anchor. Two ego nodes ("User" floating apart from "David") read
-    // as a data bug; the atlas should have exactly one unmistakable "you" at the
-    // center. Their relationships are rerouted onto the anchor below.
+    // Merge generic account-holder aliases into one identifiable center.
     let collapsedIDs: Set<String> = {
       guard let anchor else { return [] }
       return Set(
@@ -1018,7 +1016,7 @@ enum MemoryAtlasLayoutEngine {
           if let normalizedUserName, !normalizedUserName.isEmpty, label == normalizedUserName {
             return true
           }
-          return node.nodeType == .person && selfSynonyms.contains(label)
+          return isSelfNode(node)
         }.map(\.id)
       )
     }()
@@ -2214,9 +2212,11 @@ private struct CanonicalMemoryAtlasSurface: View {
       atlasSnapshot = projection.snapshot
     } else {
       let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+      let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+      let ownerName = givenName.isEmpty ? displayName : givenName
       atlasSnapshot = MemoryAtlasSnapshotCache.shared.snapshot(
         for: graph,
-        userName: givenName.isEmpty ? nil : givenName
+        userName: ownerName.isEmpty ? nil : ownerName
       )
     }
     snapshot = atlasSnapshot

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift
@@ -1427,46 +1427,24 @@ enum MemoryAtlasForceLayout {
   /// so scattering them through the middle would have the map assert structure
   /// that is not there. A faint outer halo says what is true: present, not
   /// connected to anything yet.
-  /// Each group takes one place on the rim and its members cluster there.
-  ///
-  /// Stringing every entity along the perimeter one slot at a time produced
-  /// visibly even rows and columns of dots down the edges of the canvas, which
-  /// read as a rendering artefact rather than as content. Placing a
-  /// three-entity island as one small clump says what is true — these three
-  /// know each other and nothing else — and looks deliberate.
+  /// Use a circular peripheral field: a rectangular rim is a rendering artefact,
+  /// while a hollow ring separates loose memories too far from the real graph.
   static func haloPositions(groups: [[String]], area: CGRect) -> [String: CGPoint] {
     guard !groups.isEmpty else { return [:] }
 
     var positions: [String: CGPoint] = [:]
-    let perRing = 44
+    let baseRadius = Double(min(area.width, area.height)) * 0.5
+    let goldenAngle = Double.pi * (3 - sqrt(5))
     for (offset, group) in groups.enumerated() {
-      let ring = offset / perRing
-      let indexInRing = offset % perRing
-      let occupancy = min(groups.count - ring * perRing, perRing)
-      // Deterministic per-slot jitter, so the rim reads as scattered rather
-      // than as a dotted rule drawn around the map.
-      let wobble = (stableFraction("halo-\(group.first ?? "")") - 0.5) * 0.9
-      let angle = 2 * Double.pi * (Double(indexInRing) + 0.5 + wobble) / Double(max(occupancy, 1))
-
-      // Seated just outside where the structure actually reaches in *this*
-      // direction, rather than on a fixed rim around everything.
-      //
-      // The map is not a disc and its shape changes with the account. A rim at
-      // a constant multiple of the drawing area strands an unconnected entity
-      // halfway across empty canvas whenever the structure happens to stop
-      // early on that side — which is most sides, since the fit only guarantees
-      // the *furthest* entities reach the edge. Following the silhouette keeps
-      // the same claim (outside everything, connected to nothing) at a distance
-      // that reads as deliberate instead of as debris.
-      //
-      // Depth still varies per seat: the band has to look scattered, or a run
-      // of singletons draws an evenly spaced arc that reads as a rendering
-      // artefact rather than as content.
-      let depth = 0.98 + 0.16 * stableFraction("depth-\(group.first ?? "")")
-      let spread = (1.0 + haloClearance + 0.03 * Double(ring)) * depth
-      let halfWidth = Double(area.width) / 2 * spread
-      let halfHeight = Double(area.height) / 2 * spread
-      let reach = 1 / max(abs(cos(angle)) / halfWidth, abs(sin(angle)) / halfHeight)
+      // Golden-angle seats avoid ruled rows. A uniform-area radial sample fills
+      // the peripheral field instead of turning the catalog into a hollow ring.
+      let wobble = (stableFraction("halo-\(group.first ?? "")") - 0.5) * 0.11
+      let angle = Double(offset) * goldenAngle + wobble
+      let innerRadius = baseRadius * 0.40
+      let outerRadius = baseRadius * (1.0 + haloClearance + 0.16)
+      let radialFraction = stableFraction("depth-\(group.first ?? "")")
+      let reach = sqrt(
+        innerRadius * innerRadius + (outerRadius * outerRadius - innerRadius * innerRadius) * radialFraction)
       let seat = CGPoint(
         x: area.midX + CGFloat(cos(angle) * reach),
         y: area.midY + CGFloat(sin(angle) * reach))

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -328,8 +328,10 @@ class MemoryGraphViewModel: ObservableObject {
         return
       }
       let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+      let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+      let ownerName = givenName.isEmpty ? displayName : givenName
       let projection = await Task.detached(priority: .userInitiated) {
-        MemoryAtlasProjection(graph: response.atlasResponse, userName: givenName.isEmpty ? nil : givenName)
+        MemoryAtlasProjection(graph: response.atlasResponse, userName: ownerName.isEmpty ? nil : ownerName)
       }.value
       guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
         return
@@ -384,8 +386,10 @@ class MemoryGraphViewModel: ObservableObject {
 
         if !response.atlasNodes.isEmpty || !(response.catalogNodes?.isEmpty ?? true) {
           let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+          let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+          let ownerName = givenName.isEmpty ? displayName : givenName
           let projection = await Task.detached(priority: .userInitiated) {
-            MemoryAtlasProjection(graph: response.atlasResponse, userName: givenName.isEmpty ? nil : givenName)
+            MemoryAtlasProjection(graph: response.atlasResponse, userName: ownerName.isEmpty ? nil : ownerName)
           }.value
           guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
             return false

--- a/desktop/macos/Desktop/Tests/MemoryAtlasForceLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasForceLayoutTests.swift
@@ -538,7 +538,7 @@ final class MemoryAtlasForceLayoutTests: XCTestCase {
     XCTAssertEqual(result.positions["me"]?.y ?? 0, area.midY, accuracy: 1e-9)
   }
 
-  func testLeavesSitBesideTheirParentAndIsolatesSitOutsideTheMap() throws {
+  func testLeavesSitBesideTheirParentAndIsolatesLeaveTheAnchorLegible() throws {
     var links: [Link] = [Link(a: "hub", b: "spoke", weight: 1)]
     for index in 1...6 { links.append(Link(a: "hub", b: "leaf\(index)", weight: 1)) }
     links.append(Link(a: "spoke", b: "other", weight: 1))
@@ -556,27 +556,21 @@ final class MemoryAtlasForceLayoutTests: XCTestCase {
     }
 
     let lonely = try XCTUnwrap(result.positions["lonely"])
-    XCTAssertFalse(
-      area.insetBy(dx: area.width * 0.1, dy: area.height * 0.1).contains(lonely),
-      "An unconnected entity must not sit in the middle implying structure")
+    XCTAssertGreaterThan(
+      distance(lonely, CGPoint(x: area.midX, y: area.midY)),
+      Double(min(area.width, area.height)) * 0.1,
+      "An unconnected entity must not obscure the map's anchor")
   }
 
-  /// Unconnected entities ring the map from just outside it, not from the far
-  /// edge of the canvas.
-  ///
-  /// They have to be outside: everything the relaxation placed is fitted within
-  /// the drawing area, so anything closer would sit among entities whose
-  /// positions mean something. But the band used to start a further 7% out and
-  /// step another 5% per lap, which put a lone entity most of a canvas-width
-  /// from anything it could be compared against, and the map looked like it had
-  /// shed debris rather than like it was telling you something.
-  func testUnconnectedEntitiesRingTheMapFromJustOutsideIt() throws {
+  /// Unconnected entities fill a circular peripheral field, not a rectangular
+  /// border or hollow ring around the semantic core.
+  func testUnconnectedEntitiesFillCircularPeripheralField() throws {
     var links: [Link] = []
     let spine = (0..<14).map { "spine\($0)" }
     for index in 0..<(spine.count - 1) {
       links.append(Link(a: spine[index], b: spine[index + 1], weight: 4))
     }
-    let lonely = (0..<30).map { "lonely\($0)" }
+    let lonely = (0..<600).map { "lonely\($0)" }
 
     let result = Layout.layout(
       nodeIDs: spine + lonely, links: links, anchorID: nil, typeTargets: [:], area: area)
@@ -584,16 +578,13 @@ final class MemoryAtlasForceLayoutTests: XCTestCase {
     let placed = lonely.compactMap { result.positions[$0] }
     XCTAssertEqual(placed.count, lonely.count)
 
-    for point in placed {
-      XCTAssertFalse(
-        area.contains(point), "An unconnected entity sits outside the structure's own area")
-      // Outside, but on the near side of outside. The bound is the area grown
-      // by rather more than the halo's own clearance, so ordinary tuning does
-      // not trip it and a return to a far-flung rim does.
-      let outer = area.insetBy(dx: -area.width * 0.16, dy: -area.height * 0.16)
-      XCTAssertTrue(
-        outer.contains(point), "and close enough to it to read as part of the same map")
-    }
+    let radii = placed.map { hypot($0.x - area.midX, $0.y - area.midY) }
+    let inner = min(area.width, area.height) * 0.5
+    XCTAssertGreaterThan(radii.min() ?? 0, inner * 0.35, "The catalog must leave a recognizable semantic core")
+    XCTAssertLessThan(radii.max() ?? 1, inner * 1.3, "Catalog volume must not inflate the viewport")
+    XCTAssertGreaterThan(
+      (radii.max() ?? 0) - (radii.min() ?? 0), inner * 0.25,
+      "Loose memories should fill the peripheral field, not form a hollow ring")
   }
 
   func testEveryNodeLandsOnTheCanvas() throws {

--- a/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
@@ -20,6 +20,29 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     XCTAssertEqual(Double(anchor.y), 0.5, accuracy: 1e-9)
   }
 
+  func testCanonicalSelfNodeWinsOverAWellConnectedPersonAndAbsorbsSelfAliases() throws {
+    let graph = KnowledgeGraphResponse(
+      nodes: [
+        KnowledgeGraphNode(id: "user", label: "The User", nodeType: .concept),
+        KnowledgeGraphNode(id: "self-alias", label: "the user", nodeType: .person),
+        KnowledgeGraphNode(id: "chi", label: "Chi", nodeType: .person),
+        KnowledgeGraphNode(id: "project", label: "Omi", nodeType: .thing),
+      ],
+      edges: [
+        KnowledgeGraphEdge(id: "self-project", sourceId: "user", targetId: "project", label: "uses"),
+        KnowledgeGraphEdge(id: "alias-project", sourceId: "self-alias", targetId: "project", label: "uses"),
+        KnowledgeGraphEdge(id: "chi-project", sourceId: "chi", targetId: "project", label: "works_on"),
+        KnowledgeGraphEdge(id: "chi-1", sourceId: "chi", targetId: "project", label: "mentions"),
+      ])
+
+    let snapshot = MemoryAtlasLayoutEngine.makeSnapshot(graph: graph, userName: "David")
+
+    XCTAssertEqual(snapshot.anchorNodeID, "user")
+    XCTAssertEqual(snapshot.nodeByID["user"]?.node.label, "David")
+    XCTAssertNil(snapshot.nodeByID["self-alias"], "There must be one self node, not a separate 'the user' group")
+    XCTAssertEqual(snapshot.nodeByID["user"]?.normalizedPosition, MemoryAtlasCluster.starCenter)
+  }
+
   func testCatalogNodesEnterAtlasAsNeutralUnconnectedMarks() throws {
     let assertionNodes = [
       KnowledgeGraphNode(id: "david", label: "David", nodeType: .person),
@@ -425,7 +448,7 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     XCTAssertEqual(leafPositions.count, 5)
   }
 
-  func testDegreeZeroNodeIsNotPlacedInATypeSpiral() throws {
+  func testDegreeZeroNodeCanFillThePeripheralFieldWithoutObscuringTheOwner() throws {
     let graph = KnowledgeGraphResponse(
       nodes: [
         KnowledgeGraphNode(id: "david", label: "David", nodeType: .person),
@@ -441,12 +464,13 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     let orphan = try XCTUnwrap(snapshot.nodeByID["orphan"])
 
     XCTAssertEqual(orphan.degree, 0)
-    // An entity with no relationships was positioned by nothing, so it belongs
-    // outside the region the relaxed map occupies rather than among entities
-    // whose positions do mean something.
-    XCTAssertFalse(
-      MemoryAtlasLayoutEngine.layoutArea.contains(orphan.normalizedPosition),
-      "An unconnected entity must not sit inside the structure")
+    let david = try XCTUnwrap(snapshot.nodeByID["david"])
+    XCTAssertGreaterThan(
+      hypot(
+        orphan.normalizedPosition.x - david.normalizedPosition.x,
+        orphan.normalizedPosition.y - david.normalizedPosition.y),
+      0.05,
+      "A neutral mark must not obscure the account holder")
     // Still inside the existing clamp bounds.
     XCTAssertGreaterThanOrEqual(orphan.normalizedPosition.x, 0.04)
     XCTAssertLessThanOrEqual(orphan.normalizedPosition.x, 0.96)

--- a/desktop/macos/changelog/unreleased/20260805-canonical-atlas-owner-and-cloud.json
+++ b/desktop/macos/changelog/unreleased/20260805-canonical-atlas-owner-and-cloud.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Memory Atlas so your identity stays at the center and unconnected memories form a readable circular cloud"
+}


### PR DESCRIPTION
## Summary

- Select the canonical account owner (user, then authenticated display identity) as the atlas center instead of inferring the highest-degree person.
- Collapse generic self aliases across all entity types, so there is one identifiable David node.
- Render unconnected catalog memories as a deterministic circular field: dense enough to browse, without the rectangular border or fabricated relationships.

## Invariants

- INV-MEM-1

## Verification

- xcrun swift test --package-path desktop/macos/Desktop --filter MemoryAtlasLayoutTests|MemoryAtlasForceLayoutTests — 87 passed.
- Signed local dev bundle /Applications/omi-canonical-atlas-verify.app against the development API: signed-in account, 1,264 visible entities, 1,093 catalog memories, 172 semantic nodes, and 135 edges.
- In-process visual capture confirms David is centered, no separate generic user node is shown, and catalog marks fill a circular neutral field.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

