### PR TITLE
fix(backend): treat an already-canceled Stripe subscription as canceled (#11289)

### DIFF
--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -365,7 +365,14 @@ def _cancel_subscription_for_account_deletion(uid: str) -> None:
             return
         canceled = stripe_utils.cancel_subscription(subscription_id)
         if not canceled:
-            raise RuntimeError('stripe cancel returned no subscription')
+            # The billing step owns a goal state — the subscription no longer bills — not a
+            # particular API call. Stripe rejects `cancel_at_period_end` on an already-canceled
+            # subscription, so without this the wipe fails forever and the account is never
+            # deleted even though billing is already where it must be. Asking Stripe for the
+            # status keeps this closed: anything but a terminal status is still a real failure.
+            if not stripe_utils.is_subscription_terminal(subscription_id):
+                raise RuntimeError('stripe cancel returned no subscription')
+            logger.info('delete_account billing cancellation satisfied by an already-canceled subscription')
     except Exception as e:
         raw_error = str(e)
         sanitized_error = sanitize(raw_error)

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -1204,6 +1204,72 @@ def test_background_wipe_defers_completion_for_late_vm_cleanup(monkeypatch):
     assert account_deletion.background_wipe_user_data('uid1') is False
 
 
+def _stub_wipe_steps_after_billing(monkeypatch):
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_running', MagicMock())
+    monkeypatch.setattr(account_deletion.auth, 'delete_account', MagicMock())
+    monkeypatch.setattr(account_deletion, 'delete_user_caller_ids', MagicMock())
+    monkeypatch.setattr(
+        account_deletion,
+        'purge_derived_user_data',
+        MagicMock(
+            return_value={
+                'required_failures': [],
+                'best_effort_failures': [],
+                'vectors_deleted': 0,
+                'recordings_deleted': 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(account_deletion.users_db, 'delete_user_data', MagicMock(return_value={'status': 'ok'}))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_completed', MagicMock(return_value=True))
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_wipe_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.users_db, 'mark_user_deletion_billing_failed', MagicMock())
+    monkeypatch.setattr(account_deletion.time, 'sleep', lambda *_: None)
+
+
+def test_background_wipe_proceeds_when_subscription_is_already_canceled(monkeypatch):
+    """#11289: Stripe rejects cancel_at_period_end on a canceled subscription.
+
+    The billing step owns the goal state (not billing), so an already-canceled subscription
+    must satisfy it. Otherwise the wipe fails, the reconciler re-enqueues it every 5 minutes,
+    and the user's data is never deleted.
+    """
+    _stub_wipe_steps_after_billing(monkeypatch)
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'get_user_subscription',
+        MagicMock(return_value=SimpleNamespace(stripe_subscription_id='sub_123')),
+    )
+    monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.stripe_utils, 'is_subscription_terminal', MagicMock(return_value=True))
+
+    assert account_deletion.background_wipe_user_data('uid1') is True
+
+    account_deletion.stripe_utils.is_subscription_terminal.assert_called_once_with('sub_123')
+    account_deletion.users_db.delete_user_data.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_billing_failed.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_not_called()
+
+
+def test_background_wipe_still_fails_when_subscription_is_not_terminal(monkeypatch):
+    """A cancel that failed while the subscription can still bill stays a hard failure."""
+    _stub_wipe_steps_after_billing(monkeypatch)
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'get_user_subscription',
+        MagicMock(return_value=SimpleNamespace(stripe_subscription_id='sub_123')),
+    )
+    monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.stripe_utils, 'is_subscription_terminal', MagicMock(return_value=False))
+
+    assert account_deletion.background_wipe_user_data('uid1') is False
+
+    account_deletion.users_db.delete_user_data.assert_not_called()
+    account_deletion.auth.delete_account.assert_not_called()
+    account_deletion.users_db.mark_user_deletion_billing_failed.assert_called_once()
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_called_once_with('uid1')
+
+
 def test_gce_project_uses_deployed_google_cloud_project(monkeypatch):
     for name in ('GCE_PROJECT_ID', 'FIREBASE_PROJECT_ID', 'GCP_PROJECT_ID'):
         monkeypatch.delenv(name, raising=False)

--- a/backend/tests/unit/test_stripe_subscription_terminal_status.py
+++ b/backend/tests/unit/test_stripe_subscription_terminal_status.py
@@ -1,0 +1,54 @@
+"""Regression tests for issue #11289 — reading a subscription's terminal status from Stripe.
+
+Account-deletion wipes stalled forever because `cancel_subscription` cannot cancel an
+already-canceled subscription: Stripe answers 400 "A canceled subscription can only update its
+cancellation_details and metadata". `is_subscription_terminal` is the seam that tells that case
+apart from a real failure, so it is asserted against real `stripe` SDK objects and errors — a
+subscription payload whose accessor changed shape, or an error path that returned True, would
+put the destructive wipe on the wrong side of the branch.
+"""
+
+from unittest.mock import MagicMock
+
+import stripe
+
+from utils import stripe as stripe_utils
+
+
+def _subscription(status: str) -> stripe.Subscription:
+    return stripe.Subscription.construct_from(
+        {'id': 'sub_123', 'object': 'subscription', 'status': status},
+        'sk_test_not_real',
+    )
+
+
+def test_canceled_subscription_is_terminal(monkeypatch):
+    monkeypatch.setattr(stripe_utils.stripe.Subscription, 'retrieve', MagicMock(return_value=_subscription('canceled')))
+
+    assert stripe_utils.is_subscription_terminal('sub_123') is True
+
+
+def test_incomplete_expired_subscription_is_terminal(monkeypatch):
+    monkeypatch.setattr(
+        stripe_utils.stripe.Subscription, 'retrieve', MagicMock(return_value=_subscription('incomplete_expired'))
+    )
+
+    assert stripe_utils.is_subscription_terminal('sub_123') is True
+
+
+def test_billing_subscription_is_not_terminal(monkeypatch):
+    for status in ('active', 'trialing', 'past_due', 'unpaid', 'paused'):
+        monkeypatch.setattr(stripe_utils.stripe.Subscription, 'retrieve', MagicMock(return_value=_subscription(status)))
+
+        assert stripe_utils.is_subscription_terminal('sub_123') is False, status
+
+
+def test_unreadable_subscription_is_not_terminal(monkeypatch):
+    """Fail closed: a Stripe outage must not read as 'already canceled'."""
+    monkeypatch.setattr(
+        stripe_utils.stripe.Subscription,
+        'retrieve',
+        MagicMock(side_effect=stripe.APIConnectionError('stripe unreachable')),
+    )
+
+    assert stripe_utils.is_subscription_terminal('sub_123') is False

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -107,6 +107,27 @@ def cancel_subscription(subscription_id: str):
         return None
 
 
+# Stripe statuses in which a subscription can no longer bill the customer. Stripe rejects
+# `cancel_at_period_end` on these ("A canceled subscription can only update its
+# cancellation_details and metadata"), so callers that only need the goal state — the
+# subscription is not billing — must ask Stripe rather than treat that 400 as a failure.
+TERMINAL_SUBSCRIPTION_STATUSES = frozenset({'canceled', 'incomplete_expired'})
+
+
+def is_subscription_terminal(subscription_id: str) -> bool:
+    """Whether Stripe currently reports the subscription in a terminal, non-billing state.
+
+    Fails closed: an unreadable subscription or any non-terminal status returns False, so a
+    caller never mistakes a transport error for a subscription that is already canceled.
+    """
+    try:
+        subscription = stripe.Subscription.retrieve(subscription_id)
+    except Exception as e:
+        logger.error(f"Error retrieving subscription: {e}")
+        return False
+    return subscription.get('status') in TERMINAL_SUBSCRIPTION_STATUSES
+
+
 def find_app_subscription_by_customer_id(
     customer_id: str, app_id: str, uid: str, status_filter: str = 'all'
 ) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
Fixes #11289.

## Bug

Account-deletion wipes never complete for users whose Stripe subscription is already canceled. Four accounts were stuck in this loop in prod on 2026-08-09, re-enqueued by the deletion-wipe reconciler every five minutes — the users requested deletion and their data was never wiped.

## Root cause

The billing step of `background_wipe_user_data` is written against one API call rather than the state that call is supposed to reach:

- `utils.stripe.cancel_subscription` calls `Subscription.modify(id, cancel_at_period_end=True)`.
- Stripe rejects that on an already-canceled subscription: `400 A canceled subscription can only update its cancellation_details and metadata` (prod request ids `req_suCmgcq7QS419i`, `req_uzO2RAeSYdGB9N`, `req_AuzPbJDny2WPcJ`, `req_wD3Akiz3wUx8aL`).
- The broad `except` returns `None`; `_cancel_subscription_for_account_deletion` raises `stripe cancel returned no subscription`.
- The wipe is marked failed with `failed_operations=['billing_subscription']`, `terminal=False`, so the reconciler re-enqueues it and it fails identically forever.

No retry of that call can ever succeed — the subscription is permanently in the state that rejects it — and billing is already exactly where the deletion needs it.

## Fix

`backend/utils/stripe.py` gains `is_subscription_terminal(subscription_id)`: it retrieves the subscription and reports whether Stripe currently places it in a non-billing terminal status (`canceled`, `incomplete_expired`). It fails closed — an unreadable subscription or any other status is `False`.

`_cancel_subscription_for_account_deletion` consults it only when the cancel returned nothing. A terminal status satisfies the billing step and the wipe proceeds; anything else stays the same hard failure it is today, so a subscription that can still bill can never let a wipe through. `cancel_subscription` itself and the `/v1/payments/subscription` cancel endpoint are unchanged.

## What I tested

Run with `backend/.venv` (`scripts/sync-python-deps.sh`, Python 3.11.15, stripe 11.3.0):

- `pytest tests/services/users/test_account_deletion.py` — 61 passed, including two new tests that drive the production `background_wipe_user_data` through the billing branch: an already-canceled subscription completes the wipe (`delete_user_data` called, no `mark_user_deletion_billing_failed`, no `mark_user_deletion_wipe_failed`), and a non-terminal subscription still fails closed (`delete_user_data` and `auth.delete_account` never called, wipe marked failed).
- **Reverted the production change and re-ran those two tests**: `test_background_wipe_proceeds_when_subscription_is_already_canceled` fails with the exact production symptom (`delete_account billing cancellation failed … / background wipe failed`), the fail-closed test still passes. The regression test reproduces the bug, and the fail-closed guard is not what the fix moved.
- `pytest tests/unit/test_stripe_subscription_terminal_status.py tests/unit/test_delete_account_stripe_cancel.py` — 7 passed. The new file asserts `is_subscription_terminal` against real `stripe` SDK objects (`stripe.Subscription.construct_from`) and a real `stripe.APIConnectionError`, covering both terminal statuses, five billing statuses, and the fail-closed transport-error path.

Not exercised against live Stripe or a real stuck wipe: that needs prod credentials and a production account-deletion job. The 400 behavior is taken from the four prod Stripe request ids above rather than a local reproduction.

Failure-Class: FC-permanent-write-rejection-retried-forever

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

