### PR TITLE
docs(mcp): add OpenCode client setup tab

### DIFF
--- a/docs/doc/developer/mcp/setup.mdx
+++ b/docs/doc/developer/mcp/setup.mdx
@@ -19,6 +19,7 @@ The fastest way to get started — no installation required.
     Developer API key from **Settings → Developer → Create Key**. Developer API keys look like
     `omi_dev_...`.
     </Note>
+
   </Step>
   <Step title="Configure Your Client" icon="sliders">
     Use the following connection details:
@@ -26,6 +27,7 @@ The fastest way to get started — no installation required.
     - **Server URL:** `https://api.omi.me/v1/mcp/sse`
     - **Authorization:** `Bearer omi_mcp_...` (your generated key)
     - **Transport:** Streamable HTTP (MCP 2025-03-26 spec)
+
   </Step>
 </Steps>
 
@@ -54,6 +56,7 @@ The fastest way to get started — no installation required.
     - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
     - Windows PowerShell: `$env:APPDATA\Claude\claude_desktop_config.json`
     - Windows cmd: `%APPDATA%\Claude\claude_desktop_config.json`
+
   </Tab>
   <Tab title="Cursor" icon="i-cursor">
     Go to **Cursor Settings → MCP** and add a new server:
@@ -62,11 +65,43 @@ The fastest way to get started — no installation required.
     - **Transport:** SSE
     - **URL:** `https://api.omi.me/v1/mcp/sse`
     - **Headers:** `Authorization: Bearer omi_mcp_YOUR_KEY_HERE`
+
+  </Tab>
+  <Tab title="OpenCode" icon="terminal">
+    Add to your project's `opencode.json` (or `~/.config/opencode/opencode.json` globally):
+
+    ```json
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
+        "omi": {
+          "type": "remote",
+          "url": "https://api.omi.me/v1/mcp/sse",
+          "enabled": true,
+          "headers": {
+            "Authorization": "Bearer {env:OMI_MCP_API_KEY}"
+          }
+        }
+      }
+    }
+    ```
+
+    Store your key in a local `.env` file (or export `OMI_MCP_API_KEY` in your environment):
+
+    ```bash
+    OMI_MCP_API_KEY=omi_mcp_YOUR_KEY_HERE
+    ```
+
+    <Note>
+    Be sure to use an MCP key generated from **Settings → Developer → MCP** (starts with `omi_mcp_`). Developer API keys (`omi_dev_...`) only authenticate REST endpoints and will return `401 Unauthorized`.
+    </Note>
+
   </Tab>
   <Tab title="Poke" icon="circle-play">
     <img src="/images/poke-mcp-setup.png" alt="Poke MCP Setup" className="rounded-xl border border-gray-200 dark:border-gray-800" />
 
     Enter the server URL and API key in Poke's MCP connection settings.
+
   </Tab>
   <Tab title="Custom Client" icon="code">
     Any MCP client that supports the **Streamable HTTP** transport (2025-03-26 spec) will work:
@@ -83,6 +118,7 @@ The fastest way to get started — no installation required.
     # Body (JSON-RPC 2.0)
     {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
     ```
+
   </Tab>
 </Tabs>
 
@@ -112,11 +148,13 @@ If you prefer to run the MCP server locally:
       }
     }
     ```
+
   </Step>
 </Steps>
 
 <Tip>
-The API key can also be provided with each tool call. If not provided, the server uses the `OMI_API_KEY` environment variable as a fallback.
+  The API key can also be provided with each tool call. If not provided, the
+  server uses the `OMI_API_KEY` environment variable as a fallback.
 </Tip>
 
 ---
@@ -130,5 +168,6 @@ export OMI_API_BASE_URL="https://your-backend-url.com"
 ```
 
 <Note>
-Only needed for self-hosted Omi instances. The default URL points to the official Omi API.
+  Only needed for self-hosted Omi instances. The default URL points to the
+  official Omi API.
 </Note>


### PR DESCRIPTION
## What changed and why

Adds an OpenCode client configuration tab to the MCP setup documentation (`docs/doc/developer/mcp/setup.mdx`).

OpenCode is an open-source AI coding agent that supports MCP servers natively via Streamable HTTP (2025-03-26 spec). This documents the `opencode.json` `remote` MCP configuration using an `omi_mcp_...` bearer key, plus a note on the common `omi_dev_...` vs `omi_mcp_...` key-type gotcha.

## Product invariants affected

none

## How it was verified

Validated end-to-end against `https://api.omi.me/v1/mcp/sse` using OpenCode with an `omi_mcp_...` key:
- Server initialized cleanly and reported protocol `2025-03-26`
- Tools discovered (all 22 Omi MCP tools)
- Executed `get_memories` successfully

## Tests

Docs-only change. Formatted with `npx prettier --write`.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

