### PR TITLE
fix(desktop): capture AI profile rowid so Settings edit/delete work after regenerate (#11204)

### DIFF
--- a/.github/failure-classes/FC-nonmutating-witness-drops-rowid.json
+++ b/.github/failure-classes/FC-nonmutating-witness-drops-rowid.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-nonmutating-witness-drops-rowid",
+  "violated_contract": "A record's persisted identity must be observable by the code that consumes it after the insert.",
+  "canonical_prevention": "A GRDB record that captures its rowid in a `mutating didInsert` conforms to MutablePersistableRecord, never PersistableRecord: PersistableRecord redeclares didInsert as non-mutating with an empty default, a mutating method cannot witness a non-mutating requirement, and a direct `record.insert(db)` therefore runs the no-op default and leaves `id` nil with no error or warning.",
+  "evidence_prs": [11208],
+  "scope_hints": ["desktop/macos/**"],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
@@ -4,7 +4,11 @@ import Foundation
 // MARK: - Database Record
 
 /// Database record for AI-generated user profile history
-struct AIUserProfileRecord: Codable, FetchableRecord, PersistableRecord, Identifiable {
+// `MutablePersistableRecord` — not `PersistableRecord` — because the rowid is
+// captured by a `mutating didInsert`. `PersistableRecord`'s requirement is
+// non-mutating, so a mutating declaration silently witnesses nothing and the
+// empty default runs instead, leaving `id` nil after every insert.
+struct AIUserProfileRecord: Codable, FetchableRecord, MutablePersistableRecord, Identifiable {
   var id: Int64?
   var profileText: String
   var dataSourcesUsed: Int
@@ -60,6 +64,20 @@ actor AIUserProfileService {
     _dbQueue = db
     _dbGeneration = generation
     return db
+  }
+
+  /// Insert a profile row and return it carrying its persisted rowid.
+  ///
+  /// Every caller hands the returned record's `id` to a `WHERE id = ?` consumer
+  /// (the backend-sync flag update, Settings edit/delete), so the insert must go
+  /// through the mutating path that runs `didInsert`.
+  func insertProfile(_ record: AIUserProfileRecord) async throws -> AIUserProfileRecord {
+    let db = try await ensureDB()
+    return try await db.write { database in
+      var inserted = record
+      try inserted.insert(database)
+      return inserted
+    }
   }
 
   // MARK: - Public Interface
@@ -145,10 +163,6 @@ actor AIUserProfileService {
 
   /// Save exploration text as a new profile record (when no profile exists yet)
   func saveExplorationAsProfile(text: String) async -> Bool {
-    guard let db = try? await ensureDB() else {
-      log("AIUserProfileService: DB not available for saving exploration profile")
-      return false
-    }
     let generatedAt = Date()
     let record = AIUserProfileRecord(
       profileText: String(text.prefix(maxProfileLength)),
@@ -157,11 +171,7 @@ actor AIUserProfileService {
       generatedAt: generatedAt
     )
     do {
-      let insertedId = try await db.write { database -> Int64? in
-        let mutableRecord = record
-        try mutableRecord.insert(database)
-        return mutableRecord.id
-      }
+      let insertedId = try await insertProfile(record).id
       log("AIUserProfileService: Saved exploration as new profile (\(record.profileText.count) chars)")
 
       // Sync to backend (fire-and-forget)
@@ -329,16 +339,13 @@ actor AIUserProfileService {
     let generatedAt = Date()
 
     // 6. Save to database
-    let db = try await ensureDB()
-    let record = AIUserProfileRecord(
-      profileText: truncated,
-      dataSourcesUsed: dataSourcesUsed,
-      backendSynced: false,
-      generatedAt: generatedAt
-    )
-    try await db.write { database in
-      try record.insert(database)
-    }
+    let record = try await insertProfile(
+      AIUserProfileRecord(
+        profileText: truncated,
+        dataSourcesUsed: dataSourcesUsed,
+        backendSynced: false,
+        generatedAt: generatedAt
+      ))
 
     // 7. Sync to backend (fire-and-forget)
     let recordId = record.id

--- a/desktop/macos/Desktop/Tests/AIUserProfileRowIDCaptureTests.swift
+++ b/desktop/macos/Desktop/Tests/AIUserProfileRowIDCaptureTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// `AIUserProfileRecord` captures its rowid in a `mutating didInsert`, which only
+/// witnesses `MutablePersistableRecord`. Under `PersistableRecord` a direct
+/// `record.insert(db)` picked the non-mutating overload, so the empty default ran
+/// and `id` stayed nil — silently disabling every `WHERE id = ?` consumer, notably
+/// the profile row Settings → Advanced hands to Save and Delete right after
+/// Regenerate, and the `backendSynced = 1` update after a successful sync.
+final class AIUserProfileRowIDCaptureTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "ai-user-profile-rowid")
+  }
+
+  override func tearDown() async throws {
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testInsertProfileReturnsRowIDThatIDConsumersResolve() async throws {
+    let inserted = try await AIUserProfileService.shared.insertProfile(
+      AIUserProfileRecord(
+        profileText: "- User writes Swift",
+        dataSourcesUsed: 3,
+        backendSynced: false,
+        generatedAt: Date()
+      ))
+
+    let rowID = try XCTUnwrap(inserted.id, "insertProfile must return the persisted rowid")
+    let persisted = await AIUserProfileService.shared.getLatestProfile()
+    let latest = try XCTUnwrap(persisted)
+    XCTAssertEqual(latest.id, rowID, "the reported rowid must be the row that was persisted")
+
+    // Every consumer of the returned record passes `id` to a `WHERE id = ?`
+    // statement. Deleting by it proves the reported rowid actually resolves.
+    let remaining = await AIUserProfileService.shared.deleteProfile(id: rowID)
+    XCTAssertNil(remaining, "deleteProfile(id:) must remove the row the insert reported")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260808-ai-profile-rowid.json
+++ b/desktop/macos/changelog/unreleased/20260808-ai-profile-rowid.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Settings → Advanced → AI User Profile: Save and Delete silently did nothing right after Regenerate"
+}


### PR DESCRIPTION
## Bug

Settings → Advanced → **AI User Profile**: right after pressing **Regenerate**, the **Save** and **Delete** buttons silently do nothing. Editing the profile text and pressing Save discards the edit with no feedback; Delete is a no-op. Both start working again only once the section reloads the profile from the database.

Second instance of the class filed as #11204 (first was `Screenshot`, fixed in #11208).

## Root cause

`AIUserProfileRecord` captures its rowid in a `mutating didInsert` while conforming to `PersistableRecord`. `PersistableRecord` redeclares `didInsert` as **non-mutating** with an empty default (`PersistableRecord+Insert.swift:9`). A mutating method cannot witness a non-mutating requirement, so the declaration compiles, is never called, and the no-op default runs instead — `id` is `nil` after every insert, with no error and no warning.

Both insert sites consumed that nil id:

- `generateProfile()` inserted via `try record.insert(database)` and returned `record`. `regenerateAIProfile()` stores it as `aiProfileId`; Save (`if let id = aiProfileId`) and Delete (`guard let id = aiProfileId else { return }`) then both fall through silently.
- `saveExplorationAsProfile(text:)` returned `mutableRecord.id` from a `let` binding, so the post-sync `UPDATE ai_user_profiles SET backendSynced = 1 WHERE id = ?` never ran and the row stayed marked unsynced forever.

## Fix

- Conform `AIUserProfileRecord` to `MutablePersistableRecord`, where the mutating `didInsert` is the witness (`PersistableRecord` refines it, so no call site changes).
- Route both insert sites through one `insertProfile(_:)` seam that returns the record carrying its persisted rowid, so `generateProfile()`'s return value and the backend-sync flag update share one contract.
- Register the class as `FC-nonmutating-witness-drops-rowid`.

## Scope note — the other types in #11204 are not affected

#11204 lists 15 more types with the same declaration and predicts the same nil id. That does not hold: every one of them inserts via `inserted(db)`, which is defined in `extension MutablePersistableRecord` and therefore statically binds to the **mutating** `insert` in that same extension — so the mutating `didInsert` does run. Measured against the pinned GRDB 6.29.3 (`2cf6c756`), same type, same `mutating didInsert`:

```
PersistableRecord      .inserted(db) -> id = Optional(1)
PersistableRecord      .insert(db)   -> id = nil
MutablePersistableRec  .inserted(db) -> id = Optional(1)
MutablePersistableRec  .insert(db)   -> id = Optional(2)
```

Only a direct `record.insert(db)` on the concrete type loses the rowid. This PR fixes the last such call site on a record that captures one — the other two (`RewindDatabase.insertScreenshot`, the video-chunk rebuild) are `Screenshot`, migrated in #11208. So this is a targeted fix, not the blanket 15-type sweep the issue warned against.

## What I tested

`./scripts/dev-feedback.py --once swift 'AIUserProfileRowIDCaptureTests'`

The new test goes through the production seam: it inserts a profile, asserts the returned rowid is the row that was persisted (`getLatestProfile()`), then deletes by that rowid — the exact `WHERE id = ?` shape every consumer uses. It fails on the old conformance (nil rowid) and passes on the new one.

Also ran `make preflight` — 20/20 checks pass.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

