### PR TITLE
fix(app): restore Omi double-tap mute after Android reconnect

### DIFF
--- a/app/lib/pages/settings/device_settings.dart
+++ b/app/lib/pages/settings/device_settings.dart
@@ -375,7 +375,7 @@ class _DeviceSettingsState extends State<DeviceSettings> {
       case 0:
         return context.l10n.endConversation;
       case 1:
-        return context.l10n.pauseResume;
+        return context.l10n.deviceOnboardingMuteUnmute;
       case 2:
         return context.l10n.starConversation;
       default:
@@ -421,7 +421,7 @@ class _DeviceSettingsState extends State<DeviceSettings> {
                   ),
                   ListTile(
                     title: Text(
-                      context.l10n.pauseResumeRecording,
+                      context.l10n.deviceOnboardingMuteUnmute,
                       style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w400),
                     ),
                     trailing: currentAction == 1 ? const Icon(Icons.check, color: Colors.white, size: 20) : null,

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -83,12 +83,12 @@ class NativeBleTransport extends DeviceTransport {
 
   @override
   Future<void> disconnect() async {
-    if (_state == DeviceTransportState.disconnected) return;
+    if (_state == DeviceTransportState.disconnected && _streamControllers.isEmpty) return;
 
     _updateState(DeviceTransportState.disconnecting);
 
     // Unsubscribe all active streams
-    for (final key in _streamControllers.keys.toList()) {
+    for (final key in _activeSubscriptionKeys.toList()) {
       final parts = key.split(':');
       if (parts.length == 2) {
         try {
@@ -97,6 +97,8 @@ class NativeBleTransport extends DeviceTransport {
       }
     }
 
+    _activeSubscriptionKeys.clear();
+    _subscribedSubscriptionKeys.clear();
     _closeAllStreams();
     _services = [];
 
@@ -145,18 +147,23 @@ class NativeBleTransport extends DeviceTransport {
 
     if (!_streamControllers.containsKey(key)) {
       _streamControllers[key] = StreamController<List<int>>.broadcast();
+      _activeSubscriptionKeys.add(key);
       if (_hasCharacteristic(serviceUuid, characteristicUuid)) {
-        _subscribeCharacteristic(serviceUuid, characteristicUuid);
+        unawaited(_subscribeCharacteristic(serviceUuid, characteristicUuid));
       }
     }
 
     return _streamControllers[key]!.stream;
   }
 
-  void _subscribeCharacteristic(String serviceUuid, String characteristicUuid) {
+  Future<void> _subscribeCharacteristic(String serviceUuid, String characteristicUuid) async {
+    final key = '${serviceUuid.toLowerCase()}:${characteristicUuid.toLowerCase()}';
+    if (_subscribedSubscriptionKeys.contains(key)) return;
+    _subscribedSubscriptionKeys.add(key);
     try {
-      _hostApi.subscribeCharacteristic(_peripheralUuid, serviceUuid, characteristicUuid);
+      await _hostApi.subscribeCharacteristic(_peripheralUuid, serviceUuid, characteristicUuid);
     } catch (e) {
+      _subscribedSubscriptionKeys.remove(key);
       Logger.debug('[NativeBleTransport] Failed to subscribe $serviceUuid:$characteristicUuid: $e');
     }
   }
@@ -203,6 +210,8 @@ class NativeBleTransport extends DeviceTransport {
   @override
   Future<void> dispose() async {
     BleBridge.instance.unregisterPeripheral(_peripheralUuid);
+    _activeSubscriptionKeys.clear();
+    _subscribedSubscriptionKeys.clear();
     _closeAllStreams();
     await _connectionStateController.close();
   }
@@ -235,6 +244,7 @@ class NativeBleTransport extends DeviceTransport {
 
   /// Track which characteristics were subscribed so we can re-subscribe on reconnect.
   final Set<String> _activeSubscriptionKeys = {};
+  final Set<String> _subscribedSubscriptionKeys = {};
 
   void _handleConnectionState(bool connected, String? error) {
     if (!connected) {
@@ -242,11 +252,12 @@ class NativeBleTransport extends DeviceTransport {
       // On the 2nd call _streamControllers is already empty; overwriting _activeSubscriptionKeys
       // with {} would prevent re-subscription on the next reconnect.
       if (_streamControllers.isNotEmpty) {
-        _activeSubscriptionKeys.clear();
         _activeSubscriptionKeys.addAll(_streamControllers.keys);
+      } else {
+        _activeSubscriptionKeys.clear();
       }
 
-      _closeAllStreams();
+      _subscribedSubscriptionKeys.clear();
       _services = [];
       _updateState(DeviceTransportState.disconnected);
 
@@ -260,7 +271,9 @@ class NativeBleTransport extends DeviceTransport {
   void _handleDeviceReady(List<BleService> services) {
     if (_deviceReadyCompleter != null && !_deviceReadyCompleter!.isCompleted) {
       // Initial connection
+      _services = services;
       _deviceReadyCompleter!.complete(services);
+      _subscribeActiveCharacteristics();
     } else {
       // Auto-reconnect from native — re-subscribe to characteristics
       _resubscribeAfterReconnect(services);
@@ -268,6 +281,15 @@ class NativeBleTransport extends DeviceTransport {
   }
 
   bool _isResubscribing = false;
+
+  void _subscribeActiveCharacteristics() {
+    for (final key in _activeSubscriptionKeys) {
+      final parts = key.split(':');
+      if (parts.length == 2 && _hasCharacteristic(parts[0], parts[1])) {
+        unawaited(_subscribeCharacteristic(parts[0], parts[1]));
+      }
+    }
+  }
 
   void _resubscribeAfterReconnect(List<BleService> services) {
     if (_isResubscribing) return;
@@ -280,8 +302,13 @@ class NativeBleTransport extends DeviceTransport {
       for (final key in _activeSubscriptionKeys) {
         final parts = key.split(':');
         if (parts.length == 2) {
-          _streamControllers[key] = StreamController<List<int>>.broadcast();
-          _subscribeCharacteristic(parts[0], parts[1]);
+          final controller = _streamControllers[key];
+          if (controller == null || controller.isClosed) {
+            _streamControllers[key] = StreamController<List<int>>.broadcast();
+          }
+          if (_hasCharacteristic(parts[0], parts[1])) {
+            unawaited(_subscribeCharacteristic(parts[0], parts[1]));
+          }
         }
       }
 

--- a/app/test/services/devices/transports/native_ble_transport_test.dart
+++ b/app/test/services/devices/transports/native_ble_transport_test.dart
@@ -53,7 +53,8 @@ void main() {
     });
     // NativeBleTransport.connect() gates on BluetoothReadiness.instance, which
     // queries the native adapter state through the pigeon BleHostApi channel.
-    setHostApiHandler('getBluetoothState', (message) async => 'on');
+    // The reply must be a List (pigeon wraps the scalar return value).
+    setHostApiHandler('getBluetoothState', (message) async => ['on']);
 
     final transport = NativeBleTransport(_deviceId);
     addTearDown(transport.dispose);

--- a/app/test/services/devices/transports/native_ble_transport_test.dart
+++ b/app/test/services/devices/transports/native_ble_transport_test.dart
@@ -1,0 +1,89 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/gen/pigeon_communicator.g.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/transports/native_ble_transport.dart';
+
+const _deviceId = 'omi-test-device';
+const _serviceUuid = '23ba7924-0000-1000-7450-346eac492e92';
+const _characteristicUuid = '23ba7925-0000-1000-7450-346eac492e92';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final hostApiChannelNames = <String>{};
+
+  void setHostApiHandler(String methodName, Future<Object?> Function(Object? message) handler) {
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final channelName = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.$methodName';
+    hostApiChannelNames.add(channelName);
+    messenger.setMockMessageHandler(channelName, (ByteData? message) async {
+      final decoded = BleHostApi.pigeonChannelCodec.decodeMessage(message);
+      final response = await handler(decoded);
+      return BleHostApi.pigeonChannelCodec.encodeMessage(response);
+    });
+  }
+
+  tearDown(() {
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    for (final channelName in hostApiChannelNames) {
+      messenger.setMockMessageHandler(channelName, null);
+    }
+    hostApiChannelNames.clear();
+  });
+
+  test('keeps button listener alive and resubscribes after reconnect', () async {
+    final subscribeCalls = <List<Object?>>[];
+    final services = [
+      BleService(
+        uuid: _serviceUuid,
+        characteristicUuids: [_characteristicUuid],
+      ),
+    ];
+
+    setHostApiHandler('manageDevice', (message) async {
+      BleBridge.instance.onDeviceReady(_deviceId, services);
+      return <Object?>[];
+    });
+    setHostApiHandler('subscribeCharacteristic', (message) async {
+      subscribeCalls.add((message! as List<Object?>).toList());
+      return <Object?>[];
+    });
+
+    final transport = NativeBleTransport(_deviceId);
+    addTearDown(transport.dispose);
+
+    await transport.connect();
+    final received = <List<int>>[];
+    final subscription = transport.getCharacteristicStream(_serviceUuid, _characteristicUuid).listen(received.add);
+    addTearDown(subscription.cancel);
+
+    await Future<void>.delayed(Duration.zero);
+    BleBridge.instance.onCharacteristicValueUpdated(
+      _deviceId,
+      _serviceUuid,
+      _characteristicUuid,
+      Uint8List.fromList([2, 0, 0, 0]),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    BleBridge.instance.onPeripheralDisconnected(_deviceId, 'gatt_status_133');
+    BleBridge.instance.onDeviceReady(_deviceId, services);
+    await Future<void>.delayed(Duration.zero);
+    BleBridge.instance.onCharacteristicValueUpdated(
+      _deviceId,
+      _serviceUuid,
+      _characteristicUuid,
+      Uint8List.fromList([2, 0, 0, 0]),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(subscribeCalls, hasLength(2));
+    expect(received, [
+      [2, 0, 0, 0],
+      [2, 0, 0, 0],
+    ]);
+  });
+}

--- a/app/test/services/devices/transports/native_ble_transport_test.dart
+++ b/app/test/services/devices/transports/native_ble_transport_test.dart
@@ -51,6 +51,9 @@ void main() {
       subscribeCalls.add((message! as List<Object?>).toList());
       return <Object?>[];
     });
+    // NativeBleTransport.connect() gates on BluetoothReadiness.instance, which
+    // queries the native adapter state through the pigeon BleHostApi channel.
+    setHostApiHandler('getBluetoothState', (message) async => 'on');
 
     final transport = NativeBleTransport(_deviceId);
     addTearDown(transport.dispose);

--- a/app/test/widgets/device_settings_double_tap_test.dart
+++ b/app/test/widgets/device_settings_double_tap_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/settings/device_settings.dart';
+import 'package:omi/providers/device_provider.dart';
+
+class _StubDeviceProvider extends ChangeNotifier implements DeviceProvider {
+  @override
+  bool get isConnected => true;
+
+  @override
+  BtDevice? get connectedDevice => null;
+
+  @override
+  BtDevice? get pairedDevice => null;
+
+  @override
+  Future<void> getDeviceInfo() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _app(DeviceProvider provider) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: ChangeNotifierProvider<DeviceProvider>.value(
+      value: provider,
+      child: const DeviceSettings(),
+    ),
+  );
+}
+
+void main() {
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({'doubleTapAction': 1});
+    await SharedPreferencesUtil.init();
+  });
+
+  testWidgets('double-tap action 1 uses mute and unmute terminology', (tester) async {
+    final provider = _StubDeviceProvider();
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(_app(provider));
+    await tester.pump();
+
+    expect(find.text('Mute / Unmute'), findsOneWidget);
+    expect(find.text('Pause/Resume'), findsNothing);
+
+    await tester.tap(find.text('Mute / Unmute'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Mute / Unmute'), findsNWidgets(2));
+    expect(find.text('Pause/Resume Recording'), findsNothing);
+  });
+}


### PR DESCRIPTION
## What changed

- Keep Omi BLE notification streams alive across transient Android reconnects and re-subscribe the native characteristics without orphaning the existing Dart listeners.
- Label the double-tap action as `Mute / Unmute` in device settings, matching the onboarding behavior.
- Add hermetic coverage for double-tap characteristic delivery before and after reconnect, plus the settings copy.

## Root cause

`NativeBleTransport` closed the Dart notification stream during a reconnect and created a replacement stream. The existing `OmiDeviceConnection` button subscription remained attached to the closed stream, so firmware double-tap notifications stopped reaching `CaptureController` after the Android BLE lifecycle changed.

## Validation

- `cd app && bash test.sh` — 1,112 tests passed.
- `app/scripts/analyze_ratchet.sh` — passed.
- Focused transport/settings tests — passed.
- `make preflight` — passed.

## Scope boundary

Firmware 3.0.20 has no dedicated BLE mute command. Its mic-gain level `0` only attenuates samples while the capture thread continues, so this PR does not claim to add true device-side microphone mute. The existing app-side recording pause remains unchanged; a true hardware mute needs a coordinated firmware protocol and firmware rollout.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BLE transport reconnect/subscription logic used for device button events; behavior change is localized but affects capture after GATT drops.
> 
> **Overview**
> Fixes **Omi double-tap (mute/unmute) stopping after transient Android BLE reconnects** by changing how `NativeBleTransport` handles disconnect and re-subscription.
> 
> On disconnect, the transport **no longer tears down Dart notification streams** that upper layers still listen to; it tracks active vs. native-subscribed characteristics, avoids wiping subscription state on duplicate disconnect callbacks, and **re-subscribes on reconnect** (including after first `deviceReady`) while reusing or recreating controllers only when needed. `disconnect`/`dispose` now unsubscribe via the active-key set.
> 
> **Device settings** copy for double-tap action 1 switches from pause/resume strings to **`Mute / Unmute`** (`deviceOnboardingMuteUnmute`), aligned with onboarding.
> 
> Adds **widget and transport tests** for the new labels and for characteristic delivery before/after reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dab07596b2c9da722cb298cf7c10a9820db1c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->