### PR TITLE
fix(desktop): match installed Omi name in Rewind exclusions

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindModels.swift
@@ -380,7 +380,7 @@ class RewindSettings: ObservableObject {
   static let defaultExcludedApps: Set<String> = [
     "Omi Computer",  // Our own app - no point capturing ourselves (legacy name)
     "Omi Beta",  // Legacy production app name
-    "omi",  // Production app name
+    "Omi",  // Production app name
     "Omi Dev",  // Development app name
     "Passwords",  // macOS Passwords app
     "1Password",  // 1Password (various versions)

--- a/desktop/macos/Desktop/Tests/ScreenPrivacyExclusionTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenPrivacyExclusionTests.swift
@@ -21,6 +21,12 @@ final class ScreenPrivacyExclusionTests: XCTestCase {
     }
   }
 
+  func testRewindDefaultsExcludeInstalledOmiName() {
+    XCTAssertTrue(RewindSettings.defaultExcludedApps.contains("Omi"))
+    XCTAssertFalse(RewindSettings.defaultExcludedApps.contains("omi"))
+    XCTAssertTrue(RewindSettings.shared.isAppExcluded("Omi"))
+  }
+
   // MARK: - Each assistant's isAppExcluded respects Rewind exclusions
 
   @MainActor

--- a/desktop/macos/changelog/unreleased/20260808-rewind-omi-exclusion.json
+++ b/desktop/macos/changelog/unreleased/20260808-rewind-omi-exclusion.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind privacy exclusions so the installed Omi app is not captured"
+}


### PR DESCRIPTION
## What changed and why

Rewind now excludes the installed stable app name `Omi` with the correct capitalization. The previous lowercase `omi` entry did not match the installed/displayed app name because Rewind exclusions use exact case-sensitive matching.

## Product invariants affected

none

## How it was verified

- `git diff --check`
- `python3 scripts/check_desktop_test_quality.py` — passed
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/Rewind/Core/RewindModels.swift Desktop/Tests/ScreenPrivacyExclusionTests.swift` — passed
- `xcrun swift test --package-path Desktop --filter ScreenPrivacyExclusionTests` — blocked by an unrelated existing compiler timeout in `Desktop/Sources/MainWindow/DesktopHomeView.swift:454`
- The bounded pre-push Swift compile hit the same unrelated timeout; the documented `PRE_PUSH_SKIP_DESKTOP_SWIFT=1` hatch was used for publication after all other pre-push checks passed.

## Tests

Added `testRewindDefaultsExcludeInstalledOmiName` to verify the production exclusion set contains `Omi`, rejects lowercase `omi`, and routes the installed name through `RewindSettings`.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string correction in a static default set plus tests; no auth or data-model changes.
> 
> **Overview**
> **Rewind no longer captures the stable Omi app** because the default privacy exclusion list now uses **`Omi`** (capital O) instead of lowercase **`omi`**.
> 
> Exclusions match app names **case-sensitively**, so the old entry never matched the installed/display name. Fresh installs and merges of new defaults pick up the corrected name; **`isAppExcluded("Omi")`** now returns true.
> 
> A regression test locks in the default set and exclusion behavior. An unreleased changelog note documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4bd85d5b32b2cb2659887a4cc9d0476dffac1cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->