### PR TITLE
docs(desktop): unblock agents-md-lean by moving agent-swift reference into docs/

### DIFF
--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -495,32 +495,7 @@ harness filter classes drift away.
 
 ### Verifying UI Changes (agent-swift)
 
-After editing Swift UI code, verify the change programmatically using [agent-swift](https://github.com/beastoin/agent-swift) — a CLI that controls any macOS app via the Accessibility API.
-
-**One-time setup:** `brew install beastoin/tap/agent-swift` + grant Accessibility permission to Terminal.app.
-
-```bash
-# After ./run.sh launches the app:
-agent-swift doctor                                   # verify Accessibility permission
-agent-swift connect --bundle-id com.omi.desktop-dev  # connect to running app
-agent-swift snapshot -i                              # see interactive elements
-agent-swift click @e3                                # CGEvent click (SwiftUI)
-agent-swift press @e3                                # AXPress (AppKit buttons)
-agent-swift fill @e5 "search text"                   # type into a text field
-agent-swift find role button click                   # find + chained action
-agent-swift is exists @e3                            # assert element exists (exit 0/1)
-agent-swift wait text "Settings"                     # wait for text to appear
-agent-swift screenshot /tmp/evidence.png             # capture app window
-```
-
-**Key rules:**
-- Always use `snapshot -i` (interactive only) — full snapshot of a complex SwiftUI app is extremely verbose.
-- Prefer `click` over `press` for SwiftUI — `click` sends CGEvent clicks (triggers NavigationLink), `press` sends AXPress (AppKit only).
-- Refs go stale after `click`/`press`/`fill`/`scroll` — re-snapshot before the next interaction.
-- Argument order: `get <property> <ref>`, `is <condition> <ref>`, `wait <condition> [<target>]`, `find <locator> <value>`.
-- 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
-- No app-side instrumentation needed — works via macOS Accessibility API on any Cocoa/SwiftUI app.
-- Dev bundle ID: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos` (stable) and `com.omi.computer-macos.beta` (Omi Beta) — never automate prod.
+Verify Swift UI changes programmatically with [agent-swift](https://github.com/beastoin/agent-swift) (Accessibility-API CLI): setup, command reference, and key rules in [`docs/agent-swift-ui-verification.md`](docs/agent-swift-ui-verification.md). Never automate prod bundles.
 
 ### Changelog Entries
 

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -88,8 +88,6 @@ Stable is manual:
 - App ID: `66c95e6ec76853c447b8bcbb`
 - List builds: `curl -s -H "x-auth-token: $CODEMAGIC_API_TOKEN" "https://api.codemagic.io/builds?appId=66c95e6ec76853c447b8bcbb" | python3 -c "import json,sys; [print(f\"{b.get('status','?'):12} tag={b.get('tag','-'):30} start={(b.get('startedAt') or '-')[:19]}\") for b in json.load(sys.stdin).get('builds',[])[:5]]"`
 
-Promotion from beta to stable is handled by `desktop_promote_prod.yml`, not Codemagic.
-
 ## Firebase Connection
 Use the `/firebase` command if your agent provides it.
 

--- a/desktop/macos/docs/agent-swift-ui-verification.md
+++ b/desktop/macos/docs/agent-swift-ui-verification.md
@@ -1,0 +1,28 @@
+# Verifying UI Changes (agent-swift)
+
+After editing Swift UI code, verify the change programmatically using [agent-swift](https://github.com/beastoin/agent-swift) — a CLI that controls any macOS app via the Accessibility API.
+
+**One-time setup:** `brew install beastoin/tap/agent-swift` + grant Accessibility permission to Terminal.app.
+
+```bash
+# After ./run.sh launches the app:
+agent-swift doctor                                   # verify Accessibility permission
+agent-swift connect --bundle-id com.omi.desktop-dev  # connect to running app
+agent-swift snapshot -i                              # see interactive elements
+agent-swift click @e3                                # CGEvent click (SwiftUI)
+agent-swift press @e3                                # AXPress (AppKit buttons)
+agent-swift fill @e5 "search text"                   # type into a text field
+agent-swift find role button click                   # find + chained action
+agent-swift is exists @e3                            # assert element exists (exit 0/1)
+agent-swift wait text "Settings"                     # wait for text to appear
+agent-swift screenshot /tmp/evidence.png             # capture app window
+```
+
+**Key rules:**
+- Always use `snapshot -i` (interactive only) — full snapshot of a complex SwiftUI app is extremely verbose.
+- Prefer `click` over `press` for SwiftUI — `click` sends CGEvent clicks (triggers NavigationLink), `press` sends AXPress (AppKit only).
+- Refs go stale after `click`/`press`/`fill`/`scroll` — re-snapshot before the next interaction.
+- Argument order: `get <property> <ref>`, `is <condition> <ref>`, `wait <condition> [<target>]`, `find <locator> <value>`.
+- 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
+- No app-side instrumentation needed — works via macOS Accessibility API on any Cocoa/SwiftUI app.
+- Dev bundle ID: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos` (stable) and `com.omi.computer-macos.beta` (Omi Beta) — never automate prod.


### PR DESCRIPTION
## Why

The `agents-md-lean` manifest check is **red on `main`**: `desktop/macos/AGENTS.md` was 47392 bytes against its 47000-byte budget, pushed over by `e2a792eb0a` (a 2-line Release Pipeline docs correction on Aug 10).

The check selects on `**/AGENTS.md` and the pre-push gate diffs against merge-base, so **every PR that touches any `AGENTS.md` fails**, and the failure aborts the Hygiene job before the other guards run. Tracking: #11409.

## What changed

The fix is content, not the budget — the budget is untouched.

1. **Moved** the `Verifying UI Changes (agent-swift)` section verbatim into `desktop/macos/docs/agent-swift-ui-verification.md`, leaving a one-line pointer. It is occasional tool reference, not per-session guidance — exactly what the check's own failure hint recommends (`component AGENTS.md -> docs/<topic>.md`).
2. **Deleted** one duplicated sentence in Release Pipeline (`Promotion from beta to stable is handled by desktop_promote_prod.yml, not Codemagic`), which restates the "Stable is manual" bullet directly above it. No release-contract prose was rewritten or paraphrased.

No information lost.

## Result

`desktop/macos/AGENTS.md`: **45531 bytes / 47000 (1469 bytes headroom)**, 532 / 560 lines — enough that the next small docs edit will not re-break `main`.

Headroom for the other guides:

| File | Bytes | Headroom |
|---|---|---|
| `backend/AGENTS.md` | 38936 / 39000 | **64** |
| `AGENTS.md` | 16872 / 18000 | 1128 |
| `app/AGENTS.md` | 10606 / 11500 | 894 |
| `web/admin/AGENTS.md` | 1363 / 1500 | 137 |
| `.github/AGENTS.md` | 3825 / 4500 | 675 |
| `omi/firmware/AGENTS.md` | 853 / 1500 | 647 |

`backend/AGENTS.md` is **64 bytes from the same failure** and will recur; that needs its own PR.

## Verification

- `python3 .github/scripts/check_agents_md_lean.py` → `ok: 7 AGENTS.md files within budget` (fails on clean `origin/main`)
- `make preflight` → passes with the `no-changelog-needed` label (docs-only, no user-visible change)

Product invariants affected: none (`scripts/pr-preflight --suggest`). No `fix:` commits, so no failure-class declaration is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only relocation and a one-line dedupe; no runtime, release, or product behavior changes.
> 
> **Overview**
> Brings **`desktop/macos/AGENTS.md`** back under the `agents-md-lean` byte budget so the Hygiene check and PRs that touch `AGENTS.md` can pass again.
> 
> The long **Verifying UI Changes (agent-swift)** block is moved verbatim to **`docs/agent-swift-ui-verification.md`**, with **`AGENTS.md`** keeping a short pointer plus the prod-bundle warning. One **duplicate** Release Pipeline sentence about beta→stable promotion (already covered by the Stable-is-manual bullets) is removed. No release-contract or agent-swift guidance was rewritten—only relocated or deduped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a523bbc35919238b10bd8c4bc21440e27c80471. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->