### PR TITLE
chore(desktop): OmiApp ratchet baseline for the deadlock-fix observer hop

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -5,7 +5,7 @@
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4547,
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1516,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1528,
-    "desktop/macos/Desktop/Sources/OmiApp.swift": 1584
+    "desktop/macos/Desktop/Sources/OmiApp.swift": 1590
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls. +32 keeps the durable accepted-deletion cleanup journal and owner-bound VM/sync drain inside the fenced sign-out commit so cleanup resumes after restart and credentials or owner visibility cannot change first (SCA-280).",
@@ -13,7 +13,7 @@
     "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "debug_hit_probe diagnostic action (topmost window + hit-tested view at a screen point) registers beside the other non-prod debug actions; it found the notch click-sink dead zone.",
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": "Adds the bounded shared-capture silent-microphone terminal incident so a persistent zero-sample CoreAudio route is queryable without recording sensitive content. +1 registers account-cutover retained-control fallback telemetry in the existing bounded diagnostic area.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Separates MCP data serving from production OAuth/grant authority so Beta can use dev data endpoints without issuing or reading customer grants through the dev identity plane. Pinned swift-format normalizes line layout without changing runtime behavior, and cloudOAuthGrantClientIDs keep ChatGPT directory grants on the production client for dev/Beta builds.",
-    "desktop/macos/Desktop/Sources/OmiApp.swift": "Side-by-side Omi Beta: legacy Omi Computer.app cleanup gains a stable-identity guard so the beta app can never terminate or delete a stable install. Extracts onboarding journal lifecycle and removes startup maintenance while retaining newer main additions; also wires AgentCompletionVoiceDelivery.shared.start() at the app-launch site so completed background-agent runs reach a live voice session. Notification registration repair remains explicit instead of restarting usernoted or NotificationCenter at launch. The app delegate owns the menu-bar identity fallback chain so a missing packaged asset cannot silently substitute the listening waveform."
+    "desktop/macos/Desktop/Sources/OmiApp.swift": "UserDefaults.didChangeNotification observer must document and implement the queue:nil + explicit-main-hop contract (synchronous main-queue delivery deadlocked the signed-out launch, #11396)."
   },
   "threshold": 1500
 }


### PR DESCRIPTION
Release Eligibility is red on a04f0d127c: #11396's observer-hop fix grew OmiApp.swift 1584→1590 past its frozen baseline (my --no-verify push skipped the local gate). Baseline raised with justification; no code change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

