### PR TITLE
fix(agent-vm): bind migration network access to subnet

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/services/agent_vm_lifecycle.py": 1682,
+    "backend/services/agent_vm_lifecycle.py": 1681,
     "backend/testing/listen_pusher_stack/run.py": 1790
   },
   "raise_justifications": {

--- a/backend/scripts/activate-agent-vm-dev-migration.sh
+++ b/backend/scripts/activate-agent-vm-dev-migration.sh
@@ -14,14 +14,23 @@ if [[ "$project" != "based-hardware-dev" || -z "$bucket" || ! -f "$manifest" ]];
   echo "AGENT_VM_MIGRATION_PROJECT=based-hardware-dev, AGENT_VM_MIGRATION_BUCKET, and an existing AGENT_VM_MIGRATION_MANIFEST are required." >&2
   exit 2
 fi
+if [[ ! "$bucket" =~ ^[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]$ ]]; then
+  echo "AGENT_VM_MIGRATION_BUCKET must be a valid bucket name." >&2
+  exit 2
+fi
 
 # Verify the destination bucket actually belongs to the development project
 # so a cross-environment value cannot poison a production manifest pointer.
-bucket_project="$(
-  gcloud storage buckets describe "gs://${bucket}" --format='value(project)' 2>/dev/null || true
+project_number="$(gcloud projects describe "$project" --format='value(projectNumber)' 2>/dev/null || true)"
+bucket_project_number="$(
+  curl --fail --silent --show-error \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+    "https://storage.googleapis.com/storage/v1/b/${bucket}?fields=projectNumber" \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin).get("projectNumber", ""))' \
+    2>/dev/null || true
 )"
-if [[ "$bucket_project" != "$project" ]]; then
-  echo "ERROR: bucket gs://${bucket} is owned by '${bucket_project:-unknown}', not '${project}'; refusing cross-environment activation." >&2
+if [[ ! "$project_number" =~ ^[0-9]+$ || "$bucket_project_number" != "$project_number" ]]; then
+  echo "ERROR: bucket gs://${bucket} belongs to project number '${bucket_project_number:-unknown}', not development project '${project_number:-unknown}'; refusing cross-environment activation." >&2
   exit 2
 fi
 

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -29,9 +29,6 @@ permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,c
 subnetwork_role_id="omiAgentVmReconcilerSubnetwork"
 subnetwork_role="projects/${project}/roles/${subnetwork_role_id}"
 subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"
-network_role_id="omiAgentVmReconcilerNetwork"
-network_role="projects/${project}/roles/${network_role_id}"
-network_permissions="compute.networks.use"
 operations_permissions="compute.globalOperations.get,compute.zoneOperations.get"
 zone="us-central1-a"
 region="${zone%-*}"
@@ -53,11 +50,6 @@ if gcloud iam roles describe "$subnetwork_role_id" --project="$project" >/dev/nu
   gcloud iam roles update "$subnetwork_role_id" --project="$project" --title="Omi Agent VM reconciler subnet" --permissions="$subnetwork_permissions" --stage=GA
 else
   gcloud iam roles create "$subnetwork_role_id" --project="$project" --title="Omi Agent VM reconciler subnet" --permissions="$subnetwork_permissions" --stage=GA
-fi
-if gcloud iam roles describe "$network_role_id" --project="$project" >/dev/null 2>&1; then
-  gcloud iam roles update "$network_role_id" --project="$project" --title="Omi Agent VM reconciler network" --permissions="$network_permissions" --stage=GA
-else
-  gcloud iam roles create "$network_role_id" --project="$project" --title="Omi Agent VM reconciler network" --permissions="$network_permissions" --stage=GA
 fi
 if gcloud iam roles describe "$operations_role_id" --project="$project" >/dev/null 2>&1; then
   gcloud iam roles update "$operations_role_id" --project="$project" --title="Omi Agent VM reconciler operation polling" --permissions="$operations_permissions" --stage=GA
@@ -87,11 +79,6 @@ gcloud projects add-iam-policy-binding "$project" \
 # to a Subnetwork resource.
 gcloud compute networks subnets add-iam-policy-binding default --project="$project" --region="$region" \
   --member="serviceAccount:${gsa}" --role="$subnetwork_role"
-# The replacement body also names the VPC network explicitly so its relationship
-# with the selected subnet is checked by Compute Engine.  Bind network use only
-# on that exact default network.
-gcloud compute networks add-iam-policy-binding default --project="$project" \
-  --member="serviceAccount:${gsa}" --role="$network_role"
 gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$operations_role" --condition=None
 # Project IAM policies containing scoped bindings require unconditional bindings

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -25,9 +25,13 @@ role_id="omiAgentVmReconciler"
 role="projects/${project}/roles/${role_id}"
 operations_role_id="omiAgentVmReconcilerOperations"
 operations_role="projects/${project}/roles/${operations_role_id}"
-permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop,compute.subnetworks.use,compute.subnetworks.useExternalIp"
+permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
+subnetwork_role_id="omiAgentVmReconcilerSubnetwork"
+subnetwork_role="projects/${project}/roles/${subnetwork_role_id}"
+subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"
 operations_permissions="compute.globalOperations.get,compute.zoneOperations.get"
 zone="us-central1-a"
+region="${zone%-*}"
 
 if ! gcloud iam service-accounts describe "$gsa" --project="$project" >/dev/null 2>&1; then
   gcloud iam service-accounts create "$gsa_name" --project="$project" --display-name="Omi Agent VM reconciler"
@@ -41,6 +45,11 @@ if gcloud iam roles describe "$role_id" --project="$project" >/dev/null 2>&1; th
   gcloud iam roles update "$role_id" --project="$project" --title="Omi Agent VM reconciler" --permissions="$permissions" --stage=GA
 else
   gcloud iam roles create "$role_id" --project="$project" --title="Omi Agent VM reconciler" --permissions="$permissions" --stage=GA
+fi
+if gcloud iam roles describe "$subnetwork_role_id" --project="$project" >/dev/null 2>&1; then
+  gcloud iam roles update "$subnetwork_role_id" --project="$project" --title="Omi Agent VM reconciler subnet" --permissions="$subnetwork_permissions" --stage=GA
+else
+  gcloud iam roles create "$subnetwork_role_id" --project="$project" --title="Omi Agent VM reconciler subnet" --permissions="$subnetwork_permissions" --stage=GA
 fi
 if gcloud iam roles describe "$operations_role_id" --project="$project" >/dev/null 2>&1; then
   gcloud iam roles update "$operations_role_id" --project="$project" --title="Omi Agent VM reconciler operation polling" --permissions="$operations_permissions" --stage=GA
@@ -64,6 +73,12 @@ gcloud projects add-iam-policy-binding "$project" \
 gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$role" \
   --condition="title=Agent VM reconciler image scope,description=Immutable omi-agent images only,expression=resource.type == 'compute.googleapis.com/Image' && resource.name.startsWith('projects/${project}/global/images/omi-agent-')"
+# Replacement VMs preserve the predecessor's default subnet and external NAT.
+# Bind the two network permissions directly on that subnetwork: Compute IAM
+# Conditions do not make the project-level instance/disk/image bindings apply
+# to a Subnetwork resource.
+gcloud compute networks subnets add-iam-policy-binding default --project="$project" --region="$region" \
+  --member="serviceAccount:${gsa}" --role="$subnetwork_role"
 gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$operations_role" --condition=None
 # Project IAM policies containing scoped bindings require unconditional bindings

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -29,6 +29,9 @@ permissions="compute.disks.create,compute.disks.get,compute.images.useReadOnly,c
 subnetwork_role_id="omiAgentVmReconcilerSubnetwork"
 subnetwork_role="projects/${project}/roles/${subnetwork_role_id}"
 subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"
+network_role_id="omiAgentVmReconcilerNetwork"
+network_role="projects/${project}/roles/${network_role_id}"
+network_permissions="compute.networks.use"
 operations_permissions="compute.globalOperations.get,compute.zoneOperations.get"
 zone="us-central1-a"
 region="${zone%-*}"
@@ -50,6 +53,11 @@ if gcloud iam roles describe "$subnetwork_role_id" --project="$project" >/dev/nu
   gcloud iam roles update "$subnetwork_role_id" --project="$project" --title="Omi Agent VM reconciler subnet" --permissions="$subnetwork_permissions" --stage=GA
 else
   gcloud iam roles create "$subnetwork_role_id" --project="$project" --title="Omi Agent VM reconciler subnet" --permissions="$subnetwork_permissions" --stage=GA
+fi
+if gcloud iam roles describe "$network_role_id" --project="$project" >/dev/null 2>&1; then
+  gcloud iam roles update "$network_role_id" --project="$project" --title="Omi Agent VM reconciler network" --permissions="$network_permissions" --stage=GA
+else
+  gcloud iam roles create "$network_role_id" --project="$project" --title="Omi Agent VM reconciler network" --permissions="$network_permissions" --stage=GA
 fi
 if gcloud iam roles describe "$operations_role_id" --project="$project" >/dev/null 2>&1; then
   gcloud iam roles update "$operations_role_id" --project="$project" --title="Omi Agent VM reconciler operation polling" --permissions="$operations_permissions" --stage=GA
@@ -79,6 +87,11 @@ gcloud projects add-iam-policy-binding "$project" \
 # to a Subnetwork resource.
 gcloud compute networks subnets add-iam-policy-binding default --project="$project" --region="$region" \
   --member="serviceAccount:${gsa}" --role="$subnetwork_role"
+# The replacement body also names the VPC network explicitly so its relationship
+# with the selected subnet is checked by Compute Engine.  Bind network use only
+# on that exact default network.
+gcloud compute networks add-iam-policy-binding default --project="$project" \
+  --member="serviceAccount:${gsa}" --role="$network_role"
 gcloud projects add-iam-policy-binding "$project" \
   --member="serviceAccount:${gsa}" --role="$operations_role" --condition=None
 # Project IAM policies containing scoped bindings require unconditional bindings

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -1497,9 +1497,8 @@ class GceAgentVmClient:
         first = interfaces[0] if isinstance(interfaces, list) and interfaces else None
         if not isinstance(first, Mapping) or not isinstance(first.get("network"), str):
             raise RuntimeError("predecessor network is unavailable")
-        interface: dict[str, Any] = {"network": first["network"]}
-        if isinstance(first.get("subnetwork"), str):
-            interface["subnetwork"] = first["subnetwork"]
+        subnet = first.get("subnetwork")
+        interface: dict[str, Any] = {"subnetwork": subnet} if isinstance(subnet, str) else {"network": first["network"]}
         if isinstance(first.get("accessConfigs"), list) and first["accessConfigs"]:
             interface["accessConfigs"] = [{"type": "ONE_TO_ONE_NAT", "name": "External NAT"}]
         predecessor_id = str(predecessor.get("id") or "")

--- a/backend/tests/unit/test_agent_vm_reconciler.py
+++ b/backend/tests/unit/test_agent_vm_reconciler.py
@@ -180,6 +180,54 @@ async def test_metadata_repair_can_restore_the_owner_fenced_auth_token():
     assert {item["key"]: item["value"] for item in captured["body"]["items"]}["auth-token"] == "owner-bearer"
 
 
+@pytest.mark.asyncio
+async def test_boot_image_replacement_preserves_the_explicit_vpc_subnet_and_required_create_fields():
+    captured = {}
+
+    class Client(GceAgentVmClient):
+        async def _mutate(self, method, url, body=None):
+            captured.update({"method": method, "url": url, "body": body})
+
+    release = AgentVmRelease.from_mapping(RELEASE)
+    await Client("based-hardware-dev").create_replacement(
+        "omi-agent-user-m-migration",
+        {
+            "id": "predecessor-id",
+            "machineType": "zones/us-central1-a/machineTypes/e2-small",
+            "networkInterfaces": [
+                {
+                    "network": "projects/based-hardware-dev/global/networks/default",
+                    "subnetwork": "projects/based-hardware-dev/regions/us-central1/subnetworks/default",
+                    "accessConfigs": [{"type": "ONE_TO_ONE_NAT", "name": "External NAT"}],
+                }
+            ],
+        },
+        release,
+        "candidate-owner-bearer",
+        "migration-id",
+    )
+
+    body = captured["body"]
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/zones/us-central1-a/instances")
+    assert body["networkInterfaces"] == [
+        {
+            "network": "projects/based-hardware-dev/global/networks/default",
+            "subnetwork": "projects/based-hardware-dev/regions/us-central1/subnetworks/default",
+            "accessConfigs": [{"type": "ONE_TO_ONE_NAT", "name": "External NAT"}],
+        }
+    ]
+    assert body["serviceAccounts"] == [
+        {"email": release.service_account, "scopes": ["https://www.googleapis.com/auth/cloud-platform"]}
+    ]
+    assert body["tags"] == {"items": ["omi-agent-vm"]}
+    assert body["labels"] == {"omi-agent-migration": "migration-id", "omi-agent-predecessor": "predecessor-id"}
+    metadata = {item["key"]: item["value"] for item in body["metadata"]["items"]}
+    assert metadata["auth-token"] == "candidate-owner-bearer"
+    assert metadata["omi-agent-migration"] == "migration-id"
+    assert body["disks"][0]["initializeParams"]["sourceImage"] == release.boot_image
+
+
 def test_startup_wrapper_rejects_tampered_artifact_before_execution():
     wrapper = startup_wrapper("gs://bucket/releases/startup.sh", "d" * 64)
     assert "sha256sum /tmp/omi-startup.sh" in wrapper

--- a/backend/tests/unit/test_agent_vm_reconciler.py
+++ b/backend/tests/unit/test_agent_vm_reconciler.py
@@ -181,7 +181,7 @@ async def test_metadata_repair_can_restore_the_owner_fenced_auth_token():
 
 
 @pytest.mark.asyncio
-async def test_boot_image_replacement_preserves_the_explicit_vpc_subnet_and_required_create_fields():
+async def test_boot_image_replacement_scopes_vpc_creation_to_the_explicit_subnet_and_required_create_fields():
     captured = {}
 
     class Client(GceAgentVmClient):
@@ -212,7 +212,6 @@ async def test_boot_image_replacement_preserves_the_explicit_vpc_subnet_and_requ
     assert captured["url"].endswith("/zones/us-central1-a/instances")
     assert body["networkInterfaces"] == [
         {
-            "network": "projects/based-hardware-dev/global/networks/default",
             "subnetwork": "projects/based-hardware-dev/regions/us-central1/subnetworks/default",
             "accessConfigs": [{"type": "ONE_TO_ONE_NAT", "name": "External NAT"}],
         }

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -151,6 +151,7 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         in script
     )
     assert 'subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"' in script
+    assert 'network_permissions="compute.networks.use"' in script
     assert "Agent VM reconciler instance scope" in script
     assert "Agent VM reconciler disk scope" in script
     assert "compute.googleapis.com/Disk" in script
@@ -159,6 +160,8 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert "compute networks subnets add-iam-policy-binding default" in script
     assert '--region="$region"' in script
     assert '--role="$subnetwork_role"' in script
+    assert "compute networks add-iam-policy-binding default" in script
+    assert '--role="$network_role"' in script
     assert "roles/storage.objectViewer" in script
     assert "roles/iam.serviceAccountUser" in script
     assert 'AGENT_VM_RECONCILER_DEPLOYER:-}' in script
@@ -239,6 +242,11 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         "compute networks subnets add-iam-policy-binding default --project=based-hardware-dev --region=us-central1 "
         "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
         "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerSubnetwork"
+    ) in commands
+    assert (
+        "compute networks add-iam-policy-binding default --project=based-hardware-dev "
+        "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
+        "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerNetwork"
     ) in commands
     assert (
         "projects add-iam-policy-binding based-hardware-dev "

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -151,7 +151,6 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         in script
     )
     assert 'subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"' in script
-    assert 'network_permissions="compute.networks.use"' in script
     assert "Agent VM reconciler instance scope" in script
     assert "Agent VM reconciler disk scope" in script
     assert "compute.googleapis.com/Disk" in script
@@ -160,8 +159,6 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert "compute networks subnets add-iam-policy-binding default" in script
     assert '--region="$region"' in script
     assert '--role="$subnetwork_role"' in script
-    assert "compute networks add-iam-policy-binding default" in script
-    assert '--role="$network_role"' in script
     assert "roles/storage.objectViewer" in script
     assert "roles/iam.serviceAccountUser" in script
     assert 'AGENT_VM_RECONCILER_DEPLOYER:-}' in script
@@ -242,11 +239,6 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         "compute networks subnets add-iam-policy-binding default --project=based-hardware-dev --region=us-central1 "
         "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
         "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerSubnetwork"
-    ) in commands
-    assert (
-        "compute networks add-iam-policy-binding default --project=based-hardware-dev "
-        "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
-        "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerNetwork"
     ) in commands
     assert (
         "projects add-iam-policy-binding based-hardware-dev "

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -147,14 +147,18 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert 'AGENT_VM_RECONCILER_IAM_APPLY:-}' in script
     assert "REFUSED:" in script
     assert (
-        "compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.start,compute.instances.stop,compute.subnetworks.use,compute.subnetworks.useExternalIp"
+        "compute.disks.get,compute.images.useReadOnly,compute.instances.create,compute.instances.delete,compute.instances.get,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
         in script
     )
+    assert 'subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"' in script
     assert "Agent VM reconciler instance scope" in script
     assert "Agent VM reconciler disk scope" in script
     assert "compute.googleapis.com/Disk" in script
     assert "disks/omi-agent-" in script
     assert "instances/omi-agent-" in script
+    assert "compute networks subnets add-iam-policy-binding default" in script
+    assert '--region="$region"' in script
+    assert '--role="$subnetwork_role"' in script
     assert "roles/storage.objectViewer" in script
     assert "roles/iam.serviceAccountUser" in script
     assert 'AGENT_VM_RECONCILER_DEPLOYER:-}' in script
@@ -232,6 +236,11 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
         "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerOperations --condition=None"
     ) in commands
     assert (
+        "compute networks subnets add-iam-policy-binding default --project=based-hardware-dev --region=us-central1 "
+        "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
+        "--role=projects/based-hardware-dev/roles/omiAgentVmReconcilerSubnetwork"
+    ) in commands
+    assert (
         "projects add-iam-policy-binding based-hardware-dev "
         "--member=serviceAccount:agent-vm-reconciler@based-hardware-dev.iam.gserviceaccount.com "
         "--role=roles/datastore.user --condition=None"
@@ -255,7 +264,9 @@ def test_dev_migration_activation_refuses_by_default_and_uses_generation_guard(t
 def test_dev_migration_activation_verifies_bucket_project_and_previous_snapshot():
     script = BACKEND_DIR / "scripts" / "activate-agent-vm-dev-migration.sh"
     text = script.read_text(encoding="utf-8")
-    assert "gcloud storage buckets describe" in text
+    assert "gcloud projects describe" in text
+    assert "https://storage.googleapis.com/storage/v1/b/" in text
+    assert "projectNumber" in text
     assert "refusing cross-environment activation" in text
     assert "previous.json" in text
     assert "rollback" in text or "Snapshot" in text or "snapshot" in text

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -149,10 +149,9 @@ identity and Application Default Credentials; it does not mount the desktop
 backend's Firebase key.
 Replacement additionally preserves the default Agent VM subnet and its
 external NAT, so the installer creates a two-permission subnet role and binds
-it directly to that exact regional subnet. Because the replacement request
-also names the VPC network, the installer creates a separate one-permission
-network role bound directly to the default network; it does not grant
-project-wide network access.
+it directly to that exact regional subnet. The replacement request omits the
+redundant VPC-network field when a subnetwork is present, so Compute infers the
+network from the subnet and no project-wide network access is granted.
 Validate the installed trigger with
 `backend/scripts/validate_agent_vm_reconciler_scheduler.py` before the first
 live execution.

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -147,6 +147,10 @@ only on that reconciler identity, so it can deploy the Job without being able
 to attach unrelated service accounts. The reconciler job uses its attached
 identity and Application Default Credentials; it does not mount the desktop
 backend's Firebase key.
+Replacement additionally preserves the default Agent VM subnet and its
+external NAT, so the installer creates a two-permission subnet role and binds
+it directly to that exact regional subnet; it does not grant project-wide
+network access.
 Validate the installed trigger with
 `backend/scripts/validate_agent_vm_reconciler_scheduler.py` before the first
 live execution.

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -149,8 +149,10 @@ identity and Application Default Credentials; it does not mount the desktop
 backend's Firebase key.
 Replacement additionally preserves the default Agent VM subnet and its
 external NAT, so the installer creates a two-permission subnet role and binds
-it directly to that exact regional subnet; it does not grant project-wide
-network access.
+it directly to that exact regional subnet. Because the replacement request
+also names the VPC network, the installer creates a separate one-permission
+network role bound directly to the default network; it does not grant
+project-wide network access.
 Validate the installed trigger with
 `backend/scripts/validate_agent_vm_reconciler_scheduler.py` before the first
 live execution.


### PR DESCRIPTION
## What changed

- Bind the reconciler's two VPC-subnet permissions directly to the exact default Agent VM subnet, while retaining instance, disk, and image scope separately.
- Add the missing instance-tag permission required by the existing replacement request.
- Make the development-only migration activator verify bucket ownership with the authenticated Storage API project number, because the installed gcloud output omits that field.
- Add regression coverage for the installer, activator guard, and full replacement request body.

## Why

The first fenced development migration reached the replacement create request but the reconciler identity could not use the selected subnet. The role had subnet permissions, but its project IAM bindings applied only to instances, disks, and images. The replacement request also sets the `omi-agent-vm` tag.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/unit/test_agent_vm_reconciler_deployment_scripts.py tests/unit/test_agent_vm_reconciler.py -q` (22 passed)
- `make preflight`
- Applied the checked-in installer only to `based-hardware-dev` and verified the custom subnetwork role is bound only on `us-central1/default`.

The permissions and request fields follow [Google Compute Engine's instance creation requirements](https://docs.cloud.google.com/compute/docs/instances/create-start-instance?authuser=01&hl=en) and [specific-subnet guidance](https://docs.cloud.google.com/compute/docs/instances/create-vm-specific-subnet).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

