### PR TITLE
fix(backend): classify empty Cloud Run literals as public bindings

### DIFF
--- a/backend/scripts/preflight-cloud-run-deploy.py
+++ b/backend/scripts/preflight-cloud-run-deploy.py
@@ -374,9 +374,11 @@ def _actual_runtime_bindings(
 
 
 def _observed_binding(entry: dict[str, Any]) -> str:
-    if 'value' in entry:
-        return 'public literal'
     value_from = entry.get('valueFrom')
+    if 'value' in entry or value_from is None:
+        # Cloud Run omits `value` from describe output when the literal is the
+        # empty string, so an entry with no value source at all is still public.
+        return 'public literal'
     secret_ref = value_from.get('secretKeyRef') if isinstance(value_from, dict) else None
     secret_name = secret_ref.get('name') if isinstance(secret_ref, dict) else None
     if isinstance(secret_name, str) and secret_name:

--- a/backend/tests/unit/test_preflight_cloud_run_deploy.py
+++ b/backend/tests/unit/test_preflight_cloud_run_deploy.py
@@ -335,6 +335,45 @@ environments:
     ]
 
 
+def test_runtime_binding_check_accepts_empty_public_literal_on_live_service(tmp_path: Path) -> None:
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        '''\
+environments:
+  dev:
+    gcp_project: based-hardware-dev
+    cloud_run:
+      services:
+        backend:
+          env:
+            EMPTY_PUBLIC_SETTING:
+              value: ''
+''',
+        encoding='utf-8',
+    )
+
+    def runner(command: list[str], **_kwargs):
+        assert command[:4] == ['gcloud', 'run', 'services', 'describe']
+        # Cloud Run drops `value` from describe output for an empty literal.
+        return SimpleNamespace(
+            stdout=json.dumps(
+                {'spec': {'template': {'spec': {'containers': [{'env': [{'name': 'EMPTY_PUBLIC_SETTING'}]}]}}}}
+            )
+        )
+
+    drift = preflight.check_runtime_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=runner,
+    )
+
+    assert drift == []
+
+
 def test_runtime_binding_check_ignores_undeclared_live_bindings(tmp_path: Path) -> None:
     preflight = load_preflight()
     manifest = tmp_path / 'runtime_env.yaml'


### PR DESCRIPTION
## Bug

`Auto Deploy Backend to Development` is red on `main` and the dev backend has not deployed since **2026-08-08T02:56Z**. Four consecutive runs (`634f093d4e`, `8bc142aef9`, `5f47ac813d`, `8b31ea3716`) fail in **Check development Cloud Run runtime bindings**, before the candidate deploy, with the same eight errors:

```
ERROR [runtime-binding/backend/MEMORY_ENABLED_USERS: expected public literal or absent before candidate deploy, observed unsupported value source]
ERROR [runtime-binding/backend/OMI_PARITY_PACK_ALLOWED_PRINCIPALS: ... observed unsupported value source]
… same pair for backend-sync, backend-sync-backfill, backend-integration
```

`Deploy backend to Cloud Run` is then skipped, so the whole dev lane is blocked.

## Root cause

`MEMORY_ENABLED_USERS` and `OMI_PARITY_PACK_ALLOWED_PRINCIPALS` are declared as **public literals** with `value: ''` in `backend/deploy/runtime_env.yaml` and `backend/deploy/runtime_env/dev.overlay.yaml`.

Cloud Run stores the empty literal but omits the `value` key from `gcloud run services describe` output entirely, so the live entry serializes as:

```json
{ "name": "MEMORY_ENABLED_USERS" }
```

— no `value`, and no `valueFrom`.

`_observed_binding` keyed only on `'value' in entry` and otherwise fell through to the `valueFrom` branches, whose final `return 'unsupported value source'` then caught this shape. An entry with **no value source at all** provably cannot be a Secret Manager reference, yet it was classified as drift — so the gate rejected the output of its own previous successful deploy. Self-inflicted and permanent until the classifier is fixed: every subsequent run re-reads the same live state.

## Fix

Classify an entry with no `valueFrom` as a public literal. Entries that do carry a `valueFrom` are unchanged: a `secretKeyRef` still renders as a Secret Manager reference, and any other `valueFrom` (e.g. `configMapKeyRef`) is still `unsupported value source` — the existing `test_runtime_binding_check_reports_declared_type_mismatches_only` covers that and still passes. The check remains development-only (`_require_development_scope`); no production path changes.

## What I tested

Ran the exact command `.github/actions/deploy-backend-stack/action.yml` runs, against the **live** dev services:

```
python3 backend/scripts/preflight-cloud-run-deploy.py --env dev \
  --project=based-hardware-dev --region=us-central1 --check-runtime-bindings
```

- **Before (parent commit):** exit 1, reproducing all eight CI errors byte-for-byte.
- **After:** `development Cloud Run runtime-binding contract passed`, exit 0.

Confirmed the live shape directly: `gcloud run services describe backend --project=based-hardware-dev --region=us-central1 --format=json` returns `{"name": "MEMORY_ENABLED_USERS"}` and `{"name": "OMI_PARITY_PACK_ALLOWED_PRINCIPALS"}` with no `value` and no `valueFrom`.

Regression test `test_runtime_binding_check_accepts_empty_public_literal_on_live_service` drives `check_runtime_bindings` through its injectable `runner` seam with that exact describe payload. It **fails on the parent commit** and passes here. Full file: `pytest backend/tests/unit/test_preflight_cloud_run_deploy.py` → 16 passed.

Failure-Class: FC-runtime-binding-contract

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

