### PR TITLE
fix(ci): run the release-process guard self-suite in the check manifest (#10351)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -66,6 +66,11 @@ checks:
     triggers: [".github/workflows/desktop_qualify_beta.yml", ".github/scripts/check-release-process-guards.py", ".github/scripts/git_bash.py", "scripts/dev-harness/_resolve_python.sh", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-174: qualification must check out the exact release tag inside its isolated source directory; the guard and its focused behavioral test run on every relevant diff"
+  - id: desktop-release-process-guard-tests
+    command: ["bash", "scripts/run-release-process-guard-tests.sh"]
+    triggers: [".github/scripts/check-release-process-guards.py", ".github/scripts/test_check_release_process_guards.py", ".github/scripts/git_bash.py", "codemagic.yaml", ".github/scripts/fixtures/codemagic_workflow_contract/**", "scripts/run-release-process-guard-tests.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10351: the 94-test self-suite behind the release-process guard ran in no lane, so guard regressions accumulated silently until the suite itself was red on main"
   - id: failure-class-retirement-author
     command: ["python3", ".github/scripts/test_failure_class_retirement.py"]
     triggers: [".github/scripts/failure_class_retirement.py", ".github/scripts/test_failure_class_retirement.py", ".github/workflows/repo-hygiene.yml", "scripts/failure-class", ".github/checks-manifest.yaml"]

--- a/scripts/run-release-process-guard-tests.sh
+++ b/scripts/run-release-process-guard-tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run the release-process guard self-tests with the repository's locked pytest dependency.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=dev-harness/_resolve_python.sh
+source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
+
+if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
+  || ! "$BACKEND_PYTHON" -c "import pytest, yaml" >/dev/null 2>&1; then
+  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
+    echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
+    exit 1
+  fi
+fi
+
+exec "$BACKEND_PYTHON" -m pytest "$ROOT_DIR/.github/scripts/test_check_release_process_guards.py" -q "$@"


### PR DESCRIPTION
## Bug

`.github/scripts/test_check_release_process_guards.py` — the 94-test self-suite for the release-process guard — is registered in **no lane**: it appears in neither `.github/checks-manifest.yaml` nor any workflow. Only the guard command itself (`scripts/run-release-process-guards.sh`) runs in CI, so nothing proves the guard still rejects what it exists to reject. Failures accumulated silently until #10351 found 9 red tests sitting on main.

## Root cause

The guard was wired into the manifest; its behavioral self-suite was not. A verification command that never executes reports success by absence — `FC-nonexecuting-verification-command`.

## Fix

- `scripts/run-release-process-guard-tests.sh` — sibling of the existing `run-release-process-guards.sh`. Resolves the same canonical backend interpreter (syncing locked deps when `backend/.venv` is missing) and runs the suite under the repo's locked pytest.
- `.github/checks-manifest.yaml` — register `desktop-release-process-guard-tests` on `local` + `ci`, triggered by the guard, its suite, `git_bash.py`, `codemagic.yaml`, the codemagic contract fixtures, the runner, and the manifest itself.

No workflow YAML change: the manifest is the routing authority (per `AGENTS.md`, "Register new checks in `.github/checks-manifest.yaml` with both `local` and `ci` lanes").

## What I tested

- `bash scripts/run-release-process-guard-tests.sh` → **94 passed, exit 0**. Cold path exercised too: with no `backend/.venv` it synced from `pylock.macos.toml` first, then ran green.
- **Fault injection** (proves the command executes real assertions, not an empty selection): stubbed `check_codemagic_release_publishers()` to `return []` → **67 failed, 27 passed**, non-zero exit. Restored the guard → 94 passed again.
- `python .github/scripts/run_checks.py --lane ci --base origin/main --head HEAD` → the new check is SELECTED for this diff and passes, alongside `check-manifest-contract` (validates the new entry), `diff-hygiene`, `architecture-guardrails`, `product-invariants`, `failure-class-protocol`, `desktop-changelog-data`, `deferred-work-markers`, `lifecycle-headers`, `version-prefixed-filenames`.
- The 9 failures named in #10351 are already fixed on main (`856ad94538`); this PR closes the other half of that issue — the suite is no longer orphaned.

## Product invariants

None — `product-invariants` reports no locked invariants require naming for these paths.

Failure-Class: FC-nonexecuting-verification-command

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

