### PR TITLE
Fix Agent VM partition detection on base images

### DIFF
--- a/backend/agent_vm/startup.sh
+++ b/backend/agent_vm/startup.sh
@@ -66,6 +66,7 @@ expand_root_filesystem() {
   local root_partition
   local root_filesystem
   local parent_name
+  local partition_number_file
   local partition_number
   local root_disk
   local disk_size
@@ -97,7 +98,12 @@ expand_root_filesystem() {
 
   parent_name="$(lsblk --noheadings --output PKNAME "$root_partition" | tr -d '[:space:]')" \
     || startup_fail "root disk identity is unavailable"
-  partition_number="$(lsblk --noheadings --output PARTN "$root_partition" | tr -d '[:space:]')" \
+  # Ubuntu images can carry an lsblk without the optional PARTN output column.
+  # Linux exposes the partition number directly through sysfs on every block
+  # partition, including both /dev/sda1 and NVMe-style device names.
+  partition_number_file="/sys/class/block/${root_partition##*/}/partition"
+  [[ -r "$partition_number_file" ]] || startup_fail "root partition number is unavailable"
+  IFS= read -r partition_number < "$partition_number_file" \
     || startup_fail "root partition number is unavailable"
   [[ "$parent_name" =~ ^[a-zA-Z0-9._-]+$ && "$partition_number" =~ ^[0-9]+$ ]] \
     || startup_fail "root partition identity is invalid"

--- a/backend/tests/unit/test_agent_vm_startup.py
+++ b/backend/tests/unit/test_agent_vm_startup.py
@@ -156,7 +156,9 @@ def test_startup_expands_the_gce_root_partition_before_state_or_docker_work() ->
     assert 'root_source="$(findmnt --noheadings --output SOURCE /)"' in source
     assert 'root_partition="$(readlink -f "$root_source")"' in source
     assert 'parent_name="$(lsblk --noheadings --output PKNAME "$root_partition"' in source
-    assert 'partition_number="$(lsblk --noheadings --output PARTN "$root_partition"' in source
+    assert 'partition_number_file="/sys/class/block/${root_partition##*/}/partition"' in source
+    assert 'IFS= read -r partition_number < "$partition_number_file"' in source
+    assert "--output PARTN" not in source
     assert 'disk_size="$(blockdev --getsize64 "$root_disk")"' in source
     assert 'partition_size="$(blockdev --getsize64 "$root_partition")"' in source
     assert 'growpart "$root_disk" "$partition_number"' in source


### PR DESCRIPTION
## Summary

- read the Linux root partition number from sysfs instead of the optional `lsblk PARTN` column
- preserve the existing GCE-only fence, validated partition identity, and idempotent size comparison

## Dev evidence

- a fenced one-owner migration on `omi-agent-base-v4-clean-20260805` failed closed before state or Docker work because the guest's `lsblk` reports `unknown column: PARTN`
- the exact candidate exposes `/dev/sda1`, parent `sda`, and `/sys/class/block/sda1/partition` containing `1`
- its disk and partition differ by only 116,408,832 bytes, below the 256 MiB growth threshold, and the mounted root is already 49 GiB; the corrected helper therefore no-ops safely on this image
- the durable state disk remains protected and the predecessor remains retained while rollback completes

## Verification

- `bash -n backend/agent_vm/startup.sh`
- 25 focused startup tests through `backend/test.sh`
- live read-only inspection of the exact dev candidate's sysfs and block sizes

Failure-Class: FC-agent-vm-bootstrap-contract


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

