### PR TITLE
fix(macos): isolate signed release canary startup

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -274,8 +274,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // Publish the live delegate instance for callers that can't rely on
     // `NSApp.delegate as? AppDelegate` (nil under SwiftUI's delegate adaptor).
     AppDelegate.shared = self
+    if AuthStorageCanary.isRequested || UserNotificationCallbackBridge.isSignedSmokeRequested() { return }
     OmiFontRegistration.registerAll()
-    if AuthStorageCanary.isRequested { return }
     // Single-instance guard: a second live copy of the same bundle id + launch mode
     // would race the first against the shared Rewind SQLite DB
     // (~/Library/Application Support/Omi/…) and the bundle-id UserDefaults domain,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
@@ -128,6 +128,13 @@ final class ProactiveTestNotificationObserver: NSObject, @unchecked Sendable {
 enum UserNotificationCallbackBridge {
   static let signedSmokeResultPathEnvironmentKey = "OMI_NOTIFICATION_CALLBACK_SMOKE_RESULT_PATH"
 
+  static func isSignedSmokeRequested(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> Bool {
+    guard let path = environment[signedSmokeResultPathEnvironmentKey] else { return false }
+    return !path.isEmpty
+  }
+
   typealias SettingsQuery = @Sendable (@escaping @Sendable (UserNotificationSettingsSnapshot) -> Void) -> Void
 
   nonisolated static func notificationSettings(
@@ -194,7 +201,9 @@ enum UserNotificationCallbackBridge {
   static func runSignedSmokeIfRequested(
     environment: [String: String] = ProcessInfo.processInfo.environment
   ) -> Bool {
-    guard let path = environment[signedSmokeResultPathEnvironmentKey], !path.isEmpty else { return false }
+    guard isSignedSmokeRequested(environment: environment),
+      let path = environment[signedSmokeResultPathEnvironmentKey]
+    else { return false }
     let resultURL = URL(fileURLWithPath: path)
     authorizationStatus { status in
       let succeeded = Thread.isMainThread

--- a/desktop/macos/Desktop/Tests/AuthStorageCanaryTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthStorageCanaryTests.swift
@@ -3,6 +3,23 @@ import XCTest
 @testable import Omi_Computer
 
 final class AuthStorageCanaryTests: XCTestCase {
+  func testDistributionCanariesBypassProductWillFinishStartup() throws {
+    let appFile = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/OmiApp.swift")
+    // omi-test-quality: source-inspection -- static contract: distribution canaries must return before resource loading and instance locking; launch-order behavior has no injectable runtime seam.
+    let source = try String(contentsOf: appFile, encoding: .utf8)
+    let canaryGuard = try XCTUnwrap(
+      source.range(
+        of: "if AuthStorageCanary.isRequested || UserNotificationCallbackBridge.isSignedSmokeRequested()"))
+    let fontRegistration = try XCTUnwrap(source.range(of: "OmiFontRegistration.registerAll()"))
+    let instanceGuard = try XCTUnwrap(source.range(of: "SingleInstanceGuard.enforceSingleInstanceOrExit("))
+
+    XCTAssertLessThan(canaryGuard.lowerBound, fontRegistration.lowerBound)
+    XCTAssertLessThan(canaryGuard.lowerBound, instanceGuard.lowerBound)
+  }
+
   func testCanaryProvesWriteReadAndDelete() {
     var value: String?
     let result = AuthStorageCanary.execute(

--- a/desktop/macos/Desktop/Tests/UserNotificationCallbackBridgeTests.swift
+++ b/desktop/macos/Desktop/Tests/UserNotificationCallbackBridgeTests.swift
@@ -29,6 +29,13 @@ final class UserNotificationCallbackBridgeTests: XCTestCase {
   }
 
   func testSignedSmokeRequiresExplicitResultPath() {
+    XCTAssertFalse(UserNotificationCallbackBridge.isSignedSmokeRequested(environment: [:]))
+    XCTAssertFalse(
+      UserNotificationCallbackBridge.isSignedSmokeRequested(
+        environment: [UserNotificationCallbackBridge.signedSmokeResultPathEnvironmentKey: ""]))
+    XCTAssertTrue(
+      UserNotificationCallbackBridge.isSignedSmokeRequested(
+        environment: [UserNotificationCallbackBridge.signedSmokeResultPathEnvironmentKey: "/tmp/proof"]))
     XCTAssertFalse(UserNotificationCallbackBridge.runSignedSmokeIfRequested(environment: [:]))
   }
 

--- a/desktop/macos/changelog/unreleased/20260808-signed-canary-startup.json
+++ b/desktop/macos/changelog/unreleased/20260808-signed-canary-startup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability of signed macOS Beta startup verification"
+}


### PR DESCRIPTION
## Summary

- keep signed release canaries ahead of font/resource startup and the single-instance guard
- make the UserNotifications smoke-request predicate explicit and testable
- add regression coverage for the launch-order contract

## Failure classification

Failure-Class: FC-usernotifications-callback-isolation

The v0.12.152 signed stable artifact passed build, signing, dependency audit,
notarization, DMG creation, and Beta packaging, then failed the isolated stable
smoke step. The redesign introduced font registration before the canary early
return. This change restores callback-only canary startup without weakening any
artifact, signing, Keychain, or UserNotifications gate.

## Product invariants affected

- INV-AUTH-1

## Verification

- `xcrun swift-format lint --strict` on all changed Swift files
- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter AuthStorageCanaryTests`
- `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter UserNotificationCallbackBridgeTests`

## Risk

Low. Normal launches retain font registration and single-instance enforcement.
Only explicit distribution-canary launches return before those product startup
side effects.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

