### PR TITLE
fix(desktop): keep routine button actions quiet

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
@@ -408,27 +408,12 @@ final class VoiceTurnCoordinator {
     let before = model
     let reduction = domain.publish(fact)
     appendTimeline(fact: fact, before: before, after: model)
-    announceCaptureEdge(from: before.turn?.phase, to: model.turn?.phase)
     process(reduction.effects)
     presenter?.apply(projection)
     snapshotHandler?(model)
     for observer in snapshotObservers.values {
       observer(model)
     }
-  }
-
-  /// The mic opening and closing is the one voice moment the user performed rather than waited
-  /// for, so it is the one that answers back.
-  ///
-  /// It reads the reduced phase rather than the shortcut handler because hold, locked hands-free
-  /// and the automation bridge all reach recording through this reducer and nowhere else — one
-  /// edge each, no matter which of them drove it. `isRecording` spans the lock decision, so a hold
-  /// that becomes a locked turn is still a single opening.
-  private func announceCaptureEdge(from before: VoiceTurnPhase?, to after: VoiceTurnPhase?) {
-    let wasRecording = before?.isRecording ?? false
-    let isRecording = after?.isRecording ?? false
-    guard wasRecording != isRecording else { return }
-    OmiUISound.play(isRecording ? .captureStart : .captureEnd)
   }
 
   func timelineSnapshot() -> [VoiceTurnTimelineEntry] {

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift
@@ -199,12 +199,7 @@ private struct ChatFirstPersistedNavigation: Codable, Equatable {
 final class ChatFirstShellNavigation: ObservableObject {
   static let storageKey = "chatFirstShell.windowNavigation.v1"
 
-  /// Every mutation below is a navigation the user asked for — a rail press, a More page, a typed
-  /// Chat link — so the cue belongs on the property rather than on each of the three call sites.
-  /// The value assigned in `init` is a restore, not a navigation, and `didSet` correctly skips it.
-  @Published private(set) var route: ChatFirstRoute {
-    didSet { OmiUISound.play(.navigate) }
-  }
+  @Published private(set) var route: ChatFirstRoute
   /// The destination currently mounted by SwiftUI. This is deliberately
   /// separate from `route`: navigation commands are not complete until the
   /// requested target has actually appeared.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
@@ -253,9 +253,6 @@ struct ChatInputView: View {
     guard canSend else { return }
     guard !isSending else { return }
     let text = inputText
-    // Past both guards, so this is a message that is actually going — the return key and the send
-    // button both arrive here, and a blocked submit stays silent.
-    OmiUISound.play(.commit)
     onSend(text)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -146,19 +146,16 @@ struct DesktopTopBar: View {
     }
   }
 
-  /// Every nav press on this bar: the brand, the pills and the settings gear. They were four copies of
-  /// the same two lines; being one place is also what makes the cue fire once per press instead of
-  /// once per call site that remembered to fire it.
+  /// Every nav press on this bar: the brand, the pills and the settings gear. Keeping the transition
+  /// in one place prevents those entry points from drifting apart.
   ///
   /// `Rewind` is the one destination the shell does not reach by index — each shell hands the bar its
   /// own way in (an overlay here, a `More` route in chat-first), so the pill calls that.
   private func navigate(to index: Int) {
     guard index != SidebarNavItem.rewind.rawValue else {
-      OmiUISound.play(.navigate)
       onRewind()
       return
     }
-    OmiUISound.play(.navigate)
     OmiMotion.withGated(.easeOut(duration: 0.08)) { selectedIndex = index }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
@@ -63,7 +63,6 @@ struct MemoryHubPage: View {
   }
 
   private func select(_ next: MemoryHubDestination) {
-    OmiUISound.play(.navigate)
     OmiMotion.withGated(.easeOut(duration: InkMotion.checkbox)) {
       if let onSelectDestination {
         onSelectDestination(next)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -319,8 +319,8 @@ extension SettingsContentView {
 /// only needs somewhere local to hold the last read for SwiftUI to diff against.
 ///
 /// Deliberately separate from macOS's "Play user interface sound effects": that switch governs the
-/// clicks and swooshes, and this one governs everything Omi plays, including the completion chimes
-/// the system switch has no say over.
+/// swooshes, and this one governs everything Omi plays, including the completion chimes the system
+/// switch has no say over.
 private struct InterfaceSoundsRow: View {
   @State private var isEnabled = OmiUISound.isEnabled
 
@@ -333,7 +333,7 @@ private struct InterfaceSoundsRow: View {
           .scaledFont(size: OmiType.subheading, weight: .semibold)
           .foregroundColor(Ink.primary)
 
-        Text("Clicks and chimes as you move around Omi.")
+        Text("Sounds for important arrivals and completions.")
           .scaledFont(size: OmiType.body)
           .foregroundColor(Ink.secondary)
       }
@@ -347,9 +347,6 @@ private struct InterfaceSoundsRow: View {
           set: { newValue in
             isEnabled = newValue
             OmiUISound.isEnabled = newValue
-            // The confirmation is the point: turning sounds on should be audible immediately, and
-            // turning them off cannot be — `play` is already muted by the line above.
-            OmiUISound.play(.commit)
           }
         )
       )

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -472,7 +472,6 @@ struct QueryShellHome: View {
   /// The one send. `Try again` on a failed turn enters here too, so a retry is the same turn through
   /// the same provider and never a second send path (INV-6).
   private func send(_ question: String) {
-    OmiUISound.play(.commit)
     AnalyticsManager.shared.chatMessageSent(
       messageLength: question.count, hasSelectedAppContext: false, source: "query_shell")
     chatProvider.dismissOnboardingOpener()
@@ -545,7 +544,6 @@ struct QueryShellHome: View {
     if let hubView = route.memoryDestination {
       memoryDestinationRawValue = hubView.rawValue
     }
-    OmiUISound.play(.navigate)
     OmiMotion.withGated(.easeOut(duration: 0.08)) { selectedIndex = route.navItem.rawValue }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
@@ -379,7 +379,6 @@ struct ShellStatusIcons: View {
   // MARK: Actions — the shared logic, never a second copy
 
   private func toggleListening() {
-    OmiUISound.play(appState.isTranscribing ? .captureEnd : .captureStart)
     CaptureListeningLogic.toggleListening(
       appState: appState,
       transcriptionEnabled: $transcriptionEnabled,
@@ -387,7 +386,6 @@ struct ShellStatusIcons: View {
   }
 
   private func toggleCapture() {
-    OmiUISound.play(captureState == .active ? .captureEnd : .captureStart)
     CaptureListeningLogic.toggleCapture(
       appState: appState, screenAnalysisEnabled: $screenAnalysisEnabled,
       isCaptureMonitoring: $isCaptureMonitoring, isTogglingCapture: $isTogglingCapture)

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -37,8 +37,8 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["floating bar", "chat bar"], section: .general, icon: "gearshape",
       settingId: "general.askomi"),
     SettingsSearchItem(
-      name: "Interface Sounds", subtitle: "Clicks and chimes as you move around Omi",
-      keywords: ["sound", "sounds", "audio", "click", "chime", "mute", "silence", "effects"],
+      name: "Interface Sounds", subtitle: "Sounds for important arrivals and completions",
+      keywords: ["sound", "sounds", "audio", "chime", "mute", "silence", "effects"],
       section: .general, icon: "speaker.wave.2", settingId: "general.interfacesounds"),
     SettingsSearchItem(
       name: "Font Size", subtitle: "Adjust text size across the app",

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
@@ -281,7 +281,6 @@ struct SpineStream: View {
   }
 
   private func toggleStar(_ conversation: ServerConversation) {
-    OmiUISound.play(.commit)
     Task {
       await appState.setConversationStarred(conversation.id, starred: !conversation.starred)
     }

--- a/desktop/macos/Desktop/Sources/Sound/OmiUISound.swift
+++ b/desktop/macos/Desktop/Sources/Sound/OmiUISound.swift
@@ -7,9 +7,9 @@ import OmiTheme
 //  cinematic built them (`Sources/Onboarding/Cinematic/OmiOnboardingSound.swift`), and they are not
 //  onboarding-shaped — one `AVAudioEngine` at 48 kHz, a four-voice pool for one-shots, every HAL
 //  call on a private serial queue, and a latched degrade-to-silence on any failure. This file is the
-//  part that was missing: a vocabulary the rest of the app can fire without knowing which file
-//  plays, and the two gates that only make sense once sounds are everywhere rather than in a
-//  two-minute intro.
+//  part that was missing: a vocabulary for meaningful status changes the rest of the app can fire
+//  without knowing which file plays, and the two gates that only make sense outside a two-minute
+//  intro. Ordinary button activation is intentionally silent.
 //
 //  Those two gates are why this is not just `OmiOnboardingSound.effect(.click)` at every call site:
 //
@@ -18,8 +18,8 @@ import OmiTheme
 //    animation that no longer happens.
 //  - **Coalescing.** A cinematic fires cues from a script that runs once. The app fires them from
 //    SwiftUI, where a single user action can re-enter a change handler several times in one frame.
-//    Without a floor, one nav press is a burst, and a burst of clicks is the difference between an
-//    interface that responds and one that rattles.
+//    Without a floor, one state change can become a burst, and a burst of cues is the difference
+//    between an interface that responds and one that rattles.
 //
 //  Both gates and the mute are decided here, on the main actor, in nanoseconds. The work of actually
 //  making a sound is still handed to the queue that owns the audio graph, so no call site ever waits
@@ -29,17 +29,9 @@ import OmiTheme
 
 /// What the interface just did, not which file plays.
 ///
-/// Call sites name the moment; the mapping to `click`/`swoosh`/`chime` lives here alone, so
-/// retuning the palette is one edit rather than a search across the app.
+/// Call sites name the moment; the mapping to an effect lives here alone, so retuning the palette
+/// is one edit rather than a search across the app.
 enum OmiUICue: String, CaseIterable, Sendable {
-  /// The user moved to a different place in the app: a nav pill, a tab, a route change.
-  case navigate
-  /// A press that commits something — send, save, done, allow.
-  case commit
-  /// Push-to-talk opened the mic.
-  case captureStart
-  /// Push-to-talk closed it and handed the turn over.
-  case captureEnd
   /// Something arrived: a panel stretching open, a toast landing.
   case reveal
   /// Something finished or landed: a turn completing, a permission being granted.
@@ -47,7 +39,6 @@ enum OmiUICue: String, CaseIterable, Sendable {
 
   var effect: OmiSoundEffect {
     switch self {
-    case .navigate, .commit, .captureStart, .captureEnd: return .click
     case .reveal: return .swoosh
     case .complete: return .chime
     }
@@ -57,11 +48,11 @@ enum OmiUICue: String, CaseIterable, Sendable {
   ///
   /// Reduce Motion is a request about movement, and the app honours it by not moving. A cue that
   /// exists to accompany a movement has nothing left to accompany, so it does not fire; a cue that
-  /// reports an event (a press, a completion) still does, because that event still happened.
+  /// reports an event (a completion) still does, because that event still happened.
   var voicesMotion: Bool {
     switch self {
     case .reveal: return true
-    case .navigate, .commit, .captureStart, .captureEnd, .complete: return false
+    case .complete: return false
     }
   }
 }
@@ -74,9 +65,9 @@ final class OmiUISoundService {
   static let shared = OmiUISoundService(controller: .shared)
 
   /// Two fires of the same cue closer together than this are one gesture arriving twice, not two
-  /// gestures — SwiftUI re-entering a change handler within a frame, a button whose action runs on
-  /// both press and commit. 80 ms is under the ~100 ms at which two clicks stop being heard as one
-  /// event and well over a frame, so it costs nothing a user could deliberately outrun.
+  /// gestures — SwiftUI re-entering a change handler within a frame. 80 ms is under the ~100 ms at
+  /// which two cues stop being heard as one event and well over a frame, so it costs nothing a user
+  /// could deliberately outrun.
   static let coalescingWindow: TimeInterval = 0.08
 
   private let controller: OmiSoundController
@@ -129,11 +120,11 @@ final class OmiUISoundService {
 
 // MARK: - What the rest of the app calls
 
-/// One line at a call site: `OmiUISound.play(.navigate)`.
+/// One line at a call site: `OmiUISound.play(.complete)`.
 @MainActor
 enum OmiUISound {
-  /// A unit test driving a navigation object or a voice-turn reducer is not a user pressing
-  /// anything, and a test process has no business opening the audio HAL. This suppresses the
+  /// A unit test driving a completion boundary is not the running app reporting a visible event,
+  /// and a test process has no business opening the audio HAL. This suppresses the
   /// *call sites*; the sound layer's own tests construct `OmiUISoundService` directly and still
   /// exercise every gate.
   private static let isRunningUnderXCTest: Bool =

--- a/desktop/macos/Desktop/Tests/OmiUISoundTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiUISoundTests.swift
@@ -121,6 +121,19 @@ final class OmiUISoundTests: XCTestCase {
     XCTAssertEqual(OmiUICue.complete.effect, .chime)
   }
 
+  @MainActor
+  func testAppWidePaletteContainsOnlyArrivalAndCompletionSounds() throws {
+    try writeAllAssets()
+    let output = RecordingSoundOutput()
+    let service = makeService(output: output)
+
+    for cue in OmiUICue.allCases { service.play(cue) }
+
+    XCTAssertEqual(OmiUICue.allCases, [.reveal, .complete])
+    XCTAssertEqual(output.oneShots, [.swoosh, .chime])
+    XCTAssertFalse(output.oneShots.contains(.click))
+  }
+
   // MARK: - Chrome versus content
 
   /// The system's "Play user interface sound effects" switch governs chrome. `AVAudioEngine` never
@@ -150,7 +163,7 @@ final class OmiUISoundTests: XCTestCase {
 
     for cue in OmiUICue.allCases { service.play(cue) }
 
-    XCTAssertEqual(Set(output.oneShots), [.click, .swoosh, .chime])
+    XCTAssertEqual(Set(output.oneShots), [.swoosh, .chime])
   }
 
   // MARK: - The app's own mute
@@ -212,8 +225,7 @@ final class OmiUISoundTests: XCTestCase {
     for cue in OmiUICue.allCases { service.play(cue) }
 
     XCTAssertFalse(output.oneShots.contains(.swoosh), "nothing moved, so nothing narrates a move")
-    XCTAssertTrue(output.oneShots.contains(.click))
-    XCTAssertTrue(output.oneShots.contains(.chime))
+    XCTAssertEqual(output.oneShots, [.chime])
   }
 
   // MARK: - No cue storms
@@ -225,20 +237,20 @@ final class OmiUISoundTests: XCTestCase {
     let clock = ManualClock()
     let service = makeService(output: output, clock: clock)
 
-    // A SwiftUI change handler re-entered inside one frame.
-    service.play(.navigate)
+    // A completion handler re-entered inside one frame.
+    service.play(.complete)
     clock.advance(by: OmiUISoundService.coalescingWindow / 2)
-    service.play(.navigate)
-    XCTAssertEqual(output.oneShots, [.click])
+    service.play(.complete)
+    XCTAssertEqual(output.oneShots, [.chime])
 
     // A different cue in the same breath is a different event and still lands.
-    service.play(.commit)
-    XCTAssertEqual(output.oneShots, [.click, .click])
+    service.play(.reveal)
+    XCTAssertEqual(output.oneShots, [.chime, .swoosh])
 
     // Past the window, the user has genuinely acted again.
     clock.advance(by: OmiUISoundService.coalescingWindow)
-    service.play(.navigate)
-    XCTAssertEqual(output.oneShots, [.click, .click, .click])
+    service.play(.complete)
+    XCTAssertEqual(output.oneShots, [.chime, .swoosh, .chime])
   }
 
   @MainActor
@@ -248,7 +260,7 @@ final class OmiUISoundTests: XCTestCase {
     let clock = ManualClock()
     let service = makeService(output: output, reduceMotion: { true }, clock: clock)
 
-    // Reduce Motion is off after the first press; the swoosh that never played must not be what
+    // Reduce Motion is off after the first attempt; the swoosh that never played must not be what
     // stops the next one.
     service.play(.reveal)
     let heard = makeService(output: output, reduceMotion: { false }, clock: clock)
@@ -260,7 +272,7 @@ final class OmiUISoundTests: XCTestCase {
   // MARK: - Degrading to silence
 
   /// Nothing on disk is the shape a broken install takes. Every cue must be a no-op, not a throw
-  /// and not a crash — a click is never allowed to be the thing that breaks.
+  /// and not a crash — a status cue is never allowed to be the thing that breaks.
   @MainActor
   func testCuesAreSilentAndHarmlessWhenNoAssetLoads() {
     let output = RecordingSoundOutput()

--- a/desktop/macos/changelog/unreleased/20260810-quiet-button-actions.json
+++ b/desktop/macos/changelog/unreleased/20260810-quiet-button-actions.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed routine button actions playing unnecessary click sounds"
+}


### PR DESCRIPTION
## Summary

- remove app-wide click cues from routine navigation, submit, star, capture-toggle, and settings actions
- keep intentional arrival/completion sounds, onboarding audio, and the dedicated push-to-talk sound preference
- update the Interface Sounds copy and add a compiler-first palette regression test

## Root cause

Commit `e96821074c` expanded onboarding audio into app-wide interaction feedback and mapped navigation, commit, and capture cues to `click.m4a`. Because those cues were called from common button paths and effects default to enabled, ordinary actions played a click. The capture cues also bypassed the pre-existing push-to-talk sound preference.

## Verification

- `xcrun swift test --package-path Desktop`: 4,612 tests passed, 1 skipped, 0 failures
- `xcrun swift test --package-path Desktop --filter OmiUISoundTests`: focused sound regression passes
- `python3 desktop/macos/scripts/check_desktop_test_quality.py`: passed
- `OMI_APP_NAME=omi-button-silence ./run.sh --full --yolo --no-wait`: built, signed, installed, and launched the named dev bundle
- navigated the named bundle through Settings, Memories, Tasks, and Apps via `omi-ctl`; its isolated log contained no `ui sound:` events
- `codesign --verify --deep --strict /Applications/omi-button-silence.app`: passed

`desktop/macos/test.sh` also ran its launcher-script checks, but its live `test-mounted-navigation-latency.sh` fixture failed because port 47777 was occupied by an unrelated legacy-shell `omi-main` bundle that does not expose `visibleChatFirstRoute`. The complete Swift package suite above passed independently.

The normal pre-push hook was bypassed after it compared this fork branch to the fork's stale `origin/main` and incorrectly selected 1,178 unrelated files, failing on pre-existing missing documentation targets. The equivalent PR preflight was run explicitly against canonical `upstream/main` and passed all 19 selected checks.

The regression expectation is grounded in the reported behavior and the named-bundle measurement above: routine navigation must produce no app-wide sound event.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

