### PR TITLE
fix(agent-vm): retain read-only migration clones

### DIFF
--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -1798,7 +1798,7 @@ class GceAgentVmClient:
             disks.append(
                 {
                     "boot": False,
-                    "autoDelete": True,
+                    "autoDelete": False,
                     "deviceName": STATE_SOURCE_DEVICE_NAME,
                     "mode": "READ_ONLY",
                     "source": source_clone_disk_source,

--- a/backend/tests/unit/test_agent_vm_reconciler.py
+++ b/backend/tests/unit/test_agent_vm_reconciler.py
@@ -349,7 +349,7 @@ async def test_boot_image_replacement_scopes_vpc_creation_to_the_explicit_subnet
     }
     assert body["disks"][2] == {
         "boot": False,
-        "autoDelete": True,
+        "autoDelete": False,
         "deviceName": "omi-agent-state-source",
         "mode": "READ_ONLY",
         "source": "projects/based-hardware-dev/zones/us-central1-a/disks/omi-agent-source-test",


### PR DESCRIPTION
## Summary

- attach the temporary state source clone read-only with autoDelete disabled, as required by GCE
- retain the existing journaled detach plus identity-fenced disk deletion as the only cleanup authority
- update the exact replacement request contract test

## Live dev evidence

The one-owner migration canary created both labeled state and source-clone disks after PR #11226 fixed IAM. GCE then rejected candidate creation because the read-only source attachment requested autoDelete=true. The audit record confirmed every IAM permission was granted and returned the exact validation error. Compensation removed both temporary disks, no candidate was created, and the predecessor remains stopped and intact.

The dev scheduler is paused while this fix lands. The durable journal and migration pointer remain available for automatic recovery after deployment.

## Verification

- 20 focused Agent VM reconciler tests passed
- git diff --check passed

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

