### PR TITLE
fix(desktop): stop beta window dead zones

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2704,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4929,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4934,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2807,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1658

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2704,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4934,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4929,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2807,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1658

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-floatingcontrolbar.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift": 2375,
     "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift": 2704,
-    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4934,
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift": 4920,
     "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift": 2807,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift": 1536,
     "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift": 1658

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
@@ -8,7 +8,8 @@ enum FloatingBarMouseInterceptionPolicy {
     isVisible: Bool,
     acceptsMouseHit: (NSPoint) -> Bool
   ) -> Bool {
-    guard isVisible, windowFrame.contains(mouseLocation) else { return true }
+    guard isVisible else { return true }
+    guard windowFrame.contains(mouseLocation) else { return false }
     let local = NSPoint(
       x: mouseLocation.x - windowFrame.minX,
       y: mouseLocation.y - windowFrame.minY)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
@@ -21,6 +21,7 @@ enum FloatingBarMouseInterceptionPolicy {
 final class FloatingBarMouseInterceptionReconciler {
   private nonisolated(unsafe) var monitors: [Any] = []
   private var cancellables = Set<AnyCancellable>()
+  private var pollingCancellable: AnyCancellable?
 
   init(state: FloatingControlBarState, reconcile: @escaping @MainActor @Sendable () -> Void) {
     let scheduleReconciliation: @Sendable () -> Void = {
@@ -42,13 +43,6 @@ final class FloatingBarMouseInterceptionReconciler {
       monitors.append(local)
     }
 
-    // Monitor delivery is not the correctness boundary for a top-level transparent panel.
-    // Polling also reconciles a stationary pointer after frame or state transitions.
-    Timer.publish(every: 1.0 / 30.0, on: .main, in: .common)
-      .autoconnect()
-      .sink { _ in reconcile() }
-      .store(in: &cancellables)
-
     let ownershipPublishers: [AnyPublisher<Void, Never>] = [
       state.$showingAIConversation.map { _ in () }.eraseToAnyPublisher(),
       state.$showingAIResponse.map { _ in () }.eraseToAnyPublisher(),
@@ -61,6 +55,16 @@ final class FloatingBarMouseInterceptionReconciler {
       .store(in: &cancellables)
   }
 
+  func setPollingActive(_ active: Bool, reconcile: @escaping @MainActor @Sendable () -> Void) {
+    guard active != (pollingCancellable != nil) else { return }
+    pollingCancellable =
+      active
+      ? Timer.publish(every: 1.0 / 30.0, on: .main, in: .common)
+        .autoconnect()
+        .sink { _ in reconcile() }
+      : nil
+  }
+
   deinit {
     monitors.forEach(NSEvent.removeMonitor)
   }
@@ -68,6 +72,7 @@ final class FloatingBarMouseInterceptionReconciler {
 
 extension FloatingControlBarWindow {
   func syncMouseInterception(mouseLocation: NSPoint = NSEvent.mouseLocation) {
+    setMouseInterceptionPollingActive(isVisible)
     let shouldIgnore = FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
       mouseLocation: mouseLocation,
       windowFrame: frame,
@@ -83,5 +88,10 @@ extension FloatingControlBarWindow {
       state: state,
       reconcile: { [weak self] in self?.syncMouseInterception() })
     syncMouseInterception()
+  }
+
+  func setMouseInterceptionPollingActive(_ active: Bool) {
+    mouseInterceptionReconciler?.setPollingActive(
+      active, reconcile: { [weak self] in self?.syncMouseInterception() })
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Combine
+
+enum FloatingBarMouseInterceptionPolicy {
+  static func shouldIgnoreMouseEvents(
+    mouseLocation: NSPoint,
+    windowFrame: NSRect,
+    isVisible: Bool,
+    acceptsMouseHit: (NSPoint) -> Bool
+  ) -> Bool {
+    guard isVisible, windowFrame.contains(mouseLocation) else { return true }
+    let local = NSPoint(
+      x: mouseLocation.x - windowFrame.minX,
+      y: mouseLocation.y - windowFrame.minY)
+    return !acceptsMouseHit(local)
+  }
+}
+
+@MainActor
+final class FloatingBarMouseInterceptionReconciler {
+  private nonisolated(unsafe) var monitors: [Any] = []
+  private var cancellables = Set<AnyCancellable>()
+
+  init(state: FloatingControlBarState, reconcile: @escaping @MainActor @Sendable () -> Void) {
+    let scheduleReconciliation: @Sendable () -> Void = {
+      DispatchQueue.main.async { reconcile() }
+    }
+    if let global = NSEvent.addGlobalMonitorForEvents(
+      matching: [.mouseMoved, .leftMouseDragged],
+      handler: { _ in scheduleReconciliation() })
+    {
+      monitors.append(global)
+    }
+    if let local = NSEvent.addLocalMonitorForEvents(
+      matching: [.mouseMoved],
+      handler: { event in
+        scheduleReconciliation()
+        return event
+      })
+    {
+      monitors.append(local)
+    }
+
+    // Monitor delivery is not the correctness boundary for a top-level transparent panel.
+    // Polling also reconciles a stationary pointer after frame or state transitions.
+    Timer.publish(every: 1.0 / 30.0, on: .main, in: .common)
+      .autoconnect()
+      .sink { _ in reconcile() }
+      .store(in: &cancellables)
+
+    let ownershipPublishers: [AnyPublisher<Void, Never>] = [
+      state.$showingAIConversation.map { _ in () }.eraseToAnyPublisher(),
+      state.$showingAIResponse.map { _ in () }.eraseToAnyPublisher(),
+      state.$currentNotification.map { _ in () }.eraseToAnyPublisher(),
+      state.$inputViewHeight.map { _ in () }.eraseToAnyPublisher(),
+      state.$notchHoverMenuOpen.map { _ in () }.eraseToAnyPublisher(),
+    ]
+    Publishers.MergeMany(ownershipPublishers)
+      .sink { scheduleReconciliation() }
+      .store(in: &cancellables)
+  }
+
+  deinit {
+    monitors.forEach(NSEvent.removeMonitor)
+  }
+}
+
+extension FloatingControlBarWindow {
+  func syncMouseInterception(mouseLocation: NSPoint = NSEvent.mouseLocation) {
+    let shouldIgnore = FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
+      mouseLocation: mouseLocation,
+      windowFrame: frame,
+      isVisible: isVisible,
+      acceptsMouseHit: acceptsMouseHit(inContentPoint:))
+    if ignoresMouseEvents != shouldIgnore {
+      ignoresMouseEvents = shouldIgnore
+    }
+  }
+
+  func installMouseInterceptionSync() {
+    mouseInterceptionReconciler = FloatingBarMouseInterceptionReconciler(
+      state: state,
+      reconcile: { [weak self] in self?.syncMouseInterception() })
+    syncMouseInterception()
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -1,4 +1,6 @@
 import Foundation
+import OmiTheme
+import SwiftUI
 
 /// Whether a presentation request is allowed to change the user's durable
 /// Floating Bar preference. Onboarding may borrow the real bar for a demo, but
@@ -21,6 +23,27 @@ extension FloatingControlBarWindow {
     !FloatingControlBarManager.shared.isEnabled
       && state.currentNotification == nil
       && !state.showingAIConversation
+  }
+
+  /// Starts the token-fenced retraction after presentation eligibility has
+  /// been established. Keeping this boundary independent of `isVisible`
+  /// lets lifecycle tests exercise stale deadlines on headless CI runners.
+  func beginNotchRetraction(then completion: @escaping () -> Void) {
+    notchRetractionCancellation?.cancel()
+    frameAnimationToken += 1
+    notchRetractionGeneration &+= 1
+    let generation = notchRetractionGeneration
+    OmiMotion.withGated(.easeIn(duration: 0.18)) {
+      state.notchRevealProgress = 0.01
+    }
+    notchRetractionCancellation = notchRetractionScheduler.schedule(after: 0.18) { [weak self] in
+      guard let self, self.notchRetractionGeneration == generation else { return }
+      completion()
+      // Leave the island ready to render for show paths that skip the
+      // reveal (e.g. showTemporarily) — the next reveal re-zeroes it.
+      self.state.notchRevealProgress = 1
+      self.notchRetractionCancellation = nil
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -16,6 +16,14 @@ enum FloatingBarPreferenceMutation: Equatable {
   }
 }
 
+extension FloatingControlBarWindow {
+  var shouldOrderOutAfterConversationClose: Bool {
+    !FloatingControlBarManager.shared.isEnabled
+      && state.currentNotification == nil
+      && !state.showingAIConversation
+  }
+}
+
 /// Shared reveal implementation for persistent settings, temporary snoozes,
 /// and direct Push-to-Talk presentation.
 extension FloatingControlBarManager {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2013,6 +2013,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
   /// Resize window for PTT state (expanded when listening, compact circle when idle)
   func resizeForPTTState(expanded: Bool) {
+    if expanded { cancelPendingRetraction() }
     if notchModeEnabled {
       if state.showingAIConversation {
         return
@@ -2037,7 +2038,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       animationDuration: 0.18
     )
   }
-
   /// Size the notch to fit the "thinking" indicator (active width) while a PTT
   /// query is being processed, then collapse it back once the response takes
   /// over. Voice listening and the open conversation surface own sizing while

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -203,8 +203,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   private var previousVoiceResponseGlowActive = false
   private var resizeWorkItem: DispatchWorkItem?
   var notchRetractionScheduler: DelayedActionScheduling = TaskDelayedActionScheduler()
-  private var notchRetractionCancellation: DelayedActionCancellation?
-  private var notchRetractionGeneration = 0
+  var notchRetractionCancellation: DelayedActionCancellation?
+  var notchRetractionGeneration = 0
   /// Saved center point from before chat opened, used to restore position on close.
   private var preChatCenter: NSPoint?
   /// Token incremented each time a windowDidResignKey dismiss animation starts.
@@ -222,7 +222,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// The idle pill frame captured just before morphing into the active island
   /// on a non-notch display, so the pill returns to the exact same spot.
   private var savedPillFrame: NSRect?
-  private var frameAnimationToken: Int = 0
+  var frameAnimationToken: Int = 0
   private var pendingFrameAnimationTarget: NSRect?
   private var startupDisplayRevalidationWorkItems: [DispatchWorkItem] = []
   /// In-process NSMenus (bar context menus, the model picker) render at
@@ -2121,21 +2121,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       completion()
       return
     }
-    notchRetractionCancellation?.cancel()
-    frameAnimationToken += 1
-    notchRetractionGeneration &+= 1
-    let generation = notchRetractionGeneration
-    OmiMotion.withGated(.easeIn(duration: 0.18)) {
-      state.notchRevealProgress = 0.01
-    }
-    notchRetractionCancellation = notchRetractionScheduler.schedule(after: 0.18) { [weak self] in
-      guard let self, self.notchRetractionGeneration == generation else { return }
-      completion()
-      // Leave the island ready to render for show paths that skip the
-      // reveal (e.g. showTemporarily) — the next reveal re-zeroes it.
-      self.state.notchRevealProgress = 1
-      self.notchRetractionCancellation = nil
-    }
+    beginNotchRetraction(then: completion)
   }
 
   private func cancelPendingRetraction() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -492,8 +492,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     notchRetractionCancellation?.cancel()
     notchRetractionCancellation = nil
     state.notchRevealProgress = 1
-    ignoresMouseEvents = true
     super.orderOut(sender)
+    syncMouseInterception()
   }
 
   // MARK: - Window Level

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -199,8 +199,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   private var draggableBarCancellable: AnyCancellable?
   private let cursorScreenTracker = CursorScreenTracker()
   private var pttHintCancellable: AnyCancellable?
+  var mouseInterceptionReconciler: FloatingBarMouseInterceptionReconciler?
   private var previousVoiceResponseGlowActive = false
   private var resizeWorkItem: DispatchWorkItem?
+  var notchRetractionScheduler: DelayedActionScheduling = TaskDelayedActionScheduler()
+  private var notchRetractionCancellation: DelayedActionCancellation?
   /// Saved center point from before chat opened, used to restore position on close.
   private var preChatCenter: NSPoint?
   /// Token incremented each time a windowDidResignKey dismiss animation starts.
@@ -463,12 +466,32 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     } else {
       centerOnMainScreen()
     }
+    syncMouseInterception()
     scheduleStartupDisplayRevalidation()
   }
 
   deinit {
     menuTrackingObservers.forEach(NotificationCenter.default.removeObserver)
-    interceptionMonitors.forEach(NSEvent.removeMonitor)
+  }
+
+  override func makeKeyAndOrderFront(_ sender: Any?) {
+    cancelPendingRetraction()
+    super.makeKeyAndOrderFront(sender)
+    syncMouseInterception()
+  }
+
+  override func orderFrontRegardless() {
+    cancelPendingRetraction()
+    super.orderFrontRegardless()
+    syncMouseInterception()
+  }
+
+  override func orderOut(_ sender: Any?) {
+    notchRetractionCancellation?.cancel()
+    notchRetractionCancellation = nil
+    state.notchRevealProgress = 1
+    ignoresMouseEvents = true
+    super.orderOut(sender)
   }
 
   // MARK: - Window Level
@@ -1003,48 +1026,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   // the pointer: ignored while the pointer is over dead margin, interactive over visible content.
   // Two monitors are required — the local one sees moves while we are interactive; the global one
   // while we are ignored (events then belong to the window below).
-  private nonisolated(unsafe) var interceptionMonitors: [Any] = []
-
-  fileprivate func syncMouseInterception() {
-    let mouse = NSEvent.mouseLocation
-    let shouldInteract: Bool
-    if frame.contains(mouse) {
-      let local = NSPoint(x: mouse.x - frame.minX, y: mouse.y - frame.minY)
-      shouldInteract = acceptsMouseHit(inContentPoint: local)
-    } else {
-      // Pointer elsewhere: stay interactive so tracking areas fire the moment it arrives.
-      shouldInteract = true
-    }
-    if ignoresMouseEvents == shouldInteract {
-      ignoresMouseEvents = !shouldInteract
-    }
-  }
-
-  private func installMouseInterceptionSync() {
-    // Monitor handlers are delivered on the main thread; hop back into MainActor explicitly.
-    let sync: @Sendable () -> Void = { [weak self] in
-      DispatchQueue.main.async { self?.syncMouseInterception() }
-    }
-    let global = NSEvent.addGlobalMonitorForEvents(
-      matching: [.mouseMoved, .leftMouseDragged],
-      handler: { _ in sync() })
-    if let global { interceptionMonitors.append(global) }
-    let local = NSEvent.addLocalMonitorForEvents(
-      matching: [.mouseMoved],
-      handler: { event in
-        sync()
-        return event
-      })
-    if let local { interceptionMonitors.append(local) }
-    syncMouseInterception()
-  }
-
   /// Non-production diagnostics seam for the `debug_hit_probe` bridge action.
   func automationAcceptsMouseHit(inContentPoint point: NSPoint) -> Bool {
     acceptsMouseHit(inContentPoint: point)
   }
 
-  fileprivate func acceptsMouseHit(inContentPoint point: NSPoint) -> Bool {
+  func acceptsMouseHit(inContentPoint point: NSPoint) -> Bool {
     guard notchModeEnabled else { return true }
     // Only content that visibly fills the window may own the whole frame: an expanded
     // response panel or a notification card. A conversation that is merely open (ask input,
@@ -2134,18 +2121,24 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       completion()
       return
     }
-    frameAnimationToken += 1
-    let token = frameAnimationToken
+    notchRetractionCancellation?.cancel()
     OmiMotion.withGated(.easeIn(duration: 0.18)) {
       state.notchRevealProgress = 0.01
     }
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { [weak self] in
-      guard let self, self.frameAnimationToken == token else { return }
+    notchRetractionCancellation = notchRetractionScheduler.schedule(after: 0.18) { [weak self] in
+      guard let self else { return }
       completion()
       // Leave the island ready to render for show paths that skip the
       // reveal (e.g. showTemporarily) — the next reveal re-zeroes it.
       self.state.notchRevealProgress = 1
+      self.notchRetractionCancellation = nil
     }
+  }
+
+  private func cancelPendingRetraction() {
+    notchRetractionCancellation?.cancel()
+    notchRetractionCancellation = nil
+    state.notchRevealProgress = 1
   }
 
   func showNotification(_ notification: FloatingBarNotification, animated: Bool = true) {
@@ -2433,6 +2426,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   @objc func windowDidMove(_ notification: Notification) {
+    syncMouseInterception()
     // Only persist position when the user is physically dragging the bar.
     // Programmatic moves (resize animations, chat open/close) should not
     // overwrite the saved position — that causes silent drift.
@@ -2463,6 +2457,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   func windowDidResize(_ notification: Notification) {
+    syncMouseInterception()
     // Response size persistence is committed when the user finishes dragging
     // the resize grip. Persisting ordinary resize notifications here records
     // programmatic min-height transitions as user preferences because AppKit

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1372,7 +1372,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       // AI conversation instead of leaving the compact pill visible — unless a
       // queued notification was just flushed; hiding now would swallow it, and
       // its dismissal re-hides the bar anyway.
-      if !FloatingControlBarManager.shared.isEnabled && self.state.currentNotification == nil {
+      if self.shouldOrderOutAfterConversationClose {
         self.orderOut(nil)
       }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -204,6 +204,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   private var resizeWorkItem: DispatchWorkItem?
   var notchRetractionScheduler: DelayedActionScheduling = TaskDelayedActionScheduler()
   private var notchRetractionCancellation: DelayedActionCancellation?
+  private var notchRetractionGeneration = 0
   /// Saved center point from before chat opened, used to restore position on close.
   private var preChatCenter: NSPoint?
   /// Token incremented each time a windowDidResignKey dismiss animation starts.
@@ -487,6 +488,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   override func orderOut(_ sender: Any?) {
+    notchRetractionGeneration &+= 1
     notchRetractionCancellation?.cancel()
     notchRetractionCancellation = nil
     state.notchRevealProgress = 1
@@ -1024,8 +1026,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   // an invisible click sink over everything beneath it — other apps, and Omi's own centered shell
   // (dead top-bar pills). The window-level mechanism is `ignoresMouseEvents`, kept in sync with
   // the pointer: ignored while the pointer is over dead margin, interactive over visible content.
-  // Two monitors are required — the local one sees moves while we are interactive; the global one
-  // while we are ignored (events then belong to the window below).
   /// Non-production diagnostics seam for the `debug_hit_probe` bridge action.
   func automationAcceptsMouseHit(inContentPoint point: NSPoint) -> Bool {
     acceptsMouseHit(inContentPoint: point)
@@ -2122,11 +2122,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       return
     }
     notchRetractionCancellation?.cancel()
+    frameAnimationToken += 1
+    notchRetractionGeneration &+= 1
+    let generation = notchRetractionGeneration
     OmiMotion.withGated(.easeIn(duration: 0.18)) {
       state.notchRevealProgress = 0.01
     }
     notchRetractionCancellation = notchRetractionScheduler.schedule(after: 0.18) { [weak self] in
-      guard let self else { return }
+      guard let self, self.notchRetractionGeneration == generation else { return }
       completion()
       // Leave the island ready to render for show paths that skip the
       // reveal (e.g. showTemporarily) — the next reveal re-zeroes it.
@@ -2136,6 +2139,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   private func cancelPendingRetraction() {
+    notchRetractionGeneration &+= 1
     notchRetractionCancellation?.cancel()
     notchRetractionCancellation = nil
     state.notchRevealProgress = 1
@@ -2143,6 +2147,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
   func showNotification(_ notification: FloatingBarNotification, animated: Bool = true) {
     guard !state.showingAIConversation else { return }
+    cancelPendingRetraction()
     state.currentNotification = notification
     let barHeight =
       notchModeEnabled

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -388,7 +388,7 @@ struct DesktopHomeView: View {
       }
     }
     .environment(\.colorScheme, .light)  // No window ground since `ShellWindowChrome`; each panel is its own glass.
-    .background(ShellWindowAttachment().frame(width: 0, height: 0))
+    .background(ShellWindowAttachment().frame(width: 0, height: 0)).shellWindowDragSurface()
     .frame(minWidth: DesktopWindowLayoutPolicy.width, minHeight: DesktopWindowLayoutPolicy.height)
     .preferredColorScheme(.light)  // Glass is pinned light — see `InkGlass`. Deliberate, not a bug.
     .tint(Ink.accent)

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -388,7 +388,7 @@ struct DesktopHomeView: View {
       }
     }
     .environment(\.colorScheme, .light)  // No window ground since `ShellWindowChrome`; each panel is its own glass.
-    .background(ShellWindowAttachment().frame(width: 0, height: 0)).shellWindowDragSurface()
+    .background(ShellWindowAttachment().frame(width: 0, height: 0))
     .frame(minWidth: DesktopWindowLayoutPolicy.width, minHeight: DesktopWindowLayoutPolicy.height)
     .preferredColorScheme(.light)  // Glass is pinned light — see `InkGlass`. Deliberate, not a bug.
     .tint(Ink.accent)

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -89,7 +89,9 @@ struct DesktopTopBar: View {
         .frame(width: laneWidth, height: TopNavigationLayoutMetrics.barHeight)
         .inkGlassPanel(
           cornerRadius: TopNavigationLayoutMetrics.barCornerRadius,
-          shadow: TopNavigationLayoutMetrics.barShadow)
+          shadow: TopNavigationLayoutMetrics.barShadow
+        )
+        .shellWindowDragHandle()
         Spacer(minLength: 0)
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -30,11 +30,11 @@
 //    strand a user in a window with no visible close control *and* no keyboard one.
 //  - **Moving has two handles, deliberately.** `.hiddenTitleBar` keeps a real (transparent) title bar
 //    over the top band, which still drags — that band is why the shell reserves
-//    `GlassShell.titlebarClearance` and draws nothing in it. SwiftUI's window-drag gesture covers the
-//    rest of the window. The native `isMovableByWindowBackground` switch cannot do that safely:
+//    `GlassShell.titlebarClearance` and draws nothing in it. A simultaneous SwiftUI drag gesture is
+//    confined to the visible top bar. The native `isMovableByWindowBackground` switch cannot do that safely:
 //    AppKit sees a SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background,
-//    and steals its click. Keeping both recognition paths in SwiftUI lets its gesture arena give an
-//    ordinary click to the Button and a drag to the window without intercepting either event.
+//    and steals its click. A root SwiftUI gesture also competes with every Button, Menu, search field,
+//    and filter in the shell. The top-bar-only simultaneous gesture preserves those child controls.
 //
 //  ## The two presentations, and why there are two
 //
@@ -144,7 +144,7 @@ enum ShellWindowChrome {
     hideStandardButtons(in: window)
     // AppKit cannot see SwiftUI controls inside an NSHostingView. The hosting view reports that a
     // mouse-down may move the window even when the point is a Button, so this native switch turns
-    // ordinary clicks into window drags. `ShellWindowDragSurface` keeps that ownership in SwiftUI.
+    // ordinary clicks into window drags. `ShellWindowDragHandle` keeps the explicit top-bar handle in SwiftUI.
     window.isMovableByWindowBackground = false
     window.level = presentation == .summoned ? .floating : .normal
     // Onboarding and sign-in must survive trips to a browser or System Settings. Once the shell is a
@@ -205,21 +205,22 @@ enum ShellWindowChrome {
   }
 }
 
-/// Keeps click recognition and window-drag recognition in SwiftUI's gesture arena. This is the
-/// platform boundary AppKit's background-drag switch cannot see through an `NSHostingView`.
+/// A drag handle for the visible top bar. It is intentionally not attached to the shell root: a root
+/// gesture can participate in every Button, Menu, and TextField event sequence. Simultaneous
+/// recognition keeps top-bar controls clickable while preserving drag-to-move on the bar's empty area.
 @MainActor
-struct ShellWindowDragSurface: ViewModifier {
+struct ShellWindowDragHandle: ViewModifier {
   @State private var windowOrigin: NSPoint?
 
   @ViewBuilder
   func body(content: Content) -> some View {
     if #available(macOS 15.0, *) {
-      content.gesture(WindowDragGesture(), including: .gesture)
+      content.simultaneousGesture(WindowDragGesture())
     } else {
       // `WindowDragGesture` was introduced in macOS 15. Keep the macOS 14 deployment floor usable
       // with a lower-precedence gesture: child controls keep their own clicks and drags, while the
       // shell's non-control surfaces remain window handles.
-      content.gesture(
+      content.simultaneousGesture(
         DragGesture(minimumDistance: 3)
           .onChanged { value in
             guard let window = ShellSummon.shellWindow() else { return }
@@ -228,15 +229,14 @@ struct ShellWindowDragSurface: ViewModifier {
             window.setFrameOrigin(
               ShellWindowChrome.draggedOrigin(windowOrigin: origin, translation: value.translation))
           }
-          .onEnded { _ in windowOrigin = nil },
-        including: .gesture)
+          .onEnded { _ in windowOrigin = nil })
     }
   }
 }
 
 extension View {
-  func shellWindowDragSurface() -> some View {
-    modifier(ShellWindowDragSurface())
+  func shellWindowDragHandle() -> some View {
+    modifier(ShellWindowDragHandle())
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -28,13 +28,13 @@
 //    AppKit from `.closable` / `.miniaturizable`; hiding `standardWindowButton(_:)` hides a view and
 //    changes no behaviour. `dress` re-asserts both bits so a future window-construction change cannot
 //    strand a user in a window with no visible close control *and* no keyboard one.
-//  - **Moving has two handles, deliberately.** `.hiddenTitleBar` keeps a real (transparent) title bar
-//    over the top band, which still drags — that band is why the shell reserves
-//    `GlassShell.titlebarClearance` and draws nothing in it. SwiftUI's window-drag gesture covers the
-//    rest of the window. The native `isMovableByWindowBackground` switch cannot do that safely:
+//  - **Moving uses the real transparent title bar.** `.hiddenTitleBar` keeps that native drag handle
+//    over the top band — the band is why the shell reserves `GlassShell.titlebarClearance` and draws
+//    nothing in it. The native `isMovableByWindowBackground` switch cannot extend dragging safely:
 //    AppKit sees a SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background,
-//    and steals its click. Keeping both recognition paths in SwiftUI lets its gesture arena give an
-//    ordinary click to the Button and a drag to the window without intercepting either event.
+//    and steals its click. A root SwiftUI `WindowDragGesture` has the same ownership problem in the
+//    opposite direction: it competes with every Button and Menu in the shell. Keep window dragging
+//    confined to the title bar so interactive content owns its complete event sequence.
 //
 //  ## The two presentations, and why there are two
 //
@@ -144,7 +144,7 @@ enum ShellWindowChrome {
     hideStandardButtons(in: window)
     // AppKit cannot see SwiftUI controls inside an NSHostingView. The hosting view reports that a
     // mouse-down may move the window even when the point is a Button, so this native switch turns
-    // ordinary clicks into window drags. `ShellWindowDragSurface` keeps that ownership in SwiftUI.
+    // ordinary clicks into window drags. The transparent title bar is the only drag handle.
     window.isMovableByWindowBackground = false
     window.level = presentation == .summoned ? .floating : .normal
     // Onboarding and sign-in must survive trips to a browser or System Settings. Once the shell is a
@@ -198,46 +198,6 @@ enum ShellWindowChrome {
       && hasExpectedSpaceBehavior
   }
 
-  static func draggedOrigin(windowOrigin: NSPoint, translation: CGSize) -> NSPoint {
-    NSPoint(
-      x: windowOrigin.x + translation.width,
-      y: windowOrigin.y - translation.height)
-  }
-}
-
-/// Keeps click recognition and window-drag recognition in SwiftUI's gesture arena. This is the
-/// platform boundary AppKit's background-drag switch cannot see through an `NSHostingView`.
-@MainActor
-struct ShellWindowDragSurface: ViewModifier {
-  @State private var windowOrigin: NSPoint?
-
-  @ViewBuilder
-  func body(content: Content) -> some View {
-    if #available(macOS 15.0, *) {
-      content.gesture(WindowDragGesture(), including: .gesture)
-    } else {
-      // `WindowDragGesture` was introduced in macOS 15. Keep the macOS 14 deployment floor usable
-      // with a lower-precedence gesture: child controls keep their own clicks and drags, while the
-      // shell's non-control surfaces remain window handles.
-      content.gesture(
-        DragGesture(minimumDistance: 3)
-          .onChanged { value in
-            guard let window = ShellSummon.shellWindow() else { return }
-            let origin = windowOrigin ?? window.frame.origin
-            windowOrigin = origin
-            window.setFrameOrigin(
-              ShellWindowChrome.draggedOrigin(windowOrigin: origin, translation: value.translation))
-          }
-          .onEnded { _ in windowOrigin = nil },
-        including: .gesture)
-    }
-  }
-}
-
-extension View {
-  func shellWindowDragSurface() -> some View {
-    modifier(ShellWindowDragSurface())
-  }
 }
 
 /// Binds the SwiftUI shell to the exact `NSWindow` that contains it.

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -28,13 +28,13 @@
 //    AppKit from `.closable` / `.miniaturizable`; hiding `standardWindowButton(_:)` hides a view and
 //    changes no behaviour. `dress` re-asserts both bits so a future window-construction change cannot
 //    strand a user in a window with no visible close control *and* no keyboard one.
-//  - **Moving uses the real transparent title bar.** `.hiddenTitleBar` keeps that native drag handle
-//    over the top band — the band is why the shell reserves `GlassShell.titlebarClearance` and draws
-//    nothing in it. The native `isMovableByWindowBackground` switch cannot extend dragging safely:
+//  - **Moving has two handles, deliberately.** `.hiddenTitleBar` keeps a real (transparent) title bar
+//    over the top band, which still drags — that band is why the shell reserves
+//    `GlassShell.titlebarClearance` and draws nothing in it. SwiftUI's window-drag gesture covers the
+//    rest of the window. The native `isMovableByWindowBackground` switch cannot do that safely:
 //    AppKit sees a SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background,
-//    and steals its click. A root SwiftUI `WindowDragGesture` has the same ownership problem in the
-//    opposite direction: it competes with every Button and Menu in the shell. Keep window dragging
-//    confined to the title bar so interactive content owns its complete event sequence.
+//    and steals its click. Keeping both recognition paths in SwiftUI lets its gesture arena give an
+//    ordinary click to the Button and a drag to the window without intercepting either event.
 //
 //  ## The two presentations, and why there are two
 //
@@ -144,7 +144,7 @@ enum ShellWindowChrome {
     hideStandardButtons(in: window)
     // AppKit cannot see SwiftUI controls inside an NSHostingView. The hosting view reports that a
     // mouse-down may move the window even when the point is a Button, so this native switch turns
-    // ordinary clicks into window drags. The transparent title bar is the only drag handle.
+    // ordinary clicks into window drags. `ShellWindowDragSurface` keeps that ownership in SwiftUI.
     window.isMovableByWindowBackground = false
     window.level = presentation == .summoned ? .floating : .normal
     // Onboarding and sign-in must survive trips to a browser or System Settings. Once the shell is a
@@ -198,6 +198,46 @@ enum ShellWindowChrome {
       && hasExpectedSpaceBehavior
   }
 
+  static func draggedOrigin(windowOrigin: NSPoint, translation: CGSize) -> NSPoint {
+    NSPoint(
+      x: windowOrigin.x + translation.width,
+      y: windowOrigin.y - translation.height)
+  }
+}
+
+/// Keeps click recognition and window-drag recognition in SwiftUI's gesture arena. This is the
+/// platform boundary AppKit's background-drag switch cannot see through an `NSHostingView`.
+@MainActor
+struct ShellWindowDragSurface: ViewModifier {
+  @State private var windowOrigin: NSPoint?
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if #available(macOS 15.0, *) {
+      content.gesture(WindowDragGesture(), including: .gesture)
+    } else {
+      // `WindowDragGesture` was introduced in macOS 15. Keep the macOS 14 deployment floor usable
+      // with a lower-precedence gesture: child controls keep their own clicks and drags, while the
+      // shell's non-control surfaces remain window handles.
+      content.gesture(
+        DragGesture(minimumDistance: 3)
+          .onChanged { value in
+            guard let window = ShellSummon.shellWindow() else { return }
+            let origin = windowOrigin ?? window.frame.origin
+            windowOrigin = origin
+            window.setFrameOrigin(
+              ShellWindowChrome.draggedOrigin(windowOrigin: origin, translation: value.translation))
+          }
+          .onEnded { _ in windowOrigin = nil },
+        including: .gesture)
+    }
+  }
+}
+
+extension View {
+  func shellWindowDragSurface() -> some View {
+    modifier(ShellWindowDragSurface())
+  }
 }
 
 /// Binds the SwiftUI shell to the exact `NSWindow` that contains it.

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -826,9 +826,10 @@ import XCTest
     defer { window.close() }
     let scheduler = UncancellableRetractionScheduler()
     window.notchRetractionScheduler = scheduler
+    var staleRetractionCompletionCount = 0
 
     window.makeKeyAndOrderFront(nil)
-    window.retractIntoNotch { [weak window] in window?.orderOut(nil) }
+    window.retractIntoNotch { staleRetractionCompletionCount += 1 }
     window.showNotification(
       FloatingBarNotification(
         ownerID: "owner",
@@ -838,7 +839,9 @@ import XCTest
       animated: false)
     scheduler.fire()
 
-    XCTAssertTrue(window.isVisible, "a stale retraction must not order out replacement content")
+    XCTAssertEqual(
+      staleRetractionCompletionCount, 0,
+      "replacement content must invalidate the stale retraction completion")
     XCTAssertEqual(window.state.currentNotification?.title, "Replacement notification")
     XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
   }
@@ -873,13 +876,16 @@ import XCTest
     defer { window.close() }
     let scheduler = UncancellableRetractionScheduler()
     window.notchRetractionScheduler = scheduler
+    var staleRetractionCompletionCount = 0
 
     window.makeKeyAndOrderFront(nil)
-    window.retractIntoNotch { [weak window] in window?.orderOut(nil) }
+    window.retractIntoNotch { staleRetractionCompletionCount += 1 }
     window.resizeForPTTState(expanded: true)
     scheduler.fire()
 
-    XCTAssertTrue(window.isVisible, "a stale retraction must not hide active push-to-talk")
+    XCTAssertEqual(
+      staleRetractionCompletionCount, 0,
+      "active push-to-talk must invalidate the stale retraction completion")
     XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
   }
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -883,6 +883,25 @@ import XCTest
     XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
   }
 
+  func testDisabledBarDoesNotOrderOutAReplacementConversationAfterCloseSettles() {
+    let manager = FloatingControlBarManager.shared
+    let previousEnabled = manager.isEnabled
+    manager.isEnabled = false
+    defer { manager.isEnabled = previousEnabled }
+    let window = FloatingControlBarWindow(
+      contentRect: .zero,
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    defer { window.close() }
+
+    window.state.showingAIConversation = true
+    XCTAssertFalse(window.shouldOrderOutAfterConversationClose)
+    window.state.showingAIConversation = false
+    XCTAssertTrue(window.shouldOrderOutAfterConversationClose)
+  }
+
   func testAgentSwitcherResizeMatchesContentMorphDurations() throws {
     let windowSource = try floatingControlBarWindowSource()
     let viewSource = try floatingControlBarViewSource()

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -840,6 +840,26 @@ import XCTest
     XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
   }
 
+  func testStartingPushToTalkDuringNotchRetractionKeepsThePanelVisible() {
+    let window = FloatingControlBarWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 360, height: 58),
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
+    )
+    defer { window.close() }
+    let scheduler = UncancellableRetractionScheduler()
+    window.notchRetractionScheduler = scheduler
+
+    window.makeKeyAndOrderFront(nil)
+    window.retractIntoNotch { [weak window] in window?.orderOut(nil) }
+    window.resizeForPTTState(expanded: true)
+    scheduler.fire()
+
+    XCTAssertTrue(window.isVisible, "a stale retraction must not hide active push-to-talk")
+    XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
+  }
+
   func testAgentSwitcherResizeMatchesContentMorphDurations() throws {
     let windowSource = try floatingControlBarWindowSource()
     let viewSource = try floatingControlBarViewSource()

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -828,8 +828,7 @@ import XCTest
     window.notchRetractionScheduler = scheduler
     var staleRetractionCompletionCount = 0
 
-    window.makeKeyAndOrderFront(nil)
-    window.retractIntoNotch { staleRetractionCompletionCount += 1 }
+    window.beginNotchRetraction { staleRetractionCompletionCount += 1 }
     window.showNotification(
       FloatingBarNotification(
         ownerID: "owner",
@@ -878,8 +877,7 @@ import XCTest
     window.notchRetractionScheduler = scheduler
     var staleRetractionCompletionCount = 0
 
-    window.makeKeyAndOrderFront(nil)
-    window.retractIntoNotch { staleRetractionCompletionCount += 1 }
+    window.beginNotchRetraction { staleRetractionCompletionCount += 1 }
     window.resizeForPTTState(expanded: true)
     scheduler.fire()
 

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -799,9 +799,12 @@ import XCTest
   func testPresentingDuringNotchRetractionKeepsThePanelVisibleAndRestoresItsContent() {
     let previousForceNoNotch = getenv("OMI_FORCE_NO_NOTCH").map { String(cString: $0) }
     let previousForceNotch = getenv("OMI_FORCE_NOTCH").map { String(cString: $0) }
+    let previousDraggableBarEnabled = ShortcutSettings.shared.draggableBarEnabled
+    ShortcutSettings.shared.draggableBarEnabled = false
     unsetenv("OMI_FORCE_NO_NOTCH")
     setenv("OMI_FORCE_NOTCH", "1", 1)
     defer {
+      ShortcutSettings.shared.draggableBarEnabled = previousDraggableBarEnabled
       if let previousForceNoNotch {
         setenv("OMI_FORCE_NO_NOTCH", previousForceNoNotch, 1)
       } else {
@@ -841,6 +844,26 @@ import XCTest
   }
 
   func testStartingPushToTalkDuringNotchRetractionKeepsThePanelVisible() {
+    let previousForceNoNotch = getenv("OMI_FORCE_NO_NOTCH").map { String(cString: $0) }
+    let previousForceNotch = getenv("OMI_FORCE_NOTCH").map { String(cString: $0) }
+    let previousDraggableBarEnabled = ShortcutSettings.shared.draggableBarEnabled
+    ShortcutSettings.shared.draggableBarEnabled = false
+    unsetenv("OMI_FORCE_NO_NOTCH")
+    setenv("OMI_FORCE_NOTCH", "1", 1)
+    defer {
+      ShortcutSettings.shared.draggableBarEnabled = previousDraggableBarEnabled
+      if let previousForceNoNotch {
+        setenv("OMI_FORCE_NO_NOTCH", previousForceNoNotch, 1)
+      } else {
+        unsetenv("OMI_FORCE_NO_NOTCH")
+      }
+      if let previousForceNotch {
+        setenv("OMI_FORCE_NOTCH", previousForceNotch, 1)
+      } else {
+        unsetenv("OMI_FORCE_NOTCH")
+      }
+    }
+
     let window = FloatingControlBarWindow(
       contentRect: NSRect(x: 0, y: 0, width: 360, height: 58),
       styleMask: [.borderless, .nonactivatingPanel],

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -796,6 +796,43 @@ import XCTest
     XCTAssertFalse(window.frame.contains(pointInsideFormerDeadZone))
   }
 
+  func testPresentingDuringNotchRetractionKeepsThePanelVisibleAndRestoresItsContent() {
+    let previousForceNoNotch = getenv("OMI_FORCE_NO_NOTCH").map { String(cString: $0) }
+    let previousForceNotch = getenv("OMI_FORCE_NOTCH").map { String(cString: $0) }
+    unsetenv("OMI_FORCE_NO_NOTCH")
+    setenv("OMI_FORCE_NOTCH", "1", 1)
+    defer {
+      if let previousForceNoNotch {
+        setenv("OMI_FORCE_NO_NOTCH", previousForceNoNotch, 1)
+      } else {
+        unsetenv("OMI_FORCE_NO_NOTCH")
+      }
+      if let previousForceNotch {
+        setenv("OMI_FORCE_NOTCH", previousForceNotch, 1)
+      } else {
+        unsetenv("OMI_FORCE_NOTCH")
+      }
+    }
+
+    let window = FloatingControlBarWindow(
+      contentRect: .zero,
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    defer { window.close() }
+    let scheduler = ManualDelayedActionScheduler()
+    window.notchRetractionScheduler = scheduler
+
+    window.makeKeyAndOrderFront(nil)
+    window.retractIntoNotch { [weak window] in window?.orderOut(nil) }
+    window.makeKeyAndOrderFront(nil)
+
+    XCTAssertFalse(scheduler.fireNext(), "presenting again must cancel the stale order-out deadline")
+    XCTAssertTrue(window.isVisible, "a canceled retraction must not order out a newly presented panel")
+    XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
+  }
+
   func testAgentSwitcherResizeMatchesContentMorphDurations() throws {
     let windowSource = try floatingControlBarWindowSource()
     let viewSource = try floatingControlBarViewSource()

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -821,15 +821,22 @@ import XCTest
       defer: false
     )
     defer { window.close() }
-    let scheduler = ManualDelayedActionScheduler()
+    let scheduler = UncancellableRetractionScheduler()
     window.notchRetractionScheduler = scheduler
 
     window.makeKeyAndOrderFront(nil)
     window.retractIntoNotch { [weak window] in window?.orderOut(nil) }
-    window.makeKeyAndOrderFront(nil)
+    window.showNotification(
+      FloatingBarNotification(
+        ownerID: "owner",
+        title: "Replacement notification",
+        message: "Must remain visible",
+        assistantId: "test"),
+      animated: false)
+    scheduler.fire()
 
-    XCTAssertFalse(scheduler.fireNext(), "presenting again must cancel the stale order-out deadline")
-    XCTAssertTrue(window.isVisible, "a canceled retraction must not order out a newly presented panel")
+    XCTAssertTrue(window.isVisible, "a stale retraction must not order out replacement content")
+    XCTAssertEqual(window.state.currentNotification?.title, "Replacement notification")
     XCTAssertEqual(window.state.notchRevealProgress, 1, accuracy: 0.001)
   }
 
@@ -2216,6 +2223,25 @@ import XCTest
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/Logger.swift")
     return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+}
+
+@MainActor
+private final class UncancellableRetractionScheduler: DelayedActionScheduling {
+  private var action: (@MainActor () -> Void)?
+
+  func schedule(
+    after interval: TimeInterval,
+    action: @escaping @MainActor () -> Void
+  ) -> DelayedActionCancellation {
+    _ = interval
+    self.action = action
+    return ManualDelayedActionCancellation()
+  }
+
+  func fire() {
+    action?()
+    action = nil
   }
 }
 

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -533,4 +533,38 @@ final class FloatingBarGeometryTests: XCTestCase {
         horizontalOutset: 24
       ))
   }
+
+  func testTransparentPanelIgnoresMouseOutsideItsVisibleHitRegion() {
+    let frame = NSRect(x: 500, y: 800, width: 360, height: 58)
+    let visibleLocalRegion = NSRect(x: 24, y: 24, width: 312, height: 34)
+
+    XCTAssertTrue(
+      FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
+        mouseLocation: NSPoint(x: 680, y: 790),
+        windowFrame: frame,
+        isVisible: true,
+        acceptsMouseHit: visibleLocalRegion.contains),
+      "a top-level panel must not own events while the pointer is outside its frame")
+    XCTAssertTrue(
+      FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
+        mouseLocation: NSPoint(x: 510, y: 810),
+        windowFrame: frame,
+        isVisible: true,
+        acceptsMouseHit: visibleLocalRegion.contains),
+      "transparent glow margin must pass through to the window underneath")
+    XCTAssertFalse(
+      FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
+        mouseLocation: NSPoint(x: 680, y: 840),
+        windowFrame: frame,
+        isVisible: true,
+        acceptsMouseHit: visibleLocalRegion.contains),
+      "visible notch chrome remains interactive")
+    XCTAssertTrue(
+      FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
+        mouseLocation: NSPoint(x: 680, y: 840),
+        windowFrame: frame,
+        isVisible: false,
+        acceptsMouseHit: { _ in true }),
+      "an ordered-out panel must never retain event ownership")
+  }
 }

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -538,13 +538,13 @@ final class FloatingBarGeometryTests: XCTestCase {
     let frame = NSRect(x: 500, y: 800, width: 360, height: 58)
     let visibleLocalRegion = NSRect(x: 24, y: 24, width: 312, height: 34)
 
-    XCTAssertTrue(
+    XCTAssertFalse(
       FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
         mouseLocation: NSPoint(x: 680, y: 790),
         windowFrame: frame,
         isVisible: true,
         acceptsMouseHit: visibleLocalRegion.contains),
-      "a top-level panel must not own events while the pointer is outside its frame")
+      "an ordered-in panel stays ready to receive the tracking event when the pointer enters")
     XCTAssertTrue(
       FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
         mouseLocation: NSPoint(x: 510, y: 810),

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -91,8 +91,8 @@ final class ShellWindowChromeTests: XCTestCase {
   }
 
   /// …and the window still moves. It has two handles: the transparent title bar over the reserved
-  /// band and a thresholded SwiftUI gesture across the content. The native background-drag switch is
-  /// deliberately off because AppKit mistakes hosted SwiftUI buttons for background.
+  /// band and a thresholded simultaneous SwiftUI gesture on the visible top bar. The native
+  /// background-drag switch is deliberately off because AppKit mistakes hosted buttons for background.
   func testTheWindowIsStillMovableWithoutATitleBarToGrab() {
     let window = makeWindow()
     window.isMovableByWindowBackground = false

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -90,8 +90,9 @@ final class ShellWindowChromeTests: XCTestCase {
       "the keyboard path is the only close/minimise affordance left; it may never be dropped")
   }
 
-  /// …and the window still moves. The transparent title bar covers the reserved band. Content is not
-  /// a drag handle because AppKit and root SwiftUI gestures can both mistake hosted controls for it.
+  /// …and the window still moves. It has two handles: the transparent title bar over the reserved
+  /// band and a thresholded SwiftUI gesture across the content. The native background-drag switch is
+  /// deliberately off because AppKit mistakes hosted SwiftUI buttons for background.
   func testTheWindowIsStillMovableWithoutATitleBarToGrab() {
     let window = makeWindow()
     window.isMovableByWindowBackground = false
@@ -123,6 +124,14 @@ final class ShellWindowChromeTests: XCTestCase {
     XCTAssertFalse(
       window.isMovableByWindowBackground,
       "native background dragging steals this hosted button's click before SwiftUI receives it")
+  }
+
+  func testLegacyWindowDragUsesSwiftUITranslation() {
+    XCTAssertEqual(
+      ShellWindowChrome.draggedOrigin(
+        windowOrigin: NSPoint(x: 100, y: 200),
+        translation: CGSize(width: 75, height: 40)),
+      NSPoint(x: 175, y: 160))
   }
 
   // MARK: - Summoned vs anchored

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -90,9 +90,8 @@ final class ShellWindowChromeTests: XCTestCase {
       "the keyboard path is the only close/minimise affordance left; it may never be dropped")
   }
 
-  /// …and the window still moves. It has two handles: the transparent title bar over the reserved
-  /// band and a thresholded SwiftUI gesture across the content. The native background-drag switch is
-  /// deliberately off because AppKit mistakes hosted SwiftUI buttons for background.
+  /// …and the window still moves. The transparent title bar covers the reserved band. Content is not
+  /// a drag handle because AppKit and root SwiftUI gestures can both mistake hosted controls for it.
   func testTheWindowIsStillMovableWithoutATitleBarToGrab() {
     let window = makeWindow()
     window.isMovableByWindowBackground = false
@@ -124,14 +123,6 @@ final class ShellWindowChromeTests: XCTestCase {
     XCTAssertFalse(
       window.isMovableByWindowBackground,
       "native background dragging steals this hosted button's click before SwiftUI receives it")
-  }
-
-  func testLegacyWindowDragUsesSwiftUITranslation() {
-    XCTAssertEqual(
-      ShellWindowChrome.draggedOrigin(
-        windowOrigin: NSPoint(x: 100, y: 200),
-        translation: CGSize(width: 75, height: 40)),
-      NSPoint(x: 175, y: 160))
   }
 
   // MARK: - Summoned vs anchored

--- a/desktop/macos/changelog/unreleased/20260811-beta-window-dead-zones.json
+++ b/desktop/macos/changelog/unreleased/20260811-beta-window-dead-zones.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Omi Beta dead zones that prevented clicks on navigation and filter controls"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -15,6 +15,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift


### PR DESCRIPTION
## What changed and why

Omi Beta starts with an isolated defaults domain, so its floating bar defaults to the always-on-top notch panel while named development bundles can inherit draggable pill mode. The panel's window-level click-through state was only refreshed by mouse-move monitors, leaving transparent margins able to swallow shell clicks after startup placement, resize/state transitions, or an interrupted retract. A root window-drag gesture also participated in every hosted control's event sequence. This change makes panel ownership a continuously reconciled window invariant, generation-fences retract/present transitions (including PTT), and confines window dragging to a simultaneous gesture on the visible top bar.

## Product invariants affected

- INV-CHAT-1

## How it was verified

- `xcrun swift test --package-path Desktop --filter 'FloatingBarGeometryTests|ShellWindowChromeTests|AgentPillLifecycleTests.testPresentingDuringNotchRetractionKeepsThePanelVisibleAndRestoresItsContent|AgentPillLifecycleTests.testStartingPushToTalkDuringNotchRetractionKeepsThePanelVisible|AgentPillLifecycleTests.testDisabledBarDoesNotOrderOutAReplacementConversationAfterCloseSettles'` — 47 tests passed.
- `xcrun swift test -c release --package-path Desktop --filter 'FloatingBarGeometryTests|ShellWindowChromeTests|AgentPillLifecycleTests.testPresentingDuringNotchRetractionKeepsThePanelVisibleAndRestoresItsContent'` — 44 tests passed under the production optimizer.
- Built and launched `/Applications/omi-beta-deadzone-r2.app` with settings and Rewind seeding disabled so the isolated identity took the same fresh notch-mode defaults as Omi Beta. It reached signed-in owner-ready state with `floatingBarUsesNotchIsland=true`; `debug_hit_probe` at Chat, Memories, Tasks, Rewind, Apps, search, and the Memory device/type filters reported only the main shell at each point.
- Installed Beta 0.12.158/12158 was inspected without replacement: its only visible auxiliary window was the expected layer-1500 327x58 notch panel, and its exact source still used monitor-only interception sync.

## Tests

- `FloatingBarGeometryTests.testTransparentPanelIgnoresMouseOutsideItsVisibleHitRegion` covers outside-frame, transparent-margin, visible-chrome, and ordered-out ownership.
- `AgentPillLifecycleTests.testPresentingDuringNotchRetractionKeepsThePanelVisibleAndRestoresItsContent` reproduces the retract/present race that could strand a nearly invisible interactive panel.
- `AgentPillLifecycleTests.testStartingPushToTalkDuringNotchRetractionKeepsThePanelVisible` proves a stale retract cannot hide an active PTT surface.
- `AgentPillLifecycleTests.testDisabledBarDoesNotOrderOutAReplacementConversationAfterCloseSettles` prevents a stale voice-handoff close from hiding its replacement conversation.
- `ShellWindowChromeTests` verifies the native transparent titlebar remains a drag handle while hosted SwiftUI controls are not classified as draggable background; the explicit SwiftUI drag handle is now scoped to the visible top bar.

## Failure class (fixes)

Failure-Class: FC-transparent-top-level-window-occlusion
