### PR TITLE
fix(dev-harness): report dev-up health failures instead of exiting 0 (#11268)

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -769,14 +769,20 @@ def _wait_health(
             base = timeout
         deadlines[service] = start + base
     failures: dict[str, str] = {}
+    # Detail from the most recent failed poll, folded into the deadline message.
+    # Kept separate from ``failures`` so a service that recovers before its
+    # deadline is not reported as a failure.
+    last_detail: dict[str, str] = {}
     process_records = {r["service"]: r for r in _process_records(cfg)}
     while pending:
         now = time.time()
         # Expire services whose per-service deadline has passed.
         for service in list(pending):
             if now >= deadlines[service]:
-                url = pending[service][0]
-                failures.setdefault(service, f"not healthy after {deadlines[service] - start:.0f}s at {url}")
+                url = pending[service][0] or f"127.0.0.1:{cfg.redis_port}"
+                message = f"not healthy after {deadlines[service] - start:.0f}s at {url}"
+                detail = last_detail.get(service)
+                failures.setdefault(service, f"{message}: {detail}" if detail else message)
                 pending.pop(service)
         if not pending:
             break
@@ -800,12 +806,12 @@ def _wait_health(
                 print(f"{service}: healthy ({detail})")
                 pending.pop(service)
             else:
-                failures[service] = detail
+                last_detail[service] = detail
         if pending:
             time.sleep(0.75)
-    for service, (url, _) in pending.items():
-        failures.setdefault(service, f"not healthy at {url}")
-    return [f"{service}: {failures.get(service, 'unknown failure')}" for service in pending] if failures else []
+    # ``pending`` is empty here by loop invariant, so the report is built from
+    # the services that actually expired or died — never from ``pending``.
+    return [f"{service}: {message}" for service, message in failures.items()]
 
 
 def cmd_up(args: argparse.Namespace) -> int:

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -133,6 +133,51 @@ def test_status_reports_seeded_scenario_and_summary_path(tmp_path: Path) -> None
     assert "PROVIDER_MODE=offline active" in result.stdout
 
 
+def _health_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> config.HarnessConfig:
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_process_records", lambda _cfg: [])
+    monkeypatch.setattr(cli, "_port_open", lambda *_args, **_kwargs: True)
+    return config.load_config(REPO_ROOT, create_layout=True)
+
+
+def test_wait_health_reports_a_service_that_never_becomes_healthy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg = _health_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_http_ok",
+        lambda url, headers=None: (False, "connection refused") if "/docs" in url else (True, "HTTP 200"),
+    )
+    monkeypatch.setattr(cli, "_HEALTH_TIMEOUTS", {**cli._HEALTH_TIMEOUTS, "backend": 0.4})
+
+    failures = cli._wait_health(cfg)
+
+    assert len(failures) == 1, failures
+    assert failures[0].startswith("backend: not healthy after")
+    assert "connection refused" in failures[0]
+
+
+def test_wait_health_ignores_a_service_that_recovers_before_its_deadline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg = _health_config(monkeypatch, tmp_path)
+    attempts = {"backend": 0}
+
+    def fake_http_ok(url: str, headers: dict[str, str] | None = None) -> tuple[bool, str]:
+        if "/docs" in url:
+            attempts["backend"] += 1
+            if attempts["backend"] < 3:
+                return False, "connection refused"
+        return True, "HTTP 200"
+
+    monkeypatch.setattr(cli, "_http_ok", fake_http_ok)
+
+    assert cli._wait_health(cfg) == []
+    assert attempts["backend"] == 3
+
+
 def test_session_summary_is_local_emulator_non_activation(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["PROVIDER_MODE"] = "offline"


### PR DESCRIPTION
## Bug

`make dev-up` printed `Local dev harness is up.` and exited **0 even when every harness service was unhealthy**.

`_wait_health` (`scripts/dev-harness/dev_harness/cli.py`) built its report from `pending`:

```python
return [f"{service}: {failures.get(service, 'unknown failure')}" for service in pending] if failures else []
```

The enclosing `while pending:` loop can only exit once `pending` is empty, so that comprehension always iterated an empty dict and the function **always returned `[]`**. `cmd_up`'s `if failures:` gate was therefore dead code.

Callers depend on the opposite contract: `qualify-desktop-beta.sh` comments *"Wait for dev-up to complete (success or fail)"*, and `desktop-core-harness.sh` runs `make dev-up` under `set -euo pipefail`.

**Live impact** — [Build Desktop Release Candidate run 31277339934](https://github.com/BasedHardware/omi/actions/runs/31277339934) (2026-08-08 20:37Z). dev-up printed healthy lines for redis and typesense only, then `Local dev harness is up.` and exit 0. The M1 pre-tag readiness probe re-checked and failed ~2 min later with the opaque `{"healthy": false, "reason": "health_check_failed", "failures": ["auth", "backend"]}`; the release candidate never tagged. The real failure — firestore, auth, backend and desktop-backend all missing their dev-up deadlines — was swallowed at the layer that measured it.

## Root cause

The failure report was derived from the loop's *work queue* rather than from the services that actually failed. `failures[service] = detail` was also written on every transient poll miss, so it could not be used as the report either without falsely blaming services that later recovered.

## Fix

- Build the report from `failures`, which now only records services that **expired their deadline or died**.
- Move transient poll detail into `last_detail` and fold it into the deadline message, so a service that recovers before its deadline is never reported.
- Drop the unreachable trailing `for service in pending` loop.
- The deadline message now names redis' `host:port` instead of `at None` (its check tuple carries no URL) — this message is user-visible for the first time.

## What I tested

Real end-to-end exercise against dead ports, **no HTTP mocking**, `_HEALTH_TIMEOUTS` set to 1s:

```
PRE-FIX  returned failures: []
         cmd_up would print 'Local dev harness is up.' and exit 0: True

POST-FIX returned failures: 6
  - firestore: not healthy after 1s at http://127.0.0.1:8085/: <urlopen error [Errno 61] Connection refused>
  - auth: not healthy after 1s at http://127.0.0.1:9099/: <urlopen error [Errno 61] Connection refused>
  - typesense: not healthy after 1s at http://127.0.0.1:8108/collections: <urlopen error [Errno 61] Connection refused>
  - backend: not healthy after 1s at http://127.0.0.1:8000/docs: <urlopen error [Errno 61] Connection refused>
  - desktop-backend: not healthy after 1s at http://127.0.0.1:10201/health: <urlopen error [Errno 61] Connection refused>
  - redis: not healthy after 1s at 127.0.0.1:6380
         cmd_up takes the failure branch -> exit 1
```

Regression tests (`scripts/dev-harness/tests/test_cli.py`, the `dev-harness-unit-tests` manifest lane):

- `test_wait_health_reports_a_service_that_never_becomes_healthy` — **fails on the pre-fix file**, passes on the fixed one.
- `test_wait_health_ignores_a_service_that_recovers_before_its_deadline` — passes on both; pins the recovery path so the report is not naively rebuilt from every transient miss.

`bash scripts/dev-harness/run-tests.sh` → `9 passed` in `test_cli.py`. (4 pre-existing `test_qualification_lease.py` failures on this machine are `lsof` missing from the sandbox, unrelated to this diff.)

`black --line-length 120 --skip-string-normalization --check` clean on both files.

## Note

`make dev-up` now returns 1 where it previously returned 0 with a broken stack. That is the contract its callers already assume, and it converts a silent 2-minutes-later opaque probe failure into a named service failure at the layer that measured it.

Closes #11268

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

