### PR TITLE
🧹 [code health improvement] Remove unused generate_app_icon import

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1566,7 +1566,7 @@ async def generate_app_endpoint(data: GenerateAppRequest, uid: str = Depends(aut
     Generate an app configuration from a natural language prompt.
     This is an experimental feature that uses AI to create app configurations.
     """
-    from utils.llm.app_generator import generate_app_from_prompt, generate_app_icon
+    from utils.llm.app_generator import generate_app_from_prompt
 
     prompt = data.prompt.strip()
     if not prompt:


### PR DESCRIPTION
🎯 **What:** Removed the unused `generate_app_icon` import in `backend/routers/apps.py:1569`.
💡 **Why:** Ruff statically verified that this import is never used. Removing it improves code health and readability.
✅ **Verification:** Verified via `ruff check` that the specific issue is no longer reported and ran `pytest` on tests affecting `apps.py` ensuring everything passes.
✨ **Result:** Cleaned up unused import without breaking existing functionality.

---
*PR created automatically by Jules for task [16835770164577260439](https://jules.google.com/task/16835770164577260439) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no logic changes; icon generation remains on its dedicated endpoint.
> 
> **Overview**
> Removes an unused local import of `generate_app_icon` from `generate_app_endpoint` in `backend/routers/apps.py`. That handler only calls `generate_app_from_prompt`; icon generation stays on `/v1/app/generate-icon`, which still imports `generate_app_icon` where it is used.
> 
> No API or runtime behavior changes—this is a Ruff-driven cleanup of dead import noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60834f049fba4f671d9fa998458a4be0a51a8943. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->