### PR TITLE
🧹 [code health improvement] Refactor vad utility to use domain exception instead of fastapi.HTTPException

### DIFF
--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -21,7 +21,7 @@ from utils.other.storage import (
 )
 from utils.multipart import MultipartMaxPartSizeRoute, SPEECH_PROFILE_MAX_PART_SIZE, max_part_size
 from utils.stt.speaker_embedding import extract_embedding
-from utils.stt.vad import apply_vad_for_speech_profile
+from utils.stt.vad import apply_vad_for_speech_profile, VADEmptyError
 import logging
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,10 @@ def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_ui
     if aseg.duration_seconds < 5 or aseg.duration_seconds > 120:
         raise HTTPException(status_code=400, detail="Audio duration is invalid (must be 5-120 seconds)")
 
-    apply_vad_for_speech_profile(file_path)
+    try:
+        apply_vad_for_speech_profile(file_path)
+    except VADEmptyError:
+        raise HTTPException(status_code=400, detail="Audio is empty")
 
     # Write-ahead: Cache exact duration after VAD processing (use av for fast header-only read)
     with av.open(file_path) as container:

--- a/backend/scripts/stt/j_apply_vad_to_speech_profiles.py
+++ b/backend/scripts/stt/j_apply_vad_to_speech_profiles.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from dotenv import load_dotenv
 from pydub import AudioSegment
 
-from utils.stt.vad import apply_vad_for_speech_profile
+from utils.stt.vad import apply_vad_for_speech_profile, VADEmptyError
 
 load_dotenv('../../.env')
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '../../' + os.getenv('GOOGLE_APPLICATION_CREDENTIALS', '')
@@ -25,7 +25,12 @@ def execute():
         file_path = get_profile_audio_if_exists(uid)
         if not file_path:
             return
-        apply_vad_for_speech_profile(file_path)
+        try:
+            apply_vad_for_speech_profile(file_path)
+        except VADEmptyError:
+            print('Audio is empty for', uid)
+            return
+
         aseg = cast(
             Any, AudioSegment.from_wav(file_path)
         )  # pyright: ignore[reportUnknownMemberType]  # pydub has no type stubs

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -83,7 +83,7 @@ finally:
     sys.modules.update(_saved)
 
 from fastapi import HTTPException  # noqa: E402  (import after the finder block)
-from utils.stt.vad import VADEmptyError  # noqa: E402  (import after the finder block)
+import utils.stt.vad as _vad  # noqa: E402  (import after the finder block)
 
 
 class _FakeDecodeError(Exception):
@@ -139,8 +139,10 @@ class TestUploadProfileWavDecodeGuard:
 
         with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
             mod, "AudioSegment"
-        ) as mock_aseg, patch.object(mod, "VADEmptyError", VADEmptyError), patch.object(
-            mod, "apply_vad_for_speech_profile", side_effect=VADEmptyError("Audio is empty")
+        ) as mock_aseg, patch.object(mod, "VADEmptyError", _vad.VADEmptyError), patch.object(
+            mod, "apply_vad_for_speech_profile", _vad.apply_vad_for_speech_profile
+        ), patch.object(
+            _vad, "vad_is_empty", return_value=[]
         ) as mock_vad, patch.object(
             mod, "upload_profile_audio"
         ) as mock_upload:

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -89,6 +89,10 @@ class _FakeDecodeError(Exception):
     """Stand-in for pydub.exceptions.CouldntDecodeError (pydub is stubbed here)."""
 
 
+class _FakeVADEmptyError(ValueError):
+    pass
+
+
 def _fake_upload_file(content: bytes, filename: str = "speech_profile.wav"):
     f = MagicMock()
     f.filename = filename
@@ -131,4 +135,25 @@ class TestUploadProfileWavDecodeGuard:
 
         assert exc_info.value.status_code == 400
         mock_vad.assert_not_called()
+        mock_upload.assert_not_called()
+
+    def test_empty_vad_returns_400_not_500(self):
+        fake_file = _fake_upload_file(b'silence')
+
+        with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
+            mod, "AudioSegment"
+        ) as mock_aseg, patch.object(mod, "VADEmptyError", _FakeVADEmptyError), patch.object(
+            mod, "apply_vad_for_speech_profile", side_effect=_FakeVADEmptyError("Audio is empty")
+        ) as mock_vad, patch.object(
+            mod, "upload_profile_audio"
+        ) as mock_upload:
+            mock_os.makedirs.return_value = None
+            mock_aseg.from_wav.return_value = MagicMock(frame_rate=16000, duration_seconds=5)
+
+            with pytest.raises(HTTPException) as exc_info:
+                mod.upload_profile(fake_file, uid="test-uid")
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Audio is empty"
+        mock_vad.assert_called_once()
         mock_upload.assert_not_called()

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -83,14 +83,11 @@ finally:
     sys.modules.update(_saved)
 
 from fastapi import HTTPException  # noqa: E402  (import after the finder block)
+from utils.stt.vad import VADEmptyError  # noqa: E402  (import after the finder block)
 
 
 class _FakeDecodeError(Exception):
     """Stand-in for pydub.exceptions.CouldntDecodeError (pydub is stubbed here)."""
-
-
-class _FakeVADEmptyError(ValueError):
-    pass
 
 
 def _fake_upload_file(content: bytes, filename: str = "speech_profile.wav"):
@@ -142,8 +139,8 @@ class TestUploadProfileWavDecodeGuard:
 
         with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
             mod, "AudioSegment"
-        ) as mock_aseg, patch.object(mod, "VADEmptyError", _FakeVADEmptyError), patch.object(
-            mod, "apply_vad_for_speech_profile", side_effect=_FakeVADEmptyError("Audio is empty")
+        ) as mock_aseg, patch.object(mod, "VADEmptyError", VADEmptyError), patch.object(
+            mod, "apply_vad_for_speech_profile", side_effect=VADEmptyError("Audio is empty")
         ) as mock_vad, patch.object(
             mod, "upload_profile_audio"
         ) as mock_upload:

--- a/backend/tests/unit/test_vad_onnx.py
+++ b/backend/tests/unit/test_vad_onnx.py
@@ -20,7 +20,9 @@ import pytest
 from utils.stt import vad
 from utils.stt.vad import (
     VADAudioDecodeError,
+    VADEmptyError,
     VADProcessingError,
+    apply_vad_for_speech_profile,
     vad_is_empty,
     _run_file_vad,
     _get_ort_session,
@@ -75,6 +77,12 @@ def _write_wav_file(path: str, duration_sec: float, freq_hz: float = 0.0):
     data = _make_wav_bytes(duration_sec, freq_hz)
     with open(path, 'wb') as f:
         f.write(data)
+
+
+def test_apply_vad_for_speech_profile_raises_domain_error_for_empty_vad():
+    with patch.object(vad, 'vad_is_empty', return_value=[]):
+        with pytest.raises(VADEmptyError, match='Audio is empty'):
+            apply_vad_for_speech_profile('/tmp/silent-profile.wav')
 
 
 def _mock_run_vad_window_speech(window, state, context):

--- a/backend/utils/stt/vad.py
+++ b/backend/utils/stt/vad.py
@@ -7,7 +7,6 @@ import httpx
 import numpy as np
 import onnxruntime as ort  # onnxruntime is untyped
 import requests
-from fastapi import HTTPException
 from pydub import AudioSegment  # pydub is untyped
 
 from database import redis_db
@@ -24,6 +23,10 @@ class VADAudioDecodeError(RuntimeError):
 
 class VADProcessingError(RuntimeError):
     """The local VAD could not make a trustworthy speech decision."""
+
+
+class VADEmptyError(ValueError):
+    """Audio was completely empty / had no speech segments after VAD."""
 
 
 def _hosted_vad_fallback_reason(exc: BaseException) -> str:
@@ -340,8 +343,8 @@ async def async_vad_is_empty(
 def apply_vad_for_speech_profile(file_path: str) -> None:
     logger.info(f'apply_vad_for_speech_profile {file_path}')
     voice_segments = vad_is_empty(file_path, return_segments=True)
-    if len(voice_segments) == 0:  # TODO: front error on post-processing, audio sent is bad.
-        raise HTTPException(status_code=400, detail="Audio is empty")
+    if len(voice_segments) == 0:
+        raise VADEmptyError("Audio is empty")
     joined_segments: List[Dict[str, Any]] = []
     for i, segment in enumerate(voice_segments):
         if joined_segments and (segment['start'] - joined_segments[-1]['end']) < 1:


### PR DESCRIPTION
🎯 **What:** Removed the FastAPI `HTTPException` from the `apply_vad_for_speech_profile` utility in `backend/utils/stt/vad.py` and replaced it with a domain-specific `VADEmptyError` exception. Updated `routers/speech_profile.py` and `scripts/stt/j_apply_vad_to_speech_profiles.py` to handle this exception appropriately.

💡 **Why:** `backend/utils/stt/vad.py` is a lower-level utility module and should not be coupled to FastAPI's web concerns (`HTTPException`). This ensures proper separation of concerns. It also fixes a potential crash in `j_apply_vad_to_speech_profiles.py` where a worker script was previously receiving an unhandled web exception.

✅ **Verification:** Verified by code review, `git diff`, and running the test suite for `backend/tests/unit/test_vad_onnx.py`, `backend/tests/unit/test_user_speaker_embedding.py`, and `backend/tests/unit/test_speech_profile_wav_decode.py`, ensuring all tests pass successfully.

✨ **Result:** A more robust and decoupled architecture where utility scripts don't depend on web frameworks, allowing safe reuse across web requests and background scripts.

---
*PR created automatically by Jules for task [3884123085473852924](https://jules.google.com/task/3884123085473852924) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of exception handling with preserved 400 API behavior for empty audio; no auth, data, or VAD algorithm changes.
> 
> **Overview**
> Decouples the VAD utility from FastAPI by replacing `HTTPException` in `apply_vad_for_speech_profile` with a domain-specific `VADEmptyError`.
> 
> The speech-profile upload route now catches `VADEmptyError` and maps it to a **400** response. The batch VAD script skips empty profiles instead of crashing on an unhandled web exception.
> 
> Adds unit coverage for the new domain error and the 400 mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5604f224fab526be1d54e92a082d880b882b587. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->