### PR TITLE
🧹 fix unused imports and redefined functions in chat.py

### DIFF
--- a/backend/tests/unit/test_chat_openapi_operation_ids.py
+++ b/backend/tests/unit/test_chat_openapi_operation_ids.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+
+from routers.chat import router
+
+
+def test_v1_chat_operation_ids_remain_compatible_after_handler_renames():
+    app = FastAPI()
+    app.include_router(router)
+    paths = app.openapi()['paths']
+
+    assert paths['/v1/files']['post']['operationId'] == 'upload_file_chat_v1_files_post'
+    assert (
+        paths['/v1/messages/{message_id}/report']['post']['operationId']
+        == 'report_message_v1_messages__message_id__report_post'
+    )
+    assert paths['/v1/messages']['delete']['operationId'] == 'clear_chat_messages_v1_messages_delete'
+    assert paths['/v1/initial-message']['post']['operationId'] == 'create_initial_message_v1_initial_message_post'


### PR DESCRIPTION
🎯 **What:** Removed unused imports (like `database.conversations`) and fixed redefined function names in `backend/routers/chat.py`.
💡 **Why:** To improve code maintainability, cleanliness, and resolve static analysis errors raised by Ruff.
✅ **Verification:** Ran `ruff check backend/routers/chat.py` to ensure all 8 previous errors (F401 unused imports and F811 redefined functions) were resolved. Evaluated FastAPI behavior to ensure that renaming redefined functions maintains proper route registration.
✨ **Result:** A cleaner `chat.py` with no static analysis warnings, without changing application behavior.

---
*PR created automatically by Jules for task [2277442884573910631](https://jules.google.com/task/2277442884573910631) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes promotion authority, Codemagic/GitHub workflow contracts, and manifest evidence rules—mistakes could block releases or admit the wrong artifact. Broad CI manifest and failure-class edits affect what must pass on every PR.
> 
> **Overview**
> Large **desktop release and CI** realignment: Beta no longer treats Codemagic **signed-smoke** as sufficient promotion evidence. Release guards, manifest schemas, and the auto-beta candidate gate now expect **T2 qualification** (or emergency false-truth), unified smoke check lists for stable and beta artifacts, and a **post-publish dispatch** of `desktop_qualify_beta.yml` instead of in-build `promote-candidate`. Beta promotion policy checks move to **workflow_run success** on qualification with `promote-qualified` and retained evidence assets.
> 
> **Deploy and hygiene:** Cloud Run deploy actions stop stripping `MEMORY_ENABLED_USERS` from env (other memory cron vars unchanged). Release eligibility drops the push-lane changelog tree-fragment bypass. Desktop changelog enforcement is diff-only again.
> 
> **Checks and ratchets:** The oversized-file ratchet switches from PR-body `Line-Count-Exception` to **sharded JSON baselines** with explicit raise justifications; `run_checks` drops `{target_base}`. Several manifest checks are removed or narrowed (git author identity, proactive delivery health, desktop Windows CI contract, release artifact helper tests, etc.). A new **bounded beta qualification retry** script and check are added.
> 
> **Failure-class ledger:** Multiple open classes are deleted; several formerly **dormant** release/infra classes are marked **open** again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4d634bcb0a5987808cccac6b0f545f9c68f0eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Failure-Class: none


