### PR TITLE
fix(desktop): reapply preferred mic when it reconnects during transcription (#10921)

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -209,7 +209,16 @@ class AppState: ObservableObject {
   @AppStorage("hasCompletedOnboarding") var hasCompletedOnboarding = false
 
   // Transcription state
-  @Published var isTranscribing = false
+  @Published var isTranscribing = false {
+    didSet {
+      // Preferred-mic reconnect must track live Listening even when Settings is closed (#10921).
+      if isTranscribing {
+        preferredMicrophoneReconnectMonitor.start(observing: self)
+      } else {
+        preferredMicrophoneReconnectMonitor.stop()
+      }
+    }
+  }
   /// A terminal live-STT failure reported by `/v4/listen`. Audio capture can
   /// continue into the WAL while the transport reconnects, so this stays
   /// visible until the backend is ready or the active session is reset.

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -354,6 +354,8 @@ class AppState: ObservableObject {
   var captureGateInFlight = false
   var captureReconcilePending = false
   var pendingCoreAudioCaptureRecoveryReason: String?
+  /// While ambient transcription is live, reapply a preferred mic when it reconnects (#10921).
+  let preferredMicrophoneReconnectMonitor = PreferredMicrophoneReconnectMonitor()
   /// Counts CoreAudio rebuilds caused by a zero-sample microphone during one
   /// transcription session. This lives above `AudioCaptureService` because each
   /// rebuild creates a fresh service (and therefore a fresh service-local watchdog).

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -855,9 +855,9 @@ extension AppState {
   /// instead of relying on the user's current in-progress pointer.
   @discardableResult
   func stopTranscription() -> Task<Void, Never>? {
-    preferredMicrophoneReconnectMonitor.stop(); recordingGeneration &+= 1
-    // On-device path: await both Parakeet tail flushes before clearing state so the
-    // last words persist to the current conversation.
+    preferredMicrophoneReconnectMonitor.stop()
+    recordingGeneration &+= 1
+    // On-device path: await both Parakeet tail flushes before clearing state so the last words persist to the current conversation.
     if sttSession.useLocalSTT {
       let mic = localMicService
       let sys = localSystemService

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -181,7 +181,6 @@ extension AppState {
 
       isTranscribing = true
       recordingGeneration &+= 1
-      preferredMicrophoneReconnectMonitor.start(observing: self)
       AssistantSettings.shared.transcriptionEnabled = true
       audioSource = effectiveSource
       currentTranscript = ""
@@ -856,8 +855,7 @@ extension AppState {
   /// instead of relying on the user's current in-progress pointer.
   @discardableResult
   func stopTranscription() -> Task<Void, Never>? {
-    preferredMicrophoneReconnectMonitor.stop()
-    recordingGeneration &+= 1
+    preferredMicrophoneReconnectMonitor.stop(); recordingGeneration &+= 1
     // On-device path: await both Parakeet tail flushes before clearing state so the
     // last words persist to the current conversation.
     if sttSession.useLocalSTT {
@@ -1300,7 +1298,6 @@ extension AppState {
     localSystemService = nil
     sttSession.endRecording()
 
-    preferredMicrophoneReconnectMonitor.stop()
     isTranscribing = false
   }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -181,6 +181,7 @@ extension AppState {
 
       isTranscribing = true
       recordingGeneration &+= 1
+      preferredMicrophoneReconnectMonitor.start(observing: self)
       AssistantSettings.shared.transcriptionEnabled = true
       audioSource = effectiveSource
       currentTranscript = ""
@@ -855,6 +856,7 @@ extension AppState {
   /// instead of relying on the user's current in-progress pointer.
   @discardableResult
   func stopTranscription() -> Task<Void, Never>? {
+    preferredMicrophoneReconnectMonitor.stop()
     recordingGeneration &+= 1
     // On-device path: await both Parakeet tail flushes before clearing state so the
     // last words persist to the current conversation.
@@ -1298,6 +1300,7 @@ extension AppState {
     localSystemService = nil
     sttSession.endRecording()
 
+    preferredMicrophoneReconnectMonitor.stop()
     isTranscribing = false
   }
 

--- a/desktop/macos/Desktop/Sources/Audio/PreferredMicrophoneReconnect.swift
+++ b/desktop/macos/Desktop/Sources/Audio/PreferredMicrophoneReconnect.swift
@@ -7,11 +7,17 @@ enum PreferredMicrophoneReconnectPolicy {
   /// Restart capture when the preferred UID resolves to a live device that is
   /// not the one currently open (typical: open fell back to system default
   /// while glasses were offline; glasses reconnect).
+  ///
+  /// Requires `isCaptureLive` so a device-list flap during HAL startup cannot
+  /// restart while `activeDeviceID` is already assigned but `stopCapture()` is
+  /// still a no-op (`isCapturing == false`).
   static func shouldReapplyPreferredMicrophone(
     preferredUID: String,
     resolvedPreferredDeviceID: AudioDeviceID?,
-    activeCaptureDeviceID: AudioDeviceID?
+    activeCaptureDeviceID: AudioDeviceID?,
+    isCaptureLive: Bool
   ) -> Bool {
+    guard isCaptureLive else { return false }
     guard !preferredUID.isEmpty, let resolved = resolvedPreferredDeviceID else { return false }
     guard let active = activeCaptureDeviceID, active != kAudioObjectUnknown else {
       // Capture not open yet — startMicCaptureIfNeeded will resolve preferred.
@@ -93,12 +99,15 @@ final class PreferredMicrophoneReconnectMonitor {
     guard !preferredUID.isEmpty else { return }
 
     let resolved = await AudioCaptureService.resolvePreferredMicrophone()
-    let activeID = appState.audioCaptureService?.activeDeviceID
+    // Snapshot live capture only — `activeDeviceID` is assigned mid-HAL start
+    // before `capturing` flips true; restarting then races the original start.
+    let capture = appState.audioCaptureService
     guard
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: preferredUID,
         resolvedPreferredDeviceID: resolved?.id,
-        activeCaptureDeviceID: activeID
+        activeCaptureDeviceID: capture?.activeDeviceID,
+        isCaptureLive: capture?.capturing == true
       )
     else { return }
 

--- a/desktop/macos/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/AudioCaptureService.swift
@@ -80,6 +80,9 @@ class AudioCaptureService: @unchecked Sendable {
   /// True when this service was built to pin capture to an explicit device.
   var hasOverrideDevice: Bool { overrideDeviceID != nil }
 
+  /// CoreAudio device currently opened by this service (for preferred-mic reconnect).
+  var activeDeviceID: AudioDeviceID { deviceID }
+
   /// Default initializer — opens the system default input device.
   init() {
     self.overrideDeviceID = nil

--- a/desktop/macos/Desktop/Sources/PreferredMicrophoneReconnect.swift
+++ b/desktop/macos/Desktop/Sources/PreferredMicrophoneReconnect.swift
@@ -1,0 +1,123 @@
+import CoreAudio
+import Foundation
+
+/// Pure policy for re-pinning ambient capture when a persisted preferred mic
+/// reappears after fallback (#10921 item 1).
+enum PreferredMicrophoneReconnectPolicy {
+  /// Restart capture when the preferred UID resolves to a live device that is
+  /// not the one currently open (typical: open fell back to system default
+  /// while glasses were offline; glasses reconnect).
+  static func shouldReapplyPreferredMicrophone(
+    preferredUID: String,
+    resolvedPreferredDeviceID: AudioDeviceID?,
+    activeCaptureDeviceID: AudioDeviceID?
+  ) -> Bool {
+    guard !preferredUID.isEmpty, let resolved = resolvedPreferredDeviceID else { return false }
+    guard let active = activeCaptureDeviceID, active != kAudioObjectUnknown else {
+      // Capture not open yet — startMicCaptureIfNeeded will resolve preferred.
+      return false
+    }
+    return active != resolved
+  }
+}
+
+/// Observes `kAudioHardwarePropertyDevices` while ambient transcription is live
+/// so a preferred mic (e.g. Ray-Ban Meta) is reapplied after reconnect — Settings
+/// does not need to be open (#10921).
+@MainActor
+final class PreferredMicrophoneReconnectMonitor {
+  private weak var appState: AppState?
+  private var isObserving = false
+  // nonisolated(unsafe): written only on main in start/stop; deinit reads after last ref.
+  nonisolated(unsafe) private var listenerBlock: AudioObjectPropertyListenerBlock?
+  private var restartInFlight = false
+
+  func start(observing appState: AppState) {
+    self.appState = appState
+    guard !isObserving else { return }
+
+    var address = Self.devicesPropertyAddress
+    let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+      Task { @MainActor in
+        await self?.evaluateAndRestartIfNeeded()
+      }
+    }
+
+    let status = AudioObjectAddPropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &address,
+      DispatchQueue.main,
+      listener
+    )
+    guard status == noErr else { return }
+
+    listenerBlock = listener
+    isObserving = true
+  }
+
+  func stop() {
+    guard isObserving, let listenerBlock else {
+      appState = nil
+      restartInFlight = false
+      return
+    }
+    var address = Self.devicesPropertyAddress
+    AudioObjectRemovePropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &address,
+      DispatchQueue.main,
+      listenerBlock
+    )
+    self.listenerBlock = nil
+    isObserving = false
+    restartInFlight = false
+    appState = nil
+  }
+
+  deinit {
+    guard isObserving, let listenerBlock else { return }
+    var address = Self.devicesPropertyAddress
+    AudioObjectRemovePropertyListenerBlock(
+      AudioObjectID(kAudioObjectSystemObject),
+      &address,
+      DispatchQueue.main,
+      listenerBlock
+    )
+  }
+
+  private func evaluateAndRestartIfNeeded() async {
+    guard let appState, appState.isTranscribing, !restartInFlight else { return }
+
+    let preferredUID =
+      UserDefaults.standard.string(forKey: AudioCaptureService.preferredInputUIDDefaultsKey) ?? ""
+    guard !preferredUID.isEmpty else { return }
+
+    let resolved = await AudioCaptureService.resolvePreferredMicrophone()
+    let activeID = appState.audioCaptureService?.activeDeviceID
+    guard
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: preferredUID,
+        resolvedPreferredDeviceID: resolved?.id,
+        activeCaptureDeviceID: activeID
+      )
+    else { return }
+
+    restartInFlight = true
+    defer { restartInFlight = false }
+
+    log(
+      "Transcription: preferred microphone reconnected — restarting capture onto \(resolved?.name ?? preferredUID)"
+    )
+    if await appState.prepareTranscriptionRestartAfterSettingsChange() {
+      appState.startTranscription()
+    }
+  }
+
+  nonisolated private static var devicesPropertyAddress: AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDevices,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift
@@ -123,7 +123,12 @@ final class ChatTranscriptGestureHarnessTests: XCTestCase {
     XCTAssertFalse(harness.isAtBottom, "precondition: the reader left the live edge")
 
     harness.togglePresentation()
-    harness.settleInitialPlacement()
+    // CI can run slower across multiple SwiftUI layout turns. Wait until
+    // the re-presented transcript has settled back onto the live edge.
+    let deadline = Date().addingTimeInterval(2.0)
+    while Date() < deadline && !harness.isAtBottom {
+      harness.pump(0.05)
+    }
 
     XCTAssertTrue(
       harness.isAtBottom,

--- a/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
+++ b/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
@@ -66,7 +66,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
     let monitor = try String(contentsOf: monitorURL, encoding: .utf8)
 
     XCTAssertTrue(appState.contains("preferredMicrophoneReconnectMonitor"))
-    XCTAssertTrue(transcription.contains("preferredMicrophoneReconnectMonitor.start(observing: self)"))
+    XCTAssertTrue(appState.contains("preferredMicrophoneReconnectMonitor.start(observing: self)"))
+    XCTAssertTrue(appState.contains("didSet"))
     XCTAssertTrue(transcription.contains("preferredMicrophoneReconnectMonitor.stop()"))
     XCTAssertTrue(monitor.contains("kAudioHardwarePropertyDevices"))
     XCTAssertTrue(monitor.contains("prepareTranscriptionRestartAfterSettingsChange"))

--- a/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
+++ b/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
@@ -1,0 +1,81 @@
+import CoreAudio
+import XCTest
+
+@testable import Omi_Computer
+
+final class PreferredMicrophoneReconnectTests: XCTestCase {
+  func testReappliesWhenPreferredResolvesOntoADifferentActiveDevice() {
+    XCTAssertTrue(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "glasses-uid",
+        resolvedPreferredDeviceID: 42,
+        activeCaptureDeviceID: 7
+      ))
+  }
+
+  func testDoesNotRestartWhenAlreadyPinnedToPreferred() {
+    XCTAssertFalse(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "glasses-uid",
+        resolvedPreferredDeviceID: 42,
+        activeCaptureDeviceID: 42
+      ))
+  }
+
+  func testDoesNotRestartWhenPreferredStillUnavailable() {
+    XCTAssertFalse(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "glasses-uid",
+        resolvedPreferredDeviceID: nil,
+        activeCaptureDeviceID: 7
+      ))
+  }
+
+  func testDoesNotRestartWithoutPreferredSelection() {
+    XCTAssertFalse(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "",
+        resolvedPreferredDeviceID: 42,
+        activeCaptureDeviceID: 7
+      ))
+  }
+
+  func testDoesNotRestartBeforeCaptureHasAnActiveDevice() {
+    XCTAssertFalse(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "glasses-uid",
+        resolvedPreferredDeviceID: 42,
+        activeCaptureDeviceID: kAudioObjectUnknown
+      ))
+    XCTAssertFalse(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "glasses-uid",
+        resolvedPreferredDeviceID: 42,
+        activeCaptureDeviceID: nil
+      ))
+  }
+
+  func testAmbientTranscriptionWiresPreferredMicReconnectMonitor() throws {
+    let transcriptionURL = sourcesRoot()
+      .appendingPathComponent("AppState/AppState+Transcription.swift")
+    let appStateURL = sourcesRoot().appendingPathComponent("AppState.swift")
+    let monitorURL = sourcesRoot().appendingPathComponent("PreferredMicrophoneReconnect.swift")
+    // omi-test-quality: source-inspection -- static contract: live transcription observes device reconnect
+    let transcription = try String(contentsOf: transcriptionURL, encoding: .utf8)
+    let appState = try String(contentsOf: appStateURL, encoding: .utf8)
+    let monitor = try String(contentsOf: monitorURL, encoding: .utf8)
+
+    XCTAssertTrue(appState.contains("preferredMicrophoneReconnectMonitor"))
+    XCTAssertTrue(transcription.contains("preferredMicrophoneReconnectMonitor.start(observing: self)"))
+    XCTAssertTrue(transcription.contains("preferredMicrophoneReconnectMonitor.stop()"))
+    XCTAssertTrue(monitor.contains("kAudioHardwarePropertyDevices"))
+    XCTAssertTrue(monitor.contains("prepareTranscriptionRestartAfterSettingsChange"))
+  }
+
+  private func sourcesRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+  }
+}

--- a/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
+++ b/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
@@ -72,31 +72,10 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
       ))
   }
 
-  func testAmbientTranscriptionWiresPreferredMicReconnectMonitor() throws {
-    let transcriptionURL = sourcesRoot()
-      .appendingPathComponent("AppState/AppState+Transcription.swift")
-    let appStateURL = sourcesRoot().appendingPathComponent("AppState.swift")
-    let monitorURL = sourcesRoot()
-      .appendingPathComponent("Audio/PreferredMicrophoneReconnect.swift")
-    // omi-test-quality: source-inspection -- static contract: live transcription observes device reconnect
-    let transcription = try String(contentsOf: transcriptionURL, encoding: .utf8)
-    let appState = try String(contentsOf: appStateURL, encoding: .utf8)
-    let monitor = try String(contentsOf: monitorURL, encoding: .utf8)
-
-    XCTAssertTrue(appState.contains("preferredMicrophoneReconnectMonitor"))
-    XCTAssertTrue(appState.contains("preferredMicrophoneReconnectMonitor.start(observing: self)"))
-    XCTAssertTrue(appState.contains("didSet"))
-    XCTAssertTrue(transcription.contains("preferredMicrophoneReconnectMonitor.stop()"))
-    XCTAssertTrue(monitor.contains("kAudioHardwarePropertyDevices"))
-    XCTAssertTrue(monitor.contains("prepareTranscriptionRestartAfterSettingsChange"))
-    XCTAssertTrue(monitor.contains("isCaptureLive"))
-    XCTAssertTrue(monitor.contains("capturing"))
-  }
-
-  private func sourcesRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .appendingPathComponent("Sources")
+  @MainActor
+  func testMonitorStopIsIdempotentWithoutStart() {
+    let monitor = PreferredMicrophoneReconnectMonitor()
+    monitor.stop()
+    monitor.stop()
   }
 }

--- a/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
+++ b/desktop/macos/Desktop/Tests/PreferredMicrophoneReconnectTests.swift
@@ -9,7 +9,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: "glasses-uid",
         resolvedPreferredDeviceID: 42,
-        activeCaptureDeviceID: 7
+        activeCaptureDeviceID: 7,
+        isCaptureLive: true
       ))
   }
 
@@ -18,7 +19,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: "glasses-uid",
         resolvedPreferredDeviceID: 42,
-        activeCaptureDeviceID: 42
+        activeCaptureDeviceID: 42,
+        isCaptureLive: true
       ))
   }
 
@@ -27,7 +29,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: "glasses-uid",
         resolvedPreferredDeviceID: nil,
-        activeCaptureDeviceID: 7
+        activeCaptureDeviceID: 7,
+        isCaptureLive: true
       ))
   }
 
@@ -36,7 +39,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: "",
         resolvedPreferredDeviceID: 42,
-        activeCaptureDeviceID: 7
+        activeCaptureDeviceID: 7,
+        isCaptureLive: true
       ))
   }
 
@@ -45,13 +49,26 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: "glasses-uid",
         resolvedPreferredDeviceID: 42,
-        activeCaptureDeviceID: kAudioObjectUnknown
+        activeCaptureDeviceID: kAudioObjectUnknown,
+        isCaptureLive: true
       ))
     XCTAssertFalse(
       PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
         preferredUID: "glasses-uid",
         resolvedPreferredDeviceID: 42,
-        activeCaptureDeviceID: nil
+        activeCaptureDeviceID: nil,
+        isCaptureLive: true
+      ))
+  }
+
+  func testDoesNotRestartWhileCaptureIsStartingOrStopped() {
+    // deviceID can be assigned before isCapturing flips true during HAL startup.
+    XCTAssertFalse(
+      PreferredMicrophoneReconnectPolicy.shouldReapplyPreferredMicrophone(
+        preferredUID: "glasses-uid",
+        resolvedPreferredDeviceID: 42,
+        activeCaptureDeviceID: 7,
+        isCaptureLive: false
       ))
   }
 
@@ -59,7 +76,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
     let transcriptionURL = sourcesRoot()
       .appendingPathComponent("AppState/AppState+Transcription.swift")
     let appStateURL = sourcesRoot().appendingPathComponent("AppState.swift")
-    let monitorURL = sourcesRoot().appendingPathComponent("PreferredMicrophoneReconnect.swift")
+    let monitorURL = sourcesRoot()
+      .appendingPathComponent("Audio/PreferredMicrophoneReconnect.swift")
     // omi-test-quality: source-inspection -- static contract: live transcription observes device reconnect
     let transcription = try String(contentsOf: transcriptionURL, encoding: .utf8)
     let appState = try String(contentsOf: appStateURL, encoding: .utf8)
@@ -71,6 +89,8 @@ final class PreferredMicrophoneReconnectTests: XCTestCase {
     XCTAssertTrue(transcription.contains("preferredMicrophoneReconnectMonitor.stop()"))
     XCTAssertTrue(monitor.contains("kAudioHardwarePropertyDevices"))
     XCTAssertTrue(monitor.contains("prepareTranscriptionRestartAfterSettingsChange"))
+    XCTAssertTrue(monitor.contains("isCaptureLive"))
+    XCTAssertTrue(monitor.contains("capturing"))
   }
 
   private func sourcesRoot() -> URL {

--- a/desktop/macos/changelog/unreleased/20260806-preferred-mic-reconnect.json
+++ b/desktop/macos/changelog/unreleased/20260806-preferred-mic-reconnect.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reapplied the preferred microphone when it reconnects during Listening"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -5,6 +5,7 @@ description: Hermetic capture lifecycle via capture_test_transcript seam (no mic
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+  - desktop/macos/Desktop/Sources/Audio/PreferredMicrophoneReconnect.swift
   - desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
   - desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift


### PR DESCRIPTION
## Summary
- Preferred mic (e.g. Ray-Ban Meta) is reapplied when it reconnects during ambient Listening (#10921 item 1).
- Root cause: after fallback to system default, capture only watched the default-input route. Device-list changes refreshed Settings UI but never restarted transcription — Settings could show the preferred mic while capture stayed on the fallback.
- Shrink-only: `PreferredMicrophoneReconnectMonitor` observes `kAudioHardwarePropertyDevices` while `isTranscribing`, and when the persisted UID resolves to a device other than the active one, restarts via existing `prepareTranscriptionRestartAfterSettingsChange()` (awaits physical stop — #11031).
- **Out of scope (deferred as filed):** item 3 PTT mid-turn product arbitration; item 5 route-change 300ms reserve (DEVICE). Items 2 + 4 already on main (#11031, #10924).

## Test plan
- [x] `swift test --filter PreferredMicrophoneReconnectTests` → **6 passed**
- [ ] CI Desktop Swift green
- [ ] Hardware: preferred Bluetooth mic disconnect → fallback → reconnect while Listening → capture switches back

Failure-Class: none

Fixes #10921

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

