### PR TITLE
fix(app): keep beta social auth on production identity

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -53,7 +53,9 @@ configuration, and the beta bundle ID must be registered with both Firebase and
 the Apple team. Override the default bundle ID with
 `OMI_MOBILE_BETA_BUNDLE_ID` when your team uses a different registered ID. The
 beta build uses the `mobile_beta` profile and the `omi-beta://auth/callback`
-scheme; it must not be treated as a local-emulator build.
+scheme. Product traffic uses the beta serving API, while Google and Apple OAuth
+remain on `https://api.omi.me/`; the beta must not be treated as a local-emulator
+build.
  
 3. Ensure GitHub SSH access is set up correctly for pulling certificates from repositories. After running the command below, if you're prompted for a passphrase, enter your SSH passphrase — or simply press Enter/Return if you haven't set one.
     ```bash

--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -62,6 +62,20 @@ abstract class Env {
 
   static String get authRedirectUri => '$authCallbackScheme://auth/callback';
 
+  /// OAuth remains on the production identity plane even when mobile Beta
+  /// uses the development serving API for product traffic.
+  static String get authApiBaseUrl => authApiBaseUrlForProfile(profile, servingApiBaseUrl: apiBaseUrl);
+
+  static String authApiBaseUrlForProfile(
+    AppEnvironmentProfile configuredProfile, {
+    String? servingApiBaseUrl,
+  }) {
+    if (configuredProfile == AppEnvironmentProfile.mobileBeta) {
+      return productionApiBaseUrl;
+    }
+    return servingApiBaseUrl ?? configuredProfile.defaultApiBaseUrl;
+  }
+
   static void validateProfilePairing() {
     final productionFlavor = F.env == Environment.prod;
     if (!productionFlavor && profile != AppEnvironmentProfile.localDev) {

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -465,7 +465,7 @@ class AuthService {
 
       Logger.debug('Starting OAuth flow for provider: $provider');
 
-      final authUrl = Uri.parse('${Env.apiBaseUrl}v1/auth/authorize').replace(
+      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize').replace(
         queryParameters: {
           'provider': provider,
           'redirect_uri': redirectUri,
@@ -579,7 +579,7 @@ class AuthService {
       final useCustomToken = Env.useAuthCustomToken;
 
       final response = await http.post(
-        Uri.parse('${Env.apiBaseUrl}v1/auth/token'),
+        Uri.parse('${Env.authApiBaseUrl}v1/auth/token'),
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: {
           'grant_type': 'authorization_code',
@@ -821,7 +821,7 @@ class AuthService {
 
       Logger.debug('Starting OAuth linking flow for provider: $provider');
 
-      final authUrl = Uri.parse('${Env.apiBaseUrl}v1/auth/authorize').replace(
+      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize').replace(
         queryParameters: {
           'provider': provider,
           'redirect_uri': redirectUri,

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -69,6 +69,16 @@ void main() {
       expect(AppEnvironmentProfile.mobileBeta.authCallbackScheme, 'omi-beta');
     });
 
+    test('mobile beta keeps OAuth on the production identity plane', () {
+      expect(
+        Env.authApiBaseUrlForProfile(
+          AppEnvironmentProfile.mobileBeta,
+          servingApiBaseUrl: 'https://api.omiapi.com/',
+        ),
+        Env.productionApiBaseUrl,
+      );
+    });
+
     test('local profile rejects a production Firebase project', () {
       expect(
         () => Env.validateFirebaseProject(


### PR DESCRIPTION
## Summary

- Keep mobile Beta Google and Apple OAuth authorization/token exchange on the production identity authority.
- Preserve Beta product traffic on `api.omiapi.com` and document the intentional serving/auth split.
- Add regression coverage for the Beta OAuth authority.

## Root cause

The new `mobile_beta` profile correctly selected the Beta product-serving API, but the shared web OAuth path derived its authorization and token endpoints from that same serving URL. Both onboarding providers therefore crossed the Beta API boundary instead of the canonical production identity plane.

## Verification

- `cd app && PATH=/Users/architlal/.cache/omi-flutter-3.41.9/bin:$PATH bash test.sh test/unit/env_test.dart` — 16 tests passed.
- `cd app && PATH=/Users/architlal/.cache/omi-flutter-3.41.9/bin:$PATH bash scripts/analyze_ratchet.sh` — passed.
- `cd app && PATH=/Users/architlal/.cache/omi-flutter-3.41.9/bin:$PATH bash test.sh` — 1,168 tests passed.
- Live production `/v1/auth/authorize` probes for both Google and Apple with the `omi-beta://auth/callback` redirect returned provider redirects.

## Product invariant

INV-DATA-1 — preserves the existing production Firebase/OAuth identity authority while retaining Beta's fixed serving-plane split.

Failure-Class: FC-customer-data-plane-divergence


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

