### PR TITLE
🧹 Remove unused timezone import in conversation.py

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from collections.abc import Mapping
 from typing import Dict, List, Literal, Optional
 import uuid


### PR DESCRIPTION
🎯 **What:** Removed unused `timezone` import from `backend/models/conversation.py`.
💡 **Why:** Ruff statically verified that this import is never used. Removing it improves code health and maintainability by eliminating dead code.
✅ **Verification:** Verified by running `ruff check` on the file and ensuring unit tests pass.
✨ **Result:** The `timezone` import is successfully removed from the `datetime` module import line, without altering functionality.

---
*PR created automatically by Jules for task [6792854070761851525](https://jules.google.com/task/6792854070761851525) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line import cleanup in a Pydantic model module with no runtime logic changes.
> 
> **Overview**
> Removes the unused `timezone` symbol from the `datetime` import in `backend/models/conversation.py` (`from datetime import datetime, timezone` → `from datetime import datetime`).
> 
> No behavior or API changes; this is dead-code cleanup flagged by static analysis (Ruff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c155f6cc23361c9be5d611ac87ca0adf8ef264. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->