### PR TITLE
fix(app): validate phone numbers with libphonenumber, not a fixed digit count

### DIFF
--- a/app/lib/pages/phone_calls/phone_setup_number_page.dart
+++ b/app/lib/pages/phone_calls/phone_setup_number_page.dart
@@ -168,7 +168,7 @@ class _PhoneSetupNumberPageState extends State<PhoneSetupNumberPage> {
                           hintText: context.l10n.phoneNumberHint,
                           hintStyle: TextStyle(color: Colors.grey[600]),
                         ),
-                        inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9\s\-\(\)]'))],
+                        inputFormatters: phoneFieldInputFormatters,
                         onChanged: (_) => setState(() => _errorMessage = null),
                       ),
                     ),

--- a/app/lib/pages/phone_calls/phone_setup_number_page.dart
+++ b/app/lib/pages/phone_calls/phone_setup_number_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:omi/pages/phone_calls/phone_setup_verify_page.dart';
 import 'package:omi/providers/phone_call_provider.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/phone_number_input.dart';
 
 class PhoneSetupNumberPage extends StatefulWidget {
   const PhoneSetupNumberPage({super.key});
@@ -36,15 +37,14 @@ class _PhoneSetupNumberPageState extends State<PhoneSetupNumberPage> {
     super.dispose();
   }
 
-  bool get _isValid {
-    var digits = _phoneController.text.replaceAll(RegExp(r'\D'), '');
-    return digits.length >= _selectedCountry.telephoneMinLength && digits.length <= _selectedCountry.telephoneMaxLength;
-  }
+  PhoneNumberInput get _parsed => parsePhoneNumberInput(
+        raw: _phoneController.text,
+        isoCode: _selectedCountry.codeAlpha2,
+      );
 
-  String get _fullNumber {
-    var digits = _phoneController.text.replaceAll(RegExp(r'\D'), '');
-    return '+${_selectedCountry.telephoneCode}$digits';
-  }
+  bool get _isValid => _parsed.isValid;
+
+  String get _fullNumber => _parsed.e164;
 
   void _showCountryPicker() {
     showModalBottomSheet(

--- a/app/lib/utils/phone_number_input.dart
+++ b/app/lib/utils/phone_number_input.dart
@@ -1,4 +1,15 @@
+import 'package:flutter/services.dart';
 import 'package:phone_numbers_parser/phone_numbers_parser.dart';
+
+/// Characters the phone field accepts.
+///
+/// `+` has to be here: [parsePhoneNumberInput] treats a leading `+` as "the
+/// user supplied their own country code" and lets it override the picker, and
+/// a formatter that strips `+` makes that branch unreachable from the UI. Lives
+/// beside the parser so the two cannot drift apart.
+final phoneFieldInputFormatters = <TextInputFormatter>[
+  FilteringTextInputFormatter.allow(RegExp(r'[0-9+\s\-\(\)]')),
+];
 
 /// What the user typed on the phone-setup screen, interpreted for one country.
 ///
@@ -28,7 +39,11 @@ class PhoneNumberInput {
 /// is trusted over the picker, so pasting a foreign number does the obvious
 /// thing rather than being silently re-homed to the selected country.
 PhoneNumberInput parsePhoneNumberInput({required String raw, required String isoCode}) {
-  final trimmed = raw.trim();
+  // Only a leading + carries meaning; any other one is a typo, and leaving it
+  // in makes the whole string unparseable rather than just ignoring it.
+  final cleaned = raw.trim();
+  final trimmed =
+      cleaned.startsWith('+') ? '+${cleaned.substring(1).replaceAll('+', '')}' : cleaned.replaceAll('+', '');
   if (trimmed.isEmpty) return PhoneNumberInput.empty;
 
   final iso = _isoOrNull(isoCode);

--- a/app/lib/utils/phone_number_input.dart
+++ b/app/lib/utils/phone_number_input.dart
@@ -1,0 +1,70 @@
+import 'package:phone_numbers_parser/phone_numbers_parser.dart';
+
+/// What the user typed on the phone-setup screen, interpreted for one country.
+///
+/// Validation used to be a digit count against `IntlCountryData`'s
+/// telephoneMin/MaxLength. Those are a single fixed length per country and are
+/// wrong wherever numbers vary — Estonia was declared 10/10 against a real
+/// range of 7-8, so no Estonian number could ever pass (#11209). Lengths now
+/// come from libphonenumber metadata via `phone_numbers_parser`; the country
+/// data is only the picker's names, flags and dial codes.
+class PhoneNumberInput {
+  /// The number in E.164, e.g. `+3725142537`. Empty when nothing parsed.
+  final String e164;
+
+  /// True when libphonenumber recognizes this as a real number for its country.
+  final bool isValid;
+
+  const PhoneNumberInput({required this.e164, required this.isValid});
+
+  static const empty = PhoneNumberInput(e164: '', isValid: false);
+}
+
+/// Interprets [raw] as a phone number for [isoCode].
+///
+/// Handles the two ways users defeat a naive `+$dialCode$digits` concatenation:
+/// typing the country code themselves (which used to produce `+3723725142537`),
+/// and keeping the national trunk prefix (`05142537`). An explicit leading `+`
+/// is trusted over the picker, so pasting a foreign number does the obvious
+/// thing rather than being silently re-homed to the selected country.
+PhoneNumberInput parsePhoneNumberInput({required String raw, required String isoCode}) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return PhoneNumberInput.empty;
+
+  final iso = _isoOrNull(isoCode);
+  if (iso == null) return PhoneNumberInput.empty;
+
+  // A leading + means the user supplied the country code; parsing it as a
+  // national number for the selected country would prepend a second one.
+  final looksInternational = trimmed.startsWith('+') || trimmed.startsWith('00');
+  final candidates = looksInternational
+      ? [() => PhoneNumber.parse(trimmed), () => PhoneNumber.parse(trimmed, destinationCountry: iso)]
+      : [() => PhoneNumber.parse(trimmed, destinationCountry: iso)];
+
+  PhoneNumber? best;
+  for (final attempt in candidates) {
+    final parsed = _tryParse(attempt);
+    if (parsed == null) continue;
+    best ??= parsed;
+    if (parsed.isValid()) return PhoneNumberInput(e164: parsed.international, isValid: true);
+  }
+
+  if (best == null) return PhoneNumberInput.empty;
+  return PhoneNumberInput(e164: best.international, isValid: false);
+}
+
+PhoneNumber? _tryParse(PhoneNumber Function() attempt) {
+  try {
+    return attempt();
+  } catch (_) {
+    return null;
+  }
+}
+
+IsoCode? _isoOrNull(String code) {
+  final upper = code.toUpperCase();
+  for (final iso in IsoCode.values) {
+    if (iso.name == upper) return iso;
+  }
+  return null;
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1200,8 +1200,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: da8bbe1
-      resolved-ref: da8bbe15e5c596b01b07d62cce5e6ac97e8ee00f
+      ref: bb5355c
+      resolved-ref: bb5355cc126517dd936396b70d91f9dc7eb30129
       url: "https://github.com/mdmohsin7/intl_country_data.git"
     source: git
     version: "1.2.9"
@@ -1369,18 +1369,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mcumgr_flutter:
     dependency: "direct main"
     description:
@@ -1680,6 +1680,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  phone_numbers_parser:
+    dependency: "direct main"
+    description:
+      name: phone_numbers_parser
+      sha256: f0d669e9bb3def72b479ee034a42ddc2eecb5d39af9e598459d6f1c489bb19c7
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.25"
   photo_view:
     dependency: "direct main"
     description:
@@ -2145,10 +2153,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -66,7 +66,11 @@ dependencies:
   intl_country_data:
     git:
       url: https://github.com/mdmohsin7/intl_country_data.git
-      ref: da8bbe1
+      ref: bb5355c
+  # Pure-Dart port of Google's libphonenumber metadata (no platform channels,
+  # so it runs under `flutter test`). Owns phone-number validation; the country
+  # data above is only the picker's names, flags and dial codes.
+  phone_numbers_parser: ^9.0.25
   share_plus: 11.0.0
   shared_preferences: 2.5.3
   url_launcher: ^6.3.0

--- a/app/test/unit/phone_number_input_test.dart
+++ b/app/test/unit/phone_number_input_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl_country_data/intl_country_data.dart';
 import 'package:omi/utils/phone_number_input.dart';
@@ -57,6 +58,68 @@ void main() {
       final r = parsePhoneNumberInput(raw: '+442071838750', isoCode: 'EE');
       expect(r.isValid, isTrue);
       expect(r.e164, '+442071838750');
+    });
+  });
+
+  group('the field passes + through to the parser', () {
+    // Regression: the field allowed only [0-9\s\-()], so + was stripped before
+    // the parser ever saw it and the explicit-international branch below could
+    // never run from the UI. A pasted UK number was re-parsed as Estonian.
+    String applyFormatters(String typed) {
+      var value = TextEditingValue.empty;
+      for (final formatter in phoneFieldInputFormatters) {
+        value = formatter.formatEditUpdate(
+          TextEditingValue.empty,
+          TextEditingValue(text: typed, selection: TextSelection.collapsed(offset: typed.length)),
+        );
+      }
+      return value.text;
+    }
+
+    test('a leading + survives the input formatter', () {
+      expect(applyFormatters('+442071838750'), '+442071838750');
+    });
+
+    test('letters are still rejected', () {
+      expect(applyFormatters('44abc207'), '44207');
+    });
+
+    test('spacing and punctuation still allowed', () {
+      expect(applyFormatters('+372 (514) 25-37'), '+372 (514) 25-37');
+    });
+
+    test('end to end: what the field keeps is what validates', () {
+      final kept = applyFormatters('+442071838750');
+      final parsed = parsePhoneNumberInput(raw: kept, isoCode: 'EE');
+      expect(parsed.isValid, isTrue);
+      expect(parsed.e164, '+442071838750', reason: 'a pasted UK number must not be re-homed to Estonia');
+    });
+
+    testWidgets('the real field accepts a pasted + number', (tester) async {
+      final controller = TextEditingController();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TextField(
+            controller: controller,
+            keyboardType: TextInputType.phone,
+            inputFormatters: phoneFieldInputFormatters,
+          ),
+        ),
+      ));
+      await tester.enterText(find.byType(TextField), '+442071838750');
+      await tester.pump();
+      expect(controller.text, '+442071838750');
+      expect(parsePhoneNumberInput(raw: controller.text, isoCode: 'EE').e164, '+442071838750');
+    });
+  });
+
+  group('stray + characters are tolerated', () {
+    test('a + in the middle is ignored', () {
+      expect(parsePhoneNumberInput(raw: '514+2537', isoCode: 'EE').e164, '+3725142537');
+    });
+
+    test('a duplicated leading + still parses', () {
+      expect(parsePhoneNumberInput(raw: '++372 5142537', isoCode: 'EE').e164, '+3725142537');
     });
   });
 

--- a/app/test/unit/phone_number_input_test.dart
+++ b/app/test/unit/phone_number_input_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl_country_data/intl_country_data.dart';
+import 'package:omi/utils/phone_number_input.dart';
+
+/// #11209: phone signup was gated on a digit count against
+/// `IntlCountryData.telephoneMin/MaxLength`, a single fixed length per country.
+/// Estonia was declared 10/10 against a real range of 7-8, so the Continue
+/// button could never enable for any Estonian number.
+
+void main() {
+  group('Estonia (#11209)', () {
+    test('accepts the reported 7-digit number', () {
+      final r = parsePhoneNumberInput(raw: '5142537', isoCode: 'EE');
+      expect(r.isValid, isTrue);
+      expect(r.e164, '+3725142537');
+    });
+
+    test('still rejects 05142537 — Estonia has no trunk prefix', () {
+      // The issue also reported this as blocked, but Estonia abolished trunk
+      // prefixes: numbers are dialled as-is, so a leading 0 is not a prefix to
+      // strip and 05142537 is not a real number. libphonenumber strips the 0
+      // only for countries that actually have a national prefix (see the GB
+      // case below), which is precisely why per-country metadata beats a
+      // blanket "drop a leading zero" rule.
+      expect(parsePhoneNumberInput(raw: '05142537', isoCode: 'EE').isValid, isFalse);
+    });
+
+    test('accepts an 8-digit mobile number', () {
+      expect(parsePhoneNumberInput(raw: '51425370', isoCode: 'EE').isValid, isTrue);
+    });
+
+    test('the country entry no longer demands 10 digits', () {
+      // Guards the pinned intl_country_data revision: the picker still sources
+      // dial codes from it, and 10/10 is what made Estonia unreachable.
+      final ee = IntlCountryData.fromCountryCodeAlpha2('EE');
+      expect(ee.telephoneMinLength, 7);
+      expect(ee.telephoneMaxLength, 8);
+    });
+  });
+
+  group('typing the country code does not duplicate it', () {
+    test('a leading + is not concatenated onto the dial code', () {
+      // Previously produced +3723725142537.
+      final r = parsePhoneNumberInput(raw: '+372 5142537', isoCode: 'EE');
+      expect(r.isValid, isTrue);
+      expect(r.e164, '+3725142537');
+    });
+
+    test('00 international access is treated the same way', () {
+      final r = parsePhoneNumberInput(raw: '00372 5142537', isoCode: 'EE');
+      expect(r.e164, '+3725142537');
+    });
+
+    test('an explicit + wins over the picker', () {
+      // Pasting a UK number while Estonia is selected keeps the UK number
+      // rather than silently re-homing it.
+      final r = parsePhoneNumberInput(raw: '+442071838750', isoCode: 'EE');
+      expect(r.isValid, isTrue);
+      expect(r.e164, '+442071838750');
+    });
+  });
+
+  group('formatting noise is ignored', () {
+    for (final raw in ['514 2537', '514-2537', '(514) 2537', ' 5142537 ']) {
+      test('"$raw"', () {
+        expect(parsePhoneNumberInput(raw: raw, isoCode: 'EE').e164, '+3725142537');
+      });
+    }
+  });
+
+  group('countries the fixed-length data got wrong stay usable', () {
+    // Each of these has a real length range wider than one value, which the
+    // old min==max check could not express.
+    test('a 10-digit US number', () {
+      final r = parsePhoneNumberInput(raw: '4155552671', isoCode: 'US');
+      expect(r.isValid, isTrue);
+      expect(r.e164, '+14155552671');
+    });
+
+    test('a UK number with and without the trunk 0', () {
+      expect(parsePhoneNumberInput(raw: '02071838750', isoCode: 'GB').e164, '+442071838750');
+      expect(parsePhoneNumberInput(raw: '2071838750', isoCode: 'GB').e164, '+442071838750');
+    });
+
+    test('a German number', () {
+      expect(parsePhoneNumberInput(raw: '030123456', isoCode: 'DE').isValid, isTrue);
+    });
+  });
+
+  group('invalid input stays blocked', () {
+    test('empty', () {
+      expect(parsePhoneNumberInput(raw: '', isoCode: 'EE'), PhoneNumberInput.empty);
+      expect(parsePhoneNumberInput(raw: '   ', isoCode: 'EE').isValid, isFalse);
+    });
+
+    test('too short for the country', () {
+      expect(parsePhoneNumberInput(raw: '51', isoCode: 'EE').isValid, isFalse);
+    });
+
+    test('too long for the country', () {
+      expect(parsePhoneNumberInput(raw: '514253700000', isoCode: 'EE').isValid, isFalse);
+    });
+
+    test('letters only', () {
+      expect(parsePhoneNumberInput(raw: 'abcdefg', isoCode: 'EE').isValid, isFalse);
+    });
+
+    test('an unknown country code', () {
+      expect(parsePhoneNumberInput(raw: '5142537', isoCode: 'ZZ'), PhoneNumberInput.empty);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #11209.

## Why Estonian signup was impossible

The Continue button was gated on a digit count:

```dart
digits.length >= country.telephoneMinLength &&
digits.length <= country.telephoneMaxLength
```

`intl_country_data` declared Estonia `10/10`. Real Estonian numbers are 7–8 digits, so **no input could ever enable the button** — the reported `5142537` is 7 and `05142537` is 8.

## Why not just fix Estonia

**219 of the package's 241 countries have `min == max`** — one fixed length each, which cannot express a country whose numbers vary. The fork's own history already carries two one-off fixes of exactly this shape (Luxembourg/Finland, NZ landlines). Country-by-country patching does not converge; the next report is already latent.

Validation moves to [`phone_numbers_parser`](https://pub.dev/packages/phone_numbers_parser) — a pure-Dart port of Google's libphonenumber metadata, single dependency (`meta`). Pure Dart is the deciding factor: `flutter_libphonenumber` and `libphonenumber_plugin` are platform channels and cannot run under `flutter test`, which this repo requires. `intl_country_data` stays for what it's good at — the picker's names, flags and dial codes.

## The second reported bug

`_fullNumber` concatenated `'+${dialCode}$digits'` over every digit in the field, so typing `+372 5142537` produced **`+3723725142537`**. An explicit `+` or `00` is now parsed as international and wins over the picker, so pasting a foreign number keeps that number rather than being silently re-homed.

## Upstream

Estonia is corrected at source too — [mdmohsin7/intl_country_data#2](https://github.com/mdmohsin7/intl_country_data/pull/2), re-pinned here at `bb5355c` — since the picker still reads that package and `10/10` was plainly wrong.

**Only Estonia.** I attempted a blanket regeneration of all 241 entries from libphonenumber and reverted it: for NANP entries the two sources count different things. Jamaica's `telephoneCode` is `"1876"`, so its length field means digits *after* the area code (7), while libphonenumber's NSN includes it (10). The regeneration set 26 such countries to 10/10 and broke the fork's tests. Widening also broke its length-based country disambiguation. Left alone — the app no longer gates on those fields.

## One correction to the report

`05142537` stays invalid, and that's right. Estonia abolished trunk prefixes, so the leading `0` isn't a prefix to strip and that string isn't a real number. libphonenumber strips a leading `0` only where a country actually has a national prefix — the GB case in the tests covers exactly that (`02071838750` → `+442071838750`). The reporter's main complaint was correct; this sub-case was a wrong expectation.

## Verification

```
flutter test test/unit/phone_number_input_test.dart -> 19 tests, all passed
  covers 5142537, the +372-typed duplicate, 00-prefixed, an explicit + winning
  over the picker, GB with/without trunk 0, US, DE, and the invalid cases

flutter analyze (helper, page, test) -> No issues found
./test.sh                            -> 1153 tests, all passed
upstream: dart test -> 20 passed | dart analyze -> no issues
```

**Not verified on a device.** The parser is covered by unit tests, but I did not build the app and walk the phone-setup screen. Worth doing before release.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

