### PR TITLE
fix(app): preserve live transcript follow intent

### DIFF
--- a/app/lib/pages/conversation_capturing/page.dart
+++ b/app/lib/pages/conversation_capturing/page.dart
@@ -33,8 +33,7 @@ class ConversationCapturingPage extends StatefulWidget {
 }
 
 class _ConversationCapturingPageState extends State<ConversationCapturingPage> with TickerProviderStateMixin {
-  static String? _preservedTranscriptSessionId;
-  static TranscriptScrollState _preservedTranscriptScrollState = TranscriptScrollState();
+  final TranscriptScrollStateStore _transcriptScrollStateStore = TranscriptScrollStateStore();
 
   final scaffoldKey = GlobalKey<ScaffoldState>();
   TabController? _controller;
@@ -53,11 +52,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   }
 
   TranscriptScrollState _scrollStateFor(String sessionId) {
-    if (_preservedTranscriptSessionId != sessionId) {
-      _preservedTranscriptSessionId = sessionId;
-      _preservedTranscriptScrollState = TranscriptScrollState();
-    }
-    return _preservedTranscriptScrollState;
+    return _transcriptScrollStateStore.forSession(sessionId);
   }
 
   Future<void> _toggleMute(CaptureProvider provider) async {

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -112,6 +112,24 @@ class TranscriptScrollState {
   }
 }
 
+/// Owns live-transcript scroll intent for one mounted page.
+///
+/// A new page gets a fresh store and therefore starts at the live edge. The
+/// same page can still reuse its position when its transcript switches between
+/// the text-only and photo timeline layouts.
+class TranscriptScrollStateStore {
+  String? _sessionId;
+  TranscriptScrollState _state = TranscriptScrollState();
+
+  TranscriptScrollState forSession(String sessionId) {
+    if (_sessionId != sessionId) {
+      _sessionId = sessionId;
+      _state = TranscriptScrollState();
+    }
+    return _state;
+  }
+}
+
 class _TranscriptWidgetState extends State<TranscriptWidget> {
   // Cache for person data to avoid repeated lookups
   final Map<String?, Person?> _personCache = {};
@@ -238,7 +256,7 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
         widget.segments.length != oldWidget.segments.length ||
         widget.leadingItems.length != oldWidget.leadingItems.length ||
         widget.layoutIdentity != oldWidget.layoutIdentity;
-    final shouldFollow = widget.scrollState?.isAtBottom ?? !_userHasScrolled;
+    final shouldFollow = !_userHasScrolled;
 
     if (contentChanged && !shouldFollow) _pendingAnchorRestore = true;
     _syncSegmentKeys();
@@ -289,6 +307,15 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     final currentScroll = _scrollController.offset;
     final distanceFromBottom = _scrollController.position.maxScrollExtent - currentScroll;
     final isAtBottom = distanceFromBottom <= 24;
+    if (!_isAutoScrolling && !_isRestoringAnchor && !_pendingAnchorRestore) {
+      // Record the reader's intent on the first pixel of a drag. A live update
+      // can arrive before Flutter emits the corresponding idle notification.
+      final wasUserHasScrolled = _userHasScrolled;
+      _userHasScrolled = !isAtBottom;
+      if (isAtBottom && wasUserHasScrolled) {
+        widget.scrollState?.update(offset: currentScroll, isAtBottom: true, layoutIdentity: widget.layoutIdentity);
+      }
+    }
     _setIsAtBottom(isAtBottom);
   }
 
@@ -445,8 +472,9 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     }
   }
 
-  Future<void> _scrollToBottomGently({bool animated = true}) {
+  Future<void> _scrollToBottomGently({bool animated = true, bool force = false}) {
     if (!_scrollController.hasClients) return Future.value();
+    if (!force && widget.followLatest && _userHasScrolled) return Future.value();
     _followAgain = true;
     final activeFollow = _activeFollow;
     if (activeFollow != null) return activeFollow;
@@ -476,9 +504,29 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     return false;
   }
 
+  bool _onScrollUpdate(ScrollUpdateNotification notification) {
+    if (notification.depth != 0 || notification.dragDetails == null) return false;
+    if (_isRestoringAnchor || _pendingAnchorRestore) return false;
+
+    _isUserScrolling = true;
+    if (_isAutoScrolling) {
+      _userInterruptedAutoScroll = true;
+      _followAgain = false;
+      _isAutoScrolling = false;
+    }
+    _captureCurrentPosition();
+    return false;
+  }
+
+  bool _onScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollUpdateNotification) return _onScrollUpdate(notification);
+    if (notification is UserScrollNotification) return _onUserScroll(notification);
+    return false;
+  }
+
   bool _onScrollMetrics(ScrollMetricsNotification notification) {
     if (!widget.followLatest || _isAutoScrolling) return false;
-    final shouldFollow = widget.scrollState?.isAtBottom ?? !_userHasScrolled;
+    final shouldFollow = !_userHasScrolled;
     if (shouldFollow && notification.metrics.extentAfter > 0.5) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _scrollToBottomGently(animated: false);
@@ -657,8 +705,8 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     final searchBarHeight = widget.searchQuery.isNotEmpty ? 100.0 : 0.0;
     final transcriptList = NotificationListener<ScrollMetricsNotification>(
       onNotification: _onScrollMetrics,
-      child: NotificationListener<UserScrollNotification>(
-        onNotification: _onUserScroll,
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _onScrollNotification,
         child: GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: () {
@@ -738,7 +786,7 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
                       tooltip: context.l10n.jumpToLatestMessage,
                       backgroundColor: const Color(0xFF35343B),
                       foregroundColor: Colors.white,
-                      onPressed: () => _scrollToBottomGently(),
+                      onPressed: () => _scrollToBottomGently(force: true),
                       child: const Icon(Icons.keyboard_arrow_down_rounded),
                     ),
                   ),

--- a/app/test/widgets/transcript_test.dart
+++ b/app/test/widgets/transcript_test.dart
@@ -137,6 +137,22 @@ void main() {
     });
   });
 
+  test('a transcript scroll-state store resets on a fresh page but reuses a live session', () {
+    final store = TranscriptScrollStateStore();
+    final first = store.forSession('live-session');
+    first.update(offset: 120, isAtBottom: false);
+
+    expect(store.forSession('live-session'), same(first));
+    expect(store.forSession('live-session').isAtBottom, isFalse);
+
+    final nextSession = store.forSession('next-session');
+    expect(nextSession, isNot(same(first)));
+    expect(nextSession.hasPosition, isFalse);
+
+    final freshPageStore = TranscriptScrollStateStore();
+    expect(freshPageStore.forSession('live-session').hasPosition, isFalse);
+  });
+
   group('Live transcript scrolling', () {
     late ScrollController controller;
     late TranscriptScrollState scrollState;
@@ -208,20 +224,21 @@ void main() {
       expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
     });
 
-    testWidgets('a user position away from the bottom survives reopening', (tester) async {
+    testWidgets('a fresh transcript load starts at the latest segment', (tester) async {
       await pumpTranscript(tester);
       await tester.drag(find.byType(ListView), const Offset(0, 260));
       await tester.pumpAndSettle();
 
-      final preservedOffset = controller.offset;
       expect(scrollState.isAtBottom, isFalse);
       expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox.shrink());
+      scrollState = TranscriptScrollState();
       await pumpTranscript(tester);
 
-      expect(controller.offset, closeTo(preservedOffset, 0.1));
-      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+      expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
+      expect(scrollState.isAtBottom, isTrue);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
     });
 
     testWidgets('the jump control animates to the latest segment and hides', (tester) async {
@@ -235,6 +252,71 @@ void main() {
       expect(controller.offset, closeTo(controller.position.maxScrollExtent, 0.1));
       expect(scrollState.isAtBottom, isTrue);
       expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsNothing);
+    });
+
+    testWidgets('manual scrolling up stays put while live transcript grows', (tester) async {
+      await pumpTranscript(tester);
+      await tester.drag(find.byType(ListView), const Offset(0, 260));
+      await tester.pumpAndSettle();
+
+      final preservedOffset = controller.offset;
+      expect(scrollState.isAtBottom, isFalse);
+
+      segments = [
+        ...segments,
+        TranscriptSegment(
+          id: 'live-new',
+          text: List.filled(80, 'new live words').join(' '),
+          speaker: 'SPEAKER_00',
+          isUser: false,
+          personId: null,
+          start: segments.length.toDouble(),
+          end: segments.length + 1.0,
+          translations: const [],
+        ),
+      ];
+      contentVersion++;
+      await pumpTranscript(tester);
+
+      expect(controller.offset, closeTo(preservedOffset, 0.1));
+      expect(scrollState.isAtBottom, isFalse);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+    });
+
+    testWidgets('manual scrolling up stays put when live content arrives mid-gesture', (tester) async {
+      await pumpTranscript(tester);
+      final gestureStart = tester.getCenter(find.byType(ListView));
+      final gesture = await tester.startGesture(gestureStart);
+      for (var step = 0; step < 5; step++) {
+        await gesture.moveBy(const Offset(0, 52));
+        await tester.pump(const Duration(milliseconds: 10));
+      }
+      await tester.pump();
+
+      final preservedOffset = controller.offset;
+      segments = [
+        ...segments,
+        TranscriptSegment(
+          id: 'live-mid-gesture',
+          text: List.filled(80, 'new live words').join(' '),
+          speaker: 'SPEAKER_00',
+          isUser: false,
+          personId: null,
+          start: segments.length.toDouble(),
+          end: segments.length + 1.0,
+          translations: const [],
+        ),
+      ];
+      contentVersion++;
+      await pumpTranscript(tester, settle: false);
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(controller.offset, closeTo(preservedOffset, 0.1));
+      expect(scrollState.isAtBottom, isFalse);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('same-ID transcript growth keeps following the live edge', (tester) async {


### PR DESCRIPTION
## Summary

- Preserve a reader's upward scroll position while live Listening transcript content arrives.
- Show the jump-to-latest arrow when the reader is away from the live edge; tapping it explicitly resumes following the latest segment.
- Start a newly mounted Listening page at the live edge while preserving intent across layout changes within the same page and session.

## Root cause

Live transcript follow decisions could still use the follow state while a touch gesture was in progress, so a new segment could trigger an automatic scroll before the user-scroll notification arrived. The page also kept transcript scroll state in static fields, allowing an old position to leak into a later page instance.

## Validation

- `bash app/test.sh` — 1027 tests passed.
- `flutter analyze lib/pages/conversation_capturing/page.dart lib/widgets/transcript.dart` — passed.
- `bash app/scripts/analyze_ratchet.sh` — passed.
- Sol subagent follow-up review — approved.

Failure-Class: FC-single-input-device-release

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

