### PR TITLE
fix(conversations): resolve exact IDs in search and chat

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -54,7 +54,10 @@ from utils import byok
 from utils.memory.surface_routing import pin_memory_system
 from utils.conversations.search import (
     ConversationSearchUnavailableError,
+    clamp_conversation_search_pagination,
+    conversation_matches_date_range,
     conversation_matches_speaker,
+    parse_exact_conversation_reference,
     search_conversations,
 )
 from utils.llm.conversation_processing import generate_summary_with_prompt
@@ -1253,6 +1256,31 @@ def search_conversations_endpoint(
             end_timestamp = int(datetime.fromisoformat(search_request.end_date).timestamp())
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid end_date; expected an ISO 8601 datetime string")
+
+    exact_conversation_id = parse_exact_conversation_reference(search_request.query)
+    if exact_conversation_id:
+        exact_page, exact_per_page = clamp_conversation_search_pagination(search_request.page, search_request.per_page)
+        conversations = conversations_db.get_conversations_by_id_without_photos(
+            uid,
+            [exact_conversation_id],
+            include_discarded=bool(search_request.include_discarded),
+        )
+        conversations = [conversation for conversation in conversations if not conversation.get('is_locked')]
+        conversations = [
+            conversation
+            for conversation in conversations
+            if conversation_matches_speaker(conversation, search_request.speaker_id)
+            and conversation_matches_date_range(conversation, start_timestamp, end_timestamp)
+        ]
+        if exact_page != 1:
+            conversations = []
+        redact_conversations_for_list(conversations)
+        return {
+            'items': conversations[:exact_per_page],
+            'total_pages': 1,
+            'current_page': exact_page,
+            'per_page': exact_per_page,
+        }
 
     try:
         search_results = search_conversations(

--- a/backend/routers/tools.py
+++ b/backend/routers/tools.py
@@ -58,7 +58,7 @@ def _ok(tool_name: str, text: str) -> dict:
 
 
 class SearchConversationsRequest(BaseModel):
-    query: str = Field(description="Semantic search query")
+    query: str = Field(description="Natural-language topic, canonical conversation UUID, or h.omi.me share URL")
     start_date: Optional[str] = Field(default=None, description="ISO date with timezone")
     end_date: Optional[str] = Field(default=None, description="ISO date with timezone")
     limit: int = Field(default=5, ge=1, le=20)

--- a/backend/tests/unit/test_conversation_exact_reference_search.py
+++ b/backend/tests/unit/test_conversation_exact_reference_search.py
@@ -1,0 +1,67 @@
+"""Tests for strict exact conversation-reference parsing and hydrated date filtering."""
+
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault("TYPESENSE_HOST", "localhost")
+os.environ.setdefault("TYPESENSE_HOST_PORT", "8108")
+os.environ.setdefault("TYPESENSE_PROTOCOL", "http")
+os.environ.setdefault("TYPESENSE_API_KEY", "test-key")
+
+import pytest
+
+from utils.conversations.search import conversation_matches_date_range, parse_exact_conversation_reference
+
+CONVERSATION_ID = "e8c05000-52f0-4a95-951c-ccd715523429"
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        CONVERSATION_ID,
+        CONVERSATION_ID.upper(),
+        f"https://h.omi.me/conversations/{CONVERSATION_ID}",
+        f"https://H.OMI.ME/conversations/{CONVERSATION_ID.upper()}",
+    ],
+)
+def test_parse_exact_conversation_reference_accepts_canonical_id_and_share_url(reference):
+    assert parse_exact_conversation_reference(reference) == CONVERSATION_ID
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        CONVERSATION_ID[:-1],
+        f"https://h.omi.me/conversations/{CONVERSATION_ID}/extra",
+        f"https://h.omi.me/conversations/{CONVERSATION_ID}/",
+        f"http://h.omi.me/conversations/{CONVERSATION_ID}",
+        f"https://h.omi.me.evil.example/conversations/{CONVERSATION_ID}",
+        f"https://user@h.omi.me/conversations/{CONVERSATION_ID}",
+        f"https://h.omi.me:443/conversations/{CONVERSATION_ID}",
+        f"https://h.omi.me/conversations/{CONVERSATION_ID}?source=chat",
+        f"https://h.omi.me/conversations/{CONVERSATION_ID}#transcript",
+        "find the conversation e8c05000",
+    ],
+)
+def test_parse_exact_conversation_reference_rejects_ambiguous_references(reference):
+    assert parse_exact_conversation_reference(reference) is None
+
+
+@pytest.mark.parametrize(
+    "created_at,expected",
+    [
+        (datetime(2026, 1, 15, tzinfo=timezone.utc), True),
+        ("2026-01-15T00:00:00+00:00", True),
+        (datetime(2025, 12, 31, tzinfo=timezone.utc), False),
+        (None, False),
+    ],
+)
+def test_conversation_matches_date_range_uses_created_at(created_at, expected):
+    assert (
+        conversation_matches_date_range(
+            {"created_at": created_at},
+            start_date=int(datetime(2026, 1, 1, tzinfo=timezone.utc).timestamp()),
+            end_date=int(datetime(2026, 1, 31, tzinfo=timezone.utc).timestamp()),
+        )
+        is expected
+    )

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -204,6 +204,12 @@ try:
 finally:
     _restore_stubbed_modules()
 
+# The router imports these helpers from a lightweight module stub in this test file. Keep the default
+# parser on the natural-language path; individual exact-reference tests override it explicitly.
+conv.parse_exact_conversation_reference = MagicMock(return_value=None)
+conv.clamp_conversation_search_pagination = MagicMock(return_value=(1, 10))
+conv.conversation_matches_date_range = MagicMock(return_value=True)
+
 
 def _client():
     app = FastAPI()
@@ -292,6 +298,40 @@ def test_user_speaker_does_not_require_person_record():
     assert resp.status_code == 200
     mock_get_person.assert_not_called()
     assert mock_search.call_args.kwargs['speaker_id'] == 'user'
+
+
+def test_exact_reference_uses_owner_scoped_hydration_without_semantic_search():
+    conversation_id = 'e8c05000-52f0-4a95-951c-ccd715523429'
+    hydrated = [_conversation_dict(conversation_id, [])]
+    with (
+        patch.object(conv, 'parse_exact_conversation_reference', return_value=conversation_id),
+        patch.object(conv, 'search_conversations') as mock_search,
+        patch.object(
+            conv.conversations_db,
+            'get_conversations_by_id_without_photos',
+            return_value=hydrated,
+        ) as get_by_id,
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': conversation_id})
+
+    assert resp.status_code == 200
+    assert [item['id'] for item in resp.json()['items']] == [conversation_id]
+    get_by_id.assert_called_once_with('test-uid', [conversation_id], include_discarded=True)
+    mock_search.assert_not_called()
+
+
+def test_exact_reference_missing_conversation_is_generic_empty_result():
+    conversation_id = 'e8c05000-52f0-4a95-951c-ccd715523429'
+    with (
+        patch.object(conv, 'parse_exact_conversation_reference', return_value=conversation_id),
+        patch.object(conv.conversations_db, 'get_conversations_by_id_without_photos', return_value=[]),
+    ):
+        client = _client()
+        resp = client.post('/v1/conversations/search', json={'query': conversation_id})
+
+    assert resp.status_code == 200
+    assert resp.json()['items'] == []
 
 
 def _conversation(conversation_id='conv-1', status=ConversationStatus.in_progress):

--- a/backend/tests/unit/test_conversation_tool_date_range_bound.py
+++ b/backend/tests/unit/test_conversation_tool_date_range_bound.py
@@ -12,6 +12,7 @@ import os
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -70,7 +71,12 @@ for _name, _attrs in {
     "models.other": ["Person"],
     "utils.conversations.factory": ["deserialize_conversation"],
     "utils.conversations.render": ["conversations_to_string"],
-    "utils.conversations.search": ["keyword_search_conversation_ids", "merge_conversation_search_ids"],
+    "utils.conversations.search": [
+        "keyword_search_conversation_ids",
+        "merge_conversation_search_ids",
+        "parse_exact_conversation_reference",
+        "conversation_matches_date_range",
+    ],
     "utils.llm.clients": ["embeddings"],
     "utils.retrieval.agentic": ["agent_config_context"],
 }.items():
@@ -79,6 +85,34 @@ for _name, _attrs in {
         setattr(_m, _a, MagicMock())
 
 ct = _load("utils.retrieval.tools.conversation_tools", "utils/retrieval/tools/conversation_tools.py")
+
+
+class TestExactConversationReference:
+    def test_exact_reference_skips_semantic_search(self):
+        conversation_id = "e8c05000-52f0-4a95-951c-ccd715523429"
+        ct.parse_exact_conversation_reference.return_value = conversation_id
+        ct.conversation_matches_date_range.return_value = True
+        ct.keyword_search_conversation_ids.reset_mock()
+        ct.vector_db.query_vectors = MagicMock(return_value=[])
+        ct.conversations_db.get_conversations_by_id = MagicMock(
+            return_value=[{"id": conversation_id, "transcript_segments": [], "is_locked": False}]
+        )
+        ct.deserialize_conversation = MagicMock(
+            return_value=SimpleNamespace(transcript_segments=[], model_dump=lambda: {"id": conversation_id})
+        )
+        ct.conversations_to_string = MagicMock(return_value="[formatted]")
+        ct.notification_db.get_user_time_zone = MagicMock(return_value="UTC")
+
+        result = ct.search_conversations_tool.invoke(
+            {"query": conversation_id},
+            config={"configurable": {"user_id": "test-uid", "conversations_collected": []}},
+        )
+
+        assert "matching exactly" in result
+        assert "[formatted]" in result
+        ct.keyword_search_conversation_ids.assert_not_called()
+        ct.vector_db.query_vectors.assert_not_called()
+        ct.conversations_db.get_conversations_by_id.assert_called_once_with("test-uid", [conversation_id])
 
 
 class TestCapConversationsForLlm:

--- a/backend/tests/unit/test_tools_router.py
+++ b/backend/tests/unit/test_tools_router.py
@@ -290,6 +290,8 @@ factory_mod.deserialize_conversation = MagicMock(
 )
 search_mod = _stub_module("utils.conversations.search")
 search_mod.keyword_search_conversation_ids = MagicMock(return_value=[])
+search_mod.parse_exact_conversation_reference = MagicMock(return_value=None)
+search_mod.conversation_matches_date_range = MagicMock(return_value=True)
 
 
 def _merge_conversation_search_ids(keyword_ids, vector_ids):
@@ -311,6 +313,10 @@ transcript_chunks_mod.hydrate_chunk_texts = MagicMock(side_effect=_hydrate_chunk
 def reset_conversation_search_stubs():
     search_mod.keyword_search_conversation_ids.reset_mock()
     search_mod.keyword_search_conversation_ids.return_value = []
+    search_mod.parse_exact_conversation_reference.reset_mock()
+    search_mod.parse_exact_conversation_reference.return_value = None
+    search_mod.conversation_matches_date_range.reset_mock()
+    search_mod.conversation_matches_date_range.return_value = True
     search_mod.merge_conversation_search_ids.reset_mock()
     search_mod.merge_conversation_search_ids.side_effect = _merge_conversation_search_ids
     transcript_chunks_mod.hydrate_chunk_texts.reset_mock()
@@ -603,6 +609,39 @@ class TestSearchConversationsText:
         result = conversations_svc.search_conversations_text(uid="test-uid", query="test query")
         assert "Found" in result
         assert "1 conversations formatted" in result
+
+    def test_exact_reference_bypasses_keyword_and_vector_search(self):
+        conversation_id = "e8c05000-52f0-4a95-951c-ccd715523429"
+        search_mod.parse_exact_conversation_reference.return_value = conversation_id
+        conversations_db.get_conversations_by_id.return_value = [
+            {'id': conversation_id, 'transcript_segments': [], 'is_locked': False},
+        ]
+
+        result = conversations_svc.search_conversations_text(
+            uid="test-uid", query=f"https://h.omi.me/conversations/{conversation_id}"
+        )
+
+        assert "matching exactly" in result
+        assert "1 conversations formatted" in result
+        search_mod.keyword_search_conversation_ids.assert_not_called()
+        vector_db.query_vectors.assert_not_called()
+        conversations_db.get_conversations_by_id.assert_called_once_with("test-uid", [conversation_id])
+
+    def test_exact_reference_respects_date_filter(self):
+        conversation_id = "e8c05000-52f0-4a95-951c-ccd715523429"
+        search_mod.parse_exact_conversation_reference.return_value = conversation_id
+        search_mod.conversation_matches_date_range.return_value = False
+        conversations_db.get_conversations_by_id.return_value = [
+            {'id': conversation_id, 'transcript_segments': [], 'is_locked': False},
+        ]
+
+        result = conversations_svc.search_conversations_text(
+            uid="test-uid", query=conversation_id, start_date="2026-01-01T00:00:00Z"
+        )
+
+        assert "No conversations found" in result
+        search_mod.keyword_search_conversation_ids.assert_not_called()
+        vector_db.query_vectors.assert_not_called()
 
     def test_start_date_only_sets_ends_at(self):
         """One-sided date: start_date only should set ends_at to avoid $lte: None."""

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -2,6 +2,8 @@ import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
+from urllib.parse import urlsplit
+from uuid import UUID
 
 import typesense
 
@@ -10,6 +12,84 @@ logger = logging.getLogger(__name__)
 
 class ConversationSearchUnavailableError(Exception):
     """Raised when Typesense is unreachable or times out (transient upstream failure)."""
+
+
+_EXACT_CONVERSATION_HOST = 'h.omi.me'
+_EXACT_CONVERSATION_PATH_PREFIX = '/conversations/'
+
+
+def _canonical_conversation_uuid(value: str) -> Optional[str]:
+    """Return a normalized UUID only when ``value`` is a complete canonical UUID."""
+    if len(value) != 36:
+        return None
+    try:
+        parsed = UUID(value)
+    except ValueError:
+        return None
+    if str(parsed) != value.lower():
+        return None
+    return str(parsed)
+
+
+def parse_exact_conversation_reference(query: str) -> Optional[str]:
+    """Extract a canonical conversation UUID from an ID or Omi share URL.
+
+    Exact references intentionally accept only the two values Omi presents to users: a UUID or an
+    HTTPS URL on ``h.omi.me`` with the exact ``/conversations/<uuid>`` path. Anything else remains a
+    natural-language query so partial IDs and lookalike URLs cannot turn search into document probing.
+    """
+    value = query.strip() if query else ''
+    if exact_id := _canonical_conversation_uuid(value):
+        return exact_id
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+
+    if (
+        parsed.scheme.lower() != 'https'
+        or parsed.netloc.lower() != _EXACT_CONVERSATION_HOST
+        or parsed.query
+        or parsed.fragment
+        or not parsed.path.startswith(_EXACT_CONVERSATION_PATH_PREFIX)
+    ):
+        return None
+
+    return _canonical_conversation_uuid(parsed.path[len(_EXACT_CONVERSATION_PATH_PREFIX) :])
+
+
+def clamp_conversation_search_pagination(page: Optional[int], per_page: Optional[int]) -> tuple[int, int]:
+    """Clamp the unbounded search request pagination at the shared search boundary."""
+    return max(1, page or 1), max(1, min(per_page or 10, 250))
+
+
+def conversation_matches_date_range(
+    conversation: Dict[str, Any], start_date: Optional[int] = None, end_date: Optional[int] = None
+) -> bool:
+    """Apply the same ``created_at`` timestamp filters to an exact hydrated conversation."""
+    if start_date is None and end_date is None:
+        return True
+
+    created_at = conversation.get('created_at')
+    if isinstance(created_at, datetime):
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        timestamp = created_at.timestamp()
+    elif isinstance(created_at, (int, float)):
+        timestamp = float(created_at)
+    elif isinstance(created_at, str):
+        try:
+            parsed = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            timestamp = parsed.timestamp()
+        except ValueError:
+            return False
+    else:
+        return False
+
+    return (start_date is None or timestamp >= start_date) and (end_date is None or timestamp <= end_date)
 
 
 def _is_typesense_transient_error(exc: BaseException) -> bool:
@@ -135,8 +215,7 @@ def search_conversations(
     # negative, or a huge value would otherwise TypeError here (len(...) >= per_page / page + 1) or trip
     # Typesense RequestMalformed and 500 the request. Clamp at this shared boundary, mirroring the
     # clamps in routers/memories.py and routers/mcp.py. Typesense caps a single page at 250 hits.
-    page = max(1, page or 1)
-    per_page = max(1, min(per_page or 10, 250))
+    page, per_page = clamp_conversation_search_pagination(page, per_page)
     try:
         stripped_query = query.strip() if query else ''
         has_filter_only_browse = bool(speaker_id) or start_date is not None or end_date is not None

--- a/backend/utils/retrieval/tool_services/conversations.py
+++ b/backend/utils/retrieval/tool_services/conversations.py
@@ -15,7 +15,12 @@ from models.conversation import Conversation
 from models.other import Person
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.render import conversations_to_string
-from utils.conversations.search import keyword_search_conversation_ids, merge_conversation_search_ids
+from utils.conversations.search import (
+    conversation_matches_date_range,
+    keyword_search_conversation_ids,
+    merge_conversation_search_ids,
+    parse_exact_conversation_reference,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -157,7 +162,14 @@ def search_conversations_text(
     include_timestamps: bool = False,
 ) -> str:
     """Hybrid keyword + semantic vector search for conversations, formatted as LLM-ready text."""
-    logger.info(f"search_conversations_text - uid: {uid}, query: {query}, limit: {limit}")
+    exact_conversation_id = parse_exact_conversation_reference(query)
+    logger.info(
+        "search_conversations_text - uid=%s query_mode=%s query_len=%s limit=%s",
+        uid,
+        'exact-reference' if exact_conversation_id else 'semantic',
+        len(query or ''),
+        limit,
+    )
 
     # Cap limits
     if max_transcript_segments != -1:
@@ -188,13 +200,16 @@ def search_conversations_text(
         starts_at = 0  # epoch
 
     try:
-        # Hybrid search: keyword (Typesense, exact matches on title/overview — catches proper
-        # names that embeddings miss, see #5072) + semantic vector search, keyword hits first.
-        keyword_ids = keyword_search_conversation_ids(
-            uid=uid, query=query, limit=limit, start_date=starts_at, end_date=ends_at
-        )
-        vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
-        conversation_ids = merge_conversation_search_ids(keyword_ids, vector_ids)
+        if exact_conversation_id:
+            conversation_ids = [exact_conversation_id]
+        else:
+            # Hybrid search: keyword (Typesense, exact matches on title/overview — catches proper
+            # names that embeddings miss, see #5072) + semantic vector search, keyword hits first.
+            keyword_ids = keyword_search_conversation_ids(
+                uid=uid, query=query, limit=limit, start_date=starts_at, end_date=ends_at
+            )
+            vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+            conversation_ids = merge_conversation_search_ids(keyword_ids, vector_ids)
 
         if not conversation_ids:
             date_info = ""
@@ -212,6 +227,10 @@ def search_conversations_text(
 
         # Filter locked
         conversations_data = [c for c in conversations_data if not c.get('is_locked', False)]
+        if exact_conversation_id:
+            conversations_data = [
+                c for c in conversations_data if conversation_matches_date_range(c, starts_at, ends_at)
+            ]
         if not conversations_data:
             return f"No conversations found matching query: '{query}'"
 
@@ -239,10 +258,11 @@ def search_conversations_text(
                     conversation.transcript_segments = conversation.transcript_segments[:max_transcript_segments]
                 conversations.append(conversation)
             except Exception as e:
-                logger.error(f"Error parsing conversation {conv_data.get('id')}: {e}")
+                logger.error("Error parsing conversation search result: %s", type(e).__name__)
                 continue
 
-        result = f"Found {len(conversations)} conversations matching '{query}':\n\n"
+        match_kind = 'matching exactly' if exact_conversation_id else 'matching'
+        result = f"Found {len(conversations)} conversations {match_kind} '{query}':\n\n"
         result += conversations_to_string(
             conversations,
             use_transcript=include_transcript,

--- a/backend/utils/retrieval/tools/conversation_tools.py
+++ b/backend/utils/retrieval/tools/conversation_tools.py
@@ -16,7 +16,12 @@ import database.vector_db as vector_db
 from models.other import Person
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.render import conversations_to_string
-from utils.conversations.search import keyword_search_conversation_ids, merge_conversation_search_ids
+from utils.conversations.search import (
+    conversation_matches_date_range,
+    keyword_search_conversation_ids,
+    merge_conversation_search_ids,
+    parse_exact_conversation_reference,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -317,7 +322,10 @@ def search_conversations_tool(
     config: RunnableConfig = None,  # type: ignore[reportAssignmentType]  # langchain injects at runtime; None default for direct calls
 ) -> str:
     """
-    Search conversations using hybrid keyword + semantic vector search - USE THIS FOR EVENTS/INCIDENTS.
+    Search conversations by topic/event or exact canonical conversation ID/share URL.
+
+    Natural-language queries use hybrid keyword + semantic vector search - USE THIS FOR EVENTS/INCIDENTS.
+    Canonical UUIDs and h.omi.me conversation links resolve to one exact conversation.
 
     This tool combines exact keyword matching on conversation titles/summaries (best for proper names
     like people or places) with AI embeddings that find semantically similar conversations even if
@@ -361,10 +369,15 @@ def search_conversations_tool(
         include_timestamps: Add timestamps to transcript segments (default: False)
 
     Returns:
-        Formatted string with semantically matching conversations ranked by relevance, including transcripts,
-        summaries, action items, events, and metadata.
+        Formatted string with matching conversations, including transcripts, summaries, action items, events, and
+        metadata.
     """
-    logger.info(f"🔧 search_conversations_tool called with query: {query}")
+    exact_conversation_id = parse_exact_conversation_reference(query)
+    logger.info(
+        "🔧 search_conversations_tool mode=%s query_len=%s",
+        'exact-reference' if exact_conversation_id else 'semantic',
+        len(query or ''),
+    )
 
     # Get config from parameter or context variable (like other tools do)
     cfg: Optional[Dict[str, Any]] = cast(Optional[Dict[str, Any]], config)
@@ -387,7 +400,12 @@ def search_conversations_tool(
     if not uid:
         logger.info(f"❌ search_conversations_tool - no user_id in config")
         return "Error: User ID not found in configuration"
-    logger.info(f"✅ search_conversations_tool - uid: {uid}, query: {query}, limit: {limit}")
+    logger.info(
+        "✅ search_conversations_tool - uid=%s query_mode=%s limit=%s",
+        uid,
+        'exact-reference' if exact_conversation_id else 'semantic',
+        limit,
+    )
 
     # Cap max_transcript_segments at 1000 to prevent flooding LLM context
     if max_transcript_segments != -1:
@@ -422,17 +440,25 @@ def search_conversations_tool(
     limit = min(limit, 20)
 
     try:
-        # Hybrid search: keyword (Typesense, exact matches on title/overview — catches proper
-        # names that embeddings miss, see #5072) + semantic vector search, keyword hits first.
-        keyword_ids = keyword_search_conversation_ids(
-            uid=uid, query=query, limit=limit, start_date=starts_at, end_date=ends_at
-        )
-        vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
-        conversation_ids = merge_conversation_search_ids(keyword_ids, vector_ids)
+        keyword_ids: List[str] = []
+        vector_ids: List[str] = []
+        if exact_conversation_id:
+            conversation_ids = [exact_conversation_id]
+        else:
+            # Hybrid search: keyword (Typesense, exact matches on title/overview — catches proper
+            # names that embeddings miss, see #5072) + semantic vector search, keyword hits first.
+            keyword_ids = keyword_search_conversation_ids(
+                uid=uid, query=query, limit=limit, start_date=starts_at, end_date=ends_at
+            )
+            vector_ids = vector_db.query_vectors(query=query, uid=uid, starts_at=starts_at, ends_at=ends_at, k=limit)
+            conversation_ids = merge_conversation_search_ids(keyword_ids, vector_ids)
 
         logger.info(
-            f"📊 search_conversations_tool - found {len(conversation_ids)} results "
-            f"({len(keyword_ids)} keyword, {len(vector_ids)} vector) for query: '{query}'"
+            "📊 search_conversations_tool - found %s results (%s keyword, %s vector) query_mode=%s",
+            len(conversation_ids),
+            len(keyword_ids),
+            len(vector_ids),
+            'exact-reference' if exact_conversation_id else 'semantic',
         )
 
         if not conversation_ids:
@@ -445,7 +471,10 @@ def search_conversations_tool(
                 date_info = f" before the specified end date"
 
             msg = f"No conversations found matching the concept '{query}'{date_info}. The user may not have discussed this topic yet, or it may not be in their recorded conversation history."
-            logger.info(f"⚠️ search_conversations_tool - {msg}")
+            logger.info(
+                "⚠️ search_conversations_tool - no results query_mode=%s",
+                'exact-reference' if exact_conversation_id else 'semantic',
+            )
             return msg
 
         # Get full conversation data
@@ -456,6 +485,10 @@ def search_conversations_tool(
 
         # Filter out locked conversations (paid plan required)
         conversations_data = [c for c in conversations_data if not c.get('is_locked', False)]
+        if exact_conversation_id:
+            conversations_data = [
+                c for c in conversations_data if conversation_matches_date_range(c, starts_at, ends_at)
+            ]
 
         if not conversations_data:
             return f"No conversations found matching query: '{query}'"
@@ -497,7 +530,7 @@ def search_conversations_tool(
 
                 conversations.append(conversation)
             except Exception as e:
-                logger.error(f"Error parsing conversation {conv_data.get('id')}: {str(e)}")
+                logger.error("Error parsing conversation search result: %s", type(e).__name__)
                 continue
 
         logger.info(f"🔍 search_conversations_tool - Converted {len(conversations)} conversation objects")
@@ -516,7 +549,8 @@ def search_conversations_tool(
         )
 
         # Return formatted string
-        result = f"Found {len(conversations)} conversations semantically matching '{query}':\n\n"
+        match_kind = 'matching exactly' if exact_conversation_id else 'semantically matching'
+        result = f"Found {len(conversations)} conversations {match_kind} '{query}':\n\n"
         result += conversations_to_string(
             conversations,
             use_transcript=include_transcript,

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
@@ -354,13 +354,13 @@ enum GeneratedRealtimeTools {
   {
     "type": "function",
     "name": "search_conversations",
-    "description": "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'). Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
+    "description": "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
     "parameters": {
       "type": "object",
       "properties": {
         "query": {
           "type": "string",
-          "description": "Event or topic to search for"
+          "description": "Event/topic, canonical UUID, or https://h.omi.me/conversations/<uuid> link"
         },
         "start_date": {
           "type": "string"

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -402,9 +402,10 @@ enum GeneratedToolCapabilities {
       title: "Search Conversations",
       latency: .fastNetwork,
       surfaces: Set([.desktopChat, .realtimeHub]),
-      summary: "Semantic search across the user's past conversations.",
+      summary: "Search the user's past conversations by topic or exact canonical ID/share link.",
       bullets: [
-      "Use for specific topics, decisions, or events discussed in conversations."
+      "Use for specific topics, decisions, or events discussed in conversations.",
+      "For a canonical conversation UUID or https://h.omi.me/conversations/<uuid> link, pass it unchanged for an exact lookup."
     ]
     ),
     Capability(

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -46,8 +46,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:ad2e621b4cb6e7bfc72283c8e04ec1b1beef0da4ccf8b661bebf5cc9515255ff"
-  static let chatFirstManifestDigest = "sha256:d0932dbcb287c351ca07e6cc7ec311b85abadf14c406655fef503548bddb2e85"
+  static let manifestDigest = "sha256:d5c616c33eb64d4ce6c6bdce7402a1bb7a457eb2f42c05f99edb41219e17478a"
+  static let chatFirstManifestDigest = "sha256:d622ff2e8c6527fa5e32dcc106a6765174e40696ba5e86406bccd4d4026fbca0"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -373,12 +373,15 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
     surfaces: ["desktop_chat", "realtime_voice"],
     capabilityDoc: doc(
       "Search Conversations",
-      "Semantic search across the user's past conversations.",
-      ["Use for specific topics, decisions, or events discussed in conversations."],
+      "Search the user's past conversations by topic or exact canonical ID/share link.",
+      [
+        "Use for specific topics, decisions, or events discussed in conversations.",
+        "For a canonical conversation UUID or https://h.omi.me/conversations/<uuid> link, pass it unchanged for an exact lookup.",
+      ],
     ),
     voice: {
       realtimeDescription:
-        "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'). Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
+        "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
     },
   },
   get_memories: {
@@ -954,12 +957,12 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
   {
     name: "search_conversations",
     label: "Search Conversations",
-    description: "Semantic search across conversations. Use for specific events or topics.",
-    promptSnippet: "search_conversations - Find conversations about a topic",
+    description: "Search conversations by topic or exact canonical ID/share link.",
+    promptSnippet: "search_conversations - Find conversations about a topic or exact ID/share link",
     latency: "fast network",
     inputSchema: schema(
       {
-        query: { type: "string", description: "Event or topic to search for" },
+        query: { type: "string", description: "Event/topic, canonical UUID, or https://h.omi.me/conversations/<uuid> link" },
         start_date: { type: "string" },
         end_date: { type: "string" },
         limit: { type: "number", description: "Default 5, max 20" },

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -3655,15 +3655,15 @@
   {
     "name": "search_conversations",
     "label": "Search Conversations",
-    "description": "Semantic search across conversations. Use for specific events or topics.",
-    "promptSnippet": "search_conversations - Find conversations about a topic",
+    "description": "Search conversations by topic or exact canonical ID/share link.",
+    "promptSnippet": "search_conversations - Find conversations about a topic or exact ID/share link",
     "latency": "fast network",
     "inputSchema": {
       "type": "object",
       "properties": {
         "query": {
           "type": "string",
-          "description": "Event or topic to search for"
+          "description": "Event/topic, canonical UUID, or https://h.omi.me/conversations/<uuid> link"
         },
         "start_date": {
           "type": "string"
@@ -3712,13 +3712,14 @@
     ],
     "capabilityDoc": {
       "title": "Search Conversations",
-      "summary": "Semantic search across the user's past conversations.",
+      "summary": "Search the user's past conversations by topic or exact canonical ID/share link.",
       "bullets": [
-        "Use for specific topics, decisions, or events discussed in conversations."
+        "Use for specific topics, decisions, or events discussed in conversations.",
+        "For a canonical conversation UUID or https://h.omi.me/conversations/<uuid> link, pass it unchanged for an exact lookup."
       ]
     },
     "voice": {
-      "realtimeDescription": "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'). Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result."
+      "realtimeDescription": "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result."
     }
   },
   {

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -201,6 +201,14 @@ describe("omi tool manifest", () => {
     );
   });
 
+  it("documents exact conversation IDs and share links as search inputs", () => {
+    const tool = omiToolManifest.find((entry) => entry.name === "search_conversations");
+
+    expect(tool?.capabilityDoc.summary).toContain("exact canonical ID/share link");
+    expect(tool?.capabilityDoc.bullets.join(" ")).toContain("canonical conversation UUID");
+    expect(tool?.inputSchema.properties.query.description).toContain("canonical UUID");
+  });
+
   it("advertises optional positional parameters for execute_sql", () => {
     const executeSql = mcpToolDefinitionsForAdapter("omi-tools-stdio").find(
       (tool) => tool.name === "execute_sql",

--- a/desktop/macos/changelog/unreleased/20260805-conversation-id-search.json
+++ b/desktop/macos/changelog/unreleased/20260805-conversation-id-search.json
@@ -1,0 +1,3 @@
+{
+  "change": "Pasting a conversation ID or share link into search now opens the exact conversation."
+}


### PR DESCRIPTION
## Summary

- Resolve canonical conversation UUIDs and exact `https://h.omi.me/conversations/<uuid>` share links through the existing owner-scoped lookup.
- Apply exact routing to mobile conversation search and both Chat conversation-search surfaces, bypassing Typesense/Pinecone for exact references.
- Update agent tool guidance and regenerate the checked-in macOS tool surfaces.

## User-facing behavior

Pasting the UUID copied from iOS, or the desktop share link, now finds the exact accessible conversation. Natural-language search is unchanged. Malformed, missing, foreign, or locked references return the existing generic no-result behavior.

The parser is deliberately strict: only a canonical UUID or an exact HTTPS `h.omi.me` conversation URL is treated as an identifier. Partial IDs, lookalike hosts, extra URL components, and query/fragment variants remain normal search text.

## Scope

This fixes lookup behavior in the mobile search endpoint and Chat search tools. Desktop local identity reconciliation remains separate and is tracked by issue #9355.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

## Tests

- Focused backend tests: 18 exact-reference, 23 conversation-route, 89 REST-tool, 8 LangChain-tool, and 16 hybrid-search tests passed.
- Desktop tool-surface generation check passed; manifest tests passed (23 tests).
- `make preflight` passed all 10 checks.
- The full backend suite was run; two unrelated existing timing/import-isolation failures reproduced green when rerun through the prescribed file-list runner.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

