### PR TITLE
fix(desktop): unblock the release lane — KG ResolveOutcome is Sendable

### DIFF
--- a/desktop/macos/Desktop/Sources/Services/KnowledgeGraphToolSupport.swift
+++ b/desktop/macos/Desktop/Sources/Services/KnowledgeGraphToolSupport.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 enum KnowledgeGraphToolSupport {
-  struct ClientGraph {
+  /// The dictionaries are `[String: Any]` because the tool plumbing consumes heterogeneous
+  /// JSON-shaped values, but every value put in them here is an immutable `String` or `[String]`
+  /// built locally in `resolveDiscoveryText` — nothing shared or mutable crosses the boundary.
+  /// `@unchecked` because `Any` erases what the initializer guarantees; the release
+  /// (whole-module) compile otherwise rejects returning this across the async seam.
+  struct ClientGraph: @unchecked Sendable {
     let nodes: [[String: Any]]
     let edges: [[String: Any]]
   }
 
-  enum ResolveOutcome {
+  enum ResolveOutcome: Sendable {
     case success(ClientGraph)
     case failure(String)
   }


### PR DESCRIPTION
## Summary

`Desktop Swift Release Compile` has been red on `main` since #11369 (strict-concurrency error only visible under the release lane's whole-module optimization), which fails the auto-release gate closed — no beta candidate has cut, so #11372 (and everything since the last tag) is not reaching users.

`KnowledgeGraphToolSupport.ResolveOutcome` was non-Sendable (its `ClientGraph` carries `[String: Any]` JSON-shaped dictionaries) and is returned from a nonisolated async function. The dictionaries hold only locally-built immutable `String`/`[String]` values, so `ClientGraph` is now `@unchecked Sendable` with that contract documented at the declaration, and `ResolveOutcome` is `Sendable`.

## Verification

- `xcrun swift build -c release --package-path Desktop` locally: **Build complete (353.8s), zero errors** — the exact lane that fails in CI.
- No behavior change; type-level conformance only.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

