### PR TITLE
Refactor: Remove legacy OMI_shell support

### DIFF
--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -59,9 +59,6 @@ def _get_device_by_model_number(device_model: str):
         return DeviceModel.OMI_CV1
     if device_model in ['OMI Glass', 'OmiGlass']:
         return DeviceModel.OMI_GLASS
-    # TODO: remove
-    if device_model in ['OMI_shell']:
-        return DeviceModel.OMI_CV1
     if device_model in ['nrf5340']:
         return DeviceModel.OMI_CV1
 


### PR DESCRIPTION
Removed the legacy 'OMI_shell' device model string mapping from the firmware service logic.

- Deleted the conditional check for `OMI_shell` and its corresponding `DeviceModel.OMI_CV1` return.
- Removed the associated `# TODO: remove` comment.

---
*PR created automatically by Jules for task [7420911204830702389](https://jules.google.com/task/7420911204830702389) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deletion in device string resolution only; no auth, data, or release-selection logic changes beyond dropping one legacy alias.
> 
> **Overview**
> Removes the deprecated **`OMI_shell`** string from `_get_device_by_model_number` in `firmware.py`, including the `# TODO: remove` comment and the branch that mapped it to **`DeviceModel.OMI_CV1`**.
> 
> Clients that still report `OMI_shell` will no longer resolve to Omi CV 1 firmware; those requests will hit the existing **404 Device not found** path like any other unrecognized model. **`nrf5340`** remains mapped to **`OMI_CV1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934bc7f69d99c1beff19a5824831a94c2a1b7fe2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->