### PR TITLE
SCA-297: demote stale Agent VM Firestore ready without live GCE

### DIFF
--- a/.github/failure-classes/FC-cached-provider-ready-as-live.json
+++ b/.github/failure-classes/FC-cached-provider-ready-as-live.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-cached-provider-ready-as-live",
+  "violated_contract": "A cached Firestore agentVm.status=ready record must not be treated as proof that the corresponding GCE instance is live; status/read paths must distinguish provider NOT_FOUND from API blips and demote or queue fenced reconciler demand instead of leaving eternal ready.",
+  "canonical_prevention": "Share one Agent VM read decision helper across desktop status, tools status, and proxy demotion: provider-confirmed NOT_FOUND demotes to updating and queues reconciler demand without wiping ownership; provider/API unknown preserves the owner pointer; ready+running remains unchanged. Cover the three cases with unit tests.",
+  "canonical_prevention_artifact": [
+    "backend/services/agent_vm_lifecycle.py",
+    "backend/tests/unit/test_agent_vm_read_decision.py",
+    "backend/tests/unit/test_desktop_agent_vm.py"
+  ],
+  "evidence_prs": [11164],
+  "scope_hints": [
+    "backend/services/agent_vm_lifecycle.py",
+    "backend/routers/desktop_agent_vm.py",
+    "backend/routers/agent_tools.py",
+    "backend/agent-proxy/**"
+  ],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-cached-provider-ready-as-live.json
+++ b/.github/failure-classes/FC-cached-provider-ready-as-live.json
@@ -4,13 +4,13 @@
   "violated_contract": "A cached Firestore agentVm.status=ready record must not be treated as proof that the corresponding GCE instance is live; status/read paths must distinguish provider NOT_FOUND from API blips and demote or queue fenced reconciler demand instead of leaving eternal ready.",
   "canonical_prevention": "Share one Agent VM read decision helper across desktop status, tools status, and proxy demotion: provider-confirmed NOT_FOUND demotes to updating and queues reconciler demand without wiping ownership; provider/API unknown preserves the owner pointer; ready+running remains unchanged. Cover the three cases with unit tests.",
   "canonical_prevention_artifact": [
-    "backend/services/agent_vm_lifecycle.py",
+    "backend/services/agent_vm_read.py",
     "backend/tests/unit/test_agent_vm_read_decision.py",
     "backend/tests/unit/test_desktop_agent_vm.py"
   ],
   "evidence_prs": [11164],
   "scope_hints": [
-    "backend/services/agent_vm_lifecycle.py",
+    "backend/services/agent_vm_read.py",
     "backend/routers/desktop_agent_vm.py",
     "backend/routers/agent_tools.py",
     "backend/agent-proxy/**"

--- a/backend/agent-proxy/Dockerfile
+++ b/backend/agent-proxy/Dockerfile
@@ -24,6 +24,7 @@ COPY backend/database/account_deletion_policy.py ./database/account_deletion_pol
 COPY backend/database/document_ids.py ./database/document_ids.py
 COPY backend/database/google_credentials.py ./database/google_credentials.py
 COPY backend/services/agent_vm_lifecycle.py ./services/agent_vm_lifecycle.py
+COPY backend/services/agent_vm_read.py ./services/agent_vm_read.py
 COPY backend/utils/__init__.py ./utils/__init__.py
 COPY backend/utils/executors.py ./utils/executors.py
 COPY backend/agent-proxy/resilience.py .

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -40,6 +40,7 @@ from database.account_deletion_policy import account_deletion_blocks_access, nor
 from services.agent_vm_lifecycle import (
     SESSION_LEASE_TTL_SECONDS,
     claim_session_lease,
+    demoted_updating_vm,
     heartbeat_session_lease,
     reconcile_requested,
     release_session_lease,
@@ -247,7 +248,7 @@ async def _ensure_vm_running(uid: str, vm: Dict[str, Any], health_failed: bool =
         vm_name,
         health_failed,
     )
-    return {**vm, "status": "updating", "ip": None}
+    return demoted_updating_vm(vm)
 
 
 async def _wait_for_vm_healthy(vm_ip: str, auth_token: str, timeout: float = 120) -> bool:

--- a/backend/agent-proxy/main.py
+++ b/backend/agent-proxy/main.py
@@ -40,12 +40,12 @@ from database.account_deletion_policy import account_deletion_blocks_access, nor
 from services.agent_vm_lifecycle import (
     SESSION_LEASE_TTL_SECONDS,
     claim_session_lease,
-    demoted_updating_vm,
     heartbeat_session_lease,
     reconcile_requested,
     release_session_lease,
     request_vm_start,
 )
+from services.agent_vm_read import demoted_updating_vm
 
 logger = logging.getLogger(__name__)
 

--- a/backend/charts/agent-vm-reaper/README.md
+++ b/backend/charts/agent-vm-reaper/README.md
@@ -17,10 +17,12 @@ desktop agent leaves a permanent disk (~$5/mo).
 | `RUNNING` | `creationTimestamp` older than **2d** |
 
 After a TERMINATED VM is deleted, `GET /v2/agent/status` sees `NOT_FOUND`,
-demotes the client-facing status to `updating`, and queues fenced reconciler
-demand. The reconciler records `missing` and clears Firestore `agentVm` after
-its grace/session fences, after which the desktop client re-provisions +
-re-uploads its DB (`AgentVMService`).
+demotes the client-facing status to `updating`, records `reconcile.state=missing`
+(when no reconciler lease/quarantine owns the pointer), and queues fenced
+reconciler demand. Desktop `ensureExistingOrProvision` can then claim a
+replacement immediately because missing pointers are replaceable; the
+reconciler's grace/session clear remains the backstop when the request path
+does not replace first.
 
 ## Apply (refuse-by-default)
 

--- a/backend/charts/agent-vm-reaper/README.md
+++ b/backend/charts/agent-vm-reaper/README.md
@@ -17,8 +17,10 @@ desktop agent leaves a permanent disk (~$5/mo).
 | `RUNNING` | `creationTimestamp` older than **2d** |
 
 After a TERMINATED VM is deleted, `GET /v2/agent/status` sees `NOT_FOUND`,
-clears Firestore `agentVm`, and the desktop client re-provisions + re-uploads
-its DB (`AgentVMService`).
+demotes the client-facing status to `updating`, and queues fenced reconciler
+demand. The reconciler records `missing` and clears Firestore `agentVm` after
+its grace/session fences, after which the desktop client re-provisions +
+re-uploads its DB (`AgentVMService`).
 
 ## Apply (refuse-by-default)
 

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -93,7 +93,7 @@ def get_vm_status(uid: str = Depends(get_current_user_uid)):
     logger.info(f"[vm-status] uid={uid} vm={sanitize(vm)}")
     if not vm:
         return {"has_vm": False}
-    decision = decide_agent_vm_read(vm)
+    decision = decide_agent_vm_read(vm, usable_cached_ip=_is_usable_vm_ip(vm.get("ip")))
     return _vm_info_from_decision(vm, decision.client_status)
 
 

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -19,7 +19,8 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel
 
 from database.users import get_agent_vm
-from services.agent_vm_lifecycle import decide_agent_vm_read, reconcile_requested, request_vm_start
+from services.agent_vm_lifecycle import reconcile_requested, request_vm_start
+from services.agent_vm_read import decide_agent_vm_read
 from utils.other.endpoints import get_current_user_uid, with_rate_limit
 from utils.retrieval.agentic import agent_config_context, CORE_TOOLS
 from utils.retrieval.tool_result_boundaries import preserve_chat_memory_tool_result_boundary

--- a/backend/routers/agent_tools.py
+++ b/backend/routers/agent_tools.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel
 
 from database.users import get_agent_vm
-from services.agent_vm_lifecycle import reconcile_requested, request_vm_start
+from services.agent_vm_lifecycle import decide_agent_vm_read, reconcile_requested, request_vm_start
 from utils.other.endpoints import get_current_user_uid, with_rate_limit
 from utils.retrieval.agentic import agent_config_context, CORE_TOOLS
 from utils.retrieval.tool_result_boundaries import preserve_chat_memory_tool_result_boundary
@@ -67,20 +67,33 @@ def _is_usable_vm_ip(ip) -> bool:
     return isinstance(ip, str) and bool(ip) and ip != UNRESOLVED_VM_IP
 
 
+def _vm_info_from_decision(vm: dict[str, Any] | None, decision_status: str | None) -> dict[str, Any]:
+    if not vm:
+        return {"has_vm": False}
+    if decision_status == "ready":
+        return {"has_vm": True, "status": "ready"}
+    if decision_status == "updating":
+        return {"has_vm": True, "status": "updating"}
+    return {"has_vm": False, "status": decision_status}
+
+
 # --------------- endpoints ---------------
 
 
 @router.get("/v1/agent/vm-status", response_model=AgentVmInfo)
 def get_vm_status(uid: str = Depends(get_current_user_uid)):
-    """Return the user's agent VM info from Firestore."""
+    """Return the user's agent VM info from Firestore.
+
+    Tools paths do not probe GCE (reconciler authority). They still refuse to
+    report eternal ``ready`` while reconciler demand/missing/lease state is
+    already recorded — that is the shared read contract with desktop status.
+    """
     vm = get_agent_vm(uid)
     logger.info(f"[vm-status] uid={uid} vm={sanitize(vm)}")
-    if not vm or vm.get("status") != "ready":
+    if not vm:
         return {"has_vm": False}
-    return {
-        "has_vm": True,
-        "status": vm.get("status"),
-    }
+    decision = decide_agent_vm_read(vm)
+    return _vm_info_from_decision(vm, decision.client_status)
 
 
 @router.post("/v1/agent/vm-ensure", response_model=AgentVmInfo)

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -23,17 +23,19 @@ from database import users as users_db
 from database._client import get_firestore_client
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from services.agent_vm_lifecycle import (
-    apply_agent_vm_read_decision,
     claim_vm_lease,
-    classify_provider_observation,
     clear_vm_reconcile_lease_fields,
+    request_vm_start,
+    startup_wrapper,
+    update_vm_reconcile,
+)
+from services.agent_vm_read import (
+    apply_agent_vm_read_decision,
+    classify_provider_observation,
     decide_agent_vm_read,
     demoted_updating_vm,
     reconcile_in_progress,
     reconcile_lease_active,
-    request_vm_start,
-    startup_wrapper,
-    update_vm_reconcile,
 )
 from utils.executors import db_executor, run_blocking
 from utils.other.endpoints import get_current_user_uid

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -763,8 +763,9 @@ async def get_agent_status(
             )
     if decision.queue_start:
         # Provider 404 / stopped / repairable running: queue fenced reconciler
-        # demand. Do not erase the owner pointer here — the reconciler owns
-        # missing/grace/session fences and eventual terminal cleanup.
+        # demand. Status also records ``missing`` (when allowed) so desktop
+        # provision can replace immediately; the reconciler still owns
+        # lease/quarantine fences and grace-period terminal cleanup as backstop.
         requested = await run_blocking(
             db_executor,
             request_vm_start,

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -35,8 +35,10 @@ from services.agent_vm_read import (
     decide_agent_vm_read,
     demoted_updating_vm,
     reconcile_in_progress,
+    record_provider_missing_if_current,
 )
 from utils.executors import db_executor, run_blocking
+from utils.observability.fallback import record_fallback
 from utils.other.endpoints import get_current_user_uid
 from utils.subscription import is_trial_paywalled
 
@@ -183,7 +185,12 @@ def _claim_vm_if_allowed_txn(
     snapshot = user_ref.get(transaction=transaction)
     current = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
     if isinstance(current, dict) and current.get("vmName"):
-        return current, False
+        reconcile = current.get("reconcile")
+        # A provider-confirmed missing pointer cannot be started; allow the
+        # account provisioning path to claim a replacement without waiting for
+        # the reconciler's terminal-cleanup grace to erase the record.
+        if not (isinstance(reconcile, dict) and reconcile.get("state") == "missing"):
+            return current, False
     transaction.set(user_ref, {"agentVm": candidate}, merge=True)
     return candidate, True
 
@@ -707,6 +714,13 @@ async def get_agent_status(
     except Exception as exc:
         logger.warning("Agent VM status check failed for uid=%s: %s", uid, exc)
         # GCE UNKNOWN / API blip — do not wipe Firestore ownership.
+        record_fallback(
+            component="other",
+            from_mode="provider_probe",
+            to_mode="firestore_cache",
+            reason="other",
+            outcome="degraded",
+        )
         return _response(vm)
     usable_cached_ip: bool | None = None
     if observation.kind == "running":
@@ -717,6 +731,15 @@ async def get_agent_status(
                 uid,
             )
     decision = decide_agent_vm_read(vm, observation, usable_cached_ip=usable_cached_ip)
+    if decision.record_missing:
+        await run_blocking(
+            db_executor,
+            record_provider_missing_if_current,
+            uid,
+            str(vm["vmName"]),
+            str(vm.get("zone") or _ZONE),
+            str(vm.get("authToken") or ""),
+        )
     if decision.queue_start:
         # Provider 404 / stopped / repairable running: queue fenced reconciler
         # demand. Do not erase the owner pointer here — the reconciler owns
@@ -729,5 +752,14 @@ async def get_agent_status(
             str(vm.get("authToken") or ""),
         )
         if not requested:
-            return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
+            latest = await run_blocking(db_executor, _get_vm, uid)
+            if not latest:
+                return None
+            if str(latest.get("vmName") or "") != str(vm.get("vmName") or "") or str(
+                latest.get("authToken") or ""
+            ) != str(vm.get("authToken") or ""):
+                return _response(latest)
+            # Same owner lost the race (deletion fence / concurrent claim): still
+            # demote the confirmed-stale ready view for this generation.
+            return _response(apply_agent_vm_read_decision(latest, decision))
     return _response(apply_agent_vm_read_decision(vm, decision))

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -23,9 +23,14 @@ from database import users as users_db
 from database._client import get_firestore_client
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from services.agent_vm_lifecycle import (
+    apply_agent_vm_read_decision,
     claim_vm_lease,
+    classify_provider_observation,
     clear_vm_reconcile_lease_fields,
-    reconcile_requested,
+    decide_agent_vm_read,
+    demoted_updating_vm,
+    reconcile_in_progress,
+    reconcile_lease_active,
     request_vm_start,
     startup_wrapper,
     update_vm_reconcile,
@@ -153,19 +158,15 @@ def _get_vm(uid: str) -> dict[str, Any] | None:
 
 
 def _reconcile_lease_active(vm: dict[str, Any], now: float | None = None) -> bool:
-    reconcile = vm.get("reconcile")
-    lease = reconcile.get("lease") if isinstance(reconcile, dict) else None
-    if not isinstance(lease, dict):
-        return False
-    return float(lease.get("expiresAt", 0) or 0) > (time.time() if now is None else now)
+    return reconcile_lease_active(vm, now)
 
 
 def _reconcile_in_progress(vm: dict[str, Any], now: float | None = None) -> bool:
-    return reconcile_requested(vm) or _reconcile_lease_active(vm, now)
+    return reconcile_in_progress(vm, now)
 
 
 def _updating_vm(vm: dict[str, Any]) -> dict[str, Any]:
-    return {**vm, "status": "updating", "ip": None}
+    return demoted_updating_vm(vm)
 
 
 def _validate_ready_vm_ip(status: str, ip: str | None) -> None:
@@ -693,6 +694,7 @@ async def get_agent_status(
 ) -> AgentVmResponse | None:
     if _agent_disabled():
         return None
+    del background_tasks
     vm = await run_blocking(db_executor, _get_vm, uid)
     if not vm:
         return None
@@ -704,16 +706,24 @@ async def get_agent_status(
     try:
         project = _project()
         gce_status, instance = await _instance(project, str(vm.get("zone") or _ZONE), str(vm["vmName"]))
+        observation = classify_provider_observation(gce_status=gce_status)
     except Exception as exc:
         logger.warning("Agent VM status check failed for uid=%s: %s", uid, exc)
+        # GCE UNKNOWN / API blip — do not wipe Firestore ownership.
         return _response(vm)
-    if gce_status == "NOT_FOUND":
-        # A provider 404 is a reconciler-owned terminal transition. Do not
-        # erase the owner pointer from a request path: it may be a late create
-        # or a session-protected record, and the reconciler has the complete
-        # deletion, demand, session, and grace-period fences.
-        return _response(_updating_vm(vm))
-    if gce_status in {"TERMINATED", "STOPPED"}:
+    usable_cached_ip: bool | None = None
+    if observation.kind == "running":
+        usable_cached_ip = _is_usable_vm_ip(vm.get("ip"))
+        if instance is not None and not usable_cached_ip and _ip(instance) is None:
+            logger.warning(
+                "Deferring running Agent VM without an external IP to the reconciler for uid=%s",
+                uid,
+            )
+    decision = decide_agent_vm_read(vm, observation, usable_cached_ip=usable_cached_ip)
+    if decision.queue_start:
+        # Provider 404 / stopped / repairable running: queue fenced reconciler
+        # demand. Do not erase the owner pointer here — the reconciler owns
+        # missing/grace/session fences and eventual terminal cleanup.
         requested = await run_blocking(
             db_executor,
             request_vm_start,
@@ -723,38 +733,4 @@ async def get_agent_status(
         )
         if not requested:
             return _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        return _response(_updating_vm(vm))
-    if (
-        gce_status == "RUNNING"
-        and instance is not None
-        and (status in {"error", "stopped"} or not _is_usable_vm_ip(vm.get("ip")))
-    ):
-        instance_ip = _ip(instance)
-        if instance_ip is None:
-            logger.warning(
-                "Deferring running Agent VM without an external IP to the reconciler for uid=%s",
-                uid,
-            )
-            requested = await run_blocking(
-                db_executor,
-                request_vm_start,
-                uid,
-                str(vm["vmName"]),
-                str(vm.get("authToken") or ""),
-            )
-            return (
-                _response(_updating_vm(vm))
-                if requested
-                else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-            )
-        requested = await run_blocking(
-            db_executor,
-            request_vm_start,
-            uid,
-            str(vm["vmName"]),
-            str(vm.get("authToken") or ""),
-        )
-        return (
-            _response(_updating_vm(vm)) if requested else _response(await run_blocking(db_executor, _get_vm, uid) or vm)
-        )
-    return _response(vm)
+    return _response(apply_agent_vm_read_decision(vm, decision))

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -737,14 +737,30 @@ async def get_agent_status(
             )
     decision = decide_agent_vm_read(vm, observation, usable_cached_ip=usable_cached_ip)
     if decision.record_missing:
-        await run_blocking(
-            db_executor,
-            record_provider_missing_if_current,
-            uid,
-            str(vm["vmName"]),
-            str(vm.get("zone") or _ZONE),
-            str(vm.get("authToken") or ""),
-        )
+        try:
+            await run_blocking(
+                db_executor,
+                record_provider_missing_if_current,
+                uid,
+                str(vm["vmName"]),
+                str(vm.get("zone") or _ZONE),
+                str(vm.get("authToken") or ""),
+            )
+        except Exception as exc:
+            # Marker persistence is best-effort; still queue start demand so the
+            # reconciler can observe the 404 and persist missing itself.
+            logger.warning(
+                "Agent VM missing-state marker failed for uid=%s: %s",
+                uid,
+                exc,
+            )
+            record_fallback(
+                component="other",
+                from_mode="missing_marker",
+                to_mode="reconciler_demand",
+                reason="other",
+                outcome="degraded",
+            )
     if decision.queue_start:
         # Provider 404 / stopped / repairable running: queue fenced reconciler
         # demand. Do not erase the owner pointer here — the reconciler owns

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -35,7 +35,6 @@ from services.agent_vm_read import (
     decide_agent_vm_read,
     demoted_updating_vm,
     reconcile_in_progress,
-    reconcile_lease_active,
 )
 from utils.executors import db_executor, run_blocking
 from utils.other.endpoints import get_current_user_uid
@@ -157,10 +156,6 @@ def _get_vm(uid: str) -> dict[str, Any] | None:
         return None
     vm = snapshot.to_dict().get("agentVm")
     return vm if isinstance(vm, dict) and vm.get("vmName") else None
-
-
-def _reconcile_lease_active(vm: dict[str, Any], now: float | None = None) -> bool:
-    return reconcile_lease_active(vm, now)
 
 
 def _reconcile_in_progress(vm: dict[str, Any], now: float | None = None) -> bool:

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -191,6 +191,11 @@ def _claim_vm_if_allowed_txn(
         # the reconciler's terminal-cleanup grace to erase the record.
         if not (isinstance(reconcile, dict) and reconcile.get("state") == "missing"):
             return current, False
+        # Replace the entire agentVm map. set(..., merge=True) recursively
+        # preserves nested reconcile.state/missingSince and would leave the
+        # replacement permanently treated as reconcile-in-progress.
+        transaction.update(user_ref, {"agentVm": candidate})
+        return candidate, True
     transaction.set(user_ref, {"agentVm": candidate}, merge=True)
     return candidate, True
 

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -252,157 +252,6 @@ def reconcile_requested(vm: Mapping[str, Any], now: float | None = None) -> bool
     )
 
 
-def reconcile_lease_active(vm: Mapping[str, Any], now: float | None = None) -> bool:
-    reconcile = vm.get("reconcile")
-    lease = reconcile.get("lease") if isinstance(reconcile, Mapping) else None
-    if not isinstance(lease, Mapping):
-        return False
-    return float(lease.get("expiresAt", 0) or 0) > (time.time() if now is None else now)
-
-
-def reconcile_in_progress(vm: Mapping[str, Any], now: float | None = None) -> bool:
-    """True when status/read paths must defer to the fenced reconciler."""
-    return reconcile_requested(vm, now) or reconcile_lease_active(vm, now)
-
-
-def demoted_updating_vm(vm: Mapping[str, Any]) -> dict[str, Any]:
-    """Client-facing view of a VM that is no longer safe to treat as ready."""
-    return {**dict(vm), "status": "updating", "ip": None}
-
-
-@dataclass(frozen=True)
-class AgentVmProviderObservation:
-    """Result of a request-path GCE instance lookup.
-
-    ``not_found`` is a provider-confirmed 404. ``unknown`` is an API/network
-    blip and must never erase Firestore ownership. ``running`` / ``stopped`` /
-    ``other`` are live instance states.
-    """
-
-    kind: str
-    gce_status: str | None = None
-
-
-@dataclass(frozen=True)
-class AgentVmReadDecision:
-    """Shared status/read decision for desktop, tools, and proxy paths."""
-
-    client_status: str
-    queue_start: bool
-    preserve_owner: bool
-    clear_cached_ip: bool = False
-
-
-def classify_provider_observation(
-    *,
-    gce_status: str | None = None,
-    probe_failed: bool = False,
-) -> AgentVmProviderObservation:
-    """Classify a GCE probe without mutating owner state."""
-    if probe_failed:
-        return AgentVmProviderObservation(kind="unknown")
-    normalized = str(gce_status or "").upper()
-    if normalized == "NOT_FOUND":
-        return AgentVmProviderObservation(kind="not_found", gce_status="NOT_FOUND")
-    if normalized in {"TERMINATED", "STOPPED"}:
-        return AgentVmProviderObservation(kind="stopped", gce_status=normalized)
-    if normalized == "RUNNING":
-        return AgentVmProviderObservation(kind="running", gce_status="RUNNING")
-    if not normalized:
-        return AgentVmProviderObservation(kind="unknown")
-    return AgentVmProviderObservation(kind="other", gce_status=normalized)
-
-
-def decide_agent_vm_read(
-    vm: Mapping[str, Any],
-    observation: AgentVmProviderObservation | None = None,
-    *,
-    now: float | None = None,
-    usable_cached_ip: bool | None = None,
-) -> AgentVmReadDecision:
-    """Decide how status/read paths present a Firestore agentVm record.
-
-    Behavior contract:
-    - Reconciler already owns the record → demote to ``updating``, do not probe
-      demand again from this helper (callers skip provider lookups first).
-    - Provider ``NOT_FOUND`` → demote to ``updating`` and queue reconciler
-      demand so the fenced job can mark ``missing`` and eventually clear.
-    - Provider API blip (``unknown``) → preserve the owner pointer and status.
-    - Provider running with a healthy ready cache → leave unchanged.
-    """
-    stored = str(vm.get("status") or "provisioning")
-    if reconcile_in_progress(vm, now):
-        return AgentVmReadDecision(
-            client_status="updating",
-            queue_start=False,
-            preserve_owner=True,
-            clear_cached_ip=True,
-        )
-    if observation is None:
-        if stored == "ready":
-            return AgentVmReadDecision(
-                client_status="ready",
-                queue_start=False,
-                preserve_owner=True,
-                clear_cached_ip=False,
-            )
-        return AgentVmReadDecision(
-            client_status=stored,
-            queue_start=False,
-            preserve_owner=True,
-            clear_cached_ip=False,
-        )
-    if observation.kind == "unknown":
-        return AgentVmReadDecision(
-            client_status=stored,
-            queue_start=False,
-            preserve_owner=True,
-            clear_cached_ip=False,
-        )
-    if observation.kind == "not_found":
-        return AgentVmReadDecision(
-            client_status="updating",
-            queue_start=True,
-            preserve_owner=True,
-            clear_cached_ip=True,
-        )
-    if observation.kind == "stopped":
-        return AgentVmReadDecision(
-            client_status="updating",
-            queue_start=True,
-            preserve_owner=True,
-            clear_cached_ip=True,
-        )
-    if observation.kind == "running":
-        needs_repair = stored in {"error", "stopped"} or usable_cached_ip is False
-        if needs_repair:
-            return AgentVmReadDecision(
-                client_status="updating",
-                queue_start=True,
-                preserve_owner=True,
-                clear_cached_ip=True,
-            )
-        return AgentVmReadDecision(
-            client_status=stored,
-            queue_start=False,
-            preserve_owner=True,
-            clear_cached_ip=False,
-        )
-    return AgentVmReadDecision(
-        client_status=stored,
-        queue_start=False,
-        preserve_owner=True,
-        clear_cached_ip=False,
-    )
-
-
-def apply_agent_vm_read_decision(vm: Mapping[str, Any], decision: AgentVmReadDecision) -> dict[str, Any]:
-    """Materialize the client-facing VM view for a read decision."""
-    if decision.client_status == "updating" and decision.clear_cached_ip:
-        return demoted_updating_vm(vm)
-    return {**dict(vm), "status": decision.client_status}
-
-
 @transactional
 def _claim_run_lease_txn(transaction: Any, lease_ref: Any, owner: str, now: float, ttl: int) -> bool:
     snapshot = lease_ref.get(transaction=transaction)
@@ -1793,8 +1642,6 @@ class GceAgentVmClient:
 __all__ = [
     "AgentVmLeaseLost",
     "AgentVmNotFound",
-    "AgentVmProviderObservation",
-    "AgentVmReadDecision",
     "AgentVmRelease",
     "AgentVmReleaseError",
     "DEFAULT_ZONE",
@@ -1803,25 +1650,19 @@ __all__ = [
     "RECONCILER_SCHEMA_VERSION",
     "TrustedAgentVmHealthChannelUnavailable",
     "active_session_count",
-    "apply_agent_vm_read_decision",
     "begin_boot_image_migration",
     "claim_reconciler_run_lease",
     "claim_boot_image_migration_retirement",
     "claim_session_lease",
     "claim_vm_lease",
-    "classify_provider_observation",
     "clear_missing_vm_if_current",
     "clear_vm_reconcile_lease_fields",
     "complete_boot_image_migration",
     "cutover_boot_image_migration",
-    "decide_agent_vm_read",
-    "demoted_updating_vm",
     "drift_reasons",
     "expected_release_metadata",
     "heartbeat_session_lease",
     "mark_boot_image_migration_candidate_deleted",
-    "reconcile_in_progress",
-    "reconcile_lease_active",
     "reconcile_requested",
     "release_manifest_bytes",
     "record_boot_image_candidate",

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -252,6 +252,157 @@ def reconcile_requested(vm: Mapping[str, Any], now: float | None = None) -> bool
     )
 
 
+def reconcile_lease_active(vm: Mapping[str, Any], now: float | None = None) -> bool:
+    reconcile = vm.get("reconcile")
+    lease = reconcile.get("lease") if isinstance(reconcile, Mapping) else None
+    if not isinstance(lease, Mapping):
+        return False
+    return float(lease.get("expiresAt", 0) or 0) > (time.time() if now is None else now)
+
+
+def reconcile_in_progress(vm: Mapping[str, Any], now: float | None = None) -> bool:
+    """True when status/read paths must defer to the fenced reconciler."""
+    return reconcile_requested(vm, now) or reconcile_lease_active(vm, now)
+
+
+def demoted_updating_vm(vm: Mapping[str, Any]) -> dict[str, Any]:
+    """Client-facing view of a VM that is no longer safe to treat as ready."""
+    return {**dict(vm), "status": "updating", "ip": None}
+
+
+@dataclass(frozen=True)
+class AgentVmProviderObservation:
+    """Result of a request-path GCE instance lookup.
+
+    ``not_found`` is a provider-confirmed 404. ``unknown`` is an API/network
+    blip and must never erase Firestore ownership. ``running`` / ``stopped`` /
+    ``other`` are live instance states.
+    """
+
+    kind: str
+    gce_status: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentVmReadDecision:
+    """Shared status/read decision for desktop, tools, and proxy paths."""
+
+    client_status: str
+    queue_start: bool
+    preserve_owner: bool
+    clear_cached_ip: bool = False
+
+
+def classify_provider_observation(
+    *,
+    gce_status: str | None = None,
+    probe_failed: bool = False,
+) -> AgentVmProviderObservation:
+    """Classify a GCE probe without mutating owner state."""
+    if probe_failed:
+        return AgentVmProviderObservation(kind="unknown")
+    normalized = str(gce_status or "").upper()
+    if normalized == "NOT_FOUND":
+        return AgentVmProviderObservation(kind="not_found", gce_status="NOT_FOUND")
+    if normalized in {"TERMINATED", "STOPPED"}:
+        return AgentVmProviderObservation(kind="stopped", gce_status=normalized)
+    if normalized == "RUNNING":
+        return AgentVmProviderObservation(kind="running", gce_status="RUNNING")
+    if not normalized:
+        return AgentVmProviderObservation(kind="unknown")
+    return AgentVmProviderObservation(kind="other", gce_status=normalized)
+
+
+def decide_agent_vm_read(
+    vm: Mapping[str, Any],
+    observation: AgentVmProviderObservation | None = None,
+    *,
+    now: float | None = None,
+    usable_cached_ip: bool | None = None,
+) -> AgentVmReadDecision:
+    """Decide how status/read paths present a Firestore agentVm record.
+
+    Behavior contract:
+    - Reconciler already owns the record → demote to ``updating``, do not probe
+      demand again from this helper (callers skip provider lookups first).
+    - Provider ``NOT_FOUND`` → demote to ``updating`` and queue reconciler
+      demand so the fenced job can mark ``missing`` and eventually clear.
+    - Provider API blip (``unknown``) → preserve the owner pointer and status.
+    - Provider running with a healthy ready cache → leave unchanged.
+    """
+    stored = str(vm.get("status") or "provisioning")
+    if reconcile_in_progress(vm, now):
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
+    if observation is None:
+        if stored == "ready":
+            return AgentVmReadDecision(
+                client_status="ready",
+                queue_start=False,
+                preserve_owner=True,
+                clear_cached_ip=False,
+            )
+        return AgentVmReadDecision(
+            client_status=stored,
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=False,
+        )
+    if observation.kind == "unknown":
+        return AgentVmReadDecision(
+            client_status=stored,
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=False,
+        )
+    if observation.kind == "not_found":
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=True,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
+    if observation.kind == "stopped":
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=True,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
+    if observation.kind == "running":
+        needs_repair = stored in {"error", "stopped"} or usable_cached_ip is False
+        if needs_repair:
+            return AgentVmReadDecision(
+                client_status="updating",
+                queue_start=True,
+                preserve_owner=True,
+                clear_cached_ip=True,
+            )
+        return AgentVmReadDecision(
+            client_status=stored,
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=False,
+        )
+    return AgentVmReadDecision(
+        client_status=stored,
+        queue_start=False,
+        preserve_owner=True,
+        clear_cached_ip=False,
+    )
+
+
+def apply_agent_vm_read_decision(vm: Mapping[str, Any], decision: AgentVmReadDecision) -> dict[str, Any]:
+    """Materialize the client-facing VM view for a read decision."""
+    if decision.client_status == "updating" and decision.clear_cached_ip:
+        return demoted_updating_vm(vm)
+    return {**dict(vm), "status": decision.client_status}
+
+
 @transactional
 def _claim_run_lease_txn(transaction: Any, lease_ref: Any, owner: str, now: float, ttl: int) -> bool:
     snapshot = lease_ref.get(transaction=transaction)
@@ -1642,6 +1793,8 @@ class GceAgentVmClient:
 __all__ = [
     "AgentVmLeaseLost",
     "AgentVmNotFound",
+    "AgentVmProviderObservation",
+    "AgentVmReadDecision",
     "AgentVmRelease",
     "AgentVmReleaseError",
     "DEFAULT_ZONE",
@@ -1650,19 +1803,25 @@ __all__ = [
     "RECONCILER_SCHEMA_VERSION",
     "TrustedAgentVmHealthChannelUnavailable",
     "active_session_count",
+    "apply_agent_vm_read_decision",
     "begin_boot_image_migration",
     "claim_reconciler_run_lease",
     "claim_boot_image_migration_retirement",
     "claim_session_lease",
     "claim_vm_lease",
+    "classify_provider_observation",
     "clear_missing_vm_if_current",
     "clear_vm_reconcile_lease_fields",
     "complete_boot_image_migration",
     "cutover_boot_image_migration",
+    "decide_agent_vm_read",
+    "demoted_updating_vm",
     "drift_reasons",
     "expected_release_metadata",
     "heartbeat_session_lease",
     "mark_boot_image_migration_candidate_deleted",
+    "reconcile_in_progress",
+    "reconcile_lease_active",
     "reconcile_requested",
     "release_manifest_bytes",
     "record_boot_image_candidate",

--- a/backend/services/agent_vm_read.py
+++ b/backend/services/agent_vm_read.py
@@ -218,9 +218,12 @@ def _record_provider_missing_if_current_txn(
     if reconcile.get("state") == "missing":
         return True
     # A concurrent reconciler claim can land after the status path's
-    # reconcile_in_progress snapshot. Do not stomp an active lease to
-    # ``missing`` — that would let provision replace under the owner.
+    # reconcile_in_progress snapshot. Do not stomp an active lease or a
+    # reconciler-owned terminal/in-flight state to ``missing`` — that would let
+    # provision replace under the owner (including same-release quarantine).
     if reconcile_lease_active(vm, now):
+        return False
+    if reconcile.get("state") in {"quarantined", "claimed", "draining", "deferred"}:
         return False
     missing_since = reconcile.get("missingSince")
     recorded_missing_since = float(missing_since) if isinstance(missing_since, (int, float)) else now

--- a/backend/services/agent_vm_read.py
+++ b/backend/services/agent_vm_read.py
@@ -11,7 +11,11 @@ import time
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from services.agent_vm_lifecycle import reconcile_requested
+from google.cloud.firestore import transactional
+
+from database._client import get_firestore_client
+from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
+from services.agent_vm_lifecycle import DEFAULT_ZONE, RECONCILER_SCHEMA_VERSION, reconcile_requested
 
 
 def reconcile_lease_active(vm: Mapping[str, Any], now: float | None = None) -> bool:
@@ -53,6 +57,7 @@ class AgentVmReadDecision:
     queue_start: bool
     preserve_owner: bool
     clear_cached_ip: bool = False
+    record_missing: bool = False
 
 
 def classify_provider_observation(
@@ -87,8 +92,8 @@ def decide_agent_vm_read(
     Behavior contract:
     - Reconciler already owns the record → demote to ``updating``, do not probe
       demand again from this helper (callers skip provider lookups first).
-    - Provider ``NOT_FOUND`` → demote to ``updating`` and queue reconciler
-      demand so the fenced job can mark ``missing`` and eventually clear.
+    - Provider ``NOT_FOUND`` → demote to ``updating``, queue reconciler demand,
+      and record ``missing`` so provisioning can claim a replacement.
     - Provider API blip (``unknown``) → preserve the owner pointer and status.
     - Provider running with a healthy ready cache → leave unchanged.
     """
@@ -102,6 +107,13 @@ def decide_agent_vm_read(
         )
     if observation is None:
         if stored == "ready":
+            if usable_cached_ip is False:
+                return AgentVmReadDecision(
+                    client_status="updating",
+                    queue_start=True,
+                    preserve_owner=True,
+                    clear_cached_ip=True,
+                )
             return AgentVmReadDecision(
                 client_status="ready",
                 queue_start=False,
@@ -127,6 +139,7 @@ def decide_agent_vm_read(
             queue_start=True,
             preserve_owner=True,
             clear_cached_ip=True,
+            record_missing=True,
         )
     if observation.kind == "stopped":
         return AgentVmReadDecision(
@@ -150,6 +163,15 @@ def decide_agent_vm_read(
             preserve_owner=True,
             clear_cached_ip=False,
         )
+    # Transitional / unknown live GCE states (PROVISIONING, STAGING, STOPPING, …)
+    # must not be presented as ready.
+    if stored == "ready":
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
     return AgentVmReadDecision(
         client_status=stored,
         queue_start=False,
@@ -165,6 +187,73 @@ def apply_agent_vm_read_decision(vm: Mapping[str, Any], decision: AgentVmReadDec
     return {**dict(vm), "status": decision.client_status}
 
 
+@transactional
+def _record_provider_missing_if_current_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    now: float,
+) -> bool:
+    """Record a provider-confirmed 404 without erasing the owner pointer."""
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    status = normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    if account_deletion_blocks_access(status):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    if (
+        not isinstance(vm, dict)
+        or vm.get("vmName") != vm_name
+        or (vm.get("zone") or DEFAULT_ZONE) != zone
+        or vm.get("authToken") != auth_token
+        or vm.get("status") not in {"ready", "stopped", "error"}
+    ):
+        return False
+    reconcile_raw = vm.get("reconcile")
+    reconcile: dict[str, Any] = reconcile_raw if isinstance(reconcile_raw, dict) else {}
+    if reconcile.get("state") == "missing":
+        return True
+    missing_since = reconcile.get("missingSince")
+    recorded_missing_since = float(missing_since) if isinstance(missing_since, (int, float)) else now
+    transaction.update(
+        user_ref,
+        {
+            "agentVm.reconcile.state": "missing",
+            "agentVm.reconcile.lastError": "GCE instance not found",
+            "agentVm.reconcile.missingSince": recorded_missing_since,
+            "agentVm.reconcile.schemaVersion": RECONCILER_SCHEMA_VERSION,
+        },
+    )
+    return True
+
+
+def record_provider_missing_if_current(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    now: float | None = None,
+) -> bool:
+    """Mark a provider-confirmed missing instance so provisioning can replace it."""
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    return bool(
+        _record_provider_missing_if_current_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            client.collection("users").document(uid),
+            vm_name,
+            zone,
+            auth_token,
+            now,
+        )
+    )
+
+
 __all__ = [
     "AgentVmProviderObservation",
     "AgentVmReadDecision",
@@ -174,4 +263,5 @@ __all__ = [
     "demoted_updating_vm",
     "reconcile_in_progress",
     "reconcile_lease_active",
+    "record_provider_missing_if_current",
 ]

--- a/backend/services/agent_vm_read.py
+++ b/backend/services/agent_vm_read.py
@@ -1,0 +1,177 @@
+"""Shared Agent VM status/read decisions for request paths.
+
+Firestore ``agentVm.status`` is a cache. Desktop status, tools status, and
+proxy demotion must agree on when that cache is safe to present as ready
+versus when the fenced reconciler must take over.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from services.agent_vm_lifecycle import reconcile_requested
+
+
+def reconcile_lease_active(vm: Mapping[str, Any], now: float | None = None) -> bool:
+    reconcile = vm.get("reconcile")
+    lease = reconcile.get("lease") if isinstance(reconcile, Mapping) else None
+    if not isinstance(lease, Mapping):
+        return False
+    return float(lease.get("expiresAt", 0) or 0) > (time.time() if now is None else now)
+
+
+def reconcile_in_progress(vm: Mapping[str, Any], now: float | None = None) -> bool:
+    """True when status/read paths must defer to the fenced reconciler."""
+    return reconcile_requested(vm, now) or reconcile_lease_active(vm, now)
+
+
+def demoted_updating_vm(vm: Mapping[str, Any]) -> dict[str, Any]:
+    """Client-facing view of a VM that is no longer safe to treat as ready."""
+    return {**dict(vm), "status": "updating", "ip": None}
+
+
+@dataclass(frozen=True)
+class AgentVmProviderObservation:
+    """Result of a request-path GCE instance lookup.
+
+    ``not_found`` is a provider-confirmed 404. ``unknown`` is an API/network
+    blip and must never erase Firestore ownership. ``running`` / ``stopped`` /
+    ``other`` are live instance states.
+    """
+
+    kind: str
+    gce_status: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentVmReadDecision:
+    """Shared status/read decision for desktop, tools, and proxy paths."""
+
+    client_status: str
+    queue_start: bool
+    preserve_owner: bool
+    clear_cached_ip: bool = False
+
+
+def classify_provider_observation(
+    *,
+    gce_status: str | None = None,
+    probe_failed: bool = False,
+) -> AgentVmProviderObservation:
+    """Classify a GCE probe without mutating owner state."""
+    if probe_failed:
+        return AgentVmProviderObservation(kind="unknown")
+    normalized = str(gce_status or "").upper()
+    if normalized == "NOT_FOUND":
+        return AgentVmProviderObservation(kind="not_found", gce_status="NOT_FOUND")
+    if normalized in {"TERMINATED", "STOPPED"}:
+        return AgentVmProviderObservation(kind="stopped", gce_status=normalized)
+    if normalized == "RUNNING":
+        return AgentVmProviderObservation(kind="running", gce_status="RUNNING")
+    if not normalized:
+        return AgentVmProviderObservation(kind="unknown")
+    return AgentVmProviderObservation(kind="other", gce_status=normalized)
+
+
+def decide_agent_vm_read(
+    vm: Mapping[str, Any],
+    observation: AgentVmProviderObservation | None = None,
+    *,
+    now: float | None = None,
+    usable_cached_ip: bool | None = None,
+) -> AgentVmReadDecision:
+    """Decide how status/read paths present a Firestore agentVm record.
+
+    Behavior contract:
+    - Reconciler already owns the record → demote to ``updating``, do not probe
+      demand again from this helper (callers skip provider lookups first).
+    - Provider ``NOT_FOUND`` → demote to ``updating`` and queue reconciler
+      demand so the fenced job can mark ``missing`` and eventually clear.
+    - Provider API blip (``unknown``) → preserve the owner pointer and status.
+    - Provider running with a healthy ready cache → leave unchanged.
+    """
+    stored = str(vm.get("status") or "provisioning")
+    if reconcile_in_progress(vm, now):
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
+    if observation is None:
+        if stored == "ready":
+            return AgentVmReadDecision(
+                client_status="ready",
+                queue_start=False,
+                preserve_owner=True,
+                clear_cached_ip=False,
+            )
+        return AgentVmReadDecision(
+            client_status=stored,
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=False,
+        )
+    if observation.kind == "unknown":
+        return AgentVmReadDecision(
+            client_status=stored,
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=False,
+        )
+    if observation.kind == "not_found":
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=True,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
+    if observation.kind == "stopped":
+        return AgentVmReadDecision(
+            client_status="updating",
+            queue_start=True,
+            preserve_owner=True,
+            clear_cached_ip=True,
+        )
+    if observation.kind == "running":
+        needs_repair = stored in {"error", "stopped"} or usable_cached_ip is False
+        if needs_repair:
+            return AgentVmReadDecision(
+                client_status="updating",
+                queue_start=True,
+                preserve_owner=True,
+                clear_cached_ip=True,
+            )
+        return AgentVmReadDecision(
+            client_status=stored,
+            queue_start=False,
+            preserve_owner=True,
+            clear_cached_ip=False,
+        )
+    return AgentVmReadDecision(
+        client_status=stored,
+        queue_start=False,
+        preserve_owner=True,
+        clear_cached_ip=False,
+    )
+
+
+def apply_agent_vm_read_decision(vm: Mapping[str, Any], decision: AgentVmReadDecision) -> dict[str, Any]:
+    """Materialize the client-facing VM view for a read decision."""
+    if decision.client_status == "updating" and decision.clear_cached_ip:
+        return demoted_updating_vm(vm)
+    return {**dict(vm), "status": decision.client_status}
+
+
+__all__ = [
+    "AgentVmProviderObservation",
+    "AgentVmReadDecision",
+    "apply_agent_vm_read_decision",
+    "classify_provider_observation",
+    "decide_agent_vm_read",
+    "demoted_updating_vm",
+    "reconcile_in_progress",
+    "reconcile_lease_active",
+]

--- a/backend/services/agent_vm_read.py
+++ b/backend/services/agent_vm_read.py
@@ -217,6 +217,11 @@ def _record_provider_missing_if_current_txn(
     reconcile: dict[str, Any] = reconcile_raw if isinstance(reconcile_raw, dict) else {}
     if reconcile.get("state") == "missing":
         return True
+    # A concurrent reconciler claim can land after the status path's
+    # reconcile_in_progress snapshot. Do not stomp an active lease to
+    # ``missing`` — that would let provision replace under the owner.
+    if reconcile_lease_active(vm, now):
+        return False
     missing_since = reconcile.get("missingSince")
     recorded_missing_since = float(missing_since) if isinstance(missing_since, (int, float)) else now
     transaction.update(

--- a/backend/tests/unit/test_agent_vm_read_decision.py
+++ b/backend/tests/unit/test_agent_vm_read_decision.py
@@ -22,6 +22,7 @@ def test_ready_plus_missing_instance_demotes_and_queues_reprovision_demand():
     assert observation.kind == "not_found"
     assert decision.client_status == "updating"
     assert decision.queue_start is True
+    assert decision.record_missing is True
     assert decision.preserve_owner is True
     assert apply_agent_vm_read_decision(READY_VM, decision) == {
         **READY_VM,
@@ -51,6 +52,23 @@ def test_ready_plus_running_instance_is_unchanged():
     assert decision.queue_start is False
     assert decision.preserve_owner is True
     assert apply_agent_vm_read_decision(READY_VM, decision) == dict(READY_VM)
+
+
+def test_ready_plus_transitional_gce_state_is_demoted():
+    observation = classify_provider_observation(gce_status="PROVISIONING")
+    decision = decide_agent_vm_read(READY_VM, observation)
+
+    assert observation.kind == "other"
+    assert decision.client_status == "updating"
+    assert decision.queue_start is False
+    assert apply_agent_vm_read_decision(READY_VM, decision)["ip"] is None
+
+
+def test_ready_with_unusable_cached_ip_demotes_without_provider_probe():
+    decision = decide_agent_vm_read(READY_VM, usable_cached_ip=False)
+
+    assert decision.client_status == "updating"
+    assert decision.queue_start is True
 
 
 def test_missing_reconcile_state_demotes_without_extra_demand():

--- a/backend/tests/unit/test_agent_vm_read_decision.py
+++ b/backend/tests/unit/test_agent_vm_read_decision.py
@@ -1,6 +1,6 @@
 """Shared Agent VM status/read decisions for stale ready vs provider state."""
 
-from services.agent_vm_lifecycle import (
+from services.agent_vm_read import (
     apply_agent_vm_read_decision,
     classify_provider_observation,
     decide_agent_vm_read,

--- a/backend/tests/unit/test_agent_vm_read_decision.py
+++ b/backend/tests/unit/test_agent_vm_read_decision.py
@@ -1,0 +1,65 @@
+"""Shared Agent VM status/read decisions for stale ready vs provider state."""
+
+from services.agent_vm_lifecycle import (
+    apply_agent_vm_read_decision,
+    classify_provider_observation,
+    decide_agent_vm_read,
+)
+
+READY_VM = {
+    "vmName": "omi-agent-user",
+    "zone": "us-central1-a",
+    "ip": "34.1.2.3",
+    "authToken": "token",
+    "status": "ready",
+}
+
+
+def test_ready_plus_missing_instance_demotes_and_queues_reprovision_demand():
+    observation = classify_provider_observation(gce_status="NOT_FOUND")
+    decision = decide_agent_vm_read(READY_VM, observation)
+
+    assert observation.kind == "not_found"
+    assert decision.client_status == "updating"
+    assert decision.queue_start is True
+    assert decision.preserve_owner is True
+    assert apply_agent_vm_read_decision(READY_VM, decision) == {
+        **READY_VM,
+        "status": "updating",
+        "ip": None,
+    }
+
+
+def test_ready_plus_api_error_preserves_owner_and_ready_status():
+    observation = classify_provider_observation(probe_failed=True)
+    decision = decide_agent_vm_read(READY_VM, observation)
+
+    assert observation.kind == "unknown"
+    assert decision.client_status == "ready"
+    assert decision.queue_start is False
+    assert decision.preserve_owner is True
+    assert apply_agent_vm_read_decision(READY_VM, decision)["status"] == "ready"
+    assert apply_agent_vm_read_decision(READY_VM, decision)["ip"] == "34.1.2.3"
+
+
+def test_ready_plus_running_instance_is_unchanged():
+    observation = classify_provider_observation(gce_status="RUNNING")
+    decision = decide_agent_vm_read(READY_VM, observation, usable_cached_ip=True)
+
+    assert observation.kind == "running"
+    assert decision.client_status == "ready"
+    assert decision.queue_start is False
+    assert decision.preserve_owner is True
+    assert apply_agent_vm_read_decision(READY_VM, decision) == dict(READY_VM)
+
+
+def test_missing_reconcile_state_demotes_without_extra_demand():
+    vm = {
+        **READY_VM,
+        "reconcile": {"state": "missing", "missingSince": 1.0},
+    }
+    decision = decide_agent_vm_read(vm)
+
+    assert decision.client_status == "updating"
+    assert decision.queue_start is False
+    assert apply_agent_vm_read_decision(vm, decision)["ip"] is None

--- a/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
+++ b/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
@@ -115,3 +115,14 @@ class TestVmEnsureRequestsReconciliation:
         response = agent_tools.get_vm_status(uid="uid-ready")
 
         assert response == {"has_vm": True, "status": "ready"}
+
+    def test_vm_status_demotes_ready_with_unknown_placeholder_ip(self, agent_tools, monkeypatch):
+        monkeypatch.setattr(
+            agent_tools,
+            "get_agent_vm",
+            lambda _uid: {**READY_VM, "authToken": "token", "ip": "unknown"},
+        )
+
+        response = agent_tools.get_vm_status(uid="uid-poisoned")
+
+        assert response == {"has_vm": True, "status": "updating"}

--- a/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
+++ b/backend/tests/unit/test_agent_vm_reaped_record_recovery.py
@@ -93,3 +93,25 @@ class TestVmEnsureRequestsReconciliation:
 
         assert response == {"has_vm": True, "status": "updating"}
         assert requests == [("uid-transient", "omi-agent-reaped", "token")]
+
+    def test_vm_status_demotes_ready_while_reconciler_marks_missing(self, agent_tools, monkeypatch):
+        monkeypatch.setattr(
+            agent_tools,
+            "get_agent_vm",
+            lambda _uid: {
+                **READY_VM,
+                "authToken": "token",
+                "reconcile": {"state": "missing", "missingSince": 1.0},
+            },
+        )
+
+        response = agent_tools.get_vm_status(uid="uid-missing")
+
+        assert response == {"has_vm": True, "status": "updating"}
+
+    def test_vm_status_reports_ready_only_when_cache_is_uncontested(self, agent_tools, monkeypatch):
+        monkeypatch.setattr(agent_tools, "get_agent_vm", lambda _uid: {**READY_VM, "authToken": "token"})
+
+        response = agent_tools.get_vm_status(uid="uid-ready")
+
+        assert response == {"has_vm": True, "status": "ready"}

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -285,6 +285,7 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
         "status": "ready",
         "createdAt": "2026-07-26T00:00:00Z",
     }
+    requests = []
 
     async def run_blocking(_, function, *args):
         return function(*args)
@@ -296,11 +297,75 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
+    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
     assert response.status == "updating"
     assert response.ip is None
+    assert requests == [("uid", "omi-agent-stale", "old-token")]
+
+
+@pytest.mark.asyncio
+async def test_status_preserves_ready_when_gce_probe_fails(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-blip",
+        "zone": "us-central1-a",
+        "ip": "34.1.2.3",
+        "authToken": "token",
+        "status": "ready",
+        "createdAt": "2026-07-26T00:00:00Z",
+    }
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    async def probe_failed(*_args):
+        raise RuntimeError("GCE unavailable")
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setattr(desktop_agent_vm, "_instance", probe_failed)
+    monkeypatch.setattr(
+        desktop_agent_vm, "request_vm_start", lambda *_args: pytest.fail("API blip must preserve ownership")
+    )
+
+    response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
+
+    assert response.status == "ready"
+    assert response.ip == "34.1.2.3"
+
+
+@pytest.mark.asyncio
+async def test_status_leaves_ready_running_instance_unchanged(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-live",
+        "zone": "us-central1-a",
+        "ip": "34.1.2.3",
+        "authToken": "token",
+        "status": "ready",
+        "createdAt": "2026-07-26T00:00:00Z",
+    }
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    async def running(*_args):
+        return "RUNNING", {"networkInterfaces": [{"accessConfigs": [{"natIP": "34.1.2.3"}]}]}
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setattr(desktop_agent_vm, "_instance", running)
+    monkeypatch.setattr(
+        desktop_agent_vm, "request_vm_start", lambda *_args: pytest.fail("healthy ready VM must not queue repair")
+    )
+
+    response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
+
+    assert response.status == "ready"
+    assert response.ip == "34.1.2.3"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -65,6 +65,84 @@ async def test_provision_returns_existing_vm_without_scheduling(monkeypatch):
     assert not tasks.tasks
 
 
+def test_claim_allows_replacement_when_reconciler_marked_missing():
+    class Snapshot:
+        def __init__(self, data, exists=True):
+            self._data = data
+            self.exists = exists
+
+        def to_dict(self):
+            return self._data
+
+    class Ref:
+        def __init__(self, data, exists=True):
+            self._data = data
+            self.exists = exists
+            self.writes = []
+
+        def get(self, transaction=None):
+            del transaction
+            return Snapshot(self._data, exists=self.exists)
+
+        def set(self, data, merge=False):
+            self.writes.append((data, merge))
+            self._data = {**(self._data or {}), **data} if merge else data
+
+    class Transaction:
+        def set(self, ref, data, merge=False):
+            ref.set(data, merge=merge)
+
+    user_ref = Ref(
+        {
+            "agentVm": {
+                "vmName": "omi-agent-stale",
+                "authToken": "old",
+                "status": "ready",
+                "reconcile": {"state": "missing", "missingSince": 1.0},
+            }
+        }
+    )
+    deletion_ref = Ref({}, exists=False)
+    candidate = {"vmName": "omi-agent-new", "status": "provisioning", "authToken": "new"}
+    raw = getattr(desktop_agent_vm._claim_vm_if_allowed_txn, "to_wrap", desktop_agent_vm._claim_vm_if_allowed_txn)
+
+    claimed_vm, claimed = raw(Transaction(), deletion_ref, user_ref, candidate)
+
+    assert claimed is True
+    assert claimed_vm == candidate
+    assert user_ref.writes
+
+
+@pytest.mark.asyncio
+async def test_status_keeps_demotion_when_start_request_loses_same_owner_race(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-stale",
+        "zone": "us-central1-a",
+        "ip": "34.1.2.3",
+        "authToken": "old-token",
+        "status": "ready",
+        "createdAt": "2026-07-26T00:00:00Z",
+    }
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    async def not_found(*_args):
+        return "NOT_FOUND", None
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
+    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *_args: False)
+    monkeypatch.setattr(desktop_agent_vm, "record_provider_missing_if_current", lambda *_args: True)
+
+    response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
+
+    assert response.status == "updating"
+    assert response.ip is None
+
+
 @pytest.mark.asyncio
 async def test_sparse_new_uid_is_persisted_as_provisioning_and_scheduled(monkeypatch):
     writes = []
@@ -286,6 +364,7 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
         "createdAt": "2026-07-26T00:00:00Z",
     }
     requests = []
+    marked = []
 
     async def run_blocking(_, function, *args):
         return function(*args)
@@ -298,12 +377,16 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
     monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
+    monkeypatch.setattr(
+        desktop_agent_vm, "record_provider_missing_if_current", lambda *args: marked.append(args) or True
+    )
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
     assert response.status == "updating"
     assert response.ip is None
     assert requests == [("uid", "omi-agent-stale", "old-token")]
+    assert marked == [("uid", "omi-agent-stale", "us-central1-a", "old-token")]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -66,51 +66,36 @@ async def test_provision_returns_existing_vm_without_scheduling(monkeypatch):
 
 
 def test_claim_allows_replacement_when_reconciler_marked_missing():
-    class Snapshot:
-        def __init__(self, data, exists=True):
-            self._data = data
-            self.exists = exists
+    from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 
-        def to_dict(self):
-            return self._data
-
-    class Ref:
-        def __init__(self, data, exists=True):
-            self._data = data
-            self.exists = exists
-            self.writes = []
-
-        def get(self, transaction=None):
-            del transaction
-            return Snapshot(self._data, exists=self.exists)
-
-        def set(self, data, merge=False):
-            self.writes.append((data, merge))
-            self._data = {**(self._data or {}), **data} if merge else data
-
-    class Transaction:
-        def set(self, ref, data, merge=False):
-            ref.set(data, merge=merge)
-
-    user_ref = Ref(
+    database = StrictFirestore(
         {
-            "agentVm": {
-                "vmName": "omi-agent-stale",
-                "authToken": "old",
-                "status": "ready",
-                "reconcile": {"state": "missing", "missingSince": 1.0},
+            ("users", "uid"): {
+                "agentVm": {
+                    "vmName": "omi-agent-stale",
+                    "authToken": "old",
+                    "status": "ready",
+                    "reconcile": {"state": "missing", "missingSince": 1.0},
+                }
             }
         }
     )
-    deletion_ref = Ref({}, exists=False)
     candidate = {"vmName": "omi-agent-new", "status": "provisioning", "authToken": "new"}
     raw = getattr(desktop_agent_vm._claim_vm_if_allowed_txn, "to_wrap", desktop_agent_vm._claim_vm_if_allowed_txn)
 
-    claimed_vm, claimed = raw(Transaction(), deletion_ref, user_ref, candidate)
+    claimed_vm, claimed = raw(
+        database.transaction(),
+        database.collection("account_deletions").document("uid"),
+        database.collection("users").document("uid"),
+        candidate,
+    )
 
     assert claimed is True
     assert claimed_vm == candidate
-    assert user_ref.writes
+    stored = database.rows[("users", "uid")]["agentVm"]
+    assert stored == candidate
+    assert "reconcile" not in stored
+    assert database.transactions[-1].updates[-1][1] == {"agentVm": candidate}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -141,6 +141,45 @@ def test_record_provider_missing_rejects_active_reconcile_lease(monkeypatch):
     assert database.transactions[-1].updates == []
 
 
+def test_record_provider_missing_rejects_quarantined_state():
+    from services import agent_vm_read
+    from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
+
+    now = 1_700_000_000.0
+    database = StrictFirestore(
+        {
+            ("users", "uid"): {
+                "agentVm": {
+                    "vmName": "omi-agent-stale",
+                    "zone": "us-central1-a",
+                    "authToken": "token",
+                    "status": "ready",
+                    "reconcile": {"state": "quarantined", "releaseId": "rel-1"},
+                }
+            }
+        }
+    )
+    raw = getattr(
+        agent_vm_read._record_provider_missing_if_current_txn,
+        "to_wrap",
+        agent_vm_read._record_provider_missing_if_current_txn,
+    )
+
+    marked = raw(
+        database.transaction(),
+        database.collection("account_deletions").document("uid"),
+        database.collection("users").document("uid"),
+        "omi-agent-stale",
+        "us-central1-a",
+        "token",
+        now,
+    )
+
+    assert marked is False
+    assert database.rows[("users", "uid")]["agentVm"]["reconcile"]["state"] == "quarantined"
+    assert database.transactions[-1].updates == []
+
+
 @pytest.mark.asyncio
 async def test_status_keeps_demotion_when_start_request_loses_same_owner_race(monkeypatch):
     vm = {

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -98,6 +98,49 @@ def test_claim_allows_replacement_when_reconciler_marked_missing():
     assert database.transactions[-1].updates[-1][1] == {"agentVm": candidate}
 
 
+def test_record_provider_missing_rejects_active_reconcile_lease(monkeypatch):
+    from services import agent_vm_read
+    from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
+
+    now = 1_700_000_000.0
+    database = StrictFirestore(
+        {
+            ("users", "uid"): {
+                "agentVm": {
+                    "vmName": "omi-agent-stale",
+                    "zone": "us-central1-a",
+                    "authToken": "token",
+                    "status": "ready",
+                    "reconcile": {
+                        "state": "claimed",
+                        "lease": {"owner": "worker-1", "expiresAt": now + 60},
+                    },
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(agent_vm_read, "get_firestore_client", lambda: database)
+    raw = getattr(
+        agent_vm_read._record_provider_missing_if_current_txn,
+        "to_wrap",
+        agent_vm_read._record_provider_missing_if_current_txn,
+    )
+
+    marked = raw(
+        database.transaction(),
+        database.collection("account_deletions").document("uid"),
+        database.collection("users").document("uid"),
+        "omi-agent-stale",
+        "us-central1-a",
+        "token",
+        now,
+    )
+
+    assert marked is False
+    assert database.rows[("users", "uid")]["agentVm"]["reconcile"]["state"] == "claimed"
+    assert database.transactions[-1].updates == []
+
+
 @pytest.mark.asyncio
 async def test_status_keeps_demotion_when_start_request_loses_same_owner_race(monkeypatch):
     vm = {
@@ -372,6 +415,44 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
     assert response.ip is None
     assert requests == [("uid", "omi-agent-stale", "old-token")]
     assert marked == [("uid", "omi-agent-stale", "us-central1-a", "old-token")]
+
+
+@pytest.mark.asyncio
+async def test_status_queues_start_when_missing_marker_raises(monkeypatch):
+    vm = {
+        "vmName": "omi-agent-stale",
+        "zone": "us-central1-a",
+        "ip": "34.1.2.3",
+        "authToken": "old-token",
+        "status": "ready",
+        "createdAt": "2026-07-26T00:00:00Z",
+    }
+    requests = []
+    fallbacks = []
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    async def not_found(*_args):
+        return "NOT_FOUND", None
+
+    def boom(*_args):
+        raise RuntimeError("firestore unavailable")
+
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
+    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
+    monkeypatch.setattr(desktop_agent_vm, "record_provider_missing_if_current", boom)
+    monkeypatch.setattr(desktop_agent_vm, "record_fallback", lambda **fields: fallbacks.append(fields))
+
+    response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
+
+    assert response.status == "updating"
+    assert response.ip is None
+    assert requests == [("uid", "omi-agent-stale", "old-token")]
+    assert fallbacks and fallbacks[0]["from_mode"] == "missing_marker"
 
 
 @pytest.mark.asyncio

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -25572,7 +25572,7 @@
     },
     "/v1/agent/vm-status": {
       "get": {
-        "description": "Return the user's agent VM info from Firestore.",
+        "description": "Return the user's agent VM info from Firestore.\n\nTools paths do not probe GCE (reconciler authority). They still refuse to\nreport eternal ``ready`` while reconciler demand/missing/lease state is\nalready recorded — that is the shared read contract with desktop status.",
         "operationId": "get_vm_status_v1_agent_vm_status_get",
         "parameters": [
           {


### PR DESCRIPTION
## Summary
- Shared Agent VM read decision helper demotes Firestore `ready` when GCE returns NOT_FOUND and queues fenced reconciler demand, while API blips preserve ownership and live running instances stay unchanged.
- Desktop `/v2/agent/status`, tools `/v1/agent/vm-status`, and agent-proxy demotion now use the same contract so stale ready pointers are not eternal.

Closes SCA-297

Failure-Class: new

## Test plan
- [x] `cd backend && .venv/bin/python -m pytest tests/unit/test_agent_vm_read_decision.py tests/unit/test_desktop_agent_vm.py tests/unit/test_agent_vm_reaped_record_recovery.py tests/unit/test_agent_vm_reconciler_authority.py tests/unit/test_agent_vm_async.py -q` (41 passed)
- [x] `backend/.venv/bin/python backend/scripts/runtime_image_contracts.py check` (13 images passed)
- [ ] CI green on this PR



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

