### PR TITLE
fix(app): drop stale @override on the removed EnvFields.openAIAPIKey

### DIFF
--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -86,8 +86,6 @@ BtDevice _device({required String id, required DeviceType type, String name = 'T
 /// config reading Env.apiBaseUrl) don't hit a LateInitializationError.
 class _TestEnvFields implements EnvFields {
   @override
-  String? get openAIAPIKey => null;
-  @override
   String? get posthogApiKey => null;
   @override
   String? get apiBaseUrl => null;

--- a/app/test/unit/account_cutover_gate_test.dart
+++ b/app/test/unit/account_cutover_gate_test.dart
@@ -57,9 +57,6 @@ class _CutoverTestEnv implements EnvFields {
   String? get intercomAndroidApiKey => null;
 
   @override
-  String? get openAIAPIKey => null;
-
-  @override
   String? get posthogApiKey => null;
 
   @override

--- a/app/test/unit/backend/http/shared_test.dart
+++ b/app/test/unit/backend/http/shared_test.dart
@@ -159,9 +159,6 @@ class _TestEnvFields implements EnvFields {
   String? get intercomAndroidApiKey => null;
 
   @override
-  String? get openAIAPIKey => null;
-
-  @override
   String? get posthogApiKey => null;
 
   @override

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -10,8 +10,6 @@ import 'dart:io';
 /// we test with a single init and exercise the override/flag mechanisms.
 class _TestEnvFields implements EnvFields {
   @override
-  String? get openAIAPIKey => null;
-  @override
   String? get posthogApiKey => null;
   @override
   String? get apiBaseUrl => null;

--- a/app/test/unit/http_pool_manager_retry_test.dart
+++ b/app/test/unit/http_pool_manager_retry_test.dart
@@ -107,9 +107,6 @@ class _TestEnvFields implements EnvFields {
   String? get intercomAndroidApiKey => null;
 
   @override
-  String? get openAIAPIKey => null;
-
-  @override
   String? get posthogApiKey => null;
 
   @override


### PR DESCRIPTION
## Bug

`dart analyze` reports 5 × `override_on_non_overriding_member` on `main`, and that rule's
`app/analysis_baseline.json` entry is `0`, so `app/scripts/analyze_ratchet.sh` fails. The
"Dart Analyze & Tests" job is path-filtered, so post-merge push runs on `main` **skip** it
and the breakage stayed latent — it fires on every PR that touches `app/`, with a failure
none of those authors introduced (e.g. #11366).

## Root cause

6908c4f5f6 ("refactor(app): delete dead direct-OpenAI mobile client") removed `openAIAPIKey`
from the `EnvFields` interface but left the `@override String? get openAIAPIKey => null;`
member on five `_TestEnvFields` stubs that `implements EnvFields`.

## Fix

Delete the five dead members. Nothing in `app/` reads `openAIAPIKey` any more
(`grep -rn openAIAPIKey app/` returns nothing after this change).

## Verification

- `app/scripts/analyze_ratchet.sh` on a clean `origin/main` checkout (f51681dc9e) reproduces
  `override_on_non_overriding_member: 5 found, baseline 0 — fix the new occurrences`.
  With this commit that rule no longer appears in the ratchet output.
- `flutter test test/unit/env_test.dart test/unit/account_cutover_gate_test.dart
  test/unit/backend/http/shared_test.dart test/unit/http_pool_manager_retry_test.dart
  test/providers/capture_provider_test.dart` → **104 tests, all passed**.
- `dart format --line-length 120 --set-exit-if-changed` on the five files → 0 changed.

## Failure class

Failure-Class: none

Dead code left behind by an interface removal, caught by an existing static gate. No new
semantic class: the gate that should catch this already exists and now passes.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

