### PR TITLE
feat(admin): show graph period changes and repair drag ordering

### DIFF
--- a/web/admin/app/(protected)/dashboard/chat-lab/page.tsx
+++ b/web/admin/app/(protected)/dashboard/chat-lab/page.tsx
@@ -34,6 +34,8 @@ import {
 } from "lucide-react";
 import useSWR, { mutate as globalMutate } from "swr";
 import { useAuthToken, authenticatedFetcher } from "@/hooks/useAuthToken";
+import { PeriodChangeIndicator } from "@/components/dashboard/period-change-indicator";
+import { latestPeriodChange } from "@/lib/period-change";
 import {
   Bar,
   XAxis,
@@ -186,6 +188,12 @@ export default function ChatLabPage() {
     const total = up + down;
     return { total, up, down, pct: total > 0 ? Math.round((up / total) * 100) : 0 };
   }, [ratingsData]);
+
+  const ratingsPeriodChange = latestPeriodChange(
+    ratingsData?.weeks ?? [],
+    (week) => week.thumbs_up + week.thumbs_down,
+    "vs previous week",
+  );
 
   // --- Prompts ---
   const { data: promptsData, isLoading: promptsLoading } = useSWR<PromptsData>(
@@ -430,11 +438,12 @@ export default function ChatLabPage() {
 
       {/* Section 1: Production Ratings Chart */}
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
           <CardTitle className="flex items-center gap-2">
             Production Ratings
             {ratingsLoading && <Loader2 className="h-4 w-4 animate-spin" />}
           </CardTitle>
+          <PeriodChangeIndicator change={ratingsPeriodChange} />
         </CardHeader>
         <CardContent>
           {ratingsData?.weeks?.length ? (

--- a/web/admin/app/(protected)/dashboard/page.tsx
+++ b/web/admin/app/(protected)/dashboard/page.tsx
@@ -55,6 +55,7 @@ import {
 import { AgentPromptWidget } from "@/components/dashboard/agent-prompt-widget";
 import { useResponseReliabilityItems } from "@/components/dashboard/response-reliability-summary";
 import { Sparkles } from "lucide-react";
+import { latestPeriodChange } from "@/lib/period-change";
 
 // --- Types ---
 
@@ -126,6 +127,8 @@ interface FloatingBarUsageData {
     voice_queries: number;
     unique_users: number;
     avg_per_user: number;
+    sessions: number;
+    avg_sessions_per_user: number;
   }[];
   days: number;
   summary: {
@@ -611,6 +614,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-users",
         title: "New users / day",
+        periodChange: latestPeriodChange(usersData, (point) => point.total, "vs previous day"),
         subtitle: summary
           ? `Desktop ${summary.totalNewDesktop.toLocaleString()} · Mobile ${summary.totalNewMobile.toLocaleString()}`
           : "Per-platform signups",
@@ -633,6 +637,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-revenue",
         title: "Revenue / day (est.)",
+        periodChange: latestPeriodChange(revenueData, (point) => point.total, "vs previous day"),
         subtitle: "Daily MRR share by platform active-user ratio",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -663,6 +668,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-cost-per-user",
         title: `Cost / user / day${costSource === "real" ? "" : " (est.)"}`,
+        periodChange: latestPeriodChange(costPerUserData, (point: ProfitabilityPoint) => point.total, "vs previous day"),
         subtitle: avgCostDesktop != null && avgCostMobile != null
           ? `Avg: Desktop $${avgCostDesktop.toFixed(2)} · Mobile $${avgCostMobile.toFixed(2)}`
           : "Daily infra spend ÷ active users, per platform",
@@ -685,6 +691,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-cost",
         title: `Total infra cost / day${costSource === "real" ? "" : " (est.)"}`,
+        periodChange: latestPeriodChange(costData, (point) => point.total, "vs previous day"),
         subtitle: summary?.totalCostUsd != null
           ? `Total last ${profitability?.days ?? 30}d: ${formatCurrency(summary.totalCostUsd)}`
           : "Desktop + mobile daily burn",
@@ -707,6 +714,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-conversion",
         title: "Free → paid %",
+        periodChange: latestPeriodChange(conversionData, (point) => point.total, "vs previous day"),
         subtitle: "New paid subs / new users",
         icon: <Percent className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -788,6 +796,7 @@ export default function AnalyticsPage() {
       {
         id: "rev-cumulative",
         title: "Cumulative users",
+        periodChange: latestPeriodChange(cumulativeSeries, (point) => point.cumulative, "vs previous day"),
         subtitle: "Total users across all platforms",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -816,6 +825,7 @@ export default function AnalyticsPage() {
       {
         id: "rev-mrr",
         title: "MRR over time",
+        periodChange: latestPeriodChange(mrrData, (point) => point.mrr, "vs previous month"),
         subtitle: "Monthly recurring revenue from Stripe",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -840,6 +850,7 @@ export default function AnalyticsPage() {
       {
         id: "rev-subs",
         title: "New subscriptions",
+        periodChange: latestPeriodChange(subData, (point) => point.monthly + point.annual, "vs previous month"),
         subtitle: "Monthly vs annual subscriptions created each month",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -998,6 +1009,7 @@ export default function AnalyticsPage() {
       {
         id: "macos-fb-sessions-per-user",
         title: "Floating Bar Sessions per User",
+        periodChange: latestPeriodChange(fbUsageData, (point) => point.avg_sessions_per_user, "vs previous day"),
         subtitle: "Times floating bar was opened and a question asked, per user per day (follow-ups don't count)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1053,6 +1065,7 @@ export default function AnalyticsPage() {
       {
         id: "notif-daily-sent",
         title: "Daily Notifications Sent",
+        periodChange: latestPeriodChange(notificationDailyCombined, (point) => point.totalSent, "vs previous day"),
         initialLayout: { cols: 12, rows: 4 },
         icon: <Send className="h-4 w-4" />,
         render: () => (
@@ -1078,6 +1091,7 @@ export default function AnalyticsPage() {
       {
         id: "notif-hourly-168h",
         title: "Notifications Sent, Last 168 Hours",
+        periodChange: latestPeriodChange(notificationHourlyData, (point) => point.total, "vs previous hour"),
         subtitle: "Hourly volume, with dates marked at midnight UTC.",
         icon: <Send className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1104,6 +1118,7 @@ export default function AnalyticsPage() {
       {
         id: "notif-fb-ctr",
         title: "Floating Bar Notification CTR",
+        periodChange: latestPeriodChange(floatingBarCtr?.dailyData ?? [], (point) => point.ctr, "vs previous day"),
         subtitle: floatingBarCtrSummary?.mode === "surface_tagged"
           ? "Sent vs clicked proactive notifications in the desktop floating bar."
           : "Surface-tagged floating-bar events are not populated yet, so this is currently using all desktop notification clicks as a fallback.",
@@ -1138,6 +1153,7 @@ export default function AnalyticsPage() {
       {
         id: "notif-weekly-reach",
         title: "Weekly Notification Reach",
+        periodChange: latestPeriodChange(notificationWeeklyCombined, (point) => point.totalUniqueUsers, "vs previous week"),
         subtitle: "Volume and unique recipients in one view.",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1215,6 +1231,11 @@ export default function AnalyticsPage() {
       {
         id: "ratings-weekly",
         title: "Chat Response Ratings",
+        periodChange: latestPeriodChange(
+          weeklyRatingsData,
+          (point) => point.thumbs_up + point.thumbs_down,
+          "vs previous week",
+        ),
         subtitle: "Weekly thumbs up/down from macOS floating bar. The overall positive rate is shown above.",
         icon: <MessageSquare className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1261,6 +1282,7 @@ export default function AnalyticsPage() {
       {
         id: "fb-usage-text-voice",
         title: "Floating Bar Usage",
+        periodChange: latestPeriodChange(fbUsageData, (point) => point.total_queries, "vs previous day"),
         subtitle: "Daily queries by input type — text vs voice (last 30 days)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1314,6 +1336,7 @@ export default function AnalyticsPage() {
       {
         id: "fb-avg-per-user",
         title: "Avg Queries per User per Day",
+        periodChange: latestPeriodChange(fbUsageData, (point) => point.avg_per_user, "vs previous day"),
         subtitle: "Average floating bar queries per active user, daily (last 30 days)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1375,6 +1398,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-growth-accounting",
         title: "Growth Accounting",
+        periodChange: latestPeriodChange(ga, (point) => point.active, "vs previous week"),
         subtitle: "Weekly breakdown: where do active users come from? (Churned shown as negative)",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1412,6 +1436,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-dau",
         title: "Daily Active Users",
+        periodChange: latestPeriodChange(dauData, (point) => point.dau, "vs previous day"),
         subtitle: "Unique macOS users per day",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1438,6 +1463,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-crash-rate",
         title: "App Stability",
+        periodChange: latestPeriodChange(crashRate?.data ?? [], (point) => point.crashFreeRate, "vs previous day"),
         subtitle: "Daily crashes vs active users (last 30 days)",
         icon: <AlertTriangle className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1495,6 +1521,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-daily-new-users",
         title: "Daily New Users",
+        periodChange: latestPeriodChange(dailyWithRollingAvg, (point) => point.rollingAvg, "vs previous day"),
         subtitle: "First-time sign-ins with 7-day rolling average",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1536,6 +1563,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-stickiness",
         title: "Stickiness (DAU/WAU)",
+        periodChange: latestPeriodChange(stickinessData, (point) => point.dauWau, "vs previous week"),
         subtitle: "How often weekly users come back daily (good: 30%+)",
         icon: <Zap className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1593,6 +1621,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-activation",
         title: "Activation Rate",
+        periodChange: latestPeriodChange(activationData, (point) => point.rate, "vs previous day"),
         subtitle: "% of new users who create a Memory within 7 days of signing up",
         icon: <Target className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1790,6 +1819,7 @@ export default function AnalyticsPage() {
       {
         id: "chart-total-users-cumulative",
         title: "Total Users — All-time growth",
+        periodChange: latestPeriodChange(allDailyData, (point) => point.cumulative, "vs previous day"),
         subtitle: "Cumulative signups (Firebase Auth)",
         variant: "card",
         initialLayout: { cols: 6, rows: 4 },
@@ -2353,6 +2383,13 @@ function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
     {
       id: "chat-ratings",
       title: "Chat Response Ratings",
+      periodChange: groupBy === "week"
+        ? latestPeriodChange<{ thumbs_up: number; thumbs_down: number }>(
+            chartData,
+            (point) => point.thumbs_up + point.thumbs_down,
+            "vs previous week",
+          )
+        : null,
       subtitle:
         stats.total > 0
           ? `${stats.up} 👍 · ${stats.down} 👎 · ${stats.pct}% positive`

--- a/web/admin/app/(protected)/dashboard/subscriptions/page.tsx
+++ b/web/admin/app/(protected)/dashboard/subscriptions/page.tsx
@@ -30,6 +30,8 @@ import { useAuth } from "@/components/auth-provider";
 import { useAuthFetch } from "@/hooks/useAuthToken";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Line, LineChart, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
+import { PeriodChangeIndicator } from "@/components/dashboard/period-change-indicator";
+import { latestPeriodChange } from "@/lib/period-change";
 
 interface Subscription {
   id: string;
@@ -330,6 +332,17 @@ export default function SubscriptionsPage() {
     return matchesSearch && matchesStatus;
   });
 
+  const subscriptionTrendChange = latestPeriodChange(
+    subscriptionTrends,
+    (point) => point.monthly + point.annual,
+    'vs previous month',
+  );
+  const mrrTrendChange = latestPeriodChange(
+    mrrTrends,
+    (point) => point.mrr,
+    'vs previous month',
+  );
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -437,11 +450,14 @@ export default function SubscriptionsPage() {
       {/* Charts */}
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
-          <CardHeader>
-            <CardTitle>Subscription Creation Trends</CardTitle>
-            <CardDescription>
-              Monthly and annual subscriptions created over the last 6 months
-            </CardDescription>
+          <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+            <div className="space-y-1.5">
+              <CardTitle>Subscription Creation Trends</CardTitle>
+              <CardDescription>
+                Monthly and annual subscriptions created over the last 6 months
+              </CardDescription>
+            </div>
+            <PeriodChangeIndicator change={subscriptionTrendChange} />
           </CardHeader>
           <CardContent>
             {subscriptionTrends.length > 0 ? (
@@ -498,11 +514,14 @@ export default function SubscriptionsPage() {
         </Card>
 
         <Card>
-          <CardHeader>
-            <CardTitle>Monthly Recurring Revenue (MRR)</CardTitle>
-            <CardDescription>
-              MRR trend over the last 6 months
-            </CardDescription>
+          <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+            <div className="space-y-1.5">
+              <CardTitle>Monthly Recurring Revenue (MRR)</CardTitle>
+              <CardDescription>
+                MRR trend over the last 6 months
+              </CardDescription>
+            </div>
+            <PeriodChangeIndicator change={mrrTrendChange} />
           </CardHeader>
           <CardContent>
             {mrrTrends.length > 0 ? (

--- a/web/admin/components/dashboard/__tests__/period-change-indicator.test.tsx
+++ b/web/admin/components/dashboard/__tests__/period-change-indicator.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PeriodChangeIndicator } from "@/components/dashboard/period-change-indicator";
+
+describe("PeriodChangeIndicator", () => {
+  it("shows a positive change in green with comparison context", () => {
+    render(
+      <PeriodChangeIndicator
+        change={{ percentage: 20, label: "vs previous week" }}
+      />,
+    );
+
+    const indicator = screen.getByLabelText("+20% vs previous week");
+    expect(indicator.textContent).toBe("+20%");
+    expect(indicator.classList.contains("text-green-600")).toBe(true);
+  });
+
+  it("shows a negative change in red", () => {
+    render(
+      <PeriodChangeIndicator
+        change={{ percentage: -12.5, label: "vs previous day" }}
+      />,
+    );
+
+    expect(
+      screen
+        .getByLabelText("-13% vs previous day")
+        .classList.contains("text-red-600"),
+    ).toBe(true);
+  });
+});

--- a/web/admin/components/dashboard/__tests__/resizable-chart-grid.test.tsx
+++ b/web/admin/components/dashboard/__tests__/resizable-chart-grid.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ResizableChartGrid,
+  type ChartItem,
+} from "@/components/dashboard/resizable-chart-grid";
+
+const items: ChartItem[] = [
+  { id: "one", title: "One", render: () => <div>First chart</div> },
+  { id: "two", title: "Two", render: () => <div>Second chart</div> },
+];
+
+function chartDragData(id: string) {
+  const values = new Map<string, string>([
+    ["application/x-omi-chart-id", id],
+    ["text/plain", id],
+  ]);
+  const types = Array.from(values.keys());
+
+  return {
+    effectAllowed: "move",
+    dropEffect: "none",
+    types,
+    getData: (type: string) => values.get(type) ?? "",
+    setData: (type: string, value: string) => {
+      values.set(type, value);
+      if (!types.includes(type)) types.push(type);
+    },
+  };
+}
+
+describe("ResizableChartGrid drag and drop", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("uses the drag payload to reorder cards and persists the result", async () => {
+    const dataTransfer = chartDragData("one");
+    const { unmount } = render(
+      <ResizableChartGrid storageKey="test:chart-order" items={items} />,
+    );
+    const target = document.querySelector<HTMLElement>('[data-chart-id="two"]');
+
+    expect(target).not.toBeNull();
+    fireEvent.dragStart(screen.getByRole("button", { name: "Move One" }), {
+      dataTransfer,
+    });
+    fireEvent.dragOver(target!, { dataTransfer });
+    fireEvent.drop(target!, { dataTransfer });
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByRole("heading", { level: 3 })
+          .map((heading) => heading.textContent),
+      ).toEqual(["Two", "One"]);
+    });
+    await waitFor(() => {
+      const stored = JSON.parse(
+        localStorage.getItem("test:chart-order") ?? "{}",
+      );
+      expect(stored.order).toEqual(["two", "one"]);
+    });
+
+    unmount();
+    render(<ResizableChartGrid storageKey="test:chart-order" items={items} />);
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByRole("heading", { level: 3 })
+          .map((heading) => heading.textContent),
+      ).toEqual(["Two", "One"]);
+    });
+  });
+});

--- a/web/admin/components/dashboard/period-change-indicator.tsx
+++ b/web/admin/components/dashboard/period-change-indicator.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+import { formatPeriodChange, type PeriodChange } from "@/lib/period-change";
+
+export function PeriodChangeIndicator({
+  change,
+  className,
+}: {
+  change: PeriodChange | null | undefined;
+  className?: string;
+}) {
+  if (!change) return null;
+
+  const formatted = formatPeriodChange(change.percentage);
+  const description = `${formatted} ${change.label}`;
+
+  return (
+    <span
+      aria-label={description}
+      title={description}
+      className={cn(
+        "shrink-0 text-xs font-semibold tabular-nums",
+        change.percentage > 0 && "text-green-600 dark:text-green-400",
+        change.percentage < 0 && "text-red-600 dark:text-red-400",
+        change.percentage === 0 && "text-muted-foreground",
+        className,
+      )}
+    >
+      {formatted}
+    </span>
+  );
+}

--- a/web/admin/components/dashboard/resizable-chart-grid.tsx
+++ b/web/admin/components/dashboard/resizable-chart-grid.tsx
@@ -25,6 +25,7 @@ export const GRID_ROW_HEIGHT = 90; // px
 export const GRID_GAP = 16; // px — matches Tailwind gap-4
 
 const GHOST_TRAILING_ROWS = 3;
+const CHART_DRAG_MIME = "application/x-omi-chart-id";
 
 export type ColSpan = 2 | 3 | 4 | 6 | 8 | 9 | 12;
 const COL_VALUES: ColSpan[] = [2, 3, 4, 6, 8, 9, 12];
@@ -117,13 +118,19 @@ function sanitizeLayout(l: Partial<ChartLayout> | undefined, fallback: ChartLayo
   };
 }
 
-function moveBefore(order: string[], draggedId: string, targetId: string): string[] {
+function moveToTarget(order: string[], draggedId: string, targetId: string): string[] {
   if (draggedId === targetId) return order;
+  const draggedIndex = order.indexOf(draggedId);
+  const targetIndex = order.indexOf(targetId);
+  if (draggedIndex === -1 || targetIndex === -1) return order;
+
   const without = order.filter((id) => id !== draggedId);
-  const idx = without.indexOf(targetId);
-  if (idx === -1) return order;
+  const targetIndexWithoutDragged = without.indexOf(targetId);
+  const insertionIndex = draggedIndex < targetIndex
+    ? targetIndexWithoutDragged + 1
+    : targetIndexWithoutDragged;
   const next = [...without];
-  next.splice(idx, 0, draggedId);
+  next.splice(insertionIndex, 0, draggedId);
   return next;
 }
 
@@ -172,7 +179,7 @@ function ChartCard({
   onInteractionChange: (active: boolean) => void;
   onDragStart: (id: string) => void;
   onDragOverCard: (e: DragEvent<HTMLElement>) => void;
-  onDropOnCard: (id: string) => void;
+  onDropOnCard: (targetId: string, draggedId: string | null) => void;
   onDragEnd: () => void;
   onRequestRemove: (id: string, title: string) => void;
 }) {
@@ -242,6 +249,7 @@ function ChartCard({
       className="flex h-6 w-6 shrink-0 cursor-grab items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground active:cursor-grabbing"
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData(CHART_DRAG_MIME, item.id);
         e.dataTransfer.setData("text/plain", item.id);
         onDragStart(item.id);
       }}
@@ -292,6 +300,7 @@ function ChartCard({
     return (
       <div
         ref={cardRef}
+        data-chart-id={item.id}
         className={cn(
           "group relative flex min-w-0 select-none items-end gap-2",
           dragging && "opacity-50",
@@ -299,7 +308,13 @@ function ChartCard({
         )}
         style={sharedStyle}
         onDragOver={onDragOverCard}
-        onDrop={() => onDropOnCard(item.id)}
+        onDrop={(e) => {
+          e.preventDefault();
+          onDropOnCard(
+            item.id,
+            e.dataTransfer.getData(CHART_DRAG_MIME) || e.dataTransfer.getData("text/plain") || null,
+          );
+        }}
       >
         <div className="absolute left-1 top-1 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
           {moveHandle}
@@ -320,6 +335,7 @@ function ChartCard({
     return (
       <Card
         ref={cardRef}
+        data-chart-id={item.id}
         className={cn(
           "group relative flex min-w-0 select-none flex-col gap-1 p-3 transition-shadow",
           dragging && "opacity-50 ring-2 ring-primary/40",
@@ -327,7 +343,13 @@ function ChartCard({
         )}
         style={sharedStyle}
         onDragOver={onDragOverCard}
-        onDrop={() => onDropOnCard(item.id)}
+        onDrop={(e) => {
+          e.preventDefault();
+          onDropOnCard(
+            item.id,
+            e.dataTransfer.getData(CHART_DRAG_MIME) || e.dataTransfer.getData("text/plain") || null,
+          );
+        }}
       >
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1">
@@ -348,6 +370,7 @@ function ChartCard({
   return (
     <Card
       ref={cardRef}
+      data-chart-id={item.id}
       className={cn(
         "relative flex min-w-0 select-none flex-col gap-2 p-4 transition-shadow",
         dragging && "opacity-50 ring-2 ring-primary/40",
@@ -355,7 +378,13 @@ function ChartCard({
       )}
       style={sharedStyle}
       onDragOver={onDragOverCard}
-      onDrop={() => onDropOnCard(item.id)}
+      onDrop={(e) => {
+        e.preventDefault();
+        onDropOnCard(
+          item.id,
+          e.dataTransfer.getData(CHART_DRAG_MIME) || e.dataTransfer.getData("text/plain") || null,
+        );
+      }}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex items-center gap-2">
@@ -429,10 +458,11 @@ export function ResizableChartGrid({ storageKey, items, className }: GridProps) 
     setLayouts((cur) => ({ ...cur, [id]: next }));
   }, []);
 
-  const handleDrop = useCallback((targetId: string) => {
-    setOrder((cur) => (draggingId ? moveBefore(cur, draggingId, targetId) : cur));
+  const handleDrop = useCallback((targetId: string, transferredId: string | null) => {
+    const sourceId = transferredId && itemMap.has(transferredId) ? transferredId : draggingId;
+    setOrder((cur) => (sourceId ? moveToTarget(cur, sourceId, targetId) : cur));
     setDraggingId(null);
-  }, [draggingId]);
+  }, [draggingId, itemMap]);
 
   const handleInteraction = useCallback((active: boolean) => {
     setInteractingCount((c) => Math.max(0, c + (active ? 1 : -1)));
@@ -517,7 +547,8 @@ export function ResizableChartGrid({ storageKey, items, className }: GridProps) 
               onInteractionChange={handleInteraction}
               onDragStart={setDraggingId}
               onDragOverCard={(e) => {
-                if (draggingId) {
+                const isChartDrag = Array.from(e.dataTransfer.types).includes(CHART_DRAG_MIME);
+                if (draggingId || isChartDrag) {
                   e.preventDefault();
                   e.dataTransfer.dropEffect = "move";
                 }

--- a/web/admin/components/dashboard/resizable-chart-grid.tsx
+++ b/web/admin/components/dashboard/resizable-chart-grid.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import { GripVertical, Move, X, RotateCcw } from "lucide-react";
+import { PeriodChangeIndicator } from "@/components/dashboard/period-change-indicator";
+import type { PeriodChange } from "@/lib/period-change";
 
 // 12-column grid with fixed row height so both axes snap to tiles,
 // giving the layout PostHog/Mixpanel-style rectangle behavior.
@@ -41,6 +43,7 @@ export interface ChartItem {
   title: string;
   subtitle?: string;
   icon?: ReactNode;
+  periodChange?: PeriodChange | null;
   variant?: ChartVariant;
   initialLayout?: Partial<ChartLayout>;
   // Defaults to true. Set false on widgets that must always be visible
@@ -365,7 +368,10 @@ function ChartCard({
             )}
           </div>
         </div>
-        {removeButton}
+        <div className="flex shrink-0 items-center gap-2">
+          <PeriodChangeIndicator change={item.periodChange} />
+          {removeButton}
+        </div>
       </div>
 
       <div className="min-h-0 min-w-0 flex-1">{item.render(layout)}</div>

--- a/web/admin/components/dashboard/response-reliability-summary.tsx
+++ b/web/admin/components/dashboard/response-reliability-summary.tsx
@@ -22,6 +22,7 @@ import {
   type ResponseReliabilityPayload,
   type ResponseReliabilitySeries,
 } from "@/lib/response-reliability";
+import { latestPeriodChange } from "@/lib/period-change";
 
 const tooltipStyle = {
   backgroundColor: "hsl(var(--card))",
@@ -51,6 +52,12 @@ const rateWithCounts = (
   success: number,
   failure: number,
 ): string => `${formatRate(value)} (${success}/${success + failure})`;
+
+function combinedSuccessRate(point: ReliabilityDailyPoint): number | null {
+  const success = point.chatSuccess + point.voiceSuccess;
+  const total = success + point.chatFailure + point.voiceFailure;
+  return total > 0 ? (success / total) * 100 : null;
+}
 
 function ChannelReliabilityChart({
   data,
@@ -239,6 +246,11 @@ export function useResponseReliabilityItems({
       {
         id: "response-reliability-production",
         title: "Production response reliability",
+        periodChange: latestPeriodChange(
+          coveredByChannel.production,
+          combinedSuccessRate,
+          "vs previous day",
+        ),
         subtitle: subtitle("production"),
         icon: <MessageSquare className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 5 },
@@ -247,6 +259,11 @@ export function useResponseReliabilityItems({
       {
         id: "response-reliability-beta",
         title: "Beta response reliability",
+        periodChange: latestPeriodChange(
+          coveredByChannel.beta,
+          combinedSuccessRate,
+          "vs previous day",
+        ),
         subtitle: subtitle("beta"),
         icon: <Mic2 className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 5 },

--- a/web/admin/lib/__tests__/period-change.test.ts
+++ b/web/admin/lib/__tests__/period-change.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculatePeriodChange,
+  formatPeriodChange,
+  latestPeriodChange,
+} from "@/lib/period-change";
+
+describe("period change", () => {
+  it("calculates signed changes between matching periods", () => {
+    expect(calculatePeriodChange(120, 100, "vs previous week")).toEqual({
+      percentage: 20,
+      label: "vs previous week",
+    });
+    expect(calculatePeriodChange(75, 100)?.percentage).toBe(-25);
+    expect(formatPeriodChange(20)).toBe("+20%");
+    expect(formatPeriodChange(-3.25)).toBe("-3.3%");
+  });
+
+  it("uses the latest two matching buckets", () => {
+    const change = latestPeriodChange(
+      [{ total: 80 }, { total: 100 }],
+      (point) => point.total,
+    );
+
+    expect(change?.percentage).toBe(25);
+    expect(
+      latestPeriodChange(
+        [{ total: 80 }, { total: 100 }, { total: Number.NaN }],
+        (point) => point.total,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not invent a percentage without a valid baseline", () => {
+    expect(calculatePeriodChange(5, 0)).toBeNull();
+    expect(
+      latestPeriodChange([{ total: 5 }], (point) => point.total),
+    ).toBeNull();
+    expect(calculatePeriodChange(0, 0)?.percentage).toBe(0);
+  });
+});

--- a/web/admin/lib/period-change.ts
+++ b/web/admin/lib/period-change.ts
@@ -1,0 +1,53 @@
+export interface PeriodChange {
+  percentage: number;
+  label: string;
+}
+
+type MetricValue = number | null | undefined;
+
+export function calculatePeriodChange(
+  current: MetricValue,
+  previous: MetricValue,
+  label = "vs previous period",
+): PeriodChange | null {
+  if (
+    current == null ||
+    previous == null ||
+    !Number.isFinite(current) ||
+    !Number.isFinite(previous)
+  ) {
+    return null;
+  }
+
+  if (previous === 0) {
+    return current === 0 ? { percentage: 0, label } : null;
+  }
+
+  return {
+    percentage: ((current - previous) / Math.abs(previous)) * 100,
+    label,
+  };
+}
+
+export function latestPeriodChange<T>(
+  points: readonly T[],
+  value: (point: T) => MetricValue,
+  label = "vs previous period",
+): PeriodChange | null {
+  if (points.length < 2) return null;
+  return calculatePeriodChange(
+    value(points[points.length - 1]),
+    value(points[points.length - 2]),
+    label,
+  );
+}
+
+export function formatPeriodChange(percentage: number): string {
+  const normalized = Math.abs(percentage) < 0.05 ? 0 : percentage;
+  return (
+    new Intl.NumberFormat("en-US", {
+      signDisplay: "exceptZero",
+      maximumFractionDigits: Math.abs(normalized) >= 10 ? 0 : 1,
+    }).format(normalized) + "%"
+  );
+}


### PR DESCRIPTION
## Summary

- show a compact signed change against the immediately preceding matching day, week, month, or hour on every time-series chart that has a valid comparable bucket
- color positive changes green and negative changes red, with the comparison period available to assistive technology and on hover
- repair chart drag-and-drop so downward and upward moves use the native drag payload and persist their new order

## Verification

- `cd web/admin && npm run check` — lint completed with 23 pre-existing warnings and no errors; TypeScript passed; 66 tests passed
- `cd web/admin && npm run build` — production Next.js build completed successfully
- populated local dashboard preview — visually confirmed green `+20%`, red `-8.3%`, and neutral `0%` states
- Playwright — dragged a chart downward, dragged it back upward, reloaded, and confirmed the persisted order

## Product invariants

None.

## Failure class

Failure-Class: none

The drag defect was local to the admin chart grid's drop identity and insertion direction. The behavioral regression test exercises the native drag payload, DOM order, and local-storage persistence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

