### PR TITLE
fix(app): stop a Developer Settings save from re-enabling toggled-off webhooks (#11365)

### DIFF
--- a/app/lib/providers/developer_mode_provider.dart
+++ b/app/lib/providers/developer_mode_provider.dart
@@ -13,6 +13,14 @@ import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/validators.dart';
 
 class DeveloperModeProvider extends BaseProvider {
+  /// Test seam — overrides [setUserWebhookUrl] in [saveSettings].
+  @visibleForTesting
+  Future<bool> Function({required String type, required String url})? setUserWebhookUrlOverride;
+
+  /// Test seam — overrides [disableWebhook] in [saveSettings].
+  @visibleForTesting
+  Future<void> Function({required String type})? disableWebhookOverride;
+
   final TextEditingController webhookOnConversationCreated = TextEditingController();
   final TextEditingController webhookOnTranscriptReceived = TextEditingController();
   final TextEditingController webhookAudioBytes = TextEditingController();
@@ -203,16 +211,29 @@ class DeveloperModeProvider extends BaseProvider {
     //   notifyListeners();
     //   return;
     // }
-    var w1 = setUserWebhookUrl(
+    final setUrl = setUserWebhookUrlOverride ?? setUserWebhookUrl;
+    var w1 = setUrl(
       type: 'audio_bytes',
       url: '${webhookAudioBytes.text.trim()},${webhookAudioBytesDelay.text.trim()}',
     );
-    var w2 = setUserWebhookUrl(type: 'realtime_transcript', url: webhookOnTranscriptReceived.text.trim());
-    var w3 = setUserWebhookUrl(type: 'memory_created', url: webhookOnConversationCreated.text.trim());
-    var w4 = setUserWebhookUrl(type: 'day_summary', url: webhookDaySummary.text.trim());
+    var w2 = setUrl(type: 'realtime_transcript', url: webhookOnTranscriptReceived.text.trim());
+    var w3 = setUrl(type: 'memory_created', url: webhookOnConversationCreated.text.trim());
+    var w4 = setUrl(type: 'day_summary', url: webhookDaySummary.text.trim());
     // var w4 = setUserWebhookUrl(type: 'audio_bytes_websocket', url: webhookWsAudioBytes.text.trim());
     try {
-      Future.wait([w1, w2, w3, w4]);
+      final results = await Future.wait([w1, w2, w3, w4]);
+      if (results.contains(false)) {
+        throw Exception('backend rejected one or more webhook URLs');
+      }
+      // The backend enables a webhook whenever a non-empty URL is stored, so a save
+      // would silently turn every toggle the user switched off back on.
+      final disable = disableWebhookOverride ?? disableWebhook;
+      await Future.wait([
+        if (!audioBytesToggled) disable(type: 'audio_bytes'),
+        if (!transcriptsToggled) disable(type: 'realtime_transcript'),
+        if (!conversationEventsToggled) disable(type: 'memory_created'),
+        if (!daySummaryToggled) disable(type: 'day_summary'),
+      ]);
       prefs.webhookAudioBytes = webhookAudioBytes.text;
       prefs.webhookAudioBytesDelay = webhookAudioBytesDelay.text;
       prefs.webhookOnTranscriptReceived = webhookOnTranscriptReceived.text;
@@ -220,6 +241,12 @@ class DeveloperModeProvider extends BaseProvider {
       prefs.webhookDaySummary = webhookDaySummary.text;
     } catch (e) {
       Logger.error('Error occurred while updating endpoints: $e');
+      AppSnackbar.showSnackbarError(
+        globalNavigatorKey.currentContext?.l10n.failedToSaveCheckConnection ??
+            'Failed to save. Please check your connection.',
+      );
+      setIsLoading(false);
+      return;
     }
     // Experimental
     prefs.devModeJoanFollowUpEnabled = followUpQuestionEnabled;

--- a/app/test/providers/developer_mode_provider_save_settings_test.dart
+++ b/app/test/providers/developer_mode_provider_save_settings_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/app_globals.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/providers/developer_mode_provider.dart';
+
+/// Regression guards for #11365: saving Developer Settings used to re-enable
+/// every webhook whose URL field was non-empty (the backend enables on set),
+/// and it reported success without awaiting the requests.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late DeveloperModeProvider provider;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    provider = DeveloperModeProvider();
+  });
+
+  tearDown(() {
+    provider.dispose();
+  });
+
+  Future<void> pumpHost(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: globalNavigatorKey,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Scaffold(body: SizedBox.shrink()),
+      ),
+    );
+  }
+
+  testWidgets('a save does not re-enable webhooks the user toggled off', (tester) async {
+    await pumpHost(tester);
+    final setTypes = <String>[];
+    final disabledTypes = <String>[];
+    provider.setUserWebhookUrlOverride = ({required String type, required String url}) async {
+      setTypes.add(type);
+      return true;
+    };
+    provider.disableWebhookOverride = ({required String type}) async => disabledTypes.add(type);
+
+    provider.webhookOnConversationCreated.text = 'https://example.com/memory';
+    provider.webhookOnTranscriptReceived.text = 'https://example.com/ingest';
+    provider.conversationEventsToggled = true;
+    // Off with a URL still in the field, plus audio bytes off with no URL —
+    // the ",5" payload the audio-bytes save builds is non-empty either way.
+    provider.transcriptsToggled = false;
+    provider.audioBytesToggled = false;
+    provider.daySummaryToggled = false;
+
+    provider.saveSettings();
+    await tester.pumpAndSettle();
+
+    expect(setTypes, containsAll(['audio_bytes', 'realtime_transcript', 'memory_created', 'day_summary']));
+    expect(disabledTypes, containsAll(['audio_bytes', 'realtime_transcript', 'day_summary']));
+    expect(disabledTypes, isNot(contains('memory_created')));
+    expect(SharedPreferencesUtil().webhookOnTranscriptReceived, 'https://example.com/ingest');
+  });
+
+  testWidgets('a rejected save surfaces an error and does not persist the URLs', (tester) async {
+    await pumpHost(tester);
+    provider.setUserWebhookUrlOverride =
+        ({required String type, required String url}) async => type != 'memory_created';
+    provider.disableWebhookOverride = ({required String type}) async {};
+
+    provider.webhookOnConversationCreated.text = 'https://example.com/memory';
+    provider.conversationEventsToggled = true;
+
+    provider.saveSettings();
+    await tester.pump();
+    await tester.pump();
+
+    expect(SharedPreferencesUtil().webhookOnConversationCreated, '');
+    expect(find.text('Failed to save. Please check your connection.'), findsOneWidget);
+    expect(find.text('Settings saved!'), findsNothing);
+    expect(provider.savingSettingsLoading, isFalse);
+
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
## Bug

Reported in #11365: "The Audio Bytes toggle re-enables itself after being switched off and saved. While it is enabled with an empty URL, saving Developer Settings appears to silently fail — other webhook settings on the screen are not persisted either."

## Root cause

Two independent defects in `DeveloperModeProvider.saveSettings()`.

1. **The enabled state has two writers.** The toggle calls `enable/disableWebhook`, but `POST /v1/users/developer/webhook/{wtype}` also enables the webhook whenever the stored URL is non-empty (`backend/routers/users.py:486`). `saveSettings` POSTed all four URLs unconditionally, so any webhook the user had just switched off was turned back on by the next save. Audio Bytes hit this even with an empty URL, because the client always sends `"<url>,<delay>"` and the `",5"` payload is neither `''` nor `','`.

   The URL field is only rendered while its toggle is on (`developer.dart:222`, `if (isEnabled)`), so the toggle is the sole authority for the enabled state and the stale controller text behind an off toggle should never re-enable anything.

2. **A failed save reported success.** `Future.wait([w1, w2, w3, w4]);` was never awaited, and `setUserWebhookUrl` returns `false` on failure rather than throwing — so the `try/catch` was dead code. Every save wrote the local prefs and showed "Settings saved!" regardless of what the backend did.

## Fix

`saveSettings` awaits the four writes, treats a `false` as a failure (log + error snackbar, prefs untouched, no success toast), and then re-asserts `disableWebhook` for every toggle the user left off. Two `@visibleForTesting` seams follow the existing `AppProvider.enableAppOverride` pattern.

## Also in #11365

- The realtime-transcript webhook appending `?uid=` to a URL that already has a query string is **already fixed on main** — `_append_query_params` in `backend/utils/webhooks.py` rebuilds the query with `urlencode`.
- The headline complaint (no webhooks at all for Limitless Pendant sessions) is **not** addressed here; it needs pendant hardware to reproduce and is left open on the issue.

## Tested

- `flutter test test/providers/developer_mode_provider_save_settings_test.dart` → 2 passed. Both cases were confirmed to **fail** against the pre-fix method body with the test seams kept in place (`disabledTypes` empty; the rejected save still persisted the URL).
- `flutter test test/providers/` → 178 passed.
- `flutter analyze` on both changed files → no issues.
- **Not exercised on a device:** no iOS/macOS run of the Developer Settings screen. The regression test drives the real `saveSettings()` through a real `MaterialApp`/`ScaffoldMessenger`, and asserts the snackbar text, but a human has not tapped Save in the running app.

## Product invariants

none

Failure-Class: FC-split-mutation-authority

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

