### PR TITLE
fix(admin): Net WAU Growth tile shows the net delta, not the WAU level

### DIFF
--- a/web/admin/app/(protected)/dashboard/page.tsx
+++ b/web/admin/app/(protected)/dashboard/page.tsx
@@ -1783,6 +1783,7 @@ export default function AnalyticsPage() {
   );
   const netWauNow = fullGrowthWeeks.length >= 1 ? fullGrowthWeeks[fullGrowthWeeks.length - 1].active : null;
   const netWauPrev = fullGrowthWeeks.length >= 2 ? fullGrowthWeeks[fullGrowthWeeks.length - 2].active : null;
+  const netWauDelta = netWauNow != null && netWauPrev != null ? netWauNow - netWauPrev : null;
   const netWauChange = calculatePeriodChange(netWauNow, netWauPrev, "vs previous complete week");
 
   const growthGoalItems = useMemo<ChartItem[]>(() => {
@@ -1841,11 +1842,15 @@ export default function AnalyticsPage() {
         removable: false,
         render: () => (
           <div>
-            <div className="text-2xl font-bold">
-              {netWauNow != null ? netWauNow.toLocaleString() : "--"}
+            <div className={`text-2xl font-bold ${
+              netWauDelta == null ? "" : netWauDelta > 0 ? "text-green-600" : netWauDelta < 0 ? "text-red-600" : ""
+            }`}>
+              {netWauDelta != null
+                ? `${netWauDelta > 0 ? "+" : ""}${netWauDelta.toLocaleString()}`
+                : "--"}
             </div>
             <p className="truncate text-xs text-muted-foreground">
-              new + resurrected − churned · target ≥7% WoW
+              {netWauNow != null ? `WAU ${netWauNow.toLocaleString()} last full week` : "new + resurrected − churned"} · target ≥7% WoW
             </p>
           </div>
         ),
@@ -1962,7 +1967,7 @@ export default function AnalyticsPage() {
     ];
   }, [dailyNewUsersLoading, goalProgressPct, growthRetentionLoading, growthRetentionW4,
     kFactorData, kFactorLoading, latestWeeklyActivation, latestWeeklyNewUsers,
-    netWauChange, netWauNow,
+    netWauChange, netWauDelta, netWauNow,
     totalFirebaseUsers, weeklyActivationData, weeklyNewUsersData]);
 
   const topKpiAndNewWidgets = useMemo<ChartItem[]>(() => {


### PR DESCRIPTION
## Summary

Cross-review caught the new Net WAU Growth tile displaying the WAU level (2,039) under a subtitle describing net movement. The headline is now the true net weekly delta (`active − previousActive` over the last two completed weeks = −41 today), green/red by sign; the WAU level moved to the subtitle (`WAU 2,039 last full week · target ≥7% WoW`). Period-change badge unchanged (−2% vs previous complete week) — the same movement expressed as a rate.

## Verification

- `npx tsc --noEmit` clean, `npm run lint` 0 errors.
- Local web/admin run against prod data: tile renders **−41** (red) with −2% badge and `WAU 2,039 last full week` subtitle; exercised in the running app and screenshotted.
- Math check: growthAccounting weeks 2026-07-20 → 2026-07-27: 2,080 → 2,039 = −41 ✓.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

