### PR TITLE
fix(app): strict segment seek + stop-at-end for transcript playback (#4471)

### DIFF
--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -333,8 +333,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
         final conversation = provider.conversation;
         final summaryContent =
             conversation.appResults.isNotEmpty && conversation.appResults[0].content.trim().isNotEmpty
-            ? conversation.appResults[0].content.trim()
-            : conversation.structured.toString();
+                ? conversation.appResults[0].content.trim()
+                : conversation.structured.toString();
         _copyContent(context, summaryContent);
         break;
       case 'download_audio':
@@ -764,8 +764,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                                         provider.conversation.starred = newStarredState;
                                         // Update in conversation provider
                                         context.read<ConversationProvider>().updateConversationInSortedList(
-                                          provider.conversation,
-                                        );
+                                              provider.conversation,
+                                            );
                                         // Track star/unstar action
                                         PlatformManager.instance.analytics.conversationStarToggled(
                                           conversation: provider.conversation,
@@ -1104,15 +1104,13 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                   child: Consumer<ConversationDetailProvider>(
                     builder: (context, provider, child) {
                       final conversation = provider.conversation;
-                      final hasActionItems = conversation.structured.actionItems
-                          .where((item) => !item.deleted)
-                          .isNotEmpty;
+                      final hasActionItems =
+                          conversation.structured.actionItems.where((item) => !item.deleted).isNotEmpty;
                       return ConversationBottomBar(
                         mode: ConversationBottomBarMode.detail,
                         selectedTab: selectedTab,
                         conversation: conversation,
-                        hasSegments:
-                            conversation.transcriptSegments.isNotEmpty ||
+                        hasSegments: conversation.transcriptSegments.isNotEmpty ||
                             conversation.photos.isNotEmpty ||
                             conversation.externalIntegration != null,
                         hasActionItems: hasActionItems,
@@ -1738,29 +1736,29 @@ class _CalendarEventPickerSheetState extends State<CalendarEventPickerSheet> {
             child: _isLoading
                 ? _buildShimmerList()
                 : _events.isEmpty
-                ? const Center(
-                    child: Padding(
-                      padding: EdgeInsets.all(40),
-                      child: Text(
-                        'No calendar events found around this time.',
-                        style: TextStyle(color: Colors.grey, fontSize: 15),
-                        textAlign: TextAlign.center,
+                    ? const Center(
+                        child: Padding(
+                          padding: EdgeInsets.all(40),
+                          child: Text(
+                            'No calendar events found around this time.',
+                            style: TextStyle(color: Colors.grey, fontSize: 15),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      )
+                    : ListView.separated(
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        itemCount: _events.length,
+                        separatorBuilder: (_, __) =>
+                            const Divider(color: Color(0xFF2A2A2E), height: 1, indent: 16, endIndent: 16),
+                        itemBuilder: (context, index) {
+                          final event = _events[index];
+                          final isLinkingThis = _linkingEventId == event.eventId;
+                          final isSuggested = event.eventId == _suggestedEventId;
+                          return _buildEventTile(event, isSuggested, isLinkingThis);
+                        },
                       ),
-                    ),
-                  )
-                : ListView.separated(
-                    shrinkWrap: true,
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    itemCount: _events.length,
-                    separatorBuilder: (_, __) =>
-                        const Divider(color: Color(0xFF2A2A2E), height: 1, indent: 16, endIndent: 16),
-                    itemBuilder: (context, index) {
-                      final event = _events[index];
-                      final isLinkingThis = _linkingEventId == event.eventId;
-                      final isSuggested = event.eventId == _suggestedEventId;
-                      return _buildEventTile(event, isSuggested, isLinkingThis);
-                    },
-                  ),
           ),
           SizedBox(height: MediaQuery.of(context).padding.bottom + 8),
         ],
@@ -1853,11 +1851,9 @@ class _TranscriptWidgetsState extends State<TranscriptWidgets> with AutomaticKee
                 }
                 final segments = provider.conversation.transcriptSegments;
                 final segment = segments[segmentIndex];
-                final person = segment.personId != null
-                    ? SharedPreferencesUtil().getPersonById(segment.personId!)
-                    : null;
-                final speakerName =
-                    person?.name ??
+                final person =
+                    segment.personId != null ? SharedPreferencesUtil().getPersonById(segment.personId!) : null;
+                final speakerName = person?.name ??
                     context.l10n.speakerWithId('${TranscriptSegment.getDisplaySpeakerId(segment.speakerId, segments)}');
                 PlatformManager.instance.analytics.editSegmentTextStarted();
                 bool saved = false;
@@ -1916,9 +1912,8 @@ class _TranscriptWidgetsState extends State<TranscriptWidgets> with AutomaticKee
                               );
                               if (segmentIndex == -1) continue;
                               provider.conversation.transcriptSegments[segmentIndex].isUser = finalPersonId == 'user';
-                              provider.conversation.transcriptSegments[segmentIndex].personId = finalPersonId == 'user'
-                                  ? null
-                                  : finalPersonId;
+                              provider.conversation.transcriptSegments[segmentIndex].personId =
+                                  finalPersonId == 'user' ? null : finalPersonId;
                             }
                             await assignBulkConversationTranscriptSegments(
                               provider.conversation.id,

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -76,8 +76,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
   final AppReviewService _appReviewService = AppReviewService();
   ConversationTab selectedTab = ConversationTab.summary;
 
-  // Callback to seek audio to transcript segment
-  Future<void> Function(double)? _seekToSegmentCallback;
+  // Callback to seek audio to transcript segment (start, end) in wall seconds
+  Future<void> Function(double start, double end)? _seekToSegmentCallback;
   bool _isSharing = false;
   bool _isTogglingStarred = false;
   bool _isDownloadingAudio = false;
@@ -333,8 +333,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
         final conversation = provider.conversation;
         final summaryContent =
             conversation.appResults.isNotEmpty && conversation.appResults[0].content.trim().isNotEmpty
-                ? conversation.appResults[0].content.trim()
-                : conversation.structured.toString();
+            ? conversation.appResults[0].content.trim()
+            : conversation.structured.toString();
         _copyContent(context, summaryContent);
         break;
       case 'download_audio':
@@ -764,8 +764,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                                         provider.conversation.starred = newStarredState;
                                         // Update in conversation provider
                                         context.read<ConversationProvider>().updateConversationInSortedList(
-                                              provider.conversation,
-                                            );
+                                          provider.conversation,
+                                        );
                                         // Track star/unstar action
                                         PlatformManager.instance.analytics.conversationStarToggled(
                                           conversation: provider.conversation,
@@ -1058,9 +1058,9 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                                       _controller!.animateTo(0);
                                     }
 
-                                    // Seek to segment using callback
+                                    // Seek to segment using callback (start + end for bounded play)
                                     if (_seekToSegmentCallback != null) {
-                                      await _seekToSegmentCallback!(segment.start);
+                                      await _seekToSegmentCallback!(segment.start, segment.end);
                                       HapticFeedback.lightImpact();
                                     }
                                   },
@@ -1104,13 +1104,15 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                   child: Consumer<ConversationDetailProvider>(
                     builder: (context, provider, child) {
                       final conversation = provider.conversation;
-                      final hasActionItems =
-                          conversation.structured.actionItems.where((item) => !item.deleted).isNotEmpty;
+                      final hasActionItems = conversation.structured.actionItems
+                          .where((item) => !item.deleted)
+                          .isNotEmpty;
                       return ConversationBottomBar(
                         mode: ConversationBottomBarMode.detail,
                         selectedTab: selectedTab,
                         conversation: conversation,
-                        hasSegments: conversation.transcriptSegments.isNotEmpty ||
+                        hasSegments:
+                            conversation.transcriptSegments.isNotEmpty ||
                             conversation.photos.isNotEmpty ||
                             conversation.externalIntegration != null,
                         hasActionItems: hasActionItems,
@@ -1736,29 +1738,29 @@ class _CalendarEventPickerSheetState extends State<CalendarEventPickerSheet> {
             child: _isLoading
                 ? _buildShimmerList()
                 : _events.isEmpty
-                    ? const Center(
-                        child: Padding(
-                          padding: EdgeInsets.all(40),
-                          child: Text(
-                            'No calendar events found around this time.',
-                            style: TextStyle(color: Colors.grey, fontSize: 15),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      )
-                    : ListView.separated(
-                        shrinkWrap: true,
-                        padding: const EdgeInsets.symmetric(vertical: 8),
-                        itemCount: _events.length,
-                        separatorBuilder: (_, __) =>
-                            const Divider(color: Color(0xFF2A2A2E), height: 1, indent: 16, endIndent: 16),
-                        itemBuilder: (context, index) {
-                          final event = _events[index];
-                          final isLinkingThis = _linkingEventId == event.eventId;
-                          final isSuggested = event.eventId == _suggestedEventId;
-                          return _buildEventTile(event, isSuggested, isLinkingThis);
-                        },
+                ? const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(40),
+                      child: Text(
+                        'No calendar events found around this time.',
+                        style: TextStyle(color: Colors.grey, fontSize: 15),
+                        textAlign: TextAlign.center,
                       ),
+                    ),
+                  )
+                : ListView.separated(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: _events.length,
+                    separatorBuilder: (_, __) =>
+                        const Divider(color: Color(0xFF2A2A2E), height: 1, indent: 16, endIndent: 16),
+                    itemBuilder: (context, index) {
+                      final event = _events[index];
+                      final isLinkingThis = _linkingEventId == event.eventId;
+                      final isSuggested = event.eventId == _suggestedEventId;
+                      return _buildEventTile(event, isSuggested, isLinkingThis);
+                    },
+                  ),
           ),
           SizedBox(height: MediaQuery.of(context).padding.bottom + 8),
         ],
@@ -1851,9 +1853,11 @@ class _TranscriptWidgetsState extends State<TranscriptWidgets> with AutomaticKee
                 }
                 final segments = provider.conversation.transcriptSegments;
                 final segment = segments[segmentIndex];
-                final person =
-                    segment.personId != null ? SharedPreferencesUtil().getPersonById(segment.personId!) : null;
-                final speakerName = person?.name ??
+                final person = segment.personId != null
+                    ? SharedPreferencesUtil().getPersonById(segment.personId!)
+                    : null;
+                final speakerName =
+                    person?.name ??
                     context.l10n.speakerWithId('${TranscriptSegment.getDisplaySpeakerId(segment.speakerId, segments)}');
                 PlatformManager.instance.analytics.editSegmentTextStarted();
                 bool saved = false;
@@ -1912,8 +1916,9 @@ class _TranscriptWidgetsState extends State<TranscriptWidgets> with AutomaticKee
                               );
                               if (segmentIndex == -1) continue;
                               provider.conversation.transcriptSegments[segmentIndex].isUser = finalPersonId == 'user';
-                              provider.conversation.transcriptSegments[segmentIndex].personId =
-                                  finalPersonId == 'user' ? null : finalPersonId;
+                              provider.conversation.transcriptSegments[segmentIndex].personId = finalPersonId == 'user'
+                                  ? null
+                                  : finalPersonId;
                             }
                             await assignBulkConversationTranscriptSegments(
                               provider.conversation.id,

--- a/app/lib/utils/audio/audio_timeline_mapper.dart
+++ b/app/lib/utils/audio/audio_timeline_mapper.dart
@@ -34,7 +34,7 @@ class AudioTimelineMapper {
   final List<ConversationAudioSpan> spans;
 
   AudioTimelineMapper(List<ConversationAudioSpan> spans)
-      : spans = List.of(spans)..sort((a, b) => a.wallOffset.compareTo(b.wallOffset));
+    : spans = List.of(spans)..sort((a, b) => a.wallOffset.compareTo(b.wallOffset));
 
   bool get isEmpty => spans.isEmpty;
 
@@ -44,6 +44,10 @@ class AudioTimelineMapper {
 
   /// Wall-clock seconds -> MP3 seconds. A position inside a collapsed gap
   /// snaps forward to the next span's start; before/after the timeline clamps.
+  ///
+  /// Use this for scrubber interaction. Segment taps must use
+  /// [wallToArtifactStrict] so a tap in a collapsed gap does not jump into a
+  /// later span (#4471).
   double wallToArtifact(double wallSeconds) {
     if (spans.isEmpty) return 0;
     if (wallSeconds <= spans.first.wallOffset) return spans.first.artifactOffset;
@@ -62,6 +66,31 @@ class AudioTimelineMapper {
     }
     // In the gap after this span: snap to the next span, or clamp at the end.
     return lo + 1 < spans.length ? spans[lo + 1].artifactOffset : capturedDuration;
+  }
+
+  /// Wall-clock seconds -> MP3 seconds only when [wallSeconds] falls inside a
+  /// span. Returns null in collapsed gaps / outside the timeline (macOS
+  /// CapturePlayback contract). Half-open: [wallOffset, wallEnd).
+  double? wallToArtifactStrict(double wallSeconds) {
+    if (spans.isEmpty) return null;
+    for (final span in spans) {
+      if (wallSeconds >= span.wallOffset && wallSeconds < span.wallEnd) {
+        return span.artifactOffset + (wallSeconds - span.wallOffset);
+      }
+    }
+    return null;
+  }
+
+  /// Like [wallToArtifactStrict] but inclusive of each span's [ConversationAudioSpan.wallEnd]
+  /// so a segment's stop time on a span boundary still maps.
+  double? wallToArtifactStrictInclusive(double wallSeconds) {
+    if (spans.isEmpty) return null;
+    for (final span in spans) {
+      if (wallSeconds >= span.wallOffset && wallSeconds <= span.wallEnd) {
+        return span.artifactOffset + (wallSeconds - span.wallOffset);
+      }
+    }
+    return null;
   }
 
   /// MP3 seconds -> wall-clock seconds.

--- a/app/lib/utils/audio/audio_timeline_mapper.dart
+++ b/app/lib/utils/audio/audio_timeline_mapper.dart
@@ -34,7 +34,7 @@ class AudioTimelineMapper {
   final List<ConversationAudioSpan> spans;
 
   AudioTimelineMapper(List<ConversationAudioSpan> spans)
-    : spans = List.of(spans)..sort((a, b) => a.wallOffset.compareTo(b.wallOffset));
+      : spans = List.of(spans)..sort((a, b) => a.wallOffset.compareTo(b.wallOffset));
 
   bool get isEmpty => spans.isEmpty;
 

--- a/app/lib/widgets/conversation_bottom_bar.dart
+++ b/app/lib/widgets/conversation_bottom_bar.dart
@@ -72,6 +72,10 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
   AudioTimelineMapper? _timelineMapper;
   StreamSubscription<Duration>? _segmentStopSubscription;
 
+  /// Bumped on every segment seek / scrub so a stale end-handler cannot pause
+  /// a newer tap's playback (#4471 cubic).
+  int _segmentSeekGeneration = 0;
+
   List<AudioFile> _getSortedAudioFiles() {
     if (widget.conversation == null) return [];
     final files = List<AudioFile>.from(widget.conversation!.audioFiles);
@@ -181,25 +185,32 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
       seekPositionSeconds: filePosition,
     );
 
-    await _seekToCombinedPosition(targetPosition);
+    // Seek without bumping generation — we own the token for this segment stop.
+    await _seekToCombinedPosition(targetPosition, invalidateSegmentStop: false);
+    if (!mounted || _audioPlayer == null) return;
+    final seekGeneration = ++_segmentSeekGeneration;
 
     _segmentStopSubscription = _audioPlayer!.positionStream.listen((position) async {
-      if (position >= stopPosition) {
-        await _segmentStopSubscription?.cancel();
-        _segmentStopSubscription = null;
-        if (_audioPlayer != null && _audioPlayer!.playing) {
-          await _audioPlayer!.pause();
-          if (mounted) setState(() {});
-        }
+      if (seekGeneration != _segmentSeekGeneration) return;
+      if (position < stopPosition) return;
+      if (seekGeneration != _segmentSeekGeneration) return;
+      await _segmentStopSubscription?.cancel();
+      _segmentStopSubscription = null;
+      if (seekGeneration != _segmentSeekGeneration) return;
+      if (_audioPlayer != null && _audioPlayer!.playing) {
+        await _audioPlayer!.pause();
+        if (seekGeneration != _segmentSeekGeneration) return;
+        if (mounted) setState(() {});
       }
     });
 
-    if (_audioPlayer != null && !_audioPlayer!.playing) {
+    if (!_audioPlayer!.playing) {
       PlatformManager.instance.analytics.audioPlaybackStarted(
         conversationId: conversationId,
         durationSeconds: _totalDuration.inSeconds > 0 ? _totalDuration.inSeconds : null,
       );
       await _audioPlayer!.play();
+      if (seekGeneration != _segmentSeekGeneration) return;
       if (mounted) setState(() {});
     }
   }
@@ -770,11 +781,18 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
     );
   }
 
-  Future<void> _seekToCombinedPosition(Duration targetPosition) async {
+  Future<void> _seekToCombinedPosition(
+    Duration targetPosition, {
+    bool invalidateSegmentStop = true,
+  }) async {
     if (_audioPlayer == null) return;
 
-    await _segmentStopSubscription?.cancel();
-    _segmentStopSubscription = null;
+    // Scrubber seeks invalidate any in-flight segment end-handler.
+    if (invalidateSegmentStop) {
+      _segmentSeekGeneration++;
+      await _segmentStopSubscription?.cancel();
+      _segmentStopSubscription = null;
+    }
 
     if (_singleArtifact) {
       // targetPosition is already artifact time (the scrubber runs on the dense

--- a/app/lib/widgets/conversation_bottom_bar.dart
+++ b/app/lib/widgets/conversation_bottom_bar.dart
@@ -38,7 +38,7 @@ class ConversationBottomBar extends StatefulWidget {
   final bool hasSegments;
   final bool hasActionItems;
   final ServerConversation? conversation;
-  final Function(Future<void> Function(double))? onSeekFunctionReady;
+  final Function(Future<void> Function(double start, double end))? onSeekFunctionReady;
 
   const ConversationBottomBar({
     super.key,
@@ -70,6 +70,7 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
   // the per-part ConcatenatingAudioSource playlist.
   bool _singleArtifact = false;
   AudioTimelineMapper? _timelineMapper;
+  StreamSubscription<Duration>? _segmentStopSubscription;
 
   List<AudioFile> _getSortedAudioFiles() {
     if (widget.conversation == null) return [];
@@ -100,6 +101,7 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
 
   @override
   void dispose() {
+    _segmentStopSubscription?.cancel();
     _audioPlayer?.dispose();
     super.dispose();
   }
@@ -136,84 +138,42 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
     return _trackStartOffsets[currentIndex] + trackPosition;
   }
 
-  int _findRelevantAudioFileIndex() {
-    final sortedFiles = _getSortedAudioFiles();
-    if (sortedFiles.isEmpty) {
-      return 0;
-    }
-
-    if (sortedFiles.length == 1) {
-      return 0;
-    }
-
-    final conversationStartTs = widget.conversation?.startedAt?.millisecondsSinceEpoch ?? 0;
-    var bestAudioIdx = 0;
-    var minDiff = double.infinity;
-
-    for (int i = 0; i < sortedFiles.length; i++) {
-      final audioStartTs = sortedFiles[i].startedAt?.millisecondsSinceEpoch ?? 0;
-      final diff = (audioStartTs - conversationStartTs).abs().toDouble();
-      if (diff < minDiff) {
-        minDiff = diff;
-        bestAudioIdx = i;
-      }
-    }
-
-    return bestAudioIdx;
-  }
-
-  /// Calculate the correct file position for a transcript timestamp.
+  /// Seek to a transcript segment and play until [segmentEndSeconds].
   ///
-  /// Transcript segment timestamps are relative to conversation.startedAt.
-  /// The merged audio file starts at the first chunk timestamp.
-  ///
-  /// Formula: filePosition = segment.start - chunkOffset
-  /// Where: chunkOffset = firstChunkTimestamp - conversationStartedAt
-  double _calculateFilePositionForTimestamp(double transcriptTimestamp) {
-    final conversation = widget.conversation;
-    final sortedFiles = _getSortedAudioFiles();
-    if (conversation == null || sortedFiles.isEmpty || conversation.startedAt == null) {
-      return transcriptTimestamp;
-    }
-
-    final audioFile = sortedFiles[_findRelevantAudioFileIndex()];
-
-    final double firstChunkTs;
-    if (audioFile.startedAt != null) {
-      firstChunkTs = audioFile.startedAt!.millisecondsSinceEpoch / 1000.0;
-    } else if (audioFile.chunkTimestamps.isNotEmpty) {
-      firstChunkTs = audioFile.chunkTimestamps.first;
-    } else {
-      return transcriptTimestamp;
-    }
-
-    final conversationStartTs = conversation.startedAt!.millisecondsSinceEpoch / 1000.0;
-
-    // chunkOffset = firstChunkTimestamp - conversationStartedAt
-    final chunkOffset = firstChunkTs - conversationStartTs;
-
-    // filePosition = segment.start - chunkOffset
-    return transcriptTimestamp - chunkOffset;
-  }
-
-  /// Seek to a transcript segment's timestamp and start playing.
-  /// Calculates the correct position in the merged audio file.
-  Future<void> seekToTranscriptSegment(double segmentStartSeconds) async {
+  /// Uses strict wall→artifact mapping (no gap-snap) so a segment whose start
+  /// falls in a collapsed inter-part gap does not jump into a later span
+  /// (#4471). Requires the dense conversation artifact + spans; the per-part
+  /// playlist fallback is not used for segment taps.
+  Future<void> seekToTranscriptSegment(double segmentStartSeconds, double segmentEndSeconds) async {
     if (!_isAudioInitialized) {
       await _initAudioIfNeeded();
     }
     if (!mounted || _audioPlayer == null) return;
 
-    // A transcript segment's timestamp is on the wall timeline; the spans
-    // manifest maps it to the exact position in the dense MP3 (artifact time).
-    final filePosition = _singleArtifact
-        ? _timelineMapper!.wallToArtifact(segmentStartSeconds)
-        : _calculateFilePositionForTimestamp(segmentStartSeconds);
+    await _segmentStopSubscription?.cancel();
+    _segmentStopSubscription = null;
 
-    // Ensure position is not negative
+    if (!_singleArtifact || _timelineMapper == null) {
+      if (mounted) {
+        AppSnackbar.showSnackbarError(context.l10n.audioPlaybackUnavailable);
+      }
+      return;
+    }
+
+    final filePosition = _timelineMapper!.wallToArtifactStrict(segmentStartSeconds);
+    if (filePosition == null) {
+      if (mounted) {
+        AppSnackbar.showSnackbarError(context.l10n.audioPlaybackUnavailable);
+      }
+      return;
+    }
+
+    final stopAt = _timelineMapper!.wallToArtifactStrictInclusive(segmentEndSeconds);
+    final stopSeconds = (stopAt != null && stopAt > filePosition) ? stopAt : filePosition;
+
     final targetPosition = Duration(milliseconds: (filePosition * 1000).clamp(0, double.infinity).toInt());
+    final stopPosition = Duration(milliseconds: (stopSeconds * 1000).clamp(0, double.infinity).toInt());
 
-    // Track transcript segment tap
     final conversationId = widget.conversation?.id ?? '';
     PlatformManager.instance.analytics.transcriptSegmentTapped(
       conversationId: conversationId,
@@ -223,7 +183,17 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
 
     await _seekToCombinedPosition(targetPosition);
 
-    // Auto-play after seeking to segment
+    _segmentStopSubscription = _audioPlayer!.positionStream.listen((position) async {
+      if (position >= stopPosition) {
+        await _segmentStopSubscription?.cancel();
+        _segmentStopSubscription = null;
+        if (_audioPlayer != null && _audioPlayer!.playing) {
+          await _audioPlayer!.pause();
+          if (mounted) setState(() {});
+        }
+      }
+    });
+
     if (_audioPlayer != null && !_audioPlayer!.playing) {
       PlatformManager.instance.analytics.audioPlaybackStarted(
         conversationId: conversationId,
@@ -802,6 +772,9 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
 
   Future<void> _seekToCombinedPosition(Duration targetPosition) async {
     if (_audioPlayer == null) return;
+
+    await _segmentStopSubscription?.cancel();
+    _segmentStopSubscription = null;
 
     if (_singleArtifact) {
       // targetPosition is already artifact time (the scrubber runs on the dense

--- a/app/test/unit/audio_timeline_mapper_test.dart
+++ b/app/test/unit/audio_timeline_mapper_test.dart
@@ -31,6 +31,39 @@ void main() {
       expect(mapper.wallToArtifact(209.9), 10.0);
     });
 
+    test('wallToArtifactStrict returns null in collapsed gaps (#4471)', () {
+      expect(mapper.wallToArtifactStrict(100.0), isNull);
+      expect(mapper.wallToArtifactStrict(209.9), isNull);
+      expect(mapper.wallToArtifactStrict(0.0), isNull);
+      expect(mapper.wallToArtifactStrict(999.0), isNull);
+    });
+
+    test('wallToArtifactStrict maps inside spans without snapping', () {
+      expect(mapper.wallToArtifactStrict(10.0), 0.0);
+      expect(mapper.wallToArtifactStrict(15.0), 5.0);
+      expect(mapper.wallToArtifactStrict(19.9), closeTo(9.9, 1e-9));
+      expect(mapper.wallToArtifactStrict(20.0), isNull); // half-open end of A
+      expect(mapper.wallToArtifactStrict(212.5), 12.5);
+    });
+
+    test('wallToArtifactStrictInclusive includes span wallEnd for stop-at-end', () {
+      expect(mapper.wallToArtifactStrictInclusive(20.0), 10.0);
+      expect(mapper.wallToArtifactStrictInclusive(215.0), 15.0);
+      expect(mapper.wallToArtifactStrictInclusive(100.0), isNull);
+    });
+
+    test('reporter-shaped gap: 701s snaps under scrubber but is unavailable for segment tap', () {
+      // Span A ends at wall 700; span B starts at 723 (~22s gap, matching #4471 shape).
+      final reporter = AudioTimelineMapper(const [
+        ConversationAudioSpan(fileId: 'A', wallOffset: 690.0, artifactOffset: 0.0, len: 10.0),
+        ConversationAudioSpan(fileId: 'B', wallOffset: 723.0, artifactOffset: 10.0, len: 14.0),
+      ]);
+      expect(reporter.wallToArtifact(701.0), 10.0); // scrubber snap into B @ 12:03
+      expect(reporter.wallToArtifactStrict(701.0), isNull); // segment tap must not snap
+      expect(reporter.wallToArtifactStrict(723.0), 10.0);
+      expect(reporter.wallToArtifactStrictInclusive(737.0), 24.0);
+    });
+
     test('wallToArtifact clamps outside the timeline', () {
       expect(mapper.wallToArtifact(0.0), 0.0);
       expect(mapper.wallToArtifact(-5.0), 0.0);


### PR DESCRIPTION
## Summary
- Tapping a transcript segment no longer seeks into a *later* span and plays to the end of the conversation (#4471).
- Root cause: segment taps used scrubber-oriented `wallToArtifact` **gap-snap**. After dense MP3 playback collapses gaps >90s, a segment whose wall start sits in that gap (e.g. 11:41) snaps to the next span (e.g. 12:03). macOS already uses strict in-span mapping (`CapturePlayback.artifactOffset`).
- Shrink-only: `wallToArtifactStrict` / `wallToArtifactStrictInclusive` for segment start/stop; require dense artifact + spans (no per-part fallback for taps); pause via `positionStream` at segment end. Scrubber keeps gap-snap.

## Test plan
- [x] `flutter test test/unit/audio_timeline_mapper_test.dart` → **14 passed** (incl. reporter-shaped 701→null vs scrubber snap)
- [ ] CI Dart Analyze / Android Compile green
- [ ] Not verified on-device: multi-part CV1 conversation with >90s gap; tap segment before/after gap (needs device). Hermetic tests cover the mapping contract.

## Product invariants affected
none

Failure-Class: none

Fixes #4471

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

