### PR TITLE
test(stt): align stale streaming-default assertions with the Velma-first policy

### DIFF
--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -27,9 +27,10 @@ ENV_IDENTITY_DEFAULTS = {
     },
 }
 
-SAFE_STREAMING_ROUTE = 'dg-nova-3,modulate-velma-2,parakeet'
+SAFE_STREAMING_ROUTE = 'modulate-velma-2,dg-nova-3,parakeet'
 # Batch queues, so the bounded self-hosted GPU is preferred there; the streaming
-# surface keeps hosted Deepgram first because a Parakeet admission cap fails users live.
+# surface keeps Velma-2 first with Deepgram behind it, because a Parakeet
+# admission cap fails users live.
 SAFE_PRERECORDED_ROUTE = 'parakeet,modulate-velma-2'
 
 
@@ -124,7 +125,7 @@ def test_dev_parity_pack_emptydir_is_writable_by_the_non_root_backend_image():
     assert _env_value(values, "OMI_PARITY_PACK_ROOT") == "/var/omi-parity-pack"
 
 
-def test_prod_values_make_deepgram_the_explicit_live_stt_primary():
+def test_prod_values_pin_the_explicit_policy_live_stt_route():
     values = _load_values(ENV_IDENTITY_DEFAULTS['prod']['values_file'])
 
     assert _env_value(values, 'STT_SERVICE_MODELS') == SAFE_STREAMING_ROUTE

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -532,8 +532,10 @@ class TestStreamingFactoryRouting:
             env_backup = os.environ.pop('HOSTED_PARAKEET_API_URL', None)
             try:
                 service, lang, model = get_stt_service_for_language('en')
-                assert service == STTService.deepgram
-                assert model == 'nova-3'
+                # No configured model can serve, so selection falls through to the
+                # policy default for the streaming surface, which leads with Velma-2.
+                assert service == STTService.modulate
+                assert model == 'velma-2'
             finally:
                 if env_backup:
                     os.environ['HOSTED_PARAKEET_API_URL'] = env_backup


### PR DESCRIPTION
## Bug

`Backend Unit Tests` is red on `main` since c70eee1b42 (#11239, merged 08:59Z). Two test files that #11239 did not touch still assert the old Deepgram-first streaming order, so three tests fail on every push to main:

- `test_backend_listen_helm_defaults.py::test_prod_values_make_deepgram_the_explicit_live_stt_primary`
- `test_backend_listen_helm_defaults.py::test_rendered_prod_deployment_cannot_restore_parakeet_first_streaming`
- `test_parakeet_prerecorded.py::TestStreamingFactoryRouting::test_parakeet_fallback_without_url`

## Root cause

#11239 intentionally moved `DEFAULT_MODELS_BY_SURFACE[STREAMING]` to `('modulate-velma-2', 'dg-nova-3', 'parakeet')` and updated the literals in the four suites it touched. It missed two others:

- `SAFE_STREAMING_ROUTE` was pinned to `'dg-nova-3,modulate-velma-2,parakeet'`, so both the prod-values check and the rendered-deployment check compare against the retired order.
- `test_parakeet_fallback_without_url` patches `stt_service_models` to `['parakeet']` with no `HOSTED_PARAKEET_API_URL`. Nothing configured can serve, so `get_stt_service_for_language` falls through to `default_models_for_surface(STREAMING)` — which now leads with Velma-2, returning `(modulate, 'velma-2')` instead of `(deepgram, 'nova-3')`.

## Fix

Assertions only — no production behaviour change, no policy change. Updated the two stale expectations to the current policy and renamed the prod-values test, whose name claimed Deepgram was the live primary.

## Tested

Reproduced the failure and the fix locally with the repo runner (helm installed, so the render test was not skipped):

```
BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh
# tests/unit/test_backend_listen_helm_defaults.py: 8 passed
# tests/unit/test_parakeet_prerecorded.py:        44 passed
```

Both previously-failing files pass; all three named tests pass individually.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

