### PR TITLE
fix(chat): add authoritative current-time context

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -573,10 +573,14 @@ Stream<String> makeStreamingApiCall({
     }
 
     if (streamedResponse.statusCode != 200) {
-      Logger.error('Streaming request failed: ${streamedResponse.statusCode}');
-      if (streamedResponse.statusCode == 402) {
+      // Materialize error responses so clock-skew detection sees the JSON body;
+      // streamed responses previously bypassed _checkClockSkewResponse().
+      final errorResponse = await http.Response.fromStream(streamedResponse);
+      _checkClockSkewResponse(errorResponse);
+      Logger.error('Streaming request failed: ${errorResponse.statusCode}');
+      if (errorResponse.statusCode == 402) {
         try {
-          var body = await streamedResponse.stream.bytesToString();
+          final body = errorResponse.body;
           yield 'error:402:$body';
         } catch (_) {
           yield 'error:402:{}';
@@ -663,10 +667,14 @@ Stream<String> makeMultipartStreamingApiCall({
     }
 
     if (response.statusCode != 200) {
-      Logger.error('Multipart streaming request failed: ${response.statusCode}');
-      if (response.statusCode == 402) {
+      // Materialize error responses so clock-skew detection sees the JSON body;
+      // streamed responses previously bypassed _checkClockSkewResponse().
+      final errorResponse = await http.Response.fromStream(response);
+      _checkClockSkewResponse(errorResponse);
+      Logger.error('Multipart streaming request failed: ${errorResponse.statusCode}');
+      if (errorResponse.statusCode == 402) {
         try {
-          var body = await response.stream.bytesToString();
+          final body = errorResponse.body;
           yield 'error:402:$body';
         } catch (_) {
           yield 'error:402:{}';

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -187,6 +187,17 @@ void _checkClockSkewResponse(http.Response response) {
   ClockSkewDetector.instance.checkResponse(response);
 }
 
+Future<http.Response> _materializeErrorResponse(http.StreamedResponse response) async {
+  try {
+    return await http.Response.fromStream(response);
+  } catch (e) {
+    // Preserve the quota/error sentinel even when the provider resets a
+    // truncated response before the body can be read.
+    Logger.debug('Failed to materialize streaming error response: ${e.runtimeType}');
+    return http.Response('{}', response.statusCode, reasonPhrase: response.reasonPhrase, headers: response.headers);
+  }
+}
+
 Future<void> _handleAuthUnavailable(
   AuthTokenUnavailableException exception, {
   required bool expireTerminalSession,
@@ -575,7 +586,7 @@ Stream<String> makeStreamingApiCall({
     if (streamedResponse.statusCode != 200) {
       // Materialize error responses so clock-skew detection sees the JSON body;
       // streamed responses previously bypassed _checkClockSkewResponse().
-      final errorResponse = await http.Response.fromStream(streamedResponse);
+      final errorResponse = await _materializeErrorResponse(streamedResponse);
       _checkClockSkewResponse(errorResponse);
       Logger.error('Streaming request failed: ${errorResponse.statusCode}');
       if (errorResponse.statusCode == 402) {
@@ -669,7 +680,7 @@ Stream<String> makeMultipartStreamingApiCall({
     if (response.statusCode != 200) {
       // Materialize error responses so clock-skew detection sees the JSON body;
       // streamed responses previously bypassed _checkClockSkewResponse().
-      final errorResponse = await http.Response.fromStream(response);
+      final errorResponse = await _materializeErrorResponse(response);
       _checkClockSkewResponse(errorResponse);
       Logger.error('Multipart streaming request failed: ${errorResponse.statusCode}');
       if (errorResponse.statusCode == 402) {

--- a/app/lib/services/agent_chat_service.dart
+++ b/app/lib/services/agent_chat_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -26,6 +27,15 @@ void agentLog(String msg) {
   try {
     agentLogFile?.writeAsStringSync('$line\n', mode: FileMode.append, flush: true);
   } catch (_) {}
+}
+
+Map<String, String> buildAgentWebSocketHeaders({required String token, String? timeZone}) {
+  final headers = <String, String>{'Authorization': 'Bearer $token'};
+  final normalizedTimeZone = timeZone?.trim();
+  if (normalizedTimeZone != null && normalizedTimeZone.isNotEmpty) {
+    headers['X-Timezone'] = normalizedTimeZone;
+  }
+  return headers;
 }
 
 enum AgentChatEventType { textDelta, toolActivity, result, error, status }
@@ -93,10 +103,16 @@ class AgentChatService {
 
     try {
       final uri = Uri.parse(Env.agentProxyWsUrl);
+      String? timeZone;
+      try {
+        timeZone = await FlutterTimezone.getLocalTimezone();
+      } catch (e) {
+        agentLog('Unable to resolve local timezone; agent proxy will use UTC: $e');
+      }
       agentLog('Connecting to $uri');
       _channel = IOWebSocketChannel.connect(
         uri,
-        headers: {'Authorization': 'Bearer $token'},
+        headers: buildAgentWebSocketHeaders(token: token, timeZone: timeZone),
         pingInterval: const Duration(seconds: 30),
       );
       await _channel!.ready;

--- a/app/lib/services/agent_chat_service.dart
+++ b/app/lib/services/agent_chat_service.dart
@@ -38,6 +38,28 @@ Map<String, String> buildAgentWebSocketHeaders({required String token, String? t
   return headers;
 }
 
+Map<String, dynamic> buildAgentQueryMessage({required String prompt, String? timeZone}) {
+  final normalizedTimeZone = timeZone?.trim();
+  return {
+    'type': 'query',
+    'prompt': prompt,
+    // An explicit empty value tells the proxy to use UTC when a per-query
+    // timezone lookup fails; it must not silently reuse a stale handshake zone.
+    'time_zone': normalizedTimeZone ?? '',
+  };
+}
+
+Future<String?> _resolveLocalTimezone() async {
+  try {
+    final timeZone = await FlutterTimezone.getLocalTimezone();
+    final normalizedTimeZone = timeZone.trim();
+    return normalizedTimeZone.isEmpty ? null : normalizedTimeZone;
+  } catch (e) {
+    agentLog('Unable to resolve local timezone; agent proxy will use UTC: $e');
+    return null;
+  }
+}
+
 enum AgentChatEventType { textDelta, toolActivity, result, error, status }
 
 class AgentChatEvent {
@@ -103,12 +125,7 @@ class AgentChatService {
 
     try {
       final uri = Uri.parse(Env.agentProxyWsUrl);
-      String? timeZone;
-      try {
-        timeZone = await FlutterTimezone.getLocalTimezone();
-      } catch (e) {
-        agentLog('Unable to resolve local timezone; agent proxy will use UTC: $e');
-      }
+      final timeZone = await _resolveLocalTimezone();
       agentLog('Connecting to $uri');
       _channel = IOWebSocketChannel.connect(
         uri,
@@ -255,13 +272,21 @@ class AgentChatService {
     _queryStopwatch = Stopwatch()..start();
     _firstTextReceived = false;
     agentLog('[TIMING] === QUERY START === (${prompt.length} chars)');
-    _channel!.sink.add(jsonEncode({'type': 'query', 'prompt': prompt}));
-    agentLog('[TIMING] query sent +${_queryStopwatch!.elapsedMilliseconds}ms');
-
-    // Start response timeout — if no event arrives within 45s, connection is dead
-    _resetResponseTimer();
+    final controller = _eventController!;
+    unawaited(_sendQueryWithCurrentTimezone(prompt, controller));
 
     return _eventController!.stream;
+  }
+
+  Future<void> _sendQueryWithCurrentTimezone(String prompt, StreamController<AgentChatEvent> controller) async {
+    final timeZone = await _resolveLocalTimezone();
+    if (_eventController != controller || controller.isClosed || _channel == null || !_connected) return;
+
+    _channel!.sink.add(jsonEncode(buildAgentQueryMessage(prompt: prompt, timeZone: timeZone)));
+    agentLog('[TIMING] query sent +${_queryStopwatch?.elapsedMilliseconds ?? 0}ms');
+
+    // Start response timeout — if no event arrives within 120s, connection is dead.
+    _resetResponseTimer();
   }
 
   Future<void> disconnect() async {

--- a/app/test/services/agent_chat_service_test.dart
+++ b/app/test/services/agent_chat_service_test.dart
@@ -13,6 +13,22 @@ void main() {
     expect(buildAgentWebSocketHeaders(token: 'firebase-token'), {'Authorization': 'Bearer firebase-token'});
   });
 
+  test('agent query messages carry the current per-query timezone', () {
+    expect(buildAgentQueryMessage(prompt: 'What year is it?', timeZone: ' America/Los_Angeles '), {
+      'type': 'query',
+      'prompt': 'What year is it?',
+      'time_zone': 'America/Los_Angeles',
+    });
+  });
+
+  test('agent query messages explicitly select UTC when timezone lookup fails', () {
+    expect(buildAgentQueryMessage(prompt: 'What year is it?'), {
+      'type': 'query',
+      'prompt': 'What year is it?',
+      'time_zone': '',
+    });
+  });
+
   test('agent chat events preserve structured proxy error messages', () {
     expect(
       AgentChatEvent.textFrom({

--- a/app/test/services/agent_chat_service_test.dart
+++ b/app/test/services/agent_chat_service_test.dart
@@ -2,6 +2,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/services/agent_chat_service.dart';
 
 void main() {
+  test('agent websocket headers carry the device timezone when available', () {
+    expect(buildAgentWebSocketHeaders(token: 'firebase-token', timeZone: ' America/New_York '), {
+      'Authorization': 'Bearer firebase-token',
+      'X-Timezone': 'America/New_York',
+    });
+  });
+
+  test('agent websocket headers omit an unavailable timezone', () {
+    expect(buildAgentWebSocketHeaders(token: 'firebase-token'), {'Authorization': 'Bearer firebase-token'});
+  });
+
   test('agent chat events preserve structured proxy error messages', () {
     expect(
       AgentChatEvent.textFrom({

--- a/app/test/unit/backend/http/shared_test.dart
+++ b/app/test/unit/backend/http/shared_test.dart
@@ -68,11 +68,14 @@ void main() {
 
   group('streaming clock-skew detection', () {
     late HttpServer server;
+    var requestCount = 0;
 
     setUp(() async {
+      requestCount = 0;
       server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       env.routeNextRequestTo('http://${server.address.host}:${server.port}/');
       server.listen((request) async {
+        requestCount++;
         request.response.statusCode = HttpStatus.requestTimeout;
         request.response.headers.contentType = ContentType.json;
         request.response.write(
@@ -97,7 +100,7 @@ void main() {
     }
 
     test('typed streaming requests report clock skew before returning', () async {
-      final url = '${env.apiBaseUrl!}clock-skew';
+      final url = '${env.requestBaseUrl}clock-skew';
       final eventFuture = nextClockSkewEvent();
 
       final chunks = await makeStreamingApiCall(url: url).toList();
@@ -105,13 +108,14 @@ void main() {
 
       expect(chunks, isEmpty);
       expect(event.skewMinutes, 15);
+      expect(requestCount, 1);
     });
 
     test('multipart streaming requests report clock skew before returning', () async {
       final file = File('${Directory.systemTemp.path}/omi-clock-skew-test.txt');
       await file.writeAsString('test');
       addTearDown(() => file.delete().ignore());
-      final url = '${env.apiBaseUrl!}clock-skew';
+      final url = '${env.requestBaseUrl}clock-skew';
       final eventFuture = nextClockSkewEvent();
 
       final chunks = await makeMultipartStreamingApiCall(url: url, files: [file]).toList();
@@ -119,27 +123,22 @@ void main() {
 
       expect(chunks, isEmpty);
       expect(event.skewMinutes, 15);
+      expect(requestCount, 1);
     });
   });
 }
 
 class _TestEnvFields implements EnvFields {
   String _requestBaseUrl = '';
-  var _apiBaseUrlReads = 0;
 
   void routeNextRequestTo(String baseUrl) {
     _requestBaseUrl = baseUrl;
-    _apiBaseUrlReads = 0;
   }
 
+  String get requestBaseUrl => _requestBaseUrl;
+
   @override
-  String? get apiBaseUrl {
-    _apiBaseUrlReads++;
-    // The first read builds the request URL; the second read in
-    // _isRequiredAuthCheck intentionally returns a non-matching URL so these
-    // loopback tests do not need Firebase credentials.
-    return _apiBaseUrlReads.isOdd ? _requestBaseUrl : 'https://auth-not-required.invalid/';
-  }
+  String? get apiBaseUrl => 'https://auth-not-required.invalid/';
 
   @override
   String? get googleClientId => null;

--- a/app/test/unit/backend/http/shared_test.dart
+++ b/app/test/unit/backend/http/shared_test.dart
@@ -1,7 +1,17 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/http/shared.dart';
+import 'package:omi/backend/http/clock_skew_detector.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/env/env.dart';
 import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
 
 Future<String> simulateGetAuthHeader({required bool isSignedIn, required String token}) async {
   if (token.isEmpty && isSignedIn) {
@@ -19,6 +29,22 @@ Future<Map<String, String>> simulateBuildHeaders({required Future<String> Functi
 }
 
 void main() {
+  final env = _TestEnvFields();
+
+  setUpAll(() async {
+    Env.init(env);
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    PackageInfo.setMockInitialValues(
+      appName: 'Omi Test',
+      packageName: 'com.omi.test',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    await PlatformManager.initializeServices();
+  });
+
   group('auth header guards', () {
     test('throws AuthTokenUnavailableException when signed in and token missing', () async {
       expect(() => simulateGetAuthHeader(isSignedIn: true, token: ''), throwsA(isA<AuthTokenUnavailableException>()));
@@ -39,4 +65,109 @@ void main() {
       expect(headers['Authorization'], equals('Bearer fresh-token'));
     });
   });
+
+  group('streaming clock-skew detection', () {
+    late HttpServer server;
+
+    setUp(() async {
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      env.routeNextRequestTo('http://${server.address.host}:${server.port}/');
+      server.listen((request) async {
+        request.response.statusCode = HttpStatus.requestTimeout;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'error': 'clock_skew',
+            'skew_seconds': 900,
+            'server_time': '2026-07-31T02:30:45Z',
+            'client_time': '2026-07-30T02:15:45Z',
+          }),
+        );
+        await request.response.close();
+      });
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+    });
+
+    Future<ClockSkewEvent> nextClockSkewEvent() {
+      ClockSkewDetector.instance.resetForTesting();
+      return ClockSkewDetector.instance.onClockSkew.first.timeout(const Duration(seconds: 2));
+    }
+
+    test('typed streaming requests report clock skew before returning', () async {
+      final url = '${env.apiBaseUrl!}clock-skew';
+      final eventFuture = nextClockSkewEvent();
+
+      final chunks = await makeStreamingApiCall(url: url).toList();
+      final event = await eventFuture;
+
+      expect(chunks, isEmpty);
+      expect(event.skewMinutes, 15);
+    });
+
+    test('multipart streaming requests report clock skew before returning', () async {
+      final file = File('${Directory.systemTemp.path}/omi-clock-skew-test.txt');
+      await file.writeAsString('test');
+      addTearDown(() => file.delete().ignore());
+      final url = '${env.apiBaseUrl!}clock-skew';
+      final eventFuture = nextClockSkewEvent();
+
+      final chunks = await makeMultipartStreamingApiCall(url: url, files: [file]).toList();
+      final event = await eventFuture;
+
+      expect(chunks, isEmpty);
+      expect(event.skewMinutes, 15);
+    });
+  });
+}
+
+class _TestEnvFields implements EnvFields {
+  String _requestBaseUrl = '';
+  var _apiBaseUrlReads = 0;
+
+  void routeNextRequestTo(String baseUrl) {
+    _requestBaseUrl = baseUrl;
+    _apiBaseUrlReads = 0;
+  }
+
+  @override
+  String? get apiBaseUrl {
+    _apiBaseUrlReads++;
+    // The first read builds the request URL; the second read in
+    // _isRequiredAuthCheck intentionally returns a non-matching URL so these
+    // loopback tests do not need Firebase credentials.
+    return _apiBaseUrlReads.isOdd ? _requestBaseUrl : 'https://auth-not-required.invalid/';
+  }
+
+  @override
+  String? get googleClientId => null;
+
+  @override
+  String? get googleClientSecret => null;
+
+  @override
+  String? get googleMapsApiKey => null;
+
+  @override
+  String? get intercomAppId => null;
+
+  @override
+  String? get intercomIOSApiKey => null;
+
+  @override
+  String? get intercomAndroidApiKey => null;
+
+  @override
+  String? get openAIAPIKey => null;
+
+  @override
+  String? get posthogApiKey => null;
+
+  @override
+  bool? get useAuthCustomToken => false;
+
+  @override
+  bool? get useWebAuth => false;
 }

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -17,6 +17,7 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, cast
+from zoneinfo import ZoneInfo
 
 import firebase_admin
 import httpx
@@ -68,6 +69,33 @@ AGENT_VM_SESSION_LEASES_ENABLED = os.getenv("AGENT_VM_SESSION_LEASES_ENABLED", "
     "true",
     "yes",
 }
+
+
+def _utc_now() -> datetime:
+    """Return the proxy's server clock for per-query model context."""
+    return datetime.now(timezone.utc)
+
+
+def current_time_prompt(prompt: str, time_zone: Optional[str] = None, now: Optional[datetime] = None) -> str:
+    """Prefix a mobile agent query with the proxy's authoritative current time.
+
+    The mobile Claude-agent path bypasses the normal chat backend, so it must
+    receive the same live clock context explicitly. The timezone comes from the
+    mobile OS when available; invalid or missing values fail closed to UTC.
+    """
+    zone_name = (time_zone or "UTC").strip() or "UTC"
+    try:
+        zone = ZoneInfo(zone_name)
+    except (KeyError, ValueError):
+        zone_name = "UTC"
+        zone = timezone.utc
+
+    current = now or _utc_now()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    local_time = current.astimezone(zone).replace(microsecond=0)
+    return f"# Current Time\n{local_time.isoformat()} ({zone_name})\n\n{prompt}"
+
 
 # Encryption — optional; required for users with enhanced data protection.
 ENCRYPTION_SECRET = os.getenv('ENCRYPTION_SECRET', '').encode('utf-8')
@@ -924,6 +952,7 @@ async def agent_ws(websocket: WebSocket):
             # VM already has a live Claude session carrying this conversation's context.
             vm_session_active = False
             vm_hello_received = asyncio.Event()
+            time_zone = websocket.headers.get("x-timezone")
 
             async def _save_ai_response(uid: str, text: str, session_id: str, protection_level: str) -> None:
                 """Fire-and-forget AI response save — never blocks event forwarding."""
@@ -943,6 +972,7 @@ async def agent_ws(websocket: WebSocket):
                             data = json.loads(msg)
                             if data.get('type') == 'query':
                                 prompt = data.get('prompt', '')
+                                prompt_to_forward = prompt
                                 if not first_query_sent:
                                     first_query_sent = True
                                     # Seed history only when the VM has no live session. Wait
@@ -954,19 +984,18 @@ async def agent_ws(websocket: WebSocket):
                                         logger.warning(
                                             f"[agent-proxy] uid={uid} no session_state hello before first query; seeding history"
                                         )
-                                    new_prompt = await _prepare_first_query_prompt(
+                                    prompt_to_forward = await _prepare_first_query_prompt(
                                         uid, chat_session_id, prompt, vm_session_active
                                     )
-                                    if new_prompt != prompt:
-                                        data['prompt'] = new_prompt
-                                        msg = json.dumps(data)
                                     logger.info(
                                         f"[agent-proxy] uid={uid} first query (vm_session_active={vm_session_active}, "
-                                        f"history_seeded={new_prompt != prompt})"
+                                        f"history_seeded={prompt_to_forward != prompt})"
                                     )
                                 else:
                                     # Subsequent queries: Claude session already has context
                                     logger.info(f"[agent-proxy] uid={uid} follow-up query (session has context)")
+                                data['prompt'] = current_time_prompt(prompt_to_forward, time_zone, now=_utc_now())
+                                msg = json.dumps(data)
                                 # Save user message in background — no need to block VM forwarding
                                 start_background_task(
                                     run_blocking(

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -87,6 +87,7 @@ def current_time_prompt(prompt: str, time_zone: Optional[str] = None, now: Optio
     try:
         zone = ZoneInfo(zone_name)
     except (KeyError, ValueError):
+        logger.warning("[agent-proxy] invalid client timezone; falling back to UTC")
         zone_name = "UTC"
         zone = timezone.utc
 
@@ -642,6 +643,19 @@ async def _prepare_first_query_prompt(uid: str, chat_session_id: str, prompt: st
     return _build_prompt_with_history(prompt, history)
 
 
+async def _prepare_first_query_prompt_with_fallback(
+    uid: str, chat_session_id: str, prompt: str, vm_session_active: bool
+) -> str:
+    """Keep history seeding failure isolated from per-query prompt metadata."""
+    try:
+        return await _prepare_first_query_prompt(uid, chat_session_id, prompt, vm_session_active)
+    except Exception:
+        logger.error(
+            "[agent-proxy] uid=%s failed to seed first-query history; forwarding the raw prompt", uid, exc_info=True
+        )
+        return prompt
+
+
 @app.websocket("/v1/agent/ws")
 async def agent_ws(websocket: WebSocket):
     # Validate Firebase token from Authorization header
@@ -972,6 +986,12 @@ async def agent_ws(websocket: WebSocket):
                             data = json.loads(msg)
                             if data.get('type') == 'query':
                                 prompt = data.get('prompt', '')
+                                if not isinstance(prompt, str):
+                                    # Preserve the VM's Invalid query response instead of
+                                    # coercing malformed client data into a model request.
+                                    logger.warning(f"[agent-proxy] uid={uid} rejected non-string query prompt")
+                                    await vm_ws.send(msg)
+                                    continue
                                 prompt_to_forward = prompt
                                 if not first_query_sent:
                                     first_query_sent = True
@@ -984,7 +1004,7 @@ async def agent_ws(websocket: WebSocket):
                                         logger.warning(
                                             f"[agent-proxy] uid={uid} no session_state hello before first query; seeding history"
                                         )
-                                    prompt_to_forward = await _prepare_first_query_prompt(
+                                    prompt_to_forward = await _prepare_first_query_prompt_with_fallback(
                                         uid, chat_session_id, prompt, vm_session_active
                                     )
                                     logger.info(
@@ -994,7 +1014,13 @@ async def agent_ws(websocket: WebSocket):
                                 else:
                                     # Subsequent queries: Claude session already has context
                                     logger.info(f"[agent-proxy] uid={uid} follow-up query (session has context)")
-                                data['prompt'] = current_time_prompt(prompt_to_forward, time_zone, now=_utc_now())
+                                query_time_zone = data.pop('time_zone', None)
+                                if query_time_zone is not None and not isinstance(query_time_zone, str):
+                                    query_time_zone = ''
+                                effective_time_zone = query_time_zone if query_time_zone is not None else time_zone
+                                data['prompt'] = current_time_prompt(
+                                    prompt_to_forward, effective_time_zone, now=_utc_now()
+                                )
                                 msg = json.dumps(data)
                                 # Save user message in background — no need to block VM forwarding
                                 start_background_task(

--- a/backend/tests/unit/test_agent_proxy_async_boundaries.py
+++ b/backend/tests/unit/test_agent_proxy_async_boundaries.py
@@ -3,6 +3,7 @@ import asyncio
 import importlib.util
 import json
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock
@@ -65,7 +66,7 @@ class _AsyncClient:
 
 
 class _AgentWebSocket:
-    headers = {"authorization": "Bearer firebase-token"}
+    headers = {"authorization": "Bearer firebase-token", "x-timezone": "America/New_York"}
 
     def __init__(self):
         self.accepted = False
@@ -188,6 +189,12 @@ async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy
     async def connect(*_args, **_kwargs):
         return vm_ws
 
+    monkeypatch.setattr(
+        agent_proxy,
+        "_utc_now",
+        lambda: datetime(2026, 7, 31, 2, 30, 45, tzinfo=timezone.utc),
+    )
+
     async def no_retry_sleep(seconds):
         if seconds == 2:
             return None
@@ -212,10 +219,12 @@ async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy
     await agent_proxy.drain_background_tasks(timeout=1.0)
 
     assert phone_ws.accepted is True
-    # Query forwarded to the VM (empty history → prompt passes through unchanged; assert
-    # on parsed content, not exact serialization whitespace).
+    # Query forwarded to the VM with the proxy's authoritative current-time context.
     assert len(vm_ws.sent) == 1
-    assert json.loads(vm_ws.sent[0]) == {"type": "query", "prompt": "hello"}
+    assert json.loads(vm_ws.sent[0]) == {
+        "type": "query",
+        "prompt": "# Current Time\n2026-07-30T22:30:45-04:00 (America/New_York)\n\nhello",
+    }
     assert vm_ws.closed is True
     assert _ProxyHTTPClient.post_calls == 2
     assert phone_ws.closed == [(1000, "Session ended")]

--- a/backend/tests/unit/test_agent_proxy_async_boundaries.py
+++ b/backend/tests/unit/test_agent_proxy_async_boundaries.py
@@ -68,10 +68,11 @@ class _AsyncClient:
 class _AgentWebSocket:
     headers = {"authorization": "Bearer firebase-token", "x-timezone": "America/New_York"}
 
-    def __init__(self):
+    def __init__(self, query='{"type":"query","prompt":"hello"}'):
         self.accepted = False
         self.sent = []
         self.closed = []
+        self.query = query
 
     async def accept(self):
         self.accepted = True
@@ -83,7 +84,7 @@ class _AgentWebSocket:
         self.closed.append((code, reason))
 
     async def iter_text(self):
-        yield '{"type":"query","prompt":"hello"}'
+        yield self.query
 
 
 class _VMProtocol:
@@ -176,8 +177,22 @@ class _IdleVMProtocol:
 
 
 @pytest.mark.asyncio
-async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy, monkeypatch):
-    phone_ws = _AgentWebSocket()
+@pytest.mark.parametrize(
+    ("query", "expected_prompt"),
+    [
+        (
+            '{"type":"query","prompt":"hello"}',
+            "# Current Time\n2026-07-30T22:30:45-04:00 (America/New_York)\n\nhello",
+        ),
+        (
+            '{"type":"query","prompt":"hello","time_zone":"America/Los_Angeles"}',
+            "# Current Time\n2026-07-30T19:30:45-07:00 (America/Los_Angeles)\n\nhello",
+        ),
+        ('{"type":"query","prompt":123}', 123),
+    ],
+)
+async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy, monkeypatch, query, expected_prompt):
+    phone_ws = _AgentWebSocket(query)
     vm_ws = _VMProtocol()
     _ProxyHTTPClient.post_calls = 0
     real_sleep = asyncio.sleep
@@ -219,11 +234,12 @@ async def test_agent_ws_owns_and_closes_connected_websocket_protocol(agent_proxy
     await agent_proxy.drain_background_tasks(timeout=1.0)
 
     assert phone_ws.accepted is True
-    # Query forwarded to the VM with the proxy's authoritative current-time context.
+    # Valid queries get authoritative context; malformed prompts remain untouched
+    # so the VM can return its protocol-level Invalid query response.
     assert len(vm_ws.sent) == 1
     assert json.loads(vm_ws.sent[0]) == {
         "type": "query",
-        "prompt": "# Current Time\n2026-07-30T22:30:45-04:00 (America/New_York)\n\nhello",
+        "prompt": expected_prompt,
     }
     assert vm_ws.closed is True
     assert _ProxyHTTPClient.post_calls == 2

--- a/backend/tests/unit/test_agent_proxy_history_seeding.py
+++ b/backend/tests/unit/test_agent_proxy_history_seeding.py
@@ -93,3 +93,15 @@ async def test_fresh_vm_session_seeds_history(agent_proxy, monkeypatch):
     assert "<conversation_history>" in result
     assert "what did I do yesterday" in result
     assert result.endswith("hello")  # the current prompt rides after the seeded history
+
+
+@pytest.mark.asyncio
+async def test_history_failure_falls_back_to_raw_prompt_before_time_prefix(agent_proxy, monkeypatch):
+    async def fail_history(*_args, **_kwargs):
+        raise RuntimeError("Firestore unavailable")
+
+    monkeypatch.setattr(agent_proxy, "_prepare_first_query_prompt", fail_history)
+
+    result = await agent_proxy._prepare_first_query_prompt_with_fallback("uid1", "sess1", "hello", False)
+
+    assert result == "hello"

--- a/backend/tests/unit/test_agent_proxy_history_seeding.py
+++ b/backend/tests/unit/test_agent_proxy_history_seeding.py
@@ -8,6 +8,7 @@ turns the live session already had (duplicate context, wasted tokens). The seedi
 decision now keys off the VM's reported session state.
 """
 
+from datetime import datetime, timezone
 import importlib.util
 from pathlib import Path
 from types import ModuleType
@@ -38,6 +39,26 @@ HISTORY = [
     {"sender": "human", "text": "what did I do yesterday"},
     {"sender": "ai", "text": "You had 3 meetings."},
 ]
+
+
+def test_current_time_prompt_uses_server_clock_and_mobile_timezone(agent_proxy):
+    result = agent_proxy.current_time_prompt(
+        "What year is it?",
+        "America/New_York",
+        now=datetime(2026, 7, 31, 2, 30, 45, tzinfo=timezone.utc),
+    )
+
+    assert result == "# Current Time\n2026-07-30T22:30:45-04:00 (America/New_York)\n\nWhat year is it?"
+
+
+def test_current_time_prompt_falls_back_to_utc_for_invalid_mobile_timezone(agent_proxy):
+    result = agent_proxy.current_time_prompt(
+        "What year is it?",
+        "Not/AZone",
+        now=datetime(2026, 7, 31, 2, 30, 45, tzinfo=timezone.utc),
+    )
+
+    assert result == "# Current Time\n2026-07-31T02:30:45+00:00 (UTC)\n\nWhat year is it?"
 
 
 def _patch_history(agent_proxy, monkeypatch) -> MagicMock:

--- a/desktop/windows/src/main/agentKernel/desktopChatPrompt.test.ts
+++ b/desktop/windows/src/main/agentKernel/desktopChatPrompt.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildDesktopChatSystemPrompt, buildDesktopChatPersonalization } from './desktopChatPrompt'
+import {
+  buildDesktopChatSystemPrompt,
+  buildDesktopChatPersonalization,
+  currentTimePrompt
+} from './desktopChatPrompt'
 
 describe('buildDesktopChatSystemPrompt', () => {
   it('carries the <initiative> block that routes long/coding work to spawn_agent', () => {
@@ -47,6 +51,9 @@ describe('buildDesktopChatSystemPrompt', () => {
     expect(prompt).toContain("You're a mentor, not a yes-man")
     expect(prompt).toContain('<critical_accuracy_rules>')
     expect(prompt).toContain('never from plausible invention')
+    expect(prompt).toContain(
+      "The # Current Time block prefixed to each request is Omi's authoritative clock"
+    )
   })
 
   it('interpolates a name when provided, else reads as "the user"', () => {
@@ -84,6 +91,21 @@ describe('buildDesktopChatSystemPrompt', () => {
     expect(prompt).not.toContain('<user_facts>')
     expect(prompt).not.toContain('<user_tasks>')
     expect(prompt).not.toContain('<ai_user_profile>')
+  })
+})
+
+describe('currentTimePrompt', () => {
+  it('renders one explicit local instant and timezone, matching macOS chat', () => {
+    const date = new Date('2026-07-31T02:30:45Z')
+    expect(currentTimePrompt('What day is it?', date, 'America/New_York')).toBe(
+      '# Current Time\n2026-07-30T22:30:45-04:00 (America/New_York)\n\nWhat day is it?'
+    )
+  })
+
+  it('falls back to UTC when the host timezone identifier is invalid', () => {
+    expect(
+      currentTimePrompt('What day is it?', new Date('2026-07-31T02:30:45Z'), 'Not/AZone')
+    ).toContain('# Current Time\n2026-07-31T02:30:45+00:00 (UTC)')
   })
 })
 

--- a/desktop/windows/src/main/agentKernel/desktopChatPrompt.test.ts
+++ b/desktop/windows/src/main/agentKernel/desktopChatPrompt.test.ts
@@ -107,6 +107,12 @@ describe('currentTimePrompt', () => {
       currentTimePrompt('What day is it?', new Date('2026-07-31T02:30:45Z'), 'Not/AZone')
     ).toContain('# Current Time\n2026-07-31T02:30:45+00:00 (UTC)')
   })
+
+  it('preserves non-whole-hour timezone offsets from Intl', () => {
+    expect(
+      currentTimePrompt('What day is it?', new Date('2026-07-31T02:30:45Z'), 'Asia/Kathmandu')
+    ).toContain('# Current Time\n2026-07-31T08:15:45+05:45 (Asia/Kathmandu)')
+  })
 })
 
 describe('buildDesktopChatPersonalization', () => {

--- a/desktop/windows/src/main/agentKernel/desktopChatPrompt.ts
+++ b/desktop/windows/src/main/agentKernel/desktopChatPrompt.ts
@@ -126,24 +126,19 @@ function localIsoParts(now: Date, timeZone: string): { iso: string; offset: stri
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
-    second: '2-digit'
+    second: '2-digit',
+    timeZoneName: 'longOffset'
   }).formatToParts(now)
-  const at = (type: Intl.DateTimeFormatPartTypes): number =>
-    Number(parts.find((part) => part.type === type)?.value ?? 0)
-  const wallClockMs = Date.UTC(
-    at('year'),
-    at('month') - 1,
-    at('day'),
-    at('hour'),
-    at('minute'),
-    at('second')
-  )
-  const offsetMinutes = Math.round((wallClockMs - Math.floor(now.getTime() / 1000) * 1000) / 60_000)
-  const sign = offsetMinutes >= 0 ? '+' : '-'
-  const absoluteOffset = Math.abs(offsetMinutes)
-  const offset = `${sign}${pad2(Math.floor(absoluteOffset / 60))}:${pad2(absoluteOffset % 60)}`
-  const shifted = new Date(now.getTime() + offsetMinutes * 60_000)
-  return { iso: `${shifted.toISOString().slice(0, 19)}${offset}`, offset }
+  const value = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((part) => part.type === type)?.value ?? ''
+  const offsetLabel = value('timeZoneName')
+  const offsetMatch = /^GMT(?:([+-])(\d{1,2})(?::(\d{2}))?)?$/.exec(offsetLabel)
+  if (!offsetMatch) throw new Error(`Unsupported timezone offset: ${offsetLabel}`)
+  const offset = offsetMatch[1]
+    ? `${offsetMatch[1]}${pad2(Number(offsetMatch[2]))}:${offsetMatch[3] ?? '00'}`
+    : '+00:00'
+  const iso = `${value('year')}-${value('month')}-${value('day')}T${value('hour')}:${value('minute')}:${value('second')}${offset}`
+  return { iso, offset }
 }
 
 /**

--- a/desktop/windows/src/main/agentKernel/desktopChatPrompt.ts
+++ b/desktop/windows/src/main/agentKernel/desktopChatPrompt.ts
@@ -72,6 +72,7 @@ Bright lines:
 1. Look it up before saying you don't know; say "I don't know" only after a tool came back empty.
 2. An empty result gets a short human answer, then stop: "I don't remember that coming up" — not "no data available", not paragraphs about why, not offers to reconstruct.
 3. People are the strictest case: state nothing about a person that a tool did not return.
+4. The # Current Time block prefixed to each request is Omi's authoritative clock. Use it for time-sensitive reasoning and ignore stale date references from earlier turns when they conflict.
 </critical_accuracy_rules>
 
 <tools>
@@ -109,6 +110,62 @@ export function buildDesktopChatSystemPrompt(options: DesktopChatPromptOptions =
   // when no timezone is supplied, leaving "...in the user's timezone, in a...".
   const tzClause = tz ? ` (${tz})` : ''
   return DESKTOP_CHAT_TEMPLATE.replaceAll('{user_name}', name).replaceAll('{tz}', tzClause)
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+/** Render an instant as a local ISO-8601 timestamp with its explicit offset. */
+function localIsoParts(now: Date, timeZone: string): { iso: string; offset: string } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).formatToParts(now)
+  const at = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((part) => part.type === type)?.value ?? 0)
+  const wallClockMs = Date.UTC(
+    at('year'),
+    at('month') - 1,
+    at('day'),
+    at('hour'),
+    at('minute'),
+    at('second')
+  )
+  const offsetMinutes = Math.round((wallClockMs - Math.floor(now.getTime() / 1000) * 1000) / 60_000)
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  const absoluteOffset = Math.abs(offsetMinutes)
+  const offset = `${sign}${pad2(Math.floor(absoluteOffset / 60))}:${pad2(absoluteOffset % 60)}`
+  const shifted = new Date(now.getTime() + offsetMinutes * 60_000)
+  return { iso: `${shifted.toISOString().slice(0, 19)}${offset}`, offset }
+}
+
+/**
+ * Prefix a per-turn request with the host's authoritative local time.
+ *
+ * The system prompt stays byte-stable so the pi binding can be reused; this
+ * volatile block rides in the user turn, matching macOS's chat behavior.
+ */
+export function currentTimePrompt(
+  prompt: string,
+  now: Date = new Date(),
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+): string {
+  let zone = timeZone || 'UTC'
+  let parts: { iso: string; offset: string }
+  try {
+    parts = localIsoParts(now, zone)
+  } catch {
+    zone = 'UTC'
+    parts = localIsoParts(now, zone)
+  }
+  return `# Current Time\n${parts.iso} (${zone})\n\n${prompt}`
 }
 
 // ---------------------------------------------------------------------------

--- a/desktop/windows/src/main/ipc/mainChat.test.ts
+++ b/desktop/windows/src/main/ipc/mainChat.test.ts
@@ -35,6 +35,10 @@ import type { MainChatEvent } from '../../shared/types'
 import { DEFAULT_LOCAL_OWNER_ID } from '../agentKernel/controlTools'
 import { personalizationWithFallback, projectKernelEvent, runMainChatTurn } from './mainChat'
 
+function withoutCurrentTime(prompt: string): string {
+  return prompt.replace(/^# Current Time\n[^\n]+ \([^)]+\)\n\n/, '')
+}
+
 const nodeSqliteFactory = DatabaseSync as unknown as DatabaseFactory
 const createdDirs: string[] = []
 const openStores: SqliteAgentStore[] = []
@@ -143,7 +147,8 @@ function fakeAdapter(options: FakeAdapterOptions = {}): FakeAdapter {
       ]) {
         sink(event)
       }
-      const gate = options.gates?.get(promptText)
+      const gate =
+        options.gates?.get(promptText) ?? options.gates?.get(withoutCurrentTime(promptText))
       if (gate) {
         await gate.promise
         if (signal.aborted) throw new Error('aborted')
@@ -402,6 +407,29 @@ describe('runMainChatTurn', () => {
     expect(systemPrompt).toContain('You are Omi')
   })
 
+  it('prepends the authoritative current time to each dispatched turn', async () => {
+    let dispatchedPrompt = ''
+    const adapter = fakeAdapter({
+      stream: (prompt) => {
+        dispatchedPrompt = prompt
+        return []
+      },
+      reply: () => 'ok'
+    })
+    const kernel = newKernel(adapter)
+    const now = new Date('2026-07-31T02:30:45Z')
+
+    await runMainChatTurn(
+      { requestId: 'req-time', prompt: 'What day is it?', cleanUserText: 'What day is it?' },
+      () => {},
+      { kernel, ownerId: OWNER, now: () => now, timeZone: () => 'America/New_York' }
+    )
+
+    expect(dispatchedPrompt).toContain(
+      '# Current Time\n2026-07-30T22:30:45-04:00 (America/New_York)\n\nWhat day is it?'
+    )
+  })
+
   it('personalizationWithFallback records a degrade and returns "" when the reader throws', async () => {
     const events: unknown[] = []
     const result = await personalizationWithFallback(
@@ -460,7 +488,7 @@ describe('runMainChatTurn', () => {
     )
 
     // Personalization first, then the user message (turn 1 → no history between).
-    expect(dispatchedPrompt).toBe(`${block}\n\nwhat do you know about me`)
+    expect(withoutCurrentTime(dispatchedPrompt)).toBe(`${block}\n\nwhat do you know about me`)
     // The transcript still records the CLEAN user text, never the contexted prompt.
     const turns = store.allRows('SELECT role, content FROM conversation_turns ORDER BY rowid ASC')
     expect(turns[0]).toMatchObject({ role: 'user', content: 'what do you know about me' })
@@ -486,7 +514,7 @@ describe('runMainChatTurn', () => {
       () => {},
       deps
     )
-    expect(dispatched[0]).toBe(`${block}\n\nfirst question`)
+    expect(withoutCurrentTime(dispatched[0])).toBe(`${block}\n\nfirst question`)
 
     // Turn 2 on the SAME chat: personalization, THEN the history tail, THEN the ask.
     await runMainChatTurn(
@@ -494,7 +522,7 @@ describe('runMainChatTurn', () => {
       () => {},
       deps
     )
-    const second = dispatched[1]
+    const second = withoutCurrentTime(dispatched[1])
     expect(second.startsWith(block)).toBe(true)
     expect(second).toContain('<conversation_history>')
     expect(second.endsWith('second question')).toBe(true)
@@ -553,7 +581,7 @@ describe('runMainChatTurn', () => {
     expect(store.allRows('SELECT run_id FROM runs')).toHaveLength(1)
     expect(store.allRows('SELECT attempt_id FROM run_attempts')).toHaveLength(1)
     // Adapter got the verbatim contexted prompt.
-    expect(dispatchedPrompt).toBe('<<context>>\nthe question')
+    expect(withoutCurrentTime(dispatchedPrompt)).toBe('<<context>>\nthe question')
     // Transcript: clean user turn (main-side record) THEN assistant turn (the run),
     // both on the same conversation. The user turn stores the CLEAN text, not the
     // contexted prompt.
@@ -592,8 +620,8 @@ describe('runMainChatTurn', () => {
       () => {},
       { kernel, ownerId: OWNER }
     )
-    expect(dispatched[0]).toBe('what is the capital of france')
-    expect(dispatched[0]).not.toContain('<conversation_history>')
+    expect(withoutCurrentTime(dispatched[0])).toBe('what is the capital of france')
+    expect(withoutCurrentTime(dispatched[0])).not.toContain('<conversation_history>')
 
     // Turn 2 on the SAME chat-x: turn 1's user + assistant turns are now in the
     // transcript, so they are prepended as a <conversation_history> block, and the
@@ -603,7 +631,7 @@ describe('runMainChatTurn', () => {
       () => {},
       { kernel, ownerId: OWNER }
     )
-    const second = dispatched[1]
+    const second = withoutCurrentTime(dispatched[1])
     expect(second).toContain('<conversation_history>')
     expect(second).toContain('q1') // turn-1 clean user text
     expect(second).toContain('reply-to') // turn-1 assistant text
@@ -616,8 +644,8 @@ describe('runMainChatTurn', () => {
       () => {},
       { kernel, ownerId: OWNER }
     )
-    expect(dispatched[2]).toBe('unrelated question')
-    expect(dispatched[2]).not.toContain('<conversation_history>')
+    expect(withoutCurrentTime(dispatched[2])).toBe('unrelated question')
+    expect(withoutCurrentTime(dispatched[2])).not.toContain('<conversation_history>')
   })
 
   it('isolates concurrent runs — one run’s events never leak into another’s stream', async () => {
@@ -627,7 +655,7 @@ describe('runMainChatTurn', () => {
     ])
     const adapter = fakeAdapter({
       gates,
-      stream: (prompt) => [{ type: 'text_delta', text: `delta:${prompt}` }],
+      stream: (prompt) => [{ type: 'text_delta', text: `delta:${withoutCurrentTime(prompt)}` }],
       reply: (prompt) => `reply:${prompt}`
     })
     const kernel = newKernel(adapter)

--- a/desktop/windows/src/main/ipc/mainChat.ts
+++ b/desktop/windows/src/main/ipc/mainChat.ts
@@ -12,7 +12,7 @@ import { ipcMain, BrowserWindow } from 'electron'
 import { getAppSettings } from '../appSettings'
 import { getAgentRuntimeKernel, controlPlaneOwnerId } from '../agentKernel/controlPlane'
 import { DEFAULT_LOCAL_OWNER_ID } from '../agentKernel/controlTools'
-import { buildDesktopChatSystemPrompt } from '../agentKernel/desktopChatPrompt'
+import { buildDesktopChatSystemPrompt, currentTimePrompt } from '../agentKernel/desktopChatPrompt'
 import { formatTranscriptTail } from '../agentKernel/turnContext'
 import { recordFallback, type RecordFallback } from '../observability/fallback'
 import type { AgentRuntimeKernel } from '../agentKernel/kernel'
@@ -46,6 +46,9 @@ const DESKTOP_CHAT_SYSTEM_PROMPT = buildDesktopChatSystemPrompt({
 export interface MainChatTurnDeps {
   kernel: AgentRuntimeKernel
   ownerId: string
+  /** Optional clock seams for deterministic tests; production uses the host clock. */
+  now?: () => Date
+  timeZone?: () => string
   /** Builds the per-turn <user_context> personalization block (memories / active
    *  tasks / AI profile / name), or '' when there is nothing to add. Optional and
    *  injected so tests stay hermetic; when omitted the turn carries no
@@ -287,9 +290,14 @@ export async function runMainChatTurn(
     const contextBlocks = [personalization, history].filter(
       (block): block is string => typeof block === 'string' && block.length > 0
     )
-    const effectivePrompt = contextBlocks.length
+    const promptWithContext = contextBlocks.length
       ? `${contextBlocks.join('\n\n')}\n\n${args.prompt}`
       : args.prompt
+    const effectivePrompt = currentTimePrompt(
+      promptWithContext,
+      deps.now?.() ?? new Date(),
+      deps.timeZone?.()
+    )
 
     // Record the clean user turn on the kernel transcript (empty assistant text →
     // only the user turn is appended; the run appends the assistant turn at


### PR DESCRIPTION
## Summary

Fix cross-platform chat date context so Windows and the mobile Agent VM path use an authoritative current time, matching the behavior already present on the normal Mac/mobile backend path.

## Root cause

- Windows kernel-routed typed chat built a stable system prompt but never added a per-turn current-time block.
- Mobile Claude-agent queries bypass the normal chat backend's datetime injection; the Agent VM proxy forwarded raw prompts and did not receive the device timezone.
- Typed and multipart streaming requests handled error responses as unmaterialized streams, so clock-skew responses could not reach the existing detector.

## Changes

- Add a per-turn `# Current Time` block to Windows main-chat dispatch, using the host clock, local IANA timezone, and an explicit ISO offset while keeping the system prompt byte-stable.
- Send the Android/iOS device timezone on the Agent VM WebSocket and per query, so long-lived sessions follow travel and explicitly fall back to UTC when a lookup is unavailable. The proxy prefixes every valid VM query with server-clock time rendered in that timezone.
- Preserve the VM's protocol-level `Invalid query` behavior for malformed prompts and keep current-time prefixing active when history seeding fails.
- Materialize non-200 typed/multipart streaming responses before invoking clock-skew detection, preserving the existing 402 error payload behavior even when a response body resets mid-stream.
- Add deterministic Windows, Flutter, proxy, and loopback streaming regression coverage.

## Product invariants affected

- INV-CHAT-1

## Verification

- Windows focused tests: 39 passed.
- Windows full suite: 536 files passed, 6 skipped; 5,157 tests passed, 24 skipped.
- Windows ESLint and Node typecheck passed.
- Flutter focused tests: 11 passed.
- Flutter full suite: 1,033 tests passed.
- Flutter analyzer ratchet and Dart formatting passed.
- Backend focused proxy tests: 26 passed.
- Backend prescribed reproduction of the five files that tripped the parallel CPU-time guard passed all five files, with warnings only.
- Full backend suite executed; all reported functional tests passed, but five unrelated fast-unit CPU-time guard checks exceeded the tight 0.12s local threshold under parallel load. The exact failed-file reproduction passed with the same `test.sh` timing guard.
- `make setup`, `make preflight`, and `make runtime-image-source-closure` passed.

## Failure class (fixes)

Failure-Class: none

## Scope notes

This PR does not reintroduce the removed clock-skew snackbar, which had produced false-positive user warnings from stale request timestamps. The detector remains available for logging/telemetry. Physical Windows, Android, and iOS devices were not available in this macOS validation environment.