### PR TITLE
🧪 Add tests for numberValue utility in response-reliability

### DIFF
--- a/web/admin/lib/__tests__/response-reliability.test.ts
+++ b/web/admin/lib/__tests__/response-reliability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { numberValue } from "../response-reliability";
 
 import {
   buildChannelReliabilityPayloads,
@@ -477,5 +478,40 @@ describe("response reliability", () => {
       voiceRows: [],
     });
     expect(trimDailyToCoverage(excludedOnly.daily)[0]?.date).toBe("2026-07-18");
+  });
+});
+
+describe("numberValue", () => {
+  it("returns the number for a valid number", () => {
+    expect(numberValue(42)).toBe(42);
+    expect(numberValue(-42)).toBe(-42);
+    expect(numberValue(0)).toBe(0);
+    expect(numberValue(1.5)).toBe(1.5);
+  });
+
+  it("parses valid number strings", () => {
+    expect(numberValue("42")).toBe(42);
+    expect(numberValue("-42")).toBe(-42);
+    expect(numberValue("1.5")).toBe(1.5);
+    expect(numberValue("0")).toBe(0);
+  });
+
+  it("returns 0 for undefined and null", () => {
+    expect(numberValue(undefined)).toBe(0);
+    expect(numberValue(null)).toBe(0);
+  });
+
+  it("returns 0 for non-finite values and unparseable strings", () => {
+    expect(numberValue(NaN)).toBe(0);
+    expect(numberValue(Infinity)).toBe(0);
+    expect(numberValue(-Infinity)).toBe(0);
+    expect(numberValue("not a number")).toBe(0);
+    expect(numberValue({})).toBe(0);
+  });
+
+  it("returns 0 for boolean values (unless we expect otherwise, Number(true) is 1)", () => {
+    // Number(true) is 1, Number(false) is 0
+    expect(numberValue(true)).toBe(1);
+    expect(numberValue(false)).toBe(0);
   });
 });

--- a/web/admin/lib/response-reliability.ts
+++ b/web/admin/lib/response-reliability.ts
@@ -123,7 +123,7 @@ const emptyMetric = (): MutableMetric => ({
   durationMs: 0,
 });
 
-const numberValue = (value: unknown): number => {
+export const numberValue = (value: unknown): number => {
   const parsed = Number(value ?? 0);
   return Number.isFinite(parsed) ? parsed : 0;
 };


### PR DESCRIPTION
🎯 **What:** The `numberValue` utility function in `web/admin/lib/response-reliability.ts` was untested. This PR exports the function and adds a comprehensive test suite to verify its behavior.
📊 **Coverage:** The tests now cover all happy paths (valid numbers, parseable strings) and edge cases (`null`, `undefined`, boolean values, `NaN`, `Infinity`, unparseable strings, objects).
✨ **Result:** Test coverage for `response-reliability.ts` is improved, ensuring the `numberValue` function behaves correctly and safely parses various inputs.

---
*PR created automatically by Jules for task [17006155647318755123](https://jules.google.com/task/17006155647318755123) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only surface change plus exporting an existing helper; runtime aggregation behavior is unchanged.
> 
> **Overview**
> **Exports** the `numberValue` helper in `response-reliability.ts` (previously module-private) so it can be tested directly, and **adds** a Vitest `describe("numberValue")` block in `response-reliability.test.ts`.
> 
> The new tests lock in coercion behavior: finite numbers and numeric strings pass through, `null`/`undefined` and non-finite or unparseable inputs become `0`, and booleans follow `Number()` (`true` → `1`, `false` → `0`). **No change** to the parsing logic itself—only visibility and coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2328be56c7281e91cfbfe4af5ce010af086b15a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->