### PR TITLE
fix(backend): Luna chat-agent tools need reasoning_effort=none

### DIFF
--- a/backend/llm_gateway/config/generated_route_overrides.yaml
+++ b/backend/llm_gateway/config/generated_route_overrides.yaml
@@ -4,9 +4,11 @@ generated_route_overrides:
   - feature: app_generator
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}
+  # Function tools on /v1/chat/completions require reasoning_effort=none for gpt-5.6-luna
+  # (OpenAI rejects tools + medium/high effort on that surface).
   - feature: chat_agent
     primary: {provider: openai, model: gpt-5.6-luna}
-    provider_options: {reasoning_effort: medium}
+    provider_options: {reasoning_effort: none}
   - feature: chat_extraction
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -433,7 +433,34 @@ def _provider_request(
         _remove_gpt56_cache_fields(provider_request)
     if apply_budget:
         provider_request, _ = apply_output_budget(provider_request, route.output_budget)
+    _sanitize_openai_chat_completions_request(provider_request, provider_ref)
     return provider_request
+
+
+def _sanitize_openai_chat_completions_request(
+    provider_request: dict[str, Any],
+    provider_ref: ProviderRef,
+) -> None:
+    """Normalize OpenAI chat-completions params OpenAI rejects for GPT-5.6 models.
+
+    Live OpenAI 400 (2026-08): function tools with reasoning_effort other than
+    ``none`` are unsupported for ``gpt-5.6-luna`` on ``/v1/chat/completions``.
+    Temperature must also stay at the model default (1).
+    """
+    if provider_ref.provider != 'openai':
+        return
+    model = provider_ref.model
+    if not model.startswith('gpt-5.6'):
+        return
+
+    tools = provider_request.get('tools')
+    if tools:
+        effort = provider_request.get('reasoning_effort')
+        if effort not in (None, 'none'):
+            provider_request['reasoning_effort'] = 'none'
+
+    if 'temperature' in provider_request and provider_request.get('temperature') != 1:
+        provider_request.pop('temperature', None)
 
 
 def _with_chat_agent_personality(messages: list[Any]) -> list[Any]:

--- a/backend/llm_gateway/gateway/executor.py
+++ b/backend/llm_gateway/gateway/executor.py
@@ -459,7 +459,13 @@ def _sanitize_openai_chat_completions_request(
         if effort not in (None, 'none'):
             provider_request['reasoning_effort'] = 'none'
 
-    if 'temperature' in provider_request and provider_request.get('temperature') != 1:
+    # OpenAI live 400 (2026-08): "Unsupported value: 'temperature' does not support 0.7
+    # with this model. Only the default (1) value is supported." Booleans must not slip
+    # through via True==1.
+    temperature = provider_request.get('temperature', None)
+    if 'temperature' in provider_request and (
+        isinstance(temperature, bool) or not isinstance(temperature, (int, float)) or temperature != 1
+    ):
         provider_request.pop('temperature', None)
 
 

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -44,7 +44,7 @@ def test_gateway_route_overrides_do_not_change_the_legacy_model_profile():
     assert config.route_artifacts['route.memory_l2.model_config.001'].provider_options['reasoning_effort'] == 'medium'
     assert config.route_artifacts['route.chat_agent.model_config.001'].provider_options == {
         'extra_body': {'prompt_cache_retention': '24h'},
-        'reasoning_effort': 'medium',
+        'reasoning_effort': 'none',
     }
     chat_agent_lane = config.lanes['omi:auto:chat-agent']
     assert chat_agent_lane.surface == Surface.OPENAI_CHAT_COMPLETIONS

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -183,6 +183,32 @@ def test_chat_agent_default_route_reasoning_effort_is_none():
     assert provider_request.get('reasoning_effort') == 'none'
 
 
+def test_gpt56_tools_strip_bool_temperature():
+    """True==1 must not bypass the temperature sanitize (OpenAI rejects non-default)."""
+    config = gateway_config()
+    route = config.route_artifacts['route.chat_agent.model_config.001']
+    config.route_artifacts['route.chat_agent.model_config.001'] = route.model_copy(
+        update={'provider_options': {**dict(route.provider_options), 'temperature': True}}
+    )
+    request = {
+        'model': CHAT_AGENT_LANE_ID,
+        'messages': [{'role': 'user', 'content': 'hi'}],
+        'tools': [
+            {
+                'type': 'function',
+                'function': {
+                    'name': 'get_memories_tool',
+                    'description': 'Get memories',
+                    'parameters': {'type': 'object', 'properties': {}},
+                },
+            }
+        ],
+    }
+    resolved = resolve_chat_completion_route(config, request)
+    provider_request = provider_request_for(resolved, resolved.active_route.primary)
+    assert 'temperature' not in provider_request
+
+
 @pytest.mark.asyncio
 async def test_executor_uses_lkg_route_provider_options_when_active_is_shadow():
     active_route = active_route_with_fallbacks([]).model_copy(

--- a/backend/tests/unit/test_llm_gateway_executor.py
+++ b/backend/tests/unit/test_llm_gateway_executor.py
@@ -126,6 +126,63 @@ def test_chat_agent_personality_preserves_array_system_text():
     assert system_message['content'][1:] == [{'type': 'text', 'text': 'Use the user context.'}]
 
 
+def test_chat_agent_tools_force_reasoning_effort_none_for_luna_chat_completions():
+    """gpt-5.6-luna rejects function tools when reasoning_effort != none on chat/completions."""
+    config = gateway_config()
+    # Mutate the serving route the way a bad override would: medium effort + tools.
+    route = config.route_artifacts['route.chat_agent.model_config.001']
+    config.route_artifacts['route.chat_agent.model_config.001'] = route.model_copy(
+        update={'provider_options': {**dict(route.provider_options), 'reasoning_effort': 'medium', 'temperature': 0.7}}
+    )
+    request = {
+        'model': CHAT_AGENT_LANE_ID,
+        'messages': [
+            {'role': 'system', 'content': 'Use tools when needed.'},
+            {'role': 'user', 'content': 'What did I say about coffee?'},
+        ],
+        'tools': [
+            {
+                'type': 'function',
+                'function': {
+                    'name': 'get_memories_tool',
+                    'description': 'Get memories',
+                    'parameters': {'type': 'object', 'properties': {'query': {'type': 'string'}}},
+                },
+            }
+        ],
+        'tool_choice': 'auto',
+    }
+    resolved = resolve_chat_completion_route(config, request)
+
+    provider_request = provider_request_for(resolved, resolved.active_route.primary)
+
+    assert provider_request['model'] == 'gpt-5.6-luna'
+    assert provider_request['tools']
+    assert provider_request.get('reasoning_effort') == 'none'
+    assert 'temperature' not in provider_request
+
+
+def test_chat_agent_default_route_reasoning_effort_is_none():
+    config = gateway_config()
+    request = {
+        'model': CHAT_AGENT_LANE_ID,
+        'messages': [{'role': 'user', 'content': 'Hello.'}],
+        'tools': [
+            {
+                'type': 'function',
+                'function': {
+                    'name': 'get_memories_tool',
+                    'description': 'Get memories',
+                    'parameters': {'type': 'object', 'properties': {}},
+                },
+            }
+        ],
+    }
+    resolved = resolve_chat_completion_route(config, request)
+    provider_request = provider_request_for(resolved, resolved.active_route.primary)
+    assert provider_request.get('reasoning_effort') == 'none'
+
+
 @pytest.mark.asyncio
 async def test_executor_uses_lkg_route_provider_options_when_active_is_shadow():
     active_route = active_route_with_fallbacks([]).model_copy(
@@ -134,8 +191,14 @@ async def test_executor_uses_lkg_route_provider_options_when_active_is_shadow():
             'rollout': RolloutPolicy(stage=RolloutStage.SHADOW, percent=0),
         }
     )
-    lkg_route = (
-        gateway_config().route_artifacts[LKG_ROUTE].model_copy(update={'provider_options': {'temperature': 0.1}})
+    # Use a non-gpt-5.6 LKG primary so temperature is a meaningful provider option
+    # (gpt-5.6* only accepts the default temperature and strips other values).
+    lkg_base = gateway_config().route_artifacts[LKG_ROUTE]
+    lkg_route = lkg_base.model_copy(
+        update={
+            'primary': ProviderRef(provider='openai', model='gpt-4.1-mini'),
+            'provider_options': {'temperature': 0.1},
+        }
     )
     config = config_with_routes(active_route, lkg_route)
     resolved = resolve_chat_completion_route(config, valid_request())

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -88,7 +88,8 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     # direct product route while shadow-only.
     assert provider.calls[0].model == 'gpt-5.6-luna'
     assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
-    assert provider.calls[0].request['temperature'] == 0
+    # gpt-5.6-luna only accepts default temperature; non-default values are stripped.
+    assert 'temperature' not in provider.calls[0].request
     assert provider.calls[0].request['max_completion_tokens'] == 64
     assert 'metadata' not in provider.calls[0].request
 

--- a/backend/tests/unit/test_llm_gateway_openai_compatible.py
+++ b/backend/tests/unit/test_llm_gateway_openai_compatible.py
@@ -88,7 +88,9 @@ def test_chat_completions_success_uses_lane_model_and_hides_route_metadata(monke
     # direct product route while shadow-only.
     assert provider.calls[0].model == 'gpt-5.6-luna'
     assert provider.calls[0].request['model'] == 'gpt-5.6-luna'
-    # gpt-5.6-luna only accepts default temperature; non-default values are stripped.
+    # Live OpenAI (gpt-5.6-luna, 2026-08): non-default temperature is rejected with
+    # invalid_request_error param=temperature ("Only the default (1) value is supported").
+    # Gateway strips non-default temperatures so callers cannot trip that 400.
     assert 'temperature' not in provider.calls[0].request
     assert provider.calls[0].request['max_completion_tokens'] == 64
     assert 'metadata' not in provider.calls[0].request


### PR DESCRIPTION
## Summary
Fix Luna main chat 400s on mobile/desktop agent path.

### Live OpenAI evidence (gpt-5.6-luna, prod-style key)
1. **tools + `reasoning_effort=medium`** → `400 invalid_request_error`:
   > Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
2. **tools + `reasoning_effort=none`** → **200** (reply ok)
3. **`temperature=0.7`** → `400` param=temperature:
   > Only the default (1) value is supported.

Prod symptoms matched (1): gateway terminal `provider_invalid_request` on `omi:auto:chat-agent` / `gpt-5.6-luna` with zero successes while chat was routed gateway.

### Changes
1. `chat_agent` route override: `reasoning_effort: none` (was medium)
2. Gateway `_sanitize_openai_chat_completions_request`: tools → force effort `none`; strip non-default / non-numeric / bool temperatures on gpt-5.6*
3. Regression unit tests + evidence comments

## Failure-Class
Failure-Class: none

## Test plan
- [x] unit tests (executor + config + openai compatible)
- [x] live OpenAI tools+none → 200
- [ ] prod gateway+backend deploy; CHAT_AGENT_ROUTE=gateway; chat-agent success > 0, invalid_request → 0
