### PR TITLE
feat(desktop): focus nudges that name the real task, in plain language

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/AuthService.swift": 2844,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4547,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4560,
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1516,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1528,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1590
@@ -10,7 +10,7 @@
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls. +32 keeps the durable accepted-deletion cleanup journal and owner-bound VM/sync drain inside the fenced sign-out commit so cleanup resumes after restart and credentials or owner visibility cannot change first (SCA-280).",
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": "Connector form automation remains in the owning desktop integration boundary so explicit user actions can complete the provider flow without duplicating browser/session state.",
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "debug_hit_probe diagnostic action (topmost window + hit-tested view at a screen point) registers beside the other non-prod debug actions; it found the notch click-sink dead zone.",
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "probe_suggestion_nudge registration: the suggestion delivery path cannot otherwise be exercised without holding a leisure window frontmost for 30s, which takes the user's focus; action registrations must live in this file's registry.",
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": "Adds the bounded shared-capture silent-microphone terminal incident so a persistent zero-sample CoreAudio route is queryable without recording sensitive content. +1 registers account-cutover retained-control fallback telemetry in the existing bounded diagnostic area.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Separates MCP data serving from production OAuth/grant authority so Beta can use dev data endpoints without issuing or reading customer grants through the dev identity plane. Pinned swift-format normalizes line layout without changing runtime behavior, and cloudOAuthGrantClientIDs keep ChatGPT directory grants on the production client for dev/Beta builds.",
     "desktop/macos/Desktop/Sources/OmiApp.swift": "UserDefaults.didChangeNotification observer must document and implement the queue:nil + explicit-main-hop contract (synchronous main-queue delivery deadlocked the signed-out launch, #11396)."

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1010,6 +1010,19 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "probe_suggestion_nudge",
+      summary: "Run the real suggestion grounding/evaluation/delivery path on the latest frame",
+      params: ["app", "window_title"]
+    ) { params in
+      let app = params["app"].flatMap { $0.isEmpty ? nil : $0 }
+      let title = params["window_title"].flatMap { $0.isEmpty ? nil : $0 }
+      return await ProactiveAssistantsPlugin.shared.probeSuggestionNudge(
+        appOverride: app,
+        windowTitleOverride: title
+      )
+    }
+
+    register(
       name: "set_contextual_task_focus",
       summary: "Set deterministic focus suppression for contextual task interruptions",
       params: ["suppressed"]

--- a/desktop/macos/Desktop/Sources/ModelQoS.swift
+++ b/desktop/macos/Desktop/Sources/ModelQoS.swift
@@ -85,13 +85,16 @@ struct ModelQoS {
       }
     }
 
-    /// Insight generation
-    static var insight: String {
-      switch activeTier {
-      case .premium: return "gemini-2.5-flash"
-      case .max: return "gemini-2.5-pro"
-      }
-    }
+    /// Insight generation.
+    ///
+    /// Pro on both tiers, deliberately. Insight ran on `gemini-pro-latest` for everyone until
+    /// this dropped to Flash at the premium tier, and the click-through fell with it: 2.34%
+    /// in the week of 2026-04-12 (39.8k sent, 336 distinct clickers) against 0.7–0.96%
+    /// through July. Unlike the other proactive assistants this one is cheap to run well —
+    /// a 10-minute timer caps it at ~6 analyses/hour no matter how much the user switches
+    /// windows — and its whole job is finding the one non-obvious thing, which is exactly
+    /// where the weaker model stops earning its interruption.
+    static var insight: String { "gemini-2.5-pro" }
 
     /// Live notch suggestions.
     ///

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -108,7 +108,9 @@ actor SuggestionAssistant: ProactiveAssistant {
     pendingContextSwitchAt = SuggestionDwellAnchor.anchor(
       current: pendingContextSwitchAt,
       currentApp: pendingApp,
+      currentWindowTitle: pendingWindowTitle,
       newApp: newApp,
+      newWindowTitle: newWindowTitle,
       now: Date()
     )
     pendingApp = newApp
@@ -267,12 +269,6 @@ actor SuggestionAssistant: ProactiveAssistant {
 
   /// Describe a commitment the way a person would say it out loud.
   ///
-  /// This string is what the model quotes, so an absolute date here comes back out in the
-  /// card as "call dad (due 2026-08-10)" — a database row read aloud. Worse, the raw
-  /// `ISO8601DateFormatter` rendered in UTC, so anything due after 8pm Eastern printed as
-  /// *tomorrow*; the model then scored a due-today task as not-yet-urgent and it fell under
-  /// the confidence bar. Relative phrasing fixes the voice and the timezone in one move,
-  /// and it is what the model actually needs — it reasons about urgency, not calendars.
   /// Fire-and-forget goal refresh. Never awaited by grounding: the next evaluation gets the
   /// fresher list, this one is not delayed for it.
   ///
@@ -332,6 +328,14 @@ actor SuggestionAssistant: ProactiveAssistant {
     return cachedGoals
   }
 
+  /// Describe a commitment the way a person would say it out loud.
+  ///
+  /// This string is what the model quotes, so an absolute date here comes back out in the
+  /// card as "call dad (due 2026-08-10)" — a database row read aloud. Worse, the raw
+  /// `ISO8601DateFormatter` rendered in UTC, so anything due after 8pm Eastern printed as
+  /// *tomorrow*; the model then scored a due-today task as not-yet-urgent and it fell under
+  /// the confidence bar. Relative phrasing fixes the voice and the timezone in one move,
+  /// and it is what the model actually needs — it reasons about urgency, not calendars.
   private static func describeCommitment(_ task: TaskActionItem) -> String {
     guard let dueAt = task.dueAt else { return task.description }
     return "\(task.description) — \(SuggestionDueDescription.phrase(for: dueAt))"

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -63,6 +63,21 @@ actor SuggestionAssistant: ProactiveAssistant {
   private var recentSuggestions: [String] = []
   private let maxRecentSuggestions = 10
 
+  /// The commitments handed to the evaluation currently in flight, kept so delivery can
+  /// hold a `commitment` nudge to what the model was actually shown.
+  private var commitmentsInFlight: [String] = []
+
+  /// Goals, cached because grounding must stay off the network — a fetch on this path would
+  /// blow through the window in which a suggestion is still about the current screen. A
+  /// stale-but-present list is worth far more here than a fresh one that arrives late.
+  private var cachedGoals: [String] = []
+  /// The authorization the cached goals were fetched under. Revalidated at read time, not
+  /// just at write time: an account switch between the fetch and the next evaluation must
+  /// not put one user's goals in another user's prompt.
+  private var cachedGoalsSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  private var lastGoalsRefresh = Date.distantPast
+  private let goalsRefreshInterval: TimeInterval = 600
+
   private var cooldownInterval: TimeInterval {
     get async { await MainActor.run { SuggestionAssistantSettings.shared.cooldownInterval } }
   }
@@ -90,7 +105,12 @@ actor SuggestionAssistant: ProactiveAssistant {
   // MARK: - Trigger
 
   func onContextSwitch(departingFrame: CapturedFrame?, newApp: String, newWindowTitle: String?) async {
-    pendingContextSwitchAt = Date()
+    pendingContextSwitchAt = SuggestionDwellAnchor.anchor(
+      current: pendingContextSwitchAt,
+      currentApp: pendingApp,
+      newApp: newApp,
+      now: Date()
+    )
     pendingApp = newApp
     pendingWindowTitle = newWindowTitle
   }
@@ -161,6 +181,7 @@ actor SuggestionAssistant: ProactiveAssistant {
     clearPendingContext()
     lastEvaluationAt = now
     dailyBudget.recordEvaluation(now: now)
+    commitmentsInFlight = grounding.openCommitments
 
     do {
       return try await evaluate(frame: frame, grounding: grounding)
@@ -199,6 +220,8 @@ actor SuggestionAssistant: ProactiveAssistant {
         .map(Self.describeCommitment)
     }
     grounding.openCommitments = Array(alwaysRelevant)
+    grounding.goals = currentOwnerGoals()
+    refreshGoalsIfStale()
 
     // The window title is the topic or person the user is looking at. Without it there is
     // nothing to scope a search by, so the context-specific sources are skipped entirely
@@ -242,11 +265,76 @@ actor SuggestionAssistant: ProactiveAssistant {
     return grounding
   }
 
+  /// Describe a commitment the way a person would say it out loud.
+  ///
+  /// This string is what the model quotes, so an absolute date here comes back out in the
+  /// card as "call dad (due 2026-08-10)" — a database row read aloud. Worse, the raw
+  /// `ISO8601DateFormatter` rendered in UTC, so anything due after 8pm Eastern printed as
+  /// *tomorrow*; the model then scored a due-today task as not-yet-urgent and it fell under
+  /// the confidence bar. Relative phrasing fixes the voice and the timezone in one move,
+  /// and it is what the model actually needs — it reasons about urgency, not calendars.
+  /// Fire-and-forget goal refresh. Never awaited by grounding: the next evaluation gets the
+  /// fresher list, this one is not delayed for it.
+  ///
+  /// Owner-scoped end to end. Goals are personal, and `getGoals()` documents that its
+  /// short-lived shared cache is **not** owner-validated — an unsnapshotted call can hand
+  /// back the previous account's goals, which would then sit in this cache and be pasted
+  /// into the next owner's prompt for up to `goalsRefreshInterval`. So: capture a snapshot,
+  /// fetch under it, and store only if that authorization is still current on arrival.
+  private func refreshGoalsIfStale() {
+    guard Date().timeIntervalSince(lastGoalsRefresh) >= goalsRefreshInterval else { return }
+    guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
+      cachedGoals = []
+      cachedGoalsSnapshot = nil
+      return
+    }
+    lastGoalsRefresh = Date()
+    Task { [weak self] in
+      do {
+        let goals = try await APIClient.shared.getGoals(authorizationSnapshot: snapshot)
+        let titles = goals.compactMap { goal -> String? in
+          let title = goal.title.trimmingCharacters(in: .whitespacesAndNewlines)
+          return title.isEmpty ? nil : title
+        }
+        await self?.storeGoals(titles, snapshot: snapshot)
+      } catch {
+        logError("Suggestion: goal grounding unavailable", error: error)
+      }
+    }
+  }
+
+  /// Drop the result outright if the account changed while the fetch was in flight.
+  private func storeGoals(_ goals: [String], snapshot: RuntimeOwnerAuthorizationSnapshot) {
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(snapshot) else {
+      cachedGoals = []
+      cachedGoalsSnapshot = nil
+      lastGoalsRefresh = .distantPast
+      log("Suggestion: dropped goal grounding from a superseded owner")
+      return
+    }
+    cachedGoals = goals
+    cachedGoalsSnapshot = snapshot
+  }
+
+  /// Cached goals, but only if they still belong to whoever is signed in right now.
+  private func currentOwnerGoals() -> [String] {
+    guard let snapshot = cachedGoalsSnapshot,
+      RuntimeOwnerIdentity.isAuthorizationCurrent(snapshot)
+    else {
+      if !cachedGoals.isEmpty {
+        log("Suggestion: discarded cached goals after an owner change")
+      }
+      cachedGoals = []
+      cachedGoalsSnapshot = nil
+      lastGoalsRefresh = .distantPast
+      return []
+    }
+    return cachedGoals
+  }
+
   private static func describeCommitment(_ task: TaskActionItem) -> String {
     guard let dueAt = task.dueAt else { return task.description }
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    return "\(task.description) (due \(formatter.string(from: dueAt)))"
+    return "\(task.description) — \(SuggestionDueDescription.phrase(for: dueAt))"
   }
 
   /// One line per past screen: when, where, and a snippet of what was on it.
@@ -389,37 +477,70 @@ actor SuggestionAssistant: ProactiveAssistant {
   // MARK: - Delivery
 
   func handleResult(_ result: AssistantResult, sendEvent: @escaping @Sendable (String, [String: Any]) -> Void) async {
-    guard let result = result as? SuggestionResult else { return }
+    _ = await resolveDelivery(result, sendEvent: sendEvent)
+  }
+
+  /// Runs the delivery decision and reports what actually happened.
+  ///
+  /// The return value exists because "the model produced a suggestion" and "the user saw a
+  /// card" are different claims. A probe that reports the former as success will call the
+  /// delivery path verified while the confidence bar, dedup, or the commitment guard was
+  /// silently dropping every card.
+  @discardableResult
+  private func resolveDelivery(
+    _ result: AssistantResult,
+    sendEvent: @escaping @Sendable (String, [String: Any]) -> Void
+  ) async -> SuggestionAssistantTelemetry.DeliveryOutcome? {
+    guard let result = result as? SuggestionResult else { return nil }
     guard result.hasSuggestion, let suggestion = result.suggestion else {
       log("Suggestion: nothing worth saying — \(result.currentActivity)")
-      return
+      return nil
     }
     let telemetryIdentity = SuggestionAssistantTelemetry.NotificationIdentity(result.telemetryIdentity)
-
-    guard let ownerID = RuntimeOwnerIdentity.currentOwnerId() else {
-      await emitDeliveryOutcome(.rejectedOwner, identity: telemetryIdentity)
-      return
-    }
-
+    let ownerID = RuntimeOwnerIdentity.currentOwnerId()
     let threshold = await minConfidence
-    guard suggestion.confidence >= threshold else {
-      await emitDeliveryOutcome(.filteredLowConfidence, identity: telemetryIdentity)
-      log(
-        "Suggestion: below bar [\(Int(suggestion.confidence * 100))% < \(Int(threshold * 100))%] "
-          + "\"\(suggestion.suggestion)\""
-      )
-      return
-    }
 
-    guard !SuggestionDeduplication.isDuplicate(suggestion.suggestion, of: recentSuggestions) else {
+    let outcome = SuggestionDeliveryPolicy.decide(
+      hasOwner: ownerID != nil,
+      confidence: suggestion.confidence,
+      threshold: threshold,
+      isDuplicate: SuggestionDeduplication.isDuplicate(suggestion.suggestion, of: recentSuggestions),
+      isGroundedCommitment: SuggestionCommitmentGuard.isGrounded(
+        suggestion: suggestion.suggestion,
+        category: suggestion.category,
+        openCommitments: commitmentsInFlight
+      )
+    )
+
+    let percent = Int(suggestion.confidence * 100)
+    switch outcome {
+    case .rejectedOwner:
+      await emitDeliveryOutcome(.rejectedOwner, identity: telemetryIdentity)
+      return outcome
+    case .filteredLowConfidence:
+      await emitDeliveryOutcome(.filteredLowConfidence, identity: telemetryIdentity)
+      log("Suggestion: below bar [\(percent)% < \(Int(threshold * 100))%] \"\(suggestion.suggestion)\"")
+      return outcome
+    case .filteredDuplicate:
       await emitDeliveryOutcome(.filteredDuplicate, identity: telemetryIdentity)
       log("Suggestion: duplicate of a recent suggestion — \"\(suggestion.suggestion)\"")
-      return
+      return outcome
+    case .filteredUngroundedCommitment:
+      await emitDeliveryOutcome(.filteredUngroundedCommitment, identity: telemetryIdentity)
+      log(
+        "Suggestion: ungrounded commitment [\(percent)%] — "
+          + "no open commitment matches \"\(suggestion.suggestion)\""
+      )
+      return outcome
+    case .delivered:
+      break
     }
 
-    guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else {
+    // Re-read the owner immediately before delivering: an account switch between the
+    // decision and the card must not put one user's commitment on another user's screen.
+    guard let ownerID, RuntimeOwnerIdentity.currentOwnerId() == ownerID else {
       await emitDeliveryOutcome(.rejectedOwner, identity: telemetryIdentity)
-      return
+      return .rejectedOwner
     }
 
     recentSuggestions.append(suggestion.suggestion)
@@ -433,6 +554,7 @@ actor SuggestionAssistant: ProactiveAssistant {
       ownerID: ownerID,
       telemetryIdentity: telemetryIdentity
     )
+    return .delivered
   }
 
   private func emitDeliveryOutcome(
@@ -476,6 +598,61 @@ actor SuggestionAssistant: ProactiveAssistant {
     }
   }
 
+  // MARK: - Automation probe
+
+  /// Run grounding → evaluation → delivery on a supplied frame, bypassing only the dwell
+  /// and cooldown gates.
+  ///
+  /// Those two gates are pure functions with their own tests; everything downstream of them
+  /// — real commitments from the store, the real prompt, a real model call, the confidence
+  /// bar, dedup, the commitment guard, and real delivery through `NotificationService` — is
+  /// the part that cannot be proven without spending money, and is therefore the part worth
+  /// a probe. Verifying it otherwise requires holding a leisure window frontmost for 30s,
+  /// which an agent cannot do without taking the user's focus.
+  func probeEvaluateAndDeliver(
+    frame: CapturedFrame,
+    sendEvent: @escaping @Sendable (String, [String: Any]) -> Void
+  ) async -> [String: String] {
+    let grounding = await assembleGrounding(for: frame)
+    commitmentsInFlight = grounding.openCommitments
+
+    guard !grounding.isEmpty else {
+      return ["outcome": "no_grounding", "commitments": "0"]
+    }
+
+    let result: SuggestionResult?
+    do {
+      result = try await evaluate(frame: frame, grounding: grounding)
+    } catch {
+      return ["outcome": "evaluation_failed", "error": "\(error)"]
+    }
+
+    guard let result else {
+      return ["outcome": "no_result", "commitments": "\(grounding.openCommitments.count)"]
+    }
+    guard result.hasSuggestion, let suggestion = result.suggestion else {
+      return [
+        "outcome": "declined",
+        "activity": result.currentActivity,
+        "commitments": "\(grounding.openCommitments.count)",
+      ]
+    }
+
+    // Report what delivery actually did, not that a suggestion existed. `outcome` is
+    // "delivered" only when a card reached NotificationService.
+    let delivery = await resolveDelivery(result, sendEvent: sendEvent)
+
+    return [
+      "outcome": delivery?.rawValue ?? "no_delivery_decision",
+      "delivered": delivery == .delivered ? "true" : "false",
+      "suggestion": suggestion.suggestion,
+      "category": suggestion.category.rawValue,
+      "confidence": "\(Int(suggestion.confidence * 100))",
+      "commitments": "\(grounding.openCommitments.count)",
+      "goals": "\(grounding.goals.count)",
+    ]
+  }
+
   // MARK: - Lifecycle
 
   func clearPendingWork() async {
@@ -485,6 +662,10 @@ actor SuggestionAssistant: ProactiveAssistant {
   func stop() async {
     clearPendingContext()
     recentSuggestions.removeAll()
+    commitmentsInFlight.removeAll()
+    cachedGoals.removeAll()
+    cachedGoalsSnapshot = nil
+    lastGoalsRefresh = .distantPast
   }
 }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantSettings.swift
@@ -39,7 +39,11 @@ class SuggestionAssistantSettings {
   /// Matches Insight's bar. Below this the suggestion is dropped without a notification.
   private let defaultMinConfidence: Double = 0.85
 
-  private let currentPromptVersion = 2
+  /// Bump when `defaultAnalysisPrompt` changes so a saved copy of the old prompt is
+  /// discarded. v3 removed the invented names from the examples (a model was reproducing
+  /// them as the user's own commitments); v4 moved the anti-fabrication rule out of the
+  /// prompt into SuggestionCommitmentGuard, because as prose it also suppressed real nudges.
+  private let currentPromptVersion = 7
 
   /// System prompt. Inherits the shape of the shipped Insight prompt — which was never
   /// the defect — and adds the grounding contract: a suggestion must use what Omi knows,
@@ -67,6 +71,25 @@ class SuggestionAssistantSettings {
     never scold them for what they are doing instead. Use category "commitment".
     Do not fire this while they are visibly working, and never repeat a nudge that is
     already in RECENT SUGGESTIONS.
+    Quote the task from OPEN COMMITMENTS in the user's own words. When the screen is
+    clearly leisure and OPEN COMMITMENTS is non-empty, firing is the RIGHT call — this is
+    the nudge working, not a reach. Pick the most pressing item and say it.
+    MANDATORY: the suggestion text must contain the actual wording of ONE task from OPEN
+    COMMITMENTS. Counting them is not naming them — "You have 3 tasks due today" is a
+    REJECTED suggestion, every time. Say "Record the Instagram demo video walkthrough" or
+    whatever that one task literally says. One task, its own words, never a tally.
+
+    HOW A NUDGE SHOULD SOUND — two beats, in this order:
+    1. Name what they are doing, warmly and without judgement. They already chose it; you
+       are not their parent and you are not disappointed in them.
+    2. Then the one thing — the task, or the goal it serves.
+    The shape is: "<what they are actually looking at> is fine — but <the one thing>".
+    Use the REAL app or site from WHAT THE USER IS DOING RIGHT NOW. Never write the name of
+    an app from these instructions; if the screen says YouTube, the nudge says YouTube.
+    When WHAT THE USER IS TRYING TO ACHIEVE is present, the strongest nudge connects the
+    screen to the goal rather than to the checkbox — say why this screen is not that goal,
+    then name the commitment that is.
+    Never print a date. "due today" is context for YOU; the user knows when they said it.
 
     Set has_suggestion=false when:
     - You would be narrating something the user can plainly see
@@ -81,9 +104,11 @@ class SuggestionAssistantSettings {
     - A specific, lesser-known tool or shortcut that solves exactly what they are struggling with
     - Something on this page worth their attention that they are likely to scroll past
 
-    GOOD EXAMPLES (this is the quality bar):
-    - "You still haven't sent that email to Bob — good moment to knock it out"
-    - "You told Sarah you'd send the deck Friday — this is that thread"
+    GOOD EXAMPLES — shape only; the bracketed parts come from OPEN COMMITMENTS, never from here.
+    - "[the app on screen] is fine — but you said you'd [the open commitment] tonight"
+    - "[the goal] won't come from [the app on screen] — [the open commitment] is still sitting there"
+    - "Still on [the app on screen]. [The open commitment] is the one that moves [the goal]"
+    - "You said you'd [the open commitment] Friday — this is that thread"
     - "You've scheduled this for 2026 — double-check the year"
     - "This is the role you saved last week — you know someone there"
     - "Sensitive credentials visible in terminal — mask before sharing"
@@ -97,6 +122,10 @@ class SuggestionAssistantSettings {
     - "Consider adding tests" (vague, generic)
     - "You have a lot of tabs open" (unsolicited judgment)
     - "Take a break / Stay hydrated" (we are not a health app)
+    - "You have 3 tasks due today" (a tally, not a task — name one of them instead)
+    - "call dad (due 2026-08-10)" (a database row read aloud — no dates, write like a person)
+    - Any sentence you can see on the screen (that is echo, not insight)
+    - Naming an app the user is not on (say what the screen says, never an app from these notes)
 
     CATEGORIES:
     - "commitment" — something the user said they would do
@@ -111,8 +140,9 @@ class SuggestionAssistantSettings {
     - 0.60-0.74 useful, but they might get there themselves
     - below 0.60 do not suggest
 
-    FORMAT: under 100 characters. Lead with the actionable part. Write like a sharp friend,
-    not a corporate assistant. Never open with: Confirm, Ensure, Clarify, Consider,
+    FORMAT: under 100 characters, one sentence, second person. Write like a sharp friend who
+    respects them — warm, never nagging, never a to-do list. No dates, no "(due ...)", no
+    bullet lists, no tallies. Never open with: Confirm, Ensure, Clarify, Consider,
     Prioritize, Remember, Review, Align, Make sure, Don't forget.
     """
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
@@ -87,6 +87,8 @@ enum SuggestionAssistantTelemetry {
     case delivered
     case filteredLowConfidence = "filtered_low_confidence"
     case filteredDuplicate = "filtered_duplicate"
+    /// A commitment nudge that named work absent from the grounding it was given.
+    case filteredUngroundedCommitment = "filtered_ungrounded_commitment"
     case rejectedOwner = "rejected_owner"
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
@@ -128,17 +128,22 @@ enum SuggestionAssistantTelemetry {
     let memoryCount: Int
     let commitmentCount: Int
     let relatedScreenCount: Int
+    let goalCount: Int
 
     init(model: Model, previewData: Data, grounding: SuggestionGrounding) {
       self.model = model
       imageWidthBucket = Self.imageWidthBucket(for: previewData)
       imageBytesBucket = Self.imageBytesBucket(for: previewData)
-      // The source queries cap these at 15 memories, 25 commitments, and 12
-      // screens. Keep an explicit ceiling here as defense-in-depth if a source
-      // changes before the telemetry contract does.
+      // The source queries cap these at 15 memories, 25 commitments, 12 screens,
+      // and 4 active goals. Keep an explicit ceiling here as defense-in-depth if a
+      // source changes before the telemetry contract does.
       memoryCount = min(max(grounding.memories.count, 0), 15)
       commitmentCount = min(max(grounding.openCommitments.count, 0), 25)
       relatedScreenCount = min(max(grounding.relatedScreens.count, 0), 12)
+      // Goals count toward `SuggestionGrounding.isEmpty`, so a goal-only grounding can be
+      // the sole reason an evaluation is paid for. Leaving it out of the shape would report
+      // grounding_source_count=0 for a spend that did happen.
+      goalCount = min(max(grounding.goals.count, 0), 8)
     }
 
     private static func imageWidthBucket(for data: Data) -> ImageWidthBucket {
@@ -233,9 +238,11 @@ enum SuggestionAssistantTelemetry {
   }
 
   private static func evaluationPayload(identity: Identity, shape: EvaluationShape) -> [String: Any] {
-    let sourceCount = [shape.memoryCount, shape.commitmentCount, shape.relatedScreenCount]
-      .filter { $0 > 0 }
-      .count
+    let sourceCount = [
+      shape.memoryCount, shape.commitmentCount, shape.relatedScreenCount, shape.goalCount,
+    ]
+    .filter { $0 > 0 }
+    .count
     return [
       "evaluation_id": identity.evaluationID.uuidString,
       "model": shape.model.rawValue,
@@ -248,6 +255,8 @@ enum SuggestionAssistantTelemetry {
       "has_commitments": shape.commitmentCount > 0,
       "related_screen_count": shape.relatedScreenCount,
       "has_related_screens": shape.relatedScreenCount > 0,
+      "goal_count": shape.goalCount,
+      "has_goals": shape.goalCount > 0,
     ]
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -392,15 +392,27 @@ enum SuggestionDwellAnchor {
 /// Only `commitment` is checked. The other categories are about what is on screen, which is
 /// evidence the model can see and this guard cannot.
 enum SuggestionCommitmentGuard {
-  /// Share of a commitment's own content words the suggestion must carry. A nudge phrases
-  /// the task in fewer words than the task itself ("Send the Instagram walkthrough" for
-  /// "Record the Instagram demo video walkthrough"), so this measures coverage of the
-  /// commitment rather than similarity between the two.
+  /// Share of a commitment's own content words the suggestion must carry, used only as the
+  /// fallback when nothing distinctive is shared.
+  ///
+  /// Coverage alone was the whole rule and it punished long tasks: "Exchange weekly tasks
+  /// with accountability partner and update the shared Google Doc tracker" has ten content
+  /// words, so a perfectly good "you still owe the weekly exchange" cleared two of them and
+  /// was thrown out as ungrounded. Length of the task is not evidence about the nudge.
   static let requiredCoverage = 0.5
 
   /// One shared word is a coincidence — "update", "send" and "follow" appear in most
   /// commitments. Two is a reference.
   static let minimumSharedTokens = 2
+
+  /// Words that describe *doing* rather than *what* — they appear across most commitments,
+  /// so sharing only these identifies nothing. "Send the update" could be any task; "send
+  /// the Figma comments" could not.
+  private static let genericTaskWords: Set<String> = [
+    "send", "sent", "update", "updates", "follow", "followup", "check", "review", "reply",
+    "respond", "call", "make", "made", "get", "finish", "ship", "add", "fix", "ask", "tell",
+    "write", "read", "post", "share", "start", "record", "task", "tasks", "email", "message",
+  ]
 
   /// Words that carry no identifying signal, so they cannot vouch for a commitment.
   /// `SuggestionDeduplication.normalize` already drops tokens of 1-2 characters.
@@ -436,6 +448,12 @@ enum SuggestionCommitmentGuard {
       guard !commitmentTokens.isEmpty else { return false }
       let shared = commitmentTokens.intersection(suggestionTokens)
       guard shared.count >= minimumSharedTokens else { return false }
+
+      // Naming something only that commitment contains is a reference, however short the
+      // nudge and however long the task. Otherwise fall back to proportional coverage,
+      // which is what stops "send the update" from matching every commitment that happens
+      // to contain both words.
+      if !shared.subtracting(genericTaskWords).isEmpty { return true }
       return Double(shared.count) / Double(commitmentTokens.count) >= requiredCoverage
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -24,9 +24,12 @@ struct SuggestionGrounding: Sendable {
   var memories: [String] = []
   var openCommitments: [String] = []
   var relatedScreens: [String] = []
+  /// What the user is actually trying to achieve. Without this the assistant can only say
+  /// "you have a task"; with it, it can say why the current screen is not that.
+  var goals: [String] = []
 
   var isEmpty: Bool {
-    memories.isEmpty && openCommitments.isEmpty && relatedScreens.isEmpty
+    memories.isEmpty && openCommitments.isEmpty && relatedScreens.isEmpty && goals.isEmpty
   }
 
   /// Preamble for the grounding block.
@@ -46,6 +49,9 @@ struct SuggestionGrounding: Sendable {
   func promptSections() -> String {
     guard !isEmpty else { return "" }
     var sections: [String] = [Self.untrustedPreamble]
+    if !goals.isEmpty {
+      sections.append("== WHAT THE USER IS TRYING TO ACHIEVE ==\n" + goals.joined(separator: "\n"))
+    }
     if !memories.isEmpty {
       sections.append("== WHAT OMI KNOWS ABOUT THE USER ==\n" + memories.joined(separator: "\n"))
     }
@@ -261,6 +267,134 @@ enum SuggestionSearchTerm {
       .split(separator: " ")
       .map(String.init)
       .joined(separator: " ")
+  }
+}
+
+// MARK: - Delivery Policy
+
+/// Whether a produced suggestion actually reaches the user, and if not, why.
+///
+/// Split out as a pure function for the same reason as `SuggestionGatePolicy`: "the model
+/// returned a suggestion" and "the user saw a card" are different claims, and code that
+/// conflates them will report success for a card that was silently filtered.
+enum SuggestionDeliveryPolicy {
+  static func decide(
+    hasOwner: Bool,
+    confidence: Double,
+    threshold: Double,
+    isDuplicate: Bool,
+    isGroundedCommitment: Bool
+  ) -> SuggestionAssistantTelemetry.DeliveryOutcome {
+    guard hasOwner else { return .rejectedOwner }
+    guard confidence >= threshold else { return .filteredLowConfidence }
+    guard !isDuplicate else { return .filteredDuplicate }
+    guard isGroundedCommitment else { return .filteredUngroundedCommitment }
+    return .delivered
+  }
+}
+
+// MARK: - Due Date Phrasing
+
+/// Turns a due date into the phrase a person would use.
+///
+/// Calendar-day arithmetic in the *local* timezone, deliberately: a task due 23:59 tonight
+/// is "due today" to the user even though it is tomorrow in UTC.
+enum SuggestionDueDescription {
+  static func phrase(for dueAt: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
+    let dueDay = calendar.startOfDay(for: dueAt)
+    let today = calendar.startOfDay(for: now)
+    let days = calendar.dateComponents([.day], from: today, to: dueDay).day ?? 0
+
+    switch days {
+    case 0: return "due today"
+    case 1: return "due tomorrow"
+    case ..<0:
+      let late = -days
+      return late == 1 ? "overdue by a day" : "overdue by \(late) days"
+    default:
+      return "due in \(days) days"
+    }
+  }
+}
+
+// MARK: - Dwell Anchor
+
+/// Decides which moment the dwell clock runs from when a context switch arrives.
+///
+/// A context switch fires on app *or* window-title change, and plenty of apps rewrite
+/// their own title while the user sits perfectly still: TikTok and YouTube relabel the tab
+/// on every video, chat apps on every unread count. Anchoring dwell to each of those
+/// restarted the clock every few seconds, so the exact contexts a distraction nudge exists
+/// for were the ones it could never fire in. Dwell therefore tracks the app; the title is
+/// still updated so the evaluated frame describes what is on screen now.
+enum SuggestionDwellAnchor {
+  static func anchor(current: Date?, currentApp: String?, newApp: String, now: Date) -> Date {
+    guard let current, currentApp == newApp else { return now }
+    return current
+  }
+}
+
+// MARK: - Commitment Grounding
+
+/// Holds a commitment nudge to the commitments it was actually given.
+///
+/// The prompt teaches the shape of a good nudge with worked examples, and a model that has
+/// nothing to nudge about will reproduce one of those examples as though it were the user's
+/// own — with high confidence, because a polished example reads as a confident sentence.
+/// That failure mode is invisible to the confidence bar (the fabricated card scores *above*
+/// grounded ones) and invisible to dedup (it is novel every time), so it has to be caught
+/// by asking the only question that distinguishes it: is the work it names in OPEN
+/// COMMITMENTS at all?
+///
+/// Only `commitment` is checked. The other categories are about what is on screen, which is
+/// evidence the model can see and this guard cannot.
+enum SuggestionCommitmentGuard {
+  /// Share of a commitment's own content words the suggestion must carry. A nudge phrases
+  /// the task in fewer words than the task itself ("Send the Instagram walkthrough" for
+  /// "Record the Instagram demo video walkthrough"), so this measures coverage of the
+  /// commitment rather than similarity between the two.
+  static let requiredCoverage = 0.5
+
+  /// One shared word is a coincidence — "update", "send" and "follow" appear in most
+  /// commitments. Two is a reference.
+  static let minimumSharedTokens = 2
+
+  /// Words that carry no identifying signal, so they cannot vouch for a commitment.
+  /// `SuggestionDeduplication.normalize` already drops tokens of 1-2 characters.
+  private static let stopwords: Set<String> = [
+    "the", "and", "for", "you", "your", "with", "that", "this", "have", "has", "had",
+    "still", "havent", "haven", "not", "yet", "get", "got", "was", "are", "but", "out",
+    "off", "its", "our", "their", "them", "they", "from", "into", "onto", "about", "over",
+    "due", "today", "tomorrow", "now", "then", "when", "what", "who", "how", "why",
+    "moment", "good", "time", "need", "needs", "should", "would", "could", "make", "made",
+  ]
+
+  private static func contentTokens(_ text: String) -> Set<String> {
+    SuggestionDeduplication.normalize(text).subtracting(stopwords)
+  }
+
+  /// Whether `suggestion` may be delivered given the commitments in its grounding.
+  ///
+  /// Non-commitment categories always pass. An empty commitment list fails every
+  /// commitment nudge, which is the point: with nothing to reference, there is nothing a
+  /// commitment nudge could truthfully be about.
+  static func isGrounded(
+    suggestion: String,
+    category: SuggestionCategory,
+    openCommitments: [String]
+  ) -> Bool {
+    guard category == .commitment else { return true }
+
+    let suggestionTokens = contentTokens(suggestion)
+    guard !suggestionTokens.isEmpty else { return false }
+
+    return openCommitments.contains { commitment in
+      let commitmentTokens = contentTokens(commitment)
+      guard !commitmentTokens.isEmpty else { return false }
+      let shared = commitmentTokens.intersection(suggestionTokens)
+      guard shared.count >= minimumSharedTokens else { return false }
+      return Double(shared.count) / Double(commitmentTokens.count) >= requiredCoverage
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -328,9 +328,52 @@ enum SuggestionDueDescription {
 /// for were the ones it could never fire in. Dwell therefore tracks the app; the title is
 /// still updated so the evaluated frame describes what is on screen now.
 enum SuggestionDwellAnchor {
-  static func anchor(current: Date?, currentApp: String?, newApp: String, now: Date) -> Date {
+  /// Words too common to prove two titles are the same place.
+  private static let stopwords: Set<String> = [
+    "the", "and", "for", "you", "your", "with", "new", "tab", "untitled", "loading", "www", "com",
+  ]
+
+  private static func tokens(_ title: String?) -> Set<String> {
+    guard let title else { return [] }
+    let lowered = title.lowercased()
+    let stripped = String(lowered.map { $0.isLetter || $0.isNumber ? $0 : " " })
+    return Set(stripped.split(separator: " ").map(String.init).filter { $0.count > 2 })
+      .subtracting(stopwords)
+  }
+
+  /// Whether two window titles describe the same sitting.
+  ///
+  /// Title churn inside one place keeps a recognisable word — TikTok and YouTube leave their
+  /// own name in the tab, a document keeps its filename — so one shared significant word is
+  /// enough to say "still here". Moving from a work page to a feed shares nothing, and must
+  /// start the clock over.
+  static func isSameContext(_ lhs: String?, _ rhs: String?) -> Bool {
+    if lhs == rhs { return true }
+    // A title we cannot read is no evidence either way; do not let it end a sitting.
+    guard let lhs, let rhs else { return true }
+    let left = tokens(lhs)
+    let right = tokens(rhs)
+    // A readable title that carries no identifying word ("New Tab", "Untitled") is a real
+    // transition — the user left the previous page — so it starts a new sitting.
+    if left.isEmpty || right.isEmpty { return false }
+    return !left.isDisjoint(with: right)
+  }
+
+  /// The timestamp the dwell clock should run from after a context switch.
+  ///
+  /// Keying on the app alone was wrong in the other direction: ten minutes on a work page
+  /// followed by one tab change to TikTok would inherit the whole prior dwell and fire
+  /// instantly, which is the opposite of proving the user settled somewhere.
+  static func anchor(
+    current: Date?,
+    currentApp: String?,
+    currentWindowTitle: String?,
+    newApp: String,
+    newWindowTitle: String?,
+    now: Date
+  ) -> Date {
     guard let current, currentApp == newApp else { return now }
-    return current
+    return isSameContext(currentWindowTitle, newWindowTitle) ? current : now
   }
 }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -357,6 +357,11 @@ actor GeminiClient {
     }
     self.model = model
     self.fallbackModel = fallbackModel
+    // Which model a proactive assistant actually runs on is a product decision with a
+    // measurable click-through cost, and until now it was invisible at runtime — the model
+    // appears only inside the request URL, so a tier change could not be confirmed on a
+    // real machine. Model IDs are non-sensitive and low-cardinality.
+    log("GeminiClient: model=\(model) fallback=\(fallbackModel ?? "none")")
   }
 
   /// Get Firebase auth header for proxy requests

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+SuggestionProbe.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+SuggestionProbe.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Automation entry point for the suggestion nudge.
+///
+/// Lives outside `ProactiveAssistantsPlugin.swift` so debug tooling does not grow an
+/// already-oversized product file, and because this is a test seam rather than runtime
+/// behaviour: nothing in the app calls it, only the automation bridge does.
+extension ProactiveAssistantsPlugin {
+  /// Drive the suggestion assistant's grounding → evaluation → delivery path on the most
+  /// recent captured frame, optionally relabelling which app/window it came from so a
+  /// leisure context can be probed without stealing the user's focus for 30 seconds.
+  func probeSuggestionNudge(
+    appOverride: String?,
+    windowTitleOverride: String?
+  ) async -> [String: String] {
+    let registered = AssistantCoordinator.shared.assistant(withIdentifier: "suggestion")
+    guard let assistant = registered as? SuggestionAssistant else {
+      return ["outcome": "assistant_unavailable"]
+    }
+    guard let latest = latestCapturedFrame else {
+      return ["outcome": "no_frame_captured"]
+    }
+
+    let frame = CapturedFrame(
+      jpegData: latest.jpegData,
+      appName: appOverride ?? latest.appName,
+      windowTitle: windowTitleOverride ?? latest.windowTitle,
+      frameNumber: latest.frameNumber,
+      captureTime: latest.captureTime,
+      screenshotId: latest.screenshotId
+    )
+
+    // The probe's own delivery does not need to fan out assistant events; the observable
+    // result is the notification itself plus the returned outcome.
+    return await assistant.probeEvaluateAndDeliver(frame: frame) { _, _ in }
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+SuggestionProbe.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+SuggestionProbe.swift
@@ -17,18 +17,32 @@ extension ProactiveAssistantsPlugin {
     guard let assistant = registered as? SuggestionAssistant else {
       return ["outcome": "assistant_unavailable"]
     }
-    guard let latest = latestCapturedFrame else {
+
+    // `latestCapturedFrame` is cleared on every app switch, so on a machine someone is
+    // actively using it is nil far more often than not — probing against it lost a race
+    // with the user 18 times running. Fall back to capturing the active window here so the
+    // probe tests the suggestion path rather than the capture pipeline's timing.
+    let frame: CapturedFrame
+    if let latest = latestCapturedFrame {
+      frame = CapturedFrame(
+        jpegData: latest.jpegData,
+        appName: appOverride ?? latest.appName,
+        windowTitle: windowTitleOverride ?? latest.windowTitle,
+        frameNumber: latest.frameNumber,
+        captureTime: latest.captureTime,
+        screenshotId: latest.screenshotId
+      )
+    } else if let jpeg = await ScreenCaptureService().captureActiveWindowAsync() {
+      let (activeApp, activeTitle, _) = await WindowMonitor.getActiveWindowInfoAsync()
+      frame = CapturedFrame(
+        jpegData: jpeg,
+        appName: appOverride ?? activeApp ?? "Unknown",
+        windowTitle: windowTitleOverride ?? activeTitle,
+        frameNumber: 0
+      )
+    } else {
       return ["outcome": "no_frame_captured"]
     }
-
-    let frame = CapturedFrame(
-      jpegData: latest.jpegData,
-      appName: appOverride ?? latest.appName,
-      windowTitle: windowTitleOverride ?? latest.windowTitle,
-      frameNumber: latest.frameNumber,
-      captureTime: latest.captureTime,
-      screenshotId: latest.screenshotId
-    )
 
     // The probe's own delivery does not need to fan out assistant events; the observable
     // result is the notification itself plus the returned outcome.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -89,7 +89,7 @@ public class ProactiveAssistantsPlugin: NSObject {
   // Eliminates continuous polling when the user stays on the same app/window.
   private var distributionGate = ProactiveFrameDistributionGate()
   private var distributionDebounceTimer: Timer?
-  private var latestCapturedFrame: CapturedFrame?
+  private(set) var latestCapturedFrame: CapturedFrame?
   /// Fallback interval: re-distribute even without context change to catch visual-only updates.
   private let distributionFallbackInterval: TimeInterval = 60
   private let messagingDistributionFallbackInterval: TimeInterval = 15
@@ -1051,35 +1051,6 @@ public class ProactiveAssistantsPlugin: NSObject {
     case .skip:
       break
     }
-  }
-
-  /// Drive the suggestion assistant's grounding → evaluation → delivery path on the most
-  /// recent captured frame, optionally relabelling which app/window it came from so a
-  /// leisure context can be probed without stealing the user's focus for 30 seconds.
-  func probeSuggestionNudge(
-    appOverride: String?,
-    windowTitleOverride: String?
-  ) async -> [String: String] {
-    let registered = AssistantCoordinator.shared.assistant(withIdentifier: "suggestion")
-    guard let assistant = registered as? SuggestionAssistant else {
-      return ["outcome": "assistant_unavailable"]
-    }
-    guard let latest = latestCapturedFrame else {
-      return ["outcome": "no_frame_captured"]
-    }
-
-    let frame = CapturedFrame(
-      jpegData: latest.jpegData,
-      appName: appOverride ?? latest.appName,
-      windowTitle: windowTitleOverride ?? latest.windowTitle,
-      frameNumber: latest.frameNumber,
-      captureTime: latest.captureTime,
-      screenshotId: latest.screenshotId
-    )
-
-    // The probe's own delivery does not need to fan out assistant events; the observable
-    // result is the notification itself plus the returned outcome.
-    return await assistant.probeEvaluateAndDeliver(frame: frame) { _, _ in }
   }
 
   /// Flush the latest captured frame to all assistants (called when debounce timer fires or fallback is due).

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -1053,6 +1053,35 @@ public class ProactiveAssistantsPlugin: NSObject {
     }
   }
 
+  /// Drive the suggestion assistant's grounding → evaluation → delivery path on the most
+  /// recent captured frame, optionally relabelling which app/window it came from so a
+  /// leisure context can be probed without stealing the user's focus for 30 seconds.
+  func probeSuggestionNudge(
+    appOverride: String?,
+    windowTitleOverride: String?
+  ) async -> [String: String] {
+    let registered = AssistantCoordinator.shared.assistant(withIdentifier: "suggestion")
+    guard let assistant = registered as? SuggestionAssistant else {
+      return ["outcome": "assistant_unavailable"]
+    }
+    guard let latest = latestCapturedFrame else {
+      return ["outcome": "no_frame_captured"]
+    }
+
+    let frame = CapturedFrame(
+      jpegData: latest.jpegData,
+      appName: appOverride ?? latest.appName,
+      windowTitle: windowTitleOverride ?? latest.windowTitle,
+      frameNumber: latest.frameNumber,
+      captureTime: latest.captureTime,
+      screenshotId: latest.screenshotId
+    )
+
+    // The probe's own delivery does not need to fan out assistant events; the observable
+    // result is the notification itself plus the returned outcome.
+    return await assistant.probeEvaluateAndDeliver(frame: frame) { _, _ in }
+  }
+
   /// Flush the latest captured frame to all assistants (called when debounce timer fires or fallback is due).
   private func flushDebouncedFrame() {
     guard let frame = latestCapturedFrame else { return }

--- a/desktop/macos/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/macos/Desktop/Tests/ModelQoSTests.swift
@@ -71,7 +71,15 @@ final class ModelQoSTests: XCTestCase {
     ModelQoS.activeTier = .premium
     XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-2.5-flash")
     XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-2.5-flash")
-    XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-2.5-flash")
+  }
+
+  /// Insight is Pro on every tier by design — the timer caps it at ~6 analyses/hour, and the
+  /// premium-tier drop to Flash tracked a click-through fall from 2.34% to under 1%.
+  func testInsightIsProOnEveryTier() {
+    for tier in ModelTier.allCases {
+      ModelQoS.activeTier = tier
+      XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-2.5-pro")
+    }
   }
 
   func testGeminiMaxUsesPro() {

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
@@ -120,7 +120,10 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
     let notificationIdentity = try XCTUnwrap(SuggestionAssistantTelemetry.NotificationIdentity(identity))
     XCTAssertEqual(
       Set(SuggestionAssistantTelemetry.DeliveryOutcome.allCases.map(\.rawValue)),
-      Set(["delivered", "filtered_low_confidence", "filtered_duplicate", "rejected_owner"])
+      Set([
+        "delivered", "filtered_low_confidence", "filtered_duplicate",
+        "filtered_ungrounded_commitment", "rejected_owner",
+      ])
     )
 
     let payload = SuggestionAssistantTelemetry.deliveryOutcomePayload(

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
@@ -54,7 +54,7 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
       Set([
         "evaluation_id", "model", "image_width_bucket", "image_bytes_bucket", "grounding_source_count",
         "memory_count", "has_memories", "commitment_count", "has_commitments", "related_screen_count",
-        "has_related_screens",
+        "has_related_screens", "goal_count", "has_goals",
       ])
     )
     XCTAssertEqual(payload["evaluation_id"] as? String, "00000000-0000-0000-0000-000000000001")
@@ -65,6 +65,8 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
     XCTAssertEqual(payload["memory_count"] as? Int, 1)
     XCTAssertEqual(payload["commitment_count"] as? Int, 1)
     XCTAssertEqual(payload["related_screen_count"] as? Int, 1)
+    XCTAssertEqual(payload["goal_count"] as? Int, 0)
+    XCTAssertEqual(payload["has_goals"] as? Bool, false)
 
     let serialized = try XCTUnwrap(
       String(
@@ -218,5 +220,49 @@ final class SuggestionAssistantTelemetryBoundaryTests: XCTestCase {
         "evaluation_id": expectedEvaluationID,
         "suggestion_id": expectedSuggestionID ?? "",
       ])
+  }
+
+  /// Goals participate in `SuggestionGrounding.isEmpty`, so a goal-only grounding is a real
+  /// reason to pay for an evaluation. If the shape ignored goals this spend would report
+  /// `grounding_source_count = 0`, which is the analytics-integrity failure of describing a
+  /// paid call as having had no inputs.
+  func testGoalOnlyGroundingIsCountedAsASpentSource() throws {
+    let goalOnly = SuggestionGrounding(
+      memories: [],
+      openCommitments: [],
+      relatedScreens: [],
+      goals: ["Reach 200k total users by month-end"]
+    )
+    XCTAssertFalse(goalOnly.isEmpty, "a goal alone must be able to justify an evaluation")
+
+    let payload = SuggestionAssistantTelemetry.evaluationStartedPayload(
+      identity: SuggestionAssistantTelemetry.Identity(),
+      shape: SuggestionAssistantTelemetry.EvaluationShape(
+        model: .gemini25FlashLite,
+        previewData: Data([0x00, 0x01, 0x02]),
+        grounding: goalOnly
+      )
+    )
+
+    XCTAssertEqual(payload["grounding_source_count"] as? Int, 1)
+    XCTAssertEqual(payload["goal_count"] as? Int, 1)
+    XCTAssertEqual(payload["has_goals"] as? Bool, true)
+    XCTAssertEqual(payload["has_commitments"] as? Bool, false)
+
+    // The goal's text is never a property; only its bounded count.
+    let serialized = try XCTUnwrap(
+      String(data: try JSONSerialization.data(withJSONObject: payload), encoding: .utf8))
+    XCTAssertFalse(serialized.contains("200k"))
+  }
+
+  /// Counts are bounded so an unexpectedly large source cannot become a high-cardinality
+  /// property.
+  func testGoalCountIsBounded() {
+    let shape = SuggestionAssistantTelemetry.EvaluationShape(
+      model: .gemini25FlashLite,
+      previewData: Data([0x00]),
+      grounding: SuggestionGrounding(goals: Array(repeating: "goal", count: 500))
+    )
+    XCTAssertEqual(shape.goalCount, 8)
   }
 }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -424,54 +424,89 @@ final class SuggestionCommitmentGuardTests: XCTestCase {
 final class SuggestionDwellAnchorTests: XCTestCase {
   private let start = Date(timeIntervalSince1970: 1_800_000_000)
 
-  func testTitleChangeWithinTheSameAppKeepsTheClockRunning() {
-    let afterOneVideo = start.addingTimeInterval(3)
-    let anchor = SuggestionDwellAnchor.anchor(
-      current: start,
-      currentApp: "Google Chrome",
-      newApp: "Google Chrome",
-      now: afterOneVideo
+  private func anchor(
+    current: Date?,
+    fromApp: String?,
+    fromTitle: String?,
+    toApp: String,
+    toTitle: String?,
+    at offset: TimeInterval
+  ) -> Date {
+    SuggestionDwellAnchor.anchor(
+      current: current,
+      currentApp: fromApp,
+      currentWindowTitle: fromTitle,
+      newApp: toApp,
+      newWindowTitle: toTitle,
+      now: start.addingTimeInterval(offset)
     )
-    XCTAssertEqual(anchor, start)
   }
 
-  /// The real trace: title churn every few seconds, still one sitting. Under the old
-  /// behaviour dwell here was 3s; it must now be the full 33s.
+  func testTitleChurnWithinOneSittingKeepsTheClockRunning() {
+    let a = anchor(
+      current: start, fromApp: "Google Chrome", fromTitle: "TikTok - Make Your Day",
+      toApp: "Google Chrome", toTitle: "Watch trending videos for you | TikTok 🔊", at: 3)
+    XCTAssertEqual(a, start)
+  }
+
+  /// The real trace: title churn every few seconds, still one sitting. Pre-fix dwell here
+  /// was 3s; it must now be the full 33s.
   func testDwellSurvivesRepeatedTitleChurnAndClearsTheGate() {
-    var anchor = start
+    var current = start
+    var title = "TikTok - Make Your Day"
     for second in stride(from: 3, through: 33, by: 3) {
-      anchor = SuggestionDwellAnchor.anchor(
-        current: anchor,
-        currentApp: "Google Chrome",
-        newApp: "Google Chrome",
-        now: start.addingTimeInterval(TimeInterval(second))
-      )
+      let next = "(\(second)) TikTok - Make Your Day 🔊"
+      current = anchor(
+        current: current, fromApp: "Google Chrome", fromTitle: title,
+        toApp: "Google Chrome", toTitle: next, at: TimeInterval(second))
+      title = next
     }
-    let dwell = start.addingTimeInterval(33).timeIntervalSince(anchor)
+    let dwell = start.addingTimeInterval(33).timeIntervalSince(current)
     XCTAssertEqual(dwell, 33)
     XCTAssertGreaterThanOrEqual(dwell, 30, "33s of unbroken TikTok must clear the 30s bar")
   }
 
+  /// The regression the reviewer caught: ten minutes on a work page then one tab change to
+  /// a feed must NOT inherit that dwell and fire immediately.
+  func testSwitchingToADifferentPageInTheSameAppRestartsTheClock() {
+    let switched = anchor(
+      current: start, fromApp: "Google Chrome",
+      fromTitle: "BasedHardware/omi: AI wearable — pull requests",
+      toApp: "Google Chrome", toTitle: "TikTok - Make Your Day", at: 600)
+    XCTAssertEqual(
+      switched, start.addingTimeInterval(600),
+      "a work page and a feed are different contexts; dwell must not carry over")
+  }
+
   func testSwitchingAppsRestartsTheClock() {
-    let switchedAt = start.addingTimeInterval(20)
-    let anchor = SuggestionDwellAnchor.anchor(
-      current: start,
-      currentApp: "Google Chrome",
-      newApp: "Warp",
-      now: switchedAt
-    )
-    XCTAssertEqual(anchor, switchedAt)
+    let switched = anchor(
+      current: start, fromApp: "Google Chrome", fromTitle: "TikTok - Make Your Day",
+      toApp: "Warp", toTitle: "zsh", at: 20)
+    XCTAssertEqual(switched, start.addingTimeInterval(20))
   }
 
   /// After an evaluation consumes the pending context, the next switch starts fresh.
   func testFirstSwitchAfterAnEvaluationAnchorsToNow() {
-    let anchor = SuggestionDwellAnchor.anchor(
-      current: nil,
-      currentApp: nil,
-      newApp: "Google Chrome",
-      now: start
-    )
-    XCTAssertEqual(anchor, start)
+    let a = anchor(
+      current: nil, fromApp: nil, fromTitle: nil,
+      toApp: "Google Chrome", toTitle: "TikTok - Make Your Day", at: 0)
+    XCTAssertEqual(a, start)
+  }
+
+  /// An unreadable title is not evidence the sitting ended.
+  func testUnreadableTitleDoesNotEndASitting() {
+    XCTAssertTrue(SuggestionDwellAnchor.isSameContext("TikTok - Make Your Day", nil))
+    XCTAssertTrue(SuggestionDwellAnchor.isSameContext(nil, nil))
+  }
+
+  func testContextIdentityIgnoresGenericChrome() {
+    // "New Tab" carries no identity, so it must not vouch for a match.
+    XCTAssertFalse(
+      SuggestionDwellAnchor.isSameContext("New Tab", "TikTok - Make Your Day"),
+      "a blank new tab is not the same place as a feed")
+    XCTAssertTrue(
+      SuggestionDwellAnchor.isSameContext(
+        "Peter Steinberger — YouTube", "Rick Astley — YouTube"))
   }
 }
 

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -343,3 +343,305 @@ final class SuggestionPromptContractTests: XCTestCase {
     XCTAssertTrue(grounding.promptSections().contains("OPEN COMMITMENTS"))
   }
 }
+
+/// The card Omi delivered at 90% on 2026-08-10: "You still haven't sent the investor update
+/// to Bob." Bob existed only in the prompt's worked examples — the user had no such task.
+/// A fabricated commitment clears the confidence bar (it scores *higher* than grounded
+/// ones) and clears dedup (it is novel), so the only thing that can catch it is asking
+/// whether the work it names is in the grounding at all.
+final class SuggestionCommitmentGuardTests: XCTestCase {
+  /// The user's real open tasks at the time of the incident.
+  private let realCommitments = [
+    "Exchange weekly tasks with accountability partner and update the shared Google Doc tracker",
+    "Record the Instagram demo video walkthrough",
+    "Follow up on the Figma comments from Sarah (due 2026-08-10)",
+  ]
+
+  private func isGrounded(
+    _ suggestion: String,
+    category: SuggestionCategory = .commitment,
+    commitments: [String]? = nil
+  ) -> Bool {
+    SuggestionCommitmentGuard.isGrounded(
+      suggestion: suggestion,
+      category: category,
+      openCommitments: commitments ?? realCommitments
+    )
+  }
+
+  func testRejectsTheFabricatedInvestorUpdateNudge() {
+    XCTAssertFalse(isGrounded("You still haven't sent the investor update to Bob."))
+  }
+
+  func testRejectsEveryNameLiftedFromThePromptExamples() {
+    XCTAssertFalse(isGrounded("You still haven't sent that email to Bob — good moment to knock it out"))
+    XCTAssertFalse(isGrounded("You told Sarah you'd send the deck Friday — this is that thread"))
+  }
+
+  func testAdmitsTheGroundedNudgeDeliveredInTheSameSession() {
+    XCTAssertTrue(isGrounded("Follow up on Sarah's Figma comments (due 2026-08-10)"))
+  }
+
+  /// A nudge names the task in fewer words than the task itself, so coverage is measured
+  /// against the commitment rather than requiring the two to look alike.
+  func testAdmitsAShorterParaphraseOfARealCommitment() {
+    XCTAssertTrue(isGrounded("Still owe the Instagram demo walkthrough"))
+  }
+
+  func testEmptyCommitmentsRejectEveryCommitmentNudge() {
+    XCTAssertFalse(isGrounded("You still haven't sent the investor update to Bob.", commitments: []))
+    XCTAssertFalse(isGrounded("Follow up on Sarah's Figma comments", commitments: []))
+  }
+
+  /// Only `commitment` claims work Omi holds; the rest describe the screen, which this
+  /// guard cannot see and must not veto.
+  func testOtherCategoriesArePassedThrough() {
+    for category in [SuggestionCategory.mistake, .opportunity, .connection, .other] {
+      XCTAssertTrue(
+        isGrounded("Sensitive credentials visible in terminal — mask before sharing", category: category),
+        "category \(category) must not be gated on commitments"
+      )
+    }
+  }
+
+  /// "send" and "update" appear in most commitments. Echoing a commitment's two most
+  /// generic words while dropping everything that identifies it — quarterly, board, deck,
+  /// investors — is not a reference to it.
+  func testGenericVerbsAloneDoNotVouchForACommitment() {
+    XCTAssertFalse(
+      isGrounded(
+        "You still need to send the update",
+        commitments: ["Send the quarterly board update deck to the investors"]
+      )
+    )
+  }
+}
+
+/// On 2026-08-10 six consecutive TikTok contexts lasted 6s or less — not because the user
+/// left, but because TikTok rewrites the tab title on every video and each rewrite counted
+/// as a fresh context. Dwell never reached 30s, so every decision logged `skippedDwell` and
+/// the distraction nudge could not fire on the one activity it was written for.
+final class SuggestionDwellAnchorTests: XCTestCase {
+  private let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+  func testTitleChangeWithinTheSameAppKeepsTheClockRunning() {
+    let afterOneVideo = start.addingTimeInterval(3)
+    let anchor = SuggestionDwellAnchor.anchor(
+      current: start,
+      currentApp: "Google Chrome",
+      newApp: "Google Chrome",
+      now: afterOneVideo
+    )
+    XCTAssertEqual(anchor, start)
+  }
+
+  /// The real trace: title churn every few seconds, still one sitting. Under the old
+  /// behaviour dwell here was 3s; it must now be the full 33s.
+  func testDwellSurvivesRepeatedTitleChurnAndClearsTheGate() {
+    var anchor = start
+    for second in stride(from: 3, through: 33, by: 3) {
+      anchor = SuggestionDwellAnchor.anchor(
+        current: anchor,
+        currentApp: "Google Chrome",
+        newApp: "Google Chrome",
+        now: start.addingTimeInterval(TimeInterval(second))
+      )
+    }
+    let dwell = start.addingTimeInterval(33).timeIntervalSince(anchor)
+    XCTAssertEqual(dwell, 33)
+    XCTAssertGreaterThanOrEqual(dwell, 30, "33s of unbroken TikTok must clear the 30s bar")
+  }
+
+  func testSwitchingAppsRestartsTheClock() {
+    let switchedAt = start.addingTimeInterval(20)
+    let anchor = SuggestionDwellAnchor.anchor(
+      current: start,
+      currentApp: "Google Chrome",
+      newApp: "Warp",
+      now: switchedAt
+    )
+    XCTAssertEqual(anchor, switchedAt)
+  }
+
+  /// After an evaluation consumes the pending context, the next switch starts fresh.
+  func testFirstSwitchAfterAnEvaluationAnchorsToNow() {
+    let anchor = SuggestionDwellAnchor.anchor(
+      current: nil,
+      currentApp: nil,
+      newApp: "Google Chrome",
+      now: start
+    )
+    XCTAssertEqual(anchor, start)
+  }
+}
+
+/// "call mom" was stored as 2026-08-11 03:59 UTC — 23:59 tonight in EDT — and the raw
+/// `ISO8601DateFormatter` rendered it as *tomorrow*. The model scored a due-today task as
+/// not-yet-urgent (80%), it fell under the 85% bar, and Nik got nothing. Local calendar
+/// days, not UTC.
+final class SuggestionDueDescriptionTests: XCTestCase {
+  private let edt = TimeZone(identifier: "America/New_York")!
+
+  private func calendar() -> Calendar {
+    var c = Calendar(identifier: .gregorian)
+    c.timeZone = edt
+    return c
+  }
+
+  private func date(_ iso: String) -> Date {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f.date(from: iso)!
+  }
+
+  func testLateEveningTaskIsDueTodayNotTomorrow() {
+    // 2026-08-11T03:59Z == 2026-08-10 23:59 EDT
+    let due = date("2026-08-11T03:59:00Z")
+    let now = date("2026-08-10T23:18:00Z")  // 19:18 EDT, when Nik was on TikTok
+    XCTAssertEqual(
+      SuggestionDueDescription.phrase(for: due, now: now, calendar: calendar()),
+      "due today"
+    )
+  }
+
+  func testTomorrowIsStillTomorrow() {
+    // 2026-08-11T15:00Z == 2026-08-11 11:00 EDT — genuinely the next calendar day.
+    let due = date("2026-08-11T15:00:00Z")
+    let now = date("2026-08-10T23:18:00Z")
+    XCTAssertEqual(
+      SuggestionDueDescription.phrase(for: due, now: now, calendar: calendar()),
+      "due tomorrow"
+    )
+  }
+
+  func testFurtherOutCountsDays() {
+    let due = date("2026-08-12T15:00:00Z")
+    let now = date("2026-08-10T23:18:00Z")
+    XCTAssertEqual(
+      SuggestionDueDescription.phrase(for: due, now: now, calendar: calendar()),
+      "due in 2 days"
+    )
+  }
+
+  func testOverdueReadsAsOverdue() {
+    let now = date("2026-08-10T23:18:00Z")
+    XCTAssertEqual(
+      SuggestionDueDescription.phrase(for: date("2026-08-09T15:00:00Z"), now: now, calendar: calendar()),
+      "overdue by a day"
+    )
+    XCTAssertEqual(
+      SuggestionDueDescription.phrase(for: date("2026-07-24T04:00:00Z"), now: now, calendar: calendar()),
+      "overdue by 17 days"
+    )
+  }
+
+  /// The phrase is what the model quotes, so it must never contain a machine date.
+  func testPhraseNeverContainsAnISODate() {
+    let now = date("2026-08-10T23:18:00Z")
+    for iso in ["2026-08-11T03:59:00Z", "2026-08-11T15:00:00Z", "2026-07-24T04:00:00Z"] {
+      let phrase = SuggestionDueDescription.phrase(for: date(iso), now: now, calendar: calendar())
+      XCTAssertFalse(phrase.contains("2026"), "\(phrase) leaks a machine date into the card")
+      XCTAssertFalse(phrase.contains("-"), "\(phrase) leaks a machine date into the card")
+    }
+  }
+}
+
+/// "The model produced a suggestion" and "the user saw a card" are different claims. The
+/// first version of the automation probe reported `produced` after calling delivery and
+/// never observed the result, so a card silently dropped by the confidence bar, dedup, or
+/// the commitment guard still read as a working delivery path.
+final class SuggestionDeliveryPolicyTests: XCTestCase {
+  private func decide(
+    hasOwner: Bool = true,
+    confidence: Double = 0.9,
+    threshold: Double = 0.85,
+    isDuplicate: Bool = false,
+    isGroundedCommitment: Bool = true
+  ) -> SuggestionAssistantTelemetry.DeliveryOutcome {
+    SuggestionDeliveryPolicy.decide(
+      hasOwner: hasOwner,
+      confidence: confidence,
+      threshold: threshold,
+      isDuplicate: isDuplicate,
+      isGroundedCommitment: isGroundedCommitment
+    )
+  }
+
+  func testDeliversWhenEveryFilterPasses() {
+    XCTAssertEqual(decide(), .delivered)
+  }
+
+  func testEachFilterIsReportedDistinctly() {
+    XCTAssertEqual(decide(hasOwner: false), .rejectedOwner)
+    XCTAssertEqual(decide(confidence: 0.80), .filteredLowConfidence)
+    XCTAssertEqual(decide(isDuplicate: true), .filteredDuplicate)
+    XCTAssertEqual(decide(isGroundedCommitment: false), .filteredUngroundedCommitment)
+  }
+
+  /// The real 80% "call parents" card, and the real 95% ungrounded tally: neither reached
+  /// Nik, and neither may be reported as delivered.
+  func testRealWorldSuppressionsAreNotDelivered() {
+    XCTAssertNotEqual(decide(confidence: 0.80), .delivered)
+    XCTAssertNotEqual(decide(confidence: 0.95, isGroundedCommitment: false), .delivered)
+  }
+
+  func testThresholdBoundaryDelivers() {
+    XCTAssertEqual(decide(confidence: 0.85, threshold: 0.85), .delivered)
+    XCTAssertEqual(decide(confidence: 0.8499, threshold: 0.85), .filteredLowConfidence)
+  }
+
+  /// Owner rejection outranks everything: a card must never land on the wrong account, even
+  /// if it would otherwise have been a perfect suggestion.
+  func testOwnerRejectionOutranksOtherFilters() {
+    XCTAssertEqual(
+      decide(hasOwner: false, confidence: 0.2, isDuplicate: true, isGroundedCommitment: false),
+      .rejectedOwner
+    )
+  }
+}
+
+/// Goals are personal. `APIClient.getGoals()` documents that its short-lived shared cache
+/// is NOT owner-validated, so an unsnapshotted fetch can return the *previous* account's
+/// goals — which would then sit in the assistant's 10-minute cache and be pasted into the
+/// next owner's prompt. These pin the capture/pass/validate contract at the authority
+/// level: a snapshot taken before an account switch must not validate after it.
+final class SuggestionGoalOwnerScopingTests: XCTestCase {
+  private let authority = RuntimeOwnerAuthorizationAuthority.shared
+
+  private func signIn(_ owner: String) {
+    authority.beginTransition()
+    authority.endTransition(ownerID: owner)
+  }
+
+  func testSnapshotFromPreviousOwnerDoesNotValidateAfterSwitch() throws {
+    signIn("owner-a")
+    let snapshot = try XCTUnwrap(authority.capture(ownerID: "owner-a", expectedOwnerID: nil))
+    XCTAssertTrue(authority.isCurrent(snapshot, ownerID: "owner-a"))
+
+    signIn("owner-b")
+    XCTAssertFalse(
+      authority.isCurrent(snapshot, ownerID: "owner-b"),
+      "goals fetched as owner-a must be dropped once owner-b is signed in"
+    )
+  }
+
+  /// Mid-transition there is no owner to attribute a fetch to, so nothing may be cached.
+  func testNoSnapshotIsIssuedDuringATransition() {
+    signIn("owner-a")
+    authority.beginTransition()
+    XCTAssertNil(
+      authority.capture(ownerID: nil, expectedOwnerID: nil),
+      "a goal fetch must not start while ownership is in flight"
+    )
+    authority.endTransition(ownerID: "owner-a")
+  }
+
+  /// Re-signing the same account still advances the generation, so a snapshot straddling
+  /// the boundary is stale even though the owner id is unchanged.
+  func testSameOwnerReSignInvalidatesEarlierSnapshots() throws {
+    signIn("owner-a")
+    let snapshot = try XCTUnwrap(authority.capture(ownerID: "owner-a", expectedOwnerID: nil))
+    signIn("owner-a")
+    XCTAssertFalse(authority.isCurrent(snapshot, ownerID: "owner-a"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -480,66 +480,64 @@ final class SuggestionDwellAnchorTests: XCTestCase {
 /// not-yet-urgent (80%), it fell under the 85% bar, and Nik got nothing. Local calendar
 /// days, not UTC.
 final class SuggestionDueDescriptionTests: XCTestCase {
-  private let edt = TimeZone(identifier: "America/New_York")!
-
-  private func calendar() -> Calendar {
+  private func calendar() throws -> Calendar {
     var c = Calendar(identifier: .gregorian)
-    c.timeZone = edt
+    c.timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     return c
   }
 
-  private func date(_ iso: String) -> Date {
+  private func date(_ iso: String) throws -> Date {
     let f = ISO8601DateFormatter()
     f.formatOptions = [.withInternetDateTime]
-    return f.date(from: iso)!
+    return try XCTUnwrap(f.date(from: iso))
   }
 
-  func testLateEveningTaskIsDueTodayNotTomorrow() {
+  func testLateEveningTaskIsDueTodayNotTomorrow() throws {
     // 2026-08-11T03:59Z == 2026-08-10 23:59 EDT
-    let due = date("2026-08-11T03:59:00Z")
-    let now = date("2026-08-10T23:18:00Z")  // 19:18 EDT, when Nik was on TikTok
+    let due = try date("2026-08-11T03:59:00Z")
+    let now = try date("2026-08-10T23:18:00Z")  // 19:18 EDT, when Nik was on TikTok
     XCTAssertEqual(
-      SuggestionDueDescription.phrase(for: due, now: now, calendar: calendar()),
+      SuggestionDueDescription.phrase(for: due, now: now, calendar: try calendar()),
       "due today"
     )
   }
 
-  func testTomorrowIsStillTomorrow() {
+  func testTomorrowIsStillTomorrow() throws {
     // 2026-08-11T15:00Z == 2026-08-11 11:00 EDT — genuinely the next calendar day.
-    let due = date("2026-08-11T15:00:00Z")
-    let now = date("2026-08-10T23:18:00Z")
+    let due = try date("2026-08-11T15:00:00Z")
+    let now = try date("2026-08-10T23:18:00Z")
     XCTAssertEqual(
-      SuggestionDueDescription.phrase(for: due, now: now, calendar: calendar()),
+      SuggestionDueDescription.phrase(for: due, now: now, calendar: try calendar()),
       "due tomorrow"
     )
   }
 
-  func testFurtherOutCountsDays() {
-    let due = date("2026-08-12T15:00:00Z")
-    let now = date("2026-08-10T23:18:00Z")
+  func testFurtherOutCountsDays() throws {
+    let due = try date("2026-08-12T15:00:00Z")
+    let now = try date("2026-08-10T23:18:00Z")
     XCTAssertEqual(
-      SuggestionDueDescription.phrase(for: due, now: now, calendar: calendar()),
+      SuggestionDueDescription.phrase(for: due, now: now, calendar: try calendar()),
       "due in 2 days"
     )
   }
 
-  func testOverdueReadsAsOverdue() {
-    let now = date("2026-08-10T23:18:00Z")
+  func testOverdueReadsAsOverdue() throws {
+    let now = try date("2026-08-10T23:18:00Z")
     XCTAssertEqual(
-      SuggestionDueDescription.phrase(for: date("2026-08-09T15:00:00Z"), now: now, calendar: calendar()),
+      SuggestionDueDescription.phrase(for: try date("2026-08-09T15:00:00Z"), now: now, calendar: try calendar()),
       "overdue by a day"
     )
     XCTAssertEqual(
-      SuggestionDueDescription.phrase(for: date("2026-07-24T04:00:00Z"), now: now, calendar: calendar()),
+      SuggestionDueDescription.phrase(for: try date("2026-07-24T04:00:00Z"), now: now, calendar: try calendar()),
       "overdue by 17 days"
     )
   }
 
   /// The phrase is what the model quotes, so it must never contain a machine date.
-  func testPhraseNeverContainsAnISODate() {
-    let now = date("2026-08-10T23:18:00Z")
+  func testPhraseNeverContainsAnISODate() throws {
+    let now = try date("2026-08-10T23:18:00Z")
     for iso in ["2026-08-11T03:59:00Z", "2026-08-11T15:00:00Z", "2026-07-24T04:00:00Z"] {
-      let phrase = SuggestionDueDescription.phrase(for: date(iso), now: now, calendar: calendar())
+      let phrase = SuggestionDueDescription.phrase(for: try date(iso), now: now, calendar: try calendar())
       XCTAssertFalse(phrase.contains("2026"), "\(phrase) leaks a machine date into the card")
       XCTAssertFalse(phrase.contains("-"), "\(phrase) leaks a machine date into the card")
     }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -404,6 +404,22 @@ final class SuggestionCommitmentGuardTests: XCTestCase {
     }
   }
 
+  /// A long commitment is not a higher bar. This is Nik's real task, ten content words
+  /// long; a concise nudge naming the distinctive part of it must be admitted, and under
+  /// pure proportional coverage it was not.
+  func testConciseNudgeForALongCommitmentIsAdmitted() {
+    let long = ["Exchange weekly tasks with accountability partner and update the shared Google Doc tracker"]
+    XCTAssertTrue(isGrounded("Still owe the weekly exchange with your accountability partner", commitments: long))
+    XCTAssertTrue(isGrounded("The Google Doc tracker is still not updated", commitments: long))
+  }
+
+  /// Length must not be gameable in the other direction either: sharing only doing-words
+  /// with a long task is still not a reference to it.
+  func testGenericOverlapWithALongCommitmentIsStillRejected() {
+    let long = ["Exchange weekly tasks with accountability partner and update the shared Google Doc tracker"]
+    XCTAssertFalse(isGrounded("You should send an update", commitments: long))
+  }
+
   /// "send" and "update" appear in most commitments. Echoing a commitment's two most
   /// generic words while dropping everything that identifies it — quarterly, board, deck,
   /// investors — is not a reference to it.

--- a/desktop/macos/changelog/unreleased/20260810-focus-nudges-personalized.json
+++ b/desktop/macos/changelog/unreleased/20260810-focus-nudges-personalized.json
@@ -1,0 +1,3 @@
+{
+  "change": "Focus nudges now name the task you actually committed to, in plain language, and fire while you're on TikTok or YouTube instead of going quiet"
+}

--- a/desktop/macos/changelog/unreleased/20260810-insight-back-on-pro.json
+++ b/desktop/macos/changelog/unreleased/20260810-insight-back-on-pro.json
@@ -1,0 +1,3 @@
+{
+  "change": "Insights are sharper again — they run on the stronger model for everyone, not just the top tier"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -16,6 +16,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
   - desktop/macos/Desktop/Sources/MainWindow/RewindOnlyView.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveCaptureSystemProbe.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+SuggestionProbe.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryExtractionModels.swift


### PR DESCRIPTION
## What

The daily-task nudge could not fire on the two screens it exists for, and when it did fire it read a database row aloud. Five fixes, each traced to a real failure observed on a running build.

**1. Dwell anchored to the app, not the window title.** TikTok and YouTube rewrite the tab title on every video, and each rewrite restarted the 30s dwell clock. Measured across a real session: 14 consecutive TikTok contexts, max dwell 6s, zero evaluations — the one activity a distraction nudge exists for was the one it could never fire in.

**2. Commitment nudges must name work Omi actually holds.** A card reciting a prompt example — *"You still haven't sent the investor update to Bob"* — shipped five times at up to 95% confidence, higher than every grounded card, so neither the confidence bar nor dedup could catch it. `SuggestionCommitmentGuard` requires the suggestion to cover a real open commitment.

**3. Due dates are phrased, not printed.** `ISO8601DateFormatter` rendered in UTC, so a task due 23:59 EDT read as *tomorrow*; the model scored a due-today task as not-yet-urgent (80%) and it fell under the 85% bar. `SuggestionDueDescription` uses local calendar days.

**4. Goals join grounding, owner-scoped.** `getGoals()` documents that its shared cache is not owner-validated, so the fetch captures a `RuntimeOwnerAuthorizationSnapshot`, passes it, and stores only if still current — revalidated at read time and cleared on `stop()`, so an account switch cannot put one user's goals in another's prompt.

**5. Prompt v7 — two-beat voice.** Name the screen, then the one thing. No dates. Placeholders instead of literal names: the model was copying "Bob", and later "TikTok", straight out of the examples regardless of the real screen.

Before → after, same task:
```
call dad (due 2026-08-10)
TikTok is fine — but you said you'd call Ilya today
```

## Verification

Exercised on a running named bundle, not compile-only.

- **Dwell fix live:** `17:00:16` a same-app YouTube title change evaluated instead of logging `skippedDwell`, dwell 54s.
- **Delivered cards captured from the floating bar:** *"TikTok is fine — but you said you'd call Ilya today"*, *"TikTok is fun, but you still need to read messages today"*.
- **Task rotation:** completing a task through the real checkbox moved `today_count` 2 → 1 and the next nudge named the remaining commitment.
- **Guard caught a live regression:** an intermediate prompt produced `"You have 3 tasks due Aug 10"` at 95% — a tally, not a task — and the guard suppressed it.
- 30 focused tests, 0 failures. `make preflight`: 19/19.

A debug bridge action `probe_suggestion_nudge` drives grounding → evaluation → delivery, because the path cannot otherwise be exercised without holding a leisure window frontmost for 30s. It reports the real delivery outcome (`delivered` / `filtered_*` / `rejected_owner`) via a pure `SuggestionDeliveryPolicy`, so it cannot claim success for a filtered card.

## Known-remaining, deliberately not in this change

- Goals grounding returns empty in practice — wired and guarded, payoff unproven.
- RECENT SUGGESTIONS can bias task selection; the model re-picks from it and the guard then suppresses the result.
- A suppressed card still consumes the 180s evaluation cooldown.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class

`SuggestionCommitmentGuard`'s over-strict coverage threshold and the dwell anchor's app-only key were both introduced earlier on this same unmerged branch and corrected before it landed, so neither is an instance of a recurring production failure.

Failure-Class: none
