### PR TITLE
fix(backend): clearing a webhook URL must leave the webhook disabled

### DIFF
--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -13,6 +13,21 @@ class WebhookType(str, Enum):
     day_summary = 'day_summary'
 
 
+def webhook_url_from_setting(wtype: WebhookType | str, value: Optional[str]) -> str:
+    """The endpoint a stored webhook setting points at, or '' when none is configured.
+
+    audio_bytes stores '<url>,<seconds>', so clearing only the URL leaves a ',5' setting
+    that is not an empty string yet has nowhere to deliver to. Every caller deciding
+    whether a webhook is configured must read the setting through here.
+    """
+    if not value:
+        return ''
+    # WebhookType is a str enum, so this holds for the raw wire value too.
+    if wtype == WebhookType.audio_bytes:
+        value = value.split(',')[0]
+    return value.strip()
+
+
 LOCATION_CONTEXT_PURPOSE = 'chat_city_context'
 LOCATION_CONTEXT_DISCLOSED_PROVIDERS = ('Google Maps', 'the configured AI chat provider')
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -69,6 +69,7 @@ from models.users import (
     ChatUsageQuota,
     ChatQuotaUnit,
     WebhookType,
+    webhook_url_from_setting,
     UserSubscriptionResponse,
     Subscription,
     SubscriptionPlan,
@@ -210,7 +211,6 @@ class OnboardingStateResponse(BaseModel):
 
 class UserLanguageResponse(BaseModel):
     language: Optional[str] = None
-
 
 
 class UserLanguageUpdateResponse(UserStatusResponse):
@@ -483,7 +483,7 @@ def set_user_webhook_endpoint(
 ):
     url = data.url
     set_user_webhook_db(uid, wtype, url)
-    if url == '' or url == ',':
+    if not webhook_url_from_setting(wtype, url):
         disable_user_webhook_db(uid, wtype)
     else:
         enable_user_webhook_db(uid, wtype)

--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
 
 import utils.webhooks as webhooks_module
+from models.users import WebhookType
 from utils.webhooks import realtime_transcript_webhook, send_audio_bytes_developer_webhook, day_summary_webhook
 
 
@@ -413,3 +414,24 @@ class TestCircuitBreakerIntegration:
         ):
             await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100))
             mock_client.post.assert_not_called()
+
+
+class TestWebhookFirstTimeSetup:
+    """#11365: a stored setting with no endpoint must not toggle the webhook on."""
+
+    def test_audio_bytes_delay_only_setting_stays_disabled(self):
+        """'<url>,<seconds>' with the URL cleared has nowhere to deliver to."""
+        with patch.object(webhooks_module, "get_user_webhook_db", return_value=",5"):
+            assert webhooks_module.webhook_first_time_setup("uid-1", WebhookType.audio_bytes) is False
+            webhooks_module.disable_user_webhook_db.assert_called_once_with("uid-1", WebhookType.audio_bytes)
+            webhooks_module.enable_user_webhook_db.assert_not_called()
+
+    def test_configured_audio_bytes_setting_enables(self):
+        with patch.object(webhooks_module, "get_user_webhook_db", return_value="https://example.com/audio,5"):
+            assert webhooks_module.webhook_first_time_setup("uid-1", WebhookType.audio_bytes) is True
+            webhooks_module.enable_user_webhook_db.assert_called_once_with("uid-1", WebhookType.audio_bytes)
+
+    def test_blank_url_stays_disabled(self):
+        with patch.object(webhooks_module, "get_user_webhook_db", return_value="   "):
+            assert webhooks_module.webhook_first_time_setup("uid-1", WebhookType.memory_created) is False
+            webhooks_module.disable_user_webhook_db.assert_called_once_with("uid-1", WebhookType.memory_created)

--- a/backend/tests/unit/test_users_webhook_url_validation.py
+++ b/backend/tests/unit/test_users_webhook_url_validation.py
@@ -155,6 +155,69 @@ def test_empty_url_disables_without_resetting_health():
     reset_health.assert_not_called()
 
 
+def test_cleared_audio_bytes_url_keeping_delay_disables():
+    """#11365: the app posts '<url>,<seconds>', so clearing the URL sends ',5' — not ''.
+
+    That is neither '' nor ',', so the endpoint used to re-enable the webhook the user had
+    just switched off, and the toggle came back on after every save.
+    """
+    with (
+        patch.object(users_mod, 'set_user_webhook_db') as setdb,
+        patch.object(users_mod, 'disable_user_webhook_db') as disable,
+        patch.object(users_mod, 'enable_user_webhook_db') as enable,
+        patch.object(users_mod, 'record_dev_webhook_success') as reset_health,
+    ):
+        result = users_mod.set_user_webhook_endpoint(
+            wtype='audio_bytes', data=SetUserWebhookUrlRequest(url=',5'), uid='u1'
+        )
+    assert result['status'] == 'ok'
+    disable.assert_called_once_with('u1', 'audio_bytes')
+    setdb.assert_called_once_with('u1', 'audio_bytes', ',5')
+    enable.assert_not_called()
+    reset_health.assert_not_called()
+
+
+def test_audio_bytes_url_with_delay_still_enables():
+    with (
+        patch.object(users_mod, 'set_user_webhook_db'),
+        patch.object(users_mod, 'disable_user_webhook_db') as disable,
+        patch.object(users_mod, 'enable_user_webhook_db') as enable,
+        patch.object(users_mod, 'record_dev_webhook_success'),
+    ):
+        users_mod.set_user_webhook_endpoint(
+            wtype='audio_bytes', data=SetUserWebhookUrlRequest(url='http://x,5'), uid='u1'
+        )
+    enable.assert_called_once_with('u1', 'audio_bytes')
+    disable.assert_not_called()
+
+
+def test_blank_url_disables_for_non_audio_webhooks():
+    with (
+        patch.object(users_mod, 'set_user_webhook_db'),
+        patch.object(users_mod, 'disable_user_webhook_db') as disable,
+        patch.object(users_mod, 'enable_user_webhook_db') as enable,
+        patch.object(users_mod, 'record_dev_webhook_success'),
+    ):
+        users_mod.set_user_webhook_endpoint(wtype='memory_created', data=SetUserWebhookUrlRequest(url='   '), uid='u1')
+    disable.assert_called_once_with('u1', 'memory_created')
+    enable.assert_not_called()
+
+
+def test_comma_in_non_audio_url_is_not_a_delay_separator():
+    """Only audio_bytes encodes a ',<seconds>' suffix; a query string may contain commas."""
+    with (
+        patch.object(users_mod, 'set_user_webhook_db'),
+        patch.object(users_mod, 'disable_user_webhook_db') as disable,
+        patch.object(users_mod, 'enable_user_webhook_db') as enable,
+        patch.object(users_mod, 'record_dev_webhook_success'),
+    ):
+        users_mod.set_user_webhook_endpoint(
+            wtype='realtime_transcript', data=SetUserWebhookUrlRequest(url='https://h/i?ids=1,2'), uid='u1'
+        )
+    enable.assert_called_once_with('u1', 'realtime_transcript')
+    disable.assert_not_called()
+
+
 def test_get_missing_webhook_url_validates_as_nullable_response():
     with patch.object(users_mod, 'get_user_webhook_db', return_value=None):
         result = users_mod.get_user_webhook_endpoint(wtype='audio_bytes', uid='u1')

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -15,7 +15,7 @@ from database.redis_db import (
 )
 from database.webhook_health import record_dev_webhook_failure, record_dev_webhook_success, _DEV_FAILURE_THRESHOLD
 from models.conversation import Conversation
-from models.users import WebhookType
+from models.users import WebhookType, webhook_url_from_setting
 import database.notifications as notification_db
 from utils.conversations.render import populate_speaker_names, populate_folder_names
 from utils.conversations.render import conversation_to_dict
@@ -317,7 +317,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
         webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
         if not webhook_url:
             return
-        webhook_url = webhook_url.split(',')[0]
+        webhook_url = webhook_url_from_setting(WebhookType.audio_bytes, webhook_url)
         if not webhook_url:
             return
         webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
@@ -359,8 +359,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:
     res = False
-    url = get_user_webhook_db(uid, wType)
-    if url == '' or url == ',':
+    url = webhook_url_from_setting(wType, get_user_webhook_db(uid, wType))
+    if not url:
         disable_user_webhook_db(uid, wType)
         res = False
     else:


### PR DESCRIPTION
## What

Clearing a developer webhook's URL now leaves that webhook **disabled**. Previously, saving
Developer Settings with an emptied **Audio Bytes** URL switched the webhook back on, so the
toggle the user had just turned off came back on after every save.

Fixes the "minor 2" half of #11365. The issue's headline defect (no webhooks at all for
Limitless Pendant sessions) is **not** addressed here, so the issue stays open — see below.

## Why

`audio_bytes` is the only webhook stored as `"<url>,<seconds>"`, and the app always posts both
halves (`app/lib/providers/developer_mode_provider.dart:208`):

```dart
setUserWebhookUrl(type: 'audio_bytes', url: '${webhookAudioBytes.text.trim()},${webhookAudioBytesDelay.text.trim()}');
```

So clearing only the URL field posts `,5` — not `''`. Both readers of that setting tested for
the literal empty forms:

```python
if url == '' or url == ',':      # routers/users.py, utils/webhooks.py
```

`,5` is neither, so `set_user_webhook_endpoint` took the *enable* branch and
`webhook_first_time_setup` reported the webhook as configured — exactly the reporter's
"the Audio Bytes toggle re-enables itself after being switched off and saved".

## How

Both call sites now resolve the setting through `models.users.webhook_url_from_setting`, the
single owner of the `"<url>,<seconds>"` encoding; `send_audio_bytes_developer_webhook` uses it
too instead of its own `split(',')[0]`. Whitespace-only URLs count as unconfigured. Only
`audio_bytes` carries the `,<seconds>` suffix, so a comma inside another webhook's query string
(`?ids=1,2`) is left intact.

## Tested

**Real path** — the actual FastAPI endpoints against a live Redis, replaying what the app sends
(script: `set` → `disable` → `set(',5')`, reading the toggle back from
`GET /v1/users/developer/webhooks/status`):

Before (this commit reverted):
```
1. saved url+delay 'https://example.com/audio,5' -> audio_bytes toggle = True
2. user switches the toggle off              -> audio_bytes toggle = False
3. user clears the URL and hits Save (',5')  -> audio_bytes toggle = True
RESULT: BUG REPRODUCED — toggle came back ON after saving a cleared URL
```

After:
```
1. saved url+delay 'https://example.com/audio,5' -> audio_bytes toggle = True
2. user switches the toggle off              -> audio_bytes toggle = False
3. user clears the URL and hits Save (',5')  -> audio_bytes toggle = False
   stored setting = ',5'
RESULT: FIXED — toggle stayed OFF after saving a cleared URL
```

**Regression tests** — `bash test.sh` over the two touched files, 33 passed:
`tests/unit/test_users_webhook_url_validation.py` (8) covers the router: `,5` disables,
`http://x,5` still enables, a blank non-audio URL disables, and a comma in a non-audio query
string is not treated as a delay separator. `tests/unit/test_async_webhooks.py` (25) adds
`TestWebhookFirstTimeSetup` for the first-time-status path that also flipped the toggle on.

`make preflight` clean.

## Not fixed here

The reported headline — Real-Time Transcript / Conversation Events / Audio Bytes never firing
for Limitless Pendant conversations — is untouched. Limitless-sourced captures reach the backend
through the sync-upload path, not a live listen session, so the realtime and audio-bytes
webhooks have no live session to fire from by construction; whether `memory_created` should fire
for them is a product call, and I could not reproduce a pendant session to verify either way.
The reporter's minor 1 (`?uid` appended to a URL that already has a query string) is already
fixed on `main` by `f31dae9de8` — `_append_query_params` re-encodes the query correctly.

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

