### PR TITLE
fix(desktop): make Rewind span retained history

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1734,
-    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3428
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3423
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "The bounded incomplete-task storage surface reads all dated rows and pages only No Deadline rows, so TasksStore can preserve bucket boundaries without loading the entire undated local universe; it remains beside the existing task query and persistence owner rather than duplicating SQLite semantics. Single-snapshot dated/no-deadline reads prevent due-date races from omitting tasks between bucket queries.",

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2940,47 +2940,42 @@ actor RewindDatabase {
   }
 
   /// Get screenshots sampled evenly across a date range, ordered ASC (oldest first).
-  /// If the total count for the range is <= targetCount, returns all rows ASC.
-  /// Otherwise picks every Nth screenshot to fit ~targetCount frames.
-  func getScreenshotsSampled(from startDate: Date, to endDate: Date, targetCount: Int) throws -> [Screenshot] {
+  /// Returns all rows within `targetCount`; otherwise samples evenly while retaining both endpoints.
+  func getScreenshotsSampled(
+    from startDate: Date, to endDate: Date, targetCount: Int, appFilter: String? = nil
+  ) throws -> [Screenshot] {
     guard let dbQueue = dbQueue else {
       throw RewindError.databaseNotInitialized
     }
 
     return try dbQueue.read { db in
-      // Get total count for the range
-      let totalCount =
-        try Screenshot
-        .filter(Column("timestamp") >= startDate && Column("timestamp") <= endDate)
-        .fetchCount(db)
+      var request = Screenshot.filter(Column("timestamp") >= startDate && Column("timestamp") <= endDate)
+      if let appFilter {
+        request = request.filter(Column("appName") == appFilter)
+      }
+
+      // Count only rows eligible for the timeline, so sparse app filters get a full sample.
+      let totalCount = try request.fetchCount(db)
 
       if totalCount <= targetCount {
         // Return all, ordered ASC (oldest first)
-        return
-          try Screenshot
-          .filter(Column("timestamp") >= startDate && Column("timestamp") <= endDate)
-          .order(Column("timestamp").asc)
-          .fetchAll(db)
+        return try request.order(Column("timestamp").asc).fetchAll(db)
       }
 
       // Fetch all IDs + timestamps ordered ASC, then pick every Nth
-      let rows = try Row.fetchAll(
-        db,
-        sql: """
-              SELECT id FROM screenshots
-              WHERE timestamp >= ? AND timestamp <= ?
-              ORDER BY timestamp ASC
-          """, arguments: [startDate, endDate])
+      let idRequest = request.select(Column("id")).order(Column("timestamp").asc)
+      let rows = try Row.fetchAll(db, idRequest)
 
-      let step = Double(totalCount) / Double(targetCount)
-      var sampledIds: [Int64] = []
-      var i: Double = 0
-      while Int(i) < totalCount && sampledIds.count < targetCount {
-        let index = Int(i)
-        if index < rows.count {
-          sampledIds.append(rows[index]["id"])
-        }
-        i += step
+      let sampleCount = max(1, targetCount)
+      let sampledIds: [Int64] = (0..<sampleCount).compactMap { slot in
+        let index =
+          sampleCount == 1
+          ? totalCount - 1
+          : Int(
+            (Double(slot) * Double(totalCount - 1) / Double(sampleCount - 1))
+              .rounded())
+        guard rows.indices.contains(index) else { return nil }
+        return rows[index]["id"]
       }
 
       // Batch-fetch the sampled rows and return in ASC order

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AppKit
+import Combine
 import OmiTheme
 import SwiftUI
 
@@ -144,8 +145,8 @@ struct RewindPage: View {
       }
     }
     .glassContent()
-    // The page answers arrow keys and the scroll wheel wherever the pointer is, so it holds keyboard
-    // focus itself. It is not a control, though, and this container is the whole content area: the
+    // The page answers arrow keys wherever the pointer is, so it holds keyboard focus itself. The
+    // timeline track owns scroll gestures directly. This container is not a control, though: the
     // system focus effect around it was a 1 pt accent rectangle on the window's edges, which on a
     // window with no visible extent is a blue rectangle on the wallpaper. See
     // `shellPageKeyboardTarget`.
@@ -192,11 +193,24 @@ struct RewindPage: View {
         currentIndex = newIndex
         // No need to reload frame - it's the same screenshot
       } else if !newScreenshots.isEmpty {
-        // First load or current screenshot deleted — start at newest (last index, ASC order)
-        currentIndex = newScreenshots.count - 1
+        // A viewport query may replace every sampled row. Stay near the same visible moment instead
+        // of snapping to the newest capture in all of history.
+        if !oldScreenshots.isEmpty, viewModel.activeSearchQuery == nil, trackWindow.span > 0 {
+          let centre = trackWindow.start + trackWindow.span / 2
+          currentIndex = RewindTimelineNavigation.nearestIndex(to: centre, screenshots: newScreenshots) ?? 0
+        } else {
+          currentIndex = newScreenshots.count - 1
+        }
         selectedGroupIndex = 0
         scheduleLoadCurrentFrame()
       }
+    }
+    .onReceive(
+      trackWindow.$start.combineLatest(trackWindow.$span)
+        .debounce(for: .milliseconds(120), scheduler: DispatchQueue.main)
+    ) { start, span in
+      guard span > 0, viewModel.activeSearchQuery == nil else { return }
+      Task { await viewModel.loadTimelineWindow(from: start, to: start + span) }
     }
     .onChange(of: viewModel.activeSearchQuery) { oldQuery, newQuery in
       // When search becomes active, default to results view
@@ -277,35 +291,12 @@ struct RewindPage: View {
       }
       return .ignored
     }
-    // Global scroll wheel handler - works anywhere on the page
-    .onScrollWheel { delta in
-      handleScrollWheel(delta: delta)
-    }
   }
 
-  // Handle scroll wheel to move playhead
-  private func handleScrollWheel(delta: CGFloat) {
-    log("RewindPage: Scroll wheel delta=\(delta), currentIndex=\(currentIndex), screenshots=\(activeScreenshots.count)")
-
-    guard !activeScreenshots.isEmpty else {
-      log("RewindPage: Scroll ignored - no screenshots")
-      return
-    }
-    guard searchViewMode != .results else {
-      log("RewindPage: Scroll ignored - in results view")
-      return
-    }
-
-    let sensitivity: CGFloat = 0.5  // Reduced from 3.0 - was too fast
-    let framesToMove = Int(delta * sensitivity)  // Positive delta (scroll right/down) = newer = higher index
-
-    if framesToMove != 0 {
-      let newIndex = max(0, min(activeScreenshots.count - 1, currentIndex + framesToMove))
-      if newIndex != currentIndex {
-        log("RewindPage: Scroll moving from \(currentIndex) to \(newIndex)")
-        seekToIndex(newIndex)
-      }
-    }
+  /// The AppKit track owns wheel/swipe input and forwards only gestures that begin on the timeline.
+  private func handleTimelineScroll(deltaX: CGFloat, deltaY: CGFloat) {
+    guard viewModel.activeSearchQuery == nil, searchViewMode != .results else { return }
+    trackWindow.pan(deltaX: deltaX, deltaY: deltaY)
   }
 
   // MARK: - No Search Results
@@ -496,6 +487,7 @@ struct RewindPage: View {
       let groups = viewModel.groupedSearchResults
       if groups.indices.contains(groupIndex) {
         viewModel.alignSelectedDay(to: groups[groupIndex].startTime)
+        trackWindow.center(on: groups[groupIndex].startTime.timeIntervalSince1970)
       }
       scheduleLoadCurrentFrame()
     }
@@ -586,9 +578,10 @@ struct RewindPage: View {
         selection: Binding(
           get: { viewModel.selectedDate },
           set: { newDate in
-            // Only reload if the selected day actually changed
+            // Keep one all-time source; the picker moves its playhead instead of replacing it with
+            // a day-bounded query.
             guard !Calendar.current.isDate(newDate, inSameDayAs: viewModel.selectedDate) else { return }
-            Task { await viewModel.filterByDate(newDate) }
+            seekToCapturedDay(newDate)
           }
         ),
         displayedComponents: [.date]
@@ -640,7 +633,7 @@ struct RewindPage: View {
 
       HStack(spacing: OmiSpacing.sm) {
         Button {
-          if let older { Task { await viewModel.filterByDate(older) } }
+          if let older { seekToCapturedDay(older) }
         } label: {
           Label("Older", systemImage: "chevron.left")
             .scaledFont(size: OmiType.caption)
@@ -650,7 +643,7 @@ struct RewindPage: View {
         .opacity(older == nil ? 0.35 : 1)
 
         Button {
-          if let newer { Task { await viewModel.filterByDate(newer) } }
+          if let newer { seekToCapturedDay(newer) }
         } label: {
           Label("Newer", systemImage: "chevron.right")
             .scaledFont(size: OmiType.caption)
@@ -662,7 +655,7 @@ struct RewindPage: View {
         Spacer(minLength: 0)
 
         Button {
-          if let oldest { Task { await viewModel.filterByDate(oldest) } }
+          if let oldest { seekToCapturedDay(oldest) }
         } label: {
           Text("Oldest capture")
             .scaledFont(size: OmiType.caption)
@@ -768,11 +761,13 @@ struct RewindPage: View {
     VStack(spacing: 0) {
       RewindTrackBar(
         screenshots: activeScreenshots,
+        historyRange: viewModel.historyRange,
         currentIndex: currentIndex,
         searchResultIndices: viewModel.activeSearchQuery != nil && searchViewMode != .timeline
           ? Set(searchResultIndices) : nil,
         window: trackWindow,
-        onSelect: { seekToIndex($0) })
+        onSelect: { seekToIndex($0) },
+        onScroll: { handleTimelineScroll(deltaX: $0, deltaY: $1) })
       RewindTrackFooter(
         screenshots: activeScreenshots,
         currentIndex: currentIndex,
@@ -827,6 +822,9 @@ struct RewindPage: View {
       guard isCurrentFrameLoad(index: requestedIndex, requestID: requestID, sourceToken: sourceToken) else { return }
       currentImage = image
       viewModel.selectScreenshot(screenshots[requestedIndex])
+      if viewModel.activeSearchQuery == nil {
+        viewModel.alignSelectedDay(to: screenshots[requestedIndex].timestamp)
+      }
       isLoadingFrame = false
       return
     }
@@ -893,7 +891,18 @@ struct RewindPage: View {
     guard newIndex != currentIndex else { return }
 
     currentIndex = newIndex
+    trackWindow.reveal(screenshots[newIndex].timestamp.timeIntervalSince1970)
     scheduleLoadCurrentFrame()
+  }
+
+  private func seekToCapturedDay(_ date: Date) {
+    viewModel.chooseDate(date)
+    let calendar = Calendar.current
+    let start = calendar.startOfDay(for: date)
+    let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start.addingTimeInterval(24 * 3600)
+    let span = max(trackWindow.span, end.timeIntervalSince(start))
+    let middle = start.timeIntervalSince1970 + end.timeIntervalSince(start) / 2
+    trackWindow.set(start: middle - span / 2, span: span)
   }
 
   private func nextFrame() {
@@ -1424,40 +1433,6 @@ struct RewindPage: View {
         }
       }
     }
-  }
-}
-
-// MARK: - Scroll Wheel Event Monitor
-
-/// View modifier that monitors scroll wheel events globally when the view is visible
-struct ScrollWheelMonitor: ViewModifier {
-  let onScroll: (CGFloat) -> Void
-  @State private var monitor: Any?
-
-  func body(content: Content) -> some View {
-    content
-      .onAppear {
-        // Add local monitor for scroll wheel events
-        monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
-          let delta = event.scrollingDeltaY + event.scrollingDeltaX
-          if delta != 0 {
-            onScroll(delta)
-          }
-          return event  // Pass event through
-        }
-      }
-      .onDisappear {
-        if let monitor = monitor {
-          NSEvent.removeMonitor(monitor)
-        }
-        monitor = nil
-      }
-  }
-}
-
-extension View {
-  func onScrollWheel(_ handler: @escaping (CGFloat) -> Void) -> some View {
-    modifier(ScrollWheelMonitor(onScroll: handler))
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
@@ -13,7 +13,7 @@ final class RewindTrackWindowModel: ObservableObject {
   @Published private(set) var start: Double = 0
   @Published private(set) var span: Double = 0
 
-  /// The day's full extent, set by the track as the captures load. Zooming is bounded by it.
+  /// The retained history's full extent. The visible window is independent and can pan anywhere in it.
   private(set) var range: ClosedRange<Double> = 0...1
 
   var canZoomIn: Bool { span > RewindTrackWindow.minimumSpan + 0.5 }
@@ -25,20 +25,17 @@ final class RewindTrackWindowModel: ObservableObject {
     newRange != range || span == 0
   }
 
-  /// Whether `reveal` would move the window — the same read-only question for the same reason.
-  func wouldReveal(_ instant: Double?) -> Bool {
-    guard let instant, span > 0 else { return false }
-    return instant < start || instant > start + span
-  }
-
-  /// Adopts a new day. Resets to the full extent, because a window kept across days would open on a
-  /// range the new day has no capture in.
-  func adopt(range newRange: ClosedRange<Double>) {
+  /// Adopt the database's global bounds without forcing the viewport to show all of history at once.
+  /// The first adoption starts at the already-loaded recent range; later bound extensions preserve
+  /// the user's viewport.
+  func adopt(range newRange: ClosedRange<Double>, initialWindow: ClosedRange<Double>? = nil) {
     guard needsAdoption(of: newRange) else { return }
+    let hadWindow = span > 0
     range = newRange
+    let proposed = initialWindow ?? newRange
     let clamped = RewindTrackWindow.clamp(
-      start: newRange.lowerBound,
-      span: newRange.upperBound - newRange.lowerBound,
+      start: hadWindow ? start : proposed.lowerBound,
+      span: hadWindow ? span : proposed.upperBound - proposed.lowerBound,
       within: newRange)
     start = clamped.start
     span = clamped.span
@@ -60,10 +57,25 @@ final class RewindTrackWindowModel: ObservableObject {
     set(start: clamped.start, span: clamped.span)
   }
 
+  /// Pan continuously through time. AppKit reports a rightward content gesture as a negative
+  /// horizontal delta, while the established wheel convention reports scrolling down/newer as a
+  /// positive vertical delta, so the two dominant-axis paths intentionally have opposite signs.
+  func pan(deltaX: CGFloat, deltaY: CGFloat, pointsPerSpan: CGFloat = 600) {
+    guard span > 0, pointsPerSpan > 0 else { return }
+    let movement = abs(deltaX) >= abs(deltaY) ? -deltaX : deltaY
+    set(start: start + Double(movement / pointsPerSpan) * span, span: span)
+  }
+
+  /// Move the current viewport to an instant without changing its zoom level.
+  func center(on instant: Double) {
+    guard span > 0 else { return }
+    set(start: instant - span / 2, span: span)
+  }
+
   /// Keeps an instant inside the visible window, so stepping frames with the arrow keys cannot walk
   /// the playhead off a zoomed track.
   func reveal(_ instant: Double) {
-    guard wouldReveal(instant) else { return }
+    guard span > 0, instant < start || instant > start + span else { return }
     set(start: instant - span / 2, span: span)
   }
 }
@@ -78,10 +90,12 @@ final class RewindTrackWindowModel: ObservableObject {
 /// remove.
 struct RewindTrackRepresentable: NSViewRepresentable {
   let screenshots: [Screenshot]
+  let historyRange: ClosedRange<Double>?
   let currentIndex: Int
   let searchResultIndices: Set<Int>?
   @ObservedObject var window: RewindTrackWindowModel
   let onSelect: (Int) -> Void
+  let onScroll: (CGFloat, CGFloat) -> Void
 
   @MainActor
   final class Coordinator {
@@ -119,19 +133,20 @@ struct RewindTrackRepresentable: NSViewRepresentable {
     let coordinator = context.coordinator
     coordinator.refresh(screenshots)
 
-    let range = RewindTrackWindow.fullRange(of: coordinator.instants)
+    let loadedRange = RewindTrackWindow.fullRange(of: coordinator.instants)
+    let range = historyRange ?? loadedRange
     let playheadAt =
       coordinator.instants.indices.contains(currentIndex)
       ? coordinator.instants[currentIndex] : nil
 
     // **Scheduled, not called.** `updateNSView` runs inside SwiftUI's own update pass, and publishing
     // from there is the "Publishing changes from within view updates" defect — an observable mutated
-    // mid-pass either warns or is dropped. A new day adopts its range, and a step that walked off a
-    // zoomed track pulls it back, one turn of the run loop later; neither is visible at a frame.
-    if window.needsAdoption(of: range) || window.wouldReveal(playheadAt) {
+    // mid-pass either warns or is dropped. The track adopts global bounds one turn of the run loop
+    // later. The playhead deliberately does not pull a panned viewport back; explicit frame
+    // navigation owns revealing it.
+    if window.needsAdoption(of: range) {
       DispatchQueue.main.async {
-        window.adopt(range: range)
-        if let playheadAt { window.reveal(playheadAt) }
+        window.adopt(range: range, initialWindow: loadedRange)
       }
     }
 
@@ -154,6 +169,7 @@ struct RewindTrackRepresentable: NSViewRepresentable {
     context.coordinator.onSelect = onSelect
     view.onSelect = { [weak coordinator = context.coordinator] in coordinator?.onSelect?($0) }
     view.onScrubEnd = { [weak coordinator = context.coordinator] in coordinator?.onSelect?($0) }
+    view.onScroll = onScroll
     view.onZoom = { [window] start, span in window.set(start: start, span: span) }
   }
 }
@@ -161,18 +177,22 @@ struct RewindTrackRepresentable: NSViewRepresentable {
 /// The track plus the height the badges and hour labels need.
 struct RewindTrackBar: View {
   let screenshots: [Screenshot]
+  let historyRange: ClosedRange<Double>?
   let currentIndex: Int
   let searchResultIndices: Set<Int>?
   @ObservedObject var window: RewindTrackWindowModel
   let onSelect: (Int) -> Void
+  let onScroll: (CGFloat, CGFloat) -> Void
 
   var body: some View {
     RewindTrackRepresentable(
       screenshots: screenshots,
+      historyRange: historyRange,
       currentIndex: currentIndex,
       searchResultIndices: searchResultIndices,
       window: window,
-      onSelect: onSelect
+      onSelect: onSelect,
+      onScroll: onScroll
     )
     .frame(height: RewindTrackNSView.height)
     .padding(.horizontal, 18)

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// how far back a pixel travels depends on how densely that stretch happened to be captured; a lunch
 /// break is invisible; and two frames either side of an overnight gap sit adjacent. Here x maps to
 /// the capture's `timestamp` over the visible window and the frame is found by binary search, which
-/// makes the track an honest picture of a day.
+/// makes the track an honest picture of the retained history.
 ///
 /// It is drawn in AppKit rather than SwiftUI for three reasons that are all about the pointer:
 /// pixel-exact hit testing during a drag, a scroll wheel that pans, and a hover tooltip that has to
@@ -54,6 +54,9 @@ final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
   var onScrubEnd: ((Int) -> Void)?
   /// Called while the user pinches, with the span to show.
   var onZoom: ((Double, Double) -> Void)?
+  /// Called for wheel/trackpad input that begins on the track. The page owns the current index; the
+  /// AppKit control owns whether the gesture belongs to the timeline.
+  var onScroll: ((CGFloat, CGFloat) -> Void)?
 
   private var tooltipWindow: NSWindow?
   private var tooltipContent: RewindTrackTooltipView?
@@ -372,7 +375,8 @@ final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
   /// sample of a scrub; constructing a `DateFormatter` there would put a locale lookup on the frame
   /// budget this rebuild exists to protect.
   static func tickFormatter(forInterval interval: Double) -> DateFormatter {
-    interval >= 3600 ? hourTickFormatter : minuteTickFormatter
+    if interval >= 24 * 3600 { return dayTickFormatter }
+    return interval >= 3600 ? hourTickFormatter : minuteTickFormatter
   }
 
   private static let hourTickFormatter: DateFormatter = {
@@ -384,6 +388,12 @@ final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
   private static let minuteTickFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "h:mm"
+    return formatter
+  }()
+
+  private static let dayTickFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.setLocalizedDateFormatFromTemplate("MMM d")
     return formatter
   }()
 
@@ -461,6 +471,13 @@ final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
       lastReportedIndex = index
       onScrubEnd?(index)
     }
+  }
+
+  /// Wheel and two-finger scroll gestures belong to the track under the pointer, not to a page-wide
+  /// event tap. Keeping the raw axes separate lets the navigation policy choose the gesture's
+  /// dominant direction instead of cancelling a slightly diagonal swipe by adding its axes.
+  override func scrollWheel(with event: NSEvent) {
+    onScroll?(event.scrollingDeltaX, event.scrollingDeltaY)
   }
 
   /// Moves the playhead and reports the frame under it.

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
@@ -14,7 +14,30 @@ struct RewindActivityBlock: Equatable {
   var duration: Double { max(0, endedAt - startedAt) }
 }
 
-/// The time window the track is showing, and how it is derived from a day of capture.
+/// Pure navigation policy shared by the AppKit track and the SwiftUI page.
+enum RewindTimelineNavigation {
+  /// The capture nearest an absolute moment in an ascending viewport sample.
+  static func nearestIndex(to instant: Double, screenshots: [Screenshot]) -> Int? {
+    guard !screenshots.isEmpty else { return nil }
+    var lower = 0
+    var upper = screenshots.count
+    while lower < upper {
+      let middle = lower + (upper - lower) / 2
+      if screenshots[middle].timestamp.timeIntervalSince1970 <= instant {
+        lower = middle + 1
+      } else {
+        upper = middle
+      }
+    }
+    if lower == 0 { return 0 }
+    if lower == screenshots.count { return screenshots.count - 1 }
+    let earlier = screenshots[lower - 1].timestamp.timeIntervalSince1970
+    let later = screenshots[lower].timestamp.timeIntervalSince1970
+    return instant - earlier <= later - instant ? lower - 1 : lower
+  }
+}
+
+/// The time window the track is showing, and how it is derived from the loaded capture history.
 ///
 /// Split out of the view because it is the whole of the track's arithmetic and none of its drawing:
 /// a pure function of timestamps that a hermetic test can drive without a window server.
@@ -23,6 +46,15 @@ enum RewindTrackWindow {
   /// The narrowest window a zoom may reach — a minute across the bar is already finer than the
   /// capture interval, so anything below it zooms into empty space.
   static let minimumSpan: Double = 60
+
+  /// Exact retained-history bounds, padded enough that the end captures are not flush against the
+  /// track. This range stays global while viewport samples come and go beneath it.
+  static func historyRange(oldest: Date?, newest: Date?) -> ClosedRange<Double>? {
+    guard let oldest, let newest else { return nil }
+    let lower = oldest.timeIntervalSince1970 - 30
+    let upper = max(newest.timeIntervalSince1970 + 30, lower + minimumSpan)
+    return lower...upper
+  }
 
   /// Contiguous same-app stretches, in capture order.
   ///
@@ -47,7 +79,7 @@ enum RewindTrackWindow {
     return result
   }
 
-  /// The full extent of a day's capture, padded by one sampling interval at each end so the first and
+  /// The full extent of the loaded capture history, padded by one sampling interval at each end so the first and
   /// last segments are not flush against the bar's rounded corners.
   static func fullRange(of instants: [Double]) -> ClosedRange<Double> {
     guard let first = instants.first, let last = instants.last else {
@@ -60,7 +92,7 @@ enum RewindTrackWindow {
     return lower...upper
   }
 
-  /// Clamps a proposed window so it can neither be narrower than a minute nor wander off the day.
+  /// Clamps a proposed window so it can neither be narrower than a minute nor leave retained history.
   ///
   /// One clamp for the buttons and the pinch both, so a gesture cannot leave the track in a state a
   /// button could not reach.

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindViewModel.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindViewModel.swift
@@ -22,9 +22,11 @@ class RewindViewModel: ObservableObject {
 
   /// Every local day that holds capture, newest first.
   ///
-  /// The page plays one day at a time, so this is what makes it *reachable* across the whole
-  /// history rather than only the day you happened to open it on.
+  /// Days are labels and jump targets only; the timeline itself is continuous.
   @Published private(set) var capturedDays: [Date] = []
+
+  /// Exact global bounds of retained capture. The visible track window pans and zooms inside them.
+  @Published private(set) var historyRange: ClosedRange<Double>?
 
   /// Whether the walk over the capture database's own days has finished at least once.
   ///
@@ -33,9 +35,6 @@ class RewindViewModel: ObservableObject {
   /// list an honest "there is no capture". Collapsing the two is how a surface ends up telling a
   /// user with months of history that they have none.
   @Published private(set) var didSurveyHistory = false
-
-  /// Set once the user picks a day themselves, so the automatic reveal below never overrides them.
-  private var didChooseDayManually = false
 
   @Published var stats: (total: Int, indexed: Int, storageSize: Int64)? = nil
 
@@ -81,13 +80,29 @@ class RewindViewModel: ObservableObject {
   /// Whether initial data has been loaded (prevents race condition with debounced search)
   private var isInitialized = false
 
+  /// Each visible viewport stays bounded even when capture contains hundreds of thousands of rows.
+  /// Zooming or panning issues a fresh evenly sampled query for that continuous time window.
+  static let timelineSampleTarget = 500
+  typealias TimelineScreenshotLoader =
+    @Sendable (_ start: Date, _ end: Date, _ targetCount: Int, _ appFilter: String?) async throws -> [Screenshot]
+
+  private var visibleTimelineRange: ClosedRange<Double>?
+  private var timelineLoadID = UUID()
+  private let timelineScreenshotLoader: TimelineScreenshotLoader
+
   /// Set by RewindPage when the transcript/notes panel is expanded.
   /// Auto-refresh skips when true so the view tree stays stable and @State is preserved.
   var isTranscriptExpanded = false
 
   // MARK: - Initialization
 
-  init() {
+  init(
+    timelineScreenshotLoader: @escaping TimelineScreenshotLoader = { start, end, targetCount, appFilter in
+      try RewindDatabase.shared.getScreenshotsSampled(
+        from: start, to: end, targetCount: targetCount, appFilter: appFilter)
+    }
+  ) {
+    self.timelineScreenshotLoader = timelineScreenshotLoader
     // Debounce search queries
     $searchQuery
       .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
@@ -131,8 +146,8 @@ class RewindViewModel: ObservableObject {
     let calendar = Calendar.current
     guard calendar.isDateInToday(selectedDate) else { return }
 
-    // Silent refresh: don't set isLoading, and only update if data changed
-    await silentLoadScreenshotsForDate(selectedDate)
+    // Silent refresh: append newly finalized frames without rescanning the retained history.
+    await silentlyRefreshNewestFrames()
   }
 
   /// Update only the stats (for live frame count updates)
@@ -168,7 +183,7 @@ class RewindViewModel: ObservableObject {
         log("RewindViewModel: Database was recovered from corruption, \(recoveredCount) records salvaged")
       }
 
-      // Load today's screenshots (date filter is always active)
+      // Load today's screenshots for a fast first paint.
       await loadScreenshotsForDate(selectedDate)
 
       // Load available apps for filtering
@@ -188,11 +203,12 @@ class RewindViewModel: ObservableObject {
     log("RewindViewModel: Posting rewindPageDidLoad notification")
     NotificationCenter.default.post(name: .rewindPageDidLoad, object: nil)
 
-    // How far back Rewind goes, asked after the first day is already on screen.
+    // Discover the continuous retained bounds behind the newest day's first paint.
     //
     // **Deliberately not awaited above.** The newest day is the one the user opened the page to
     // see, and it must be drawable before anything else finishes; the survey is one index seek per
-    // captured day and lands behind an already-readable timeline.
+    // captured day. The track keeps today's first paint as its initial viewport and loads other
+    // windows only as zoom or pan reaches them.
     Task { await self.surveyCapturedHistory() }
 
     // Load stats asynchronously (includes storage size calculation which can be slow)
@@ -203,13 +219,11 @@ class RewindViewModel: ObservableObject {
     }
   }
 
-  /// Ask the capture database which days it actually holds, and open the newest one that does.
+  /// Ask the capture database which days it holds and publish the exact continuous history bounds.
   ///
-  /// The second half matters as much as the first: capture stops when the Mac sleeps, when screen
-  /// recording permission is revoked, and when the user turns it off, so "today" is regularly a day
-  /// with nothing in it. Landing on an empty today and stopping there is indistinguishable from
-  /// having no history at all — the reveal below is what turns that into the newest day that does
-  /// hold capture, without the user having to guess a date.
+  /// Capture stops when the Mac sleeps, when screen recording permission is revoked, and when the
+  /// user turns it off, so a one-day source regularly looks empty despite months of retained data.
+  /// The day list powers labels and jumps; exact database extrema bound one time-linear track.
   /// - Parameter attempts: how many times a database that is still opening is re-asked.
   ///
   /// **A failed read is never reported as "no capture".** Rewind's pool opens asynchronously, and
@@ -221,14 +235,10 @@ class RewindViewModel: ObservableObject {
     for attempt in 0..<max(1, attempts) {
       do {
         let days = try await RewindDatabase.shared.capturedDayStarts()
+        let stats = try await RewindDatabase.shared.getStats()
         capturedDays = days
+        historyRange = RewindTrackWindow.historyRange(oldest: stats.oldestDate, newest: stats.newestDate)
         didSurveyHistory = true
-
-        guard !didChooseDayManually, activeSearchQuery == nil, screenshots.isEmpty else { return }
-        guard let newest = days.first, !Calendar.current.isDate(newest, inSameDayAs: selectedDate) else { return }
-        log("RewindViewModel: Selected day holds no capture; revealing newest captured day \(newest)")
-        selectedDate = newest
-        await loadScreenshotsForDate(newest)
         return
       } catch {
         if attempt + 1 < attempts { try? await Task.sleep(for: .milliseconds(500)) }
@@ -277,10 +287,10 @@ class RewindViewModel: ObservableObject {
     let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
     if trimmedQuery.isEmpty {
-      // Reset to date-filtered view (date filter is always active)
+      // Restore the viewport that was visible before search.
       isSearching = false
       activeSearchQuery = nil
-      await loadScreenshotsForDate(selectedDate)
+      await reloadVisibleTimeline(showLoading: true)
       return
     }
 
@@ -352,19 +362,13 @@ class RewindViewModel: ObservableObject {
     if !searchQuery.isEmpty {
       await performSearch(query: searchQuery)
     } else {
-      await loadScreenshotsForDate(selectedDate)
+      await reloadVisibleTimeline(showLoading: true)
     }
   }
 
-  func filterByDate(_ date: Date) async {
-    didChooseDayManually = true
-    selectedDate = date
-
-    if !searchQuery.isEmpty {
-      await performSearch(query: searchQuery)
-    } else {
-      await loadScreenshotsForDate(date)
-    }
+  /// Move the date control without replacing the all-time timeline source.
+  func chooseDate(_ date: Date) {
+    selectedDate = Calendar.current.startOfDay(for: date)
   }
 
   /// Point the day control at `date` without reloading the timeline.
@@ -376,8 +380,46 @@ class RewindViewModel: ObservableObject {
   func alignSelectedDay(to date: Date) {
     let day = Calendar.current.startOfDay(for: date)
     guard !Calendar.current.isDate(day, inSameDayAs: selectedDate) else { return }
-    didChooseDayManually = true
     selectedDate = day
+  }
+
+  /// Load a bounded sample for the current continuous viewport. Queries are overscanned by one
+  /// quarter-window on either side so a continuing pan keeps drawing while the next read is pending.
+  func loadTimelineWindow(from start: Double, to end: Double, showLoading: Bool = false) async {
+    guard activeSearchQuery == nil, end > start else { return }
+    if showLoading { isLoading = true }
+    defer {
+      if showLoading { isLoading = false }
+    }
+
+    let requested = RewindTrackWindow.clamp(
+      start: start,
+      span: end - start,
+      within: historyRange ?? (start...end))
+    let overscan = requested.span / 4
+    let queryStart = max(historyRange?.lowerBound ?? requested.start, requested.start - overscan)
+    let queryEnd = min(historyRange?.upperBound ?? end, requested.start + requested.span + overscan)
+    let loadID = UUID()
+    timelineLoadID = loadID
+
+    do {
+      let results = try await timelineScreenshotLoader(
+        Date(timeIntervalSince1970: queryStart),
+        Date(timeIntervalSince1970: queryEnd),
+        Self.timelineSampleTarget,
+        selectedApp)
+      guard timelineLoadID == loadID, activeSearchQuery == nil else { return }
+      visibleTimelineRange = requested.start...(requested.start + requested.span)
+      screenshots = await displayableScreenshots(from: results)
+    } catch {
+      guard timelineLoadID == loadID, activeSearchQuery == nil else { return }
+      logError("RewindViewModel: Failed to load timeline viewport: \(error)")
+    }
+  }
+
+  private func reloadVisibleTimeline(showLoading: Bool = false) async {
+    guard let range = visibleTimelineRange ?? historyRange else { return }
+    await loadTimelineWindow(from: range.lowerBound, to: range.upperBound, showLoading: showLoading)
   }
 
   private func loadScreenshotsForDate(_ date: Date) async {
@@ -386,6 +428,7 @@ class RewindViewModel: ObservableObject {
     let calendar = Calendar.current
     let startOfDay = calendar.startOfDay(for: date)
     let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+    visibleTimelineRange = startOfDay.timeIntervalSince1970...endOfDay.timeIntervalSince1970
 
     do {
       var results = try await RewindDatabase.shared.getScreenshotsSampled(
@@ -414,48 +457,58 @@ class RewindViewModel: ObservableObject {
     isLoading = false
   }
 
-  /// Silent variant for auto-refresh: never touches isLoading, and only
-  /// updates `screenshots` when the fetched IDs differ from the current set.
-  /// This prevents unnecessary SwiftUI view-tree rebuilds that destroy @State.
-  private func silentLoadScreenshotsForDate(_ date: Date) async {
+  /// Append newly finalized captures without repeating the all-time sample query every three seconds.
+  private func silentlyRefreshNewestFrames() async {
+    guard let newest = screenshots.last else {
+      await reloadVisibleTimeline()
+      return
+    }
+
     let calendar = Calendar.current
-    let startOfDay = calendar.startOfDay(for: date)
-    let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+    let startOfToday = calendar.startOfDay(for: Date())
+    guard let endOfToday = calendar.date(byAdding: .day, value: 1, to: startOfToday) else { return }
 
     do {
-      var results = try await RewindDatabase.shared.getScreenshotsSampled(
-        from: startOfDay,
-        to: endOfDay,
-        targetCount: 500
+      let fetched = try await RewindDatabase.shared.getScreenshots(
+        from: newest.timestamp,
+        to: endOfToday,
+        limit: Self.timelineSampleTarget
       )
-
-      // Filter out frames from the active (unfinalized) video chunk
-      let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
-      if let activeChunk = activeChunk {
-        results = results.filter { $0.videoChunkPath != activeChunk }
+      let candidates = await displayableScreenshots(from: fetched.reversed())
+      let existingIDs = Set(screenshots.compactMap(\.id))
+      let additions = candidates.filter { screenshot in
+        if let id = screenshot.id { return !existingIDs.contains(id) }
+        return screenshot.timestamp > newest.timestamp
       }
+      guard !additions.isEmpty else { return }
+      screenshots.append(contentsOf: additions)
 
-      // Apply app filter if set
-      if let app = selectedApp {
-        results = results.filter { $0.appName == app }
+      let today = calendar.startOfDay(for: additions[additions.count - 1].timestamp)
+      if !capturedDays.contains(where: { calendar.isDate($0, inSameDayAs: today) }) {
+        capturedDays.insert(today, at: 0)
       }
-
-      // Only update if the data actually changed (compare by IDs)
-      let oldIds = screenshots.compactMap { $0.id }
-      let newIds = results.compactMap { $0.id }
-      if oldIds != newIds {
-        screenshots = results
-      }
-
     } catch {
-      logError("RewindViewModel: Failed to silently refresh screenshots: \(error)")
+      logError("RewindViewModel: Failed to refresh newest timeline frames: \(error)")
     }
+  }
+
+  private func displayableScreenshots<S: Sequence>(from source: S) async -> [Screenshot]
+  where S.Element == Screenshot {
+    var results = Array(source)
+    if let activeChunk = await VideoChunkEncoder.shared.currentChunkPath {
+      results.removeAll { $0.videoChunkPath == activeChunk }
+    }
+    if let app = selectedApp {
+      results.removeAll { $0.appName != app }
+    }
+    return results
   }
 
   // MARK: - Screenshot Selection
 
   func selectScreenshot(_ screenshot: Screenshot) {
     selectedScreenshot = screenshot
+    alignSelectedDay(to: screenshot.timestamp)
     AnalyticsManager.shared.rewindScreenshotViewed(timestamp: screenshot.timestamp)
   }
 

--- a/desktop/macos/Desktop/Tests/RewindAllTimeSearchTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindAllTimeSearchTests.swift
@@ -80,12 +80,14 @@ final class RewindAllTimeSearchTests: XCTestCase {
   }
 
   @discardableResult
-  private func insert(daysAgo: Int, text: String, embedding: Data? = nil) async throws -> Screenshot {
+  private func insert(
+    daysAgo: Int, text: String, appName: String = "AllTimeTest", embedding: Data? = nil
+  ) async throws -> Screenshot {
     let stamp = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()))
     let inserted = try await RewindDatabase.shared.insertScreenshot(
       Screenshot(
         timestamp: stamp,
-        appName: "AllTimeTest",
+        appName: appName,
         videoChunkPath: "alltime/\(daysAgo).mp4",
         frameOffset: 0,
         ocrText: text,
@@ -211,5 +213,131 @@ final class RewindAllTimeSearchTests: XCTestCase {
   func testCapturedDayStartsIsEmptyWhenNothingWasEverCaptured() async throws {
     let days = try await RewindDatabase.shared.capturedDayStarts()
     XCTAssertTrue(days.isEmpty, "an account with no capture must report no captured days, not a walk to 1970")
+  }
+
+  // MARK: - The continuous timeline reaches retained history
+
+  func testHistorySurveyPublishesGlobalBoundsWithoutReplacingTheVisibleWindow() async throws {
+    let newest = try await insert(daysAgo: 0, text: "newest day")
+    try await insert(daysAgo: 2, text: "middle day")
+    let oldest = try await insert(daysAgo: 9, text: "oldest day")
+
+    let viewModel = await MainActor.run { RewindViewModel() }
+    await viewModel.surveyCapturedHistory(attempts: 1)
+    let snapshot = await MainActor.run {
+      (dayCount: viewModel.capturedDays.count, range: viewModel.historyRange, count: viewModel.screenshots.count)
+    }
+
+    XCTAssertEqual(snapshot.dayCount, 3)
+    XCTAssertEqual(
+      snapshot.count, 0, "surveying bounds must not replace the current viewport with a fixed all-time sample")
+    XCTAssertLessThan(snapshot.range?.lowerBound ?? .infinity, oldest.timestamp.timeIntervalSince1970)
+    XCTAssertGreaterThan(snapshot.range?.upperBound ?? -.infinity, newest.timestamp.timeIntervalSince1970)
+  }
+
+  func testPanningReloadsOnlyTheRequestedContinuousWindow() async throws {
+    let newest = try await insert(daysAgo: 0, text: "newest day")
+    let middle = try await insert(daysAgo: 2, text: "middle day")
+    let oldest = try await insert(daysAgo: 9, text: "oldest day")
+    let viewModel = await MainActor.run { RewindViewModel() }
+    await viewModel.surveyCapturedHistory(attempts: 1)
+
+    await viewModel.loadTimelineWindow(
+      from: middle.timestamp.addingTimeInterval(-3600).timeIntervalSince1970,
+      to: middle.timestamp.addingTimeInterval(3600).timeIntervalSince1970)
+    var text = await MainActor.run { viewModel.screenshots.compactMap(\.ocrText) }
+    XCTAssertEqual(text, ["middle day"])
+
+    await viewModel.loadTimelineWindow(
+      from: oldest.timestamp.addingTimeInterval(-3600).timeIntervalSince1970,
+      to: oldest.timestamp.addingTimeInterval(3600).timeIntervalSince1970)
+    text = await MainActor.run { viewModel.screenshots.compactMap(\.ocrText) }
+    XCTAssertEqual(text, ["oldest day"], "panning back must query the older viewport without a day transition")
+
+    await viewModel.loadTimelineWindow(
+      from: newest.timestamp.addingTimeInterval(-3600).timeIntervalSince1970,
+      to: newest.timestamp.addingTimeInterval(3600).timeIntervalSince1970)
+    text = await MainActor.run { viewModel.screenshots.compactMap(\.ocrText) }
+    XCTAssertEqual(text, ["newest day"])
+  }
+
+  func testTimelineLoadCannotReplaceSearchResultsThatStartWhileItsQueryIsInFlight() async throws {
+    let queryStarted = expectation(description: "timeline query started")
+    let releaseQuery = AsyncStream<Void>.makeStream()
+    let staleTimelineFrame = Screenshot(
+      timestamp: Date(timeIntervalSince1970: 200), appName: "Timeline", imagePath: "timeline.jpg")
+    let searchFrame = Screenshot(
+      timestamp: Date(timeIntervalSince1970: 300), appName: "Search", imagePath: "search.jpg")
+    let viewModel = await MainActor.run {
+      RewindViewModel { _, _, _, _ in
+        queryStarted.fulfill()
+        for await _ in releaseQuery.stream { break }
+        return [staleTimelineFrame]
+      }
+    }
+
+    let load = Task {
+      await viewModel.loadTimelineWindow(from: 100, to: 400)
+    }
+    await fulfillment(of: [queryStarted])
+    await MainActor.run {
+      viewModel.activeSearchQuery = "needle"
+      viewModel.screenshots = [searchFrame]
+    }
+    releaseQuery.continuation.yield()
+    await load.value
+
+    let visible = await MainActor.run { viewModel.screenshots }
+    XCTAssertEqual(visible, [searchFrame], "an older timeline read must not overwrite the active search source")
+  }
+
+  func testAppFilterIsAppliedBeforeTimelineSampling() async throws {
+    let now = Date()
+    for offset in 0..<12 {
+      _ = try await RewindDatabase.shared.insertScreenshot(
+        Screenshot(
+          timestamp: now.addingTimeInterval(Double(offset)),
+          appName: "BusyApp",
+          videoChunkPath: "busy/\(offset).mp4",
+          frameOffset: 0,
+          ocrText: "busy \(offset)",
+          isIndexed: true))
+    }
+    for offset in 0..<3 {
+      _ = try await RewindDatabase.shared.insertScreenshot(
+        Screenshot(
+          timestamp: now.addingTimeInterval(Double(offset) + 0.5),
+          appName: "SparseApp",
+          videoChunkPath: "sparse/\(offset).mp4",
+          frameOffset: 0,
+          ocrText: "sparse \(offset)",
+          isIndexed: true))
+    }
+
+    let sample = try await RewindDatabase.shared.getScreenshotsSampled(
+      from: now.addingTimeInterval(-1),
+      to: now.addingTimeInterval(20),
+      targetCount: 3,
+      appFilter: "SparseApp")
+
+    XCTAssertEqual(sample.count, 3)
+    XCTAssertTrue(sample.allSatisfy { $0.appName == "SparseApp" })
+  }
+
+  func testBoundedAllTimeSampleIncludesTheOldestAndNewestCapture() async throws {
+    for offset in (0..<10).reversed() {
+      try await insert(daysAgo: offset, text: "day \(offset)")
+    }
+    let calendar = Calendar.current
+    let start = calendar.startOfDay(
+      for: try XCTUnwrap(calendar.date(byAdding: .day, value: -10, to: Date())))
+    let end = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: Date()))
+
+    let sample = try await RewindDatabase.shared.getScreenshotsSampled(
+      from: start, to: end, targetCount: 3)
+
+    XCTAssertEqual(sample.count, 3)
+    XCTAssertEqual(sample.first?.ocrText, "day 9", "the all-time range must retain its oldest end")
+    XCTAssertEqual(sample.last?.ocrText, "day 0", "the all-time range must retain its live/newest end")
   }
 }

--- a/desktop/macos/Desktop/Tests/RewindHistoryReachTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindHistoryReachTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// Rewind is a one-day-at-a-time player, so "how far back does this go" is a question it answers in
-/// words. These pin the two things that wording has to get right:
+/// Rewind's track spans retained history, while the day popover states the same boundary in words
+/// and offers precise day jumps. These pin the two things that wording has to get right:
 ///
 ///  1. **Not-yet-surveyed is not "none".** The capture-day walk runs behind first paint; an empty
 ///     list before it finishes means "not looked yet". Printing "No screen capture yet" over an

--- a/desktop/macos/Desktop/Tests/RewindTrackTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindTrackTests.swift
@@ -176,26 +176,80 @@ final class RewindTrackTests: XCTestCase {
       "two ticks a minute apart must not carry the same label")
   }
 
+  func testAllTimeDayTicksNameDatesRatherThanRepeatingMidnight() {
+    let first = Date(timeIntervalSince1970: 1_700_000_000)
+    let formatter = RewindTrackNSView.tickFormatter(forInterval: 24 * 3600)
+
+    XCTAssertNotEqual(
+      formatter.string(from: first),
+      formatter.string(from: first.addingTimeInterval(24 * 3600)),
+      "an all-time track must distinguish consecutive day ticks")
+  }
+
+  // MARK: - Continuous pan direction
+
+  func testRightwardSwipeMovesTheAscendingTimelineTowardsNewerFrames() {
+    let model = RewindTrackWindowModel()
+    model.adopt(range: 0...10_000, initialWindow: 4_000...5_000)
+    model.pan(deltaX: -60, deltaY: 0, pointsPerSpan: 600)
+    XCTAssertEqual(
+      model.start, 4_100, accuracy: 0.001,
+      "AppKit reports a rightward swipe with a negative delta; the viewport must still move right/newer")
+  }
+
+  func testLeftwardSwipeMovesTheAscendingTimelineTowardsOlderFrames() {
+    let model = RewindTrackWindowModel()
+    model.adopt(range: 0...10_000, initialWindow: 4_000...5_000)
+    model.pan(deltaX: 60, deltaY: 0, pointsPerSpan: 600)
+    XCTAssertEqual(model.start, 3_900, accuracy: 0.001)
+  }
+
+  func testDiagonalSwipeUsesItsDominantAxisInsteadOfCancellingDirections() {
+    let model = RewindTrackWindowModel()
+    model.adopt(range: 0...10_000, initialWindow: 4_000...5_000)
+    model.pan(deltaX: -60, deltaY: 50, pointsPerSpan: 600)
+    XCTAssertEqual(model.start, 4_100, accuracy: 0.001, "a slight vertical component must not cancel the pan")
+  }
+
+  func testScrollDownMovesTheAscendingTimelineTowardsNewerFrames() {
+    let model = RewindTrackWindowModel()
+    model.adopt(range: 0...10_000, initialWindow: 4_000...5_000)
+    model.pan(deltaX: 0, deltaY: 60, pointsPerSpan: 600)
+    XCTAssertEqual(model.start, 4_100, accuracy: 0.001)
+  }
+
+  func testViewportReloadTargetsTheCaptureNearestItsCentre() {
+    let screenshots = [
+      Screenshot(timestamp: Date(timeIntervalSince1970: 100), appName: "A", imagePath: "1.jpg"),
+      Screenshot(timestamp: Date(timeIntervalSince1970: 200), appName: "A", imagePath: "2.jpg"),
+      Screenshot(timestamp: Date(timeIntervalSince1970: 300), appName: "B", imagePath: "3.jpg"),
+    ]
+
+    XCTAssertEqual(RewindTimelineNavigation.nearestIndex(to: 249, screenshots: screenshots), 1)
+    XCTAssertEqual(RewindTimelineNavigation.nearestIndex(to: 251, screenshots: screenshots), 2)
+  }
+
   // MARK: - Zoom bounds
 
-  func testClampKeepsTheWindowInsideTheDay() {
+  func testClampKeepsTheWindowInsideRetainedHistory() {
     let range: ClosedRange<Double> = 0...3600
     let past = RewindTrackWindow.clamp(start: 3500, span: 600, within: range)
-    XCTAssertEqual(past.start, 3000, accuracy: 0.001, "a window may not hang off the end of the day")
+    XCTAssertEqual(past.start, 3000, accuracy: 0.001, "a window may not hang off the end of history")
     XCTAssertEqual(past.span, 600, accuracy: 0.001)
 
     let tooWide = RewindTrackWindow.clamp(start: -500, span: 999_999, within: range)
     XCTAssertEqual(tooWide.start, 0, accuracy: 0.001)
-    XCTAssertEqual(tooWide.span, 3600, accuracy: 0.001, "a window may not be wider than the day")
+    XCTAssertEqual(tooWide.span, 3600, accuracy: 0.001, "a window may not be wider than history")
 
     let tooNarrow = RewindTrackWindow.clamp(start: 0, span: 1, within: range)
     XCTAssertEqual(tooNarrow.span, RewindTrackWindow.minimumSpan, accuracy: 0.001)
   }
 
-  func testZoomOutStopsAtTheWholeDayAndZoomInAtAMinute() {
+  func testZoomOutProgressivelyReachesAllHistoryAndZoomInStopsAtAMinute() {
     let model = RewindTrackWindowModel()
-    model.adopt(range: 0...3600)
-    XCTAssertFalse(model.canZoomOut, "a freshly loaded day is already showing all of itself")
+    model.adopt(range: 0...14_400, initialWindow: 10_800...14_400)
+    XCTAssertEqual(model.span, 3600, accuracy: 0.001, "first paint stays on the recent window")
+    XCTAssertTrue(model.canZoomOut, "older retained history remains reachable without a day reload")
     XCTAssertTrue(model.canZoomIn)
 
     for _ in 0..<20 { model.zoom(in: true) }
@@ -203,7 +257,8 @@ final class RewindTrackTests: XCTestCase {
     XCTAssertFalse(model.canZoomIn)
 
     for _ in 0..<20 { model.zoom(in: false) }
-    XCTAssertEqual(model.span, 3600, accuracy: 0.001)
+    XCTAssertEqual(model.start, 0, accuracy: 0.001)
+    XCTAssertEqual(model.span, 14_400, accuracy: 0.001)
     XCTAssertFalse(model.canZoomOut)
   }
 

--- a/desktop/macos/changelog/unreleased/20260807-rewind-all-time-timeline.json
+++ b/desktop/macos/changelog/unreleased/20260807-rewind-all-time-timeline.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind so zooming out or swiping back moves smoothly through all retained screen history instead of stopping at one day"
+}

--- a/desktop/macos/e2e/flows/rewind.yaml
+++ b/desktop/macos/e2e/flows/rewind.yaml
@@ -27,8 +27,8 @@ covers:
   # `OCREmbeddingService.searchSimilar` -> `readEmbeddingBatch`, which is the only caller; it runs
   # unbounded and newest-first, so an all-time query is what proves the range and the ordering.
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
-  # Rewind is the page that holds keyboard focus itself so arrow keys and the scroll wheel work
-  # wherever the pointer is (S3b). The focus effect that came with it is what S3d looks for.
+  # Rewind is the page that holds keyboard focus itself so arrow keys work wherever the pointer is.
+  # The track owns wheel/swipe input (S3b). The focus effect that came with it is what S3d looks for.
   - desktop/macos/Desktop/Sources/MainWindow/ShellPageKeyboardTarget.swift
 preconditions:
   - auth_ready
@@ -43,7 +43,7 @@ steps:
 
   - id: S2
     name: Verify Rewind overlay controls
-    do: "Verify the Rewind overlay shows: search bar ('Search your screen history...'), date picker (showing today's date), settings gear icon, and a toggle. The keyboard shortcut badge (⌘⌥R) should be visible near the Rewind title."
+    do: "Verify the Rewind overlay shows: search bar ('Search your screen history...'), timestamp pill for the current frame, settings gear icon, and a toggle. The keyboard shortcut badge (⌘⌥R) should be visible near the Rewind title."
     expect:
       interactive_count: { min: 3 }
 
@@ -53,7 +53,7 @@ steps:
     # absences must not collapse into one: before the survey finishes the line reads "Checking how
     # far back your capture goes…", and only a finished survey that found nothing may say "No screen
     # capture yet". A confident "no screen capture" over an account with months of it is the defect.
-    do: "Click the timestamp pill at the bottom-left of the frame stage (calendar glyph, date, chevron) to open the day popover. Verify it shows a graphical date picker, one line stating the real span ('N days of capture · <oldest> – <newest>'), and a second line naming the retention setting ('Capture older than N days is deleted', or 'Keeping everything — nothing is deleted' when retention is unlimited). Verify the span line never reads 'No screen capture yet' on an account that has capture. Press 'Oldest capture' and verify the timeline jumps to a day that actually holds frames and the button then disables; press 'Newer' and verify it steps to the next day holding capture rather than to the next calendar day."
+    do: "With capture on at least two non-adjacent days, verify Rewind opens on a recent, readable timeline window. Repeatedly zoom out and verify the axis expands smoothly past midnight until it reaches the oldest and newest retained captures; the footer count may change as each visible window is sampled, but the timeline must not reload as separate days. Swipe left/back through the track and verify the viewport moves continuously toward older timestamps, then swipe right and verify it moves toward newer timestamps. Click the timestamp pill at the bottom-left of the frame stage (calendar glyph, date, chevron) to open the day popover. Verify it shows a graphical date picker, one line stating the real span ('N days of capture · <oldest> – <newest>'), and a second line naming the retention setting ('Capture older than N days is deleted', or 'Keeping everything — nothing is deleted' when retention is unlimited). Verify the span line never reads 'No screen capture yet' on an account that has capture. Press 'Oldest capture' and verify the timeline centers a window containing that day; press 'Newer' and verify it centers the next day holding capture without changing to a day-scoped timeline."
     expect:
       interactive_count: { min: 3 }
 
@@ -65,7 +65,7 @@ steps:
 
   - id: S3b
     name: Verify per-app colour identity and scrub smoothness
-    do: "With the timeline showing, find an app badge whose real icon could not be resolved — it draws as a letter monogram on a filled circle. Verify the circle is a solid, saturated colour (not grey) and that the letter is white and legible on it. Verify two different apps get two different colours, and that the same app keeps its colour after quitting and relaunching the app (RewindPalette hashes the name, so the colour must not change across launches). Then hold the left/right arrow keys to scrub several seconds of frames and verify the stage image keeps up with the keypresses rather than lagging behind them."
+    do: "With the timeline showing, find an app badge whose real icon could not be resolved — it draws as a letter monogram on a filled circle. Verify the circle is a solid, saturated colour (not grey) and that the letter is white and legible on it. Verify two different apps get two different colours, and that the same app keeps its colour after quitting and relaunching the app (RewindPalette hashes the name, so the colour must not change across launches). Hold the left/right arrow keys to scrub several frames and verify the stage image keeps up. Then place the pointer on the timeline track: swipe right and verify the playhead moves right/newer, swipe left and verify it moves left/older; swiping over the frame or day popover must not move the track."
     expect:
       interactive_count: { min: 1 }
 
@@ -83,8 +83,8 @@ steps:
 
   - id: S3d
     name: The page takes keyboard focus without tracing the window
-    # The page is `focusable()` so its arrow-key and scroll-wheel handlers fire wherever the pointer
-    # is. AppKit draws a focus effect around whatever holds focus, and at content-area scale on a
+    # The page is `focusable()` so its arrow-key handlers fire wherever the pointer is. AppKit draws
+    # a focus effect around whatever holds focus, and at content-area scale on a
     # window with no visible extent that effect is a 1 pt accent rectangle on the user's wallpaper —
     # in the one hue this product never uses (INV-UI-1). Focus is kept; the paint is not.
     do: "Click once on the Rewind page background so the page itself holds keyboard focus, then look at the window's left, right and bottom edges and at the line under the top bar. Verify no accent-coloured rectangle or hairline is traced there and none appears on the wallpaper. Then press the arrow keys and verify frames still step, confirming focus was kept rather than removed."


### PR DESCRIPTION
## Summary

- make Rewind one continuous retained-history timeline: it opens on a readable recent window, then progressively reveals older history as the user zooms or pans
- query an overscanned, bounded sample for the visible time window instead of fixing one 500-frame sample across the entire database
- route wheel/trackpad input through the timeline viewport and make horizontal swipes pan time in the same direction as the gesture
- apply app filters before bounded sampling and fence in-flight viewport reads when search takes ownership of the results
- keep dates only as labels and jump targets; day navigation centers a window on the chosen day without replacing the timeline source

## Root cause

The captured-history survey introduced the list of retained days, but `viewModel.screenshots` remained owned by `loadScreenshotsForDate(selectedDate)`. The first revision repaired that ownership by loading one fixed all-time sample, but that was still the wrong interaction boundary: zoom changed only the scale of the same sparse rows and could not progressively reveal history. Rewind now owns exact global bounds separately from a replaceable viewport sample, and every debounced zoom or pan queries that continuous visible time range with overscan.

Swipe handling lived in a page-wide local event monitor. It added the horizontal and vertical axes together and applied the signed AppKit delta directly to an older-to-newer frame index, so a horizontal gesture moved opposite the finger, slightly diagonal gestures could cancel themselves, and scrolling stepped frames instead of moving continuously through time. The track now pans the time window by the dominant gesture axis. Explicit frame navigation reveals the playhead, but a stationary playhead cannot pull a freely panned viewport back.

## Verification

- `xcrun swift test --package-path Desktop --filter 'RewindTrackTests|RewindAllTimeSearchTests'` — 32 passed
- `xcrun swift test --package-path Desktop --filter Rewind` — 192 passed
- `python3 scripts/check_desktop_test_quality.py` — passed
- `agent-logic-harness --cross-surface-smoke` — passed
- built and launched `/Applications/omi-rewind-history.app`; the isolated profile still contains 336 captures on three non-adjacent days (Aug 4, Aug 5, Aug 7). A fresh UI pass was blocked before the shell by macOS asking for the login-keychain password after the named app was re-signed, so no post-revision visual claim is made.

The swipe expectations follow AppKit's signed horizontal delta contract: [NSEvent.deltaX](https://developer.apple.com/documentation/appkit/nsevent/deltax). The updated E2E expectation is also grounded in the live three-day measurement above.

## Product invariants

- INV-AUTH-1 — cited because the desktop view-model path is covered by the invariant's path rule; this PR does not change authentication or session ownership.

## Failure class

Failure-Class: none

This is a local Rewind source-ownership and gesture-sign defect; no registered cross-system failure class applies. Regression coverage now exercises the production database/view-model viewport boundary, progressive zoom bounds, and continuous gesture navigation policy.
