### PR TITLE
fix(desktop): capture screenshot rowid so new frames get embedded (#11204)

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
@@ -4,7 +4,11 @@ import Foundation
 // MARK: - Screenshot Model
 
 /// Represents a captured screenshot stored in the Rewind database
-struct Screenshot: Codable, FetchableRecord, PersistableRecord, Identifiable, Equatable {
+// `MutablePersistableRecord` — not `PersistableRecord` — because the rowid is
+// captured by a `mutating didInsert`. `PersistableRecord`'s requirement is
+// non-mutating, so a mutating declaration silently witnesses nothing and the
+// empty default runs instead, leaving `id` nil after every insert.
+struct Screenshot: Codable, FetchableRecord, MutablePersistableRecord, Identifiable, Equatable {
   /// Database row ID (auto-generated)
   var id: Int64?
 

--- a/desktop/macos/Desktop/Tests/RewindScreenshotRowIDCaptureTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindScreenshotRowIDCaptureTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// `Screenshot` captures its rowid in a `mutating didInsert`, which only
+/// witnesses `MutablePersistableRecord`. Under `PersistableRecord` the
+/// declaration compiles, is never called, and `insertScreenshot` returns
+/// `id == nil` — silently disabling every `if let id = inserted.id` consumer,
+/// notably the OCR embedding queue in `RewindIndexer`.
+final class RewindScreenshotRowIDCaptureTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "rewind-screenshot-rowid")
+  }
+
+  override func tearDown() async throws {
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testInsertScreenshotReturnsPersistedRowID() async throws {
+    let screenshot = Screenshot(
+      timestamp: Date(),
+      appName: "RowIDCapture",
+      windowTitle: "Rowid capture",
+      ocrText: "captured ocr text",
+      isIndexed: true
+    )
+
+    let inserted = try await RewindDatabase.shared.insertScreenshot(screenshot)
+
+    let rowID = try XCTUnwrap(inserted.id, "insertScreenshot must return the persisted rowid")
+    let persisted = try await RewindDatabase.shared.getRecentScreenshots(limit: 1)
+    XCTAssertEqual(persisted.first?.id, rowID)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260807-rewind-embedding-rowid.json
+++ b/desktop/macos/changelog/unreleased/20260807-rewind-embedding-rowid.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed screen-history semantic search missing everything captured after the initial backfill \u2014 newly captured frames were never queued for embedding"
+}


### PR DESCRIPTION
Refs #11204. This fixes the one confirmed-harmful instance; the issue stays **open** for the remaining 14 record types it lists.

## Bug

Screen-history semantic search silently stops covering anything captured after the first backfill. No error, no crash, no warning — newly captured frames are simply never embedded.

## Root cause

`Screenshot` captures its rowid in a `mutating didInsert`, but conformed to GRDB's `PersistableRecord`, whose `didInsert` requirement is **non-mutating** and ships an empty default implementation. A `mutating` method cannot witness a non-mutating requirement, so the declaration compiled, was never called, and the no-op default ran instead.

Consequence: `RewindDatabase.insertScreenshot` returned `id == nil` for every frame, and all three `RewindIndexer` call sites gate the OCR embedding on `if let id = inserted.id` (`RewindIndexer.swift:328/418/542`) — so no captured frame was ever queued for embedding. It looked fine only because `OCREmbeddingService.backfillIfNeeded()` derives its own ids from `SELECT id … WHERE embedding IS NULL`; once that backfill marks itself complete, nothing captured afterwards is ever embedded.

## Fix

Conform `Screenshot` to `MutablePersistableRecord`, where the mutating `didInsert` is the witness. `PersistableRecord` refines `MutablePersistableRecord`, and the sole insert call site (`insertScreenshot`, which already uses `var record`) is unaffected — there are no `.save`/`.upsert` call sites for this type.

## What I tested

- **Standalone GRDB 6.29.3 repro** (the exact pinned version): the same struct shape under `PersistableRecord` returns `id = nil` after insert; under `MutablePersistableRecord` it returns the rowid.
- **New regression test** `RewindScreenshotRowIDCaptureTests` inserts through the production `RewindDatabase.insertScreenshot` seam and asserts the returned id matches the persisted row. It **fails on the pre-fix conformance** (`XCTUnwrap failed: expected non-nil value of type "Int64" - insertScreenshot must return the persisted rowid`) and passes after — verified by reverting the one-line conformance, rebuilding, and re-running.
- `xcrun swift test -c debug --filter "Rewind|OCREmbedding|ScreenCapture"` → **126 tests, 0 failures**, including `RewindAbandonedChunkRecoveryTests` / `RewindArtifactGauntletTests` / `RewindOCRContinuationTests`, which drive `RewindIndexer.processFrame` into `insertScreenshot` end to end.
- `xcrun swift build -c debug --build-tests` clean.

## Scope

Issue #11204 lists 14 further record types with the same shape. They are deliberately left alone: harm there is per-type and unproven, and the issue explicitly asks for per-type evidence rather than a blanket sweep. This PR fixes the one confirmed-harmful instance and adds the guard test for it.

Failure-Class: none

(Declared `none` rather than registering a new class: this is a single confirmed instance, and the class-level question — 14 more record types with the same shape, and whether a lint or per-type insert test should cover them — is exactly what #11204 tracks and stays open for.)

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

