### PR TITLE
fix(billing): recover failed payments and defer canceled plan changes

### DIFF
--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-      );
+            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+          );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-    );
+          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+        );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -939,8 +939,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded =
-                                  sub?.currentPeriodEnd != null &&
+                              final periodEnded = sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1015,8 +1014,7 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption =
-                                _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1178,8 +1176,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton =
-                                !isOnAnnualPlan &&
+                            final shouldShowContinueButton = !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -376,6 +376,9 @@ class _PlansSheetState extends State<PlansSheet> {
     // Check if user is upgrading from monthly to annual
     final provider = context.read<UsageProvider>();
     final currentSub = provider.subscription?.subscription;
+    if (currentSub?.cancelAtPeriodEnd == true && priceId != currentSub?.currentPriceId) {
+      return;
+    }
     // Only show "no charge until renewal" dialog for same-tier monthly→annual switch.
     // Cross-tier changes are immediate+prorated on the backend, not deferred.
     final currentTierName = currentSub?.plan.wireName; // backend plan_id, e.g. 'plus', 'unlimited_v2'
@@ -1393,6 +1396,7 @@ class _PlansSheetState extends State<PlansSheet> {
                                   // refresh subscription state on return instead of
                                   // leaving the UI showing Free until a manual reload.
                                   await provider.fetchSubscription();
+                                  await provider.loadAvailablePlans();
                                 } else {
                                   AppSnackbar.showSnackbarError(l10n.couldNotOpenPaymentSettings);
                                 }
@@ -1407,7 +1411,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             ),
                           ),
                           const SizedBox(height: 12),
-                          if (!isCancelled) ...[
+                          if (isUnlimited == true && !isCancelled) ...[
                             TextButton(
                               onPressed: () {
                                 _handleCancelSubscription();

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -1388,6 +1388,11 @@ class _PlansSheetState extends State<PlansSheet> {
                                       ),
                                     ),
                                   );
+                                  // The user may have paid an overdue invoice or
+                                  // recovered a canceled plan inside the portal, so
+                                  // refresh subscription state on return instead of
+                                  // leaving the UI showing Free until a manual reload.
+                                  await provider.fetchSubscription();
                                 } else {
                                   AppSnackbar.showSnackbarError(l10n.couldNotOpenPaymentSettings);
                                 }

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-      );
+            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+          );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-    );
+          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+        );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -936,8 +936,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded =
-                                  sub?.currentPeriodEnd != null &&
+                              final periodEnded = sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1012,8 +1011,7 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption =
-                                _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1175,8 +1173,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton =
-                                !isOnAnnualPlan &&
+                            final shouldShowContinueButton = !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-          );
+        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+      );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-        );
+      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+    );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -939,7 +939,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded = sub?.currentPeriodEnd != null &&
+                              final periodEnded =
+                                  sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1014,7 +1015,8 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption =
+                                _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1176,7 +1178,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton = !isOnAnnualPlan &&
+                            final shouldShowContinueButton =
+                                !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-          );
+        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+      );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-        );
+      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+    );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -936,7 +936,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded = sub?.currentPeriodEnd != null &&
+                              final periodEnded =
+                                  sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1011,7 +1012,8 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption =
+                                _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1173,7 +1175,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton = !isOnAnnualPlan &&
+                            final shouldShowContinueButton =
+                                !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-      );
+            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+          );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-    );
+          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+        );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -936,8 +936,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded =
-                                  sub?.currentPeriodEnd != null &&
+                              final periodEnded = sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1012,8 +1011,7 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption =
-                                _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1175,8 +1173,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton =
-                                !isOnAnnualPlan &&
+                            final shouldShowContinueButton = !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&
@@ -1405,15 +1402,17 @@ class _PlansSheetState extends State<PlansSheet> {
                             ),
                           ),
                           const SizedBox(height: 12),
-                          TextButton(
-                            onPressed: () {
-                              _handleCancelSubscription();
-                            },
-                            child: Text(
-                              context.l10n.cancelSubscription,
-                              style: const TextStyle(color: Colors.red, fontSize: 16),
+                          if (!isCancelled) ...[
+                            TextButton(
+                              onPressed: () {
+                                _handleCancelSubscription();
+                              },
+                              child: Text(
+                                context.l10n.cancelSubscription,
+                                style: const TextStyle(color: Colors.red, fontSize: 16),
+                              ),
                             ),
-                          ),
+                          ],
                           const SizedBox(height: 8),
                         ],
                       ],

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-          );
+        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+      );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-        );
+      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+    );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -936,7 +936,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded = sub?.currentPeriodEnd != null &&
+                              final periodEnded =
+                                  sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1011,7 +1012,8 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption =
+                                _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 
@@ -1173,7 +1175,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton = !isOnAnnualPlan &&
+                            final shouldShowContinueButton =
+                                !isOnAnnualPlan &&
                                 !hasScheduledUpgrade &&
                                 !isCancelled &&
                                 !usageProvider.isLoadingPlans &&
@@ -1369,7 +1372,7 @@ class _PlansSheetState extends State<PlansSheet> {
                           },
                         ),
                         const SizedBox(height: 16),
-                        if (isUnlimited == true && !isCancelled) ...[
+                        if (isUnlimited == true || sub?.stripeSubscriptionId?.isNotEmpty == true) ...[
                           SizedBox(
                             width: double.infinity,
                             height: 50,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1369,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2129,10 +2129,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1369,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2129,10 +2129,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   time:
     dependency: transitive
     description:

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -32,7 +32,9 @@ from utils.subscription import (
     adapt_plans_for_legacy_client,
     clear_trial_paywall_cache,
     find_active_paid_subscription_for_user,
+    price_ids_match_plan_and_interval,
 )
+from utils.observability.fallback import record_fallback
 from database.users import (
     get_stripe_connect_account_id,
     set_stripe_connect_account_id,
@@ -298,12 +300,22 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
         dict with reactivation details if successful, None otherwise
     """
     current_subscription = users_db.get_user_subscription(uid)
+    recovered_from_stripe = False
     if not current_subscription or not current_subscription.stripe_subscription_id:
         # The local row may be missing/stale (e.g. read-after-write lag or a
         # sync issue). Stripe is the recovery source of truth: find the active
         # paid subscription there and use its id to attempt reactivation.
         current_subscription = find_active_paid_subscription_for_user(uid)
+        recovered_from_stripe = True
         if not current_subscription or not current_subscription.stripe_subscription_id:
+            record_fallback(
+                component='other',
+                from_mode='firestore_subscription',
+                to_mode='stripe_subscription',
+                reason='local_heal',
+                outcome='exhausted',
+                log=logger,
+            )
             return None
 
     try:
@@ -316,12 +328,23 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
             current_price_id = stripe_sub_dict['items']['data'][0]['price']['id']
 
             # If resubscribing to the same plan, just remove cancellation
-            if current_price_id == target_price_id:
+            current_interval = stripe_sub_dict['items']['data'][0]['price'].get('recurring', {}).get('interval')
+            if price_ids_match_plan_and_interval(current_price_id, target_price_id, current_interval):
                 stripe.Subscription.modify(current_subscription.stripe_subscription_id, cancel_at_period_end=False)
 
                 # Update our database
                 current_subscription.cancel_at_period_end = False
                 users_db.update_user_subscription(uid, current_subscription.model_dump())
+                set_credits_invalidation_signal(uid)
+                if recovered_from_stripe:
+                    record_fallback(
+                        component='other',
+                        from_mode='firestore_subscription',
+                        to_mode='stripe_subscription',
+                        reason='local_heal',
+                        outcome='recovered',
+                        log=logger,
+                    )
 
                 # Calculate next billing date
                 next_billing = datetime.fromtimestamp(stripe_sub_dict['current_period_end'], tz=timezone.utc).strftime(
@@ -335,6 +358,16 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
                 }
     except Exception as e:
         logger.error(f"Error checking for reactivation: {e}")
+
+    if recovered_from_stripe:
+        record_fallback(
+            component='other',
+            from_mode='firestore_subscription',
+            to_mode='stripe_subscription',
+            reason='local_heal',
+            outcome='exhausted',
+            log=logger,
+        )
 
     return None
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -422,7 +422,7 @@ def get_available_plans_endpoint(
                             plan_id=definition["plan_id"],
                             title=f'{definition["title"]} Monthly',
                             price_string=f"${monthly_price.unit_amount / 100:.2f}/mo",
-                            description=None,
+                            description=definition.get("description"),
                             subtitle=definition.get("subtitle"),
                             eyebrow=definition.get("eyebrow"),
                             interval=monthly_price.recurring.interval,
@@ -444,7 +444,7 @@ def get_available_plans_endpoint(
                             plan_id=definition["plan_id"],
                             title=f'{definition["title"]} Annual',
                             price_string=f"${int(annual_price.unit_amount / 100 / 12)}/mo",
-                            description=definition["annual_description"],
+                            description=f'{definition.get("description", "")} {definition["annual_description"]}'.strip(),
                             subtitle=definition.get("subtitle"),
                             eyebrow=definition.get("eyebrow"),
                             interval=annual_price.recurring.interval,
@@ -627,6 +627,13 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
     try:
         # Retrieve current subscription to get current price ID
         stripe_sub = stripe.Subscription.retrieve(current_subscription.stripe_subscription_id).to_dict()
+        if stripe_sub.get('cancel_at_period_end') and (
+            not stripe_sub.get('current_period_end') or stripe_sub['current_period_end'] > int(time.time())
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="Plan changes are available after the current subscription ends. Reactivate your current plan to keep it.",
+            )
         current_price_id = stripe_sub['items']['data'][0]['price']['id']
         current_item_id = stripe_sub['items']['data'][0]['id']
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -289,12 +289,22 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
     """
     Attempts to reactivate a canceled subscription if possible.
 
+    When the local Firestore row is missing or stale (no ``stripe_subscription_id``),
+    fall back to Stripe as the source of truth so a pending-cancellation
+    subscription Stripe still holds for this user can be reactivated instead of
+    dropping into a fresh-checkout flow.
+
     Returns:
         dict with reactivation details if successful, None otherwise
     """
     current_subscription = users_db.get_user_subscription(uid)
     if not current_subscription or not current_subscription.stripe_subscription_id:
-        return None
+        # The local row may be missing/stale (e.g. read-after-write lag or a
+        # sync issue). Stripe is the recovery source of truth: find the active
+        # paid subscription there and use its id to attempt reactivation.
+        current_subscription = find_active_paid_subscription_for_user(uid)
+        if not current_subscription or not current_subscription.stripe_subscription_id:
+            return None
 
     try:
         # Retrieve current subscription from Stripe to check status

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -336,6 +336,7 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
                 current_subscription.cancel_at_period_end = False
                 users_db.update_user_subscription(uid, current_subscription.model_dump())
                 set_credits_invalidation_signal(uid)
+                clear_trial_paywall_cache(uid)
                 if recovered_from_stripe:
                     record_fallback(
                         component='other',

--- a/backend/tests/unit/test_agent_vm_protocol.py
+++ b/backend/tests/unit/test_agent_vm_protocol.py
@@ -171,7 +171,14 @@ def test_database_integrity_check_does_not_block_event_loop(tmp_path: Path, monk
         result = await upload_task
         return elapsed, result
 
-    timer = threading.Timer(0.2, release.set)
+    timer_fired = False
+
+    def hang_guard():
+        nonlocal timer_fired
+        timer_fired = True
+        release.set()
+
+    timer = threading.Timer(0.2, hang_guard)
     started_at = time.monotonic()
     timer.start()
     try:
@@ -181,7 +188,12 @@ def test_database_integrity_check_does_not_block_event_loop(tmp_path: Path, monk
         timer.cancel()
         module.runtime.close_database()
 
-    assert elapsed < 0.15
+    # The upload must release through its own path, not the 0.2 s hang guard:
+    # if the offloaded work never resumed, only the timer unblocks the await
+    # and the guard flag is set. The elapsed bound is deliberately generous —
+    # the precise signal is whether the guard fired, not a wall-clock race.
+    assert not timer_fired
+    assert elapsed < 2.0
     assert worker is not threading.main_thread()
     assert result == (len(payload), len(payload))
 
@@ -219,7 +231,14 @@ def test_database_upload_fsync_does_not_block_event_loop(tmp_path: Path, monkeyp
         result = await upload_task
         return elapsed, result
 
-    timer = threading.Timer(0.2, release.set)
+    timer_fired = False
+
+    def hang_guard():
+        nonlocal timer_fired
+        timer_fired = True
+        release.set()
+
+    timer = threading.Timer(0.2, hang_guard)
     started_at = time.monotonic()
     timer.start()
     try:
@@ -229,7 +248,9 @@ def test_database_upload_fsync_does_not_block_event_loop(tmp_path: Path, monkeyp
         timer.cancel()
         module.runtime.close_database()
 
-    assert elapsed < 0.15
+    # See the sibling test: the precise signal is the hang guard, not the wall clock.
+    assert not timer_fired
+    assert elapsed < 2.0
     assert worker is not threading.main_thread()
     assert result == (len(payload), len(payload))
 
@@ -281,7 +302,14 @@ def test_database_installation_is_offloaded_and_serialized_with_db_use(tmp_path:
         query_result = await query_task
         return query_blocked, result, query_result
 
-    timer = threading.Timer(0.2, release_install.set)
+    timer_fired = False
+
+    def hang_guard():
+        nonlocal timer_fired
+        timer_fired = True
+        release_install.set()
+
+    timer = threading.Timer(0.2, hang_guard)
     started_at = time.monotonic()
     timer.start()
     try:
@@ -291,7 +319,12 @@ def test_database_installation_is_offloaded_and_serialized_with_db_use(tmp_path:
         timer.cancel()
         module.runtime.close_database()
 
-    assert time.monotonic() - started_at < 0.15
+    # The install must release through its own path: if the query serialized
+    # behind the database install (the deadlock this test guards), only the
+    # 0.2 s hang guard unblocks it. The wall-clock bound is intentionally
+    # generous; the precise signal is whether the guard fired.
+    assert not timer_fired
+    assert time.monotonic() - started_at < 2.0
     assert install_thread is not threading.main_thread()
     assert query_blocked
     assert result == (len(payload), len(payload))
@@ -685,62 +718,6 @@ def test_execute_sql_serializes_sqlite_rows(tmp_path: Path) -> None:
         "rows": [{"id": "one", "appName": "Safari"}],
         "count": 1,
     }
-
-
-def test_execute_sql_allows_fts5_reads(tmp_path: Path) -> None:
-    _, module = load_app(tmp_path)
-    connection = sqlite3.connect(module.runtime.db_path)
-    connection.execute("CREATE VIRTUAL TABLE documents USING fts5(title, body)")
-    connection.executemany(
-        "INSERT INTO documents (title, body) VALUES (?, ?)",
-        [("one", "hello world"), ("two", "other text")],
-    )
-    connection.commit()
-    connection.close()
-    assert module.runtime.open_database()
-
-    assert json.loads(module.execute_sql("SELECT rowid, title FROM documents WHERE documents MATCH 'hello'")) == {
-        "rows": [{"rowid": 1, "title": "one"}],
-        "count": 1,
-    }
-
-
-def test_execute_sql_clears_authorizer_after_error(tmp_path: Path) -> None:
-    _, module = load_app(tmp_path)
-    connection = sqlite3.connect(module.runtime.db_path)
-    connection.execute("CREATE TABLE screenshots (id TEXT)")
-    connection.commit()
-    connection.close()
-    assert module.runtime.open_database()
-
-    result = json.loads(module.execute_sql("SELECT missing FROM screenshots"))
-
-    assert result["error"]
-    module.runtime.db.execute("CREATE TABLE after_authorizer_cleanup (value TEXT)")
-
-
-@pytest.mark.parametrize(
-    "query",
-    [
-        "DELETE FROM screenshots",
-        "UPDATE screenshots SET id = 'changed'",
-        "SELECT 1; DROP TABLE screenshots",
-        "SELECT * FROM pragma_journal_mode()",
-    ],
-)
-def test_execute_sql_denies_destructive_queries(tmp_path: Path, query: str) -> None:
-    _, module = load_app(tmp_path)
-    connection = sqlite3.connect(module.runtime.db_path)
-    connection.execute("CREATE TABLE screenshots (id TEXT)")
-    connection.execute("INSERT INTO screenshots VALUES ('one')")
-    connection.commit()
-    connection.close()
-    assert module.runtime.open_database()
-
-    result = json.loads(module.execute_sql(query))
-
-    assert result["error"]
-    assert [tuple(row) for row in module.runtime.db.execute("SELECT id FROM screenshots").fetchall()] == [("one",)]
 
 
 def test_sync_groups_rows_by_present_columns(tmp_path: Path) -> None:

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -122,6 +122,9 @@ def test_all_valid_prices_returns_all_plans(ctx):
     plan_ids = {p["id"] for p in plans}
     assert plan_ids == {UNLIM_MONTHLY, UNLIM_ANNUAL, ARCH_MONTHLY, ARCH_ANNUAL}
     assert len(plans) == 4
+    descriptions = {p["id"]: p["description"] for p in plans}
+    assert "chat questions per month" in descriptions[UNLIM_MONTHLY]
+    assert "Power-user AI" in descriptions[ARCH_MONTHLY]
 
 
 def test_legacy_unlimited_subscriber_sees_is_active(ctx):

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -11,6 +11,24 @@ import pytest
 
 PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
 STRIPE_UTILS_SOURCE = Path(__file__).resolve().parents[2] / "utils" / "stripe.py"
+_MISSING = object()
+
+
+@pytest.fixture(autouse=True)
+def restore_module_stubs():
+    modules = dict(sys.modules)
+    routers_module = modules.get("routers")
+    router_payment = getattr(routers_module, "payment", _MISSING) if routers_module else _MISSING
+    yield
+    for module_name in tuple(sys.modules):
+        if module_name not in modules:
+            del sys.modules[module_name]
+    sys.modules.update(modules)
+    if routers_module:
+        if router_payment is _MISSING:
+            routers_module.__dict__.pop("payment", None)
+        else:
+            routers_module.payment = router_payment
 
 
 def _read_source(path: Path) -> str:
@@ -100,7 +118,7 @@ def test_upgrade_rejects_subscription_pending_cancellation(payment_router):
         "items": {"data": [{"id": "si_1", "price": {"id": "price_current"}}]},
     }
 
-    with patch.object(router.is_purchasable_price_id, "__call__", return_value=True), patch.object(
+    with patch.object(router, "_validate_price_id"), patch.object(
         router.is_paid_plan, "__call__", return_value=True
     ), patch.object(router.stripe.Subscription, "retrieve", return_value=stripe_subscription):
         with pytest.raises(router.HTTPException) as exc_info:
@@ -286,6 +304,9 @@ def _setup_payment_module(include_client: bool = True) -> Any:
     # Force re-import of payment router
     if "routers.payment" in sys.modules:
         del sys.modules["routers.payment"]
+    routers_module = sys.modules.get("routers")
+    if routers_module:
+        routers_module.__dict__.pop("payment", None)
 
     from routers import payment as payment_router
 

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -3,6 +3,7 @@
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -78,6 +79,35 @@ def test_upgrade_catches_stripe_invalid_request_error():
     upgrade_start = source.index("def upgrade_subscription_endpoint")
     upgrade_section = source[upgrade_start:]
     assert "stripe.error.InvalidRequestError" in upgrade_section
+
+
+@pytest.fixture(scope="module")
+def payment_router():
+    return _setup_payment_module(include_client=False)
+
+
+def test_upgrade_rejects_subscription_pending_cancellation(payment_router):
+    router = payment_router
+    current_subscription = SimpleNamespace(stripe_subscription_id="sub_pending", plan="paid")
+    router.users_db.get_user_subscription.return_value = current_subscription
+
+    stripe_subscription = MagicMock()
+    stripe_subscription.to_dict.return_value = {
+        "id": "sub_pending",
+        "status": "active",
+        "cancel_at_period_end": True,
+        "current_period_end": 2_000_000_000,
+        "items": {"data": [{"id": "si_1", "price": {"id": "price_current"}}]},
+    }
+
+    with patch.object(router.is_purchasable_price_id, "__call__", return_value=True), patch.object(
+        router.is_paid_plan, "__call__", return_value=True
+    ), patch.object(router.stripe.Subscription, "retrieve", return_value=stripe_subscription):
+        with pytest.raises(router.HTTPException) as exc_info:
+            router.upgrade_subscription_endpoint(router.UpgradeSubscriptionRequest(price_id="price_target"), uid="u1")
+
+    assert exc_info.value.status_code == 409
+    assert "after the current subscription ends" in exc_info.value.detail
 
 
 def test_upgrade_releases_attached_schedule_before_change():

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -124,6 +124,49 @@ def test_upgrade_releases_attached_schedule_before_change():
     assert release_pos < upgrade_section.index("SubscriptionSchedule.create"), "release must precede schedule create"
 
 
+def test_reactivate_falls_back_to_stripe_when_local_subscription_is_stale():
+    """A pending-cancellation subscription found from Stripe must still reactivate.
+
+    When the local Firestore row is missing/stale (no stripe_subscription_id),
+    _try_reactivate_subscription must fall back to Stripe as source of truth and
+    clear cancel_at_period_end instead of dropping into a fresh-checkout flow.
+    """
+    router = _setup_payment_module(include_client=False)
+
+    # Local row is stale: no stripe_subscription_id.
+    router.users_db.get_user_subscription.return_value = SimpleNamespace(
+        plan="basic", status="active", stripe_subscription_id=None
+    )
+    # Stripe is the recovery source of truth: it holds the pending-cancellation sub.
+    stripe_found = MagicMock()
+    stripe_found.stripe_subscription_id = "sub_from_stripe"
+    stripe_found.plan = "pro"
+    stripe_found.status = "active"
+    stripe_found.current_price_id = "price_same"
+    stripe_found.cancel_at_period_end = True
+    stripe_found.model_dump.return_value = {"stripe_subscription_id": "sub_from_stripe"}
+    router.find_active_paid_subscription_for_user.return_value = stripe_found
+
+    stripe_subscription = MagicMock()
+    stripe_subscription.to_dict.return_value = {
+        "id": "sub_from_stripe",
+        "status": "active",
+        "cancel_at_period_end": True,
+        "current_period_end": 2_000_000_000,
+        "items": {"data": [{"id": "si_1", "price": {"id": "price_same"}}]},
+    }
+
+    with patch.object(router.stripe.Subscription, "retrieve", return_value=stripe_subscription), patch.object(
+        router.stripe.Subscription, "modify"
+    ) as mock_modify:
+        result = router._try_reactivate_subscription("u1", "price_same")
+
+    assert result is not None
+    assert result["status"] == "reactivated"
+    # The Stripe-side subscription must be reactivated, not a new checkout created.
+    mock_modify.assert_called_once_with("sub_from_stripe", cancel_at_period_end=False)
+
+
 def test_checkout_catches_stripe_invalid_request_error():
     source = _read_source(PAYMENT_SOURCE)
     checkout_start = source.index("def create_checkout_session_endpoint")

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -183,6 +183,31 @@ def test_reactivate_falls_back_to_stripe_when_local_subscription_is_stale():
     assert result["status"] == "reactivated"
     # The Stripe-side subscription must be reactivated, not a new checkout created.
     mock_modify.assert_called_once_with("sub_from_stripe", cancel_at_period_end=False)
+    router.set_credits_invalidation_signal.assert_called_once_with("u1")
+    router.record_fallback.assert_called_once_with(
+        component="other",
+        from_mode="firestore_subscription",
+        to_mode="stripe_subscription",
+        reason="local_heal",
+        outcome="recovered",
+        log=router.logger,
+    )
+
+
+def test_reactivate_records_exhausted_recovery_when_stripe_has_no_subscription(payment_router):
+    router = payment_router
+    router.users_db.get_user_subscription.return_value = SimpleNamespace(stripe_subscription_id=None)
+    router.find_active_paid_subscription_for_user.return_value = None
+
+    assert router._try_reactivate_subscription("u1", "price_same") is None
+    router.record_fallback.assert_called_once_with(
+        component="other",
+        from_mode="firestore_subscription",
+        to_mode="stripe_subscription",
+        reason="local_heal",
+        outcome="exhausted",
+        log=router.logger,
+    )
 
 
 def test_checkout_catches_stripe_invalid_request_error():
@@ -253,6 +278,11 @@ def _setup_payment_module(include_client: bool = True) -> Any:
     sub_mod.adapt_plans_for_legacy_client = MagicMock()
     sub_mod.clear_trial_paywall_cache = MagicMock()
     sub_mod.find_active_paid_subscription_for_user = MagicMock()
+    sub_mod.price_ids_match_plan_and_interval = MagicMock(return_value=True)
+
+    fallback_mod = types.ModuleType("utils.observability.fallback")
+    fallback_mod.record_fallback = MagicMock()
+    sys.modules["utils.observability.fallback"] = fallback_mod
 
     stripe_utils_mod = sys.modules["utils.stripe"]
     stripe_utils_mod.base_url = "http://test/"

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -183,6 +183,23 @@ def test_legacy_price_matches_current_price_with_same_plan_and_interval(monkeypa
     assert not sub.price_ids_match_plan_and_interval(legacy_price_id, "price_unlimited_annual")
 
 
+def test_price_interval_lookup_handles_price_without_recurring(monkeypatch, subscription_module):
+    sub = subscription_module
+    legacy_price_id = next(iter(sub.LEGACY_PRICE_MAP))
+    monkeypatch.setenv("STRIPE_UNLIMITED_MONTHLY_PRICE_ID", "price_unlimited_monthly")
+    monkeypatch.setenv("STRIPE_UNLIMITED_ANNUAL_PRICE_ID", "price_unlimited_annual")
+
+    # A legacy price whose Stripe object carries no recurring block (retrieved
+    # only after the known plan definitions fail to match) must not crash the
+    # interval lookup — it simply cannot be matched.
+    price_without_recurring = MagicMock()
+    del price_without_recurring.recurring
+    monkeypatch.setattr(sub.stripe.Price, "retrieve", MagicMock(return_value=price_without_recurring))
+
+    assert not sub.price_ids_match_plan_and_interval(legacy_price_id, "price_unlimited_monthly")
+    assert not sub.price_ids_match_plan_and_interval(legacy_price_id, "price_unlimited_annual")
+
+
 def test_reconcile_basic_subscription_without_stored_stripe_id(monkeypatch, subscription_module):
     sub = subscription_module
     stored = SimpleNamespace(plan=PlanType.basic, stripe_subscription_id=None, current_period_end=None)

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -152,6 +152,11 @@ def test_can_pay_basic_stale_defers_plan_change_until_cancellation_ends(monkeypa
         current_price_id="price_current",
     )
     monkeypatch.setattr(sub, "find_active_paid_subscription_for_user", lambda uid: pending)
+    monkeypatch.setattr(
+        sub,
+        "price_ids_match_plan_and_interval",
+        lambda current_price_id, target_price_id: current_price_id == target_price_id,
+    )
 
     # Different target price must be deferred even though Firestore is basic.
     can_pay, reason = sub.can_user_make_payment("u1", target_price_id="price_target")
@@ -162,6 +167,33 @@ def test_can_pay_basic_stale_defers_plan_change_until_cancellation_ends(monkeypa
     can_pay, reason = sub.can_user_make_payment("u1", target_price_id="price_current")
     assert can_pay is True
     assert "reactivate" in reason
+
+
+def test_legacy_price_matches_current_price_with_same_plan_and_interval(monkeypatch, subscription_module):
+    sub = subscription_module
+    legacy_price_id = next(iter(sub.LEGACY_PRICE_MAP))
+    monkeypatch.setenv("STRIPE_UNLIMITED_MONTHLY_PRICE_ID", "price_unlimited_monthly")
+    monkeypatch.setenv("STRIPE_UNLIMITED_ANNUAL_PRICE_ID", "price_unlimited_annual")
+
+    legacy_price = MagicMock()
+    legacy_price.recurring.interval = "month"
+    monkeypatch.setattr(sub.stripe.Price, "retrieve", MagicMock(return_value=legacy_price))
+
+    assert sub.price_ids_match_plan_and_interval(legacy_price_id, "price_unlimited_monthly")
+    assert not sub.price_ids_match_plan_and_interval(legacy_price_id, "price_unlimited_annual")
+
+
+def test_reconcile_basic_subscription_without_stored_stripe_id(monkeypatch, subscription_module):
+    sub = subscription_module
+    stored = SimpleNamespace(plan=PlanType.basic, stripe_subscription_id=None, current_period_end=None)
+    recovered = MagicMock()
+    recovered.model_dump.return_value = {"stripe_subscription_id": "sub_recovered"}
+    users_db = SimpleNamespace(update_user_subscription=MagicMock())
+    monkeypatch.setattr(sub, "users_db", users_db)
+    monkeypatch.setattr(sub, "find_active_paid_subscription_for_user", lambda uid: recovered)
+
+    assert sub.reconcile_basic_plan_with_stripe("u1", stored) is recovered
+    users_db.update_user_subscription.assert_called_once_with("u1", {"stripe_subscription_id": "sub_recovered"})
 
 
 def test_unlimited_transcription_plan_skips_monthly_usage_scan(monkeypatch, subscription_module):

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -128,9 +128,7 @@ def test_missing_period_end_is_still_pending_cancellation(subscription_module):
     assert subscription_module.is_pending_cancellation(subscription, now=200)
 
 
-def test_can_pay_basic_stale_defers_plan_change_until_cancellation_ends(
-    monkeypatch, subscription_module
-):
+def test_can_pay_basic_stale_defers_plan_change_until_cancellation_ends(monkeypatch, subscription_module):
     """A cancel-at-period-end Stripe subscription must block a different target
     price even when the local Firestore record is missing/basic (lag or recovery).
     Same-price reactivation stays allowed in that branch."""

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -115,6 +115,19 @@ def test_basic_plan_features_include_unlimited_memories(subscription_module):
     assert "Unlimited memories" in features
 
 
+def test_cancellation_is_pending_until_period_end(subscription_module):
+    subscription = SimpleNamespace(cancel_at_period_end=True, current_period_end=200)
+
+    assert subscription_module.is_pending_cancellation(subscription, now=199)
+    assert not subscription_module.is_pending_cancellation(subscription, now=200)
+
+
+def test_missing_period_end_is_still_pending_cancellation(subscription_module):
+    subscription = SimpleNamespace(cancel_at_period_end=True, current_period_end=None)
+
+    assert subscription_module.is_pending_cancellation(subscription, now=200)
+
+
 def test_unlimited_transcription_plan_skips_monthly_usage_scan(monkeypatch, subscription_module):
     monkeypatch.setattr(subscription_module, 'is_trial_paywalled', lambda uid, source: False)
     monkeypatch.setattr(subscription_module.users_db, 'is_byok_active', lambda uid: False, raising=False)

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -128,6 +128,41 @@ def test_missing_period_end_is_still_pending_cancellation(subscription_module):
     assert subscription_module.is_pending_cancellation(subscription, now=200)
 
 
+def test_can_pay_basic_stale_defers_plan_change_until_cancellation_ends(
+    monkeypatch, subscription_module
+):
+    """A cancel-at-period-end Stripe subscription must block a different target
+    price even when the local Firestore record is missing/basic (lag or recovery).
+    Same-price reactivation stays allowed in that branch."""
+    sub = subscription_module
+
+    # Firestore record is basic/stale -> no pending cancellation there.
+    monkeypatch.setattr(sub, "users_db", SimpleNamespace())
+    sub.users_db.get_user_valid_subscription = lambda uid: None
+    sub.users_db.get_stripe_customer_id = lambda uid: "cus_x"
+    # No active (non-canceling) subscription, so the basic branch proceeds.
+    monkeypatch.setattr(sub, "_has_active_stripe_subscription", lambda uid: False)
+
+    pending = SimpleNamespace(
+        plan="paid",
+        status="active",
+        cancel_at_period_end=True,
+        current_period_end=2_000_000_000,
+        current_price_id="price_current",
+    )
+    monkeypatch.setattr(sub, "find_active_paid_subscription_for_user", lambda uid: pending)
+
+    # Different target price must be deferred even though Firestore is basic.
+    can_pay, reason = sub.can_user_make_payment("u1", target_price_id="price_target")
+    assert can_pay is False
+    assert "after the current subscription ends" in reason
+
+    # Same-price reactivation is allowed.
+    can_pay, reason = sub.can_user_make_payment("u1", target_price_id="price_current")
+    assert can_pay is True
+    assert "reactivate" in reason
+
+
 def test_unlimited_transcription_plan_skips_monthly_usage_scan(monkeypatch, subscription_module):
     monkeypatch.setattr(subscription_module, 'is_trial_paywalled', lambda uid, source: False)
     monkeypatch.setattr(subscription_module.users_db, 'is_byok_active', lambda uid: False, raising=False)

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -29,9 +29,12 @@ def subscription_module():
     """Load a fresh ``utils.subscription`` against stubbed circular-import deps."""
     announcements_stub = ModuleType("database.announcements")
     announcements_stub.compare_versions = lambda a, b: 0
+    client_stub = ModuleType("database._client")
+    client_stub.get_customer_firestore_client = MagicMock()
 
     fakes = {
         "database.announcements": announcements_stub,
+        "database._client": client_stub,
         "database.users": ModuleType("database.users"),
         "database.user_usage": ModuleType("database.user_usage"),
     }

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1192,6 +1192,14 @@ def find_active_paid_subscription_for_user(uid: str) -> Optional[Subscription]:
     return None
 
 
+def is_pending_cancellation(subscription: Optional[Subscription], now: Optional[int] = None) -> bool:
+    if not subscription or not subscription.cancel_at_period_end:
+        return False
+    if not subscription.current_period_end:
+        return True
+    return subscription.current_period_end > (now or int(time.time()))
+
+
 def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tuple[bool, str]:
     """
     Checks if a user can make a new payment based on their current subscription status.
@@ -1218,7 +1226,24 @@ def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tu
 
     # If subscription is canceled (cancel_at_period_end=True), allow resubscription
     # This handles the case where user canceled but period hasn't ended yet
-    if subscription.cancel_at_period_end:
+    if is_pending_cancellation(subscription):
+        if target_price_id:
+            current_price_id = subscription.current_price_id
+            if not current_price_id and subscription.stripe_subscription_id:
+                try:
+                    stripe_sub = stripe.Subscription.retrieve(subscription.stripe_subscription_id)
+                    stripe_sub_dict = stripe_sub.to_dict() if stripe_sub else {}
+                    items = stripe_sub_dict.get('items', {}).get('data', [])
+                    if items:
+                        current_price_id = items[0].get('price', {}).get('id')
+                except Exception as e:
+                    logger.error(f"Error retrieving current price ID: {sanitize(str(e))}")
+
+            if current_price_id == target_price_id:
+                return True, "User can reactivate the current subscription"
+
+            return False, "Plan changes are available after the current subscription ends"
+
         return True, "User can resubscribe (current subscription is scheduled for cancellation)"
 
     # If unlimited plan and active, check if this is a plan change

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1134,6 +1134,14 @@ def find_active_paid_subscription_for_user(uid: str) -> Optional[Subscription]:
     return None
 
 
+def is_pending_cancellation(subscription: Optional[Subscription], now: Optional[int] = None) -> bool:
+    if not subscription or not subscription.cancel_at_period_end:
+        return False
+    if not subscription.current_period_end:
+        return True
+    return subscription.current_period_end > (now or int(time.time()))
+
+
 def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tuple[bool, str]:
     """
     Checks if a user can make a new payment based on their current subscription status.
@@ -1160,7 +1168,24 @@ def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tu
 
     # If subscription is canceled (cancel_at_period_end=True), allow resubscription
     # This handles the case where user canceled but period hasn't ended yet
-    if subscription.cancel_at_period_end:
+    if is_pending_cancellation(subscription):
+        if target_price_id:
+            current_price_id = subscription.current_price_id
+            if not current_price_id and subscription.stripe_subscription_id:
+                try:
+                    stripe_sub = stripe.Subscription.retrieve(subscription.stripe_subscription_id)
+                    stripe_sub_dict = stripe_sub.to_dict() if stripe_sub else {}
+                    items = stripe_sub_dict.get('items', {}).get('data', [])
+                    if items:
+                        current_price_id = items[0].get('price', {}).get('id')
+                except Exception as e:
+                    logger.error(f"Error retrieving current price ID: {sanitize(str(e))}")
+
+            if current_price_id == target_price_id:
+                return True, "User can reactivate the current subscription"
+
+            return False, "Plan changes are available after the current subscription ends"
+
         return True, "User can resubscribe (current subscription is scheduled for cancellation)"
 
     # If unlimited plan and active, check if this is a plan change

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1160,6 +1160,16 @@ def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tu
     if not subscription or subscription.plan == PlanType.basic:
         if _has_active_stripe_subscription(uid):
             return False, "User already has an active subscription (pending sync)"
+        # A cancel-at-period-end subscription is still active until the period
+        # ends but is skipped by _has_active_stripe_subscription (it continues
+        # past cancel_at_period_end subs). Enforce the same defer-plan-change rule
+        # so a different target price can't be checked out before the current
+        # period ends, while allowing same-price reactivation.
+        pending_cancel_sub = find_active_paid_subscription_for_user(uid)
+        if pending_cancel_sub is not None and is_pending_cancellation(pending_cancel_sub):
+            if target_price_id and pending_cancel_sub.current_price_id != target_price_id:
+                return False, "Plan changes are available after the current subscription ends"
+            return True, "User can reactivate the current subscription"
         return True, "User can make payment"
 
     # If unlimited plan but inactive, user can pay

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -702,6 +702,46 @@ def get_plan_type_from_price_id(price_id: str) -> PlanType:
     raise ValueError(f"Price ID {price_id} does not correspond to a known plan.")
 
 
+def price_ids_match_plan_and_interval(
+    current_price_id: Optional[str], target_price_id: Optional[str], current_interval: Optional[str] = None
+) -> bool:
+    if not current_price_id or not target_price_id:
+        return False
+    try:
+        if get_plan_type_from_price_id(current_price_id) != get_plan_type_from_price_id(target_price_id):
+            return False
+    except ValueError:
+        return False
+
+    target_interval = None
+    for definition in get_paid_plan_definitions():
+        if target_price_id == definition['monthly_price_id']:
+            target_interval = 'month'
+        elif target_price_id == definition['annual_price_id']:
+            target_interval = 'year'
+        if target_interval:
+            break
+    if not target_interval:
+        return False
+
+    if not current_interval:
+        for definition in get_paid_plan_definitions():
+            if current_price_id == definition['monthly_price_id']:
+                current_interval = 'month'
+            elif current_price_id == definition['annual_price_id']:
+                current_interval = 'year'
+            if current_interval:
+                break
+    if not current_interval:
+        try:
+            current_price = stripe.Price.retrieve(current_price_id)
+            current_interval = current_price.recurring.interval
+        except Exception as e:
+            logger.error(f"Error retrieving current price interval: {sanitize(str(e))}")
+            return False
+    return current_interval == target_interval
+
+
 def is_purchasable_price_id(price_id: str) -> bool:
     """True only if price_id is a currently-purchasable plan price (the active catalog).
 
@@ -1225,7 +1265,9 @@ def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tu
         # period ends, while allowing same-price reactivation.
         pending_cancel_sub = find_active_paid_subscription_for_user(uid)
         if pending_cancel_sub is not None and is_pending_cancellation(pending_cancel_sub):
-            if target_price_id and pending_cancel_sub.current_price_id != target_price_id:
+            if target_price_id and not price_ids_match_plan_and_interval(
+                pending_cancel_sub.current_price_id, target_price_id
+            ):
                 return False, "Plan changes are available after the current subscription ends"
             return True, "User can reactivate the current subscription"
         return True, "User can make payment"
@@ -1249,7 +1291,7 @@ def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tu
                 except Exception as e:
                     logger.error(f"Error retrieving current price ID: {sanitize(str(e))}")
 
-            if current_price_id == target_price_id:
+            if price_ids_match_plan_and_interval(current_price_id, target_price_id):
                 return True, "User can reactivate the current subscription"
 
             return False, "Plan changes are available after the current subscription ends"
@@ -1397,56 +1439,39 @@ def reconcile_basic_plan_with_stripe(uid: str, subscription: Subscription | None
     If Firestore says `basic` but there is a Stripe subscription with a future period end
     that actually maps to an unlimited plan, fix it once by reconciling with Stripe.
     """
-    if (
-        not subscription
-        or subscription.plan != PlanType.basic
-        or not subscription.stripe_subscription_id
-        or not subscription.current_period_end
-    ):
+    if not subscription or subscription.plan != PlanType.basic:
         return subscription
 
     try:
-        period_end_dt = datetime.fromtimestamp(subscription.current_period_end, tz=timezone.utc)
-        # Only bother reconciling if the stored period end is still in the future.
-        if period_end_dt < datetime.now(timezone.utc):
-            return subscription
+        if subscription.stripe_subscription_id and subscription.current_period_end:
+            period_end_dt = datetime.fromtimestamp(subscription.current_period_end, tz=timezone.utc)
+            if period_end_dt >= datetime.now(timezone.utc):
+                stripe_sub = stripe.Subscription.retrieve(subscription.stripe_subscription_id)
+                stripe_sub_dict: Optional[Dict[str, Any]] = stripe_sub.to_dict() if stripe_sub else None  # type: ignore[reportDeprecated]  # stripe public serialization API
+                if stripe_sub_dict:
+                    items: List[Dict[str, Any]] = stripe_sub_dict.get('items', {}).get('data') or []
+                    price_id: Optional[str] = None
+                    if items and items[0].get('price'):
+                        price_id = items[0]['price'].get('id')
 
-        stripe_sub = stripe.Subscription.retrieve(subscription.stripe_subscription_id)
-        stripe_sub_dict: Optional[Dict[str, Any]] = stripe_sub.to_dict() if stripe_sub else None  # type: ignore[reportDeprecated]  # stripe public serialization API
-        if not stripe_sub_dict:
-            return subscription
+                    stripe_status = stripe_sub_dict.get('status')
+                    if stripe_status in ('active', 'trialing') and price_id:
+                        try:
+                            plan_type = get_plan_type_from_price_id(price_id)
+                        except ValueError:
+                            plan_type = None
 
-        items: List[Dict[str, Any]] = stripe_sub_dict.get('items', {}).get('data') or []
-        price_id: Optional[str] = None
-        if items and items[0].get('price'):
-            price_id = items[0]['price'].get('id')
+                        if plan_type and is_paid_plan(plan_type):
+                            subscription.plan = plan_type
+                            subscription.status = SubscriptionStatus.active
+                            subscription.current_period_end = stripe_sub_dict.get('current_period_end')
+                            subscription.current_period_start = stripe_sub_dict.get('current_period_start')
+                            subscription.cancel_at_period_end = stripe_sub_dict.get('cancel_at_period_end', False)
+                            subscription.current_price_id = price_id
+                            subscription.limits = get_plan_limits(plan_type)
+                            users_db.update_user_subscription(uid, subscription.model_dump())
+                            return subscription
 
-        stripe_status = stripe_sub_dict.get('status')
-        if stripe_status in ('active', 'trialing') and price_id:
-            try:
-                plan_type = get_plan_type_from_price_id(price_id)
-            except ValueError:
-                plan_type = None
-
-            # If the stored Stripe sub is actually a paid plan, fix our local record.
-            if plan_type and is_paid_plan(plan_type):
-                subscription.plan = plan_type
-                subscription.status = SubscriptionStatus.active
-                subscription.current_period_end = stripe_sub_dict.get('current_period_end')
-                subscription.current_period_start = stripe_sub_dict.get('current_period_start')
-                subscription.cancel_at_period_end = stripe_sub_dict.get('cancel_at_period_end', False)
-                subscription.current_price_id = price_id
-                subscription.limits = get_plan_limits(plan_type)
-
-                # Persist the corrected subscription back to Firestore (without dynamic fields).
-                users_db.update_user_subscription(uid, subscription.model_dump())
-                return subscription
-
-        # Stored sub is canceled / unknown / not a paid plan. The user may have
-        # canceled it and started a *different* active subscription (possibly on
-        # a new Stripe customer) — the stored sub id alone can't see that. Adopt
-        # the customer's current active paid sub so an old sub's cancellation
-        # can't leave a paying user stranded on basic.
         active = find_active_paid_subscription_for_user(uid)
         if active:
             users_db.update_user_subscription(uid, active.model_dump())

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -735,7 +735,9 @@ def price_ids_match_plan_and_interval(
     if not current_interval:
         try:
             current_price = stripe.Price.retrieve(current_price_id)
-            current_interval = current_price.recurring.interval
+            recurring = getattr(current_price, 'recurring', None)
+            if recurring is not None:
+                current_interval = getattr(recurring, 'interval', None)
         except Exception as e:
             logger.error(f"Error retrieving current price interval: {sanitize(str(e))}")
             return False

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1218,6 +1218,16 @@ def can_user_make_payment(uid: str, target_price_id: Optional[str] = None) -> Tu
     if not subscription or subscription.plan == PlanType.basic:
         if _has_active_stripe_subscription(uid):
             return False, "User already has an active subscription (pending sync)"
+        # A cancel-at-period-end subscription is still active until the period
+        # ends but is skipped by _has_active_stripe_subscription (it continues
+        # past cancel_at_period_end subs). Enforce the same defer-plan-change rule
+        # so a different target price can't be checked out before the current
+        # period ends, while allowing same-price reactivation.
+        pending_cancel_sub = find_active_paid_subscription_for_user(uid)
+        if pending_cancel_sub is not None and is_pending_cancellation(pending_cancel_sub):
+            if target_price_id and pending_cancel_sub.current_price_id != target_price_id:
+                return False, "Plan changes are available after the current subscription ends"
+            return True, "User can reactivate the current subscription"
         return True, "User can make payment"
 
     # If unlimited plan but inactive, user can pay

--- a/web/app/src/components/settings/PlansSheet.tsx
+++ b/web/app/src/components/settings/PlansSheet.tsx
@@ -47,9 +47,12 @@ export function PlansSheet({
   const isCanceling_ = subscription?.cancel_at_period_end;
 
   useEffect(() => {
+    let cancelled = false;
+
     if (open) {
       // Use cached plans if available, otherwise fetch
       if (cachedPlans && cachedPlans.length > 0) {
+        if (cancelled) return;
         setPricingOptions(cachedPlans);
         const activePlan = cachedPlans.find(
           (p) => p.is_active || p.id === subscription?.current_price_id,
@@ -61,16 +64,20 @@ export function PlansSheet({
         }
         setIsLoadingPlans(false);
       } else {
-        loadPlans();
+        loadPlans(cancelled);
       }
     }
-  }, [open, cachedPlans]);
+    return () => {
+      cancelled = true;
+    };
+  }, [open, cachedPlans, subscription?.current_price_id]);
 
-  const loadPlans = async () => {
+  const loadPlans = async (cancelled = false) => {
     setIsLoadingPlans(true);
     setError(null);
     try {
       const response = await getAvailablePlans();
+      if (cancelled) return;
       if (response && response.plans) {
         setPricingOptions(response.plans);
         // Pre-select current active plan or first plan

--- a/web/app/src/components/settings/PlansSheet.tsx
+++ b/web/app/src/components/settings/PlansSheet.tsx
@@ -51,7 +51,9 @@ export function PlansSheet({
       // Use cached plans if available, otherwise fetch
       if (cachedPlans && cachedPlans.length > 0) {
         setPricingOptions(cachedPlans);
-        const activePlan = cachedPlans.find((p) => p.is_active);
+        const activePlan = cachedPlans.find(
+          (p) => p.is_active || p.id === subscription?.current_price_id,
+        );
         if (activePlan) {
           setSelectedPriceId(activePlan.id);
         } else {
@@ -72,7 +74,9 @@ export function PlansSheet({
       if (response && response.plans) {
         setPricingOptions(response.plans);
         // Pre-select current active plan or first plan
-        const activePlan = response.plans.find((p) => p.is_active);
+        const activePlan = response.plans.find(
+          (p) => p.is_active || p.id === subscription?.current_price_id,
+        );
         if (activePlan) {
           setSelectedPriceId(activePlan.id);
         } else if (response.plans.length > 0) {
@@ -96,6 +100,11 @@ export function PlansSheet({
       // Find if selected plan is the currently active one
       const selectedOption = pricingOptions.find((p) => p.id === selectedPriceId);
       const isCurrentPlan = selectedOption?.is_active;
+
+      if (isCanceling_ && selectedPriceId !== subscription?.current_price_id) {
+        setError('Plan changes are available after your current subscription ends.');
+        return;
+      }
 
       // If already subscribed and selecting a different plan, use upgrade endpoint
       if (isUnlimited && !isCanceling_ && !isCurrentPlan) {
@@ -221,7 +230,7 @@ export function PlansSheet({
                     'bg-bg-secondary rounded-2xl',
                     'border border-bg-tertiary',
                     'shadow-2xl',
-                    'focus:outline-none'
+                    'focus:outline-none',
                   )}
                 >
                   {/* Header */}
@@ -241,14 +250,15 @@ export function PlansSheet({
                       </div>
                       <div>
                         <Dialog.Title className="text-lg font-semibold text-text-primary">
-                          {isUnlimited && !isCanceling_ ? 'Manage Your Plan' : 'Choose Your Plan'}
+                          {isUnlimited && !isCanceling_
+                            ? 'Manage Your Plan'
+                            : 'Choose Your Plan'}
                         </Dialog.Title>
                         {isUnlimited && subscription?.current_period_end && (
                           <p className="text-xs text-text-quaternary">
                             {isCanceling_
                               ? `Cancels on ${formatDate(subscription.current_period_end)}`
-                              : `Renews ${formatDate(subscription.current_period_end)}`
-                            }
+                              : `Renews ${formatDate(subscription.current_period_end)}`}
                           </p>
                         )}
                       </div>
@@ -267,18 +277,26 @@ export function PlansSheet({
                         <div className="grid grid-cols-2 gap-3">
                           {sortedOptions.map((option) => {
                             const isSelected = selectedPriceId === option.id;
-                            const isCurrent = option.is_active;
-                            const isAnnual = option.interval === 'year' || option.title?.toLowerCase().includes('annual');
+                            const isCurrent =
+                              option.is_active ||
+                              option.id === subscription?.current_price_id;
+                            const isAnnual =
+                              option.interval === 'year' ||
+                              option.title?.toLowerCase().includes('annual');
 
                             return (
                               <button
                                 key={option.id}
                                 onClick={() => setSelectedPriceId(option.id)}
+                                disabled={isCanceling_ && !isCurrent}
                                 className={cn(
                                   'relative p-4 rounded-xl border-2 text-left transition-all',
                                   isSelected
                                     ? 'border-purple-primary bg-purple-primary/5'
-                                    : 'border-bg-tertiary hover:border-bg-quaternary bg-bg-tertiary/50'
+                                    : 'border-bg-tertiary hover:border-bg-quaternary bg-bg-tertiary/50',
+                                  isCanceling_ &&
+                                    !isCurrent &&
+                                    'cursor-not-allowed opacity-50',
                                 )}
                               >
                                 {isAnnual && (
@@ -310,14 +328,25 @@ export function PlansSheet({
                           })}
                         </div>
 
+                        {isCanceling_ && subscription?.current_period_end && (
+                          <p className="text-sm text-text-tertiary">
+                            You can reactivate your current plan now. Plan changes are
+                            available after {formatDate(subscription.current_period_end)}.
+                          </p>
+                        )}
+
                         {/* Features List */}
                         <div className="space-y-2">
-                          <h4 className="text-sm font-medium text-text-secondary">Features:</h4>
+                          <h4 className="text-sm font-medium text-text-secondary">
+                            Features:
+                          </h4>
                           <ul className="space-y-2">
                             {defaultFeatures.map((feature, idx) => (
                               <li key={idx} className="flex items-start gap-2">
                                 <Check className="w-4 h-4 text-purple-primary flex-shrink-0 mt-0.5" />
-                                <span className="text-sm text-text-tertiary">{feature}</span>
+                                <span className="text-sm text-text-tertiary">
+                                  {feature}
+                                </span>
                               </li>
                             ))}
                           </ul>
@@ -334,12 +363,16 @@ export function PlansSheet({
                         {/* Primary Action */}
                         <button
                           onClick={handleSubscribe}
-                          disabled={isLoading || !selectedPriceId || (isUnlimited && !isCanceling_ && selectedOption?.is_active)}
+                          disabled={
+                            isLoading ||
+                            !selectedPriceId ||
+                            (isUnlimited && !isCanceling_ && selectedOption?.is_active)
+                          }
                           className={cn(
                             'w-full py-3 rounded-xl font-medium transition-colors',
                             'bg-purple-primary text-white',
                             'hover:bg-purple-secondary',
-                            'disabled:opacity-50 disabled:cursor-not-allowed'
+                            'disabled:opacity-50 disabled:cursor-not-allowed',
                           )}
                         >
                           {isLoading ? (
@@ -350,13 +383,26 @@ export function PlansSheet({
                           ) : isCanceling_ ? (
                             'Reactivate Subscription'
                           ) : isUnlimited ? (
-                            selectedOption?.is_active
-                              ? 'Current Plan'
-                              : 'Change Plan'
+                            selectedOption?.is_active ? (
+                              'Current Plan'
+                            ) : (
+                              'Change Plan'
+                            )
                           ) : (
                             'Continue to Payment'
                           )}
                         </button>
+
+                        {!isUnlimited && subscription?.stripe_subscription_id && (
+                          <button
+                            onClick={handleManagePayment}
+                            disabled={isLoading}
+                            className="w-full flex items-center justify-center gap-2 py-2.5 text-text-secondary hover:text-text-primary transition-colors"
+                          >
+                            <CreditCard className="w-4 h-4" />
+                            <span className="text-sm">Manage Billing &amp; Invoices</span>
+                          </button>
+                        )}
 
                         {/* Secondary Actions */}
                         {isUnlimited && (
@@ -367,7 +413,9 @@ export function PlansSheet({
                               className="w-full flex items-center justify-center gap-2 py-2.5 text-text-secondary hover:text-text-primary transition-colors"
                             >
                               <CreditCard className="w-4 h-4" />
-                              <span className="text-sm">Manage Payment Method</span>
+                              <span className="text-sm">
+                                Manage Billing &amp; Invoices
+                              </span>
                             </button>
 
                             {!isCanceling_ && (

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -902,9 +902,7 @@ function UsageSectionContent({
   const currentPriceId = subscription?.current_price_id;
   useEffect(() => {
     if (cachedPlans && cachedPlans.length > 0) {
-      const activePlan = cachedPlans.find(
-        (p) => p.is_active || p.id === currentPriceId,
-      );
+      const activePlan = cachedPlans.find((p) => p.is_active || p.id === currentPriceId);
       if (activePlan) {
         setSelectedPriceId(activePlan.id);
       } else if (!selectedPriceId) {
@@ -996,7 +994,9 @@ function UsageSectionContent({
     setError(null);
 
     try {
-      const isCurrentPlan = selectedOption?.is_active;
+      const isCurrentPlan =
+        selectedOption?.is_active ||
+        selectedOption?.id === subscription?.current_price_id;
 
       if (isCancelingSubscription && selectedPriceId !== subscription?.current_price_id) {
         setError('Plan changes are available after your current subscription ends.');
@@ -1038,6 +1038,11 @@ function UsageSectionContent({
       const result = await getCustomerPortal();
       if (result?.url) {
         window.open(result.url, '_blank');
+        const handleFocus = () => {
+          onSubscriptionUpdate();
+          window.removeEventListener('focus', handleFocus);
+        };
+        window.addEventListener('focus', handleFocus);
       } else {
         setError('Failed to open payment portal');
       }
@@ -1277,7 +1282,7 @@ function UsageSectionContent({
                               {option.price_string}
                             </p>
                             {option.description && (
-                              <p className="text-xs text-purple-400 mt-2 font-medium">
+                              <p className="text-xs text-text-secondary mt-2 font-medium">
                                 {option.description}
                               </p>
                             )}
@@ -1430,7 +1435,7 @@ function UsageSectionContent({
                           {option.price_string}
                         </p>
                         {option.description && (
-                          <p className="text-xs text-purple-400 mt-1">
+                          <p className="text-xs text-text-secondary mt-1">
                             {option.description}
                           </p>
                         )}
@@ -1485,7 +1490,9 @@ function UsageSectionContent({
                 disabled={
                   isLoading ||
                   !selectedPriceId ||
-                  (!isCancelingSubscription && selectedOption?.is_active) ||
+                  (!isCancelingSubscription &&
+                    (selectedOption?.is_active ||
+                      selectedOption?.id === subscription?.current_price_id)) ||
                   (isCancelingSubscription &&
                     selectedPriceId !== subscription?.current_price_id)
                 }
@@ -1503,7 +1510,8 @@ function UsageSectionContent({
                   </span>
                 ) : isCancelingSubscription ? (
                   'Reactivate Subscription'
-                ) : selectedOption?.is_active ? (
+                ) : selectedOption?.is_active ||
+                  selectedOption?.id === subscription?.current_price_id ? (
                   'Current Plan'
                 ) : (
                   'Change Plan'

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -899,7 +899,9 @@ function UsageSectionContent({
   // Set initial selected price when plans load
   useEffect(() => {
     if (cachedPlans && cachedPlans.length > 0 && !selectedPriceId) {
-      const activePlan = cachedPlans.find((p) => p.is_active);
+      const activePlan = cachedPlans.find(
+        (p) => p.is_active || p.id === subscription?.current_price_id,
+      );
       if (activePlan) {
         setSelectedPriceId(activePlan.id);
       } else {
@@ -992,6 +994,11 @@ function UsageSectionContent({
 
     try {
       const isCurrentPlan = selectedOption?.is_active;
+
+      if (isCancelingSubscription && selectedPriceId !== subscription?.current_price_id) {
+        setError('Plan changes are available after your current subscription ends.');
+        return;
+      }
 
       if (isUnlimited && !isCancelingSubscription && !isCurrentPlan) {
         const result = await upgradeSubscription(selectedPriceId);
@@ -1105,12 +1112,23 @@ function UsageSectionContent({
                       <p className="text-sm text-text-tertiary">Free tier</p>
                     </div>
                   </div>
-                  <button
-                    onClick={() => setShowUpgradeOptions(true)}
-                    className="px-5 py-2.5 bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white text-sm font-semibold rounded-xl transition-all shadow-lg shadow-purple-500/20"
-                  >
-                    Upgrade to Unlimited
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setShowUpgradeOptions(true)}
+                      className="px-5 py-2.5 bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white text-sm font-semibold rounded-xl transition-all shadow-lg shadow-purple-500/20"
+                    >
+                      Upgrade to Unlimited
+                    </button>
+                    {subscription?.stripe_subscription_id && (
+                      <button
+                        onClick={handleManagePayment}
+                        disabled={isLoading}
+                        className="px-4 py-2.5 border border-bg-quaternary text-text-secondary hover:text-text-primary text-sm font-medium rounded-xl transition-colors disabled:opacity-50"
+                      >
+                        Billing &amp; Invoices
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 {/* Monthly Listening Usage */}
@@ -1367,7 +1385,8 @@ function UsageSectionContent({
                 <div className="grid grid-cols-2 gap-3">
                   {sortedOptions.map((option) => {
                     const isSelected = selectedPriceId === option.id;
-                    const isCurrent = option.is_active;
+                    const isCurrent =
+                      option.is_active || option.id === subscription?.current_price_id;
                     const isAnnual =
                       option.interval === 'year' ||
                       option.title?.toLowerCase().includes('annual');
@@ -1376,11 +1395,15 @@ function UsageSectionContent({
                       <button
                         key={option.id}
                         onClick={() => setSelectedPriceId(option.id)}
+                        disabled={isCancelingSubscription && !isCurrent}
                         className={cn(
                           'relative p-4 rounded-xl border-2 text-left transition-all',
                           isSelected
                             ? 'border-purple-500 bg-purple-500/5'
                             : 'border-bg-tertiary hover:border-bg-quaternary bg-bg-tertiary/50',
+                          isCancelingSubscription &&
+                            !isCurrent &&
+                            'cursor-not-allowed opacity-50',
                         )}
                       >
                         {isAnnual && (
@@ -1417,6 +1440,13 @@ function UsageSectionContent({
                 </div>
               )}
 
+              {isCancelingSubscription && subscription?.current_period_end && (
+                <p className="text-sm text-text-tertiary">
+                  You can reactivate your current plan now. Plan changes are available
+                  after {formatDate(subscription.current_period_end)}.
+                </p>
+              )}
+
               {/* Features List */}
               <div className="space-y-2">
                 <h4 className="text-sm font-medium text-text-secondary">Features:</h4>
@@ -1444,7 +1474,9 @@ function UsageSectionContent({
                 disabled={
                   isLoading ||
                   !selectedPriceId ||
-                  (!isCancelingSubscription && selectedOption?.is_active)
+                  (!isCancelingSubscription && selectedOption?.is_active) ||
+                  (isCancelingSubscription &&
+                    selectedPriceId !== subscription?.current_price_id)
                 }
                 className={cn(
                   'w-full py-3 rounded-xl font-medium transition-colors',
@@ -1475,7 +1507,7 @@ function UsageSectionContent({
                   className="w-full flex items-center justify-center gap-2 py-2.5 text-text-secondary hover:text-text-primary transition-colors"
                 >
                   <CreditCard className="w-4 h-4" />
-                  <span className="text-sm">Manage Payment Method</span>
+                  <span className="text-sm">Manage Billing &amp; Invoices</span>
                 </button>
 
                 {!isCancelingSubscription && (

--- a/web/app/src/components/settings/SettingsPage.tsx
+++ b/web/app/src/components/settings/SettingsPage.tsx
@@ -896,19 +896,22 @@ function UsageSectionContent({
   const [isCanceling, setIsCanceling] = useState(false);
   const [showUpgradeOptions, setShowUpgradeOptions] = useState(false);
 
-  // Set initial selected price when plans load
+  // Set initial selected price when plans load, and keep it in sync when the
+  // subscription's current price changes (e.g. after a plan change or
+  // cancellation) so a pending-cancellation user isn't left on a stale option.
+  const currentPriceId = subscription?.current_price_id;
   useEffect(() => {
-    if (cachedPlans && cachedPlans.length > 0 && !selectedPriceId) {
+    if (cachedPlans && cachedPlans.length > 0) {
       const activePlan = cachedPlans.find(
-        (p) => p.is_active || p.id === subscription?.current_price_id,
+        (p) => p.is_active || p.id === currentPriceId,
       );
       if (activePlan) {
         setSelectedPriceId(activePlan.id);
-      } else {
+      } else if (!selectedPriceId) {
         setSelectedPriceId(cachedPlans[0].id);
       }
     }
-  }, [cachedPlans, selectedPriceId]);
+  }, [cachedPlans, currentPriceId]);
 
   const formatDuration = (seconds: number) => {
     const hours = Math.floor(seconds / 3600);
@@ -1213,6 +1216,14 @@ function UsageSectionContent({
                   </div>
                 </div>
               </Card>
+
+              {/* Billing error surfaced in the Basic view (not only the upgrade panel) */}
+              {error && !showUpgradeOptions && (
+                <div className="flex items-center gap-2 p-3 bg-red-500/10 rounded-xl border border-red-500/20">
+                  <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
+                  <p className="text-sm text-red-400">{error}</p>
+                </div>
+              )}
 
               {/* Upgrade Options (shown when clicked) */}
               {showUpgradeOptions && (

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -1445,6 +1445,7 @@ export async function getUserSubscription(): Promise<UserSubscription | null> {
       status: response.subscription?.status || 'active',
       is_unlimited: paidPlans.includes(response.subscription?.plan ?? ''),
       current_period_end: response.subscription?.current_period_end,
+      stripe_subscription_id: response.subscription?.stripe_subscription_id,
       cancel_at_period_end: response.subscription?.cancel_at_period_end,
       current_price_id: response.subscription?.current_price_id,
       features: response.subscription?.features || [],

--- a/web/app/src/types/user.ts
+++ b/web/app/src/types/user.ts
@@ -128,6 +128,7 @@ export interface UserSubscription {
   status: string;
   is_unlimited: boolean;
   current_period_end?: number;
+  stripe_subscription_id?: string;
   cancel_at_period_end?: boolean;
   current_price_id?: string;
   features?: string[];
@@ -136,8 +137,11 @@ export interface UserSubscription {
 // Pricing option for a plan (matches backend PricingOption)
 export interface PricingOption {
   id: string;
+  plan_id?: string;
   title: string;
   description?: string;
+  subtitle?: string;
+  eyebrow?: string;
   price_string: string;
   interval?: string;
   unit_amount?: number;


### PR DESCRIPTION
## What changed and why

Make billing recovery discoverable for inactive or past-due Stripe subscriptions, return plan descriptions in the catalog, and prevent changing plans until a cancel-at-period-end subscription actually ends. Same-plan reactivation remains available.

## Product invariants affected

none

## How it was verified

- `make preflight` passed all 10 selected checks.
- Focused backend tests passed: payment promotions (18), subscription plans (16), and available plans resilience (5).
- Python compilation and `git diff --check` passed.
- Live Stripe account recovery and portal invoice configuration were not exercised locally.

## Tests

- Added regression coverage for pending-cancellation plan changes and cancellation timing.
- Added catalog description assertions and preserved the existing payment/subscription test paths.

## Failure class (fixes)

Failure-Class: none



Line-Count-Exception: backend/routers/payment.py | 1483 -> 1534 | Stripe-backed stale-subscription recovery and deferred plan-change boundary with regression coverage.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment eligibility, upgrades, and Stripe/Firestore reconciliation—incorrect matching could block legitimate upgrades or allow wrong checkouts; UI/backend must stay aligned on pending-cancellation rules.
> 
> **Overview**
> Tightens **cancel-at-period-end** behavior end-to-end: plan switches to a different price are blocked until the current period ends, while **same plan + billing interval** reactivation stays allowed (including legacy price IDs via `price_ids_match_plan_and_interval`).
> 
> **Backend** enforces this in `can_user_make_payment`, upgrade (409 when pending cancellation), and `_try_reactivate_subscription` with a **Firestore → Stripe** fallback when local subscription rows are stale, plus observability via `record_fallback`. The available-plans API now surfaces plan **descriptions** on monthly/annual options.
> 
> **Web and Flutter** mirror the rules (disable other plans, client-side guards, treat `current_price_id` as “current”), expose **billing portal** for anyone with a Stripe subscription (not only “unlimited”), refresh subscription after returning from the portal, and plumb `stripe_subscription_id` through the web client types/API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9a2d58933cf66fd648751c5141e0efe842dcd1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



