### PR TITLE
fix(desktop): conversation bridge actions collapse a live search on Home

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -213,8 +213,12 @@ struct QueryShellHome: View {
     // name over a different destination and let a flow assert a tray while watching another page, so
     // the bridge refuses it here instead — keyed on the stage mode this surface never publishes.
     // See `DesktopAutomationActionRegistry.registerBuiltins`.
+    // Each handler applies `HomeBridgeIntent.searchTextAfter` first: mode is derived from the
+    // search text, so an action that promises the conversation must clear it or its effect lands
+    // hidden behind the results panel while the bridge reports success.
     .onReceive(NotificationCenter.default.publisher(for: .homeStageOpenChat)) { _ in
       guard !usesLegacyPresentation else { return }
+      searchText = HomeBridgeIntent.openChat.searchTextAfter(searchText)
       claimCaret()
     }
     // `home_close_panel` collapses Home to its resting chat state — the same thing Escape does.
@@ -222,16 +226,18 @@ struct QueryShellHome: View {
     // be the "bridge answered ok and nothing happened" defect this file's actions exist to avoid.
     .onReceive(NotificationCenter.default.publisher(for: .homeStageClose)) { _ in
       guard !usesLegacyPresentation else { return }
-      searchText = ""
+      searchText = HomeBridgeIntent.closePanel.searchTextAfter(searchText)
       claimCaret()
     }
     .onReceive(NotificationCenter.default.publisher(for: .homeStageAsk)) { note in
       guard !usesLegacyPresentation, let query = note.userInfo?["query"] as? String else { return }
+      searchText = HomeBridgeIntent.ask.searchTextAfter(searchText)
       chatProvider.draftText = query
       ask()
     }
     .onReceive(NotificationCenter.default.publisher(for: .homeStageAttach)) { note in
       guard !usesLegacyPresentation, let path = note.userInfo?["path"] as? String else { return }
+      searchText = HomeBridgeIntent.attach.searchTextAfter(searchText)
       stageAttachments([URL(fileURLWithPath: path)])
     }
     // Escape while searching clears the search and lands back on the conversation; with an empty

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -141,6 +141,28 @@ enum QueryShellMode: Equatable, Sendable {
   static let homeDefault: QueryShellMode = .answer
 }
 
+/// The `home_*` bridge actions, as the search-text transition each one promises.
+///
+/// Home's mode is derived from the search text, so a bridge action that promises the conversation
+/// (`home_open_chat`, `home_ask`, `home_close_panel`) must clear the search — otherwise it reports
+/// success while its effect stays hidden behind the results panel the user was filtering. One pure
+/// function, so the handlers and the tests cannot disagree about which actions collapse the search.
+enum HomeBridgeIntent: CaseIterable, Sendable {
+  case openChat
+  case ask
+  case closePanel
+  case attach
+
+  /// The search text after this intent runs. Everything that lands the user in the conversation
+  /// clears it; staging an attachment narrows nothing and keeps the search where it was.
+  func searchTextAfter(_ current: String) -> String {
+    switch self {
+    case .openChat, .ask, .closePanel: return ""
+    case .attach: return current
+    }
+  }
+}
+
 /// **Where the one composer is standing.**
 ///
 /// While you are searching, a field above the panel is the right arrangement: you type at the top

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -79,6 +79,21 @@ final class QueryShellTests: XCTestCase {
   /// unobserved notification is a bridge action that silently does nothing — the defect the home
   /// automation entry points exist to avoid (it shipped once: the modern surface dropped its
   /// `.homeStageClose` handler while the registry kept answering "ok").
+  /// **A bridge action that promises the conversation leaves no search behind.** Mode is derived
+  /// from the search text, so `home_open_chat` / `home_ask` / `home_close_panel` reporting success
+  /// while the text survives would leave their effect hidden behind the results panel — the
+  /// regression cross-review caught after the close handler landed without covering open/ask.
+  func testConversationBridgeIntentsCollapseTheSearchAndAttachDoesNot() {
+    for intent in [HomeBridgeIntent.openChat, .ask, .closePanel] {
+      XCTAssertEqual(intent.searchTextAfter("standup notes"), "", "\(intent) must land on the conversation")
+    }
+    XCTAssertEqual(HomeBridgeIntent.attach.searchTextAfter("standup notes"), "standup notes")
+    // The transition is total: every intent has an explicit answer for live search text.
+    for intent in HomeBridgeIntent.allCases {
+      _ = intent.searchTextAfter("x")
+    }
+  }
+
   func testEveryBridgeHomeStageNotificationIsObservedByTheModernSurface() throws {
     // omi-test-quality: source-inspection -- static contract: SwiftUI @State/onReceive wiring cannot be driven hermetically without mounting the view; pins the registration sites for the bridge's four homeStage notifications.
     let source = try String(
@@ -91,6 +106,13 @@ final class QueryShellTests: XCTestCase {
       XCTAssertTrue(
         source.contains("publisher(for: .\(name))"),
         "QueryShellHome no longer observes .\(name); its bridge action now succeeds while doing nothing")
+    }
+    // …and each handler applies the shared search-text transition, so an action cannot succeed
+    // while its effect stays hidden behind a live search.
+    for intent in ["openChat", "closePanel", "ask", "attach"] {
+      XCTAssertTrue(
+        source.contains("HomeBridgeIntent.\(intent).searchTextAfter"),
+        "the .\(intent) handler no longer applies HomeBridgeIntent.searchTextAfter")
     }
   }
 


### PR DESCRIPTION
Cross-review follow-on to #11390: `home_open_chat`/`home_ask` reported success while leaving `searchText` intact — mid-search, the claimed caret or the sent answer stayed hidden behind the results panel. `HomeBridgeIntent` is now the single pure search-text transition shared by all four `homeStage*` handlers (openChat/ask/closePanel collapse, attach preserves), unit-tested directly, with the wiring tripwire extended so a handler that drops the transition reddens CI.

## Product invariants affected

- INV-CHAT-1

## Verification

- QueryShellTests 39/39 (`--disable-sandbox -c debug`); desktop test-quality ratchet at baseline.
- Pure-policy coverage asserts the transition per intent; the annotated tripwire pins each handler's use of it (SwiftUI @State cannot be driven hermetically without mounting the view).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

