### PR TITLE
Recover Agent VM migrations across releases

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-other.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/jobs/agent_vm_reconciler.py": 1783,
+    "backend/jobs/agent_vm_reconciler.py": 1745,
     "backend/services/agent_vm_lifecycle.py": 2071,
     "backend/testing/listen_pusher_stack/run.py": 1790
   },

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -61,6 +61,16 @@ from services.agent_vm_lifecycle import (
     update_vm_reconcile,
     validate_release_manifest,
 )
+from services.agent_vm_migration_control import (
+    BootImageMigrationPlan,
+    boot_image_candidate_name as _boot_image_candidate_name,
+    boot_image_migration_id as _boot_image_migration_id,
+    boot_image_migration_plan as _boot_image_migration_plan,
+    owner_disk_label as _owner_disk_label,
+    source_clone_disk_name as _source_clone_disk_name,
+    state_disk_name as _state_disk_name,
+    supersede_rolled_back_boot_image_migration,
+)
 from utils.env_loader import firebase_admin_options
 from utils.observability.fallback import record_fallback
 
@@ -88,59 +98,6 @@ class ReconcileResult:
     uid: str
     state: str
     detail: str = ""
-
-
-@dataclass(frozen=True)
-class BootImageMigrationPlan:
-    """An explicit, dev-only plan for replacing stopped boot-image-drift VMs.
-
-    This plan deliberately does not inherit the normal release rollout.  A
-    release publication must never become a destructive migration merely
-    because it happens to carry a new immutable boot image.
-    """
-
-    allowed_uids: frozenset[str]
-    max_concurrency: int
-    soak_seconds: int
-
-
-def _boot_image_migration_plan(raw: Mapping[str, Any], release: AgentVmRelease) -> BootImageMigrationPlan | None:
-    """Return a safe replacement plan, or ``None`` when migration is disabled.
-
-    The plan lives in a separately named manifest section and is accepted only
-    for development.  Production is hard-disabled in code even if a manifest
-    is malformed or accidentally promoted with this section present.
-    """
-    migration = raw.get("bootImageMigration")
-    if not isinstance(migration, Mapping) or migration.get("enabled") is not True:
-        return None
-    if release.environment != "development" or os.getenv("AGENT_VM_ENVIRONMENT", "").strip() != "development":
-        raise ValueError("boot-image migration is development-only")
-    if os.getenv("GCE_PROJECT_ID", "").strip() != "based-hardware-dev":
-        raise ValueError("boot-image migration requires the approved development project")
-    owners = migration.get("allowedUids")
-    if not isinstance(owners, list) or not owners or not all(isinstance(uid, str) and uid.strip() for uid in owners):
-        raise ValueError("boot-image migration requires a non-empty allowedUids list")
-    max_concurrency = migration.get("maxConcurrency", 1)
-    soak_seconds = migration.get("soakSeconds", 600)
-    if not isinstance(max_concurrency, int) or max_concurrency != 1:
-        raise ValueError("boot-image migration maxConcurrency must be exactly 1")
-    if not isinstance(soak_seconds, int) or soak_seconds < 60:
-        raise ValueError("boot-image migration soakSeconds must be at least 60")
-    return BootImageMigrationPlan(frozenset(owners), max_concurrency, soak_seconds)
-
-
-def _boot_image_migration_id(uid: str, vm_name: str, instance_id: str, release_id: str) -> str:
-    return hashlib.sha256(f"{uid}:{vm_name}:{instance_id}:{release_id}".encode()).hexdigest()[:24]
-
-
-def _boot_image_candidate_name(vm_name: str, migration_id: str) -> str:
-    if not _MIGRATION_ID.fullmatch(migration_id):
-        raise ValueError("boot-image migration id is invalid")
-    suffix = f"-m-{migration_id[:12]}"
-    # GCE names are limited to 63 characters and the predecessor identity is
-    # also recorded independently in the durable migration journal.
-    return f"{vm_name[: 63 - len(suffix)]}{suffix}"
 
 
 def _disk_attachment(instance: Mapping[str, Any], device_name: str) -> Mapping[str, Any] | None:
@@ -180,18 +137,6 @@ def _normalized_disk_users(disk: Mapping[str, Any]) -> list[str] | None:
     if not isinstance(users, list):
         return None
     return [str(user).split("/compute/v1/")[-1] for user in users]
-
-
-def _state_disk_name(migration_id: str) -> str:
-    return f"omi-agent-state-{migration_id[:16]}"
-
-
-def _source_clone_disk_name(migration_id: str) -> str:
-    return f"omi-agent-source-{migration_id[:16]}"
-
-
-def _owner_disk_label(uid: str) -> str:
-    return hashlib.sha256(uid.encode()).hexdigest()[:20]
 
 
 def _disk_source(project: str, zone: str, disk_name: str) -> str:
@@ -696,6 +641,23 @@ async def _replace_stopped_boot_image_drift(
         state_disk_name = str(recovery_journal.get("stateDiskName") or "")
         state_disk_reused = recovery_journal.get("stateDiskReused") is True
         source_clone_name = str(recovery_journal.get("sourceCloneDiskName") or "")
+        supersession = await supersede_rolled_back_boot_image_migration(
+            uid=uid,
+            vm_name=vm_name,
+            zone=zone,
+            auth_token=auth_token,
+            owner=owner,
+            old_instance_id=old_instance_id,
+            replacement_release_id=release.release_id,
+            recovery_journal=recovery_journal,
+            owner_label=_owner_disk_label(uid),
+            cleanup_context=cleanup_context,
+            rollback=lambda context: _rollback_failed_boot_image_candidate(api, uid, vm_name, context),
+        )
+        if supersession == "stale":
+            return ReconcileResult(uid, "stale", "failed migration supersession fence changed")
+        if supersession == "superseded":
+            return ReconcileResult(uid, "retry", "superseded a rolled-back migration from an older release")
         if (
             not _MIGRATION_ID.fullmatch(migration_id)
             or recovery_journal.get("oldVmName") != vm_name

--- a/backend/services/agent_vm_migration_control.py
+++ b/backend/services/agent_vm_migration_control.py
@@ -1,0 +1,280 @@
+"""Development Agent VM boot-image migration control and supersession fences."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import time
+from collections.abc import Awaitable, Callable, Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any
+
+from google.cloud.firestore import DELETE_FIELD, transactional
+
+from database._client import get_firestore_client
+from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
+from services.agent_vm_lifecycle import AgentVmRelease, DEFAULT_ZONE, clear_vm_reconcile_lease_fields
+from utils.executors import db_executor, run_blocking
+
+_MIGRATION_ID = re.compile(r"^[0-9a-f]{24}$")
+
+
+@dataclass(frozen=True)
+class BootImageMigrationPlan:
+    """An explicit, development-only plan for stopped boot-image drift."""
+
+    allowed_uids: frozenset[str]
+    max_concurrency: int
+    soak_seconds: int
+
+
+def boot_image_migration_plan(raw: Mapping[str, Any], release: AgentVmRelease) -> BootImageMigrationPlan | None:
+    migration = raw.get("bootImageMigration")
+    if not isinstance(migration, Mapping) or migration.get("enabled") is not True:
+        return None
+    if release.environment != "development" or os.getenv("AGENT_VM_ENVIRONMENT", "").strip() != "development":
+        raise ValueError("boot-image migration is development-only")
+    if os.getenv("GCE_PROJECT_ID", "").strip() != "based-hardware-dev":
+        raise ValueError("boot-image migration requires the approved development project")
+    owners = migration.get("allowedUids")
+    if not isinstance(owners, list) or not owners or not all(isinstance(uid, str) and uid.strip() for uid in owners):
+        raise ValueError("boot-image migration requires a non-empty allowedUids list")
+    max_concurrency = migration.get("maxConcurrency", 1)
+    soak_seconds = migration.get("soakSeconds", 600)
+    if not isinstance(max_concurrency, int) or max_concurrency != 1:
+        raise ValueError("boot-image migration maxConcurrency must be exactly 1")
+    if not isinstance(soak_seconds, int) or soak_seconds < 60:
+        raise ValueError("boot-image migration soakSeconds must be at least 60")
+    return BootImageMigrationPlan(frozenset(uid.strip() for uid in owners), max_concurrency, soak_seconds)
+
+
+def boot_image_migration_id(uid: str, vm_name: str, instance_id: str, release_id: str) -> str:
+    return hashlib.sha256(f"{uid}:{vm_name}:{instance_id}:{release_id}".encode()).hexdigest()[:24]
+
+
+def boot_image_candidate_name(vm_name: str, migration_id: str) -> str:
+    if not _MIGRATION_ID.fullmatch(migration_id):
+        raise ValueError("boot-image migration id is invalid")
+    suffix = f"-m-{migration_id[:12]}"
+    return f"{vm_name[: 63 - len(suffix)]}{suffix}"
+
+
+def state_disk_name(migration_id: str) -> str:
+    return f"omi-agent-state-{migration_id[:16]}"
+
+
+def source_clone_disk_name(migration_id: str) -> str:
+    return f"omi-agent-source-{migration_id[:16]}"
+
+
+def owner_disk_label(uid: str) -> str:
+    return hashlib.sha256(uid.encode()).hexdigest()[:20]
+
+
+def _owner_lease_matches(
+    vm: Mapping[str, Any],
+    *,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    instance_id: str,
+    now: float,
+) -> bool:
+    reconcile = vm.get("reconcile")
+    reconcile = reconcile if isinstance(reconcile, Mapping) else {}
+    lease = reconcile.get("lease")
+    return (
+        vm.get("vmName") == vm_name
+        and (vm.get("zone") or DEFAULT_ZONE) == zone
+        and vm.get("authToken") == auth_token
+        and str(vm.get("instanceId") or "") == instance_id
+        and not bool(reconcile.get("startRequested"))
+        and not bool(reconcile.get("drainRequested"))
+        and isinstance(lease, Mapping)
+        and lease.get("owner") == owner
+        and float(lease.get("expiresAt", 0) or 0) > now
+    )
+
+
+@transactional
+def _supersede_failed_boot_image_migration_txn(
+    transaction: Any,
+    deletion_ref: Any,
+    user_ref: Any,
+    migration_ref: Any,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    replacement_release_id: str,
+    now: float,
+) -> bool:
+    deletion = deletion_ref.get(transaction=transaction)
+    raw_status = (deletion.to_dict() or {}).get("wipe_status") if deletion.exists else None
+    if account_deletion_blocks_access(
+        normalize_account_deletion_status(marker_exists=deletion.exists, raw_status=raw_status)
+    ):
+        return False
+    snapshot = user_ref.get(transaction=transaction)
+    migration_snapshot = migration_ref.get(transaction=transaction)
+    vm = (snapshot.to_dict() or {}).get("agentVm") if snapshot.exists else None
+    migration = migration_snapshot.to_dict() if migration_snapshot.exists else None
+    reconcile = vm.get("reconcile") if isinstance(vm, Mapping) else None
+    old_instance_id = str(migration.get("oldInstanceId") or "") if isinstance(migration, Mapping) else ""
+    if (
+        not isinstance(vm, dict)
+        or not isinstance(migration, dict)
+        or not isinstance(reconcile, Mapping)
+        or migration.get("migrationId") != migration_id
+        or migration.get("state") != "candidate_deleted"
+        or not isinstance(migration.get("candidateDeletedAt"), (int, float))
+        or migration.get("targetRelease") == replacement_release_id
+        or migration.get("oldVmName") != vm_name
+        or migration.get("oldAuthToken") != auth_token
+        or not old_instance_id
+        or reconcile.get("durableMigration") != migration_id
+        or not _owner_lease_matches(
+            vm,
+            vm_name=vm_name,
+            zone=zone,
+            auth_token=auth_token,
+            owner=owner,
+            instance_id=old_instance_id,
+            now=now,
+        )
+    ):
+        return False
+    owner_update: dict[str, Any] = {
+        "agentVm.reconcile.durableMigration": DELETE_FIELD,
+        "agentVm.reconcile.state": "ready",
+        "agentVm.reconcile.retryCount": 0,
+        "agentVm.reconcile.retryAt": DELETE_FIELD,
+        "agentVm.reconcile.lastError": DELETE_FIELD,
+        "agentVm.reconcile.driftReasons": DELETE_FIELD,
+    }
+    owner_update.update({f"agentVm.reconcile.{key}": value for key, value in clear_vm_reconcile_lease_fields().items()})
+    transaction.update(user_ref, owner_update)
+    transaction.update(
+        migration_ref,
+        {
+            "state": "superseded",
+            "supersededAt": now,
+            "supersededByRelease": replacement_release_id,
+            "updatedAt": now,
+        },
+    )
+    return True
+
+
+def supersede_failed_boot_image_migration(
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    migration_id: str,
+    replacement_release_id: str,
+    now: float | None = None,
+) -> bool:
+    now = time.time() if now is None else now
+    client = get_firestore_client()
+    user_ref = client.collection("users").document(uid)
+    return bool(
+        _supersede_failed_boot_image_migration_txn(
+            client.transaction(),
+            client.collection("account_deletions").document(uid),
+            user_ref,
+            user_ref.collection("agentVmMigrations").document(migration_id),
+            vm_name,
+            zone,
+            auth_token,
+            owner,
+            migration_id,
+            replacement_release_id,
+            now,
+        )
+    )
+
+
+async def supersede_rolled_back_boot_image_migration(
+    *,
+    uid: str,
+    vm_name: str,
+    zone: str,
+    auth_token: str,
+    owner: str,
+    old_instance_id: str,
+    replacement_release_id: str,
+    recovery_journal: Mapping[str, Any],
+    owner_label: str,
+    cleanup_context: MutableMapping[str, str],
+    rollback: Callable[[Mapping[str, str]], Awaitable[bool]],
+) -> str | None:
+    """Revalidate and supersede a failed journal from an older release."""
+    if recovery_journal.get("targetRelease") == replacement_release_id:
+        return None
+    migration_id = str(recovery_journal.get("migrationId") or "")
+    candidate_name = str(recovery_journal.get("candidateVmName") or "")
+    candidate_id = str(recovery_journal.get("candidateInstanceId") or "")
+    state_disk_name_value = str(recovery_journal.get("stateDiskName") or "")
+    state_disk_id = str(recovery_journal.get("stateDiskId") or "")
+    state_disk_reused = recovery_journal.get("stateDiskReused") is True
+    source_clone_name_value = str(recovery_journal.get("sourceCloneDiskName") or "")
+    source_clone_id = str(recovery_journal.get("sourceCloneDiskId") or "")
+    if (
+        recovery_journal.get("state") != "candidate_deleted"
+        or not _MIGRATION_ID.fullmatch(migration_id)
+        or recovery_journal.get("oldVmName") != vm_name
+        or str(recovery_journal.get("oldInstanceId") or "") != old_instance_id
+        or not candidate_name
+        or not candidate_id
+        or not state_disk_name_value
+        or not state_disk_id
+        or (not state_disk_reused and (not source_clone_name_value or not source_clone_id))
+    ):
+        raise RuntimeError("durable boot-image migration journal is not recoverable by the active release")
+    cleanup_context.update(
+        {
+            "vmName": candidate_name,
+            "instanceId": candidate_id,
+            "oldInstanceId": old_instance_id,
+            "migrationId": migration_id,
+            "stateDiskName": state_disk_name_value,
+            "stateDiskId": state_disk_id,
+            "stateDiskReused": "true" if state_disk_reused else "false",
+            "ownerLabel": owner_label,
+            "sourceCloneDiskName": source_clone_name_value,
+            "sourceCloneDiskId": source_clone_id,
+        }
+    )
+    if not await rollback(cleanup_context):
+        raise RuntimeError("rolled-back boot-image migration provider state is ambiguous")
+    superseded = await run_blocking(
+        db_executor,
+        supersede_failed_boot_image_migration,
+        uid,
+        vm_name,
+        zone,
+        auth_token,
+        owner,
+        migration_id,
+        replacement_release_id,
+    )
+    cleanup_context.clear()
+    return "superseded" if superseded else "stale"
+
+
+__all__ = [
+    "BootImageMigrationPlan",
+    "boot_image_candidate_name",
+    "boot_image_migration_id",
+    "boot_image_migration_plan",
+    "owner_disk_label",
+    "source_clone_disk_name",
+    "state_disk_name",
+    "supersede_failed_boot_image_migration",
+    "supersede_rolled_back_boot_image_migration",
+]

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -9,6 +9,7 @@ import pytest
 
 import jobs.agent_vm_reconciler as reconciler
 import services.agent_vm_lifecycle as lifecycle
+import services.agent_vm_migration_control as migration_control
 from services.agent_vm_lifecycle import AgentVmRelease
 from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 
@@ -246,6 +247,25 @@ def test_boot_image_migration_plan_rejects_whitespace_only_allowed_uids(monkeypa
 
     with pytest.raises(ValueError, match="allowedUids"):
         reconciler._boot_image_migration_plan(raw, RELEASE)
+
+
+def test_boot_image_migration_plan_normalizes_allowlisted_uids(monkeypatch):
+    monkeypatch.setenv("AGENT_VM_ENVIRONMENT", "development")
+    monkeypatch.setenv("GCE_PROJECT_ID", "based-hardware-dev")
+
+    plan = reconciler._boot_image_migration_plan(
+        {
+            "bootImageMigration": {
+                "enabled": True,
+                "allowedUids": ["  dev-user  "],
+                "maxConcurrency": 1,
+                "soakSeconds": 60,
+            }
+        },
+        RELEASE,
+    )
+
+    assert plan == reconciler.BootImageMigrationPlan(frozenset({"dev-user"}), 1, 60)
 
 
 @pytest.mark.parametrize("firestore_status", ["stopped", "ready"])
@@ -1690,6 +1710,197 @@ def test_durable_pre_cutover_journal_recovers_detached_state_without_manifest_op
     assert cutovers and cutovers[-1]["instanceId"] == "candidate-id"
 
 
+def test_older_candidate_deleted_journal_is_superseded_only_after_provider_rollback(monkeypatch):
+    migration_id = "6" * 24
+    current_release = replace(RELEASE, source_sha="d" * 40)
+    predecessor_name = "omi-agent-user"
+    state_disk_name = "omi-agent-state-6666666666666666"
+    instance = {
+        "id": "old-id",
+        "status": "TERMINATED",
+        "disks": [
+            {
+                "boot": True,
+                "source": "projects/project/zones/us-central1-a/disks/old-boot",
+                "autoDelete": True,
+            },
+            {
+                "boot": False,
+                "deviceName": lifecycle.STATE_DISK_DEVICE_NAME,
+                "source": f"projects/project/zones/us-central1-a/disks/{state_disk_name}",
+                "autoDelete": True,
+            },
+        ],
+    }
+    journal = {
+        "migrationId": migration_id,
+        "state": "candidate_deleted",
+        "candidateDeletedAt": 90.0,
+        "oldVmName": predecessor_name,
+        "oldZone": "us-central1-a",
+        "oldAuthToken": "old-token",
+        "oldInstanceId": "old-id",
+        "candidateVmName": "omi-agent-user-m-666666666666",
+        "candidateAuthToken": "candidate-token",
+        "candidateInstanceId": "candidate-id",
+        "targetRelease": RELEASE.release_id,
+        "targetBootImage": RELEASE.boot_image,
+        "soakSeconds": 60,
+        "stateDiskName": state_disk_name,
+        "stateDiskId": "state-id",
+        "stateDiskReused": True,
+        "sourceCloneDiskName": "",
+    }
+
+    class RolledBackApi:
+        project = "project"
+        zone = "us-central1-a"
+
+        async def get_instance(self, name: str) -> dict[str, Any] | None:
+            return instance if name == predecessor_name else None
+
+        async def get_disk(self, name: str) -> dict[str, Any] | None:
+            assert name == state_disk_name
+            return {
+                "id": "state-id",
+                "labels": {
+                    "omi-agent-role": "state",
+                    "omi-agent-owner": reconciler._owner_disk_label("dev-user"),
+                },
+                "users": [f"projects/project/zones/us-central1-a/instances/{predecessor_name}"],
+            }
+
+    superseded: list[tuple[Any, ...]] = []
+    cleanup_context: dict[str, str] = {}
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 0)
+    monkeypatch.setattr(
+        migration_control,
+        "supersede_failed_boot_image_migration",
+        lambda *args: superseded.append(args) or True,
+    )
+
+    result = asyncio.run(
+        reconciler._replace_stopped_boot_image_drift(
+            "dev-user",
+            {
+                "vmName": predecessor_name,
+                "zone": "us-central1-a",
+                "status": "stopped",
+                "instanceId": "old-id",
+                "authToken": "old-token",
+            },
+            instance,
+            current_release,
+            reconciler.BootImageMigrationPlan(frozenset({"dev-user"}), 1, 60),
+            owner="worker",
+            api=RolledBackApi(),
+            cleanup_context=cleanup_context,
+            recovery_journal=journal,
+        )
+    )
+
+    assert result == reconciler.ReconcileResult(
+        "dev-user", "retry", "superseded a rolled-back migration from an older release"
+    )
+    assert superseded and superseded[-1][-2:] == (migration_id, current_release.release_id)
+    assert cleanup_context == {}
+
+
+def test_older_candidate_deleted_journal_stays_fail_closed_when_provider_rollback_is_ambiguous(monkeypatch):
+    migration_id = "8" * 24
+    cleanup_context: dict[str, str] = {}
+    superseded: list[tuple[Any, ...]] = []
+
+    async def ambiguous_rollback(_context: Mapping[str, str]) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        migration_control,
+        "supersede_failed_boot_image_migration",
+        lambda *args: superseded.append(args) or True,
+    )
+
+    with pytest.raises(RuntimeError, match="provider state is ambiguous"):
+        asyncio.run(
+            migration_control.supersede_rolled_back_boot_image_migration(
+                uid="dev-user",
+                vm_name="omi-agent-user",
+                zone="us-central1-a",
+                auth_token="old-token",
+                owner="worker",
+                old_instance_id="old-id",
+                replacement_release_id=replace(RELEASE, source_sha="d" * 40).release_id,
+                recovery_journal={
+                    "migrationId": migration_id,
+                    "state": "candidate_deleted",
+                    "candidateDeletedAt": 90.0,
+                    "oldVmName": "omi-agent-user",
+                    "oldInstanceId": "old-id",
+                    "candidateVmName": "omi-agent-user-m-888888888888",
+                    "candidateInstanceId": "candidate-id",
+                    "targetRelease": RELEASE.release_id,
+                    "stateDiskName": "omi-agent-state-8888888888888888",
+                    "stateDiskId": "state-id",
+                    "stateDiskReused": True,
+                },
+                owner_label=reconciler._owner_disk_label("dev-user"),
+                cleanup_context=cleanup_context,
+                rollback=ambiguous_rollback,
+            )
+        )
+
+    assert superseded == []
+    assert cleanup_context["migrationId"] == migration_id
+
+
+def test_older_candidate_deleted_journal_reports_stale_when_firestore_fence_changes(monkeypatch):
+    migration_id = "9" * 24
+    cleanup_context: dict[str, str] = {}
+    blocking_calls: list[tuple[Any, ...]] = []
+
+    async def rolled_back(_context: Mapping[str, str]) -> bool:
+        return True
+
+    async def bounded_run(executor: Any, function: Any, *args: Any) -> bool:
+        blocking_calls.append((executor, function, *args))
+        return False
+
+    monkeypatch.setattr(migration_control, "run_blocking", bounded_run)
+
+    result = asyncio.run(
+        migration_control.supersede_rolled_back_boot_image_migration(
+            uid="dev-user",
+            vm_name="omi-agent-user",
+            zone="us-central1-a",
+            auth_token="old-token",
+            owner="worker",
+            old_instance_id="old-id",
+            replacement_release_id=replace(RELEASE, source_sha="d" * 40).release_id,
+            recovery_journal={
+                "migrationId": migration_id,
+                "state": "candidate_deleted",
+                "candidateDeletedAt": 90.0,
+                "oldVmName": "omi-agent-user",
+                "oldInstanceId": "old-id",
+                "candidateVmName": "omi-agent-user-m-999999999999",
+                "candidateInstanceId": "candidate-id",
+                "targetRelease": RELEASE.release_id,
+                "stateDiskName": "omi-agent-state-9999999999999999",
+                "stateDiskId": "state-id",
+                "stateDiskReused": True,
+            },
+            owner_label=reconciler._owner_disk_label("dev-user"),
+            cleanup_context=cleanup_context,
+            rollback=rolled_back,
+        )
+    )
+
+    assert result == "stale"
+    assert blocking_calls and blocking_calls[-1][0] is migration_control.db_executor
+    assert blocking_calls[-1][1] is migration_control.supersede_failed_boot_image_migration
+    assert cleanup_context == {}
+
+
 def test_terminal_quarantine_with_non_pre_cutover_journal_stays_fail_closed(monkeypatch):
     migration_id = "7" * 24
 
@@ -1927,6 +2138,82 @@ def test_boot_image_migration_journal_fences_predecessor_and_resumes_candidate_r
         {"vmName": migration["candidateVmName"], "instanceId": "candidate-id"},
         now=now,
     )
+
+
+def test_candidate_deleted_journal_supersession_requires_exact_owner_lease_and_new_release(monkeypatch):
+    now = 100.0
+    migration_id = "f" * 24
+    replacement_release_id = "d" * 40
+    vm = {
+        "vmName": "omi-agent-user",
+        "zone": "us-central1-a",
+        "status": "stopped",
+        "instanceId": "old-id",
+        "authToken": "old-token",
+        "reconcile": {
+            "state": "claimed",
+            "durableMigration": migration_id,
+            "lease": {"owner": "worker", "expiresAt": 200.0},
+        },
+    }
+    journal = {
+        "migrationId": migration_id,
+        "state": "candidate_deleted",
+        "candidateDeletedAt": 90.0,
+        "oldVmName": vm["vmName"],
+        "oldZone": vm["zone"],
+        "oldAuthToken": vm["authToken"],
+        "oldInstanceId": vm["instanceId"],
+        "targetRelease": RELEASE.release_id,
+    }
+    client = StrictFirestore(
+        {
+            ("users", "dev-user"): {"agentVm": vm},
+            ("users", "dev-user", "agentVmMigrations", migration_id): journal,
+        }
+    )
+    monkeypatch.setattr(migration_control, "get_firestore_client", lambda: client)
+
+    assert migration_control.supersede_failed_boot_image_migration(
+        "dev-user",
+        vm["vmName"],
+        vm["zone"],
+        vm["authToken"],
+        "worker",
+        migration_id,
+        replacement_release_id,
+        now=now,
+    )
+    owner_update = client.transactions[-1].updates[-2][1]
+    journal_update = client.transactions[-1].updates[-1][1]
+    assert owner_update["agentVm.reconcile.durableMigration"] is lifecycle.DELETE_FIELD
+    assert owner_update["agentVm.reconcile.lease"] is lifecycle.DELETE_FIELD
+    assert owner_update["agentVm.reconcile.state"] == "ready"
+    assert journal_update == {
+        "state": "superseded",
+        "supersededAt": now,
+        "supersededByRelease": replacement_release_id,
+        "updatedAt": now,
+    }
+
+    same_release_client = StrictFirestore(
+        {
+            ("users", "dev-user"): {"agentVm": vm},
+            ("users", "dev-user", "agentVmMigrations", migration_id): journal,
+        }
+    )
+    monkeypatch.setattr(migration_control, "get_firestore_client", lambda: same_release_client)
+    assert not migration_control.supersede_failed_boot_image_migration(
+        "dev-user",
+        vm["vmName"],
+        vm["zone"],
+        vm["authToken"],
+        "worker",
+        migration_id,
+        RELEASE.release_id,
+        now=now,
+    )
+    assert same_release_client.transactions[-1].updates == []
 
 
 def test_boot_image_state_journal_respects_account_deletion_fence(monkeypatch):

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -127,6 +127,15 @@ active-owner `autoDelete: true`, and identity-fenced cleanup across a complete
 soak and rollback exercise. The production manifest must continue to omit the
 migration flag until that evidence is reviewed and accepted.
 
+A pre-cutover failure remains retryable under the same immutable release. If a
+normal deployment advances the release first, the reconciler does not require
+an operator to edit Firestore: it revalidates that the exact candidate is gone,
+the journaled state disk is attached to the numeric-ID-fenced predecessor, and
+the disk deletion policy is restored. Only then may a lease-guarded transaction
+mark the old journal `superseded` and clear its durable owner marker. Any
+identity or cleanup ambiguity stays fail-closed instead of starting a candidate
+for the newer release.
+
 Generate the opt-in manifest with the checked-in renderer; do not hand-edit a
 manifest after it receives `manifestSha256`:
 


### PR DESCRIPTION
## Summary

- supersede a rolled-back `candidate_deleted` Agent VM migration journal when a newer immutable release is active
- revalidate the exact candidate absence, numeric-ID-fenced predecessor, persistent state disk attachment, owner labels, and `autoDelete` policy before the Firestore transition
- clear the durable owner marker only through the active reconciler lease and preserve same-release retries

## Failure evidence

Development execution `agent-vm-reconciler-xdf5p` read release `856ad94538024d301dc28e560ec1e4f3e716b506` after the earlier `d382cd52a38f3948b93e9c780befc5d8dc87a821` canary had rolled back. The exact candidate was absent and state disk `8738154573549185611` was attached to predecessor instance `900676343180208709`, but Firestore still carried durable migration `8f00b08b26d1f1bcc62b5d57` in `candidate_deleted`. Recovery rejected its older `targetRelease` before creating a candidate, leaving future releases unable to retry without an operator edit.

Failure-Class: FC-split-mutation-authority

## Safety

- supersession is valid only for `candidate_deleted`, never an in-flight or post-cutover journal
- provider cleanup is rechecked before the transaction; ambiguity remains fail-closed
- the transaction requires the exact predecessor name, auth token, numeric instance ID, durable migration ID, active worker lease, and a different replacement release
- same-release retries retain their deterministic candidate identity and existing behavior
- production boot-image replacement remains disabled

## Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_agent_vm_reconciler_job.py backend/tests/unit/test_agent_vm_reconciler.py backend/tests/unit/test_agent_vm_reconciler_deployment_scripts.py` (112 passed)
- `black --check --line-length=120 --skip-string-normalization backend/jobs/agent_vm_reconciler.py backend/services/agent_vm_lifecycle.py backend/tests/unit/test_agent_vm_reconciler_job.py`

## Rollout

After merge and the exact auto-development deployment, re-run the checked-in one-owner development migration. The first execution should supersede the old rolled-back journal; the next should create and validate a fresh candidate for the merged release. Keep the Scheduler paused and restore the normal release pointer with its generation guard after the soak and retirement proof.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

