### PR TITLE
fix(desktop): honor share base URL env for conversation links (#4339)

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -721,7 +721,7 @@ extension APIClient {
     // Set visibility to shared
     try await setConversationVisibility(id: id, visibility: "shared")
     // Return the web URL for the shared conversation
-    return "https://h.omi.me/conversations/\(id)"
+    return DesktopBackendEnvironment.conversationShareURL(id: id)
   }
 
   /// Updates the title of a conversation

--- a/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -5,6 +5,8 @@ enum DesktopBackendEnvironment {
   static let productionRustBackendURL = "https://desktop-backend-hhibjajaja-uc.a.run.app/"
   static let developmentPythonAPIURL = "https://api.omiapi.com/"
   static let developmentRustBackendURL = "https://desktop-backend-dt5lrfkkoa-uc.a.run.app/"
+  /// Public web share origin (conversation / chat / task links). Override with ``OMI_SHARE_BASE_URL``.
+  static let productionShareBaseURL = "https://h.omi.me"
 
   static var shouldUseDevelopmentBackends: Bool {
     shouldUseDevelopmentBackends(
@@ -149,6 +151,32 @@ enum DesktopBackendEnvironment {
     }
 
     return developmentRustBackendURL
+  }
+
+  /// Public share origin used when minting conversation links (#4339).
+  /// Matches backend ``OMI_SHARE_BASE_URL`` (default ``https://h.omi.me``).
+  static func shareBaseURL(
+    environmentValue: String? = currentEnvironmentValue("OMI_SHARE_BASE_URL")
+  ) -> String {
+    guard var raw = environmentValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !raw.isEmpty
+    else {
+      return productionShareBaseURL
+    }
+    if !raw.contains("://") {
+      raw = "https://\(raw)"
+    }
+    while raw.hasSuffix("/") {
+      raw.removeLast()
+    }
+    return raw
+  }
+
+  static func conversationShareURL(
+    id: String,
+    environmentValue: String? = currentEnvironmentValue("OMI_SHARE_BASE_URL")
+  ) -> String {
+    "\(shareBaseURL(environmentValue: environmentValue))/conversations/\(id)"
   }
 
   static func applyReleaseChannelDefaults() {

--- a/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -169,6 +169,14 @@ enum DesktopBackendEnvironment {
     while raw.hasSuffix("/") {
       raw.removeLast()
     }
+    guard let url = URL(string: raw),
+      let scheme = url.scheme?.lowercased(),
+      ["http", "https"].contains(scheme),
+      let host = url.host,
+      !host.isEmpty
+    else {
+      return productionShareBaseURL
+    }
     return raw
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -132,7 +132,7 @@ struct ConversationRowView: View {
         id: conversation.id, visibility: "shared")
 
       // Then copy the link
-      let link = "https://h.omi.me/conversations/\(conversation.id)"
+      let link = DesktopBackendEnvironment.conversationShareURL(id: conversation.id)
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       pasteboard.setString(link, forType: .string)
@@ -140,7 +140,7 @@ struct ConversationRowView: View {
     } catch {
       log("Failed to set conversation visibility: \(error)")
       // Still copy the link even if visibility fails - user might have shared it before
-      let link = "https://h.omi.me/conversations/\(conversation.id)"
+      let link = DesktopBackendEnvironment.conversationShareURL(id: conversation.id)
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       pasteboard.setString(link, forType: .string)

--- a/desktop/macos/Desktop/Tests/ShareLinksEnvironmentTests.swift
+++ b/desktop/macos/Desktop/Tests/ShareLinksEnvironmentTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ShareLinksEnvironmentTests: XCTestCase {
+  func testShareBaseURLDefaultsToProduction() {
+    XCTAssertEqual(
+      DesktopBackendEnvironment.shareBaseURL(environmentValue: nil),
+      "https://h.omi.me"
+    )
+    XCTAssertEqual(
+      DesktopBackendEnvironment.conversationShareURL(id: "abc", environmentValue: nil),
+      "https://h.omi.me/conversations/abc"
+    )
+  }
+
+  func testShareBaseURLHonorsOverride() {
+    XCTAssertEqual(
+      DesktopBackendEnvironment.shareBaseURL(environmentValue: "https://share.example.com/"),
+      "https://share.example.com"
+    )
+    XCTAssertEqual(
+      DesktopBackendEnvironment.shareBaseURL(environmentValue: "share.example.com"),
+      "https://share.example.com"
+    )
+    XCTAssertEqual(
+      DesktopBackendEnvironment.conversationShareURL(
+        id: "abc",
+        environmentValue: "https://share.example.com"
+      ),
+      "https://share.example.com/conversations/abc"
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/ShareLinksEnvironmentTests.swift
+++ b/desktop/macos/Desktop/Tests/ShareLinksEnvironmentTests.swift
@@ -31,4 +31,15 @@ final class ShareLinksEnvironmentTests: XCTestCase {
       "https://share.example.com/conversations/abc"
     )
   }
+
+  func testShareBaseURLFallsBackForMalformedOverride() {
+    XCTAssertEqual(
+      DesktopBackendEnvironment.shareBaseURL(environmentValue: "not a url"),
+      "https://h.omi.me"
+    )
+    XCTAssertEqual(
+      DesktopBackendEnvironment.shareBaseURL(environmentValue: "ftp://share.example.com"),
+      "https://h.omi.me"
+    )
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260807-share-base-url.json
+++ b/desktop/macos/changelog/unreleased/20260807-share-base-url.json
@@ -1,0 +1,3 @@
+{
+  "change": "Conversation share links now honor the configured share host"
+}

--- a/desktop/windows/src/renderer/src/env.d.ts
+++ b/desktop/windows/src/renderer/src/env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Public share origin for conversation links (#4339). Default https://h.omi.me */
+  readonly VITE_OMI_SHARE_BASE_URL?: string
+}

--- a/desktop/windows/src/renderer/src/lib/conversations/mutations.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/mutations.ts
@@ -6,6 +6,7 @@
 
 import { omiApi } from '../apiClient'
 import type { MergeConversationsResponse } from '../omiApi.generated'
+import { conversationShareUrl } from '../shareLinks'
 
 /** Toggle a conversation's starred flag. Backend contract: starred is a QUERY
  *  param on a bodyless PATCH (not a JSON body). */
@@ -37,7 +38,7 @@ export async function getConversationShareLink(id: string): Promise<string> {
   await omiApi.patch(`/v1/conversations/${id}/visibility`, null, {
     params: { value: 'shared' }
   })
-  return `https://h.omi.me/conversations/${id}`
+  return conversationShareUrl(id)
 }
 
 /** Re-run Omi's summarization. `appId` targets a specific app (Mac's App Insights

--- a/desktop/windows/src/renderer/src/lib/shareLinks.test.ts
+++ b/desktop/windows/src/renderer/src/lib/shareLinks.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { conversationShareUrl, shareBaseUrl } from './shareLinks'
+
+describe('shareLinks (#4339)', () => {
+  it('defaults to production h.omi.me', () => {
+    expect(shareBaseUrl('')).toBe('https://h.omi.me')
+    expect(shareBaseUrl(undefined)).toBe('https://h.omi.me')
+    expect(conversationShareUrl('abc', '')).toBe('https://h.omi.me/conversations/abc')
+  })
+
+  it('honors VITE_OMI_SHARE_BASE_URL overrides', () => {
+    expect(shareBaseUrl('https://share.example.com/')).toBe('https://share.example.com')
+    expect(shareBaseUrl('share.example.com')).toBe('https://share.example.com')
+    expect(conversationShareUrl('abc', 'https://share.example.com')).toBe(
+      'https://share.example.com/conversations/abc'
+    )
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/shareLinks.test.ts
+++ b/desktop/windows/src/renderer/src/lib/shareLinks.test.ts
@@ -15,4 +15,9 @@ describe('shareLinks (#4339)', () => {
       'https://share.example.com/conversations/abc'
     )
   })
+
+  it('falls back for malformed or unsupported overrides', () => {
+    expect(shareBaseUrl('ftp://share.example.com')).toBe('https://h.omi.me')
+    expect(shareBaseUrl('not a url')).toBe('https://h.omi.me')
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/shareLinks.ts
+++ b/desktop/windows/src/renderer/src/lib/shareLinks.ts
@@ -8,6 +8,12 @@ export function shareBaseUrl(
   let value = (raw ?? '').trim()
   if (!value) value = DEFAULT_SHARE_BASE
   if (!value.includes('://')) value = `https://${value}`
+  try {
+    const parsed = new URL(value)
+    if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname) return DEFAULT_SHARE_BASE
+  } catch {
+    return DEFAULT_SHARE_BASE
+  }
   return value.replace(/\/+$/, '')
 }
 

--- a/desktop/windows/src/renderer/src/lib/shareLinks.ts
+++ b/desktop/windows/src/renderer/src/lib/shareLinks.ts
@@ -1,0 +1,19 @@
+/** Public share-link base URL for self-hosting (#4339). Matches backend OMI_SHARE_BASE_URL. */
+
+const DEFAULT_SHARE_BASE = 'https://h.omi.me'
+
+export function shareBaseUrl(
+  raw: string | undefined = import.meta.env.VITE_OMI_SHARE_BASE_URL as string | undefined
+): string {
+  let value = (raw ?? '').trim()
+  if (!value) value = DEFAULT_SHARE_BASE
+  if (!value.includes('://')) value = `https://${value}`
+  return value.replace(/\/+$/, '')
+}
+
+export function conversationShareUrl(
+  id: string,
+  raw?: string | undefined
+): string {
+  return `${shareBaseUrl(raw)}/conversations/${id}`
+}


### PR DESCRIPTION
## What changed and why

Desktop follow-up to backend [#11189](https://github.com/BasedHardware/omi/pull/11189) for #4339: conversation share links on **macOS** and **Windows** no longer hardcode `https://h.omi.me`.

- macOS: `DesktopBackendEnvironment.shareBaseURL` / `conversationShareURL` (`OMI_SHARE_BASE_URL`)
- Windows: `shareLinks.ts` (`VITE_OMI_SHARE_BASE_URL`)
- Default remains `https://h.omi.me`

**Out of scope:** Flutter app hardcodes; generated agent tool-manifest description strings that *mention* `h.omi.me` as an example URL shape (not minting).

## Product invariants affected

- INV-AUTH-1

## How it was verified

- Logic smoke for Windows `shareBaseUrl` / `conversationShareUrl` (default + override)
- Added `ShareLinksEnvironmentTests.swift` and `shareLinks.test.ts` for CI
- Local Windows `vitest` not run here (worktree has no `node_modules`; Node must be 22.x per package engines)

## Tests

- `desktop/macos/Desktop/Tests/ShareLinksEnvironmentTests.swift`
- `desktop/windows/src/renderer/src/lib/shareLinks.test.ts`

## Failure class (fixes)

Failure-Class: none

## Env

- macOS: `OMI_SHARE_BASE_URL` (same name as backend)
- Windows: `VITE_OMI_SHARE_BASE_URL`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


