### PR TITLE
fix(agent-vm): resume drained migration journals

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,12 +1,12 @@
 {
   "files": {
     "backend/jobs/agent_vm_reconciler.py": 1754,
-    "backend/services/agent_vm_lifecycle.py": 2044,
+    "backend/services/agent_vm_lifecycle.py": 2076,
     "backend/testing/listen_pusher_stack/run.py": 1790
   },
   "raise_justifications": {
     "backend/jobs/agent_vm_reconciler.py": "The state-preserving replacement keeps provider compensation, disk identity checks, candidate health, cutover, soak, and retirement in one crash-recoverable owner loop; splitting the loop would obscure mutation ordering and failure compensation. +100 keeps durable pre-cutover journal recovery and post-retirement auto-delete ordering in that same provider-mutation loop. +25 pins the migration release snapshot so soak and retirement remain recoverable while the active release advances. +8 records the protected-disk repair fallback after migration completion so deferred lifecycle repair is visible to shared operations telemetry. +9 resolves the mutable active pointer through authenticated metadata and generation-pins the media read so a public GCS cache cannot serve a predecessor release. +2 passes the exact durable recovery identity into the lease transaction so terminal quarantine cannot bypass journal validation.",
-    "backend/services/agent_vm_lifecycle.py": "The lifecycle owner keeps state-disk and migration journal transactions beside the existing account-deletion, lease, pointer, and GCE identity fences so every transition shares one transactional safety boundary. +67 adds durable active-journal discovery and provider-identity lookup beside those transaction states so crash recovery cannot depend on a mutable release manifest. +28 atomically validates quarantined recovery against the durable journal state plus owner, token, instance, and target-release fences before claiming the VM lease.",
+    "backend/services/agent_vm_lifecycle.py": "The lifecycle owner keeps state-disk and migration journal transactions beside the existing account-deletion, lease, pointer, and GCE identity fences so every transition shares one transactional safety boundary. +67 adds durable active-journal discovery and provider-identity lookup beside those transaction states so crash recovery cannot depend on a mutable release manifest. +28 atomically validates quarantined recovery against the durable journal state plus owner, token, instance, and target-release fences before claiming the VM lease. +32 atomically exchanges a crash-retained drain marker for the equally admission-blocking migration state only when the exact pre-cutover journal still matches every durable identity fence.",
     "backend/testing/listen_pusher_stack/run.py": "#10577 keeps the operation-scoped persistence-fault controls beside the real listener/Pusher/Firestore assertions they qualify. +79 for #9809: the cloud-orphan-recovery scenario stays in the existing end-to-end listener/Pusher gauntlet rather than forking a second harness."
   },
   "threshold": 1500

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -700,6 +700,7 @@ def _migration_matches(
     owner: str,
     now: float,
     instance_id: str | None = None,
+    allow_drain_requested: bool = False,
 ) -> bool:
     """Validate the active pointer and reconciler lease for a migration CAS."""
     reconcile = vm.get("reconcile")
@@ -710,7 +711,7 @@ def _migration_matches(
         or vm.get("authToken") != auth_token
         or (instance_id is not None and str(vm.get("instanceId") or "") != instance_id)
         or bool(reconcile.get("startRequested"))
-        or bool(reconcile.get("drainRequested"))
+        or (bool(reconcile.get("drainRequested")) and not allow_drain_requested)
     ):
         return False
     lease = reconcile.get("lease")
@@ -770,11 +771,37 @@ def _begin_boot_image_migration_txn(
         return None
     snapshot = user_ref.get(transaction=transaction)
     vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    existing = migration_ref.get(transaction=transaction)
+    current = existing.to_dict() if existing.exists else None
+    durable_migration_id = migration.get("migrationId")
+    reconcile = vm.get("reconcile") if isinstance(vm, dict) else None
+    existing_matches = isinstance(current, dict) and (
+        current.get("oldVmName") == vm_name
+        and current.get("oldAuthToken") == auth_token
+        and current.get("oldInstanceId") == migration.get("oldInstanceId")
+        and current.get("candidateVmName") == migration.get("candidateVmName")
+        and current.get("targetRelease") == migration.get("targetRelease")
+    )
+    recovering_pre_cutover = (
+        existing_matches
+        and isinstance(current, dict)
+        and isinstance(reconcile, Mapping)
+        and reconcile.get("durableMigration") == durable_migration_id
+        and current.get("migrationId") == durable_migration_id
+        and current.get("state") in PRE_CUTOVER_BOOT_IMAGE_MIGRATION_STATES
+        and current.get("candidateAuthToken") == migration.get("candidateAuthToken")
+        and current.get("targetBootImage") == migration.get("targetBootImage")
+    )
     if not isinstance(vm, dict) or not _migration_matches(
-        vm, vm_name=vm_name, zone=zone, auth_token=auth_token, owner=owner, now=now
+        vm,
+        vm_name=vm_name,
+        zone=zone,
+        auth_token=auth_token,
+        owner=owner,
+        now=now,
+        allow_drain_requested=recovering_pre_cutover,
     ):
         return None
-    durable_migration_id = migration.get("migrationId")
     old_instance_id = str(migration.get("oldInstanceId") or "")
     if not isinstance(durable_migration_id, str) or not durable_migration_id or not old_instance_id:
         return None
@@ -783,17 +810,22 @@ def _begin_boot_image_migration_txn(
         return None
     if str(vm.get("status") or "") not in {"stopped", "ready"}:
         return None
-    existing = migration_ref.get(transaction=transaction)
     if existing.exists:
-        current = existing.to_dict() or {}
-        if not (
-            current.get("oldVmName") == vm_name
-            and current.get("oldAuthToken") == auth_token
-            and current.get("oldInstanceId") == migration.get("oldInstanceId")
-            and current.get("candidateVmName") == migration.get("candidateVmName")
-            and current.get("targetRelease") == migration.get("targetRelease")
-        ):
+        if not existing_matches:
             return None
+        assert isinstance(current, dict)
+        if recovering_pre_cutover:
+            # Atomically exchange the crash-retained drain marker for the
+            # migration state. Both block new admission, while later journal
+            # transitions continue to reject unrelated drain requests.
+            transaction.update(
+                user_ref,
+                {
+                    "agentVm.reconcile.state": "migration_claimed",
+                    "agentVm.reconcile.drainRequested": DELETE_FIELD,
+                    "agentVm.reconcile.drainRequestedAt": DELETE_FIELD,
+                },
+            )
         # A terminal candidate cleanup is explicitly retryable.  Reuse the
         # durable candidate name/token but remove its old provider identity so
         # the next creation can be recorded under the same fenced journal.

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -1638,6 +1638,8 @@ def test_durable_pre_cutover_journal_recovers_detached_state_without_manifest_op
             "releaseId": RELEASE.release_id,
             "lastError": "RuntimeError",
             "durableMigration": migration_id,
+            "drainRequested": True,
+            "drainRequestedAt": 90.0,
         },
     }
     client = StrictFirestore(
@@ -2039,6 +2041,113 @@ def test_boot_image_migration_cas_rejects_ready_legacy_status_with_new_demand(mo
         is None
     )
     assert not client.transactions[-1].updates
+
+
+def test_boot_image_migration_recovery_drain_requires_exact_durable_marker(monkeypatch):
+    migration_id = "8" * 24
+    migration = {
+        "migrationId": migration_id,
+        "state": "candidate_creating",
+        "oldVmName": "omi-agent-user",
+        "oldAuthToken": "old-token",
+        "oldInstanceId": "old-id",
+        "candidateVmName": "candidate",
+        "candidateAuthToken": "candidate-token",
+        "targetRelease": RELEASE.release_id,
+        "targetBootImage": RELEASE.boot_image,
+        "soakSeconds": 60,
+    }
+    client = StrictFirestore(
+        {
+            ("users", "dev-user"): {
+                "agentVm": {
+                    "vmName": "omi-agent-user",
+                    "zone": "us-central1-a",
+                    "status": "ready",
+                    "instanceId": "old-id",
+                    "authToken": "old-token",
+                    "reconcile": {
+                        "lease": {"owner": "worker", "expiresAt": 200.0},
+                        "durableMigration": "9" * 24,
+                        "drainRequested": True,
+                    },
+                }
+            },
+            ("users", "dev-user", "agentVmMigrations", migration_id): migration,
+        }
+    )
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+
+    assert (
+        lifecycle.begin_boot_image_migration(
+            "dev-user",
+            "omi-agent-user",
+            "us-central1-a",
+            "old-token",
+            "worker",
+            migration_id,
+            migration,
+            now=100.0,
+        )
+        is None
+    )
+    assert not client.transactions[-1].updates
+
+
+def test_boot_image_migration_recovery_atomically_replaces_crash_retained_drain(monkeypatch):
+    migration_id = "8" * 24
+    migration = {
+        "migrationId": migration_id,
+        "state": "candidate_creating",
+        "oldVmName": "omi-agent-user",
+        "oldAuthToken": "old-token",
+        "oldInstanceId": "old-id",
+        "candidateVmName": "candidate",
+        "candidateAuthToken": "candidate-token",
+        "targetRelease": RELEASE.release_id,
+        "targetBootImage": RELEASE.boot_image,
+        "soakSeconds": 60,
+    }
+    client = StrictFirestore(
+        {
+            ("users", "dev-user"): {
+                "agentVm": {
+                    "vmName": "omi-agent-user",
+                    "zone": "us-central1-a",
+                    "status": "ready",
+                    "instanceId": "old-id",
+                    "authToken": "old-token",
+                    "reconcile": {
+                        "state": "claimed",
+                        "lease": {"owner": "worker", "expiresAt": 200.0},
+                        "durableMigration": migration_id,
+                        "drainRequested": True,
+                        "drainRequestedAt": 90.0,
+                    },
+                }
+            },
+            ("users", "dev-user", "agentVmMigrations", migration_id): migration,
+        }
+    )
+    monkeypatch.setattr(lifecycle, "get_firestore_client", lambda: client)
+
+    assert (
+        lifecycle.begin_boot_image_migration(
+            "dev-user",
+            "omi-agent-user",
+            "us-central1-a",
+            "old-token",
+            "worker",
+            migration_id,
+            migration,
+            now=100.0,
+        )
+        == migration
+    )
+    recovery_update = client.transactions[-1].updates[-1][1]
+    assert recovery_update["agentVm.reconcile.state"] == "migration_claimed"
+    assert recovery_update["agentVm.reconcile.drainRequested"] is lifecycle.DELETE_FIELD
+    assert recovery_update["agentVm.reconcile.drainRequestedAt"] is lifecycle.DELETE_FIELD
 
 
 def test_boot_image_migration_completion_requires_candidate_pointer_and_lease(monkeypatch):

--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -27,9 +27,9 @@ ENV_IDENTITY_DEFAULTS = {
     },
 }
 
-SAFE_STREAMING_ROUTE = 'dg-nova-3,modulate-velma-2,parakeet'
-# Batch queues, so the bounded self-hosted GPU is preferred there; the streaming
-# surface keeps hosted Deepgram first because a Parakeet admission cap fails users live.
+SAFE_STREAMING_ROUTE = 'modulate-velma-2,dg-nova-3,parakeet'
+# Live streaming prefers Velma, then Deepgram; the separately deployed bounded
+# Parakeet service remains last in this route. Batch transcription has its own order.
 SAFE_PRERECORDED_ROUTE = 'parakeet,modulate-velma-2'
 
 
@@ -124,7 +124,7 @@ def test_dev_parity_pack_emptydir_is_writable_by_the_non_root_backend_image():
     assert _env_value(values, "OMI_PARITY_PACK_ROOT") == "/var/omi-parity-pack"
 
 
-def test_prod_values_make_deepgram_the_explicit_live_stt_primary():
+def test_prod_values_make_velma_the_explicit_live_stt_primary():
     values = _load_values(ENV_IDENTITY_DEFAULTS['prod']['values_file'])
 
     assert _env_value(values, 'STT_SERVICE_MODELS') == SAFE_STREAMING_ROUTE

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -525,15 +525,15 @@ class TestStreamingFactoryRouting:
             assert service == STTService.deepgram
             assert model == 'nova-3'
 
-    def test_parakeet_fallback_without_url(self):
+    def test_parakeet_fallback_without_url_uses_velma(self):
         from utils.stt.streaming import STTService, get_stt_service_for_language
 
         with patch('utils.stt.streaming.stt_service_models', ['parakeet']), patch.dict(os.environ, {}, clear=False):
             env_backup = os.environ.pop('HOSTED_PARAKEET_API_URL', None)
             try:
                 service, lang, model = get_stt_service_for_language('en')
-                assert service == STTService.deepgram
-                assert model == 'nova-3'
+                assert service == STTService.modulate
+                assert model == 'velma-2'
             finally:
                 if env_backup:
                     os.environ['HOSTED_PARAKEET_API_URL'] = env_backup


### PR DESCRIPTION
## Summary

- recover an exact durable pre-cutover Agent VM migration when a failed candidate cleanup retained `drainRequested`
- atomically exchange that drain marker for `migration_claimed`, preserving the same admission block without weakening later migration CAS checks
- keep fresh demand, mismatched durable markers, post-cutover journals, owner/token/instance drift, and account deletion fail-closed
- align two residual backend tests with the Velma-first streaming policy already merged in #11239

## Incident evidence

Dev execution `agent-vm-reconciler-smqc4` on reconciler release `efb273e273133ca4b121be4761857808543ba9be` successfully claimed the quarantined owner, then returned `stale: boot-image migration claim fence changed`. The exact owner record still had `drainRequested=true`; its journal remained `candidate_creating` with the original predecessor and protected state disk identities. No candidate was created and no cutover occurred.

## Verification

- `79 passed` in `backend/tests/unit/test_agent_vm_reconciler_job.py`
- focused transaction cases prove exact recovery succeeds and a mismatched durable marker cannot write
- `52 passed` across the two backend test files that retained pre-#11239 Deepgram-first expectations
- `backend/scripts/typecheck.sh`: `0 errors`
- product file line-count ratchet: pass
- Black and `git diff --check`: pass

## Rollout

After auto-deploy to development, reactivate the generation-fenced one-owner migration manifest, resume the paused development scheduler, and verify candidate creation, private runtime/state receipt, cutover, soak, identity-fenced predecessor/source retirement, rollback to the normal release, and the local desktop UI against development APIs. Production is out of scope.

Failure-Class: none

Product invariants: none
