### PR TITLE
fix(app): soft-retry leave/background offline upload aborts (#4587)

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -33,25 +33,28 @@ class AuthTokenUnavailableException implements Exception {
 }
 
 // Normal-mode connectivity failures on mobile (no network, DNS failure,
-// connection reset, TLS handshake during reconnect, request timeout). Reporting
-// these to Crashlytics drowns out real signal — caller logs them locally and
-// either returns null or rethrows for the upstream sync state machine.
-bool _isTransientNetworkError(Object e) {
+// connection reset, TLS handshake during reconnect, request timeout, OS abort
+// when the app backgrounds mid-upload). Reporting these to Crashlytics drowns
+// out real signal — caller logs them locally and either returns null or
+// rethrows for the upstream sync state machine.
+bool isTransientNetworkError(Object e) {
   if (e is SocketException) return true;
   if (e is HandshakeException) return true;
   if (e is TimeoutException) return true;
-  if (e is http.ClientException) {
-    final m = e.message;
-    return m.contains('SocketException') ||
-        m.contains('HandshakeException') ||
-        m.contains('TimeoutException') ||
-        m.contains('Connection closed') ||
-        m.contains('Connection reset') ||
-        m.contains('Failed host lookup') ||
-        m.contains('Network is unreachable') ||
-        m.contains('Bad file descriptor');
-  }
-  return false;
+  final text = e is http.ClientException ? e.message : e.toString();
+  return text.contains('SocketException') ||
+      text.contains('HandshakeException') ||
+      text.contains('TimeoutException') ||
+      text.contains('Connection closed') ||
+      text.contains('Connection reset') ||
+      text.contains('Failed host lookup') ||
+      text.contains('Network is unreachable') ||
+      text.contains('Bad file descriptor') ||
+      // Android leaves/backgrounds mid-multipart (#4587 screenshot):
+      // "ClientSoftware caused connection abort"
+      text.contains('connection abort') ||
+      text.contains('ClientSoftware') ||
+      text.contains('Software caused connection abort');
 }
 
 Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
@@ -62,9 +65,10 @@ Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
   final expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
   bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
 
-  bool isExpirationDateValid = !(expiry.isBefore(DateTime.now()) ||
-      expiry.isAtSameMomentAs(DateTime.fromMillisecondsSinceEpoch(0)) ||
-      (expiry.isBefore(DateTime.now().add(const Duration(minutes: 5))) && expiry.isAfter(DateTime.now())));
+  bool isExpirationDateValid =
+      !(expiry.isBefore(DateTime.now()) ||
+          expiry.isAtSameMomentAs(DateTime.fromMillisecondsSinceEpoch(0)) ||
+          (expiry.isBefore(DateTime.now().add(const Duration(minutes: 5))) && expiry.isAfter(DateTime.now())));
 
   if (!hasAuthToken || !isExpirationDateValid) {
     final refreshResult = await AuthService.instance.refreshIdToken();
@@ -196,9 +200,9 @@ Future<void> _handleAuthUnavailable(
     AuthTokenMissingUser() => null,
     AuthTokenMissingToken() => const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingToken),
     AuthTokenTerminalFailure(:final code) => AuthSessionExpiredEvent(
-        reason: AuthSessionExpirationReason.terminalTokenFailure,
-        code: code,
-      ),
+      reason: AuthSessionExpirationReason.terminalTokenFailure,
+      code: code,
+    ),
     _ => null,
   };
   if (event != null) await AuthService.instance.expireSession(event);
@@ -318,7 +322,7 @@ Future<http.Response?> makeApiCall({
     return null;
   } catch (e, stackTrace) {
     Logger.debug('HTTP request failed: $e, $stackTrace');
-    if (!_isTransientNetworkError(e)) {
+    if (!isTransientNetworkError(e)) {
       PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
     }
     return null;
@@ -457,7 +461,7 @@ Future<http.Response> makeMultipartApiCall({
     return http.Response('', 401, reasonPhrase: 'Authentication unavailable');
   } catch (e, stackTrace) {
     Logger.debug('Multipart HTTP request failed: $e, $stackTrace');
-    if (!_isTransientNetworkError(e)) {
+    if (!isTransientNetworkError(e)) {
       PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
     }
     rethrow;
@@ -523,7 +527,7 @@ Future<http.Response> makeMultipartApiCallUnpooled({
     return http.Response('', 401, reasonPhrase: 'Authentication unavailable');
   } catch (e, stackTrace) {
     Logger.debug('Unpooled multipart HTTP request failed: $e, $stackTrace');
-    if (!_isTransientNetworkError(e)) {
+    if (!isTransientNetworkError(e)) {
       PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
     }
     rethrow;
@@ -612,7 +616,7 @@ Stream<String> makeStreamingApiCall({
     Logger.debug('Authenticated streaming request blocked before send: ${e.result.runtimeType}');
   } catch (e, stackTrace) {
     Logger.error('Streaming request error: $e');
-    if (!_isTransientNetworkError(e)) {
+    if (!isTransientNetworkError(e)) {
       PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
     }
   }
@@ -696,7 +700,7 @@ Stream<String> makeMultipartStreamingApiCall({
     Logger.debug('Authenticated multipart streaming request blocked before send: ${e.result.runtimeType}');
   } catch (e, stackTrace) {
     Logger.error('Multipart streaming request error: $e');
-    if (!_isTransientNetworkError(e)) {
+    if (!isTransientNetworkError(e)) {
       PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': 'POST'});
     }
   }

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -42,6 +42,7 @@ bool isTransientNetworkError(Object e) {
   if (e is HandshakeException) return true;
   if (e is TimeoutException) return true;
   final text = e is http.ClientException ? e.message : e.toString();
+  final lower = text.toLowerCase();
   return text.contains('SocketException') ||
       text.contains('HandshakeException') ||
       text.contains('TimeoutException') ||
@@ -50,11 +51,9 @@ bool isTransientNetworkError(Object e) {
       text.contains('Failed host lookup') ||
       text.contains('Network is unreachable') ||
       text.contains('Bad file descriptor') ||
-      // Android leaves/backgrounds mid-multipart (#4587 screenshot):
-      // "ClientSoftware caused connection abort"
-      text.contains('connection abort') ||
-      text.contains('ClientSoftware') ||
-      text.contains('Software caused connection abort');
+      // Android leave/background mid-multipart (#4587): match the full abort
+      // phrase only — a bare "ClientSoftware" token is not a connectivity signal.
+      lower.contains('software caused connection abort');
 }
 
 Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
@@ -65,10 +64,9 @@ Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
   final expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
   bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
 
-  bool isExpirationDateValid =
-      !(expiry.isBefore(DateTime.now()) ||
-          expiry.isAtSameMomentAs(DateTime.fromMillisecondsSinceEpoch(0)) ||
-          (expiry.isBefore(DateTime.now().add(const Duration(minutes: 5))) && expiry.isAfter(DateTime.now())));
+  bool isExpirationDateValid = !(expiry.isBefore(DateTime.now()) ||
+      expiry.isAtSameMomentAs(DateTime.fromMillisecondsSinceEpoch(0)) ||
+      (expiry.isBefore(DateTime.now().add(const Duration(minutes: 5))) && expiry.isAfter(DateTime.now())));
 
   if (!hasAuthToken || !isExpirationDateValid) {
     final refreshResult = await AuthService.instance.refreshIdToken();
@@ -200,9 +198,9 @@ Future<void> _handleAuthUnavailable(
     AuthTokenMissingUser() => null,
     AuthTokenMissingToken() => const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.missingToken),
     AuthTokenTerminalFailure(:final code) => AuthSessionExpiredEvent(
-      reason: AuthSessionExpirationReason.terminalTokenFailure,
-      code: code,
-    ),
+        reason: AuthSessionExpirationReason.terminalTokenFailure,
+        code: code,
+      ),
     _ => null,
   };
   if (event != null) await AuthService.instance.expireSession(event);

--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -587,6 +587,13 @@ class SyncLocalFilesResponse {
   /// recovery rather than presenting a completed sync.
   int localUploadFailures;
 
+  /// Subset of [localUploadFailures] that are permanent server refusals
+  /// (HTTP 400/413, etc.). Soft-retry only applies when this stays zero.
+  int localUploadPermanentFailures;
+
+  /// Last permanent upload error message for SyncStatus.error surfacing.
+  String? localUploadPermanentError;
+
   SyncLocalFilesResponse({
     required this.newConversationIds,
     required this.updatedConversationIds,
@@ -594,6 +601,8 @@ class SyncLocalFilesResponse {
     this.totalSegments = 0,
     this.errors = const [],
     this.localUploadFailures = 0,
+    this.localUploadPermanentFailures = 0,
+    this.localUploadPermanentError,
   });
 
   bool get hasPartialFailure => failedSegments > 0;

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -214,11 +214,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// for being too old. Surfaced explicitly so a failure is never mistaken for
   /// a recording that simply hasn't synced yet.
   int get needsAttentionWalsCount => _countWhere(
-    (s) =>
-        s == WalSyncDisplayState.failed ||
-        s == WalSyncDisplayState.corrupted ||
-        s == WalSyncDisplayState.outsideRecoveryWindow,
-  );
+        (s) =>
+            s == WalSyncDisplayState.failed ||
+            s == WalSyncDisplayState.corrupted ||
+            s == WalSyncDisplayState.outsideRecoveryWindow,
+      );
 
   int get retryingWalsCount => _countWhere((s) => s == WalSyncDisplayState.retrying);
 
@@ -338,12 +338,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
     @visibleForTesting Future<void> Function()? startRecovery,
     @visibleForTesting Future<void> Function(WakeTrigger trigger)? wakeTransfer,
-  }) : _walServiceOverride = walService,
-       _uploadGate = uploadGate ?? SyncUploadGate.instance,
-       _startBackgroundSync = startBackgroundSync,
-       _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
-       _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
-       _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
+  })  : _walServiceOverride = walService,
+        _uploadGate = uploadGate ?? SyncUploadGate.instance,
+        _startBackgroundSync = startBackgroundSync,
+        _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
+        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
+        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _rateLimitWasActive = SyncRateLimiter.instance.isLimited;
@@ -556,8 +556,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       failedWal: wal,
     );
     // A 202 leaves the WAL `uploaded` — wake the single owner so reconcile
-    // is scheduled (do not poke SyncReconciler here).
-    if (result != null && _startBackgroundSync) {
+    // is scheduled (do not poke SyncReconciler here). Soft-retry failures wake
+    // from _performSync itself; do not double-wake here.
+    if (result != null &&
+        result.localUploadFailures == 0 &&
+        result.localUploadPermanentFailures == 0 &&
+        _startBackgroundSync) {
       unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
     }
   }
@@ -614,13 +618,28 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       }
 
       // Client-side upload aborts (leave/background mid-multipart, #4587) leave
-      // WALs as `miss`. Schema requires re-arming recovery — not SyncStatus.error.
-      if ((result?.localUploadFailures ?? 0) > 0) {
+      // WALs as `miss`. Soft-retry only when failures are transient; permanent
+      // server refusals (400/413) still surface SyncStatus.error.
+      final permanentFailures = result?.localUploadPermanentFailures ?? 0;
+      final localFailures = result?.localUploadFailures ?? 0;
+      if (permanentFailures > 0) {
+        final hint = result?.localUploadPermanentError;
+        final errorMessage = _formatSyncError(
+          hint != null ? Exception(hint) : Exception('Upload failed. Check your connection and try again'),
+          failedWal,
+        );
         DebugLogManager.logWarning(
-          'SyncProvider: $context had ${result!.localUploadFailures} local upload failure(s); re-arming recovery',
+          'SyncProvider: $context had $permanentFailures permanent local upload failure(s)',
+        );
+        _updateSyncState(_syncState.toError(message: errorMessage, failedWal: failedWal));
+      } else if (localFailures > 0) {
+        DebugLogManager.logWarning(
+          'SyncProvider: $context had $localFailures transient local upload failure(s); re-arming recovery',
         );
         _updateSyncState(_syncState.toIdle());
-        if (_startBackgroundSync) {
+        // Coordinator drains use rethrowOnError and schedule their own cooldown
+        // via RecordingTransferCoordinator._runPass — do not double-wake here.
+        if (_startBackgroundSync && !rethrowOnError) {
           unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
         }
       }
@@ -629,7 +648,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       if (isTransientNetworkError(e)) {
         DebugLogManager.logWarning('SyncProvider: $context hit transient network error; re-arming recovery: $e');
         _updateSyncState(_syncState.toIdle());
-        if (_startBackgroundSync) {
+        // Wake only for direct/manual calls; coordinator owns retry scheduling.
+        if (_startBackgroundSync && !rethrowOnError) {
           unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
         }
         if (rethrowOnError) rethrow;

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/services/connectivity_service.dart';
@@ -19,9 +20,7 @@ enum WalStatusFilter { pending, synced, corrupted }
 
 enum WalDisplayFilter { all, pending, synced }
 
-List<SyncedConversationPointer> sortSyncedConversationPointers(
-  Iterable<SyncedConversationPointer> pointers,
-) {
+List<SyncedConversationPointer> sortSyncedConversationPointers(Iterable<SyncedConversationPointer> pointers) {
   final sorted = List<SyncedConversationPointer>.from(pointers);
   sorted.sort((a, b) {
     final aDate = a.conversation.startedAt ?? a.conversation.createdAt;
@@ -214,10 +213,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   /// exhausted), the file is unreadable, or the server permanently refused it
   /// for being too old. Surfaced explicitly so a failure is never mistaken for
   /// a recording that simply hasn't synced yet.
-  int get needsAttentionWalsCount => _countWhere((s) =>
-      s == WalSyncDisplayState.failed ||
-      s == WalSyncDisplayState.corrupted ||
-      s == WalSyncDisplayState.outsideRecoveryWindow);
+  int get needsAttentionWalsCount => _countWhere(
+    (s) =>
+        s == WalSyncDisplayState.failed ||
+        s == WalSyncDisplayState.corrupted ||
+        s == WalSyncDisplayState.outsideRecoveryWindow,
+  );
 
   int get retryingWalsCount => _countWhere((s) => s == WalSyncDisplayState.retrying);
 
@@ -337,12 +338,12 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     @visibleForTesting Future<void> Function(LocalWalSyncImpl phone)? waitForWalReady,
     @visibleForTesting Future<void> Function()? startRecovery,
     @visibleForTesting Future<void> Function(WakeTrigger trigger)? wakeTransfer,
-  })  : _walServiceOverride = walService,
-        _uploadGate = uploadGate ?? SyncUploadGate.instance,
-        _startBackgroundSync = startBackgroundSync,
-        _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
-        _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
-        _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
+  }) : _walServiceOverride = walService,
+       _uploadGate = uploadGate ?? SyncUploadGate.instance,
+       _startBackgroundSync = startBackgroundSync,
+       _waitForWalReady = waitForWalReady ?? ((phone) => phone.walReady),
+       _startRecovery = startRecovery ?? (() => RecordingTransferCoordinator.instance.wake(WakeTrigger.startup)),
+       _wakeTransfer = wakeTransfer ?? ((trigger) => RecordingTransferCoordinator.instance.wake(trigger)) {
     _walService.subscribe(this, this);
     _audioPlayerUtils.addListener(_onAudioPlayerStateChanged);
     _rateLimitWasActive = SyncRateLimiter.instance.isLimited;
@@ -612,11 +613,28 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
         _updateSyncState(_syncState.toCompleted(conversations: []));
       }
 
+      // Client-side upload aborts (leave/background mid-multipart, #4587) leave
+      // WALs as `miss`. Schema requires re-arming recovery — not SyncStatus.error.
       if ((result?.localUploadFailures ?? 0) > 0) {
-        _updateSyncState(_syncState.toError(message: 'Upload failed. Check your connection and try again'));
+        DebugLogManager.logWarning(
+          'SyncProvider: $context had ${result!.localUploadFailures} local upload failure(s); re-arming recovery',
+        );
+        _updateSyncState(_syncState.toIdle());
+        if (_startBackgroundSync) {
+          unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
+        }
       }
       return result;
     } catch (e) {
+      if (isTransientNetworkError(e)) {
+        DebugLogManager.logWarning('SyncProvider: $context hit transient network error; re-arming recovery: $e');
+        _updateSyncState(_syncState.toIdle());
+        if (_startBackgroundSync) {
+          unawaited(_wakeTransfer(WakeTrigger.cooldownElapsed));
+        }
+        if (rethrowOnError) rethrow;
+        return null;
+      }
       final errorMessage = _formatSyncError(e, failedWal);
       Logger.debug('SyncProvider: Error in $context: $errorMessage');
       DebugLogManager.logError(e, null, 'SyncProvider: $context failed: $errorMessage', {

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:omi/backend/http/shared.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/models/sync_state.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
@@ -807,9 +808,14 @@ class LocalWalSyncImpl implements LocalWalSync {
       } catch (e) {
         print('Local WAL upload batch failed: $e, continuing with remaining files');
         batchesFailed++;
+        if (!isTransientNetworkError(e)) {
+          resp.localUploadPermanentFailures++;
+          resp.localUploadPermanentError = e.toString();
+        }
         DebugLogManager.logError(e, null, 'Local upload batch failed: ${e.toString()}', {
           'batchIndex': batchesCompleted + batchesFailed,
           'filesInBatch': files.length,
+          'transient': isTransientNetworkError(e),
         });
         // Upload failed: clear the transient flag, leave status `miss` so the
         // batch is retried on the next sync.
@@ -827,6 +833,7 @@ class LocalWalSyncImpl implements LocalWalSync {
     DebugLogManager.logEvent('local_upload_finished', {
       'batchesUploaded': batchesCompleted,
       'batchesFailed': batchesFailed,
+      'permanentFailures': resp.localUploadPermanentFailures,
       'corrupted': corruptedCount,
       'newConversations': resp.newConversationIds.length,
       'updatedConversations': resp.updatedConversationIds.length,

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -274,6 +274,8 @@ class WalSyncs implements IWalSync {
         ),
       );
       resp.localUploadFailures += preDrainResult.localUploadFailures;
+      resp.localUploadPermanentFailures += preDrainResult.localUploadPermanentFailures;
+      resp.localUploadPermanentError ??= preDrainResult.localUploadPermanentError;
     }
 
     // Phase 0: New offline storage sync, gated by firmware version.
@@ -358,6 +360,8 @@ class WalSyncs implements IWalSync {
         ),
       );
       resp.localUploadFailures += partialRes.localUploadFailures;
+      resp.localUploadPermanentFailures += partialRes.localUploadPermanentFailures;
+      resp.localUploadPermanentError ??= partialRes.localUploadPermanentError;
     }
 
     DebugLogManager.logEvent('sync_completed', {

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -91,16 +91,15 @@ void main() {
     await provider.syncWal(wal);
 
     expect(syncs.syncWalCalls, 1);
-    expect(
-        wakes,
-        [
-          WakeTrigger.cooldownElapsed,
-        ],
-        reason: 'successful syncWal must wake coordinator so uploaded WALs reconcile');
+    expect(wakes, [
+      WakeTrigger.cooldownElapsed,
+    ], reason: 'successful syncWal must wake coordinator so uploaded WALs reconcile');
     provider.dispose();
   });
 
-  test('partial localUploadFailures still complete then surface error', () async {
+  test('partial localUploadFailures re-arm recovery without SyncStatus.error', () async {
+    // Regression #4587: leave/background aborts paint as localUploadFailures;
+    // schema says those WALs stay miss and must soft-retry, not red-error.
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
     SyncRateLimiter.instance.clear();
@@ -127,10 +126,13 @@ void main() {
 
     await provider.syncWal(wal);
 
-    expect(provider.syncState.hasError, isTrue);
-    expect(provider.syncError, contains('Upload failed'));
-    // Still wakes — successful HTTP return with partial failures may include uploads.
-    expect(wakes, [WakeTrigger.cooldownElapsed]);
+    expect(provider.syncState.hasError, isFalse);
+    expect(provider.syncState.isIdle, isTrue);
+    expect(
+      wakes.where((w) => w == WakeTrigger.cooldownElapsed).length,
+      greaterThanOrEqualTo(1),
+      reason: 'localUploadFailures must re-arm coordinator cooldown wake',
+    );
     provider.dispose();
   });
 

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -91,9 +91,12 @@ void main() {
     await provider.syncWal(wal);
 
     expect(syncs.syncWalCalls, 1);
-    expect(wakes, [
-      WakeTrigger.cooldownElapsed,
-    ], reason: 'successful syncWal must wake coordinator so uploaded WALs reconcile');
+    expect(
+        wakes,
+        [
+          WakeTrigger.cooldownElapsed,
+        ],
+        reason: 'successful syncWal must wake coordinator so uploaded WALs reconcile');
     provider.dispose();
   });
 
@@ -128,11 +131,46 @@ void main() {
 
     expect(provider.syncState.hasError, isFalse);
     expect(provider.syncState.isIdle, isTrue);
+    expect(wal.status, WalStatus.miss);
     expect(
-      wakes.where((w) => w == WakeTrigger.cooldownElapsed).length,
-      greaterThanOrEqualTo(1),
-      reason: 'localUploadFailures must re-arm coordinator cooldown wake',
+      wakes,
+      [WakeTrigger.cooldownElapsed],
+      reason: 'transient localUploadFailures must emit exactly one re-arm wake from _performSync',
     );
+    provider.dispose();
+  });
+
+  test('permanent localUploadFailures still surface SyncStatus.error', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final syncs = _FakeSyncs([wal])
+      ..nextSyncResult = SyncLocalFilesResponse(
+        newConversationIds: [],
+        updatedConversationIds: [],
+        localUploadFailures: 1,
+        localUploadPermanentFailures: 1,
+        localUploadPermanentError: 'Exception: Audio file could not be processed by server',
+      );
+    final wakes = <WakeTrigger>[];
+
+    final provider = SyncProvider(
+      walService: _FakeWalService(syncs),
+      startBackgroundSync: true,
+      waitForWalReady: (_) async {},
+      startRecovery: () async {},
+      wakeTransfer: (trigger) async {
+        wakes.add(trigger);
+      },
+    );
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(provider.syncState.hasError, isTrue);
+    expect(wakes, isEmpty, reason: 'permanent refusals must not soft-retry via cooldown wake');
     provider.dispose();
   });
 

--- a/app/test/unit/transient_network_error_test.dart
+++ b/app/test/unit/transient_network_error_test.dart
@@ -12,6 +12,11 @@ void main() {
     );
     expect(isTransientNetworkError(abort), isTrue);
     expect(isTransientNetworkError(Exception('Software caused connection abort')), isTrue);
+    expect(isTransientNetworkError(Exception('software caused connection abort')), isTrue);
+  });
+
+  test('standalone ClientSoftware token is not treated as transient', () {
+    expect(isTransientNetworkError(Exception('ClientSoftware HTTP 400')), isFalse);
   });
 
   test('permanent HTTP errors are not transient', () {

--- a/app/test/unit/transient_network_error_test.dart
+++ b/app/test/unit/transient_network_error_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:omi/backend/http/shared.dart';
+
+void main() {
+  test('Android leave/background multipart abort is transient (#4587)', () {
+    final abort = http.ClientException(
+      'ClientSoftware caused connection abort',
+      Uri.parse('https://api.omi.me/v2/sync-local-files'),
+    );
+    expect(isTransientNetworkError(abort), isTrue);
+    expect(isTransientNetworkError(Exception('Software caused connection abort')), isTrue);
+  });
+
+  test('permanent HTTP errors are not transient', () {
+    expect(isTransientNetworkError(Exception('401 Unauthorized')), isFalse);
+    expect(isTransientNetworkError(Exception('Audio file could not be processed')), isFalse);
+  });
+
+  test('classic connectivity failures remain transient', () {
+    expect(isTransientNetworkError(const SocketException('Network is unreachable')), isTrue);
+    expect(isTransientNetworkError(http.ClientException('Connection reset by peer')), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Leaving the Offline Sync page (or backgrounding the app) mid-upload no longer paints a hard **Processing Failed** / `ClientSoftware caused connection abort` red error (#4587).
- Root cause: UI promises leave-safe sync (`syncProcessingBackgroundHint`), but architecture is foreground-only. OS aborts in-flight multipart; batches increment `localUploadFailures` and correctly leave WALs as `miss`, then `SyncProvider._performSync` fail-closed with `toError`.
- Shrink-only: on `localUploadFailures > 0` → `toIdle` + cooldown wake (matches schema: retryable, re-arm recovery — not completed, not terminal error). Transient network catch (incl. connection abort / ClientSoftware) same soft path. No FGS/Workmanager.
- Orthogonal to [#11127](https://github.com/BasedHardware/omi/pull/11127) (#7221 screen-lock grace).

## Test plan
- [x] `flutter test test/providers/sync_provider_sync_wal_wake_test.dart test/unit/transient_network_error_test.dart` → **7 passed**
- [ ] CI Dart Analyze / hermetic green
- [ ] Not verified on-device: Android leave sync page mid-upload with pendant backlog (needs device). Hermetic tests cover the fail-closed → soft-retry contract.

Failure-Class: none

Fixes #4587

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


