### PR TITLE
feat: reconcile dev Agent VM boot-image migrations

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,8 +1,10 @@
 {
   "files": {
+    "backend/services/agent_vm_lifecycle.py": 1682,
     "backend/testing/listen_pusher_stack/run.py": 1790
   },
   "raise_justifications": {
+    "backend/services/agent_vm_lifecycle.py": "#11164's lifecycle owner now keeps the migration journal's account-deletion, lease, pointer, GCE identity, and missing-candidate retry fences alongside the existing Agent VM transitions; splitting those transaction primitives would duplicate the safety boundary.",
     "backend/testing/listen_pusher_stack/run.py": "#10577 keeps the operation-scoped persistence-fault controls beside the real listener/Pusher/Firestore assertions they qualify. +79 for #9809: the cloud-orphan-recovery scenario stays in the existing end-to-end listener/Pusher gauntlet rather than forking a second harness."
   },
   "threshold": 1500

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import time
 import uuid
 from dataclasses import dataclass
@@ -35,14 +36,21 @@ from services.agent_vm_lifecycle import (
     AgentVmRelease,
     GceAgentVmClient,
     active_session_count,
+    begin_boot_image_migration,
+    claim_boot_image_migration_retirement,
     claim_reconciler_run_lease,
     claim_vm_lease,
     clear_missing_vm_if_current,
     clear_vm_reconcile_lease_fields,
+    complete_boot_image_migration,
+    cutover_boot_image_migration,
     drift_reasons,
+    mark_boot_image_migration_candidate_deleted,
+    recover_missing_boot_image_candidate,
     release_reconciler_run_lease,
     renew_reconciler_run_lease,
     renew_vm_lease,
+    record_boot_image_candidate,
     retry_delay_seconds,
     rollout_selected,
     update_vm_reconcile,
@@ -67,6 +75,7 @@ FAILED_JOB_STATES = {"retry", "quarantined", "missing", "stale", "recreate_requi
 DEFAULT_MISSING_CLEANUP_GRACE_SECONDS = 24 * 60 * 60
 MIN_MISSING_CLEANUP_GRACE_SECONDS = 60
 _IMMUTABLE_BOOT_IMAGE = re.compile(r"^projects/[^/]+/global/images/[^/]+$")
+_MIGRATION_ID = re.compile(r"^[0-9a-f]{24}$")
 
 
 @dataclass(frozen=True)
@@ -74,6 +83,59 @@ class ReconcileResult:
     uid: str
     state: str
     detail: str = ""
+
+
+@dataclass(frozen=True)
+class BootImageMigrationPlan:
+    """An explicit, dev-only plan for replacing stopped boot-image-drift VMs.
+
+    This plan deliberately does not inherit the normal release rollout.  A
+    release publication must never become a destructive migration merely
+    because it happens to carry a new immutable boot image.
+    """
+
+    allowed_uids: frozenset[str]
+    max_concurrency: int
+    soak_seconds: int
+
+
+def _boot_image_migration_plan(raw: Mapping[str, Any], release: AgentVmRelease) -> BootImageMigrationPlan | None:
+    """Return a safe replacement plan, or ``None`` when migration is disabled.
+
+    The plan lives in a separately named manifest section and is accepted only
+    for development.  Production is hard-disabled in code even if a manifest
+    is malformed or accidentally promoted with this section present.
+    """
+    migration = raw.get("bootImageMigration")
+    if not isinstance(migration, Mapping) or migration.get("enabled") is not True:
+        return None
+    if release.environment != "development" or os.getenv("AGENT_VM_ENVIRONMENT", "").strip() != "development":
+        raise ValueError("boot-image migration is development-only")
+    if os.getenv("GCE_PROJECT_ID", "").strip() != "based-hardware-dev":
+        raise ValueError("boot-image migration requires the approved development project")
+    owners = migration.get("allowedUids")
+    if not isinstance(owners, list) or not owners or not all(isinstance(uid, str) and uid for uid in owners):
+        raise ValueError("boot-image migration requires a non-empty allowedUids list")
+    max_concurrency = migration.get("maxConcurrency", 1)
+    soak_seconds = migration.get("soakSeconds", 600)
+    if not isinstance(max_concurrency, int) or max_concurrency != 1:
+        raise ValueError("boot-image migration maxConcurrency must be exactly 1")
+    if not isinstance(soak_seconds, int) or soak_seconds < 60:
+        raise ValueError("boot-image migration soakSeconds must be at least 60")
+    return BootImageMigrationPlan(frozenset(owners), max_concurrency, soak_seconds)
+
+
+def _boot_image_migration_id(uid: str, vm_name: str, instance_id: str, release_id: str) -> str:
+    return hashlib.sha256(f"{uid}:{vm_name}:{instance_id}:{release_id}".encode()).hexdigest()[:24]
+
+
+def _boot_image_candidate_name(vm_name: str, migration_id: str) -> str:
+    if not _MIGRATION_ID.fullmatch(migration_id):
+        raise ValueError("boot-image migration id is invalid")
+    suffix = f"-m-{migration_id[:12]}"
+    # GCE names are limited to 63 characters and the predecessor identity is
+    # also recorded independently in the durable migration journal.
+    return f"{vm_name[: 63 - len(suffix)]}{suffix}"
 
 
 def _init_firebase() -> None:
@@ -341,6 +403,208 @@ async def _boot_image_drift(
     return None
 
 
+async def _replace_stopped_boot_image_drift(
+    uid: str,
+    vm: Mapping[str, Any],
+    instance: Mapping[str, Any],
+    release: AgentVmRelease,
+    plan: BootImageMigrationPlan,
+    *,
+    owner: str,
+    api: GceAgentVmClient,
+    cleanup_context: dict[str, str] | None = None,
+) -> ReconcileResult:
+    """Create and cut over a stopped, explicitly allowlisted predecessor.
+
+    Old instances are tagged before candidate creation and deliberately remain
+    stopped after cutover.  A later reconciliation may retire that immutable,
+    ID-fenced predecessor after its soak period; a failed candidate never
+    changes the active owner pointer.
+    """
+    vm_name = str(vm["vmName"])
+    zone = str(vm.get("zone") or DEFAULT_ZONE)
+    auth_token = str(vm["authToken"])
+    if uid not in plan.allowed_uids:
+        return ReconcileResult(uid, "recreate_required", "boot-image migration is not allowlisted for this owner")
+    if str(instance.get("status") or "") not in {"TERMINATED", "STOPPED"} or vm.get("status") != "stopped":
+        return ReconcileResult(uid, "recreate_required", "boot-image migration requires an already stopped VM")
+    active = await asyncio.to_thread(active_session_count, uid, vm_name)
+    if active:
+        return ReconcileResult(uid, "recreate_required", f"{active} active session(s) block boot-image migration")
+    old_instance_id = str(instance.get("id") or "")
+    if not old_instance_id:
+        return ReconcileResult(uid, "recreate_required", "predecessor instance identity is unavailable")
+    migration_id = _boot_image_migration_id(uid, vm_name, old_instance_id, release.release_id)
+    candidate_name = _boot_image_candidate_name(vm_name, migration_id)
+    candidate_token = secrets.token_urlsafe(32)
+    migration = {
+        "migrationId": migration_id,
+        "oldVmName": vm_name,
+        "oldZone": zone,
+        "oldAuthToken": auth_token,
+        "oldInstanceId": old_instance_id,
+        "candidateVmName": candidate_name,
+        "candidateAuthToken": candidate_token,
+        "targetRelease": release.release_id,
+        "targetBootImage": release.boot_image,
+        "soakSeconds": plan.soak_seconds,
+    }
+    journal = await asyncio.to_thread(
+        begin_boot_image_migration, uid, vm_name, zone, auth_token, owner, migration_id, migration
+    )
+    if journal is None:
+        return ReconcileResult(uid, "stale", "boot-image migration claim fence changed")
+    candidate_token = journal.get("candidateAuthToken") if isinstance(journal.get("candidateAuthToken"), str) else ""
+    if not candidate_token:
+        raise RuntimeError("boot-image migration journal has no candidate token")
+    await api.set_migration_labels(vm_name, instance, migration_id)
+    candidate = await api.get_instance(candidate_name)
+    if candidate is None:
+        if not await asyncio.to_thread(
+            recover_missing_boot_image_candidate, uid, vm_name, zone, auth_token, owner, migration_id
+        ):
+            return ReconcileResult(uid, "stale", "missing candidate recovery fence changed")
+        await api.create_replacement(candidate_name, instance, release, candidate_token, migration_id)
+        candidate = await api.get_instance(candidate_name)
+    if candidate is None or str(candidate.get("id") or "") == "":
+        raise RuntimeError("replacement candidate is unavailable")
+    labels = candidate.get("labels")
+    service_accounts = candidate.get("serviceAccounts")
+    first_service_account = service_accounts[0] if isinstance(service_accounts, list) and service_accounts else None
+    candidate_service_account = (
+        first_service_account.get("email") if isinstance(first_service_account, Mapping) else None
+    )
+    if (
+        not isinstance(labels, Mapping)
+        or labels.get("omi-agent-migration") != migration_id
+        or labels.get("omi-agent-predecessor") != old_instance_id
+        or candidate_service_account != release.service_account
+    ):
+        raise RuntimeError("replacement candidate identity is ambiguous")
+    candidate_boot_drift = await _boot_image_drift(api, candidate, release)
+    if candidate_boot_drift:
+        raise RuntimeError("replacement candidate boot image does not match the pinned release")
+    candidate_id = str(candidate["id"])
+    if cleanup_context is not None:
+        cleanup_context.update({"vmName": candidate_name, "instanceId": candidate_id, "migrationId": migration_id})
+    if not await asyncio.to_thread(
+        record_boot_image_candidate, uid, vm_name, zone, auth_token, owner, migration_id, candidate_id
+    ):
+        return ReconcileResult(uid, "stale", "boot-image candidate journal fence changed")
+    private_ip = api.private_instance_ip(candidate)
+    if not private_ip:
+        raise RuntimeError("replacement candidate has no usable private IP")
+    await api.wait_for_runtime(private_ip, candidate_token, release)
+    # The lifecycle lease blocks new proxy admission.  Recheck pre-existing
+    # sessions immediately before the irreversible pointer swap.
+    if await asyncio.to_thread(active_session_count, uid, vm_name):
+        return ReconcileResult(uid, "deferred", "session appeared before boot-image cutover")
+    candidate_vm = {
+        "vmName": candidate_name,
+        "zone": zone,
+        "status": "ready",
+        "authToken": candidate_token,
+        "instanceId": candidate_id,
+        "privateIp": private_ip,
+        **({"ip": api.instance_ip(candidate)} if api.instance_ip(candidate) else {}),
+        "reconcile": {
+            "state": "ready",
+            "releaseId": release.release_id,
+            "observedRelease": release.release_id,
+            "observedImageDigest": release.image_digest,
+            "observedStartupSha256": release.startup_sha256,
+            "migration": {
+                **migration,
+                "candidateInstanceId": candidate_id,
+                "cutoverAt": time.time(),
+                "cutoverPending": True,
+            },
+        },
+    }
+    if not await asyncio.to_thread(
+        cutover_boot_image_migration, uid, vm_name, zone, auth_token, owner, migration_id, candidate_vm
+    ):
+        return ReconcileResult(uid, "stale", "boot-image cutover fence changed; predecessor remains active")
+    if cleanup_context is not None:
+        cleanup_context.clear()
+    return ReconcileResult(uid, "migrated", f"cut over to {candidate_name}; predecessor retained for soak")
+
+
+async def _retire_soaked_boot_image_predecessor(
+    uid: str,
+    vm: Mapping[str, Any],
+    *,
+    owner: str,
+    api: GceAgentVmClient,
+) -> ReconcileResult | None:
+    """Retire a migrated predecessor only after its durable soak deadline.
+
+    This is deliberately a separate recovery-safe phase: once the candidate
+    is active, deletion is guarded by both the predecessor GCE numeric ID and
+    migration label.  If a worker crashes after deletion, the next run sees a
+    404 as success and can complete the Firestore journal.
+    """
+    reconcile = vm.get("reconcile")
+    migration = reconcile.get("migration") if isinstance(reconcile, Mapping) else None
+    if not isinstance(migration, Mapping):
+        return None
+    migration_id = migration.get("migrationId")
+    old_vm_name = migration.get("oldVmName")
+    old_instance_id = migration.get("oldInstanceId")
+    candidate_id = migration.get("candidateInstanceId")
+    if not (
+        isinstance(migration_id, str)
+        and _MIGRATION_ID.fullmatch(migration_id)
+        and isinstance(old_vm_name, str)
+        and old_vm_name
+        and isinstance(old_instance_id, str)
+        and old_instance_id
+        and isinstance(candidate_id, str)
+        and candidate_id == str(vm.get("instanceId") or "")
+    ):
+        return ReconcileResult(uid, "retry", "migration retirement record is incomplete")
+    # A lease for the predecessor must have expired before deleting it. New
+    # sessions can only bind to the candidate after the pointer cutover.
+    if await asyncio.to_thread(active_session_count, uid, old_vm_name):
+        return ReconcileResult(uid, "soaking", "predecessor still has an active session lease")
+    vm_name = str(vm["vmName"])
+    zone = str(vm.get("zone") or DEFAULT_ZONE)
+    auth_token = str(vm["authToken"])
+    retirement = await asyncio.to_thread(
+        claim_boot_image_migration_retirement,
+        uid,
+        vm_name,
+        zone,
+        auth_token,
+        owner,
+        migration_id,
+        candidate_id,
+    )
+    if retirement is None:
+        return ReconcileResult(uid, "stale", "migration retirement fence changed")
+    if retirement.get("state") == "soaking":
+        return ReconcileResult(uid, "soaking", "replacement candidate is within its journaled soak")
+    claimed_old_vm_name = retirement.get("oldVmName")
+    claimed_old_instance_id = retirement.get("oldInstanceId")
+    if not isinstance(claimed_old_vm_name, str) or not isinstance(claimed_old_instance_id, str):
+        return ReconcileResult(uid, "stale", "migration retirement predecessor identity is incomplete")
+    if not await api.delete_replacement(claimed_old_vm_name, claimed_old_instance_id, migration_id):
+        return ReconcileResult(uid, "stale", "predecessor identity fence changed before retirement")
+    completed = await asyncio.to_thread(
+        complete_boot_image_migration,
+        uid,
+        vm_name,
+        zone,
+        auth_token,
+        owner,
+        migration_id,
+        candidate_id,
+    )
+    if not completed:
+        return ReconcileResult(uid, "stale", "predecessor retired; migration completion fence changed")
+    return ReconcileResult(uid, "retired", f"retired soaked predecessor {old_vm_name}")
+
+
 async def _update_reconcile(
     uid: str,
     vm_name: str,
@@ -374,6 +638,8 @@ async def reconcile_one(
     project: str,
     dry_run: bool = False,
     missing_cleanup_grace_seconds: int | None = None,
+    boot_image_migration: BootImageMigrationPlan | None = None,
+    boot_image_migration_lock: asyncio.Semaphore | None = None,
 ) -> ReconcileResult:
     vm_name = str(vm["vmName"])
     auth_token = str(vm["authToken"])
@@ -408,6 +674,7 @@ async def reconcile_one(
     missing_cleanup_grace_seconds = (
         _missing_cleanup_grace_seconds() if missing_cleanup_grace_seconds is None else missing_cleanup_grace_seconds
     )
+    failed_candidate: dict[str, str] = {}
     try:
         instance = await api.get_instance(vm_name)
         if instance is None:
@@ -468,6 +735,34 @@ async def reconcile_one(
         boot_drift = await _boot_image_drift(api, instance, release)
         if boot_drift:
             reason, actual = boot_drift
+            # A mutable, malformed, or unreadable source is a fail-closed
+            # observation, never permission to replace an instance.
+            if boot_image_migration is not None and reason == "boot_image_recreate_required":
+                if boot_image_migration_lock is None:
+                    migration = await _replace_stopped_boot_image_drift(
+                        uid,
+                        vm,
+                        instance,
+                        release,
+                        boot_image_migration,
+                        owner=owner,
+                        api=api,
+                        cleanup_context=failed_candidate,
+                    )
+                else:
+                    async with boot_image_migration_lock:
+                        migration = await _replace_stopped_boot_image_drift(
+                            uid,
+                            vm,
+                            instance,
+                            release,
+                            boot_image_migration,
+                            owner=owner,
+                            api=api,
+                            cleanup_context=failed_candidate,
+                        )
+                if migration.state != "recreate_required":
+                    return migration
             if not await _update_reconcile(
                 uid,
                 vm_name,
@@ -490,6 +785,10 @@ async def reconcile_one(
                 "recreate_required",
                 f"{reason}; operator must recreate VM from exact immutable image {release.boot_image}",
             )
+        if boot_image_migration is not None:
+            retirement = await _retire_soaked_boot_image_predecessor(uid, vm, owner=owner, api=api)
+            if retirement is not None:
+                return retirement
         reasons = drift_reasons(instance, release)
         if str(instance.get("status")) == "RUNNING":
             private_ip = api.private_instance_ip(instance)
@@ -618,6 +917,31 @@ async def reconcile_one(
         )
         retry_at = time.time() + retry_delay_seconds(retry_count)
         retry_state = "quarantined" if retry_count >= 3 else "retry"
+        if retry_state == "quarantined" and failed_candidate:
+            try:
+                deleted = await api.delete_replacement(
+                    failed_candidate["vmName"],
+                    failed_candidate["instanceId"],
+                    failed_candidate["migrationId"],
+                )
+                if not deleted:
+                    logger.warning("Agent VM migration candidate cleanup fence changed for uid=%s", uid)
+                elif not await asyncio.to_thread(
+                    mark_boot_image_migration_candidate_deleted,
+                    uid,
+                    vm_name,
+                    zone,
+                    auth_token,
+                    owner,
+                    failed_candidate["migrationId"],
+                    failed_candidate["instanceId"],
+                ):
+                    logger.warning("Agent VM migration candidate journal fence changed after cleanup for uid=%s", uid)
+            except Exception:
+                # Quarantine still protects the predecessor pointer. Record the
+                # provider cleanup failure without allowing it to hide the
+                # original candidate-readiness failure.
+                logger.exception("Agent VM migration candidate cleanup failed for uid=%s", uid)
         if not await _update_reconcile(
             uid,
             vm_name,
@@ -649,6 +973,9 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
     project = os.getenv("GCE_PROJECT_ID")
     if not project:
         raise RuntimeError("GCE_PROJECT_ID is required for Agent VM reconciliation")
+    # Validate before owner discovery so an accidentally promoted migration
+    # section cannot look harmless just because this run has no matching VMs.
+    migration_plan = _boot_image_migration_plan(raw_manifest, release)
     missing_cleanup_grace_seconds = _missing_cleanup_grace_seconds()
     owner = f"{os.getenv('K_REVISION', 'local')}:{uuid.uuid4().hex}"
     if not dry_run and not await asyncio.to_thread(claim_reconciler_run_lease, environment, owner):
@@ -680,20 +1007,41 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
             target_percent, max_concurrency = _rollout_spec(raw_manifest, phase)
             owners = await asyncio.to_thread(_owners)
             rollout_selected = _select_rollout_owners(owners, release.release_id, target_percent)
-            selected = _select_reconcile_owners(owners, release.release_id, target_percent)
+            selected = sorted(
+                _select_reconcile_owners(owners, release.release_id, target_percent), key=lambda item: item[0]
+            )
+            # A migration plan has its own explicit maxConcurrency contract and
+            # never inherits the normal release rollout's wider semaphore.
+            # Every selected allowlisted owner gets a chance; the dedicated
+            # lock serializes potentially long candidate readiness checks.
+            migration_lock = asyncio.Semaphore(migration_plan.max_concurrency) if migration_plan is not None else None
             semaphore = asyncio.Semaphore(max_concurrency)
 
             async def one(uid: str, vm: dict[str, Any]) -> ReconcileResult:
-                async with semaphore:
-                    return await reconcile_one(
-                        uid,
-                        vm,
-                        release,
-                        owner=owner,
-                        project=project,
-                        dry_run=dry_run,
-                        missing_cleanup_grace_seconds=missing_cleanup_grace_seconds,
-                    )
+                migration_for_owner = (
+                    migration_plan if migration_plan is not None and uid in migration_plan.allowed_uids else None
+                )
+
+                async def reconcile() -> ReconcileResult:
+                    async with semaphore:
+                        return await reconcile_one(
+                            uid,
+                            vm,
+                            release,
+                            owner=owner,
+                            project=project,
+                            dry_run=dry_run,
+                            missing_cleanup_grace_seconds=missing_cleanup_grace_seconds,
+                            boot_image_migration=migration_for_owner,
+                        )
+
+                # Do not claim an owner VM lease until this migration has the
+                # one permitted slot. A health wait can last minutes; claiming
+                # first would make queued owner leases expire before mutation.
+                if migration_for_owner is not None and migration_lock is not None:
+                    async with migration_lock:
+                        return await reconcile()
+                return await reconcile()
 
             results = await asyncio.gather(*(one(uid, vm) for uid, vm in selected))
             if lease_lost.is_set() and not dry_run:

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -114,7 +114,7 @@ def _boot_image_migration_plan(raw: Mapping[str, Any], release: AgentVmRelease) 
     if os.getenv("GCE_PROJECT_ID", "").strip() != "based-hardware-dev":
         raise ValueError("boot-image migration requires the approved development project")
     owners = migration.get("allowedUids")
-    if not isinstance(owners, list) or not owners or not all(isinstance(uid, str) and uid for uid in owners):
+    if not isinstance(owners, list) or not owners or not all(isinstance(uid, str) and uid.strip() for uid in owners):
         raise ValueError("boot-image migration requires a non-empty allowedUids list")
     max_concurrency = migration.get("maxConcurrency", 1)
     soak_seconds = migration.get("soakSeconds", 600)
@@ -639,7 +639,6 @@ async def reconcile_one(
     dry_run: bool = False,
     missing_cleanup_grace_seconds: int | None = None,
     boot_image_migration: BootImageMigrationPlan | None = None,
-    boot_image_migration_lock: asyncio.Semaphore | None = None,
 ) -> ReconcileResult:
     vm_name = str(vm["vmName"])
     auth_token = str(vm["authToken"])
@@ -738,29 +737,16 @@ async def reconcile_one(
             # A mutable, malformed, or unreadable source is a fail-closed
             # observation, never permission to replace an instance.
             if boot_image_migration is not None and reason == "boot_image_recreate_required":
-                if boot_image_migration_lock is None:
-                    migration = await _replace_stopped_boot_image_drift(
-                        uid,
-                        vm,
-                        instance,
-                        release,
-                        boot_image_migration,
-                        owner=owner,
-                        api=api,
-                        cleanup_context=failed_candidate,
-                    )
-                else:
-                    async with boot_image_migration_lock:
-                        migration = await _replace_stopped_boot_image_drift(
-                            uid,
-                            vm,
-                            instance,
-                            release,
-                            boot_image_migration,
-                            owner=owner,
-                            api=api,
-                            cleanup_context=failed_candidate,
-                        )
+                migration = await _replace_stopped_boot_image_drift(
+                    uid,
+                    vm,
+                    instance,
+                    release,
+                    boot_image_migration,
+                    owner=owner,
+                    api=api,
+                    cleanup_context=failed_candidate,
+                )
                 if migration.state != "recreate_required":
                     return migration
             if not await _update_reconcile(
@@ -1010,6 +996,21 @@ async def run_reconciler(*, dry_run: bool = False) -> list[ReconcileResult]:
             selected = sorted(
                 _select_reconcile_owners(owners, release.release_id, target_percent), key=lambda item: item[0]
             )
+            # An explicit boot-image migration allowlist is independent of the
+            # ordinary release rollout cohort.  A stopped allowlisted VM that is
+            # not in the current cohort must still be selected so its drift can
+            # be replaced.  Rollout advancement only consumes rollout_selected
+            # results, so these extra owners never advance the rollout phase.
+            if migration_plan is not None:
+                selected_uids = {uid for uid, _ in selected}
+                migration_candidates = [
+                    (uid, vm)
+                    for uid, vm in owners
+                    if uid not in selected_uids
+                    and uid in migration_plan.allowed_uids
+                    and str(vm.get("status") or "") == "stopped"
+                ]
+                selected.extend(migration_candidates)
             # A migration plan has its own explicit maxConcurrency contract and
             # never inherits the normal release rollout's wider semaphore.
             # Every selected allowlisted owner gets a chance; the dedicated

--- a/backend/scripts/activate-agent-vm-dev-migration.sh
+++ b/backend/scripts/activate-agent-vm-dev-migration.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Publish one explicit development-only Agent VM boot-image migration artifact.
+set -euo pipefail
+
+if [[ "${AGENT_VM_MIGRATION_APPLY:-}" != "1" ]]; then
+  echo "REFUSED: set AGENT_VM_MIGRATION_APPLY=1 to activate a development Agent VM migration." >&2
+  exit 1
+fi
+
+project="${AGENT_VM_MIGRATION_PROJECT:-}"
+bucket="${AGENT_VM_MIGRATION_BUCKET:-}"
+manifest="${AGENT_VM_MIGRATION_MANIFEST:-}"
+if [[ "$project" != "based-hardware-dev" || -z "$bucket" || ! -f "$manifest" ]]; then
+  echo "AGENT_VM_MIGRATION_PROJECT=based-hardware-dev, AGENT_VM_MIGRATION_BUCKET, and an existing AGENT_VM_MIGRATION_MANIFEST are required." >&2
+  exit 2
+fi
+
+manifest_sha="$({
+  python3 - "$manifest" <<'PY'
+import hashlib
+import json
+import sys
+
+path = sys.argv[1]
+raw = json.load(open(path, encoding="utf-8"))
+declared = raw.pop("manifestSha256", None)
+canonical = (json.dumps(raw, sort_keys=True, separators=(",", ":")) + "\n").encode()
+migration = raw.get("bootImageMigration")
+if (
+    raw.get("environment") != "development"
+    or not isinstance(declared, str)
+    or declared != hashlib.sha256(canonical).hexdigest()
+    or not isinstance(migration, dict)
+    or migration.get("enabled") is not True
+    or not isinstance(migration.get("allowedUids"), list)
+    or not migration["allowedUids"]
+    or migration.get("maxConcurrency") != 1
+    or not isinstance(migration.get("soakSeconds"), int)
+    or migration["soakSeconds"] < 60
+):
+    raise SystemExit("migration manifest is not a canonical explicit development plan")
+print(declared)
+PY
+} )"
+
+manifest_uri="gs://${bucket}/agent-vm/migrations/${manifest_sha}.json"
+active_uri="gs://${bucket}/agent-vm/releases/active.json"
+gcloud storage cp --no-clobber "$manifest" "$manifest_uri"
+readback="$(mktemp)"
+trap 'rm -f "$readback"' EXIT
+gcloud storage cp "$manifest_uri" "$readback"
+cmp -s "$manifest" "$readback"
+
+pointer_error="$(mktemp)"
+trap 'rm -f "$readback" "$pointer_error"' EXIT
+if active_generation="$(gcloud storage objects describe "$active_uri" --format='value(generation)' 2>"$pointer_error")"; then
+  [[ "$active_generation" =~ ^[0-9]+$ ]]
+elif grep -Eq '(^|[^0-9])404([^0-9]|$)|NOT_FOUND' "$pointer_error"; then
+  active_generation=0
+else
+  cat "$pointer_error" >&2
+  echo "ERROR: active Agent VM manifest pointer could not be read; refusing activation." >&2
+  exit 1
+fi
+gcloud storage cp "$manifest_uri" "$active_uri" --if-generation-match="$active_generation"
+activated_generation="$(gcloud storage objects describe "$active_uri" --format='value(generation)')"
+[[ "$activated_generation" =~ ^[0-9]+$ ]]
+gcloud storage cp "${active_uri}#${activated_generation}" "$readback"
+cmp -s "$manifest" "$readback"
+echo "Activated development Agent VM migration manifest ${manifest_sha} at generation ${activated_generation}."

--- a/backend/scripts/activate-agent-vm-dev-migration.sh
+++ b/backend/scripts/activate-agent-vm-dev-migration.sh
@@ -15,6 +15,16 @@ if [[ "$project" != "based-hardware-dev" || -z "$bucket" || ! -f "$manifest" ]];
   exit 2
 fi
 
+# Verify the destination bucket actually belongs to the development project
+# so a cross-environment value cannot poison a production manifest pointer.
+bucket_project="$(
+  gcloud storage buckets describe "gs://${bucket}" --format='value(project)' 2>/dev/null || true
+)"
+if [[ "$bucket_project" != "$project" ]]; then
+  echo "ERROR: bucket gs://${bucket} is owned by '${bucket_project:-unknown}', not '${project}'; refusing cross-environment activation." >&2
+  exit 2
+fi
+
 manifest_sha="$({
   python3 - "$manifest" <<'PY'
 import hashlib
@@ -26,14 +36,16 @@ raw = json.load(open(path, encoding="utf-8"))
 declared = raw.pop("manifestSha256", None)
 canonical = (json.dumps(raw, sort_keys=True, separators=(",", ":")) + "\n").encode()
 migration = raw.get("bootImageMigration")
+allowed = migration.get("allowedUids") if isinstance(migration, dict) else None
 if (
     raw.get("environment") != "development"
     or not isinstance(declared, str)
     or declared != hashlib.sha256(canonical).hexdigest()
     or not isinstance(migration, dict)
     or migration.get("enabled") is not True
-    or not isinstance(migration.get("allowedUids"), list)
-    or not migration["allowedUids"]
+    or not isinstance(allowed, list)
+    or not allowed
+    or not all(isinstance(uid, str) and uid.strip() for uid in allowed)
     or migration.get("maxConcurrency") != 1
     or not isinstance(migration.get("soakSeconds"), int)
     or migration["soakSeconds"] < 60
@@ -45,6 +57,7 @@ PY
 
 manifest_uri="gs://${bucket}/agent-vm/migrations/${manifest_sha}.json"
 active_uri="gs://${bucket}/agent-vm/releases/active.json"
+previous_uri="gs://${bucket}/agent-vm/releases/previous.json"
 gcloud storage cp --no-clobber "$manifest" "$manifest_uri"
 readback="$(mktemp)"
 trap 'rm -f "$readback"' EXIT
@@ -55,13 +68,26 @@ pointer_error="$(mktemp)"
 trap 'rm -f "$readback" "$pointer_error"' EXIT
 if active_generation="$(gcloud storage objects describe "$active_uri" --format='value(generation)' 2>"$pointer_error")"; then
   [[ "$active_generation" =~ ^[0-9]+$ ]]
-elif grep -Eq '(^|[^0-9])404([^0-9]|$)|NOT_FOUND' "$pointer_error"; then
+elif grep -Eq '(^|[^-0-9])404([^0-9]|$)|NOT_FOUND' "$pointer_error"; then
   active_generation=0
 else
   cat "$pointer_error" >&2
   echo "ERROR: active Agent VM manifest pointer could not be read; refusing activation." >&2
   exit 1
 fi
+
+# Snapshot the observed active generation into previous.json with its own
+# compare-and-swap before changing the active pointer, so rollback can
+# reliably return to the release that preceded this migration.
+if [[ "$active_generation" != "0" ]]; then
+  if previous_generation="$(gcloud storage objects describe "$previous_uri" --format='value(generation)' 2>/dev/null)"; then
+    [[ "$previous_generation" =~ ^[0-9]+$ ]]
+  else
+    previous_generation=0
+  fi
+  gcloud storage cp "${active_uri}#${active_generation}" "$previous_uri" --if-generation-match="$previous_generation"
+fi
+
 gcloud storage cp "$manifest_uri" "$active_uri" --if-generation-match="$active_generation"
 activated_generation="$(gcloud storage objects describe "$active_uri" --format='value(generation)')"
 [[ "$activated_generation" =~ ^[0-9]+$ ]]

--- a/backend/scripts/agent_vm_release.py
+++ b/backend/scripts/agent_vm_release.py
@@ -87,7 +87,7 @@ def validate_manifest(payload: Mapping[str, Any]) -> None:
             or migration.get("enabled") is not True
             or not isinstance(migration.get("allowedUids"), list)
             or not migration["allowedUids"]
-            or not all(isinstance(uid, str) and uid for uid in migration["allowedUids"])
+            or not all(isinstance(uid, str) and uid.strip() for uid in migration["allowedUids"])
             or migration.get("maxConcurrency") != 1
             or not isinstance(migration.get("soakSeconds"), int)
             or migration["soakSeconds"] < 60

--- a/backend/scripts/agent_vm_release.py
+++ b/backend/scripts/agent_vm_release.py
@@ -41,6 +41,18 @@ def render_manifest(args: argparse.Namespace) -> dict[str, Any]:
             "maxConcurrency": args.max_concurrency,
         },
     }
+    # Replacement is deliberately a separately selected artifact, not an
+    # automatic consequence of publishing a newer boot image.  The runtime
+    # rejects this section outside development as a second independent fence.
+    if args.boot_image_migration_allowed_uid:
+        if args.environment != "development":
+            raise ValueError("boot-image migration manifests may only target development")
+        values["bootImageMigration"] = {
+            "enabled": True,
+            "allowedUids": sorted(set(args.boot_image_migration_allowed_uid)),
+            "maxConcurrency": 1,
+            "soakSeconds": args.boot_image_migration_soak_seconds,
+        }
     validate_manifest(values)
     values["manifestSha256"] = hashlib.sha256(canonical_bytes(values)).hexdigest()
     return values
@@ -66,6 +78,21 @@ def validate_manifest(payload: Mapping[str, Any]) -> None:
         raise ValueError("startupSha256 must be a lowercase SHA-256 digest")
     if not SERVICE_ACCOUNT.fullmatch(str(payload["serviceAccount"])):
         raise ValueError("serviceAccount must be a Google service-account email")
+    migration = payload.get("bootImageMigration")
+    if migration is not None:
+        if payload.get("environment") != "development":
+            raise ValueError("bootImageMigration is development-only")
+        if (
+            not isinstance(migration, Mapping)
+            or migration.get("enabled") is not True
+            or not isinstance(migration.get("allowedUids"), list)
+            or not migration["allowedUids"]
+            or not all(isinstance(uid, str) and uid for uid in migration["allowedUids"])
+            or migration.get("maxConcurrency") != 1
+            or not isinstance(migration.get("soakSeconds"), int)
+            or migration["soakSeconds"] < 60
+        ):
+            raise ValueError("bootImageMigration must be an explicit development allowlist with a safe soak")
     if "manifestSha256" in payload:
         unsigned = dict(payload)
         declared = unsigned.pop("manifestSha256")
@@ -88,6 +115,13 @@ def parser() -> argparse.ArgumentParser:
     command.add_argument("--rollout-target-percent", type=int, default=100)
     command.add_argument("--max-concurrency", type=int, default=5)
     command.add_argument("--rollout-phase", choices=("sentinel", "canary", "quarter", "remainder"), default="remainder")
+    command.add_argument(
+        "--boot-image-migration-allowed-uid",
+        action="append",
+        default=[],
+        help="Development-only explicit migration allowlist; repeat for each owner.",
+    )
+    command.add_argument("--boot-image-migration-soak-seconds", type=int, default=600)
     return command
 
 
@@ -97,6 +131,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise SystemExit("rollout target must be between 0 and 100")
     if not 1 <= args.max_concurrency <= 50:
         raise SystemExit("max concurrency must be between 1 and 50")
+    if args.boot_image_migration_soak_seconds < 60:
+        raise SystemExit("boot-image migration soak must be at least 60 seconds")
     payload = render_manifest(args)
     args.output.write_bytes(canonical_bytes(payload))
     print(json.dumps({"manifestSha256": payload["manifestSha256"], "sourceSha": args.source_sha}))

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -25,7 +25,7 @@ role_id="omiAgentVmReconciler"
 role="projects/${project}/roles/${role_id}"
 operations_role_id="omiAgentVmReconcilerOperations"
 operations_role="projects/${project}/roles/${operations_role_id}"
-permissions="compute.disks.get,compute.instances.get,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop"
+permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop"
 operations_permissions="compute.globalOperations.get,compute.zoneOperations.get"
 zone="us-central1-a"
 
@@ -58,6 +58,12 @@ gcloud projects add-iam-policy-binding "$project" \
 gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$role" \
   --condition="title=Agent VM reconciler disk scope,description=Boot disk reads for omi-agent instances in the Agent VM zone,expression=resource.type == 'compute.googleapis.com/Disk' && resource.name.startsWith('projects/${project}/zones/${zone}/disks/omi-agent-')"
+# An explicit dev migration may create a replacement only from the immutable
+# Agent VM image family.  Image use is evaluated against the Image resource,
+# not the instance/disk scopes above.
+gcloud projects add-iam-policy-binding "$project" \
+  --member="serviceAccount:${gsa}" --role="$role" \
+  --condition="title=Agent VM reconciler image scope,description=Immutable omi-agent images only,expression=resource.type == 'compute.googleapis.com/Image' && resource.name.startsWith('projects/${project}/global/images/omi-agent-')"
 gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$operations_role" --condition=None
 # Project IAM policies containing scoped bindings require unconditional bindings

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -25,7 +25,7 @@ role_id="omiAgentVmReconciler"
 role="projects/${project}/roles/${role_id}"
 operations_role_id="omiAgentVmReconcilerOperations"
 operations_role="projects/${project}/roles/${operations_role_id}"
-permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop"
+permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop,compute.subnetworks.use,compute.subnetworks.useExternalIp"
 operations_permissions="compute.globalOperations.get,compute.zoneOperations.get"
 zone="us-central1-a"
 

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -640,6 +640,593 @@ def clear_vm_reconcile_lease_fields() -> dict[str, Any]:
     }
 
 
+def _migration_matches(
+    vm: Mapping[str, Any],
+    *,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    now: float,
+    instance_id: str | None = None,
+) -> bool:
+    """Validate the active pointer and reconciler lease for a migration CAS."""
+    reconcile = vm.get("reconcile")
+    reconcile = reconcile if isinstance(reconcile, Mapping) else {}
+    if (
+        vm.get("vmName") != vm_name
+        or (vm.get("zone") or DEFAULT_ZONE) != zone
+        or vm.get("authToken") != auth_token
+        or (instance_id is not None and str(vm.get("instanceId") or "") != instance_id)
+        or bool(reconcile.get("startRequested"))
+        or bool(reconcile.get("drainRequested"))
+    ):
+        return False
+    lease = reconcile.get("lease")
+    return isinstance(lease, Mapping) and lease.get("owner") == owner and float(lease.get("expiresAt", 0) or 0) > now
+
+
+@transactional
+def _begin_boot_image_migration_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration: Mapping[str, Any],
+    now: float,
+) -> dict[str, Any] | None:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return None
+    snapshot = user_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    if not isinstance(vm, dict) or not _migration_matches(
+        vm, vm_name=vm_name, zone=zone, auth_token=auth_token, owner=owner, now=now
+    ):
+        return None
+    old_instance_id = str(migration.get("oldInstanceId") or "")
+    if not old_instance_id:
+        return None
+    recorded_instance_id = str(vm.get("instanceId") or "")
+    if recorded_instance_id and recorded_instance_id != old_instance_id:
+        return None
+    if str(vm.get("status") or "") not in {"stopped", "ready"}:
+        return None
+    existing = migration_ref.get(transaction=transaction)
+    if existing.exists:
+        current = existing.to_dict() or {}
+        if not (
+            current.get("oldVmName") == vm_name
+            and current.get("oldAuthToken") == auth_token
+            and current.get("oldInstanceId") == migration.get("oldInstanceId")
+            and current.get("candidateVmName") == migration.get("candidateVmName")
+            and current.get("targetRelease") == migration.get("targetRelease")
+        ):
+            return None
+        # A terminal candidate cleanup is explicitly retryable.  Reuse the
+        # durable candidate name/token but remove its old provider identity so
+        # the next creation can be recorded under the same fenced journal.
+        if current.get("state") == "candidate_deleted":
+            transaction.update(
+                migration_ref,
+                {"state": "candidate_creating", "candidateInstanceId": DELETE_FIELD, "updatedAt": now},
+            )
+            return {**current, "state": "candidate_creating"}
+        return current
+    record = {**migration, "state": "candidate_creating", "createdAt": now, "updatedAt": now}
+    transaction.set(migration_ref, record)
+    update = {"agentVm.reconcile.state": "migration_claimed"}
+    if not recorded_instance_id:
+        # Legacy owner records predate the explicit GCE ID field. Bind it only
+        # inside this stopped-only, owner-token-and-lease CAS, then every
+        # subsequent journal transition requires that exact provider identity.
+        update["agentVm.instanceId"] = old_instance_id
+    transaction.update(user_ref, update)
+    return record
+
+
+def begin_boot_image_migration(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    migration: Mapping[str, Any],
+    now: float | None = None,
+) -> dict[str, Any] | None:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    result = _begin_boot_image_migration_txn(
+        client.transaction(),
+        client.collection("account_deletions").document(uid),
+        user_ref,
+        user_ref.collection("agentVmMigrations").document(migration_id),
+        vm_name,
+        zone,
+        auth_token,
+        owner,
+        migration,
+        now,
+    )
+    return result if isinstance(result, dict) else None
+
+
+@transactional
+def _record_boot_image_candidate_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    candidate_instance_id: str,
+    now: float,
+) -> bool:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or not _migration_matches(
+            vm,
+            vm_name=vm_name,
+            zone=zone,
+            auth_token=auth_token,
+            owner=owner,
+            now=now,
+            instance_id=str(migration.get("oldInstanceId") or ""),
+        )
+    ):
+        return False
+    if migration.get("state") == "candidate_ready":
+        return migration.get("candidateInstanceId") == candidate_instance_id
+    if migration.get("state") != "candidate_creating":
+        return False
+    transaction.update(
+        migration_ref,
+        {"state": "candidate_ready", "candidateInstanceId": candidate_instance_id, "updatedAt": now},
+    )
+    return True
+
+
+def record_boot_image_candidate(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate_instance_id: str,
+    now: float | None = None,
+) -> bool:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    return bool(
+        _record_boot_image_candidate_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            user_ref,
+            user_ref.collection("agentVmMigrations").document(migration_id),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            candidate_instance_id,
+            now,
+        )
+    )
+
+
+@transactional
+def _mark_boot_image_migration_candidate_deleted_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    candidate_instance_id: str,
+    now: float,
+) -> bool:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or migration.get("state") != "candidate_ready"
+        or migration.get("candidateInstanceId") != candidate_instance_id
+        or not _migration_matches(vm, vm_name=vm_name, zone=zone, auth_token=auth_token, owner=owner, now=now)
+    ):
+        return False
+    transaction.update(
+        migration_ref,
+        {"state": "candidate_deleted", "candidateDeletedAt": now, "updatedAt": now},
+    )
+    return True
+
+
+def mark_boot_image_migration_candidate_deleted(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate_instance_id: str,
+    now: float | None = None,
+) -> bool:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    return bool(
+        _mark_boot_image_migration_candidate_deleted_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            user_ref,
+            user_ref.collection("agentVmMigrations").document(migration_id),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            candidate_instance_id,
+            now,
+        )
+    )
+
+
+@transactional
+def _recover_missing_boot_image_candidate_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    now: float,
+) -> bool:
+    """Permit recreation only after GCE has confirmed the candidate is gone."""
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or migration.get("state") not in {"candidate_creating", "candidate_ready", "candidate_deleted"}
+        or not _migration_matches(vm, vm_name=vm_name, zone=zone, auth_token=auth_token, owner=owner, now=now)
+    ):
+        return False
+    if migration.get("state") != "candidate_creating":
+        transaction.update(
+            migration_ref,
+            {"state": "candidate_creating", "candidateInstanceId": DELETE_FIELD, "updatedAt": now},
+        )
+    return True
+
+
+def recover_missing_boot_image_candidate(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    now: float | None = None,
+) -> bool:
+    """Fence a retry after a candidate has been observed absent in GCE."""
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    return bool(
+        _recover_missing_boot_image_candidate_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            user_ref,
+            user_ref.collection("agentVmMigrations").document(migration_id),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            now,
+        )
+    )
+
+
+@transactional
+def _cutover_boot_image_migration_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    candidate: Mapping[str, Any],
+    now: float,
+) -> bool:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or migration.get("state") not in {"candidate_creating", "candidate_ready"}
+        or not _migration_matches(
+            vm,
+            vm_name=vm_name,
+            zone=zone,
+            auth_token=auth_token,
+            owner=owner,
+            now=now,
+            instance_id=str(migration.get("oldInstanceId") or ""),
+        )
+    ):
+        return False
+    if migration.get("candidateVmName") != candidate.get("vmName") or migration.get(
+        "candidateInstanceId"
+    ) != candidate.get("instanceId"):
+        return False
+    soak_seconds = migration.get("soakSeconds")
+    if not isinstance(soak_seconds, int) or soak_seconds < 60:
+        return False
+    transaction.update(user_ref, {"agentVm": dict(candidate)})
+    transaction.update(
+        migration_ref,
+        {
+            "state": "cutover",
+            "cutoverAt": now,
+            "retireAfter": now + soak_seconds,
+            "updatedAt": now,
+        },
+    )
+    return True
+
+
+@transactional
+def _claim_boot_image_migration_retirement_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate_instance_id: str,
+    now: float,
+) -> dict[str, Any] | None:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return None
+    snapshot = user_ref.get(transaction=transaction)
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    reconcile = vm.get("reconcile") if isinstance(vm, Mapping) else None
+    active_migration = reconcile.get("migration") if isinstance(reconcile, Mapping) else None
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or not isinstance(active_migration, Mapping)
+        or migration.get("migrationId") != migration_id
+        or active_migration.get("migrationId") != migration_id
+        or active_migration.get("oldVmName") != migration.get("oldVmName")
+        or active_migration.get("oldInstanceId") != migration.get("oldInstanceId")
+        or migration.get("candidateInstanceId") != candidate_instance_id
+        or not _migration_matches(
+            vm,
+            vm_name=vm_name,
+            zone=zone,
+            auth_token=auth_token,
+            owner=owner,
+            now=now,
+            instance_id=candidate_instance_id,
+        )
+    ):
+        return None
+    if migration.get("state") == "cutover":
+        retire_after = migration.get("retireAfter")
+        if not isinstance(retire_after, (int, float)):
+            return None
+        if now < float(retire_after):
+            return {**migration, "state": "soaking"}
+        transaction.update(migration_ref, {"state": "retiring", "retirementClaimedAt": now, "updatedAt": now})
+        return {**migration, "state": "retiring"}
+    return migration if migration.get("state") == "retiring" else None
+
+
+def claim_boot_image_migration_retirement(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate_instance_id: str,
+    now: float | None = None,
+) -> dict[str, Any] | None:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    result = _claim_boot_image_migration_retirement_txn(
+        client.transaction(),
+        client.collection("account_deletions").document(uid),
+        user_ref,
+        user_ref.collection("agentVmMigrations").document(migration_id),
+        vm_name,
+        zone,
+        auth_token,
+        owner,
+        migration_id,
+        candidate_instance_id,
+        now,
+    )
+    return result if isinstance(result, dict) else None
+
+
+@transactional
+def _complete_boot_image_migration_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate_instance_id: str,
+    now: float,
+) -> bool:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    reconcile = vm.get("reconcile") if isinstance(vm, Mapping) else None
+    active_migration = reconcile.get("migration") if isinstance(reconcile, Mapping) else None
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or not isinstance(active_migration, Mapping)
+        or migration.get("state") != "retiring"
+        or migration.get("migrationId") != migration_id
+        or active_migration.get("migrationId") != migration_id
+        or active_migration.get("oldVmName") != migration.get("oldVmName")
+        or active_migration.get("oldInstanceId") != migration.get("oldInstanceId")
+        or migration.get("candidateInstanceId") != candidate_instance_id
+        or not _migration_matches(
+            vm,
+            vm_name=vm_name,
+            zone=zone,
+            auth_token=auth_token,
+            owner=owner,
+            now=now,
+            instance_id=candidate_instance_id,
+        )
+    ):
+        return False
+    completion = {"agentVm.reconcile.migration": DELETE_FIELD, "agentVm.reconcile.state": "ready"}
+    completion.update({f"agentVm.reconcile.{key}": value for key, value in clear_vm_reconcile_lease_fields().items()})
+    transaction.update(user_ref, completion)
+    transaction.update(migration_ref, {"state": "completed", "completedAt": now, "updatedAt": now})
+    return True
+
+
+def complete_boot_image_migration(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate_instance_id: str,
+    now: float | None = None,
+) -> bool:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    return bool(
+        _complete_boot_image_migration_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            user_ref,
+            user_ref.collection("agentVmMigrations").document(migration_id),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            migration_id,
+            candidate_instance_id,
+            now,
+        )
+    )
+
+
+def cutover_boot_image_migration(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    candidate: Mapping[str, Any],
+    now: float | None = None,
+) -> bool:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    return bool(
+        _cutover_boot_image_migration_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            user_ref,
+            user_ref.collection("agentVmMigrations").document(migration_id),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            candidate,
+            now,
+        )
+    )
+
+
 @transactional
 def _request_vm_start_txn(
     transaction: Any,
@@ -871,11 +1458,101 @@ class GceAgentVmClient:
             },
         )
 
+    async def set_migration_labels(self, vm_name: str, instance: Mapping[str, Any], migration_id: str) -> None:
+        fingerprint = instance.get("labelFingerprint")
+        if not isinstance(fingerprint, str) or not fingerprint:
+            raise RuntimeError("GCE instance label fingerprint missing")
+        labels = instance.get("labels")
+        current = dict(labels) if isinstance(labels, Mapping) else {}
+        current["omi-agent-migration"] = migration_id
+        current["omi-agent-predecessor"] = str(instance.get("id") or "")
+        await self._mutate(
+            "POST", self.instance_url(vm_name) + "/setLabels", {"labelFingerprint": fingerprint, "labels": current}
+        )
+
     async def stop(self, vm_name: str) -> None:
         await self._mutate("POST", self.instance_url(vm_name) + "/stop")
 
     async def start(self, vm_name: str) -> None:
         await self._mutate("POST", self.instance_url(vm_name) + "/start")
+
+    async def create_replacement(
+        self,
+        vm_name: str,
+        predecessor: Mapping[str, Any],
+        release: AgentVmRelease,
+        auth_token: str,
+        migration_id: str,
+    ) -> None:
+        """Create a labelled replacement from the pinned immutable boot image.
+
+        The caller first writes a journal record, making a create retry find the
+        same deterministic VM name.  We deliberately do not copy a private IP,
+        disk, token, or arbitrary metadata from the predecessor.
+        """
+        machine_type = predecessor.get("machineType")
+        if not isinstance(machine_type, str) or not machine_type:
+            raise RuntimeError("predecessor machine type is unavailable")
+        interfaces = predecessor.get("networkInterfaces")
+        first = interfaces[0] if isinstance(interfaces, list) and interfaces else None
+        if not isinstance(first, Mapping) or not isinstance(first.get("network"), str):
+            raise RuntimeError("predecessor network is unavailable")
+        interface: dict[str, Any] = {"network": first["network"]}
+        if isinstance(first.get("subnetwork"), str):
+            interface["subnetwork"] = first["subnetwork"]
+        if isinstance(first.get("accessConfigs"), list) and first["accessConfigs"]:
+            interface["accessConfigs"] = [{"type": "ONE_TO_ONE_NAT", "name": "External NAT"}]
+        predecessor_id = str(predecessor.get("id") or "")
+        if not predecessor_id:
+            raise RuntimeError("predecessor instance ID is unavailable")
+        body = {
+            "name": vm_name,
+            "machineType": machine_type,
+            "disks": [
+                {
+                    "boot": True,
+                    "autoDelete": True,
+                    "initializeParams": {
+                        "sourceImage": release.boot_image,
+                        "diskSizeGb": "50",
+                        "diskType": f"zones/{self.zone}/diskTypes/pd-balanced",
+                    },
+                }
+            ],
+            "serviceAccounts": [
+                {"email": release.service_account, "scopes": ["https://www.googleapis.com/auth/cloud-platform"]}
+            ],
+            "networkInterfaces": [interface],
+            "tags": {"items": ["omi-agent-vm"]},
+            "labels": {"omi-agent-migration": migration_id, "omi-agent-predecessor": predecessor_id},
+            "metadata": {
+                "items": [
+                    *[{"key": key, "value": value} for key, value in expected_release_metadata(release).items()],
+                    {"key": "auth-token", "value": auth_token},
+                    {"key": "omi-agent-migration", "value": migration_id},
+                ]
+            },
+        }
+        await self._mutate(
+            "POST",
+            f"https://compute.googleapis.com/compute/v1/projects/{self.project}/zones/{self.zone}/instances",
+            body,
+        )
+
+    async def delete_replacement(self, vm_name: str, expected_instance_id: str, migration_id: str) -> bool:
+        """Delete only the labelled, numeric-ID-matched predecessor/candidate."""
+        instance = await self.get_instance(vm_name)
+        if instance is None:
+            return True
+        labels = instance.get("labels")
+        if (
+            str(instance.get("id") or "") != expected_instance_id
+            or not isinstance(labels, Mapping)
+            or labels.get("omi-agent-migration") != migration_id
+        ):
+            return False
+        await self._mutate("DELETE", self.instance_url(vm_name))
+        return True
 
     @staticmethod
     def instance_ip(instance: Mapping[str, Any]) -> str | None:
@@ -974,16 +1651,23 @@ __all__ = [
     "RECONCILER_SCHEMA_VERSION",
     "TrustedAgentVmHealthChannelUnavailable",
     "active_session_count",
+    "begin_boot_image_migration",
     "claim_reconciler_run_lease",
+    "claim_boot_image_migration_retirement",
     "claim_session_lease",
     "claim_vm_lease",
     "clear_missing_vm_if_current",
     "clear_vm_reconcile_lease_fields",
+    "complete_boot_image_migration",
+    "cutover_boot_image_migration",
     "drift_reasons",
     "expected_release_metadata",
     "heartbeat_session_lease",
+    "mark_boot_image_migration_candidate_deleted",
     "reconcile_requested",
     "release_manifest_bytes",
+    "record_boot_image_candidate",
+    "recover_missing_boot_image_candidate",
     "release_reconciler_run_lease",
     "request_vm_start",
     "renew_reconciler_run_lease",

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -37,6 +38,71 @@ def test_release_renderer_rejects_the_runtime_invalid_service_account_format():
 
     with pytest.raises(ValueError, match="serviceAccount"):
         release.validate_manifest(payload)
+
+
+def test_release_renderer_emits_a_hash_covered_dev_only_migration_plan(tmp_path):
+    release = _release_module()
+    output = tmp_path / "migration.json"
+    assert (
+        release.main(
+            [
+                "--output",
+                str(output),
+                "--environment",
+                "development",
+                "--source-sha",
+                "a" * 40,
+                "--image-digest",
+                f"gcr.io/project/agent-vm@sha256:{'b' * 64}",
+                "--startup-uri",
+                "gs://bucket/agent-vm/releases/startup.sh",
+                "--startup-sha256",
+                "c" * 64,
+                "--boot-image",
+                "projects/project/global/images/omi-agent-20260805",
+                "--service-account",
+                "omi-agent-vm-bootstrap@project.iam.gserviceaccount.com",
+                "--boot-image-migration-allowed-uid",
+                "dev-owner",
+                "--boot-image-migration-soak-seconds",
+                "60",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["bootImageMigration"] == {
+        "enabled": True,
+        "allowedUids": ["dev-owner"],
+        "maxConcurrency": 1,
+        "soakSeconds": 60,
+    }
+    release.validate_manifest(payload)
+    with pytest.raises(ValueError, match="development"):
+        release.render_manifest(
+            release.parser().parse_args(
+                [
+                    "--output",
+                    str(output),
+                    "--environment",
+                    "production",
+                    "--source-sha",
+                    "a" * 40,
+                    "--image-digest",
+                    f"gcr.io/project/agent-vm@sha256:{'b' * 64}",
+                    "--startup-uri",
+                    "gs://bucket/agent-vm/releases/startup.sh",
+                    "--startup-sha256",
+                    "c" * 64,
+                    "--boot-image",
+                    "projects/project/global/images/omi-agent-20260805",
+                    "--service-account",
+                    "omi-agent-vm-bootstrap@project.iam.gserviceaccount.com",
+                    "--boot-image-migration-allowed-uid",
+                    "dev-owner",
+                ]
+            )
+        )
 
 
 def test_desktop_workflows_guard_active_pointer_reads_writes_and_cleanup_rollbacks():
@@ -81,7 +147,7 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert 'AGENT_VM_RECONCILER_IAM_APPLY:-}' in script
     assert "REFUSED:" in script
     assert (
-        "compute.disks.get,compute.instances.get,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop"
+        "compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop"
         in script
     )
     assert "Agent VM reconciler instance scope" in script
@@ -170,6 +236,20 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
         "--role=roles/datastore.user --condition=None"
     ) in commands
+
+
+def test_dev_migration_activation_refuses_by_default_and_uses_generation_guard(tmp_path):
+    script = BACKEND_DIR / "scripts" / "activate-agent-vm-dev-migration.sh"
+    text = script.read_text(encoding="utf-8")
+    assert 'AGENT_VM_MIGRATION_APPLY:-}' in text
+    assert 'project" != "based-hardware-dev"' in text
+    assert "gcloud storage cp --no-clobber" in text
+    assert "--if-generation-match" in text
+    assert "cmp -s" in text
+
+    refused = subprocess.run(["bash", str(script)], cwd=REPO_DIR, text=True, capture_output=True, check=False)
+    assert refused.returncode == 1
+    assert "REFUSED:" in refused.stderr
 
 
 def test_revoke_script_removes_all_conditional_bindings_and_verifies_absence():

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -147,7 +147,7 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert 'AGENT_VM_RECONCILER_IAM_APPLY:-}' in script
     assert "REFUSED:" in script
     assert (
-        "compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop"
+        "compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop,compute.subnetworks.use,compute.subnetworks.useExternalIp"
         in script
     )
     assert "Agent VM reconciler instance scope" in script
@@ -250,6 +250,16 @@ def test_dev_migration_activation_refuses_by_default_and_uses_generation_guard(t
     refused = subprocess.run(["bash", str(script)], cwd=REPO_DIR, text=True, capture_output=True, check=False)
     assert refused.returncode == 1
     assert "REFUSED:" in refused.stderr
+
+
+def test_dev_migration_activation_verifies_bucket_project_and_previous_snapshot():
+    script = BACKEND_DIR / "scripts" / "activate-agent-vm-dev-migration.sh"
+    text = script.read_text(encoding="utf-8")
+    assert "gcloud storage buckets describe" in text
+    assert "refusing cross-environment activation" in text
+    assert "previous.json" in text
+    assert "rollback" in text or "Snapshot" in text or "snapshot" in text
+    assert "uid.strip()" in text
 
 
 def test_revoke_script_removes_all_conditional_bindings_and_verifies_absence():

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -209,6 +209,460 @@ def test_boot_image_drift_requires_operator_recreate_without_mutating_vm(monkeyp
     assert not DriftApi.mutated
 
 
+def test_boot_image_migration_plan_is_explicit_allowlisted_and_dev_only(monkeypatch):
+    raw = RELEASE.to_mapping() | {
+        "bootImageMigration": {
+            "enabled": True,
+            "allowedUids": ["dev-user"],
+            "maxConcurrency": 1,
+            "soakSeconds": 60,
+        }
+    }
+    monkeypatch.setenv("AGENT_VM_ENVIRONMENT", "development")
+    monkeypatch.setenv("GCE_PROJECT_ID", "based-hardware-dev")
+
+    plan = reconciler._boot_image_migration_plan(raw, RELEASE)
+
+    assert plan is not None
+    assert plan.allowed_uids == frozenset({"dev-user"})
+    assert plan.max_concurrency == 1
+    with pytest.raises(ValueError, match="development-only"):
+        reconciler._boot_image_migration_plan(raw, replace(RELEASE, environment="production"))
+
+
+def test_boot_image_migration_replaces_only_an_already_stopped_allowlisted_vm(monkeypatch):
+    class MigrationApi:
+        creates: list[tuple[Any, ...]] = []
+        labels: list[str] = []
+        waits: list[tuple[str, str]] = []
+        candidate: dict[str, Any] | None = None
+
+        def __init__(self, _project: str, _zone: str) -> None:
+            self.old = {
+                "id": "old-id",
+                "status": "TERMINATED",
+                "machineType": "zones/us-central1-a/machineTypes/e2-small",
+                "networkInterfaces": [{"network": "global/networks/default", "networkIP": "10.128.0.8"}],
+                "metadata": {},
+                "serviceAccounts": [],
+                "disks": [{"boot": True, "source": "projects/project/zones/us-central1-a/disks/omi-agent-user"}],
+                "labelFingerprint": "fingerprint",
+            }
+
+        async def get_instance(self, name: str) -> dict[str, Any] | None:
+            return self.old if name == "omi-agent-user" else type(self).candidate
+
+        async def request(self, _method: str, url: str) -> Any:
+            class Response:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict[str, str]:
+                    return {
+                        "sourceImage": (
+                            "projects/project/global/images/omi-agent-20260805"
+                            if "candidate-disk" in url
+                            else "projects/project/global/images/omi-agent-old"
+                        )
+                    }
+
+            return Response()
+
+        async def set_migration_labels(self, _name: str, _instance: dict[str, Any], migration_id: str) -> None:
+            type(self).labels.append(migration_id)
+
+        async def create_replacement(self, *args: Any) -> None:
+            type(self).creates.append(args)
+            type(self).candidate = {
+                "id": "candidate-id",
+                "labels": {"omi-agent-migration": args[-1], "omi-agent-predecessor": "old-id"},
+                "networkInterfaces": [{"networkIP": "10.128.0.9", "accessConfigs": [{"natIP": "34.1.2.3"}]}],
+                "serviceAccounts": [{"email": RELEASE.service_account}],
+                "disks": [{"boot": True, "source": "projects/project/zones/us-central1-a/disks/candidate-disk"}],
+            }
+
+        @staticmethod
+        def private_instance_ip(_instance: dict[str, Any]) -> str:
+            return "10.128.0.9"
+
+        @staticmethod
+        def instance_ip(_instance: dict[str, Any]) -> str:
+            return "34.1.2.3"
+
+        async def wait_for_runtime(self, ip: str, token: str, _release: AgentVmRelease) -> None:
+            type(self).waits.append((ip, token))
+
+    cutovers: list[dict[str, Any]] = []
+    MigrationApi.creates = []
+    MigrationApi.labels = []
+    MigrationApi.waits = []
+    MigrationApi.candidate = None
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", MigrationApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(
+        reconciler, "begin_boot_image_migration", lambda *args: {"candidateAuthToken": args[-1]["candidateAuthToken"]}
+    )
+    monkeypatch.setattr(reconciler, "recover_missing_boot_image_candidate", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "record_boot_image_candidate", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "cutover_boot_image_migration", lambda *args: cutovers.append(args[-1]) or True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 0)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "dev-user",
+            {"vmName": "omi-agent-user", "authToken": "old-token", "status": "stopped"},
+            RELEASE,
+            owner="worker",
+            project="project",
+            boot_image_migration=reconciler.BootImageMigrationPlan(frozenset({"dev-user"}), 1, 60),
+        )
+    )
+
+    assert result.state == "migrated"
+    assert MigrationApi.labels and MigrationApi.creates and MigrationApi.waits
+    assert cutovers[-1]["vmName"].startswith("omi-agent-user-m-")
+    assert cutovers[-1]["authToken"] != "old-token"
+
+
+def test_boot_image_migration_fails_closed_for_an_unverifiable_source(monkeypatch):
+    class UnverifiableApi(FakeApi):
+        async def request(self, _method: str, _url: str) -> Any:
+            class Response:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict[str, str]:
+                    return {}
+
+            return Response()
+
+        async def create_replacement(self, *_args: Any) -> None:
+            pytest.fail("unverifiable source images must never create candidates")
+
+    updates: list[dict[str, Any]] = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", UnverifiableApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *args, **_kwargs: updates.append(args[4]) or True)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "dev-user",
+            {"vmName": "omi-agent-user", "authToken": "token", "status": "stopped"},
+            RELEASE,
+            owner="worker",
+            project="project",
+            boot_image_migration=reconciler.BootImageMigrationPlan(frozenset({"dev-user"}), 1, 60),
+        )
+    )
+
+    assert result.state == "recreate_required"
+    assert updates[-1]["lastError"] == "boot_image_source_unverifiable"
+
+
+def test_boot_image_migration_quarantine_deletes_a_failed_candidate_with_its_identity_fence(monkeypatch):
+    class DriftApi(FakeApi):
+        deleted: list[tuple[str, str, str]] = []
+
+        async def request(self, _method: str, _url: str) -> Any:
+            class Response:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict[str, str]:
+                    return {"sourceImage": "projects/project/global/images/omi-agent-old"}
+
+            return Response()
+
+        async def delete_replacement(self, vm_name: str, instance_id: str, migration_id: str) -> bool:
+            type(self).deleted.append((vm_name, instance_id, migration_id))
+            return True
+
+    async def failed_candidate(*_args: Any, **kwargs: Any) -> reconciler.ReconcileResult:
+        kwargs["cleanup_context"].update({"vmName": "candidate", "instanceId": "candidate-id", "migrationId": "d" * 24})
+        raise RuntimeError("candidate health failed")
+
+    updates: list[dict[str, Any]] = []
+    DriftApi.deleted = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", DriftApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "_replace_stopped_boot_image_drift", failed_candidate)
+    monkeypatch.setattr(reconciler, "mark_boot_image_migration_candidate_deleted", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *args, **_kwargs: updates.append(args[4]) or True)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "dev-user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "status": "stopped",
+                "reconcile": {"retryCount": 2, "releaseId": RELEASE.release_id},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            boot_image_migration=reconciler.BootImageMigrationPlan(frozenset({"dev-user"}), 1, 60),
+        )
+    )
+
+    assert result.state == "quarantined"
+    assert DriftApi.deleted == [("candidate", "candidate-id", "d" * 24)]
+    assert updates[-1]["state"] == "quarantined"
+
+
+def test_boot_image_migration_never_creates_for_an_active_session(monkeypatch):
+    class DriftApi(FakeApi):
+        async def request(self, _method: str, _url: str) -> Any:
+            class Response:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict[str, str]:
+                    return {"sourceImage": "projects/project/global/images/omi-agent-old"}
+
+            return Response()
+
+        async def create_replacement(self, *_args: Any) -> None:
+            pytest.fail("active sessions must block replacement")
+
+    updates: list[dict[str, Any]] = []
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", DriftApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 1)
+    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *args, **_kwargs: updates.append(args[4]) or True)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "dev-user",
+            {"vmName": "omi-agent-user", "authToken": "token", "status": "stopped"},
+            RELEASE,
+            owner="worker",
+            project="project",
+            boot_image_migration=reconciler.BootImageMigrationPlan(frozenset({"dev-user"}), 1, 60),
+        )
+    )
+
+    assert result.state == "recreate_required"
+    assert updates[-1]["state"] == "recreate_required"
+
+
+def test_boot_image_migration_journal_fences_predecessor_and_resumes_candidate_ready(monkeypatch):
+    now = 100.0
+    migration_id = "a" * 24
+    user = {
+        "agentVm": {
+            "vmName": "omi-agent-user",
+            "zone": "us-central1-a",
+            "status": "stopped",
+            "instanceId": "old-id",
+            "authToken": "old-token",
+            "reconcile": {"lease": {"owner": "worker", "expiresAt": 200.0}},
+        }
+    }
+    client = StrictFirestore({("users", "dev-user"): user})
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+    migration = {
+        "migrationId": migration_id,
+        "oldVmName": "omi-agent-user",
+        "oldZone": "us-central1-a",
+        "oldAuthToken": "old-token",
+        "oldInstanceId": "old-id",
+        "candidateVmName": "omi-agent-user-m-aaaaaaaaaaaa",
+        "candidateAuthToken": "candidate-token",
+        "targetRelease": RELEASE.release_id,
+        "targetBootImage": RELEASE.boot_image,
+        "soakSeconds": 60,
+    }
+
+    journal = lifecycle.begin_boot_image_migration(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, migration, now=now
+    )
+    assert journal and journal["candidateAuthToken"] == "candidate-token"
+    assert lifecycle.record_boot_image_candidate(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, "candidate-id", now=now
+    )
+    # A health-check retry sees the same candidate identity and does not need
+    # to create a second VM or change its bearer token.
+    assert lifecycle.record_boot_image_candidate(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, "candidate-id", now=now + 1
+    )
+    assert lifecycle.mark_boot_image_migration_candidate_deleted(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, "candidate-id", now=now + 2
+    )
+    assert client.transactions[-1].updates[-1][1]["state"] == "candidate_deleted"
+    # A terminal cleanup resumes with the same deterministic candidate name and
+    # token, but removes the stale provider ID before replacement is retried.
+    journal = lifecycle.begin_boot_image_migration(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, migration, now=now + 3
+    )
+    assert journal and journal["state"] == "candidate_creating"
+    assert client.transactions[-1].updates[-1][1]["candidateInstanceId"] is lifecycle.DELETE_FIELD
+
+    # If deletion succeeded just before the worker could journal it, the next
+    # worker first observes the candidate absent in GCE and may reset the
+    # still-ready journal before it creates a replacement.
+    missing_candidate_client = StrictFirestore(
+        {
+            ("users", "dev-user"): user,
+            ("users", "dev-user", "agentVmMigrations", migration_id): {
+                **migration,
+                "state": "candidate_ready",
+                "candidateInstanceId": "candidate-id",
+            },
+        }
+    )
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: missing_candidate_client)
+    assert lifecycle.recover_missing_boot_image_candidate(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, now=now + 4
+    )
+    assert missing_candidate_client.transactions[-1].updates[-1][1]["state"] == "candidate_creating"
+
+    bad_client = StrictFirestore(
+        {
+            ("users", "dev-user"): {
+                "agentVm": {**user["agentVm"], "instanceId": "repointed-id"},
+            },
+            ("users", "dev-user", "agentVmMigrations", migration_id): {
+                **migration,
+                "state": "candidate_ready",
+                "candidateInstanceId": "candidate-id",
+            },
+        }
+    )
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: bad_client)
+    assert not lifecycle.cutover_boot_image_migration(
+        "dev-user",
+        "omi-agent-user",
+        "us-central1-a",
+        "old-token",
+        "worker",
+        migration_id,
+        {"vmName": migration["candidateVmName"], "instanceId": "candidate-id"},
+        now=now,
+    )
+
+
+def test_boot_image_migration_binds_a_legacy_pointer_to_the_provider_instance_id(monkeypatch):
+    migration_id = "c" * 24
+    client = StrictFirestore(
+        {
+            ("users", "dev-user"): {
+                "agentVm": {
+                    "vmName": "omi-agent-user",
+                    "zone": "us-central1-a",
+                    "status": "stopped",
+                    "authToken": "old-token",
+                    "reconcile": {"lease": {"owner": "worker", "expiresAt": 200.0}},
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+    migration = {
+        "migrationId": migration_id,
+        "oldVmName": "omi-agent-user",
+        "oldAuthToken": "old-token",
+        "oldInstanceId": "old-id",
+        "candidateVmName": "omi-agent-user-m-cccccccccccc",
+        "candidateAuthToken": "candidate-token",
+        "targetRelease": RELEASE.release_id,
+        "targetBootImage": RELEASE.boot_image,
+        "soakSeconds": 60,
+    }
+
+    assert lifecycle.begin_boot_image_migration(
+        "dev-user", "omi-agent-user", "us-central1-a", "old-token", "worker", migration_id, migration, now=100
+    )
+    assert client.transactions[-1].updates[-1][1]["agentVm.instanceId"] == "old-id"
+
+
+def test_boot_image_migration_completion_requires_candidate_pointer_and_lease(monkeypatch):
+    now = 200.0
+    migration_id = "b" * 24
+    candidate_name = "omi-agent-user-m-bbbbbbbbbbbb"
+    migration = {
+        "migrationId": migration_id,
+        "oldVmName": "omi-agent-user",
+        "oldInstanceId": "old-id",
+        "candidateVmName": candidate_name,
+        "candidateInstanceId": "candidate-id",
+        "state": "retiring",
+    }
+    client = StrictFirestore(
+        {
+            ("users", "dev-user"): {
+                "agentVm": {
+                    "vmName": candidate_name,
+                    "zone": "us-central1-a",
+                    "instanceId": "candidate-id",
+                    "authToken": "candidate-token",
+                    "reconcile": {
+                        "migration": dict(migration),
+                        "lease": {"owner": "worker", "expiresAt": 300.0},
+                    },
+                }
+            },
+            ("users", "dev-user", "agentVmMigrations", migration_id): migration,
+        }
+    )
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+
+    assert lifecycle.complete_boot_image_migration(
+        "dev-user", candidate_name, "us-central1-a", "candidate-token", "worker", migration_id, "candidate-id", now=now
+    )
+    updates = client.transactions[-1].updates
+    assert updates[-2][1]["agentVm.reconcile.migration"] is lifecycle.DELETE_FIELD
+    assert updates[-2][1]["agentVm.reconcile.lease"] is lifecycle.DELETE_FIELD
+    assert updates[-1][1]["state"] == "completed"
+
+
+def test_boot_image_migration_retirement_claim_uses_the_journaled_deadline(monkeypatch):
+    migration_id = "e" * 24
+    candidate_name = "omi-agent-user-m-eeeeeeeeeeee"
+    migration = {
+        "migrationId": migration_id,
+        "oldVmName": "omi-agent-user",
+        "oldInstanceId": "old-id",
+        "candidateVmName": candidate_name,
+        "candidateInstanceId": "candidate-id",
+        "state": "cutover",
+        "retireAfter": 300.0,
+    }
+    rows = {
+        ("users", "dev-user"): {
+            "agentVm": {
+                "vmName": candidate_name,
+                "zone": "us-central1-a",
+                "instanceId": "candidate-id",
+                "authToken": "candidate-token",
+                "reconcile": {"migration": dict(migration), "lease": {"owner": "worker", "expiresAt": 400.0}},
+            }
+        },
+        ("users", "dev-user", "agentVmMigrations", migration_id): migration,
+    }
+    client = StrictFirestore(rows)
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+
+    soaking = lifecycle.claim_boot_image_migration_retirement(
+        "dev-user", candidate_name, "us-central1-a", "candidate-token", "worker", migration_id, "candidate-id", now=299
+    )
+    assert soaking and soaking["state"] == "soaking"
+    assert not client.transactions[-1].updates
+    claimed = lifecycle.claim_boot_image_migration_retirement(
+        "dev-user", candidate_name, "us-central1-a", "candidate-token", "worker", migration_id, "candidate-id", now=300
+    )
+    assert claimed and claimed["state"] == "retiring"
+    assert client.transactions[-1].updates[-1][1]["state"] == "retiring"
+
+
 def test_mutable_boot_image_manifest_fails_closed_without_disk_lookup():
     class NoRequestApi(FakeApi):
         async def request(self, _method: str, _url: str) -> Any:

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -230,6 +230,22 @@ def test_boot_image_migration_plan_is_explicit_allowlisted_and_dev_only(monkeypa
         reconciler._boot_image_migration_plan(raw, replace(RELEASE, environment="production"))
 
 
+def test_boot_image_migration_plan_rejects_whitespace_only_allowed_uids(monkeypatch):
+    raw = RELEASE.to_mapping() | {
+        "bootImageMigration": {
+            "enabled": True,
+            "allowedUids": ["  "],
+            "maxConcurrency": 1,
+            "soakSeconds": 60,
+        }
+    }
+    monkeypatch.setenv("AGENT_VM_ENVIRONMENT", "development")
+    monkeypatch.setenv("GCE_PROJECT_ID", "based-hardware-dev")
+
+    with pytest.raises(ValueError, match="allowedUids"):
+        reconciler._boot_image_migration_plan(raw, RELEASE)
+
+
 def test_boot_image_migration_replaces_only_an_already_stopped_allowlisted_vm(monkeypatch):
     class MigrationApi:
         creates: list[tuple[Any, ...]] = []
@@ -324,6 +340,50 @@ def test_boot_image_migration_replaces_only_an_already_stopped_allowlisted_vm(mo
     assert MigrationApi.labels and MigrationApi.creates and MigrationApi.waits
     assert cutovers[-1]["vmName"].startswith("omi-agent-user-m-")
     assert cutovers[-1]["authToken"] != "old-token"
+
+
+def test_migration_allowlist_owners_are_selected_outside_the_rollout_cohort(monkeypatch):
+    """An explicitly allowlisted, stopped VM that is not in the normal rollout
+    cohort must still be selected so its boot-image drift can be replaced."""
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", FakeApi)
+    monkeypatch.setattr(reconciler, "_init_firebase", lambda: None)
+    monkeypatch.setattr(reconciler, "claim_reconciler_run_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "renew_reconciler_run_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "release_reconciler_run_lease", lambda *_args: None)
+    monkeypatch.setattr(reconciler, "_rollout_phase", lambda *_args, **_kwargs: "remainder")
+    raw_manifest = RELEASE.to_mapping() | {
+        "bootImageMigration": {
+            "enabled": True,
+            "allowedUids": ["migration-owner"],
+            "maxConcurrency": 1,
+            "soakSeconds": 60,
+        }
+    }
+
+    def fake_owners() -> list[tuple[str, dict[str, Any]]]:
+        return [
+            ("migration-owner", {"vmName": "omi-agent-migration-owner", "status": "stopped"}),
+            ("rollout-owner", {"vmName": "omi-agent-rollout-owner", "status": "stopped"}),
+        ]
+
+    captured_uids: list[str] = []
+
+    async def fake_reconcile_one(uid, vm, release, **kwargs):
+        captured_uids.append(uid)
+        return reconciler.ReconcileResult(uid, "ready", "test")
+
+    monkeypatch.setattr(reconciler, "_owners", fake_owners)
+    monkeypatch.setattr(reconciler, "reconcile_one", fake_reconcile_one)
+    monkeypatch.setattr(reconciler, "_advance_rollout", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(reconciler, "load_active_release", lambda: (RELEASE, raw_manifest))
+    monkeypatch.setenv("GCE_PROJECT_ID", "based-hardware-dev")
+    monkeypatch.setenv("AGENT_VM_ENVIRONMENT", "development")
+
+    asyncio.run(reconciler.run_reconciler())
+
+    assert "migration-owner" in captured_uids, (
+        "allowlisted migration owner must be selected even when outside the rollout cohort"
+    )
 
 
 def test_boot_image_migration_fails_closed_for_an_unverifiable_source(monkeypatch):

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -381,9 +381,9 @@ def test_migration_allowlist_owners_are_selected_outside_the_rollout_cohort(monk
 
     asyncio.run(reconciler.run_reconciler())
 
-    assert "migration-owner" in captured_uids, (
-        "allowlisted migration owner must be selected even when outside the rollout cohort"
-    )
+    assert (
+        "migration-owner" in captured_uids
+    ), "allowlisted migration owner must be selected even when outside the rollout cohort"
 
 
 def test_boot_image_migration_fails_closed_for_an_unverifiable_source(monkeypatch):

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -50,6 +50,64 @@ reconciler records `recreate_required` and does not stop, replace, or start the
 VM. An operator must recreate that dev/prod VM through the owner provisioning
 path with the exact image reference before the fleet can converge.
 
+## Development-only boot-image replacement
+
+Ordinary release rollout is never permission to replace a VM. A manifest may
+carry a separate `bootImageMigration` object only for a deliberately selected
+development owner:
+
+```json
+{
+  "bootImageMigration": {
+    "enabled": true,
+    "allowedUids": ["development-only-owner"],
+    "maxConcurrency": 1,
+    "soakSeconds": 600
+  }
+}
+```
+
+The job rejects this object outside development, requires a non-empty explicit
+allowlist, and only considers an already stopped owner with no session/start or
+drain demand. It journals a deterministic replacement candidate, verifies its
+private authenticated health and release identity, then atomically cuts the
+owner pointer over. The predecessor remains stopped and labelled during the
+soak window, then the same migration journal deletes it only after its numeric
+instance ID, label, active pointer, account-deletion, and lease fences still
+match. Candidate health retries reuse the journaled name and bearer token; a
+candidate that exhausts the normal retry budget is identity-fenced deleted
+before the owner record is quarantined. Production replacement is hard-disabled
+in code.
+
+Generate the opt-in manifest with the checked-in renderer; do not hand-edit a
+manifest after it receives `manifestSha256`:
+
+```bash
+python3 backend/scripts/agent_vm_release.py \
+  --output /tmp/agent-vm-migration.json \
+  --environment development \
+  --source-sha "$SOURCE_SHA" --image-digest "$IMAGE_DIGEST" \
+  --startup-uri "$STARTUP_URI" --startup-sha256 "$STARTUP_SHA256" \
+  --boot-image "$BOOT_IMAGE" --service-account "$SERVICE_ACCOUNT" \
+  --boot-image-migration-allowed-uid development-only-owner \
+  --boot-image-migration-soak-seconds 600
+```
+
+Activate it only with the checked-in dev-only, generation-guarded control:
+
+```bash
+AGENT_VM_MIGRATION_APPLY=1 \
+  AGENT_VM_MIGRATION_PROJECT=based-hardware-dev \
+  AGENT_VM_MIGRATION_BUCKET=based-hardware-dev-agent \
+  AGENT_VM_MIGRATION_MANIFEST=/tmp/agent-vm-migration.json \
+  bash backend/scripts/activate-agent-vm-dev-migration.sh
+```
+
+It refuses any other project, uploads a content-addressed immutable artifact,
+uses the current active-pointer generation for the compare-and-swap, and reads
+the activated generation back byte-for-byte. The next normal release manifest
+omits this flag, so migration cannot persist accidentally.
+
 ## Installation order
 
 Deploy Agent Proxy with session leases first. Before the desktop-backend


### PR DESCRIPTION
## Summary

- add an explicit development-only Agent VM boot-image migration plan, rendered and activated through a canonical, generation-guarded manifest path
- reconcile stopped allowlisted VMs through a journaled candidate, private authenticated readiness check, fenced pointer cutover, retained soak, and ID/label-fenced predecessor retirement
- preserve safe retry and cleanup behavior: durable candidate tokens, legacy instance-ID binding, candidate cleanup on terminal quarantine, and Firestore retirement claims before provider deletion
- extend the reconciler IAM role only with the GCE create/image/label/delete permissions needed for the fenced dev workflow

## Safety and rollout

Ordinary release manifests cannot enable replacement. The runtime additionally rejects migration outside `based-hardware-dev`, requires an explicit UID allowlist and one-at-a-time concurrency, and does not stop an active VM. Production replacement remains hard-disabled.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/unit/test_agent_vm_reconciler_job.py tests/unit/test_agent_vm_reconciler.py tests/unit/test_agent_vm_reconciler_deployment_scripts.py` (64 passed)
- `bash backend/scripts/typecheck.sh` (0 errors)
- `make preflight` (24 selected checks passed)
- Luna swarm review, including follow-up review of retry, retirement, scheduling, activation, and cleanup fences


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Failure-Class: none
