### PR TITLE
chore(desktop): changelog fragment for #11393

### DIFF
--- a/desktop/macos/changelog/unreleased/20260811-bridge-search-collapse.json
+++ b/desktop/macos/changelog/unreleased/20260811-bridge-search-collapse.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat shortcuts and automations now land on the conversation instead of leaving their result hidden behind an active search"
+}


### PR DESCRIPTION
Release Eligibility is red on the tip because #11393 merged without a changelog fragment (my admin-merge outran its checks) and the consolidated 12156 release emptied `unreleased/`, so the tree-fragment fallback correctly found nothing. Fragment only; restores the release train's source gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

