### PR TITLE
Refactor visualization functions

### DIFF
--- a/backend/scripts/rag/current.py
+++ b/backend/scripts/rag/current.py
@@ -121,16 +121,40 @@ def generate_visualization(
     else:
         data = get_data(topics)
     # print('data', len(data))
-    all_embeddings = cast(Any, np.array([item[1] for item in data.values()]))
 
-    topic_embeddings = [openai_embeddings.embed_query(topic) for topic in topics]
-    all_embeddings = cast(Any, np.vstack([all_embeddings] + topic_embeddings))
+    embedding_values = [item[1] for item in data.values()]
+    if not embedding_values:
+        return
 
-    umap_transform = cast(Any, umap.UMAP(n_components=2, random_state=0, transform_seed=0))
+    all_embeddings = cast(Any, np.array(embedding_values))
+    if all_embeddings.ndim != 2:
+        return
+
+    topic_points: Any = []
+    if topics:
+        topic_embeddings = [openai_embeddings.embed_query(topic) for topic in topics]
+        all_embeddings = cast(Any, np.vstack([all_embeddings] + topic_embeddings))
+
+    if all_embeddings.shape[0] < 3:
+        return
+
+    umap_transform = cast(
+        Any,
+        umap.UMAP(
+            init='random' if all_embeddings.shape[0] == 3 else 'spectral',
+            n_neighbors=min(15, all_embeddings.shape[0] - 1),
+            n_components=2,
+            random_state=0,
+            transform_seed=0,
+        ),
+    )
     umap_embeddings = umap_transform.fit_transform(all_embeddings)
 
-    data_points = umap_embeddings[: -len(topics)]
-    topic_points = umap_embeddings[-len(topics) :]
+    if topics:
+        data_points = umap_embeddings[: -len(topics)]
+        topic_points = umap_embeddings[-len(topics) :]
+    else:
+        data_points = umap_embeddings
 
     fig: Any = make_subplots(rows=1, cols=1)
 

--- a/backend/tests/unit/test_rag_visualization.py
+++ b/backend/tests/unit/test_rag_visualization.py
@@ -57,6 +57,8 @@ def test_generate_visualization_uses_get_data_without_memories(monkeypatch, tmp_
     module.get_data.assert_called_once_with(['topic'])
     module.get_data2.assert_not_called()
     assert umap_module.UMAP.call_args.kwargs == {
+        'init': 'random',
+        'n_neighbors': 2,
         'n_components': 2,
         'random_state': 0,
         'transform_seed': 0,
@@ -89,4 +91,104 @@ def test_generate_visualization_uses_get_data2_with_memories(monkeypatch, tmp_pa
 
     module.get_data2.assert_called_once_with(['topic'], memories)
     module.get_data.assert_not_called()
+    assert module.generate_html_visualization.called
+
+
+def test_generate_visualization_keeps_topic_augmented_small_memory_set(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    module.get_data = lambda topics: {
+        'memory-1': ['First', [1.0, 0.0], ['topic']],
+        'memory-2': ['Second', [0.0, 1.0], []],
+    }
+    module.openai_embeddings = SimpleNamespace(embed_query=lambda topic: [0.5, 0.5])
+    module.get_markers = MagicMock(return_value=object())
+    module.get_query_marker = MagicMock(return_value=object())
+    module.generate_html_visualization = MagicMock()
+    module.go = SimpleNamespace(Scatter=MagicMock())
+    figure = MagicMock()
+    module.make_subplots = MagicMock(return_value=figure)
+    umap_instance = MagicMock()
+    umap_instance.fit_transform.return_value = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    umap_module.UMAP.return_value = umap_instance
+
+    module.generate_visualization(['topic'])
+
+    assert umap_instance.fit_transform.call_args.args[0].shape == (3, 2)
+    assert module.generate_html_visualization.called
+
+
+def test_generate_visualization_keeps_all_memory_points_without_topics(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    module.get_data = lambda topics: {
+        'memory-1': ['First', [1.0, 0.0], []],
+        'memory-2': ['Second', [0.0, 1.0], []],
+        'memory-3': ['Third', [1.0, 1.0], []],
+    }
+    module.get_markers = MagicMock(return_value=object())
+    module.generate_html_visualization = MagicMock()
+    figure = MagicMock()
+    module.make_subplots = MagicMock(return_value=figure)
+    umap_instance = MagicMock()
+    umap_instance.fit_transform.return_value = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    umap_module.UMAP.return_value = umap_instance
+
+    module.generate_visualization([])
+
+    assert umap_instance.fit_transform.call_args.args[0].shape == (3, 2)
+    np.testing.assert_array_equal(module.get_markers.call_args.args[1], np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]))
+    assert umap_module.UMAP.call_args.kwargs['init'] == 'random'
+    assert module.generate_html_visualization.called
+
+
+def test_generate_visualization_skips_empty_data(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    module.get_data = lambda topics: {}
+    module.generate_html_visualization = MagicMock()
+
+    module.generate_visualization([])
+
+    umap_module.UMAP.assert_not_called()
+    module.generate_html_visualization.assert_not_called()
+
+
+def test_generate_visualization_skips_below_three_samples(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    module.get_data = lambda topics: {'memory-1': ['First', [1.0, 0.0], []]}
+    module.generate_html_visualization = MagicMock()
+
+    module.generate_visualization([])
+
+    umap_module.UMAP.assert_not_called()
+    module.generate_html_visualization.assert_not_called()
+
+
+def test_generate_visualization_uses_retrieved_memories(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    memories = [SimpleNamespace(id='memory-1')]
+    module.get_data2 = MagicMock(
+        return_value={
+            'memory-1': ['First', [1.0, 0.0], ['topic']],
+            'memory-2': ['Second', [0.0, 1.0], []],
+            'memory-3': ['Third', [1.0, 1.0], []],
+        }
+    )
+    module.get_markers = MagicMock(return_value=object())
+    module.generate_html_visualization = MagicMock()
+    figure = MagicMock()
+    module.make_subplots = MagicMock(return_value=figure)
+    umap_instance = MagicMock()
+    umap_instance.fit_transform.return_value = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+    umap_module.UMAP.return_value = umap_instance
+    module.openai_embeddings = SimpleNamespace(embed_query=lambda topic: [0.5, 0.5])
+    module.get_query_marker = MagicMock(return_value=object())
+    module.go = SimpleNamespace(Scatter=MagicMock())
+
+    module.generate_visualization(['topic'], memories=memories)
+
+    module.get_data2.assert_called_once_with(['topic'], memories)
     assert module.generate_html_visualization.called


### PR DESCRIPTION
Combines `generate_topics_visualization` into `generate_visualization` in `backend/scripts/rag/current.py` as requested.
- Implements `memories: List[Conversation] | None = None` support to allow calling either `get_data2` or `get_data`.
- Fixes edge cases with `len(topics) == 0` preventing slicing exceptions.
- Removes redundant code.
- Updates entrypoint in `__main__` to run `generate_visualization([])`.

---
*PR created automatically by Jules for task [12965376793190174944](https://jules.google.com/task/12965376793190174944) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a RAG script helper and new unit tests; no production API or auth paths.
> 
> **Overview**
> **Refactors RAG embedding HTML visualization** in `backend/scripts/rag/current.py` by removing `generate_topics_visualization` and folding its behavior into `generate_visualization`.
> 
> `generate_visualization` now takes optional `memories`; when set it uses `get_data2`, otherwise `get_data`. Topic query embeddings are only stacked when `topics` is non-empty, fixing slice errors when `topics` is `[]`. The function **no-ops** when there are no embeddings, invalid embedding shape, or fewer than three UMAP samples, and tunes UMAP (`init`, `n_neighbors`) for small point counts. The `__main__` entrypoint calls `generate_visualization([])`.
> 
> Adds **`backend/tests/unit/test_rag_visualization.py`** with isolated module loads and tests for topic vs no-topic paths, empty/insufficient data skips, and the `memories` → `get_data2` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286335137b17a5c17080516cc6caf6933d9573aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Failure-Class: none