### PR TITLE
test(desktop): home flow steps describe the chat-first surface

### DIFF
--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -28,20 +28,20 @@ steps:
         - Chat
 
   - id: S2
-    name: Verify the query bar is a composer
-    do: "Verify the query bar carries every control needed to hold a conversation: the text field, a paperclip (Attach files), the two keyboard hints ('⏎ Search' and '⌘⏎ Ask'), and the push-to-talk microphone disc."
+    name: Verify the two inputs are distinct
+    do: "Verify the search bar above the panel is pure search (magnifying glass, no send control) and the chat composer inside the panel carries the conversation controls: text field, paperclip (Attach files), microphone, and the send disc."
     expect:
       interactive_count: { min: 4 }
 
   - id: S2b
     name: Ask, then stop
-    do: "Type a question and press ⌘⏎. The panel swaps to the answer thread. While the answer is still streaming, verify the '⌘⏎ Ask' hint has been replaced by a 'Stop' button in the same slot, and click it. The turn ends without an error card."
+    do: "Type a question in the chat composer and press ⏎. The answer streams into the transcript. While it is still streaming, verify the send disc has been replaced by a Stop control in the same slot, and click it. The turn ends without an error card."
     expect:
       interactive_count: { min: 2 }
 
   - id: S2c
     name: Conversation menu and the way back
-    do: "In answer mode, open the '…' menu next to '‹ Results' and verify it offers Copy conversation, Clear conversation and AI settings. Click '‹ Results', then navigate to Conversations and back to Home: the panel's corner now offers a 'Chat ›' chip. Click it and verify the same conversation is still there with no duplicated turns."
+    do: "Open the '…' menu in the panel's corner and verify it offers Copy conversation, Clear conversation and AI settings. Type in the search bar and verify the panel shows live-narrowing results; clear it (or press esc) and verify the same conversation returns with no duplicated turns."
     expect:
       interactive_count: { min: 2 }
 


### PR DESCRIPTION
S2/S2b/S2c in `e2e/flows/home.yaml` still describe the retired search-first surface (⌘⏎ Ask hints, mode-swapping hero, Chat › re-entry chip). Rewritten for the shipped chat-first Home. E2E flows are changelog-exempt harness artifacts.

Also deliberately advances the newest releasable desktop source SHA: `a04f0d127c` carries an immutable red Release Eligibility (the OmiApp line-count ratchet, fixed on main in #11397 but unrepairable retroactively on that SHA), which wedges the release train's source gate. This commit's fresh eligibility run gates the deadlock-fix candidate instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

