### PR TITLE
🧹 fix unused imports and code health issues in apps.py

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/backend-routers.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "backend/routers/apps.py": 2419,
+    "backend/routers/apps.py": 2416,
     "backend/routers/chat.py": 1716,
     "backend/routers/developer.py": 2282,
     "backend/routers/mcp_sse.py": 2009,

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -63,7 +63,6 @@ from database.apps import (
 from database.webhook_health import clear_app_webhook_health
 from database.auth import get_user_from_uid
 from database.redis_db import (
-    delete_generic_cache,
     get_generic_cache,
     set_generic_cache,
     get_specific_user_review,
@@ -73,7 +72,6 @@ from database.redis_db import (
     disable_app,
     is_app_enabled,
     delete_app_cache_by_id,
-    is_username_taken,
     save_username,
     get_enabled_apps,
     get_conversation_summary_app_ids,
@@ -146,7 +144,6 @@ from utils.social import (
     upsert_persona_from_twitter_profile,
     add_twitter_to_persona,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -860,7 +857,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
                         status_code=422,
                         detail=f'Unsupported action type. Supported types: {", ".join([action_type.value for action_type in ActionType])}',
                     )
-    os.makedirs(f'_temp/apps', exist_ok=True)
+    os.makedirs('_temp/apps', exist_ok=True)
     file_path = f"_temp/apps/{file.filename}"
     with open(file_path, 'wb') as f:
         f.write(file.file.read())
@@ -917,7 +914,7 @@ async def create_persona(
         data['connected_accounts'] = ['omi']
     data['persona_prompt'] = await generate_persona_prompt(uid, data)
     data['description'] = await run_blocking(llm_executor, generate_persona_desc, uid, data['name'])
-    os.makedirs(f'_temp/apps', exist_ok=True)
+    os.makedirs('_temp/apps', exist_ok=True)
     file_path = f"_temp/apps/{file.filename}"
     contents = await file.read()
     await run_blocking(storage_executor, _write_file, file_path, contents)
@@ -958,7 +955,7 @@ async def update_persona(
             and persona['image'].startswith('https://storage.googleapis.com/')
         ):
             await run_blocking(storage_executor, delete_app_logo, persona['image'])
-        os.makedirs(f'_temp/apps', exist_ok=True)
+        os.makedirs('_temp/apps', exist_ok=True)
         file_path = f"_temp/apps/{file.filename}"
         contents = await file.read()
         await run_blocking(storage_executor, _write_file, file_path, contents)
@@ -1073,7 +1070,7 @@ def update_app(
     if file:
         if 'image' in app and len(app['image']) > 0 and app['image'].startswith('https://storage.googleapis.com/'):
             delete_app_logo(app['image'])
-        os.makedirs(f'_temp/apps', exist_ok=True)
+        os.makedirs('_temp/apps', exist_ok=True)
         file_path = f"_temp/apps/{file.filename}"
         with open(file_path, 'wb') as f:
             f.write(file.file.read())
@@ -2147,7 +2144,7 @@ async def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_u
             raise HTTPException(status_code=400, detail='App setup is not completed')
 
     # Check payment status
-    if app.is_paid and await run_blocking(db_executor, get_is_user_paid_app, app.id, uid) == False:
+    if app.is_paid and not await run_blocking(db_executor, get_is_user_paid_app, app.id, uid):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
 
     await run_blocking(db_executor, enable_app, uid, app_id)


### PR DESCRIPTION
🎯 **What:** Removed unused imports, eliminated unnecessary `f`-strings, and fixed a suboptimal boolean condition (E712) in `backend/routers/apps.py`.
💡 **Why:** These changes improve code health and maintainability by removing dead code and enforcing correct Pythonic formatting as validated by Ruff.
✅ **Verification:** Ran `pytest` ensuring no tests failed due to these changes, and reviewed the patch manually. The code review confirmed it correctly addressed the issue with no side effects.
✨ **Result:** A cleaner and more maintainable `apps.py` without unused imports or unnecessary code fragments.

---
*PR created automatically by Jules for task [13502740807240188782](https://jules.google.com/task/13502740807240188782) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic and dead-code removal only; the enable paid-check rewrite is logically equivalent to the prior `== False` form.
> 
> **Overview**
> **Housekeeping** in `backend/routers/apps.py`: drops unused Redis imports (`delete_generic_cache`, `is_username_taken`), removes a duplicate mid-file `import logging` (module-level import remains), and updates the product line-count ratchet baseline from **2419 → 2416** lines.
> 
> **Style-only tweaks** with no intended behavior change: `os.makedirs('_temp/apps', …)` no longer uses pointless f-strings in four create/update logo paths, and paid-app gating on enable uses `if app.is_paid and not await … get_is_user_paid_app` instead of comparing to `False` (Ruff E712).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c498a108ca68fa299ba455cf98218f7c432f2b72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->