### PR TITLE
fix(sdks/device): document codec 21 (opusFS320) and map it in every SDK

### DIFF
--- a/sdks/device/PROTOCOL.md
+++ b/sdks/device/PROTOCOL.md
@@ -14,13 +14,20 @@ Shared contract for device SDKs (`sdks/python`, `sdks/swift`, `sdks/react-native
 
 ## Codec IDs (first byte of codec characteristic)
 
-| ID | Codec |
-|----|-------|
-| 0 | PCM 16-bit |
-| 1 | PCM 8-bit |
-| 20 / `0x14` | Opus (common on Friend/Omi) |
+| ID | Codec | Firmware |
+|----|-------|----------|
+| 0 | PCM 16-bit | |
+| 1 | PCM 8-bit | |
+| 20 / `0x14` | Opus — 160-sample PDM frames (10 ms) @ 100 fps | DevKit (`omi/firmware/devkit/src/config.h`) |
+| 21 / `0x15` | Opus FS320 (`opus_fs320`) — 320-sample PDM frames (20 ms) @ 50 fps | Omi CV1 (`omi/firmware/omi/src/lib/core/config.h`) |
 
-Default stream assumption in thin SDKs: **Opus @ 16 kHz mono**, frame size **960 samples**.
+Both Opus IDs decode to the same PCM contract; they differ only in frame duration, so a
+decoder that assumes 10 ms frames mis-times a CV1 stream. Codec/frame parity source of
+truth is the app's `BleAudioCodec` (`app/lib/backend/schema/bt_device/bt_device.dart`).
+
+Default stream assumption in thin SDKs: **Opus @ 16 kHz mono**. The `OPUS_FRAME_SAMPLES`
+= 960 constant each SDK exports is a **decode buffer bound** for `opus_decode`, not a wire
+frame size — the wire frame is 160 or 320 samples per the table above.
 
 ## Audio packet framing
 

--- a/sdks/device/cpp/include/omi/device/protocol.hpp
+++ b/sdks/device/cpp/include/omi/device/protocol.hpp
@@ -16,8 +16,17 @@ inline constexpr const char* kBatteryLevelUuid = "00002a19-0000-1000-8000-00805f
 
 inline constexpr std::size_t kPacketHeaderBytes = 3;
 inline constexpr int kPcmSampleRateHz = 16000;
+// Decode buffer bound for opus_decode, not the wire frame size (160 or 320 samples).
 inline constexpr int kOpusFrameSamples = 960;
 inline constexpr int kPcmChannels = 1;
+
+// First byte of the audio codec characteristic. See sdks/device/PROTOCOL.md.
+inline constexpr std::uint8_t kCodecPcm16 = 0;
+inline constexpr std::uint8_t kCodecPcm8 = 1;
+// 160-sample frames @ 100 fps (DevKit firmware).
+inline constexpr std::uint8_t kCodecOpus = 20;
+// 320-sample frames @ 50 fps (Omi CV1 firmware).
+inline constexpr std::uint8_t kCodecOpusFs320 = 21;
 
 // Returns payload after the 3-byte header; empty if packet too short.
 std::vector<std::uint8_t> StripPacketHeader(const std::uint8_t* data, std::size_t len);

--- a/sdks/device/go/omidevice/protocol.go
+++ b/sdks/device/go/omidevice/protocol.go
@@ -24,7 +24,10 @@ type CodecID byte
 const (
 	CodecPCM16 CodecID = 0
 	CodecPCM8  CodecID = 1
-	CodecOpus  CodecID = 20
+	// CodecOpus is 160-sample frames @ 100 fps (DevKit firmware).
+	CodecOpus CodecID = 20
+	// CodecOpusFS320 is 320-sample frames @ 50 fps (Omi CV1 firmware).
+	CodecOpusFS320 CodecID = 21
 )
 
 // StripPacketHeader removes the 3-byte Omi audio header.

--- a/sdks/device/go/omidevice/protocol_test.go
+++ b/sdks/device/go/omidevice/protocol_test.go
@@ -15,3 +15,21 @@ func TestStripPacketHeader(t *testing.T) {
 		t.Fatal("uuids empty")
 	}
 }
+
+// Codec IDs are firmware-coupled: 20 is DevKit, 21 is Omi CV1 (opusFS320).
+func TestCodecIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  CodecID
+		want byte
+	}{
+		{"pcm16", CodecPCM16, 0},
+		{"pcm8", CodecPCM8, 1},
+		{"opus", CodecOpus, 20},
+		{"opusFS320", CodecOpusFS320, 21},
+	} {
+		if byte(tc.got) != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+}

--- a/sdks/device/rust/src/lib.rs
+++ b/sdks/device/rust/src/lib.rs
@@ -14,8 +14,17 @@ pub const BATTERY_LEVEL_UUID: &str = "00002a19-0000-1000-8000-00805f9b34fb";
 
 pub const PACKET_HEADER_BYTES: usize = 3;
 pub const PCM_SAMPLE_RATE_HZ: u32 = 16_000;
+/// Decode buffer bound for `opus_decode`, not the wire frame size (160 or 320 samples).
 pub const OPUS_FRAME_SAMPLES: usize = 960;
 pub const PCM_CHANNELS: u8 = 1;
+
+/// First byte of the audio codec characteristic. See `sdks/device/PROTOCOL.md`.
+pub const CODEC_PCM16: u8 = 0;
+pub const CODEC_PCM8: u8 = 1;
+/// 160-sample frames @ 100 fps (DevKit firmware).
+pub const CODEC_OPUS: u8 = 20;
+/// 320-sample frames @ 50 fps (Omi CV1 firmware).
+pub const CODEC_OPUS_FS320: u8 = 21;
 
 /// Strip the 3-byte Omi audio packet header.
 pub fn strip_packet_header(packet: &[u8]) -> &[u8] {
@@ -97,6 +106,15 @@ mod tests {
     fn strips_header() {
         assert!(strip_packet_header(&[1, 2]).is_empty());
         assert_eq!(strip_packet_header(&[0, 0, 0, 9, 8]), &[9, 8]);
+    }
+
+    // Codec IDs are firmware-coupled: 20 is DevKit, 21 is Omi CV1 (opusFS320).
+    #[test]
+    fn codec_ids() {
+        assert_eq!(CODEC_PCM16, 0);
+        assert_eq!(CODEC_PCM8, 1);
+        assert_eq!(CODEC_OPUS, 20);
+        assert_eq!(CODEC_OPUS_FS320, 21);
     }
 
     #[test]

--- a/sdks/device/typescript/src/index.test.ts
+++ b/sdks/device/typescript/src/index.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { BleAudioCodec, mapCodecId } from './index.ts';
+
+// Codec IDs are firmware-coupled: 20 is DevKit, 21 is Omi CV1 (opusFS320).
+describe('mapCodecId', () => {
+  test('maps known codec ids to enum members', () => {
+    expect(mapCodecId(0)).toBe(BleAudioCodec.Pcm16);
+    expect(mapCodecId(1)).toBe(BleAudioCodec.Pcm8);
+    expect(mapCodecId(20)).toBe(BleAudioCodec.Opus);
+    expect(mapCodecId(21)).toBe(BleAudioCodec.OpusFs320);
+  });
+
+  test('passes an unknown id through', () => {
+    expect(mapCodecId(99)).toBe(99);
+  });
+});

--- a/sdks/device/typescript/src/index.test.ts
+++ b/sdks/device/typescript/src/index.test.ts
@@ -1,16 +1,29 @@
 import { describe, expect, test } from 'bun:test';
 import { BleAudioCodec, mapCodecId } from './index.ts';
 
-// Codec IDs are firmware-coupled: 20 is DevKit, 21 is Omi CV1 (opusFS320).
+// Numeric enum members are plain numbers at runtime, so `mapCodecId(21) === 21`
+// whether or not the codec is named. The checkable contract is the reverse map.
+describe('BleAudioCodec', () => {
+  test('names the codec ids firmware reports', () => {
+    expect(BleAudioCodec[BleAudioCodec.Pcm16]).toBe('Pcm16');
+    expect(BleAudioCodec[BleAudioCodec.Pcm8]).toBe('Pcm8');
+    // 20 is DevKit, 21 is Omi CV1 (opusFS320).
+    expect(BleAudioCodec.Opus).toBe(20);
+    expect(BleAudioCodec[BleAudioCodec.Opus]).toBe('Opus');
+    expect(BleAudioCodec.OpusFs320).toBe(21);
+    expect(BleAudioCodec[BleAudioCodec.OpusFs320]).toBe('OpusFs320');
+  });
+});
+
 describe('mapCodecId', () => {
-  test('maps known codec ids to enum members', () => {
-    expect(mapCodecId(0)).toBe(BleAudioCodec.Pcm16);
-    expect(mapCodecId(1)).toBe(BleAudioCodec.Pcm8);
-    expect(mapCodecId(20)).toBe(BleAudioCodec.Opus);
-    expect(mapCodecId(21)).toBe(BleAudioCodec.OpusFs320);
+  test('resolves every known id to a named member', () => {
+    for (const id of [0, 1, 20, 21]) {
+      expect(BleAudioCodec[mapCodecId(id)]).toBeDefined();
+    }
   });
 
-  test('passes an unknown id through', () => {
+  test('passes an unknown id through unnamed', () => {
     expect(mapCodecId(99)).toBe(99);
+    expect(BleAudioCodec[99]).toBeUndefined();
   });
 });

--- a/sdks/device/typescript/src/index.ts
+++ b/sdks/device/typescript/src/index.ts
@@ -14,13 +14,17 @@ export const PCM_CHANNELS = 1;
 export enum BleAudioCodec {
   Pcm16 = 0,
   Pcm8 = 1,
+  /** 160-sample frames @ 100 fps (DevKit firmware). */
   Opus = 20,
+  /** 320-sample frames @ 50 fps (Omi CV1 firmware). */
+  OpusFs320 = 21,
 }
 
 export function mapCodecId(id: number): BleAudioCodec | number {
   if (id === 0) return BleAudioCodec.Pcm16;
   if (id === 1) return BleAudioCodec.Pcm8;
   if (id === 20) return BleAudioCodec.Opus;
+  if (id === 21) return BleAudioCodec.OpusFs320;
   return id;
 }
 


### PR DESCRIPTION
Fixes #11254.

## What

`sdks/device` documented only codec ID `20` (Opus, DevKit) on the audio-codec characteristic `19b10002-…`, and omitted `21` (`opusFS320`) — which is what shipping **Omi CV1** firmware reports and streams.

- `sdks/device/PROTOCOL.md` — add the codec-21 row, name the owning firmware per ID, record the frame-duration/rate difference, and note that `OPUS_FRAME_SAMPLES = 960` is a decode buffer bound for `opus_decode`, not a wire frame size.
- `go/omidevice/protocol.go` — `CodecOpusFS320 CodecID = 21`.
- `typescript/src/index.ts` — `BleAudioCodec.OpusFs320 = 21` + `mapCodecId()` handling.
- `rust/src/lib.rs`, `cpp/include/omi/device/protocol.hpp` — add the codec-ID constants; neither SDK exposed any, so all four thin SDKs now carry the same map.

Dart needs no change — its device SDK returns the raw codec byte and defers to the app's `BleAudioCodec`, which already has `opusFS320`.

## Why

Evidence from the issue, re-verified against current `main`:

- Firmware disagrees per product: `omi/firmware/omi/src/lib/core/config.h:37` → `#define CODEC_ID 21` (CV1); `omi/firmware/devkit/src/config.h:37` → `20` (DevKit).
- The app already maps it: `app/lib/services/devices/connectors/omi_connection.dart:150` → `case 21: return BleAudioCodec.opusFS320;`.
- The concrete defect: `mapCodecId()` returned the bare number `21` for every CV1 device instead of a named `BleAudioCodec` member, so callers had no way to identify the codec the device is actually streaming.

The two Opus IDs are not interchangeable — `20` is 160-sample PDM frames (10 ms) @ 100 fps, `21` is 320-sample frames (20 ms) @ 50 fps (`app/lib/backend/schema/bt_device/bt_device.dart`) — so a decoder that assumes 10 ms frames mis-times a CV1 stream. That difference is now written down in `PROTOCOL.md` rather than living only in the Flutter app.

## Tested

No physical Omi CV1 was attached — this is verified at the byte the codec characteristic returns, not over the radio. Every check was run locally on macOS:

| Check | Result |
|---|---|
| `go vet ./... && go test ./...` (`sdks/device/go`) | ok — incl. new `TestCodecIDs` |
| `bun test` (`sdks/device/typescript`) | 12 pass / 0 fail — incl. new `src/index.test.ts` |
| `bunx tsc --noEmit` | clean |
| `cargo test` (`sdks/device/rust`) | 3 passed — incl. new `codec_ids` |
| `clang++ -std=c++17 -Wall -Wextra` + `static_assert` on all four codec IDs | compiles, runs clean |
| `make preflight` | all selected manifest checks pass |

Both regression tests fail on the parent commit, as they should:

```
PRE-FIX  TS  : expect(BleAudioCodec[mapCodecId(21)]).toBeDefined()
               Received: undefined                        (2 of 3 fail)
PRE-FIX  GO  : protocol_test.go:29:17: undefined: CodecOpusFS320
               FAIL … [build failed]
```

The Rust and C++ constants are new surface (neither SDK had codec IDs before), so there is no pre-fix failure to show for those — their tests are guards against future drift, not regression proofs.

**On the TS test's reach** (cubic caught the first version of it): numeric enum members are plain numbers at runtime, so `mapCodecId(21) === 21` whether or not the codec is named, and no runtime assertion can catch removal of only the `mapCodecId` branch. The test therefore asserts the reverse map — `BleAudioCodec[21] === 'OpusFs320'`, the contract this PR actually adds — plus that every known id resolves to a *named* member while an unknown id stays unnamed. That does catch removal of the enum member.

**Not covered:** nothing here exercises a live BLE link. The audio path itself is untouched — this PR adds constants, a `mapCodecId` branch, and docs — but confirming that a CV1 actually reads back `21` end-to-end needs hardware.

## Review

@TuEmb @mdmohsin7 — flagging you as the BLE owners. This touches the device SDK's codec map, so please confirm the CV1 mapping and merge if it looks right; I'm deliberately not self-merging a BLE-path change that I could not verify against a physical device.

Failure-Class: none

No semantic failure class: this is a missing constant and undocumented protocol row in a package that landed recently (#10227), not a violated runtime contract. Adding a class would create a definition with one instance and no reusable guard surface, which the guard-artifact ratchet exists to discourage. The durable guard is the per-language codec-ID test added here, which fails if any SDK's map drifts from the firmware again.

## Product invariants

None — `scripts/pr-preflight --suggest` reports no invariant path globs matched by this diff.

---

Auto-generated from issue feedback by the mini issues-improver — tested, and left for BLE-owner review rather than auto-merged.
