### PR TITLE
fix(app): tear down Android BLE GATT on disconnect tap even if unmanaged (#5361)

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleHostApiImpl.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleHostApiImpl.kt
@@ -7,6 +7,7 @@ import com.friend.ios.BleHostApi
 
 import android.app.Activity
 import android.bluetooth.BluetoothAdapter
+import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -53,8 +54,21 @@ class BleHostApiImpl(private val getActivity: () -> Activity?) : BleHostApi {
 
     override fun unmanageDevice(uuid: String) {
         Log.i(TAG, "unmanageDevice: $uuid")
-        OmiBleForegroundService.instance?.unmanageDevice(uuid)
-            ?: bleManager.closeGatt(uuid) // Fallback if service not running
+        val service = OmiBleForegroundService.instance
+        if (service != null) {
+            service.unmanageDevice(uuid)
+            return
+        }
+        // Service not running — still tear down any live GATT and record user
+        // disconnect intent so companion / sticky restart cannot revive (#5361).
+        bleManager.disconnectGatt(uuid)
+        bleManager.closeGatt(uuid)
+        val context = getActivity()?.applicationContext ?: return
+        context.getSharedPreferences(OmiBleForegroundService.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(OmiBleForegroundService.PREFS_USER_DISCONNECTED, true)
+            .remove(OmiBleForegroundService.PREFS_KEY)
+            .apply()
     }
 
     // ── Bonding ──

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleUnmanagePolicy.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleUnmanagePolicy.kt
@@ -1,0 +1,40 @@
+package com.friend.ios.ble
+
+/**
+ * Pure contract for user-initiated BLE disconnect (#5361).
+ *
+ * The foreground service's `managedDevices` map can desync from a live GATT
+ * (strict BG/BLE policy, GrapheneOS, FGS restart races). Unmanage must still
+ * tear down GATT and record user intent — never no-op just because the map
+ * entry is missing.
+ */
+object BleUnmanagePolicy {
+    data class Plan(
+        /** Cancel scheduled reconnect / stability timers if a managed entry existed. */
+        val cancelManagedTimers: Boolean,
+        /** Always call disconnectGatt then closeGatt for the address. */
+        val tearDownGatt: Boolean,
+        /** Persist user_disconnected=true so companion / sticky restart do not reconnect. */
+        val markUserDisconnected: Boolean,
+        /** Remove managed_device so sticky restore cannot revive the session. */
+        val clearManagedDevicePref: Boolean,
+        /** Notify Flutter that the peripheral disconnected. */
+        val notifyFlutterDisconnected: Boolean,
+        /** Stop the foreground service after a manual unmanage. */
+        val stopService: Boolean,
+    )
+
+    /**
+     * @param managedEntryPresent whether [address] was present in `managedDevices`
+     *        before removal. Does not change teardown / prefs / notify / stop —
+     *        those always run for a user disconnect tap.
+     */
+    fun plan(managedEntryPresent: Boolean): Plan = Plan(
+        cancelManagedTimers = managedEntryPresent,
+        tearDownGatt = true,
+        markUserDisconnected = true,
+        clearManagedDevicePref = true,
+        notifyFlutterDisconnected = true,
+        stopService = true,
+    )
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/BleUnmanagePolicy.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/BleUnmanagePolicy.kt
@@ -25,9 +25,9 @@ object BleUnmanagePolicy {
     )
 
     /**
-     * @param managedEntryPresent whether [address] was present in `managedDevices`
-     *        before removal. Does not change teardown / prefs / notify / stop —
-     *        those always run for a user disconnect tap.
+     * @param managedEntryPresent whether the requested address was present in
+     *        `managedDevices` before removal. Does not change teardown / prefs /
+     *        notify / stop — those always run for a user disconnect tap.
      */
     fun plan(managedEntryPresent: Boolean): Plan = Plan(
         cancelManagedTimers = managedEntryPresent,

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -46,9 +46,9 @@ class OmiBleForegroundService : Service() {
         private const val STABILITY_TIMER_MS = 60_000L
         private const val RECONNECT_DELAY_MS = 3_000L
         private const val COMPANION_RATE_LIMIT_MS = 15_000L
-        private const val PREFS_NAME = "ble_config"
-        private const val PREFS_KEY = "managed_device"
-        private const val PREFS_USER_DISCONNECTED = "user_disconnected"
+        const val PREFS_NAME = "ble_config"
+        const val PREFS_KEY = "managed_device"
+        const val PREFS_USER_DISCONNECTED = "user_disconnected"
         private const val DFU_SERVICE_UUID = "00001530-1212-efde-1523-785feabcd123"
         private const val PREFS_DIAGNOSTICS = "ble_diagnostics"
         private const val KEY_DISCONNECT_HISTORY = "disconnect_history"
@@ -369,27 +369,41 @@ class OmiBleForegroundService : Service() {
 
     fun unmanageDevice(address: String) {
         val addr = address.uppercase()
-        val managed = managedDevices.remove(addr) ?: return
+        val managed = managedDevices.remove(addr)
+        val plan = BleUnmanagePolicy.plan(managedEntryPresent = managed != null)
 
-        Log.i(TAG, "unmanageDevice: $addr")
+        // Never early-return when the map entry is missing (#5361): GATT may still
+        // be live while Dart has already flipped UI to disconnected.
+        Log.i(TAG, "unmanageDevice: $addr (managedEntry=${managed != null})")
 
-        managed.pendingReconnect?.let { handler.removeCallbacks(it) }
-        managed.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
+        if (plan.cancelManagedTimers) {
+            managed?.pendingReconnect?.let { handler.removeCallbacks(it) }
+            managed?.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
+        }
 
-        bleManager.disconnectGatt(addr)
-        bleManager.closeGatt(addr)
+        if (plan.tearDownGatt) {
+            bleManager.disconnectGatt(addr)
+            bleManager.closeGatt(addr)
+        }
 
-        getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
-            .putBoolean(PREFS_USER_DISCONNECTED, true)
-            .apply()
+        if (plan.markUserDisconnected || plan.clearManagedDevicePref) {
+            val editor = getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+            if (plan.markUserDisconnected) editor.putBoolean(PREFS_USER_DISCONNECTED, true)
+            if (plan.clearManagedDevicePref) editor.remove(PREFS_KEY)
+            editor.apply()
+        }
 
         persistDisconnectEvent(addr, 0, isManual = true, eventType = "disconnect")
 
-        bleManager.mainHandler.post {
-            bleManager.flutterApi?.onPeripheralDisconnected(addr, "unmanaged") {}
+        if (plan.notifyFlutterDisconnected) {
+            bleManager.mainHandler.post {
+                bleManager.flutterApi?.onPeripheralDisconnected(addr, "unmanaged") {}
+            }
         }
 
-        stopSelf()
+        if (plan.stopService) {
+            stopSelf()
+        }
     }
 
     // ── Connection ──

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/BleUnmanagePolicyTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/BleUnmanagePolicyTest.kt
@@ -1,0 +1,36 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression for #5361: disconnect tap must tear down GATT and record user intent
+ * even when the foreground service's managedDevices map is empty / desynced.
+ */
+class BleUnmanagePolicyTest {
+
+    @Test
+    fun plan_withoutManagedEntry_stillTearsDownGattAndPrefs() {
+        val plan = BleUnmanagePolicy.plan(managedEntryPresent = false)
+
+        assertFalse(plan.cancelManagedTimers)
+        assertTrue(plan.tearDownGatt)
+        assertTrue(plan.markUserDisconnected)
+        assertTrue(plan.clearManagedDevicePref)
+        assertTrue(plan.notifyFlutterDisconnected)
+        assertTrue(plan.stopService)
+    }
+
+    @Test
+    fun plan_withManagedEntry_cancelsTimersAndTearsDown() {
+        val plan = BleUnmanagePolicy.plan(managedEntryPresent = true)
+
+        assertTrue(plan.cancelManagedTimers)
+        assertTrue(plan.tearDownGatt)
+        assertTrue(plan.markUserDisconnected)
+        assertTrue(plan.clearManagedDevicePref)
+        assertTrue(plan.notifyFlutterDisconnected)
+        assertTrue(plan.stopService)
+    }
+}


### PR DESCRIPTION
## Summary
- Disconnect tap no longer leaves the pendant connected (blue LED / still listening) while the app shows red/disconnected (#5361).
- Root cause: `OmiBleForegroundService.unmanageDevice` early-returned when the address was missing from `managedDevices`, so a FGS/map desync skipped `disconnectGatt`/`closeGatt`. Dart still cleared prefs and flipped UI. Service-not-running fallback only called `closeGatt` (no `disconnect()`, no `user_disconnected` / `managed_device` clear).
- Shrink-only: always tear down GATT; set `user_disconnected`; remove `managed_device`; notify Flutter; stop service. `BleUnmanagePolicy` encodes the contract. Fallback path mirrors the same teardown.
- Orthogonal to [#10908](https://github.com/BasedHardware/omi/pull/10908) (#10847 — inverse desync / forceReconnect).

## Test plan
- [x] `BleUnmanagePolicyTest` (JVM hermetic) — managed-entry absent still plans full teardown
- [ ] CI Android Compile Smoke / Dart Analyze green
- [ ] Not verified on-device: Pixel / GrapheneOS disconnect tap → LED red + capture stops (needs device). Hermetic policy covers the fail-closed contract.

## Product invariants affected
none

Failure-Class: none

Fixes #5361

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

