### PR TITLE
🧪 [testing improvement] Add test coverage for conversation finalization jobs

### DIFF
--- a/backend/tests/services/test_conversation_finalization.py
+++ b/backend/tests/services/test_conversation_finalization.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest import mock
+from services import conversation_finalization
+from services.conversation_finalization import reconcile_listen_finalization_jobs
+
+@pytest.fixture
+def mock_dependencies(monkeypatch):
+    mocks = {
+        "is_enabled": mock.Mock(return_value=True),
+        "publish_metrics": mock.Mock(),
+        "get_stale_after": mock.Mock(return_value="stale_after"),
+        "get_candidates": mock.Mock(return_value=[]),
+        "claim_replay": mock.Mock(),
+        "enqueue_job": mock.Mock(),
+        "record_reconciliation": mock.Mock(),
+        "record_fallback": mock.Mock(),
+        "inc_retries": mock.Mock(),
+    }
+    monkeypatch.setattr(conversation_finalization, "is_listen_finalization_dispatch_enabled", mocks["is_enabled"])
+    monkeypatch.setattr(conversation_finalization, "_publish_job_metrics", mocks["publish_metrics"])
+    monkeypatch.setattr(conversation_finalization.jobs_db, "get_finalization_reconcile_stale_after", mocks["get_stale_after"])
+    monkeypatch.setattr(conversation_finalization.jobs_db, "get_finalization_replay_candidates", mocks["get_candidates"])
+    monkeypatch.setattr(conversation_finalization.jobs_db, "claim_finalization_replay", mocks["claim_replay"])
+    monkeypatch.setattr(conversation_finalization, "enqueue_listen_finalization_job", mocks["enqueue_job"])
+    monkeypatch.setattr(conversation_finalization, "record_capture_finalization_reconciliation", mocks["record_reconciliation"])
+    monkeypatch.setattr(conversation_finalization, "record_fallback", mocks["record_fallback"])
+    monkeypatch.setattr(conversation_finalization.LISTEN_FINALIZATION_RETRIES_TOTAL, "inc", mocks["inc_retries"])
+
+    return mocks
+
+def test_reconcile_listen_finalization_jobs_disabled(mock_dependencies):
+    mock_dependencies["is_enabled"].return_value = False
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 0, 'skipped': 0, 'enqueue_failed': 0}
+    mock_dependencies["publish_metrics"].assert_called_once()
+    mock_dependencies["get_candidates"].assert_not_called()
+
+def test_reconcile_listen_finalization_jobs_query_fails(mock_dependencies):
+    mock_dependencies["get_candidates"].side_effect = Exception("DB error")
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 0, 'skipped': 0, 'enqueue_failed': 0, 'error': 1}
+    mock_dependencies["publish_metrics"].assert_called_once()
+
+def test_reconcile_listen_finalization_jobs_skips_invalid_job_id(mock_dependencies):
+    mock_dependencies["get_candidates"].return_value = [{"job_id": None}, {"job_id": 123}, {}]
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 0, 'skipped': 3, 'enqueue_failed': 0}
+    mock_dependencies["claim_replay"].assert_not_called()
+    mock_dependencies["publish_metrics"].assert_called_once()
+
+def test_reconcile_listen_finalization_jobs_claim_fails(mock_dependencies):
+    mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}]
+    mock_dependencies["claim_replay"].side_effect = Exception("Claim error")
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 0, 'skipped': 1, 'enqueue_failed': 0}
+    mock_dependencies["publish_metrics"].assert_called_once()
+
+def test_reconcile_listen_finalization_jobs_claim_not_queued(mock_dependencies):
+    mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}, {"job_id": "job2"}]
+    mock_dependencies["claim_replay"].side_effect = [
+        {"status": "processing", "dispatch_generation": 1},
+        {"status": "queued", "dispatch_generation": None}
+    ]
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 0, 'skipped': 2, 'enqueue_failed': 0}
+    assert mock_dependencies["claim_replay"].call_count == 2
+    mock_dependencies["enqueue_job"].assert_not_called()
+    mock_dependencies["publish_metrics"].assert_called_once()
+
+def test_reconcile_listen_finalization_jobs_enqueue_fails(mock_dependencies):
+    mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}]
+    mock_dependencies["claim_replay"].return_value = {"status": "queued", "dispatch_generation": 1}
+    mock_dependencies["enqueue_job"].side_effect = Exception("Enqueue error")
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 0, 'skipped': 0, 'enqueue_failed': 1}
+    mock_dependencies["record_reconciliation"].assert_called_once_with('enqueue_failed')
+    mock_dependencies["record_fallback"].assert_called_once()
+    mock_dependencies["publish_metrics"].assert_called_once()
+
+def test_reconcile_listen_finalization_jobs_success(mock_dependencies):
+    mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}]
+    mock_dependencies["claim_replay"].return_value = {"status": "queued", "dispatch_generation": 1}
+
+    result = reconcile_listen_finalization_jobs()
+
+    assert result == {'requeued': 1, 'skipped': 0, 'enqueue_failed': 0}
+    mock_dependencies["claim_replay"].assert_called_once_with("job1", stale_after="stale_after", firestore_client=None)
+    mock_dependencies["enqueue_job"].assert_called_once_with("job1", 1)
+    mock_dependencies["record_reconciliation"].assert_called_once_with('requeued')
+    mock_dependencies["inc_retries"].assert_called_once()
+    mock_dependencies["publish_metrics"].assert_called_once()

--- a/backend/tests/services/test_conversation_finalization.py
+++ b/backend/tests/services/test_conversation_finalization.py
@@ -3,6 +3,7 @@ from unittest import mock
 from services import conversation_finalization
 from services.conversation_finalization import reconcile_listen_finalization_jobs
 
+
 @pytest.fixture
 def mock_dependencies(monkeypatch):
     mocks = {
@@ -18,15 +19,22 @@ def mock_dependencies(monkeypatch):
     }
     monkeypatch.setattr(conversation_finalization, "is_listen_finalization_dispatch_enabled", mocks["is_enabled"])
     monkeypatch.setattr(conversation_finalization, "_publish_job_metrics", mocks["publish_metrics"])
-    monkeypatch.setattr(conversation_finalization.jobs_db, "get_finalization_reconcile_stale_after", mocks["get_stale_after"])
-    monkeypatch.setattr(conversation_finalization.jobs_db, "get_finalization_replay_candidates", mocks["get_candidates"])
+    monkeypatch.setattr(
+        conversation_finalization.jobs_db, "get_finalization_reconcile_stale_after", mocks["get_stale_after"]
+    )
+    monkeypatch.setattr(
+        conversation_finalization.jobs_db, "get_finalization_replay_candidates", mocks["get_candidates"]
+    )
     monkeypatch.setattr(conversation_finalization.jobs_db, "claim_finalization_replay", mocks["claim_replay"])
     monkeypatch.setattr(conversation_finalization, "enqueue_listen_finalization_job", mocks["enqueue_job"])
-    monkeypatch.setattr(conversation_finalization, "record_capture_finalization_reconciliation", mocks["record_reconciliation"])
+    monkeypatch.setattr(
+        conversation_finalization, "record_capture_finalization_reconciliation", mocks["record_reconciliation"]
+    )
     monkeypatch.setattr(conversation_finalization, "record_fallback", mocks["record_fallback"])
     monkeypatch.setattr(conversation_finalization.LISTEN_FINALIZATION_RETRIES_TOTAL, "inc", mocks["inc_retries"])
 
     return mocks
+
 
 def test_reconcile_listen_finalization_jobs_disabled(mock_dependencies):
     mock_dependencies["is_enabled"].return_value = False
@@ -37,6 +45,7 @@ def test_reconcile_listen_finalization_jobs_disabled(mock_dependencies):
     mock_dependencies["publish_metrics"].assert_called_once()
     mock_dependencies["get_candidates"].assert_not_called()
 
+
 def test_reconcile_listen_finalization_jobs_query_fails(mock_dependencies):
     mock_dependencies["get_candidates"].side_effect = Exception("DB error")
 
@@ -44,6 +53,7 @@ def test_reconcile_listen_finalization_jobs_query_fails(mock_dependencies):
 
     assert result == {'requeued': 0, 'skipped': 0, 'enqueue_failed': 0, 'error': 1}
     mock_dependencies["publish_metrics"].assert_called_once()
+
 
 def test_reconcile_listen_finalization_jobs_skips_invalid_job_id(mock_dependencies):
     mock_dependencies["get_candidates"].return_value = [{"job_id": None}, {"job_id": 123}, {}]
@@ -54,6 +64,7 @@ def test_reconcile_listen_finalization_jobs_skips_invalid_job_id(mock_dependenci
     mock_dependencies["claim_replay"].assert_not_called()
     mock_dependencies["publish_metrics"].assert_called_once()
 
+
 def test_reconcile_listen_finalization_jobs_claim_fails(mock_dependencies):
     mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}]
     mock_dependencies["claim_replay"].side_effect = Exception("Claim error")
@@ -63,11 +74,12 @@ def test_reconcile_listen_finalization_jobs_claim_fails(mock_dependencies):
     assert result == {'requeued': 0, 'skipped': 1, 'enqueue_failed': 0}
     mock_dependencies["publish_metrics"].assert_called_once()
 
+
 def test_reconcile_listen_finalization_jobs_claim_not_queued(mock_dependencies):
     mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}, {"job_id": "job2"}]
     mock_dependencies["claim_replay"].side_effect = [
         {"status": "processing", "dispatch_generation": 1},
-        {"status": "queued", "dispatch_generation": None}
+        {"status": "queued", "dispatch_generation": None},
     ]
 
     result = reconcile_listen_finalization_jobs()
@@ -76,6 +88,7 @@ def test_reconcile_listen_finalization_jobs_claim_not_queued(mock_dependencies):
     assert mock_dependencies["claim_replay"].call_count == 2
     mock_dependencies["enqueue_job"].assert_not_called()
     mock_dependencies["publish_metrics"].assert_called_once()
+
 
 def test_reconcile_listen_finalization_jobs_enqueue_fails(mock_dependencies):
     mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}]
@@ -88,6 +101,7 @@ def test_reconcile_listen_finalization_jobs_enqueue_fails(mock_dependencies):
     mock_dependencies["record_reconciliation"].assert_called_once_with('enqueue_failed')
     mock_dependencies["record_fallback"].assert_called_once()
     mock_dependencies["publish_metrics"].assert_called_once()
+
 
 def test_reconcile_listen_finalization_jobs_success(mock_dependencies):
     mock_dependencies["get_candidates"].return_value = [{"job_id": "job1"}]


### PR DESCRIPTION
🎯 **What:** The testing gap for `reconcile_listen_finalization_jobs` in `backend/services/conversation_finalization.py` has been addressed.
📊 **Coverage:** Added test file `backend/tests/services/test_conversation_finalization.py`. Scenarios tested include dispatch disabled, database query failures, invalid `job_id` handling, claim failures, non-queued claim status, enqueue failures, and successful processing paths.
✨ **Result:** Test coverage for `conversation_finalization.py` has significantly improved, ensuring the reliable orchestration of finalization jobs.

---
*PR created automatically by Jules for task [12464063995653141073](https://jules.google.com/task/12464063995653141073) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications; risk is limited to test maintenance and mock drift if the reconciliation API changes.
> 
> **Overview**
> Adds **`backend/tests/services/test_conversation_finalization.py`** with isolated unit tests for **`reconcile_listen_finalization_jobs`** in `conversation_finalization.py`.
> 
> A shared **`mock_dependencies`** fixture patches dispatch enablement, job DB helpers, enqueue, reconciliation/fallback recording, metrics, and retry counters. Seven cases cover early exit when dispatch is disabled, candidate query errors, invalid **`job_id`** values, claim failures, claims that are not **`queued`** or lack **`dispatch_generation`**, enqueue failures (with reconciliation/fallback side effects), and the happy path that claims replay and re-enqueues with metrics updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aed387d36fb24ab00c09d905a5dbe1f7a3b8cf2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->