### PR TITLE
fix(web): point shared-conversation Order Now to www.omi.me (#4709)

### DIFF
--- a/web/frontend/src/components/shared/app-header.tsx
+++ b/web/frontend/src/components/shared/app-header.tsx
@@ -182,7 +182,7 @@ export default function AppHeader({
       }`,
     },
     {
-      href: 'https://www.omi.me/products/omi-dev-kit-2',
+      href: 'https://www.omi.me/',
       label: 'Order Now',
       className: 'text-white hover:text-gray-300',
     },


### PR DESCRIPTION
## Summary
- Shared conversation mobile menu **Order Now** pointed at stale `omi-dev-kit-2` shop path.
- Point it at `https://www.omi.me/` per [#4709](https://github.com/BasedHardware/omi/issues/4709).

Supersedes #11181 (head SHA stuck after Failure-Class amend).

Fixes #4709

## Failure Class
Failure-Class: none

## Test plan
- [ ] Open a shared conversation on mobile web (`h.omi.me/conversations/...`)
- [ ] Header menu → Order Now → lands on `https://www.omi.me/`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
