### PR TITLE
feat: Lock and rate limit webhook audio bytes

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -2,7 +2,6 @@ import ast
 import base64
 import json
 import os
-import uuid
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
 from datetime import datetime, timedelta, timezone
 
@@ -959,30 +958,10 @@ def try_acquire_listen_lock(uid: str, ttl: int = 7) -> bool:
     return result is not None
 
 
-def try_acquire_audio_bytes_webhook_lock(uid: str, ttl: int = 180) -> Optional[str]:
+def try_acquire_audio_bytes_webhook_lock(uid: str, ttl: int = 5) -> bool:
     """Atomically try to acquire audio bytes webhook rate limit lock. Returns True if acquired (not rate limited), False if already rate limited."""
-    token = str(uuid.uuid4())
-    try:
-        result = r.set(f'users:{uid}:audio_bytes_webhook_lock', token, ex=ttl, nx=True)
-    except Exception as e:
-        logger.warning('audio bytes webhook lock unavailable; proceeding without lock error=%s', type(e).__name__)
-        return token
-    return token if result is not None else None
-
-
-_RELEASE_AUDIO_BYTES_WEBHOOK_LOCK_SCRIPT = """
-if redis.call('get', KEYS[1]) == ARGV[1] then
-    return redis.call('del', KEYS[1])
-end
-return 0
-"""
-
-
-def release_audio_bytes_webhook_lock(uid: str, token: str) -> None:
-    try:
-        r.eval(_RELEASE_AUDIO_BYTES_WEBHOOK_LOCK_SCRIPT, 1, f'users:{uid}:audio_bytes_webhook_lock', token)
-    except Exception as e:
-        logger.warning('release audio bytes webhook lock failed error=%s', type(e).__name__)
+    result = r.set(f'users:{uid}:audio_bytes_webhook_lock', '1', ex=ttl, nx=True)
+    return result is not None
 
 
 def try_acquire_client_device_write_lock(uid: str, client_device_id: str, ttl: int = 600) -> bool:

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -958,6 +958,12 @@ def try_acquire_listen_lock(uid: str, ttl: int = 7) -> bool:
     return result is not None
 
 
+def try_acquire_audio_bytes_webhook_lock(uid: str, ttl: int = 5) -> bool:
+    """Atomically try to acquire audio bytes webhook rate limit lock. Returns True if acquired (not rate limited), False if already rate limited."""
+    result = r.set(f'users:{uid}:audio_bytes_webhook_lock', '1', ex=ttl, nx=True)
+    return result is not None
+
+
 def try_acquire_client_device_write_lock(uid: str, client_device_id: str, ttl: int = 600) -> bool:
     """Throttle client_devices registry upserts to once per (uid, device) every `ttl` seconds."""
     try:

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -976,13 +976,17 @@ if redis.call('get', KEYS[1]) == ARGV[1] then
 end
 return 0
 """
+_AUDIO_BYTES_WEBHOOK_LOCK_RELEASE_ATTEMPTS = 3
 
 
 def release_audio_bytes_webhook_lock(uid: str, token: str) -> None:
-    try:
-        r.eval(_RELEASE_AUDIO_BYTES_WEBHOOK_LOCK_SCRIPT, 1, f'users:{uid}:audio_bytes_webhook_lock', token)
-    except Exception as e:
-        logger.warning('release audio bytes webhook lock failed error=%s', type(e).__name__)
+    for attempt in range(_AUDIO_BYTES_WEBHOOK_LOCK_RELEASE_ATTEMPTS):
+        try:
+            r.eval(_RELEASE_AUDIO_BYTES_WEBHOOK_LOCK_SCRIPT, 1, f'users:{uid}:audio_bytes_webhook_lock', token)
+            return
+        except Exception as e:
+            if attempt == _AUDIO_BYTES_WEBHOOK_LOCK_RELEASE_ATTEMPTS - 1:
+                logger.warning('release audio bytes webhook lock failed error=%s', type(e).__name__)
 
 
 def try_acquire_client_device_write_lock(uid: str, client_device_id: str, ttl: int = 600) -> bool:

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -2,6 +2,7 @@ import ast
 import base64
 import json
 import os
+import uuid
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
 from datetime import datetime, timedelta, timezone
 
@@ -958,10 +959,30 @@ def try_acquire_listen_lock(uid: str, ttl: int = 7) -> bool:
     return result is not None
 
 
-def try_acquire_audio_bytes_webhook_lock(uid: str, ttl: int = 5) -> bool:
+def try_acquire_audio_bytes_webhook_lock(uid: str, ttl: int = 180) -> Optional[str]:
     """Atomically try to acquire audio bytes webhook rate limit lock. Returns True if acquired (not rate limited), False if already rate limited."""
-    result = r.set(f'users:{uid}:audio_bytes_webhook_lock', '1', ex=ttl, nx=True)
-    return result is not None
+    token = str(uuid.uuid4())
+    try:
+        result = r.set(f'users:{uid}:audio_bytes_webhook_lock', token, ex=ttl, nx=True)
+    except Exception as e:
+        logger.warning('audio bytes webhook lock unavailable; proceeding without lock error=%s', type(e).__name__)
+        return token
+    return token if result is not None else None
+
+
+_RELEASE_AUDIO_BYTES_WEBHOOK_LOCK_SCRIPT = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
+
+
+def release_audio_bytes_webhook_lock(uid: str, token: str) -> None:
+    try:
+        r.eval(_RELEASE_AUDIO_BYTES_WEBHOOK_LOCK_SCRIPT, 1, f'users:{uid}:audio_bytes_webhook_lock', token)
+    except Exception as e:
+        logger.warning('release audio bytes webhook lock failed error=%s', type(e).__name__)
 
 
 def try_acquire_client_device_write_lock(uid: str, client_device_id: str, ttl: int = 600) -> bool:

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -637,8 +637,8 @@ async def _websocket_util_trigger(
                             {
                                 'type': 'webhook',
                                 'sample_rate': sample_rate,
-                                'data': take_bounded_chunk(
-                                    audiobuffer, sample_rate * audio_bytes_webhook_delay_seconds * 2
+                                'data': bytearray(
+                                    take_bounded_chunk(audiobuffer, sample_rate * audio_bytes_webhook_delay_seconds * 2)
                                 ),
                             },
                             'audio_bytes',

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -27,6 +27,7 @@ from utils.pusher_protocol import (
     frame_header,
     json_object,
     pusher_session_outcome,
+    take_bounded_chunk,
 )
 from utils.apps import is_audio_bytes_app_enabled
 from utils.app_integrations import (
@@ -627,7 +628,7 @@ async def _websocket_util_trigger(
                         trigger_audiobuffer = bytearray()
                     if (
                         audio_bytes_webhook_delay_seconds is not None
-                        and len(audiobuffer) > sample_rate * audio_bytes_webhook_delay_seconds * 2
+                        and len(audiobuffer) >= sample_rate * audio_bytes_webhook_delay_seconds * 2
                     ):
                         if len(audio_bytes_queue) >= AUDIO_BYTES_QUEUE_WARN_SIZE:
                             logger.warning(f"Warning: audio_bytes_queue size {len(audio_bytes_queue)} {uid}")
@@ -636,14 +637,15 @@ async def _websocket_util_trigger(
                             {
                                 'type': 'webhook',
                                 'sample_rate': sample_rate,
-                                'data': audiobuffer.copy(),
+                                'data': take_bounded_chunk(
+                                    audiobuffer, sample_rate * audio_bytes_webhook_delay_seconds * 2
+                                ),
                             },
                             'audio_bytes',
                             byte_budget=audio_budget,
                             size_of=lambda item: len(item['data']),
                         )
                         audio_bytes_event.set()  # Wake consumer immediately
-                        audiobuffer = bytearray()
                     continue
 
         except (ValueError, struct.error, UnicodeDecodeError) as exc:

--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -131,6 +131,17 @@ class TestWebhookCircuitBreaker:
         assert cb.allow_request() is True  # first probe
         assert cb.allow_request() is False  # second blocked
 
+    def test_half_open_probe_can_be_released_after_lock_contention(self):
+        cb = WebhookCircuitBreaker("test-host")
+        for _ in range(_CIRCUIT_BREAKER_FAILURE_THRESHOLD):
+            cb.record_failure()
+        cb._last_failure_time = time.monotonic() - _CIRCUIT_BREAKER_RECOVERY_TIMEOUT - 1
+
+        assert cb.state == 'half_open'
+        assert cb.allow_request() is True
+        cb.release_probe()
+        assert cb.allow_request() is True
+
     def test_half_open_success_closes(self):
         cb = WebhookCircuitBreaker("test-host")
         for _ in range(_CIRCUIT_BREAKER_FAILURE_THRESHOLD):

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -5,12 +5,14 @@ use httpx.AsyncClient instead of blocking requests.post.
 """
 
 import ast
+import asyncio
 import os
 import re
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
+import database.redis_db as redis_db_module
 import utils.webhooks as webhooks_module
 from models.users import WebhookType
 from utils.webhooks import realtime_transcript_webhook, send_audio_bytes_developer_webhook, day_summary_webhook
@@ -24,7 +26,8 @@ def _stub_webhook_db_helpers(monkeypatch):
     etc. Individual tests override specific names via ``with patch(...)`` as needed.
     """
     monkeypatch.setattr(webhooks_module, "user_webhook_status_db", MagicMock(return_value=True))
-    monkeypatch.setattr(webhooks_module, "try_acquire_audio_bytes_webhook_lock", MagicMock(return_value=True))
+    monkeypatch.setattr(webhooks_module, "try_acquire_audio_bytes_webhook_lock", MagicMock(return_value="lock-token"))
+    monkeypatch.setattr(webhooks_module, "release_audio_bytes_webhook_lock", MagicMock())
     monkeypatch.setattr(webhooks_module, "get_user_webhook_db", MagicMock(return_value="https://example.com/webhook"))
     monkeypatch.setattr(webhooks_module, "disable_user_webhook_db", MagicMock())
     monkeypatch.setattr(webhooks_module, "enable_user_webhook_db", MagicMock())
@@ -175,6 +178,118 @@ class TestSendAudioBytesDeveloperWebhook:
         ):
             await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
             mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_contention_skips_delivery_while_first_request_is_in_flight(self):
+        first_post_started = asyncio.Event()
+        allow_first_post_to_finish = asyncio.Event()
+        mock_response = MagicMock(status_code=200)
+
+        async def post(*_args, **_kwargs):
+            first_post_started.set()
+            await allow_first_post_to_finish.wait()
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = post
+        lock = MagicMock(side_effect=["first-token", None])
+
+        with patch.object(webhooks_module, "try_acquire_audio_bytes_webhook_lock", lock), patch.object(
+            webhooks_module,
+            "get_webhook_circuit_breaker",
+            return_value=MagicMock(allow_request=MagicMock(return_value=True)),
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            first_delivery = asyncio.create_task(
+                send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100))
+            )
+            await first_post_started.wait()
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100))
+            allow_first_post_to_finish.set()
+            await first_delivery
+
+        assert mock_client.post.call_count == 1
+        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "first-token")
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_releases_lock_without_delivery(self):
+        mock_client = AsyncMock()
+
+        with patch.object(
+            webhooks_module, "get_user_webhook_db", return_value="ftp://example.com/audio,10"
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
+
+        mock_client.post.assert_not_called()
+        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
+
+    @pytest.mark.asyncio
+    async def test_configured_duration_controls_payload_truncation(self):
+        mock_response = MagicMock(status_code=200)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(
+            webhooks_module, "get_user_webhook_db", return_value="https://example.com/audio,10"
+        ), patch.object(
+            webhooks_module,
+            "get_webhook_circuit_breaker",
+            return_value=MagicMock(allow_request=MagicMock(return_value=True)),
+        ), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * (8000 * 2 * 15)))
+
+        sent_content = mock_client.post.call_args.kwargs["content"]
+        assert len(sent_content) == 8000 * 2 * 10
+
+    @pytest.mark.asyncio
+    async def test_delivery_failure_records_failure_and_releases_lock(self):
+        mock_cb = MagicMock()
+        mock_cb.allow_request.return_value = True
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=RuntimeError("delivery failed"))
+
+        with patch.object(webhooks_module, "get_webhook_circuit_breaker", return_value=mock_cb), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ), patch.object(webhooks_module, "_get_dev_webhook_retry_delays", return_value=()):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
+
+        mock_cb.record_failure.assert_called_once()
+        webhooks_module.record_dev_webhook_failure.assert_called_once_with(
+            "uid-1", webhooks_module.WebhookType.audio_bytes, 0, "RuntimeError"
+        )
+        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
+
+
+class TestAudioBytesWebhookRedisLock:
+    def test_redis_outage_preserves_fail_open_delivery_decision(self, monkeypatch):
+        mock_redis = MagicMock()
+        mock_redis.set.side_effect = ConnectionError("redis unavailable")
+        monkeypatch.setattr(redis_db_module, "r", mock_redis)
+
+        token = redis_db_module.try_acquire_audio_bytes_webhook_lock("uid-1", ttl=181)
+
+        assert token
+        mock_redis.set.assert_called_once_with("users:uid-1:audio_bytes_webhook_lock", token, ex=181, nx=True)
+
+    def test_release_only_deletes_matching_lock_token(self, monkeypatch):
+        mock_redis = MagicMock()
+        monkeypatch.setattr(redis_db_module, "r", mock_redis)
+
+        redis_db_module.release_audio_bytes_webhook_lock("uid-1", "lock-token")
+
+        script, key_count, key, token = mock_redis.eval.call_args.args
+        assert key_count == 1
+        assert key == "users:uid-1:audio_bytes_webhook_lock"
+        assert token == "lock-token"
+        assert "redis.call('get', KEYS[1]) == ARGV[1]" in script
+
+    def test_release_redis_failure_is_best_effort(self, monkeypatch):
+        mock_redis = MagicMock()
+        mock_redis.eval.side_effect = ConnectionError("redis unavailable")
+        monkeypatch.setattr(redis_db_module, "r", mock_redis)
+
+        redis_db_module.release_audio_bytes_webhook_lock("uid-1", "lock-token")
 
 
 class TestConversationAndSummaryWebhooksStructural:

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -26,8 +26,10 @@ def _stub_webhook_db_helpers(monkeypatch):
     etc. Individual tests override specific names via ``with patch(...)`` as needed.
     """
     monkeypatch.setattr(webhooks_module, "user_webhook_status_db", MagicMock(return_value=True))
-    monkeypatch.setattr(webhooks_module, "try_acquire_audio_bytes_webhook_lock", MagicMock(return_value="lock-token"))
-    monkeypatch.setattr(webhooks_module, "release_audio_bytes_webhook_lock", MagicMock())
+    redis_helpers = MagicMock()
+    redis_helpers.try_acquire_audio_bytes_webhook_lock = MagicMock(return_value="lock-token")
+    redis_helpers.release_audio_bytes_webhook_lock = MagicMock()
+    monkeypatch.setattr(webhooks_module, "redis_db", redis_helpers)
     monkeypatch.setattr(webhooks_module, "get_user_webhook_db", MagicMock(return_value="https://example.com/webhook"))
     monkeypatch.setattr(webhooks_module, "disable_user_webhook_db", MagicMock())
     monkeypatch.setattr(webhooks_module, "enable_user_webhook_db", MagicMock())
@@ -194,7 +196,7 @@ class TestSendAudioBytesDeveloperWebhook:
         mock_client.post.side_effect = post
         lock = MagicMock(side_effect=["first-token", None])
 
-        with patch.object(webhooks_module, "try_acquire_audio_bytes_webhook_lock", lock), patch.object(
+        with patch.object(webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", lock), patch.object(
             webhooks_module,
             "get_webhook_circuit_breaker",
             return_value=MagicMock(allow_request=MagicMock(return_value=True)),
@@ -208,7 +210,7 @@ class TestSendAudioBytesDeveloperWebhook:
             await first_delivery
 
         assert mock_client.post.call_count == 1
-        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "first-token")
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "first-token")
 
     @pytest.mark.asyncio
     async def test_invalid_url_releases_lock_without_delivery(self):
@@ -220,7 +222,7 @@ class TestSendAudioBytesDeveloperWebhook:
             await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
 
         mock_client.post.assert_not_called()
-        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
 
     @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):
@@ -258,7 +260,7 @@ class TestSendAudioBytesDeveloperWebhook:
         webhooks_module.record_dev_webhook_failure.assert_called_once_with(
             "uid-1", webhooks_module.WebhookType.audio_bytes, 0, "RuntimeError"
         )
-        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
 
 
 class TestAudioBytesWebhookRedisLock:
@@ -286,10 +288,11 @@ class TestAudioBytesWebhookRedisLock:
 
     def test_release_redis_failure_is_best_effort(self, monkeypatch):
         mock_redis = MagicMock()
-        mock_redis.eval.side_effect = ConnectionError("redis unavailable")
+        mock_redis.eval.side_effect = [ConnectionError("redis unavailable"), 1]
         monkeypatch.setattr(redis_db_module, "r", mock_redis)
 
         redis_db_module.release_audio_bytes_webhook_lock("uid-1", "lock-token")
+        assert mock_redis.eval.call_count == 2
 
 
 class TestConversationAndSummaryWebhooksStructural:

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -5,14 +5,12 @@ use httpx.AsyncClient instead of blocking requests.post.
 """
 
 import ast
-import asyncio
 import os
 import re
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
-import database.redis_db as redis_db_module
 import utils.webhooks as webhooks_module
 from models.users import WebhookType
 from utils.webhooks import realtime_transcript_webhook, send_audio_bytes_developer_webhook, day_summary_webhook
@@ -26,8 +24,7 @@ def _stub_webhook_db_helpers(monkeypatch):
     etc. Individual tests override specific names via ``with patch(...)`` as needed.
     """
     monkeypatch.setattr(webhooks_module, "user_webhook_status_db", MagicMock(return_value=True))
-    monkeypatch.setattr(webhooks_module, "try_acquire_audio_bytes_webhook_lock", MagicMock(return_value="lock-token"))
-    monkeypatch.setattr(webhooks_module, "release_audio_bytes_webhook_lock", MagicMock())
+    monkeypatch.setattr(webhooks_module, "try_acquire_audio_bytes_webhook_lock", MagicMock(return_value=True))
     monkeypatch.setattr(webhooks_module, "get_user_webhook_db", MagicMock(return_value="https://example.com/webhook"))
     monkeypatch.setattr(webhooks_module, "disable_user_webhook_db", MagicMock())
     monkeypatch.setattr(webhooks_module, "enable_user_webhook_db", MagicMock())
@@ -178,118 +175,6 @@ class TestSendAudioBytesDeveloperWebhook:
         ):
             await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
             mock_client.post.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_contention_skips_delivery_while_first_request_is_in_flight(self):
-        first_post_started = asyncio.Event()
-        allow_first_post_to_finish = asyncio.Event()
-        mock_response = MagicMock(status_code=200)
-
-        async def post(*_args, **_kwargs):
-            first_post_started.set()
-            await allow_first_post_to_finish.wait()
-            return mock_response
-
-        mock_client = AsyncMock()
-        mock_client.post.side_effect = post
-        lock = MagicMock(side_effect=["first-token", None])
-
-        with patch.object(webhooks_module, "try_acquire_audio_bytes_webhook_lock", lock), patch.object(
-            webhooks_module,
-            "get_webhook_circuit_breaker",
-            return_value=MagicMock(allow_request=MagicMock(return_value=True)),
-        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
-            first_delivery = asyncio.create_task(
-                send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100))
-            )
-            await first_post_started.wait()
-            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100))
-            allow_first_post_to_finish.set()
-            await first_delivery
-
-        assert mock_client.post.call_count == 1
-        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "first-token")
-
-    @pytest.mark.asyncio
-    async def test_invalid_url_releases_lock_without_delivery(self):
-        mock_client = AsyncMock()
-
-        with patch.object(
-            webhooks_module, "get_user_webhook_db", return_value="ftp://example.com/audio,10"
-        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
-            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
-
-        mock_client.post.assert_not_called()
-        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
-
-    @pytest.mark.asyncio
-    async def test_configured_duration_controls_payload_truncation(self):
-        mock_response = MagicMock(status_code=200)
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-
-        with patch.object(
-            webhooks_module, "get_user_webhook_db", return_value="https://example.com/audio,10"
-        ), patch.object(
-            webhooks_module,
-            "get_webhook_circuit_breaker",
-            return_value=MagicMock(allow_request=MagicMock(return_value=True)),
-        ), patch.object(
-            webhooks_module, "get_webhook_client", return_value=mock_client
-        ):
-            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * (8000 * 2 * 15)))
-
-        sent_content = mock_client.post.call_args.kwargs["content"]
-        assert len(sent_content) == 8000 * 2 * 10
-
-    @pytest.mark.asyncio
-    async def test_delivery_failure_records_failure_and_releases_lock(self):
-        mock_cb = MagicMock()
-        mock_cb.allow_request.return_value = True
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=RuntimeError("delivery failed"))
-
-        with patch.object(webhooks_module, "get_webhook_circuit_breaker", return_value=mock_cb), patch.object(
-            webhooks_module, "get_webhook_client", return_value=mock_client
-        ), patch.object(webhooks_module, "_get_dev_webhook_retry_delays", return_value=()):
-            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
-
-        mock_cb.record_failure.assert_called_once()
-        webhooks_module.record_dev_webhook_failure.assert_called_once_with(
-            "uid-1", webhooks_module.WebhookType.audio_bytes, 0, "RuntimeError"
-        )
-        webhooks_module.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
-
-
-class TestAudioBytesWebhookRedisLock:
-    def test_redis_outage_preserves_fail_open_delivery_decision(self, monkeypatch):
-        mock_redis = MagicMock()
-        mock_redis.set.side_effect = ConnectionError("redis unavailable")
-        monkeypatch.setattr(redis_db_module, "r", mock_redis)
-
-        token = redis_db_module.try_acquire_audio_bytes_webhook_lock("uid-1", ttl=181)
-
-        assert token
-        mock_redis.set.assert_called_once_with("users:uid-1:audio_bytes_webhook_lock", token, ex=181, nx=True)
-
-    def test_release_only_deletes_matching_lock_token(self, monkeypatch):
-        mock_redis = MagicMock()
-        monkeypatch.setattr(redis_db_module, "r", mock_redis)
-
-        redis_db_module.release_audio_bytes_webhook_lock("uid-1", "lock-token")
-
-        script, key_count, key, token = mock_redis.eval.call_args.args
-        assert key_count == 1
-        assert key == "users:uid-1:audio_bytes_webhook_lock"
-        assert token == "lock-token"
-        assert "redis.call('get', KEYS[1]) == ARGV[1]" in script
-
-    def test_release_redis_failure_is_best_effort(self, monkeypatch):
-        mock_redis = MagicMock()
-        mock_redis.eval.side_effect = ConnectionError("redis unavailable")
-        monkeypatch.setattr(redis_db_module, "r", mock_redis)
-
-        redis_db_module.release_audio_bytes_webhook_lock("uid-1", "lock-token")
 
 
 class TestConversationAndSummaryWebhooksStructural:

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -24,6 +24,7 @@ def _stub_webhook_db_helpers(monkeypatch):
     etc. Individual tests override specific names via ``with patch(...)`` as needed.
     """
     monkeypatch.setattr(webhooks_module, "user_webhook_status_db", MagicMock(return_value=True))
+    monkeypatch.setattr(webhooks_module, "try_acquire_audio_bytes_webhook_lock", MagicMock(return_value=True))
     monkeypatch.setattr(webhooks_module, "get_user_webhook_db", MagicMock(return_value="https://example.com/webhook"))
     monkeypatch.setattr(webhooks_module, "disable_user_webhook_db", MagicMock())
     monkeypatch.setattr(webhooks_module, "enable_user_webhook_db", MagicMock())

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -6,6 +6,7 @@ use httpx.AsyncClient instead of blocking requests.post.
 
 import ast
 import asyncio
+from contextlib import asynccontextmanager
 import os
 import re
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -213,7 +214,7 @@ class TestSendAudioBytesDeveloperWebhook:
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "first-token")
 
     @pytest.mark.asyncio
-    async def test_invalid_url_releases_lock_without_delivery(self):
+    async def test_invalid_url_skips_lock_and_delivery(self):
         mock_client = AsyncMock()
 
         with patch.object(
@@ -222,7 +223,39 @@ class TestSendAudioBytesDeveloperWebhook:
             await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
 
         mock_client.post.assert_not_called()
-        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
+        webhooks_module.redis_db.try_acquire_audio_bytes_webhook_lock.assert_not_called()
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lock_acquisition_waits_for_webhook_semaphore(self):
+        semaphore_entered = asyncio.Event()
+        allow_semaphore = asyncio.Event()
+        mock_response = MagicMock(status_code=200)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        @asynccontextmanager
+        async def delayed_semaphore():
+            semaphore_entered.set()
+            await allow_semaphore.wait()
+            yield
+
+        with patch.object(webhooks_module, "get_webhook_semaphore", return_value=delayed_semaphore()), patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value="lock-token"
+        ) as acquire_lock, patch.object(
+            webhooks_module,
+            "get_webhook_circuit_breaker",
+            return_value=MagicMock(allow_request=MagicMock(return_value=True)),
+        ), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ):
+            delivery = asyncio.create_task(send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100)))
+            await semaphore_entered.wait()
+            acquire_lock.assert_not_called()
+            allow_semaphore.set()
+            await delivery
+
+        acquire_lock.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -9,6 +9,7 @@ import asyncio
 from contextlib import asynccontextmanager
 import os
 import re
+import time
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
@@ -172,6 +173,19 @@ class TestSendAudioBytesDeveloperWebhook:
         assert ",10" not in call_url
 
     @pytest.mark.asyncio
+    async def test_url_whitespace_is_normalized(self):
+        mock_response = MagicMock(status_code=200)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch.object(
+            webhooks_module, "get_user_webhook_db", return_value=" https://example.com/audio,10 "
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
+
+        assert mock_client.post.call_args.args[0].startswith("https://example.com/audio?")
+
+    @pytest.mark.asyncio
     async def test_disabled_webhook_skips(self):
         """Verify disabled webhook returns early."""
         mock_client = AsyncMock()
@@ -318,6 +332,27 @@ class TestSendAudioBytesDeveloperWebhook:
 
         await semaphore_started.wait()
         assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_lock_acquisition_is_not_cancelled_by_request_timeout(self):
+        mock_response = MagicMock(status_code=200)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        def acquire_lock(*_args, **_kwargs):
+            time.sleep(0.05)
+            return "lock-token"
+
+        with patch.object(webhooks_module, "_get_dev_webhook_retry_delays", return_value=()), patch.object(
+            webhooks_module, "_WEBHOOK_REQUEST_TIMEOUT_SECONDS", 0.01
+        ), patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", side_effect=acquire_lock
+        ), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
+
+        mock_client.post.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -371,6 +371,52 @@ class TestSendAudioBytesDeveloperWebhook:
         mock_client.post.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_cancellation_during_lock_acquisition_releases_late_token(self):
+        acquisition_started = asyncio.Event()
+        mock_client = AsyncMock()
+
+        def acquire_lock(*_args, **_kwargs):
+            acquisition_started.set()
+            time.sleep(0.05)
+            return "late-lock-token"
+
+        with patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", side_effect=acquire_lock
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            delivery = asyncio.create_task(send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00")))
+            await acquisition_started.wait()
+            delivery.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await delivery
+
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
+
+    @pytest.mark.asyncio
+    async def test_semaphore_admission_timeout_does_not_record_endpoint_failure(self):
+        mock_client = AsyncMock()
+        mock_cb = MagicMock(allow_request=MagicMock(return_value=True))
+
+        @asynccontextmanager
+        async def blocked_semaphore():
+            await asyncio.Event().wait()
+            yield
+
+        with patch.object(webhooks_module, "_get_dev_webhook_retry_delays", return_value=()), patch.object(
+            webhooks_module, "_WEBHOOK_REQUEST_TIMEOUT_SECONDS", 0.01
+        ), patch.object(webhooks_module, "get_webhook_semaphore", return_value=blocked_semaphore()), patch.object(
+            webhooks_module,
+            "get_webhook_circuit_breaker",
+            return_value=mock_cb,
+        ), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00"))
+
+        mock_client.post.assert_not_called()
+        mock_cb.record_failure.assert_not_called()
+        webhooks_module.record_dev_webhook_failure.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):
         mock_response = MagicMock(status_code=200)
         mock_client = AsyncMock()

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -439,6 +439,34 @@ class TestSendAudioBytesDeveloperWebhook:
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
 
     @pytest.mark.asyncio
+    async def test_repeated_cancellation_during_lock_acquisition_releases_late_token(self):
+        acquisition_started = asyncio.Event()
+        mock_client = AsyncMock()
+
+        def acquire_lock(*_args, **_kwargs):
+            acquisition_started.set()
+            time.sleep(0.05)
+            return "late-lock-token"
+
+        with patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", side_effect=acquire_lock
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            delivery = asyncio.create_task(send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00')))
+            await acquisition_started.wait()
+            delivery.cancel()
+            await asyncio.sleep(0)
+            delivery.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await delivery
+
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
+
+    def test_non_finite_retry_delays_use_default_schedule(self, monkeypatch):
+        monkeypatch.setenv("DEV_WEBHOOK_RETRY_DELAYS", "1,nan,inf")
+
+        assert webhooks_module._get_dev_webhook_retry_delays() == webhooks_module._DEV_WEBHOOK_RETRY_DELAYS
+
+    @pytest.mark.asyncio
     async def test_semaphore_admission_timeout_does_not_record_endpoint_failure(self):
         mock_client = AsyncMock()
         mock_cb = MagicMock(allow_request=MagicMock(return_value=True))

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -436,6 +436,11 @@ class TestSendAudioBytesDeveloperWebhook:
             with pytest.raises(asyncio.CancelledError):
                 await delivery
 
+            for _ in range(20):
+                if webhooks_module.redis_db.release_audio_bytes_webhook_lock.called:
+                    break
+                await asyncio.sleep(0.01)
+
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
 
     @pytest.mark.asyncio
@@ -458,6 +463,11 @@ class TestSendAudioBytesDeveloperWebhook:
             delivery.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await delivery
+
+            for _ in range(20):
+                if webhooks_module.redis_db.release_audio_bytes_webhook_lock.called:
+                    break
+                await asyncio.sleep(0.01)
 
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
 

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -286,8 +286,8 @@ class TestSendAudioBytesDeveloperWebhook:
             await delivery
 
         assert mock_client.post.call_count == 2
-        assert events[0] == 'semaphore-enter'
-        assert events.index('lock-acquire') > events.index('semaphore-enter')
+        assert events[0] == 'lock-acquire'
+        assert events.index('semaphore-enter') > events.index('lock-acquire')
         assert events.count('semaphore-enter') == 2
 
     @pytest.mark.asyncio
@@ -332,6 +332,22 @@ class TestSendAudioBytesDeveloperWebhook:
 
         await semaphore_started.wait()
         assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cancellation_releases_half_open_probe(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=asyncio.CancelledError)
+        mock_cb = MagicMock()
+        mock_cb.allow_request.return_value = True
+
+        with patch.object(webhooks_module, "get_webhook_circuit_breaker", return_value=mock_cb), patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value="lock-token"
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            with pytest.raises(asyncio.CancelledError):
+                await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00"))
+
+        mock_cb.release_probe.assert_called_once()
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
 
     @pytest.mark.asyncio
     async def test_lock_acquisition_is_not_cancelled_by_request_timeout(self):

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -461,34 +461,6 @@ class TestSendAudioBytesDeveloperWebhook:
 
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
 
-    @pytest.mark.asyncio
-    async def test_child_lock_acquisition_cancellation_does_not_spin(self):
-        acquisition_started = asyncio.Event()
-        mock_client = AsyncMock()
-
-        def acquire_lock(*_args, **_kwargs):
-            acquisition_started.set()
-            time.sleep(0.05)
-            return "late-lock-token"
-
-        with patch.object(
-            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", side_effect=acquire_lock
-        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
-            delivery = asyncio.create_task(send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00")))
-            await acquisition_started.wait()
-            acquisition_tasks = [
-                task
-                for task in asyncio.all_tasks()
-                if task is not asyncio.current_task() and task is not delivery and not task.done()
-            ]
-            assert acquisition_tasks
-            acquisition_tasks[0].cancel()
-            delivery.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await delivery
-
-        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_not_called()
-
     def test_non_finite_retry_delays_use_default_schedule(self, monkeypatch):
         monkeypatch.setenv("DEV_WEBHOOK_RETRY_DELAYS", "1,nan,inf")
 

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -339,6 +339,7 @@ class TestSendAudioBytesDeveloperWebhook:
         mock_client.post = AsyncMock(side_effect=asyncio.CancelledError)
         mock_cb = MagicMock()
         mock_cb.allow_request.return_value = True
+        mock_cb.state = 'half_open'
 
         with patch.object(webhooks_module, "get_webhook_circuit_breaker", return_value=mock_cb), patch.object(
             webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value="lock-token"
@@ -348,6 +349,52 @@ class TestSendAudioBytesDeveloperWebhook:
 
         mock_cb.release_probe.assert_called_once()
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "lock-token")
+
+    @pytest.mark.asyncio
+    async def test_lock_contention_releases_a_half_open_probe_once(self):
+        mock_client = AsyncMock()
+        mock_cb = MagicMock()
+        mock_cb.allow_request.return_value = True
+        mock_cb.state = 'half_open'
+
+        with patch.object(webhooks_module, "get_webhook_circuit_breaker", return_value=mock_cb), patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value=None
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00"))
+
+        mock_cb.release_probe.assert_called_once()
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_admission_timeout_preserves_prior_endpoint_failure(self):
+        mock_response = MagicMock(status_code=500)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        semaphore_calls = 0
+
+        @asynccontextmanager
+        async def semaphore():
+            nonlocal semaphore_calls
+            semaphore_calls += 1
+            if semaphore_calls > 1:
+                await asyncio.Event().wait()
+            yield
+
+        mock_cb = MagicMock(allow_request=MagicMock(return_value=True))
+        with patch.object(webhooks_module, "_get_dev_webhook_retry_delays", return_value=(0,)), patch.object(
+            webhooks_module, "_WEBHOOK_REQUEST_TIMEOUT_SECONDS", 0.01
+        ), patch.object(webhooks_module, "get_webhook_semaphore", side_effect=lambda: semaphore()), patch.object(
+            webhooks_module, "get_webhook_circuit_breaker", return_value=mock_cb
+        ), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00"))
+
+        mock_client.post.assert_called_once()
+        mock_cb.record_failure.assert_called_once()
+        webhooks_module.record_dev_webhook_failure.assert_called_once_with(
+            "uid-1", webhooks_module.WebhookType.audio_bytes, 500, "HTTP 500"
+        )
 
     @pytest.mark.asyncio
     async def test_lock_acquisition_is_not_cancelled_by_request_timeout(self):

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -277,6 +277,49 @@ class TestSendAudioBytesDeveloperWebhook:
         assert events.count('semaphore-enter') == 2
 
     @pytest.mark.asyncio
+    async def test_retry_semaphore_wait_is_bounded_by_audio_lock_lease(self):
+        semaphore_started = asyncio.Event()
+        release_semaphore = asyncio.Event()
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=RuntimeError("retry"))
+        semaphore_calls = 0
+
+        @asynccontextmanager
+        async def blocked_semaphore():
+            nonlocal semaphore_calls
+            semaphore_calls += 1
+            if semaphore_calls > 1:
+                semaphore_started.set()
+                await release_semaphore.wait()
+            yield
+
+        with patch.object(
+            webhooks_module, "get_webhook_semaphore", side_effect=lambda: blocked_semaphore()
+        ), patch.object(
+            webhooks_module,
+            "_get_dev_webhook_retry_delays",
+            return_value=(0,),
+        ), patch.object(
+            webhooks_module,
+            "_WEBHOOK_REQUEST_TIMEOUT_SECONDS",
+            0.01,
+        ), patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value="lock-token"
+        ), patch.object(
+            webhooks_module.redis_db, "release_audio_bytes_webhook_lock"
+        ), patch.object(
+            webhooks_module,
+            "get_webhook_circuit_breaker",
+            return_value=MagicMock(allow_request=MagicMock(return_value=True)),
+        ), patch.object(
+            webhooks_module, "get_webhook_client", return_value=mock_client
+        ):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00"))
+
+        await semaphore_started.wait()
+        assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):
         mock_response = MagicMock(status_code=200)
         mock_client = AsyncMock()

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -461,6 +461,34 @@ class TestSendAudioBytesDeveloperWebhook:
 
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_called_once_with("uid-1", "late-lock-token")
 
+    @pytest.mark.asyncio
+    async def test_child_lock_acquisition_cancellation_does_not_spin(self):
+        acquisition_started = asyncio.Event()
+        mock_client = AsyncMock()
+
+        def acquire_lock(*_args, **_kwargs):
+            acquisition_started.set()
+            time.sleep(0.05)
+            return "late-lock-token"
+
+        with patch.object(
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", side_effect=acquire_lock
+        ), patch.object(webhooks_module, "get_webhook_client", return_value=mock_client):
+            delivery = asyncio.create_task(send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b"\x00")))
+            await acquisition_started.wait()
+            acquisition_tasks = [
+                task
+                for task in asyncio.all_tasks()
+                if task is not asyncio.current_task() and task is not delivery and not task.done()
+            ]
+            assert acquisition_tasks
+            acquisition_tasks[0].cancel()
+            delivery.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await delivery
+
+        webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_not_called()
+
     def test_non_finite_retry_delays_use_default_schedule(self, monkeypatch):
         monkeypatch.setenv("DEV_WEBHOOK_RETRY_DELAYS", "1,nan,inf")
 

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -233,6 +233,7 @@ class TestSendAudioBytesDeveloperWebhook:
         mock_response = MagicMock(status_code=200)
         mock_client = AsyncMock()
         mock_client.post = AsyncMock()
+        events = []
 
         async def post(*_args, **_kwargs):
             if mock_client.post.call_count == 1:
@@ -245,12 +246,18 @@ class TestSendAudioBytesDeveloperWebhook:
 
         @asynccontextmanager
         async def tracked_semaphore():
+            events.append('semaphore-enter')
             yield
+            events.append('semaphore-exit')
+
+        def acquire_lock(*_args, **_kwargs):
+            events.append('lock-acquire')
+            return 'lock-token'
 
         with patch.object(
             webhooks_module, "get_webhook_semaphore", side_effect=lambda: tracked_semaphore()
         ), patch.object(
-            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value="lock-token"
+            webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", side_effect=acquire_lock
         ) as acquire_lock, patch.object(
             webhooks_module,
             "get_webhook_circuit_breaker",
@@ -265,6 +272,9 @@ class TestSendAudioBytesDeveloperWebhook:
             await delivery
 
         assert mock_client.post.call_count == 2
+        assert events[0] == 'semaphore-enter'
+        assert events.index('lock-acquire') > events.index('semaphore-enter')
+        assert events.count('semaphore-enter') == 2
 
     @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -227,20 +227,29 @@ class TestSendAudioBytesDeveloperWebhook:
         webhooks_module.redis_db.release_audio_bytes_webhook_lock.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_lock_acquisition_waits_for_webhook_semaphore(self):
-        semaphore_entered = asyncio.Event()
-        allow_semaphore = asyncio.Event()
+    async def test_retry_backoff_releases_webhook_semaphore(self):
+        first_post_started = asyncio.Event()
+        allow_first_post_to_finish = asyncio.Event()
         mock_response = MagicMock(status_code=200)
         mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.post = AsyncMock()
+
+        async def post(*_args, **_kwargs):
+            if mock_client.post.call_count == 1:
+                first_post_started.set()
+                await allow_first_post_to_finish.wait()
+                raise RuntimeError('retry')
+            return mock_response
+
+        mock_client.post.side_effect = post
 
         @asynccontextmanager
-        async def delayed_semaphore():
-            semaphore_entered.set()
-            await allow_semaphore.wait()
+        async def tracked_semaphore():
             yield
 
-        with patch.object(webhooks_module, "get_webhook_semaphore", return_value=delayed_semaphore()), patch.object(
+        with patch.object(
+            webhooks_module, "get_webhook_semaphore", side_effect=lambda: tracked_semaphore()
+        ), patch.object(
             webhooks_module.redis_db, "try_acquire_audio_bytes_webhook_lock", return_value="lock-token"
         ) as acquire_lock, patch.object(
             webhooks_module,
@@ -250,12 +259,12 @@ class TestSendAudioBytesDeveloperWebhook:
             webhooks_module, "get_webhook_client", return_value=mock_client
         ):
             delivery = asyncio.create_task(send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100)))
-            await semaphore_entered.wait()
-            acquire_lock.assert_not_called()
-            allow_semaphore.set()
+            await first_post_started.wait()
+            acquire_lock.assert_called_once()
+            allow_first_post_to_finish.set()
             await delivery
 
-        acquire_lock.assert_called_once()
+        assert mock_client.post.call_count == 2
 
     @pytest.mark.asyncio
     async def test_configured_duration_controls_payload_truncation(self):

--- a/backend/tests/unit/test_pusher_runtime_protocol.py
+++ b/backend/tests/unit/test_pusher_runtime_protocol.py
@@ -104,6 +104,13 @@ def test_audio_budget_rejects_bytes_above_shared_limit(monkeypatch):
     dropped_bytes.labels.return_value.inc.assert_called_once_with(1)
 
 
+def test_take_bounded_chunk_preserves_audio_remainder():
+    buffer = bytearray(b'abcdef')
+
+    assert pusher_protocol.take_bounded_chunk(buffer, 4) == b'abcd'
+    assert buffer == b'ef'
+
+
 def test_private_pending_evicts_oldest_and_releases_bytes(monkeypatch):
     monkeypatch.setattr(pusher_protocol, 'PUSHER_QUEUE_DROPS', MagicMock())
     monkeypatch.setattr(pusher_protocol, 'PUSHER_QUEUE_DROPPED_BYTES', MagicMock())

--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -181,6 +181,10 @@ class WebhookCircuitBreaker:
         self._state = 'closed'
         self._half_open_in_flight = 0
 
+    def release_probe(self):
+        if self._state == 'half_open' and self._half_open_in_flight:
+            self._half_open_in_flight -= 1
+
     def record_failure(self):
         self._failures += 1
         self._last_failure_time = time.monotonic()

--- a/backend/utils/pusher_protocol.py
+++ b/backend/utils/pusher_protocol.py
@@ -120,7 +120,7 @@ class TranscriptQueueItem(TypedDict):
 class AudioBytesQueueItem(TypedDict):
     type: str
     sample_rate: int
-    data: bytearray
+    data: bytes | bytearray
 
 
 class PrivateCloudChunk(TypedDict):

--- a/backend/utils/pusher_protocol.py
+++ b/backend/utils/pusher_protocol.py
@@ -62,6 +62,12 @@ def extend_bounded(buffer: bytearray, data: bytes, queue_name: str, byte_budget:
     return True
 
 
+def take_bounded_chunk(buffer: bytearray, size: int) -> bytes:
+    chunk = bytes(buffer[:size])
+    del buffer[:size]
+    return chunk
+
+
 def bound_private_pending(pending: Dict[str, Dict[str, Any]], byte_budget: ByteBudget) -> None:
     if len(pending) < PRIVATE_CLOUD_PENDING_MAX_CONVERSATIONS:
         return

--- a/backend/utils/pusher_protocol.py
+++ b/backend/utils/pusher_protocol.py
@@ -120,7 +120,7 @@ class TranscriptQueueItem(TypedDict):
 class AudioBytesQueueItem(TypedDict):
     type: str
     sample_rate: int
-    data: bytes | bytearray
+    data: bytearray
 
 
 class PrivateCloudChunk(TypedDict):

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -11,6 +11,7 @@ from database.redis_db import (
     get_user_webhook_db,
     user_webhook_status_db,
     try_acquire_audio_bytes_webhook_lock,
+    release_audio_bytes_webhook_lock,
     disable_user_webhook_db,
     enable_user_webhook_db,
     set_user_webhook_db,
@@ -29,6 +30,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 _DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
+_AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS = 5
+_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS = 180
+_WEBHOOK_REQUEST_TIMEOUT_SECONDS = 30
 
 
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
@@ -110,6 +114,23 @@ async def _post_dev_webhook(
         raise RuntimeError(f'{webhook_name}: delivery failed without a response or exception')
     logger.error(f'{webhook_name}: delivery failed error={type(last_exception).__name__} attempts={attempts}')
     raise last_exception
+
+
+def _audio_bytes_webhook_lock_ttl(retry_delays: tuple[float, ...]) -> int:
+    request_seconds = _WEBHOOK_REQUEST_TIMEOUT_SECONDS * (len(retry_delays) + 1)
+    delay_seconds = sum(max(delay, 0) for delay in retry_delays)
+    return max(_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS, int(request_seconds + delay_seconds) + 1)
+
+
+def _parse_audio_bytes_webhook_config(webhook_url: str) -> tuple[str, int]:
+    parts = webhook_url.split(',', 1)
+    seconds = _AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS
+    if len(parts) == 2:
+        try:
+            seconds = int(parts[1])
+        except ValueError:
+            pass
+    return parts[0], seconds
 
 
 async def _handle_dev_webhook_disable(uid: str, wtype: str, should_disable: bool):
@@ -300,13 +321,7 @@ def get_audio_bytes_webhook_seconds(uid: str):
         webhook_url = get_user_webhook_db(uid, WebhookType.audio_bytes)
         if not webhook_url:
             return
-        parts = webhook_url.split(',')
-        if len(parts) == 2:
-            try:
-                return int(parts[1])
-            except ValueError:
-                pass
-        return 5
+        return _parse_audio_bytes_webhook_config(webhook_url)[1]
     else:
         return
 
@@ -314,31 +329,40 @@ def get_audio_bytes_webhook_seconds(uid: str):
 async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: bytearray):
     logger.info(f"send_audio_bytes_developer_webhook {uid}")
 
-    if not await run_blocking(db_executor, try_acquire_audio_bytes_webhook_lock, uid):
+    retry_delays = _get_dev_webhook_retry_delays()
+    lock_token = await run_blocking(
+        db_executor,
+        try_acquire_audio_bytes_webhook_lock,
+        uid,
+        _audio_bytes_webhook_lock_ttl(retry_delays),
+    )
+    if not lock_token:
         return
 
-    toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
-    if toggled:
-        webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
-        if not webhook_url:
-            return
-        webhook_url = webhook_url_from_setting(WebhookType.audio_bytes, webhook_url)
-        if not webhook_url or not re.match(r"^https?://", webhook_url):
-            return
+    cb = None
+    try:
+        toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
+        if toggled:
+            webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
+            if not webhook_url:
+                return
+            webhook_url, configured_seconds = _parse_audio_bytes_webhook_config(webhook_url)
+            if not webhook_url or not re.match(r"^https?://", webhook_url) or not urlsplit(webhook_url).netloc:
+                return
 
-        webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
-        cb = get_webhook_circuit_breaker(webhook_url)
-        if not cb.allow_request():
-            logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
-            return
+            webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
+            cb = get_webhook_circuit_breaker(webhook_url)
+            if not cb.allow_request():
+                logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
+                return
 
-        max_bytes = sample_rate * 2 * 5
-        data = data[:max_bytes]
+            max_bytes = sample_rate * 2 * configured_seconds
+            data = data[:max_bytes]
 
-        try:
             response = await _post_dev_webhook(
                 'send_audio_bytes_developer_webhook',
                 webhook_url,
+                retry_delays=retry_delays,
                 content=bytes(data),
                 headers={'Content-Type': 'application/octet-stream'},
             )
@@ -356,15 +380,18 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
                     f'HTTP {response.status_code}',
                 )
                 await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        except Exception as e:
+        else:
+            return
+    except Exception as e:
+        if cb is not None:
             cb.record_failure()
-            should_disable = await run_blocking(
-                db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
-            )
-            await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-            logger.error(f"Error sending audio bytes to developer webhook: {e}")
-    else:
-        return
+        should_disable = await run_blocking(
+            db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
+        )
+        await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+        logger.error(f"Error sending audio bytes to developer webhook: {e}")
+    finally:
+        await run_blocking(db_executor, release_audio_bytes_webhook_lock, uid, lock_token)
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -11,7 +11,6 @@ from database.redis_db import (
     get_user_webhook_db,
     user_webhook_status_db,
     try_acquire_audio_bytes_webhook_lock,
-    release_audio_bytes_webhook_lock,
     disable_user_webhook_db,
     enable_user_webhook_db,
     set_user_webhook_db,
@@ -30,9 +29,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 _DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
-_AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS = 5
-_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS = 180
-_WEBHOOK_REQUEST_TIMEOUT_SECONDS = 30
 
 
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
@@ -114,23 +110,6 @@ async def _post_dev_webhook(
         raise RuntimeError(f'{webhook_name}: delivery failed without a response or exception')
     logger.error(f'{webhook_name}: delivery failed error={type(last_exception).__name__} attempts={attempts}')
     raise last_exception
-
-
-def _audio_bytes_webhook_lock_ttl(retry_delays: tuple[float, ...]) -> int:
-    request_seconds = _WEBHOOK_REQUEST_TIMEOUT_SECONDS * (len(retry_delays) + 1)
-    delay_seconds = sum(max(delay, 0) for delay in retry_delays)
-    return max(_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS, int(request_seconds + delay_seconds) + 1)
-
-
-def _parse_audio_bytes_webhook_config(webhook_url: str) -> tuple[str, int]:
-    parts = webhook_url.split(',', 1)
-    seconds = _AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS
-    if len(parts) == 2:
-        try:
-            seconds = int(parts[1])
-        except ValueError:
-            pass
-    return parts[0], seconds
 
 
 async def _handle_dev_webhook_disable(uid: str, wtype: str, should_disable: bool):
@@ -321,7 +300,13 @@ def get_audio_bytes_webhook_seconds(uid: str):
         webhook_url = get_user_webhook_db(uid, WebhookType.audio_bytes)
         if not webhook_url:
             return
-        return _parse_audio_bytes_webhook_config(webhook_url)[1]
+        parts = webhook_url.split(',')
+        if len(parts) == 2:
+            try:
+                return int(parts[1])
+            except ValueError:
+                pass
+        return 5
     else:
         return
 
@@ -329,40 +314,31 @@ def get_audio_bytes_webhook_seconds(uid: str):
 async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: bytearray):
     logger.info(f"send_audio_bytes_developer_webhook {uid}")
 
-    retry_delays = _get_dev_webhook_retry_delays()
-    lock_token = await run_blocking(
-        db_executor,
-        try_acquire_audio_bytes_webhook_lock,
-        uid,
-        _audio_bytes_webhook_lock_ttl(retry_delays),
-    )
-    if not lock_token:
+    if not await run_blocking(db_executor, try_acquire_audio_bytes_webhook_lock, uid):
         return
 
-    cb = None
-    try:
-        toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
-        if toggled:
-            webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
-            if not webhook_url:
-                return
-            webhook_url, configured_seconds = _parse_audio_bytes_webhook_config(webhook_url)
-            if not webhook_url or not re.match(r"^https?://", webhook_url) or not urlsplit(webhook_url).netloc:
-                return
+    toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
+    if toggled:
+        webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
+        if not webhook_url:
+            return
+        webhook_url = webhook_url.split(',')[0]
+        if not webhook_url or not re.match(r"^https?://", webhook_url):
+            return
 
-            webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
-            cb = get_webhook_circuit_breaker(webhook_url)
-            if not cb.allow_request():
-                logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
-                return
+        webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
+        cb = get_webhook_circuit_breaker(webhook_url)
+        if not cb.allow_request():
+            logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
+            return
 
-            max_bytes = sample_rate * 2 * configured_seconds
-            data = data[:max_bytes]
+        max_bytes = sample_rate * 2 * 5
+        data = data[:max_bytes]
 
+        try:
             response = await _post_dev_webhook(
                 'send_audio_bytes_developer_webhook',
                 webhook_url,
-                retry_delays=retry_delays,
                 content=bytes(data),
                 headers={'Content-Type': 'application/octet-stream'},
             )
@@ -380,18 +356,15 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
                     f'HTTP {response.status_code}',
                 )
                 await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        else:
-            return
-    except Exception as e:
-        if cb is not None:
+        except Exception as e:
             cb.record_failure()
-        should_disable = await run_blocking(
-            db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
-        )
-        await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        logger.error(f"Error sending audio bytes to developer webhook: {e}")
-    finally:
-        await run_blocking(db_executor, release_audio_bytes_webhook_lock, uid, lock_token)
+            should_disable = await run_blocking(
+                db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
+            )
+            await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+            logger.error(f"Error sending audio bytes to developer webhook: {e}")
+    else:
+        return
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -11,6 +11,7 @@ from database.redis_db import (
     get_user_webhook_db,
     user_webhook_status_db,
     try_acquire_audio_bytes_webhook_lock,
+    release_audio_bytes_webhook_lock,
     disable_user_webhook_db,
     enable_user_webhook_db,
     set_user_webhook_db,
@@ -29,6 +30,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 _DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
+_AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS = 5
+_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS = 180
+_WEBHOOK_REQUEST_TIMEOUT_SECONDS = 30
 
 
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
@@ -110,6 +114,23 @@ async def _post_dev_webhook(
         raise RuntimeError(f'{webhook_name}: delivery failed without a response or exception')
     logger.error(f'{webhook_name}: delivery failed error={type(last_exception).__name__} attempts={attempts}')
     raise last_exception
+
+
+def _audio_bytes_webhook_lock_ttl(retry_delays: tuple[float, ...]) -> int:
+    request_seconds = _WEBHOOK_REQUEST_TIMEOUT_SECONDS * (len(retry_delays) + 1)
+    delay_seconds = sum(max(delay, 0) for delay in retry_delays)
+    return max(_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS, int(request_seconds + delay_seconds) + 1)
+
+
+def _parse_audio_bytes_webhook_config(webhook_url: str) -> tuple[str, int]:
+    parts = webhook_url.split(',', 1)
+    seconds = _AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS
+    if len(parts) == 2:
+        try:
+            seconds = int(parts[1])
+        except ValueError:
+            pass
+    return parts[0], seconds
 
 
 async def _handle_dev_webhook_disable(uid: str, wtype: str, should_disable: bool):
@@ -300,13 +321,7 @@ def get_audio_bytes_webhook_seconds(uid: str):
         webhook_url = get_user_webhook_db(uid, WebhookType.audio_bytes)
         if not webhook_url:
             return
-        parts = webhook_url.split(',')
-        if len(parts) == 2:
-            try:
-                return int(parts[1])
-            except ValueError:
-                pass
-        return 5
+        return _parse_audio_bytes_webhook_config(webhook_url)[1]
     else:
         return
 
@@ -314,31 +329,40 @@ def get_audio_bytes_webhook_seconds(uid: str):
 async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: bytearray):
     logger.info(f"send_audio_bytes_developer_webhook {uid}")
 
-    if not await run_blocking(db_executor, try_acquire_audio_bytes_webhook_lock, uid):
+    retry_delays = _get_dev_webhook_retry_delays()
+    lock_token = await run_blocking(
+        db_executor,
+        try_acquire_audio_bytes_webhook_lock,
+        uid,
+        _audio_bytes_webhook_lock_ttl(retry_delays),
+    )
+    if not lock_token:
         return
 
-    toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
-    if toggled:
-        webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
-        if not webhook_url:
-            return
-        webhook_url = webhook_url.split(',')[0]
-        if not webhook_url or not re.match(r"^https?://", webhook_url):
-            return
+    cb = None
+    try:
+        toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
+        if toggled:
+            webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
+            if not webhook_url:
+                return
+            webhook_url, configured_seconds = _parse_audio_bytes_webhook_config(webhook_url)
+            if not webhook_url or not re.match(r"^https?://", webhook_url) or not urlsplit(webhook_url).netloc:
+                return
 
-        webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
-        cb = get_webhook_circuit_breaker(webhook_url)
-        if not cb.allow_request():
-            logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
-            return
+            webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
+            cb = get_webhook_circuit_breaker(webhook_url)
+            if not cb.allow_request():
+                logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
+                return
 
-        max_bytes = sample_rate * 2 * 5
-        data = data[:max_bytes]
+            max_bytes = sample_rate * 2 * configured_seconds
+            data = data[:max_bytes]
 
-        try:
             response = await _post_dev_webhook(
                 'send_audio_bytes_developer_webhook',
                 webhook_url,
+                retry_delays=retry_delays,
                 content=bytes(data),
                 headers={'Content-Type': 'application/octet-stream'},
             )
@@ -356,15 +380,18 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
                     f'HTTP {response.status_code}',
                 )
                 await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        except Exception as e:
+        else:
+            return
+    except Exception as e:
+        if cb is not None:
             cb.record_failure()
-            should_disable = await run_blocking(
-                db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
-            )
-            await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-            logger.error(f"Error sending audio bytes to developer webhook: {e}")
-    else:
-        return
+        should_disable = await run_blocking(
+            db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
+        )
+        await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+        logger.error(f"Error sending audio bytes to developer webhook: {e}")
+    finally:
+        await run_blocking(db_executor, release_audio_bytes_webhook_lock, uid, lock_token)
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -1,3 +1,4 @@
+import re
 import asyncio
 import json
 import os
@@ -9,6 +10,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from database.redis_db import (
     get_user_webhook_db,
     user_webhook_status_db,
+    try_acquire_audio_bytes_webhook_lock,
     disable_user_webhook_db,
     enable_user_webhook_db,
     set_user_webhook_db,
@@ -311,20 +313,28 @@ def get_audio_bytes_webhook_seconds(uid: str):
 
 async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: bytearray):
     logger.info(f"send_audio_bytes_developer_webhook {uid}")
-    # TODO: add a lock, send shorter segments, validate regex.
+
+    if not await run_blocking(db_executor, try_acquire_audio_bytes_webhook_lock, uid):
+        return
+
     toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
     if toggled:
         webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
         if not webhook_url:
             return
         webhook_url = webhook_url_from_setting(WebhookType.audio_bytes, webhook_url)
-        if not webhook_url:
+        if not webhook_url or not re.match(r"^https?://", webhook_url):
             return
+
         webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
         cb = get_webhook_circuit_breaker(webhook_url)
         if not cb.allow_request():
             logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
             return
+
+        max_bytes = sample_rate * 2 * 5
+        data = data[:max_bytes]
+
         try:
             response = await _post_dev_webhook(
                 'send_audio_bytes_developer_webhook',

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -7,11 +7,10 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+import database.redis_db as redis_db
 from database.redis_db import (
     get_user_webhook_db,
     user_webhook_status_db,
-    try_acquire_audio_bytes_webhook_lock,
-    release_audio_bytes_webhook_lock,
     disable_user_webhook_db,
     enable_user_webhook_db,
     set_user_webhook_db,
@@ -32,6 +31,7 @@ logger = logging.getLogger(__name__)
 _DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
 _AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS = 5
 _AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS = 180
+_AUDIO_BYTES_WEBHOOK_LOCK_RELEASE_ATTEMPTS = 3
 _WEBHOOK_REQUEST_TIMEOUT_SECONDS = 30
 
 
@@ -332,7 +332,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
     retry_delays = _get_dev_webhook_retry_delays()
     lock_token = await run_blocking(
         db_executor,
-        try_acquire_audio_bytes_webhook_lock,
+        redis_db.try_acquire_audio_bytes_webhook_lock,
         uid,
         _audio_bytes_webhook_lock_ttl(retry_delays),
     )
@@ -391,7 +391,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
         logger.error(f"Error sending audio bytes to developer webhook: {e}")
     finally:
-        await run_blocking(db_executor, release_audio_bytes_webhook_lock, uid, lock_token)
+        await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -60,6 +60,7 @@ async def _post_dev_webhook(
     *,
     retry_delays: Optional[tuple[float, ...]] = None,
     idempotency_key: Optional[str] = None,
+    acquire_semaphore: bool = True,
     **request_kwargs,
 ):
     if retry_delays is None:
@@ -78,7 +79,10 @@ async def _post_dev_webhook(
         attempt_number = attempt_index + 1
         failure_reason = None
         try:
-            async with get_webhook_semaphore():
+            if acquire_semaphore:
+                async with get_webhook_semaphore():
+                    response = await client.post(webhook_url, **request_kwargs)
+            else:
                 response = await client.post(webhook_url, **request_kwargs)
             last_response = response
             last_exception = None
@@ -328,44 +332,41 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
     logger.info(f"send_audio_bytes_developer_webhook {uid}")
 
     retry_delays = _get_dev_webhook_retry_delays()
-    lock_token = await run_blocking(
-        db_executor,
-        redis_db.try_acquire_audio_bytes_webhook_lock,
-        uid,
-        _audio_bytes_webhook_lock_ttl(retry_delays),
-    )
-    if not lock_token:
+    toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
+    if not toggled:
         return
 
-    cb = None
-    try:
-        toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
-        if toggled:
-            webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
-            if not webhook_url:
-                return
-            webhook_url, configured_seconds = _parse_audio_bytes_webhook_config(webhook_url)
-            if (
-                not webhook_url
-                or not webhook_url.startswith(("http://", "https://"))
-                or not urlsplit(webhook_url).netloc
-            ):
-                return
+    webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
+    if not webhook_url:
+        return
+    webhook_url, configured_seconds = _parse_audio_bytes_webhook_config(webhook_url)
+    if not webhook_url or not webhook_url.startswith(("http://", "https://")) or not urlsplit(webhook_url).netloc:
+        return
 
-            webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
-            cb = get_webhook_circuit_breaker(webhook_url)
-            if not cb.allow_request():
-                logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
-                return
+    webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
+    cb = get_webhook_circuit_breaker(webhook_url)
+    if not cb.allow_request():
+        logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
+        return
 
+    async with get_webhook_semaphore():
+        lock_token = await run_blocking(
+            db_executor,
+            redis_db.try_acquire_audio_bytes_webhook_lock,
+            uid,
+            _audio_bytes_webhook_lock_ttl(retry_delays),
+        )
+        if not lock_token:
+            return
+
+        try:
             max_bytes = sample_rate * 2 * configured_seconds
-            data = data[:max_bytes]
-
             response = await _post_dev_webhook(
                 'send_audio_bytes_developer_webhook',
                 webhook_url,
                 retry_delays=retry_delays,
-                content=bytes(data),
+                acquire_semaphore=False,
+                content=bytes(data[:max_bytes]),
                 headers={'Content-Type': 'application/octet-stream'},
             )
             if response.status_code >= 200 and response.status_code < 300:
@@ -382,18 +383,15 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
                     f'HTTP {response.status_code}',
                 )
                 await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        else:
-            return
-    except Exception as e:
-        if cb is not None:
+        except Exception as e:
             cb.record_failure()
-        should_disable = await run_blocking(
-            db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
-        )
-        await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        logger.error(f"Error sending audio bytes to developer webhook: {e}")
-    finally:
-        await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
+            should_disable = await run_blocking(
+                db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
+            )
+            await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+            logger.error(f"Error sending audio bytes to developer webhook: {e}")
+        finally:
+            await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -33,6 +33,10 @@ _AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS = 180
 _WEBHOOK_REQUEST_TIMEOUT_SECONDS = 30
 
 
+class _WebhookLockUnavailable(Exception):
+    pass
+
+
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
     raw_delays = os.getenv('DEV_WEBHOOK_RETRY_DELAYS')
     if raw_delays is None:
@@ -61,6 +65,7 @@ async def _post_dev_webhook(
     retry_delays: Optional[tuple[float, ...]] = None,
     idempotency_key: Optional[str] = None,
     acquire_semaphore: bool = True,
+    before_first_request=None,
     **request_kwargs,
 ):
     if retry_delays is None:
@@ -81,8 +86,12 @@ async def _post_dev_webhook(
         try:
             if acquire_semaphore:
                 async with get_webhook_semaphore():
+                    if attempt_index == 0 and before_first_request is not None:
+                        await before_first_request()
                     response = await client.post(webhook_url, **request_kwargs)
             else:
+                if attempt_index == 0 and before_first_request is not None:
+                    await before_first_request()
                 response = await client.post(webhook_url, **request_kwargs)
             last_response = response
             last_exception = None
@@ -94,6 +103,8 @@ async def _post_dev_webhook(
                 return response
             failure_reason = f'HTTP {response.status_code}'
         except Exception as e:
+            if isinstance(e, _WebhookLockUnavailable):
+                raise
             last_response = None
             last_exception = e
             failure_reason = type(e).__name__
@@ -349,15 +360,19 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
         return
 
-    lock_token = await run_blocking(
-        db_executor,
-        redis_db.try_acquire_audio_bytes_webhook_lock,
-        uid,
-        _audio_bytes_webhook_lock_ttl(retry_delays),
-    )
-    if not lock_token:
-        cb.release_probe()
-        return
+    lock_token = None
+
+    async def acquire_audio_lock():
+        nonlocal lock_token
+        lock_token = await run_blocking(
+            db_executor,
+            redis_db.try_acquire_audio_bytes_webhook_lock,
+            uid,
+            _audio_bytes_webhook_lock_ttl(retry_delays),
+        )
+        if not lock_token:
+            cb.release_probe()
+            raise _WebhookLockUnavailable()
 
     try:
         max_bytes = sample_rate * 2 * configured_seconds
@@ -365,6 +380,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             'send_audio_bytes_developer_webhook',
             webhook_url,
             retry_delays=retry_delays,
+            before_first_request=acquire_audio_lock,
             content=bytes(data[:max_bytes]),
             headers={'Content-Type': 'application/octet-stream'},
         )
@@ -382,6 +398,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
                 f'HTTP {response.status_code}',
             )
             await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+    except _WebhookLockUnavailable:
+        return
     except Exception as e:
         cb.record_failure()
         should_disable = await run_blocking(
@@ -390,7 +408,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
         logger.error(f"Error sending audio bytes to developer webhook: {e}")
     finally:
-        await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
+        if lock_token:
+            await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -349,49 +349,48 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
         return
 
-    async with get_webhook_semaphore():
-        lock_token = await run_blocking(
-            db_executor,
-            redis_db.try_acquire_audio_bytes_webhook_lock,
-            uid,
-            _audio_bytes_webhook_lock_ttl(retry_delays),
-        )
-        if not lock_token:
-            return
+    lock_token = await run_blocking(
+        db_executor,
+        redis_db.try_acquire_audio_bytes_webhook_lock,
+        uid,
+        _audio_bytes_webhook_lock_ttl(retry_delays),
+    )
+    if not lock_token:
+        cb.release_probe()
+        return
 
-        try:
-            max_bytes = sample_rate * 2 * configured_seconds
-            response = await _post_dev_webhook(
-                'send_audio_bytes_developer_webhook',
-                webhook_url,
-                retry_delays=retry_delays,
-                acquire_semaphore=False,
-                content=bytes(data[:max_bytes]),
-                headers={'Content-Type': 'application/octet-stream'},
-            )
-            if response.status_code >= 200 and response.status_code < 300:
-                cb.record_success()
-                await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.audio_bytes)
-            else:
-                cb.record_failure()
-                should_disable = await run_blocking(
-                    db_executor,
-                    record_dev_webhook_failure,
-                    uid,
-                    WebhookType.audio_bytes,
-                    response.status_code,
-                    f'HTTP {response.status_code}',
-                )
-                await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-        except Exception as e:
+    try:
+        max_bytes = sample_rate * 2 * configured_seconds
+        response = await _post_dev_webhook(
+            'send_audio_bytes_developer_webhook',
+            webhook_url,
+            retry_delays=retry_delays,
+            content=bytes(data[:max_bytes]),
+            headers={'Content-Type': 'application/octet-stream'},
+        )
+        if response.status_code >= 200 and response.status_code < 300:
+            cb.record_success()
+            await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.audio_bytes)
+        else:
             cb.record_failure()
             should_disable = await run_blocking(
-                db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
+                db_executor,
+                record_dev_webhook_failure,
+                uid,
+                WebhookType.audio_bytes,
+                response.status_code,
+                f'HTTP {response.status_code}',
             )
             await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
-            logger.error(f"Error sending audio bytes to developer webhook: {e}")
-        finally:
-            await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
+    except Exception as e:
+        cb.record_failure()
+        should_disable = await run_blocking(
+            db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
+        )
+        await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+        logger.error(f"Error sending audio bytes to developer webhook: {e}")
+    finally:
+        await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -37,6 +37,10 @@ class _WebhookLockUnavailable(Exception):
     pass
 
 
+class _WebhookAdmissionTimeout(Exception):
+    pass
+
+
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
     raw_delays = os.getenv('DEV_WEBHOOK_RETRY_DELAYS')
     if raw_delays is None:
@@ -102,7 +106,10 @@ async def _post_dev_webhook(
                 if attempt_timeout is None:
                     await semaphore_context.__aenter__()
                 else:
-                    await asyncio.wait_for(semaphore_context.__aenter__(), timeout=attempt_timeout)
+                    try:
+                        await asyncio.wait_for(semaphore_context.__aenter__(), timeout=attempt_timeout)
+                    except asyncio.TimeoutError as e:
+                        raise _WebhookAdmissionTimeout() from e
                 try:
                     return await post_with_timeout()
                 finally:
@@ -119,7 +126,7 @@ async def _post_dev_webhook(
                 return response
             failure_reason = f'HTTP {response.status_code}'
         except Exception as e:
-            if isinstance(e, _WebhookLockUnavailable):
+            if isinstance(e, (_WebhookLockUnavailable, _WebhookAdmissionTimeout)):
                 raise
             last_response = None
             last_exception = e
@@ -380,12 +387,19 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
 
     async def acquire_audio_lock():
         nonlocal lock_token
-        lock_token = await run_blocking(
-            db_executor,
-            redis_db.try_acquire_audio_bytes_webhook_lock,
-            uid,
-            _audio_bytes_webhook_lock_ttl(retry_delays),
+        acquisition = asyncio.create_task(
+            run_blocking(
+                db_executor,
+                redis_db.try_acquire_audio_bytes_webhook_lock,
+                uid,
+                _audio_bytes_webhook_lock_ttl(retry_delays),
+            )
         )
+        try:
+            lock_token = await asyncio.shield(acquisition)
+        except asyncio.CancelledError:
+            lock_token = await acquisition
+            raise
         if not lock_token:
             cb.release_probe()
             raise _WebhookLockUnavailable()
@@ -416,6 +430,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             )
             await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
     except _WebhookLockUnavailable:
+        return
+    except _WebhookAdmissionTimeout:
         return
     except Exception as e:
         cb.record_failure()

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -94,20 +94,19 @@ async def _post_dev_webhook(
 
             async def send_request():
                 if attempt_index == 0 and before_first_request is not None:
-                    if acquire_semaphore:
-                        async with get_webhook_semaphore():
-                            await before_first_request()
-                            return await post_with_timeout()
                     await before_first_request()
+                if not acquire_semaphore:
                     return await post_with_timeout()
-                if acquire_semaphore:
-                    if attempt_timeout is None:
-                        async with get_webhook_semaphore():
-                            return await client.post(webhook_url, **request_kwargs)
-                    async with asyncio.timeout(attempt_timeout):
-                        async with get_webhook_semaphore():
-                            return await client.post(webhook_url, **request_kwargs)
-                return await post_with_timeout()
+
+                semaphore_context = get_webhook_semaphore()
+                if attempt_timeout is None:
+                    await semaphore_context.__aenter__()
+                else:
+                    await asyncio.wait_for(semaphore_context.__aenter__(), timeout=attempt_timeout)
+                try:
+                    return await post_with_timeout()
+                finally:
+                    await semaphore_context.__aexit__(None, None, None)
 
             response = await send_request()
             last_response = response
@@ -147,9 +146,9 @@ async def _post_dev_webhook(
 
 
 def _audio_bytes_webhook_lock_ttl(retry_delays: tuple[float, ...]) -> int:
-    request_seconds = _WEBHOOK_REQUEST_TIMEOUT_SECONDS * (len(retry_delays) + 1)
+    attempt_seconds = 2 * _WEBHOOK_REQUEST_TIMEOUT_SECONDS * (len(retry_delays) + 1)
     delay_seconds = sum(max(delay, 0) for delay in retry_delays)
-    return max(_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS, int(request_seconds + delay_seconds) + 1)
+    return max(_AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS, int(attempt_seconds + delay_seconds) + 1)
 
 
 def _parse_audio_bytes_webhook_config(webhook_url: str) -> tuple[str, int]:
@@ -426,8 +425,16 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
         logger.error(f"Error sending audio bytes to developer webhook: {e}")
     finally:
+        cb.release_probe()
         if lock_token:
-            await run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
+            release_task = asyncio.create_task(
+                run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)
+            )
+            try:
+                await asyncio.shield(release_task)
+            except asyncio.CancelledError:
+                await asyncio.shield(release_task)
+                raise
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -1,4 +1,3 @@
-import re
 import asyncio
 import json
 import os
@@ -31,7 +30,6 @@ logger = logging.getLogger(__name__)
 _DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
 _AUDIO_BYTES_WEBHOOK_DEFAULT_SECONDS = 5
 _AUDIO_BYTES_WEBHOOK_LOCK_MIN_TTL_SECONDS = 180
-_AUDIO_BYTES_WEBHOOK_LOCK_RELEASE_ATTEMPTS = 3
 _WEBHOOK_REQUEST_TIMEOUT_SECONDS = 30
 
 
@@ -347,7 +345,11 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             if not webhook_url:
                 return
             webhook_url, configured_seconds = _parse_audio_bytes_webhook_config(webhook_url)
-            if not webhook_url or not re.match(r"^https?://", webhook_url) or not urlsplit(webhook_url).netloc:
+            if (
+                not webhook_url
+                or not webhook_url.startswith(("http://", "https://"))
+                or not urlsplit(webhook_url).netloc
+            ):
                 return
 
             webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -86,21 +86,30 @@ async def _post_dev_webhook(
         failure_reason = None
         try:
 
-            async def send_request():
-                if acquire_semaphore:
-                    async with get_webhook_semaphore():
-                        if attempt_index == 0 and before_first_request is not None:
-                            await before_first_request()
-                        return await client.post(webhook_url, **request_kwargs)
-                if attempt_index == 0 and before_first_request is not None:
-                    await before_first_request()
-                return await client.post(webhook_url, **request_kwargs)
-
-            if attempt_timeout is None:
-                response = await send_request()
-            else:
+            async def post_with_timeout():
+                if attempt_timeout is None:
+                    return await client.post(webhook_url, **request_kwargs)
                 async with asyncio.timeout(attempt_timeout):
-                    response = await send_request()
+                    return await client.post(webhook_url, **request_kwargs)
+
+            async def send_request():
+                if attempt_index == 0 and before_first_request is not None:
+                    if acquire_semaphore:
+                        async with get_webhook_semaphore():
+                            await before_first_request()
+                            return await post_with_timeout()
+                    await before_first_request()
+                    return await post_with_timeout()
+                if acquire_semaphore:
+                    if attempt_timeout is None:
+                        async with get_webhook_semaphore():
+                            return await client.post(webhook_url, **request_kwargs)
+                    async with asyncio.timeout(attempt_timeout):
+                        async with get_webhook_semaphore():
+                            return await client.post(webhook_url, **request_kwargs)
+                return await post_with_timeout()
+
+            response = await send_request()
             last_response = response
             last_exception = None
             if 200 <= response.status_code < 300:
@@ -151,7 +160,7 @@ def _parse_audio_bytes_webhook_config(webhook_url: str) -> tuple[str, int]:
             seconds = int(parts[1])
         except ValueError:
             pass
-    return parts[0], seconds
+    return parts[0].strip(), seconds
 
 
 async def _handle_dev_webhook_disable(uid: str, wtype: str, should_disable: bool):

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import math
 import os
 import uuid
 from datetime import datetime, timezone
@@ -46,10 +47,14 @@ def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
     if raw_delays is None:
         return _DEV_WEBHOOK_RETRY_DELAYS
     try:
-        return tuple(float(delay.strip()) for delay in raw_delays.split(',') if delay.strip())
+        delays = tuple(float(delay.strip()) for delay in raw_delays.split(',') if delay.strip())
     except ValueError:
         logger.warning(f'Invalid DEV_WEBHOOK_RETRY_DELAYS={raw_delays!r}; using default schedule')
         return _DEV_WEBHOOK_RETRY_DELAYS
+    if not all(math.isfinite(delay) for delay in delays):
+        logger.warning(f'Invalid DEV_WEBHOOK_RETRY_DELAYS={raw_delays!r}; using default schedule')
+        return _DEV_WEBHOOK_RETRY_DELAYS
+    return delays
 
 
 def _append_query_params(url: str, params: dict) -> str:
@@ -406,7 +411,12 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         try:
             lock_token = await asyncio.shield(acquisition)
         except asyncio.CancelledError:
-            lock_token = await acquisition
+            while True:
+                try:
+                    lock_token = await asyncio.shield(acquisition)
+                    break
+                except asyncio.CancelledError:
+                    continue
             raise
         if not lock_token:
             raise _WebhookLockUnavailable()

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -42,6 +42,22 @@ class _WebhookAdmissionTimeout(Exception):
     pass
 
 
+def _release_audio_lock_after_acquisition(uid: str, future) -> None:
+    if future.cancelled():
+        return
+    try:
+        lock_token = future.result()
+    except Exception as exc:
+        logger.warning(f'Audio webhook lock acquisition failed after cancellation: {type(exc).__name__}')
+        return
+    if not lock_token:
+        return
+    try:
+        redis_db.release_audio_bytes_webhook_lock(uid, lock_token)
+    except Exception as exc:
+        logger.warning(f'Audio webhook late lock release failed: {type(exc).__name__}')
+
+
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
     raw_delays = os.getenv('DEV_WEBHOOK_RETRY_DELAYS')
     if raw_delays is None:
@@ -400,23 +416,17 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
 
     async def acquire_audio_lock():
         nonlocal lock_token
-        acquisition = asyncio.wrap_future(
-            submit_with_context(
-                db_executor,
-                redis_db.try_acquire_audio_bytes_webhook_lock,
-                uid,
-                _audio_bytes_webhook_lock_ttl(retry_delays),
-            )
+        acquisition_future = submit_with_context(
+            db_executor,
+            redis_db.try_acquire_audio_bytes_webhook_lock,
+            uid,
+            _audio_bytes_webhook_lock_ttl(retry_delays),
         )
+        acquisition = asyncio.wrap_future(acquisition_future)
         try:
             lock_token = await asyncio.shield(acquisition)
         except asyncio.CancelledError:
-            while True:
-                try:
-                    lock_token = await asyncio.shield(acquisition)
-                    break
-                except asyncio.CancelledError:
-                    continue
+            acquisition_future.add_done_callback(lambda future: _release_audio_lock_after_acquisition(uid, future))
             raise
         if not lock_token:
             raise _WebhookLockUnavailable()

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -21,7 +21,7 @@ from models.users import WebhookType, webhook_url_from_setting
 import database.notifications as notification_db
 from utils.conversations.render import populate_speaker_names, populate_folder_names
 from utils.conversations.render import conversation_to_dict
-from utils.executors import db_executor, run_blocking
+from utils.executors import db_executor, run_blocking, submit_with_context
 from utils.http_client import get_webhook_client, get_webhook_circuit_breaker, get_webhook_semaphore
 from utils.notifications import send_notification
 import logging
@@ -400,8 +400,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
 
     async def acquire_audio_lock():
         nonlocal lock_token
-        acquisition = asyncio.create_task(
-            run_blocking(
+        acquisition = asyncio.wrap_future(
+            submit_with_context(
                 db_executor,
                 redis_db.try_acquire_audio_bytes_webhook_lock,
                 uid,
@@ -412,8 +412,6 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             lock_token = await asyncio.shield(acquisition)
         except asyncio.CancelledError:
             while True:
-                if acquisition.cancelled():
-                    raise
                 try:
                     lock_token = await asyncio.shield(acquisition)
                     break

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -412,6 +412,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             lock_token = await asyncio.shield(acquisition)
         except asyncio.CancelledError:
             while True:
+                if acquisition.cancelled():
+                    raise
                 try:
                     lock_token = await asyncio.shield(acquisition)
                     break

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -66,6 +66,7 @@ async def _post_dev_webhook(
     idempotency_key: Optional[str] = None,
     acquire_semaphore: bool = True,
     before_first_request=None,
+    attempt_timeout: Optional[float] = None,
     **request_kwargs,
 ):
     if retry_delays is None:
@@ -84,15 +85,22 @@ async def _post_dev_webhook(
         attempt_number = attempt_index + 1
         failure_reason = None
         try:
-            if acquire_semaphore:
-                async with get_webhook_semaphore():
-                    if attempt_index == 0 and before_first_request is not None:
-                        await before_first_request()
-                    response = await client.post(webhook_url, **request_kwargs)
-            else:
+
+            async def send_request():
+                if acquire_semaphore:
+                    async with get_webhook_semaphore():
+                        if attempt_index == 0 and before_first_request is not None:
+                            await before_first_request()
+                        return await client.post(webhook_url, **request_kwargs)
                 if attempt_index == 0 and before_first_request is not None:
                     await before_first_request()
-                response = await client.post(webhook_url, **request_kwargs)
+                return await client.post(webhook_url, **request_kwargs)
+
+            if attempt_timeout is None:
+                response = await send_request()
+            else:
+                async with asyncio.timeout(attempt_timeout):
+                    response = await send_request()
             last_response = response
             last_exception = None
             if 200 <= response.status_code < 300:
@@ -381,6 +389,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             webhook_url,
             retry_delays=retry_delays,
             before_first_request=acquire_audio_lock,
+            attempt_timeout=_WEBHOOK_REQUEST_TIMEOUT_SECONDS,
             content=bytes(data[:max_bytes]),
             headers={'Content-Type': 'application/octet-stream'},
         )

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -115,7 +115,14 @@ async def _post_dev_webhook(
                 finally:
                     await semaphore_context.__aexit__(None, None, None)
 
-            response = await send_request()
+            try:
+                response = await send_request()
+            except _WebhookAdmissionTimeout:
+                if last_response is not None:
+                    return last_response
+                if last_exception is not None:
+                    raise last_exception
+                raise
             last_response = response
             last_exception = None
             if 200 <= response.status_code < 300:
@@ -382,6 +389,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
     if not cb.allow_request():
         logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
         return
+    probe_claimed = cb.state == 'half_open'
 
     lock_token = None
 
@@ -401,7 +409,6 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             lock_token = await acquisition
             raise
         if not lock_token:
-            cb.release_probe()
             raise _WebhookLockUnavailable()
 
     try:
@@ -417,9 +424,11 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         )
         if response.status_code >= 200 and response.status_code < 300:
             cb.record_success()
+            probe_claimed = False
             await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.audio_bytes)
         else:
             cb.record_failure()
+            probe_claimed = False
             should_disable = await run_blocking(
                 db_executor,
                 record_dev_webhook_failure,
@@ -435,13 +444,15 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         return
     except Exception as e:
         cb.record_failure()
+        probe_claimed = False
         should_disable = await run_blocking(
             db_executor, record_dev_webhook_failure, uid, WebhookType.audio_bytes, 0, type(e).__name__
         )
         await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
         logger.error(f"Error sending audio bytes to developer webhook: {e}")
     finally:
-        cb.release_probe()
+        if probe_claimed:
+            cb.release_probe()
         if lock_token:
             release_task = asyncio.create_task(
                 run_blocking(db_executor, redis_db.release_audio_bytes_webhook_lock, uid, lock_token)

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -26,6 +26,11 @@ retains the pending item for reconnect replay; buffers are cleared only after th
 send completes. Finalization opcode `104` carries the durable job id and dispatch
 generation, and Pusher claims that Firestore-owned job before processing.
 
+Developer audio-byte webhooks serialize delivery per user through a Redis lock
+after acquiring the shared webhook semaphore, so semaphore queue time cannot
+expire the delivery lock. The configured `url,seconds` value limits each payload
+to `sample_rate * 2 * seconds` bytes; invalid URLs are skipped without delivery.
+
 ## 1. Connection + Streaming + Transcription
 
 The STT provider is selected at session start via `STT_SERVICE_MODELS` env var

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -27,7 +27,7 @@ send completes. Finalization opcode `104` carries the durable job id and dispatc
 generation, and Pusher claims that Firestore-owned job before processing.
 
 Developer audio-byte webhooks serialize delivery per user through a Redis lock
-after acquiring the shared webhook semaphore, so semaphore queue time cannot
+before entering the shared webhook semaphore, so semaphore queue time cannot
 expire the delivery lock. The configured `url,seconds` value limits each payload
 to `sample_rate * 2 * seconds` bytes; invalid URLs are skipped without delivery.
 


### PR DESCRIPTION
Implemented concurrency locking, shortened audio segment lengths, and regex validation for developer audio webhooks as detailed in the task description.

---
*PR created automatically by Jules for task [1937260442649585048](https://jules.google.com/task/1937260442649585048) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime developer webhook delivery (locking, chunking, timeouts, and skip paths), so mis-tuned behavior could drop or delay audio payloads for active listen sessions.
> 
> **Overview**
> Developer **audio-byte webhooks** are now **serialized per user** via a Redis token lock (with safe release on cancel/contention) **before** entering the shared webhook semaphore, so slow queueing cannot overlap in-flight deliveries for the same uid.
> 
> **Pusher** no longer flushes the whole webhook audio buffer on each trigger: it enqueues a **fixed-duration chunk** and keeps the remainder, and delivery payloads are **capped** to `sample_rate * 2 * configured_seconds` from the `url,seconds` setting. **Invalid/non-HTTP URLs** are skipped without posting.
> 
> **`_post_dev_webhook`** gains bounded semaphore admission, per-attempt timeouts, and **half-open circuit-breaker probe release** when delivery is skipped or cancelled; docs describe the new pipeline behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b1cf79a14769c035e98f71f6519042e15c12d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Failure-Class: none