### PR TITLE
fix(desktop): chat-first shell wires the Activity tab rewind route

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -190,7 +190,10 @@ struct ChatFirstShell: View {
         viewModelContainer: viewModelContainer,
         memoriesViewModel: viewModelContainer.memoriesViewModel,
         destinationRawValue: $memoryDestinationRawValue,
-        onSelectDestination: selectHubDestination
+        onSelectDestination: selectHubDestination,
+        // The Activity spine's screenshot rows leave for Rewind through the
+        // shell that owns the route — without this the rows are inert here.
+        onOpenRewind: { navigation.selectMore(.rewind) }
       )
       .accessibilityIdentifier("chat-first-route-memories")
       .onAppear { navigation.markRouteVisible(.memories) }


### PR DESCRIPTION
Cross-review of the release-train PRs caught that `ChatFirstShell` mounts `MemoryHubPage` without `onOpenRewind`, leaving the new Activity tab's screenshot rows inert on the chat-first cohort surface. One-line closure routing through the shell's existing `navigation.selectMore(.rewind)` (the same call its More→Rewind pill uses at ChatFirstShell.swift:57).

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

## Verification

- Focused suite 126/126: ChatFirstDestinationParityTests, MemoryHubSidebarRoutingTests, QueryShellTests, TopNavigationBarLayoutTests, FloatingBarGeometryTests, ShellWindowChromeTests, ShellSummonTests (`--disable-sandbox -c debug`).
- Debug build compiles (40s incremental).
- UNVERIFIED by click: the chat-first cohort surface is sampled and not enabled on the local test bundle; the closure is call-parity with the shell's existing More→Rewind pill route.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

