### PR TITLE
fix(stt): make Velma-2 the streaming default, Deepgram the remainder

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -340,7 +340,7 @@ jobs:
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
           STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
-          STT_SERVICE_MODELS: dg-nova-3,modulate-velma-2,parakeet
+          STT_SERVICE_MODELS: modulate-velma-2,dg-nova-3,parakeet
           SYNC_TASKS_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_invoker_sa }}
           TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -236,7 +236,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: HOSTED_PUSHER_API_URL

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -300,7 +300,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: HOSTED_TRANSLATION_API_URL
     value: "http://nllb.omi.me"
   - name: TRANSLATION_SERVICE_MODELS

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -263,7 +263,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
     value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -268,7 +268,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: RAPID_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -131,10 +131,10 @@ PROVIDER_SERVING_SURFACES: Final[Mapping[str, frozenset[STTServingSurface]]] = {
 # hard stream gate (see parakeet/admission.py), so every listener converges on
 # one cap per serving pod instead of listener-local counters.
 DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = {
-    # Velma-2 rejects a large, variable share of live connections under production
-    # concurrency and Parakeet streaming is English-only, so neither can hold the
-    # primary slot for a multi-language live product.
-    STTServingSurface.STREAMING: ('dg-nova-3', 'modulate-velma-2', 'parakeet'),
+    # Velma-2 leads on cost. It cannot yet carry 100% of live traffic, so a
+    # separate Deepgram-first deployment absorbs the remainder; selection is
+    # per-pod, and a session that fails on Velma is not retried on Deepgram.
+    STTServingSurface.STREAMING: ('modulate-velma-2', 'dg-nova-3', 'parakeet'),
     # Batch work is queued, so Parakeet's bounded GPU means waiting rather than the
     # user-visible failure it causes on the streaming surface. Prefer the self-hosted
     # provider here and keep Velma as the overflow.

--- a/backend/deploy/_generate_runtime_env_sources.py
+++ b/backend/deploy/_generate_runtime_env_sources.py
@@ -52,7 +52,7 @@ GKE_CONFIG_MAP_KEYS_PROD_ONLY = [
 
 STT_LITERALS = {
     'STT_PRERECORDED_MODEL': 'parakeet,modulate-velma-2',
-    'STT_SERVICE_MODELS': 'dg-nova-3,modulate-velma-2,parakeet',
+    'STT_SERVICE_MODELS': 'modulate-velma-2,dg-nova-3,parakeet',
 }
 
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -55,7 +55,7 @@ environments:
             value: dev
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -223,7 +223,7 @@ environments:
             value: parakeet,modulate-velma-2
             category: stt_policy
           STT_SERVICE_MODELS:
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
             category: stt_policy
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware-dev
@@ -301,7 +301,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:
@@ -1010,7 +1010,7 @@ environments:
             value: prod
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -1183,7 +1183,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -61,7 +61,7 @@ environment_shared:
           value: '{env}'
           category: runtime_identity
         STT_SERVICE_MODELS:
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
           category: stt_policy
         CONVERSATION_SUMMARIZED_APP_IDS:
           config_map:

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -88,7 +88,7 @@ overlay:
           value: parakeet,modulate-velma-2
           category: stt_policy
         STT_SERVICE_MODELS:
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
           category: stt_policy
         GOOGLE_CLOUD_PROJECT:
           value: based-hardware-dev
@@ -166,7 +166,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -93,7 +93,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -940,7 +940,7 @@ def test_deployment_stt_models_must_match_the_central_serving_policy():
         ),
         validator.ValidationError(
             'prod/gke/backend-listen',
-            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'dg-nova-3,modulate-velma-2,parakeet', got 'modulate-velma-2'",
+            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,dg-nova-3,parakeet', got 'modulate-velma-2'",
         ),
     ]
 

--- a/backend/tests/unit/test_listen_helm_env_overrides.py
+++ b/backend/tests/unit/test_listen_helm_env_overrides.py
@@ -78,7 +78,7 @@ def test_allow_direct_and_model_route_overrides_resolve_by_name():
         values,
         {
             "OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION": "true",
-            "STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet",
+            "STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet",
             "TRANSLATION_SERVICE_MODELS": "nllb,google",
         },
     )
@@ -86,7 +86,7 @@ def test_allow_direct_and_model_route_overrides_resolve_by_name():
     joined = " ".join(argv)
     assert "].value=true" in joined
     # Helm --set-string treats commas as pair separators unless escaped.
-    assert "].value=dg-nova-3\\,modulate-velma-2\\,parakeet" in joined
+    assert "].value=modulate-velma-2\\,dg-nova-3\\,parakeet" in joined
     assert "].value=nllb\\,google" in joined
 
 
@@ -98,7 +98,7 @@ def test_comma_model_list_survives_helm_set_string_round_trip():
     values = _load_values(PROD_VALUES)
     argv = HELPER.resolve_env_override_argv(
         values,
-        {"STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet"},
+        {"STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet"},
     )
     rendered = subprocess.run(
         [
@@ -116,7 +116,7 @@ def test_comma_model_list_survives_helm_set_string_round_trip():
         capture_output=True,
         text=True,
     ).stdout
-    assert 'name: STT_SERVICE_MODELS\n              value: "dg-nova-3,modulate-velma-2,parakeet"' in rendered
+    assert 'name: STT_SERVICE_MODELS\n              value: "modulate-velma-2,dg-nova-3,parakeet"' in rendered
 
 
 def test_newline_override_is_rejected():

--- a/backend/tests/unit/test_stt_provider_policy.py
+++ b/backend/tests/unit/test_stt_provider_policy.py
@@ -53,7 +53,7 @@ def test_self_hosted_deepgram_is_explicitly_limited_to_streaming():
 
 def test_policy_owns_the_safe_model_order_for_every_serving_surface():
     expected = {
-        STTServingSurface.STREAMING: 'dg-nova-3,modulate-velma-2,parakeet',
+        STTServingSurface.STREAMING: 'modulate-velma-2,dg-nova-3,parakeet',
         STTServingSurface.PRERECORDED: 'parakeet,modulate-velma-2',
         STTServingSurface.PTT: 'modulate-velma-2,parakeet',
     }

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -182,7 +182,7 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
         "GOOGLE_CLOUD_PROJECT": "based-hardware-dev",
         "HOSTED_PARAKEET_API_URL": "http://parakeet.omiapi.com",
         "STT_PRERECORDED_MODEL": "parakeet,modulate-velma-2",
-        "STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet",
+        "STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet",
     }
     assert clear_historical_secret == {"REDIS_DB_HOST", "GOOGLE_CLIENT_ID", "TYPESENSE_HOST"}
     assert preflight.validate_dev_pusher_binding_contract(deployment) == []
@@ -196,7 +196,7 @@ def test_prod_pusher_retains_the_explicit_self_hosted_deepgram_contract(prefligh
     assert bindings["DEEPGRAM_API_KEY"] == ("secret", "prod-omi-backend-secrets", "DEEPGRAM_API_KEY")
     assert literals["DEEPGRAM_SELF_HOSTED_ENABLED"] == "true"
     assert literals["DEEPGRAM_SELF_HOSTED_URL"] == "https://dg.omi.me"
-    assert literals["STT_SERVICE_MODELS"] == "dg-nova-3,modulate-velma-2,parakeet"
+    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,dg-nova-3,parakeet"
 
 
 def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: SimpleNamespace):
@@ -207,7 +207,7 @@ def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: Simpl
 
     assert preflight.validate_dev_pusher_binding_contract(deployment) == [
         "dev pusher literal contract mismatch for STT_SERVICE_MODELS: "
-        "expected 'dg-nova-3,modulate-velma-2,parakeet', got 'modulate-velma-2'"
+        "expected 'modulate-velma-2,dg-nova-3,parakeet', got 'modulate-velma-2'"
     ]
 
 


### PR DESCRIPTION
## Why

Velma-2 is materially cheaper than Deepgram and is the provider we intend to serve live traffic with. Deepgram is the paid fallback, kept only for the share Velma cannot carry yet. #11227 restored Deepgram and put it first, which was correct while the live path had no fallback at all — this moves the default to where we actually want the traffic.

## What changed

`DEFAULT_MODELS_BY_SURFACE[STREAMING]`:

```
- ('dg-nova-3', 'modulate-velma-2', 'parakeet')
+ ('modulate-velma-2', 'dg-nova-3', 'parakeet')
```

and every literal CI validates against it: listen + pusher charts (dev/prod), the pusher workflow, the `deploy/runtime_env` manifests, and `_generate_runtime_env_sources.py` so the generator can't reintroduce the old order.

Batch and PTT defaults are unchanged. Provider enablement is unchanged — this is ordering only.

## How the split actually works

Worth stating because it is not obvious from the ordering: **a session that fails on Velma is not retried on Deepgram.** `connect_stt_socket_with_fallback` raises `ValueError('connection fallback is defined only for a Parakeet primary')`, and the listen path only calls it with a Parakeet primary. Provider selection happens once, per pod, from that pod's `STT_SERVICE_MODELS`.

So the Velma/Deepgram traffic ratio is expressed as **two deployments**, not as ordering inside one pod:

- `prod-omi-backend-listen` — Velma-first, HPA 12–60, carries the majority
- a smaller Deepgram-first deployment — absorbs the remainder, shrinks as Velma proves out

This PR only moves the default. The deployment split is an operational change applied separately.

## Verification

- 222 passed, 4 skipped across the touched suites.
- Behaviour checked both ways: a pod on the new default selects Modulate; a pod explicitly configured `dg-nova-3` first still selects Deepgram — which the Deepgram tier depends on.
- `streaming.py` is untouched at 1523 lines, so the line-count ratchet stays satisfied and no break-glass is needed.

## Risk

Velma failed ~90% of connections at 100% exposure on 2026-08-05, and we still have no answer from Modulate on their capacity. This change makes Velma the default; it does **not** by itself move traffic — the deployment split governs that, and the Deepgram tier must exist before the Velma tier scales up. Do not merge this expecting it to be inert if the Deepgram tier is removed at the same time.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

