### PR TITLE
feat(sdks): document and export codec ID 21 (opusFS320 / Omi CV1)

### DIFF
--- a/sdks/device/PROTOCOL.md
+++ b/sdks/device/PROTOCOL.md
@@ -18,7 +18,8 @@ Shared contract for device SDKs (`sdks/python`, `sdks/swift`, `sdks/react-native
 |----|-------|
 | 0 | PCM 16-bit |
 | 1 | PCM 8-bit |
-| 20 / `0x14` | Opus (common on Friend/Omi) |
+| 20 / `0x14` | Opus / 10ms (common on DevKit) |
+| 21 / `0x15` | opusFS320 / 20ms (Omi CV1, 50 fps) |
 
 Default stream assumption in thin SDKs: **Opus @ 16 kHz mono**, frame size **960 samples**.
 

--- a/sdks/device/cpp/include/omi/device/protocol.hpp
+++ b/sdks/device/cpp/include/omi/device/protocol.hpp
@@ -19,6 +19,23 @@ inline constexpr int kPcmSampleRateHz = 16000;
 inline constexpr int kOpusFrameSamples = 960;
 inline constexpr int kPcmChannels = 1;
 
+enum class BleAudioCodec : std::uint8_t {
+  Pcm16 = 0,
+  Pcm8 = 1,
+  Opus = 20,
+  OpusFs320 = 21,
+};
+
+inline constexpr BleAudioCodec MapCodecId(std::uint8_t id) {
+  switch (id) {
+    case 0: return BleAudioCodec::Pcm16;
+    case 1: return BleAudioCodec::Pcm8;
+    case 20: return BleAudioCodec::Opus;
+    case 21: return BleAudioCodec::OpusFs320;
+    default: return static_cast<BleAudioCodec>(id);
+  }
+}
+
 // Returns payload after the 3-byte header; empty if packet too short.
 std::vector<std::uint8_t> StripPacketHeader(const std::uint8_t* data, std::size_t len);
 

--- a/sdks/device/go/omidevice/protocol.go
+++ b/sdks/device/go/omidevice/protocol.go
@@ -22,9 +22,10 @@ const (
 type CodecID byte
 
 const (
-	CodecPCM16 CodecID = 0
-	CodecPCM8  CodecID = 1
-	CodecOpus  CodecID = 20
+	CodecPCM16     CodecID = 0
+	CodecPCM8      CodecID = 1
+	CodecOpus      CodecID = 20
+	CodecOpusFS320 CodecID = 21
 )
 
 // StripPacketHeader removes the 3-byte Omi audio header.

--- a/sdks/device/go/omidevice/protocol_test.go
+++ b/sdks/device/go/omidevice/protocol_test.go
@@ -14,4 +14,7 @@ func TestStripPacketHeader(t *testing.T) {
 	if AudioDataUUID == "" || ServiceUUID == "" {
 		t.Fatal("uuids empty")
 	}
+	if CodecOpus != 20 || CodecOpusFS320 != 21 {
+		t.Fatalf("unexpected codec ids: opus=%d, opusFS320=%d", CodecOpus, CodecOpusFS320)
+	}
 }

--- a/sdks/device/rust/src/lib.rs
+++ b/sdks/device/rust/src/lib.rs
@@ -27,6 +27,37 @@ pub fn strip_packet_header(packet: &[u8]) -> &[u8] {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BleAudioCodec {
+    Pcm16,
+    Pcm8,
+    Opus,
+    OpusFs320,
+    Unknown(u8),
+}
+
+impl BleAudioCodec {
+    pub const fn from_id(id: u8) -> Self {
+        match id {
+            0 => Self::Pcm16,
+            1 => Self::Pcm8,
+            20 => Self::Opus,
+            21 => Self::OpusFs320,
+            other => Self::Unknown(other),
+        }
+    }
+
+    pub const fn to_id(self) -> u8 {
+        match self {
+            Self::Pcm16 => 0,
+            Self::Pcm8 => 1,
+            Self::Opus => 20,
+            Self::OpusFs320 => 21,
+            Self::Unknown(id) => id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SttEngine {
     Deepgram,
     Whisper,
@@ -105,5 +136,14 @@ mod tests {
             parakeet_ws_url("https://parakeet.example/", 16000),
             "wss://parakeet.example/v3/stream?sample_rate=16000"
         );
+    }
+
+    #[test]
+    fn codec_ids() {
+        assert_eq!(BleAudioCodec::from_id(0), BleAudioCodec::Pcm16);
+        assert_eq!(BleAudioCodec::from_id(1), BleAudioCodec::Pcm8);
+        assert_eq!(BleAudioCodec::from_id(20), BleAudioCodec::Opus);
+        assert_eq!(BleAudioCodec::from_id(21), BleAudioCodec::OpusFs320);
+        assert_eq!(BleAudioCodec::from_id(99), BleAudioCodec::Unknown(99));
     }
 }

--- a/sdks/device/typescript/src/index.test.ts
+++ b/sdks/device/typescript/src/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { BleAudioCodec, mapCodecId, stripPacketHeader } from './index.ts';
+
+describe('stripPacketHeader', () => {
+  test('strips 3-byte header', () => {
+    expect(stripPacketHeader(new Uint8Array([1, 2]))).toEqual(new Uint8Array(0));
+    expect(stripPacketHeader(new Uint8Array([0, 0, 0, 9, 8]))).toEqual(new Uint8Array([9, 8]));
+  });
+});
+
+describe('mapCodecId', () => {
+  test('maps known codec IDs', () => {
+    expect(mapCodecId(0)).toBe(BleAudioCodec.Pcm16);
+    expect(mapCodecId(1)).toBe(BleAudioCodec.Pcm8);
+    expect(mapCodecId(20)).toBe(BleAudioCodec.Opus);
+    expect(mapCodecId(21)).toBe(BleAudioCodec.OpusFs320);
+    expect(mapCodecId(99)).toBe(99);
+  });
+});

--- a/sdks/device/typescript/src/index.ts
+++ b/sdks/device/typescript/src/index.ts
@@ -15,12 +15,14 @@ export enum BleAudioCodec {
   Pcm16 = 0,
   Pcm8 = 1,
   Opus = 20,
+  OpusFs320 = 21,
 }
 
 export function mapCodecId(id: number): BleAudioCodec | number {
   if (id === 0) return BleAudioCodec.Pcm16;
   if (id === 1) return BleAudioCodec.Pcm8;
   if (id === 20) return BleAudioCodec.Opus;
+  if (id === 21) return BleAudioCodec.OpusFs320;
   return id;
 }
 


### PR DESCRIPTION
## Summary

Adds audio codec ID `21` (`opusFS320`, 20ms frames @ 50 fps) to the multi-language device SDK specification (`sdks/device/PROTOCOL.md`) and per-language codec definitions:
- `sdks/device/PROTOCOL.md`: add row for codec `21 / 0x15` (`opusFS320`)
- `sdks/device/go/omidevice`: export `CodecOpusFS320 CodecID = 21`
- `sdks/device/rust`: add `BleAudioCodec` enum (`Pcm16`, `Pcm8`, `Opus`, `OpusFs320`, `Unknown`)
- `sdks/device/typescript`: add `BleAudioCodec.OpusFs320` and update `mapCodecId()`
- `sdks/device/cpp`: add `BleAudioCodec` enum and `MapCodecId()` helper

Aligns `sdks/device` with existing in-repo definitions in `app/lib/backend/schema/bt_device/bt_device.dart` and `sdks/rust/omi-device`.

Closes #11254

## Product invariants affected

none

## Test plan

- [x] Go: `go test ./...` in `sdks/device/go`
- [x] Rust: `cargo test` in `sdks/device/rust` (3 passed)
- [x] TS: `bun test` in `sdks/device/typescript` (11 passed)
- [x] C++: `cmake -B build && cmake --build build` in `sdks/device/cpp`
- [x] Local preflight: `scripts/pr-preflight --suggest` passed cleanly

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

