### PR TITLE
chore(desktop): changelog fragment for task nudges, Suggestions, and the capture fixes

### DIFF
--- a/desktop/macos/changelog/unreleased/20260810-task-nudges-and-suggestions.json
+++ b/desktop/macos/changelog/unreleased/20260810-task-nudges-and-suggestions.json
@@ -1,0 +1,3 @@
+{
+  "change": "Focus nudges now name your due-today tasks when you're drifting, AI-captured tasks wait in a collapsed Suggestions section until you accept them, and two capture bugs that silently disabled all proactive notifications (phantom Mission Control, phantom idle) are fixed"
+}


### PR DESCRIPTION
PR #11378 merged the task-aware focus nudges, the collapsed Suggestions task category, and the two proactive-capture fixes (phantom Mission Control from the Dock wallpaper backstop; phantom idle from the .null event-type sentinel), but its only changelog fragment covered the notch-card redesign. This adds the missing user-facing entry so the release notes describe what actually shipped.

Docs-only: one JSON fragment under desktop/macos/changelog/unreleased/.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

