### PR TITLE
test(desktop): unskip ChatDiscoverabilityTests after tool-surface codegen (#9030)

### DIFF
--- a/desktop/macos/scripts/swift-test-skips.json
+++ b/desktop/macos/scripts/swift-test-skips.json
@@ -1,21 +1,9 @@
 {
-  "max_skip_count": 4,
+  "max_skip_count": 1,
   "allowed_tests": [
-    "ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest",
-    "ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations",
     "APIClientRoutingTests/testDeleteConversationRoutesToPython"
   ],
   "skips": [
-    {
-      "test": "ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest",
-      "issue": "https://github.com/BasedHardware/omi/issues/9030",
-      "reason": "Swift DesktopCapabilityRegistry, agent control-tool-manifest.ts, and the desktop chat prompt have drifted; reconciling the canonical tool set is a product decision."
-    },
-    {
-      "test": "ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations",
-      "issue": "https://github.com/BasedHardware/omi/issues/9030",
-      "reason": "Swift DesktopCapabilityRegistry, agent control-tool-manifest.ts, and the desktop chat prompt have drifted; reconciling the canonical tool set is a product decision."
-    },
     {
       "test": "APIClientRoutingTests/testDeleteConversationRoutesToPython",
       "issue": "https://github.com/BasedHardware/omi/issues/9031",

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -159,7 +159,7 @@ fi
 if ! grep -q "Ran 6 Swift suites in isolation with 2 worker(s)." "$TMPDIR/runner.out"; then
   fail "runner did not report suite count and worker count"
 fi
-if ! grep -q -- "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest" "$FAKE_XCRUN_LOG"; then
+if ! grep -q -- "--skip APIClientRoutingTests/testDeleteConversationRoutesToPython" "$FAKE_XCRUN_LOG"; then
   fail "runner did not pass ratcheted skips to SwiftPM"
 fi
 scratch_paths="$(awk -F '\t' '{print $2}' "$FAKE_XCRUN_SCRATCH_LOG" | sort -u | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Summary
- Capability contract drift in [#9030](https://github.com/BasedHardware/omi/issues/9030) is fixed on main via tool-surface codegen (`omi-tool-manifest.ts` → `GeneratedToolCapabilities.swift`).
- Remove the two stale `ChatDiscoverabilityTests` entries from `swift-test-skips.json` and ratchet `max_skip_count` 4 → 1 (remaining: #9031).
- Update the suites meta-test to assert the remaining ratcheted skip is still forwarded.

## Test plan
- [x] `bash desktop/macos/tests/test-swift-test-skip-ratchet.sh`
- [x] `bash desktop/macos/tests/test-swift-test-suites.sh`
- [x] `xcrun swift test --package-path Desktop --filter ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest --filter ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations` (2/2 passed)

Fixes #9030

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

