### PR TITLE
🧹 Remove unused users_db import in conversations.py

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-database.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/database/conversations.py": 1729,
+    "backend/database/conversations.py": 1728,
     "backend/database/memory_apply_store.py": 1912,
     "backend/database/users.py": 2121
   },

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -12,7 +12,6 @@ from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 import utils.other.hume as hume
-from database import users as users_db
 from models.audio_file import AudioFile
 from models.conversation_enums import ConversationStatus, PostProcessingModel, PostProcessingStatus
 from models.conversation_photo import ConversationPhoto


### PR DESCRIPTION
🎯 **What:** Removed unused import `database.users as users_db` in `backend/database/conversations.py`.
💡 **Why:** Fixes code health issue flagged by Ruff linter. Unused imports clutter the namespace and decrease readability.
✅ **Verification:** Verified fix locally using `ruff check` and ran relevant tests with `pytest`.
✨ **Result:** Improved maintainability and zero linter warnings in `backend/database/conversations.py`.

---
*PR created automatically by Jules for task [14902378257747139385](https://jules.google.com/task/14902378257747139385) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no runtime or data-path changes.
> 
> **Overview**
> Removes the unused `from database import users as users_db` import from `conversations.py` to clear the Ruff unused-import warning.
> 
> The product file line-count ratchet baseline for that file is updated from **1729** to **1728** lines so CI stays aligned with the one-line reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044b3cfb53544d0a10b651b93fdfe5fdb79a47aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->