### PR TITLE
Fix mobile auth success redirect fallback

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -7,7 +7,7 @@ import hashlib
 import time
 import jwt
 from typing import Any, Dict, Optional, cast
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlencode, urlparse, urlsplit, urlunsplit
 from cryptography.hazmat.primitives import serialization
 from jwt.algorithms import RSAAlgorithm
 from fastapi import APIRouter, Request, HTTPException, Form
@@ -217,6 +217,20 @@ def _redirect_scheme(redirect_uri: Optional[str]) -> str:
     if not redirect_uri:
         return "missing"
     return (urlparse(redirect_uri).scheme or "missing").lower()[:64]
+
+
+def _build_callback_redirect_url(redirect_uri: str, code: str, state: Optional[str]) -> str:
+    """Append the one-time callback parameters without losing a URI fragment.
+
+    The value is rendered into the callback page's native link as well as used
+    by its automatic navigation. Rendering it in the HTML keeps the manual
+    fallback usable when a mobile browser blocks inline JavaScript or automatic
+    custom-scheme navigation.
+    """
+    parsed = urlsplit(redirect_uri)
+    callback_query = urlencode({"code": code, **({"state": state} if state else {})})
+    query = f"{parsed.query}&{callback_query}" if parsed.query else callback_query
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
 
 
 def _failure_class(error: Optional[object]) -> str:
@@ -437,6 +451,7 @@ async def auth_callback_google(
             "code": auth_code,
             "state": session_data['state'] or '',
             "redirect_uri": app_redirect_uri,
+            "redirect_url": _build_callback_redirect_url(app_redirect_uri, auth_code, session_data['state']),
         },
     )
 
@@ -538,6 +553,7 @@ async def auth_callback_apple_post(
             "code": auth_code,
             "state": session_data['state'] or '',
             "redirect_uri": app_redirect_uri,
+            "redirect_url": _build_callback_redirect_url(app_redirect_uri, auth_code, session_data['state']),
         },
     )
 

--- a/backend/templates/auth_callback.html
+++ b/backend/templates/auth_callback.html
@@ -88,19 +88,22 @@
         <p id="message">Redirecting you back to the app...</p>
         <div class="spinner" id="spinner"></div>
         <div class="error" id="error"></div>
-        <a href="#" id="manualLink" class="manual-link">Open App Manually</a>
+        <!-- Render a working native-app URL up front. Some mobile browsers block
+             automatic custom-scheme navigation or inline scripts, but still
+             honor a user-initiated link tap. -->
+        <a href="{{ redirect_url | default('#') }}" id="manualLink" class="manual-link">Open App Manually</a>
     </div>
 
     <script>
         // Get values from template variables (passed from backend).
         // Use |tojson for safe JS interpolation (prevents XSS via template injection).
-        // ``baseRedirect`` was validated server-side at /authorize time; here
-        // we still re-check the scheme/host before navigating, as defense in
-        // depth against a misconfigured upstream.
+        // ``redirectUrl`` was built from the redirect URI validated server-side
+        // at /authorize time. Re-check the scheme/host before navigating as
+        // defense in depth against a misconfigured upstream.
         const code = {{ code | tojson }};
         const state = {{ state | tojson }};
         const error = {{ (error if error is defined else '') | tojson }};
-        const baseRedirect = {{ redirect_uri | default('omi://auth/callback') | tojson }};
+        const redirectUrl = {{ redirect_url | default('') | tojson }};
 
         const errorElement = document.getElementById('error');
         const messageElement = document.getElementById('message');
@@ -147,17 +150,12 @@
             spinnerElement.style.display = 'none';
             messageElement.textContent = 'Please close this window and try again.';
         } else if (code) {
-            if (!isAllowedRedirect(baseRedirect)) {
+            if (!isAllowedRedirect(redirectUrl)) {
                 errorElement.textContent = 'Invalid redirect target. Please close this window.';
                 spinnerElement.style.display = 'none';
+                manualLinkElement.style.display = 'none';
                 messageElement.textContent = '';
             } else {
-                // Append code + state preserving any existing query params.
-                const sep = baseRedirect.indexOf('?') === -1 ? '?' : '&';
-                let redirectUrl = baseRedirect + sep + 'code=' + encodeURIComponent(code);
-                if (state) {
-                    redirectUrl += '&state=' + encodeURIComponent(state);
-                }
                 const isLoopback = redirectUrl.indexOf('http://') === 0;
 
                 // Loopback users (CLI / desktop apps) get a "you can close this tab" hint —
@@ -169,8 +167,6 @@
                     messageElement.textContent = 'Redirecting you back to the app...';
                 }
 
-                // Set up manual link
-                manualLinkElement.href = redirectUrl;
                 if (isLoopback) {
                     manualLinkElement.textContent = 'Open Manually';
                 }
@@ -178,7 +174,7 @@
                 // Attempt automatic redirect
                 try {
                     console.log('Redirecting to:', redirectUrl);
-                    window.location.href = redirectUrl;
+                    window.location.assign(redirectUrl);
 
                     // Show manual link after 3 seconds if automatic redirect doesn't work
                     setTimeout(() => {

--- a/backend/templates/auth_callback.html
+++ b/backend/templates/auth_callback.html
@@ -66,7 +66,7 @@
         }
 
         .manual-link {
-            display: none;
+            display: inline-block;
             margin-top: 24px;
             padding: 12px 24px;
             background-color: #333;
@@ -88,9 +88,9 @@
         <p id="message">Redirecting you back to the app...</p>
         <div class="spinner" id="spinner"></div>
         <div class="error" id="error"></div>
-        <!-- Render a working native-app URL up front. Some mobile browsers block
-             automatic custom-scheme navigation or inline scripts, but still
-             honor a user-initiated link tap. -->
+        <!-- Keep the server-rendered native-app link visible: mobile browsers
+             can block script-driven custom-scheme navigation, but honor a
+             user-initiated link tap even without JavaScript. -->
         <a href="{{ redirect_url | default('#') }}" id="manualLink" class="manual-link">Open App Manually</a>
     </div>
 

--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -529,10 +529,14 @@ class TestCallbackTemplateRendering:
             code="test-auth-code",
             state="test-state",
             redirect_uri="omi-computer://auth/callback",
+            redirect_url="omi-computer://auth/callback?code=test-auth-code&state=test-state",
         )
 
         assert 'omi-computer://auth/callback' in html
         assert "omi://auth/callback" not in html  # hardcoded value must not appear
+        assert 'href="omi-computer://auth/callback?code=test-auth-code&amp;state=test-state"' in html
+        assert 'const redirectUrl = "omi-computer://auth/callback?code=test-auth-code\\u0026state=test-state"' in html
+        assert 'window.location.assign(redirectUrl);' in html
 
     def test_template_json_escapes_redirect_uri(self):
         """Verify redirect_uri is JSON-escaped in the template (XSS prevention)."""
@@ -548,6 +552,7 @@ class TestCallbackTemplateRendering:
             code='test</script><script>alert(1)',
             state='test-state',
             redirect_uri='omi-computer://auth/callback',
+            redirect_url='omi-computer://auth/callback?code=test-auth-code',
         )
 
         assert '</script><script>' not in html
@@ -565,9 +570,38 @@ class TestCallbackTemplateRendering:
         html = template.render(
             code="test-code",
             state="test-state",
+            redirect_url="omi://auth/callback?code=test-code&state=test-state",
         )
 
         assert 'omi://auth/callback' in html
+
+    def test_template_manual_link_is_usable_without_javascript(self):
+        """Native callback URL is present in HTML before script execution."""
+        pytest.importorskip("jinja2")
+        from jinja2 import Environment, FileSystemLoader
+        import pathlib
+
+        templates_dir = pathlib.Path(__file__).parent.parent.parent / "templates"
+        env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
+        template = env.get_template("auth_callback.html")
+
+        html = template.render(
+            code="test-code",
+            state="test-state",
+            redirect_uri="omi://auth/callback",
+            redirect_url="omi://auth/callback?code=test-code&state=test-state",
+        )
+
+        assert 'href="omi://auth/callback?code=test-code&amp;state=test-state"' in html
+
+
+def test_build_callback_redirect_url_preserves_query_and_fragment():
+    from routers.auth import _build_callback_redirect_url
+
+    assert (
+        _build_callback_redirect_url("omi://auth/callback?source=mobile#complete", "test-code", "test-state")
+        == "omi://auth/callback?source=mobile&code=test-code&state=test-state#complete"
+    )
 
 
 class TestCallbackEndpoints:
@@ -609,6 +643,9 @@ class TestCallbackEndpoints:
             assert stored['code_challenge_method'] == 'S256'
             assert 'credentials' in stored
             assert ttl == 300
+            callback_context = mock_templates.TemplateResponse.call_args.args[2]
+            assert callback_context['redirect_url'].startswith('omi-computer://auth/callback?code=')
+            assert callback_context['redirect_url'].endswith('&state=test-state')
 
     def test_callback_defaults_redirect_uri_when_missing_from_session(self):
         """When session has no redirect_uri, callback falls back to default."""
@@ -637,6 +674,9 @@ class TestCallbackEndpoints:
             stored = json.loads(mock_set_code.call_args[0][1])
             assert stored['redirect_uri'] == _DEFAULT_MOBILE_REDIRECT
             assert stored['code_challenge'] == _PKCE_CHALLENGE
+            callback_context = mock_templates.TemplateResponse.call_args.args[2]
+            assert callback_context['redirect_url'].startswith('omi://auth/callback?code=')
+            assert callback_context['redirect_url'].endswith('&state=test-state')
 
 
 class TestTokenEdgeCases:

--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -538,8 +538,8 @@ class TestCallbackTemplateRendering:
         assert 'const redirectUrl = "omi-computer://auth/callback?code=test-auth-code\\u0026state=test-state"' in html
         assert 'window.location.assign(redirectUrl);' in html
 
-    def test_template_json_escapes_redirect_uri(self):
-        """Verify redirect_uri is JSON-escaped in the template (XSS prevention)."""
+    def test_template_escapes_hostile_redirect_url_in_html_and_javascript(self):
+        """The rendered native-link URL cannot break the HTML attribute or inline script."""
         pytest.importorskip("jinja2")
         from jinja2 import Environment, FileSystemLoader
         import pathlib
@@ -548,17 +548,32 @@ class TestCallbackTemplateRendering:
         env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
         template = env.get_template("auth_callback.html")
 
+        hostile_code = 'test</script><script>alert(1)'
+        hostile_state = 'state"&<script>alert(2)</script>'
+        hostile_redirect_url = f'omi://auth/callback?code={hostile_code}&state={hostile_state}'
+
         html = template.render(
-            code='test</script><script>alert(1)',
-            state='test-state',
-            redirect_uri='omi-computer://auth/callback',
-            redirect_url='omi-computer://auth/callback?code=test-auth-code',
+            code=hostile_code,
+            state=hostile_state,
+            redirect_uri='omi://auth/callback',
+            redirect_url=hostile_redirect_url,
         )
 
-        assert '</script><script>' not in html
+        assert '</script><script>alert(1)' not in html
+        assert (
+            'href="omi://auth/callback?code=test&lt;/script&gt;&lt;script&gt;alert(1)&amp;state=state&#34;&amp;&lt;script&gt;alert(2)&lt;/script&gt;"'
+            in html
+        )
+        redirect_url_line = next(
+            line.strip() for line in html.splitlines() if line.strip().startswith("const redirectUrl")
+        )
+        assert hostile_redirect_url not in redirect_url_line
+        assert "\\u003c" in redirect_url_line
+        assert "\\u0026" in redirect_url_line
+        assert chr(92) + '"' in redirect_url_line
 
-    def test_template_defaults_when_redirect_uri_missing(self):
-        """Verify template falls back to omi://auth/callback when redirect_uri not provided."""
+    def test_template_defaults_when_redirect_url_missing(self):
+        """Missing redirect_url leaves a safe inert href and empty JavaScript value."""
         pytest.importorskip("jinja2")
         from jinja2 import Environment, FileSystemLoader
         import pathlib
@@ -570,10 +585,10 @@ class TestCallbackTemplateRendering:
         html = template.render(
             code="test-code",
             state="test-state",
-            redirect_url="omi://auth/callback?code=test-code&state=test-state",
         )
 
-        assert 'omi://auth/callback' in html
+        assert 'href="#"' in html
+        assert 'const redirectUrl = "";' in html
 
     def test_template_manual_link_is_usable_without_javascript(self):
         """Native callback URL is present in HTML before script execution."""
@@ -593,6 +608,7 @@ class TestCallbackTemplateRendering:
         )
 
         assert 'href="omi://auth/callback?code=test-code&amp;state=test-state"' in html
+        assert '.manual-link {\n            display: inline-block;' in html
 
 
 def test_build_callback_redirect_url_preserves_query_and_fragment():


### PR DESCRIPTION
## Summary

- Render the validated native OAuth callback URL directly in the mobile success page's manual link.
- Use that same URL for automatic navigation, preserving existing desktop loopback behavior and callback token handoff.
- Cover native-link rendering, redirect selection, and query/fragment preservation.

## Verification

- `cd backend && PYTHON=.venv/bin/python bash test-preflight.sh` — passed (18 checks, 8 optional warnings).
- `cd backend && .venv/bin/pytest -q tests/unit/test_auth_redirect_uri.py` — passed (61 tests).
- `make preflight` and `scripts/pr-preflight --pr-body-file pr-body.md` — started locally. The direct PR gate stalled in the shared route-policy inventory, and the pre-push retry cleared its earlier checks but remained CPU-bound in runtime-image source-closure for over ten minutes; both were stopped. Neither check reported an auth-path defect.
- `cd backend && bash test.sh` — blocked by an unrelated existing fast-unit duration guard: `tests/services/users/test_data_export.py::test_iter_user_data_export_paginates_complete_collections` took 0.13s (limit 0.12s). The auth-focused suite passes.

## Device validation

No physical iOS/Android device was available. The callback page now contains a real `omi://auth/callback?...` anchor before JavaScript executes, so a user tap remains an OS-recognized, user-initiated app-open fallback when a mobile browser blocks automatic custom-scheme navigation.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

