### PR TITLE
fix(llm): derive extracted knowledge-graph ids from the owner and label

### DIFF
--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -224,7 +224,7 @@ async def extract_knowledge_graph(
     )
     if extraction is None:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="knowledge_graph_extract_failed")
-    graph = getattr(kg_mod, "extraction_to_client_graph")(extraction)
+    graph = getattr(kg_mod, "extraction_to_client_graph")(extraction, uid=uid)
     return ExtractKnowledgeGraphResponse(nodes=graph['nodes'], edges=graph['edges'])
 
 

--- a/backend/tests/unit/test_knowledge_graph_extract_helper.py
+++ b/backend/tests/unit/test_knowledge_graph_extract_helper.py
@@ -23,12 +23,66 @@ def test_extraction_to_client_graph_assigns_stable_ids_and_skips_self_edges():
             ExtractedEdge(source_label='Neo', target_label='Neo', label='is'),
         ],
     )
-    graph = kg.extraction_to_client_graph(extraction)
+    graph = kg.extraction_to_client_graph(extraction, uid='uid-1')
     assert len(graph['nodes']) == 2
     assert len(graph['edges']) == 1
     assert graph['edges'][0]['source_id'] == graph['nodes'][0]['id']
     assert graph['edges'][0]['target_id'] == graph['nodes'][1]['id']
     assert 'id' in graph['edges'][0]
+
+
+def test_repeated_extractions_reuse_ids_so_local_upserts_merge():
+    """Both desktop graphs upsert by id: a fresh id per call would duplicate the entity."""
+
+    def extract() -> KnowledgeGraphExtraction:
+        return KnowledgeGraphExtraction(
+            nodes=[ExtractedNode(label='Neo', node_type='person', aliases=['Thomas'])],
+            edges=[],
+        )
+
+    first = kg.extraction_to_client_graph(extract(), uid='uid-1')
+    second = kg.extraction_to_client_graph(extract(), uid='uid-1')
+    assert first['nodes'][0]['id'] == second['nodes'][0]['id']
+
+    # Label normalization is stable across casing and spacing.
+    spaced = KnowledgeGraphExtraction(nodes=[ExtractedNode(label='  neo ', node_type='person', aliases=[])], edges=[])
+    assert kg.extraction_to_client_graph(spaced, uid='uid-1')['nodes'][0]['id'] == first['nodes'][0]['id']
+
+    # Ids are per-owner, so they are not comparable across accounts.
+    assert kg.extraction_to_client_graph(extract(), uid='uid-2')['nodes'][0]['id'] != first['nodes'][0]['id']
+
+
+def test_duplicate_labels_merge_into_one_node_instead_of_colliding_ids():
+    """Two rows sharing an id would overwrite each other on upsert."""
+    extraction = KnowledgeGraphExtraction(
+        nodes=[
+            ExtractedNode(label='Neo', node_type='person', aliases=['Thomas']),
+            ExtractedNode(label='neo', node_type='person', aliases=['The One']),
+        ],
+        edges=[],
+    )
+
+    graph = kg.extraction_to_client_graph(extraction, uid='uid-1')
+
+    assert len(graph['nodes']) == 1
+    assert graph['nodes'][0]['aliases'] == ['Thomas', 'The One']
+
+
+def test_duplicate_edges_are_emitted_once():
+    extraction = KnowledgeGraphExtraction(
+        nodes=[
+            ExtractedNode(label='Neo', node_type='person', aliases=[]),
+            ExtractedNode(label='Zion', node_type='place', aliases=[]),
+        ],
+        edges=[
+            ExtractedEdge(source_label='Neo', target_label='Zion', label='lives in'),
+            ExtractedEdge(source_label='neo', target_label='zion', label='Lives In'),
+        ],
+    )
+
+    graph = kg.extraction_to_client_graph(extraction, uid='uid-1')
+
+    assert len(graph['edges']) == 1
 
 
 def test_extract_kg_from_text_uses_knowledge_graph_feature(monkeypatch):

--- a/backend/tests/unit/test_knowledge_graph_extract_route.py
+++ b/backend/tests/unit/test_knowledge_graph_extract_route.py
@@ -32,7 +32,8 @@ async def test_extract_knowledge_graph_returns_client_graph_without_persisting(m
             edges=[ExtractedEdge(source_label='Neo', target_label='Neo', label='is')],
         )
 
-    def fake_to_client(extraction):
+    def fake_to_client(extraction, *, uid):
+        calls['client_graph_uid'] = uid
         return {
             'nodes': [{'id': 'n1', 'label': 'Neo', 'node_type': 'person', 'aliases': ['Thomas']}],
             'edges': [],
@@ -58,6 +59,8 @@ async def test_extract_knowledge_graph_returns_client_graph_without_persisting(m
     assert calls['kwargs']['load_existing_from_db'] is False
     # A malformed model response must fail closed rather than look like "no entities".
     assert calls['kwargs']['strict_parse'] is True
+    # Client ids are owner-scoped, so the uid must reach the id derivation.
+    assert calls['client_graph_uid'] == UID
 
 
 async def test_extract_knowledge_graph_fails_closed_when_extractor_returns_none(monkeypatch):

--- a/backend/utils/llm/knowledge_graph.py
+++ b/backend/utils/llm/knowledge_graph.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import List, Dict, Any, Optional, cast
 import threading
+import hashlib
 import uuid
 import logging
 import json
@@ -166,38 +167,81 @@ def extract_kg_from_text(
         return None
 
 
-def extraction_to_client_graph(extraction: KnowledgeGraphExtraction) -> Dict[str, List[Dict[str, Any]]]:
-    """Assign stable local ids so desktop save tools can persist without inventing schema."""
+def _normalized_label(label: str) -> str:
+    return " ".join(label.split()).lower()
+
+
+def client_node_id(uid: str, label: str) -> str:
+    """Stable per-user id for an extracted entity.
+
+    Both desktop graphs upsert by id, so a random id per extraction made a second
+    discovery of the same entity a second node instead of a merge. Deriving the id from
+    the owner plus the normalized label makes repeat discoveries converge, and scoping it
+    to the uid keeps ids from being comparable across accounts.
+    """
+    digest = hashlib.sha256(f"{uid}\x1f{_normalized_label(label)}".encode("utf-8")).hexdigest()
+    return f"kg_{digest[:32]}"
+
+
+def extraction_to_client_graph(extraction: KnowledgeGraphExtraction, *, uid: str) -> Dict[str, List[Dict[str, Any]]]:
+    """Assign stable local ids so desktop save tools can persist without inventing schema.
+
+    Ids are deterministic per (uid, normalized label), so two entries for the same entity
+    in one extraction merge into one node rather than emitting duplicate rows that share
+    an id — colliding ids would overwrite each other on upsert.
+    """
     label_to_node_id: Dict[str, str] = {}
-    nodes: List[Dict[str, Any]] = []
+    nodes_by_id: Dict[str, Dict[str, Any]] = {}
+    ordered_ids: List[str] = []
+
     for node in extraction.nodes:
-        node_id = label_to_node_id.get(node.label.lower()) or str(uuid.uuid4())
-        label_to_node_id[node.label.lower()] = node_id
-        for alias in node.aliases:
-            label_to_node_id.setdefault(alias.lower(), node_id)
-        nodes.append(
-            {
+        key = _normalized_label(node.label)
+        if not key:
+            continue
+        node_id = client_node_id(uid, key)
+        # A node's own label always wins over an alias another node claimed.
+        label_to_node_id[key] = node_id
+
+        existing = nodes_by_id.get(node_id)
+        if existing is None:
+            nodes_by_id[node_id] = {
                 'id': node_id,
                 'label': node.label,
                 'node_type': node.node_type,
-                'aliases': list(node.aliases),
+                'aliases': list(dict.fromkeys(a for a in node.aliases if a.strip())),
             }
-        )
+            ordered_ids.append(node_id)
+        else:
+            for alias in node.aliases:
+                if alias.strip() and alias not in existing['aliases']:
+                    existing['aliases'].append(alias)
+
+        for alias in node.aliases:
+            alias_key = _normalized_label(alias)
+            if alias_key:
+                label_to_node_id.setdefault(alias_key, node_id)
+
+    nodes = [nodes_by_id[node_id] for node_id in ordered_ids]
 
     edges: List[Dict[str, Any]] = []
+    seen_edge_ids: set[str] = set()
     for edge in extraction.edges:
-        source_id = label_to_node_id.get(edge.source_label.lower())
-        target_id = label_to_node_id.get(edge.target_label.lower())
-        if source_id and target_id and source_id != target_id:
-            edge_id = f'{source_id}_{target_id}_{edge.label.lower().replace(" ", "_")}'
-            edges.append(
-                {
-                    'id': edge_id,
-                    'source_id': source_id,
-                    'target_id': target_id,
-                    'label': edge.label,
-                }
-            )
+        source_id = label_to_node_id.get(_normalized_label(edge.source_label))
+        target_id = label_to_node_id.get(_normalized_label(edge.target_label))
+        if not source_id or not target_id or source_id == target_id:
+            continue
+        edge_id = f'{source_id}_{target_id}_{_normalized_label(edge.label).replace(" ", "_")}'
+        if edge_id in seen_edge_ids:
+            continue
+        seen_edge_ids.add(edge_id)
+        edges.append(
+            {
+                'id': edge_id,
+                'source_id': source_id,
+                'target_id': target_id,
+                'label': edge.label,
+            }
+        )
     return {'nodes': nodes, 'edges': edges}
 
 


### PR DESCRIPTION
## Summary
- Derive extracted knowledge-graph node ids from `sha256(uid + normalized label)` instead of a fresh `uuid4` per call, so a second `discovery_text` save merges the entity both desktop graphs already upsert by id.
- Merge duplicate labels within one extraction into a single node (unioned aliases) instead of emitting two rows that share an id and overwrite each other; a node's own label wins over an alias another node claimed; duplicate edges are emitted once.

## Product invariants affected

Stacked on `backend-ssot-kg-chat`, so the diff-vs-main path globs cover the whole stack:
- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1
- INV-INT-1
- INV-MEM-1

## Failure class (fixes)

Failure-Class: none

## Test plan
- [x] `backend/.venv/bin/python -m pytest tests/unit/test_knowledge_graph_extract_helper.py tests/unit/test_knowledge_graph_extract_route.py` — 8 passed (id stability across calls, casing/spacing normalization, per-owner scoping, duplicate-label merge, duplicate-edge suppression)
- [ ] Desktop: two `save_knowledge_graph` calls with overlapping `discovery_text` produce one node per entity


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how client-facing node/edge ids are computed for KG extract, which affects desktop upsert/merge behavior; server-side `_persist_extraction` is unchanged.
> 
> **Overview**
> **Extracted knowledge-graph client IDs are now deterministic** so repeated desktop saves merge entities instead of duplicating them. `extraction_to_client_graph` takes a required `uid`, and node ids come from `sha256(uid + normalized label)` (`client_node_id`) rather than a new `uuid4` per call; the `/v1/knowledge-graph/extract` route passes the authenticated `uid` through.
> 
> Within a single extraction, **duplicate entities collapse**: labels normalized for casing/spacing map to one node (aliases unioned), and duplicate edges are emitted once. Edge resolution uses the same normalization rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70cb89c940fa1be8dac37c389bacdb2554fbc66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->