### PR TITLE
docs: update MCP setup for OAuth and manual clients

### DIFF
--- a/docs/doc/developer/mcp/examples.mdx
+++ b/docs/doc/developer/mcp/examples.mdx
@@ -55,14 +55,20 @@ Once connected, try these prompts with your AI assistant:
 
 ## Python SDK Example
 
+This programmatic example uses the manual MCP-key fallback because the adapter receives
+static headers. Create an `omi_mcp_...` key as described in the [Setup guide](/doc/developer/mcp/setup)
+and load it from a secret store or environment variable in production.
+
 ```python
+import os
+
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
 async with MultiServerMCPClient({
     "omi": {
         "url": "https://api.omi.me/v1/mcp/sse",
         "transport": "streamable_http",
-        "headers": {"Authorization": "Bearer omi_mcp_YOUR_KEY"},
+        "headers": {"Authorization": f"Bearer {os.environ['OMI_MCP_API_KEY']}"},
     }
 }) as client:
     tools = client.get_tools()

--- a/docs/doc/developer/mcp/examples.mdx
+++ b/docs/doc/developer/mcp/examples.mdx
@@ -60,23 +60,29 @@ static headers. Create an `omi_mcp_...` key as described in the [Setup guide](/d
 and load it from a secret store or environment variable in production.
 
 ```python
+import asyncio
 import os
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
-async with MultiServerMCPClient({
-    "omi": {
-        "url": "https://api.omi.me/v1/mcp/sse",
-        "transport": "streamable_http",
-        "headers": {"Authorization": f"Bearer {os.environ['OMI_MCP_API_KEY']}"},
-    }
-}) as client:
-    tools = client.get_tools()
+async def main():
+    async with MultiServerMCPClient({
+        "omi": {
+            "url": "https://api.omi.me/v1/mcp/sse",
+            "transport": "streamable_http",
+            "headers": {"Authorization": f"Bearer {os.environ['OMI_MCP_API_KEY']}"},
+        }
+    }) as client:
+        tools = client.get_tools()
 
-    # Search memories
-    result = await client.call_tool("omi", "search_memories", {
-        "query": "morning routine",
-        "limit": 5,
-    })
-    print(result)
+        # Search memories
+        result = await client.call_tool("omi", "search_memories", {
+            "query": "morning routine",
+            "limit": 5,
+        })
+        print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```

--- a/docs/doc/developer/mcp/introduction.mdx
+++ b/docs/doc/developer/mcp/introduction.mdx
@@ -31,14 +31,17 @@ sequenceDiagram
     participant D as Your Omi Data
 
     A->>M: tools/list (discover available tools)
-    M-->>A: 8 tools available
+    M-->>A: Tools allowed by the user's OAuth grant or MCP key
     A->>M: tools/call search_memories {query: "morning routine"}
     M->>D: Semantic search via Pinecone
     D-->>M: Ranked results
     M-->>A: Memories with relevance scores
 ```
 
-Your AI assistant connects to the Omi MCP server, discovers available tools, and calls them as needed during your conversations. All data stays within your Omi account — the MCP server authenticates via your personal API key.
+Your AI assistant connects to the Omi MCP server, discovers the tools allowed by its
+authorization, and calls them as needed during your conversations. The hosted server
+supports OAuth access tokens (the default for supported ChatGPT and Claude cloud flows)
+and manually provisioned `omi_mcp_...` keys for compatible clients and local servers.
 
 The same hosted MCP connection works across Claude, Claude Code, ChatGPT, Codex, and any compatible client. It exposes the user's Omi context as scoped tools: durable memories, conversations, people, action items, goals, chat history, daily summaries, and synced screen activity. The server's initialization instructions tell clients to retrieve task-specific evidence, confirm important claims against source records, and avoid writes unless the user clearly requested them.
 
@@ -58,6 +61,15 @@ When the Omi macOS app connects Claude Code or Codex, it also installs a small `
 | `get_conversations` | List conversations with date/category filters |
 | `search_conversations` | Semantic search across conversations |
 | `get_conversation_by_id` | Get full conversation with transcript |
+| `get_user_profile` | Get Omi's cached high-level user summary |
+| `get_x_posts`, `search_x_posts` | Browse or search imported X posts and bookmarks |
+| `get_action_items`, `search_action_items` | Browse or search tasks |
+| `create_action_item`, `update_action_item`, `complete_action_item`, `delete_action_item` | Manage tasks |
+| `get_goals` | Retrieve active or historical goals |
+| `get_chat_messages` | Retrieve recent Omi chat history |
+| `get_people` | Retrieve recognized people and speaker samples |
+| `get_screen_activity` | Retrieve or summarize synced screen activity |
+| `get_daily_summaries` | Retrieve Omi's daily summaries |
 
 See the [Tools Reference](/doc/developer/mcp/tools) for full parameter documentation.
 

--- a/docs/doc/developer/mcp/setup.mdx
+++ b/docs/doc/developer/mcp/setup.mdx
@@ -4,20 +4,112 @@ icon: "gear"
 description: "Connect your AI assistant to the Omi MCP server"
 ---
 
-## Hosted Server (Recommended)
+## Choose a setup method
 
-The fastest way to get started — no installation required.
+Omi supports four setup paths:
+
+| Method | Authentication | Best for |
+| --- | --- | --- |
+| Omi's guided connection | OAuth for ChatGPT and Claude; a generated MCP key for local clients | The current Omi macOS app (recommended) |
+| Hosted server with OAuth | Browser sign-in and consent; no key to copy | Supported cloud clients |
+| Hosted server with an MCP key | `Authorization: Bearer omi_mcp_...` | Clients that accept custom headers |
+| Local stdio server | An MCP key passed to `mcp-server-omi` | Clients that require a local process or a self-hosted backend |
+
+OAuth and MCP keys grant access to the same hosted endpoint. OAuth is the default for the
+new cloud-connector UI; manual MCP keys remain available as a fallback.
+
+## Connect from the Omi macOS app (Recommended)
+
+On the Omi home screen, find **Use omi memory anywhere**, choose a destination, and follow
+the connection card:
+
+- **ChatGPT:** choose **ChatGPT / Codex**, then add Omi from its approved ChatGPT listing.
+  ChatGPT opens Omi's OAuth consent flow; you do not need to create or paste a key.
+- **Claude:** choose **Claude / Claude Code**, then **Claude (cloud)**. Omi opens Claude's
+  custom-connector flow with the registered public OAuth client.
+- **Claude Code, Codex, OpenClaw, and Hermes:** Omi generates an MCP connection key and
+  offers guided local setup. Expand **Manual installation** to copy the server URL, key,
+  command, or configuration yourself.
+- **ChatGPT custom app:** expand **Developer-mode fallback** only if your workspace cannot
+  use the approved directory listing.
+
+OAuth grants can be reviewed or revoked from the connected client. Revoking an MCP key is
+separate; use the Developer settings described below.
+
+---
+
+## Hosted Server with OAuth
+
+Use the hosted server URL as the remote MCP URL:
+
+```text
+https://api.omi.me/v1/mcp/sse
+```
+
+The endpoint supports MCP Streamable HTTP (`2025-03-26`) and advertises OAuth metadata at:
+
+```text
+https://api.omi.me/.well-known/oauth-protected-resource/v1/mcp/sse
+https://api.omi.me/.well-known/oauth-authorization-server
+```
+
+OAuth uses browser sign-in, explicit consent, authorization code + PKCE, and refresh
+tokens. Omi currently provides registered public clients for its ChatGPT and Claude setup
+flows. A generic MCP client cannot invent a client ID; if it is not one of those supported
+flows, use an MCP key instead.
+
+<Tabs>
+  <Tab title="ChatGPT" icon="robot">
+    The preferred path is **Omi → Use omi memory anywhere → ChatGPT / Codex → ChatGPT
+    (cloud)**. Add Omi from the directory page and approve the OAuth consent screen.
+
+    For the advanced developer-mode fallback, use:
+
+    - **Connection / server URL:** `https://api.omi.me/v1/mcp/sse`
+    - **Authentication:** OAuth
+    - **OAuth Client ID:** `omi-chatgpt-prod`
+    - **OAuth Client Secret:** leave blank
+    - **Token auth method:** `none`
+    - **Authorization URL:** `https://api.omi.me/authorize`
+    - **Token URL:** `https://api.omi.me/token`
+  </Tab>
+  <Tab title="Claude" icon="robot">
+    In Claude, open **Customize → Connectors → Add custom connector**, then use:
+
+    - **Name:** Omi Memory
+    - **Remote MCP server URL:** `https://api.omi.me/v1/mcp/sse`
+    - **OAuth Client ID:** `omi-claude-prod`
+    - **OAuth Client Secret:** leave blank
+
+    Click **Add**, then **Connect**, and approve Omi's OAuth consent screen. The Omi macOS
+    app exposes the same flow under **Use omi memory anywhere → Claude / Claude Code →
+    Claude (cloud)**.
+  </Tab>
+</Tabs>
+
+---
+
+## Manual MCP-key fallback
+
+Use a manual key for clients that support a bearer header but cannot use Omi's registered
+OAuth flows.
 
 <Steps>
-  <Step title="Generate an API Key" icon="key">
-    Open the Omi app and navigate to **Settings → Developer → MCP** to generate your API key.
+  <Step title="Find or create an MCP key" icon="key">
+    In the current macOS UI, open **Use omi memory anywhere**, choose Claude Code, Codex,
+    OpenClaw, or Hermes, and expand **Manual installation**. Omi generates the connection
+    key and shows a masked **Your key** row with a **Copy** button.
+
+    You can also use the cross-platform Omi app: open **Settings → Developer Settings**,
+    scroll to **MCP Server**, and create a key in its **API Keys** list. The complete
+    `omi_mcp_...` value is shown only when it is created, so copy and store it then.
 
     Your key will look like: `omi_mcp_...`
 
     <Note>
-    This key is only for MCP clients. To call REST Developer API endpoints directly, create a separate
-    Developer API key from **Settings → Developer → Create Key**. Developer API keys look like
-    `omi_dev_...`.
+    MCP keys are distinct from Developer API keys. An `omi_mcp_...` key authenticates the
+    hosted MCP endpoint and `/v1/mcp/...` REST routes. An `omi_dev_...` key authenticates
+    `/v1/dev/...` routes and will not authenticate MCP.
     </Note>
 
   </Step>
@@ -26,18 +118,19 @@ The fastest way to get started — no installation required.
 
     - **Server URL:** `https://api.omi.me/v1/mcp/sse`
     - **Authorization:** `Bearer omi_mcp_...` (your generated key)
-    - **Transport:** Streamable HTTP (MCP 2025-03-26 spec)
+    - **Transport:** Streamable HTTP (MCP `2025-03-26`)
 
   </Step>
 </Steps>
 
 ---
 
-## Client Configuration
+## Manual hosted-client configuration
 
 <Tabs>
-  <Tab title="Claude Desktop" icon="robot">
-    Add to your `claude_desktop_config.json`:
+  <Tab title="Claude Desktop / Claude Code" icon="robot">
+    Claude's cloud connector supports OAuth as described above. For a manual-key fallback,
+    add this to `claude_desktop_config.json`:
 
     ```json
     {
@@ -57,6 +150,14 @@ The fastest way to get started — no installation required.
     - Windows PowerShell: `$env:APPDATA\Claude\claude_desktop_config.json`
     - Windows cmd: `%APPDATA%\Claude\claude_desktop_config.json`
 
+    Claude Code can be configured at user scope instead:
+
+    ```bash
+    claude mcp add --scope user --transport http omi-memory \
+      https://api.omi.me/v1/mcp/sse \
+      --header "Authorization: Bearer omi_mcp_YOUR_KEY_HERE"
+    ```
+
   </Tab>
   <Tab title="Cursor" icon="i-cursor">
     Go to **Cursor Settings → MCP** and add a new server:
@@ -66,6 +167,17 @@ The fastest way to get started — no installation required.
     - **URL:** `https://api.omi.me/v1/mcp/sse`
     - **Headers:** `Authorization: Bearer omi_mcp_YOUR_KEY_HERE`
 
+  </Tab>
+  <Tab title="Codex" icon="terminal">
+    Add this to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.omi-memory]
+    command = "npx"
+    args = ["-y", "mcp-remote", "https://api.omi.me/v1/mcp/sse", "--header", "Authorization: Bearer omi_mcp_YOUR_KEY_HERE"]
+    ```
+
+    Restart Codex after saving the file.
   </Tab>
   <Tab title="OpenCode" icon="terminal">
     Add to your project's `opencode.json` (or `~/.config/opencode/opencode.json` globally):
@@ -93,7 +205,10 @@ The fastest way to get started — no installation required.
     ```
 
     <Note>
-    Be sure to use an MCP key generated from **Settings → Developer → MCP** (starts with `omi_mcp_`). Developer API keys (`omi_dev_...`) only authenticate REST endpoints and will return `401 Unauthorized`.
+    Be sure to use an MCP key from one of the locations in
+    [Manual MCP-key fallback](#manual-mcp-key-fallback). It starts with `omi_mcp_`.
+    Developer API keys (`omi_dev_...`) only authenticate Developer API endpoints and will
+    return `401 Unauthorized` here.
     </Note>
 
   </Tab>
@@ -103,8 +218,14 @@ The fastest way to get started — no installation required.
     Enter the server URL and API key in Poke's MCP connection settings.
 
   </Tab>
+  <Tab title="OpenClaw / Hermes" icon="terminal">
+    The Omi macOS app provides the current command or configuration under each client's
+    **Manual installation** disclosure. Copy it there so the generated key is inserted
+    without retyping it.
+  </Tab>
   <Tab title="Custom Client" icon="code">
-    Any MCP client that supports the **Streamable HTTP** transport (2025-03-26 spec) will work:
+    Any MCP client that supports **Streamable HTTP** and custom authorization headers can
+    use the manual-key path:
 
     ```bash
     # Endpoint
@@ -124,13 +245,72 @@ The fastest way to get started — no installation required.
 
 ---
 
-## Docker (Self-Hosted)
+## Local stdio server with uvx or Python
+
+Run the MCP server locally over the standard input/output transport. `uvx` downloads and
+runs the published package without a separate installation. Python 3.11.6 or newer is
+required.
+
+<Tabs>
+  <Tab title="uvx" icon="terminal">
+    Add this to your MCP client's local-server configuration:
+
+    ```json
+    {
+      "mcpServers": {
+        "omi": {
+          "command": "uvx",
+          "args": ["mcp-server-omi"],
+          "env": {
+            "OMI_API_KEY": "omi_mcp_YOUR_KEY_HERE"
+          }
+        }
+      }
+    }
+    ```
+
+    Install [uv](https://docs.astral.sh/uv/getting-started/installation/) first. The
+    `OMI_API_KEY` value can also be supplied with each tool call.
+  </Tab>
+  <Tab title="Python" icon="python">
+    Install the package in a Python 3.11.6+ environment:
+
+    ```bash
+    pip install mcp-server-omi
+    ```
+
+    Then configure your MCP client to launch the local server:
+
+    ```json
+    {
+      "mcpServers": {
+        "omi": {
+          "command": "mcp-server-omi",
+          "env": {
+            "OMI_API_KEY": "omi_mcp_YOUR_KEY_HERE"
+          }
+        }
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+  Generate the MCP key using either location in [Manual MCP-key fallback](#manual-mcp-key-fallback).
+  Developer API keys that start with `omi_dev_` will not authenticate MCP requests.
+</Note>
+
+---
+
+## Local stdio server with Docker
 
 If you prefer to run the MCP server locally:
 
 <Steps>
   <Step title="Generate an API Key" icon="key">
-    Open the Omi app → **Settings → Developer → MCP** to generate your key.
+    Generate an MCP key using either location in
+    [Manual MCP-key fallback](#manual-mcp-key-fallback).
   </Step>
   <Step title="Install Docker" icon="docker">
     Install Docker. We recommend [OrbStack](https://orbstack.dev/) for macOS.
@@ -151,6 +331,16 @@ If you prefer to run the MCP server locally:
 
   </Step>
 </Steps>
+
+The same Docker command can be used by any MCP client that supports local stdio servers.
+If you prefer to keep the key out of the configuration file, pass it through the
+`OMI_API_KEY` environment variable:
+
+```bash
+docker run --rm -i \
+  -e OMI_API_KEY="omi_mcp_YOUR_KEY_HERE" \
+  omiai/mcp-server
+```
 
 <Tip>
   The API key can also be provided with each tool call. If not provided, the

--- a/docs/doc/developer/mcp/tools.mdx
+++ b/docs/doc/developer/mcp/tools.mdx
@@ -6,6 +6,10 @@ description: "Complete reference for all Omi MCP tools"
 
 ## Memory Tools
 
+The hosted server returns only the tools allowed by the OAuth grant or MCP key. A local
+`mcp-server-omi` stdio process currently exposes the eight memory and conversation tools
+in the first two sections below; the additional tools are hosted-server tools.
+
 <AccordionGroup>
   <Accordion title="get_memories" icon="brain">
     Retrieve a list of user memories with optional filtering.
@@ -154,6 +158,39 @@ description: "Complete reference for all Omi MCP tools"
 
 ---
 
+## Profile, Imported Data, and Activity Tools
+
+| Tool | Parameters | Description |
+| --- | --- | --- |
+| `get_user_profile` | None | Return Omi's cached high-level user summary, if generated |
+| `get_x_posts` | `kind?` (`tweet` or `bookmark`), `limit?` (default 50) | List imported X posts and bookmarks, newest first |
+| `search_x_posts` | `query`, `limit?` (default 10) | Semantic search over imported X posts and bookmarks |
+| `get_goals` | `include_inactive?` (default false) | List goals, active by default |
+| `get_chat_messages` | `limit?` (default 50), `offset?` | List recent Omi chat messages, newest first |
+| `get_people` | None | List recognized people with speaker samples |
+| `get_screen_activity` | `start_date?`, `end_date?`, `app?`, `summary?`, `limit?` | List synced screen activity or return a per-app summary |
+| `get_daily_summaries` | `start_date?`, `end_date?`, `limit?` (default 30), `offset?` | List Omi's daily summaries, newest first |
+
+Dates use `YYYY-MM-DD`. `get_screen_activity` defaults to 200 raw rows; `limit` is ignored
+when `summary` is true.
+
+---
+
+## Action Item Tools
+
+| Tool | Required parameters | Optional parameters | Description |
+| --- | --- | --- | --- |
+| `get_action_items` | None | `completed`, `due_start_date`, `due_end_date`, `limit` (default 100), `offset` | List tasks and to-dos |
+| `search_action_items` | `query` | `limit` (default 10) | Semantic search over tasks |
+| `create_action_item` | `description` | `due_at`, `completed` (default false) | Create a task; identical retries do not duplicate it |
+| `complete_action_item` | `action_item_id` | `completed` (default true) | Complete or reopen a task |
+| `update_action_item` | `action_item_id` | `description`, `due_at` | Update only the supplied fields |
+| `delete_action_item` | `action_item_id` | None | Delete a task |
+
+Due dates accept `YYYY-MM-DD` or an ISO 8601 date-time where noted by the client schema.
+
+---
+
 ## Error Handling
 
 All tools return JSON-RPC 2.0 errors when something goes wrong:
@@ -163,6 +200,8 @@ All tools return JSON-RPC 2.0 errors when something goes wrong:
 | `-32602` | Invalid parameters (bad date format, unknown category) |
 | `-32001` | Resource not found (memory or conversation doesn't exist) |
 | `-32002` | Locked content (paid plan required) |
+| `-32003` | The OAuth grant is missing the tool's required scope |
+| `-32009` | Authorization or serving policy denied the operation |
 | `-32601` | Unknown tool name |
 
 **Example error response:**

--- a/docs/doc/developer/mcp/troubleshooting.mdx
+++ b/docs/doc/developer/mcp/troubleshooting.mdx
@@ -7,11 +7,19 @@ description: "Debug and fix common MCP connection issues"
 ## Common Issues
 
 <AccordionGroup>
+  <Accordion title="OAuth sign-in or consent does not open" icon="lock">
+    - Confirm the remote server URL is exactly `https://api.omi.me/v1/mcp/sse`
+    - Use Omi's registered ChatGPT or Claude connection flow; arbitrary client IDs are not accepted
+    - For Claude, use client ID `omi-claude-prod` and leave the client secret blank
+    - For ChatGPT's developer-mode fallback, use `omi-chatgpt-prod`, leave the secret blank, and set token auth method to `none`
+    - If the client cannot complete OAuth, use the manual MCP-key fallback in the [Setup guide](/doc/developer/mcp/setup)
+  </Accordion>
   <Accordion title="Connection refused or 401 Unauthorized" icon="lock">
-    - Verify your API key starts with `omi_mcp_`
-    - Check that the `Authorization` header uses `Bearer` prefix: `Bearer omi_mcp_...`
-    - Generate a new key in the Omi app: **Settings → Developer → MCP**
-    - Ensure the key hasn't been revoked
+    - OAuth clients: reconnect so the client can refresh or replace its OAuth access token
+    - Manual-key clients: verify the key starts with `omi_mcp_`
+    - Check that the header uses the `Bearer` prefix: `Bearer omi_mcp_...`
+    - Generate a new key from the macOS connection card's **Manual installation** section, or from **Settings → Developer Settings → MCP Server → API Keys** in the cross-platform app
+    - Ensure the OAuth grant or MCP key has not been revoked
   </Accordion>
   <Accordion title="Calling the REST API with an MCP key (404 or 401)" icon="code">
     An `omi_mcp_...` key authenticates the MCP endpoints only. Two things follow:
@@ -25,12 +33,12 @@ description: "Debug and fix common MCP connection issues"
     ```
 
     To call the [Developer API](/doc/developer/api/overview) (`/v1/dev/...`) instead, create a separate
-    key in **Settings → Developer → Create Key**; it starts with `omi_dev_`. Using either key on the
+    key in **Settings → Developer Settings → Developer API Keys**; it starts with `omi_dev_`. Using either key on the
     other's endpoints returns a `401` that names the endpoints that key does authenticate.
   </Accordion>
   <Accordion title="No tools showing up" icon="toolbox">
     - Send an `initialize` request first — tools are only available after initialization
-    - Check that your client supports the Streamable HTTP transport (2025-03-26 spec)
+    - Check that your client supports the Streamable HTTP transport (`2025-03-26`)
     - Try the `/v1/mcp/sse/info` endpoint to verify the server is reachable:
       ```bash
       curl https://api.omi.me/v1/mcp/sse/info

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -43,11 +43,38 @@ A Model Context Protocol server for Omi interaction and automation. This server 
 
 ### API Key
 
-To use the Omi MCP server, you need an API key. You can generate one in the Omi app under `Settings > Developer > MCP`. The API key can be provided with each tool call. If not provided, the server will use the `OMI_API_KEY` environment variable as a fallback.
+This local stdio server uses an MCP API key. In the current Omi macOS app, choose a
+key-based destination under `Use omi memory anywhere` and expand `Manual installation` to
+copy the generated key. In the cross-platform app, open `Settings > Developer Settings`,
+scroll to `MCP Server`, and create a key in the `API Keys` list. Copy the complete
+`omi_mcp_...` value when it is created.
+
+The key can be provided with each tool call. If it is omitted, the server uses the
+`OMI_API_KEY` environment variable. The hosted Omi MCP endpoint also supports OAuth for
+registered cloud clients; this local stdio package uses the manual-key path.
 
 ### Usage with Claude Desktop
 
 Add this to your `claude_desktop_config.json`:
+
+<details>
+<summary>Using uvx (recommended)</summary>
+
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/) first. No separate
+package installation is needed; `uvx` downloads and runs the published server:
+
+```json
+"mcpServers": {
+  "omi": {
+    "command": "uvx",
+    "args": ["mcp-server-omi"],
+    "env": {
+      "OMI_API_KEY": "omi_mcp_YOUR_KEY_HERE"
+    }
+  }
+}
+```
+</details>
 
 <details>
 <summary>Using docker</summary>
@@ -66,22 +93,26 @@ Replace `your_api_key_here` with the key you generated in the Omi app.
 ```
 </details>
 
-<!-- <details>
-<summary>Using pip installation</summary>
+<details>
+<summary>Using pip</summary>
 
-Requires python >= 3.11.6. 
-- Check `python --version`, and `brew list --versions | grep python` (you might have other versions of python installed)
-- Get the path of the python version (`which python`) or with brew
+Requires Python 3.11.6 or newer:
+
+```bash
+pip install mcp-server-omi
+```
 
 ```json
 "mcpServers": {
   "omi": {
-    "command": "/opt/homebrew/bin/python3.12",
-    "args": ["-m", "mcp_server_omi"]
+    "command": "mcp-server-omi",
+    "env": {
+      "OMI_API_KEY": "omi_mcp_YOUR_KEY_HERE"
+    }
   }
 }
 ```
-</details> -->
+</details>
 
 ## Debugging
 


### PR DESCRIPTION
## What changed

- Update MCP setup documentation for OAuth-first hosted connections.
- Document the current Omi macOS connection flows for ChatGPT, Claude, Claude Code, Codex, OpenClaw, and Hermes.
- Preserve and clarify manual `omi_mcp_...` key fallback setup, including where keys are created in the current UI.
- List hosted and local MCP setup methods: Streamable HTTP, uvx, Python, and Docker.
- Reconcile MCP tool references, examples, troubleshooting, and the local server README with the current hosted and local tool surfaces.

## Why

The product moved from key-only MCP setup to OAuth for supported cloud connectors, but the docs still directed users to the old MCP key screen and described an outdated hosted tool surface.

## Validation

- `git diff --check`
- MDX component balance check for `docs/doc/developer/mcp/*.mdx`
- `npm run build --prefix docs`
- `make preflight`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

