### PR TITLE
fix(app): restore dart formatting in plans_sheet (main red)

### DIFF
--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-      );
+            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+          );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-    );
+          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+        );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -936,8 +936,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded =
-                                  sub?.currentPeriodEnd != null &&
+                              final periodEnded = sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1012,8 +1011,7 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption =
-                                _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1175,8 +1173,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton =
-                                !isOnAnnualPlan &&
+                            final shouldShowContinueButton = !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&


### PR DESCRIPTION
## Bug

`Repo Checks` is red on `main` — the required "Check Dart formatting" step fails (run 31090178093, exit 123) on `app/lib/pages/settings/widgets/plans_sheet.dart`.

## Root cause

PR #11177 ("fix(app): localize the plans sheet") reformatted large parts of `plans_sheet.dart` but landed with five spots not matching `dart format`. Repo Checks only formats *changed* files, so the PR lane didn't see it — the file was untouched in that PR's diff base for the formatting step, and the violation only surfaced on the merge commit.

## Fix

Reran the exact command the lane runs, with the exact SDK it uses:

```
dart format --line-length 120 --language-version=3.0 app/lib/pages/settings/widgets/plans_sheet.dart
```

Dart 3.12.2 (the SDK bundled with Flutter stable 3.44.5, which the lane pins); language version 3.0 comes from `app/pubspec.yaml` (`sdk: ">=3.0.0 <4.0.0"`), so this is short-style, not tall-style, formatting.

Whitespace only — 7 insertions / 10 deletions, all line-wrapping.

## Tested

- Reproduced the failure locally with that SDK: `--set-exit-if-changed` → exit 1, "Changed app/lib/pages/settings/widgets/plans_sheet.dart" (identical to CI).
- After the fix: `--set-exit-if-changed` → exit 0.
- Proved semantic equivalence: whitespace-stripped source before vs. after is byte-identical, so no behavior change.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

