### PR TITLE
perf(backend): bound the chat-quota month read to the current month

### DIFF
--- a/backend/database/firestore_read_metrics.py
+++ b/backend/database/firestore_read_metrics.py
@@ -13,6 +13,7 @@ class FirestoreReadFamily(StrEnum):
     ACTION_ITEMS_LIST = 'action_items_list'
     LISTEN_MONTHLY_USAGE = 'listen_monthly_usage'
     ALL_TIME_USAGE = 'all_time_usage'
+    CHAT_QUOTA_MONTHLY_USAGE = 'chat_quota_monthly_usage'
 
 
 class FirestoreReadMode(StrEnum):

--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -12,11 +12,42 @@ from models.user_usage import UsageStats
 
 logger = logging.getLogger(__name__)
 
+# Firestore's document-id sentinel field path (`FieldPath.document_id()`), spelled
+# literally: tests that stub `google.cloud.firestore_v1` as a plain module cannot
+# import its `field_path` submodule.
+_DOCUMENT_ID_FIELD = '__name__'
+
 
 def _typed_doc(doc: Any) -> Dict[str, Any]:
     """Typed adapter for a Firestore snapshot's `to_dict()` (SDK stub gap)."""
     raw: object = doc.to_dict()
     return cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
+
+
+def _next_month(now: datetime) -> Tuple[int, int]:
+    """(year, month) of the UTC month after ``now`` — the quota bucket boundary."""
+    if now.month == 12:
+        return now.year + 1, 1
+    return now.year, now.month + 1
+
+
+def _current_month_llm_usage_docs(llm_usage_ref: Any, now: datetime) -> Iterable[Any]:
+    """Stream only the current month's `llm_usage/{YYYY-MM-DD}` docs.
+
+    Bounded by document id, so the read stays at "days elapsed this month"
+    regardless of how long the account has existed. Listing the whole
+    collection and fetching the in-month days one at a time grew both the read
+    count and the round-trips with account age, on the path every chat request
+    takes through ``enforce_chat_quota``.
+    """
+    next_year, next_month = _next_month(now)
+    start = llm_usage_ref.document(f'{now.year}-{now.month:02d}-01')
+    end = llm_usage_ref.document(f'{next_year}-{next_month:02d}-01')
+    return (
+        llm_usage_ref.where(filter=FieldFilter(_DOCUMENT_ID_FIELD, '>=', start))
+        .where(filter=FieldFilter(_DOCUMENT_ID_FIELD, '<', end))
+        .stream()
+    )
 
 
 def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> Dict[str, Any]:
@@ -31,17 +62,13 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> Dict[str
     excluded on purpose — those are company-driven, not user-initiated questions.
     """
     now = now or datetime.now(timezone.utc)
-    month_prefix = f'{now.year}-{now.month:02d}-'
 
     llm_usage_ref = db.collection('users').document(uid).collection('llm_usage')
     questions = 0
     cost_usd = 0.0
-    for doc in llm_usage_ref.list_documents():
-        if not doc.id.startswith(month_prefix):
-            continue
-        snap = doc.get()
-        if not snap.exists:
-            continue
+    document_count = 0
+    for snap in _current_month_llm_usage_docs(llm_usage_ref, now):
+        document_count += 1
         data: Dict[str, Any] = _typed_doc(snap)
         has_desktop_realtime_quota_questions = 'desktop_chat_realtime.quota_questions' in data or (
             isinstance(data.get('desktop_chat_realtime'), dict) and 'quota_questions' in data['desktop_chat_realtime']
@@ -86,11 +113,14 @@ def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> Dict[str
                 # backend_chat.quota_questions so LLM telemetry no longer drives quota.
                 questions += int(value)
 
+    record_firestore_read(
+        FirestoreReadFamily.CHAT_QUOTA_MONTHLY_USAGE,
+        FirestoreReadMode.BOUNDED,
+        document_count,
+    )
+
     # Compute end-of-month boundary in UTC for the reset timestamp.
-    if now.month == 12:
-        next_year, next_month = now.year + 1, 1
-    else:
-        next_year, next_month = now.year, now.month + 1
+    next_year, next_month = _next_month(now)
     reset_at = int(datetime(next_year, next_month, 1, tzinfo=timezone.utc).timestamp())
 
     return {

--- a/backend/tests/unit/test_user_usage.py
+++ b/backend/tests/unit/test_user_usage.py
@@ -32,8 +32,9 @@ def mock_db(monkeypatch):
 
 
 class _Snap:
-    def __init__(self, data):
+    def __init__(self, data, doc_id=None):
         self._d = data
+        self.id = doc_id
         self.exists = True
 
     def to_dict(self):
@@ -46,14 +47,44 @@ class _DocRef:
         self._data = data
 
     def get(self):
-        return _Snap(self._data)
+        return _Snap(self._data, self.id)
+
+
+class _LlmUsageCollection:
+    """Firestore collection fake that actually applies the `__name__` range
+    filters the month query issues, so the first/last day of the month and the
+    adjacent months are exercised rather than assumed. `list_documents` raises:
+    the quota reader must never fall back to scanning the account's whole
+    llm_usage history."""
+
+    def __init__(self, docs, filters=()):
+        self._docs = docs
+        self._filters = filters
+
+    def document(self, doc_id):
+        return _DocRef(doc_id, self._docs.get(doc_id, {}))
+
+    def list_documents(self):
+        raise AssertionError("chat-quota reads must stay bounded to the current month")
+
+    def where(self, filter):
+        return _LlmUsageCollection(self._docs, (*self._filters, filter))
+
+    def stream(self):
+        def _match(doc_id):
+            for f in self._filters:
+                assert f.field_path == "__name__"  # Firestore's document-id sentinel
+                if f.op_string == ">=" and doc_id < f.value.id:
+                    return False
+                if f.op_string == "<" and doc_id >= f.value.id:
+                    return False
+            return True
+
+        return iter([_Snap(data, doc_id) for doc_id, data in self._docs.items() if _match(doc_id)])
 
 
 def _setup_docs(mock_db, docs):
-    refs = [_DocRef(k, v) for k, v in docs.items()]
-    llm_usage_ref = MagicMock()
-    llm_usage_ref.list_documents.return_value = refs
-    mock_db.collection.return_value.document.return_value.collection.return_value = llm_usage_ref
+    mock_db.collection.return_value.document.return_value.collection.return_value = _LlmUsageCollection(docs)
 
 
 NOW = datetime(2026, 6, 23, tzinfo=timezone.utc)
@@ -107,6 +138,41 @@ def test_realtime_ptt_included_via_grand_total(mock_db):
 def test_only_proactive_counts_zero(mock_db):
     _setup_docs(mock_db, {"2026-06-23": {"conv_apps.gpt-5.call_count": 100, "memories.gpt-4.call_count": 50}})
     assert user_usage.get_monthly_chat_usage("uid", now=NOW)["questions"] == 0
+
+
+def test_month_read_is_bounded_to_the_current_month(mock_db, monkeypatch):
+    # `enforce_chat_quota` calls this on every chat request. Reading the whole
+    # llm_usage collection made the cost of asking a question grow with how long
+    # the account had existed.
+    _setup_docs(
+        mock_db,
+        {
+            "2025-06-23": {"desktop_chat": {"quota_questions": 500}},  # last year
+            "2026-05-31": {"desktop_chat": {"quota_questions": 400}},  # day before the month
+            "2026-06-01": {"desktop_chat": {"quota_questions": 1}},  # first day, inclusive
+            "2026-06-30": {"desktop_chat": {"quota_questions": 2}},  # last day, inclusive
+            "2026-07-01": {"desktop_chat": {"quota_questions": 300}},  # day after the month
+        },
+    )
+    observed = []
+    monkeypatch.setattr(user_usage, "record_firestore_read", lambda *args: observed.append(args))
+
+    assert user_usage.get_monthly_chat_usage("uid", now=NOW)["questions"] == 3
+    assert observed == [(FirestoreReadFamily.CHAT_QUOTA_MONTHLY_USAGE, FirestoreReadMode.BOUNDED, 2)]
+
+
+def test_december_month_read_stops_at_the_january_boundary(mock_db):
+    _setup_docs(
+        mock_db,
+        {
+            "2026-12-01": {"desktop_chat": {"quota_questions": 4}},
+            "2026-12-31": {"desktop_chat": {"quota_questions": 6}},
+            "2027-01-01": {"desktop_chat": {"quota_questions": 900}},
+        },
+    )
+    usage = user_usage.get_monthly_chat_usage("uid", now=datetime(2026, 12, 15, tzinfo=timezone.utc))
+    assert usage["questions"] == 10
+    assert usage["reset_at"] == int(datetime(2027, 1, 1, tzinfo=timezone.utc).timestamp())
 
 
 def test_monthly_usage_since_observes_every_scanned_hourly_document(mock_db, monkeypatch):


### PR DESCRIPTION
## What

`get_monthly_chat_usage` — the chat-quota counter read — now issues one bounded
document-id range query over the current month instead of listing the account's
entire `llm_usage` collection and fetching the in-month days one at a time.

## Why

This is not a reporting path. It runs inside `enforce_chat_quota`, so **every
chat request pays for it** (`backend/routers/desktop_chat.py:1217`,
`backend/routers/chat.py:299,586`), plus the overage check
(`backend/utils/overage.py:112`) and `/v1/users/me/usage-quota`.

The old shape (`backend/database/user_usage.py`):

```python
for doc in llm_usage_ref.list_documents():      # every day the account ever wrote
    if not doc.id.startswith(month_prefix):     # filtered client-side
        continue
    snap = doc.get()                            # one more RPC per in-month day
```

`llm_usage` holds one `YYYY-MM-DD` doc per day of activity, so both the reads and
the round-trips grew with **account age**: a two-year daily-active account listed
~730 document ids and then made ~30 sequential `get()` calls to answer "how many
questions this month". New accounts are cheap; the longest-tenured, heaviest users
— the ones behind the read spikes in #10950 / #10817 — are charged the most per
message, and they pay it in latency on every send.

This is the "narrowly scoped first implementation" #9889 asks for, with the source
and measurement its last triage comment asked for before another change landed.

## What changed

- `_current_month_llm_usage_docs()` streams `[YYYY-MM-01, <next month>-01)` by
  document id — a single-field `__name__` range, so no composite index (the
  `firestore-query-coverage` preflight check agrees).
- The read is reported through the existing `record_firestore_read` telemetry as
  a new `chat_quota_monthly_usage` **bounded** family, matching how
  `get_monthly_usage_stats_since` and `_read_all_time_usage` already report — the
  per-family, no-user-content attribution #9889 wants.
- `_next_month()` extracted so the query boundary and the `reset_at` boundary
  cannot drift apart.

No change to which documents are summed or how their fields are interpreted.

## Verification

**Differential run against a real Firestore emulator** (`gcloud emulators
firestore`, 56 seeded `llm_usage` docs spanning 2025–2027 for one uid), executing
the old reader and the new one side by side:

| `now` | old | new | docs read |
|---|---|---|---|
| 2026-08 | 28 questions / $2.75 | 28 / $2.75 | **61 → 5** |
| 2026-12 (Dec→Jan rollover) | 38 questions | 38 | **60 → 4** |
| 2024-03 (month with no data) | 0 | 0 | **56 → 0** |

`RESULT: PASS — identical totals, bounded reads`. Boundary documents
`2026-07-31`, `2026-09-01` and `2027-01-01` stay excluded; `2026-08-01` and
`2026-08-31` stay included.

**Regression tests** (`backend/tests/unit/test_user_usage.py`): the collection
fake now applies the real `__name__` range filters instead of returning
everything, and raises if anything calls `list_documents()`, so an all-time scan
cannot come back unnoticed. Both new tests fail on the parent commit
(`AssertionError: chat-quota reads must stay bounded to the current month`) and
pass here.

The full suite also caught a first attempt that imported
`google.cloud.firestore_v1.field_path`: several backend tests stub
`google.cloud.firestore_v1` as a plain module, so that submodule import broke
`test_users_add_sample_transaction.py` at import time. The field path is now
spelled literally (`'__name__'`, which is exactly what `FieldPath.document_id()`
returns) and that file passes again.

Commands run:

- `pytest tests/unit/test_user_usage.py tests/unit/test_chat_quota.py` → 27 passed
- `backend/test.sh` (full, 841 files) → the 14 failing files are **identical on
  this branch and on `origin/main`** when re-run with the same runner
  (`test_agent_vm_startup`, `test_sync_v2`, `test_http_timeout_defaults`,
  `test_action_item_canonical_contract`, … — local CPU-time guard/environment
  failures, none of them touched here)
- `backend/scripts/typecheck.sh` → 0 errors
- `make preflight` → 24 checks passed
- `black --line-length 120 --skip-string-normalization` → clean

Refs #9889, #10950, #10817.

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

