### PR TITLE
fix(release): train throttle reads candidate publication time, not commit time

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -347,6 +347,41 @@ def github_candidate_release_published(repository: str, tag: str) -> tuple[bool 
     return release.get("isDraft") is False and isinstance(release.get("publishedAt"), str), None
 
 
+def candidate_publication_age_seconds(repository: str, tag: str) -> int | None:
+    """Age of the candidate's GitHub release, the hourly train's throttle clock.
+
+    Candidate tags are lightweight, so no local timestamp records when the tag
+    was CREATED — `git log --format=%ct <tag>` reads the tagged COMMIT's time,
+    and a tag pushed minutes ago onto an older commit would defeat the
+    throttle entirely. The release's createdAt is the authoritative
+    publication clock. No release yet means the candidate is still building
+    (the one-active-release fence owns that) or its build failed (the train
+    SHOULD cut a replacement), so the throttle deliberately stands aside.
+    """
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repository, "--json", "tagName,createdAt"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        release = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(release, dict) or release.get("tagName") != tag:
+        return None
+    created_at = release.get("createdAt")
+    if not isinstance(created_at, str):
+        return None
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0, int(time.time() - created.timestamp()))
+
+
 def normal_candidate_lifecycle(repository: str, source_sha: str, tag: str) -> tuple[str, str]:
     """Return the tag-triggered candidate lifecycle without mutating it."""
     status, conclusion, error = codemagic_check_status(repository, source_sha)
@@ -497,21 +532,22 @@ def main() -> int:
         )
 
     latest_tag = latest_desktop_tag()
-    changes = releasable_desktop_changes_since(latest_tag)
     set_output("latest_tag", latest_tag or "")
 
     if args.min_tag_interval_seconds > 0 and latest_tag is not None:
-        latest_tag_age = tag_age_seconds(latest_tag)
-        if latest_tag_age is not None and latest_tag_age < args.min_tag_interval_seconds:
-            remaining = args.min_tag_interval_seconds - latest_tag_age
+        latest_candidate_age = candidate_publication_age_seconds(args.repository, latest_tag)
+        if latest_candidate_age is not None and latest_candidate_age < args.min_tag_interval_seconds:
+            remaining = args.min_tag_interval_seconds - latest_candidate_age
             set_output("source_sha", "")
             set_output("should_release", "false")
             set_output(
                 "reason",
-                f"Hourly release train: latest tag {latest_tag} is {latest_tag_age}s old; "
+                f"Hourly release train: candidate {latest_tag} published {latest_candidate_age}s ago; "
                 f"next candidate in {remaining}s.",
             )
             return 0
+
+    changes = releasable_desktop_changes_since(latest_tag)
 
     if not changes:
         set_output("source_sha", "")

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
@@ -569,12 +570,12 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
             workflow,
         )
 
-    def test_hourly_train_defers_while_the_latest_tag_is_young(self) -> None:
+    def test_hourly_train_defers_while_the_latest_candidate_is_young(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "github-output"
             with (
                 patch.object(planner, "latest_desktop_tag", return_value=LATEST_TAG),
-                patch.object(planner, "tag_age_seconds", return_value=120),
+                patch.object(planner, "candidate_publication_age_seconds", return_value=120),
                 patch.object(planner, "releasable_desktop_changes_since") as changes,
                 patch.object(
                     sys,
@@ -586,17 +587,74 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
                 self.assertEqual(planner.main(), 0)
             outputs = output_path.read_text(encoding="utf-8")
 
+        changes.assert_not_called()
         self.assertIn("should_release=false", outputs)
         self.assertIn("Hourly release train", outputs)
 
-    def test_manual_dispatch_ignores_the_train_interval(self) -> None:
-        # --min-tag-interval-seconds defaults to 0: a fresh tag never defers a
-        # deliberate dispatch.
+    def test_train_throttle_reads_release_publication_time_not_commit_time(self) -> None:
+        # Candidate tags are lightweight: a tag pushed minutes ago onto an old
+        # commit has an old `git log --format=%ct` answer, which would defeat
+        # the throttle. The clock is the release's createdAt, and the commit
+        # time must never be consulted.
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "github-output"
+            release_json = json.dumps(
+                {
+                    "tagName": LATEST_TAG,
+                    "createdAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                }
+            )
+            completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=release_json, stderr="")
+            with (
+                patch.object(planner, "latest_desktop_tag", return_value=LATEST_TAG),
+                patch.object(planner.subprocess, "run", return_value=completed),
+                patch.object(planner, "tag_age_seconds") as commit_age,
+                patch.object(planner, "releasable_desktop_changes_since") as changes,
+                patch.object(
+                    sys,
+                    "argv",
+                    [str(SCRIPT), "--repository", REPOSITORY, "--min-tag-interval-seconds", "3300"],
+                ),
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+            ):
+                self.assertEqual(planner.main(), 0)
+            outputs = output_path.read_text(encoding="utf-8")
+
+        commit_age.assert_not_called()
+        changes.assert_not_called()
+        self.assertIn("should_release=false", outputs)
+        self.assertIn("Hourly release train", outputs)
+
+    def test_train_throttle_stands_aside_when_the_candidate_has_no_release(self) -> None:
+        # No release for the latest tag = build in flight (the one-active-release
+        # fence owns it) or a failed build the train should replace.
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "github-output"
             with (
                 patch.object(planner, "latest_desktop_tag", return_value=LATEST_TAG),
-                patch.object(planner, "tag_age_seconds", return_value=1) as age,
+                patch.object(planner, "candidate_publication_age_seconds", return_value=None),
+                patch.object(planner, "releasable_desktop_changes_since", return_value=[]),
+                patch.object(
+                    sys,
+                    "argv",
+                    [str(SCRIPT), "--repository", REPOSITORY, "--min-tag-interval-seconds", "3300"],
+                ),
+                patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),
+            ):
+                self.assertEqual(planner.main(), 0)
+            outputs = output_path.read_text(encoding="utf-8")
+
+        self.assertNotIn("Hourly release train", outputs)
+        self.assertIn("No releasable desktop app changes", outputs)
+
+    def test_manual_dispatch_ignores_the_train_interval(self) -> None:
+        # --min-tag-interval-seconds defaults to 0: a fresh candidate never
+        # defers a deliberate dispatch.
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "github-output"
+            with (
+                patch.object(planner, "latest_desktop_tag", return_value=LATEST_TAG),
+                patch.object(planner, "candidate_publication_age_seconds", return_value=1) as age,
                 patch.object(planner, "releasable_desktop_changes_since", return_value=[]),
                 patch.object(sys, "argv", [str(SCRIPT), "--repository", REPOSITORY]),
                 patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_path)}, clear=False),


### PR DESCRIPTION
## Summary

Cross-review of #11381 caught a real defect: the hourly-train throttle read `git log --format=%ct <tag>` — the tagged COMMIT's time — and candidate tags are lightweight, so a tag pushed minutes ago onto an older commit looked hours old and bypassed the throttle.

The throttle clock is now the candidate release's `createdAt` (the authoritative publication time, from `gh release view`). A tag with no release deliberately stands aside: in-flight builds are owned by the one-active-release fence, and a failed build is exactly what the train should replace. The deferral check also moved ahead of the diff scan.

## Product invariants affected

- INV-BETA-1

## Verification

- `test_plan_desktop_release.py` 25/25 — new regression test constructs a fresh release on an old commit and asserts `tag_age_seconds` (commit time) is never consulted; a second test covers the no-release stand-aside.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

