### PR TITLE
fix(desktop): signed-out launch no longer deadlocks the main thread; stranded frames recover

### DIFF
--- a/desktop/macos/Desktop/Sources/Auth/AuthSessionAttemptFence.swift
+++ b/desktop/macos/Desktop/Sources/Auth/AuthSessionAttemptFence.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// A monotonic capability for asynchronous authentication work.
 ///
@@ -12,35 +13,47 @@ struct AuthSessionAttempt: Equatable, Sendable {
 }
 
 final class AuthSessionAttemptFence: @unchecked Sendable {
-  private let lock = NSLock()
-  private var generation: UInt64 = 0
+  /// Serialises `begin` against `commitIfCurrent` so a newer attempt cannot
+  /// start while a commit's credential/defaults mutation is mid-flight.
+  ///
+  /// **Never taken by the read paths.** A commit's operation can post a
+  /// `UserDefaults` change notification, and notification delivery to
+  /// queue-based observers is synchronous — a background commit can therefore
+  /// legitimately wait on the main thread. If the main thread then needed this
+  /// lock merely to *read* the current attempt (`APIClient.buildHeaders` does,
+  /// on every request), the app deadlocked with a frozen UI: the shipped
+  /// sign-in screen whose buttons answered nothing (#11374 follow-up).
+  private let commitLock = NSLock()
+  /// The generation value, behind its own micro-lock that is never held across
+  /// caller code — readers always complete promptly on any thread.
+  private let generation = OSAllocatedUnfairLock<UInt64>(initialState: 0)
 
   func begin() -> AuthSessionAttempt {
-    lock.withLock {
-      generation &+= 1
-      return AuthSessionAttempt(generation: generation)
+    commitLock.withLock {
+      generation.withLock { value in
+        value &+= 1
+        return AuthSessionAttempt(generation: value)
+      }
     }
   }
 
   func current() -> AuthSessionAttempt {
-    lock.withLock {
-      AuthSessionAttempt(generation: generation)
-    }
+    AuthSessionAttempt(generation: generation.withLock { $0 })
   }
 
   func isCurrent(_ attempt: AuthSessionAttempt) -> Bool {
-    lock.withLock { generation == attempt.generation }
+    generation.withLock { $0 } == attempt.generation
   }
 
   /// Execute a synchronous commit only while `attempt` remains authoritative.
-  /// Holding the lock makes beginning a newer attempt mutually exclusive with
-  /// the credential/defaults mutation itself.
+  /// Holding `commitLock` makes beginning a newer attempt mutually exclusive
+  /// with the credential/defaults mutation itself; reads stay lock-free.
   func commitIfCurrent<T>(
     _ attempt: AuthSessionAttempt,
     _ operation: () throws -> T
   ) rethrows -> T? {
-    try lock.withLock {
-      guard generation == attempt.generation else { return nil }
+    try commitLock.withLock {
+      guard generation.withLock({ $0 }) == attempt.generation else { return nil }
       return try operation()
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -484,6 +484,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
   }
 
   func prewarmBackgroundAgentKickoffPhrases() {
+    // Synthesis needs an authenticated backend call; signed out it can only fail — and at launch
+    // it walked the main thread into the auth fence while a restore held it (#11374).
+    guard AuthService.shared.isSignedIn else { return }
     let mode = currentMode ?? resolvePlaybackMode()
     currentMode = mode
     guard case .openAI(let voiceID, let instructions) = mode else { return }

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -68,6 +68,23 @@ enum ShellSummonPlacement {
     return clamped(NSRect(origin: remembered.origin, size: size), into: visibleFrame)
   }
 
+  /// The least of a shell a person can actually use: enough visible surface to read the panel and
+  /// press its controls. Anything less is a stranded window — a sliver in a corner from a frame
+  /// restored across a display change (or persisted by an automation park), whose buttons exist at
+  /// coordinates no screen shows. The sign-in window shipped exactly that: restored to a 24×32
+  /// corner sliver, its "Continue" buttons unclickable at any version (#11374 follow-up).
+  static let minimumUsableOverlap = NSSize(width: 320, height: 240)
+
+  /// Whether a frame is meaningfully on some display — not merely intersecting an edge.
+  static func isMeaningfullyOnScreen(
+    _ frame: NSRect, visibleFrames: [NSRect], minimumOverlap: NSSize = minimumUsableOverlap
+  ) -> Bool {
+    visibleFrames.contains { visible in
+      let overlap = visible.intersection(frame)
+      return overlap.width >= minimumOverlap.width && overlap.height >= minimumOverlap.height
+    }
+  }
+
   /// Whether this summon should place the window at all.
   ///
   /// `false` is the interesting answer: a shell already up on the display you are on is a shell you
@@ -397,12 +414,42 @@ enum ShellSummon {
   /// callback: an observer block delivered on the main queue is still a non-isolated closure, so
   /// reading an `NSWindow` out of the notification would be a `sending` race. Passing the window as
   /// the observed object keeps the filtering in `NotificationCenter`, where it is free and safe.
+  /// Re-place a visible shell whose frame no display meaningfully shows.
+  ///
+  /// Restored frames outlive the arrangement that produced them: a display unplugs, a resolution
+  /// changes, or an automation park's corner frame gets persisted — and the next launch restores a
+  /// window whose controls exist off every screen, with no affordance to recover it (the sign-in
+  /// window has no rail, no hotkey and no drag handle a user can reach). Automation presentations
+  /// park deliberately and are exempt; `normal` mode is the user's window and must be reachable.
+  static func recoverStrandedFrameIfNeeded() {
+    guard DesktopAutomationWindowPresentation.currentMode == .normal else { return }
+    guard let window = shellWindow(), window.isVisible else { return }
+    let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+    guard !visibleFrames.isEmpty,
+      !ShellSummonPlacement.isMeaningfullyOnScreen(window.frame, visibleFrames: visibleFrames)
+    else { return }
+    guard let screen = ActiveDisplay.screen() ?? NSScreen.main ?? NSScreen.screens.first else { return }
+    window.setFrame(landingFrame(on: screen), display: true)
+    window.makeKeyAndOrderFront(nil)
+    rememberFrame(of: window)
+  }
+
   private static func rebind(to window: NSWindow) {
     let center = NotificationCenter.default
     for observer in observers { center.removeObserver(observer) }
     observers.removeAll()
     unregisterEscapeRoute()
     boundWindow = window
+    recoverStrandedFrameIfNeeded()
+    for name in [
+      NSApplication.didBecomeActiveNotification,
+      NSApplication.didChangeScreenParametersNotification,
+    ] {
+      observers.append(
+        center.addObserver(forName: name, object: nil, queue: .main) { _ in
+          MainActor.assumeIsolated { recoverStrandedFrameIfNeeded() }
+        })
+    }
     for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification] {
       observers.append(
         center.addObserver(forName: name, object: window, queue: .main) { _ in
@@ -430,11 +477,17 @@ enum ShellSummon {
     // Onboarding completion and sign-out are both `UserDefaults` writes, so this is the one signal
     // that covers the switch in either direction. Re-dressing only on a real change keeps it off the
     // hot path of every other `@AppStorage` write in the app.
+    // `queue: nil` + explicit hop, never `queue: .main`: notification delivery to queue-based
+    // observers is synchronous, so a main-queue observer makes every background
+    // `UserDefaults.set` wait on the main thread — which deadlocked the app when an auth commit
+    // held the session fence while posting and the main thread wanted that fence (#11374).
     observers.append(
-      center.addObserver(forName: UserDefaults.didChangeNotification, object: nil, queue: .main) { _ in
-        MainActor.assumeIsolated {
-          guard let window = shellWindow(), presentation() != appliedPresentation else { return }
-          applyPresentation(to: window)
+      center.addObserver(forName: UserDefaults.didChangeNotification, object: nil, queue: nil) { _ in
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated {
+            guard let window = shellWindow(), presentation() != appliedPresentation else { return }
+            applyPresentation(to: window)
+          }
         }
       })
   }

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -556,13 +556,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     migrateAppName()
 
     updateOnboardingLifecyclePolicy(reason: "launch")
+    // `queue: nil` + explicit hop, never `queue: .main`: synchronous main-queue delivery makes
+    // every background `UserDefaults.set` wait on the main thread, which deadlocked the app when
+    // an auth commit held the session fence while posting and the main thread wanted that fence
+    // (frozen sign-in screen, #11374).
     userDefaultsObserver = NotificationCenter.default.addObserver(
       forName: UserDefaults.didChangeNotification,
       object: nil,
-      queue: .main
+      queue: nil
     ) { [weak self] _ in
-      MainActor.assumeIsolated {
-        self?.updateOnboardingLifecyclePolicy(reason: "user_defaults_changed")
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          self?.updateOnboardingLifecyclePolicy(reason: "user_defaults_changed")
+        }
       }
     }
 

--- a/desktop/macos/Desktop/Tests/AuthSessionAttemptFenceTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthSessionAttemptFenceTests.swift
@@ -102,6 +102,43 @@ final class AuthSessionAttemptFenceTests: XCTestCase {
     AuthState.shared.transition(to: originalPhase)
   }
 
+  /// **Fence reads never wait on an in-flight commit.** The shipped deadlock: a background auth
+  /// commit held the fence while its defaults write synchronously waited on a main-queue
+  /// notification observer — and the main thread was itself inside `current()` waiting for the
+  /// fence (every `APIClient.buildHeaders` reads it). Frozen sign-in screen, no clickable
+  /// buttons (#11374 follow-up). Reads are lock-free; only begin/commit serialize.
+  func testReadersCompleteWhileACommitHoldsTheFence() {
+    let fence = AuthSessionAttemptFence()
+    let attempt = fence.begin()
+    let commitEntered = DispatchSemaphore(value: 0)
+    let releaseCommit = DispatchSemaphore(value: 0)
+    let commitDone = expectation(description: "commit finished")
+
+    DispatchQueue.global().async {
+      _ = fence.commitIfCurrent(attempt) {
+        commitEntered.signal()
+        releaseCommit.wait()
+        return true
+      }
+      commitDone.fulfill()
+    }
+    commitEntered.wait()
+
+    // Pre-fix these two calls hang forever; the test's own timeout is the tripwire.
+    XCTAssertEqual(fence.current(), attempt)
+    XCTAssertTrue(fence.isCurrent(attempt))
+
+    releaseCommit.signal()
+    wait(for: [commitDone], timeout: 5)
+
+    // Serialisation between begin and commit is intact: nothing newer began mid-commit,
+    // and a subsequent begin still supersedes.
+    XCTAssertTrue(fence.isCurrent(attempt))
+    let newer = fence.begin()
+    XCTAssertFalse(fence.isCurrent(attempt))
+    XCTAssertTrue(fence.isCurrent(newer))
+  }
+
   func testNewSignInTokensSurviveSupersededSignOutWaitingOnOwnerTransition() async throws {
     let ownerA = makeOwnerID("signout-a")
     let ownerB = makeOwnerID("signin-b")

--- a/desktop/macos/Desktop/Tests/ShellSummonTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellSummonTests.swift
@@ -313,6 +313,60 @@ final class ShellSummonTests: XCTestCase {
   }
 
   @MainActor
+  // MARK: - Stranded-frame recovery
+
+  /// **A restored frame no display shows is not a placement, it is a lockout.** The sign-in window
+  /// shipped restored to a bottom-right corner sliver (a persisted automation-park frame after a
+  /// display change), leaving its only controls at coordinates no screen shows — with no rail, no
+  /// hotkey and no reachable drag handle to recover it (#11374 follow-up).
+  func testACornerSliverFrameIsNotMeaningfullyOnScreen() {
+    let primary = NSRect(x: 0, y: 0, width: 2048, height: 1330)
+    let secondary = NSRect(x: -1920, y: 250, width: 1920, height: 1080)
+    // The exact shipped failure: 960×712 restored so only a 24×32 sliver overlaps the primary.
+    let stranded = NSRect(x: 2024, y: -382, width: 960, height: 712)
+    XCTAssertFalse(
+      ShellSummonPlacement.isMeaningfullyOnScreen(stranded, visibleFrames: [primary, secondary]))
+    // Centred on either display is fine.
+    XCTAssertTrue(
+      ShellSummonPlacement.isMeaningfullyOnScreen(
+        ShellSummonPlacement.centered(NSSize(width: 960, height: 700), in: primary),
+        visibleFrames: [primary, secondary]))
+    // Straddling the seam still counts once a usable panel area is visible somewhere.
+    XCTAssertTrue(
+      ShellSummonPlacement.isMeaningfullyOnScreen(
+        NSRect(x: -400, y: 400, width: 960, height: 700), visibleFrames: [primary, secondary]))
+    // An edge-touching hairline does not.
+    XCTAssertFalse(
+      ShellSummonPlacement.isMeaningfullyOnScreen(
+        NSRect(x: 2040, y: 1320, width: 960, height: 700), visibleFrames: [primary]))
+    XCTAssertFalse(ShellSummonPlacement.isMeaningfullyOnScreen(stranded, visibleFrames: []))
+  }
+
+  @MainActor
+  func testRecoveryRePlacesAVisibleStrandedShellOntoARealDisplay() throws {
+    guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+      throw XCTSkip("no display in this session")
+    }
+    let window = makeShellWindow()
+    window.title = OMIApp.currentWindowTitle
+    // Strand it: a frame whose overlap with every display is a corner sliver.
+    let visible = screen.visibleFrame
+    window.setFrame(
+      NSRect(x: visible.maxX - 24, y: visible.minY - 680, width: 960, height: 712), display: false)
+    NonintrusiveTestWindow.orderIn(window, preserveFrame: true)
+    defer { window.orderOut(nil) }
+    try XCTSkipIf(
+      !window.isVisible, "session cannot order windows in; recovery is untestable here")
+
+    ShellSummon.recoverStrandedFrameIfNeeded()
+
+    XCTAssertTrue(
+      ShellSummonPlacement.isMeaningfullyOnScreen(
+        window.frame, visibleFrames: NSScreen.screens.map(\.visibleFrame)),
+      "recovery must land the shell where its controls are reachable")
+  }
+
+  @MainActor
   private func makeShellWindow() -> NSWindow {
     NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 960, height: 700),

--- a/desktop/macos/changelog/unreleased/20260811-signin-deadlock.json
+++ b/desktop/macos/changelog/unreleased/20260811-signin-deadlock.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a freeze that could make the whole app unclickable — including the sign-in buttons — right after launch"
+}


### PR DESCRIPTION
## Summary

Root cause of the released-build "dead zone" that survived every notch fix (Nik + David, versions 0.12.154-157): **the signed-out launch path deadlocks the main thread**, freezing all input — including the sign-in buttons. Local main builds never showed it because run.sh seeds a signed-in session (path never taken) and debug timing hides the race the release DMG hits.

Deadlock (sampled live, both stacks): a background auth commit held `AuthSessionAttemptFence` while its UserDefaults write synchronously waited on a main-queue notification observer; the main thread waited on the same fence via `APIClient.buildHeaders` (voice-prewarm at launch, signed out).

Three independent cuts:
1. **Fence reads are lock-free** (`OSAllocatedUnfairLock` value; `NSLock` only serialises begin/commit — the mutual-exclusion contract is unchanged and covered).
2. **Both `UserDefaults.didChangeNotification` observers** (OmiApp, ShellSummon) take `queue: nil` + explicit main hop — `queue: .main` makes every background defaults write synchronously wait on main.
3. **Voice prewarm guards on `isSignedIn`** — signed out it can only fail, and it was the main-thread walk into the fence.

Plus: **`ShellSummon.recoverStrandedFrameIfNeeded`** — a restored window frame no display meaningfully shows (persisted automation-park frame, display unplugged) is re-placed on the active display at bind/activation/screen-change; the sign-in window shipped restored to a 24×32 corner sliver with no recovery affordance (no rail, no hotkey, no reachable drag handle).

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

## Verification

- Live repro then live fix on a signed-out named bundle (normal presentation): pre-fix sample shows both deadlocked stacks; post-fix the main thread is healthy (zero 'main thread busy'), the stranded sign-in window self-recovered to screen centre, and a real click on **Continue with Google opened the OAuth flow in Chrome** (app-switch logged).
- `AuthSessionAttemptFenceTests` 27/27 — new `testReadersCompleteWhileACommitHoldsTheFence` hangs pre-fix (its timeout is the tripwire) and proves begin/commit serialisation is intact.
- `ShellSummonTests`+`ShellWindowChromeTests` 43/43 — new pure stranded-frame geometry cases (the exact shipped 24×32 sliver) + behavioral recovery test with the frame-less-session skip guard.
- Desktop test-quality ratchet at baseline.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

