### PR TITLE
chore(ci): baseline streaming.py line count after Deepgram restore

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-utils.json
@@ -9,6 +9,7 @@
     "backend/utils/other/storage.py": 1587,
     "backend/utils/retrieval/agentic.py": 1514,
     "backend/utils/retrieval/tools/calendar_tools.py": 1513,
+    "backend/utils/stt/streaming.py": 1523,
     "backend/utils/sync/pipeline.py": 2491
   },
   "raise_justifications": {
@@ -19,6 +20,7 @@
     "backend/utils/memory/legacy_backfill.py": "Public inventory wrappers for bulk backfill without exposing private helpers; keep one backfill module.",
     "backend/utils/other/storage.py": "delete_app_logo now requires an exact app-logo bucket prefix (startswith) so a foreign URL embedding the prefix later cannot delete an unrelated object on this deletion path (David review on #9873); the deletion purge path additionally records bounded storage wipe counters for telemetry.",
     "backend/utils/retrieval/agentic.py": "Split setup vs post-setup TTFT clocks, emit an early think: progress event after setup, and persist typed timeout/failure answers so the chat router cannot append the generic canned sorry after error: (SCA-296). +8 accepts a shared absolute setup deadline from the chat router so metadata + prompt/tool load use one budget (SCA-296).",
+    "backend/utils/stt/streaming.py": "Restoring hosted Deepgram added the provider client lifecycle back to this module: a lazily built account client, the self-hosted endpoint guard, and BYOK selection. The lifecycle is a coherent unit and should move to utils/stt/deepgram_client.py; this entry records the debt rather than hiding it.",
     "backend/utils/sync/pipeline.py": "Plan-aware soft-cap evaluation and its default-tier fallback remain in a small helper beside Sync's idempotent fresh-speech metering rather than overgrowing the durable worker coordinator."
   },
   "threshold": 1500


### PR DESCRIPTION
## Why

#11227 restored the Deepgram client lifecycle to `backend/utils/stt/streaming.py` — a lazily built account client, the self-hosted endpoint guard, and BYOK selection. That took the file from **1466 to 1523 lines**, past the ratchet's 1500 threshold.

Release Eligibility fails on `9df47fa`:

```
FAIL: product file line-count ratchet
- backend/utils/stt/streaming.py: 1523 lines has no baseline entry.
```

Because `gcp_backend.yml` admits only SHAs with a passing Release Eligibility run, that blocks the prod deploy of the live-STT fallback fix — which is the thing keeping transcription off a provider that fails 90%+ at full exposure.

## What this does

Takes the second of the two remedies the check itself names ("Split the file, or add its exact count and a one-line raise_justifications entry"): records 1523 with a justification.

## Why not split now

Splitting is the better answer and the justification says so — the client lifecycle is a coherent unit that belongs in `utils/stt/deepgram_client.py`. It is deliberately not done here: that refactor moves code several tests monkeypatch (`streaming.deepgram`, `streaming._managed_deepgram_ready`, `streaming._deepgram_client_for_request`), so it deserves its own PR and its own review rather than being rushed onto a deploy-blocking fix.

This entry names the debt instead of hiding it.

## Verification

```
python3 .github/scripts/check_product_file_line_count_ratchet.py \
  --changed-files backend/utils/stt/streaming.py
OK: no line-count increase across 0 changed product source file(s).
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

