### PR TITLE
Fix Agent VM boot capacity and state cleanup IAM

### DIFF
--- a/backend/agent_vm/startup.sh
+++ b/backend/agent_vm/startup.sh
@@ -61,6 +61,7 @@ startup_fail() {
 }
 
 expand_root_filesystem() {
+  local system_vendor
   local root_source
   local root_partition
   local root_filesystem
@@ -72,9 +73,13 @@ expand_root_filesystem() {
   local growth_headroom=$((256 * 1024 * 1024))
   local tool
 
-  # Unit tests also execute this script on macOS. A real Agent VM always has
-  # Linux block-device inventory; non-Linux harnesses have nothing to grow.
-  [[ -d /sys/class/block ]] || return 0
+  # This mutates a partition table and therefore stays fenced to the GCE guest
+  # environment this startup script owns. Unit and container harnesses can
+  # expose host block devices that are neither accessible nor safe to inspect.
+  [[ -r /sys/class/dmi/id/sys_vendor ]] || return 0
+  IFS= read -r system_vendor < /sys/class/dmi/id/sys_vendor || return 0
+  [[ "$system_vendor" == "Google" ]] || return 0
+  [[ -d /sys/class/block ]] || startup_fail "GCE block-device inventory is unavailable"
   for tool in findmnt readlink lsblk blockdev growpart resize2fs tr; do
     command -v "$tool" >/dev/null 2>&1 || startup_fail "$tool is required to size the root filesystem"
   done

--- a/backend/agent_vm/startup.sh
+++ b/backend/agent_vm/startup.sh
@@ -60,6 +60,59 @@ startup_fail() {
   exit 1
 }
 
+expand_root_filesystem() {
+  local root_source
+  local root_partition
+  local root_filesystem
+  local parent_name
+  local partition_number
+  local root_disk
+  local disk_size
+  local partition_size
+  local growth_headroom=$((256 * 1024 * 1024))
+  local tool
+
+  # Unit tests also execute this script on macOS. A real Agent VM always has
+  # Linux block-device inventory; non-Linux harnesses have nothing to grow.
+  [[ -d /sys/class/block ]] || return 0
+  for tool in findmnt readlink lsblk blockdev growpart resize2fs tr; do
+    command -v "$tool" >/dev/null 2>&1 || startup_fail "$tool is required to size the root filesystem"
+  done
+
+  root_source="$(findmnt --noheadings --output SOURCE /)" \
+    || startup_fail "root filesystem source is unavailable"
+  root_partition="$(readlink -f "$root_source")" \
+    || startup_fail "root filesystem source cannot be resolved"
+  # Containerized test runners commonly expose overlayfs rather than a block
+  # device. The GCE guest path below is intentionally limited to a partition.
+  [[ -b "$root_partition" ]] || return 0
+  root_filesystem="$(findmnt --noheadings --output FSTYPE /)" \
+    || startup_fail "root filesystem type is unavailable"
+  [[ "$root_filesystem" == "ext4" ]] || startup_fail "unsupported root filesystem type: $root_filesystem"
+
+  parent_name="$(lsblk --noheadings --output PKNAME "$root_partition" | tr -d '[:space:]')" \
+    || startup_fail "root disk identity is unavailable"
+  partition_number="$(lsblk --noheadings --output PARTN "$root_partition" | tr -d '[:space:]')" \
+    || startup_fail "root partition number is unavailable"
+  [[ "$parent_name" =~ ^[a-zA-Z0-9._-]+$ && "$partition_number" =~ ^[0-9]+$ ]] \
+    || startup_fail "root partition identity is invalid"
+  root_disk="/dev/${parent_name}"
+  [[ -b "$root_disk" ]] || startup_fail "root disk is not a block device"
+
+  disk_size="$(blockdev --getsize64 "$root_disk")" \
+    || startup_fail "root disk size is unavailable"
+  partition_size="$(blockdev --getsize64 "$root_partition")" \
+    || startup_fail "root partition size is unavailable"
+  [[ "$disk_size" =~ ^[0-9]+$ && "$partition_size" =~ ^[0-9]+$ ]] \
+    || startup_fail "root filesystem size is invalid"
+  if ((disk_size - partition_size > growth_headroom)); then
+    growpart "$root_disk" "$partition_number" \
+      || startup_fail "root partition could not be expanded"
+    resize2fs "$root_partition" \
+      || startup_fail "root filesystem could not be expanded"
+  fi
+}
+
 ensure_docker_daemon() {
   if ! command -v docker >/dev/null 2>&1; then
     apt-get update
@@ -422,6 +475,7 @@ ensure_state_tools() {
   done
 }
 
+expand_root_filesystem
 quiesce_docker_before_state_mount
 
 state_required_raw=""

--- a/backend/scripts/apply-agent-vm-reconciler-iam.sh
+++ b/backend/scripts/apply-agent-vm-reconciler-iam.sh
@@ -30,7 +30,10 @@ operations_role="projects/${project}/roles/${operations_role_id}"
 # below still constrain Disk and Instance resources to omi-agent-* names.
 # Creating an already-labeled disk checks both compute.disks.create and
 # compute.disks.setLabels against the target Disk resource.
-permissions="compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.setLabels,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
+# Changing an attachment's auto-delete flag checks both
+# compute.instances.setDiskAutoDelete on the VM and compute.disks.update on
+# the attached state disk, so both remain inside their name-scoped bindings.
+permissions="compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.setLabels,compute.disks.update,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
 subnetwork_role_id="omiAgentVmReconcilerSubnetwork"
 subnetwork_role="projects/${project}/roles/${subnetwork_role_id}"
 subnetwork_permissions="compute.subnetworks.use,compute.subnetworks.useExternalIp"

--- a/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py
@@ -148,7 +148,7 @@ def test_reconciler_iam_installer_refuses_by_default_and_keeps_bindings_scoped(t
     assert 'AGENT_VM_RECONCILER_IAM_APPLY:-}' in script
     assert "REFUSED:" in script
     assert (
-        "compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.setLabels,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
+        "compute.disks.create,compute.disks.delete,compute.disks.get,compute.disks.setLabels,compute.disks.update,compute.disks.use,compute.disks.useReadOnly,compute.images.useReadOnly,compute.instances.attachDisk,compute.instances.create,compute.instances.delete,compute.instances.detachDisk,compute.instances.get,compute.instances.setDiskAutoDelete,compute.instances.setLabels,compute.instances.setMetadata,compute.instances.setServiceAccount,compute.instances.setTags,compute.instances.start,compute.instances.stop"
         in script
     )
     assert "compute.disks.setLabels" in script

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -148,6 +148,21 @@ def test_startup_bootstraps_read_only_state_tooling_contract() -> None:
     assert source.index('state_fsync_tree "$data_dir"') < source.index('state_write_receipt "$state_receipt"')
 
 
+def test_startup_expands_the_gce_root_partition_before_state_or_docker_work() -> None:
+    source = STARTUP.read_text(encoding="utf-8")
+
+    assert 'root_source="$(findmnt --noheadings --output SOURCE /)"' in source
+    assert 'root_partition="$(readlink -f "$root_source")"' in source
+    assert 'parent_name="$(lsblk --noheadings --output PKNAME "$root_partition"' in source
+    assert 'partition_number="$(lsblk --noheadings --output PARTN "$root_partition"' in source
+    assert 'disk_size="$(blockdev --getsize64 "$root_disk")"' in source
+    assert 'partition_size="$(blockdev --getsize64 "$root_partition")"' in source
+    assert 'growpart "$root_disk" "$partition_number"' in source
+    assert 'resize2fs "$root_partition"' in source
+    assert source.index("expand_root_filesystem\n") < source.index("quiesce_docker_before_state_mount\n")
+    assert source.index("quiesce_docker_before_state_mount\n") < source.index("ensure_docker_daemon\n")
+
+
 def _write_fake_command(bin_dir: Path, name: str, body: str) -> None:
     path = bin_dir / name
     path.write_text(f"#!/bin/bash\n{body}\n", encoding="utf-8")

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -151,6 +151,8 @@ def test_startup_bootstraps_read_only_state_tooling_contract() -> None:
 def test_startup_expands_the_gce_root_partition_before_state_or_docker_work() -> None:
     source = STARTUP.read_text(encoding="utf-8")
 
+    assert '[[ -r /sys/class/dmi/id/sys_vendor ]] || return 0' in source
+    assert '[[ "$system_vendor" == "Google" ]] || return 0' in source
     assert 'root_source="$(findmnt --noheadings --output SOURCE /)"' in source
     assert 'root_partition="$(readlink -f "$root_source")"' in source
     assert 'parent_name="$(lsblk --noheadings --output PKNAME "$root_partition"' in source

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -60,6 +60,13 @@ that same identity-checked disk to the candidate. The candidate's state disk
 becomes the active owner's state surface only after the health,
 release-identity, lease, and cutover checks succeed.
 
+Replacement creation attaches only the new boot disk and durable state disk.
+The full predecessor clone is hot-attached read-only with `autoDelete: false`
+after the guest kernel has selected its root device, avoiding duplicate legacy
+filesystem labels during boot. Startup waits a bounded interval for required
+state devices and expands the image's ext4 root partition to the provisioned
+boot-disk size before installing or pulling Docker content.
+
 The **explicit ephemeral browser policy** is part of this contract: only paths
 listed in the state-disk contract are persistent. Browser cache, temporary
 profiles, downloads, and other unlisted browser data are ephemeral and must be
@@ -70,7 +77,8 @@ separate reviewed state contract names them.
 The active owner's boot disk and initial state-disk attachment are created with
 `autoDelete: true`. Once migration must preserve state across VM replacement,
 the reconciler changes the state-disk attachment to `autoDelete: false` before
-detaching it; the temporary read-only source clone remains `autoDelete: true`.
+detaching it; the temporary read-only source clone remains protected with
+`autoDelete: false` until explicit retirement.
 During migration, the stopped predecessor, detached persistent state disk, and
 temporary clone are preserved through the journaled soak window; candidate
 health alone never authorizes cleanup. After cutover, cleanup is
@@ -194,7 +202,7 @@ redundant VPC-network field when a subnetwork is present, so Compute infers the
 network from the subnet and no project-wide network access is granted.
 The same custom role includes only the additional state-disk/clone operations
 `compute.disks.create`, `compute.disks.delete`, `compute.disks.get`,
-`compute.disks.use`, `compute.disks.useReadOnly`,
+`compute.disks.update`, `compute.disks.use`, `compute.disks.useReadOnly`,
 `compute.instances.attachDisk`, `compute.instances.detachDisk`, and
 `compute.instances.setDiskAutoDelete`. The existing `omi-agent-*` instance,
 disk, and image conditions remain in force; no broad Compute role or


### PR DESCRIPTION
## Summary

- expand an Agent VM image's ext4 root partition to the provisioned GCE boot-disk size before state or Docker work
- add the disk-scoped `compute.disks.update` permission GCE requires when changing a state attachment's auto-delete policy
- document the late read-only source-clone attachment and protected cleanup contract

## Dev evidence

- a fenced one-owner migration created the replacement with boot + state only, then hot-attached the exact source clone read-only with `autoDelete=false`
- guest startup mounted and verified the source state, private `/health` returned HTTP 200, and the owner pointer cut over
- the soak pass detached/deleted the source clone and deleted the numeric-ID-fenced predecessor
- Cloud Audit Logs showed the remaining auto-delete repair was denied only because `compute.disks.update` was absent; the state disk stayed protected with `autoDelete=false`
- the probe image exposed a 50 GB boot disk with a 3.9 GB root partition, reproducing the Docker `no space left on device` failure this change prevents

## Verification

- `bash -n backend/agent_vm/startup.sh`
- `bash -n backend/scripts/apply-agent-vm-reconciler-iam.sh`
- 135 focused Agent VM unit tests
- `make preflight`
- `make runtime-image-source-closure`

Failure-Class: FC-agent-vm-bootstrap-contract

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

