### PR TITLE
fix(desktop): hide cutover overlay during bootstrap

### DIFF
--- a/desktop/macos/Desktop/Sources/AccountCutover/AccountCutoverBlockingOverlay.swift
+++ b/desktop/macos/Desktop/Sources/AccountCutover/AccountCutoverBlockingOverlay.swift
@@ -67,10 +67,12 @@ private struct AccountCutoverBlockingOverlayHost: View {
   let onOpenDownload: (DesktopUpdatePolicyResponse) -> Void
 
   var body: some View {
-    AccountCutoverBlockingOverlay(
-      decision: manager.overlayDecision,
-      strandedNewData: manager.control.strandedNewData,
-      onOpenDownload: onOpenDownload
-    )
+    if let decision = manager.overlayDecision {
+      AccountCutoverBlockingOverlay(
+        decision: decision,
+        strandedNewData: manager.control.strandedNewData,
+        onOpenDownload: onOpenDownload
+      )
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/AccountCutover/AccountCutoverControl.swift
+++ b/desktop/macos/Desktop/Sources/AccountCutover/AccountCutoverControl.swift
@@ -167,9 +167,12 @@ final class AccountCutoverControlManager: ObservableObject {
     bootstrapPhase == .ready && decision == .allowProductTraffic
   }
 
-  /// Overlay decision while bootstrap is pending: fail closed into maintenance.
-  var overlayDecision: AccountCutoverGateDecision {
-    bootstrapPhase == .ready ? decision : .migrationMaintenance
+  /// A blocking overlay is user-facing evidence of an authoritative server decision.
+  /// Bootstrap remains fail-closed for product traffic, but an unconfirmed pending
+  /// state must not masquerade as a migration or intercept the shell while control loads.
+  var overlayDecision: AccountCutoverGateDecision? {
+    guard bootstrapPhase == .ready else { return nil }
+    return decision == .allowProductTraffic ? nil : decision
   }
 
   /// Install activation / owner observers once and bind+refresh the current owner.

--- a/desktop/macos/Desktop/Tests/AccountCutoverControlTests.swift
+++ b/desktop/macos/Desktop/Tests/AccountCutoverControlTests.swift
@@ -68,7 +68,7 @@ final class AccountCutoverControlTests: XCTestCase {
     XCTAssertTrue(manager.blocksProductTraffic)
     XCTAssertFalse(manager.isProductShellAdmitted)
     XCTAssertFalse(manager.allowsOfflineQueueUpload)
-    XCTAssertEqual(manager.overlayDecision, .migrationMaintenance)
+    XCTAssertNil(manager.overlayDecision)
   }
 
   func testManagerAppliesFetchedControl() async {
@@ -91,6 +91,7 @@ final class AccountCutoverControlTests: XCTestCase {
     XCTAssertFalse(manager.allowsOfflineQueueUpload)
     XCTAssertTrue(manager.blocksProductTraffic)
     XCTAssertFalse(manager.isProductShellAdmitted)
+    XCTAssertEqual(manager.overlayDecision, .migrationMaintenance)
   }
 
   func testRefreshFailureRetainsLastConfirmedControl() async throws {
@@ -203,7 +204,20 @@ final class AccountCutoverControlTests: XCTestCase {
     XCTAssertEqual(manager.bootstrapPhase, .pending)
     XCTAssertTrue(manager.blocksProductTraffic)
     XCTAssertFalse(manager.allowsOfflineQueueUpload)
+    XCTAssertNil(manager.overlayDecision)
     XCTAssertEqual(try accountCutoverFallbackCount(), beforeCount)
+  }
+
+  func testAllowingControlDoesNotMountABlockingOverlay() async {
+    let manager = AccountCutoverControlManager(
+      fetchControl: { AccountCutoverControl.legacyDefault },
+      currentOwnerID: { "owner-a" }
+    )
+
+    await manager.bindCurrentOwnerAndRefresh()
+
+    XCTAssertTrue(manager.isProductShellAdmitted)
+    XCTAssertNil(manager.overlayDecision)
   }
 
   func testOfflineUploadAdmissionRequiresReadyAllowingControl() {

--- a/desktop/macos/changelog/unreleased/20260811-account-cutover-bootstrap-overlay.json
+++ b/desktop/macos/changelog/unreleased/20260811-account-cutover-bootstrap-overlay.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped the reserved account-migration prompt from flashing and blocking clicks during normal app launch"
+}


### PR DESCRIPTION
## What changed and why

Stop treating the account-cutover bootstrap's unconfirmed pending state as an active migration. Product traffic remains fail-closed until control loads, but the reserved migration overlay now appears only after an authoritative blocking decision, preventing the launch-time migration flash and full-window click interception.

## Product invariants affected

none

## How it was verified

- `xcrun swift test -c debug --package-path Desktop --filter AccountCutoverControlTests` — 12 tests passed, including pending bootstrap, authoritative migration, failed first fetch, and allowed control.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — Swift and agent cross-surface contract smoke passed.
- Built and launched `/Applications/omi-beta-migration-popup.app` signed in against the development backend; `omi-ctl wait-ready`, `health`, and `state` confirmed the named bundle reached the signed-in main shell with the expected bundle identity.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed.

## Tests

`AccountCutoverControlTests` now asserts that pending bootstrap mounts no blocking overlay, an authoritative migration decision still does, a first-fetch failure remains traffic-blocking without claiming migration, and an allowing decision mounts no overlay.

## Failure class (fixes)

Failure-Class: FC-unestablished-capability-default


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

