### PR TITLE
feat(admin): restore add-person access control

### DIFF
--- a/web/admin/app/(protected)/dashboard/team/__tests__/page.test.tsx
+++ b/web/admin/app/(protected)/dashboard/team/__tests__/page.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/useTeamMembers", () => ({
+  useTeamMembers: () => ({
+    teamMembers: [],
+    isLoading: false,
+    error: null,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useAuthToken", () => ({
+  useAuthFetch: () => ({ fetchWithAuth: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import TeamPage from "../page";
+
+describe("TeamPage", () => {
+  it("keeps the add-person action visible and opens its email form", () => {
+    render(<TeamPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add new person" }));
+
+    expect(screen.getByRole("dialog", { name: "Add new person" })).toBeTruthy();
+    expect(screen.getByLabelText("Email").getAttribute("type")).toBe("email");
+  });
+});

--- a/web/admin/app/(protected)/dashboard/team/page.tsx
+++ b/web/admin/app/(protected)/dashboard/team/page.tsx
@@ -1,8 +1,17 @@
-"use client"
+"use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { useTeamMembers } from "@/hooks/useTeamMembers"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { AddTeamMemberDialog } from "@/components/dashboard/add-team-member-dialog";
+import { useTeamMembers } from "@/hooks/useTeamMembers";
+import { Plus } from "lucide-react";
 
 // Simple spinner component
 const Spinner = () => (
@@ -10,24 +19,39 @@ const Spinner = () => (
 );
 
 export default function TeamPage() {
-  const { teamMembers, isLoading, error } = useTeamMembers();
+  const { teamMembers, isLoading, error, mutate } = useTeamMembers();
 
   // Generate avatar initials from name
   const getAvatarInitials = (name: string) => {
     return name
-      .split(' ')
-      .map(word => word.charAt(0))
-      .join('')
+      .split(" ")
+      .map((word) => word.charAt(0))
+      .join("")
       .toUpperCase()
       .slice(0, 2);
   };
 
+  const header = (
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Team Members</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          People with access to the Omi admin dashboard.
+        </p>
+      </div>
+      <AddTeamMemberDialog onMemberAdded={async () => void (await mutate())}>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Add new person
+        </Button>
+      </AddTeamMemberDialog>
+    </div>
+  );
+
   if (isLoading) {
     return (
       <div className="p-6 space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold tracking-tight">Team Members</h1>
-        </div>
+        {header}
         <div className="flex items-center justify-center min-h-[300px]">
           <Spinner />
         </div>
@@ -38,9 +62,7 @@ export default function TeamPage() {
   if (error) {
     return (
       <div className="p-6 space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold tracking-tight">Team Members</h1>
-        </div>
+        {header}
         <div className="text-red-500 text-center py-10">
           Error loading team members: {error.message}
         </div>
@@ -50,10 +72,8 @@ export default function TeamPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <div className="flex justify-between items-center">
-        <h1 className="text-3xl font-bold tracking-tight">Team Members</h1>
-      </div>
-      
+      {header}
+
       {teamMembers.length === 0 ? (
         <div className="text-center py-10 text-muted-foreground">
           No team members found.
@@ -64,7 +84,9 @@ export default function TeamPage() {
             <Card key={member.id}>
               <CardHeader className="flex flex-row items-center gap-4">
                 <Avatar>
-                  <AvatarFallback>{getAvatarInitials(member.name)}</AvatarFallback>
+                  <AvatarFallback>
+                    {getAvatarInitials(member.name)}
+                  </AvatarFallback>
                 </Avatar>
                 <div>
                   <CardTitle className="text-lg">{member.name}</CardTitle>
@@ -79,5 +101,5 @@ export default function TeamPage() {
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/web/admin/app/api/omi/team-members/__tests__/route.test.ts
+++ b/web/admin/app/api/omi/team-members/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  getUserByEmail: vi.fn(),
+  memberGet: vi.fn(),
+  memberSet: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ verifyAdmin: mocks.verifyAdmin }));
+vi.mock("@/lib/firebase/admin", () => ({
+  getAdminAuth: () => ({ getUserByEmail: mocks.getUserByEmail }),
+  getDb: () => ({
+    collection: () => ({
+      doc: () => ({ get: mocks.memberGet, set: mocks.memberSet }),
+    }),
+  }),
+}));
+
+import { POST } from "../route";
+
+function requestWith(body: unknown) {
+  return { json: vi.fn().mockResolvedValue(body) } as never;
+}
+
+describe("POST /api/omi/team-members", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.verifyAdmin.mockResolvedValue({ uid: "requesting-admin" });
+    mocks.memberGet.mockResolvedValue({ exists: false });
+    mocks.memberSet.mockResolvedValue(undefined);
+  });
+
+  it("grants dashboard access to an existing Omi user", async () => {
+    mocks.getUserByEmail.mockResolvedValue({
+      uid: "archit-uid",
+      displayName: "Archit",
+    });
+
+    const response = await POST(
+      requestWith({ email: " ARCHITDRAFTID@GMAIL.COM " }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      teamMember: {
+        id: "archit-uid",
+        name: "Archit",
+        role: "Admin",
+        email: "architdraftid@gmail.com",
+      },
+    });
+    expect(mocks.getUserByEmail).toHaveBeenCalledWith(
+      "architdraftid@gmail.com",
+    );
+    expect(mocks.memberSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Archit",
+        role: "Admin",
+        email: "architdraftid@gmail.com",
+      }),
+    );
+  });
+
+  it("explains when the person has not signed in to Omi yet", async () => {
+    mocks.getUserByEmail.mockRejectedValue({ code: "auth/user-not-found" });
+
+    const response = await POST(
+      requestWith({ email: "architdraftid@gmail.com" }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "No Omi account found for architdraftid@gmail.com. Ask them to sign in to Omi once, then try again.",
+    });
+    expect(mocks.memberSet).not.toHaveBeenCalled();
+  });
+});

--- a/web/admin/app/api/omi/team-members/route.ts
+++ b/web/admin/app/api/omi/team-members/route.ts
@@ -1,8 +1,17 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyAdmin } from '@/lib/auth';
-import { getDb } from '@/lib/firebase/admin';
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { verifyAdmin } from "@/lib/auth";
+import { getAdminAuth, getDb } from "@/lib/firebase/admin";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
+
+const addTeamMemberSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .email()
+    .transform((email) => email.toLowerCase()),
+});
 
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
@@ -10,25 +19,102 @@ export async function GET(request: NextRequest) {
 
   try {
     const db = getDb();
-    const snapshot = await db.collection('adminData').get();
+    const snapshot = await db.collection("adminData").get();
 
     const members = snapshot.docs.map((doc) => {
       const data = doc.data();
       return {
         id: doc.id,
-        name: data.name || 'Unknown',
-        role: data.role || 'Admin',
-        email: data.email || 'No email',
+        name: data.name || "Unknown",
+        role: data.role || "Admin",
+        email: data.email || "No email",
         createdAt: data.createdAt || null,
       };
     });
 
     return NextResponse.json({ teamMembers: members });
   } catch (error) {
-    console.error('Error fetching team members:', error);
+    console.error("Error fetching team members:", error);
     return NextResponse.json(
-      { error: 'Failed to fetch team members' },
-      { status: 500 }
+      { error: "Failed to fetch team members" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "A valid email is required" },
+      { status: 400 },
+    );
+  }
+
+  const parsedBody = addTeamMemberSchema.safeParse(body);
+  if (!parsedBody.success) {
+    return NextResponse.json(
+      { error: "A valid email is required" },
+      { status: 400 },
+    );
+  }
+
+  const { email } = parsedBody.data;
+
+  try {
+    let firebaseUser;
+    try {
+      firebaseUser = await getAdminAuth().getUserByEmail(email);
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? error.code
+          : undefined;
+      if (code === "auth/user-not-found") {
+        return NextResponse.json(
+          {
+            error: `No Omi account found for ${email}. Ask them to sign in to Omi once, then try again.`,
+          },
+          { status: 404 },
+        );
+      }
+      throw error;
+    }
+
+    const db = getDb();
+    const memberRef = db.collection("adminData").doc(firebaseUser.uid);
+    if ((await memberRef.get()).exists) {
+      return NextResponse.json(
+        { error: `${email} already has admin access.` },
+        { status: 409 },
+      );
+    }
+
+    const teamMember = {
+      id: firebaseUser.uid,
+      name: firebaseUser.displayName || email,
+      role: "Admin",
+      email,
+    };
+
+    await memberRef.set({
+      name: teamMember.name,
+      role: teamMember.role,
+      email: teamMember.email,
+      createdAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ teamMember }, { status: 201 });
+  } catch (error) {
+    console.error("Error adding team member:", error);
+    return NextResponse.json(
+      { error: "Failed to add team member" },
+      { status: 500 },
     );
   }
 }

--- a/web/admin/components/dashboard/add-team-member-dialog.tsx
+++ b/web/admin/components/dashboard/add-team-member-dialog.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { FormEvent, ReactNode, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { useAuthFetch } from "@/hooks/useAuthToken";
+
+interface AddTeamMemberDialogProps {
+  children: ReactNode;
+  onMemberAdded: () => void | Promise<void>;
+}
+
+export function AddTeamMemberDialog({
+  children,
+  onMemberAdded,
+}: AddTeamMemberDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+  const { fetchWithAuth } = useAuthFetch();
+
+  const close = () => {
+    setOpen(false);
+    setEmail("");
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) return;
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetchWithAuth("/api/omi/team-members", {
+        method: "POST",
+        body: JSON.stringify({ email: normalizedEmail }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to add person");
+      }
+
+      await onMemberAdded();
+      toast({
+        title: "Person added",
+        description: `${normalizedEmail} now has admin dashboard access.`,
+      });
+      close();
+    } catch (error) {
+      toast({
+        title: "Could not add person",
+        description:
+          error instanceof Error ? error.message : "Failed to add person",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setEmail("");
+      }}
+    >
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-[440px]">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <DialogHeader>
+            <DialogTitle>Add new person</DialogTitle>
+            <DialogDescription>
+              Grant admin dashboard access to an existing Omi user. They must
+              have signed in to Omi at least once.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="team-member-email">Email</Label>
+            <Input
+              id="team-member-email"
+              type="email"
+              placeholder="person@example.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              autoComplete="email"
+              autoFocus
+              required
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={close}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting || !email.trim()}>
+              {isSubmitting ? (
+                <Loader2
+                  className="h-4 w-4 animate-spin"
+                  aria-label="Adding person"
+                />
+              ) : (
+                "Add person"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/admin/hooks/useTeamMembers.ts
+++ b/web/admin/hooks/useTeamMembers.ts
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import useSWR from 'swr';
-import { useAuthToken, authenticatedFetcher } from '@/hooks/useAuthToken';
+import useSWR from "swr";
+import { useAuthToken, authenticatedFetcher } from "@/hooks/useAuthToken";
 
 export interface TeamMember {
   id: string;
@@ -14,15 +14,16 @@ export interface TeamMember {
 export function useTeamMembers() {
   const { token, loading: tokenLoading } = useAuthToken();
 
-  const { data, error, isLoading } = useSWR<{ teamMembers: TeamMember[] }>(
-    token ? ['/api/omi/team-members', token] : null,
-    authenticatedFetcher,
-    { revalidateOnFocus: false }
-  );
+  const { data, error, isLoading, mutate } = useSWR<{
+    teamMembers: TeamMember[];
+  }>(token ? ["/api/omi/team-members", token] : null, authenticatedFetcher, {
+    revalidateOnFocus: false,
+  });
 
   return {
     teamMembers: data?.teamMembers ?? [],
     isLoading: tokenLoading || isLoading,
     error: error ?? null,
+    mutate,
   };
 }


### PR DESCRIPTION
## Summary

- restore the top-right **Add new person** action on the Team page
- grant access only to an existing Firebase Authentication user and key the `adminData` document by that user's UID
- refresh the visible team list after a successful add and show actionable errors for unknown or duplicate users

## Verification

- `npm run check` — 72 tests passed; lint had 20 pre-existing warnings and no errors
- `npm run build` — passed
- `make preflight` — 12 selected checks passed
- exercised the button and email dialog locally in Chrome with `architdraftid@gmail.com`
- added `architdraftid@gmail.com` to production `adminData` and confirmed the person is visible on the signed-in production Team page

## Access-control authorization

The workspace owner explicitly requested both the production admin grant for `architdraftid@gmail.com` and merging this access-management UI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

