### PR TITLE
🧹 Decouple HTTP exceptions from VAD utility

### DIFF
--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -21,7 +21,7 @@ from utils.other.storage import (
 )
 from utils.multipart import MultipartMaxPartSizeRoute, SPEECH_PROFILE_MAX_PART_SIZE, max_part_size
 from utils.stt.speaker_embedding import extract_embedding
-from utils.stt.vad import apply_vad_for_speech_profile
+from utils.stt.vad import apply_vad_for_speech_profile, VADEmptyError
 import logging
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,10 @@ def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_ui
     if aseg.duration_seconds < 5 or aseg.duration_seconds > 120:
         raise HTTPException(status_code=400, detail="Audio duration is invalid (must be 5-120 seconds)")
 
-    apply_vad_for_speech_profile(file_path)
+    try:
+        apply_vad_for_speech_profile(file_path)
+    except VADEmptyError:
+        raise HTTPException(status_code=400, detail="Audio is empty")
 
     # Write-ahead: Cache exact duration after VAD processing (use av for fast header-only read)
     with av.open(file_path) as container:

--- a/backend/scripts/stt/j_apply_vad_to_speech_profiles.py
+++ b/backend/scripts/stt/j_apply_vad_to_speech_profiles.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from dotenv import load_dotenv
 from pydub import AudioSegment
 
-from utils.stt.vad import apply_vad_for_speech_profile
+from utils.stt.vad import apply_vad_for_speech_profile, VADEmptyError
 
 load_dotenv('../../.env')
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '../../' + os.getenv('GOOGLE_APPLICATION_CREDENTIALS', '')
@@ -25,7 +25,13 @@ def execute():
         file_path = get_profile_audio_if_exists(uid)
         if not file_path:
             return
-        apply_vad_for_speech_profile(file_path)
+
+        try:
+            apply_vad_for_speech_profile(file_path)
+        except VADEmptyError:
+            print('VAD empty for', uid)
+            return
+
         aseg = cast(
             Any, AudioSegment.from_wav(file_path)
         )  # pyright: ignore[reportUnknownMemberType]  # pydub has no type stubs

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -19,6 +19,8 @@ import types
 from unittest.mock import MagicMock, patch
 
 import pytest
+from scripts.stt import j_apply_vad_to_speech_profiles as batch_mod
+from utils.stt import vad as vad_mod
 
 os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
@@ -72,8 +74,6 @@ for _n in list(sys.modules):
 sys.meta_path.insert(0, _f)
 try:
     from routers import speech_profile as mod
-    from scripts.stt import j_apply_vad_to_speech_profiles as batch_mod
-    from utils.stt import vad as vad_mod
 finally:
     sys.meta_path.remove(_f)
     for _n in list(sys.modules):

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -89,6 +89,10 @@ class _FakeDecodeError(Exception):
     """Stand-in for pydub.exceptions.CouldntDecodeError (pydub is stubbed here)."""
 
 
+class _FakeVADEmptyError(ValueError):
+    pass
+
+
 def _fake_upload_file(content: bytes, filename: str = "speech_profile.wav"):
     f = MagicMock()
     f.filename = filename
@@ -131,4 +135,25 @@ class TestUploadProfileWavDecodeGuard:
 
         assert exc_info.value.status_code == 400
         mock_vad.assert_not_called()
+        mock_upload.assert_not_called()
+
+    def test_empty_vad_returns_400_not_500(self):
+        fake_file = _fake_upload_file(b'silence')
+
+        with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
+            mod, "AudioSegment"
+        ) as mock_aseg, patch.object(mod, "VADEmptyError", _FakeVADEmptyError), patch.object(
+            mod, "apply_vad_for_speech_profile", side_effect=_FakeVADEmptyError("Audio is empty")
+        ) as mock_vad, patch.object(
+            mod, "upload_profile_audio"
+        ) as mock_upload:
+            mock_os.makedirs.return_value = None
+            mock_aseg.from_wav.return_value = MagicMock(frame_rate=16000, duration_seconds=5)
+
+            with pytest.raises(HTTPException) as exc_info:
+                mod.upload_profile(fake_file, uid="test-uid")
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Audio is empty"
+        mock_vad.assert_called_once()
         mock_upload.assert_not_called()

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -12,7 +12,6 @@ and green once the decode is wrapped in a try/except that returns 400.
 
 import importlib.abc
 import importlib.machinery
-import importlib.util
 import io
 import os
 import sys
@@ -156,11 +155,11 @@ class TestUploadProfileWavDecodeGuard:
         with patch.object(batch_mod.os, "makedirs"), patch.object(
             batch_mod, "get_users_uid", return_value=["test-uid"]
         ), patch.object(batch_mod, "get_profile_audio_if_exists", return_value="/tmp/profile.wav"), patch.object(
-            batch_mod, "apply_vad_for_speech_profile", side_effect=batch_mod.VADEmptyError("Audio is empty")
-        ) as mock_vad, patch.object(
             batch_mod, "upload_profile_audio"
-        ) as mock_upload:
+        ) as mock_upload, patch.object(
+            vad_mod, "vad_is_empty", return_value=[]
+        ) as mock_vad:
             batch_mod.execute()
 
-        mock_vad.assert_called_once_with("/tmp/profile.wav")
+        mock_vad.assert_called_once_with("/tmp/profile.wav", return_segments=True)
         mock_upload.assert_not_called()

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -29,9 +29,7 @@ _STUB = (
     "database",
     "utils.other.storage",
     "utils.stt.speaker_embedding",
-    "utils.stt.vad",
     "av",
-    "pydub",
     "firebase_admin",
     "google",
     "pinecone",
@@ -75,6 +73,8 @@ for _n in list(sys.modules):
 sys.meta_path.insert(0, _f)
 try:
     from routers import speech_profile as mod
+    from scripts.stt import j_apply_vad_to_speech_profiles as batch_mod
+    from utils.stt import vad as vad_mod
 finally:
     sys.meta_path.remove(_f)
     for _n in list(sys.modules):
@@ -87,10 +87,6 @@ from fastapi import HTTPException  # noqa: E402  (import after the finder block)
 
 class _FakeDecodeError(Exception):
     """Stand-in for pydub.exceptions.CouldntDecodeError (pydub is stubbed here)."""
-
-
-class _FakeVADEmptyError(ValueError):
-    pass
 
 
 def _fake_upload_file(content: bytes, filename: str = "speech_profile.wav"):
@@ -142,9 +138,7 @@ class TestUploadProfileWavDecodeGuard:
 
         with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
             mod, "AudioSegment"
-        ) as mock_aseg, patch.object(mod, "VADEmptyError", _FakeVADEmptyError), patch.object(
-            mod, "apply_vad_for_speech_profile", side_effect=_FakeVADEmptyError("Audio is empty")
-        ) as mock_vad, patch.object(
+        ) as mock_aseg, patch.object(vad_mod, "vad_is_empty", return_value=[]) as mock_vad, patch.object(
             mod, "upload_profile_audio"
         ) as mock_upload:
             mock_os.makedirs.return_value = None
@@ -155,5 +149,18 @@ class TestUploadProfileWavDecodeGuard:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "Audio is empty"
-        mock_vad.assert_called_once()
+        mock_vad.assert_called_once_with("_temp/test-uid/speech_profile.wav", return_segments=True)
+        mock_upload.assert_not_called()
+
+    def test_batch_skips_empty_vad_without_uploading(self):
+        with patch.object(batch_mod.os, "makedirs"), patch.object(
+            batch_mod, "get_users_uid", return_value=["test-uid"]
+        ), patch.object(batch_mod, "get_profile_audio_if_exists", return_value="/tmp/profile.wav"), patch.object(
+            batch_mod, "apply_vad_for_speech_profile", side_effect=batch_mod.VADEmptyError("Audio is empty")
+        ) as mock_vad, patch.object(
+            batch_mod, "upload_profile_audio"
+        ) as mock_upload:
+            batch_mod.execute()
+
+        mock_vad.assert_called_once_with("/tmp/profile.wav")
         mock_upload.assert_not_called()

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -152,13 +152,26 @@ class TestUploadProfileWavDecodeGuard:
         mock_upload.assert_not_called()
 
     def test_batch_skips_empty_vad_without_uploading(self):
+        class ImmediateThread:
+            def __init__(self, target, args):
+                self.target = target
+                self.args = args
+
+            def start(self):
+                self.target(*self.args)
+
+            def join(self):
+                pass
+
         with patch.object(batch_mod.os, "makedirs"), patch.object(
             batch_mod, "get_users_uid", return_value=["test-uid"]
         ), patch.object(batch_mod, "get_profile_audio_if_exists", return_value="/tmp/profile.wav"), patch.object(
             batch_mod, "upload_profile_audio"
         ) as mock_upload, patch.object(
             vad_mod, "vad_is_empty", return_value=[]
-        ) as mock_vad:
+        ) as mock_vad, patch.object(
+            batch_mod.threading, "Thread", ImmediateThread
+        ):
             batch_mod.execute()
 
         mock_vad.assert_called_once_with("/tmp/profile.wav", return_segments=True)

--- a/backend/tests/unit/test_vad_onnx.py
+++ b/backend/tests/unit/test_vad_onnx.py
@@ -21,6 +21,7 @@ from utils.stt import vad
 from utils.stt.vad import (
     VADAudioDecodeError,
     VADProcessingError,
+    VADEmptyError,
     vad_is_empty,
     _run_file_vad,
     _get_ort_session,
@@ -33,6 +34,13 @@ from utils.stt.vad import (
     linear16_pcm_is_silent,
     _STATE_SHAPE,
 )
+
+
+def test_apply_vad_for_speech_profile_raises_for_zero_segments():
+    with patch.object(vad, 'vad_is_empty', return_value=[]):
+        with pytest.raises(VADEmptyError, match='Audio is empty'):
+            vad.apply_vad_for_speech_profile('/fake/path.wav')
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/backend/utils/stt/vad.py
+++ b/backend/utils/stt/vad.py
@@ -7,7 +7,6 @@ import httpx
 import numpy as np
 import onnxruntime as ort  # onnxruntime is untyped
 import requests
-from fastapi import HTTPException
 from pydub import AudioSegment  # pydub is untyped
 
 from database import redis_db
@@ -24,6 +23,10 @@ class VADAudioDecodeError(RuntimeError):
 
 class VADProcessingError(RuntimeError):
     """The local VAD could not make a trustworthy speech decision."""
+
+
+class VADEmptyError(ValueError):
+    """The VAD found no speech segments in the audio."""
 
 
 def _hosted_vad_fallback_reason(exc: BaseException) -> str:
@@ -340,8 +343,8 @@ async def async_vad_is_empty(
 def apply_vad_for_speech_profile(file_path: str) -> None:
     logger.info(f'apply_vad_for_speech_profile {file_path}')
     voice_segments = vad_is_empty(file_path, return_segments=True)
-    if len(voice_segments) == 0:  # TODO: front error on post-processing, audio sent is bad.
-        raise HTTPException(status_code=400, detail="Audio is empty")
+    if len(voice_segments) == 0:
+        raise VADEmptyError("Audio is empty")
     joined_segments: List[Dict[str, Any]] = []
     for i, segment in enumerate(voice_segments):
         if joined_segments and (segment['start'] - joined_segments[-1]['end']) < 1:


### PR DESCRIPTION
🎯 **What:** The `apply_vad_for_speech_profile` utility function in `backend/utils/stt/vad.py` was directly raising a FastAPI `HTTPException(400)` when a processed audio file was empty. This has been replaced with a domain-specific `VADEmptyError`. The `HTTPException` logic has been moved up to the routing layer in `backend/routers/speech_profile.py`. The background script `backend/scripts/stt/j_apply_vad_to_speech_profiles.py` was also updated to catch `VADEmptyError`.

💡 **Why:** This change separates concerns and decouples domain/utility logic from web framework-specific exceptions. `HTTPException` should only be thrown from routing layers. This makes the utility function safer to reuse across different contexts, such as the `j_apply_vad_to_speech_profiles.py` background script which previously would have crashed upon encountering an empty audio file.

✅ **Verification:** Ran pytest tests against the updated files (`backend/tests/unit/test_speech_profile_wav_decode.py`, `backend/tests/unit/test_user_speaker_embedding.py`, `backend/tests/unit/test_vad_onnx.py`) to confirm no regressions and tested API compatibility. Code Review was completed.

✨ **Result:** A cleaner architectural separation of concerns between core utility code and web layers, and a more robust background script that won't crash when encountering empty voice segments.

---
*PR created automatically by Jules for task [5064561204901573843](https://jules.google.com/task/5064561204901573843) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layering change with preserved upload 400 semantics; limited to speech-profile VAD paths and covered by new unit tests.
> 
> **Overview**
> **Speech-profile VAD no longer raises FastAPI errors from the STT utility layer.** When VAD finds no speech segments, `apply_vad_for_speech_profile` now raises a domain `VADEmptyError` instead of `HTTPException(400)`, and the FastAPI dependency on `vad.py` is removed.
> 
> The **`POST /v3/upload-audio`** handler catches `VADEmptyError` and still returns **400** with detail **"Audio is empty"**, so client behavior for empty/silent uploads stays the same while upload does not proceed to storage.
> 
> The **batch script** `j_apply_vad_to_speech_profiles` catches `VADEmptyError`, logs, and skips that user instead of failing the job thread. Unit tests cover the router mapping, batch skip behavior, and the utility raising `VADEmptyError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb9888a78cfb0bb1ac2cae57e9112b38e192276. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->