### PR TITLE
fix(ci): rename listen helm gateway mode choice off → disabled

### DIFF
--- a/.github/scripts/listen_helm_env_overrides.py
+++ b/.github/scripts/listen_helm_env_overrides.py
@@ -73,6 +73,9 @@ def resolve_env_override_argv(
         # chart-default sentinel means "leave the values file alone", same as "".
         if value in ("", "chart-default"):
             continue
+        # workflow_dispatch choice cannot ship literal "off"; accept disabled alias.
+        if name == "OMI_LLM_GATEWAY_FEATURE_MODE" and value == "disabled":
+            value = "off"
         if name not in indices:
             raise ValueError(f"env {name} not found in values env list")
         index = indices[name]

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -35,13 +35,15 @@ on:
         required: false
         default: ''
       gateway_feature_mode:
-        description: 'Optional OMI_LLM_GATEWAY_FEATURE_MODE override (chart-default = values file)'
+        # GitHub Actions rejects choice option literal "off" (422 on workflow_dispatch).
+        # Use "disabled" in the UI/API; the resolve step maps it to env value "off".
+        description: 'Optional OMI_LLM_GATEWAY_FEATURE_MODE override (chart-default = values file; disabled = off)'
         required: false
         default: chart-default
         type: choice
         options:
           - chart-default
-          - off
+          - disabled
           - gateway
       allow_direct_model_exception:
         description: 'Optional OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION override (chart-default = values file)'
@@ -247,10 +249,15 @@ jobs:
           set -euo pipefail
           python3 -m pip install -q pyyaml
           ARGV_FILE="${RUNNER_TEMP}/listen-helm-env-overrides.argv"
+          # workflow_dispatch choice cannot use literal "off" (GitHub 422); map UI token.
+          FEATURE_MODE_VALUE="${GATEWAY_FEATURE_MODE:-}"
+          if [[ "${FEATURE_MODE_VALUE}" == "disabled" ]]; then
+            FEATURE_MODE_VALUE="off"
+          fi
           python3 .github/scripts/listen_helm_env_overrides.py \
             --values-file "$VALUES_FILE" \
             --output-argv-file "$ARGV_FILE" \
-            --set "OMI_LLM_GATEWAY_FEATURE_MODE=${GATEWAY_FEATURE_MODE:-}" \
+            --set "OMI_LLM_GATEWAY_FEATURE_MODE=${FEATURE_MODE_VALUE}" \
             --set "OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION=${ALLOW_DIRECT_MODEL_EXCEPTION:-}" \
             --set "STT_SERVICE_MODELS=${STT_SERVICE_MODELS:-}" \
             --set "TRANSLATION_SERVICE_MODELS=${TRANSLATION_SERVICE_MODELS:-}"

--- a/backend/tests/unit/test_listen_helm_env_overrides.py
+++ b/backend/tests/unit/test_listen_helm_env_overrides.py
@@ -48,6 +48,17 @@ def test_blank_overrides_produce_no_helm_set_args():
     assert not any("env[" in token and "FEATURE_MODE" in token for token in argv)
 
 
+def test_gateway_feature_mode_disabled_alias_maps_to_off():
+    """GitHub rejects choice value off; workflow/UI uses disabled -> env off."""
+    values = _load_values(PROD_VALUES)
+    argv = HELPER.resolve_env_override_argv(
+        values,
+        {"OMI_LLM_GATEWAY_FEATURE_MODE": "disabled"},
+    )
+    assert argv[0] == "--set-string"
+    assert argv[1].endswith("].value=off")
+
+
 def test_gateway_feature_mode_off_produces_helm_argv_override():
     values = _load_values(PROD_VALUES)
     argv = HELPER.resolve_env_override_argv(
@@ -191,5 +202,12 @@ def test_workflow_exposes_optional_override_inputs_and_applies_them_on_both_helm
     assert text.count('${LISTEN_ENV_OVERRIDES[@]+"${LISTEN_ENV_OVERRIDES[@]}"}') == 2
     # Auto-push / blank overrides must still leave chart defaults authoritative:
     # the helper is only invoked with input env vars, never hard-coded modes.
-    assert "OMI_LLM_GATEWAY_FEATURE_MODE=${GATEWAY_FEATURE_MODE:-}" in text
+    # FEATURE_MODE uses FEATURE_MODE_VALUE after mapping workflow token disabled -> off
+    # (GitHub Actions rejects choice literal "off" with HTTP 422).
+    assert "FEATURE_MODE_VALUE" in text
+    assert (
+        'FEATURE_MODE_VALUE="off"' in text or "FEATURE_MODE_VALUE=\"off\"" in text or 'FEATURE_MODE_VALUE="off"' in text
+    )
+    assert "disabled" in text
+    assert "OMI_LLM_GATEWAY_FEATURE_MODE=${FEATURE_MODE_VALUE}" in text
     assert "OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION=${ALLOW_DIRECT_MODEL_EXCEPTION:-}" in text


### PR DESCRIPTION
## Summary
GitHub Actions rejects `workflow_dispatch` choice option literal `off` with HTTP 422, so prod step 1 (`gateway_feature_mode=off`) could not be dispatched after #11202.

- Rename choice token to `disabled`
- Map `disabled` → env `OMI_LLM_GATEWAY_FEATURE_MODE=off` in workflow + helper
- Keep helper accepting raw `off` for direct CLI use
- Unit tests for alias

## Test plan
- [x] `pytest backend/tests/unit/test_listen_helm_env_overrides.py`
- [ ] CI green
- [ ] After merge: dispatch step 1 with `-f gateway_feature_mode=disabled`

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

