### PR TITLE
fix(desktop): separate shell clicks from window drags

### DIFF
--- a/.github/failure-classes/FC-hosted-control-window-drag-ownership.json
+++ b/.github/failure-classes/FC-hosted-control-window-drag-ownership.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-hosted-control-window-drag-ownership",
+  "violated_contract": "A pointer gesture over hosted application content must have one owner: an ordinary click belongs to the control beneath it, a window drag belongs to the shell, and a native drag control keeps its own gesture. AppKit background dragging cannot enforce that boundary because it hit-tests SwiftUI controls as their transparent hosting view.",
+  "canonical_prevention": "Classify shell clicks and window drags in one thresholded coordinator before hosted button tracking begins, and give native drag controls a typed opt-out from shell movement.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift",
+    "desktop/macos/Desktop/Tests/RewindTrackTests.swift"
+  ],
+  "evidence_prs": [
+    11117
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/MainWindow/**",
+    "desktop/macos/Desktop/Sources/Rewind/UI/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -30,11 +30,11 @@
 //    strand a user in a window with no visible close control *and* no keyboard one.
 //  - **Moving has two handles, deliberately.** `.hiddenTitleBar` keeps a real (transparent) title bar
 //    over the top band, which still drags — that band is why the shell reserves
-//    `GlassShell.titlebarClearance` and draws nothing in it. `isMovableByWindowBackground` adds the
-//    second: on a window that is mostly desktop, the parts that are not a control drag it too, which is
-//    how the bar this file's chrome sits in becomes a drag handle without any view knowing it is one.
-//    Controls, text fields and scroll views consume their own drags and are unaffected. Views that own
-//    their own drags opt out with `mouseDownCanMoveWindow` (see `RewindTrackNSView`).
+//    `GlassShell.titlebarClearance` and draws nothing in it. A thresholded mouse monitor covers the
+//    rest of the window. The native `isMovableByWindowBackground` switch cannot do that safely:
+//    AppKit sees a SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background,
+//    and steals its click. The monitor waits for an actual drag, while views that own their own
+//    drags opt out through `ShellWindowDragExcluding` (see `RewindTrackNSView`).
 //
 //  ## The two presentations, and why there are two
 //
@@ -77,8 +77,13 @@
 //
 
 import AppKit
+@preconcurrency import ObjectiveC
 import OmiTheme
 import SwiftUI
+
+/// A represented AppKit view whose pointer drag belongs to the control rather than the shell.
+@MainActor
+protocol ShellWindowDragExcluding: AnyObject {}
 
 /// The main window's chrome: transparent, light-pinned, and without the system's window buttons.
 @MainActor
@@ -159,7 +164,11 @@ enum ShellWindowChrome {
     // window between the two calls with no way to be closed at all.
     window.styleMask.formUnion(keyboardWindowCommands)
     hideStandardButtons(in: window)
-    window.isMovableByWindowBackground = true
+    // AppKit cannot see SwiftUI controls inside an NSHostingView. The hosting view reports that a
+    // mouse-down may move the window even when the point is a Button, so this native switch turns
+    // ordinary clicks into window drags. A thresholded monitor keeps clicks and drags separate.
+    window.isMovableByWindowBackground = false
+    installDragMonitor(in: window)
     window.level = presentation == .summoned ? .floating : .normal
     // Always `false`, in both presentations, and asserted rather than omitted — see this file's
     // header. A shell that ordered itself out whenever another app took focus deleted the window
@@ -206,11 +215,125 @@ enum ShellWindowChrome {
       && window.titleVisibility == .hidden
       && window.titlebarSeparatorStyle == .none
       && buttonsAreHidden
-      && window.isMovableByWindowBackground
+      && !window.isMovableByWindowBackground
+      && hasDragMonitor(in: window)
       && window.level == (presentation == .summoned ? .floating : .normal)
       && !window.hidesOnDeactivate
       && window.collectionBehavior.contains(.moveToActiveSpace)
       && hasExpectedSpaceBehavior
+  }
+
+  private static var dragCoordinatorAssociationKey: UInt8 = 0
+
+  static func installDragMonitor(in window: NSWindow) {
+    guard let contentView = window.contentView else { return }
+    if let coordinator = objc_getAssociatedObject(contentView, &dragCoordinatorAssociationKey)
+      as? ShellWindowDragCoordinator
+    {
+      coordinator.window = window
+      return
+    }
+
+    let coordinator = ShellWindowDragCoordinator(window: window)
+    objc_setAssociatedObject(
+      contentView, &dragCoordinatorAssociationKey, coordinator, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+  }
+
+  static func hasDragMonitor(in window: NSWindow) -> Bool {
+    guard let contentView = window.contentView else { return false }
+    return objc_getAssociatedObject(contentView, &dragCoordinatorAssociationKey)
+      is ShellWindowDragCoordinator
+  }
+
+  static func shouldBeginDrag(at location: NSPoint, in window: NSWindow) -> Bool {
+    var hit = window.contentView?.hitTest(location)
+    while let view = hit {
+      if view is any ShellWindowDragExcluding || view is NSControl || view is NSScrollView || view is NSTextView {
+        return false
+      }
+      hit = view.superview
+    }
+    return true
+  }
+}
+
+/// Holds a hosted SwiftUI mouse-down until it knows whether the gesture is a click or a window drag.
+/// A click is replayed untouched; a drag never enters SwiftUI button tracking, so moving the hosting
+/// window cannot fire or latch the control that happened to be beneath the pointer.
+@MainActor
+final class ShellWindowDragCoordinator: NSObject {
+  weak var window: NSWindow?
+  private var pendingMouseDown: NSEvent?
+  private var windowOrigin: NSPoint?
+  private var pointerOrigin: NSPoint?
+  private var canMoveWindow = false
+  private var isDraggingWindow = false
+  private var replayEventsRemaining = 0
+  private nonisolated(unsafe) var monitor: Any?
+
+  init(window: NSWindow) {
+    self.window = window
+    super.init()
+    monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]) {
+      [weak self] event in
+      let consumesEvent = MainActor.assumeIsolated {
+        self?.handle(event) ?? false
+      }
+      return consumesEvent ? nil : event
+    }
+  }
+
+  deinit {
+    if let monitor { NSEvent.removeMonitor(monitor) }
+  }
+
+  private func handle(_ event: NSEvent) -> Bool {
+    guard let window, event.window === window else { return false }
+    if replayEventsRemaining > 0 {
+      replayEventsRemaining -= 1
+      return false
+    }
+
+    switch event.type {
+    case .leftMouseDown:
+      canMoveWindow = ShellWindowChrome.shouldBeginDrag(at: event.locationInWindow, in: window)
+      guard canMoveWindow else { return false }
+      pendingMouseDown = event
+      windowOrigin = window.frame.origin
+      pointerOrigin = NSEvent.mouseLocation
+      isDraggingWindow = false
+      return true
+    case .leftMouseDragged:
+      guard canMoveWindow, let windowOrigin, let pointerOrigin else { return false }
+      let pointer = NSEvent.mouseLocation
+      guard isDraggingWindow || hypot(pointer.x - pointerOrigin.x, pointer.y - pointerOrigin.y) >= 3 else {
+        return false
+      }
+      isDraggingWindow = true
+      window.setFrameOrigin(
+        NSPoint(
+          x: windowOrigin.x + pointer.x - pointerOrigin.x,
+          y: windowOrigin.y + pointer.y - pointerOrigin.y))
+      // Keep the mouse-drag sequence flowing even though its down was withheld. No SwiftUI responder
+      // owns it, and AppKit otherwise stops producing subsequent drag events after a consumed event.
+      return false
+    case .leftMouseUp:
+      guard canMoveWindow else { return false }
+      if !isDraggingWindow, let pendingMouseDown {
+        // `atStart` prepends, so enqueue up first and down second to replay down → up.
+        replayEventsRemaining = 2
+        NSApplication.shared.postEvent(event, atStart: true)
+        NSApplication.shared.postEvent(pendingMouseDown, atStart: true)
+      }
+      pendingMouseDown = nil
+      windowOrigin = nil
+      pointerOrigin = nil
+      canMoveWindow = false
+      isDraggingWindow = false
+      return true
+    default:
+      return false
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
@@ -19,7 +19,7 @@ import SwiftUI
 /// pixel-exact hit testing during a drag, a scroll wheel that pans, and a hover tooltip that has to
 /// be able to escape the window's rounded bounds without being clipped.
 @MainActor
-final class RewindTrackNSView: NSView {
+final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
 
   /// Total height of the control: the bar, plus room for the badges that straddle it and the hour
   /// labels beneath.

--- a/desktop/macos/Desktop/Tests/RewindTrackTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindTrackTests.swift
@@ -44,17 +44,28 @@ final class RewindTrackTests: XCTestCase {
 
   // MARK: - The drag belongs to the scrubber, not to the window
 
-  /// The shell's window is `isMovableByWindowBackground`, so every view that does not say otherwise
-  /// hands AppKit its drags. This one is a scrubber: its whole gesture *is* a drag, and giving it
+  /// The shell's window monitor offers hosted content drags to the window unless an AppKit control
+  /// explicitly owns them. This one is a scrubber: its whole gesture *is* a drag, and giving it
   /// away leaves a control where a click seeks and a drag walks the window sideways — a failure that
   /// reads as a rendering quirk rather than a dead gesture, which is why it needs a test rather than
   /// a screenshot.
   func testTheTrackKeepsItsDragsRatherThanHandingThemToTheWindow() {
     let day = gappedDay()
-    XCTAssertFalse(track(day.instants, day.apps).mouseDownCanMoveWindow)
+    let track = track(day.instants, day.apps)
+    track.frame = NSRect(x: 0, y: 0, width: 400, height: 300)
+    let window = NSWindow(
+      contentRect: track.frame,
+      styleMask: [.titled, .fullSizeContentView],
+      backing: .buffered,
+      defer: true)
+    window.contentView = track
+    ShellWindowChrome.dress(window)
+
+    XCTAssertFalse(track.mouseDownCanMoveWindow)
+    XCTAssertFalse(ShellWindowChrome.shouldBeginDrag(at: NSPoint(x: 200, y: 150), in: window))
   }
 
-  /// …and the reason it has to say so: the window really is draggable by its background.
+  /// …and the reason it has to say so: the shell installs its own drag monitor.
   func testTheShellWindowIsTheOneThatMakesThatOptOutNecessary() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
@@ -62,7 +73,8 @@ final class RewindTrackTests: XCTestCase {
       backing: .buffered,
       defer: true)
     ShellWindowChrome.dress(window)
-    XCTAssertTrue(window.isMovableByWindowBackground)
+    XCTAssertFalse(window.isMovableByWindowBackground)
+    XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window))
   }
 
   // MARK: - The time-linearity contract

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -91,9 +91,8 @@ final class ShellWindowChromeTests: XCTestCase {
   }
 
   /// …and the window still moves. It has two handles: the transparent title bar over the reserved
-  /// band (`GlassShell.titlebarClearance`, which is why the shell draws nothing up there) and the
-  /// window background, which is what makes the top bar a drag handle without any view knowing it is
-  /// one.
+  /// band and a thresholded mouse monitor across the content. The native background-drag switch is
+  /// deliberately off because AppKit mistakes hosted SwiftUI buttons for background.
   func testTheWindowIsStillMovableWithoutATitleBarToGrab() {
     let window = makeWindow()
     window.isMovableByWindowBackground = false
@@ -101,12 +100,44 @@ final class ShellWindowChromeTests: XCTestCase {
     ShellWindowChrome.dress(window)
 
     XCTAssertTrue(window.isMovable, "a floating window that cannot be moved is stranded")
-    XCTAssertTrue(
-      window.isMovableByWindowBackground,
-      "with no visible frame, the panels and the empty desktop between them are the drag handles")
+    XCTAssertFalse(window.isMovableByWindowBackground)
+    XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window))
     XCTAssertTrue(
       window.styleMask.contains(.titled),
-      "the transparent title bar is the second drag handle; a borderless window loses it")
+      "the transparent title bar remains an independent drag handle")
+  }
+
+  func testHostedSwiftUIButtonsDoNotEnableNativeBackgroundDragging() throws {
+    let window = makeWindow()
+    let host = NSHostingView(
+      rootView: Button("Rewind") {}
+        .buttonStyle(.plain)
+        .frame(width: Self.contentSize.width, height: Self.contentSize.height))
+    host.frame = NSRect(origin: .zero, size: Self.contentSize)
+    window.contentView = host
+    ShellWindowChrome.dress(window)
+    host.layoutSubtreeIfNeeded()
+
+    let hit = try XCTUnwrap(host.hitTest(NSPoint(x: 450, y: 300)))
+    XCTAssertTrue(
+      hit.mouseDownCanMoveWindow,
+      "the regression fixture no longer reproduces AppKit's SwiftUI misclassification")
+    XCTAssertTrue(
+      ShellWindowChrome.shouldBeginDrag(at: NSPoint(x: 450, y: 300), in: window),
+      "the replacement must allow a real drag to start over the same hosted SwiftUI surface")
+    XCTAssertFalse(
+      window.isMovableByWindowBackground,
+      "native background dragging steals this hosted button's click before SwiftUI receives it")
+    XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window))
+  }
+
+  func testNativeDragControlsKeepTheirOwnGestures() {
+    let window = makeWindow()
+    let scrollView = NSScrollView(frame: NSRect(origin: .zero, size: Self.contentSize))
+    window.contentView = scrollView
+    ShellWindowChrome.dress(window)
+
+    XCTAssertFalse(ShellWindowChrome.shouldBeginDrag(at: NSPoint(x: 450, y: 300), in: window))
   }
 
   // MARK: - Summoned vs anchored
@@ -191,7 +222,7 @@ final class ShellWindowChromeTests: XCTestCase {
       "the panels inside draw their own ambient shadow; the shell does not add an outer frame shadow")
     XCTAssertTrue(
       WindowGlass.hasTitlebar(ShellWindowChrome.glassKind),
-      "the transparent title bar is one of the shell's two drag handles, and ⌘W routes from the mask")
+      "the transparent title bar remains a drag handle, and ⌘W routes from the mask")
   }
 
   /// …and `dress` really applies it, in both presentations. The mapping above is a value; this is the
@@ -224,7 +255,8 @@ final class ShellWindowChromeTests: XCTestCase {
       XCTAssertTrue(
         window.styleMask.isSuperset(of: ShellWindowChrome.keyboardWindowCommands),
         "\(presentation) has no ⌘W or ⌘M and no buttons either")
-      XCTAssertTrue(window.isMovableByWindowBackground, "\(presentation) cannot be dragged anywhere")
+      XCTAssertFalse(window.isMovableByWindowBackground, "\(presentation) can steal hosted button clicks")
+      XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window), "\(presentation) cannot be dragged")
     }
   }
 

--- a/desktop/macos/changelog/unreleased/20260808-window-click-and-drag.json
+++ b/desktop/macos/changelog/unreleased/20260808-window-click-and-drag.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed dead zones that prevented dragging the window and opening Chat, Rewind, and Apps"
+}


### PR DESCRIPTION
## What changed and why

AppKit's native background-drag mode hit-tests SwiftUI buttons as their transparent `NSHostingView`, so it stole clicks from Chat, Rewind, and Apps. Replace that mode with a thresholded shell drag coordinator that distinguishes clicks from window drags and lets native drag controls, including the Rewind scrubber, retain their gestures.

## Product invariants affected

none

## How it was verified

- Built and launched `/Applications/omi-window-hit-zones.app` as the isolated `com.omi.omi-window-hit-zones` bundle.
- Reproduced the original dead controls, then physically dragged from a top-bar control: the window moved without navigating. The next click opened Apps; Chat opened its transcript; top-bar Rewind navigated; and the normal Rewind filter remained clickable.
- `./scripts/dev-feedback.py --once swift 'ShellWindowChromeTests|RewindTrackTests'` — 31 tests passed.
- `python3 scripts/check_desktop_test_quality.py` — passed.
- `./scripts/swiftlint-wrapper.sh lint` — 1,160 files, 0 violations.
- Pinned swift-format lint passed for every changed Swift file. The repository-wide formatter invocation still reports pre-existing errors in unrelated files.
- `swift test --package-path Desktop` executed 4,560 tests; the changed suites passed, while two unrelated full-suite tests failed amid existing Contacts/CoreData XPC errors. The umbrella `./test.sh` likewise stopped at `test-mounted-navigation-latency.sh` because no harness was listening on shared port 47777.

## Tests

`ShellWindowChromeTests.testHostedSwiftUIButtonsDoNotEnableNativeBackgroundDragging` mounts a real SwiftUI button, proves AppKit misclassifies its hosting view as draggable background, and asserts the replacement drag policy. `testNativeDragControlsKeepTheirOwnGestures` and the Rewind track regression cover the opt-out path.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: window movement and hosted-control activation must be mutually exclusive outcomes of one pointer gesture. Canonical guard: the shell owns gesture classification in one coordinator, delays hosted button delivery until the gesture is known to be a click, and uses a typed opt-out for native drag controls. Evidence is the reported dead Chat/Rewind/Apps controls, the prior Rewind scrubber ownership fix (`a58ea9b102`), and the real `NSHostingView<Button>` regression fixture that fails under native background dragging.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

