### PR TITLE
fix(backend): make share links honor OMI_SHARE_BASE_URL (#4339)

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -21,6 +21,7 @@ from database.vector_db import (
     search_action_items_by_vector,
 )
 from utils.users import get_user_display_name
+from utils.share_links import build_share_url
 from utils.other import endpoints as auth
 from utils.notifications import (
     send_notification,
@@ -728,7 +729,7 @@ def share_action_items(request: ShareTasksRequest, uid: str = Depends(auth.get_c
     if result is None:
         raise HTTPException(status_code=500, detail="Failed to create share link")
 
-    return {"url": f"https://h.omi.me/tasks/{token}", "token": token}
+    return {"url": build_share_url(f"/tasks/{token}"), "token": token}
 
 
 @router.get("/v1/action-items/shared/{token}", response_model=SharedActionItemsResponse, tags=['action-items'])

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -68,6 +68,7 @@ from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit
 from database.users import set_chat_message_rating_score
 from utils.rate_limit_config import get_effective_limit, RATE_LIMIT_SHADOW
 from utils.subscription import enforce_chat_quota, is_trial_paywalled
+from utils.share_links import build_share_url
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
 from utils.multipart import (
@@ -1600,7 +1601,7 @@ def share_chat_messages(
     if result is None:
         raise HTTPException(status_code=500, detail='Failed to create share link')
 
-    return {"url": f"https://h.omi.me/chat/{token}", "token": token}
+    return {"url": build_share_url(f"/chat/{token}"), "token": token}
 
 
 @router.get('/v2/messages/shared/{token}', tags=['chat'], response_model=SharedChatMessagesResponse)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -8,7 +8,6 @@ import base64
 from datetime import datetime, timezone
 from typing import List, Optional
 from pathlib import Path
-
 from utils.executors import critical_executor, db_executor, llm_executor, storage_executor, sync_executor, run_blocking
 
 from fastapi import (
@@ -68,7 +67,7 @@ from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit
 from database.users import set_chat_message_rating_score
 from utils.rate_limit_config import get_effective_limit, RATE_LIMIT_SHADOW
 from utils.subscription import enforce_chat_quota, is_trial_paywalled
-from utils.share_links import build_share_url
+from utils import share_links
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
 from utils.multipart import (
@@ -1601,7 +1600,7 @@ def share_chat_messages(
     if result is None:
         raise HTTPException(status_code=500, detail='Failed to create share link')
 
-    return {"url": build_share_url(f"/chat/{token}"), "token": token}
+    return {"url": share_links.build_share_url(f"/chat/{token}"), "token": token}
 
 
 @router.get('/v2/messages/shared/{token}', tags=['chat'], response_model=SharedChatMessagesResponse)

--- a/backend/tests/unit/test_share_links.py
+++ b/backend/tests/unit/test_share_links.py
@@ -25,13 +25,20 @@ def test_share_base_url_honors_env_override(monkeypatch):
 
 
 def test_parse_exact_conversation_reference_accepts_configured_host(monkeypatch):
-    monkeypatch.setenv("OMI_SHARE_BASE_URL", "https://share.example.com")
+    monkeypatch.setenv("OMI_SHARE_BASE_URL", "https://share.example.com:8443/omi/")
     assert (
-        parse_exact_conversation_reference(f"https://share.example.com/conversations/{CONVERSATION_ID}")
+        parse_exact_conversation_reference(f"https://share.example.com:8443/omi/conversations/{CONVERSATION_ID}")
         == CONVERSATION_ID
     )
     # Production links still resolve for self-hosted deployments.
+    monkeypatch.setenv("OMI_SHARE_BASE_URL", "https://share.example.com")
     assert parse_exact_conversation_reference(f"https://h.omi.me/conversations/{CONVERSATION_ID}") == CONVERSATION_ID
+
+
+def test_parse_exact_conversation_reference_rejects_malformed_port(monkeypatch):
+    monkeypatch.delenv("OMI_SHARE_BASE_URL", raising=False)
+    assert parse_exact_conversation_reference(f"https://h.omi.me:bad/conversations/{CONVERSATION_ID}") is None
+    assert parse_exact_conversation_reference(f"https://h.omi.me:99999/conversations/{CONVERSATION_ID}") is None
 
 
 def test_share_base_url_adds_https_when_scheme_missing(monkeypatch):

--- a/backend/tests/unit/test_share_links.py
+++ b/backend/tests/unit/test_share_links.py
@@ -31,9 +31,7 @@ def test_parse_exact_conversation_reference_accepts_configured_host(monkeypatch)
         == CONVERSATION_ID
     )
     # Production links still resolve for self-hosted deployments.
-    assert (
-        parse_exact_conversation_reference(f"https://h.omi.me/conversations/{CONVERSATION_ID}") == CONVERSATION_ID
-    )
+    assert parse_exact_conversation_reference(f"https://h.omi.me/conversations/{CONVERSATION_ID}") == CONVERSATION_ID
 
 
 def test_share_base_url_adds_https_when_scheme_missing(monkeypatch):

--- a/backend/tests/unit/test_share_links.py
+++ b/backend/tests/unit/test_share_links.py
@@ -1,0 +1,41 @@
+"""Unit coverage for OMI_SHARE_BASE_URL (#4339)."""
+
+import pytest
+
+from utils import share_links
+from utils.conversations.search import parse_exact_conversation_reference
+
+CONVERSATION_ID = "e8c05000-52f0-4a95-951c-ccd715523429"
+
+
+def test_share_base_url_defaults_to_production(monkeypatch):
+    monkeypatch.delenv("OMI_SHARE_BASE_URL", raising=False)
+    assert share_links.share_base_url() == "https://h.omi.me"
+    assert share_links.build_share_url("/chat/abc") == "https://h.omi.me/chat/abc"
+    assert share_links.share_host() == "h.omi.me"
+
+
+def test_share_base_url_honors_env_override(monkeypatch):
+    monkeypatch.setenv("OMI_SHARE_BASE_URL", "https://share.example.com/")
+    assert share_links.share_base_url() == "https://share.example.com"
+    assert share_links.build_share_url("/tasks/tok") == "https://share.example.com/tasks/tok"
+    assert share_links.share_host() == "share.example.com"
+    assert "h.omi.me" in share_links.accepted_share_hosts()
+    assert "share.example.com" in share_links.accepted_share_hosts()
+
+
+def test_parse_exact_conversation_reference_accepts_configured_host(monkeypatch):
+    monkeypatch.setenv("OMI_SHARE_BASE_URL", "https://share.example.com")
+    assert (
+        parse_exact_conversation_reference(f"https://share.example.com/conversations/{CONVERSATION_ID}")
+        == CONVERSATION_ID
+    )
+    # Production links still resolve for self-hosted deployments.
+    assert (
+        parse_exact_conversation_reference(f"https://h.omi.me/conversations/{CONVERSATION_ID}") == CONVERSATION_ID
+    )
+
+
+def test_share_base_url_adds_https_when_scheme_missing(monkeypatch):
+    monkeypatch.setenv("OMI_SHARE_BASE_URL", "share.example.com")
+    assert share_links.share_base_url() == "https://share.example.com"

--- a/backend/utils/conversations/calendar_linking.py
+++ b/backend/utils/conversations/calendar_linking.py
@@ -25,6 +25,7 @@ from utils.integration_telemetry import (
     emit_sync_failed,
     emit_sync_succeeded,
 )
+from utils.share_links import build_share_url
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +172,7 @@ async def write_conversation_link_to_calendar_event(
     """
     Write the conversation link into the Google Calendar event description.
 
-    Appends https://h.omi.me/conversations/<conversation_id> to the event description.
+    Appends a share URL for the conversation to the event description.
     Silently no-ops on any error — linking the conversation to the event is the primary
     action; failing to write the description link should not block the caller.
     """
@@ -184,7 +185,7 @@ async def write_conversation_link_to_calendar_event(
     if not access_token:
         return
 
-    conversation_link = f"https://h.omi.me/conversations/{conversation_id}"
+    conversation_link = build_share_url(f'/conversations/{conversation_id}')
     telemetry_context = IntegrationTelemetryContext(
         integration_name=GOOGLE_CALENDAR,
         operation='write_conversation_link',

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import typesense
 
-from utils.share_links import accepted_share_hosts
+from utils.share_links import accepted_share_hosts, share_base_url
 
 logger = logging.getLogger(__name__)
 
@@ -50,19 +50,34 @@ def parse_exact_conversation_reference(query: str) -> Optional[str]:
         return None
 
     host = (parsed.hostname or '').lower()
+    try:
+        configured = urlsplit(share_base_url())
+        port = parsed.port
+        configured_port = configured.port
+    except ValueError:
+        return None
+    configured_host = (configured.hostname or '').lower()
+    if host == configured_host:
+        expected_port = configured_port
+        expected_path_prefix = f'{configured.path.rstrip("/")}{_EXACT_CONVERSATION_PATH_PREFIX}'
+    elif host == 'h.omi.me':
+        expected_port = None
+        expected_path_prefix = _EXACT_CONVERSATION_PATH_PREFIX
+    else:
+        return None
     if (
         parsed.scheme.lower() != 'https'
         or host not in accepted_share_hosts()
         or parsed.username is not None
         or parsed.password is not None
-        or parsed.port is not None
+        or port != expected_port
         or parsed.query
         or parsed.fragment
-        or not parsed.path.startswith(_EXACT_CONVERSATION_PATH_PREFIX)
+        or not parsed.path.startswith(expected_path_prefix)
     ):
         return None
 
-    return _canonical_conversation_uuid(parsed.path[len(_EXACT_CONVERSATION_PATH_PREFIX) :])
+    return _canonical_conversation_uuid(parsed.path[len(expected_path_prefix) :])
 
 
 def clamp_conversation_search_pagination(page: Optional[int], per_page: Optional[int]) -> tuple[int, int]:

--- a/backend/utils/conversations/search.py
+++ b/backend/utils/conversations/search.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 import typesense
 
+from utils.share_links import accepted_share_hosts
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,7 +16,6 @@ class ConversationSearchUnavailableError(Exception):
     """Raised when Typesense is unreachable or times out (transient upstream failure)."""
 
 
-_EXACT_CONVERSATION_HOST = 'h.omi.me'
 _EXACT_CONVERSATION_PATH_PREFIX = '/conversations/'
 
 
@@ -35,8 +36,9 @@ def parse_exact_conversation_reference(query: str) -> Optional[str]:
     """Extract a canonical conversation UUID from an ID or Omi share URL.
 
     Exact references intentionally accept only the two values Omi presents to users: a UUID or an
-    HTTPS URL on ``h.omi.me`` with the exact ``/conversations/<uuid>`` path. Anything else remains a
-    natural-language query so partial IDs and lookalike URLs cannot turn search into document probing.
+    HTTPS URL on the configured share host (default ``h.omi.me``) with the exact
+    ``/conversations/<uuid>`` path. Anything else remains a natural-language query so partial IDs
+    and lookalike URLs cannot turn search into document probing.
     """
     value = query.strip() if query else ''
     if exact_id := _canonical_conversation_uuid(value):
@@ -47,9 +49,13 @@ def parse_exact_conversation_reference(query: str) -> Optional[str]:
     except ValueError:
         return None
 
+    host = (parsed.hostname or '').lower()
     if (
         parsed.scheme.lower() != 'https'
-        or parsed.netloc.lower() != _EXACT_CONVERSATION_HOST
+        or host not in accepted_share_hosts()
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
         or parsed.query
         or parsed.fragment
         or not parsed.path.startswith(_EXACT_CONVERSATION_PATH_PREFIX)

--- a/backend/utils/share_links.py
+++ b/backend/utils/share_links.py
@@ -1,0 +1,46 @@
+"""Public share-link base URL for self-hosting (#4339).
+
+Default production host remains ``https://h.omi.me``. Override with
+``OMI_SHARE_BASE_URL`` (scheme + host, optional path prefix, no trailing slash).
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit
+
+DEFAULT_SHARE_BASE_URL = 'https://h.omi.me'
+_ENV_KEY = 'OMI_SHARE_BASE_URL'
+
+
+def share_base_url() -> str:
+    """Return the configured share origin (no trailing slash)."""
+    raw = (os.getenv(_ENV_KEY) or DEFAULT_SHARE_BASE_URL).strip()
+    if not raw:
+        raw = DEFAULT_SHARE_BASE_URL
+    if '://' not in raw:
+        raw = f'https://{raw}'
+    return raw.rstrip('/')
+
+
+def share_host() -> str:
+    """Hostname used when minting share URLs (lowercase netloc without userinfo)."""
+    parsed = urlsplit(share_base_url())
+    return (parsed.hostname or 'h.omi.me').lower()
+
+
+def accepted_share_hosts() -> frozenset[str]:
+    """Hosts accepted when parsing inbound share URLs.
+
+    Always includes the production default so existing ``h.omi.me`` links keep
+    resolving even when ``OMI_SHARE_BASE_URL`` is customized.
+    """
+    hosts = {share_host(), 'h.omi.me'}
+    return frozenset(hosts)
+
+
+def build_share_url(path: str) -> str:
+    """Join ``share_base_url()`` with a path that starts with ``/``."""
+    if not path.startswith('/'):
+        path = f'/{path}'
+    return f'{share_base_url()}{path}'


### PR DESCRIPTION
## What changed and why

Shrink-only backend slice of #4339: public share URL minting no longer hardcodes `https://h.omi.me`. New helper `utils/share_links.py` reads `OMI_SHARE_BASE_URL` (default `https://h.omi.me`) and is used for chat shares, task shares, and calendar conversation links. Exact conversation-reference parsing accepts the configured host **and** keeps accepting production `h.omi.me` so existing links still resolve.

**Out of scope (follow-up):** Flutter app + desktop macOS hardcodes — separate PRs so this stays reviewable.

## Product invariants affected

none

## How it was verified

- `pytest backend/tests/unit/test_share_links.py backend/tests/unit/test_conversation_exact_reference_search.py backend/tests/unit/test_task_sharing.py` — 52 passed

## Tests

- New: `test_share_links.py` (default, env override, configured-host parse)
- Existing exact-reference + task-sharing tests still pass with the default host

## Failure class (fixes)

Failure-Class: none

## Env

Optional: `OMI_SHARE_BASE_URL=https://your-share-host` (scheme optional; trailing slash stripped).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

