### PR TITLE
Reconcile terminal Agent VM records

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -509,6 +509,7 @@ jobs:
             AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc
             AGENT_VM_ACTIVE_RELEASE_URI=${{ steps.agent-vm-release.outputs.active_manifest_uri }}
             AGENT_VM_RECONCILER_MAX_CONCURRENCY=5
+            AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS=300
 
       - name: Save previous Agent VM release pointer
         if: success() && steps.route-traffic.outcome == 'success' && steps.agent-vm-release.outputs.manifest_uri != ''

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -560,6 +560,7 @@ jobs:
             AGENT_VM_ENVIRONMENT=production
             AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc
             AGENT_VM_ACTIVE_RELEASE_URI=${{ steps.agent-vm-release.outputs.active_manifest_uri }}
+            AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS=86400
 
       - name: Save previous Agent VM release pointer
         if: success() && steps.route-traffic.outcome == 'success' && steps.agent-vm-release.outputs.manifest_uri != ''

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -37,6 +37,7 @@ from services.agent_vm_lifecycle import (
     active_session_count,
     claim_reconciler_run_lease,
     claim_vm_lease,
+    clear_missing_vm_if_current,
     clear_vm_reconcile_lease_fields,
     drift_reasons,
     release_reconciler_run_lease,
@@ -63,6 +64,8 @@ ROLLOUT_STABLE_RUNS = 3
 OWNER_DISCOVERY_LIMIT = 10_000
 OWNER_FALLBACK_SCAN_LIMIT = 1_000
 FAILED_JOB_STATES = {"retry", "quarantined", "missing", "stale", "recreate_required"}
+DEFAULT_MISSING_CLEANUP_GRACE_SECONDS = 24 * 60 * 60
+MIN_MISSING_CLEANUP_GRACE_SECONDS = 60
 _IMMUTABLE_BOOT_IMAGE = re.compile(r"^projects/[^/]+/global/images/[^/]+$")
 
 
@@ -267,16 +270,38 @@ def _select_rollout_owners(
 def _select_reconcile_owners(
     owners: Sequence[tuple[str, dict[str, Any]]], release_id: str, target_percent: int
 ) -> list[tuple[str, dict[str, Any]]]:
-    """Add user-demanded repairs to the rollout cohort without duplicating owners."""
+    """Add demanded or terminal-cleanup work to the rollout cohort without duplicates."""
     selected = _select_rollout_owners(owners, release_id, target_percent)
     selected_uids = {uid for uid, _ in selected}
-    selected.extend((uid, vm) for uid, vm in owners if uid not in selected_uids and _start_requested(vm))
+    selected.extend(
+        (uid, vm)
+        for uid, vm in owners
+        if uid not in selected_uids and (_start_requested(vm) or _missing_cleanup_candidate(vm))
+    )
     return selected
 
 
 def _start_requested(vm: Mapping[str, Any]) -> bool:
     reconcile = vm.get("reconcile")
     return isinstance(reconcile, Mapping) and bool(reconcile.get("startRequested"))
+
+
+def _missing_cleanup_candidate(vm: Mapping[str, Any]) -> bool:
+    reconcile = vm.get("reconcile")
+    return isinstance(reconcile, Mapping) and reconcile.get("state") == "missing"
+
+
+def _missing_cleanup_grace_seconds() -> int:
+    raw = os.getenv("AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS")
+    if raw is None or not raw.strip():
+        return DEFAULT_MISSING_CLEANUP_GRACE_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError("AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS must be an integer") from exc
+    if value < MIN_MISSING_CLEANUP_GRACE_SECONDS:
+        raise ValueError(f"AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS must be at least {MIN_MISSING_CLEANUP_GRACE_SECONDS}")
+    return value
 
 
 def _canonical_image_ref(value: str) -> str:
@@ -348,6 +373,7 @@ async def reconcile_one(
     owner: str,
     project: str,
     dry_run: bool = False,
+    missing_cleanup_grace_seconds: int | None = None,
 ) -> ReconcileResult:
     vm_name = str(vm["vmName"])
     auth_token = str(vm["authToken"])
@@ -368,6 +394,8 @@ async def reconcile_one(
         return ReconcileResult(uid, "drift" if reasons else "ready", ",".join(sorted(set(reasons))))
     reconcile_raw = vm.get("reconcile")
     reconcile_state = reconcile_raw if isinstance(reconcile_raw, Mapping) else {}
+    missing_since_raw = reconcile_state.get("missingSince")
+    missing_since = float(missing_since_raw) if isinstance(missing_since_raw, (int, float)) else None
     start_requested = bool(reconcile_state.get("startRequested"))
     start_requested_at = reconcile_state.get("startRequestedAt") if start_requested else None
     observed_start_request_at = float(start_requested_at) if isinstance(start_requested_at, (int, float)) else None
@@ -377,19 +405,66 @@ async def reconcile_one(
         return ReconcileResult(uid, "busy")
 
     now = time.time()
+    missing_cleanup_grace_seconds = (
+        _missing_cleanup_grace_seconds() if missing_cleanup_grace_seconds is None else missing_cleanup_grace_seconds
+    )
     try:
         instance = await api.get_instance(vm_name)
         if instance is None:
+            terminal_cleanup_due = (
+                not start_requested
+                and missing_since is not None
+                and missing_since <= now - missing_cleanup_grace_seconds
+            )
+            cleanup_blocked_detail: str | None = None
+            if terminal_cleanup_due:
+                if vm.get("status") not in {"ready", "stopped"}:
+                    cleanup_blocked_detail = (
+                        "GCE instance not found; original provisioning outcome is not safe to clean"
+                    )
+                else:
+                    active = await asyncio.to_thread(active_session_count, uid, vm_name)
+                    if active:
+                        cleanup_blocked_detail = f"GCE instance not found; {active} active session(s) block cleanup"
+            if terminal_cleanup_due and cleanup_blocked_detail is None:
+                assert missing_since is not None
+                deleted = await asyncio.to_thread(
+                    clear_missing_vm_if_current,
+                    uid,
+                    vm_name,
+                    zone,
+                    auth_token,
+                    owner,
+                    missing_since,
+                )
+                if deleted:
+                    return ReconcileResult(uid, "cleaned", "removed abandoned missing VM record")
+                return ReconcileResult(uid, "stale", "owner lease or terminal-cleanup fence changed")
+            recorded_missing_since = missing_since if missing_since is not None else now
+            missing_fields: dict[str, Any] = {
+                "state": "missing",
+                "lastError": "GCE instance not found",
+                "missingSince": recorded_missing_since,
+                "lease": DELETE_FIELD,
+                "drainRequested": DELETE_FIELD,
+                "drainRequestedAt": DELETE_FIELD,
+            }
+            # A provider-confirmed 404 makes the observed demand impossible to
+            # fulfill. Consume only that exact request, while the transaction
+            # preserves any newer demand that arrives during this check.
+            missing_fields.update({"startRequested": DELETE_FIELD, "startRequestedAt": DELETE_FIELD})
             if not await _update_reconcile(
                 uid,
                 vm_name,
                 auth_token,
                 owner,
-                {"state": "missing", "lastError": "GCE instance not found", **clear_vm_reconcile_lease_fields()},
+                missing_fields,
                 consume_start_request_at=observed_start_request_at,
             ):
                 return ReconcileResult(uid, "stale", "owner lease lost while recording missing VM")
-            return ReconcileResult(uid, "missing", "GCE instance not found")
+            if cleanup_blocked_detail:
+                return ReconcileResult(uid, "missing", cleanup_blocked_detail)
+            return ReconcileResult(uid, "cleanup_pending", "GCE instance not found; waiting for terminal cleanup grace")
         boot_drift = await _boot_image_drift(api, instance, release)
         if boot_drift:
             reason, actual = boot_drift
@@ -404,6 +479,7 @@ async def reconcile_one(
                     "driftReasons": [reason],
                     "requiredBootImage": release.boot_image,
                     "observedBootImage": actual,
+                    "missingSince": DELETE_FIELD,
                     **clear_vm_reconcile_lease_fields(),
                 },
                 consume_start_request_at=observed_start_request_at,
@@ -462,6 +538,7 @@ async def reconcile_one(
                     "retryCount": 0,
                     "lastError": None,
                     "retryAt": None,
+                    "missingSince": DELETE_FIELD,
                     **clear_vm_reconcile_lease_fields(),
                 },
                 vm_fields={"status": "stopped"},
@@ -517,6 +594,7 @@ async def reconcile_one(
                 "retryCount": 0,
                 "lastError": None,
                 "retryAt": None,
+                "missingSince": DELETE_FIELD,
                 **clear_vm_reconcile_lease_fields(),
             },
             vm_fields={
@@ -571,6 +649,7 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
     project = os.getenv("GCE_PROJECT_ID")
     if not project:
         raise RuntimeError("GCE_PROJECT_ID is required for Agent VM reconciliation")
+    missing_cleanup_grace_seconds = _missing_cleanup_grace_seconds()
     owner = f"{os.getenv('K_REVISION', 'local')}:{uuid.uuid4().hex}"
     if not dry_run and not await asyncio.to_thread(claim_reconciler_run_lease, environment, owner):
         logger.info("Agent VM reconciler skipped: another run owns the %s lease", environment)
@@ -606,7 +685,15 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
 
             async def one(uid: str, vm: dict[str, Any]) -> ReconcileResult:
                 async with semaphore:
-                    return await reconcile_one(uid, vm, release, owner=owner, project=project, dry_run=dry_run)
+                    return await reconcile_one(
+                        uid,
+                        vm,
+                        release,
+                        owner=owner,
+                        project=project,
+                        dry_run=dry_run,
+                        missing_cleanup_grace_seconds=missing_cleanup_grace_seconds,
+                    )
 
             results = await asyncio.gather(*(one(uid, vm) for uid, vm in selected))
             if lease_lost.is_set() and not dry_run:

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -15,7 +15,7 @@ import google.auth.transport.requests
 import google.oauth2.id_token
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from google.cloud.firestore import DELETE_FIELD, transactional
+from google.cloud.firestore import transactional
 from google.cloud.firestore_v1.base_query import FieldFilter
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -272,28 +272,6 @@ def _set_vm_if_current(
         status,
         ip,
         zone,
-    )
-
-
-@transactional
-def _delete_vm_if_current_txn(transaction, user_ref, expected_vm_name: str, expected_auth_token: str) -> bool:
-    snapshot = user_ref.get(transaction=transaction)
-    current = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
-    if not isinstance(current, dict):
-        return False
-    if current.get("vmName") != expected_vm_name or current.get("authToken") != expected_auth_token:
-        return False
-    transaction.update(user_ref, {"agentVm": DELETE_FIELD})
-    return True
-
-
-def _delete_vm_if_current(uid: str, expected_vm_name: str, expected_auth_token: str) -> bool:
-    client = get_firestore_client()
-    return _delete_vm_if_current_txn(
-        client.transaction(),
-        client.collection("users").document(uid),
-        expected_vm_name,
-        expected_auth_token,
     )
 
 
@@ -718,7 +696,7 @@ async def get_agent_status(
     vm = await run_blocking(db_executor, _get_vm, uid)
     if not vm:
         return None
-    if _reconcile_lease_active(vm):
+    if _reconcile_in_progress(vm):
         return _response(_updating_vm(vm))
     status = str(vm.get("status") or "provisioning")
     if status not in {"ready", "error", "stopped"}:
@@ -730,14 +708,11 @@ async def get_agent_status(
         logger.warning("Agent VM status check failed for uid=%s: %s", uid, exc)
         return _response(vm)
     if gce_status == "NOT_FOUND":
-        deleted = await run_blocking(
-            db_executor,
-            _delete_vm_if_current,
-            uid,
-            str(vm["vmName"]),
-            str(vm.get("authToken") or ""),
-        )
-        return None if deleted else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
+        # A provider 404 is a reconciler-owned terminal transition. Do not
+        # erase the owner pointer from a request path: it may be a late create
+        # or a session-protected record, and the reconciler has the complete
+        # deletion, demand, session, and grace-period fences.
+        return _response(_updating_vm(vm))
     if gce_status in {"TERMINATED", "STOPPED"}:
         requested = await run_blocking(
             db_executor,

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -247,7 +247,7 @@ def reconcile_requested(vm: Mapping[str, Any], now: float | None = None) -> bool
     return (
         bool(reconcile.get("startRequested"))
         or bool(reconcile.get("drainRequested"))
-        or reconcile.get("state") in {"draining", "deferred"}
+        or reconcile.get("state") in {"draining", "deferred", "missing"}
         or lease_active
     )
 
@@ -547,6 +547,85 @@ def update_vm_reconcile(
             now,
             consume_start_request_at,
             force_consume_start_request,
+        )
+    )
+
+
+@transactional
+def _clear_missing_vm_if_current_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    expected_missing_since: float,
+    now: float,
+) -> bool:
+    """Remove one terminal VM pointer only while this worker still owns it.
+
+    A prior reconcile lease prevents a new session admission. The caller must
+    separately observe that no pre-existing session lease remains before this
+    compare-and-swap deletes the pointer.
+    """
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    status = normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    if account_deletion_blocks_access(status):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    if (
+        not isinstance(vm, dict)
+        or vm.get("vmName") != vm_name
+        or (vm.get("zone") or DEFAULT_ZONE) != zone
+        or vm.get("authToken") != auth_token
+        or vm.get("status") not in {"ready", "stopped"}
+    ):
+        return False
+    reconcile_raw = vm.get("reconcile")
+    reconcile: dict[str, Any] = reconcile_raw if isinstance(reconcile_raw, dict) else {}
+    lease_raw = reconcile.get("lease")
+    lease: dict[str, Any] = lease_raw if isinstance(lease_raw, dict) else {}
+    if (
+        reconcile.get("state") != "claimed"
+        or lease.get("owner") != owner
+        or float(lease.get("expiresAt", 0) or 0) <= now
+        or bool(reconcile.get("startRequested"))
+        or bool(reconcile.get("drainRequested"))
+    ):
+        return False
+    missing_since = reconcile.get("missingSince")
+    if not isinstance(missing_since, (int, float)) or float(missing_since) != expected_missing_since:
+        return False
+    transaction.update(user_ref, {"agentVm": DELETE_FIELD})
+    return True
+
+
+def clear_missing_vm_if_current(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    expected_missing_since: float,
+    now: float | None = None,
+) -> bool:
+    """Delete a proven-abandoned missing VM record with deletion and owner fences."""
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    return bool(
+        _clear_missing_vm_if_current_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            client.collection("users").document(uid),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            expected_missing_since,
+            now,
         )
     )
 
@@ -898,6 +977,7 @@ __all__ = [
     "claim_reconciler_run_lease",
     "claim_session_lease",
     "claim_vm_lease",
+    "clear_missing_vm_if_current",
     "clear_vm_reconcile_lease_fields",
     "drift_reasons",
     "expected_release_metadata",

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -10,6 +10,7 @@ import pytest
 import jobs.agent_vm_reconciler as reconciler
 import services.agent_vm_lifecycle as lifecycle
 from services.agent_vm_lifecycle import AgentVmRelease
+from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 
 RELEASE = AgentVmRelease.from_mapping(
     {
@@ -296,6 +297,16 @@ def test_start_requests_bypass_the_release_cohort_without_displacing_it(monkeypa
     assert reconciler._select_reconcile_owners(owners, RELEASE.release_id, 1) == owners
 
 
+def test_terminal_missing_records_bypass_the_release_cohort_without_displacing_it(monkeypatch):
+    owners = [
+        ("cohort", {"vmName": "cohort"}),
+        ("missing", {"vmName": "missing", "reconcile": {"state": "missing", "missingSince": 1.0}}),
+    ]
+    monkeypatch.setattr(reconciler, "rollout_selected", lambda uid, *_args: uid == "cohort")
+
+    assert reconciler._select_reconcile_owners(owners, RELEASE.release_id, 1) == owners
+
+
 def test_terminal_reconcile_write_preserves_a_newer_start_request():
     terminal_fields = lifecycle.clear_vm_reconcile_lease_fields()
 
@@ -310,6 +321,7 @@ def test_terminal_reconcile_write_preserves_a_newer_start_request():
 
 def test_active_lifecycle_lease_blocks_new_session_admission():
     assert lifecycle.reconcile_requested({"reconcile": {"lease": {"expiresAt": 101}}}, now=100)
+    assert lifecycle.reconcile_requested({"reconcile": {"state": "missing"}}, now=100)
     assert not lifecycle.reconcile_requested({"reconcile": {"lease": {"expiresAt": 100}}}, now=100)
 
 
@@ -524,9 +536,205 @@ def test_firestore_claim_and_update_are_offloaded_from_event_loop(monkeypatch):
         )
     )
 
-    assert result.state == "missing"
+    assert result.state == "cleanup_pending"
     assert len(call_threads) == 2
     assert all(thread_id != loop_thread for thread_id in call_threads)
+
+
+def test_missing_vm_is_cleaned_only_after_grace_without_sessions_or_demand(monkeypatch):
+    now = 500.0
+    deleted: list[tuple[Any, ...]] = []
+
+    class MissingApi:
+        def __init__(self, _project: str, _zone: str) -> None:
+            pass
+
+        async def get_instance(self, _vm_name: str) -> None:
+            return None
+
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", MissingApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 0)
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+    monkeypatch.setattr(reconciler, "clear_missing_vm_if_current", lambda *args: deleted.append(args) or True)
+    monkeypatch.setattr(
+        reconciler, "update_vm_reconcile", lambda *_args, **_kwargs: pytest.fail("cleaned records stay deleted")
+    )
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "zone": "us-central1-a",
+                "status": "ready",
+                "authToken": "token",
+                "reconcile": {"state": "missing", "missingSince": now - 120},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            missing_cleanup_grace_seconds=60,
+        )
+    )
+
+    assert result.state == "cleaned"
+    assert deleted == [("user", "omi-agent-user", "us-central1-a", "token", "worker", now - 120)]
+
+
+def test_missing_404_consumes_the_observed_start_request_before_cleanup_grace(monkeypatch):
+    class MissingApi:
+        def __init__(self, _project: str, _zone: str) -> None:
+            pass
+
+        async def get_instance(self, _vm_name: str) -> None:
+            return None
+
+    updates: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", MissingApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "clear_missing_vm_if_current", lambda *_args: pytest.fail("grace has not elapsed"))
+    monkeypatch.setattr(
+        reconciler, "update_vm_reconcile", lambda *args, **kwargs: updates.append((args[4], kwargs)) or True
+    )
+    monkeypatch.setattr(reconciler.time, "time", lambda: 500.0)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "status": "ready",
+                "authToken": "token",
+                "reconcile": {
+                    "state": "missing",
+                    "missingSince": 1.0,
+                    "startRequested": True,
+                    "startRequestedAt": 450.0,
+                },
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            missing_cleanup_grace_seconds=60,
+        )
+    )
+
+    assert result.state == "cleanup_pending"
+    fields, kwargs = updates[-1]
+    assert fields["startRequested"] is lifecycle.DELETE_FIELD
+    assert fields["startRequestedAt"] is lifecycle.DELETE_FIELD
+    assert kwargs["consume_start_request_at"] == 450.0
+
+
+def test_terminal_cleanup_refuses_an_active_missing_vm(monkeypatch):
+    class MissingApi:
+        def __init__(self, _project: str, _zone: str) -> None:
+            pass
+
+        async def get_instance(self, _vm_name: str) -> None:
+            return None
+
+    updates: list[dict[str, Any]] = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", MissingApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 1)
+    monkeypatch.setattr(
+        reconciler, "clear_missing_vm_if_current", lambda *_args: pytest.fail("terminal cleanup must be fenced")
+    )
+    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *args, **_kwargs: updates.append(args[4]) or True)
+    monkeypatch.setattr(reconciler.time, "time", lambda: 500.0)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "status": "ready",
+                "authToken": "token",
+                "reconcile": {"state": "missing", "missingSince": 1.0},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            missing_cleanup_grace_seconds=60,
+        )
+    )
+
+    assert result.state == "missing"
+    assert "1 active session" in result.detail
+    assert updates[-1]["missingSince"] == 1.0
+
+
+def test_missing_cleanup_lifecycle_compare_and_swap_requires_exact_owner_generation(monkeypatch):
+    def database(
+        *, start_requested: bool = False, zone: str | None = "us-central1-a", status: str = "ready"
+    ) -> StrictFirestore:
+        return StrictFirestore(
+            {
+                (
+                    "users",
+                    "user",
+                ): {
+                    "agentVm": {
+                        "vmName": "omi-agent-user",
+                        "zone": zone,
+                        "status": status,
+                        "authToken": "token",
+                        "reconcile": {
+                            "state": "claimed",
+                            "missingSince": 100.0,
+                            "startRequested": start_requested,
+                            "lease": {"owner": "worker", "expiresAt": 200.0},
+                        },
+                    }
+                }
+            }
+        )
+
+    client = database()
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+    assert lifecycle.clear_missing_vm_if_current(
+        "user", "omi-agent-user", "us-central1-a", "token", "worker", 100.0, now=150
+    )
+    assert client.transactions[-1].updates[-1][1] == {"agentVm": lifecycle.DELETE_FIELD}
+
+    legacy_zone_client = database(zone=None)
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: legacy_zone_client)
+    assert lifecycle.clear_missing_vm_if_current(
+        "user", "omi-agent-user", "us-central1-a", "token", "worker", 100.0, now=150
+    )
+
+    for bad_client, zone, missing_since in [
+        (database(start_requested=True), "us-central1-a", 100.0),
+        (database(status="provisioning"), "us-central1-a", 100.0),
+        (database(), "wrong-zone", 100.0),
+        (database(), "us-central1-a", 99.0),
+    ]:
+        monkeypatch.setattr(lifecycle, "get_firestore_client", lambda client=bad_client: client)
+        assert not lifecycle.clear_missing_vm_if_current(
+            "user", "omi-agent-user", zone, "token", "worker", missing_since, now=150
+        )
+        assert not bad_client.transactions[-1].updates
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, reconciler.DEFAULT_MISSING_CLEANUP_GRACE_SECONDS), ("60", 60)],
+)
+def test_missing_cleanup_grace_uses_a_safe_default_or_valid_override(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS", raising=False)
+    else:
+        monkeypatch.setenv("AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS", value)
+    assert reconciler._missing_cleanup_grace_seconds() == expected
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "59"])
+def test_missing_cleanup_grace_rejects_unsafe_configuration(monkeypatch, value):
+    monkeypatch.setenv("AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS", value)
+    with pytest.raises(ValueError, match="AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS"):
+        reconciler._missing_cleanup_grace_seconds()
 
 
 @pytest.mark.parametrize("state", ["quarantined", "missing", "stale", "recreate_required"])
@@ -538,6 +746,17 @@ def test_main_reports_nonconverged_states_as_failed_job(monkeypatch, state):
     monkeypatch.setattr(reconciler, "run_reconciler", run_reconciler)
 
     assert reconciler.main([]) == 1
+
+
+@pytest.mark.parametrize("state", ["cleanup_pending", "cleaned"])
+def test_main_accepts_expected_terminal_cleanup_states(monkeypatch, state):
+    async def run_reconciler(*, dry_run: bool = False) -> list[reconciler.ReconcileResult]:
+        assert not dry_run
+        return [reconciler.ReconcileResult("uid", state)]
+
+    monkeypatch.setattr(reconciler, "run_reconciler", run_reconciler)
+
+    assert reconciler.main([]) == 0
 
 
 class OwnerSnapshot:

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -276,7 +276,7 @@ async def test_provision_reports_updating_without_overriding_a_reconciler_reques
 
 
 @pytest.mark.asyncio
-async def test_status_clears_stale_gce_pointer_with_current_vm_fence(monkeypatch):
+async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkeypatch):
     vm = {
         "vmName": "omi-agent-stale",
         "zone": "us-central1-a",
@@ -285,7 +285,6 @@ async def test_status_clears_stale_gce_pointer_with_current_vm_fence(monkeypatch
         "status": "ready",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    clears = []
 
     async def run_blocking(_, function, *args):
         return function(*args)
@@ -297,12 +296,34 @@ async def test_status_clears_stale_gce_pointer_with_current_vm_fence(monkeypatch
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
-    monkeypatch.setattr(desktop_agent_vm, "_delete_vm_if_current", lambda *args: clears.append(args) or True)
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
-    assert response is None
-    assert clears == [("uid", "omi-agent-stale", "old-token")]
+    assert response.status == "updating"
+    assert response.ip is None
+
+
+@pytest.mark.asyncio
+async def test_status_does_not_probe_a_missing_record_while_reconciler_cleanup_is_pending(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-missing",
+        "zone": "us-central1-a",
+        "authToken": "current-token",
+        "status": "ready",
+        "reconcile": {"state": "missing", "missingSince": time.time() - 60},
+    }
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_instance", lambda *_args: pytest.fail("reconciler owns missing records"))
+
+    response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
+
+    assert response.status == "updating"
+    assert response.ip is None
 
 
 @pytest.mark.asyncio

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -23,7 +23,17 @@ before acceptance, so an unaccepted candidate cannot escape the staged gate.
    Agent VM subnet and set `AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc`; it
    refuses to send the bearer token over a NAT address. A healthy
    stopped VM with no drift remains stopped so idle self-stop is preserved.
-4. Success records the observed release and clears the lease/drain fields by
+4. A provider-confirmed missing VM is recorded with `missingSince`. The
+   reconciler selects that terminal record independently of the rollout cohort
+   and deletes only its Firestore `agentVm` pointer after the configured grace
+   period, zero active session leases, no queued start/drain demand, and a
+   final account-deletion, `{vmName, zone, authToken}`, ready/stopped creation
+   outcome, owner-lease, and `missingSince` compare-and-swap all succeed. It
+   never creates a replacement;
+   the normal account provisioning path owns replacement creation. Development
+   uses a five-minute grace to exercise this exact cleanup path after each
+   merged auto-deploy. Production uses the same code with a 24-hour grace.
+5. Success records the observed release and clears the lease/drain fields by
    compare-and-swap. Three successful five-minute runs advance the rollout
    gate from sentinel (1%) to canary (5%), quarter (25%), and remainder (100%).
    Three failures quarantine that owner and stop it from being retried until an
@@ -31,8 +41,9 @@ before acceptance, so an unaccepted candidate cannot escape the staged gate.
 
 Legacy VMs with absent metadata are ordinary drift and are repaired on their
 first selected reconciliation. A missing GCE instance is recorded as `missing`
-and is left for the existing provisioning/reaper recovery path; the reconciler
-never creates a replacement without the account request path's owner claim.
+before it becomes eligible for the fenced terminal-cleanup path. The
+reconciler never creates a replacement without the account request path's
+owner claim.
 
 If the immutable `bootImage` differs from the actual boot disk source, the
 reconciler records `recreate_required` and does not stop, replace, or start the
@@ -97,10 +108,18 @@ current Firestore owner before issuing the exact stop operation.
 ## Recovery
 
 `retry` uses bounded exponential backoff. `deferred` means an active session
-is still present and retains the drain fence. `quarantined` requires operator
-inspection of the per-owner `agentVm.reconcile.lastError` and a new release or
-explicit state repair. The terminal reaper remains a separate, dry-run-first
-cleanup backstop for abandoned terminated instances.
+is still present and retains the drain fence. `cleanup_pending` means a
+provider-confirmed missing VM is inside its grace period; it is an expected
+successful job outcome, not a rollout failure. A missing VM with active demand
+or a live session remains visible and fails closed rather than being deleted.
+The reconciler consumes an observed start request only after it receives the
+provider 404 for that exact owner generation; the transactional timestamp fence
+preserves a newer request. That makes the impossible request terminal rather
+than leaving an uncleanable missing pointer.
+`quarantined` requires operator inspection of the per-owner
+`agentVm.reconcile.lastError` and a new release or explicit state repair. The
+terminal reaper remains a separate, dry-run-first cleanup backstop for
+abandoned terminated instances.
 
 To roll the fleet back to the previous accepted release, inspect the active
 and previous manifests, then run the refuse-by-default helper in the target


### PR DESCRIPTION
## Summary

- add reconciler-owned cleanup for terminal Agent VM records whose GCE instance is provider-confirmed missing
- keep one code path across environments: development uses a five-minute grace to exercise it after merge; production uses a 24-hour grace
- remove the desktop status-route deletion bypass so request paths cannot skip the cleanup grace or ownership/session/demand fences

## Safety contract

Cleanup deletes only the current `agentVm` Firestore pointer after the reconciler owns its lease, the original ready/stopped creation outcome is known, the grace period has elapsed, there is no start/drain demand, there are no active sessions, and the deletion/owner/zone/token/missing-timestamp compare-and-swap succeeds. It never creates or recreates a VM. Boot-image drift remains `recreate_required` and operator-owned.

## Validation

- `pytest -q backend/tests/unit/test_desktop_agent_vm.py backend/tests/unit/test_agent_vm_reconciler.py backend/tests/unit/test_agent_vm_reconciler_job.py backend/tests/unit/test_agent_vm_reconciler_authority.py backend/tests/unit/test_agent_vm_reaped_record_recovery.py` (77 passed)
- `.github/scripts/test_check_desktop_backend_release_policy.py` (28 passed)
- `make preflight` and enforced pre-push gate
- independent Sol review; addressed the direct status-route deletion P1

## Rollout

Merge auto-deploys the same reconciler artifact to dev. The dev scheduler should first mark eligible records as `cleanup_pending`, then remove safe records on the next scheduled run after the five-minute grace. Production is not mutated by this PR; a later normal production desktop-backend deploy supplies the same logic with its 24-hour grace.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

