### PR TITLE
fix(backend): stub transcript_for_llm in KG import-isolation fakes (main red)

### DIFF
--- a/backend/tests/unit/test_kg_user_type_mismatch.py
+++ b/backend/tests/unit/test_kg_user_type_mismatch.py
@@ -254,6 +254,7 @@ def _build_fakes() -> dict[str, ModuleType]:
     for name in [
         "utils.conversations.factory",
         "utils.conversations.transcript_chunks",
+        "utils.conversations.transcript_for_llm",
         "utils.conversations.memory_extraction_telemetry",
         "utils.memory.canonical_activation",
         "utils.memory.memory_service",


### PR DESCRIPTION
## Bug

`Backend Unit Tests` has been red on `main` since **6723bf3ab5** (`fix(backend): pass profile name into summarization-app transcripts (#5319)`, PR #11143, merged 14:35Z today) — six consecutive failing runs, latest 31217505762 on `79f36ade93`.

All 11 tests in `backend/tests/unit/test_kg_user_type_mismatch.py` error at collection with:

```
ModuleNotFoundError: No module named 'utils.conversations.transcript_for_llm'
```

## Root cause

#11143 added a new import to `utils/conversations/process_conversation.py`:

```python
from utils.conversations.transcript_for_llm import conversation_transcript_for_llm
```

`test_kg_user_type_mismatch.py` exec's `process_conversation` fresh inside a `stub_modules` block (the sanctioned Tier-2 import-isolation seam), which replaces the `utils.conversations` package with an empty-`__path__` stub so no heavy import chain is pulled from disk. Every `utils.conversations.*` leaf that `process_conversation` imports must therefore be registered in the test's fakes. The new leaf was not, so the fresh load raised `ModuleNotFoundError`.

The production import is correct; only the test's stub list was stale.

## Fix

One line: add `utils.conversations.transcript_for_llm` to the existing list of `utils.conversations.*` / `utils.memory.*` leaves imported by `process_conversation`. This is the same one-line update the file already carries for `utils.llm.temporal` after an earlier merge. No production code is touched.

## What I tested

- **Reproduced red locally** at `origin/main` (`79f36ade93`), fresh `backend/.venv` on Python 3.11.15 with pinned `requirements.txt`:
  `.venv/bin/python -m pytest tests/unit/test_kg_user_type_mismatch.py -q` → **11 errors**, identical `ModuleNotFoundError` to CI run 31217505762.
- **Green after the fix**, same command → **11 passed**.
- **Authoritative runner with the CI timing guard**, exactly as the CI failure output instructs:
  ```
  echo tests/unit/test_kg_user_type_mismatch.py > /tmp/omi-backend-unit-failures.txt
  BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh
  ```
  → **11 passed in 0.84s**.
- `make preflight` (local lane, python3.12) — all manifest checks pass.

CI run 31217505762 named this as the only failing file, so this restores the `Backend Unit Tests` lane on `main`.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

