### PR TITLE
fix(app): keep a progress indicator running for the whole app search

### DIFF
--- a/app/lib/pages/apps/explore_install_page.dart
+++ b/app/lib/pages/apps/explore_install_page.dart
@@ -15,6 +15,7 @@ import 'package:omi/pages/apps/widgets/category_apps_page.dart';
 import 'package:omi/pages/apps/widgets/category_section.dart';
 import 'package:omi/pages/apps/widgets/filter_sheet.dart';
 import 'package:omi/pages/apps/widgets/popular_apps_section.dart';
+import 'package:omi/pages/apps/widgets/search_loading_sliver.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/utils/app_localizations_helper.dart';
@@ -376,73 +377,6 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
         _buildShimmerCategorySection(),
         const SizedBox(height: 100),
       ],
-    );
-  }
-
-  Widget _buildSearchLoadingSliver() {
-    return SliverPadding(
-      padding: const EdgeInsets.only(bottom: 64, left: 20, right: 20, top: 20),
-      sliver: SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) => _buildShimmerListItem(),
-          childCount: 5, // Show 5 shimmer items
-        ),
-      ),
-    );
-  }
-
-  Widget _buildShimmerListItem() {
-    return ShimmerWithTimeout(
-      baseColor: AppStyles.backgroundSecondary,
-      highlightColor: AppStyles.backgroundTertiary,
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        margin: const EdgeInsets.only(bottom: 8),
-        decoration: BoxDecoration(color: AppStyles.backgroundSecondary, borderRadius: BorderRadius.circular(16)),
-        child: Row(
-          children: [
-            // App icon shimmer
-            Container(
-              width: 60,
-              height: 60,
-              decoration: BoxDecoration(color: AppStyles.backgroundTertiary, borderRadius: BorderRadius.circular(12)),
-            ),
-            const SizedBox(width: 16),
-            // App info shimmer
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    width: double.infinity,
-                    height: 18,
-                    decoration: BoxDecoration(
-                      color: AppStyles.backgroundTertiary,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Container(
-                    width: 150,
-                    height: 14,
-                    decoration: BoxDecoration(
-                      color: AppStyles.backgroundTertiary,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 12),
-            // Button shimmer
-            Container(
-              width: 72,
-              height: 32,
-              decoration: BoxDecoration(color: AppStyles.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
-            ),
-          ],
-        ),
-      ),
     );
   }
 
@@ -896,7 +830,7 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                 if (state.isLoading)
                   SliverToBoxAdapter(child: _buildShimmerAppsView())
                 else if (state.isSearching)
-                  _buildSearchLoadingSliver()
+                  const SearchLoadingSliver()
                 else if (state.isFilterActive || state.isSearchActive)
                   _buildFilteredAppsSlivers()
                 else

--- a/app/lib/pages/apps/widgets/search_loading_sliver.dart
+++ b/app/lib/pages/apps/widgets/search_loading_sliver.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/utils/ui_guidelines.dart';
+import 'package:omi/widgets/shimmer_with_timeout.dart';
+
+/// Placeholder rows shown while an app search is running.
+///
+/// Extracted from `ExploreInstallPage` so the loading state can be pumped on its
+/// own in a widget test — a search that outlives the shimmer animation is the
+/// case that matters here, and it is not reachable through the full page without
+/// a live backend.
+class SearchLoadingSliver extends StatelessWidget {
+  /// Creates the loading placeholder shown during a search.
+  const SearchLoadingSliver({super.key, this.placeholderCount = 5});
+
+  /// How many placeholder rows to draw.
+  final int placeholderCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPadding(
+      padding: const EdgeInsets.only(bottom: 64, left: 20, right: 20, top: 20),
+      sliver: SliverMainAxisGroup(
+        slivers: [
+          const SliverToBoxAdapter(child: _SearchProgressBar()),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => const _ShimmerListItem(),
+              childCount: placeholderCount,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The one thing on screen that keeps moving for as long as the search runs.
+///
+/// The shimmer placeholders below it stop animating after five seconds and go
+/// static, so on a slow search they stop being evidence of anything. This does
+/// not time out, which is the whole point: it separates "still working" from
+/// "wedged" at the moment the user starts to wonder.
+class _SearchProgressBar extends StatelessWidget {
+  const _SearchProgressBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppStyles.spacingL),
+      child: LinearProgressIndicator(
+        // Indeterminate: a search has no known duration, and a determinate bar
+        // would have to invent a percentage that then appears to stall.
+        minHeight: 3,
+        backgroundColor: AppStyles.backgroundSecondary,
+        valueColor: const AlwaysStoppedAnimation<Color>(AppStyles.textPrimary),
+        borderRadius: BorderRadius.circular(AppStyles.radiusSmall),
+      ),
+    );
+  }
+}
+
+class _ShimmerListItem extends StatelessWidget {
+  const _ShimmerListItem();
+
+  @override
+  Widget build(BuildContext context) {
+    return ShimmerWithTimeout(
+      baseColor: AppStyles.backgroundSecondary,
+      highlightColor: AppStyles.backgroundTertiary,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        margin: const EdgeInsets.only(bottom: 8),
+        decoration: BoxDecoration(color: AppStyles.backgroundSecondary, borderRadius: BorderRadius.circular(16)),
+        child: Row(
+          children: [
+            Container(
+              width: 60,
+              height: 60,
+              decoration: BoxDecoration(color: AppStyles.backgroundTertiary, borderRadius: BorderRadius.circular(12)),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: double.infinity,
+                    height: 18,
+                    decoration: BoxDecoration(
+                      color: AppStyles.backgroundTertiary,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    width: 150,
+                    height: 14,
+                    decoration: BoxDecoration(
+                      color: AppStyles.backgroundTertiary,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            Container(
+              width: 72,
+              height: 32,
+              decoration: BoxDecoration(color: AppStyles.backgroundTertiary, borderRadius: BorderRadius.circular(16)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/widgets/search_loading_sliver_test.dart
+++ b/app/test/widgets/search_loading_sliver_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/apps/widgets/search_loading_sliver.dart';
+import 'package:omi/widgets/shimmer_with_timeout.dart';
+
+/// The shimmer placeholders stop animating after [ShimmerWithTimeout]'s timeout
+/// and fall back to static blocks. A search that takes longer than that is then
+/// indistinguishable from a frozen screen, which is the bug these tests pin.
+Future<void> _pumpLoadingState(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(
+      home: Scaffold(
+        body: CustomScrollView(slivers: [SearchLoadingSliver()]),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('search loading state', () {
+    testWidgets('shows placeholder rows while the search runs', (tester) async {
+      await _pumpLoadingState(tester);
+
+      expect(find.byType(ShimmerWithTimeout), findsNWidgets(5));
+    });
+
+    testWidgets('still shows a running progress indicator after the shimmer has timed out', (tester) async {
+      await _pumpLoadingState(tester);
+
+      // Past ShimmerWithTimeout's 5s fallback, where the placeholders go static.
+      await tester.pump(const Duration(seconds: 10));
+
+      // The user must still be able to tell the search is running rather than wedged.
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('the progress indicator is indeterminate, because search has no known duration', (tester) async {
+      await _pumpLoadingState(tester);
+      await tester.pump(const Duration(seconds: 10));
+
+      final indicator = tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+
+      // A determinate bar would have to invent a percentage; a stuck one at a fixed
+      // value is exactly the "is it working?" doubt this is meant to remove.
+      expect(indicator.value, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Searching the Apps tab shows five shimmer placeholders. `ShimmerWithTimeout` stops
animating after five seconds and falls back to static blocks
(`app/lib/widgets/shimmer_with_timeout.dart:57`), so any search slower than that leaves
five motionless grey rectangles and nothing else moving on screen.

At that point a working search and a wedged one look identical. This is the state users
report as the app having hung: on a slow search the screen settles into five unmoving grey
rectangles with no spinner, no bar, and no text.

Related: #11292 covers why those searches are slow in the first place. This PR is only
about the screen not looking dead while they run, and stands on its own.

## Change

Adds an indeterminate `LinearProgressIndicator` above the placeholders that does not time
out, so there is always one moving thing for as long as the request is in flight.

Indeterminate on purpose: a search has no known duration, and a determinate bar would have
to invent a percentage that then appears to stall — the same doubt in a different shape.

The loading state moves into `SearchLoadingSliver` so it can be pumped on its own in a
widget test. Reaching it through `ExploreInstallPage` would need a live backend, which
would put the regression test outside CI.

`ShimmerWithTimeout` itself is untouched. It has 45 call sites across 22 files, and its
timeout is reasonable where something else already signals liveness; the defect here is
that on this screen nothing else did.

No new user-facing strings, so no ARB changes.

## Verification

- `flutter test test/widgets/search_loading_sliver_test.dart` — 3/3 pass. The two
  progress-indicator assertions fail on the parent commit; that is the regression this fixes.
- `flutter test test/widgets` — 146 pass.
- `flutter test` — 1119 pass, 2 fail: `plans_sheet_l10n` and `voice_recorder_mic_contention`.
  Both reproduce with this work stashed on `d60ab7a1c`, so neither is from this change; the
  latter is a Windows temp-directory teardown lock.
- `dart analyze` on all three changed files — no issues.
- `dart format --line-length 120` — no changes.

**I could not run the app.** No macOS and no Android SDK on this machine, so this is not
verified on a device. The widget test asserts the behaviour, but that is not the same as
having seen it, and I would rather say so than imply otherwise.

## Product invariants

`scripts/pr-preflight --suggest` reports none affected. `brand-ui` (INV-UI-1) is selected
because the diff touches UI sources: the indicator is `AppStyles.textPrimary` on
`AppStyles.backgroundSecondary` — white on neutral, no purple.

## Failure class

Failure-Class: none

No existing class covers it — the registry's closest entries are scoped to specific
subsystems (`FC-media-track-output-liveness` is desktop Windows rewind capture). I have not
declared `new`, because a new class asks for a canonical prevention artifact and a reusable
guard surface, and I do not think one UI liveness affordance earns that yet. Happy to
classify it differently if you would rather it were tracked.

---

*Written with Claude Code. Every file:line above was verified against `d60ab7a1c`.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

