### PR TITLE
fix(app): surface disabled Bluetooth

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
@@ -168,8 +168,9 @@ class OmiBleManager private constructor(private val application: Application) {
     private val adapterStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             if (intent.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+            val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
             mainHandler.post {
-                flutterApi?.onBluetoothStateChanged(getBluetoothState()) {}
+                flutterApi?.onBluetoothStateChanged(bluetoothStateFrom(state)) {}
             }
         }
     }
@@ -483,7 +484,11 @@ class OmiBleManager private constructor(private val application: Application) {
 
     fun getBluetoothState(): String {
         val adapter = bluetoothAdapter ?: return "unsupported"
-        return when (adapter.state) {
+        return bluetoothStateFrom(adapter.state)
+    }
+
+    private fun bluetoothStateFrom(state: Int): String {
+        return when (state) {
             BluetoothAdapter.STATE_ON -> "on"
             BluetoothAdapter.STATE_OFF -> "off"
             BluetoothAdapter.STATE_TURNING_ON -> "resetting"

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleManager.kt
@@ -165,9 +165,24 @@ class OmiBleManager private constructor(private val application: Application) {
         }
     }
 
+    private val adapterStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+            mainHandler.post {
+                flutterApi?.onBluetoothStateChanged(getBluetoothState()) {}
+            }
+        }
+    }
+
     init {
         Log.i(TAG, "OmiBleManager initialized")
         application.registerReceiver(bondStateReceiver, IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED))
+        ContextCompat.registerReceiver(
+            application,
+            adapterStateReceiver,
+            IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
     }
 
     // ── Scanning ──

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -112,6 +112,7 @@ final class OmiBleManager: NSObject {
     }
 
     func stopScan() {
+        pendingScan = nil
         guard isScanning else { return }
         isScanning = false
         scanTimer?.invalidate()

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/widgets/bluetooth_guidance_listener.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:opus_dart/opus_dart.dart';
@@ -399,9 +400,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                 return CustomErrorWidget(errorMessage: errorDetails.exceptionAsString());
               };
               final content = child!;
+              final guidedContent = BluetoothGuidanceListener(child: content);
               return PlatformService.isIOS && Env.posthogApiKey != null
-                  ? RageClickContextTracker(child: content)
-                  : content;
+                  ? RageClickContextTracker(child: guidedContent)
+                  : guidedContent;
             },
             home: TalkerWrapper(
               talker: Logger.instance.talker,

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -17,6 +17,7 @@ import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/providers/base_provider.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/bluetooth_readiness.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/audio/foreground.dart';
@@ -129,15 +130,6 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       Logger.debug('bleStatus: $bleStatus');
       updateBluetoothPermission(bleStatus.isGranted);
     } else {
-      if (Platform.isAndroid) {
-        // Show the system "enable Bluetooth" prompt if the adapter is off.
-        // No-op when Bluetooth is already on.
-        try {
-          await BleHostApi().enableBluetooth();
-        } catch (e) {
-          Logger.debug('enableBluetooth failed: $e');
-        }
-      }
       PermissionStatus bleScanStatus = await Permission.bluetoothScan.request();
       PermissionStatus bleConnectStatus = await Permission.bluetoothConnect.request();
       updateBluetoothPermission(bleConnectStatus.isGranted && bleScanStatus.isGranted);
@@ -149,6 +141,9 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
           updateLocationPermission(locationStatus.isGranted);
         }
       }
+    }
+    if (hasBluetoothPermission) {
+      await BluetoothReadiness.instance.ensureReady(BluetoothUse.discovery);
     }
     notifyListeners();
   }
@@ -293,6 +288,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       deviceAlreadyUnpaired();
     }
 
+    // Subscribe before checking the adapter so a successful enable action can
+    // retry discovery and publish its results back to this page.
+    ServiceManager.instance().device.subscribe(this, this);
+
     // check if bluetooth is enabled on both platforms
     if (!hasBluetoothPermission) {
       await askForBluetoothPermissions();
@@ -300,6 +299,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
         onShowDialog();
         return;
       }
+    }
+
+    if (!await BluetoothReadiness.instance.ensureReady(BluetoothUse.discovery)) {
+      return;
     }
 
     // Android 11 and below: location permission required for BLE scanning
@@ -320,7 +323,6 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       notifyListeners();
     });
 
-    ServiceManager.instance().device.subscribe(this, this);
     await deviceProvider?.initiateConnection("Onboarding");
   }
 

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -301,10 +301,6 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       }
     }
 
-    if (!await BluetoothReadiness.instance.ensureReady(BluetoothUse.discovery)) {
-      return;
-    }
-
     // Android 11 and below: location permission required for BLE scanning
     if (PlatformService.isAndroid) {
       final deviceInfo = await DeviceInfoPlugin().androidInfo;
@@ -316,6 +312,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
           return;
         }
       }
+    }
+
+    if (!await BluetoothReadiness.instance.ensureReady(BluetoothUse.discovery)) {
+      return;
     }
 
     _didNotMakeItTimer = Timer(const Duration(seconds: 10), () {

--- a/app/lib/services/bridges/ble_bridge.dart
+++ b/app/lib/services/bridges/ble_bridge.dart
@@ -27,7 +27,7 @@ class BleBridge implements BleFlutterApi {
   final Map<String, DeviceReadyCallback> _deviceReadyCallbacks = {};
   final Map<String, RssiUpdateCallback> _rssiCallbacks = {};
 
-  void Function(String state)? bluetoothStateChangedCallback;
+  final Set<void Function(String state)> _bluetoothStateListeners = {};
   void Function(BlePeripheral peripheral)? peripheralDiscoveredCallback;
   void Function(List<String> peripheralUuids)? stateRestoredCallback;
   VoidCallback? pairingLostCallback;
@@ -39,6 +39,14 @@ class BleBridge implements BleFlutterApi {
 
   void removeBatchRecordingFinalizedListener(void Function(String fileName) cb) =>
       _batchRecordingFinalizedListeners.remove(cb);
+
+  /// Registers a listener for adapter-state changes without taking ownership of
+  /// the bridge's other BLE callbacks. Returns a disposer so short-lived UI and
+  /// service consumers cannot leave stale listeners behind.
+  VoidCallback addBluetoothStateListener(void Function(String state) listener) {
+    _bluetoothStateListeners.add(listener);
+    return () => _bluetoothStateListeners.remove(listener);
+  }
 
   void registerPeripheral({
     required String peripheralUuid,
@@ -69,7 +77,9 @@ class BleBridge implements BleFlutterApi {
 
   @override
   void onBluetoothStateChanged(String state) {
-    bluetoothStateChangedCallback?.call(state);
+    for (final listener in List.of(_bluetoothStateListeners)) {
+      listener(state);
+    }
   }
 
   @override

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -9,7 +9,6 @@ import 'package:omi/services/devices/discovery/apple_watch_discoverer.dart';
 import 'package:omi/services/devices/discovery/rayban_meta_discoverer.dart';
 import 'package:omi/services/devices/discovery/device_discoverer.dart';
 import 'package:omi/services/devices/discovery/native_bluetooth_discoverer.dart';
-import 'package:omi/services/devices/errors.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/mutex.dart';
@@ -44,6 +43,8 @@ abstract class IDeviceServiceSubsciption {
 class DeviceService {
   DeviceServiceStatus _status = DeviceServiceStatus.init;
   List<BtDevice> _devices = [];
+  Future<void>? _activeDiscovery;
+  Future<void>? _queuedDiscovery;
 
   final List<DeviceDiscoverer> _discoverers = [
     NativeBluetoothDiscoverer(),
@@ -60,13 +61,36 @@ class DeviceService {
 
   DateTime? _firstConnectedAt;
 
-  Future<void> discover({String? desirableDeviceId, int timeout = 5}) async {
-    Logger.debug("Device discovering...");
-    if (_status != DeviceServiceStatus.ready) {
-      logCommonErrorMessage("Device service is not ready, may busying or stop");
-      return;
+  /// Runs one follow-up scan when a caller retries while the current scan is
+  /// still winding down. In particular, this makes the Bluetooth-enable
+  /// recovery action reliable instead of silently returning while a blocked
+  /// scan still owns the service.
+  Future<void> discover({String? desirableDeviceId, int timeout = 5}) {
+    if (_queuedDiscovery != null) return _queuedDiscovery!;
+    if (_status == DeviceServiceStatus.scanning) {
+      final activeDiscovery = _activeDiscovery;
+      if (activeDiscovery == null) return Future.value();
+      return _queuedDiscovery ??= activeDiscovery.then<void>(
+        (_) => _runQueuedDiscovery(desirableDeviceId: desirableDeviceId, timeout: timeout),
+        onError: (_, __) => _runQueuedDiscovery(desirableDeviceId: desirableDeviceId, timeout: timeout),
+      );
     }
+    if (_status != DeviceServiceStatus.ready) {
+      Logger.debug('Device service is not ready, may busying or stop');
+      return Future.value();
+    }
+    return _discover(desirableDeviceId: desirableDeviceId, timeout: timeout);
+  }
 
+  Future<void> _runQueuedDiscovery({String? desirableDeviceId, required int timeout}) async {
+    _queuedDiscovery = null;
+    await discover(desirableDeviceId: desirableDeviceId, timeout: timeout);
+  }
+
+  Future<void> _discover({String? desirableDeviceId, required int timeout}) async {
+    Logger.debug("Device discovering...");
+    final completion = Completer<void>();
+    _activeDiscovery = completion.future;
     _status = DeviceServiceStatus.scanning;
 
     try {
@@ -100,6 +124,8 @@ class DeviceService {
       }
     } finally {
       _status = DeviceServiceStatus.ready;
+      if (!completion.isCompleted) completion.complete();
+      _activeDiscovery = null;
     }
   }
 

--- a/app/lib/services/devices/bluetooth_readiness.dart
+++ b/app/lib/services/devices/bluetooth_readiness.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'package:omi/gen/pigeon_communicator.g.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
+
+enum BluetoothAdapterState { on, off, unauthorized, unsupported, resetting, unknown }
+
+enum BluetoothUse { discovery, connection }
+
+/// A user-actionable adapter problem. Permissions and radio power are distinct:
+/// a granted Bluetooth permission does not mean the adapter is switched on.
+class BluetoothGuidance {
+  final int id;
+  final BluetoothAdapterState state;
+  final BluetoothUse use;
+
+  const BluetoothGuidance({required this.id, required this.state, required this.use});
+}
+
+/// Thrown after guidance has been published so callers cannot mistake a blocked
+/// connection attempt for a successfully created transport.
+class BluetoothAdapterUnavailableException implements Exception {
+  final BluetoothAdapterState state;
+
+  const BluetoothAdapterUnavailableException(this.state);
+
+  @override
+  String toString() => 'Bluetooth adapter is unavailable: $state';
+}
+
+/// Shared adapter readiness boundary for BLE discovery and connection attempts.
+///
+/// Native callbacks are treated as updates, while every user-visible operation
+/// queries the authoritative native state immediately before it starts. This
+/// avoids relying on a startup callback that can arrive before Dart is ready.
+class BluetoothReadiness extends ChangeNotifier {
+  BluetoothReadiness({
+    Future<String> Function()? readState,
+    Future<bool> Function()? requestEnable,
+    Future<BluetoothAdapterState?> Function(BluetoothUse use)? permissionState,
+    bool observeBridge = true,
+  })  : _readState = readState ?? (() => BleHostApi().getBluetoothState()),
+        _requestEnable = requestEnable ?? (() => BleHostApi().enableBluetooth()),
+        _permissionState = permissionState {
+    if (observeBridge) {
+      _removeBridgeListener = BleBridge.instance.addBluetoothStateListener(_onNativeStateChanged);
+    }
+  }
+
+  static final BluetoothReadiness instance = BluetoothReadiness();
+
+  final Future<String> Function() _readState;
+  final Future<bool> Function() _requestEnable;
+  final Future<BluetoothAdapterState?> Function(BluetoothUse use)? _permissionState;
+  VoidCallback? _removeBridgeListener;
+
+  BluetoothAdapterState _state = BluetoothAdapterState.unknown;
+  BluetoothGuidance? _guidance;
+  BluetoothAdapterState? _dismissedBlockedState;
+  int _nextGuidanceId = 0;
+
+  BluetoothAdapterState get state => _state;
+  BluetoothGuidance? get guidance => _guidance;
+
+  static BluetoothAdapterState parse(String value) => switch (value) {
+        'on' => BluetoothAdapterState.on,
+        'off' => BluetoothAdapterState.off,
+        'unauthorized' => BluetoothAdapterState.unauthorized,
+        'unsupported' => BluetoothAdapterState.unsupported,
+        'resetting' => BluetoothAdapterState.resetting,
+        _ => BluetoothAdapterState.unknown,
+      };
+
+  /// Returns false and publishes one deduplicated guidance event when BLE is
+  /// unavailable. Call this directly before beginning a BLE operation.
+  Future<bool> ensureReady(BluetoothUse use) async {
+    final permissionState = await (_permissionState?.call(use) ?? _currentPermissionState(use));
+    if (permissionState != null) {
+      _applyState(permissionState, use: use);
+      return false;
+    }
+    _applyState(parse(await _readState()), use: use);
+    return _state == BluetoothAdapterState.on;
+  }
+
+  Future<BluetoothAdapterState?> _currentPermissionState(BluetoothUse use) async {
+    if (Platform.isIOS) {
+      return await Permission.bluetooth.isGranted ? null : BluetoothAdapterState.unauthorized;
+    }
+    if (!Platform.isAndroid) return null;
+
+    final sdk = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
+    if (sdk < 31) return null;
+    final connectGranted = await Permission.bluetoothConnect.isGranted;
+    final scanGranted = use == BluetoothUse.discovery ? await Permission.bluetoothScan.isGranted : true;
+    return connectGranted && scanGranted ? null : BluetoothAdapterState.unauthorized;
+  }
+
+  /// Android opens the platform enable prompt. iOS reports false; its dialog
+  /// explains that the user must switch Bluetooth on outside the app.
+  Future<bool> requestEnable(BluetoothUse use) async {
+    try {
+      await _requestEnable();
+    } finally {
+      final next = parse(await _readState());
+      if (next == BluetoothAdapterState.on) {
+        _applyState(next);
+      } else {
+        // The system prompt was cancelled or declined. Suppress the same
+        // guidance until the adapter changes state so it cannot immediately
+        // reopen after the user dismisses the platform prompt.
+        _dismissedBlockedState = next;
+        _guidance = null;
+        _applyState(next);
+        notifyListeners();
+      }
+    }
+    return _state == BluetoothAdapterState.on;
+  }
+
+  void dismissGuidance(int id) {
+    if (_guidance?.id != id) return;
+    _dismissedBlockedState = _guidance!.state;
+    _guidance = null;
+    notifyListeners();
+  }
+
+  @visibleForTesting
+  void onNativeStateChangedForTesting(String value) => _onNativeStateChanged(value);
+
+  void _onNativeStateChanged(String value) {
+    _applyState(parse(value));
+  }
+
+  void _applyState(BluetoothAdapterState next, {BluetoothUse? use}) {
+    final previous = _state;
+    _state = next;
+    if (next == BluetoothAdapterState.on) {
+      _dismissedBlockedState = null;
+      if (_guidance != null || previous != next) {
+        _guidance = null;
+        notifyListeners();
+      }
+      return;
+    }
+
+    if (use != null && _guidance == null && _dismissedBlockedState != next) {
+      _guidance = BluetoothGuidance(id: ++_nextGuidanceId, state: next, use: use);
+      notifyListeners();
+      return;
+    }
+    if (previous != next) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _removeBridgeListener?.call();
+    _removeBridgeListener = null;
+    super.dispose();
+  }
+}

--- a/app/lib/services/devices/bluetooth_readiness.dart
+++ b/app/lib/services/devices/bluetooth_readiness.dart
@@ -7,6 +7,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/utils/logger.dart';
 
 enum BluetoothAdapterState { on, off, unauthorized, unsupported, resetting, unknown }
 
@@ -79,13 +80,20 @@ class BluetoothReadiness extends ChangeNotifier {
   /// Returns false and publishes one deduplicated guidance event when BLE is
   /// unavailable. Call this directly before beginning a BLE operation.
   Future<bool> ensureReady(BluetoothUse use) async {
-    final permissionState = await (_permissionState?.call(use) ?? _currentPermissionState(use));
-    if (permissionState != null) {
-      _applyState(permissionState, use: use);
+    try {
+      final permissionState = await (_permissionState?.call(use) ?? _currentPermissionState(use));
+      if (permissionState != null) {
+        _applyState(permissionState, use: use);
+        return false;
+      }
+      _applyState(parse(await _readState()), use: use);
+      return _state == BluetoothAdapterState.on;
+    } catch (error, stackTrace) {
+      Logger.warning('Bluetooth readiness check failed: $error');
+      Logger.debug('$stackTrace');
+      _applyState(BluetoothAdapterState.unknown, use: use);
       return false;
     }
-    _applyState(parse(await _readState()), use: use);
-    return _state == BluetoothAdapterState.on;
   }
 
   Future<BluetoothAdapterState?> _currentPermissionState(BluetoothUse use) async {
@@ -95,7 +103,11 @@ class BluetoothReadiness extends ChangeNotifier {
     if (!Platform.isAndroid) return null;
 
     final sdk = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
-    if (sdk < 31) return null;
+    if (sdk < 31) {
+      return use == BluetoothUse.discovery && !await Permission.locationWhenInUse.isGranted
+          ? BluetoothAdapterState.unauthorized
+          : null;
+    }
     final connectGranted = await Permission.bluetoothConnect.isGranted;
     final scanGranted = use == BluetoothUse.discovery ? await Permission.bluetoothScan.isGranted : true;
     return connectGranted && scanGranted ? null : BluetoothAdapterState.unauthorized;
@@ -106,10 +118,15 @@ class BluetoothReadiness extends ChangeNotifier {
   Future<bool> requestEnable(BluetoothUse use) async {
     try {
       await _requestEnable();
-    } finally {
+    } catch (error, stackTrace) {
+      Logger.warning('Bluetooth enable request failed: $error');
+      Logger.debug('$stackTrace');
+    }
+
+    try {
       final next = parse(await _readState());
       if (next == BluetoothAdapterState.on) {
-        _applyState(next);
+        _applyState(next, use: use);
       } else {
         // The system prompt was cancelled or declined. Suppress the same
         // guidance until the adapter changes state so it cannot immediately
@@ -119,6 +136,12 @@ class BluetoothReadiness extends ChangeNotifier {
         _applyState(next);
         notifyListeners();
       }
+    } catch (error, stackTrace) {
+      Logger.warning('Bluetooth state refresh after enable failed: $error');
+      Logger.debug('$stackTrace');
+      _dismissedBlockedState = _state;
+      _guidance = null;
+      notifyListeners();
     }
     return _state == BluetoothAdapterState.on;
   }

--- a/app/lib/services/devices/discovery/device_discoverer.dart
+++ b/app/lib/services/devices/discovery/device_discoverer.dart
@@ -4,7 +4,12 @@ class DeviceDiscoveryResult {
   final List<BtDevice> devices;
   final Map<String, dynamic>? metadata;
 
-  const DeviceDiscoveryResult({required this.devices, this.metadata});
+  /// True when discovery was intentionally not started because the BLE radio
+  /// or its required permission was unavailable. This is distinct from a scan
+  /// that completed without finding a device.
+  final bool isBlocked;
+
+  const DeviceDiscoveryResult({required this.devices, this.metadata, this.isBlocked = false});
 }
 
 abstract class DeviceDiscoverer {

--- a/app/lib/services/devices/discovery/native_bluetooth_discoverer.dart
+++ b/app/lib/services/devices/discovery/native_bluetooth_discoverer.dart
@@ -23,7 +23,7 @@ class NativeBluetoothDiscoverer extends DeviceDiscoverer {
   @override
   Future<DeviceDiscoveryResult> discover({int timeout = 5}) async {
     if (!await BluetoothReadiness.instance.ensureReady(BluetoothUse.discovery)) {
-      return const DeviceDiscoveryResult(devices: []);
+      return const DeviceDiscoveryResult(devices: [], isBlocked: true);
     }
     final List<BlePeripheral> results = [];
     final completer = Completer<void>();

--- a/app/lib/services/devices/discovery/native_bluetooth_discoverer.dart
+++ b/app/lib/services/devices/discovery/native_bluetooth_discoverer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/bluetooth_readiness.dart';
 import 'package:omi/services/devices/discovery/device_locator.dart';
 import 'package:omi/services/devices/models.dart';
 import 'package:omi/utils/logger.dart';
@@ -21,6 +22,9 @@ class NativeBluetoothDiscoverer extends DeviceDiscoverer {
 
   @override
   Future<DeviceDiscoveryResult> discover({int timeout = 5}) async {
+    if (!await BluetoothReadiness.instance.ensureReady(BluetoothUse.discovery)) {
+      return const DeviceDiscoveryResult(devices: []);
+    }
     final List<BlePeripheral> results = [];
     final completer = Completer<void>();
 

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/bluetooth_readiness.dart';
 import 'package:omi/utils/logger.dart';
 import 'device_transport.dart';
 
@@ -47,6 +48,10 @@ class NativeBleTransport extends DeviceTransport {
   @override
   Future<void> connect() async {
     if (_state == DeviceTransportState.connected) return;
+
+    if (!await BluetoothReadiness.instance.ensureReady(BluetoothUse.connection)) {
+      throw BluetoothAdapterUnavailableException(BluetoothReadiness.instance.state);
+    }
 
     _updateState(DeviceTransportState.connecting);
 

--- a/app/lib/widgets/bluetooth_guidance_listener.dart
+++ b/app/lib/widgets/bluetooth_guidance_listener.dart
@@ -3,10 +3,12 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import 'package:omi/app_globals.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/services/devices/bluetooth_readiness.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/logger.dart';
 import 'package:omi/widgets/dialog.dart';
 
 /// Presents a single recovery prompt for a blocked BLE operation. Providers and
@@ -14,9 +16,20 @@ import 'package:omi/widgets/dialog.dart';
 class BluetoothGuidanceListener extends StatefulWidget {
   final Widget child;
   final BluetoothReadiness readiness;
+  final GlobalKey<NavigatorState> navigatorKey;
+  final bool isAndroid;
+  final Future<void> Function(BluetoothUse use)? retryBlockedOperation;
 
-  BluetoothGuidanceListener({super.key, required this.child, BluetoothReadiness? readiness})
-      : readiness = readiness ?? BluetoothReadiness.instance;
+  BluetoothGuidanceListener({
+    super.key,
+    required this.child,
+    BluetoothReadiness? readiness,
+    GlobalKey<NavigatorState>? navigatorKey,
+    bool? isAndroid,
+    this.retryBlockedOperation,
+  })  : readiness = readiness ?? BluetoothReadiness.instance,
+        navigatorKey = navigatorKey ?? globalNavigatorKey,
+        isAndroid = isAndroid ?? Platform.isAndroid;
 
   @override
   State<BluetoothGuidanceListener> createState() => _BluetoothGuidanceListenerState();
@@ -39,6 +52,7 @@ class _BluetoothGuidanceListenerState extends State<BluetoothGuidanceListener> {
     if (oldWidget.readiness == widget.readiness) return;
     oldWidget.readiness.removeListener(_schedulePresentation);
     widget.readiness.addListener(_schedulePresentation);
+    _presentedGuidanceId = null;
     _schedulePresentation();
   }
 
@@ -49,55 +63,77 @@ class _BluetoothGuidanceListenerState extends State<BluetoothGuidanceListener> {
   }
 
   void _schedulePresentation() {
-    final guidance = widget.readiness.guidance;
+    final readiness = widget.readiness;
+    final guidance = readiness.guidance;
     if (!mounted || _requestingEnable || guidance == null || guidance.id == _presentedGuidanceId) return;
     _presentedGuidanceId = guidance.id;
-    WidgetsBinding.instance.addPostFrameCallback((_) => _present(guidance));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || readiness != widget.readiness) return;
+      _present(readiness, guidance);
+    });
   }
 
-  Future<void> _present(BluetoothGuidance guidance) async {
-    if (!mounted || widget.readiness.guidance?.id != guidance.id) return;
+  Future<void> _present(BluetoothReadiness readiness, BluetoothGuidance guidance) async {
+    if (!mounted || readiness != widget.readiness || readiness.guidance?.id != guidance.id) return;
     var requestedEnable = false;
     final needsPermission = guidance.state == BluetoothAdapterState.unauthorized;
     await showDialog<void>(
-      context: context,
+      // This listener is mounted from MaterialApp.builder, above the app's
+      // navigator. Always obtain the navigator context from its key so the
+      // recovery prompt can be presented in production as well as in tests.
+      context: widget.navigatorKey.currentContext ?? context,
       builder: (dialogContext) => getDialog(
         dialogContext,
         () async {
           Navigator.of(dialogContext).pop();
-          if (needsPermission) await openAppSettings();
+          if (needsPermission) {
+            try {
+              await openAppSettings();
+            } catch (error, stackTrace) {
+              Logger.warning('Could not open Bluetooth permission Settings: $error');
+              Logger.debug('$stackTrace');
+            }
+          }
         },
         () async {
           requestedEnable = true;
           _requestingEnable = true;
           Navigator.of(dialogContext).pop();
           try {
-            if (await widget.readiness.requestEnable(guidance.use)) {
+            if (await readiness.requestEnable(guidance.use)) {
               await _retryBlockedOperation(guidance.use);
             }
+          } catch (error, stackTrace) {
+            Logger.warning('Bluetooth recovery retry failed: $error');
+            Logger.debug('$stackTrace');
           } finally {
             _requestingEnable = false;
             _schedulePresentation();
           }
         },
-        needsPermission ? context.l10n.permissionsRequired : context.l10n.enableBluetooth,
-        needsPermission ? context.l10n.permissionsRequiredDesc : context.l10n.bluetoothNeeded,
-        singleButton: needsPermission || !Platform.isAndroid || guidance.state != BluetoothAdapterState.off,
+        needsPermission ? dialogContext.l10n.permissionsRequired : dialogContext.l10n.enableBluetooth,
+        needsPermission ? dialogContext.l10n.permissionsRequiredDesc : dialogContext.l10n.bluetoothNeeded,
+        singleButton: needsPermission || !widget.isAndroid || guidance.state != BluetoothAdapterState.off,
         okButtonText: needsPermission
-            ? context.l10n.openSettings
-            : Platform.isAndroid && guidance.state == BluetoothAdapterState.off
-                ? context.l10n.enableBluetooth
+            ? dialogContext.l10n.openSettings
+            : widget.isAndroid && guidance.state == BluetoothAdapterState.off
+                ? dialogContext.l10n.enableBluetooth
                 : null,
       ),
     );
-    if (!requestedEnable && widget.readiness.guidance?.id == guidance.id) {
-      widget.readiness.dismissGuidance(guidance.id);
+    if (!requestedEnable && readiness == widget.readiness && readiness.guidance?.id == guidance.id) {
+      readiness.dismissGuidance(guidance.id);
     }
     _presentedGuidanceId = null;
     _schedulePresentation();
   }
 
   Future<void> _retryBlockedOperation(BluetoothUse use) async {
+    final retry = widget.retryBlockedOperation;
+    if (retry != null) {
+      await retry(use);
+      return;
+    }
     final deviceService = ServiceManager.instance().device;
     if (use == BluetoothUse.discovery) {
       await deviceService.discover();

--- a/app/lib/widgets/bluetooth_guidance_listener.dart
+++ b/app/lib/widgets/bluetooth_guidance_listener.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/services/devices/bluetooth_readiness.dart';
+import 'package:omi/services/services.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/widgets/dialog.dart';
+
+/// Presents a single recovery prompt for a blocked BLE operation. Providers and
+/// transports publish state only; this widget owns BuildContext and dialogs.
+class BluetoothGuidanceListener extends StatefulWidget {
+  final Widget child;
+  final BluetoothReadiness readiness;
+
+  BluetoothGuidanceListener({super.key, required this.child, BluetoothReadiness? readiness})
+      : readiness = readiness ?? BluetoothReadiness.instance;
+
+  @override
+  State<BluetoothGuidanceListener> createState() => _BluetoothGuidanceListenerState();
+}
+
+class _BluetoothGuidanceListenerState extends State<BluetoothGuidanceListener> {
+  int? _presentedGuidanceId;
+  bool _requestingEnable = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.readiness.addListener(_schedulePresentation);
+    _schedulePresentation();
+  }
+
+  @override
+  void didUpdateWidget(covariant BluetoothGuidanceListener oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.readiness == widget.readiness) return;
+    oldWidget.readiness.removeListener(_schedulePresentation);
+    widget.readiness.addListener(_schedulePresentation);
+    _schedulePresentation();
+  }
+
+  @override
+  void dispose() {
+    widget.readiness.removeListener(_schedulePresentation);
+    super.dispose();
+  }
+
+  void _schedulePresentation() {
+    final guidance = widget.readiness.guidance;
+    if (!mounted || _requestingEnable || guidance == null || guidance.id == _presentedGuidanceId) return;
+    _presentedGuidanceId = guidance.id;
+    WidgetsBinding.instance.addPostFrameCallback((_) => _present(guidance));
+  }
+
+  Future<void> _present(BluetoothGuidance guidance) async {
+    if (!mounted || widget.readiness.guidance?.id != guidance.id) return;
+    var requestedEnable = false;
+    final needsPermission = guidance.state == BluetoothAdapterState.unauthorized;
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => getDialog(
+        dialogContext,
+        () async {
+          Navigator.of(dialogContext).pop();
+          if (needsPermission) await openAppSettings();
+        },
+        () async {
+          requestedEnable = true;
+          _requestingEnable = true;
+          Navigator.of(dialogContext).pop();
+          try {
+            if (await widget.readiness.requestEnable(guidance.use)) {
+              await _retryBlockedOperation(guidance.use);
+            }
+          } finally {
+            _requestingEnable = false;
+            _schedulePresentation();
+          }
+        },
+        needsPermission ? context.l10n.permissionsRequired : context.l10n.enableBluetooth,
+        needsPermission ? context.l10n.permissionsRequiredDesc : context.l10n.bluetoothNeeded,
+        singleButton: needsPermission || !Platform.isAndroid || guidance.state != BluetoothAdapterState.off,
+        okButtonText: needsPermission
+            ? context.l10n.openSettings
+            : Platform.isAndroid && guidance.state == BluetoothAdapterState.off
+                ? context.l10n.enableBluetooth
+                : null,
+      ),
+    );
+    if (!requestedEnable && widget.readiness.guidance?.id == guidance.id) {
+      widget.readiness.dismissGuidance(guidance.id);
+    }
+    _presentedGuidanceId = null;
+    _schedulePresentation();
+  }
+
+  Future<void> _retryBlockedOperation(BluetoothUse use) async {
+    final deviceService = ServiceManager.instance().device;
+    if (use == BluetoothUse.discovery) {
+      await deviceService.discover();
+      return;
+    }
+
+    final deviceId = SharedPreferencesUtil().btDevice.id;
+    if (deviceId.isNotEmpty) {
+      await deviceService.ensureConnection(deviceId, force: true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/app/test/services/devices/bluetooth_readiness_test.dart
+++ b/app/test/services/devices/bluetooth_readiness_test.dart
@@ -60,6 +60,37 @@ void main() {
       expect(readiness.guidance, isNull);
     });
 
+    test('contains a failed enable request without reopening its guidance', () async {
+      final readiness = BluetoothReadiness(
+        readState: () async => 'off',
+        requestEnable: () async => throw StateError('platform channel unavailable'),
+        observeBridge: false,
+      );
+
+      await readiness.ensureReady(BluetoothUse.connection);
+
+      expect(await readiness.requestEnable(BluetoothUse.connection), isFalse);
+      expect(readiness.guidance, isNull);
+    });
+
+    test('contains a failed state refresh after an enable request', () async {
+      var reads = 0;
+      final readiness = BluetoothReadiness(
+        readState: () async {
+          reads++;
+          if (reads == 1) return 'off';
+          throw StateError('platform channel unavailable');
+        },
+        requestEnable: () async => true,
+        observeBridge: false,
+      );
+
+      await readiness.ensureReady(BluetoothUse.connection);
+
+      expect(await readiness.requestEnable(BluetoothUse.connection), isFalse);
+      expect(readiness.guidance, isNull);
+    });
+
     test('shares one guidance event across overlapping blocked operations', () async {
       final readiness = BluetoothReadiness(readState: () async => 'off', observeBridge: false);
 

--- a/app/test/services/devices/bluetooth_readiness_test.dart
+++ b/app/test/services/devices/bluetooth_readiness_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/devices/bluetooth_readiness.dart';
+
+void main() {
+  group('BluetoothReadiness', () {
+    test('blocks a powered-off discovery and publishes one actionable guidance event', () async {
+      final readiness = BluetoothReadiness(readState: () async => 'off', observeBridge: false);
+
+      expect(await readiness.ensureReady(BluetoothUse.discovery), isFalse);
+      expect(readiness.state, BluetoothAdapterState.off);
+      expect(readiness.guidance?.use, BluetoothUse.discovery);
+
+      final firstGuidance = readiness.guidance!;
+      readiness.dismissGuidance(firstGuidance.id);
+      expect(await readiness.ensureReady(BluetoothUse.discovery), isFalse);
+      expect(readiness.guidance, isNull, reason: 'periodic scans must not reopen a dismissed prompt');
+    });
+
+    test('clears a dismissed blocked state when Bluetooth comes back on', () async {
+      var nativeState = 'off';
+      final readiness = BluetoothReadiness(readState: () async => nativeState, observeBridge: false);
+
+      await readiness.ensureReady(BluetoothUse.connection);
+      readiness.dismissGuidance(readiness.guidance!.id);
+      readiness.onNativeStateChangedForTesting('on');
+      nativeState = 'off';
+
+      expect(await readiness.ensureReady(BluetoothUse.connection), isFalse);
+      expect(readiness.guidance?.state, BluetoothAdapterState.off);
+    });
+
+    test('refreshes state after Android enable request instead of trusting its result', () async {
+      var nativeState = 'off';
+      final readiness = BluetoothReadiness(
+        readState: () async => nativeState,
+        requestEnable: () async {
+          nativeState = 'on';
+          return false;
+        },
+        observeBridge: false,
+      );
+
+      expect(await readiness.requestEnable(BluetoothUse.discovery), isTrue);
+      expect(readiness.state, BluetoothAdapterState.on);
+      expect(readiness.guidance, isNull);
+    });
+
+    test('does not reopen guidance when the Android enable prompt is cancelled', () async {
+      final readiness = BluetoothReadiness(
+        readState: () async => 'off',
+        requestEnable: () async => false,
+        observeBridge: false,
+      );
+
+      await readiness.ensureReady(BluetoothUse.connection);
+      await readiness.requestEnable(BluetoothUse.connection);
+
+      expect(readiness.guidance, isNull);
+      expect(await readiness.ensureReady(BluetoothUse.connection), isFalse);
+      expect(readiness.guidance, isNull);
+    });
+
+    test('shares one guidance event across overlapping blocked operations', () async {
+      final readiness = BluetoothReadiness(readState: () async => 'off', observeBridge: false);
+
+      await readiness.ensureReady(BluetoothUse.discovery);
+      final firstGuidanceId = readiness.guidance!.id;
+      await readiness.ensureReady(BluetoothUse.connection);
+
+      expect(readiness.guidance?.id, firstGuidanceId);
+    });
+
+    test('surfaces revoked Bluetooth permission separately from adapter power', () async {
+      final readiness = BluetoothReadiness(
+        readState: () async => 'on',
+        permissionState: (_) async => BluetoothAdapterState.unauthorized,
+        observeBridge: false,
+      );
+
+      expect(await readiness.ensureReady(BluetoothUse.discovery), isFalse);
+      expect(readiness.state, BluetoothAdapterState.unauthorized);
+      expect(readiness.guidance?.state, BluetoothAdapterState.unauthorized);
+    });
+  });
+}

--- a/app/test/widgets/bluetooth_guidance_listener_test.dart
+++ b/app/test/widgets/bluetooth_guidance_listener_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/services/devices/bluetooth_readiness.dart';
+import 'package:omi/widgets/bluetooth_guidance_listener.dart';
+
+void main() {
+  testWidgets('shows one actionable dialog when a BLE operation is blocked by adapter power', (tester) async {
+    final readiness = BluetoothReadiness(readState: () async => 'off', observeBridge: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BluetoothGuidanceListener(readiness: readiness, child: const Scaffold(body: SizedBox())),
+      ),
+    );
+
+    expect(await readiness.ensureReady(BluetoothUse.discovery), isFalse);
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enable Bluetooth'), findsOneWidget);
+    expect(find.text('Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.'),
+        findsOneWidget);
+
+    await tester.tap(find.text('Ok'));
+    await tester.pumpAndSettle();
+
+    expect(readiness.guidance, isNull);
+  });
+
+  testWidgets('sends revoked Bluetooth permission to Settings instead of the adapter-enable flow', (tester) async {
+    final readiness = BluetoothReadiness(
+      readState: () async => 'on',
+      permissionState: (_) async => BluetoothAdapterState.unauthorized,
+      observeBridge: false,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BluetoothGuidanceListener(readiness: readiness, child: const Scaffold(body: SizedBox())),
+      ),
+    );
+
+    expect(await readiness.ensureReady(BluetoothUse.connection), isFalse);
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Permissions Required'), findsOneWidget);
+    expect(find.text('Open Settings'), findsOneWidget);
+  });
+}

--- a/app/test/widgets/bluetooth_guidance_listener_test.dart
+++ b/app/test/widgets/bluetooth_guidance_listener_test.dart
@@ -8,12 +8,19 @@ import 'package:omi/widgets/bluetooth_guidance_listener.dart';
 void main() {
   testWidgets('shows one actionable dialog when a BLE operation is blocked by adapter power', (tester) async {
     final readiness = BluetoothReadiness(readState: () async => 'off', observeBridge: false);
+    final navigatorKey = GlobalKey<NavigatorState>();
 
     await tester.pumpWidget(
       MaterialApp(
+        navigatorKey: navigatorKey,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: BluetoothGuidanceListener(readiness: readiness, child: const Scaffold(body: SizedBox())),
+        builder: (context, child) => BluetoothGuidanceListener(
+          readiness: readiness,
+          navigatorKey: navigatorKey,
+          child: child!,
+        ),
+        home: const Scaffold(body: SizedBox()),
       ),
     );
 
@@ -29,6 +36,42 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(readiness.guidance, isNull);
+  });
+
+  testWidgets('Android enable action refreshes readiness and retries the blocked operation', (tester) async {
+    var nativeState = 'off';
+    var retriedUse = <BluetoothUse>[];
+    final readiness = BluetoothReadiness(
+      readState: () async => nativeState,
+      requestEnable: () async {
+        nativeState = 'on';
+        return true;
+      },
+      observeBridge: false,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BluetoothGuidanceListener(
+          readiness: readiness,
+          isAndroid: true,
+          retryBlockedOperation: (use) async => retriedUse.add(use),
+          child: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+
+    expect(await readiness.ensureReady(BluetoothUse.discovery), isFalse);
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(TextButton, 'Enable Bluetooth'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Enable Bluetooth'));
+    await tester.pumpAndSettle();
+
+    expect(readiness.state, BluetoothAdapterState.on);
+    expect(retriedUse, [BluetoothUse.discovery]);
   });
 
   testWidgets('sends revoked Bluetooth permission to Settings instead of the adapter-enable flow', (tester) async {


### PR DESCRIPTION
## Summary

Surface Bluetooth adapter power and permission failures before device discovery or connection begins.

## Root cause

The app treated granted Bluetooth permission as proof that Bluetooth was usable. With the adapter off, native discovery silently stopped and paired reconnection could wait or report a misleading state without a user-facing recovery path.

## User impact

Android now offers the system Bluetooth-enable request and retries the blocked operation after it succeeds. iOS explains the blocked state without trying to enable Bluetooth programmatically. Revoked Bluetooth permissions open the app Settings recovery path. Duplicate, cancelled, and stale prompts are suppressed.

## Validation

- `bash test.sh test/services/devices/bluetooth_readiness_test.dart test/widgets/bluetooth_guidance_listener_test.dart`
- `bash scripts/analyze_ratchet.sh`
- `flutter build ios --debug --no-codesign --flavor dev`
- Independent Luna review of adapter-off, permission-denied, retry, and prompt-deduplication paths.
- Android debug build was attempted but this machine has no Android SDK configured.

## Failure class

Failure-Class: FC-denial-rendered-as-empty-success


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

