### PR TITLE
fix(agent-vm): allow labels on migration disks

### DIFF
--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -28,7 +28,9 @@ operations_role="projects/${project}/roles/${operations_role_id}"
 # State-disk creation/clone and attachment are carried by the same narrow
 # custom role as the existing VM lifecycle permissions. The project bindings
 # below still constrain Disk and Instance resources to omi-agent-* names.
-permissions="compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
+# Creating an already-labeled disk checks both compute.disks.create and
+# compute.disks.setLabels against the target Disk resource.
+permissions="compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.setLabels,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
 subnetwork_role_id="omiAgentVmReconcilerSubnetwork"
 subnetwork_role="projects/${project}/roles/${subnetwork_role_id}"
 subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -148,9 +148,10 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert 'AGENT_VM_RECONCILER_IAM_APPLY:-}' in script
     assert "REFUSED:" in script
     assert (
-        "compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
+        "compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.setLabels,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
         in script
     )
+    assert "compute.disks.setLabels" in script
     assert 'subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"' in script
     assert "Agent VM reconciler instance scope" in script
     assert "Agent VM reconciler disk scope" in script


### PR DESCRIPTION
## Summary

- add the missing compute.disks.setLabels permission to the narrowly scoped Agent VM reconciler role
- preserve the existing omi-agent disk resource-name condition
- lock the permission into the IAM installer contract test

## Live dev evidence

The fenced one-owner migration canary reached state-disk creation and Compute denied only compute.disks.setLabels. The same audit record showed compute.disks.create granted and identified the exact target disk under us-central1-a/disks/omi-agent-state-*. No state disk or candidate VM was created, and the predecessor remains retained and stopped.

The dev scheduler is paused while this fix lands. After merge, the checked-in installer will be reapplied and the durable migration journal will resume from candidate creation.

## Verification

- 10 focused deployment-script tests passed
- bash syntax check passed
- shellcheck passed
- git diff --check passed

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

