### PR TITLE
test(desktop): align glass release tripwires

### DIFF
--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1607,7 +1607,7 @@ import XCTest
     XCTAssertTrue(chatBubbleSource.contains("private var header: some View"))
     XCTAssertTrue(chatBubbleSource.contains("private var expandedToolCalls: some View"))
     XCTAssertTrue(chatBubbleSource.contains("VStack(alignment: .leading, spacing: compact ? 0 : 6)"))
-    XCTAssertTrue(chatBubbleSource.contains(".frame(height: compact ? 34 : nil)"))
+    XCTAssertTrue(chatBubbleSource.contains("minimumHeight: compact ? 34 : nil"))
     XCTAssertTrue(chatBubbleSource.contains("Image(systemName: isExpanded ? \"chevron.up\" : \"chevron.down\")"))
     XCTAssertTrue(chatBubbleSource.contains("ToolCallCard(\n              name: name"))
     XCTAssertTrue(chatBubbleSource.contains("agentOpenRef: block.agentOpenRef"))

--- a/desktop/macos/Desktop/Tests/SettingsGlassChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsGlassChromeTests.swift
@@ -128,7 +128,7 @@ final class SettingsGlassChromeTests: XCTestCase {
   func testHelpWebViewDoesNotFlashOpaqueWhiteWhileLoading() throws {
     let helpSource = try XCTUnwrap(
       try restyledSources().first(where: { $0.0 == "MainWindow/HelpPage.swift" })?.1)
-    XCTAssertTrue(helpSource.contains("webView.setValue(false, forKey: \"opaque\")"))
+    XCTAssertTrue(helpSource.contains("webView.setValue(false, forKeyPath: \"opaque\")"))
     XCTAssertTrue(helpSource.contains("webView.underPageBackgroundColor = .clear"))
   }
 


### PR DESCRIPTION
## What changed

- update the compact tool-call static tripwire to follow the current `StableChatCardHeader.minimumHeight` API
- update the Help web-view transparency tripwire to match the existing KVC `forKeyPath:` implementation

## Why

The macOS redesign merged production refactors and their source-inspection tests with two stale implementation strings. Exact-main Desktop Swift CI therefore failed even though the intended compact height and transparent Help loading behavior remain present. This test-only repair realigns the tripwires with the production implementation and unblocks the macOS Beta release gate.

## Impact

No production behavior changes. The release gate now checks the current implementation spelling instead of a retired one.

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter 'AgentPillLifecycleTests|SettingsGlassChromeTests'` — 86 tests passed
- dashboard continuation failure from the first CI attempt did not reproduce in 21 focused stress runs and was absent from the latest-main CI rerun
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- `make preflight` — 17 selected checks passed
- pre-push gate — passed, including debug Swift compile

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

