### PR TITLE
fix(desktop): preserve clicks while dragging shell

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -388,7 +388,7 @@ struct DesktopHomeView: View {
       }
     }
     .environment(\.colorScheme, .light)  // No window ground since `ShellWindowChrome`; each panel is its own glass.
-    .background(ShellWindowAttachment().frame(width: 0, height: 0))
+    .background(ShellWindowAttachment().frame(width: 0, height: 0)).shellWindowDragSurface()
     .frame(minWidth: DesktopWindowLayoutPolicy.width, minHeight: DesktopWindowLayoutPolicy.height)
     .preferredColorScheme(.light)  // Glass is pinned light — see `InkGlass`. Deliberate, not a bug.
     .tint(Ink.accent)

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -30,11 +30,11 @@
 //    strand a user in a window with no visible close control *and* no keyboard one.
 //  - **Moving has two handles, deliberately.** `.hiddenTitleBar` keeps a real (transparent) title bar
 //    over the top band, which still drags — that band is why the shell reserves
-//    `GlassShell.titlebarClearance` and draws nothing in it. A thresholded mouse monitor covers the
+//    `GlassShell.titlebarClearance` and draws nothing in it. SwiftUI's window-drag gesture covers the
 //    rest of the window. The native `isMovableByWindowBackground` switch cannot do that safely:
 //    AppKit sees a SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background,
-//    and steals its click. The monitor waits for an actual drag, while views that own their own
-//    drags opt out through `ShellWindowDragExcluding` (see `RewindTrackNSView`).
+//    and steals its click. Keeping both recognition paths in SwiftUI lets its gesture arena give an
+//    ordinary click to the Button and a drag to the window without intercepting either event.
 //
 //  ## The two presentations, and why there are two
 //
@@ -77,13 +77,8 @@
 //
 
 import AppKit
-@preconcurrency import ObjectiveC
 import OmiTheme
 import SwiftUI
-
-/// A represented AppKit view whose pointer drag belongs to the control rather than the shell.
-@MainActor
-protocol ShellWindowDragExcluding: AnyObject {}
 
 /// The main window's chrome: transparent, light-pinned, and without the system's window buttons.
 @MainActor
@@ -166,9 +161,8 @@ enum ShellWindowChrome {
     hideStandardButtons(in: window)
     // AppKit cannot see SwiftUI controls inside an NSHostingView. The hosting view reports that a
     // mouse-down may move the window even when the point is a Button, so this native switch turns
-    // ordinary clicks into window drags. A thresholded monitor keeps clicks and drags separate.
+    // ordinary clicks into window drags. `ShellWindowDragSurface` keeps that ownership in SwiftUI.
     window.isMovableByWindowBackground = false
-    installDragMonitor(in: window)
     window.level = presentation == .summoned ? .floating : .normal
     // Always `false`, in both presentations, and asserted rather than omitted — see this file's
     // header. A shell that ordered itself out whenever another app took focus deleted the window
@@ -216,124 +210,51 @@ enum ShellWindowChrome {
       && window.titlebarSeparatorStyle == .none
       && buttonsAreHidden
       && !window.isMovableByWindowBackground
-      && hasDragMonitor(in: window)
       && window.level == (presentation == .summoned ? .floating : .normal)
       && !window.hidesOnDeactivate
       && window.collectionBehavior.contains(.moveToActiveSpace)
       && hasExpectedSpaceBehavior
   }
 
-  private static var dragCoordinatorAssociationKey: UInt8 = 0
-
-  static func installDragMonitor(in window: NSWindow) {
-    guard let contentView = window.contentView else { return }
-    if let coordinator = objc_getAssociatedObject(contentView, &dragCoordinatorAssociationKey)
-      as? ShellWindowDragCoordinator
-    {
-      coordinator.window = window
-      return
-    }
-
-    let coordinator = ShellWindowDragCoordinator(window: window)
-    objc_setAssociatedObject(
-      contentView, &dragCoordinatorAssociationKey, coordinator, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-  }
-
-  static func hasDragMonitor(in window: NSWindow) -> Bool {
-    guard let contentView = window.contentView else { return false }
-    return objc_getAssociatedObject(contentView, &dragCoordinatorAssociationKey)
-      is ShellWindowDragCoordinator
-  }
-
-  static func shouldBeginDrag(at location: NSPoint, in window: NSWindow) -> Bool {
-    var hit = window.contentView?.hitTest(location)
-    while let view = hit {
-      if view is any ShellWindowDragExcluding || view is NSControl || view is NSScrollView || view is NSTextView {
-        return false
-      }
-      hit = view.superview
-    }
-    return true
+  static func draggedOrigin(windowOrigin: NSPoint, translation: CGSize) -> NSPoint {
+    NSPoint(
+      x: windowOrigin.x + translation.width,
+      y: windowOrigin.y - translation.height)
   }
 }
 
-/// Holds a hosted SwiftUI mouse-down until it knows whether the gesture is a click or a window drag.
-/// A click is replayed untouched; a drag never enters SwiftUI button tracking, so moving the hosting
-/// window cannot fire or latch the control that happened to be beneath the pointer.
+/// Keeps click recognition and window-drag recognition in SwiftUI's gesture arena. This is the
+/// platform boundary AppKit's background-drag switch cannot see through an `NSHostingView`.
 @MainActor
-final class ShellWindowDragCoordinator: NSObject {
-  weak var window: NSWindow?
-  private var pendingMouseDown: NSEvent?
-  private var windowOrigin: NSPoint?
-  private var pointerOrigin: NSPoint?
-  private var canMoveWindow = false
-  private var isDraggingWindow = false
-  private var replayEventsRemaining = 0
-  private nonisolated(unsafe) var monitor: Any?
+struct ShellWindowDragSurface: ViewModifier {
+  @State private var windowOrigin: NSPoint?
 
-  init(window: NSWindow) {
-    self.window = window
-    super.init()
-    monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]) {
-      [weak self] event in
-      let consumesEvent = MainActor.assumeIsolated {
-        self?.handle(event) ?? false
-      }
-      return consumesEvent ? nil : event
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if #available(macOS 15.0, *) {
+      content.gesture(WindowDragGesture(), including: .gesture)
+    } else {
+      // `WindowDragGesture` was introduced in macOS 15. Keep the macOS 14 deployment floor usable
+      // with a lower-precedence gesture: child controls keep their own clicks and drags, while the
+      // shell's non-control surfaces remain window handles.
+      content.gesture(
+        DragGesture(minimumDistance: 3)
+          .onChanged { value in
+            guard let window = ShellSummon.shellWindow() else { return }
+            let origin = windowOrigin ?? window.frame.origin
+            windowOrigin = origin
+            window.setFrameOrigin(
+              ShellWindowChrome.draggedOrigin(windowOrigin: origin, translation: value.translation))
+          }
+          .onEnded { _ in windowOrigin = nil },
+        including: .gesture)
     }
   }
+}
 
-  deinit {
-    if let monitor { NSEvent.removeMonitor(monitor) }
-  }
-
-  private func handle(_ event: NSEvent) -> Bool {
-    guard let window, event.window === window else { return false }
-    if replayEventsRemaining > 0 {
-      replayEventsRemaining -= 1
-      return false
-    }
-
-    switch event.type {
-    case .leftMouseDown:
-      canMoveWindow = ShellWindowChrome.shouldBeginDrag(at: event.locationInWindow, in: window)
-      guard canMoveWindow else { return false }
-      pendingMouseDown = event
-      windowOrigin = window.frame.origin
-      pointerOrigin = NSEvent.mouseLocation
-      isDraggingWindow = false
-      return true
-    case .leftMouseDragged:
-      guard canMoveWindow, let windowOrigin, let pointerOrigin else { return false }
-      let pointer = NSEvent.mouseLocation
-      guard isDraggingWindow || hypot(pointer.x - pointerOrigin.x, pointer.y - pointerOrigin.y) >= 3 else {
-        return false
-      }
-      isDraggingWindow = true
-      window.setFrameOrigin(
-        NSPoint(
-          x: windowOrigin.x + pointer.x - pointerOrigin.x,
-          y: windowOrigin.y + pointer.y - pointerOrigin.y))
-      // Keep the mouse-drag sequence flowing even though its down was withheld. No SwiftUI responder
-      // owns it, and AppKit otherwise stops producing subsequent drag events after a consumed event.
-      return false
-    case .leftMouseUp:
-      guard canMoveWindow else { return false }
-      if !isDraggingWindow, let pendingMouseDown {
-        // `atStart` prepends, so enqueue up first and down second to replay down → up.
-        replayEventsRemaining = 2
-        NSApplication.shared.postEvent(event, atStart: true)
-        NSApplication.shared.postEvent(pendingMouseDown, atStart: true)
-      }
-      pendingMouseDown = nil
-      windowOrigin = nil
-      pointerOrigin = nil
-      canMoveWindow = false
-      isDraggingWindow = false
-      return true
-    default:
-      return false
-    }
+extension View {
+  func shellWindowDragSurface() -> some View {
+    modifier(ShellWindowDragSurface())
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
@@ -19,7 +19,7 @@ import SwiftUI
 /// pixel-exact hit testing during a drag, a scroll wheel that pans, and a hover tooltip that has to
 /// be able to escape the window's rounded bounds without being clipped.
 @MainActor
-final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
+final class RewindTrackNSView: NSView {
 
   /// Total height of the control: the bar, plus room for the badges that straddle it and the hour
   /// labels beneath.
@@ -423,13 +423,9 @@ final class RewindTrackNSView: NSView, ShellWindowDragExcluding {
 
   /// **The scrubber keeps its own drags.**
   ///
-  /// `NSView`'s default answer to this is yes for any view that is not opaque, and the shell's window
-  /// is `isMovableByWindowBackground` (see `ShellWindowChrome`) so that the parts of a mostly-desktop
-  /// window that are not a control drag it. This *is* a control, and it is the one control in the app
-  /// whose entire gesture is a drag: without opting out, `mouseDown` seeks once and then AppKit takes
-  /// the first `mouseDragged` to move the window, so dragging the playhead walks the whole window
-  /// sideways and never advances the day. A click still seeks, which is what makes the failure look
-  /// like a rendering quirk rather than a dead gesture.
+  /// This *is* a control, and it is the one control in the app whose entire gesture is a drag. Keep
+  /// its AppKit ownership explicit so a future change to shell movement cannot let the first
+  /// `mouseDragged` walk the whole window sideways instead of advancing the day.
   override var mouseDownCanMoveWindow: Bool { false }
 
   override func resetCursorRects() {

--- a/desktop/macos/Desktop/Tests/RewindTrackTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindTrackTests.swift
@@ -44,37 +44,14 @@ final class RewindTrackTests: XCTestCase {
 
   // MARK: - The drag belongs to the scrubber, not to the window
 
-  /// The shell's window monitor offers hosted content drags to the window unless an AppKit control
-  /// explicitly owns them. This one is a scrubber: its whole gesture *is* a drag, and giving it
+  /// The scrubber's whole gesture *is* a drag. Giving it to AppKit's native window-background mode
   /// away leaves a control where a click seeks and a drag walks the window sideways — a failure that
   /// reads as a rendering quirk rather than a dead gesture, which is why it needs a test rather than
   /// a screenshot.
   func testTheTrackKeepsItsDragsRatherThanHandingThemToTheWindow() {
     let day = gappedDay()
     let track = track(day.instants, day.apps)
-    track.frame = NSRect(x: 0, y: 0, width: 400, height: 300)
-    let window = NSWindow(
-      contentRect: track.frame,
-      styleMask: [.titled, .fullSizeContentView],
-      backing: .buffered,
-      defer: true)
-    window.contentView = track
-    ShellWindowChrome.dress(window)
-
     XCTAssertFalse(track.mouseDownCanMoveWindow)
-    XCTAssertFalse(ShellWindowChrome.shouldBeginDrag(at: NSPoint(x: 200, y: 150), in: window))
-  }
-
-  /// …and the reason it has to say so: the shell installs its own drag monitor.
-  func testTheShellWindowIsTheOneThatMakesThatOptOutNecessary() {
-    let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-      styleMask: [.titled, .closable, .miniaturizable, .resizable],
-      backing: .buffered,
-      defer: true)
-    ShellWindowChrome.dress(window)
-    XCTAssertFalse(window.isMovableByWindowBackground)
-    XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window))
   }
 
   // MARK: - The time-linearity contract

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -91,7 +91,7 @@ final class ShellWindowChromeTests: XCTestCase {
   }
 
   /// …and the window still moves. It has two handles: the transparent title bar over the reserved
-  /// band and a thresholded mouse monitor across the content. The native background-drag switch is
+  /// band and a thresholded SwiftUI gesture across the content. The native background-drag switch is
   /// deliberately off because AppKit mistakes hosted SwiftUI buttons for background.
   func testTheWindowIsStillMovableWithoutATitleBarToGrab() {
     let window = makeWindow()
@@ -101,7 +101,6 @@ final class ShellWindowChromeTests: XCTestCase {
 
     XCTAssertTrue(window.isMovable, "a floating window that cannot be moved is stranded")
     XCTAssertFalse(window.isMovableByWindowBackground)
-    XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window))
     XCTAssertTrue(
       window.styleMask.contains(.titled),
       "the transparent title bar remains an independent drag handle")
@@ -122,22 +121,17 @@ final class ShellWindowChromeTests: XCTestCase {
     XCTAssertTrue(
       hit.mouseDownCanMoveWindow,
       "the regression fixture no longer reproduces AppKit's SwiftUI misclassification")
-    XCTAssertTrue(
-      ShellWindowChrome.shouldBeginDrag(at: NSPoint(x: 450, y: 300), in: window),
-      "the replacement must allow a real drag to start over the same hosted SwiftUI surface")
     XCTAssertFalse(
       window.isMovableByWindowBackground,
       "native background dragging steals this hosted button's click before SwiftUI receives it")
-    XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window))
   }
 
-  func testNativeDragControlsKeepTheirOwnGestures() {
-    let window = makeWindow()
-    let scrollView = NSScrollView(frame: NSRect(origin: .zero, size: Self.contentSize))
-    window.contentView = scrollView
-    ShellWindowChrome.dress(window)
-
-    XCTAssertFalse(ShellWindowChrome.shouldBeginDrag(at: NSPoint(x: 450, y: 300), in: window))
+  func testLegacyWindowDragUsesSwiftUITranslation() {
+    XCTAssertEqual(
+      ShellWindowChrome.draggedOrigin(
+        windowOrigin: NSPoint(x: 100, y: 200),
+        translation: CGSize(width: 75, height: 40)),
+      NSPoint(x: 175, y: 160))
   }
 
   // MARK: - Summoned vs anchored
@@ -256,7 +250,6 @@ final class ShellWindowChromeTests: XCTestCase {
         window.styleMask.isSuperset(of: ShellWindowChrome.keyboardWindowCommands),
         "\(presentation) has no ⌘W or ⌘M and no buttons either")
       XCTAssertFalse(window.isMovableByWindowBackground, "\(presentation) can steal hosted button clicks")
-      XCTAssertTrue(ShellWindowChrome.hasDragMonitor(in: window), "\(presentation) cannot be dragged")
     }
   }
 

--- a/desktop/macos/changelog/unreleased/20260808-window-drag-click-replay.json
+++ b/desktop/macos/changelog/unreleased/20260808-window-drag-click-replay.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed window dragging without blocking Chat, Rewind, Apps, or other clicks"
+}


### PR DESCRIPTION
## Summary

- remove the local mouse-event monitor introduced in #11223; it consumed the hardware mouse-down and replayed synthetic events that SwiftUI did not treat as the original button gesture
- keep AppKit background dragging disabled and attach SwiftUI's native `WindowDragGesture` to the shell without including child-control gestures
- retain a lower-precedence macOS 14 fallback and explicit Rewind scrubber ownership

## Verification

- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ShellWindowChromeTests|RewindTrackTests'` — 30 tests passed
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- built and launched isolated named bundles (`omi-window-drag-v3` / `omi-window-drag-v4`)
- hardware-style `cliclick` press on Apps changed the live automation state from Home to Apps
- hardware-style `cliclick` press on the top-bar Rewind control opened its overlay
- plain-click validation was repeated after testing both the default and simultaneous gesture masks; only the final child-excluding gesture mask preserved control activation

## Failure class

Failure-Class: FC-hosted-control-window-drag-ownership

The reusable guard is the typed SwiftUI/AppKit boundary in `ShellWindowChrome`: AppKit background dragging remains disabled, the platform window-drag recognizer owns only the shell gesture, and child controls keep their own gesture recognizers. This is the recurrence of #11223 that the boundary would have prevented.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

