### PR TITLE
test(stt): align Deepgram serving contracts

### DIFF
--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -27,9 +27,9 @@ ENV_IDENTITY_DEFAULTS = {
     },
 }
 
-SAFE_STREAMING_ROUTE = 'modulate-velma-2,parakeet'
+SAFE_STREAMING_ROUTE = 'dg-nova-3,modulate-velma-2,parakeet'
 # Batch queues, so the bounded self-hosted GPU is preferred there; the streaming
-# surface must stay Velma-first because a Parakeet admission cap fails users live.
+# surface keeps hosted Deepgram first because a Parakeet admission cap fails users live.
 SAFE_PRERECORDED_ROUTE = 'parakeet,modulate-velma-2'
 
 
@@ -124,7 +124,7 @@ def test_dev_parity_pack_emptydir_is_writable_by_the_non_root_backend_image():
     assert _env_value(values, "OMI_PARITY_PACK_ROOT") == "/var/omi-parity-pack"
 
 
-def test_prod_values_make_modulate_the_explicit_live_stt_primary():
+def test_prod_values_make_deepgram_the_explicit_live_stt_primary():
     values = _load_values(ENV_IDENTITY_DEFAULTS['prod']['values_file'])
 
     assert _env_value(values, 'STT_SERVICE_MODELS') == SAFE_STREAMING_ROUTE

--- a/backend/tests/unit/test_dg_start_guard.py
+++ b/backend/tests/unit/test_dg_start_guard.py
@@ -3,11 +3,11 @@
 Verifies that connect_to_deepgram returns None when dg_connection.start()
 returns False, preventing dead connections from being passed to callers.
 
-Hosted Deepgram serving is disabled; connect_to_deepgram is only reachable
-when self-hosted Deepgram is configured, so these tests enable that gate.
+The client is selected lazily per request, so these tests isolate the start
+guard by replacing that selector with a deterministic client.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,13 +17,12 @@ from utils.stt.streaming import connect_to_deepgram
 class TestConnectToDeepgramStartGuard:
     """Verify connect_to_deepgram returns None when start() returns False."""
 
-    @patch('utils.stt.streaming.is_dg_self_hosted', True)
-    @patch('utils.stt.streaming.deepgram')
-    def test_returns_none_when_start_fails(self, mock_dg):
+    @patch('utils.stt.streaming._deepgram_client_for_request')
+    def test_returns_none_when_start_fails(self, mock_client_for_request):
         """If dg_connection.start() returns False, must return None (#6302)."""
         mock_dg_conn = MagicMock()
         mock_dg_conn.start.return_value = False
-        mock_dg.listen.websocket.v.return_value = mock_dg_conn
+        mock_client_for_request.return_value.listen.websocket.v.return_value = mock_dg_conn
 
         result = connect_to_deepgram(
             on_message=MagicMock(),
@@ -35,13 +34,12 @@ class TestConnectToDeepgramStartGuard:
         )
         assert result is None
 
-    @patch('utils.stt.streaming.is_dg_self_hosted', True)
-    @patch('utils.stt.streaming.deepgram')
-    def test_returns_connection_when_start_succeeds(self, mock_dg):
+    @patch('utils.stt.streaming._deepgram_client_for_request')
+    def test_returns_connection_when_start_succeeds(self, mock_client_for_request):
         """If dg_connection.start() returns True, returns the connection."""
         mock_dg_conn = MagicMock()
         mock_dg_conn.start.return_value = True
-        mock_dg.listen.websocket.v.return_value = mock_dg_conn
+        mock_client_for_request.return_value.listen.websocket.v.return_value = mock_dg_conn
 
         result = connect_to_deepgram(
             on_message=MagicMock(),

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -515,15 +515,15 @@ class TestStreamingFactoryRouting:
             assert service == STTService.parakeet
             assert model == 'parakeet'
 
-    def test_parakeet_streaming_fallback_for_cjk_uses_modulate(self):
+    def test_parakeet_streaming_fallback_for_cjk_uses_deepgram(self):
         from utils.stt.streaming import STTService, get_stt_service_for_language
 
         with patch('utils.stt.streaming.stt_service_models', ['parakeet', 'dg-nova-3']), patch.dict(
             os.environ, {'HOSTED_PARAKEET_API_URL': 'http://fake-parakeet:8080'}
         ):
             service, lang, model = get_stt_service_for_language('ja')
-            assert service == STTService.modulate
-            assert model == 'velma-2'
+            assert service == STTService.deepgram
+            assert model == 'nova-3'
 
     def test_parakeet_fallback_without_url(self):
         from utils.stt.streaming import STTService, get_stt_service_for_language
@@ -532,7 +532,8 @@ class TestStreamingFactoryRouting:
             env_backup = os.environ.pop('HOSTED_PARAKEET_API_URL', None)
             try:
                 service, lang, model = get_stt_service_for_language('en')
-                assert service == STTService.modulate
+                assert service == STTService.deepgram
+                assert model == 'nova-3'
             finally:
                 if env_backup:
                     os.environ['HOSTED_PARAKEET_API_URL'] = env_backup


### PR DESCRIPTION
## Summary

- align backend-listen Helm assertions with the hosted-Deepgram-first streaming route merged in #11227
- mock the new lazy per-request Deepgram client selector in the start-guard tests
- assert Deepgram as the policy fallback when Parakeet is unavailable or lacks language support

This is a test-only follow-up for stale contracts exposed by the full backend unit suite on #11232. Runtime behavior is unchanged.

## Verification

- `python -m pytest backend/tests/unit/test_backend_listen_helm_defaults.py backend/tests/unit/test_dg_start_guard.py backend/tests/unit/test_parakeet_prerecorded.py -q` (54 passed)
- `black --check` on all three changed files
- `git diff --check`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

