### PR TITLE
fix(release): repair cold pre-tag stack readiness

### DIFF
--- a/desktop/macos/changelog/unreleased/20260808-pretag-readiness-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260808-pretag-readiness-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved macOS beta release reliability when the trusted readiness stack starts slowly"
+}

--- a/desktop/macos/docs/release.md
+++ b/desktop/macos/docs/release.md
@@ -14,6 +14,8 @@ python3 .github/scripts/plan-desktop-release.py \
 
 The watcher reports only lifecycle transitions and never creates tags or builds, dispatches qualification, promotes channels, or changes release pointers.
 
+Before a tag is published, trusted-M1 readiness starts the exact source's offline stack. A service that exhausts its own health deadline is a failed startup even after it is removed from the polling set; the harness reports that service and endpoint, cleans only the current authenticated lease, and retries the full startup once. Both attempts must satisfy the unchanged offline health probe. This gate is intentionally separate from the signed-artifact rehearsal below, which cannot reproduce self-hosted Firebase/backend startup.
+
 ## Failed Codemagic build rehearsal
 
 A failed canonical Codemagic check triggers **Desktop Release Recovery Required**. Its job summary and retained JSON capsule bind the build ID, immutable tag, source SHA, failed step, sanitized diagnostics, and whether the step is locally reproducible. This is the just-in-time handoff for operators and agents; do not infer a fix from the generic Codemagic check title alone.

--- a/desktop/macos/scripts/desktop-core-harness.sh
+++ b/desktop/macos/scripts/desktop-core-harness.sh
@@ -500,7 +500,7 @@ PY
 }
 
 ensure_dev_stack() {
-  local probe_json probe_status attempt
+  local probe_json probe_status attempt startup_attempt startup_attempt_limit dev_up_status
   set +e
   probe_json="$(probe_dev_stack)"
   probe_status=$?
@@ -521,25 +521,40 @@ ensure_dev_stack() {
 
   echo "desktop-core-harness: dev stack not healthy; starting with PROVIDER_MODE=offline"
   echo "$probe_json"
-  PROVIDER_MODE=offline make -C "$REPO_ROOT" dev-up
+  startup_attempt_limit=1
+  if [[ "$READINESS" -eq 1 && "$KEEP_STACK" -eq 0 ]]; then
+    startup_attempt_limit=2
+  fi
 
-  for attempt in $(seq 1 15); do
-    set +e
-    probe_json="$(probe_dev_stack)"
-    probe_status=$?
-    set -e
-    if [[ "$probe_status" -eq 0 ]]; then
-      DEV_STACK_PROVIDER_MODE="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["provider_mode"])' "$probe_json")"
-      echo "desktop-core-harness: dev stack ready (provider_mode=${DEV_STACK_PROVIDER_MODE})"
-      return 0
-    fi
-    if [[ "$probe_status" -eq 2 ]]; then
-      echo "desktop-core-harness: dev stack provider_mode is not offline after dev-up" >&2
-      echo "$probe_json" >&2
-      exit 1
-    fi
-    if [[ "$attempt" -lt 15 ]]; then
+  for startup_attempt in $(seq 1 "$startup_attempt_limit"); do
+    dev_up_status=0
+    PROVIDER_MODE=offline make -C "$REPO_ROOT" dev-up || dev_up_status=$?
+
+    for attempt in $(seq 1 15); do
+      set +e
+      probe_json="$(probe_dev_stack)"
+      probe_status=$?
+      set -e
+      if [[ "$probe_status" -eq 0 ]]; then
+        DEV_STACK_PROVIDER_MODE="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["provider_mode"])' "$probe_json")"
+        echo "desktop-core-harness: dev stack ready (provider_mode=${DEV_STACK_PROVIDER_MODE})"
+        return 0
+      fi
+      if [[ "$probe_status" -eq 2 ]]; then
+        echo "desktop-core-harness: dev stack provider_mode is not offline after dev-up" >&2
+        echo "$probe_json" >&2
+        exit 1
+      fi
+      if [[ "$dev_up_status" -ne 0 || "$attempt" -eq 15 ]]; then
+        break
+      fi
       sleep 2
+    done
+
+    if [[ "$startup_attempt" -lt "$startup_attempt_limit" ]]; then
+      echo "desktop-core-harness: offline stack startup failed; cleaning owned state and retrying once" >&2
+      echo "$probe_json" >&2
+      make -C "$REPO_ROOT" dev-down
     fi
   done
 

--- a/desktop/macos/tests/test-desktop-core-harness-readiness-teardown.sh
+++ b/desktop/macos/tests/test-desktop-core-harness-readiness-teardown.sh
@@ -46,7 +46,9 @@ set -euo pipefail
 log="${OMI_TEST_MAKE_LOG:?}"
 case "$*" in
   *dev-up*)
-    : >"${OMI_TEST_DEV_UP_MARKER:?}"
+    count=0
+    [[ ! -f "${OMI_TEST_DEV_UP_MARKER:?}" ]] || count="$(cat "$OMI_TEST_DEV_UP_MARKER")"
+    printf '%s\n' "$((count + 1))" >"$OMI_TEST_DEV_UP_MARKER"
     printf 'dev-up\n' >>"$log"
     ;;
   *dev-down*)
@@ -67,6 +69,10 @@ if [[ "${1:-}" == "-" ]]; then
   if [[ "$script" == *"REQUIRED_SERVICES"* ]]; then
     if [[ "$scenario" == "ensure_dev_stack_fail" && -f "${OMI_TEST_DEV_UP_MARKER:-}" ]]; then
       printf '%s\n' '{"healthy":false,"reason":"injected_probe_failure"}'
+      exit 1
+    fi
+    if [[ "$scenario" == "ensure_dev_stack_retry" && "$(cat "${OMI_TEST_DEV_UP_MARKER:-/dev/null}" 2>/dev/null || true)" -lt 2 ]]; then
+      printf '%s\n' '{"healthy":false,"reason":"injected_transient_startup_failure"}'
       exit 1
     fi
     if [[ -f "${OMI_TEST_DEV_UP_MARKER:-}" || "$scenario" == "success" || "$scenario" == "keep_stack_fail" ]]; then
@@ -99,7 +105,12 @@ fi
 exit 0
 SH
 
-  chmod +x "$bin_dir/uname" "$bin_dir/git" "$bin_dir/make" "$bin_dir/python3"
+  cat >"$bin_dir/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  chmod +x "$bin_dir/uname" "$bin_dir/git" "$bin_dir/make" "$bin_dir/python3" "$bin_dir/sleep"
 }
 
 prepare_fixture_repo() {
@@ -170,8 +181,18 @@ assert_ensure_dev_stack_failure_triggers_dev_down() {
   status="$(printf '%s\n' "$parsed" | sed -n '1p')"
   make_log="$(printf '%s\n' "$parsed" | sed -n '2p')"
   [[ "$status" -ne 0 ]] || fail "ensure_dev_stack failure should exit non-zero"
-  [[ "$(count_make_target "$make_log" dev-up)" -eq 1 ]] || fail "ensure_dev_stack failure must start dev-up before failing"
-  [[ "$(count_make_target "$make_log" dev-down)" -eq 1 ]] || fail "ensure_dev_stack failure must run dev-down once (got: $(cat "$make_log"))"
+  [[ "$(count_make_target "$make_log" dev-up)" -eq 2 ]] || fail "readiness must bound failed startup to two dev-up attempts"
+  [[ "$(count_make_target "$make_log" dev-down)" -eq 2 ]] || fail "failed retry must clean between attempts and at exit (got: $(cat "$make_log"))"
+}
+
+assert_transient_startup_failure_retries_once() {
+  local parsed status make_log
+  parsed="$(run_readiness_case ensure_dev_stack_retry)"
+  status="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  make_log="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  [[ "$status" -eq 0 ]] || fail "readiness should recover from one transient startup failure"
+  [[ "$(count_make_target "$make_log" dev-up)" -eq 2 ]] || fail "transient startup must retry exactly once"
+  [[ "$(count_make_target "$make_log" dev-down)" -eq 2 ]] || fail "retry success must clean between attempts and at exit"
 }
 
 assert_keep_stack_skips_dev_down_on_failure() {
@@ -194,6 +215,7 @@ assert_success_teardowns_once() {
 
 assert_self_check_failure_triggers_dev_down
 assert_ensure_dev_stack_failure_triggers_dev_down
+assert_transient_startup_failure_retries_once
 assert_keep_stack_skips_dev_down_on_failure
 assert_success_teardowns_once
 

--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -730,9 +730,11 @@ def _start_services(cfg: config.HarnessConfig) -> None:
 # 45 s (the old flat deadline shared across *all* services) is not enough.
 _HEALTH_TIMEOUTS: dict[str, float] = {
     "firestore": 45.0,
-    "auth": 45.0,
+    # The combined Firebase process can report Firestore ready before Auth has
+    # finished its cold startup on the qualification runner.
+    "auth": 90.0,
     "typesense": 45.0,
-    "backend": 90.0,
+    "backend": 180.0,
     "desktop-backend": 60.0,
     "redis": 30.0,
 }
@@ -776,7 +778,8 @@ def _wait_health(
         for service in list(pending):
             if now >= deadlines[service]:
                 url = pending[service][0]
-                failures.setdefault(service, f"not healthy after {deadlines[service] - start:.0f}s at {url}")
+                endpoint = url or f"127.0.0.1:{cfg.redis_port}"
+                failures[service] = f"not healthy after {deadlines[service] - start:.0f}s at {endpoint}"
                 pending.pop(service)
         if not pending:
             break
@@ -794,18 +797,18 @@ def _wait_health(
                 if _port_open("127.0.0.1", cfg.redis_port):
                     print("redis: healthy (port-open)")
                     pending.pop(service)
+                    failures.pop(service, None)
                 continue
             ok, detail = _http_ok(url, headers=headers)
             if ok:
                 print(f"{service}: healthy ({detail})")
                 pending.pop(service)
+                failures.pop(service, None)
             else:
                 failures[service] = detail
         if pending:
             time.sleep(0.75)
-    for service, (url, _) in pending.items():
-        failures.setdefault(service, f"not healthy at {url}")
-    return [f"{service}: {failures.get(service, 'unknown failure')}" for service in pending] if failures else []
+    return [f"{service}: {detail}" for service, detail in failures.items()]
 
 
 def cmd_up(args: argparse.Namespace) -> int:

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -76,6 +76,45 @@ def test_firebase_command_writes_the_configured_emulator_ports(monkeypatch: pyte
     assert payload["emulators"]["auth"]["port"] == 9420
 
 
+def test_wait_health_returns_services_that_exhaust_their_deadlines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    cfg = config.load_config(REPO_ROOT)
+    ticks = iter((0.0, 181.0))
+    monkeypatch.setattr(cli.time, "time", lambda: next(ticks))
+    monkeypatch.setattr(cli, "_process_records", lambda _cfg: [])
+
+    failures = cli._wait_health(cfg)
+
+    assert failures == [
+        "firestore: not healthy after 45s at http://127.0.0.1:8085/",
+        "auth: not healthy after 90s at http://127.0.0.1:9099/",
+        "typesense: not healthy after 45s at http://127.0.0.1:8108/collections",
+        "backend: not healthy after 180s at http://127.0.0.1:8000/docs",
+        "desktop-backend: not healthy after 60s at http://127.0.0.1:10201/health",
+        "redis: not healthy after 30s at 127.0.0.1:6380",
+    ]
+
+
+def test_wait_health_discards_transient_failure_after_recovery(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    cfg = config.load_config(REPO_ROOT)
+    ticks = iter((0.0, 1.0, 2.0))
+    monkeypatch.setattr(cli.time, "time", lambda: next(ticks))
+    monkeypatch.setattr(cli.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(cli, "_process_records", lambda _cfg: [])
+    monkeypatch.setattr(cli, "_port_open", lambda _host, _port: True)
+    outcomes = iter([(False, "connection refused")] * 5 + [(True, "ok")] * 5)
+    monkeypatch.setattr(cli, "_http_ok", lambda _url, headers=None: next(outcomes))
+
+    assert cli._wait_health(cfg) == []
+
+
 def test_reset_command_is_idempotent_with_temp_state(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["PROVIDER_MODE"] = "offline"


### PR DESCRIPTION
## What changed and why

Fix the trusted-M1 pre-tag readiness failure from Actions run [31277339934](https://github.com/BasedHardware/omi/actions/runs/31277339934). The shared dev harness discarded services after their deadlines and then returned failures by iterating the now-empty pending set, so `dev-up` could report success while Auth or backend were still unhealthy; cold starts also had less headroom than the observed runner cost.

The harness now reports every exhausted service deadline, clears transient errors only after recovery, gives Firebase Auth and backend cold-start headroom, and lets the ownership-scoped readiness lane clean its authenticated stack and retry once before failing closed. The health probe and offline-provider requirements are unchanged.

## Product invariants affected

none

## How it was verified

- `bash scripts/dev-harness/run-tests.sh` — 77 passed, 8 skipped
- `bash desktop/macos/tests/test-desktop-core-harness-readiness-teardown.sh` — passed
- `bash desktop/macos/tests/test-pre-tag-readiness-contract.sh` — passed
- `python3 .github/scripts/test_verify_pre_tag_readiness.py` — 2 passed
- `git diff --check` — passed
- Separately started the exact-source Firebase Auth emulator and backend locally and observed HTTP 200 readiness; the full offline stack could not be reproduced locally because this machine does not have the release runner's Docker/Typesense environment.

## Tests

`test_wait_health_returns_services_that_exhaust_their_deadlines` would have caught the false-success accounting bug. `test_wait_health_discards_transient_failure_after_recovery` covers recovery semantics, and `test-desktop-core-harness-readiness-teardown.sh` now proves the release lane performs exactly one owned cleanup/retry and still fails closed after the second unhealthy attempt.

The manual Codemagic rehearsal did not catch this failure because it replays signed-artifact build and smoke steps. Run 31277339934 failed earlier, on the trusted M1 while preparing the offline Firebase/backend stack, before a release tag or Codemagic build existed.

## Failure class (fixes)

Failure-Class: FC-gate-timeout-below-cold-cost


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

