### PR TITLE
fix(desktop): wait for the transcript remount in the gesture harness

### DIFF
--- a/desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift
@@ -123,7 +123,7 @@ final class ChatTranscriptGestureHarnessTests: XCTestCase {
     XCTAssertFalse(harness.isAtBottom, "precondition: the reader left the live edge")
 
     harness.togglePresentation()
-    harness.pump(1.0)
+    harness.settleInitialPlacement()
 
     XCTAssertTrue(
       harness.isAtBottom,
@@ -551,12 +551,29 @@ final class ChatTranscriptGestureHarnessTests: XCTestCase {
 
     /// Removes the transcript from the hierarchy and puts it back, the way
     /// Home's stage transition does.
+    ///
+    /// Both halves wait on the hierarchy, not on a fixed pump. SwiftUI commits
+    /// the removal on its own update turn, and on a loaded machine that turn can
+    /// land after a fixed pump ends — the `false`/`true` flips then coalesce into
+    /// no change at all, so nothing unmounts, `onAppear` never runs, and the
+    /// caller silently measures the same transcript the reader already scrolled.
     func togglePresentation() {
       model.isPresented = false
-      pump(0.2)
+      waitForTranscript(mounted: false)
       model.isPresented = true
-      pump(0.2)
+      waitForTranscript(mounted: true)
       if let discovered = Self.firstScrollView(in: hostingView) { scrollView = discovered }
+    }
+
+    /// Pumps until the transcript's scroll view reaches `mounted`, then returns.
+    /// On timeout it returns anyway so the caller's assertion reports the real
+    /// state rather than this helper's own failure.
+    private func waitForTranscript(mounted: Bool, timeout: TimeInterval = 2) {
+      let deadline = Date().addingTimeInterval(timeout)
+      repeat {
+        pump(0.02)
+        if (Self.firstScrollView(in: hostingView) != nil) == mounted { return }
+      } while Date() < deadline
     }
 
     // MARK: Plumbing


### PR DESCRIPTION
## Bug

`ChatTranscriptGestureHarnessTests.testRePresentingTheTranscriptOpensAtTheLiveEdgeAgain` is red on `main` (run [31071838964](https://github.com/BasedHardware/omi/actions/runs/31071838964), commit `5fd2b60ac3` — a diff that touches no transcript code), taking `Desktop Swift Static & Test Contracts` and `Desktop Swift Build & Tests` down with it.

```
ChatTranscriptGestureHarnessTests.swift:128: error: XCTAssertTrue failed -
a re-presented transcript starts at the live edge (scrollTop=2733.0 of 5133.0)
```

This is a harness defect, not a product regression.

## Root cause

`scrollTop=2733.0` is byte-for-byte the position the reader's gesture had just left — not a partial or mis-settled placement. The transcript was never re-presented at all.

`togglePresentation()` flipped `isPresented` to `false` and back to `true` with a fixed `pump(0.2)` between them. SwiftUI commits the removal on its own update turn; when that turn lands after the fixed pump ends, the two flips coalesce into no change — nothing unmounts, `onAppear` never runs, and the harness then measures the same transcript the reader already scrolled.

## Fix

Both halves of `togglePresentation()` now wait on the view hierarchy (bounded at 2s) instead of a fixed pump, and the test settles with the documented `settleInitialPlacement()` so its budget still outlives `ChatScrollLiveEdge.initialRestoreSettlingDelays`. Test-harness only; no production code touched.

## Verification

- Reproduced the exact CI signature by starving the update turn (zero-gap toggle): `top=2733/5133 bottom=false`. Any gap that lets the teardown commit gives `top=5133/5133 bottom=true` — production placement is correct.
- Post-fix, four consecutive re-presentations all land at `5133/5133 bottom=true`.
- `swift test --filter ChatTranscriptGestureHarnessTests` — 14/14 pass.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — debt at baseline (19 wall-clock waits, unchanged).
- `make preflight` — passed.

## Product invariants affected

none

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

