### PR TITLE
fix(memory): enforce graph planner deadline off the main thread

### DIFF
--- a/.github/failure-classes/FC-main-thread-primitive-in-worker-context.json
+++ b/.github/failure-classes/FC-main-thread-primitive-in-worker-context.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-main-thread-primitive-in-worker-context",
+  "violated_contract": "Code that an entrypoint schedules onto an executor or worker thread must not depend on main-thread-only process primitives (POSIX signal timers and handlers); deadline and interrupt enforcement must function in whichever execution context callers schedule.",
+  "canonical_prevention": "Enforce call deadlines with context-agnostic mechanisms (watchdog futures plus transport-level timeouts) instead of signal timers, and cover the seam with a regression test that exercises the wrapper from a non-main thread.",
+  "evidence_prs": [
+    11163
+  ],
+  "scope_hints": [
+    "backend/**"
+  ],
+  "status": "open"
+}

--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -11,7 +11,6 @@ import json
 import os
 import sys
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -32,6 +31,7 @@ from database.firestore_index_registry import CANONICAL_MEMORY_ATLAS_READ_QUERY 
 from models.memory_apply import ApplyStatus, MemoryControlState  # noqa: E402
 from models.memory_promotion import PromotionGraphPlan  # noqa: E402
 from models.product_memory import MemoryItem  # noqa: E402
+from utils.executors import llm_executor, submit_with_context  # noqa: E402
 from utils.llm.clients import get_llm  # noqa: E402
 from utils.memory.graph_enrichment import prepare_graph_enrichment  # noqa: E402
 from utils.memory.historical_graph_enrichment import (  # noqa: E402
@@ -42,6 +42,11 @@ from utils.memory.historical_graph_enrichment import (  # noqa: E402
 MAX_PAGE_SIZE = 25
 MAX_STRUCTURED_SCAN_SIZE = 1250
 HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS = 20.0
+# A timed-out planner call is abandoned to its transport timeout while it
+# occupies one shared-executor slot. Consecutive misses mean the planner is
+# down, not that one item is pathological: stop the page instead of stacking
+# abandoned workers, and let a later run retry from the same cursor.
+PLANNER_CONSECUTIVE_TIMEOUT_LIMIT = 3
 
 
 class HistoricalGraphPlannerTimeout(TimeoutError):
@@ -173,20 +178,19 @@ def _plan_with_deadline(*, item: MemoryItem, control: MemoryControlState, llm: A
     Scheduled maintenance runs this page inside a ``db_executor`` worker
     thread, where installing a POSIX signal timer raises ``ValueError`` —
     which silently turned every candidate into ``planner_error`` before a
-    single provider request was made. A single-use watchdog future enforces
-    the same deadline from any thread. A call that outlives the deadline is
-    abandoned to its own transport timeout (the planner LLM is constructed
-    with ``request_timeout``), so the timed-out worker still ends on its own.
+    single provider request was made. A watchdog future on the shared LLM
+    executor enforces the same deadline from any thread and carries the
+    caller's contextvars, so gateway usage stays attributed to the user. A
+    call that outlives the deadline is abandoned to its own transport timeout
+    (the planner LLM is constructed with ``request_timeout``); the page's
+    consecutive-timeout breaker keeps abandoned workers bounded.
     """
-    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="historical-graph-planner")
+    future = submit_with_context(llm_executor, plan_historical_graph_enrichment, item=item, control=control, llm=llm)
     try:
-        future = pool.submit(plan_historical_graph_enrichment, item=item, control=control, llm=llm)
-        try:
-            return future.result(timeout=HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
-        except FuturesTimeoutError as exc:
-            raise HistoricalGraphPlannerTimeout("historical graph planner deadline exceeded") from exc
-    finally:
-        pool.shutdown(wait=False, cancel_futures=True)
+        return future.result(timeout=HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
+    except FuturesTimeoutError as exc:
+        future.cancel()
+        raise HistoricalGraphPlannerTimeout("historical graph planner deadline exceeded") from exc
 
 
 def _arguments() -> argparse.Namespace:
@@ -357,6 +361,7 @@ def run_enrichment(
         llm = get_llm("memory_l2", request_timeout=HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
     report: Counter[str] = Counter()
     applied = 0
+    consecutive_planner_timeouts = 0
     if not apply:
         control = _control(uid, db_client=db_client)
         for item in _candidates(
@@ -368,6 +373,13 @@ def run_enrichment(
                     if structured_only
                     else _plan_with_deadline(item=item, control=control, llm=llm)
                 )
+            except HistoricalGraphPlannerTimeout:
+                report["planner_error"] += 1
+                consecutive_planner_timeouts += 1
+                if consecutive_planner_timeouts >= PLANNER_CONSECUTIVE_TIMEOUT_LIMIT:
+                    report["planner_timeout_circuit_break"] += 1
+                    break
+                continue
             # The planner is an external dependency. A transient transport or
             # provider failure must not make a bounded page fail closed for all
             # of a user's remaining historical memories; leave this item
@@ -375,6 +387,7 @@ def run_enrichment(
             except Exception:
                 report["planner_error"] += 1
                 continue
+            consecutive_planner_timeouts = 0
             if planned is None:
                 report["not_structured"] += 1
             elif planned.status == "ready" and planned.operation is not None:
@@ -416,12 +429,25 @@ def run_enrichment(
                     if structured_only
                     else _plan_with_deadline(item=item, control=control, llm=llm)
                 )
+            except HistoricalGraphPlannerTimeout:
+                # A planner that misses several deadlines in a row is down,
+                # not unlucky. Stop the page without advancing the cursor so
+                # a later run retries these rows and abandoned workers on the
+                # shared executor stay bounded.
+                report["planner_error"] += 1
+                consecutive_planner_timeouts += 1
+                if consecutive_planner_timeouts >= PLANNER_CONSECUTIVE_TIMEOUT_LIMIT:
+                    report["planner_timeout_circuit_break"] += 1
+                    completed_page = False
+                    break
+                continue
             # A failed planner is still an examined row. Advancing past it lets
             # a later candidate in this page make progress; a subsequent full
             # cursor rotation retries the failure without starving older rows.
             except Exception:
                 report["planner_error"] += 1
                 continue
+            consecutive_planner_timeouts = 0
             if planned is None:
                 report["not_structured"] += 1
                 continue

--- a/backend/scripts/enrich_historical_memory_graph.py
+++ b/backend/scripts/enrich_historical_memory_graph.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import signal
 import sys
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -169,22 +170,23 @@ def _advance_historical_graph_cursor_txn(
 def _plan_with_deadline(*, item: MemoryItem, control: MemoryControlState, llm: Any):
     """Enforce the planner deadline even if a provider client ignores its timeout.
 
-    Cloud Run runs this synchronous script in its main thread on POSIX.  The
-    signal interrupts a stuck socket/read and is handled by the existing
-    per-item error path, so the page can continue to another candidate.
+    Scheduled maintenance runs this page inside a ``db_executor`` worker
+    thread, where installing a POSIX signal timer raises ``ValueError`` —
+    which silently turned every candidate into ``planner_error`` before a
+    single provider request was made. A single-use watchdog future enforces
+    the same deadline from any thread. A call that outlives the deadline is
+    abandoned to its own transport timeout (the planner LLM is constructed
+    with ``request_timeout``), so the timed-out worker still ends on its own.
     """
-    previous_handler = signal.getsignal(signal.SIGALRM)
-
-    def _expired(_signum, _frame):
-        raise HistoricalGraphPlannerTimeout("historical graph planner deadline exceeded")
-
-    signal.signal(signal.SIGALRM, _expired)
-    signal.setitimer(signal.ITIMER_REAL, HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="historical-graph-planner")
     try:
-        return plan_historical_graph_enrichment(item=item, control=control, llm=llm)
+        future = pool.submit(plan_historical_graph_enrichment, item=item, control=control, llm=llm)
+        try:
+            return future.result(timeout=HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS)
+        except FuturesTimeoutError as exc:
+            raise HistoricalGraphPlannerTimeout("historical graph planner deadline exceeded") from exc
     finally:
-        signal.setitimer(signal.ITIMER_REAL, 0)
-        signal.signal(signal.SIGALRM, previous_handler)
+        pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _arguments() -> argparse.Namespace:

--- a/backend/tests/unit/test_canonical_cohort_lifecycle.py
+++ b/backend/tests/unit/test_canonical_cohort_lifecycle.py
@@ -117,6 +117,95 @@ def test_terminal_backfill_reconciles_only_the_scheduler_owned_write_generation(
     assert db.payload(_path(uid))["account_generation"] == 1
 
 
+def test_one_principal_missing_state_head_does_not_starve_the_rest_of_the_cohort(monkeypatch):
+    """The dev cohort carries synthetic principals with read_ready checkpoints
+    and no migrated state head; raising for them starved every other user's
+    lifecycle progression on each scheduled run."""
+    legacy_uid = "cohort-legacy"
+    healthy_uid = "cohort-healthy"
+    db = _Db(
+        {
+            _path(legacy_uid): lifecycle._write_control_payload(legacy_uid),
+            _path(healthy_uid): lifecycle._write_control_payload(healthy_uid),
+        }
+    )
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [legacy_uid, healthy_uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: SimpleNamespace())
+    monkeypatch.setattr(
+        lifecycle,
+        "run_canonical_legacy_backfill_page",
+        lambda **_kwargs: SimpleNamespace(summary=SimpleNamespace(read_ready_count=2)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "FirestoreCheckpointStore",
+        lambda _db: SimpleNamespace(read=lambda _uid: SimpleNamespace(state=lifecycle.MigrationState.read_ready)),
+    )
+
+    def _trusted_read(**kwargs):
+        uid = kwargs["uid"]
+        if uid == legacy_uid:
+            return SimpleNamespace(
+                require_account_generation=lambda: (_ for _ in ()).throw(
+                    lifecycle.V3TrustedAccountGenerationReadError(
+                        lifecycle.V3AccountGenerationFailureReason.MISSING_STATE_HEAD
+                    )
+                )
+            )
+        return SimpleNamespace(require_account_generation=lambda: 3)
+
+    monkeypatch.setattr(lifecycle, "read_memory_v3_trusted_account_generation", _trusted_read)
+
+    report = lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert report.generation_reconciled_uids == (healthy_uid,)
+    assert report.generation_reconcile_errors == ()
+    assert db.payload(_path(healthy_uid))["account_generation"] == 3
+
+
+def test_a_malformed_state_head_is_reported_per_principal_without_starving_the_cohort(monkeypatch):
+    broken_uid = "cohort-broken"
+    healthy_uid = "cohort-healthy"
+    db = _Db(
+        {
+            _path(broken_uid): lifecycle._write_control_payload(broken_uid),
+            _path(healthy_uid): lifecycle._write_control_payload(healthy_uid),
+        }
+    )
+    monkeypatch.setattr(lifecycle, "list_canonical_cohort_uids", lambda: [broken_uid, healthy_uid])
+    monkeypatch.setattr(lifecycle, "reconcile_canonical_memory_onboarding", lambda _db: SimpleNamespace())
+    monkeypatch.setattr(
+        lifecycle,
+        "run_canonical_legacy_backfill_page",
+        lambda **_kwargs: SimpleNamespace(summary=SimpleNamespace(read_ready_count=2)),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "FirestoreCheckpointStore",
+        lambda _db: SimpleNamespace(read=lambda _uid: SimpleNamespace(state=lifecycle.MigrationState.read_ready)),
+    )
+
+    def _trusted_read(**kwargs):
+        uid = kwargs["uid"]
+        if uid == broken_uid:
+            return SimpleNamespace(
+                require_account_generation=lambda: (_ for _ in ()).throw(
+                    lifecycle.V3TrustedAccountGenerationReadError(
+                        lifecycle.V3AccountGenerationFailureReason.MALFORMED_STATE_HEAD
+                    )
+                )
+            )
+        return SimpleNamespace(require_account_generation=lambda: 4)
+
+    monkeypatch.setattr(lifecycle, "read_memory_v3_trusted_account_generation", _trusted_read)
+
+    report = lifecycle.run_canonical_cohort_lifecycle(db_client=db)
+
+    assert report.generation_reconciled_uids == (healthy_uid,)
+    assert report.generation_reconcile_errors == (f"uid={broken_uid}: generation_reconcile:malformed_state_head",)
+    assert db.payload(_path(healthy_uid))["account_generation"] == 4
+
+
 def test_terminal_backfill_reconciles_a_newer_trusted_head_after_a_prior_scheduler_generation(monkeypatch):
     uid = "cohort-a"
     db = _Db({_path(uid): lifecycle._write_control_payload(uid, account_generation=1)})

--- a/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
+++ b/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
@@ -39,6 +39,7 @@ def _enable_for(monkeypatch, *uids: str) -> None:
             backfill=SimpleNamespace(summary=SimpleNamespace(read_ready_count=0)),
             backfill_ready_uids=tuple(uids),
             generation_reconciled_uids=(),
+            generation_reconcile_errors=(),
         ),
     )
 
@@ -70,6 +71,7 @@ def test_enabled_cohort_runs_lifecycle_before_maintenance(monkeypatch):
         backfill=SimpleNamespace(summary=SimpleNamespace(read_ready_count=1)),
         backfill_ready_uids=(CANONICAL_A,),
         generation_reconciled_uids=(CANONICAL_A,),
+        generation_reconcile_errors=(),
     )
     lifecycle_calls = []
     monkeypatch.setattr(
@@ -154,6 +156,7 @@ def test_graph_backfill_uses_per_item_fences_while_lifecycle_staging_is_incomple
             backfill=SimpleNamespace(summary=SimpleNamespace(read_ready_count=0)),
             backfill_ready_uids=(),
             generation_reconciled_uids=(),
+            generation_reconcile_errors=(),
         ),
     )
     monkeypatch.setattr(

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -499,3 +499,81 @@ def test_historical_planner_deadline_enforcement_works_off_the_main_thread(monke
     assert not worker.is_alive(), "planner deadline wrapper hung off the main thread"
     assert outcome.get("error") is None, f"planner raised off the main thread: {outcome.get('error')!r}"
     assert outcome.get("planned") is sentinel
+
+
+def test_historical_planner_deadline_fires_off_the_main_thread(monkeypatch: pytest.MonkeyPatch):
+    """The timeout branch must also work in the worker-thread context the
+    maintenance cron uses — not only when the planner returns promptly."""
+    monkeypatch.setattr(historical_runner, "HISTORICAL_GRAPH_PLANNER_TIMEOUT_SECONDS", 0.01)
+    release = threading.Event()
+    monkeypatch.setattr(historical_runner, "plan_historical_graph_enrichment", lambda **_kwargs: release.wait(5))
+
+    outcome: dict[str, object] = {}
+
+    def _run_off_main_thread() -> None:
+        try:
+            historical_runner._plan_with_deadline(
+                item=_item(),
+                control=MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2),
+                llm=object(),
+            )
+            outcome["error"] = AssertionError("deadline never fired")
+        except historical_runner.HistoricalGraphPlannerTimeout:
+            outcome["timed_out"] = True
+        except Exception as exc:  # pragma: no cover - the failure being guarded against
+            outcome["error"] = exc
+
+    worker = threading.Thread(target=_run_off_main_thread)
+    worker.start()
+    worker.join(timeout=5)
+    release.set()
+
+    assert not worker.is_alive(), "planner deadline wrapper hung off the main thread"
+    assert outcome.get("error") is None, f"unexpected outcome off the main thread: {outcome.get('error')!r}"
+    assert outcome.get("timed_out") is True
+
+
+def test_consecutive_planner_timeouts_stop_the_page_without_advancing_the_cursor(monkeypatch: pytest.MonkeyPatch):
+    """Each timed-out planner call abandons a worker on the shared executor;
+    a page must stop stacking them once the planner is clearly down, and the
+    unexamined rows must be retried by a later run from the same cursor."""
+    control = MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2)
+    items = [_item(memory_id=f"mem_{index}") for index in range(5)]
+    cursor_store = _CursorStore()
+    examined: list[str] = []
+
+    monkeypatch.setattr(historical_runner, "_control", lambda *_args, **_kwargs: control)
+    monkeypatch.setattr(
+        historical_runner,
+        "_candidate_page",
+        lambda *_args, **_kwargs: historical_runner.HistoricalGraphCandidatePage(
+            items=items, last_scanned=items[-1], exhausted=False
+        ),
+    )
+
+    def _always_times_out(*, item: MemoryItem, **_kwargs: object):
+        examined.append(item.memory_id)
+        raise historical_runner.HistoricalGraphPlannerTimeout("historical graph planner deadline exceeded")
+
+    monkeypatch.setattr(historical_runner, "_plan_with_deadline", _always_times_out)
+
+    report = run_enrichment(
+        uid="u1",
+        firestore_project="test",
+        limit=5,
+        scan_limit=5,
+        apply=True,
+        confirm_uid="u1",
+        structured_only=False,
+        apply_limit=5,
+        db_client=object(),
+        llm=object(),
+        cursor_store=cursor_store,
+    )
+
+    assert report["outcomes"] == {
+        "planner_error": historical_runner.PLANNER_CONSECUTIVE_TIMEOUT_LIMIT,
+        "planner_timeout_circuit_break": 1,
+    }
+    assert examined == ["mem_0", "mem_1", "mem_2"]
+    assert cursor_store.advances == []

--- a/backend/tests/unit/test_historical_graph_enrichment.py
+++ b/backend/tests/unit/test_historical_graph_enrichment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -467,3 +468,34 @@ def test_historical_planner_deadline_interrupts_a_stuck_sync_call(monkeypatch: p
             control=MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2),
             llm=object(),
         )
+
+
+def test_historical_planner_deadline_enforcement_works_off_the_main_thread(monkeypatch: pytest.MonkeyPatch):
+    """The maintenance cron runs enrichment on a ``db_executor`` worker thread.
+
+    The former POSIX signal timer raises ``ValueError`` there, which turned
+    every scheduled candidate into a silent ``planner_error`` (0 committed,
+    every outcome blocked) while the CLI kept working from the main thread.
+    """
+    sentinel = object()
+    monkeypatch.setattr(historical_runner, "plan_historical_graph_enrichment", lambda **_kwargs: sentinel)
+
+    outcome: dict[str, object] = {}
+
+    def _run_off_main_thread() -> None:
+        try:
+            outcome["planned"] = historical_runner._plan_with_deadline(
+                item=_item(),
+                control=MemoryControlState(uid="u1", head_commit_id="head0", account_generation=1, source_generation=2),
+                llm=object(),
+            )
+        except Exception as exc:  # pragma: no cover - the failure being guarded against
+            outcome["error"] = exc
+
+    worker = threading.Thread(target=_run_off_main_thread)
+    worker.start()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive(), "planner deadline wrapper hung off the main thread"
+    assert outcome.get("error") is None, f"planner raised off the main thread: {outcome.get('error')!r}"
+    assert outcome.get("planned") is sentinel

--- a/backend/utils/memory/canonical_cohort_lifecycle.py
+++ b/backend/utils/memory/canonical_cohort_lifecycle.py
@@ -32,7 +32,11 @@ from utils.memory.canonical_memory_onboarding import (
     reconcile_canonical_memory_onboarding,
 )
 from utils.memory.memory_system import list_canonical_cohort_uids
-from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import (
+    V3AccountGenerationFailureReason,
+    V3TrustedAccountGenerationReadError,
+    read_memory_v3_trusted_account_generation,
+)
 from utils.memory.v3.limited_rollout_config import build_whitelisted_user_control_state
 
 
@@ -44,6 +48,7 @@ class CanonicalCohortLifecycleReport:
     backfill_ready_uids: tuple[str, ...]
     generation_reconciled_uids: tuple[str, ...]
     backfill: CanonicalLegacyBackfillPage
+    generation_reconcile_errors: tuple[str, ...] = ()
 
 
 def _inert_control_payload(uid: str) -> dict[str, Any]:
@@ -224,16 +229,32 @@ def run_canonical_cohort_lifecycle(*, db_client: Any) -> CanonicalCohortLifecycl
     backfill_ready = tuple(
         uid for uid in list_canonical_cohort_uids() if checkpoint_store.read(uid).state == MigrationState.read_ready
     )
-    generation_reconciled = tuple(
-        uid for uid in backfill_ready if _reconcile_terminal_backfill_generation(uid=uid, db_client=db_client)
-    )
+    # One principal's malformed or missing trusted state must fail closed for
+    # that principal only. Raising here starved every other cohort user's
+    # lifecycle progression on each scheduled run.
+    generation_reconciled: list[str] = []
+    reconcile_errors: list[str] = []
+    for uid in backfill_ready:
+        try:
+            if _reconcile_terminal_backfill_generation(uid=uid, db_client=db_client):
+                generation_reconciled.append(uid)
+        except V3TrustedAccountGenerationReadError as exc:
+            if exc.reason == V3AccountGenerationFailureReason.MISSING_STATE_HEAD:
+                # A read_ready checkpoint without a migrated state head is a
+                # legacy principal that has not produced one yet: preserved,
+                # reconciled once the head exists, and not a cohort error.
+                continue
+            reconcile_errors.append(f"uid={uid}: generation_reconcile:{exc.reason.value}")
+        except RuntimeError as exc:
+            reconcile_errors.append(f"uid={uid}: generation_reconcile:{exc}")
     return CanonicalCohortLifecycleReport(
         onboarding=onboarding,
         write_enrolled_uids=tuple(write_enrolled),
         preserved_uids=tuple(preserved),
         backfill_ready_uids=backfill_ready,
-        generation_reconciled_uids=generation_reconciled,
+        generation_reconciled_uids=tuple(generation_reconciled),
         backfill=backfill,
+        generation_reconcile_errors=tuple(reconcile_errors),
     )
 
 

--- a/backend/utils/memory/canonical_short_term_maintenance_cron.py
+++ b/backend/utils/memory/canonical_short_term_maintenance_cron.py
@@ -179,6 +179,10 @@ def run_canonical_short_term_maintenance_for_cohort(
         summary.lifecycle_write_enrolled_total = len(lifecycle.write_enrolled_uids)
         summary.lifecycle_backfill_read_ready_total = lifecycle.backfill.summary.read_ready_count
         summary.lifecycle_generation_reconciled_total = len(lifecycle.generation_reconciled_uids)
+        for reconcile_error in lifecycle.generation_reconcile_errors:
+            message = f"canonical_cohort_lifecycle:{reconcile_error}"
+            logger.warning("canonical_short_term_maintenance_cron: %s", message)
+            summary.errors.append(message)
     logger.info(
         "canonical_short_term_maintenance_cron: start run_id=%s user_count=%d",
         effective_run_id,


### PR DESCRIPTION
Two defects found by executing the official dev `memory-maintenance-job` (image `8366138`) and reading its logs: runs `cron-20260806042620` / `cron-20260806043314` reported `graph_enriched_total=0 graph_enrichment_blocked_total=28 errors=2` with no planner HTTP traffic.

## Fix 1 — graph planner deadline enforced off the main thread

The job entrypoint runs the cron via `asyncio.run(...)` → `run_blocking(db_executor, ...)`, so `run_enrichment` executes on a worker thread. `_plan_with_deadline` installed a POSIX `SIGALRM` timer, and `signal.signal()` raises `ValueError` off the main thread — every candidate silently became `planner_error` before a single provider request. The arithmetic matches exactly: 25 planner errors (page size) + 3 `cursor_advanced` (one per cohort user) = 28 blocked. The CLI kept working because it runs on the main thread.

Fixed by replacing the signal timer with a single-use watchdog future (`ThreadPoolExecutor` + `future.result(timeout=...)`) enforcing the same deadline in any execution context; a call that outlives the deadline is abandoned to its own transport timeout (the planner LLM is constructed with `request_timeout`).

## Fix 2 — cohort lifecycle reconcile failures isolated per principal

`run_canonical_cohort_lifecycle` reconciled terminal backfill generations in a comprehension, so one principal with a missing/malformed trusted state head (`V3TrustedAccountGenerationReadError`) raised out of the whole lifecycle run. The dev cohort's synthetic smoke/emulator principals (`read_ready` checkpoints, no `memory_state/head`) starved every real user's lifecycle progression on every scheduled run.

Now: `missing_state_head` is treated as a legacy principal that has not produced a migrated head yet — preserved, retried once the head exists, not a cohort error (legacy-principal fallback). Any other per-principal reconcile failure is reported per uid through the lifecycle report and cron summary — the job still fails visibly — without blocking other principals.

## Verification

- New regression test `test_historical_planner_deadline_enforcement_works_off_the_main_thread` executes the wrapper from a non-main thread through the production API; proven to fail with `ValueError` against the previous implementation and pass with the fix. Existing stuck-call deadline test still passes (21 passed in `test_historical_graph_enrichment.py`).
- New starvation regression tests: `test_one_principal_missing_state_head_does_not_starve_the_rest_of_the_cohort` and `test_a_malformed_state_head_is_reported_per_principal_without_starving_the_cohort` (8 passed in `test_canonical_cohort_lifecycle.py`).
- `test_canonical_short_term_maintenance_cron.py` — 16 passed (per-uid reconcile errors surface in the cron summary).
- Dev-data read-only reproduction: for the cohort, `read_memory_v3_trusted_account_generation` returns `MISSING_STATE_HEAD` for both synthetic principals and generation 1 for the real user; the job's candidate page for the real user holds 125 eligible items, first 25 all hash-valid — consistent with silent per-candidate planner failure, not data problems.

Failure-Class: new

`FC-main-thread-primitive-in-worker-context`: code scheduled onto an executor must not depend on main-thread-only process primitives; deadline/interrupt enforcement must be context-agnostic and tested from a non-main thread. (Fix 2 is an instance of per-principal fail-closed scope: one malformed principal must not starve the cohort.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Product invariants affected

- INV-MEM-1 (path-matched: scheduler/lifecycle files under `backend/utils/memory/`; tier semantics unchanged — no tier is added, removed, or re-routed)
