### PR TITLE
🧹 [code health] Enforce maximum segment size limit in STT pre_recorded merging

### DIFF
--- a/backend/tests/unit/test_pre_recorded_merge.py
+++ b/backend/tests/unit/test_pre_recorded_merge.py
@@ -4,6 +4,28 @@ from utils.stt.pre_recorded import _merge_segments
 def test_merge_segments_max_size():
     words = [{"text": "word", "start": i, "end": i + 0.5, "speaker": "SPEAKER_00"} for i in range(100)]
     segments = _merge_segments(words, skip_n_seconds=0, user_speaker_id=None)
-    assert len(segments) > 1, f"Expected more than 1 segment, got {len(segments)}"
+    assert len(segments) == 4
+    assert [len(segment["text"].split()) for segment in segments] == [30, 30, 30, 10]
     for s in segments:
-        assert s["end"] - s["start"] < 30, f"Segment duration exceeded 30s: {s['end'] - s['start']}"
+        assert s["end"] - s["start"] <= 30
+
+
+def test_merge_segments_splits_long_provider_entry():
+    words = [
+        {
+            "text": "one two three four five six seven eight nine ten eleven twelve",
+            "start": 0,
+            "end": 75,
+            "speaker": "SPEAKER_00",
+        }
+    ]
+
+    segments = _merge_segments(words, skip_n_seconds=0, user_speaker_id=None)
+
+    assert [(segment["start"], segment["end"]) for segment in segments] == [(0, 30), (30, 60), (60, 75)]
+    assert [segment["text"] for segment in segments] == [
+        "one two three four",
+        "five six seven eight",
+        "nine ten eleven twelve",
+    ]
+    assert " ".join(segment["text"] for segment in segments) == words[0]["text"]

--- a/backend/tests/unit/test_pre_recorded_merge.py
+++ b/backend/tests/unit/test_pre_recorded_merge.py
@@ -1,9 +1,8 @@
 from utils.stt.pre_recorded import _merge_segments
 
+
 def test_merge_segments_max_size():
-    words = [
-        {"text": "word", "start": i, "end": i + 0.5, "speaker": "SPEAKER_00"} for i in range(100)
-    ]
+    words = [{"text": "word", "start": i, "end": i + 0.5, "speaker": "SPEAKER_00"} for i in range(100)]
     segments = _merge_segments(words, skip_n_seconds=0, user_speaker_id=None)
     assert len(segments) > 1, f"Expected more than 1 segment, got {len(segments)}"
     for s in segments:

--- a/backend/tests/unit/test_pre_recorded_merge.py
+++ b/backend/tests/unit/test_pre_recorded_merge.py
@@ -1,0 +1,10 @@
+from utils.stt.pre_recorded import _merge_segments
+
+def test_merge_segments_max_size():
+    words = [
+        {"text": "word", "start": i, "end": i + 0.5, "speaker": "SPEAKER_00"} for i in range(100)
+    ]
+    segments = _merge_segments(words, skip_n_seconds=0, user_speaker_id=None)
+    assert len(segments) > 1, f"Expected more than 1 segment, got {len(segments)}"
+    for s in segments:
+        assert s["end"] - s["start"] < 30, f"Segment duration exceeded 30s: {s['end'] - s['start']}"

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -4,6 +4,7 @@ import wave as _wave
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from io import BytesIO
+from math import ceil
 from threading import RLock
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
 
@@ -37,6 +38,7 @@ from utils.stt.speaker_embedding import SPEAKER_MATCH_THRESHOLD, compare_embeddi
 
 _DG_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
 _MODULATE_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
+_MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS = 30.0
 
 logger = logging.getLogger(__name__)
 
@@ -1183,21 +1185,52 @@ def _retrieve_user_speaker_id(words: List[Dict[str, Any]], skip_n_seconds: int) 
 def _merge_segments(
     words: List[Dict[str, Any]], skip_n_seconds: int, user_speaker_id: Optional[str]
 ) -> List[Dict[str, Any]]:
+    def split_long_entry(entry: Dict[str, Any]) -> List[Dict[str, Any]]:
+        start = float(entry['start'])
+        end = float(entry['end'])
+        duration = end - start
+        if duration <= _MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS:
+            return [entry]
+
+        chunk_count = ceil(duration / _MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS)
+        text_words = str(entry['text']).split()
+        words_per_chunk, remainder = divmod(len(text_words), chunk_count)
+        chunks: List[Dict[str, Any]] = []
+        text_offset = 0
+        for index in range(chunk_count):
+            chunk_word_count = words_per_chunk + (1 if index < remainder else 0)
+            next_text_offset = text_offset + chunk_word_count
+            chunk = dict(entry)
+            chunk['start'] = start + index * _MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS
+            chunk['end'] = min(start + (index + 1) * _MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS, end)
+            chunk['text'] = ' '.join(text_words[text_offset:next_text_offset])
+            chunks.append(chunk)
+            text_offset = next_text_offset
+        return chunks
+
     segments: List[Dict[str, Any]] = []
     for word in words:
         if word['start'] < skip_n_seconds:
             continue
-        word['is_user'] = word['speaker'] == user_speaker_id if word['speaker'] else False
+        for entry in split_long_entry(word):
+            entry['is_user'] = entry['speaker'] == user_speaker_id if entry['speaker'] else False
 
-        same_prev_speaker = word['speaker'] == segments[-1]['speaker'] if segments else False
-        seconds_from_prev = word['start'] - segments[-1]['end'] if segments else 0
+            same_prev_speaker = entry['speaker'] == segments[-1]['speaker'] if segments else False
+            seconds_from_prev = entry['start'] - segments[-1]['end'] if segments else 0
 
-        within_max_duration = word['end'] - segments[-1]['start'] < 30 if segments else False
-        if segments and same_prev_speaker and seconds_from_prev < 30 and within_max_duration:
-            segments[-1]['end'] = word['end']
-            segments[-1]['text'] += ' ' + word['text']
-        else:
-            segments.append(word)
+            within_max_duration = (
+                entry['end'] - segments[-1]['start'] < _MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS if segments else False
+            )
+            if (
+                segments
+                and same_prev_speaker
+                and seconds_from_prev < _MAX_PRE_RECORDED_SEGMENT_DURATION_SECONDS
+                and within_max_duration
+            ):
+                segments[-1]['end'] = entry['end']
+                segments[-1]['text'] += ' ' + entry['text']
+            else:
+                segments.append(entry)
     return segments
 
 

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -1192,8 +1192,8 @@ def _merge_segments(
         same_prev_speaker = word['speaker'] == segments[-1]['speaker'] if segments else False
         seconds_from_prev = word['start'] - segments[-1]['end'] if segments else 0
 
-        # TODO: consider having a max segment size too
-        if segments and same_prev_speaker and seconds_from_prev < 30:
+        within_max_duration = word['end'] - segments[-1]['start'] < 30 if segments else False
+        if segments and same_prev_speaker and seconds_from_prev < 30 and within_max_duration:
             segments[-1]['end'] = word['end']
             segments[-1]['text'] += ' ' + word['text']
         else:

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -45,6 +45,13 @@ before processing — this corrects non-deterministic WebSocket arrival order
 from providers like Modulate whose internal parallelism can deliver shorter
 utterances before longer ones.
 
+Pre-recorded STT results from providers such as Modulate and Parakeet are
+normalized before they are written as transcript segments. Consecutive entries
+from the same speaker may be merged when their gap is under 30 seconds, but no
+normalized segment may span more than 30 seconds. A provider entry that is
+already longer than 30 seconds is split into contiguous slices before merging,
+with its text distributed across those slices.
+
 Every `/v4/listen` stream receives a durable, user-scoped `recording_session`
 resource before it creates or resumes a conversation. A client-generated
 `client_conversation_id` remains that resource's ID when present; legacy


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The actionable `TODO: consider having a max segment size too` comment in `backend/utils/stt/pre_recorded.py` was resolved by introducing a max segment size limit of 30 seconds.

💡 **Why:** How this improves maintainability
If a speaker speaks continuously for a long time, the segment could grow indefinitely without this limit, leading to very long segments which can be harder to process or display. Enforcing a 30-second cap prevents unbounded growth of STT segments and improves the consistency of the output.

✅ **Verification:** How you confirmed the change is safe
Ran the specific test `test_pre_recorded_merge.py` and the `test_parakeet_prerecorded.py` test suite with `PYTHONPATH=backend pytest` to ensure no regressions were introduced.

✨ **Result:** The improvement achieved
A cleaner codebase with the TODO removed, proper limits enforced on STT transcription segments, and corresponding unit tests to verify the behavior.

---
*PR created automatically by Jules for task [14521290945147442483](https://jules.google.com/task/14521290945147442483) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized post-processing change to transcript chunking; may split long monologues into more segments but does not touch auth, storage, or provider APIs.
> 
> **Overview**
> **Pre-recorded STT segment merging** now stops extending a segment once it would reach **30 seconds**, even when the same speaker continues with short gaps. The existing rules (same speaker, &lt;30s pause) still apply; the new `within_max_duration` guard replaces the old TODO.
> 
> A **unit test** (`test_merge_segments_max_size`) checks that long single-speaker word streams split into multiple segments, each under 30s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb61698296d717b015c6e56e51967fd3c54f558. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->