### PR TITLE
🧹 [Code Health] Restore sorting in RAG context extraction

### DIFF
--- a/backend/utils/retrieval/rag.py
+++ b/backend/utils/retrieval/rag.py
@@ -119,7 +119,6 @@ def retrieve_rag_conversation_context(uid: str, memory: Conversation) -> Tuple[s
     user_name = get_user_name(uid, use_default=False) or ''
 
     if memories_id_to_topics:
-        # TODO: restore sorting here
         context_data: Dict[str, str] = {}
         futures = [
             db_executor.submit(
@@ -129,7 +128,8 @@ def retrieve_rag_conversation_context(uid: str, memory: Conversation) -> Tuple[s
         ]
         for f in futures:
             f.result()
-        context_str = '\n'.join(context_data.values()).strip()
+        ordered_chunks = [context_data[m.id] for m in memories if m.id in context_data]
+        context_str = '\n'.join(ordered_chunks).strip()
     else:
         context_str = conversations_to_string(memories, people=people, user_name=user_name)
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is a missing sort restoration of retrieved conversation chunks in the RAG retrieval flow. A TODO comment (`# TODO: restore sorting here`) flagged the problem.
💡 **Why:** How this improves maintainability: The chunks retrieved using futures were previously compiled via `.values()`, which is arbitrary due to the non-deterministic completion of tasks in the thread pool. This fix ensures the original sorted order of `memories` (which represents vector similarity ranking) is strictly maintained, making the logic predictable and preserving the intention of the sorting step that occurred right before fetching chunks.
✅ **Verification:** Validated by running related unit tests in `pytest backend/tests/unit/test_process_conversation_usage_context.py` to ensure RAG retrieval doesn't break, and the code logic itself is safe via a key check `if m.id in context_data`.
✨ **Result:** A consistent, correct implementation that eliminates the TODO comment without altering broader system behaviors.

---
*PR created automatically by Jules for task [702183629910592339](https://jules.google.com/task/702183629910592339) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized retrieval formatting change with a safe key guard; no auth, data, or API surface changes.
> 
> **Overview**
> RAG context strings were built from `context_data.values()` after parallel chunk extraction, so chunk order could differ from the ranked `memories` list.
> 
> The change rebuilds the string by walking `memories` in order and joining only chunks that exist (`if m.id in context_data`), and removes the TODO about restoring sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc82126403679df0b4024b2cd6db157ff10fae5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->