### PR TITLE
harden(desktop): rehearse failed Codemagic releases

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -470,6 +470,16 @@ checks:
     triggers: [".github/scripts/check-codemagic-tag-intake.py", ".github/scripts/test_check_codemagic_tag_intake.py", ".github/workflows/desktop_auto_release.yml", "codemagic.yaml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-179 requires bounded exact-tag evidence that native Codemagic intake selected the release workflow and immutable source"
+  - id: desktop-codemagic-failure-recovery
+    command: ["python3", ".github/scripts/test_desktop_codemagic_failure_recovery.py"]
+    triggers: [".github/scripts/desktop-codemagic-failure-recovery.py", ".github/scripts/desktop-codemagic-recovery-profiles.json", ".github/scripts/test_desktop_codemagic_failure_recovery.py", ".github/workflows/desktop_codemagic_failure_recovery.yml", "desktop/macos/scripts/rehearse-desktop-release.sh", "desktop/macos/scripts/smoke-signed-desktop-artifact.sh", "desktop/macos/scripts/agent-runtime-payload.sh", "desktop/macos/tests/test-signed-artifact-smoke.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "failed desktop Codemagic builds must emit a credential-safe exact-build recovery capsule and prescribe a manual rehearsal only for locally reproducible gates"
+  - id: desktop-release-rehearsal-contract
+    command: ["bash", "desktop/macos/tests/test-desktop-release-rehearsal.sh"]
+    triggers: ["desktop/macos/scripts/rehearse-desktop-release.sh", "desktop/macos/tests/test-desktop-release-rehearsal.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the local desktop release rehearsal must remain manual, exact-failed-build-bound, credential-safe, and incapable of publishing or changing a release channel"
   - id: mobile-internal-build-cadence
     command: ["python3", ".github/scripts/test_dispatch_mobile_internal_builds.py"]
     triggers: [".github/scripts/dispatch_mobile_internal_builds.py", ".github/scripts/test_dispatch_mobile_internal_builds.py", ".github/workflows/mobile_internal_build.yml", "codemagic.yaml", ".github/checks-manifest.yaml"]

--- a/.github/scripts/desktop-codemagic-failure-recovery.py
+++ b/.github/scripts/desktop-codemagic-failure-recovery.py
@@ -30,8 +30,12 @@ MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 DIAGNOSTIC_RE = re.compile(r"^(?:FAIL|ERROR|WARN):\s+.{1,600}$")
 AUTHORIZATION_RE = re.compile(r"(?i)(\bauthorization\b\s*[:=]\s*)(?:bearer\s+)?\S+")
+CREDENTIAL_HEADER_RE = re.compile(r"(?i)(\b(?:cookie|set-cookie)\b\s*:\s*).*$")
 CREDENTIAL_RE = re.compile(
-    r"(?i)(\b(?:x-auth-token|api[\s_-]?key|client[\s_-]?secret|token|secret|password)\b\s*[:=]\s*)\S+"
+    r"(?i)((?<![?&])\b(?:"
+    r"x-auth-token|api[\s_-]?key|client[\s_-]?secret|"
+    r"(?:[a-z0-9]+_)*(?:key|token|secret|password)"
+    r")\b\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|\S+)"
 )
 BEARER_RE = re.compile(r"(?i)(\bbearer\s+)\S+")
 URL_CREDENTIAL_RE = re.compile(
@@ -148,6 +152,7 @@ def sanitize_diagnostics(log: bytes) -> list[str]:
         line = ANSI_RE.sub("", raw_line).strip()
         if not DIAGNOSTIC_RE.fullmatch(line):
             continue
+        line = CREDENTIAL_HEADER_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = AUTHORIZATION_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = BEARER_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)

--- a/.github/scripts/desktop-codemagic-failure-recovery.py
+++ b/.github/scripts/desktop-codemagic-failure-recovery.py
@@ -31,6 +31,9 @@ ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 DIAGNOSTIC_RE = re.compile(r"^(?:FAIL|ERROR|WARN):\s+.{1,600}$")
 AUTHORIZATION_RE = re.compile(r"(?i)(\bauthorization\b\s*[:=]\s*)(?:bearer\s+)?\S+")
 CREDENTIAL_HEADER_RE = re.compile(r"(?i)(\b(?:cookie|set-cookie)\b\s*:\s*).*$")
+ENV_ASSIGNMENT_RE = re.compile(
+    r"((?<![?&])\b[A-Z][A-Z0-9_]{1,127}\s*=\s*)(?:\"[^\"]*\"|'[^']*'|\S+)"
+)
 CREDENTIAL_RE = re.compile(
     r"(?i)((?<![?&])\b(?:"
     r"x-auth-token|api[\s_-]?key|client[\s_-]?secret|"
@@ -154,6 +157,7 @@ def sanitize_diagnostics(log: bytes) -> list[str]:
             continue
         line = CREDENTIAL_HEADER_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = AUTHORIZATION_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+        line = ENV_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = BEARER_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
         line = URL_CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)

--- a/.github/scripts/desktop-codemagic-failure-recovery.py
+++ b/.github/scripts/desktop-codemagic-failure-recovery.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Create a credential-safe, agent-readable recovery capsule for a failed desktop release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+APP_ID = "66c95e6ec76853c447b8bcbb"
+WORKFLOW_ID = "omi-desktop-swift-release"
+CHECK_NAME = "Release OMI Desktop (Swift)"
+BUILD_ID_RE = re.compile(r"^[0-9a-f]{24}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+-macos$")
+DETAILS_RE = re.compile(
+    rf"^https://codemagic\.io/app/{APP_ID}/build/(?P<build_id>[0-9a-f]{{24}})(?:[?#].*)?$"
+)
+LOG_RE = re.compile(
+    r"^https://api\.codemagic\.io/builds/(?P<build_id>[0-9a-f]{24})/"
+    r"(?:step/[0-9a-f]{24}|logs/[0-9]+)$"
+)
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+DIAGNOSTIC_RE = re.compile(r"^(?:FAIL|ERROR|WARN):\s+.{1,600}$")
+AUTHORIZATION_RE = re.compile(r"(?i)(\bauthorization\b\s*[:=]\s*)(?:bearer\s+)?\S+")
+CREDENTIAL_RE = re.compile(
+    r"(?i)(\b(?:x-auth-token|api[\s_-]?key|client[\s_-]?secret|token|secret|password)\b\s*[:=]\s*)\S+"
+)
+BEARER_RE = re.compile(r"(?i)(\bbearer\s+)\S+")
+URL_CREDENTIAL_RE = re.compile(
+    r"(?i)([?&](?:access_token|refresh_token|id_token|api_key|key|signature|x-goog-signature)=)[^&\s]+"
+)
+
+
+class RecoveryError(RuntimeError):
+    pass
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+def request_bytes(
+    url: str,
+    *,
+    token: str,
+    opener: Callable[..., Any] | None = None,
+) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json, text/plain", "x-auth-token": token},
+        method="GET",
+    )
+    if opener is None:
+        opener = urllib.request.build_opener(NoRedirect()).open
+    try:
+        with opener(request, timeout=30) as response:
+            body = response.read(MAX_RESPONSE_BYTES + 1)
+            if len(body) > MAX_RESPONSE_BYTES:
+                raise RecoveryError("Codemagic API response exceeded the safe size limit")
+            return body
+    except urllib.error.HTTPError as error:
+        raise RecoveryError(f"Codemagic API returned HTTP {error.code}") from error
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise RecoveryError(f"Codemagic API unavailable: {type(error).__name__}") from error
+
+
+def request_json(url: str, *, token: str, opener: Callable[..., Any] | None = None) -> dict[str, Any]:
+    try:
+        payload = json.loads(request_bytes(url, token=token, opener=opener).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RecoveryError("Codemagic API returned invalid JSON") from error
+    if not isinstance(payload, dict):
+        raise RecoveryError("Codemagic API returned an unexpected payload")
+    return payload
+
+
+def build_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    build = payload.get("build", payload)
+    if not isinstance(build, dict):
+        raise RecoveryError("Codemagic build payload is missing build metadata")
+    return build
+
+
+def commit_sha(build: dict[str, Any]) -> str:
+    commit = build.get("commit")
+    if isinstance(commit, str):
+        return commit
+    if isinstance(commit, dict):
+        for key in ("hash", "sha", "id"):
+            value = commit.get(key)
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def first_string(build: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = build.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def flattened_actions(build: dict[str, Any]) -> list[dict[str, Any]]:
+    actions = build.get("buildActions")
+    if not isinstance(actions, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        subactions = action.get("subactions")
+        if isinstance(subactions, list) and subactions:
+            for item in subactions:
+                if not isinstance(item, dict):
+                    continue
+                inherited = dict(item)
+                for key in ("name", "status", "logUrl"):
+                    if not isinstance(inherited.get(key), str) and isinstance(action.get(key), str):
+                        inherited[key] = action[key]
+                result.append(inherited)
+        else:
+            result.append(action)
+    return result
+
+
+def failed_action(build: dict[str, Any]) -> dict[str, Any]:
+    failed = [action for action in flattened_actions(build) if action.get("status") == "failed"]
+    if len(failed) != 1:
+        raise RecoveryError(f"expected exactly one failed Codemagic step, found {len(failed)}")
+    return failed[0]
+
+
+def sanitize_diagnostics(log: bytes) -> list[str]:
+    text = log.decode("utf-8", errors="replace")
+    diagnostics: list[str] = []
+    for raw_line in text.splitlines():
+        line = ANSI_RE.sub("", raw_line).strip()
+        if not DIAGNOSTIC_RE.fullmatch(line):
+            continue
+        line = AUTHORIZATION_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+        line = CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+        line = BEARER_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+        line = URL_CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+        diagnostics.append(line[:600])
+        if len(diagnostics) == 20:
+            break
+    return diagnostics
+
+
+def load_profiles(path: Path) -> dict[str, dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != "desktop-codemagic-recovery-profiles/v1":
+        raise RecoveryError("unsupported recovery profile schema")
+    profiles = payload.get("profiles")
+    if not isinstance(profiles, dict):
+        raise RecoveryError("recovery profiles must be an object")
+    return {key: value for key, value in profiles.items() if isinstance(key, str) and isinstance(value, dict)}
+
+
+def event_build_id(event: dict[str, Any]) -> str:
+    check = event.get("check_run")
+    if not isinstance(check, dict):
+        raise RecoveryError("check_run event is missing")
+    app = check.get("app")
+    app_slug = app.get("slug") if isinstance(app, dict) else None
+    repository = event.get("repository")
+    repository_name = repository.get("full_name") if isinstance(repository, dict) else None
+    if (
+        check.get("status") != "completed"
+        or check.get("name") != CHECK_NAME
+        or check.get("conclusion") != "failure"
+        or app_slug != "codemagic-ci-cd"
+        or repository_name != "BasedHardware/omi"
+    ):
+        raise RecoveryError("event is not a failed canonical desktop Codemagic check")
+    details_url = check.get("details_url")
+    match = DETAILS_RE.fullmatch(details_url if isinstance(details_url, str) else "")
+    if match is None:
+        raise RecoveryError("check_run details URL is not the canonical Codemagic desktop app")
+    return match.group("build_id")
+
+
+def event_source_sha(event: dict[str, Any]) -> str:
+    check = event.get("check_run")
+    sha = check.get("head_sha") if isinstance(check, dict) else None
+    if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
+        raise RecoveryError("check_run event has an invalid source SHA")
+    return sha
+
+
+def build_capsule(
+    *,
+    build_id: str,
+    token: str,
+    profiles: dict[str, dict[str, Any]],
+    opener: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    if not BUILD_ID_RE.fullmatch(build_id):
+        raise RecoveryError("build id must be 24 lowercase hexadecimal characters")
+    payload = request_json(f"https://api.codemagic.io/builds/{build_id}", token=token, opener=opener)
+    build = build_from_payload(payload)
+    observed_id = first_string(build, "_id", "id", "buildId")
+    workflow_id = first_string(build, "fileWorkflowId", "workflowId", "workflow_id")
+    tag = build.get("tag")
+    sha = commit_sha(build)
+    if observed_id != build_id or build.get("appId") != APP_ID or workflow_id != WORKFLOW_ID:
+        raise RecoveryError("Codemagic build identity does not match the canonical desktop release workflow")
+    if not isinstance(tag, str) or not TAG_RE.fullmatch(tag):
+        raise RecoveryError("Codemagic build has an invalid release tag")
+    if not SHA_RE.fullmatch(sha):
+        raise RecoveryError("Codemagic build has an invalid source SHA")
+    if build.get("status") != "failed":
+        raise RecoveryError(f"Codemagic build is not failed: {build.get('status')}")
+
+    action = failed_action(build)
+    step_name = action.get("name") if isinstance(action.get("name"), str) else ""
+    log_url = action.get("logUrl") if isinstance(action.get("logUrl"), str) else ""
+    match = LOG_RE.fullmatch(log_url)
+    if match is None or match.group("build_id") != build_id:
+        raise RecoveryError("failed-step log URL is missing or unsafe")
+    diagnostics = sanitize_diagnostics(request_bytes(log_url, token=token, opener=opener))
+
+    profile = profiles.get(step_name, {})
+    failure_profile = profile.get("failure_profile", "unclassified")
+    locally_reproducible = profile.get("locally_reproducible") is True
+    arguments = profile.get("rehearsal_arguments") if locally_reproducible else []
+    if not isinstance(arguments, list) or not all(isinstance(value, str) for value in arguments):
+        raise RecoveryError("recovery profile rehearsal arguments must be strings")
+    command = None
+    if locally_reproducible:
+        rendered = " ".join(["desktop/macos/scripts/rehearse-desktop-release.sh", "--codemagic-build-id", build_id, *arguments])
+        command = rendered
+
+    return {
+        "schema": "desktop-codemagic-failure-recovery/v1",
+        "build_id": build_id,
+        "release_tag": tag,
+        "source_sha": sha,
+        "failed_step": step_name,
+        "failure_profile": failure_profile,
+        "locally_reproducible": locally_reproducible,
+        "rehearsal_command": command,
+        "diagnostics": diagnostics,
+        "codemagic_url": f"https://codemagic.io/app/{APP_ID}/build/{build_id}",
+    }
+
+
+def markdown_summary(capsule: dict[str, Any]) -> str:
+    lines = [
+        "## Desktop Release Recovery Required",
+        "",
+        f"- Candidate: `{capsule['release_tag']}`",
+        f"- Source: `{capsule['source_sha']}`",
+        f"- Codemagic build: [`{capsule['build_id']}`]({capsule['codemagic_url']})",
+        f"- Failed step: `{capsule['failed_step']}`",
+        f"- Failure profile: `{capsule['failure_profile']}`",
+    ]
+    diagnostics = capsule.get("diagnostics") or []
+    if diagnostics:
+        lines.extend(["", "### Credential-safe diagnostics", ""])
+        lines.extend(f"- `{line}`" for line in diagnostics)
+    command = capsule.get("rehearsal_command")
+    if isinstance(command, str):
+        lines.extend(
+            [
+                "",
+                "### Manual clean rehearsal",
+                "",
+                "Do not cut another candidate until this command passes or the failure is proven provider-only.",
+                "",
+                "```bash",
+                '. "$HOME/.config/omi/codemagic-env.sh"',
+                command,
+                "```",
+            ]
+        )
+    else:
+        lines.extend(["", "This failure is classified as provider-only; do not run the local clean rehearsal automatically."])
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event")
+    parser.add_argument("--build-id")
+    parser.add_argument("--profiles", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--summary", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("CODEMAGIC_API_TOKEN", "")
+    if not token:
+        raise RecoveryError("CODEMAGIC_API_TOKEN is required")
+    build_id = args.build_id or ""
+    expected_source_sha = ""
+    if args.event:
+        event = json.loads(Path(args.event).read_text(encoding="utf-8"))
+        build_id = event_build_id(event)
+        expected_source_sha = event_source_sha(event)
+    capsule = build_capsule(build_id=build_id, token=token, profiles=load_profiles(args.profiles))
+    if expected_source_sha and capsule["source_sha"] != expected_source_sha:
+        raise RecoveryError("Codemagic build source does not match the triggering check run")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(capsule, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.summary.write_text(markdown_summary(capsule), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RecoveryError, OSError, json.JSONDecodeError) as error:
+        print(f"FAIL: {error}", file=os.sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/desktop-codemagic-recovery-profiles.json
+++ b/.github/scripts/desktop-codemagic-recovery-profiles.json
@@ -1,0 +1,30 @@
+{
+  "schema": "desktop-codemagic-recovery-profiles/v1",
+  "profiles": {
+    "Audit app bundle dependencies": {
+      "failure_profile": "bundle-audit",
+      "locally_reproducible": true,
+      "rehearsal_arguments": ["--clean", "--failed-step", "bundle-audit"]
+    },
+    "Smoke signed desktop artifact": {
+      "failure_profile": "stable-signed-smoke",
+      "locally_reproducible": true,
+      "rehearsal_arguments": ["--clean", "--failed-step", "stable-signed-smoke"]
+    },
+    "Smoke signed desktop beta artifact": {
+      "failure_profile": "beta-signed-smoke",
+      "locally_reproducible": true,
+      "rehearsal_arguments": ["--clean", "--failed-step", "beta-signed-smoke"]
+    },
+    "Notarize app": {
+      "failure_profile": "apple-notarization",
+      "locally_reproducible": false,
+      "rehearsal_arguments": []
+    },
+    "Sign, notarize, and staple DMG": {
+      "failure_profile": "apple-notarization",
+      "locally_reproducible": false,
+      "rehearsal_arguments": []
+    }
+  }
+}

--- a/.github/scripts/test_desktop_codemagic_failure_recovery.py
+++ b/.github/scripts/test_desktop_codemagic_failure_recovery.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("desktop-codemagic-failure-recovery.py")
+SPEC = importlib.util.spec_from_file_location("desktop_codemagic_failure_recovery", SCRIPT)
+assert SPEC and SPEC.loader
+RECOVERY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RECOVERY)
+
+BUILD_ID = "6a774ecc151b6c9b80558c06"
+SHA = "5f6a6967cb1512ac6a06770fa8084649ecaf8bb7"
+
+
+class FakeResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        return self.body if size < 0 else self.body[:size]
+
+
+def build_payload(step: str = "Smoke signed desktop artifact") -> dict[str, object]:
+    return {
+        "build": {
+            "_id": BUILD_ID,
+            "appId": RECOVERY.APP_ID,
+            "fileWorkflowId": RECOVERY.WORKFLOW_ID,
+            "tag": "v0.12.153+12153-macos",
+            "commit": {"hash": SHA},
+            "status": "failed",
+            "buildActions": [
+                {
+                    "name": step,
+                    "subactions": [
+                        {
+                            "status": "failed",
+                            "logUrl": f"https://api.codemagic.io/builds/{BUILD_ID}/step/6a774ecd3749c8b7cfa41988",
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+
+
+class RecoveryTests(unittest.TestCase):
+    def profiles(self) -> dict[str, dict[str, object]]:
+        path = Path(__file__).with_name("desktop-codemagic-recovery-profiles.json")
+        return RECOVERY.load_profiles(path)
+
+    def opener(self, payload: dict[str, object], log: bytes):
+        def open_request(request, timeout=0):
+            del timeout
+            if request.full_url.endswith(f"/builds/{BUILD_ID}"):
+                return FakeResponse(json.dumps(payload).encode())
+            if "/step/" in request.full_url or "/logs/" in request.full_url:
+                return FakeResponse(log)
+            raise AssertionError(request.full_url)
+
+        return open_request
+
+    def test_build_capsule_maps_signed_smoke_and_redacts_diagnostics(self) -> None:
+        log = (
+            b"PASS: identity\nFAIL: agent tool manifest missing\n"
+            b"ERROR: token=super-secret\nFAIL: Authorization: Bearer bearer-secret\n"
+            b"ERROR: API key: api-secret\nWARN: client_secret=client-secret-value\n"
+            b"FAIL: https://example.test/callback?access_token=query-secret&mode=test\n"
+        )
+        capsule = RECOVERY.build_capsule(
+            build_id=BUILD_ID,
+            token="not-recorded",
+            profiles=self.profiles(),
+            opener=self.opener(build_payload(), log),
+        )
+        self.assertEqual(capsule["failure_profile"], "stable-signed-smoke")
+        self.assertTrue(capsule["locally_reproducible"])
+        self.assertIn("--clean --failed-step stable-signed-smoke", capsule["rehearsal_command"])
+        self.assertEqual(
+            capsule["diagnostics"],
+            [
+                "FAIL: agent tool manifest missing",
+                "ERROR: token=<redacted>",
+                "FAIL: Authorization: <redacted>",
+                "ERROR: API key: <redacted>",
+                "WARN: client_secret=<redacted>",
+                "FAIL: https://example.test/callback?access_token=<redacted>&mode=test",
+            ],
+        )
+        self.assertNotIn("super-secret", json.dumps(capsule))
+        self.assertNotIn("bearer-secret", json.dumps(capsule))
+        self.assertNotIn("api-secret", json.dumps(capsule))
+        self.assertNotIn("client-secret-value", json.dumps(capsule))
+        self.assertNotIn("query-secret", json.dumps(capsule))
+
+    def test_provider_only_failure_does_not_prescribe_local_rehearsal(self) -> None:
+        capsule = RECOVERY.build_capsule(
+            build_id=BUILD_ID,
+            token="not-recorded",
+            profiles=self.profiles(),
+            opener=self.opener(build_payload("Notarize app"), b"ERROR: Apple service unavailable\n"),
+        )
+        self.assertEqual(capsule["failure_profile"], "apple-notarization")
+        self.assertFalse(capsule["locally_reproducible"])
+        self.assertIsNone(capsule["rehearsal_command"])
+
+    def test_multiple_failed_steps_fail_closed(self) -> None:
+        payload = build_payload()
+        payload["build"]["buildActions"].append(
+            {
+                "name": "Smoke signed desktop beta artifact",
+                "status": "failed",
+                "logUrl": f"https://api.codemagic.io/builds/{BUILD_ID}/step/6a774ecd3749c8b7cfa41989",
+            }
+        )
+        with self.assertRaisesRegex(RECOVERY.RecoveryError, "exactly one failed Codemagic step"):
+            RECOVERY.build_capsule(
+                build_id=BUILD_ID,
+                token="not-recorded",
+                profiles=self.profiles(),
+                opener=self.opener(payload, b"FAIL: deterministic failure\n"),
+            )
+
+    def test_api_client_refuses_redirects(self) -> None:
+        handler = RECOVERY.NoRedirect()
+        self.assertIsNone(handler.redirect_request(None, None, 302, "redirect", {}, "https://evil.example"))
+
+    def test_event_requires_exact_failed_codemagic_check(self) -> None:
+        event = {
+            "check_run": {
+                "status": "completed",
+                "name": RECOVERY.CHECK_NAME,
+                "conclusion": "failure",
+                "app": {"slug": "codemagic-ci-cd"},
+                "head_sha": SHA,
+                "details_url": f"https://codemagic.io/app/{RECOVERY.APP_ID}/build/{BUILD_ID}?open-step=build-step-21",
+            },
+            "repository": {"full_name": "BasedHardware/omi"},
+        }
+        self.assertEqual(RECOVERY.event_build_id(event), BUILD_ID)
+        self.assertEqual(RECOVERY.event_source_sha(event), SHA)
+        event["check_run"]["details_url"] = f"https://evil.example/build/{BUILD_ID}"
+        with self.assertRaises(RECOVERY.RecoveryError):
+            RECOVERY.event_build_id(event)
+
+    def test_numeric_log_endpoint_and_alternate_identity_fields_are_supported(self) -> None:
+        payload = build_payload()
+        build = payload["build"]
+        build["id"] = build.pop("_id")
+        build["workflowId"] = build.pop("fileWorkflowId")
+        build["buildActions"][0]["subactions"][0]["logUrl"] = (
+            f"https://api.codemagic.io/builds/{BUILD_ID}/logs/21"
+        )
+        capsule = RECOVERY.build_capsule(
+            build_id=BUILD_ID,
+            token="not-recorded",
+            profiles=self.profiles(),
+            opener=self.opener(payload, b"FAIL: deterministic failure\n"),
+        )
+        self.assertEqual(capsule["failed_step"], "Smoke signed desktop artifact")
+
+    def test_summary_is_agent_readable_and_contains_no_token(self) -> None:
+        capsule = RECOVERY.build_capsule(
+            build_id=BUILD_ID,
+            token="not-recorded",
+            profiles=self.profiles(),
+            opener=self.opener(build_payload(), b"FAIL: deterministic failure\n"),
+        )
+        summary = RECOVERY.markdown_summary(capsule)
+        self.assertIn("Desktop Release Recovery Required", summary)
+        self.assertIn("Do not cut another candidate", summary)
+        self.assertIn("codemagic-env.sh", summary)
+        self.assertNotIn("not-recorded", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_desktop_codemagic_failure_recovery.py
+++ b/.github/scripts/test_desktop_codemagic_failure_recovery.py
@@ -77,6 +77,12 @@ class RecoveryTests(unittest.TestCase):
             b"PASS: identity\nFAIL: agent tool manifest missing\n"
             b"ERROR: token=super-secret\nFAIL: Authorization: Bearer bearer-secret\n"
             b"ERROR: API key: api-secret\nWARN: client_secret=client-secret-value\n"
+            b"ERROR: RELEASE_SECRET=release-secret-value\n"
+            b"WARN: GITHUB_TOKEN=github-token-value\n"
+            b"FAIL: SIGNING_KEY='quoted signing key'\n"
+            b"WARN: AWS_SECRET_ACCESS_KEY=aws-secret-value\n"
+            b"ERROR: Cookie: session=session-secret; csrf=csrf-secret\n"
+            b"WARN: Set-Cookie: auth=set-cookie-secret; Secure; HttpOnly\n"
             b"FAIL: https://example.test/callback?access_token=query-secret&mode=test\n"
         )
         capsule = RECOVERY.build_capsule(
@@ -96,6 +102,12 @@ class RecoveryTests(unittest.TestCase):
                 "FAIL: Authorization: <redacted>",
                 "ERROR: API key: <redacted>",
                 "WARN: client_secret=<redacted>",
+                "ERROR: RELEASE_SECRET=<redacted>",
+                "WARN: GITHUB_TOKEN=<redacted>",
+                "FAIL: SIGNING_KEY=<redacted>",
+                "WARN: AWS_SECRET_ACCESS_KEY=<redacted>",
+                "ERROR: Cookie: <redacted>",
+                "WARN: Set-Cookie: <redacted>",
                 "FAIL: https://example.test/callback?access_token=<redacted>&mode=test",
             ],
         )
@@ -103,6 +115,13 @@ class RecoveryTests(unittest.TestCase):
         self.assertNotIn("bearer-secret", json.dumps(capsule))
         self.assertNotIn("api-secret", json.dumps(capsule))
         self.assertNotIn("client-secret-value", json.dumps(capsule))
+        self.assertNotIn("release-secret-value", json.dumps(capsule))
+        self.assertNotIn("github-token-value", json.dumps(capsule))
+        self.assertNotIn("quoted signing key", json.dumps(capsule))
+        self.assertNotIn("aws-secret-value", json.dumps(capsule))
+        self.assertNotIn("session-secret", json.dumps(capsule))
+        self.assertNotIn("csrf-secret", json.dumps(capsule))
+        self.assertNotIn("set-cookie-secret", json.dumps(capsule))
         self.assertNotIn("query-secret", json.dumps(capsule))
 
     def test_provider_only_failure_does_not_prescribe_local_rehearsal(self) -> None:

--- a/.github/scripts/test_desktop_codemagic_failure_recovery.py
+++ b/.github/scripts/test_desktop_codemagic_failure_recovery.py
@@ -81,6 +81,9 @@ class RecoveryTests(unittest.TestCase):
             b"WARN: GITHUB_TOKEN=github-token-value\n"
             b"FAIL: SIGNING_KEY='quoted signing key'\n"
             b"WARN: AWS_SECRET_ACCESS_KEY=aws-secret-value\n"
+            b"ERROR: AWS_ACCESS_KEY_ID=aws-access-id\n"
+            b"WARN: GOOGLE_APPLICATION_CREDENTIALS=/private/credentials.json\n"
+            b"FAIL: SERVICE_ACCOUNT_JSON='{\"private_key\":\"json-secret\"}'\n"
             b"ERROR: Cookie: session=session-secret; csrf=csrf-secret\n"
             b"WARN: Set-Cookie: auth=set-cookie-secret; Secure; HttpOnly\n"
             b"FAIL: https://example.test/callback?access_token=query-secret&mode=test\n"
@@ -106,6 +109,9 @@ class RecoveryTests(unittest.TestCase):
                 "WARN: GITHUB_TOKEN=<redacted>",
                 "FAIL: SIGNING_KEY=<redacted>",
                 "WARN: AWS_SECRET_ACCESS_KEY=<redacted>",
+                "ERROR: AWS_ACCESS_KEY_ID=<redacted>",
+                "WARN: GOOGLE_APPLICATION_CREDENTIALS=<redacted>",
+                "FAIL: SERVICE_ACCOUNT_JSON=<redacted>",
                 "ERROR: Cookie: <redacted>",
                 "WARN: Set-Cookie: <redacted>",
                 "FAIL: https://example.test/callback?access_token=<redacted>&mode=test",
@@ -119,6 +125,9 @@ class RecoveryTests(unittest.TestCase):
         self.assertNotIn("github-token-value", json.dumps(capsule))
         self.assertNotIn("quoted signing key", json.dumps(capsule))
         self.assertNotIn("aws-secret-value", json.dumps(capsule))
+        self.assertNotIn("aws-access-id", json.dumps(capsule))
+        self.assertNotIn("credentials.json", json.dumps(capsule))
+        self.assertNotIn("json-secret", json.dumps(capsule))
         self.assertNotIn("session-secret", json.dumps(capsule))
         self.assertNotIn("csrf-secret", json.dumps(capsule))
         self.assertNotIn("set-cookie-secret", json.dumps(capsule))

--- a/.github/workflows/desktop_codemagic_failure_recovery.yml
+++ b/.github/workflows/desktop_codemagic_failure_recovery.yml
@@ -1,0 +1,75 @@
+name: Desktop Release Recovery Required
+
+on:
+  check_run:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: Exact failed Codemagic build ID
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-codemagic-recovery-${{ github.event.check_run.id || inputs.build_id }}
+  cancel-in-progress: false
+
+jobs:
+  recovery-capsule:
+    name: Agent recovery capsule
+    if: >-
+      github.repository == 'BasedHardware/omi' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.check_run.name == 'Release OMI Desktop (Swift)' &&
+        github.event.check_run.status == 'completed' &&
+        github.event.check_run.conclusion == 'failure' &&
+        github.event.check_run.app.slug == 'codemagic-ci-cd' &&
+        startsWith(github.event.check_run.details_url, 'https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout recovery controls
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Create credential-safe recovery capsule
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          EVENT_PATH: ${{ github.event_path }}
+          MANUAL_BUILD_ID: ${{ inputs.build_id }}
+        run: |
+          args=(
+            --profiles .github/scripts/desktop-codemagic-recovery-profiles.json
+            --output "$RUNNER_TEMP/desktop-codemagic-recovery.json"
+            --summary "$RUNNER_TEMP/desktop-codemagic-recovery.md"
+          )
+          if [[ "${{ github.event_name }}" == "check_run" ]]; then
+            args+=(--event "$EVENT_PATH")
+          else
+            args+=(--build-id "$MANUAL_BUILD_ID")
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            if python3 .github/scripts/desktop-codemagic-failure-recovery.py "${args[@]}"; then
+              break
+            fi
+            if [[ "$attempt" == "6" ]]; then
+              echo "Codemagic recovery metadata was not ready after six attempts" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          cat "$RUNNER_TEMP/desktop-codemagic-recovery.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain recovery capsule
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-codemagic-recovery-${{ github.event.check_run.id || inputs.build_id }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/desktop-codemagic-recovery.json
+          if-no-files-found: error
+          overwrite: false

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimePayload.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimePayload.swift
@@ -27,6 +27,7 @@ enum AgentRuntimePayload {
   /// `agent/` and `pi-mono-extension/`. `agent/dist/index.js` is deliberately
   /// absent: `findBridgeScript()` already proved it exists.
   static let components: [Component] = [
+    Component(relativePath: "agent/dist/runtime/omi-tool-manifest.js", kind: .file),
     Component(relativePath: "agent/package.json", kind: .file),
     Component(relativePath: "agent/node_modules", kind: .directory),
     Component(relativePath: "pi-mono-extension/index.ts", kind: .file),

--- a/desktop/macos/Desktop/Tests/AgentRuntimePayloadTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimePayloadTests.swift
@@ -40,6 +40,7 @@ final class AgentRuntimePayloadTests: XCTestCase {
   /// Mirrors what `run.sh` packages into `Contents/Resources`.
   private func installCompleteRuntime() throws {
     try write("agent/dist/index.js")
+    try write("agent/dist/runtime/omi-tool-manifest.js")
     try write("agent/package.json")
     try write("agent/node_modules/@omi/placeholder/package.json")
     try write("pi-mono-extension/index.ts")
@@ -78,6 +79,13 @@ final class AgentRuntimePayloadTests: XCTestCase {
     XCTAssertEqual(
       AgentRuntimePayload.missingComponents(bridgeScriptPath: bridgeScriptPath),
       ["agent/node_modules"])
+  }
+
+  func testAMissingCompiledToolManifestIsReportedBeforeAnySpawn() throws {
+    try remove("agent/dist/runtime/omi-tool-manifest.js")
+    XCTAssertEqual(
+      AgentRuntimePayload.missingComponents(bridgeScriptPath: bridgeScriptPath),
+      ["agent/dist/runtime/omi-tool-manifest.js"])
   }
 
   /// A partially-copied bundle leaves the directory behind with nothing in it.

--- a/desktop/macos/changelog/unreleased/20260808-agent-runtime-package-validation.json
+++ b/desktop/macos/changelog/unreleased/20260808-agent-runtime-package-validation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved the reliability of the macOS local AI runtime after app updates"
+}

--- a/desktop/macos/docs/release.md
+++ b/desktop/macos/docs/release.md
@@ -14,6 +14,24 @@ python3 .github/scripts/plan-desktop-release.py \
 
 The watcher reports only lifecycle transitions and never creates tags or builds, dispatches qualification, promotes channels, or changes release pointers.
 
+## Failed Codemagic build rehearsal
+
+A failed canonical Codemagic check triggers **Desktop Release Recovery Required**. Its job summary and retained JSON capsule bind the build ID, immutable tag, source SHA, failed step, sanitized diagnostics, and whether the step is locally reproducible. This is the just-in-time handoff for operators and agents; do not infer a fix from the generic Codemagic check title alone.
+
+For a locally reproducible bundle-audit or signed-smoke failure, run the capsule's exact command manually. On a managed Omi Mac:
+
+```bash
+. "$HOME/.config/omi/codemagic-env.sh"
+desktop/macos/scripts/rehearse-desktop-release.sh \
+  --codemagic-build-id <24-character-build-id> \
+  --clean \
+  --failed-step <failure-profile>
+```
+
+The rehearsal validates the provider build identity, workflow, tag, source SHA, terminal failure, failed-step log URL, and artifact URL before downloading anything. `--clean` performs an isolated arm64 release compile of the caller's current source (the proposed fix, not the failed tag), then the command replays the exact signed Stable or Beta Sparkle archive from the failed build, including the Keychain and UserNotifications canaries. Evidence records both identities plus current dirty state and a tracked-diff digest, and is retained under Ephemeral scratch by default. It cannot dispatch Codemagic, create or move a tag, publish a release, qualify a candidate, or update Beta/Stable. Universal assembly, Developer ID signing, notarization/stapling, and DMG packaging remain provider-only gates.
+
+Run this loop only in response to a failed Codemagic build. Do not create a replacement candidate until the rehearsal passes or the recovery capsule classifies the failure as provider-only.
+
 If a signed, qualified candidate did not reach Beta, run **Recover Qualified Desktop Beta** with `release_tag`, `confirm=recover-beta`, and a short `reason`. The backend rechecks immutable evidence, qualification, admission state, and the pointer transaction; the workflow run is the recovery audit record.
 
 To make that exact current Beta candidate Stable, run **Promote Qualified Desktop Stable** with `release_tag` and `confirm=promote-stable`. It reads the current pointer, uses its generation for the atomic transition, and verifies the published pointer, hashes, and appcast. It only changes the desktop Stable channel; backend production deployment remains a separate approval plane.

--- a/desktop/macos/scripts/agent-runtime-payload.sh
+++ b/desktop/macos/scripts/agent-runtime-payload.sh
@@ -14,6 +14,7 @@
 # Bundle-relative files that must exist and be non-empty.
 OMI_AGENT_RUNTIME_REQUIRED_FILES=(
   "Contents/Resources/agent/dist/index.js"
+  "Contents/Resources/agent/dist/runtime/omi-tool-manifest.js"
   "Contents/Resources/agent/package.json"
   "Contents/Resources/pi-mono-extension/index.ts"
   "Contents/Resources/pi-mono-extension/package.json"

--- a/desktop/macos/scripts/rehearse-desktop-release.sh
+++ b/desktop/macos/scripts/rehearse-desktop-release.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Manually replay a failed Codemagic desktop release against its exact signed
+# artifact, optionally preceded by a clean local release build.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MACOS_DIR/../.." && pwd)"
+CODEMAGIC_APP_ID="66c95e6ec76853c447b8bcbb"
+CODEMAGIC_WORKFLOW_ID="omi-desktop-swift-release"
+
+BUILD_ID=""
+FAILED_STEP=""
+OUTPUT_DIR=""
+RUN_CLEAN_BUILD=false
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/rehearse-desktop-release.sh --codemagic-build-id ID [options]
+
+Options:
+  --codemagic-build-id ID  Exact failed Codemagic build to replay
+  --failed-step PROFILE    Expected recovery profile (recorded in evidence)
+  --clean                  Run a clean local release compile before artifact replay
+  --output-dir PATH        Retained evidence directory (default: Ephemeral scratch)
+  -h, --help               Show this help
+
+The command is intentionally manual. It never dispatches Codemagic, creates a
+tag or release, or changes Beta/Stable. CODEMAGIC_API_TOKEN must be exported;
+on managed Omi Macs, source ~/.config/omi/codemagic-env.sh first.
+USAGE
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+codemagic_get() {
+  local url="$1"
+  curl --fail-with-body --silent --show-error \
+    --config <(printf 'header = "x-auth-token: %s"\n' "$CODEMAGIC_API_TOKEN") \
+    "$url"
+}
+
+require_value() {
+  [[ -n "${2:-}" && "${2:-}" != -* ]] || fail "$1 requires a value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --codemagic-build-id) require_value "$1" "${2:-}"; BUILD_ID="$2"; shift 2 ;;
+    --failed-step) require_value "$1" "${2:-}"; FAILED_STEP="$2"; shift 2 ;;
+    --clean) RUN_CLEAN_BUILD=true; shift ;;
+    --output-dir) require_value "$1" "${2:-}"; OUTPUT_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+[[ "$BUILD_ID" =~ ^[0-9a-f]{24}$ ]] || fail "--codemagic-build-id must be 24 lowercase hexadecimal characters"
+: "${CODEMAGIC_API_TOKEN:?CODEMAGIC_API_TOKEN is required; source ~/.config/omi/codemagic-env.sh}"
+[[ "$CODEMAGIC_API_TOKEN" =~ ^[A-Za-z0-9._~-]+$ ]] \
+  || fail "CODEMAGIC_API_TOKEN contains unsupported characters"
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  scratch_root="${SCRATCH_ROOT:-/Volumes/Ephemeral/scratch}"
+  [[ -d "$scratch_root" ]] || scratch_root="${TMPDIR:-/tmp}"
+  OUTPUT_DIR="$scratch_root/release-rehearsals/$BUILD_ID-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+mkdir -p "$OUTPUT_DIR"
+chmod 700 "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+BUILD_JSON="$OUTPUT_DIR/codemagic-build.json"
+codemagic_get "https://api.codemagic.io/builds/$BUILD_ID" > "$BUILD_JSON"
+chmod 600 "$BUILD_JSON"
+
+build_field() {
+  jq -er "$1" "$BUILD_JSON"
+}
+
+observed_id="$(build_field '.build._id // .build.id // .build.buildId')"
+app_id="$(build_field '.build.appId')"
+workflow_id="$(build_field '.build.fileWorkflowId // .build.workflowId // .build.workflow_id')"
+release_tag="$(build_field '.build.tag')"
+source_sha="$(build_field '.build.commit.hash // .build.commit.sha // .build.commit.id // .build.commit')"
+provider_status="$(build_field '.build.status')"
+
+[[ "$observed_id" == "$BUILD_ID" ]] || fail "Codemagic returned a different build id"
+[[ "$app_id" == "$CODEMAGIC_APP_ID" ]] || fail "Codemagic build belongs to unexpected app $app_id"
+[[ "$workflow_id" == "$CODEMAGIC_WORKFLOW_ID" ]] || fail "unexpected Codemagic workflow $workflow_id"
+[[ "$release_tag" =~ ^v[0-9]+[.][0-9]+[.][0-9]+[+][0-9]+-macos$ ]] || fail "invalid release tag from Codemagic"
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || fail "invalid source SHA from Codemagic"
+[[ "$provider_status" == "failed" ]] || fail "rehearsal requires a failed Codemagic build, got $provider_status"
+git -C "$REPO_ROOT" cat-file -e "$source_sha^{commit}" || fail "source SHA is not available locally: $source_sha"
+
+failed_step_count="$(
+  jq -er '[.build.buildActions[] as $action | (($action.subactions[]? // $action) | select(.status == "failed"))] | length' "$BUILD_JSON"
+)"
+[[ "$failed_step_count" == "1" ]] || fail "expected exactly one failed Codemagic step, found $failed_step_count"
+failed_step_name="$(
+  jq -er '[.build.buildActions[] as $action | (($action.subactions[]? // $action) | select(.status == "failed") | (.name // $action.name))] | .[0]' "$BUILD_JSON"
+)"
+failed_log_url="$(
+  jq -er '[.build.buildActions[] as $action | (($action.subactions[]? // $action) | select(.status == "failed") | (.logUrl // $action.logUrl))] | .[0]' "$BUILD_JSON"
+)"
+[[ "$failed_log_url" =~ ^https://api[.]codemagic[.]io/builds/$BUILD_ID/(step/[0-9a-f]{24}|logs/[0-9]+)$ ]] \
+  || fail "Codemagic returned an unsafe failed-step log URL"
+
+codemagic_get "$failed_log_url" > "$OUTPUT_DIR/codemagic-failed-step.log"
+chmod 600 "$OUTPUT_DIR/codemagic-failed-step.log"
+
+case "$failed_step_name" in
+  "Audit app bundle dependencies") observed_profile="bundle-audit" ;;
+  "Smoke signed desktop artifact") observed_profile="stable-signed-smoke" ;;
+  "Smoke signed desktop beta artifact") observed_profile="beta-signed-smoke" ;;
+  *) fail "failed step is not locally rehearsable: $failed_step_name" ;;
+esac
+if [[ -n "$FAILED_STEP" && "$FAILED_STEP" != "$observed_profile" ]]; then
+  fail "requested failure profile $FAILED_STEP does not match observed profile $observed_profile"
+fi
+
+artifact_name="Omi.zip"
+app_name="Omi.app"
+if [[ "$observed_profile" == "bundle-audit" ]]; then
+  artifact_name="Omi.app.zip"
+elif [[ "$observed_profile" == "beta-signed-smoke" ]]; then
+  artifact_name="Omi.Beta.zip"
+  app_name="Omi Beta.app"
+fi
+
+artifact_count="$(
+  jq -er --arg artifact "$artifact_name" '[.build.artefacts[] | select((.name // .path // .fileName) == $artifact)] | length' "$BUILD_JSON"
+)"
+[[ "$artifact_count" == "1" ]] || fail "expected exactly one $artifact_name artifact, found $artifact_count"
+artifact_url="$(
+  jq -er --arg artifact "$artifact_name" '[.build.artefacts[] | select((.name // .path // .fileName) == $artifact) | (.url // .secureUrl // .downloadUrl)] | .[0]' "$BUILD_JSON"
+)"
+[[ "$artifact_url" =~ ^https://api[.]codemagic[.]io/artifacts/ ]] || fail "Codemagic $artifact_name URL is missing or unsafe"
+
+echo "Rehearsing $release_tag ($source_sha) from Codemagic build $BUILD_ID"
+echo "Provider failure: $failed_step_name"
+
+if [[ "$RUN_CLEAN_BUILD" == true ]]; then
+  clean_scratch="$OUTPUT_DIR/swift-release"
+  clean_timeout_seconds="${OMI_RELEASE_REHEARSAL_CLEAN_TIMEOUT_SECONDS:-2700}"
+  [[ "$clean_timeout_seconds" =~ ^[0-9]+$ && "$clean_timeout_seconds" -ge 60 ]] \
+    || fail "OMI_RELEASE_REHEARSAL_CLEAN_TIMEOUT_SECONDS must be an integer of at least 60"
+  mkdir -p "$clean_scratch"
+  echo "== Clean local release compile"
+  python3 - "$MACOS_DIR" "$clean_scratch" "$clean_timeout_seconds" 2>&1 <<'PY' | tee "$OUTPUT_DIR/clean-release-build.log"
+import os
+import signal
+import subprocess
+import sys
+
+working_directory, scratch_path, timeout_text = sys.argv[1:]
+command = [
+    "xcrun", "swift", "build", "-c", "release", "--package-path", "Desktop",
+    "--scratch-path", scratch_path, "--triple", "arm64-apple-macosx",
+]
+process = subprocess.Popen(command, cwd=working_directory, start_new_session=True)
+try:
+    raise SystemExit(process.wait(timeout=int(timeout_text)))
+except subprocess.TimeoutExpired:
+    print(f"FAIL: clean local release compile exceeded {timeout_text}s", file=sys.stderr)
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    raise SystemExit(124)
+PY
+fi
+
+echo "== Download exact signed Sparkle artifact"
+artifact_headers="$OUTPUT_DIR/codemagic-artifact-headers.txt"
+curl --fail-with-body --silent --show-error --head \
+  --config <(printf 'header = "x-auth-token: %s"\n' "$CODEMAGIC_API_TOKEN") \
+  --dump-header "$artifact_headers" \
+  --output /dev/null \
+  "$artifact_url"
+signed_artifact_url="$(awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }' "$artifact_headers")"
+rm -f "$artifact_headers"
+[[ "$signed_artifact_url" != *$'\r'* && "$signed_artifact_url" != *$'\n'* && "$signed_artifact_url" != *'"'* && "$signed_artifact_url" != *'\\'* ]] \
+  || fail "Codemagic artifact redirect contains unsafe characters"
+[[ "$signed_artifact_url" =~ ^https://storage[.]googleapis[.]com/codemagic-build-artifacts/ ]] \
+  || fail "Codemagic artifact redirect is missing or unsafe"
+curl --fail-with-body --silent --show-error \
+  --config <(printf 'url = "%s"\n' "$signed_artifact_url") \
+  > "$OUTPUT_DIR/$artifact_name"
+chmod 600 "$OUTPUT_DIR/$artifact_name"
+
+exact_app_dir="$OUTPUT_DIR/exact-artifact"
+mkdir -p "$exact_app_dir"
+ditto -x -k "$OUTPUT_DIR/$artifact_name" "$exact_app_dir"
+exact_app="$exact_app_dir/$app_name"
+[[ -d "$exact_app/Contents" ]] || fail "$artifact_name did not contain exact $app_name"
+
+if [[ "$observed_profile" == "bundle-audit" ]]; then
+  echo "== Replay app bundle dependency audit"
+  set +e
+  "$SCRIPT_DIR/audit-desktop-bundle-deps.sh" "$exact_app" \
+    > >(tee "$OUTPUT_DIR/rehearsal-audit.log") \
+    2> >(tee "$OUTPUT_DIR/rehearsal-audit.err" >&2)
+  gate_status=$?
+  set -e
+else
+  echo "== Replay $observed_profile signed-artifact smoke"
+  identity_args=()
+  if [[ "$observed_profile" == "beta-signed-smoke" ]]; then
+    identity_args+=(
+      --expected-bundle-id com.omi.computer-macos.beta
+      --expected-feed-url 'https://api.omi.me/v2/desktop/appcast.xml?identity=beta'
+      --expected-python-api-url 'https://api.omiapi.com/'
+      --expected-desktop-api-url 'https://desktop-backend-dt5lrfkkoa-uc.a.run.app/'
+    )
+  fi
+  set +e
+  OMI_SIGNED_ARTIFACT_SMOKE_ALLOW_PRODUCTION_LAUNCH=1 \
+    "$SCRIPT_DIR/smoke-signed-desktop-artifact.sh" \
+      --app "$exact_app" \
+      --zip "$OUTPUT_DIR/$artifact_name" \
+      --tag "$release_tag" \
+      --source-sha "$source_sha" \
+      --expected-channel beta \
+      "${identity_args[@]}" \
+      --launch \
+      --auth-storage-canary \
+      --notification-callback-canary \
+      --timeout 90 \
+      --result-json "$OUTPUT_DIR/desktop-smoke-result.json" \
+      > >(tee "$OUTPUT_DIR/rehearsal-smoke.log") \
+      2> >(tee "$OUTPUT_DIR/rehearsal-smoke.err" >&2)
+  gate_status=$?
+  set -e
+fi
+
+current_head_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+current_worktree_dirty=false
+[[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]] || current_worktree_dirty=true
+current_diff_sha256="$(git -C "$REPO_ROOT" diff --binary HEAD | shasum -a 256 | awk '{print $1}')"
+
+python3 - "$OUTPUT_DIR/rehearsal-evidence.json" <<PY
+import json
+from pathlib import Path
+
+Path("$OUTPUT_DIR/rehearsal-evidence.json").write_text(json.dumps({
+    "schema": "desktop-release-rehearsal/v1",
+    "codemagic_build_id": "$BUILD_ID",
+    "release_tag": "$release_tag",
+    "source_sha": "$source_sha",
+    "current_head_sha": "$current_head_sha",
+    "current_worktree_dirty": $([[ "$current_worktree_dirty" == true ]] && echo True || echo False),
+    "current_tracked_diff_sha256": "$current_diff_sha256",
+    "provider_failed_step": "$failed_step_name",
+    "requested_failure_profile": "$FAILED_STEP" or None,
+    "clean_release_compile": $([[ "$RUN_CLEAN_BUILD" == true ]] && echo True || echo False),
+    "rehearsed_gate_passed": $([[ "$gate_status" -eq 0 ]] && echo True || echo False),
+    "signed_artifact_smoke_passed": $(if [[ "$observed_profile" == "bundle-audit" ]]; then echo None; elif [[ "$gate_status" -eq 0 ]]; then echo True; else echo False; fi),
+}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+chmod 600 "$OUTPUT_DIR/rehearsal-evidence.json"
+
+echo "Rehearsal evidence: $OUTPUT_DIR"
+[[ "$gate_status" -eq 0 ]] || exit "$gate_status"
+echo "Desktop release rehearsal passed"

--- a/desktop/macos/scripts/rehearse-desktop-release.sh
+++ b/desktop/macos/scripts/rehearse-desktop-release.sh
@@ -145,11 +145,14 @@ echo "Provider failure: $failed_step_name"
 if [[ "$RUN_CLEAN_BUILD" == true ]]; then
   clean_scratch="$OUTPUT_DIR/swift-release"
   clean_timeout_seconds="${OMI_RELEASE_REHEARSAL_CLEAN_TIMEOUT_SECONDS:-2700}"
-  [[ "$clean_timeout_seconds" =~ ^[0-9]+$ && "$clean_timeout_seconds" -ge 60 ]] \
+  [[ "$clean_timeout_seconds" =~ ^[0-9]+$ ]] \
+    || fail "OMI_RELEASE_REHEARSAL_CLEAN_TIMEOUT_SECONDS must be an integer of at least 60"
+  clean_timeout_decimal=$((10#$clean_timeout_seconds))
+  (( clean_timeout_decimal >= 60 )) \
     || fail "OMI_RELEASE_REHEARSAL_CLEAN_TIMEOUT_SECONDS must be an integer of at least 60"
   mkdir -p "$clean_scratch"
   echo "== Clean local release compile"
-  python3 - "$MACOS_DIR" "$clean_scratch" "$clean_timeout_seconds" 2>&1 <<'PY' | tee "$OUTPUT_DIR/clean-release-build.log"
+  python3 - "$MACOS_DIR" "$clean_scratch" "$clean_timeout_decimal" 2>&1 <<'PY' | tee "$OUTPUT_DIR/clean-release-build.log"
 import os
 import signal
 import subprocess

--- a/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
+++ b/desktop/macos/scripts/smoke-signed-desktop-artifact.sh
@@ -554,7 +554,6 @@ assert_helper_runtime_integrity() {
   missing_runtime_payload="$(omi_agent_runtime_payload_missing "$APP_BUNDLE" | tr '\n' ' ')"
   [[ -z "${missing_runtime_payload// /}" ]] \
     || fail "agent runtime payload incomplete: $missing_runtime_payload"
-  [[ -f "$resources/agent/src/runtime/omi-tool-manifest.ts" ]] || fail "agent tool manifest missing"
   [[ -x "$resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node" ]] || fail "bundled node missing"
   local sharp_arch expected_arch sharp_native libvips_native
   for sharp_arch in arm64 x64; do
@@ -745,7 +744,7 @@ if result.get("success") is not True or result.get("stage") != "complete":
     raise SystemExit(f"auth storage canary result: {result}")
 PY
   started_at=$SECONDS
-  while kill -0 "$canary_pid" >/dev/null 2>&1 && $((SECONDS - started_at)) -lt 5; do
+  while kill -0 "$canary_pid" >/dev/null 2>&1 && (( SECONDS - started_at < 5 )); do
     sleep 1
   done
   if kill -0 "$canary_pid" >/dev/null 2>&1; then

--- a/desktop/macos/tests/test-desktop-release-rehearsal.sh
+++ b/desktop/macos/tests/test-desktop-release-rehearsal.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REHEARSAL="$SCRIPT_DIR/../scripts/rehearse-desktop-release.sh"
+
+bash -n "$REHEARSAL"
+help_output="$("$REHEARSAL" --help)"
+[[ "$help_output" == *"intentionally manual"* ]]
+[[ "$help_output" == *"never dispatches Codemagic"* ]]
+
+set +e
+invalid_output="$("$REHEARSAL" --codemagic-build-id invalid 2>&1)"
+invalid_status=$?
+set -e
+[[ "$invalid_status" -ne 0 ]]
+[[ "$invalid_output" == *"must be 24 lowercase hexadecimal characters"* ]]
+
+! rg -n -- '--request[[:space:]]+POST|gh[[:space:]]+release|gh[[:space:]]+workflow[[:space:]]+run' "$REHEARSAL"
+rg -q '\[\[ "\$provider_status" == "failed" \]\]' "$REHEARSAL"
+rg -Fq 'storage[.]googleapis[.]com/codemagic-build-artifacts' "$REHEARSAL"
+rg -q 'expected exactly one failed Codemagic step' "$REHEARSAL"
+rg -q 'expected exactly one \$artifact_name artifact' "$REHEARSAL"
+rg -q -- '--expected-bundle-id com.omi.computer-macos.beta' "$REHEARSAL"
+rg -q -- '--expected-feed-url.*identity=beta' "$REHEARSAL"
+rg -q -- '--expected-python-api-url.*api.omiapi.com' "$REHEARSAL"
+rg -q 'CODEMAGIC_API_TOKEN.*unsupported characters' "$REHEARSAL"
+rg -q 'artifact_name="Omi.app.zip"' "$REHEARSAL"
+rg -q 'audit-desktop-bundle-deps.sh' "$REHEARSAL"
+
+echo "PASS: desktop release rehearsal is manual, fail-closed, and non-publishing"

--- a/desktop/macos/tests/test-desktop-release-rehearsal.sh
+++ b/desktop/macos/tests/test-desktop-release-rehearsal.sh
@@ -16,16 +16,17 @@ set -e
 [[ "$invalid_status" -ne 0 ]]
 [[ "$invalid_output" == *"must be 24 lowercase hexadecimal characters"* ]]
 
-! rg -n -- '--request[[:space:]]+POST|gh[[:space:]]+release|gh[[:space:]]+workflow[[:space:]]+run' "$REHEARSAL"
-rg -q '\[\[ "\$provider_status" == "failed" \]\]' "$REHEARSAL"
-rg -Fq 'storage[.]googleapis[.]com/codemagic-build-artifacts' "$REHEARSAL"
-rg -q 'expected exactly one failed Codemagic step' "$REHEARSAL"
-rg -q 'expected exactly one \$artifact_name artifact' "$REHEARSAL"
-rg -q -- '--expected-bundle-id com.omi.computer-macos.beta' "$REHEARSAL"
-rg -q -- '--expected-feed-url.*identity=beta' "$REHEARSAL"
-rg -q -- '--expected-python-api-url.*api.omiapi.com' "$REHEARSAL"
-rg -q 'CODEMAGIC_API_TOKEN.*unsupported characters' "$REHEARSAL"
-rg -q 'artifact_name="Omi.app.zip"' "$REHEARSAL"
-rg -q 'audit-desktop-bundle-deps.sh' "$REHEARSAL"
+! grep -En -- '--request[[:space:]]+POST|gh[[:space:]]+release|gh[[:space:]]+workflow[[:space:]]+run' "$REHEARSAL"
+grep -Eq '\[\[ "\$provider_status" == "failed" \]\]' "$REHEARSAL"
+grep -Fq 'storage[.]googleapis[.]com/codemagic-build-artifacts' "$REHEARSAL"
+grep -Eq 'expected exactly one failed Codemagic step' "$REHEARSAL"
+grep -Eq 'expected exactly one \$artifact_name artifact' "$REHEARSAL"
+grep -Eq -- '--expected-bundle-id com.omi.computer-macos.beta' "$REHEARSAL"
+grep -Eq -- '--expected-feed-url.*identity=beta' "$REHEARSAL"
+grep -Eq -- '--expected-python-api-url.*api.omiapi.com' "$REHEARSAL"
+grep -Eq 'CODEMAGIC_API_TOKEN.*unsupported characters' "$REHEARSAL"
+grep -Eq 'artifact_name="Omi.app.zip"' "$REHEARSAL"
+grep -Eq 'audit-desktop-bundle-deps.sh' "$REHEARSAL"
+grep -Fq '10#$clean_timeout_seconds' "$REHEARSAL"
 
 echo "PASS: desktop release rehearsal is manual, fail-closed, and non-publishing"

--- a/desktop/macos/tests/test-signed-artifact-smoke.sh
+++ b/desktop/macos/tests/test-signed-artifact-smoke.sh
@@ -150,7 +150,7 @@ make_signed_smoke_fixture() {
     "$app/Contents/Resources/agent/node_modules/@img/sharp-darwin-x64/lib" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-libvips-darwin-arm64/lib" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-libvips-darwin-x64/lib" \
-    "$app/Contents/Resources/agent/dist" \
+    "$app/Contents/Resources/agent/dist/runtime" \
     "$app/Contents/Resources/pi-mono-extension/node_modules/@omi/placeholder" \
     "$app/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources"
   cat > "$app/Contents/Info.plist" <<PLIST
@@ -181,13 +181,13 @@ PLIST
   # The runtime payload pi-mono loads after the bridge script. Non-empty on
   # purpose: a zero-byte entry point cannot answer a turn either.
   printf 'runtime\n' > "$app/Contents/Resources/agent/dist/index.js"
+  printf 'manifest\n' > "$app/Contents/Resources/agent/dist/runtime/omi-tool-manifest.js"
   printf '{}\n' > "$app/Contents/Resources/agent/package.json"
   printf 'extension\n' > "$app/Contents/Resources/pi-mono-extension/index.ts"
   printf '{}\n' > "$app/Contents/Resources/pi-mono-extension/package.json"
   printf '{}\n' > "$app/Contents/Resources/pi-mono-extension/node_modules/@omi/placeholder/package.json"
   printf '{}\n' > "$app/Contents/Resources/agent/node_modules/@img/sharp-darwin-arm64/package.json"
   touch \
-    "$app/Contents/Resources/agent/src/runtime/omi-tool-manifest.ts" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-darwin-x64/lib/sharp-darwin-x64.node" \
     "$app/Contents/Resources/agent/node_modules/@img/sharp-libvips-darwin-arm64/lib/libvips-cpp.42.dylib" \
@@ -351,6 +351,18 @@ grep -q "agent runtime payload incomplete" /tmp/omi-smoke-hollow-runtime.err \
   || fail "incomplete runtime payload rejection should name the contract"
 grep -q "pi-mono-extension/index.ts" /tmp/omi-smoke-hollow-runtime.err \
   || fail "incomplete runtime payload rejection should name the missing component"
+
+mkdir -p "$tmp_root/missing-tool-manifest"
+missing_tool_manifest_app="$tmp_root/missing-tool-manifest/Omi.app"
+cp -R "$canonical_dmg_app" "$missing_tool_manifest_app"
+rm -f "$missing_tool_manifest_app/Contents/Resources/agent/dist/runtime/omi-tool-manifest.js"
+if PATH="$mock_bin:$PATH" OMI_TEST_DMG_APP_SOURCE="$missing_tool_manifest_app" \
+  "$SMOKE" --app "$missing_tool_manifest_app" --tag v0.12.34+12034-macos \
+  >/tmp/omi-smoke-missing-tool-manifest.out 2>/tmp/omi-smoke-missing-tool-manifest.err; then
+  fail "smoke must reject an artifact whose compiled agent tool manifest is missing"
+fi
+grep -q "agent/dist/runtime/omi-tool-manifest.js" /tmp/omi-smoke-missing-tool-manifest.err \
+  || fail "compiled tool manifest rejection should name the missing component"
 
 # Regression (v0.12.91 build failure): macOS mktemp creates the LITERAL template
 # file when characters follow the final XXXXXX, so the second smoke invocation


### PR DESCRIPTION
## What changed and why

Add an automatic, credential-safe recovery capsule for failed desktop Codemagic checks and a manual exact-build rehearsal loop. The same change fixes the v0.12.153 smoke failure by validating the compiled agent tool manifest that is actually shipped instead of a TypeScript source file that is intentionally absent from release artifacts.

## Product invariants affected

- INV-AUTH-1: the exact signed-artifact rehearsal preserves the mandatory Keychain canary.
- INV-CHAT-1: a packaged agent runtime now refuses a turn before spawn when its compiled tool manifest is absent.

## How it was verified

- Queried Codemagic build `6a774ecc151b6c9b80558c06` through the authenticated API; the recovery capsule classified `Smoke signed desktop artifact` / `stable-signed-smoke` and retained only `FAIL: agent tool manifest missing`.
- Replayed that build's exact signed `Omi.zip`; runtime integrity, Keychain write/read/delete, launch, and UserNotifications callback all passed with the corrected contract. Evidence: `/Volumes/Ephemeral/scratch/release-rehearsals/6a774ecc151b6c9b80558c06-pr-final`.
- Ran a fresh isolated arm64 release compile plus exact signed-artifact replay with `rehearse-desktop-release.sh --clean`.
- Ran `xcrun swift test --package-path desktop/macos/Desktop --filter AgentRuntimePayloadTests`: 11 tests passed.
- Ran the local check manifest with `--skip-changelog`: 26 selected checks passed, including format, SwiftLint, runtime payload, signed smoke, workflow contracts, and recovery tests.

Universal assembly, Developer ID signing, notarization/stapling, and DMG packaging remain provider-only gates and are not claimed by the local rehearsal.

## Tests

- `.github/scripts/test_desktop_codemagic_failure_recovery.py` covers identity binding, exact failed-step selection, provider-only classification, event/app/repository validation, alternate API shapes, redirect refusal, and credential redaction.
- `desktop/macos/tests/test-desktop-release-rehearsal.sh` pins the manual/non-publishing contract, exact-one fences, token safety, and Beta routing.
- `desktop/macos/tests/test-signed-artifact-smoke.sh` now proves a missing compiled manifest fails signed smoke.
- `AgentRuntimePayloadTests` proves the app refuses the same incomplete runtime before spawn.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

This guard would have caught the failed [v0.12.153 Codemagic build](https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/6a774ecc151b6c9b80558c06) and immediately handed an agent the exact safe rehearsal command. It is not a broader shared primitive because the build identity, artifact names, signed-smoke profiles, and provider API are specific to the macOS desktop release lane.

## Scoped cleanups (optional)

- Corrected the auth-storage canary's arithmetic wait expression, which previously emitted `0: command not found` after a successful canary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

