### PR TITLE
fix(desktop): suppress previous-owner tool write results after an owner transition

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1238,7 +1238,7 @@ class ChatToolExecutor {
     }
     let changes: Int
     do {
-      changes = try await authorization.withCommitLease {
+      changes = try await authorization.withCommitLeaseSuppressingSupersededResult {
         try await dbQueue.write { db -> Int in
           try authorization.require()
           try db.execute(sql: query, arguments: StatementArguments(parameters))

--- a/desktop/macos/Desktop/Sources/Services/LocalMutationAuthorization.swift
+++ b/desktop/macos/Desktop/Sources/Services/LocalMutationAuthorization.swift
@@ -19,6 +19,7 @@ actor EffectiveOwnerTransitionFence {
   static let shared = EffectiveOwnerTransitionFence()
 
   private var activeMutationLeaseIDs: Set<UUID> = []
+  private var leaseIDsSupersededByTransition: Set<UUID> = []
   private var transitionActive = false
   private var transitionWaiters: [CheckedContinuation<Void, Never>] = []
   private var mutationWaiters: [CheckedContinuation<Void, Never>] = []
@@ -43,9 +44,15 @@ actor EffectiveOwnerTransitionFence {
     return lease
   }
 
-  func releaseMutationLease(_ lease: MutationLease) {
-    guard activeMutationLeaseIDs.remove(lease.id) != nil else { return }
+  /// Returns whether an effective-owner transition queued behind this lease
+  /// while it was held. Such a commit is durable for the previous owner, but the
+  /// next owner is already decided, so its result must not publish into them.
+  @discardableResult
+  func releaseMutationLease(_ lease: MutationLease) -> Bool {
+    guard activeMutationLeaseIDs.remove(lease.id) != nil else { return false }
+    let superseded = leaseIDsSupersededByTransition.remove(lease.id) != nil
     admitNextTransitionIfPossible()
+    return superseded
   }
 
   /// Perform an effective-owner mutation and deliver its cache-invalidation
@@ -140,6 +147,9 @@ actor EffectiveOwnerTransitionFence {
       return
     }
 
+    // The next owner is decided from here on. Leases that are already mid-commit
+    // may still finish, but they belong to the previous owner.
+    leaseIDsSupersededByTransition.formUnion(activeMutationLeaseIDs)
     await withCheckedContinuation { continuation in
       transitionWaiters.append(continuation)
       let observers = pendingTransitionObservers
@@ -193,12 +203,37 @@ struct LocalMutationAuthorization: Sendable {
   func withCommitLease<T: Sendable>(
     _ operation: @escaping @Sendable () async throws -> T
   ) async throws -> T {
+    try await withCommitLeaseReportingOwnerTransition(operation).value
+  }
+
+  /// `withCommitLease` for callers that publish the operation's result back into
+  /// the session. The commit itself stays durable for the owner that made it, but
+  /// if an effective-owner transition queued behind the lease, the next owner is
+  /// already decided even though the current owner may still read as the previous
+  /// one — releasing the lease only admits the transition, it does not wait for it
+  /// to publish. Such a result must not reach the incoming owner, so it surfaces
+  /// as `LocalMutationAuthorizationError.revoked` for the caller's existing
+  /// owner-changed path.
+  func withCommitLeaseSuppressingSupersededResult<T: Sendable>(
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    let (value, ownerTransitionQueued) = try await withCommitLeaseReportingOwnerTransition(
+      operation)
+    guard !ownerTransitionQueued else { throw LocalMutationAuthorizationError.revoked }
+    return value
+  }
+
+  /// `withCommitLease` plus the fence's verdict on whether an effective-owner
+  /// transition queued behind the lease while it was held.
+  func withCommitLeaseReportingOwnerTransition<T: Sendable>(
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> (value: T, ownerTransitionQueued: Bool) {
     let fence = EffectiveOwnerTransitionFence.shared
     let lease = try await fence.acquireMutationLease(validating: validator)
     do {
       let result = try await operation()
-      await fence.releaseMutationLease(lease)
-      return result
+      let ownerTransitionQueued = await fence.releaseMutationLease(lease)
+      return (result, ownerTransitionQueued)
     } catch {
       await fence.releaseMutationLease(lease)
       throw error

--- a/desktop/macos/Desktop/Tests/LocalMutationAuthorizationTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalMutationAuthorizationTests.swift
@@ -288,6 +288,40 @@ final class LocalMutationAuthorizationTests: XCTestCase {
       ])
   }
 
+  func testLeaseHeldAcrossQueuedTransitionIsReportedSuperseded() async throws {
+    let fence = EffectiveOwnerTransitionFence()
+    let probe = EffectiveOwnerTransitionProbe()
+
+    let ownerALease = try await fence.acquireMutationLease(validating: { true })
+    let transition = Task {
+      try await fence.performEffectiveOwnerTransition(
+        currentOwner: { probe.owner() },
+        plannedNextOwner: { _ in "owner-b" },
+        quiescePreviousOwner: { _, _ in },
+        transition: { probe.setOwner("owner-b") },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {})
+    }
+    await fence.waitUntilTransitionIsPending()
+
+    // The owner is still A here: the transition is queued behind this lease and
+    // has not published B yet. The lease must still learn that it was superseded.
+    XCTAssertEqual(probe.owner(), "owner-a")
+    let ownerASuperseded = await fence.releaseMutationLease(ownerALease)
+    XCTAssertTrue(
+      ownerASuperseded,
+      "a lease held across a queued owner transition must report as superseded")
+
+    try await transition.value
+    XCTAssertEqual(probe.owner(), "owner-b")
+
+    let ownerBLease = try await fence.acquireMutationLease(validating: { true })
+    let ownerBSuperseded = await fence.releaseMutationLease(ownerBLease)
+    XCTAssertFalse(
+      ownerBSuperseded,
+      "a lease acquired after the transition completed must not report as superseded")
+  }
+
   private func assertRevoked(
     _ operation: () async throws -> Void,
     file: StaticString = #filePath,

--- a/desktop/macos/changelog/unreleased/20260805-owner-switch-tool-result-boundary.json
+++ b/desktop/macos/changelog/unreleased/20260805-owner-switch-tool-result-boundary.json
@@ -1,0 +1,3 @@
+{
+  "change": "Switching accounts while a chat tool is writing to your local data no longer reports that write's result into the new account's chat."
+}

--- a/docs/product/invariants/auth-session.md
+++ b/docs/product/invariants/auth-session.md
@@ -15,7 +15,11 @@ leases remain held through physical SQLite commit/rollback; the transition
 closes the prior `RewindDatabase` pool, configures the next owner's lazy-open
 target, and purges every cached pool/directory/encoder before it publishes one
 content-free MainActor invalidation or admits new-owner work. A suspended
-initializer may not publish a pool after its owner/generation is stale.
+initializer may not publish a pool after its owner/generation is stale. A lease
+that a queued transition superseded may still commit for the previous owner, but
+its result may never publish into a session: the fence reports that verdict, and
+callers must not infer it from whichever owner happens to be visible after the
+lease is released.
 
 Owner replacement is also a hard voice boundary. Before persisted defaults
 mutate, the transition exposes no authorized owner, terminalizes the canonical


### PR DESCRIPTION
## Bug

An authorized chat `execute_sql` write can publish the **previous** account's result into the **next** account's session when the user switches accounts mid-write.

`executeWriteQuery` holds a `LocalMutationAuthorization` commit lease across the physical SQLite commit. If an effective-owner transition arrives while that lease is held, it parks in `EffectiveOwnerTransitionFence.transitionWaiters`. Releasing the lease only *admits* the queued transition — it does not wait for it to publish the new owner. The post-commit `guard ownerIsCurrent(expectedOwnerID)` therefore still sees owner A in that window and returns `OK: N row(s) affected`, which renders in owner B's chat.

This is also the source of the `EffectiveOwnerDatabaseBoundaryTests` flake on `main` — run 31050864483 (commit f148dc925d) failed with:

```
XCTAssertEqual failed: ("OK: 1 row(s) affected") is not equal to
("{"ok":false,"error":{"code":"authorized_execution_owner_changed", ...}}")
- A may commit before the queued transition, but its result must not publish into B
```

## Root cause

The publish decision was derived from *observed current owner*, which is a lagging projection of the transition, instead of from the fence's own knowledge that the next owner is already decided.

## Fix

- `EffectiveOwnerTransitionFence` records the mutation leases that are active when a transition parks (`leaseIDsSupersededByTransition`); `releaseMutationLease` returns that verdict.
- `LocalMutationAuthorization.withCommitLeaseReportingOwnerTransition` surfaces the verdict to callers that publish a result back into the session. `withCommitLease` delegates to it and is behaviorally unchanged, so no other call site changes.
- `ChatToolExecutor.executeWriteQuery` returns `authorizedOwnerChangedResult()` whenever its lease was superseded — no longer dependent on whether the transition has published the next owner yet. The commit itself remains durable for the previous owner, which is what the boundary test asserts.

## Verification

Focused Swift suites via `desktop/macos/scripts/dev-feedback.py --once swift`:

- new `LocalMutationAuthorizationTests/testLeaseHeldAcrossQueuedTransitionIsReportedSuperseded` — PASS (deterministically asserts the superseded verdict while the owner is *still* A)
- `EffectiveOwnerDatabaseBoundaryTests` — PASS x4 (the previously flaky suite)
- `LocalMutationAuthorizationTests`, `ChatToolExecutorSQLTests` (8 tests), `AuthSessionAttemptFenceTests`, `TasksStoreOwnerBoundaryTests`, `AuthorizedToolOwnerBoundAuthTests` — all PASS

Exercised through production code paths (real `DatabasePool`, real commit-blocking transaction observer, real fence), not compile-only. The wall-clock account-switch race is not hand-reproducible; the boundary test drives the identical code path through its deterministic concurrency seam.

## Product invariants

- **INV-AUTH-1** — this is the owner-transition/mutation-lease boundary the invariant already governs. The fix makes the existing rule enforceable rather than changing it, and `docs/product/invariants/auth-session.md` now states it explicitly: a superseded lease may commit for the previous owner, but its result may never publish into a session, and callers must not infer that from whichever owner is visible after release. Guard: the new `testLeaseHeldAcrossQueuedTransitionIsReportedSuperseded` plus the now-deterministic `EffectiveOwnerDatabaseBoundaryTests`.
- **INV-CHAT-1** — matched via `ChatToolExecutor.swift`. No transcript ownership or storage change; only the authorized-tool result that may be published into the session.

Failure-Class: FC-superseded-connection-mutates-live-session

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

