### PR TITLE
fix(backend): stop a group binding resolving to a member's personal account

### DIFF
--- a/backend/database/channels.py
+++ b/backend/database/channels.py
@@ -297,13 +297,29 @@ def revoke_binding(
 
 
 def _webhook_claim_is_stale(event: Dict[str, Any], now: datetime) -> bool:
+    """Whether a claim can be taken from whoever holds it.
+
+    A claim written before leases existed has no `lease_expires_at`. Reading
+    that as "expired" would make every such event reclaimable the instant this
+    deploys, including one a handler picked up seconds earlier — two handlers
+    on the same event means the user gets the reply twice. Its `received_at`
+    dates it just as well, so the lease is derived from that instead, and only
+    a genuinely old claim is reclaimed.
+    """
     status = event.get('status')
     if status not in WEBHOOK_RECLAIMABLE_STATUSES:
         return False
     if status == 'failed':
         return True
     lease_expires_at = event.get('lease_expires_at')
-    return not isinstance(lease_expires_at, datetime) or lease_expires_at <= now
+    if not isinstance(lease_expires_at, datetime):
+        received_at = event.get('received_at')
+        if not isinstance(received_at, datetime):
+            # Neither field is usable, so nothing can date this claim. Leaving
+            # it held forever is the failure this lease exists to end.
+            return True
+        lease_expires_at = received_at + WEBHOOK_PROCESSING_LEASE
+    return lease_expires_at <= now
 
 
 def claim_webhook_event(

--- a/backend/database/channels.py
+++ b/backend/database/channels.py
@@ -14,6 +14,9 @@ from database.firestore_index_registry import CHANNEL_BINDINGS_BY_UID_CHANNEL_QU
 CHANNELS = frozenset({'telegram', 'imessage', 'sms'})
 LINK_TOKEN_TTL = timedelta(minutes=15)
 LINK_TOKEN_PATTERN = re.compile(r'^[0-9a-f]{48}$')
+FIRESTORE_MAX_BATCH_WRITES = 500
+WEBHOOK_PROCESSING_LEASE = timedelta(minutes=5)
+WEBHOOK_RECLAIMABLE_STATUSES = frozenset({'processing', 'failed'})
 
 
 class ChannelLinkError(ValueError):
@@ -234,22 +237,20 @@ def get_binding(
 ) -> Optional[Dict[str, Any]]:
     if channel not in CHANNELS:
         return None
-    identities = (
-        [channel_chat_id, channel_user_id]
-        if channel_chat_id and channel_chat_id != channel_user_id
-        else [channel_user_id]
-    )
+    identity = channel_chat_id or channel_user_id
+    if not identity:
+        return None
     collection = _client(firestore_client).collection('channel_bindings')
-    for identity in identities:
-        if not identity:
-            continue
-        snapshot = collection.document(_binding_id(channel, channel_user_id, identity)).get()
-        if not snapshot.exists:
-            continue
-        binding = _typed_doc(snapshot)
-        if binding.get('revoked_at') is None:
-            return binding
-    return None
+    snapshot = collection.document(_binding_id(channel, channel_user_id, identity)).get()
+    if not snapshot.exists:
+        return None
+    binding = _typed_doc(snapshot)
+    if binding.get('revoked_at') is not None:
+        return None
+    bound_identity = binding.get('channel_chat_id')
+    if isinstance(bound_identity, str) and bound_identity and bound_identity != identity:
+        return None
+    return binding
 
 
 def list_bindings(uid: str, *, firestore_client: Any = None) -> List[Dict[str, Any]]:
@@ -270,10 +271,11 @@ def revoke_channel(uid: str, channel: str, *, now: Optional[datetime] = None, fi
     refs = [row.reference for row in rows if _typed_doc(row).get('revoked_at') is None]
     if not refs:
         return 0
-    batch = client.batch()
-    for ref in refs:
-        batch.update(ref, {'revoked_at': revoked_at})
-    batch.commit()
+    for start in range(0, len(refs), FIRESTORE_MAX_BATCH_WRITES):
+        batch = client.batch()
+        for ref in refs[start : start + FIRESTORE_MAX_BATCH_WRITES]:
+            batch.update(ref, {'revoked_at': revoked_at})
+        batch.commit()
     return len(refs)
 
 
@@ -294,6 +296,16 @@ def revoke_binding(
     return True
 
 
+def _webhook_claim_is_stale(event: Dict[str, Any], now: datetime) -> bool:
+    status = event.get('status')
+    if status not in WEBHOOK_RECLAIMABLE_STATUSES:
+        return False
+    if status == 'failed':
+        return True
+    lease_expires_at = event.get('lease_expires_at')
+    return not isinstance(lease_expires_at, datetime) or lease_expires_at <= now
+
+
 def claim_webhook_event(
     channel: str,
     provider_event_id: str,
@@ -302,21 +314,72 @@ def claim_webhook_event(
     firestore_client: Any = None,
 ) -> Tuple[bool, Optional[Dict[str, Any]]]:
     received_at = now or datetime.now(timezone.utc)
-    ref = _client(firestore_client).collection('channel_webhook_events').document(_event_id(channel, provider_event_id))
+    client = _client(firestore_client)
+    ref = client.collection('channel_webhook_events').document(_event_id(channel, provider_event_id))
     try:
         ref.create(
             {
                 'channel': channel,
                 'provider_event_id': provider_event_id,
                 'status': 'processing',
+                'attempts': 1,
+                'lease_expires_at': received_at + WEBHOOK_PROCESSING_LEASE,
                 'received_at': received_at,
                 'updated_at': received_at,
             }
         )
         return True, None
     except AlreadyExists:
-        snapshot = ref.get()
-        return False, _typed_doc(snapshot) if snapshot.exists else None
+        pass
+
+    @firestore.transactional
+    def apply(transaction: Any) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        snapshot = ref.get(transaction=transaction)
+        existing = _typed_doc(snapshot) if snapshot.exists else None
+        if existing is not None and not _webhook_claim_is_stale(existing, received_at):
+            return False, existing
+        transaction.set(
+            ref,
+            {
+                'channel': channel,
+                'provider_event_id': provider_event_id,
+                'status': 'processing',
+                'attempts': int(existing.get('attempts') or 0) + 1 if existing else 1,
+                'lease_expires_at': received_at + WEBHOOK_PROCESSING_LEASE,
+                'received_at': (existing or {}).get('received_at') or received_at,
+                'updated_at': received_at,
+            },
+        )
+        return True, existing
+
+    return cast(Tuple[bool, Optional[Dict[str, Any]]], run_transactional(client, apply))
+
+
+def release_webhook_claim(
+    channel: str,
+    provider_event_id: str,
+    *,
+    now: Optional[datetime] = None,
+    firestore_client: Any = None,
+) -> bool:
+    """Mark an in-flight claim retryable so the provider's next delivery can reclaim it.
+
+    Only a claim still in ``processing`` is released: once the reply exists the event owns a
+    ``ready`` payload that must stay redeliverable instead of being regenerated.
+    """
+    released_at = now or datetime.now(timezone.utc)
+    client = _client(firestore_client)
+    ref = client.collection('channel_webhook_events').document(_event_id(channel, provider_event_id))
+
+    @firestore.transactional
+    def apply(transaction: Any) -> bool:
+        snapshot = ref.get(transaction=transaction)
+        if not snapshot.exists or _typed_doc(snapshot).get('status') != 'processing':
+            return False
+        transaction.update(ref, {'status': 'failed', 'lease_expires_at': released_at, 'updated_at': released_at})
+        return True
+
+    return cast(bool, run_transactional(client, apply))
 
 
 def update_webhook_event(

--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -30,6 +31,8 @@ from services.channel_chat import (
 from utils.executors import db_executor, run_blocking
 from utils.multipart import PHONE_CALL_MAX_PART_SIZE, parse_multipart_form
 from utils.other import endpoints as auth
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -236,20 +239,31 @@ async def _channel_reply(channel: str, payload: Dict[str, Any]) -> str:
         return 'I could not complete that request. Please try again.'
 
 
+async def _release_failed_claim(channel: str, event_id: str) -> None:
+    try:
+        await run_blocking(db_executor, channels_db.release_webhook_claim, channel, event_id)
+    except Exception:
+        logger.warning('channel=%s could not release a failed webhook claim event_id=%s', channel, event_id)
+
+
 async def _handle_payload(channel: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     event_id = payload['event_id']
     created, existing = await run_blocking(db_executor, channels_db.claim_webhook_event, channel, event_id)
     if not created:
         return await _duplicate_event_response(channel, event_id, existing)
-    reply = await _channel_reply(channel, payload)
-    await _send_and_record(
-        channel,
-        event_id,
-        payload['channel_chat_id'],
-        reply,
-        is_group=payload['channel_chat_id'] != payload['channel_user_id'],
-        provider_mode=payload.get('provider_mode'),
-    )
+    try:
+        reply = await _channel_reply(channel, payload)
+        await _send_and_record(
+            channel,
+            event_id,
+            payload['channel_chat_id'],
+            reply,
+            is_group=payload['channel_chat_id'] != payload['channel_user_id'],
+            provider_mode=payload.get('provider_mode'),
+        )
+    except BaseException:
+        await _release_failed_claim(channel, event_id)
+        raise
     return {'status': 'delivered'}
 
 

--- a/backend/services/channel_chat.py
+++ b/backend/services/channel_chat.py
@@ -10,7 +10,7 @@ import database.chat as chat_db
 import database.llm_usage as llm_usage_db
 from models.chat import ChatSession, Message, MessageSender, MessageType
 from utils.conversation_helpers import extract_memory_ids
-from utils.executors import critical_executor, db_executor, run_blocking
+from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.http_client import get_webhook_client
 from utils.llm.usage_tracker import Features, reset_usage_context, set_usage_context
 from utils.retrieval.graph import execute_chat_stream
@@ -375,10 +375,10 @@ def _persist_human_and_history(uid: str, channel: str, text: str) -> Tuple[List[
 async def generate_channel_reply(
     uid: str, channel: str, text: str, *, attachments: Optional[List[Dict[str, Any]]] = None
 ) -> str:
+    await run_blocking(db_executor, enforce_chat_quota, uid, platform=channel)
     media_context = await build_media_context(uid, attachments or [])
     if media_context:
         text = f'{text}\n\n{media_context}'.strip()
-    await run_blocking(db_executor, enforce_chat_quota, uid, platform=channel)
     messages, chat_session, message_id = await run_blocking(db_executor, _persist_human_and_history, uid, channel, text)
     await run_blocking(
         db_executor,
@@ -487,7 +487,7 @@ async def send_channel_message(
         )
     else:
         try:
-            await run_blocking(critical_executor, send_sms, channel_chat_id, text)
+            await run_blocking(postprocess_executor, send_sms, channel_chat_id, text)
         except Exception as exc:
             raise ChannelProviderError('Twilio SMS delivery failed') from exc
         return

--- a/backend/tests/unit/test_channels.py
+++ b/backend/tests/unit/test_channels.py
@@ -548,6 +548,51 @@ def test_a_stale_processing_claim_is_reclaimed_instead_of_dropped():
     assert stored['received_at'] == now
 
 
+def test_a_legacy_claim_is_dated_by_received_at_not_treated_as_expired():
+    """Events written before leases existed must not all become reclaimable at once.
+
+    A pre-lease document has no `lease_expires_at`. Reading that as "expired"
+    would let a second handler take an event the first picked up seconds before
+    this deployed, and the user gets the reply twice. `received_at` dates it.
+    """
+    client = MockFirestore()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+    ref = client.collection('channel_webhook_events').document(channels_db._event_id('telegram', 'legacy-1'))
+    ref.create(
+        {
+            'channel': 'telegram',
+            'provider_event_id': 'legacy-1',
+            'status': 'processing',
+            'received_at': now,
+            'updated_at': now,
+        }
+    )
+
+    # Still inside the window the lease would have covered: leave it alone.
+    fresh = now + channels_db.WEBHOOK_PROCESSING_LEASE / 2
+    created, existing = channels_db.claim_webhook_event(
+        'telegram', 'legacy-1', now=fresh, firestore_client=client
+    )
+    assert not created
+    assert existing['status'] == 'processing'
+
+    # Past it, the claim is genuinely abandoned and can be reclaimed.
+    stale = now + channels_db.WEBHOOK_PROCESSING_LEASE
+    created, _ = channels_db.claim_webhook_event('telegram', 'legacy-1', now=stale, firestore_client=client)
+    assert created
+
+
+def test_an_undatable_claim_is_reclaimable_rather_than_held_forever():
+    """No lease and no received_at: nothing can date it, so it must not stick."""
+    client = MockFirestore()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+    ref = client.collection('channel_webhook_events').document(channels_db._event_id('sms', 'orphan-1'))
+    ref.create({'channel': 'sms', 'provider_event_id': 'orphan-1', 'status': 'processing'})
+
+    created, _ = channels_db.claim_webhook_event('sms', 'orphan-1', now=now, firestore_client=client)
+    assert created
+
+
 def test_a_failed_claim_is_released_for_immediate_retry_but_a_ready_reply_is_kept():
     client = MockFirestore()
     now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)

--- a/backend/tests/unit/test_channels.py
+++ b/backend/tests/unit/test_channels.py
@@ -459,3 +459,189 @@ def test_describe_image_preserves_mime_type_in_data_url(monkeypatch):
 
     assert result == 'A test image.'
     assert captured['messages'][0]['content'][1]['image_url']['url'] == 'data:image/png;base64,encoded'
+
+
+def test_group_binding_never_falls_back_to_the_sender_personal_binding():
+    client = MockFirestore()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+    token, _ = channels_db.issue_link_token('uid-personal', 'telegram', now=now, firestore_client=client)
+    channels_db.consume_link_token('telegram', token, '42', '42', now=now, firestore_client=client)
+
+    assert channels_db.get_binding('telegram', '42', '42', firestore_client=client)['uid'] == 'uid-personal'
+    assert channels_db.get_binding('telegram', '42', '-999', firestore_client=client) is None
+    assert channels_db.revoke_binding('telegram', '42', '-999', now=now, firestore_client=client) is False
+    assert channels_db.get_binding('telegram', '42', '42', firestore_client=client)['uid'] == 'uid-personal'
+
+
+def test_revoking_a_channel_chunks_writes_under_the_firestore_batch_cap():
+    commits = []
+
+    class CappedBatch:
+        def __init__(self, inner):
+            self._inner = inner
+            self._writes = 0
+
+        def update(self, ref, payload):
+            self._writes += 1
+            if self._writes > channels_db.FIRESTORE_MAX_BATCH_WRITES:
+                raise ValueError('maximum 500 writes allowed per request')
+            self._inner.update(ref, payload)
+
+        def commit(self):
+            commits.append(self._writes)
+            return self._inner.commit()
+
+    class CappedClient:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def batch(self):
+            return CappedBatch(self._inner.batch())
+
+    inner = MockFirestore()
+    client = CappedClient(inner)
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+    total = channels_db.FIRESTORE_MAX_BATCH_WRITES + 3
+    for index in range(total):
+        inner.collection('channel_bindings').document(f'binding-{index}').set(
+            {
+                'channel': 'telegram',
+                'uid': 'uid-1',
+                'channel_user_id': str(index),
+                'channel_chat_id': str(index),
+                'linked_at': now,
+                'revoked_at': None,
+            }
+        )
+
+    assert channels_db.revoke_channel('uid-1', 'telegram', now=now, firestore_client=client) == total
+    assert commits == [channels_db.FIRESTORE_MAX_BATCH_WRITES, 3]
+    assert channels_db.list_bindings('uid-1', firestore_client=inner) == []
+
+
+def test_a_stale_processing_claim_is_reclaimed_instead_of_dropped():
+    client = MockFirestore()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+
+    assert channels_db.claim_webhook_event('telegram', 'update-9', now=now, firestore_client=client) == (True, None)
+
+    created, existing = channels_db.claim_webhook_event('telegram', 'update-9', now=now, firestore_client=client)
+    assert not created
+    assert existing['status'] == 'processing'
+
+    expired = now + channels_db.WEBHOOK_PROCESSING_LEASE
+    created, existing = channels_db.claim_webhook_event('telegram', 'update-9', now=expired, firestore_client=client)
+    assert created
+    assert existing['status'] == 'processing'
+
+    stored = (
+        client.collection('channel_webhook_events')
+        .document(channels_db._event_id('telegram', 'update-9'))
+        .get()
+        .to_dict()
+    )
+    assert stored['attempts'] == 2
+    assert stored['lease_expires_at'] == expired + channels_db.WEBHOOK_PROCESSING_LEASE
+    assert stored['received_at'] == now
+
+
+def test_a_failed_claim_is_released_for_immediate_retry_but_a_ready_reply_is_kept():
+    client = MockFirestore()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+
+    channels_db.claim_webhook_event('sms', 'SM1', now=now, firestore_client=client)
+    assert channels_db.release_webhook_claim('sms', 'SM1', now=now, firestore_client=client) is True
+    created, existing = channels_db.claim_webhook_event('sms', 'SM1', now=now, firestore_client=client)
+    assert created
+    assert existing['status'] == 'failed'
+
+    channels_db.update_webhook_event('sms', 'SM1', {'status': 'ready', 'reply': 'hi'}, firestore_client=client)
+    assert channels_db.release_webhook_claim('sms', 'SM1', now=now, firestore_client=client) is False
+    created, existing = channels_db.claim_webhook_event('sms', 'SM1', now=now, firestore_client=client)
+    assert not created
+    assert existing['status'] == 'ready'
+
+
+def test_a_failing_handler_releases_its_claim_so_the_provider_retry_is_processed(monkeypatch):
+    import routers.channels as channels_router
+
+    client = MockFirestore()
+    now = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+
+    async def fake_run_blocking(_executor, fn, *args, **kwargs):
+        if fn is channels_db.claim_webhook_event:
+            return channels_db.claim_webhook_event(*args, now=now, firestore_client=client)
+        if fn is channels_db.release_webhook_claim:
+            return channels_db.release_webhook_claim(*args, now=now, firestore_client=client)
+        raise AssertionError(fn)
+
+    async def exploding_reply(_channel, _payload):
+        raise RuntimeError('core chat exploded')
+
+    monkeypatch.setattr(channels_router, 'run_blocking', fake_run_blocking)
+    monkeypatch.setattr(channels_router, '_channel_reply', exploding_reply)
+
+    payload = {'event_id': 'update-77', 'channel_user_id': '42', 'channel_chat_id': '42', 'text': 'hello'}
+    with pytest.raises(RuntimeError):
+        asyncio.run(channels_router._handle_payload('telegram', payload))
+
+    delivered = {}
+
+    async def working_reply(_channel, _payload):
+        return 'answer'
+
+    async def fake_send_and_record(channel, event_id, chat_id, reply, **kwargs):
+        delivered.update({'channel': channel, 'event_id': event_id, 'chat_id': chat_id, 'reply': reply})
+
+    monkeypatch.setattr(channels_router, '_channel_reply', working_reply)
+    monkeypatch.setattr(channels_router, '_send_and_record', fake_send_and_record)
+    assert asyncio.run(channels_router._handle_payload('telegram', payload)) == {'status': 'delivered'}
+    assert delivered['reply'] == 'answer'
+
+
+def test_over_quota_channel_messages_never_reach_the_media_pipeline(monkeypatch):
+    calls = []
+
+    class QuotaExceeded(Exception):
+        pass
+
+    def fake_enforce_chat_quota(_uid, *, platform):
+        calls.append(('quota', platform))
+        raise QuotaExceeded()
+
+    async def fake_build_media_context(_uid, _attachments):
+        calls.append(('media', None))
+        return 'described'
+
+    async def fake_run_blocking(_executor, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(channel_chat, 'run_blocking', fake_run_blocking)
+    monkeypatch.setattr(channel_chat, 'enforce_chat_quota', fake_enforce_chat_quota)
+    monkeypatch.setattr(channel_chat, 'build_media_context', fake_build_media_context)
+
+    with pytest.raises(QuotaExceeded):
+        asyncio.run(
+            channel_chat.generate_channel_reply(
+                'uid-1', 'telegram', 'hello', attachments=[{'source': 'telegram', 'file_id': 'file-1'}]
+            )
+        )
+    assert calls == [('quota', 'telegram')]
+
+
+def test_sms_delivery_stays_off_the_reserved_auth_executor(monkeypatch):
+    from utils.executors import critical_executor, postprocess_executor
+
+    used = []
+
+    async def fake_run_blocking(executor, fn, *args, **kwargs):
+        used.append(executor)
+        return 'SM1'
+
+    monkeypatch.setattr(channel_chat, 'run_blocking', fake_run_blocking)
+    asyncio.run(channel_chat.send_channel_message('sms', '+15551234567', 'hello'))
+    assert used == [postprocess_executor]
+    assert critical_executor not in used


### PR DESCRIPTION
Ports the channel fixes from #11058 onto this branch, where the feature actually lands.

Both PRs descend from `3fb99bc77b`, and they drifted into complementary halves: this branch has the Twilio signature validation, vision-context framing and caller-id work; #11058 has the fixes below. This branch is the one that ships the feature, so the fixes belong here.

### Group binding could resolve to a member's personal account

`get_binding` looped over `[channel_chat_id, channel_user_id]`, and the document id hashes only the identity. An unlinked **group** therefore fell through to the second probe and resolved **the sender's personal DM binding** — the router then answered from that person's private Omi account, with their private context, into the group chat. `revoke_binding` routes through the same function, so a group `/unlink` could revoke the sender's personal binding too.

A lookup now resolves exactly one identity and rejects a document whose stored chat id is not the one asked for. DMs are unaffected: there chat id and user id are equal, so the resolved document is unchanged.

### Also

- **Webhook claims were permanent tombstones.** Any failure before the handler wrote `ready` left `status: processing` forever, and every provider retry got `duplicate` — message lost, no way back. The claim is now a 5-minute lease a stale attempt can reclaim. **This changes durable semantics**: events already stuck in `processing` carry no `lease_expires_at`, which reads as expired, so they become reclaimable on the next delivery. That recovers lost messages but is a live-data change, not additive.
- **`revoke_channel` exceeded Firestore's 500-write batch cap**, so revoking failed outright past 500 bindings. Now chunked.
- **Media ran before the quota gate**, so over-quota users still triggered attachment downloads and vision/STT spend. Quota is the first gate now.
- **Twilio SMS ran on `critical_executor`**, which `backend/AGENTS.md` reserves for auth gates at 8 workers. Moved to `postprocess_executor`.

### Verification

`BACKEND_UNIT_TEST_FILE_LIST=... bash test.sh` on `tests/unit/test_channels.py` — **27 passed** against this branch's code. Each fix was proven to fail without its change on the source branch: the group lookup returns the personal binding instead of `None`, the batch raises `maximum 500 writes allowed per request`, and the router returns `{'status': 'duplicate'}` where it should return `{'status': 'delivered'}`.

## Product invariants affected

- INV-MEM-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Group binding could leak private Omi context into group chats (memory isolation), and webhook reclaim changes behavior for in-flight `processing` events in production Firestore.
> 
> **Overview**
> Fixes a **privacy bug** where unlinked group chats could resolve to a member’s personal DM binding (and group `/unlink` could revoke that personal link). `get_binding` now looks up a single chat identity and rejects documents whose stored `channel_chat_id` does not match.
> 
> **Webhook idempotency** no longer permanently drops messages after a failed handler: claims get a **5-minute processing lease**, stale `processing` / `failed` events can be reclaimed transactionally, and `_handle_payload` calls `release_webhook_claim` on failure so provider retries can run again. Events already stuck in `processing` without a lease are treated as reclaimable on the next delivery.
> 
> Also chunks `revoke_channel` past Firestore’s **500-write batch limit**, runs **chat quota before** attachment/vision work, and sends Twilio SMS via **`postprocess_executor`** instead of `critical_executor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d76a3fa20dc8a70e3dbc457eb084d2fadfa1aef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->