### PR TITLE
docs(desktop): release-lane Sendable contract note (re-arms the release gate)

### DIFF
--- a/desktop/macos/Desktop/Sources/Services/KnowledgeGraphToolSupport.swift
+++ b/desktop/macos/Desktop/Sources/Services/KnowledgeGraphToolSupport.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 enum KnowledgeGraphToolSupport {
+  /// Release-lane contract: this type crosses the async seam out of `resolveDiscoveryText`, so it
+  /// must stay `Sendable` — the whole-module release compile (the auto-release gate) rejects a
+  /// non-Sendable return here even when debug builds stay quiet. See #11373/#11374.
+  ///
   /// The dictionaries are `[String: Any]` because the tool plumbing consumes heterogeneous
   /// JSON-shaped values, but every value put in them here is an immutable `String` or `[String]`
   /// built locally in `resolveDiscoveryText` — nothing shared or mutable crosses the boundary.


### PR DESCRIPTION
The release planner binds to the newest releasable desktop SHA — currently #11373's, which carries an immutable Release Eligibility failure (its changelog exemption label is invisible to the main push lane; fragment landed later in #11375). This Swift-path commit makes the newest releasable SHA one whose tree contains the fragment, so eligibility passes and the candidate for the broken served beta (#11374) can cut. Comment-only change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

