### PR TITLE
🧹 code health: Remove unused variable `result` in action items migration script

### DIFF
--- a/backend/migrations/004_migrate_action_items_to_collection.py
+++ b/backend/migrations/004_migrate_action_items_to_collection.py
@@ -374,7 +374,7 @@ def migrate_action_items():
                     completed_futures = []
                     for future in as_completed(list(future_to_batch.keys())):
                         try:
-                            result = future.result()
+                            future.result()
                             completed_futures.append(future)
                         except Exception as e:
                             batch_id = future_to_batch[future]
@@ -389,7 +389,7 @@ def migrate_action_items():
 
             for future in as_completed(future_to_batch.keys()):
                 try:
-                    result = future.result()
+                    future.result()
                 except Exception as e:
                     batch_id = future_to_batch[future]
                     log_progress(f"Error in batch {batch_id}: {str(e)}")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused variable `result` when calling `future.result()` in `backend/migrations/004_migrate_action_items_to_collection.py`.

💡 **Why:** How this improves maintainability
The variable `result` was assigned but never used, leading to dead code and Ruff lint warnings. This improves code clarity.

✅ **Verification:** How you confirmed the change is safe
The only change was removing the unused variable assignment, keeping the actual `future.result()` call which still propagates any exceptions from the background thread properly. Ran `pytest` locally to confirm basic correctness, and test failures found were pre-existing environment issues (segmentation faults with `grpc`/`google-cloud` native modules). Also successfully passed an LLM code review.

✨ **Result:** The improvement achieved
A clean resolution of the dead code issue, satisfying Ruff and improving codebase health.

---
*PR created automatically by Jules for task [11011918579064292753](https://jules.google.com/task/11011918579064292753) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic lint fix with no behavior change beyond preserving existing exception propagation from `future.result()`.
> 
> **Overview**
> Removes dead assignments in **`004_migrate_action_items_to_collection.py`** where `future.result()` was stored in `result` but never read.
> 
> Both the in-flight batch drain loop and the final `as_completed` cleanup still invoke **`future.result()`** so worker exceptions continue to surface and get logged; only the unused variable is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c0ea906ece3b7371fc79da5955c1aebbd3d119. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->