### PR TITLE
🧹 [code health] Remove unused imports and fix function redefinitions in chat.py

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "backend/routers/apps.py": 2425,
-    "backend/routers/chat.py": 1716,
+    "backend/routers/chat.py": 1714,
     "backend/routers/developer.py": 2282,
     "backend/routers/mcp_sse.py": 2009,
     "backend/routers/sync.py": 2083,

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -27,7 +27,6 @@ from multipart.multipart import shutil
 from pydantic import BaseModel
 
 import database.chat as chat_db
-import database.conversations as conversations_db
 import database.llm_usage as llm_usage_db
 from database.apps import record_app_usage
 from models.app import App, UsageHistoryType
@@ -48,7 +47,6 @@ from utils.chat import (
     acquire_chat_session,
     emit_stream_error_fallback,
     initial_message_util,
-    process_voice_message_segment,
     process_voice_message_segment_stream,
     resolve_voice_message_language,
     transcribe_voice_message_segment,
@@ -77,7 +75,7 @@ from utils.multipart import (
     max_part_size,
     parse_multipart_form,
 )
-from utils.retrieval.graph import execute_graph_chat, execute_chat_stream, execute_persona_chat_stream
+from utils.retrieval.graph import execute_chat_stream
 from utils.llm.usage_tracker import set_usage_context, reset_usage_context, Features
 from utils.users import get_user_display_name
 from utils.log_sanitizer import sanitize_pii
@@ -1506,7 +1504,7 @@ def upload_file_chat(
 
 @router.post('/v1/files', response_model=List[FileChat], tags=['chat'])
 @max_part_size(CHAT_FILE_MAX_PART_SIZE)
-def upload_file_chat(
+def upload_file_chat_v1(
     files: List[UploadFile] = File(...),
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "file:upload")),
 ):
@@ -1561,7 +1559,7 @@ def upload_file_chat(
 
 
 @router.post('/v1/messages/{message_id}/report', tags=['chat'], response_model=dict)
-def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def report_message_v1(message_id: str, uid: str = Depends(auth.get_current_user_uid)):
     result = chat_db.get_message(uid, message_id)
     if result is None:
         raise HTTPException(status_code=404, detail='Message not found')
@@ -1575,7 +1573,7 @@ def report_message(message_id: str, uid: str = Depends(auth.get_current_user_uid
 
 
 @router.delete('/v1/messages', tags=['chat'], response_model=Message)
-def clear_chat_messages(
+def clear_chat_messages_v1(
     plugin_id: Optional[str] = None, app_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
 ):
     compat_app_id = app_id or plugin_id
@@ -1607,7 +1605,7 @@ def clear_chat_messages(
 
 
 @router.post('/v1/initial-message', tags=['chat'], response_model=Message)
-def create_initial_message(
+def create_initial_message_v1(
     plugin_id: Optional[str] = None,
     app_id: Optional[str] = None,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "chat:initial")),

--- a/backend/tests/unit/test_report_missing_message.py
+++ b/backend/tests/unit/test_report_missing_message.py
@@ -103,6 +103,6 @@ def test_report_missing_message_returns_404_not_500(chat_router):
     # 404, not crash trying to unpack None into (message, doc_id).
     with patch.object(chat_router.chat_db, "get_message", return_value=None):
         with pytest.raises(HTTPException) as exc:
-            chat_router.report_message(message_id="does-not-exist", uid="u1")
+            chat_router.report_message_v1(message_id="does-not-exist", uid="u1")
 
     assert exc.value.status_code == 404

--- a/backend/tests/unit/test_report_missing_message.py
+++ b/backend/tests/unit/test_report_missing_message.py
@@ -98,11 +98,12 @@ def chat_router():
     return mod
 
 
-def test_report_missing_message_returns_404_not_500(chat_router):
+@pytest.mark.parametrize('handler_name', ['report_message_v1', 'report_message'])
+def test_report_missing_message_returns_404_not_500(chat_router, handler_name):
     # get_message returns None for an unknown id; the handler must translate that into a
     # 404, not crash trying to unpack None into (message, doc_id).
     with patch.object(chat_router.chat_db, "get_message", return_value=None):
         with pytest.raises(HTTPException) as exc:
-            chat_router.report_message_v1(message_id="does-not-exist", uid="u1")
+            getattr(chat_router, handler_name)(message_id="does-not-exist", uid="u1")
 
     assert exc.value.status_code == 404


### PR DESCRIPTION
🎯 **What:** Removed unused imports (like `execute_graph_chat` and `conversations_db`) and fixed `F811` redefinition errors for v1/v2 routes by suffixing v1 functions with `_v1`.
💡 **Why:** To fix Ruff static analysis errors, improving the maintainability and cleanliness of the code. Renaming duplicate function names also prevents issues with OpenAPI schema operation ID conflicts.
✅ **Verification:** Verified changes locally using `ruff check --fix` and manual edits, and confirmed 0 errors remain in `backend/routers/chat.py`. Ran test suites (tests could not be fully run due to missing environment packages, but verified lint).
✨ **Result:** A cleaner `backend/routers/chat.py` file passing all static analysis checks with no duplicate function names.

---
*PR created automatically by Jules for task [1664572956185321208](https://jules.google.com/task/1664572956185321208) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and naming-only changes with no route or handler logic edits; low risk aside from OpenAPI client codegen if it keyed off old operation IDs.
> 
> **Overview**
> Cleans up **`backend/routers/chat.py`** for Ruff: drops unused imports (`conversations_db`, `process_voice_message_segment`, and unused retrieval graph helpers) and narrows the graph import to **`execute_chat_stream`** only.
> 
> **Legacy `/v1/*` handlers** that duplicated v2 function names are renamed with an **`_v1` suffix** (`upload_file_chat_v1`, `report_message_v1`, `clear_chat_messages_v1`, `create_initial_message_v1`) so F811 redefinition warnings go away and OpenAPI operation IDs stay unique; **HTTP paths and behavior are unchanged**.
> 
> The **line-count ratchet** for `chat.py` is lowered by 2 lines, and the **missing-message report** unit test now parametrizes over both **`report_message_v1`** and **`report_message`** so v1 and v2 share the same 404-not-500 contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6edc797841d293ddba5728c3c2daec15e162b46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->