### PR TITLE
chore(desktop): changelog fragment for the KG Sendable fix (release-gate unblock)

### DIFF
--- a/desktop/macos/changelog/unreleased/20260810-kg-tool-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260810-kg-tool-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Reliability fix in the chat knowledge-graph tooling"
+}


### PR DESCRIPTION
Release Eligibility re-runs the desktop-changelog-entry check on the main push lane where #11373's no-changelog-needed label is invisible, so the release gate stayed red and no candidate can cut while the served beta (v0.12.154) is broken (#11374). The fragment satisfies the check in every lane. No code change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

