### PR TITLE
🧪 test: add missing test coverage for data export

### DIFF
--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -6,6 +6,8 @@ import types
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, call
 
+import pytest
+
 
 class _AutoMockModule(types.ModuleType):
     __path__ = []
@@ -132,7 +134,6 @@ def test_iter_user_data_export_yields_before_heavy_reads(monkeypatch):
 
 
 def test_json_default_raises_type_error_for_unsupported_types():
-    import pytest
     with pytest.raises(TypeError, match="Type <class 'set'> not serializable"):
         data_export._json_default(set())
 

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -131,6 +131,35 @@ def test_iter_user_data_export_yields_before_heavy_reads(monkeypatch):
     get_profile.assert_not_called()
 
 
+def test_json_default_raises_type_error_for_unsupported_types():
+    import pytest
+    with pytest.raises(TypeError, match="Type <class 'set'> not serializable"):
+        data_export._json_default(set())
+
+
+def test_iter_user_data_export_skips_none_conversations_and_formats_arrays(monkeypatch):
+    monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value={}))
+    monkeypatch.setattr(data_export.memories_db, 'get_non_filtered_memories', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[]))
+    monkeypatch.setattr(data_export, 'get_standalone_action_items', MagicMock(return_value=[]))
+    monkeypatch.setattr(
+        data_export.conversations_db,
+        'iter_all_conversations',
+        MagicMock(return_value=iter([{'id': 'conv1'}, None, {'id': 'conv2'}])),
+    )
+    monkeypatch.setattr(
+        data_export.chat_db,
+        'iter_all_messages',
+        MagicMock(return_value=iter([{'id': 'msg1'}, {'id': 'msg2'}])),
+    )
+
+    body = ''.join(data_export.iter_user_data_export('uid1'))
+    payload = json.loads(body)
+
+    assert payload['conversations'] == [{'id': 'conv1'}, {'id': 'conv2'}]
+    assert payload['chat_messages'] == [{'id': 'msg1'}, {'id': 'msg2'}]
+
+
 def test_iter_user_data_export_paginates_complete_collections(monkeypatch):
     monkeypatch.setattr(data_export, 'get_user_profile', MagicMock(return_value={}))
     monkeypatch.setattr(data_export, 'get_people', MagicMock(return_value=[]))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed involves adding tests for missing coverage in `backend/services/users/data_export.py`, specifically testing logic that skips `None` values during conversation processing, and tests for fallback typing error throwing during json serialization.
📊 **Coverage:** Added tests to reach 100% test coverage on `backend/services/users/data_export.py`. Included tests `test_json_default_raises_type_error_for_unsupported_types` and `test_iter_user_data_export_skips_none_conversations_and_formats_arrays`.
✨ **Result:** Improved test coverage safely mapping out edge cases, giving better assurances on correct outputs during account data exporting.

---
*PR created automatically by Jules for task [906683028557927131](https://jules.google.com/task/906683028557927131) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test additions; no production code or export behavior changes.
> 
> **Overview**
> Adds **test-only** coverage in `test_data_export.py` for behaviors already implemented in `data_export.py`, aiming for full line coverage on that module.
> 
> New tests assert that `_json_default` raises `TypeError` for unsupported types (e.g. `set`), and that `iter_user_data_export` **drops `None` entries** from the conversations iterator while still emitting valid `conversations` and `chat_messages` JSON arrays. The file also imports `pytest` for `pytest.raises`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac38980057cc3f923625a576c55c5f472a26ec2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->