### PR TITLE
fix(desktop): home_close_panel collapses the modern Home again

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -217,6 +217,14 @@ struct QueryShellHome: View {
       guard !usesLegacyPresentation else { return }
       claimCaret()
     }
+    // `home_close_panel` collapses Home to its resting chat state — the same thing Escape does.
+    // The bridge action posts this and reports success, so an unobserved notification here would
+    // be the "bridge answered ok and nothing happened" defect this file's actions exist to avoid.
+    .onReceive(NotificationCenter.default.publisher(for: .homeStageClose)) { _ in
+      guard !usesLegacyPresentation else { return }
+      searchText = ""
+      claimCaret()
+    }
     .onReceive(NotificationCenter.default.publisher(for: .homeStageAsk)) { note in
       guard !usesLegacyPresentation, let query = note.userInfo?["query"] as? String else { return }
       chatProvider.draftText = query

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -74,6 +74,26 @@ final class QueryShellTests: XCTestCase {
     XCTAssertEqual(QueryComposerPlacement.of(QueryShellMode.homeDefault), .panelFooter)
   }
 
+  /// **Every `homeStage*` notification the bridge posts has an observer on the modern surface.**
+  /// The `home_close_panel` action posts `.homeStageClose` and reports success to the caller, so an
+  /// unobserved notification is a bridge action that silently does nothing — the defect the home
+  /// automation entry points exist to avoid (it shipped once: the modern surface dropped its
+  /// `.homeStageClose` handler while the registry kept answering "ok").
+  func testEveryBridgeHomeStageNotificationIsObservedByTheModernSurface() throws {
+    // omi-test-quality: source-inspection -- static contract: SwiftUI @State/onReceive wiring cannot be driven hermetically without mounting the view; pins the registration sites for the bridge's four homeStage notifications.
+    let source = try String(
+      contentsOf: URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // Tests/
+        .deletingLastPathComponent()  // Desktop/
+        .appendingPathComponent("Sources/MainWindow/QueryShell/QueryShellHome.swift"),
+      encoding: .utf8)
+    for name in ["homeStageOpenChat", "homeStageClose", "homeStageAsk", "homeStageAttach"] {
+      XCTAssertTrue(
+        source.contains("publisher(for: .\(name))"),
+        "QueryShellHome no longer observes .\(name); its bridge action now succeeds while doing nothing")
+    }
+  }
+
   // MARK: - Where the composer stands
 
   /// **A chat you have opened is not searching.** The field belongs above the rows it filters and


### PR DESCRIPTION
Cross-review caught that `QueryShellHome` no longer observes `.homeStageClose`, so the `home_close_panel` bridge action posted an unobserved notification and reported success — the exact silent-no-op defect the home automation entry points exist to avoid. Close now clears the search text (identical collapse to Escape: derived mode returns to the resting chat), and an annotated source-inspection tripwire pins the registration sites of all four `homeStage*` notifications so a future drop reddens CI instead of shipping.

## Product invariants affected

- INV-CHAT-1

## Verification

- QueryShellTests 38/38 (`--disable-sandbox -c debug`); `check_desktop_test_quality.py` at baseline (annotated tripwire, no ratchet growth).
- Live bridge exercise on the rebuilt bundle follows in-session (home_close_panel → home rests on chat).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

