### PR TITLE
🧪 [Testing Improvement] Add unit tests for agent_vm_account_cleanup

### DIFF
--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -156,6 +156,7 @@ AREA_TESTS = (
             'tests/unit/test_users_*.py',
             'tests/unit/test_delete_account_*.py',
             'tests/unit/test_claim_deletion_*.py',
+            'tests/unit/test_agent_vm_account_cleanup.py',
         ),
     ),
     (

--- a/backend/tests/unit/test_agent_vm_account_cleanup.py
+++ b/backend/tests/unit/test_agent_vm_account_cleanup.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from services.users import agent_vm_account_cleanup
+
+
+def test_gce_project_id_precedence():
+    with patch.dict(
+        os.environ,
+        {
+            'GCE_PROJECT_ID': 'gce-project',
+            'GOOGLE_CLOUD_PROJECT': 'google-cloud-project',
+            'FIREBASE_PROJECT_ID': 'firebase-project',
+            'GCP_PROJECT_ID': 'gcp-project',
+        },
+    ):
+        assert agent_vm_account_cleanup._gce_project_id() == 'gce-project'
+
+    with patch.dict(
+        os.environ,
+        {
+            'GOOGLE_CLOUD_PROJECT': 'google-cloud-project',
+            'FIREBASE_PROJECT_ID': 'firebase-project',
+            'GCP_PROJECT_ID': 'gcp-project',
+        },
+        clear=True,
+    ):
+        assert agent_vm_account_cleanup._gce_project_id() == 'google-cloud-project'
+
+    with patch.dict(
+        os.environ,
+        {
+            'FIREBASE_PROJECT_ID': 'firebase-project',
+            'GCP_PROJECT_ID': 'gcp-project',
+        },
+        clear=True,
+    ):
+        assert agent_vm_account_cleanup._gce_project_id() == 'firebase-project'
+
+    with patch.dict(
+        os.environ,
+        {
+            'GCP_PROJECT_ID': 'gcp-project',
+        },
+        clear=True,
+    ):
+        assert agent_vm_account_cleanup._gce_project_id() == 'gcp-project'
+
+    with patch.dict(os.environ, {}, clear=True):
+        assert agent_vm_account_cleanup._gce_project_id() is None
+
+
+def test_owner_disk_label():
+    uid = 'test-user-id'
+    expected_hash = agent_vm_account_cleanup.hashlib.sha256(uid.encode('utf-8')).hexdigest()[:20]
+    assert agent_vm_account_cleanup._owner_disk_label(uid) == expected_hash
+
+
+@patch('services.users.agent_vm_account_cleanup.users_db')
+@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
+@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
+def test_delete_agent_vm_for_account_no_vm(
+    mock_lease_active, mock_read_journals, mock_users_db
+):
+    uid = 'test-uid'
+    mock_users_db.get_agent_vm.return_value = None
+    mock_users_db.get_late_agent_vm_cleanup.return_value = None
+    mock_read_journals.return_value = []
+    mock_lease_active.return_value = False
+
+    # Should just return without doing anything
+    agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+
+    mock_users_db.get_agent_vm.assert_called_once_with(uid)
+    mock_read_journals.assert_called_once_with(uid)
+
+
+@patch('services.users.agent_vm_account_cleanup.users_db')
+@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
+@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
+def test_delete_agent_vm_for_account_lease_active(
+    mock_lease_active, mock_read_journals, mock_users_db
+):
+    uid = 'test-uid'
+    mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
+    mock_read_journals.return_value = []
+    mock_lease_active.return_value = True
+
+    with pytest.raises(RuntimeError, match='Agent VM migration reconcile lease is active'):
+        agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+
+
+@patch('services.users.agent_vm_account_cleanup._gce_project_id')
+@patch('services.users.agent_vm_account_cleanup.users_db')
+@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
+@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
+def test_delete_agent_vm_for_account_no_gce_project(
+    mock_lease_active, mock_read_journals, mock_users_db, mock_gce_project_id
+):
+    uid = 'test-uid'
+    mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
+    mock_read_journals.return_value = []
+    mock_lease_active.return_value = False
+    mock_gce_project_id.return_value = None
+
+    with pytest.raises(RuntimeError, match='GCE project is not configured for account-deletion VM cleanup'):
+        agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+
+
+@patch('services.users.agent_vm_account_cleanup.google.auth.default')
+@patch('services.users.agent_vm_account_cleanup.httpx.Client')
+@patch('services.users.agent_vm_account_cleanup._cleanup_agent_vm_migration_resources')
+@patch('services.users.agent_vm_account_cleanup._delete_current_agent_vm')
+@patch('services.users.agent_vm_account_cleanup._load_agent_vm_migration_cleanup_plans')
+@patch('services.users.agent_vm_account_cleanup._gce_project_id')
+@patch('services.users.agent_vm_account_cleanup.users_db')
+@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
+@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
+def test_delete_agent_vm_for_account_success(
+    mock_lease_active,
+    mock_read_journals,
+    mock_users_db,
+    mock_gce_project_id,
+    mock_load_plans,
+    mock_delete_current,
+    mock_cleanup_migration,
+    mock_httpx_client,
+    mock_google_auth,
+):
+    uid = 'test-uid'
+    vm = {'vmName': 'test-vm'}
+    mock_users_db.get_agent_vm.return_value = vm
+    journals = []
+    mock_read_journals.return_value = journals
+    mock_lease_active.return_value = False
+    mock_gce_project_id.return_value = 'test-project'
+
+    mock_credentials = MagicMock()
+    mock_credentials.token = 'test-token'
+    mock_google_auth.return_value = (mock_credentials, 'project')
+
+    mock_client = MagicMock()
+    mock_httpx_client.return_value.__enter__.return_value = mock_client
+
+    mock_plans = [{'plan': 'data'}]
+    mock_load_plans.return_value = mock_plans
+
+    agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+
+    mock_credentials.refresh.assert_called_once()
+
+    headers = {'Authorization': 'Bearer test-token'}
+
+    mock_load_plans.assert_called_once_with(
+        uid, journals, vm, 'test-project', mock_client, headers
+    )
+
+    mock_delete_current.assert_called_once_with(
+        uid, vm, mock_plans, 'test-project', mock_client, headers, legacy_late_cleanup=False
+    )
+
+    mock_cleanup_migration.assert_called_once_with(
+        uid, mock_plans, 'test-project', mock_client, headers
+    )

--- a/backend/tests/unit/test_agent_vm_account_cleanup.py
+++ b/backend/tests/unit/test_agent_vm_account_cleanup.py
@@ -63,9 +63,7 @@ def test_owner_disk_label():
 @patch('services.users.agent_vm_account_cleanup.users_db')
 @patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
 @patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
-def test_delete_agent_vm_for_account_no_vm(
-    mock_lease_active, mock_read_journals, mock_users_db
-):
+def test_delete_agent_vm_for_account_no_vm(mock_lease_active, mock_read_journals, mock_users_db):
     uid = 'test-uid'
     mock_users_db.get_agent_vm.return_value = None
     mock_users_db.get_late_agent_vm_cleanup.return_value = None
@@ -82,9 +80,7 @@ def test_delete_agent_vm_for_account_no_vm(
 @patch('services.users.agent_vm_account_cleanup.users_db')
 @patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
 @patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
-def test_delete_agent_vm_for_account_lease_active(
-    mock_lease_active, mock_read_journals, mock_users_db
-):
+def test_delete_agent_vm_for_account_lease_active(mock_lease_active, mock_read_journals, mock_users_db):
     uid = 'test-uid'
     mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
     mock_read_journals.return_value = []
@@ -155,14 +151,10 @@ def test_delete_agent_vm_for_account_success(
 
     headers = {'Authorization': 'Bearer test-token'}
 
-    mock_load_plans.assert_called_once_with(
-        uid, journals, vm, 'test-project', mock_client, headers
-    )
+    mock_load_plans.assert_called_once_with(uid, journals, vm, 'test-project', mock_client, headers)
 
     mock_delete_current.assert_called_once_with(
         uid, vm, mock_plans, 'test-project', mock_client, headers, legacy_late_cleanup=False
     )
 
-    mock_cleanup_migration.assert_called_once_with(
-        uid, mock_plans, 'test-project', mock_client, headers
-    )
+    mock_cleanup_migration.assert_called_once_with(uid, mock_plans, 'test-project', mock_client, headers)

--- a/backend/tests/unit/test_agent_vm_account_cleanup.py
+++ b/backend/tests/unit/test_agent_vm_account_cleanup.py
@@ -1,57 +1,30 @@
 from __future__ import annotations
 
-import importlib
-import importlib.abc
-import importlib.machinery
 import os
-import sys
-import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 
-class _AutoMockModule(types.ModuleType):
-    __path__ = []
-
-    def __getattr__(self, name):
-        if name.startswith('__') and name.endswith('__'):
-            raise AttributeError(name)
-        mock = MagicMock()
-        setattr(self, name, mock)
-        return mock
+BACKEND_DIR = Path(__file__).resolve().parents[2]
 
 
-class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
-    def __init__(self):
-        self._created = set()
-
-    def find_spec(self, name, path=None, target=None):
-        if name == 'database' or name.startswith('database.') or name == 'utils' or name.startswith('utils.'):
-            return importlib.machinery.ModuleSpec(name, self, is_package=True)
-        return None
-
-    def create_module(self, spec):
-        self._created.add(spec.name)
-        return _AutoMockModule(spec.name)
-
-    def exec_module(self, module):
-        pass
+@pytest.fixture(scope='module')
+def agent_vm_account_cleanup():
+    stubs = {
+        name: AutoMockModule(name) for name in ('database', 'database.users', 'database.account_deletion_transitions')
+    }
+    stubs['database'].__path__ = []
+    with stub_modules(stubs):
+        yield load_module_fresh(
+            'services.users.agent_vm_account_cleanup',
+            str(BACKEND_DIR / 'services' / 'users' / 'agent_vm_account_cleanup.py'),
+        )
 
 
-_finder = _StubFinder()
-sys.meta_path.insert(0, _finder)
-try:
-    agent_vm_account_cleanup = importlib.import_module('services.users.agent_vm_account_cleanup')
-finally:
-    sys.meta_path.remove(_finder)
-    for _name in _finder._created:
-        sys.modules.pop(_name, None)
-    for _name in ('services.users.agent_vm_account_cleanup', 'services.users', 'services'):
-        sys.modules.pop(_name, None)
-
-
-def test_gce_project_id_precedence():
+def test_gce_project_id_precedence(agent_vm_account_cleanup):
     with patch.dict(
         os.environ,
         {
@@ -97,13 +70,13 @@ def test_gce_project_id_precedence():
         assert agent_vm_account_cleanup._gce_project_id() is None
 
 
-def test_owner_disk_label():
+def test_owner_disk_label(agent_vm_account_cleanup):
     uid = 'test-user-id'
     expected_hash = agent_vm_account_cleanup.hashlib.sha256(uid.encode('utf-8')).hexdigest()[:20]
     assert agent_vm_account_cleanup._owner_disk_label(uid) == expected_hash
 
 
-def test_delete_agent_vm_for_account_no_vm():
+def test_delete_agent_vm_for_account_no_vm(agent_vm_account_cleanup):
     uid = 'test-uid'
     with (
         patch.object(agent_vm_account_cleanup, 'users_db') as mock_users_db,
@@ -122,7 +95,7 @@ def test_delete_agent_vm_for_account_no_vm():
         mock_read_journals.assert_called_once_with(uid)
 
 
-def test_delete_agent_vm_for_account_lease_active():
+def test_delete_agent_vm_for_account_lease_active(agent_vm_account_cleanup):
     uid = 'test-uid'
     with (
         patch.object(agent_vm_account_cleanup, 'users_db') as mock_users_db,
@@ -137,7 +110,7 @@ def test_delete_agent_vm_for_account_lease_active():
             agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
 
 
-def test_delete_agent_vm_for_account_no_gce_project():
+def test_delete_agent_vm_for_account_no_gce_project(agent_vm_account_cleanup):
     uid = 'test-uid'
     with (
         patch.object(agent_vm_account_cleanup, '_gce_project_id') as mock_gce_project_id,
@@ -154,7 +127,7 @@ def test_delete_agent_vm_for_account_no_gce_project():
             agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
 
 
-def test_delete_agent_vm_for_account_success():
+def test_delete_agent_vm_for_account_success(agent_vm_account_cleanup):
     uid = 'test-uid'
     vm = {'vmName': 'test-vm'}
     with (

--- a/backend/tests/unit/test_agent_vm_account_cleanup.py
+++ b/backend/tests/unit/test_agent_vm_account_cleanup.py
@@ -1,11 +1,54 @@
 from __future__ import annotations
 
+import importlib
+import importlib.abc
+import importlib.machinery
 import os
-from unittest.mock import patch, MagicMock
+import sys
+import types
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from services.users import agent_vm_account_cleanup
+
+class _AutoMockModule(types.ModuleType):
+    __path__ = []
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+class _StubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def __init__(self):
+        self._created = set()
+
+    def find_spec(self, name, path=None, target=None):
+        if name == 'database' or name.startswith('database.') or name == 'utils' or name.startswith('utils.'):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
+
+    def create_module(self, spec):
+        self._created.add(spec.name)
+        return _AutoMockModule(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+_finder = _StubFinder()
+sys.meta_path.insert(0, _finder)
+try:
+    agent_vm_account_cleanup = importlib.import_module('services.users.agent_vm_account_cleanup')
+finally:
+    sys.meta_path.remove(_finder)
+    for _name in _finder._created:
+        sys.modules.pop(_name, None)
+    for _name in ('services.users.agent_vm_account_cleanup', 'services.users', 'services'):
+        sys.modules.pop(_name, None)
 
 
 def test_gce_project_id_precedence():
@@ -60,101 +103,98 @@ def test_owner_disk_label():
     assert agent_vm_account_cleanup._owner_disk_label(uid) == expected_hash
 
 
-@patch('services.users.agent_vm_account_cleanup.users_db')
-@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
-@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
-def test_delete_agent_vm_for_account_no_vm(mock_lease_active, mock_read_journals, mock_users_db):
+def test_delete_agent_vm_for_account_no_vm():
     uid = 'test-uid'
-    mock_users_db.get_agent_vm.return_value = None
-    mock_users_db.get_late_agent_vm_cleanup.return_value = None
-    mock_read_journals.return_value = []
-    mock_lease_active.return_value = False
+    with (
+        patch.object(agent_vm_account_cleanup, 'users_db') as mock_users_db,
+        patch.object(agent_vm_account_cleanup, 'read_agent_vm_migration_journals') as mock_read_journals,
+        patch.object(agent_vm_account_cleanup, '_migration_reconcile_lease_active') as mock_lease_active,
+    ):
+        mock_users_db.get_agent_vm.return_value = None
+        mock_users_db.get_late_agent_vm_cleanup.return_value = None
+        mock_read_journals.return_value = []
+        mock_lease_active.return_value = False
 
-    # Should just return without doing anything
-    agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
-
-    mock_users_db.get_agent_vm.assert_called_once_with(uid)
-    mock_read_journals.assert_called_once_with(uid)
-
-
-@patch('services.users.agent_vm_account_cleanup.users_db')
-@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
-@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
-def test_delete_agent_vm_for_account_lease_active(mock_lease_active, mock_read_journals, mock_users_db):
-    uid = 'test-uid'
-    mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
-    mock_read_journals.return_value = []
-    mock_lease_active.return_value = True
-
-    with pytest.raises(RuntimeError, match='Agent VM migration reconcile lease is active'):
+        # Should just return without doing anything
         agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
 
+        mock_users_db.get_agent_vm.assert_called_once_with(uid)
+        mock_read_journals.assert_called_once_with(uid)
 
-@patch('services.users.agent_vm_account_cleanup._gce_project_id')
-@patch('services.users.agent_vm_account_cleanup.users_db')
-@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
-@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
-def test_delete_agent_vm_for_account_no_gce_project(
-    mock_lease_active, mock_read_journals, mock_users_db, mock_gce_project_id
-):
+
+def test_delete_agent_vm_for_account_lease_active():
     uid = 'test-uid'
-    mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
-    mock_read_journals.return_value = []
-    mock_lease_active.return_value = False
-    mock_gce_project_id.return_value = None
+    with (
+        patch.object(agent_vm_account_cleanup, 'users_db') as mock_users_db,
+        patch.object(agent_vm_account_cleanup, 'read_agent_vm_migration_journals') as mock_read_journals,
+        patch.object(agent_vm_account_cleanup, '_migration_reconcile_lease_active') as mock_lease_active,
+    ):
+        mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
+        mock_read_journals.return_value = []
+        mock_lease_active.return_value = True
 
-    with pytest.raises(RuntimeError, match='GCE project is not configured for account-deletion VM cleanup'):
-        agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+        with pytest.raises(RuntimeError, match='Agent VM migration reconcile lease is active'):
+            agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
 
 
-@patch('services.users.agent_vm_account_cleanup.google.auth.default')
-@patch('services.users.agent_vm_account_cleanup.httpx.Client')
-@patch('services.users.agent_vm_account_cleanup._cleanup_agent_vm_migration_resources')
-@patch('services.users.agent_vm_account_cleanup._delete_current_agent_vm')
-@patch('services.users.agent_vm_account_cleanup._load_agent_vm_migration_cleanup_plans')
-@patch('services.users.agent_vm_account_cleanup._gce_project_id')
-@patch('services.users.agent_vm_account_cleanup.users_db')
-@patch('services.users.agent_vm_account_cleanup.read_agent_vm_migration_journals')
-@patch('services.users.agent_vm_account_cleanup._migration_reconcile_lease_active')
-def test_delete_agent_vm_for_account_success(
-    mock_lease_active,
-    mock_read_journals,
-    mock_users_db,
-    mock_gce_project_id,
-    mock_load_plans,
-    mock_delete_current,
-    mock_cleanup_migration,
-    mock_httpx_client,
-    mock_google_auth,
-):
+def test_delete_agent_vm_for_account_no_gce_project():
+    uid = 'test-uid'
+    with (
+        patch.object(agent_vm_account_cleanup, '_gce_project_id') as mock_gce_project_id,
+        patch.object(agent_vm_account_cleanup, 'users_db') as mock_users_db,
+        patch.object(agent_vm_account_cleanup, 'read_agent_vm_migration_journals') as mock_read_journals,
+        patch.object(agent_vm_account_cleanup, '_migration_reconcile_lease_active') as mock_lease_active,
+    ):
+        mock_users_db.get_agent_vm.return_value = {'vmName': 'test-vm'}
+        mock_read_journals.return_value = []
+        mock_lease_active.return_value = False
+        mock_gce_project_id.return_value = None
+
+        with pytest.raises(RuntimeError, match='GCE project is not configured for account-deletion VM cleanup'):
+            agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+
+
+def test_delete_agent_vm_for_account_success():
     uid = 'test-uid'
     vm = {'vmName': 'test-vm'}
-    mock_users_db.get_agent_vm.return_value = vm
-    journals = []
-    mock_read_journals.return_value = journals
-    mock_lease_active.return_value = False
-    mock_gce_project_id.return_value = 'test-project'
+    with (
+        patch.object(agent_vm_account_cleanup, 'google') as mock_google,
+        patch.object(agent_vm_account_cleanup, 'httpx') as mock_httpx,
+        patch.object(agent_vm_account_cleanup, '_cleanup_agent_vm_migration_resources') as mock_cleanup_migration,
+        patch.object(agent_vm_account_cleanup, '_delete_current_agent_vm') as mock_delete_current,
+        patch.object(agent_vm_account_cleanup, '_load_agent_vm_migration_cleanup_plans') as mock_load_plans,
+        patch.object(agent_vm_account_cleanup, '_gce_project_id') as mock_gce_project_id,
+        patch.object(agent_vm_account_cleanup, 'users_db') as mock_users_db,
+        patch.object(agent_vm_account_cleanup, 'read_agent_vm_migration_journals') as mock_read_journals,
+        patch.object(agent_vm_account_cleanup, '_migration_reconcile_lease_active') as mock_lease_active,
+    ):
+        mock_users_db.get_agent_vm.return_value = vm
+        journals = []
+        mock_read_journals.return_value = journals
+        mock_lease_active.return_value = False
+        mock_gce_project_id.return_value = 'test-project'
 
-    mock_credentials = MagicMock()
-    mock_credentials.token = 'test-token'
-    mock_google_auth.return_value = (mock_credentials, 'project')
+        mock_credentials = MagicMock()
+        mock_credentials.token = 'test-token'
+        mock_google.auth.default.return_value = (mock_credentials, 'project')
 
-    mock_client = MagicMock()
-    mock_httpx_client.return_value.__enter__.return_value = mock_client
+        mock_client = MagicMock()
+        mock_httpx.Client.return_value.__enter__.return_value = mock_client
 
-    mock_plans = [{'plan': 'data'}]
-    mock_load_plans.return_value = mock_plans
+        mock_plans = [{'plan': 'data'}]
+        mock_load_plans.return_value = mock_plans
 
-    agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
+        agent_vm_account_cleanup.delete_agent_vm_for_account(uid)
 
-    mock_credentials.refresh.assert_called_once()
+        mock_google.auth.default.assert_called_once_with(scopes=['https://www.googleapis.com/auth/cloud-platform'])
+        mock_credentials.refresh.assert_called_once()
 
-    headers = {'Authorization': 'Bearer test-token'}
+        headers = {'Authorization': 'Bearer test-token'}
 
-    mock_load_plans.assert_called_once_with(uid, journals, vm, 'test-project', mock_client, headers)
+        mock_load_plans.assert_called_once_with(uid, journals, vm, 'test-project', mock_client, headers)
 
-    mock_delete_current.assert_called_once_with(
-        uid, vm, mock_plans, 'test-project', mock_client, headers, legacy_late_cleanup=False
-    )
+        mock_delete_current.assert_called_once_with(
+            uid, vm, mock_plans, 'test-project', mock_client, headers, legacy_late_cleanup=False
+        )
 
-    mock_cleanup_migration.assert_called_once_with(uid, mock_plans, 'test-project', mock_client, headers)
+        mock_cleanup_migration.assert_called_once_with(uid, mock_plans, 'test-project', mock_client, headers)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `backend/services/users/agent_vm_account_cleanup.py` file was missing a dedicated test file to guarantee that account deletions and their associated VM cleanup logic execute flawlessly and fail gracefully in misconfigured environments.

📊 **Coverage:** What scenarios are now tested
- Environment variable precedence testing for GCE project ID logic.
- Owner disk label creation logic and hashing formatting.
- `delete_agent_vm_for_account` missing VM behavior.
- `delete_agent_vm_for_account` active lease block behavior.
- `delete_agent_vm_for_account` missing GCE configuration block behavior.
- Complete success path mock integration traversing the sub-function calls, testing httpx client scopes, and tracking proper auth credential refresh flows.

✨ **Result:** The improvement in test coverage
The module now possesses comprehensive test coverage across its major account cleanup entry points and utilities, ensuring better reliability and robust refactoring capabilities going forward.

---
*PR created automatically by Jules for task [10345052882773169899](https://jules.google.com/task/10345052882773169899) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production logic modified; low risk aside from ensuring mocks stay aligned with the cleanup module.
> 
> **Overview**
> Adds **`tests/unit/test_agent_vm_account_cleanup.py`** with isolated module loading and mocks for **`services.users.agent_vm_account_cleanup`**, covering GCE project env precedence, owner disk label hashing, and **`delete_agent_vm_for_account`** paths (no VM, active migration lease, missing GCE project, and the happy path through auth, httpx, and cleanup helpers).
> 
> Registers that file under the users **`AREA_TESTS`** mapping in **`select_backend_unit_tests.py`** so PRs touching user/agent VM cleanup code run these tests in narrow selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9decd152f5e0d1d30aba82e247e8b596e3b976. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->