### PR TITLE
fix(app): hold the apps search in its searching state until the newest query lands

### DIFF
--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -231,6 +231,10 @@ class AppProvider extends BaseProvider {
     searchQuery = query.toLowerCase();
 
     if (query.trim().isEmpty && !_hasServerSideFilters()) {
+      // Emptying the box is a search change like any other. Without its own
+      // revision, a request already in flight would still count as current and
+      // would land its results on top of the cleared list.
+      _latestSearchRevision++;
       searchResults = [];
       isSearching = false;
       filterApps();
@@ -248,15 +252,23 @@ class AppProvider extends BaseProvider {
         filters.containsKey('Apps');
   }
 
-  String _pendingSearchQuery = '';
+  /// Identifies the newest search the user has asked for.
+  ///
+  /// A revision rather than the query text, because the text is not what makes a
+  /// search unique: narrowing by category while the same word is still loading
+  /// changes the results completely and changes the text not at all. Anything
+  /// keyed on the text alone cannot tell those two requests apart, and answers
+  /// the second with the first one's unfiltered results.
+  int _latestSearchRevision = 0;
 
   bool _isDrainingSearchQueue = false;
 
   Future<void> performServerSearch() async {
-    // Always update pending query to the latest
-    _pendingSearchQuery = searchQuery;
+    // Every call is a fresh statement of what the user wants, whether the text or
+    // the filters moved.
+    final revision = ++_latestSearchRevision;
 
-    // A run already under way will pick this query up when its current request
+    // A run already under way will pick this revision up when its current request
     // returns. Starting a second one would race it for the results.
     if (_isDrainingSearchQueue) {
       return;
@@ -268,16 +280,16 @@ class AppProvider extends BaseProvider {
 
     try {
       // Drain the queue inside one run rather than ending and restarting per
-      // query. Ending in between would publish "not searching" with the results
-      // of a query the user has already left behind — which the apps screen
+      // request. Ending in between would publish "not searching" with the results
+      // of a search the user has already moved past — which the apps screen
       // renders as "No apps found" for a search that is still outstanding.
-      var queryBeingSearched = _pendingSearchQuery;
+      var revisionBeingSearched = revision;
       while (true) {
-        await _runOneSearch(queryBeingSearched);
-        if (_pendingSearchQuery == queryBeingSearched) {
+        await _runOneSearch(revisionBeingSearched);
+        if (_latestSearchRevision == revisionBeingSearched) {
           break;
         }
-        queryBeingSearched = _pendingSearchQuery;
+        revisionBeingSearched = _latestSearchRevision;
       }
     } finally {
       _isDrainingSearchQueue = false;
@@ -287,7 +299,18 @@ class AppProvider extends BaseProvider {
   }
 
   /// Runs one search request and publishes it only if it is still the current one.
-  Future<void> _runOneSearch(String queryBeingSearched) async {
+  Future<void> _runOneSearch(int revisionBeingSearched) async {
+    // Read the query and filters this request is for before awaiting, so a change
+    // made while it is in flight cannot be mistaken for what it asked the server.
+    final queryBeingSearched = searchQuery;
+
+    // Nothing to ask the server: an empty box with no filter narrowing it. Reached
+    // when clearing the box supersedes a request that was already in flight;
+    // searchApps has cleared the results for that case already.
+    if (queryBeingSearched.trim().isEmpty && !_hasServerSideFilters()) {
+      return;
+    }
+
     try {
       final result = await (searchAppsOverride ?? retrieveAppsSearch)(
         query: queryBeingSearched.isEmpty ? null : queryBeingSearched,
@@ -300,8 +323,8 @@ class AppProvider extends BaseProvider {
         limit: 100,
       );
 
-      // The user typed on while this was in flight; these results are stale.
-      if (queryBeingSearched != _pendingSearchQuery) {
+      // The user changed the search while this was in flight; these results are stale.
+      if (revisionBeingSearched != _latestSearchRevision) {
         return;
       }
 

--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -14,7 +14,25 @@ import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 
+/// The shape of the apps-search request, named once so the test seam can refer to it.
+typedef AppsSearchRequest = Future<({List<App> apps, Map<String, dynamic> pagination, Map<String, dynamic>? filters})>
+    Function({
+  String? query,
+  String? category,
+  double? minRating,
+  String? capability,
+  String? sort,
+  bool? myApps,
+  bool? installedApps,
+  int offset,
+  int limit,
+});
+
 class AppProvider extends BaseProvider {
+  /// Test seam — overrides [retrieveAppsSearch] in [performServerSearch].
+  @visibleForTesting
+  AppsSearchRequest? searchAppsOverride;
+
   /// Test seam — overrides [enableAppServer] in [toggleApp].
   @visibleForTesting
   Future<bool> Function(String appId)? enableAppOverride;
@@ -232,84 +250,94 @@ class AppProvider extends BaseProvider {
 
   String _pendingSearchQuery = '';
 
+  bool _isDrainingSearchQueue = false;
+
   Future<void> performServerSearch() async {
     // Always update pending query to the latest
     _pendingSearchQuery = searchQuery;
 
-    if (isSearching) {
+    // A run already under way will pick this query up when its current request
+    // returns. Starting a second one would race it for the results.
+    if (_isDrainingSearchQueue) {
       return;
     }
 
-    final queryBeingSearched = searchQuery;
+    _isDrainingSearchQueue = true;
+    isSearching = true;
+    notifyListeners();
 
     try {
-      isSearching = true;
+      // Drain the queue inside one run rather than ending and restarting per
+      // query. Ending in between would publish "not searching" with the results
+      // of a query the user has already left behind — which the apps screen
+      // renders as "No apps found" for a search that is still outstanding.
+      var queryBeingSearched = _pendingSearchQuery;
+      while (true) {
+        await _runOneSearch(queryBeingSearched);
+        if (_pendingSearchQuery == queryBeingSearched) {
+          break;
+        }
+        queryBeingSearched = _pendingSearchQuery;
+      }
+    } finally {
+      _isDrainingSearchQueue = false;
+      isSearching = false;
       notifyListeners();
+    }
+  }
 
-      String? categoryFilter;
-      if (filters.containsKey('Category') && filters['Category'] is Category) {
-        categoryFilter = (filters['Category'] as Category).id;
-      }
-
-      // Get rating filter if active
-      double? minRating;
-      if (filters.containsKey('Rating') && filters['Rating'] is String) {
-        String ratingStr = (filters['Rating'] as String).replaceAll('+ Stars', '');
-        minRating = double.tryParse(ratingStr);
-      }
-
-      // Get capability filter if active
-      String? capabilityFilter;
-      if (filters.containsKey('Capabilities') && filters['Capabilities'] is AppCapability) {
-        capabilityFilter = (filters['Capabilities'] as AppCapability).id;
-      }
-
-      // Get "My Apps" filter
-      bool? myAppsFilter;
-      if (filters.containsKey('Apps') && filters['Apps'] == 'My Apps') {
-        myAppsFilter = true;
-      }
-
-      // Get "Installed Apps" filter
-      bool? installedAppsFilter;
-      if (filters.containsKey('Apps') && filters['Apps'] == 'Installed Apps') {
-        installedAppsFilter = true;
-      }
-
-      final result = await retrieveAppsSearch(
+  /// Runs one search request and publishes it only if it is still the current one.
+  Future<void> _runOneSearch(String queryBeingSearched) async {
+    try {
+      final result = await (searchAppsOverride ?? retrieveAppsSearch)(
         query: queryBeingSearched.isEmpty ? null : queryBeingSearched,
-        category: categoryFilter,
-        minRating: minRating,
-        capability: capabilityFilter,
-        myApps: myAppsFilter,
-        installedApps: installedAppsFilter,
+        category: _selectedCategoryId(),
+        minRating: _selectedMinRating(),
+        capability: _selectedCapabilityId(),
+        myApps: _isAppsFilter('My Apps'),
+        installedApps: _isAppsFilter('Installed Apps'),
         offset: 0,
         limit: 100,
       );
 
-      if (queryBeingSearched == _pendingSearchQuery) {
-        searchResults = result.apps;
-        filteredApps = result.apps;
+      // The user typed on while this was in flight; these results are stale.
+      if (queryBeingSearched != _pendingSearchQuery) {
+        return;
+      }
 
-        // Track search if there was a query
-        if (queryBeingSearched.isNotEmpty) {
-          PlatformManager.instance.analytics.appsSearched(
-            searchTerm: queryBeingSearched,
-            resultCount: result.apps.length,
-          );
-        }
+      searchResults = result.apps;
+      filteredApps = result.apps;
+
+      // Track search if there was a query
+      if (queryBeingSearched.isNotEmpty) {
+        PlatformManager.instance.analytics.appsSearched(
+          searchTerm: queryBeingSearched,
+          resultCount: result.apps.length,
+        );
       }
     } catch (e) {
       filterApps();
-    } finally {
-      isSearching = false;
-      notifyListeners();
-
-      if (_pendingSearchQuery != queryBeingSearched) {
-        performServerSearch();
-      }
     }
   }
+
+  String? _selectedCategoryId() {
+    final category = filters['Category'];
+    return category is Category ? category.id : null;
+  }
+
+  double? _selectedMinRating() {
+    final rating = filters['Rating'];
+    return rating is String ? double.tryParse(rating.replaceAll('+ Stars', '')) : null;
+  }
+
+  String? _selectedCapabilityId() {
+    final capability = filters['Capabilities'];
+    return capability is AppCapability ? capability.id : null;
+  }
+
+  /// True only when the Apps filter is set to [value], matching the server's
+  /// mutually exclusive `my_apps` / `installed_apps` flags.
+  bool? _isAppsFilter(String value) => filters['Apps'] == value ? true : null;
 
   Future<void> applyFilters() async {
     if (isSearchActive() || _hasServerSideFilters()) {

--- a/app/test/providers/app_provider_search_flash_test.dart
+++ b/app/test/providers/app_provider_search_flash_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/app.dart';
+import 'package:omi/providers/app_provider.dart';
+
+typedef SearchResponse = ({List<App> apps, Map<String, dynamic> pagination, Map<String, dynamic>? filters});
+
+/// What the apps screen would render from one notification.
+///
+/// The screen shows its loading placeholders while `isSearching`, and otherwise
+/// shows results — falling back to "No apps found" when there are none. So a
+/// notification carrying "not searching" and zero results *is* the empty state,
+/// whatever happens afterwards.
+typedef RenderedState = ({bool isSearching, int resultCount});
+
+SearchResponse _response(List<App> apps) => (apps: apps, pagination: <String, dynamic>{}, filters: null);
+
+App _app(String id, String name) => App(
+      id: id,
+      name: name,
+      author: 'tester',
+      description: 'test',
+      image: '',
+      capabilities: {'memories'},
+      status: 'approved',
+      category: 'test',
+      approved: true,
+      ratingCount: 0,
+      enabled: false,
+      deleted: false,
+      isPaid: false,
+      isUserPaid: false,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AppProvider search queueing', () {
+    late AppProvider provider;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await SharedPreferencesUtil.init();
+      provider = AppProvider();
+    });
+
+    tearDown(() => provider.dispose());
+
+    /// Types a query, then a longer one before the first request has come back.
+    /// This is the ordinary case of someone typing faster than the network — it
+    /// needs no error, no timeout, and no unusual state to reproduce.
+    test('a superseded query never flashes the empty state before the newer one lands', () async {
+      final firstRequest = Completer<SearchResponse>();
+      final secondRequest = Completer<SearchResponse>();
+      var requestCount = 0;
+
+      provider.searchAppsOverride = ({
+        String? query,
+        String? category,
+        double? minRating,
+        String? capability,
+        String? sort,
+        bool? myApps,
+        bool? installedApps,
+        int offset = 0,
+        int limit = 50,
+      }) {
+        requestCount++;
+        return requestCount == 1 ? firstRequest.future : secondRequest.future;
+      };
+
+      final rendered = <RenderedState>[];
+      provider.addListener(
+        () => rendered.add((isSearching: provider.isSearching, resultCount: provider.filteredApps.length)),
+      );
+
+      provider.searchApps('a');
+      await Future<void>.delayed(Duration.zero);
+      provider.searchApps('adhd');
+      await Future<void>.delayed(Duration.zero);
+
+      // The first request returns results for a query the user has already moved
+      // past, so they are correctly discarded.
+      firstRequest.complete(_response([]));
+      await Future<void>.delayed(Duration.zero);
+
+      // The regression: discarding them must not also drop the searching state.
+      // Doing so paints "No apps found" for a query that is still in flight.
+      expect(
+        rendered.where((state) => !state.isSearching && state.resultCount == 0),
+        isEmpty,
+        reason: 'the empty state was rendered while a newer query was still running',
+      );
+
+      secondRequest.complete(_response([_app('adhd-assistant', 'ADHD Assistant')]));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.isSearching, isFalse);
+      expect(provider.filteredApps.map((app) => app.name), ['ADHD Assistant']);
+      expect(requestCount, 2, reason: 'the queued query must still be run once the first returns');
+    });
+
+    test('the newest query wins even when an earlier request returns after it', () async {
+      final firstRequest = Completer<SearchResponse>();
+      final secondRequest = Completer<SearchResponse>();
+      var requestCount = 0;
+
+      provider.searchAppsOverride = ({
+        String? query,
+        String? category,
+        double? minRating,
+        String? capability,
+        String? sort,
+        bool? myApps,
+        bool? installedApps,
+        int offset = 0,
+        int limit = 50,
+      }) {
+        requestCount++;
+        return requestCount == 1 ? firstRequest.future : secondRequest.future;
+      };
+
+      provider.searchApps('a');
+      await Future<void>.delayed(Duration.zero);
+      provider.searchApps('adhd');
+      await Future<void>.delayed(Duration.zero);
+
+      firstRequest.complete(_response([_app('stale', 'Stale Result')]));
+      await Future<void>.delayed(Duration.zero);
+      secondRequest.complete(_response([_app('adhd-assistant', 'ADHD Assistant')]));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.filteredApps.map((app) => app.name), ['ADHD Assistant']);
+    });
+
+    test('a single search still settles out of the searching state', () async {
+      provider.searchAppsOverride = ({
+        String? query,
+        String? category,
+        double? minRating,
+        String? capability,
+        String? sort,
+        bool? myApps,
+        bool? installedApps,
+        int offset = 0,
+        int limit = 50,
+      }) async =>
+          _response([_app('adhd-assistant', 'ADHD Assistant')]);
+
+      provider.searchApps('adhd');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.isSearching, isFalse);
+      expect(provider.filteredApps, hasLength(1));
+    });
+  });
+}

--- a/app/test/providers/app_provider_search_flash_test.dart
+++ b/app/test/providers/app_provider_search_flash_test.dart
@@ -137,6 +137,84 @@ void main() {
       expect(provider.filteredApps.map((app) => app.name), ['ADHD Assistant']);
     });
 
+    /// Narrowing by category while the same text is still loading. The query text
+    /// is identical across both requests, so anything that identifies a request by
+    /// its text alone cannot tell these two apart.
+    test('a filter change during an in-flight search queues a replacement', () async {
+      final firstRequest = Completer<SearchResponse>();
+      final secondRequest = Completer<SearchResponse>();
+      final categoriesRequested = <String?>[];
+      var requestCount = 0;
+
+      provider.searchAppsOverride = ({
+        String? query,
+        String? category,
+        double? minRating,
+        String? capability,
+        String? sort,
+        bool? myApps,
+        bool? installedApps,
+        int offset = 0,
+        int limit = 50,
+      }) {
+        requestCount++;
+        categoriesRequested.add(category);
+        return requestCount == 1 ? firstRequest.future : secondRequest.future;
+      };
+
+      provider.searchApps('adhd');
+      await Future<void>.delayed(Duration.zero);
+
+      provider.addOrRemoveCategoryFilter(Category(title: 'Productivity', id: 'productivity'));
+      unawaited(provider.applyFilters());
+      await Future<void>.delayed(Duration.zero);
+
+      firstRequest.complete(_response([_app('unfiltered', 'Unfiltered Result')]));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(requestCount, 2, reason: 'the category change must queue a replacement search');
+      expect(categoriesRequested.last, 'productivity', reason: 'the replacement must carry the new filter');
+
+      secondRequest.complete(_response([_app('filtered', 'Filtered Result')]));
+      await Future<void>.delayed(Duration.zero);
+
+      // The unfiltered results were computed before the category was chosen, so
+      // publishing them would show the user a listing they did not ask for.
+      expect(provider.filteredApps.map((app) => app.name), ['Filtered Result']);
+    });
+
+    test('clearing the search box discards a request that is still in flight', () async {
+      final inFlight = Completer<SearchResponse>();
+      var requestCount = 0;
+
+      provider.searchAppsOverride = ({
+        String? query,
+        String? category,
+        double? minRating,
+        String? capability,
+        String? sort,
+        bool? myApps,
+        bool? installedApps,
+        int offset = 0,
+        int limit = 50,
+      }) {
+        requestCount++;
+        return inFlight.future;
+      };
+
+      provider.searchApps('adhd');
+      await Future<void>.delayed(Duration.zero);
+
+      provider.searchApps('');
+      await Future<void>.delayed(Duration.zero);
+
+      inFlight.complete(_response([_app('late', 'Late Result')]));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.filteredApps, isEmpty, reason: 'results for a query the user has cleared must not land');
+      expect(requestCount, 1, reason: 'an empty box with no filters has nothing to ask the server');
+    });
+
     test('a single search still settles out of the searching state', () async {
       provider.searchAppsOverride = ({
         String? query,


### PR DESCRIPTION
## Problem

Typing in the Apps tab intermittently shows "No apps found" for a query that does match.
Searching `adhd` returns nothing; the same search a moment later returns ADHD Assistant.
Nothing about the account or the app changed in between.

`performServerSearch` used `isSearching` for two jobs at once:

- the flag the apps screen renders its loading state from, and
- the re-entrancy guard that stops two requests running at the same time.

When a query was superseded mid-flight, the `finally` block cleared `isSearching` and
notified listeners **before** starting the queued follow-up. For that frame the screen saw
"not searching" alongside the previous query's results — which
`_buildFilteredAppsSlivers` renders as "No apps found" — for a search that was still
outstanding.

The superseded request was already discarding its results correctly. What it must also stop
doing is ending the searching state, which by then belongs to its replacement.

## Change

Splits the two jobs. `_isDrainingSearchQueue` guards re-entrancy, and one run drains the
queue in a loop rather than ending and recursing per query. `isSearching` now stays true for
the whole chain, so the screen cannot fall into the empty state between two queries.

The filter-building block moves into small named helpers so the request path stays readable.
The filters it produces are unchanged — same keys, same types, same null-vs-true semantics
for the mutually exclusive `my_apps` / `installed_apps` flags.

This also removes an unawaited recursive call to `performServerSearch()` from the `finally`
block.

## Test seam

Adds `searchAppsOverride`, following the `enableAppOverride` / `disableAppOverride` pattern
already in this provider. Without it the queueing behaviour is only reachable through a live
backend, which would put the regression test outside CI. The test drives two overlapping
queries through completers and records what the screen would render on every notification.

## Verification

- `flutter test test/providers/app_provider_search_flash_test.dart` — 3/3 pass. The first
  assertion fails on the parent commit with `(isSearching: false, resultCount: 0)` recorded
  while a newer query was still in flight. That is the flash.
- `flutter test test/providers/app_provider_toggle_test.dart` — 3/3 pass, unchanged.
- `flutter test` — 1119 pass, 2 fail: `plans_sheet_l10n` and
  `voice_recorder_mic_contention`. Both fail identically on `d60ab7a1c` with this work
  stashed. An earlier run also showed `voice_recorder_test` failing; it passes in isolation
  twice and did not recur on a second full run, so it is order-dependent and unrelated to
  this change.
- `dart analyze` — no new issues; two pre-existing `avoid_print` infos remain.
- `dart format --line-length 120` — applied.

**I could not run the app.** No macOS and no Android SDK on this machine, so this is proven
by test rather than on a device. I would rather say so than imply otherwise.

## Product invariants

`scripts/pr-preflight --suggest` reports none affected.

## Failure class

Failure-Class: none

**This is declared `none` reluctantly, and the reason is probably worth your attention.**

`FC-superseded-connection-mutates-live-session` describes this defect exactly. Its violated
contract — *a callback registered on an operation that has since been replaced must never
mutate the state its replacement now owns* — is precisely what went wrong; the retired
operation is an in-flight search rather than a socket, and the state it wrongly wrote is
`isSearching` rather than session connectedness. Its canonical prevention matches the fix
too: return early when the operation is no longer current, and prove it by delivering the
retired one's completion after the replacement is live. That is what the new test does.

I declared it, and `failure-class-protocol` passed. But `failure-class-guard-artifact-ratchet`
then failed:

```
FC-superseded-connection-mutates-live-session: 3 declarations in the window
(threshold 3) with no 'canonical_prevention_artifact'.
```

So this would be the third recurrence in 90 days of a class that still has no reusable guard
surface — which is exactly the signal that ratchet exists to raise. Clearing it means either
adding a `canonical_prevention_artifact` to the definition or grandfathering it in the
allowlist, and both are registry edits that `AGENTS.md` says an instance fix must never make.

I have declared `none` so this PR does not smuggle a registry change through a bug fix. If
you would rather it were classified, the honest sequence is a registry-only PR naming a guard
artifact for that class, then re-declaring here — happy to do either, but that is your call,
not mine.

---

*Written with Claude Code. Every file:line above was verified against `d60ab7a1c`.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

