### PR TITLE
chore(desktop): prune dead HomeChatReentry (and give the train a compile-bearing SHA)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryChatCapability.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryChatCapability.swift
@@ -59,22 +59,3 @@ enum HomeChatTranscript {
       .joined(separator: "\n\n")
   }
 }
-
-/// Whether the results panel offers the way back into the transcript.
-///
-/// **This is the difference between "chat exists" and "chat is reachable".** Asking is a mode of
-/// this query, so the answer thread is entered with `⌘⏎` and left with Escape — which is right
-/// until you navigate to another destination and come back, at which point the mode is gone, the
-/// transcript is still on the provider, and the only way to see it again is to ask something else.
-/// One chip in the panel's corner, mirroring the `‹ Results` chip the answer mode already has,
-/// restores reachability without adding a destination.
-///
-/// It reuses `HomeHistoryPresentationPolicy` rather than restating the rule: Home already decided
-/// once that a loaded, non-empty transcript is worth showing, and one product cannot hold two
-/// opinions about that.
-enum HomeChatReentry {
-  static func isOffered(messageCount: Int, isLoading: Bool) -> Bool {
-    HomeHistoryPresentationPolicy.restingMode(isLoading: isLoading, messageCount: messageCount)
-      == .chat
-  }
-}

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -561,26 +561,4 @@ final class QueryShellTests: XCTestCase {
     ]
     XCTAssertEqual(HomeChatTranscript.plainText(messages), "You: hello")
   }
-
-  /// **"All of chat is there" is not the same as "chat is reachable".** Asking is a mode, and the
-  /// mode is view state, so leaving Home and coming back leaves the transcript on the provider and
-  /// nothing on screen admitting it exists. The panel's corner offers the way back — but only once
-  /// history has actually loaded, or the chip flickers in during every launch.
-  func testTheWayBackIntoTheTranscriptAppearsOnlyForLoadedHistory() {
-    XCTAssertFalse(HomeChatReentry.isOffered(messageCount: 0, isLoading: false))
-    XCTAssertFalse(
-      HomeChatReentry.isOffered(messageCount: 12, isLoading: true),
-      "a count that is still being restored is not history yet")
-    XCTAssertTrue(HomeChatReentry.isOffered(messageCount: 12, isLoading: false))
-  }
-
-  /// It is the same rule Home already had for its resting mode. Two opinions about "is there
-  /// history worth showing" is how one of them silently stops matching the other.
-  func testReentryReusesHomesOneOpinionAboutExistingHistory() {
-    for (count, loading) in [(0, false), (12, true), (12, false), (1, false)] {
-      XCTAssertEqual(
-        HomeChatReentry.isOffered(messageCount: count, isLoading: loading),
-        HomeHistoryPresentationPolicy.restingMode(isLoading: loading, messageCount: count) == .chat)
-    }
-  }
 }


### PR DESCRIPTION
`HomeChatReentry` lost its last mount when Home became chat-resting (#11390/#11393) — deleting the enum and its two tests; zero references remain (QueryShellTests 37/37 after the prune).

Also intentionally advances the release train's source SHA to one whose CI produces a release-compile verdict: the current newest releasable SHA (#11398) is an e2e-flow-only change whose CI correctly skipped the compile, but the candidate source gate requires `success` on the exact SHA, so the train reads it as missing evidence and blocks. Planner handling of deliberately-skipped checks tracked in #11382.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

