### PR TITLE
Fix: Use app_id for bot message sender names in chat models

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -133,11 +133,9 @@ class Message(BaseModel):
         def get_sender_name(message: Message) -> str:
             if message.sender == 'human':
                 return 'User'
-            # elif use_plugin_name_if_available and message.app_id is not None:
-            #     plugin = next((p for p in plugins if p.id == message.app_id), None)
-            #     if plugin:
-            #         return plugin.name RESTORE ME
-            return message.sender.upper()  # TODO: use app id
+            if message.app_id is not None and use_plugin_name_if_available:
+                return message.app_id
+            return message.sender.upper()
 
         formatted_messages = []
         for message in sorted_messages:
@@ -166,11 +164,9 @@ class Message(BaseModel):
         def get_sender_name(message: Message) -> str:
             if message.sender == 'human':
                 return 'User'
-            # elif use_plugin_name_if_available and message.app_id is not None:
-            #     plugin = next((p for p in plugins if p.id == message.app_id), None)
-            #     if plugin:
-            #         return plugin.name RESTORE ME
-            return message.sender.upper()  # TODO: use app id
+            if message.app_id is not None and use_plugin_name_if_available:
+                return message.app_id
+            return message.sender.upper()
 
         formatted_messages = []
         for message in sorted_messages:

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -133,7 +133,7 @@ class Message(BaseModel):
         def get_sender_name(message: Message) -> str:
             if message.sender == 'human':
                 return 'User'
-            if message.app_id is not None and use_plugin_name_if_available:
+            if use_plugin_name_if_available and message.app_id and message.app_id.strip():
                 return message.app_id
             return message.sender.upper()
 
@@ -164,7 +164,7 @@ class Message(BaseModel):
         def get_sender_name(message: Message) -> str:
             if message.sender == 'human':
                 return 'User'
-            if message.app_id is not None and use_plugin_name_if_available:
+            if use_plugin_name_if_available and message.app_id and message.app_id.strip():
                 return message.app_id
             return message.sender.upper()
 

--- a/backend/tests/unit/test_message_formatting.py
+++ b/backend/tests/unit/test_message_formatting.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from models.chat import Message, MessageSender, MessageType
+
+
+def test_get_messages_as_string_sender_app_id():
+    m = Message(
+        id='m1',
+        text='hello',
+        created_at=datetime.now(timezone.utc),
+        sender=MessageSender.ai,
+        type=MessageType.text,
+        app_id='some-app-id',
+    )
+    result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+    assert "some-app-id" in result
+
+
+def test_get_messages_as_xml_sender_app_id():
+    m = Message(
+        id='m1',
+        text='hello',
+        created_at=datetime.now(timezone.utc),
+        sender=MessageSender.ai,
+        type=MessageType.text,
+        app_id='some-app-id',
+    )
+    result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+    assert "<sender>some-app-id</sender>" in result
+
+
+def test_get_messages_as_string_defaults_to_ai_sender_for_app_id():
+    m = Message(
+        id='m1',
+        text='hello',
+        created_at=datetime.now(timezone.utc),
+        sender=MessageSender.ai,
+        type=MessageType.text,
+        app_id='some-app-id',
+    )
+
+    result = Message.get_messages_as_string([m])
+
+    assert "AI: hello" in result
+
+
+def test_get_messages_as_xml_defaults_to_ai_sender_for_app_id():
+    m = Message(
+        id='m1',
+        text='hello',
+        created_at=datetime.now(timezone.utc),
+        sender=MessageSender.ai,
+        type=MessageType.text,
+        app_id='some-app-id',
+    )
+
+    result = Message.get_messages_as_xml([m])
+
+    assert "<sender>AI</sender>" in result

--- a/backend/tests/unit/test_message_formatting.py
+++ b/backend/tests/unit/test_message_formatting.py
@@ -56,3 +56,39 @@ def test_get_messages_as_xml_defaults_to_ai_sender_for_app_id():
     result = Message.get_messages_as_xml([m])
 
     assert "<sender>AI</sender>" in result
+
+
+def _blank_app_id_variants():
+    return [None, '', '   ']
+
+
+def test_get_messages_as_string_blank_app_id_falls_back_to_ai_sender():
+    for app_id in _blank_app_id_variants():
+        m = Message(
+            id='m1',
+            text='hello',
+            created_at=datetime.now(timezone.utc),
+            sender=MessageSender.ai,
+            type=MessageType.text,
+            app_id=app_id,
+        )
+
+        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+
+        assert "AI: hello" in result, f"blank app_id={app_id!r} must not emit an empty sender"
+
+
+def test_get_messages_as_xml_blank_app_id_falls_back_to_ai_sender():
+    for app_id in _blank_app_id_variants():
+        m = Message(
+            id='m1',
+            text='hello',
+            created_at=datetime.now(timezone.utc),
+            sender=MessageSender.ai,
+            type=MessageType.text,
+            app_id=app_id,
+        )
+
+        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+
+        assert "<sender>AI</sender>" in result, f"blank app_id={app_id!r} must not emit an empty sender"


### PR DESCRIPTION
Fix: Use app_id for bot message sender names in chat models

Failure-Class: none

Updated `get_messages_as_string` and `get_messages_as_xml` in `backend/models/chat.py` to correctly use `message.app_id` as the sender name when available, rather than always falling back to the uppercase sender name (e.g. 'AI'). This addresses the TODO comment in the codebase.
Added corresponding unit tests in `tests/unit/test_message_formatting.py` to ensure the sender app_id logic functions as expected.

---
*PR created automatically by Jules for task [5516219173950432024](https://jules.google.com/task/5516219173950432024) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in change to chat history formatting for LLM prompts; default behavior unchanged when the flag is false.
> 
> **Overview**
> When **`use_plugin_name_if_available`** is enabled, **`get_messages_as_string`** and **`get_messages_as_xml`** now label non-human senders with **`message.app_id`** instead of always using **`AI`**. Blank or whitespace-only **`app_id`** values still fall back to the uppercase sender name.
> 
> Commented-out plugin lookup code was removed in favor of this direct **`app_id`** behavior. Unit tests cover the opt-in path, default **`AI`** labeling, and blank **`app_id`** fallbacks for both formatters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8409bb142cf9a50c7cb7904446f10d01bdf0c2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

