### PR TITLE
🧹 [Code Health] Remove unused import PlanLimits

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -2,7 +2,7 @@
   "files": {
     "backend/database/conversations.py": 1729,
     "backend/database/memory_apply_store.py": 1912,
-    "backend/database/users.py": 2121
+    "backend/database/users.py": 2120
   },
   "raise_justifications": {
     "backend/database/conversations.py": "Chat-first capture archive filtering and the #9809 orphaned in_progress selection belong beside the shared conversation query and cursor invariants; extraction would duplicate their ordered query contracts. Null-aware user-field preservation and folder_user_set marker so AI folder assignment does not clobber stub nulls or explicit user unfile.",

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -25,7 +25,6 @@ from models.users import (
     LocationContextConsent,
     LocationContextConsentStatus,
     Subscription,
-    PlanLimits,
     PlanType,
     SubscriptionStatus,
 )


### PR DESCRIPTION
🎯 **What:** Removed unused import `PlanLimits` from `backend/database/users.py`.
💡 **Why:** Fixes code health issue identified by Ruff. Removing dead code improves maintainability and readability.
✅ **Verification:** Ran `ruff check backend/database/users.py` and confirmed no errors are reported.
✨ **Result:** A cleaner codebase free of unused imports.

---
*PR created automatically by Jules for task [2871523820672714136](https://jules.google.com/task/2871523820672714136) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no runtime or behavioral changes.
> 
> **Overview**
> Removes the unused **`PlanLimits`** import from `backend/database/users.py` so Ruff no longer flags dead imports.
> 
> The product file line-count ratchet baseline for that file is lowered by one line (**2121 → 2120**) to match the smaller file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57310b57f345fed8d8788e43d0b25e951aae6722. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->