### PR TITLE
feat: teach connected agents to use Omi context

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -3,7 +3,7 @@
     "backend/routers/apps.py": 2391,
     "backend/routers/chat.py": 1716,
     "backend/routers/developer.py": 2282,
-    "backend/routers/mcp_sse.py": 1992,
+    "backend/routers/mcp_sse.py": 1988,
     "backend/routers/sync.py": 2083,
     "backend/routers/users.py": 2086
   },

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -4,7 +4,7 @@
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4492,
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1516,
-    "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1575,
+    "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1528,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1584
   },
   "raise_justifications": {

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -70,6 +70,7 @@ from utils.mcp_data import (
     end_of_day_utc,
     parse_date_only_utc,
 )
+from utils.mcp_context import MCP_SERVER_INSTRUCTIONS
 import utils.mcp_action_items as mcp_action_items
 from utils.mcp_memories import (
     McpVerifiedAuth,
@@ -1458,12 +1459,7 @@ def handle_mcp_message(
                     "protocolVersion": "2025-03-26",
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "omi-mcp-server", "version": "1.0.0"},
-                    "instructions": (
-                        "This server exposes the user's Omi memory (their personal AI memory bank). "
-                        "`get_user_profile` returns a cached high-level profile when available. Use it as a "
-                        "starting point, then call `search_memories`, `get_memories`, or conversation tools for "
-                        "task-specific evidence."
-                    ),
+                    "instructions": MCP_SERVER_INSTRUCTIONS,
                 },
             ),
             None,

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -258,6 +258,27 @@ def test_sse_tools_list_filters_by_oauth_scopes():
     assert 'get_conversations' not in names
 
 
+def test_sse_initialize_teaches_every_agent_to_retrieve_full_omi_context_safely():
+    auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
+    response, session_id = sse.handle_mcp_message(auth_context, {'id': 1, 'method': 'initialize'})
+    instructions = response['result']['instructions']
+
+    assert session_id is None
+    assert response['result']['serverInfo']['name'] == 'omi-mcp-server'
+    for tool in (
+        'get_user_profile',
+        'search_memories',
+        'search_conversations',
+        'get_people',
+        'get_action_items',
+        'get_screen_activity',
+    ):
+        assert f'`{tool}`' in instructions
+    assert 'Use only tools exposed by `tools/list`' in instructions
+    assert 'confirm important claims' in instructions
+    assert 'user clearly asked' in instructions
+
+
 @pytest.mark.asyncio
 async def test_sse_post_tools_list_accepts_missing_session_id():
     auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])

--- a/backend/utils/mcp_context.py
+++ b/backend/utils/mcp_context.py
@@ -1,0 +1,9 @@
+MCP_SERVER_INSTRUCTIONS = (
+    "Omi is the user's persistent context, not a general knowledge source. When a request depends on "
+    "something the user has already lived through, retrieve it before asking them to repeat themselves. "
+    "Use only tools exposed by `tools/list`. Start with `get_user_profile` for orientation when available, "
+    "then use `search_memories` and `search_conversations` for task-specific evidence. Use `get_people` for "
+    "relationship context, `get_action_items` for commitments, and `get_screen_activity` for synced screen "
+    "history. Treat semantic-search results as leads and confirm important claims against returned source "
+    "records. Only create, edit, complete, or delete data when the user clearly asked for that change."
+)

--- a/desktop/macos/Desktop/Sources/Integrations/AgentContextSkillInstaller.swift
+++ b/desktop/macos/Desktop/Sources/Integrations/AgentContextSkillInstaller.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Installs the small routing guide that teaches local coding agents when to use
+/// the Omi MCP server they have just connected.
+///
+/// The hosted MCP server remains the data authority. This file contains no user
+/// context or credential; it only points the agent at the tools exposed by that
+/// server. Existing user-authored skills are preserved verbatim.
+enum AgentContextSkillInstaller {
+  static var document: String {
+    """
+    ---
+    name: omi
+    description: Retrieve Omi memories, conversations, people, commitments, screen history, and same-Mac context when the user's request depends on their life or work history.
+    ---
+
+    # Omi Agent Skill
+
+    Use this skill whenever a request depends on context the user has already lived through: a person, conversation, decision, commitment, project, screen, transcription, or recent activity. Retrieve it before asking the user to repeat themselves.
+
+    ## Discovery
+
+    - Hosted MCP: list available tools before use. If `get_user_profile` exists, use it for a high-level summary. If it is absent or returns `profile: null`, use `get_memories(limit=5)` and `search_memories`.
+    - Local Omi CLI: run `omi --json local status` and `omi --json local tools` before local work. If status fails, Omi Desktop, the local URL, or the local token is not ready.
+
+    ## Routing
+
+    - Hosted MCP: durable memories, synced conversations, people, commitments, preferences, projects, goals, chat history, and synced screen activity.
+    - Local CLI: this Mac's screen history, screenshots, app/window activity, local transcriptions, read-only SQL, daily recaps, indexed files, local goals, and tasks.
+    - Use `search_conversations` for synced meetings, calls, and remembered events. Use local transcription tables only for recent same-Mac or unsynced local history.
+    - Use `get_people` for relationship context, `get_action_items` for commitments, and `get_screen_activity` for synced screen history.
+    - Use `omi --json local search-screen` for fuzzy Rewind/OCR questions. Use `omi --json local screenshot` only after a result returns a screenshot ID and the screenshot tool is present.
+    - Use `omi --json local sql` for read-only counts, exact filters, local transcriptions, action items, indexed files, goals, and database questions.
+    - Use `omi --json local task search` only if task tools are listed.
+    - Use `omi --json local task complete` or `omi --json local task delete --yes` only when the user clearly asked you to complete or delete that task. If task tools are absent, do not mutate tasks.
+    - Use `omi --json local call <tool> --args-json '{...}'` only when a listed local tool is not covered by a friendly command.
+    - Create, edit, or delete hosted memories only after explicit user intent.
+
+    ## Verification Checklist
+
+    - Hosted MCP tools are listed.
+    - Hosted memory query succeeds with `get_memories(limit=5)` or equivalent.
+    - Local status succeeds with `omi --json local status`.
+    - Local tools are listed with `omi --json local tools`.
+    - Route only to tools that were discovered.
+    - Treat semantic-search results as leads. Confirm important claims against the returned memory, conversation, or screen evidence before presenting them as fact.
+
+    ## Write Discipline
+
+    - Do not create, edit, complete, or delete Omi memories or local tasks unless the user clearly asked for that change.
+    - Prefer proposing the memory or task change first when intent is ambiguous.
+    - Never treat transient screen activity as a durable memory without explicit user intent or strong evidence.
+
+    ## Setup
+
+    Hosted MCP endpoint: \(MemoryExportDestination.mcpServerURL)
+    Authorization header: Bearer <omi_mcp_key>
+    Config-file MCP clients should prefer `mcp-remote` with the endpoint and Authorization header above.
+
+    Local Omi Desktop CLI:
+    - Install or update `omi-cli`.
+    - Configure local access with `omi local configure --url <local_api_url> --token <omi_local_key>`.
+    """
+  }
+
+  enum Outcome: Equatable {
+    case installed
+    case unchanged
+    case preservedExisting
+  }
+
+  static func install(
+    for destination: MemoryExportDestination,
+    home: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) throws -> Outcome? {
+    guard let skillsDirectory = skillsDirectory(for: destination, home: home) else {
+      return nil
+    }
+
+    let skillDirectory = skillsDirectory.appendingPathComponent("omi", isDirectory: true)
+    let skillURL = skillDirectory.appendingPathComponent("SKILL.md")
+    let document = Self.document
+
+    if let existing = try? String(contentsOf: skillURL, encoding: .utf8) {
+      return existing == document ? .unchanged : .preservedExisting
+    }
+
+    try FileManager.default.createDirectory(
+      at: skillDirectory,
+      withIntermediateDirectories: true,
+      attributes: nil
+    )
+    try document.write(to: skillURL, atomically: true, encoding: .utf8)
+    return .installed
+  }
+
+  static func skillURL(
+    for destination: MemoryExportDestination,
+    home: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) -> URL? {
+    skillsDirectory(for: destination, home: home)?
+      .appendingPathComponent("omi", isDirectory: true)
+      .appendingPathComponent("SKILL.md")
+  }
+
+  private static func skillsDirectory(
+    for destination: MemoryExportDestination,
+    home: URL
+  ) -> URL? {
+    switch destination {
+    case .claudeCode:
+      return home.appendingPathComponent(".claude/skills", isDirectory: true)
+    case .codex:
+      return home.appendingPathComponent(".codex/skills", isDirectory: true)
+    case .notion, .obsidian, .chatgpt, .claude, .gemini, .agents, .openclaw, .hermes:
+      return nil
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
+++ b/desktop/macos/Desktop/Sources/MemoryBankConnector.swift
@@ -62,13 +62,16 @@ enum MemoryBankConnector {
   /// `ConnectError.notInstalled` when the framework isn't found locally.
   @discardableResult
   static func connect(_ destination: MemoryExportDestination, key: String) throws -> String {
+    let message: String
     switch destination {
-    case .claudeCode: return try connectClaudeCode(key: key)
-    case .codex: return try connectCodex(key: key)
-    case .openclaw: return try connectOpenClaw(key: key)
-    case .hermes: return try connectHermes(key: key)
+    case .claudeCode: message = try connectClaudeCode(key: key)
+    case .codex: message = try connectCodex(key: key)
+    case .openclaw: message = try connectOpenClaw(key: key)
+    case .hermes: message = try connectHermes(key: key)
     default: throw ConnectError.notInstalled("\(destination.title) is not a local memory-bank target.")
     }
+    installAgentContextSkillIfSupported(for: destination)
+    return message
   }
 
   nonisolated(unsafe) static var homeOverrideForTesting: URL?
@@ -78,6 +81,29 @@ enum MemoryBankConnector {
   nonisolated(unsafe) static var processTimeoutSecondsForTesting: TimeInterval?
   private static var home: URL { homeOverrideForTesting ?? FileManager.default.homeDirectoryForCurrentUser }
   private static var processTimeoutSeconds: TimeInterval { processTimeoutSecondsForTesting ?? 20 }
+
+  private static func installAgentContextSkillIfSupported(for destination: MemoryExportDestination) {
+    do {
+      guard let outcome = try AgentContextSkillInstaller.install(for: destination, home: home) else {
+        return
+      }
+      switch outcome {
+      case .installed:
+        log("MemoryBankConnector: installed Omi context skill for \(destination.title)")
+      case .unchanged:
+        break
+      case .preservedExisting:
+        log("MemoryBankConnector: preserved existing Omi skill for \(destination.title)")
+      }
+    } catch {
+      // MCP is the connection contract; the skill only improves tool discovery.
+      // A skill-directory permission failure must not turn a working connector
+      // into a failed one.
+      log(
+        "MemoryBankConnector: couldn't install Omi context skill for \(destination.title): \(error.localizedDescription)"
+      )
+    }
+  }
 
   // MARK: - Claude Code (~/.claude.json mcpServers)
 

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -167,12 +167,12 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     switch self {
     case .notion: return "Live page in your workspace"
     case .obsidian: return "Choose once, refresh anytime"
-    case .chatgpt: return "Add Omi from the ChatGPT directory"
-    case .claude: return "Live MCP or memory pack"
+    case .chatgpt: return "Use your Omi context in every chat"
+    case .claude: return "Use your Omi context in every chat"
     case .gemini: return "Prompt + memory pack"
     case .agents: return "One prompt for your agent"
-    case .claudeCode: return "Connect via MCP"
-    case .codex: return "Connect via MCP"
+    case .claudeCode: return "MCP + context skill"
+    case .codex: return "MCP + context skill"
     case .openclaw: return "Memory bank for OpenClaw"
     case .hermes: return "Memory bank for Hermes"
     }
@@ -183,13 +183,16 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
     case .notion: return "Connect once and Omi keeps an Omi Memories page fresh in your workspace."
     case .obsidian: return "Write Omi memories into your Obsidian vault."
     case .chatgpt:
-      return "Add Omi in ChatGPT, authorize once, and use your memories in every ChatGPT chat."
+      return
+        "Add Omi in ChatGPT once, then retrieve memories, conversations, people, commitments, and screen history with source evidence."
     case .claude:
-      return "Connect over MCP so Claude reads your memories live, or copy a memory pack."
+      return "Connect over MCP so Claude can retrieve your Omi context live with source evidence."
     case .gemini: return "Copy the prompt and memory pack, then open Gemini."
     case .agents: return "Give your agent one prompt that connects Omi memories and this Mac."
-    case .claudeCode: return "Add Omi as an MCP server so Claude Code always reads your memories."
-    case .codex: return "Add Omi as an MCP server so Codex always reads your memories."
+    case .claudeCode:
+      return "Connect Omi MCP and install a skill that teaches Claude Code when to retrieve your context."
+    case .codex:
+      return "Connect Omi MCP and install a skill that teaches Codex when to retrieve your context."
     case .openclaw: return "Wire Omi memory into OpenClaw so your agent reads your memories."
     case .hermes: return "Wire Omi memory into Hermes so your agent reads your memories."
     }
@@ -1119,57 +1122,7 @@ actor MemoryExportService {
   }
 
   static var omiAgentSkillText: String {
-    """
-    ---
-    name: omi
-    description: Use Omi memories, conversations, and same-Mac context through hosted MCP and the Omi local CLI.
-    ---
-
-    # Omi Agent Skill
-
-    Use this skill when the user asks about their Omi memories, conversations, screen history, transcriptions, tasks, or wants you to use Omi context while helping.
-
-    ## Discovery
-
-    - Hosted MCP: list available tools before use. If `get_user_profile` exists, use it for a high-level summary. If it is absent or returns `profile: null`, use `get_memories(limit=5)` and `search_memories`.
-    - Local Omi CLI: run `omi --json local status` and `omi --json local tools` before local work. If status fails, Omi Desktop, the local URL, or the local token is not ready.
-
-    ## Routing
-
-    - Hosted MCP: durable memories, synced conversations, preferences, relationships, projects, goals, and profile-like context.
-    - Local CLI: this Mac's screen history, screenshots, app/window activity, local transcriptions, read-only SQL, daily recaps, indexed files, local goals, and tasks.
-    - Use `search_conversations` for synced meetings, calls, and remembered events. Use local transcription tables only for recent same-Mac or unsynced local history.
-    - Use `omi --json local search-screen` for fuzzy Rewind/OCR questions. Use `omi --json local screenshot` only after a result returns a screenshot ID and the screenshot tool is present.
-    - Use `omi --json local sql` for read-only counts, exact filters, local transcriptions, action items, indexed files, goals, and database questions.
-    - Use `omi --json local task search` only if task tools are listed.
-    - Use `omi --json local task complete` or `omi --json local task delete --yes` only when the user clearly asked you to complete or delete that task. If task tools are absent, do not mutate tasks.
-    - Use `omi --json local call <tool> --args-json '{...}'` only when a listed local tool is not covered by a friendly command.
-    - Create, edit, or delete hosted memories only after explicit user intent.
-
-    ## Verification Checklist
-
-    - Hosted MCP tools are listed.
-    - Hosted memory query succeeds with `get_memories(limit=5)` or equivalent.
-    - Local status succeeds with `omi --json local status`.
-    - Local tools are listed with `omi --json local tools`.
-    - Route only to tools that were discovered.
-
-    ## Write Discipline
-
-    - Do not create, edit, complete, or delete Omi memories or local tasks unless the user clearly asked for that change.
-    - Prefer proposing the memory or task change first when intent is ambiguous.
-    - Never treat transient screen activity as a durable memory without explicit user intent or strong evidence.
-
-    ## Setup
-
-    Hosted MCP endpoint: \(MemoryExportDestination.mcpServerURL)
-    Authorization header: Bearer <omi_mcp_key>
-    Config-file MCP clients should prefer `mcp-remote` with the endpoint and Authorization header above.
-
-    Local Omi Desktop CLI:
-    - Install or update `omi-cli`.
-    - Configure local access with `omi local configure --url <local_api_url> --token <omi_local_key>`.
-    """
+    AgentContextSkillInstaller.document
   }
 
   static func omiAgentSetupPrompt(

--- a/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryBankConnectorTests.swift
@@ -59,6 +59,13 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertEqual(headers["Authorization"] as? String, "Bearer test-key")
     XCTAssertNotNil(servers["other"])
     XCTAssertTrue(MemoryExportConnectionDetector.hasExistingConnection(for: .claudeCode, matchingKey: "test-key"))
+    let skillURL = try XCTUnwrap(AgentContextSkillInstaller.skillURL(for: .claudeCode, home: tempHome))
+    let skill = try String(contentsOf: skillURL, encoding: .utf8)
+    XCTAssertEqual(skill, MemoryExportService.omiAgentSkillText)
+    XCTAssertTrue(skill.contains("`search_conversations`"))
+    XCTAssertTrue(skill.contains("`get_people`"))
+    XCTAssertTrue(skill.contains("`get_action_items`"))
+    XCTAssertTrue(skill.contains("`get_screen_activity`"))
 
     let backups = try FileManager.default.contentsOfDirectory(
       at: tempHome.appendingPathComponent(".claude/backups", isDirectory: true),
@@ -132,6 +139,28 @@ final class MemoryBankConnectorTests: XCTestCase {
     XCTAssertTrue(content.contains(MemoryExportDestination.mcpServerURL))
     XCTAssertTrue(content.contains("Authorization: Bearer test-key"))
     XCTAssertTrue(MemoryExportConnectionDetector.hasExistingConnection(for: .codex, matchingKey: "test-key"))
+    let skillURL = try XCTUnwrap(AgentContextSkillInstaller.skillURL(for: .codex, home: tempHome))
+    XCTAssertEqual(
+      try String(contentsOf: skillURL, encoding: .utf8),
+      MemoryExportService.omiAgentSkillText
+    )
+  }
+
+  func testClaudeCodeConnectPreservesExistingUserAuthoredOmiSkill() throws {
+    try "{}".write(
+      to: tempHome.appendingPathComponent(".claude.json"),
+      atomically: true,
+      encoding: .utf8
+    )
+    let skillURL = try XCTUnwrap(AgentContextSkillInstaller.skillURL(for: .claudeCode, home: tempHome))
+    try FileManager.default.createDirectory(
+      at: skillURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "user-authored".write(to: skillURL, atomically: true, encoding: .utf8)
+
+    XCTAssertEqual(try MemoryBankConnector.connect(.claudeCode, key: "test-key"), "Claude Code is now connected.")
+    XCTAssertEqual(try String(contentsOf: skillURL, encoding: .utf8), "user-authored")
   }
 
   func testCodexConnectRequiresCLI() throws {

--- a/desktop/macos/changelog/unreleased/20260808-agent-context-connectors.json
+++ b/desktop/macos/changelog/unreleased/20260808-agent-context-connectors.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved Claude Code and Codex connections so they automatically know how to use your Omi context"
+}

--- a/desktop/macos/e2e/flows/connector-import-progress.yaml
+++ b/desktop/macos/e2e/flows/connector-import-progress.yaml
@@ -8,6 +8,7 @@ covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExport/MemoryExportModels.swift
   - desktop/macos/Desktop/Sources/MemoryExportService.swift
+  - desktop/macos/Desktop/Sources/Integrations/AgentContextSkillInstaller.swift
   - desktop/macos/Desktop/Sources/MemoryExportExecutor.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift

--- a/docs/doc/developer/mcp/introduction.mdx
+++ b/docs/doc/developer/mcp/introduction.mdx
@@ -40,6 +40,10 @@ sequenceDiagram
 
 Your AI assistant connects to the Omi MCP server, discovers available tools, and calls them as needed during your conversations. All data stays within your Omi account — the MCP server authenticates via your personal API key.
 
+The same hosted MCP connection works across Claude, Claude Code, ChatGPT, Codex, and any compatible client. It exposes the user's Omi context as scoped tools: durable memories, conversations, people, action items, goals, chat history, daily summaries, and synced screen activity. The server's initialization instructions tell clients to retrieve task-specific evidence, confirm important claims against source records, and avoid writes unless the user clearly requested them.
+
+When the Omi macOS app connects Claude Code or Codex, it also installs a small `omi` skill in that client's personal skills directory. The skill contains routing guidance only—never credentials or user data—and Omi preserves an existing user-authored skill with the same name.
+
 ---
 
 ## Available Tools


### PR DESCRIPTION
## What changed and why

Teach every hosted Omi MCP client to retrieve the user's scoped Omi context with source discipline, and have the macOS app install the same routing guidance when it connects Claude Code or Codex. The hosted backend remains the sole context authority; local skills contain no credentials or user data and preserve existing user-authored skills.

## Product invariants affected

- INV-INT-1
- INV-MEM-1

The connector remains deterministic and API/CLI-backed, and default MCP memory access still uses the existing canonical memory policy without adding a tier or collection.

## How it was verified

- `python -m pytest tests/unit/test_mcp_data_endpoints.py -q` — 67 passed
- `xcrun swift test --package-path Desktop --filter MemoryBankConnectorTests` — 31 passed
- `python3 scripts/check_desktop_test_quality.py` — passed at or below the baseline
- Built and launched `/Applications/omi-agent-context.app`, seeded its isolated named-bundle profile, navigated the live bridge to Apps, and ran `apps_catalog_snapshot` successfully (`capability_count=6`, `group_count=5`, `marketplace_count=179`)
- `make preflight` — passed the complete diff-selected local manifest

The legacy `apps-marketplace.yaml` visual flow was not counted as verification because its current steps have no typed harness operations; the live named-bundle bridge probe above exercised the surface instead.

## Tests

- Backend initialization coverage asserts all clients receive scoped retrieval, evidence-confirmation, and explicit-write guidance.
- macOS connector coverage asserts Claude Code and Codex receive the Omi skill, and that an existing user-authored Omi skill is preserved.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

