### PR TITLE
feat(desktop): wider, more legible notch notifications + focus nudges & Suggestions

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2666,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2710,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4969,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2807,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
@@ -9,7 +9,7 @@
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": "Agent completion presentation now follows the canonical terminal lifecycle used by PTT and chat.",
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "Onboarding bar glow, reach-error handling, and the notch hover/voice surface-state boundary render on the shared bar surface. The live-suggestion notch card, hover shortcut legend, Second Brain onboarding, reach-error, and notch-moment UI remain distinct overlay branches; the centered notch voice morph stays frontmost through waveform transitions, while the reducer-owned speaking projection keeps response playback synchronized.",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": "Onboarding bar glow, reach-error handling, and the notch hover/voice surface-state boundary render on the shared bar surface. The live-suggestion notch card, hover shortcut legend, Second Brain onboarding, reach-error, and notch-moment UI remain distinct overlay branches; the centered notch voice morph stays frontmost through waveform transitions, while the reducer-owned speaking projection keeps response playback synchronized. The default notification and focus-suggestion cards each carry their own accent-icon tile, header, and dismiss layout so proactive nudges are legible at a glance.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": "Pointer-synced ignoresMouseEvents click-through (notch overlay dead-zone fix) must live beside the acceptsMouseHit region logic it corrects; view-level hitTest cannot make a window click-through.",
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": "Strict concurrency annotations, the capture-free owner-boundary setup seam, and off-main-thread CoreAudio input warmup remain beside PTT entry points. Warm mic keep-alive parks finished capture behind a lock-guarded lease so the next turn reuses the IOProc; the lease and park/adopt state stay beside the capture generation counter (BasedHardware/omi#10499, #10442, #9181).",
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": "Adds bounded realtime mint-failure outcome correlation and close-resolution telemetry so release health distinguishes started recovery from exhaustion; telemetry-only, no lifecycle change (#10425).",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -7,7 +7,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3468,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4399,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1636,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 6615,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 6745,
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1507
   },
   "raise_justifications": {
@@ -18,7 +18,7 @@
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": "Server pages remain the visible authority after lifecycle resolution; MemoryPageProjection, owner authorization snapshots, cache/API scope fencing, canonical capability updates, server-advertised default-delete capability gating, Brain Map evidence/list-detail/delete lifecycle, and layer-filter reload routing (authoritative loadMemories only on default access) stay with the Memories page's single projection owner rather than exposing coordination state across view-model boundaries. A component split would fragment the cache/server projection contract and remains tracked follow-up.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": "The Canonical Memory Atlas owns progressive disclosure, island territories and captions, selection-trail Escape behavior, in-place evidence inspection, and related render policies. Geometry and territory labels are extracted where possible; a further surface split remains tracked separately.",
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": "Relatedness layout, Louvain neighbourhood detection, and the group-separation and anchor-repulsion forces the island map is built on; no baseline entry existed because the file crossed the threshold in this change. It is already separate from the atlas view \u2014 a further split of detection from simulation is tracked follow-up.",
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Task detail-panel presentation (escape dismiss, stale detail clearing, workstream-aware chat open), task/chat mutual exclusion, TaskMultiSelectionState wiring with Select/Done affordance and batch bulk delete, bottom-sentinel pagination, filter-aware rendered-order drag/drop, sparse rank allocation, hidden-row rebasing, stale-ID filtering, local-to-backend promotion remapping, generation-fenced serialized local/cloud commits, retry cleanup, and description-addressable reorder automation remain with the Tasks page state owner; recovery coordination stays separately in TasksStore. Splitting the page would fragment its row-to-panel navigation and pagination state; a component split is tracked follow-up.",
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": "Suggestions category: collapsed AI-capture section, Accept affordance, nav/select-all scope",
     "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": "Strict concurrency imports annotate legacy AppKit image usage without changing runtime behavior. SB redesign adds the hover-expand AppNavRail (icons\u2192labels) and merged navigation (Memory) driving selectedIndex; a component split is tracked follow-up."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-proactiveassistants.json
@@ -1,11 +1,11 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": 1741,
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1606
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": 1651
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift": "Task candidate context now carries only backend action-item IDs, while local SQLite/staged evidence remains id-less so the model cannot target it for a backend mutation.",
-    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "A nonisolated UserNotifications callback bridge now performs an explicit MainActor hop so macOS callback queues cannot trap the public app at launch. Rewind capture policy adds per-app heartbeat and preview skip logic inline; also registers SuggestionAssistant (event-driven) with logic in Assistants/Suggestions/."
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift": "CaptureGate transition diagnostics + kCGAnyInputEventType idle-sentinel fix"
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3697
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3736
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Dated-versus-No Deadline task surfaces (apiDatedBucketCount includes retired dated rows for null-due API boundary), IncompleteTaskSurfaceState offset consolidation, raw API cursor accounting, owner-fenced page fetches, bounded local reloads, duplicate filtering, full-sync refresh, task-detail recovery, retry cleanup, and destructive server reconciliation remain with the TasksStore owner and its existing mutation/recovery gates; splitting these coupled cache/API/presentation transitions would create competing pagination authority and is disproportionate. +8 fences durable task retries at entry and before every send using the shared account-cutover admission seam."
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Suggestion triage: AI captures excluded from dashboard lanes, acceptSuggestedTask"
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -67,6 +67,9 @@ enum DefaultsKey: String {
   // migration contract instead of repeating raw UserDefaults literals.
   case tasksCategoryOrder = "TasksCategoryOrder"
   case tasksSortOrderMigrated = "TasksSortOrderMigrated"
+  /// Whether the Suggestions section on the Tasks page is expanded. Shared by the
+  /// view (@AppStorage) and the view model's keyboard-navigation/select-all scope.
+  case tasksSuggestionsSectionExpanded = "tasksSuggestionsSectionExpanded"
   case onboardingChatGPTImportedMemories = "onboardingChatGPTImportedMemoriesCount"
   case gmailSelectedCookiePath = "gmailSelectedCookiePath"
   case gmailSelectedAccountLabel = "gmailSelectedAccountLabel"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -590,37 +590,70 @@ struct FloatingControlBarView: View {
     Button {
       FloatingControlBarManager.shared.openNotificationAsChat(notification)
     } label: {
-      HStack(spacing: OmiSpacing.sm) {
-        Image(systemName: "lightbulb")
-          .scaledFont(size: 13, weight: .medium)
-          .foregroundColor(.white.opacity(0.75))
+      HStack(alignment: .top, spacing: OmiSpacing.md) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 13, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: [Color.white.opacity(0.18), Color.white.opacity(0.08)],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+            )
+            .frame(width: 44, height: 44)
 
-        Text(notification.message)
-          .scaledFont(size: 13, weight: .medium)
-          .foregroundColor(.white)
-          .lineLimit(2)
-          .multilineTextAlignment(.leading)
-          .fixedSize(horizontal: false, vertical: true)
+          Image(systemName: "lightbulb.fill")
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundColor(.white)
+        }
+
+        VStack(alignment: .leading, spacing: 3) {
+          Text("Suggested by Omi")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundColor(.white.opacity(0.5))
+            .lineLimit(1)
+
+          Text(notification.message)
+            .scaledFont(size: OmiType.subheading, weight: .medium)
+            .foregroundColor(.white)
+            .lineLimit(3)
+            .multilineTextAlignment(.leading)
+            .lineSpacing(1.5)
+            .fixedSize(horizontal: false, vertical: true)
+        }
 
         Spacer(minLength: OmiSpacing.xs)
 
-        Button {
-          FloatingControlBarManager.shared.dismissCurrentNotification()
-        } label: {
-          Image(systemName: "xmark")
-            .scaledFont(size: 10, weight: .semibold)
-            .foregroundColor(.white.opacity(0.45))
-            .padding(OmiSpacing.xxs)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Dismiss suggestion")
+        // Reserve room so copy never runs under the overlaid dismiss button.
+        Color.clear
+          .frame(width: 28, height: 20)
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.md)
+      .padding(.horizontal, OmiSpacing.lg)
+      .padding(.vertical, OmiSpacing.md + 2)
       .frame(maxWidth: .infinity, alignment: .leading)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
+    .overlay(alignment: .topTrailing) {
+      Button {
+        FloatingControlBarManager.shared.dismissCurrentNotification()
+      } label: {
+        Image(systemName: "xmark")
+          .font(.system(size: 10, weight: .bold))
+          .foregroundColor(.white.opacity(0.62))
+          .frame(width: 18, height: 18)
+          .background(Color.white.opacity(0.08))
+          .clipShape(Circle())
+      }
+      .buttonStyle(.plain)
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.md)
+      .accessibilityLabel("Dismiss suggestion")
+    }
   }
 
   /// Conversation ends — the USP moment. "N follow-ups ready" + Review / Later.
@@ -1115,27 +1148,38 @@ struct FloatingControlBarView: View {
     Button {
       FloatingControlBarManager.shared.openNotificationAsChat(notification)
     } label: {
-      HStack(alignment: .top, spacing: 10) {
+      HStack(alignment: .top, spacing: OmiSpacing.md) {
         ZStack {
-          RoundedRectangle(cornerRadius: 10)
-            .fill(Color.white.opacity(0.08))
-            .frame(width: 34, height: 34)
+          RoundedRectangle(cornerRadius: 13, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: [Color.white.opacity(0.18), Color.white.opacity(0.08)],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+            )
+            .frame(width: 44, height: 44)
 
           Image(systemName: "bell.badge.fill")
-            .font(.system(size: 14, weight: .semibold))
+            .font(.system(size: 18, weight: .semibold))
             .foregroundColor(.white)
         }
 
-        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+        VStack(alignment: .leading, spacing: 3) {
           Text(notification.title)
-            .scaledFont(size: OmiType.body, weight: .semibold)
+            .scaledFont(size: OmiType.subheading, weight: .semibold)
             .foregroundColor(.white)
             .lineLimit(1)
 
           Text(notification.message)
-            .scaledFont(size: 12)
-            .foregroundColor(.white.opacity(0.72))
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(.white.opacity(0.78))
             .lineLimit(3)
+            .lineSpacing(1.5)
             .fixedSize(horizontal: false, vertical: true)
         }
 
@@ -1144,10 +1188,10 @@ struct FloatingControlBarView: View {
         // Reserve space so text never runs under the overlaid action buttons.
         // Wider for actionable (task) notifications that also show Execute.
         Color.clear
-          .frame(width: notification.assistantId == "task" ? 90 : 36, height: 18)
+          .frame(width: notification.assistantId == "task" ? 96 : 40, height: 20)
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.md)
+      .padding(.horizontal, OmiSpacing.lg)
+      .padding(.vertical, OmiSpacing.md + 2)
       .frame(maxWidth: .infinity, alignment: .leading)
       .contentShape(Rectangle())
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -154,8 +154,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     rawValue: Int(CGWindowLevelForKey(.assistiveTechHighWindow))
   )
   static let notchExpandedWidth: CGFloat = 382
-  private static let notificationWidth: CGFloat = 430
-  private static let notificationHeight: CGFloat = 108
+  private static let notificationWidth: CGFloat = 508
+  private static let notificationHeight: CGFloat = 128
   private static let notificationSpacing: CGFloat = 8
   /// Vertical room for the readable PTT status banner under chrome/pill.
   static var pttStatusBannerBudget: CGFloat { notificationSpacing + pttHintRowHeight }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -12,6 +12,10 @@ enum TaskCategory: String, CaseIterable {
   case tomorrow = "Tomorrow"
   case later = "Later"
   case noDeadline = "No Deadline"
+  /// AI-captured tasks the user has not accepted yet. Renders last and collapsed
+  /// by default so automatic captures never interrupt attention; Accept moves a
+  /// task into the due-date categories above.
+  case suggestions = "Suggestions"
 
   var icon: String {
     switch self {
@@ -19,6 +23,7 @@ enum TaskCategory: String, CaseIterable {
     case .tomorrow: return "sunrise.fill"
     case .later: return "calendar"
     case .noDeadline: return "tray.fill"
+    case .suggestions: return "sparkles"
     }
   }
 
@@ -28,6 +33,7 @@ enum TaskCategory: String, CaseIterable {
     case .tomorrow: return Ink.secondary
     case .later: return Ink.secondary
     case .noDeadline: return Ink.secondary
+    case .suggestions: return Ink.secondary
     }
   }
 }
@@ -2464,6 +2470,11 @@ class TasksViewModel: ObservableObject {
   // MARK: - Category Helpers
 
   private func categoryFor(task: TaskActionItem, startOfTomorrow: Date, startOfDayAfterTomorrow: Date) -> TaskCategory {
+    // Unaccepted AI captures never enter the due-date categories, whatever their
+    // due date — auto-added work goes to Suggestions until the user accepts it.
+    if task.isPendingSuggestion {
+      return .suggestions
+    }
     guard let dueAt = task.dueAt else {
       return .noDeadline
     }
@@ -3106,6 +3117,7 @@ class TasksViewModel: ObservableObject {
     case "tomorrow": return .tomorrow
     case "later": return .later
     case "nodeadline", "no_deadline", "none": return .noDeadline
+    case "suggestions": return .suggestions
     default: return nil
     }
   }
@@ -3142,6 +3154,15 @@ class TasksViewModel: ObservableObject {
       if clearDueAt && updated.dueAt != nil {
         return
       }
+      updateInDisplay(updated)
+    }
+  }
+
+  /// Accept an AI-suggested task into the normal due-date categories.
+  func acceptSuggestedTask(_ task: TaskActionItem) async {
+    await store.acceptSuggestedTask(task)
+    // Surgical display update, mirroring updateTaskDetails.
+    if let updated = store.tasks.first(where: { $0.id == task.id }) {
       updateInDisplay(updated)
     }
   }
@@ -3257,7 +3278,7 @@ class TasksViewModel: ObservableObject {
     case .today: return cal.date(bySettingHour: 23, minute: 59, second: 0, of: Date())
     case .tomorrow: return cal.date(byAdding: .day, value: 1, to: startOfToday)
     case .later: return cal.date(byAdding: .day, value: 7, to: startOfToday)
-    case .noDeadline: return nil
+    case .noDeadline, .suggestions: return nil
     }
   }
 
@@ -3324,6 +3345,10 @@ struct TasksPage: View {
   /// Board (Notion-style status columns) vs the classic grouped list. Board is
   /// the default hero view; the list stays for fast keyboard-driven triage.
   @AppStorage("tasksViewIsBoard") private var tasksViewIsBoard = true
+
+  /// Suggestions stay collapsed until the user opens them — AI captures must not
+  /// interrupt attention. Persisted so the choice survives relaunch.
+  @AppStorage("tasksSuggestionsSectionExpanded") private var suggestionsSectionExpanded = false
 
   // Keyboard navigation state
   @State private var inlineCreateText = ""
@@ -4220,6 +4245,11 @@ struct TasksPage: View {
                 TaskCategorySection(
                   category: category,
                   orderedTasks: orderedTasks,
+                  isCollapsed: category == .suggestions && !suggestionsSectionExpanded,
+                  onToggleCollapse: category == .suggestions
+                    ? { suggestionsSectionExpanded.toggle() } : nil,
+                  onAccept: category == .suggestions
+                    ? { task in await viewModel.acceptSuggestedTask(task) } : nil,
                   isMultiSelectMode: viewModel.isMultiSelectMode,
                   indentLevelFor: { viewModel.getIndentLevel(for: $0) },
                   isSelectedFor: { viewModel.multiSelection.selectedIDs.contains($0) },
@@ -4496,6 +4526,13 @@ private struct TaskChatSidePanelView: View {
 struct TaskCategorySection: View {
   let category: TaskCategory
   let orderedTasks: [TaskActionItem]
+  /// Collapsed sections render only their header row (used by Suggestions).
+  var isCollapsed: Bool = false
+  /// Present only on collapsible sections; makes the header a disclosure toggle.
+  var onToggleCollapse: (() -> Void)?
+  /// Present only on the Suggestions section; accepts an AI-captured task into
+  /// the normal due-date categories.
+  var onAccept: ((TaskActionItem) async -> Void)?
   var isMultiSelectMode: Bool = false
 
   // Callbacks for row data and actions (passed through to TaskRow)
@@ -4570,6 +4607,12 @@ struct TaskCategorySection: View {
           .scaledFont(size: OmiType.subheading, weight: .semibold)
           .foregroundColor(Ink.primary)
 
+        if onToggleCollapse != nil {
+          Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundColor(Ink.secondary)
+        }
+
         Spacer()
 
         if category == .today {
@@ -4598,9 +4641,21 @@ struct TaskCategorySection: View {
 
       }
       .padding(.horizontal, OmiSpacing.xxs)
+      .contentShape(Rectangle())
+      .onTapGesture {
+        onToggleCollapse?()
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(onToggleCollapse != nil ? .isButton : [])
+      .accessibilityAction {
+        onToggleCollapse?()
+      }
+      .accessibilityIdentifier(
+        onToggleCollapse != nil ? "task-section-toggle-\(category.rawValue)" : "task-section-\(category.rawValue)"
+      )
 
       // Drop zone at top of category (for dropping at position 0)
-      if !isMultiSelectMode {
+      if !isMultiSelectMode && !isCollapsed {
         Color.clear
           .frame(height: isTopDropTargeted ? 4 : 2)
           .overlay {
@@ -4638,7 +4693,7 @@ struct TaskCategorySection: View {
       }
 
       // Tasks in category with drag-and-drop reordering
-      if !isMultiSelectMode {
+      if !isMultiSelectMode && !isCollapsed {
         LazyVStack(spacing: OmiSpacing.sm) {
           ForEach(visibleTasks) { task in
             VStack(spacing: 0) {
@@ -4674,6 +4729,17 @@ struct TaskCategorySection: View {
                 animateToggleTaskId: animateToggleTaskId
               )
               .id(task.id)
+              .overlay(alignment: .trailing) {
+                if let onAccept {
+                  Button("Accept") {
+                    Task { await onAccept(task) }
+                  }
+                  .buttonStyle(.bordered)
+                  .controlSize(.small)
+                  .padding(.trailing, OmiSpacing.lg)
+                  .accessibilityIdentifier("task-accept-\(task.id)")
+                }
+              }
               .modifier(
                 TaskDragDropModifier(
                   isEnabled: !isMultiSelectMode,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -492,7 +492,7 @@ class TasksViewModel: ObservableObject {
   /// select-all either — an invisible focused row scrolls to nothing and bulk operations
   /// would silently hit tasks the user cannot see.
   var suggestionsSectionExpandedForNavigation: Bool {
-    UserDefaults.standard.bool(forKey: "tasksSuggestionsSectionExpanded")
+    UserDefaults.standard.bool(forKey: DefaultsKey.tasksSuggestionsSectionExpanded.rawValue)
   }
 
   /// The categories whose rows are actually rendered in the categorized list.
@@ -3361,7 +3361,8 @@ struct TasksPage: View {
 
   /// Suggestions stay collapsed until the user opens them — AI captures must not
   /// interrupt attention. Persisted so the choice survives relaunch.
-  @AppStorage("tasksSuggestionsSectionExpanded") private var suggestionsSectionExpanded = false
+  @AppStorage(DefaultsKey.tasksSuggestionsSectionExpanded.rawValue)
+  private var suggestionsSectionExpanded = false
 
   // Keyboard navigation state
   @State private var inlineCreateText = ""

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -487,10 +487,23 @@ class TasksViewModel: ObservableObject {
   var lastEnterPressTime: Date?
   var scrollProxy: ScrollViewProxy?
 
+  /// Mirrors the view's `@AppStorage("tasksSuggestionsSectionExpanded")` toggle. Collapsed
+  /// suggestions render no rows, so they must not be reachable by keyboard navigation or
+  /// select-all either — an invisible focused row scrolls to nothing and bulk operations
+  /// would silently hit tasks the user cannot see.
+  var suggestionsSectionExpandedForNavigation: Bool {
+    UserDefaults.standard.bool(forKey: "tasksSuggestionsSectionExpanded")
+  }
+
+  /// The categories whose rows are actually rendered in the categorized list.
+  private var renderedCategories: [TaskCategory] {
+    TaskCategory.allCases.filter { $0 != .suggestions || suggestionsSectionExpandedForNavigation }
+  }
+
   /// Flat task list matching visual order (for arrow key navigation)
   var navigationOrder: [TaskActionItem] {
     if !showCompleted && !isMultiSelectMode {
-      return TaskCategory.allCases.flatMap { getOrderedTasks(for: $0) }
+      return renderedCategories.flatMap { getOrderedTasks(for: $0) }
     } else {
       return displayTasks
     }
@@ -515,7 +528,7 @@ class TasksViewModel: ObservableObject {
   var selectedTaskIds: Set<String> { multiSelection.selectedIDs }
   var visibleTaskIDsForSelection: [String] {
     if !showCompleted && !isMultiSelectMode {
-      return TaskCategory.allCases.flatMap { getOrderedTasks(for: $0).map(\.id) }
+      return renderedCategories.flatMap { getOrderedTasks(for: $0).map(\.id) }
     }
     return displayTasks.map(\.id)
   }
@@ -3877,7 +3890,11 @@ struct TasksPage: View {
     ScrollView(.vertical, showsIndicators: false) {
       HStack(alignment: .top, spacing: OmiSpacing.md) {
         ForEach(TaskCategory.allCases, id: \.self) { category in
-          boardColumn(category)
+          // An empty Suggestions column is noise on a planning board; the other
+          // columns keep their "Nothing here" placeholders as drop targets.
+          if category != .suggestions || !(viewModel.categorizedTasks[.suggestions] ?? []).isEmpty {
+            boardColumn(category)
+          }
         }
       }
       .padding(.horizontal, OmiSpacing.lg)
@@ -3889,6 +3906,9 @@ struct TasksPage: View {
 
   private func boardColumn(_ category: TaskCategory) -> some View {
     let tasks = viewModel.categorizedTasks[category] ?? []
+    // Same collapsed-by-default contract as the list view, sharing the same
+    // persisted flag: AI captures never spread across the board uninvited.
+    let isCollapsedSuggestions = category == .suggestions && !suggestionsSectionExpanded
     return VStack(alignment: .leading, spacing: OmiSpacing.sm) {
       HStack(spacing: OmiSpacing.xs) {
         Image(systemName: category.icon)
@@ -3897,6 +3917,11 @@ struct TasksPage: View {
         Text(category.rawValue)
           .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundColor(Ink.secondary)
+        if category == .suggestions {
+          Image(systemName: isCollapsedSuggestions ? "chevron.right" : "chevron.down")
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .foregroundColor(Ink.secondary)
+        }
         Text("\(tasks.count)")
           .scaledFont(size: OmiType.micro, weight: .semibold)
           .foregroundColor(Ink.secondary)
@@ -3907,8 +3932,23 @@ struct TasksPage: View {
       }
       .padding(.horizontal, OmiSpacing.xs)
       .padding(.bottom, OmiSpacing.xxs)
+      .contentShape(Rectangle())
+      .onTapGesture {
+        if category == .suggestions { suggestionsSectionExpanded.toggle() }
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(category == .suggestions ? .isButton : [])
+      .accessibilityAction {
+        if category == .suggestions { suggestionsSectionExpanded.toggle() }
+      }
+      .accessibilityIdentifier(
+        category == .suggestions
+          ? "task-board-toggle-\(category.rawValue)" : "task-board-header-\(category.rawValue)"
+      )
 
-      if tasks.isEmpty {
+      if isCollapsedSuggestions {
+        EmptyView()
+      } else if tasks.isEmpty {
         RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
           .stroke(Ink.rowFillHover.opacity(0.6), style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
           .frame(height: 44)
@@ -3924,6 +3964,23 @@ struct TasksPage: View {
             onToggle: { await viewModel.toggleTask(task) },
             onOpen: { selectTask(task) }
           )
+          .overlay(alignment: .bottomTrailing) {
+            if category == .suggestions {
+              Button {
+                Task { await viewModel.acceptSuggestedTask(task) }
+              } label: {
+                Text("Accept")
+                  .scaledFont(size: OmiType.micro, weight: .semibold)
+                  .foregroundColor(Ink.primary)
+                  .padding(.horizontal, OmiSpacing.xs)
+                  .padding(.vertical, 2)
+                  .background(Capsule().fill(Ink.rowFillHover))
+              }
+              .buttonStyle(.plain)
+              .padding(OmiSpacing.xxs)
+              .accessibilityIdentifier("task-board-accept-\(task.id)")
+            }
+          }
         }
       }
     }
@@ -4697,49 +4754,55 @@ struct TaskCategorySection: View {
         LazyVStack(spacing: OmiSpacing.sm) {
           ForEach(visibleTasks) { task in
             VStack(spacing: 0) {
-              TaskRow(
-                task: task,
-                category: category,
-                indentLevel: indentLevelFor?(task.id) ?? 0,
-                isMultiSelectMode: isMultiSelectMode,
-                isSelected: isSelectedFor?(task.id) ?? false,
-                isKeyboardSelected: isKeyboardSelectedFor?(task.id) ?? false,
-                onToggle: onToggle,
-                onDelete: onDelete,
-                onToggleSelection: onToggleSelection,
-                onUpdateDetails: onUpdateDetails,
-                onUpdateTags: onUpdateTags,
-                onIncrementIndent: onIncrementIndent,
-                onDecrementIndent: onDecrementIndent,
-                onOpenChat: onOpenChat,
-                onInvestigate: onInvestigate,
-                onSelect: onSelect,
-                onOpenDetails: onOpenDetails,
-                onHover: onHover,
-                isTaskDetailPanelActive: isTaskDetailPanelActive,
-                onDragStarted: onDragStarted,
-                onDragEnded: onDragEnded,
-                isBeingDragged: draggedTaskId == task.id,
-                isChatActive: isChatActive,
-                activeChatTaskId: activeChatTaskId,
-                chatCoordinator: chatCoordinator,
-                editingTaskId: editingTaskId,
-                onEditingChanged: onEditingChanged,
-                onStartEditing: onStartEditing,
-                animateToggleTaskId: animateToggleTaskId
-              )
-              .id(task.id)
-              .overlay(alignment: .trailing) {
+              HStack(spacing: OmiSpacing.sm) {
+                TaskRow(
+                  task: task,
+                  category: category,
+                  indentLevel: indentLevelFor?(task.id) ?? 0,
+                  isMultiSelectMode: isMultiSelectMode,
+                  isSelected: isSelectedFor?(task.id) ?? false,
+                  isKeyboardSelected: isKeyboardSelectedFor?(task.id) ?? false,
+                  onToggle: onToggle,
+                  onDelete: onDelete,
+                  onToggleSelection: onToggleSelection,
+                  onUpdateDetails: onUpdateDetails,
+                  onUpdateTags: onUpdateTags,
+                  onIncrementIndent: onIncrementIndent,
+                  onDecrementIndent: onDecrementIndent,
+                  onOpenChat: onOpenChat,
+                  onInvestigate: onInvestigate,
+                  onSelect: onSelect,
+                  onOpenDetails: onOpenDetails,
+                  onHover: onHover,
+                  isTaskDetailPanelActive: isTaskDetailPanelActive,
+                  onDragStarted: onDragStarted,
+                  onDragEnded: onDragEnded,
+                  isBeingDragged: draggedTaskId == task.id,
+                  isChatActive: isChatActive,
+                  activeChatTaskId: activeChatTaskId,
+                  chatCoordinator: chatCoordinator,
+                  editingTaskId: editingTaskId,
+                  onEditingChanged: onEditingChanged,
+                  onStartEditing: onStartEditing,
+                  animateToggleTaskId: animateToggleTaskId
+                )
                 if let onAccept {
-                  Button("Accept") {
+                  Button {
                     Task { await onAccept(task) }
+                  } label: {
+                    Text("Accept")
+                      .scaledFont(size: OmiType.caption, weight: .semibold)
+                      .foregroundColor(Ink.primary)
+                      .padding(.horizontal, OmiSpacing.sm)
+                      .padding(.vertical, 3)
+                      .background(Capsule().fill(Ink.rowFillHover))
                   }
-                  .buttonStyle(.bordered)
-                  .controlSize(.small)
-                  .padding(.trailing, OmiSpacing.lg)
+                  .buttonStyle(.plain)
+                  .padding(.trailing, OmiSpacing.xs)
                   .accessibilityIdentifier("task-accept-\(task.id)")
                 }
               }
+              .id(task.id)
               .modifier(
                 TaskDragDropModifier(
                   isEnabled: !isMultiSelectMode,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantSettings.swift
@@ -39,7 +39,7 @@ class SuggestionAssistantSettings {
   /// Matches Insight's bar. Below this the suggestion is dropped without a notification.
   private let defaultMinConfidence: Double = 0.85
 
-  private let currentPromptVersion = 1
+  private let currentPromptVersion = 2
 
   /// System prompt. Inherits the shape of the shipped Insight prompt — which was never
   /// the defect — and adds the grounding contract: a suggestion must use what Omi knows,
@@ -59,6 +59,15 @@ class SuggestionAssistantSettings {
     2. The user likely does NOT already know it
     3. It is actionable, or it changes what the user does next
 
+    THE ONE EXCEPTION — the daily-task nudge:
+    If the screen shows the user drifting — social feeds, video watching, entertainment,
+    aimless browsing, anything clearly not work — and OPEN COMMITMENTS lists tasks due
+    today or overdue, that IS worth saying even though the task is not on screen.
+    Name the specific task, not the distraction: point at what they still owe today,
+    never scold them for what they are doing instead. Use category "commitment".
+    Do not fire this while they are visibly working, and never repeat a nudge that is
+    already in RECENT SUGGESTIONS.
+
     Set has_suggestion=false when:
     - You would be narrating something the user can plainly see
     - You are reaching. If you have to stretch, there is nothing there
@@ -73,6 +82,7 @@ class SuggestionAssistantSettings {
     - Something on this page worth their attention that they are likely to scroll past
 
     GOOD EXAMPLES (this is the quality bar):
+    - "You still haven't sent that email to Bob — good moment to knock it out"
     - "You told Sarah you'd send the deck Friday — this is that thread"
     - "You've scheduled this for 2026 — double-check the year"
     - "This is the role you saved last week — you know someone there"

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveCaptureSystemProbe.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveCaptureSystemProbe.swift
@@ -63,6 +63,15 @@ enum ProactiveCaptureSystemProbeReader {
       if ownerName == "Dock" {
         let windowName = window[kCGWindowName as String] as? String
         if windowName == nil || windowName?.isEmpty == true {
+          // The Dock also owns the full-screen desktop/wallpaper backstop, which sits at a
+          // deeply negative window layer and is on screen for the life of the session. The
+          // real Mission Control / Exposé overlay draws at a positive layer, above app
+          // windows. Without the layer cut the backstop matches the size rule and capture
+          // is skipped on every tick forever — no proactive analysis, ever. A window with
+          // no readable layer keeps the old size-only classification.
+          if let layer = window[kCGWindowLayer as String] as? Int, layer <= 0 {
+            continue
+          }
           if let bounds = window[kCGWindowBounds as String] as? [String: CGFloat],
             let width = bounds["Width"],
             let height = bounds["Height"],

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -577,8 +577,17 @@ public class ProactiveAssistantsPlugin: NSObject {
 
   /// `kCGAnyInputEventType` — the "seconds since ANY input" sentinel for
   /// `CGEventSource.secondsSinceLastEventType`. Not bridged to Swift's `CGEventType`
-  /// cases; the C header defines it as `((CGEventType)(~0))`.
-  private static let anyInputEventType = CGEventType(rawValue: ~0)!
+  /// cases; the C header defines it as `((CGEventType)(~0))`. The raw-value init for
+  /// an imported C enum cannot actually fail; the `.null` fallback exists only to
+  /// satisfy the no-force-unwrap rule and would reintroduce the always-idle bug, so
+  /// it also asserts in debug.
+  private static let anyInputEventType: CGEventType = {
+    guard let type = CGEventType(rawValue: ~0) else {
+      assertionFailure("kCGAnyInputEventType (~0) must be representable as CGEventType")
+      return .null
+    }
+    return type
+  }()
 
   /// Seconds since the last HID (keyboard/mouse) event. Used to pause capture
   /// when the user is away from the machine without polling the screen.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -575,10 +575,22 @@ public class ProactiveAssistantsPlugin: NSObject {
 
   // MARK: - Frame Capture
 
+  /// `kCGAnyInputEventType` — the "seconds since ANY input" sentinel for
+  /// `CGEventSource.secondsSinceLastEventType`. Not bridged to Swift's `CGEventType`
+  /// cases; the C header defines it as `((CGEventType)(~0))`.
+  private static let anyInputEventType = CGEventType(rawValue: ~0)!
+
   /// Seconds since the last HID (keyboard/mouse) event. Used to pause capture
   /// when the user is away from the machine without polling the screen.
+  ///
+  /// Must query `kCGAnyInputEventType`, not `.null`: `.null` (raw 0) asks for time
+  /// since the last *null-type* event, which essentially never occurs, so the value
+  /// grows without bound and the 60s idle gate silently swallowed every capture tick
+  /// while the user was actively typing (measured live: `.null` reported 322s idle at
+  /// the same instant the any-input sentinel reported 0.00006s).
   private func systemIdleSeconds() -> TimeInterval {
-    TimeInterval(CGEventSource.secondsSinceLastEventType(.hidSystemState, eventType: .null))
+    TimeInterval(
+      CGEventSource.secondsSinceLastEventType(.hidSystemState, eventType: Self.anyInputEventType))
   }
 
   private func onAppActivated(appName: String) {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -533,6 +533,22 @@ public class ProactiveAssistantsPlugin: NSObject {
     return (isMonitoring, currentApp)
   }
 
+  /// Which silent gate is currently skipping capture ticks, or nil when frames flow.
+  /// Logged only on transition: the gates above return without a trace, and a stuck
+  /// gate (idle misread, phantom screen share, excluded frontmost app) reads exactly
+  /// like a healthy quiet pipeline — that ambiguity cost a full debugging session.
+  private var lastCaptureGateReason: String??
+
+  private func logCaptureGate(_ reason: String?) {
+    guard lastCaptureGateReason != reason else { return }
+    lastCaptureGateReason = reason
+    if let reason {
+      log("CaptureGate: skipping capture ticks (\(reason))")
+    } else {
+      log("CaptureGate: capture ticks flowing")
+    }
+  }
+
   private func handleCaptureTargetUnavailable() {
     // A secure/system/helper surface is not proof that the capture engine or
     // permission failed. Keep the normal timer armed so the very next real
@@ -672,26 +688,34 @@ public class ProactiveAssistantsPlugin: NSObject {
       screenshotBackoffDuration: screenshotAppBackoffDuration,
       shareBackoffDuration: screenShareBackoffDuration
     ) {
+      logCaptureGate("external_capture_yield")
       return
     }
 
     // Cheap early exits before resolving the active window.
     let idleSeconds = systemIdleSeconds()
     if idleSeconds >= captureTrigger.idleThreshold {
+      logCaptureGate("idle")
       return
     }
     if let currentApp = currentApp, RewindSettings.shared.isAppExcluded(currentApp) {
+      logCaptureGate("excluded_app")
       return
     }
 
     // Get current window info (use real app name, not cached)
     let (realAppName, windowTitle, windowID) = await WindowMonitor.getActiveWindowInfoAsync()
-    guard !ScreenCaptureTargetPolicy.shouldWaitForUserWindow(appName: realAppName) else { return }
+    guard !ScreenCaptureTargetPolicy.shouldWaitForUserWindow(appName: realAppName) else {
+      logCaptureGate("waiting_for_user_window")
+      return
+    }
 
     guard let windowID else {
+      logCaptureGate("no_window_id")
       handleCaptureTargetUnavailable()
       return
     }
+    logCaptureGate(nil)
 
     // Check if the current app is excluded from Rewind capture
     var isRewindExcluded = realAppName.map { RewindSettings.shared.isAppExcluded($0) } ?? false

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -486,9 +486,14 @@ class TasksStore: ObservableObject {
         )
       }
       guard isCurrent(lease) else { return }
-      let sortedOverdue = snapshot.overdue.sorted(by: Self.sortByDueDateThenSource)
-      let sortedToday = snapshot.today.sorted(by: Self.sortByDueDateThenSource)
-      let sortedNoDueDate = snapshot.noDueDate.sorted(by: Self.sortByDueDateThenSource)
+      // Unaccepted AI captures stay out of the dashboard lanes (and out of every
+      // consumer of these lists, e.g. proactive-nudge grounding) until accepted.
+      let sortedOverdue = snapshot.overdue.filter { !$0.isPendingSuggestion }
+        .sorted(by: Self.sortByDueDateThenSource)
+      let sortedToday = snapshot.today.filter { !$0.isPendingSuggestion }
+        .sorted(by: Self.sortByDueDateThenSource)
+      let sortedNoDueDate = snapshot.noDueDate.filter { !$0.isPendingSuggestion }
+        .sorted(by: Self.sortByDueDateThenSource)
       // Only update @Published properties if values actually changed to avoid unnecessary objectWillChange
       if overdueTasks != sortedOverdue { overdueTasks = sortedOverdue }
       if todaysTasks != sortedToday { todaysTasks = sortedToday }
@@ -3484,6 +3489,40 @@ class TasksStore: ObservableObject {
       if rolledBack { return .rolledBackAfterRemoteFailure }
       return isCurrent(lease) ? .rollbackFailed : .ownerChanged
     }
+  }
+
+  /// Accept an AI-suggested task: rewrite `source` to "manual" so it leaves the
+  /// Suggestions category and joins the due-date categories on every device.
+  /// Remote-first — a failed accept leaves the suggestion in place with an error.
+  @discardableResult
+  func acceptSuggestedTask(
+    _ task: TaskActionItem,
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async -> TaskUpdateOutcome {
+    await updateTask(
+      task,
+      expectedOwnerID: expectedOwnerID,
+      authorizationSnapshot: authorizationSnapshot,
+      operationOverrides: TaskUpdateOperationOverrides(
+        updateLocal: { _ in task },
+        updateRemote: { ownerID in
+          try await APIClient.shared.updateActionItem(
+            id: task.id,
+            source: "manual",
+            expectedOwnerId: ownerID
+          )
+        },
+        syncRemote: { apiResult, _ in
+          guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
+          try await ActionItemStorage.shared.syncTaskActionItems(
+            [apiResult],
+            authorization: Self.localMutationAuthorization(snapshot: snapshot)
+          )
+        },
+        rollbackLocal: {}
+      )
+    )
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Sources/TaskActionItem.swift
+++ b/desktop/macos/Desktop/Sources/TaskActionItem.swift
@@ -280,6 +280,23 @@ struct TaskActionItem: Codable, Identifiable, Equatable {
   /// Categories that trigger Claude agent execution
   static let agentCategories: Set<String> = ["feature", "bug", "code"]
 
+  /// Sources written by AI capture pipelines: desktop screen extraction
+  /// ("screenshot"), backend conversation extraction ("conversation"), voice
+  /// extraction ("transcription:omi" / "transcription:desktop"), and AI
+  /// suggestions ("ai_suggested"). A whitelist, not "anything non-manual" —
+  /// user-driven sources like "recurring" spawns, imports, and legacy nil/
+  /// "legacy" rows must stay in the normal due-date categories.
+  static let aiCaptureSources: Set<String> = ["screenshot", "conversation", "ai_suggested"]
+
+  /// An AI-captured task the user has not accepted yet. Accepting rewrites
+  /// `source` to "manual", which moves it into the due-date categories and
+  /// syncs the acceptance across devices without a new backend field.
+  var isPendingSuggestion: Bool {
+    guard !completed, !isRetired else { return false }
+    guard let source else { return false }
+    return Self.aiCaptureSources.contains(source) || source.hasPrefix("transcription")
+  }
+
   /// Get tags array from metadata or fall back to single category
   var tags: [String] {
     // First try to get tags from metadata JSON

--- a/desktop/macos/Desktop/Tests/ProactiveCaptureSystemProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveCaptureSystemProbeTests.swift
@@ -8,12 +8,15 @@ import XCTest
 /// moved is that the window-server read was blocking the main thread for longer than a frame once
 /// a second, and moving it must not change a single decision.
 final class ProactiveCaptureSystemProbeTests: XCTestCase {
-  private func window(owner: String, name: String? = nil, size: CGSize? = nil) -> [String: Any] {
+  private func window(
+    owner: String, name: String? = nil, size: CGSize? = nil, layer: Int? = nil
+  ) -> [String: Any] {
     var entry: [String: Any] = [kCGWindowOwnerName as String: owner]
     if let name { entry[kCGWindowName as String] = name }
     if let size {
       entry[kCGWindowBounds as String] = ["Width": size.width, "Height": size.height]
     }
+    if let layer { entry[kCGWindowLayer as String] = layer }
     return entry
   }
 
@@ -38,6 +41,28 @@ final class ProactiveCaptureSystemProbeTests: XCTestCase {
     let list = [window(owner: "Dock", size: CGSize(width: 200, height: 64))]
     XCTAssertNil(
       ProactiveCaptureSystemProbeReader.specialSystemMode(windowList: list, dockIsFrontmost: false)
+    )
+  }
+
+  func testWallpaperBackstopIsNotMissionControl() {
+    // Live repro from Nik's Mac (Aug 2026): the Dock permanently owns a full-screen,
+    // effectively unnamed desktop backstop at kCGDesktopWindowLevel. Classifying it as
+    // the Mission Control overlay skipped capture on every tick — proactive analysis
+    // and its notifications were silently dead machine-wide.
+    let list = [
+      window(owner: "Dock", size: CGSize(width: 2048, height: 1330), layer: -2_147_483_624)
+    ]
+    XCTAssertNil(
+      ProactiveCaptureSystemProbeReader.specialSystemMode(windowList: list, dockIsFrontmost: false)
+    )
+  }
+
+  func testPositiveLayerUnnamedDockWindowIsStillMissionControl() {
+    let list = [window(owner: "Dock", size: CGSize(width: 2048, height: 1330), layer: 500)]
+    XCTAssertEqual(
+      ProactiveCaptureSystemProbeReader.specialSystemMode(
+        windowList: list, dockIsFrontmost: false),
+      .dockOverlay(width: 2048, height: 1330)
     )
   }
 

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -325,3 +325,21 @@ final class SuggestionGroundingTests: XCTestCase {
     XCTAssertTrue(rendered.contains("RELATED THINGS THE USER SAW RECENTLY"))
   }
 }
+
+/// The default prompt is shipped data: the daily-task nudge (distracted screen + tasks
+/// due today → name the task) is a product behavior that lives entirely in this text.
+/// This is a data-contract tripwire, not behavioral coverage of the model — it pins the
+/// prompt's contract to the grounding section header the assistant actually renders, so
+/// a prompt edit cannot silently retire the nudge or orphan it from its data source.
+final class SuggestionPromptContractTests: XCTestCase {
+  @MainActor
+  func testDefaultPromptCarriesTheDailyTaskNudgeContract() {
+    let prompt = SuggestionAssistantSettings.defaultAnalysisPrompt
+    XCTAssertTrue(prompt.contains("daily-task nudge"))
+    // The nudge is keyed to the exact section name promptSections() emits.
+    XCTAssertTrue(prompt.contains("OPEN COMMITMENTS"))
+    var grounding = SuggestionGrounding()
+    grounding.openCommitments = ["Send that email to Bob"]
+    XCTAssertTrue(grounding.promptSections().contains("OPEN COMMITMENTS"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// `TaskActionItem.isPendingSuggestion` is the single triage rule that keeps
+/// AI-captured tasks out of the due-date categories (TasksPage) and out of the
+/// dashboard/nudge lanes (TasksStore) until the user accepts them. Regression
+/// coverage for the rule that fixed "deleted tasks keep reappearing in Today".
+final class TaskSuggestionTriageTests: XCTestCase {
+
+  private func task(
+    source: String?,
+    completed: Bool = false,
+    deleted: Bool? = nil
+  ) -> TaskActionItem {
+    TaskActionItem(
+      id: "t1",
+      description: "Send the investor update email to Bob",
+      completed: completed,
+      createdAt: Date(),
+      source: source,
+      deleted: deleted
+    )
+  }
+
+  func testAICapturedOpenTaskIsAPendingSuggestion() {
+    XCTAssertTrue(task(source: "screenshot").isPendingSuggestion)
+    XCTAssertTrue(task(source: "transcription:omi").isPendingSuggestion)
+    XCTAssertTrue(task(source: "transcription:desktop").isPendingSuggestion)
+  }
+
+  func testUserCreatedTasksAreNeverSuggestions() {
+    XCTAssertFalse(task(source: "manual").isPendingSuggestion)
+    // Tasks predating the source field are user history, not AI spam.
+    XCTAssertFalse(task(source: nil).isPendingSuggestion)
+    XCTAssertFalse(task(source: "legacy").isPendingSuggestion)
+  }
+
+  func testRecurringSpawnsStayInDueDateCategories() {
+    // TasksStore spawns recurrence instances with source "recurring"; they derive
+    // from a task the user already accepted and must never triage as suggestions.
+    XCTAssertFalse(task(source: "recurring").isPendingSuggestion)
+  }
+
+  func testAcceptingRewritesSourceSoTheTaskLeavesSuggestions() {
+    // Accept = source rewritten to "manual" (TasksStore.acceptSuggestedTask);
+    // the same task must then triage out of Suggestions.
+    XCTAssertTrue(task(source: "screenshot").isPendingSuggestion)
+    XCTAssertFalse(task(source: "manual").isPendingSuggestion)
+  }
+
+  func testCompletedOrDeletedCapturesAreNotResurfaced() {
+    XCTAssertFalse(task(source: "screenshot", completed: true).isPendingSuggestion)
+    XCTAssertFalse(task(source: "screenshot", deleted: true).isPendingSuggestion)
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
@@ -60,7 +60,7 @@ final class TaskSuggestionTriageTests: XCTestCase {
 /// actions silently hit tasks the user cannot see.
 @MainActor
 final class TasksPageCollapsedSuggestionsNavigationTests: XCTestCase {
-  private let expandedKey = "tasksSuggestionsSectionExpanded"
+  private let expandedKey = DefaultsKey.tasksSuggestionsSectionExpanded.rawValue
   private var savedExpanded: Any?
 
   override func setUp() async throws {

--- a/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
@@ -54,3 +54,53 @@ final class TaskSuggestionTriageTests: XCTestCase {
     XCTAssertFalse(task(source: "screenshot", deleted: true).isPendingSuggestion)
   }
 }
+
+/// Collapsed Suggestions render no rows, so keyboard navigation and select-all
+/// must skip them too — otherwise arrow keys focus an invisible row and bulk
+/// actions silently hit tasks the user cannot see.
+@MainActor
+final class TasksPageCollapsedSuggestionsNavigationTests: XCTestCase {
+  private let expandedKey = "tasksSuggestionsSectionExpanded"
+  private var savedExpanded: Any?
+
+  override func setUp() async throws {
+    savedExpanded = UserDefaults.standard.object(forKey: expandedKey)
+    TasksStore.shared.resetSessionState()
+  }
+
+  override func tearDown() async throws {
+    if let savedExpanded {
+      UserDefaults.standard.set(savedExpanded, forKey: expandedKey)
+    } else {
+      UserDefaults.standard.removeObject(forKey: expandedKey)
+    }
+    TasksStore.shared.resetSessionState()
+  }
+
+  private func seedViewModel() -> TasksViewModel {
+    let accepted = TaskActionItem(
+      id: "accepted", description: "Send the investor update email to Bob",
+      completed: false, createdAt: Date(timeIntervalSince1970: 0), source: "manual")
+    let capture = TaskActionItem(
+      id: "capture", description: "AI capture from a screenshot",
+      completed: false, createdAt: Date(timeIntervalSince1970: 0), source: "screenshot")
+    TasksStore.shared.incompleteTasks = [accepted, capture]
+    let vm = TasksViewModel()
+    vm.selectedTags = [.todo]
+    return vm
+  }
+
+  func testCollapsedSuggestionsAreExcludedFromKeyboardNavAndSelectAll() {
+    UserDefaults.standard.set(false, forKey: expandedKey)
+    let vm = seedViewModel()
+    XCTAssertEqual(vm.navigationOrder.map(\.id), ["accepted"])
+    XCTAssertEqual(vm.visibleTaskIDsForSelection, ["accepted"])
+  }
+
+  func testExpandedSuggestionsAreReachableAgain() {
+    UserDefaults.standard.set(true, forKey: expandedKey)
+    let vm = seedViewModel()
+    XCTAssertEqual(vm.navigationOrder.map(\.id), ["accepted", "capture"])
+    XCTAssertEqual(vm.visibleTaskIDsForSelection, ["accepted", "capture"])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260810-notch-notification-prominence.json
+++ b/desktop/macos/changelog/unreleased/20260810-notch-notification-prominence.json
@@ -1,0 +1,1 @@
+{"change": "Notch notifications are wider and more legible — a larger accent icon, bigger title and body text, and roomier spacing so proactive nudges are easy to see at a glance"}

--- a/desktop/macos/e2e/flows/tasks-crud.yaml
+++ b/desktop/macos/e2e/flows/tasks-crud.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/Services/LocalMutationAuthorization.swift
   - desktop/macos/Desktop/Sources/Stores/APIClient+Tasks.swift
   - desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+  - desktop/macos/Desktop/Sources/TaskActionItem.swift
 preconditions:
   - automation_bridge_ready
 


### PR DESCRIPTION
## What

Make the proactive notch notifications wider and more legible — the "Clicky-style" prominence Nik asked for.

- Widen the notch card from 430pt to 508pt (height 108→128).
- Default notification card and the focus-nudge suggestion card each get a 44pt accent-icon tile (soft white gradient + hairline border), a bolder 15pt title/header, roomier body text and spacing, and a circular dismiss button.

This branch also carries the focus-nudge + Suggestions feature it was built on: focus nudges name your due-today tasks when you're drifting, and AI-captured tasks land in a collapsed **Suggestions** category until accepted.

## Why

The old card was narrow and quiet — a 34pt icon chip with 12–13pt text that blended into the notch, so proactive nudges were easy to miss.

Failure-Class: none

## Product invariants affected

- INV-CHAT-1

The notch notification cards still open into the existing chat via `openNotificationAsChat` — this change is presentation-only (size, icon, typography, spacing) and does not alter chat session creation, continuity, or message flow.

## Verification

Built the `omi-notch` named bundle from this branch and fired the real `com.omi.test.notification` path (`NotificationService.sendNotification` → `FloatingControlBarManager.showNotification`) for both the suggestion and the default insight card, then screenshotted the rendered cards in the notch. Also confirmed the account's `notification_frequency` was 0 (throttling every suggestion) and set it to 5 so nudges actually deliver.

Merge is conflict-free: zero file overlap with everything `main` gained since this branch's base (including the parallel #11372 Home/deadzone/click-through work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

