### PR TITLE
fix(backend): attribute live STT failures to the provider actually serving (#11306)

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -127,6 +127,15 @@ class ListenReceiver:
         except Exception as error:
             logger.warning('Listen parity capture failed method=%s type=%s', method, type(error).__name__)
 
+    def _serving_provider(self) -> str:
+        """Resolve the provider actually serving this session, read at use time.
+
+        ``_create_stt_socket`` can fall back from Parakeet to Modulate, so a
+        value snapshotted before the socket exists attributes a Modulate
+        failure to Parakeet (#11306).
+        """
+        return getattr(self.host.stt_service, 'value', self.host.stt_service)
+
     def initialize_decoders(self) -> None:
         request = self.host.request
         if self.host.is_multi_channel:
@@ -208,7 +217,6 @@ class ListenReceiver:
 
     async def initialize_stt(self) -> bool:
         request = self.host.request
-        provider = getattr(self.host.stt_service, 'value', self.host.stt_service)
         if self.host.use_custom_stt:
             return True
         try:
@@ -228,7 +236,7 @@ class ListenReceiver:
                         await terminate_live_stt_session(
                             request.websocket,
                             self.host.state,
-                            failure=live_stt_upstream_failure(provider),
+                            failure=live_stt_upstream_failure(self._serving_provider()),
                             reason='initialization_failed',
                             platform=self.host.client_device_context.platform,
                         )
@@ -263,7 +271,7 @@ class ListenReceiver:
                 await terminate_live_stt_session(
                     request.websocket,
                     self.host.state,
-                    failure=live_stt_upstream_failure(provider),
+                    failure=live_stt_upstream_failure(self._serving_provider()),
                     reason='initialization_failed',
                     platform=self.host.client_device_context.platform,
                 )
@@ -272,20 +280,20 @@ class ListenReceiver:
             self.stt_socket = (
                 GatedSTTSocket(raw, gate=self.vad_gate, passthrough_audio=passthrough) if self.vad_gate else raw
             )
-            self.host.spawn(self._monitor_stt_death(provider), name='stt_death_monitor')
+            self.host.spawn(self._monitor_stt_death(), name='stt_death_monitor')
             return True
         except Exception as error:
             await self._drain_stt_sockets()
             await terminate_live_stt_session(
                 request.websocket,
                 self.host.state,
-                failure=live_stt_initialization_failure(error, provider),
+                failure=live_stt_initialization_failure(error, self._serving_provider()),
                 reason='initialization_failed',
                 platform=self.host.client_device_context.platform,
             )
             return False
 
-    async def _monitor_stt_death(self, provider: str) -> None:
+    async def _monitor_stt_death(self) -> None:
         """Terminate the client session promptly when the provider STT socket dies.
 
         The receive loop only observes provider death while flushing a client
@@ -301,7 +309,7 @@ class ListenReceiver:
                 await terminate_live_stt_session(
                     self.host.request.websocket,
                     self.host.state,
-                    failure=live_stt_upstream_failure(provider),
+                    failure=live_stt_upstream_failure(self._serving_provider()),
                     reason='connection_lost',
                     platform=self.host.client_device_context.platform,
                 )
@@ -380,7 +388,7 @@ class ListenReceiver:
             self.host.state,
             stt_socket=self.stt_socket,
             buffer=buffer,
-            provider=getattr(self.host.stt_service, 'value', self.host.stt_service),
+            provider=self._serving_provider(),
             platform=self.host.client_device_context.platform,
         )
         if sent:
@@ -424,7 +432,7 @@ class ListenReceiver:
                     self.host.state,
                     stt_socket=self.stt_sockets_multi[channel_index],
                     audio=pcm,
-                    provider=getattr(self.host.stt_service, 'value', self.host.stt_service),
+                    provider=self._serving_provider(),
                     platform=self.host.client_device_context.platform,
                 )
                 if sent:

--- a/backend/tests/unit/test_listen_stt_death_monitor.py
+++ b/backend/tests/unit/test_listen_stt_death_monitor.py
@@ -14,6 +14,7 @@ import pytest
 
 from routers.listen import receiver as receiver_mod
 from routers.listen.receiver import ListenReceiver
+from utils.stt.streaming import STTService
 
 
 @pytest.fixture
@@ -21,7 +22,7 @@ def anyio_backend():
     return 'asyncio'
 
 
-def _monitor_self(*, dead: bool):
+def _monitor_self(*, dead: bool, stt_service=STTService.parakeet):
     """Duck-typed receiver exposing only what `_monitor_stt_death` touches."""
     state = SimpleNamespace(active=True, stt_terminal_failure=False)
 
@@ -34,25 +35,40 @@ def _monitor_self(*, dead: bool):
         state=state,
         request=SimpleNamespace(websocket=object()),
         client_device_context=SimpleNamespace(platform='ios'),
+        stt_service=stt_service,
         wait=wait,
     )
-    return SimpleNamespace(host=host, stt_socket=SimpleNamespace(is_connection_dead=dead))
+    monitor_self = SimpleNamespace(host=host, stt_socket=SimpleNamespace(is_connection_dead=dead))
+    monitor_self._serving_provider = lambda: ListenReceiver._serving_provider(monitor_self)
+    return monitor_self
 
 
 @pytest.mark.anyio
 async def test_monitor_terminates_when_provider_socket_dead():
     monitor_self = _monitor_self(dead=True)
     with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
-        await ListenReceiver._monitor_stt_death(monitor_self, provider='parakeet')
+        await ListenReceiver._monitor_stt_death(monitor_self)
     terminate.assert_awaited_once()
     assert terminate.await_args.kwargs['reason'] == 'connection_lost'
+
+
+@pytest.mark.anyio
+async def test_monitor_reports_the_provider_actually_serving_the_session():
+    """Regression (#11306): a Parakeet request served by the Modulate fallback
+    must terminalize as Modulate. The provider used to be snapshotted before
+    ``_create_stt_socket`` could fall back, so every post-fallback death was
+    attributed to Parakeet."""
+    monitor_self = _monitor_self(dead=True, stt_service=STTService.modulate)
+    with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
+        await ListenReceiver._monitor_stt_death(monitor_self)
+    assert terminate.await_args.kwargs['failure'].provider == 'modulate'
 
 
 @pytest.mark.anyio
 async def test_monitor_does_not_terminate_a_live_socket():
     monitor_self = _monitor_self(dead=False)
     with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
-        await ListenReceiver._monitor_stt_death(monitor_self, provider='parakeet')
+        await ListenReceiver._monitor_stt_death(monitor_self)
     terminate.assert_not_awaited()
 
 
@@ -61,5 +77,5 @@ async def test_monitor_exits_without_terminating_once_already_terminal():
     monitor_self = _monitor_self(dead=True)
     monitor_self.host.state.stt_terminal_failure = True  # another path already terminalized
     with patch.object(receiver_mod, 'terminate_live_stt_session', new=AsyncMock()) as terminate:
-        await ListenReceiver._monitor_stt_death(monitor_self, provider='parakeet')
+        await ListenReceiver._monitor_stt_death(monitor_self)
     terminate.assert_not_awaited()


### PR DESCRIPTION
## Bug

#11306: an iOS client that explicitly selects **Omi Parakeet** can be served by the Modulate fallback, and the terminal failure contract could still name Parakeet — so a failing fallback is indistinguishable from a healthy primary session in `stt_failed`, in `record_live_stt_failure`, and in the `live_transcription_attempt` record.

## Root cause

`ListenReceiver.initialize_stt` snapshotted the provider name **before** `_create_stt_socket` ran:

```python
provider = getattr(self.host.stt_service, 'value', self.host.stt_service)
...
raw = await self._create_stt_socket(...)          # may fall back parakeet -> modulate
self.host.spawn(self._monitor_stt_death(provider))  # stale 'parakeet'
```

`_create_stt_socket` calls `connect_stt_socket_with_fallback`, which on a Parakeet capacity rejection / timeout / open circuit returns a **Modulate** socket and rewrites `host.stt_service`. Every failure raised after that point — the frame-independent death monitor (#10028) and the initialization exception path — kept labelling the session `parakeet`. The audio send paths already resolved the provider live, which is why the same session could report Modulate on one path and Parakeet on another.

## Fix

Resolve the serving provider at use time through one `_serving_provider()` helper, and use it at every failure site. The two send paths that already inlined the identical expression now share the helper.

## Tested

- New regression test `test_monitor_reports_the_provider_actually_serving_the_session`: a Parakeet request served by the Modulate fallback must terminalize as `modulate`. Pinning `_serving_provider()` back to the pre-fallback snapshot makes it fail with `assert 'parakeet' == 'modulate'` (verified locally).
- `BACKEND_UNIT_TEST_FILE_LIST` run of the 8 receiver / live-failure unit files: **81 passed**.
- Pre-existing local-env failures in `test_modulate_stt.py` / `test_streaming_deepgram_backoff.py` (retired-Deepgram-config routing) were diffed against a clean `origin/main` baseline: identical set, unrelated to this diff.

This does not by itself stop Parakeet sessions from falling back — it makes the fallback correctly attributable, which is the part of #11306 the backend contract owns.

## Product invariants

none

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

