### PR TITLE
feat(backend): set default 'en' language for Friend conversations

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -167,7 +167,7 @@ class Conversation(BaseModel):
     finished_at: Optional[datetime]
 
     source: Optional[ConversationSource] = ConversationSource.omi
-    language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'
+    language: Optional[str] = None  # applies only to Friend; Friend conversations default to 'en'
 
     structured: Structured
     transcript_segments: List[TranscriptSegment] = []
@@ -212,6 +212,14 @@ class Conversation(BaseModel):
     # Capture-device provenance (optional; absent on legacy conversations).
     client_device_id: Optional[str] = None
     client_platform: Optional[str] = None
+
+    @model_validator(mode='after')
+    def apply_friend_language_default(self):
+        if self.source in (ConversationSource.friend, ConversationSource.friend_com) and (
+            self.language is None or not self.language.strip()
+        ):
+            self.language = 'en'
+        return self
 
     def __init__(self, **data):
         raw_segments = data.get('transcript_segments')
@@ -300,6 +308,14 @@ class CreateConversation(BaseModel):
     # only after process_conversation has already persisted the row.
     external_data: Optional[Dict] = None
 
+    @model_validator(mode='after')
+    def apply_friend_language_default(self):
+        if self.source in (ConversationSource.friend, ConversationSource.friend_com) and (
+            self.language is None or not self.language.strip()
+        ):
+            self.language = 'en'
+        return self
+
     def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         return TranscriptSegment.segments_as_string(
             self.transcript_segments, include_timestamps=include_timestamps, user_name=user_name, people=people
@@ -326,6 +342,14 @@ class ExternalIntegrationCreateConversation(BaseModel):
 
     client_device_id: Optional[str] = None
     client_platform: Optional[str] = None
+
+    @model_validator(mode='after')
+    def apply_friend_language_default(self):
+        if self.source in (ConversationSource.friend, ConversationSource.friend_com) and (
+            self.language is None or not self.language.strip()
+        ):
+            self.language = 'en'
+        return self
 
     def get_transcript(self, include_timestamps: bool) -> str:
         return self.text

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -156,6 +156,15 @@ class ConversationAudio(BaseModel):
     built_at: Optional[datetime] = None
 
 
+def _apply_friend_language_default(instance):
+    """Shared model_validator logic: default language to 'en' for Friend / Friend-com sources."""
+    if instance.source in (ConversationSource.friend, ConversationSource.friend_com) and (
+        instance.language is None or not instance.language.strip()
+    ):
+        instance.language = 'en'
+    return instance
+
+
 class Conversation(BaseModel):
     id: str
     created_at: datetime
@@ -215,11 +224,7 @@ class Conversation(BaseModel):
 
     @model_validator(mode='after')
     def apply_friend_language_default(self):
-        if self.source in (ConversationSource.friend, ConversationSource.friend_com) and (
-            self.language is None or not self.language.strip()
-        ):
-            self.language = 'en'
-        return self
+        return _apply_friend_language_default(self)
 
     def __init__(self, **data):
         raw_segments = data.get('transcript_segments')
@@ -310,11 +315,7 @@ class CreateConversation(BaseModel):
 
     @model_validator(mode='after')
     def apply_friend_language_default(self):
-        if self.source in (ConversationSource.friend, ConversationSource.friend_com) and (
-            self.language is None or not self.language.strip()
-        ):
-            self.language = 'en'
-        return self
+        return _apply_friend_language_default(self)
 
     def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         return TranscriptSegment.segments_as_string(
@@ -345,11 +346,7 @@ class ExternalIntegrationCreateConversation(BaseModel):
 
     @model_validator(mode='after')
     def apply_friend_language_default(self):
-        if self.source in (ConversationSource.friend, ConversationSource.friend_com) and (
-            self.language is None or not self.language.strip()
-        ):
-            self.language = 'en'
-        return self
+        return _apply_friend_language_default(self)
 
     def get_transcript(self, include_timestamps: bool) -> str:
         return self.text

--- a/backend/scripts/migrate_conversation_language.py
+++ b/backend/scripts/migrate_conversation_language.py
@@ -1,0 +1,117 @@
+"""One-time migration: set default 'en' language for conversations from the Friend source.
+
+The Friend source will now use 'en' as the default language. This script updates
+any existing conversations with source 'friend' or 'friend_com' that have a null or missing language.
+"""
+
+import argparse
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List
+
+from google.cloud import firestore
+
+from database._client import get_firestore_client, get_users_uid
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError('must be at least 1')
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError('must be non-negative')
+    return parsed
+
+
+def process_user(uid: str, dry_run: bool, firestore_client: Any = None) -> Dict[str, Any]:
+    """Fix language for one user's conversations."""
+    fixed = 0
+    try:
+        client = firestore_client or get_firestore_client()
+        convs = (
+            client.collection('users')
+            .document(uid)
+            .collection('conversations')
+            .where(filter=firestore.FieldFilter('source', 'in', ['friend', 'friend_com']))
+            .stream()
+        )
+        for conv in convs:
+            data: Dict[str, Any] = conv.to_dict() or {}
+
+            # Check if source is 'friend' or 'friend_com' and language is missing or None
+            source = data.get('source')
+            if source not in ('friend', 'friend_com'):
+                continue
+
+            language = data.get('language')
+            if language is not None and (not isinstance(language, str) or language.strip()):
+                continue
+
+            updates = {'language': 'en'}
+
+            if dry_run:
+                print(f'DRY {uid}/{conv.id}: {updates}')
+            else:
+                conv.reference.update(updates)
+            fixed += 1
+        return {'uid': uid, 'fixed': fixed, 'status': 'ok'}
+    except Exception as e:  # noqa: BLE001 — one user shouldn't abort the run
+        return {'uid': uid, 'fixed': fixed, 'status': f'error: {e}'}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Set default "en" language for Friend conversations')
+    parser.add_argument('--dry-run', action='store_true', help='Only print what would change')
+    parser.add_argument('--uid', help='Process a single user by uid instead of all users')
+    parser.add_argument('--workers', type=_positive_int, default=10, help='Number of parallel workers (default 10)')
+    parser.add_argument('--limit', type=_nonnegative_int, default=0, help='Max users to process (0 = all)')
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    print(f'Conversation language migration — {"DRY RUN" if args.dry_run else "APPLY"}')
+
+    if args.uid is not None:
+        if not args.uid.strip():
+            parser.error('--uid must not be empty')
+        uids = [args.uid.strip()]
+    else:
+        uids = get_users_uid()
+        if args.limit:
+            uids = uids[: args.limit]
+    print(f'Processing {len(uids)} user(s) with {args.workers} workers')
+
+    results: List[Dict[str, Any]] = []
+    firestore_client = get_firestore_client()
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = [executor.submit(process_user, uid, args.dry_run, firestore_client) for uid in uids]
+        for i, future in enumerate(futures):
+            results.append(future.result())
+            if (i + 1) % 1000 == 0:
+                done = sum(r['fixed'] for r in results)
+                print(f'  processed {i + 1}/{len(uids)} users, convs_fixed={done}...', flush=True)
+
+    convs_fixed = sum(r['fixed'] for r in results)
+    users_with_fixes = sum(1 for r in results if r['fixed'])
+    errors: List[Dict[str, Any]] = [r for r in results if r['status'].startswith('error')]
+
+    print('=' * 60)
+    print(f'users_scanned={len(results)} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}', end='')
+    print(' (dry-run, no writes)' if args.dry_run else '')
+    print(f'errors={len(errors)}')
+    for r in errors:
+        print(f'  {r["uid"]}: {r["status"]}')
+
+    return 1 if errors else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/backend/scripts/migrate_conversation_language.py
+++ b/backend/scripts/migrate_conversation_language.py
@@ -43,11 +43,6 @@ def process_user(uid: str, dry_run: bool, firestore_client: Any = None) -> Dict[
         for conv in convs:
             data: Dict[str, Any] = conv.to_dict() or {}
 
-            # Check if source is 'friend' or 'friend_com' and language is missing or None
-            source = data.get('source')
-            if source not in ('friend', 'friend_com'):
-                continue
-
             language = data.get('language')
             if language is not None and (not isinstance(language, str) or language.strip()):
                 continue

--- a/backend/scripts/migrate_conversation_language.py
+++ b/backend/scripts/migrate_conversation_language.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """One-time migration: set default 'en' language for conversations from the Friend source.
 
 The Friend source will now use 'en' as the default language. This script updates
@@ -7,11 +8,27 @@ any existing conversations with source 'friend' or 'friend_com' that have a null
 import argparse
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 from google.cloud import firestore
 
-from database._client import get_firestore_client, get_users_uid
+from database._client import get_firestore_client
+
+USER_PAGE_SIZE = 1000
+
+
+def _iter_user_pages(firestore_client: Any, page_size: int = USER_PAGE_SIZE) -> Iterator[List[str]]:
+    users_query = firestore_client.collection('users').order_by('__name__')
+    cursor = None
+    while True:
+        page_query = users_query.start_after(cursor) if cursor is not None else users_query
+        documents = list(page_query.limit(page_size).stream())
+        if not documents:
+            return
+        yield [str(document.id) for document in documents]
+        if len(documents) < page_size:
+            return
+        cursor = documents[-1]
 
 
 def _positive_int(value: str) -> int:
@@ -77,29 +94,38 @@ def main() -> int:
     if args.uid is not None:
         if not args.uid.strip():
             parser.error('--uid must not be empty')
-        uids = [args.uid.strip()]
+        firestore_client = get_firestore_client()
+        user_pages = iter([[args.uid.strip()]])
     else:
-        uids = get_users_uid()
-        if args.limit:
-            uids = uids[: args.limit]
-    print(f'Processing {len(uids)} user(s) with {args.workers} workers')
+        firestore_client = get_firestore_client()
+        user_pages = _iter_user_pages(firestore_client)
+    total_label = '1' if args.uid is not None else (str(args.limit) if args.limit else 'all')
+    print(f'Processing {total_label} user(s) with {args.workers} workers')
 
-    results: List[Dict[str, Any]] = []
-    firestore_client = get_firestore_client()
+    users_scanned = 0
+    convs_fixed = 0
+    users_with_fixes = 0
+    errors: List[Dict[str, Any]] = []
     with ThreadPoolExecutor(max_workers=args.workers) as executor:
-        futures = [executor.submit(process_user, uid, args.dry_run, firestore_client) for uid in uids]
-        for i, future in enumerate(futures):
-            results.append(future.result())
-            if (i + 1) % 1000 == 0:
-                done = sum(r['fixed'] for r in results)
-                print(f'  processed {i + 1}/{len(uids)} users, convs_fixed={done}...', flush=True)
-
-    convs_fixed = sum(r['fixed'] for r in results)
-    users_with_fixes = sum(1 for r in results if r['fixed'])
-    errors: List[Dict[str, Any]] = [r for r in results if r['status'].startswith('error')]
+        for page in user_pages:
+            if args.limit:
+                remaining = args.limit - users_scanned
+                if remaining <= 0:
+                    break
+                page = page[:remaining]
+            futures = [executor.submit(process_user, uid, args.dry_run, firestore_client) for uid in page]
+            for future in futures:
+                result = future.result()
+                users_scanned += 1
+                convs_fixed += result['fixed']
+                users_with_fixes += bool(result['fixed'])
+                if result['status'].startswith('error'):
+                    errors.append(result)
+                if users_scanned % 1000 == 0:
+                    print(f'  processed {users_scanned}/{total_label} users, convs_fixed={convs_fixed}...', flush=True)
 
     print('=' * 60)
-    print(f'users_scanned={len(results)} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}', end='')
+    print(f'users_scanned={users_scanned} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}', end='')
     print(' (dry-run, no writes)' if args.dry_run else '')
     print(f'errors={len(errors)}')
     for r in errors:

--- a/backend/scripts/migrate_conversation_language.py
+++ b/backend/scripts/migrate_conversation_language.py
@@ -8,9 +8,14 @@ any existing conversations with source 'friend' or 'friend_com' that have a null
 import argparse
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Any, Dict, Iterator, List
 
 from google.cloud import firestore
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
 
 from database._client import get_firestore_client
 

--- a/backend/tests/unit/test_migrate_conversation_language.py
+++ b/backend/tests/unit/test_migrate_conversation_language.py
@@ -1,0 +1,81 @@
+from argparse import ArgumentTypeError
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from models.conversation import CreateConversation
+from models.conversation_enums import ConversationSource
+from scripts import migrate_conversation_language
+
+
+def test_migration_updates_only_blank_friend_languages(monkeypatch):
+    conversations = []
+    updated = []
+    for conversation_id, data in (
+        ('missing', {'source': 'friend'}),
+        ('blank', {'source': 'friend', 'language': '  '}),
+        ('french', {'source': 'friend', 'language': 'fr'}),
+        ('omi', {'source': 'omi'}),
+    ):
+        conversation = MagicMock(id=conversation_id)
+        conversation.to_dict.return_value = data
+        conversation.reference.update.side_effect = lambda updates, conversation_id=conversation_id: updated.append(
+            (conversation_id, updates)
+        )
+        conversations.append(conversation)
+
+    firestore_client = MagicMock()
+    conversations_ref = firestore_client.collection.return_value.document.return_value.collection.return_value
+    conversations_ref.where.return_value.stream.return_value = conversations
+
+    result = migrate_conversation_language.process_user('uid', dry_run=False, firestore_client=firestore_client)
+
+    assert result == {'uid': 'uid', 'fixed': 2, 'status': 'ok'}
+    assert updated == [('missing', {'language': 'en'}), ('blank', {'language': 'en'})]
+    conversations_ref.where.assert_called_once()
+
+
+def test_conversation_language_default_is_scoped_to_friend_source():
+    values = {
+        'started_at': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        'finished_at': datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        'transcript_segments': [],
+    }
+
+    assert CreateConversation(**values).language is None
+    assert CreateConversation(**values, source=ConversationSource.friend).language == 'en'
+    assert CreateConversation(**values, source=ConversationSource.friend, language='  ').language == 'en'
+    assert CreateConversation(**values, source=ConversationSource.friend, language='fr').language == 'fr'
+
+
+def test_worker_count_must_be_positive():
+    with pytest.raises(ArgumentTypeError):
+        migrate_conversation_language._positive_int('0')
+    with pytest.raises(SystemExit):
+        migrate_conversation_language._build_parser().parse_args(['--workers', '0'])
+
+
+def test_user_limit_must_be_nonnegative():
+    with pytest.raises(ArgumentTypeError):
+        migrate_conversation_language._nonnegative_int('-1')
+    with pytest.raises(SystemExit):
+        migrate_conversation_language._build_parser().parse_args(['--limit', '-1'])
+
+
+def test_empty_uid_is_rejected_before_user_enumeration(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['migrate_conversation_language', '--uid', '  '])
+
+    with pytest.raises(SystemExit):
+        migrate_conversation_language.main()
+
+
+def test_migration_worker_reports_client_errors():
+    firestore_client = MagicMock()
+    firestore_client.collection.side_effect = RuntimeError('test client failure')
+
+    result = migrate_conversation_language.process_user('uid', dry_run=True, firestore_client=firestore_client)
+
+    assert result['uid'] == 'uid'
+    assert result['fixed'] == 0
+    assert result['status'] == 'error: test client failure'

--- a/backend/tests/unit/test_migrate_conversation_language.py
+++ b/backend/tests/unit/test_migrate_conversation_language.py
@@ -67,6 +67,22 @@ def test_user_limit_must_be_nonnegative():
         migrate_conversation_language._build_parser().parse_args(['--limit', '-1'])
 
 
+def test_user_pages_are_bounded_and_resume_after_last_document():
+    first_page = [MagicMock(id='a'), MagicMock(id='b')]
+    second_page = [MagicMock(id='c')]
+    firestore_client = MagicMock()
+    users_query = firestore_client.collection.return_value.order_by.return_value
+    first_query = users_query
+    second_query = users_query.start_after.return_value
+    first_query.limit.return_value.stream.return_value = first_page
+    second_query.limit.return_value.stream.return_value = second_page
+
+    assert list(migrate_conversation_language._iter_user_pages(firestore_client, page_size=2)) == [['a', 'b'], ['c']]
+    users_query.start_after.assert_called_once_with(first_page[-1])
+    first_query.limit.assert_called_once_with(2)
+    second_query.limit.assert_called_once_with(2)
+
+
 def test_empty_uid_is_rejected_before_user_enumeration(monkeypatch):
     monkeypatch.setattr('sys.argv', ['migrate_conversation_language', '--uid', '  '])
 

--- a/backend/tests/unit/test_migrate_conversation_language.py
+++ b/backend/tests/unit/test_migrate_conversation_language.py
@@ -16,7 +16,7 @@ def test_migration_updates_only_blank_friend_languages(monkeypatch):
         ('missing', {'source': 'friend'}),
         ('blank', {'source': 'friend', 'language': '  '}),
         ('french', {'source': 'friend', 'language': 'fr'}),
-        ('omi', {'source': 'omi'}),
+        ('friend_com_missing', {'source': 'friend_com'}),
     ):
         conversation = MagicMock(id=conversation_id)
         conversation.to_dict.return_value = data
@@ -31,8 +31,12 @@ def test_migration_updates_only_blank_friend_languages(monkeypatch):
 
     result = migrate_conversation_language.process_user('uid', dry_run=False, firestore_client=firestore_client)
 
-    assert result == {'uid': 'uid', 'fixed': 2, 'status': 'ok'}
-    assert updated == [('missing', {'language': 'en'}), ('blank', {'language': 'en'})]
+    assert result == {'uid': 'uid', 'fixed': 3, 'status': 'ok'}
+    assert updated == [
+        ('missing', {'language': 'en'}),
+        ('blank', {'language': 'en'}),
+        ('friend_com_missing', {'language': 'en'}),
+    ]
     conversations_ref.where.assert_called_once()
 
 

--- a/backend/tests/unit/test_migrate_conversation_language.py
+++ b/backend/tests/unit/test_migrate_conversation_language.py
@@ -1,5 +1,9 @@
 from argparse import ArgumentTypeError
 from datetime import datetime, timezone
+import os
+from pathlib import Path
+import subprocess
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -88,6 +92,23 @@ def test_empty_uid_is_rejected_before_user_enumeration(monkeypatch):
 
     with pytest.raises(SystemExit):
         migrate_conversation_language.main()
+
+
+def test_executable_entrypoint_supports_help():
+    script = Path(__file__).resolve().parents[2] / 'scripts' / 'migrate_conversation_language.py'
+    environment = os.environ.copy()
+    environment['PATH'] = f'{Path(sys.executable).parent}{os.pathsep}{environment["PATH"]}'
+    result = subprocess.run(
+        [str(script), '--help'],
+        cwd=script.parents[1],
+        capture_output=True,
+        env=environment,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert 'Set default "en" language for Friend conversations' in result.stdout
 
 
 def test_migration_worker_reports_client_errors():

--- a/backend/tests/unit/test_sync_transcription_prefs.py
+++ b/backend/tests/unit/test_sync_transcription_prefs.py
@@ -660,6 +660,38 @@ class TestProcessSegmentPreferences:
         create_conversation = mock_process.call_args[0][2]
         assert create_conversation.private_cloud_sync_enabled is True
 
+    @patch('utils.sync.pipeline.process_conversation')
+    @patch('utils.sync.pipeline.get_closest_conversation_to_timestamps', return_value=None)
+    @patch('utils.sync.pipeline.get_timestamp_from_path', return_value=1700000000)
+    @patch('utils.sync.pipeline.prerecorded')
+    @patch('utils.sync.pipeline.delete_syncing_temporal_file')
+    @patch('utils.sync.pipeline.get_syncing_file_temporal_signed_url', return_value='http://example.com/audio.wav')
+    def test_detected_language_is_persisted_on_new_conversation(
+        self, mock_url, mock_delete, mock_dg, mock_ts, mock_closest, mock_process
+    ):
+        """Detected language must be passed into CreateConversation so the 'en' default cannot replace it."""
+        from models.conversation_enums import ConversationSource
+        from utils.sync.pipeline import process_segment
+
+        mock_dg.return_value = (self._make_mock_words(), 'es')
+        mock_process.return_value = MagicMock(id='test-id')
+
+        response = {'new_memories': set(), 'updated_memories': set()}
+        lock = threading.Lock()
+        errors = []
+
+        process_segment(
+            'test/path.bin',
+            'uid123',
+            response,
+            lock,
+            errors,
+            source=ConversationSource.friend,
+        )
+
+        create_conversation = mock_process.call_args[0][2]
+        assert create_conversation.language == 'es'
+
 
 # ---------------------------------------------------------------------------
 # Structural: endpoint wires transcription_prefs into threads

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -1151,6 +1151,7 @@ def process_segment(
                 finished_at=finished_at,
                 transcript_segments=transcript_segments,
                 source=source,
+                language=language,
                 is_locked=is_locked,
                 private_cloud_sync_enabled=private_cloud_sync_enabled,
                 client_device_id=client_device_id,


### PR DESCRIPTION
feat(backend): set default 'en' language for Friend conversations

Friend-scoped 'en' default: `Conversation`, `CreateConversation`, and `ExternalIntegrationCreateConversation` keep `language` nullable and apply `'en'` only when `source` is `friend`/`friend_com` via model validators, preserving explicit non-English values. The sync pipeline threads the resolved detected language into `CreateConversation`. A one-time migration backfills blank/missing Friend languages with `--dry-run`/`--workers`/`--limit`/`--uid` controls.

Tests: 71 passed (migration script + sync transcription prefs).

Line-Count-Exception: backend/utils/sync/pipeline.py | 2499 -> 2500 | threads the resolved detected language into CreateConversation so Friend conversations persist the actual language instead of the 'en' default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conversation persistence and a bulk Firestore migration; wrong scoping could set language on non-Friend rows, though validators and migration filters limit that.
> 
> **Overview**
> Friend and Friend-com conversations now **default `language` to `'en'`** when it is missing or blank, via shared Pydantic validators on `Conversation`, `CreateConversation`, and `ExternalIntegrationCreateConversation`. Non-Friend sources stay nullable; explicit non-English values are unchanged.
> 
> Offline sync **passes detected/resolved language into `CreateConversation`** when creating a new conversation, so Friend sync does not overwrite Spanish (etc.) with the `'en'` default.
> 
> A **one-time Firestore migration** backfills `language: 'en'` on existing `friend` / `friend_com` docs with null or whitespace-only language (`--dry-run`, `--uid`, `--workers`, `--limit`). Unit tests cover the migration, model scoping, and sync persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3fa9b661b64b5cb2ce2d7d18a0db4561c19c08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Failure-Class: none