### PR TITLE
docs(backend): restore agents-md-lean headroom for backend/AGENTS.md

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -80,6 +80,7 @@ backend/
     prompts.py            #   LLM prompt templates for memory extraction, categorization, etc.
     translation.py        #   Multi-language translation coordination
     speaker_identification.py  # Speaker diarization + person matching against speech profiles
+  #   Per-subservice internals: backend/docs/subservice-internals.md
   pusher/                 # Subservice: real-time data distribution hub (separate Docker)
   llm_gateway/            # Subservice: internal Omi-managed LLM auto-lane gateway
   diarizer/              # Subservice: speaker audio analysis (separate Docker, GPU/CUDA)

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -222,15 +222,7 @@ Pre-mock heavy deps before importing the module under test. Use `patch.object(ta
 
 Do not confuse these gates — a green live gauntlet does **not** prove hermetic
 pipeline invariants, and hermetic tests do **not** prove deployed-backend continuity.
-
-| Gate | What it covers | What it does **not** cover |
-| --- | --- | --- |
-| **Hermetic pipeline E2E** (`testing/e2e/test_canonical_memory_pipeline.py`) | capture→consolidate→promote→read, archive excluded from default reads, surface default-access matrix, projection fail-closed without legacy bleed | Deployed revision identity, prod IAM/index deltas, live LLM consolidation |
-| **Gauntlet `--self-check`** | Required files, `canonical_memory_pipeline` workflow registration, suite/nonce wiring in `memory-continuity-gauntlet.py` | Any memory write or HTTP probe |
-| **Live gauntlet** (`memory-continuity-gauntlet.sh` with `ADMIN_KEY` + reachable backend) | Structural `/v3/memories` probes per suite on a running backend | Full Gate 2 synthetic matrix or Gate 3 prod activation |
-| **Gate 2 dev-cloud proof** (`v3_dev_cloud_proof.py` + deployed branch revision) | Multi-user synthetic matrix, indexes, IAM, auth, rollback on dev-cloud | Local hermetic fakes; not production activation |
-| **Gate 3 production proof** (`docs/rollout/memory-v3-proof-order.md`) | Prod-specific deltas after Gate 2 GO + independent review | Substitute for hermetic pipeline E2E or gauntlet self-check |
-
+Gate-by-gate coverage matrix: `backend/docs/memory-continuity-gates.md`.
 CI runs `python3 backend/scripts/memory-continuity-gauntlet.py --self-check` only.
 Live suites record `NOT_RUN` when credentials/backend are unavailable — never fake `GO`.
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -81,32 +81,12 @@ backend/
     translation.py        #   Multi-language translation coordination
     speaker_identification.py  # Speaker diarization + person matching against speech profiles
   pusher/                 # Subservice: real-time data distribution hub (separate Docker)
-                          #   - Receives audio + transcripts from backend-listen via binary WebSocket protocol
-                          #   - Routes transcripts to integrations/webhooks in 1s batches
-                          #   - Streams audio to ML services and developer webhooks (4s accumulation)
-                          #   - Runs LLM-powered conversation analysis (memories, action items, insights)
-                          #   - Batches + uploads audio to private cloud storage (60s batches, 3 retries)
-                          #   - Queues speaker sample extraction (120s age minimum)
-                          #   - 5 concurrent background tasks per WebSocket connection
   llm_gateway/            # Subservice: internal Omi-managed LLM auto-lane gateway
   diarizer/              # Subservice: speaker audio analysis (separate Docker, GPU/CUDA)
-                          #   - POST /v1/diarization — speaker boundary detection (pyannote/speaker-diarization)
-                          #   - POST /v1/embedding — speaker vector extraction (pyannote/embedding)
-                          #   - POST /v2/embedding — alt speaker vectors (wespeaker-voxceleb-resnet34-LM)
   agent-proxy/           # Subservice: WebSocket bridge between mobile app and user's agent VM
-                          #   - Firebase auth → Firestore VM lookup → GCE lifecycle (start/reset/health)
-                          #   - Bidirectional message pump with keepalive (120s)
-                          #   - Chat history injection (last 10 messages on first query)
-                          #   - Optional AES-256-GCM message encryption
   nllb_translation/      # Subservice: self-hosted NLLB translation (separate Docker, GPU/CUDA)
-                          #   - POST /v1/translate — batch sentence translation (NLLB-200 + CTranslate2)
-                          #   - Prometheus metrics at /metrics, health at /health, readiness at /ready
-                          #   - Fallback to Gemini 2.5 Flash-Lite when NLLB is unavailable
   modal/                 # Serverless GPU services (deployed on Modal) + Cloud Run Jobs
-                          #   - Speaker identification: matches segments to speech profiles (SpeechBrain, T4 GPU)
-                          #   - VAD: voice activity detection (pyannote/voice-activity-detection)
-                          #   - notifications-job: hourly push notifications + X sync (Cloud Run Job)
-                          #   - memory-maintenance-job: canonical ST→LT maintenance (Cloud Run Job)
+                          #   Per-subservice internals: backend/docs/subservice-internals.md
   tests/unit/            # 50+ unit tests (no external service deps)
   tests/integration/     # Integration tests (need Redis, Firebase, API keys)
   scripts/run-unit-ci.sh # Full CI unit-test contract

--- a/backend/docs/memory-continuity-gates.md
+++ b/backend/docs/memory-continuity-gates.md
@@ -1,0 +1,19 @@
+# Memory Continuity Gauntlet Gates
+
+Moved out of `backend/AGENTS.md` (size ratchet:
+`.github/scripts/check_agents_md_lean.py`). Read this before claiming any
+canonical-memory rollout gate is satisfied.
+
+Do not confuse these gates — a green live gauntlet does **not** prove hermetic
+pipeline invariants, and hermetic tests do **not** prove deployed-backend continuity.
+
+| Gate | What it covers | What it does **not** cover |
+| --- | --- | --- |
+| **Hermetic pipeline E2E** (`testing/e2e/test_canonical_memory_pipeline.py`) | capture→consolidate→promote→read, archive excluded from default reads, surface default-access matrix, projection fail-closed without legacy bleed | Deployed revision identity, prod IAM/index deltas, live LLM consolidation |
+| **Gauntlet `--self-check`** | Required files, `canonical_memory_pipeline` workflow registration, suite/nonce wiring in `memory-continuity-gauntlet.py` | Any memory write or HTTP probe |
+| **Live gauntlet** (`memory-continuity-gauntlet.sh` with `ADMIN_KEY` + reachable backend) | Structural `/v3/memories` probes per suite on a running backend | Full Gate 2 synthetic matrix or Gate 3 prod activation |
+| **Gate 2 dev-cloud proof** (`v3_dev_cloud_proof.py` + deployed branch revision) | Multi-user synthetic matrix, indexes, IAM, auth, rollback on dev-cloud | Local hermetic fakes; not production activation |
+| **Gate 3 production proof** (`docs/rollout/memory-v3-proof-order.md`) | Prod-specific deltas after Gate 2 GO + independent review | Substitute for hermetic pipeline E2E or gauntlet self-check |
+
+CI runs `python3 backend/scripts/memory-continuity-gauntlet.py --self-check` only.
+Live suites record `NOT_RUN` when credentials/backend are unavailable — never fake `GO`.

--- a/backend/docs/subservice-internals.md
+++ b/backend/docs/subservice-internals.md
@@ -1,0 +1,41 @@
+# Backend Subservice Internals
+
+Per-subservice internal detail moved out of `backend/AGENTS.md` (size ratchet:
+`.github/scripts/check_agents_md_lean.py`). The inter-service call graph and the
+deploy/runtime contracts stay in `backend/AGENTS.md` → Service Map; this file
+holds what each subservice does inside its own process.
+
+```
+pusher/                 # Subservice: real-time data distribution hub (separate Docker)
+                        #   - Receives audio + transcripts from backend-listen via binary WebSocket protocol
+                        #   - Routes transcripts to integrations/webhooks in 1s batches
+                        #   - Streams audio to ML services and developer webhooks (4s accumulation)
+                        #   - Runs LLM-powered conversation analysis (memories, action items, insights)
+                        #   - Batches + uploads audio to private cloud storage (60s batches, 3 retries)
+                        #   - Queues speaker sample extraction (120s age minimum)
+                        #   - 5 concurrent background tasks per WebSocket connection
+
+llm_gateway/            # Subservice: internal Omi-managed LLM auto-lane gateway
+
+diarizer/               # Subservice: speaker audio analysis (separate Docker, GPU/CUDA)
+                        #   - POST /v1/diarization — speaker boundary detection (pyannote/speaker-diarization)
+                        #   - POST /v1/embedding — speaker vector extraction (pyannote/embedding)
+                        #   - POST /v2/embedding — alt speaker vectors (wespeaker-voxceleb-resnet34-LM)
+
+agent-proxy/            # Subservice: WebSocket bridge between mobile app and user's agent VM
+                        #   - Firebase auth → Firestore VM lookup → GCE lifecycle (start/reset/health)
+                        #   - Bidirectional message pump with keepalive (120s)
+                        #   - Chat history injection (last 10 messages on first query)
+                        #   - Optional AES-256-GCM message encryption
+
+nllb_translation/       # Subservice: self-hosted NLLB translation (separate Docker, GPU/CUDA)
+                        #   - POST /v1/translate — batch sentence translation (NLLB-200 + CTranslate2)
+                        #   - Prometheus metrics at /metrics, health at /health, readiness at /ready
+                        #   - Fallback to Gemini 2.5 Flash-Lite when NLLB is unavailable
+
+modal/                  # Serverless GPU services (deployed on Modal) + Cloud Run Jobs
+                        #   - Speaker identification: matches segments to speech profiles (SpeechBrain, T4 GPU)
+                        #   - VAD: voice activity detection (pyannote/voice-activity-detection)
+                        #   - notifications-job: hourly push notifications + X sync (Cloud Run Job)
+                        #   - memory-maintenance-job: canonical ST→LT maintenance (Cloud Run Job)
+```


### PR DESCRIPTION
Preventive: `backend/AGENTS.md` had **64 bytes** of headroom under its 39,000-byte `agents-md-lean` budget. When a component guide blows its budget the check goes red on `main`, and since it triggers on `**/AGENTS.md`, **every** PR touching any AGENTS.md then fails and aborts Hygiene before the other guards run. That just happened with `desktop/macos/AGENTS.md` (#11409, fix in #11410). Backend was one sentence away from a repeat.

## What moved (nothing deleted, nothing paraphrased)

| From `backend/AGENTS.md` | To |
|---|---|
| Per-subservice internal bullets in the Directory Structure tree (pusher, diarizer, agent-proxy, nllb_translation, modal) | `backend/docs/subservice-internals.md` |
| Five-row memory continuity gauntlet gate coverage table | `backend/docs/memory-continuity-gates.md` |

Both moved verbatim, each leaving a pointer. Setup, test commands, the Service Map and its deploy contracts, async/executor rules, and logging-security rules all stay in `AGENTS.md` — that is what agents read constantly.

## Result

`backend/AGENTS.md`: 38,936 → **35,829 bytes** (headroom **3,171**), 337 → 309 lines (headroom 41). No budget in `check_agents_md_lean.py` was touched.

## Verification

- `python3 .github/scripts/check_agents_md_lean.py` — backend passes; the only remaining failure is the pre-existing `desktop/macos/AGENTS.md` overage that #11410 fixes.
- `make preflight` — with #11410 merged locally into a throwaway branch, `agents-md-lean` and every other selected check passes on this diff.

## Also worth flagging (not fixed here)

`web/admin/AGENTS.md` is at **137 bytes** of headroom (1,363 / 1,500) and 4 lines spare — next candidate for the same treatment.

Product invariants affected: none (`scripts/pr-preflight --suggest`). No `fix:` commits, so no failure-class declaration is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only relocation with no code, config, or runtime changes. Content is moved verbatim with pointers left in place.
> 
> **Overview**
> Shrinks `backend/AGENTS.md` under the `agents-md-lean` size ratchet by moving two verbatim detail blocks into dedicated docs, leaving pointers behind.
> 
> **Subservice internals** (pusher, diarizer, agent-proxy, nllb_translation, modal bullets) move to `backend/docs/subservice-internals.md`. The Service Map and deploy contracts stay in `AGENTS.md`.
> 
> **Memory continuity gate coverage table** moves to `backend/docs/memory-continuity-gates.md`. No product or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7906af5331879dc7f181556165c1008b88cc3fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->