### PR TITLE
fix(hooks): stop the unpinned-formatter rewrites, register a web/frontend test lane, unblock web/admin/AGENTS.md

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -386,7 +386,7 @@ checks:
     reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
   - id: web-frontend-tests
     command: ["bash", "scripts/run-web-frontend-tests.sh"]
-    triggers: ["web/frontend/**", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml"]
+    triggers: ["web/frontend/**", "scripts/run-web-frontend-tests.sh", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "web/frontend's node --test suite had no lane, so its guards never ran in CI and a deleted frontend test had to be re-homed into a backend pytest to keep running"
   - id: web-llm-gateway-only-tests

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -385,8 +385,8 @@ checks:
     lanes: ["local", "ci"]
     reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
   - id: web-frontend-tests
-    command: ["node", "--test", "web/frontend/src/__tests__/**/*.test.mjs"]
-    triggers: ["web/frontend/**", ".github/checks-manifest.yaml"]
+    command: ["node", "--test", "web/frontend/src/__tests__"]
+    triggers: ["web/frontend/**", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "web/frontend's node --test suite had no lane, so its guards never ran in CI and a deleted frontend test had to be re-homed into a backend pytest to keep running"
   - id: web-llm-gateway-only-tests

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -386,7 +386,7 @@ checks:
     reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
   - id: web-frontend-tests
     command: ["bash", "scripts/run-web-frontend-tests.sh"]
-    triggers: ["web/frontend/**", "scripts/run-web-frontend-tests.sh", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml"]
+    triggers: ["web/frontend/**", "scripts/run-web-frontend-tests.sh", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml", "app/android/app/src/main/AndroidManifest.xml"]
     lanes: ["local", "ci"]
     reason: "web/frontend's node --test suite had no lane, so its guards never ran in CI and a deleted frontend test had to be re-homed into a backend pytest to keep running"
   - id: web-llm-gateway-only-tests

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -385,7 +385,7 @@ checks:
     lanes: ["local", "ci"]
     reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
   - id: web-frontend-tests
-    command: ["node", "--test", "web/frontend/src/__tests__"]
+    command: ["bash", "scripts/run-web-frontend-tests.sh"]
     triggers: ["web/frontend/**", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "web/frontend's node --test suite had no lane, so its guards never ran in CI and a deleted frontend test had to be re-homed into a backend pytest to keep running"

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -24,6 +24,11 @@ checks:
     triggers: ["scripts/pre-commit", "scripts/test-pre-commit-pinned-toolchains.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#11304: the hook's floating prettier fallback (prettier 3 against web/frontend's pinned ^2.8.8) rewrote getPlatformLink in web/frontend/src/app/apps/[id]/page.tsx into a CI-rejected shape and polluted four PRs in one day; an unpinned formatter must refuse, never silently rewrite"
+  - id: pre-push-backend-test-cap
+    command: ["bash", "scripts/test-pre-push-backend-test-cap.sh"]
+    triggers: ["scripts/pre-push", "scripts/test-pre-push-backend-test-cap.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#11018: the over-broad-selection fallback swapped in the diff's own changed backend test files without re-applying PRE_PUSH_MAX_BACKEND_UNIT_TEST_FILES, so a diff changing more than the cap ran unbounded while printing 'cap is 40'; the bounded push gate must never run more than the cap it advertises"
   - id: pre-push-ci-prediction-tests
     command: ["python3", ".github/scripts/test_pre_push_ci_prediction.py"]
     triggers: ["scripts/pre-push", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_pre_push_ci_prediction.py", "desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/scripts/desktop_flow_contract.py", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -19,6 +19,11 @@ checks:
     triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
+  - id: pre-commit-pinned-toolchains
+    command: ["bash", "scripts/test-pre-commit-pinned-toolchains.sh"]
+    triggers: ["scripts/pre-commit", "scripts/test-pre-commit-pinned-toolchains.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#11304: the hook's floating prettier fallback (prettier 3 against web/frontend's pinned ^2.8.8) rewrote getPlatformLink in web/frontend/src/app/apps/[id]/page.tsx into a CI-rejected shape and polluted four PRs in one day; an unpinned formatter must refuse, never silently rewrite"
   - id: pre-push-ci-prediction-tests
     command: ["python3", ".github/scripts/test_pre_push_ci_prediction.py"]
     triggers: ["scripts/pre-push", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_pre_push_ci_prediction.py", "desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/scripts/desktop_flow_contract.py", ".github/checks-manifest.yaml"]
@@ -374,6 +379,11 @@ checks:
     triggers: ["web/**/*.js", "web/**/*.jsx", "web/**/*.mjs", "web/**/*.ts", "web/**/*.tsx", "web/**/package.json", ".github/scripts/check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-118: production web LLM traffic must not regain direct provider SDKs, URLs, or credentials"
+  - id: web-frontend-tests
+    command: ["node", "--test", "web/frontend/src/__tests__/**/*.test.mjs"]
+    triggers: ["web/frontend/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "web/frontend's node --test suite had no lane, so its guards never ran in CI and a deleted frontend test had to be re-homed into a backend pytest to keep running"
   - id: web-llm-gateway-only-tests
     command: ["python3", ".github/scripts/test_check_web_llm_gateway_only.py"]
     triggers: [".github/scripts/check_web_llm_gateway_only.py", ".github/scripts/test_check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Formatting
 
-The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. It refuses to format rather than reformat with an unpinned toolchain: web needs the installed Prettier to match the version resolved in `package-lock.json` (run `npm ci` in the changed web dir), Dart needs the pinned Flutter and its sibling `dart`. Hatches: `OMI_SKIP_WEB_FORMAT=1`, `OMI_SKIP_DART_FORMAT=1`. Manual commands:
+The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. It refuses to format rather than reformat with an unpinned toolchain: web needs the installed Prettier and its resolved plugins to match the versions in `package-lock.json` (run `npm ci` in the changed web dir), Dart needs the pinned Flutter and its sibling `dart`. Hatches: `OMI_SKIP_WEB_FORMAT=1`, `OMI_SKIP_DART_FORMAT=1`. Manual commands:
 
 | Language | Manual command |
 |----------|----------------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Formatting
 
-The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. Manual commands:
+The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. It refuses to format rather than reformat with an unpinned toolchain: web needs each dir's pinned prettier (`npm ci`), Dart needs the pinned Flutter. Hatches: `OMI_SKIP_WEB_FORMAT=1`, `OMI_SKIP_DART_FORMAT=1`. Manual commands:
 
 | Language | Manual command |
 |----------|----------------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Formatting
 
-The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. It refuses to format rather than reformat with an unpinned toolchain: web needs each dir's pinned prettier (`npm ci`), Dart needs the pinned Flutter. Hatches: `OMI_SKIP_WEB_FORMAT=1`, `OMI_SKIP_DART_FORMAT=1`. Manual commands:
+The pre-commit hook (installed by `make setup`) auto-formats staged files. Verify: `test -x "$(git rev-parse --git-path hooks)/pre-commit" && echo OK`. It refuses to format rather than reformat with an unpinned toolchain: web needs the installed Prettier to match the version resolved in `package-lock.json` (run `npm ci` in the changed web dir), Dart needs the pinned Flutter and its sibling `dart`. Hatches: `OMI_SKIP_WEB_FORMAT=1`, `OMI_SKIP_DART_FORMAT=1`. Manual commands:
 
 | Language | Manual command |
 |----------|----------------|

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -46,7 +46,12 @@ if [ -n "$STAGED_DART_FILES" ]; then
     exit 1
   fi
   if command -v flutter >/dev/null 2>&1; then
-    LOCAL_FLUTTER=$(flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][^ ]*\).*/\1/p' | head -1)
+    # Git exports linked-worktree metadata to hooks. Flutter resolves its own
+    # SDK version through Git, so those variables must not leak into the probe.
+    LOCAL_FLUTTER=$(
+      unset GIT_DIR GIT_WORK_TREE
+      flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][^ ]*\).*/\1/p' | head -1
+    )
   else
     LOCAL_FLUTTER=""
   fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -171,6 +171,13 @@ if [ -n "$STAGED_WEB_FILES" ]; then
         fi
       fi
     done
+    for file in $DIR_FILES; do
+      if ! git diff --quiet -- "$file"; then
+        echo "$file has unstaged edits; refusing to format-and-add because it would sweep them into the commit." >&2
+        echo "Stage or commit the remaining edits first, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+        exit 1
+      fi
+    done
     echo "$DIR_FILES" | xargs "$PRETTIER_BIN" --write
     echo "$DIR_FILES" | xargs git add
   done

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -147,6 +147,12 @@ if [ -n "$STAGED_WEB_FILES" ]; then
         echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
         exit 1
       fi
+      if [ "$(git show :"$dir/package-lock.json" 2>/dev/null | wc -c)" -gt 0 ]; then
+        echo "Prettier lockfile could not be resolved in $dir: refusing to compare against a guessed version." >&2
+        echo "A stale or unparseable lockfile reformats files into a shape CI rejects." >&2
+        echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+        exit 1
+      fi
     fi
     for plugin in prettier-plugin-tailwindcss; do
       PLUGIN_RESOLVED=$(git show :"$dir/package-lock.json" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('packages',{}).get('node_modules/' + sys.argv[1]) or {}).get('version',''))" "$plugin" 2>/dev/null)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -101,7 +101,9 @@ if [ -n "$STAGED_ARB_FILES" ]; then
 fi
 
 # Web (JS/TS/JSX/TSX) formatting with Prettier
-STAGED_WEB_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$' | grep -E '^web/')
+# Auto-generated TypeScript (e.g. the admin OpenAPI client) is excluded: a
+# regenerated artifact must not be swept through Prettier's format-and-add.
+STAGED_WEB_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$' | grep -E '^web/' | grep -v '\.generated\.ts$')
 
 if [ -n "$STAGED_WEB_FILES" ] && [ "${OMI_SKIP_WEB_FORMAT:-}" = "1" ]; then
   echo "OMI_SKIP_WEB_FORMAT=1: leaving staged web files unformatted."
@@ -139,20 +141,10 @@ if [ -n "$STAGED_WEB_FILES" ]; then
         exit 1
       fi
     else
-      PINNED_MAJOR=$(echo "$PINNED" | sed 's/^[^0-9]*//' | cut -d. -f1)
-      LOCAL_MAJOR=$(echo "$LOCAL_VERSION" | cut -d. -f1)
-      if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_MAJOR" != "$PINNED_MAJOR" ]; then
-        echo "Prettier toolchain mismatch in $dir: package.json pins $PINNED, found ${LOCAL_VERSION:-no $dir/node_modules/.bin/prettier}." >&2
-        echo "A floating prettier reformats files into a shape CI rejects, so formatting is refused." >&2
-        echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
-        exit 1
-      fi
-      if [ "$(git show :"$dir/package-lock.json" 2>/dev/null | wc -c)" -gt 0 ]; then
-        echo "Prettier lockfile could not be resolved in $dir: refusing to compare against a guessed version." >&2
-        echo "A stale or unparseable lockfile reformats files into a shape CI rejects." >&2
-        echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
-        exit 1
-      fi
+      echo "Prettier lockfile pin missing or unresolvable in $dir: refusing to format $dir." >&2
+      echo "A missing, empty, or unparseable package-lock.json lets a floating prettier reformat files into a shape CI rejects." >&2
+      echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+      exit 1
     fi
     for plugin in prettier-plugin-tailwindcss; do
       PLUGIN_RESOLVED=$(git show :"$dir/package-lock.json" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('packages',{}).get('node_modules/' + sys.argv[1]) or {}).get('version',''))" "$plugin" 2>/dev/null)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -29,9 +29,36 @@ fi
 # Dart formatting for app/
 STAGED_DART_FILES=$(git diff --cached --name-only --diff-filter=ACM "app/**.dart" | grep -v -e '\.gen\.dart$' -e '\.g\.dart$' -e '^app/lib/l10n/app_localizations.*\.dart$')
 
+if [ -n "$STAGED_DART_FILES" ] && [ "${OMI_SKIP_DART_FORMAT:-}" = "1" ]; then
+  echo "OMI_SKIP_DART_FORMAT=1: leaving staged Dart files unformatted."
+  STAGED_DART_FILES=""
+fi
+
 if [ -n "$STAGED_DART_FILES" ]; then
-  echo "Formatting staged Dart files in app/..."
-  echo "$STAGED_DART_FILES" | xargs dart format --line-length 120
+  ROOT="$(git rev-parse --show-toplevel)"
+  PINNED_FLUTTER=$(sed -n 's/^[[:space:]]*flutter-version:[[:space:]]*//p' "$ROOT/.github/workflows/repo-checks.yml" 2>/dev/null | head -1 | tr -d "\"' ")
+  if [ -z "$PINNED_FLUTTER" ]; then
+    echo "Could not read the pinned flutter-version from .github/workflows/repo-checks.yml." >&2
+    echo "Refusing to run 'dart format' with an unknown toolchain. Set OMI_SKIP_DART_FORMAT=1 to commit unformatted." >&2
+    exit 1
+  fi
+  if command -v flutter >/dev/null 2>&1; then
+    LOCAL_FLUTTER=$(flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][^ ]*\).*/\1/p' | head -1)
+  else
+    LOCAL_FLUTTER=""
+  fi
+  if [ "$LOCAL_FLUTTER" != "$PINNED_FLUTTER" ]; then
+    echo "Dart formatter toolchain mismatch: repo pins Flutter $PINNED_FLUTTER, found ${LOCAL_FLUTTER:-no flutter on PATH}." >&2
+    echo "A different Dart SDK reformats untouched files into a shape CI rejects, so formatting is refused." >&2
+    echo "Install Flutter $PINNED_FLUTTER (fvm use $PINNED_FLUTTER), or set OMI_SKIP_DART_FORMAT=1 to commit unformatted." >&2
+    exit 1
+  fi
+  DART_BIN="$(dirname "$(command -v flutter)")/dart"
+  if [ ! -x "$DART_BIN" ]; then
+    DART_BIN="dart"
+  fi
+  echo "Formatting staged Dart files in app/ with Flutter $PINNED_FLUTTER..."
+  echo "$STAGED_DART_FILES" | xargs "$DART_BIN" format --line-length 120
   echo "$STAGED_DART_FILES" | xargs git add
 fi
 
@@ -71,23 +98,39 @@ fi
 # Web (JS/TS/JSX/TSX) formatting with Prettier
 STAGED_WEB_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$' | grep -E '^web/')
 
+if [ -n "$STAGED_WEB_FILES" ] && [ "${OMI_SKIP_WEB_FORMAT:-}" = "1" ]; then
+  echo "OMI_SKIP_WEB_FORMAT=1: leaving staged web files unformatted."
+  STAGED_WEB_FILES=""
+fi
+
 if [ -n "$STAGED_WEB_FILES" ]; then
   echo "Formatting staged web files with Prettier..."
-  for dir in web/frontend web/app web/personas-open-source; do
+  for dir in $(echo "$STAGED_WEB_FILES" | cut -d/ -f1-2 | sort -u); do
     DIR_FILES=$(echo "$STAGED_WEB_FILES" | grep "^$dir/")
     if [ -z "$DIR_FILES" ]; then
       continue
     fi
-    if [ -x "$dir/node_modules/.bin/prettier" ]; then
-      echo "$DIR_FILES" | xargs "$dir/node_modules/.bin/prettier" --write
-    elif command -v npx >/dev/null 2>&1; then
-      echo "$DIR_FILES" | xargs npx --prefix "$dir" prettier --write
-    elif command -v prettier >/dev/null 2>&1; then
-      echo "$DIR_FILES" | xargs prettier --write
-    else
-      echo "prettier not found for $dir. Run 'npm install' in $dir or install prettier globally." >&2
+    PINNED=$(sed -n 's/.*"prettier"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" 2>/dev/null | head -1)
+    if [ -z "$PINNED" ]; then
+      echo "$dir/package.json does not pin prettier; refusing to format $dir." >&2
+      echo "Pin prettier there, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
       exit 1
     fi
+    PINNED_MAJOR=$(echo "$PINNED" | sed 's/^[^0-9]*//' | cut -d. -f1)
+    PRETTIER_BIN="$dir/node_modules/.bin/prettier"
+    if [ -x "$PRETTIER_BIN" ]; then
+      LOCAL_VERSION=$("$PRETTIER_BIN" --version 2>/dev/null)
+    else
+      LOCAL_VERSION=""
+    fi
+    LOCAL_MAJOR=$(echo "$LOCAL_VERSION" | cut -d. -f1)
+    if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_MAJOR" != "$PINNED_MAJOR" ]; then
+      echo "Prettier toolchain mismatch in $dir: package.json pins $PINNED, found ${LOCAL_VERSION:-no $dir/node_modules/.bin/prettier}." >&2
+      echo "A floating prettier reformats files into a shape CI rejects, so formatting is refused." >&2
+      echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+      exit 1
+    fi
+    echo "$DIR_FILES" | xargs "$PRETTIER_BIN" --write
     echo "$DIR_FILES" | xargs git add
   done
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -153,19 +153,30 @@ if [ -n "$STAGED_WEB_FILES" ]; then
     fi
     for plugin in prettier-plugin-tailwindcss; do
       PLUGIN_RESOLVED=$(git show :"$dir/package-lock.json" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('packages',{}).get('node_modules/' + sys.argv[1]) or {}).get('version',''))" "$plugin" 2>/dev/null)
-      if [ -n "$PLUGIN_RESOLVED" ]; then
-        PLUGIN_PKG="$dir/node_modules/$plugin/package.json"
-        if [ -f "$PLUGIN_PKG" ]; then
-          PLUGIN_LOCAL=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('version',''))" "$PLUGIN_PKG" 2>/dev/null)
-        else
-          PLUGIN_LOCAL=""
-        fi
-        if [ -z "$PLUGIN_LOCAL" ] || [ "$PLUGIN_LOCAL" != "$PLUGIN_RESOLVED" ]; then
-          echo "Prettier plugin toolchain mismatch in $dir: package-lock resolves $plugin $PLUGIN_RESOLVED, found ${PLUGIN_LOCAL:-no $dir/node_modules/$plugin}." >&2
-          echo "A missing or stale plugin reformats files into a shape CI rejects, so formatting is refused." >&2
+      PLUGIN_DECLARED=$(git show :"$dir/package.json" 2>/dev/null | sed -n "s/.*\"$plugin\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1)
+      if [ -z "$PLUGIN_DECLARED" ]; then
+        PLUGIN_DECLARED=$(sed -n "s/.*\"$plugin\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$dir/package.json" 2>/dev/null | head -1)
+      fi
+      if [ -z "$PLUGIN_RESOLVED" ]; then
+        if [ -n "$PLUGIN_DECLARED" ]; then
+          echo "Prettier plugin toolchain unresolved in $dir: package.json declares $plugin $PLUGIN_DECLARED, package-lock.json has no entry for it." >&2
+          echo "Prettier auto-loads any installed plugin, so a stale or missing one reformats files into a shape CI rejects; formatting is refused." >&2
           echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
           exit 1
         fi
+        continue
+      fi
+      PLUGIN_PKG="$dir/node_modules/$plugin/package.json"
+      if [ -f "$PLUGIN_PKG" ]; then
+        PLUGIN_LOCAL=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('version',''))" "$PLUGIN_PKG" 2>/dev/null)
+      else
+        PLUGIN_LOCAL=""
+      fi
+      if [ -z "$PLUGIN_LOCAL" ] || [ "$PLUGIN_LOCAL" != "$PLUGIN_RESOLVED" ]; then
+        echo "Prettier plugin toolchain mismatch in $dir: package-lock resolves $plugin $PLUGIN_RESOLVED, found ${PLUGIN_LOCAL:-no $dir/node_modules/$plugin}." >&2
+        echo "A missing or stale plugin reformats files into a shape CI rejects, so formatting is refused." >&2
+        echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+        exit 1
       fi
     done
     for file in $DIR_FILES; do

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -148,6 +148,23 @@ if [ -n "$STAGED_WEB_FILES" ]; then
         exit 1
       fi
     fi
+    for plugin in prettier-plugin-tailwindcss; do
+      PLUGIN_RESOLVED=$(git show :"$dir/package-lock.json" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('packages',{}).get('node_modules/' + sys.argv[1]) or {}).get('version',''))" "$plugin" 2>/dev/null)
+      if [ -n "$PLUGIN_RESOLVED" ]; then
+        PLUGIN_PKG="$dir/node_modules/$plugin/package.json"
+        if [ -f "$PLUGIN_PKG" ]; then
+          PLUGIN_LOCAL=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('version',''))" "$PLUGIN_PKG" 2>/dev/null)
+        else
+          PLUGIN_LOCAL=""
+        fi
+        if [ -z "$PLUGIN_LOCAL" ] || [ "$PLUGIN_LOCAL" != "$PLUGIN_RESOLVED" ]; then
+          echo "Prettier plugin toolchain mismatch in $dir: package-lock resolves $plugin $PLUGIN_RESOLVED, found ${PLUGIN_LOCAL:-no $dir/node_modules/$plugin}." >&2
+          echo "A missing or stale plugin reformats files into a shape CI rejects, so formatting is refused." >&2
+          echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+          exit 1
+        fi
+      fi
+    done
     echo "$DIR_FILES" | xargs "$PRETTIER_BIN" --write
     echo "$DIR_FILES" | xargs git add
   done

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -36,7 +36,10 @@ fi
 
 if [ -n "$STAGED_DART_FILES" ]; then
   ROOT="$(git rev-parse --show-toplevel)"
-  PINNED_FLUTTER=$(sed -n 's/^[[:space:]]*flutter-version:[[:space:]]*//p' "$ROOT/.github/workflows/repo-checks.yml" 2>/dev/null | head -1 | tr -d "\"' ")
+  PINNED_FLUTTER=$(git show :.github/workflows/repo-checks.yml 2>/dev/null | sed -n 's/^[[:space:]]*flutter-version:[[:space:]]*//p' | head -1 | tr -d "\"' ")
+  if [ -z "$PINNED_FLUTTER" ]; then
+    PINNED_FLUTTER=$(sed -n 's/^[[:space:]]*flutter-version:[[:space:]]*//p' "$ROOT/.github/workflows/repo-checks.yml" 2>/dev/null | head -1 | tr -d "\"' ")
+  fi
   if [ -z "$PINNED_FLUTTER" ]; then
     echo "Could not read the pinned flutter-version from .github/workflows/repo-checks.yml." >&2
     echo "Refusing to run 'dart format' with an unknown toolchain. Set OMI_SKIP_DART_FORMAT=1 to commit unformatted." >&2
@@ -55,7 +58,9 @@ if [ -n "$STAGED_DART_FILES" ]; then
   fi
   DART_BIN="$(dirname "$(command -v flutter)")/dart"
   if [ ! -x "$DART_BIN" ]; then
-    DART_BIN="dart"
+    echo "Dart formatter sibling not found: expected $DART_BIN next to the validated flutter." >&2
+    echo "Refusing to run an unrelated 'dart' from PATH. Set OMI_SKIP_DART_FORMAT=1 to commit unformatted." >&2
+    exit 1
   fi
   echo "Formatting staged Dart files in app/ with Flutter $PINNED_FLUTTER..."
   echo "$STAGED_DART_FILES" | xargs "$DART_BIN" format --line-length 120
@@ -110,25 +115,38 @@ if [ -n "$STAGED_WEB_FILES" ]; then
     if [ -z "$DIR_FILES" ]; then
       continue
     fi
-    PINNED=$(sed -n 's/.*"prettier"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" 2>/dev/null | head -1)
+    PINNED=$(git show :"$dir/package.json" 2>/dev/null | sed -n 's/.*"prettier"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+    if [ -z "$PINNED" ]; then
+      PINNED=$(sed -n 's/.*"prettier"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/package.json" 2>/dev/null | head -1)
+    fi
     if [ -z "$PINNED" ]; then
       echo "$dir/package.json does not pin prettier; refusing to format $dir." >&2
       echo "Pin prettier there, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
       exit 1
     fi
-    PINNED_MAJOR=$(echo "$PINNED" | sed 's/^[^0-9]*//' | cut -d. -f1)
     PRETTIER_BIN="$dir/node_modules/.bin/prettier"
     if [ -x "$PRETTIER_BIN" ]; then
       LOCAL_VERSION=$("$PRETTIER_BIN" --version 2>/dev/null)
     else
       LOCAL_VERSION=""
     fi
-    LOCAL_MAJOR=$(echo "$LOCAL_VERSION" | cut -d. -f1)
-    if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_MAJOR" != "$PINNED_MAJOR" ]; then
-      echo "Prettier toolchain mismatch in $dir: package.json pins $PINNED, found ${LOCAL_VERSION:-no $dir/node_modules/.bin/prettier}." >&2
-      echo "A floating prettier reformats files into a shape CI rejects, so formatting is refused." >&2
-      echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
-      exit 1
+    RESOLVED_VERSION=$(git show :"$dir/package-lock.json" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('packages',{}).get('node_modules/prettier') or {}).get('version',''))" 2>/dev/null)
+    if [ -n "$RESOLVED_VERSION" ]; then
+      if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_VERSION" != "$RESOLVED_VERSION" ]; then
+        echo "Prettier toolchain mismatch in $dir: package-lock resolves $RESOLVED_VERSION, found ${LOCAL_VERSION:-no $dir/node_modules/.bin/prettier}." >&2
+        echo "A floating prettier reformats files into a shape CI rejects, so formatting is refused." >&2
+        echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+        exit 1
+      fi
+    else
+      PINNED_MAJOR=$(echo "$PINNED" | sed 's/^[^0-9]*//' | cut -d. -f1)
+      LOCAL_MAJOR=$(echo "$LOCAL_VERSION" | cut -d. -f1)
+      if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_MAJOR" != "$PINNED_MAJOR" ]; then
+        echo "Prettier toolchain mismatch in $dir: package.json pins $PINNED, found ${LOCAL_VERSION:-no $dir/node_modules/.bin/prettier}." >&2
+        echo "A floating prettier reformats files into a shape CI rejects, so formatting is refused." >&2
+        echo "Run 'npm ci' in $dir, or set OMI_SKIP_WEB_FORMAT=1 to commit unformatted." >&2
+        exit 1
+      fi
     fi
     echo "$DIR_FILES" | xargs "$PRETTIER_BIN" --write
     echo "$DIR_FILES" | xargs git add

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -504,6 +504,7 @@ check_backend_typecheck_if_needed() {
 check_backend_unit_tests_if_needed() {
   local selected_count
   local original_selected_count
+  local changed_test_count
   local max_pre_push_tests
   local reason
   local file
@@ -572,8 +573,17 @@ check_backend_unit_tests_if_needed() {
     done
     if [ -s "$FAST_BACKEND_TESTS" ]; then
       sort -u "$FAST_BACKEND_TESTS" -o "$FAST_BACKEND_TESTS"
-      selected_count=$(wc -l < "$FAST_BACKEND_TESTS" | tr -d ' ')
-      echo "Selector requested $reason ($original_selected_count files; running $selected_count changed backend test file(s) instead; cap is $max_pre_push_tests)."
+      changed_test_count=$(wc -l < "$FAST_BACKEND_TESTS" | tr -d ' ')
+      if [ "$changed_test_count" -gt "$max_pre_push_tests" ]; then
+        head -n "$max_pre_push_tests" "$FAST_BACKEND_TESTS" > "$FAST_BACKEND_TESTS.capped"
+        mv "$FAST_BACKEND_TESTS.capped" "$FAST_BACKEND_TESTS"
+        selected_count=$(wc -l < "$FAST_BACKEND_TESTS" | tr -d ' ')
+        echo "Selector requested $reason ($original_selected_count files); the diff changes $changed_test_count backend test file(s), also over the cap of $max_pre_push_tests."
+        echo "Running the first $selected_count in sorted order; run cd backend && bash test.sh for the rest, or rely on CI."
+      else
+        selected_count="$changed_test_count"
+        echo "Selector requested $reason ($original_selected_count files; running $selected_count changed backend test file(s) instead; cap is $max_pre_push_tests)."
+      fi
       cp "$FAST_BACKEND_TESTS" "$SELECTED_BACKEND_TESTS"
     else
       echo "Skipping broad backend unit suite in pre-push: $reason ($selected_count files; cap is $max_pre_push_tests)."

--- a/scripts/run-web-frontend-tests.sh
+++ b/scripts/run-web-frontend-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s failglob
+node --test web/frontend/src/__tests__/*.test.mjs

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -19,21 +19,59 @@ git -C "$REPO" config user.email test@example.com
 git -C "$REPO" config user.name test
 printf 'jobs:\n  flutter:\n    steps:\n      - uses: subosito/flutter-action@v2\n        with:\n          flutter-version: 9.9.9\n' >"$REPO/.github/workflows/repo-checks.yml"
 printf '{\n  "devDependencies": {\n    "eslint-plugin-prettier": "^4.2.1",\n    "prettier": "^2.8.8"\n  }\n}\n' >"$REPO/web/frontend/package.json"
+cat >"$REPO/web/frontend/package-lock.json" <<LOCK
+{
+  "name": "fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "fixture",
+      "version": "0.0.0"
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8"
+    }
+  }
+}
+LOCK
 printf 'const a = 0\n' >"$REPO/web/frontend/src/a.ts"
 printf 'void main() {}\n' >"$REPO/app/lib/main.dart"
 git -C "$REPO" add -A
 git -C "$REPO" commit -qm base
 
 make_prettier_stub() {
-  version="$1"
-  mkdir -p "$REPO/web/frontend/node_modules/.bin"
-  cat >"$REPO/web/frontend/node_modules/.bin/prettier" <<STUB
+  target_dir="$1"
+  version="$2"
+  mkdir -p "$target_dir/node_modules/.bin"
+  cat >"$target_dir/node_modules/.bin/prettier" <<STUB
 #!/bin/sh
 if [ "\$1" = "--version" ]; then echo "$version"; exit 0; fi
 shift
 for f in "\$@"; do printf 'PRETTIER_${version}_FORMATTED\n' >"\$f"; done
 STUB
-  chmod +x "$REPO/web/frontend/node_modules/.bin/prettier"
+  chmod +x "$target_dir/node_modules/.bin/prettier"
+}
+
+make_prettier_lock() {
+  target_dir="$1"
+  version="$2"
+  cat >"$target_dir/package-lock.json" <<LOCK
+{
+  "name": "fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "fixture",
+      "version": "0.0.0"
+    },
+    "node_modules/prettier": {
+      "version": "$version"
+    }
+  }
+}
+LOCK
 }
 
 make_flutter_stub() {
@@ -79,13 +117,18 @@ rm -rf "$REPO/web/frontend/node_modules"
 expect_refusal "missing pinned prettier"
 test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
 
-# --- Prettier: a mismatched major (the floating npx hazard) must refuse ---
-make_prettier_stub 3.4.2
-expect_refusal "prettier major mismatch"
+# --- Prettier: a mismatched version (the floating npx hazard) must refuse ---
+make_prettier_stub "$REPO/web/frontend" 3.4.2
+expect_refusal "prettier version mismatch"
 test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
 
-# --- Prettier: the pinned major formats ---
-make_prettier_stub 2.8.8
+# --- Prettier: an older same-major release must still be refused when package-lock pins newer ---
+make_prettier_stub "$REPO/web/frontend" 2.0.0
+expect_refusal "prettier same-major stale lock"
+test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
+
+# --- Prettier: the pinned version formats ---
+make_prettier_stub "$REPO/web/frontend" 2.8.8
 run_hook >/dev/null
 grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/web/frontend/src/a.ts"
 git -C "$REPO" reset -q --hard
@@ -115,5 +158,27 @@ rm -rf "$REPO/web/frontend/node_modules" "$STUBS/flutter"
 run_hook OMI_SKIP_WEB_FORMAT=1 OMI_SKIP_DART_FORMAT=1 >/dev/null
 test "$(cat "$REPO/web/frontend/src/a.ts")" = "const c = {d:1}"
 test "$(cat "$REPO/app/lib/main.dart")" = "void main() {   }"
+
+# --- Web/app and web/admin now pin prettier, so they format like web/frontend ---
+for webdir in web/app web/admin; do
+  mkdir -p "$REPO/$webdir/src"
+  printf '{\n  "devDependencies": {\n    "prettier": "^2.8.8",\n    "prettier-plugin-tailwindcss": "^0.3.0"\n  }\n}\n' >"$REPO/$webdir/package.json"
+  make_prettier_lock "$REPO/$webdir" 2.8.8
+  make_prettier_stub "$REPO/$webdir" 2.8.8
+  printf 'const %s = {b:1}\n' "$(basename "$webdir")" >"$REPO/$webdir/src/a.ts"
+  git -C "$REPO" add -A
+  run_hook >/dev/null
+  grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/$webdir/src/a.ts"
+  git -C "$REPO" reset -q --hard
+  rm -rf "$REPO/$webdir"
+done
+
+# --- A web directory without a prettier pin is still refused ---
+mkdir -p "$REPO/web/unpinned/src"
+printf '{ "devDependencies": {} }\n' >"$REPO/web/unpinned/package.json"
+printf 'const x = {b:1}\n' >"$REPO/web/unpinned/src/a.ts"
+git -C "$REPO" add -A
+expect_refusal "unpinned web dir"
+test "$(cat "$REPO/web/unpinned/src/a.ts")" = "const x = {b:1}"
 
 echo "pre-commit pinned-toolchain refusal tests passed"

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -97,6 +97,9 @@ make_prettier_plugin() {
 make_flutter_stub() {
   cat >"$STUBS/flutter" <<STUB
 #!/bin/sh
+# Mimic Flutter's Git-based SDK-version resolution: a leaked hook GIT_DIR (as in
+# a linked worktree) makes the probe report nothing even for a valid install.
+if [ -n "\${GIT_DIR:-}" ]; then exit 0; fi
 echo "Flutter $1 • channel stable"
 STUB
   cat >"$STUBS/dart" <<'STUB'
@@ -177,6 +180,12 @@ test "$(cat "$REPO/app/lib/main.dart")" = "void main() {  }"
 # --- Dart: the pinned Flutter formats ---
 make_flutter_stub 9.9.9
 run_hook >/dev/null
+grep -q 'DART_FORMATTED' "$REPO/app/lib/main.dart"
+
+# --- Dart: a linked-worktree GIT_DIR must not leak into the flutter probe ---
+printf 'void main() {  }\n' >"$REPO/app/lib/main.dart"
+git -C "$REPO" add app/lib/main.dart
+run_hook GIT_DIR="$REPO/.git" >/dev/null
 grep -q 'DART_FORMATTED' "$REPO/app/lib/main.dart"
 
 # --- Both hatches leave staged files untouched and still commit ---

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -31,6 +31,9 @@ cat >"$REPO/web/frontend/package-lock.json" <<LOCK
     },
     "node_modules/prettier": {
       "version": "2.8.8"
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.3.0"
     }
   }
 }
@@ -68,10 +71,20 @@ make_prettier_lock() {
     },
     "node_modules/prettier": {
       "version": "$version"
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.3.0"
     }
   }
 }
 LOCK
+}
+
+make_prettier_plugin() {
+  target_dir="$1"
+  version="${2:-0.3.0}"
+  mkdir -p "$target_dir/node_modules/prettier-plugin-tailwindcss"
+  printf '{"name": "prettier-plugin-tailwindcss", "version": "%s"}\n' "$version" >"$target_dir/node_modules/prettier-plugin-tailwindcss/package.json"
 }
 
 make_flutter_stub() {
@@ -129,8 +142,18 @@ test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
 
 # --- Prettier: the pinned version formats ---
 make_prettier_stub "$REPO/web/frontend" 2.8.8
+make_prettier_plugin "$REPO/web/frontend" 0.3.0
 run_hook >/dev/null
 grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/web/frontend/src/a.ts"
+git -C "$REPO" reset -q --hard
+
+# --- Prettier: a stale plugin must still be refused when prettier matches ---
+printf 'const a = {b:1}\n' >"$REPO/web/frontend/src/a.ts"
+git -C "$REPO" add web/frontend/src/a.ts
+make_prettier_stub "$REPO/web/frontend" 2.8.8
+make_prettier_plugin "$REPO/web/frontend" 0.2.0
+expect_refusal "prettier plugin version mismatch"
+test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
 git -C "$REPO" reset -q --hard
 
 # --- Dart: no flutter on PATH must refuse ---
@@ -159,12 +182,15 @@ run_hook OMI_SKIP_WEB_FORMAT=1 OMI_SKIP_DART_FORMAT=1 >/dev/null
 test "$(cat "$REPO/web/frontend/src/a.ts")" = "const c = {d:1}"
 test "$(cat "$REPO/app/lib/main.dart")" = "void main() {   }"
 
+git -C "$REPO" reset -q --hard
+
 # --- Web/app and web/admin now pin prettier, so they format like web/frontend ---
 for webdir in web/app web/admin; do
   mkdir -p "$REPO/$webdir/src"
   printf '{\n  "devDependencies": {\n    "prettier": "^2.8.8",\n    "prettier-plugin-tailwindcss": "^0.3.0"\n  }\n}\n' >"$REPO/$webdir/package.json"
   make_prettier_lock "$REPO/$webdir" 2.8.8
   make_prettier_stub "$REPO/$webdir" 2.8.8
+  make_prettier_plugin "$REPO/$webdir" 0.3.0
   printf 'const %s = {b:1}\n' "$(basename "$webdir")" >"$REPO/$webdir/src/a.ts"
   git -C "$REPO" add -A
   run_hook >/dev/null

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -220,6 +220,7 @@ printf '{\n  "devDependencies": {\n    "prettier": "^2.8.8",\n    "prettier-plug
 make_prettier_lock "$REPO/web/admin" 2.8.8
 make_prettier_stub "$REPO/web/admin" 2.8.8
 make_prettier_plugin "$REPO/web/admin" 0.3.0
+git -C "$REPO" add web/admin/package.json web/admin/package-lock.json
 printf 'const staged = {b:1}\n' >"$REPO/web/admin/src/a.ts"
 git -C "$REPO" add web/admin/src/a.ts
 printf 'const staged = {b:1}\nconst unstaged = 2\n' >"$REPO/web/admin/src/a.ts"
@@ -231,5 +232,25 @@ rm -rf "$REPO/web/unpinned"
 git -C "$REPO" reset -q -- web/unpinned
 run_hook >/dev/null
 grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/web/admin/src/a.ts"
+
+# --- The generated OpenAPI client under web/admin is excluded from format-and-add ---
+mkdir -p "$REPO/web/admin/lib/services/omi-api"
+printf 'export const omiApi = {  untouched: 1 }\n' >"$REPO/web/admin/lib/services/omi-api/omiApi.generated.ts"
+printf 'const gen = {b:1}\n' >"$REPO/web/admin/src/b.ts"
+git -C "$REPO" add web/admin/lib/services/omi-api/omiApi.generated.ts web/admin/src/b.ts
+run_hook >/dev/null
+grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/web/admin/src/b.ts"
+test "$(cat "$REPO/web/admin/lib/services/omi-api/omiApi.generated.ts")" = "export const omiApi = {  untouched: 1 }"
+git -C "$REPO" reset -q --hard
+
+# --- A missing package-lock with a matching-major prettier must refuse, not fall back (#11304) ---
+mkdir -p "$REPO/web/nolock/src"
+printf '{\n  "devDependencies": {\n    "prettier": "^2.8.8",\n    "prettier-plugin-tailwindcss": "^0.3.0"\n  }\n}\n' >"$REPO/web/nolock/package.json"
+make_prettier_stub "$REPO/web/nolock" 2.0.0
+make_prettier_plugin "$REPO/web/nolock" 0.3.0
+printf 'const nolock = {b:1}\n' >"$REPO/web/nolock/src/a.ts"
+git -C "$REPO" add web/nolock/src/a.ts web/nolock/package.json
+expect_refusal "missing lockfile with same-major prettier"
+test "$(cat "$REPO/web/nolock/src/a.ts")" = "const nolock = {b:1}"
 
 echo "pre-commit pinned-toolchain refusal tests passed"

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Git hooks export their own repository environment. This fixture creates a
+# separate temporary repository, so it must not inherit that hook context.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/scripts/pre-commit"
+TMPDIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+REPO="$TMPDIR/repo"
+STUBS="$TMPDIR/stubs"
+mkdir -p "$REPO/web/frontend/src" "$REPO/app/lib" "$REPO/.github/workflows" "$STUBS"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+printf 'jobs:\n  flutter:\n    steps:\n      - uses: subosito/flutter-action@v2\n        with:\n          flutter-version: 9.9.9\n' >"$REPO/.github/workflows/repo-checks.yml"
+printf '{\n  "devDependencies": {\n    "eslint-plugin-prettier": "^4.2.1",\n    "prettier": "^2.8.8"\n  }\n}\n' >"$REPO/web/frontend/package.json"
+printf 'const a = 0\n' >"$REPO/web/frontend/src/a.ts"
+printf 'void main() {}\n' >"$REPO/app/lib/main.dart"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm base
+
+make_prettier_stub() {
+  version="$1"
+  mkdir -p "$REPO/web/frontend/node_modules/.bin"
+  cat >"$REPO/web/frontend/node_modules/.bin/prettier" <<STUB
+#!/bin/sh
+if [ "\$1" = "--version" ]; then echo "$version"; exit 0; fi
+shift
+for f in "\$@"; do printf 'PRETTIER_${version}_FORMATTED\n' >"\$f"; done
+STUB
+  chmod +x "$REPO/web/frontend/node_modules/.bin/prettier"
+}
+
+make_flutter_stub() {
+  cat >"$STUBS/flutter" <<STUB
+#!/bin/sh
+echo "Flutter $1 • channel stable"
+STUB
+  cat >"$STUBS/dart" <<'STUB'
+#!/bin/sh
+for f in "$@"; do
+  case "$f" in
+    *.dart) printf 'DART_FORMATTED\n' >"$f" ;;
+  esac
+done
+STUB
+  chmod +x "$STUBS/flutter" "$STUBS/dart"
+}
+
+run_hook() {
+  ( cd "$REPO" && env PATH="$STUBS:$PATH" "$@" sh "$HOOK" )
+}
+
+expect_refusal() {
+  label="$1"
+  shift
+  out="$TMPDIR/out.txt"
+  if run_hook "$@" >"$out" 2>&1; then
+    echo "FAIL: $label — hook exited 0 instead of refusing" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+  if ! grep -q "mismatch\|refusing" "$out"; then
+    echo "FAIL: $label — refusal message is not actionable" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+}
+
+# --- Prettier: no pinned toolchain installed must refuse, not reformat ---
+printf 'const a = {b:1}\n' >"$REPO/web/frontend/src/a.ts"
+git -C "$REPO" add web/frontend/src/a.ts
+rm -rf "$REPO/web/frontend/node_modules"
+expect_refusal "missing pinned prettier"
+test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
+
+# --- Prettier: a mismatched major (the floating npx hazard) must refuse ---
+make_prettier_stub 3.4.2
+expect_refusal "prettier major mismatch"
+test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
+
+# --- Prettier: the pinned major formats ---
+make_prettier_stub 2.8.8
+run_hook >/dev/null
+grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/web/frontend/src/a.ts"
+git -C "$REPO" reset -q --hard
+
+# --- Dart: no flutter on PATH must refuse ---
+printf 'void main() {  }\n' >"$REPO/app/lib/main.dart"
+git -C "$REPO" add app/lib/main.dart
+expect_refusal "no flutter toolchain"
+test "$(cat "$REPO/app/lib/main.dart")" = "void main() {  }"
+
+# --- Dart: a Flutter version other than the repo pin must refuse ---
+make_flutter_stub 8.8.8
+expect_refusal "flutter version mismatch"
+test "$(cat "$REPO/app/lib/main.dart")" = "void main() {  }"
+
+# --- Dart: the pinned Flutter formats ---
+make_flutter_stub 9.9.9
+run_hook >/dev/null
+grep -q 'DART_FORMATTED' "$REPO/app/lib/main.dart"
+
+# --- Both hatches leave staged files untouched and still commit ---
+git -C "$REPO" reset -q --hard
+printf 'const c = {d:1}\n' >"$REPO/web/frontend/src/a.ts"
+printf 'void main() {   }\n' >"$REPO/app/lib/main.dart"
+git -C "$REPO" add -A
+rm -rf "$REPO/web/frontend/node_modules" "$STUBS/flutter"
+run_hook OMI_SKIP_WEB_FORMAT=1 OMI_SKIP_DART_FORMAT=1 >/dev/null
+test "$(cat "$REPO/web/frontend/src/a.ts")" = "const c = {d:1}"
+test "$(cat "$REPO/app/lib/main.dart")" = "void main() {   }"
+
+echo "pre-commit pinned-toolchain refusal tests passed"

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -25,7 +25,7 @@ import sys
 sys.exit(0)
 PY
 printf 'jobs:\n  flutter:\n    steps:\n      - uses: subosito/flutter-action@v2\n        with:\n          flutter-version: 9.9.9\n' >"$REPO/.github/workflows/repo-checks.yml"
-printf '{\n  "devDependencies": {\n    "eslint-plugin-prettier": "^4.2.1",\n    "prettier": "^2.8.8"\n  }\n}\n' >"$REPO/web/frontend/package.json"
+printf '{\n  "devDependencies": {\n    "eslint-plugin-prettier": "^4.2.1",\n    "prettier": "^2.8.8",\n    "prettier-plugin-tailwindcss": "^0.3.0"\n  }\n}\n' >"$REPO/web/frontend/package.json"
 cat >"$REPO/web/frontend/package-lock.json" <<LOCK
 {
   "name": "fixture",
@@ -126,7 +126,7 @@ expect_refusal() {
     cat "$out" >&2
     exit 1
   fi
-  if ! grep -q "mismatch\|refusing" "$out"; then
+  if ! grep -q "mismatch\|refus\|unresolved" "$out"; then
     echo "FAIL: $label — refusal message is not actionable" >&2
     cat "$out" >&2
     exit 1
@@ -163,6 +163,32 @@ git -C "$REPO" add web/frontend/src/a.ts
 make_prettier_stub "$REPO/web/frontend" 2.8.8
 make_prettier_plugin "$REPO/web/frontend" 0.2.0
 expect_refusal "prettier plugin version mismatch"
+test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
+git -C "$REPO" reset -q --hard
+
+# --- Prettier: a declared plugin missing from the lockfile must refuse, not skip ---
+printf 'const a = {b:1}\n' >"$REPO/web/frontend/src/a.ts"
+git -C "$REPO" add web/frontend/src/a.ts
+cat >"$REPO/web/frontend/package-lock.json" <<LOCK
+{
+  "name": "fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "fixture",
+      "version": "0.0.0"
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8"
+    }
+  }
+}
+LOCK
+git -C "$REPO" add web/frontend/package-lock.json
+make_prettier_stub "$REPO/web/frontend" 2.8.8
+make_prettier_plugin "$REPO/web/frontend" 0.2.0
+expect_refusal "declared prettier plugin unresolved in lockfile"
 test "$(cat "$REPO/web/frontend/src/a.ts")" = "const a = {b:1}"
 git -C "$REPO" reset -q --hard
 

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -207,4 +207,22 @@ git -C "$REPO" add -A
 expect_refusal "unpinned web dir"
 test "$(cat "$REPO/web/unpinned/src/a.ts")" = "const x = {b:1}"
 
+# --- A staged web file with unstaged edits is refused instead of sweeping them in ---
+mkdir -p "$REPO/web/admin/src"
+printf '{\n  "devDependencies": {\n    "prettier": "^2.8.8",\n    "prettier-plugin-tailwindcss": "^0.3.0"\n  }\n}\n' >"$REPO/web/admin/package.json"
+make_prettier_lock "$REPO/web/admin" 2.8.8
+make_prettier_stub "$REPO/web/admin" 2.8.8
+make_prettier_plugin "$REPO/web/admin" 0.3.0
+printf 'const staged = {b:1}\n' >"$REPO/web/admin/src/a.ts"
+git -C "$REPO" add web/admin/src/a.ts
+printf 'const staged = {b:1}\nconst unstaged = 2\n' >"$REPO/web/admin/src/a.ts"
+expect_refusal "web file with unstaged edits"
+test "$(cat "$REPO/web/admin/src/a.ts")" = "const staged = {b:1}
+const unstaged = 2"
+git -C "$REPO" add web/admin/src/a.ts
+rm -rf "$REPO/web/unpinned"
+git -C "$REPO" reset -q -- web/unpinned
+run_hook >/dev/null
+grep -q 'PRETTIER_2.8.8_FORMATTED' "$REPO/web/admin/src/a.ts"
+
 echo "pre-commit pinned-toolchain refusal tests passed"

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -13,10 +13,17 @@ trap cleanup EXIT
 
 REPO="$TMPDIR/repo"
 STUBS="$TMPDIR/stubs"
-mkdir -p "$REPO/web/frontend/src" "$REPO/app/lib" "$REPO/.github/workflows" "$STUBS"
+mkdir -p "$REPO/web/frontend/src" "$REPO/app/lib" "$REPO/.github/workflows" "$REPO/.github/scripts" "$STUBS"
 git -C "$REPO" init -q
 git -C "$REPO" config user.email test@example.com
 git -C "$REPO" config user.name test
+# The hook gates the fixture repo's commit identity; the author check is not
+# what this lane covers, so stub it to always pass.
+cat >"$REPO/.github/scripts/check_git_author_identity.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+sys.exit(0)
+PY
 printf 'jobs:\n  flutter:\n    steps:\n      - uses: subosito/flutter-action@v2\n        with:\n          flutter-version: 9.9.9\n' >"$REPO/.github/workflows/repo-checks.yml"
 printf '{\n  "devDependencies": {\n    "eslint-plugin-prettier": "^4.2.1",\n    "prettier": "^2.8.8"\n  }\n}\n' >"$REPO/web/frontend/package.json"
 cat >"$REPO/web/frontend/package-lock.json" <<LOCK

--- a/scripts/test-pre-push-backend-test-cap.sh
+++ b/scripts/test-pre-push-backend-test-cap.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The pre-push hooks export their own repository environment; an author pushing
+# with a backend hatch set (e.g. PRE_PUSH_SKIP_BACKEND_UNIT_TESTS=1) must not
+# leak into this lane — the cap logic has to run regardless of how the author
+# is pushing.
+unset PRE_PUSH_SKIP_BACKEND_UNIT_TESTS PRE_PUSH_SKIP_BACKEND_TYPECHECK PRE_PUSH_SKIP_BACKEND_RUNTIME_ENV
+
 unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/test-pre-push-backend-test-cap.sh
+++ b/scripts/test-pre-push-backend-test-cap.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/scripts/pre-push"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+FUNC="$WORK/check_backend_unit_tests_if_needed.sh"
+awk '/^check_backend_unit_tests_if_needed\(\) \{$/,/^\}$/' "$HOOK" > "$FUNC"
+if ! grep -q '^}$' "$FUNC"; then
+  echo "FAIL: could not extract check_backend_unit_tests_if_needed from $HOOK" >&2
+  exit 1
+fi
+
+# Stub interpreter standing in for the backend selector: emits a caller-chosen
+# number of selected test paths plus a reason.
+cat > "$WORK/fake-python" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+reason_output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    --reason-output) reason_output="$2"; shift 2 ;;
+    --changed-files) shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$output"
+i=0
+while [ "$i" -lt "${STUB_SELECTED_COUNT:-0}" ]; do
+  printf 'tests/selector_%03d_test.py\n' "$i" >> "$output"
+  i=$((i + 1))
+done
+printf '%s\n' "${STUB_REASON:-broad selector fallout}" > "$reason_output"
+STUB
+chmod +x "$WORK/fake-python"
+
+mkdir -p "$WORK/repo/backend/tests" "$WORK/repo/backend/scripts"
+touch "$WORK/repo/backend/scripts/select_backend_unit_tests.py"
+cat > "$WORK/repo/backend/test-preflight.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+cat > "$WORK/repo/backend/test.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+wc -l < "$BACKEND_UNIT_TEST_FILE_LIST" | tr -d ' ' > "$RAN_COUNT_FILE"
+cp "$BACKEND_UNIT_TEST_FILE_LIST" "$RAN_LIST_FILE"
+STUB
+
+# $1 = number of changed backend test files in the diff, $2 = cap
+run_case() {
+  local changed_test_files="$1" cap="$2" i
+  rm -f "$WORK/ran_count" "$WORK/ran_list"
+  rm -f "$WORK/repo/backend/tests/"*.py
+  local -a changed=()
+  for ((i = 0; i < changed_test_files; i++)); do
+    printf -v name 'backend/tests/changed_%03d_test.py' "$i"
+    touch "$WORK/repo/$name"
+    changed+=("$name")
+  done
+
+  (
+    cd "$WORK/repo"
+    # shellcheck disable=SC2034
+    CHANGED_FILES=("${changed[@]+"${changed[@]}"}" "backend/app.py")
+    BACKEND_PYTHON="$WORK/fake-python"
+    CHANGED_FILES_LIST="$WORK/changed"
+    SELECTED_BACKEND_TESTS="$WORK/selected"
+    SELECTED_BACKEND_TESTS_REASON="$WORK/reason"
+    FAST_BACKEND_TESTS="$WORK/fast"
+    PRE_PUSH_MAX_BACKEND_UNIT_TEST_FILES="$cap"
+    export RAN_COUNT_FILE="$WORK/ran_count" RAN_LIST_FILE="$WORK/ran_list"
+    printf '%s\n' "${CHANGED_FILES[@]}" > "$CHANGED_FILES_LIST"
+    : > "$SELECTED_BACKEND_TESTS"
+    : > "$SELECTED_BACKEND_TESTS_REASON"
+    : > "$FAST_BACKEND_TESTS"
+    changed_matches() { return 0; }
+    require_backend_python() { :; }
+    # shellcheck source=/dev/null
+    source "$FUNC"
+    check_backend_unit_tests_if_needed
+  )
+}
+
+CAP=10
+export STUB_SELECTED_COUNT=500 STUB_REASON="broad selector fallout"
+
+# Regression (#11018 class): a diff whose own changed backend test files exceed
+# the cap must still run at most the cap. Before the bound this ran all 25.
+output="$(run_case 25 "$CAP")"
+ran="$(cat "$WORK/ran_count")"
+if [ "$ran" -gt "$CAP" ]; then
+  echo "FAIL: fallback ran $ran backend test file(s), over the cap of $CAP" >&2
+  echo "$output" >&2
+  exit 1
+fi
+case "$output" in
+  *"cap is $CAP"*)
+    echo "FAIL: message advertises a cap the run may exceed instead of reporting the truncation" >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac
+grep -q "25 backend test file(s), also over the cap of $CAP" <<<"$output" || {
+  echo "FAIL: message does not report requested vs actual counts" >&2; echo "$output" >&2; exit 1; }
+grep -q "Running the first $ran in sorted order" <<<"$output" || {
+  echo "FAIL: message does not report what actually ran" >&2; echo "$output" >&2; exit 1; }
+
+# Truncation is deterministic: the same diff selects the same files every push.
+first_list="$(cat "$WORK/ran_list")"
+run_case 25 "$CAP" >/dev/null
+test "$first_list" = "$(cat "$WORK/ran_list")" || {
+  echo "FAIL: truncated selection is not stable across runs" >&2; exit 1; }
+test "$first_list" = "$(sort "$WORK/ran_list")" || {
+  echo "FAIL: truncated selection is not sorted" >&2; exit 1; }
+
+# Under the cap the existing fallback behavior is unchanged.
+output="$(run_case 4 "$CAP")"
+test "$(cat "$WORK/ran_count")" = "4"
+grep -q "running 4 changed backend test file(s) instead; cap is $CAP" <<<"$output" || {
+  echo "FAIL: under-cap fallback message regressed" >&2; echo "$output" >&2; exit 1; }
+
+# No changed backend test files still skips the broad suite entirely.
+output="$(run_case 0 "$CAP")"
+test ! -f "$WORK/ran_count"
+grep -q "Skipping broad backend unit suite in pre-push" <<<"$output" || {
+  echo "FAIL: empty fallback no longer skips" >&2; echo "$output" >&2; exit 1; }
+
+echo "pre-push backend unit test cap tests passed"

--- a/web/admin/AGENTS.md
+++ b/web/admin/AGENTS.md
@@ -1,25 +1,8 @@
 # Web Admin Dashboard
 
-## Networking
+- **Networking:** all fetches use `hooks/useAuthToken.ts`; never call `getIdToken()`, create auth headers, or read Firestore in the client. Server routes call `verifyAdmin(request)` from `lib/auth.ts`.
+- **Revenue metrics:** subscription metrics use `lib/stripe-subscriptions.ts`; never list subscriptions by price ID.
 
-All fetches use `hooks/useAuthToken.ts`; never call `getIdToken()`, create auth headers, or read Firestore in the client.
-
-- Reads: `useAuthToken()` + `authenticatedFetcher`; mutations: `useAuthFetch()` → `fetchWithAuth(url, init)`.
-- Server routes call `verifyAdmin(request)` from `lib/auth.ts`.
-- Parallel fetches use `Promise.allSettled`, returning `partial: true` on partial failure and 502 on total failure.
-- SWR configuration belongs in `components/swr-provider.tsx`; keys are `token ? [url, token] : null`.
-- Partial data shows an amber warning. On error, clear stale data and show N/A; never show stale data with an error flag.
-- Do not add custom fetchers, `useEffect` token handling, manual-auth `fetch()`, `Promise.all` upstream calls, or zero metrics for upstream failures.
-
-## Revenue metrics
-
-Subscription metrics use `lib/stripe-subscriptions.ts`; never list subscriptions by price ID.
-
-- `OMI_PLAN_PRODUCTS` defines the subscription scope; it excludes marketplace apps and internal test products. Add a line when launching a plan.
-- Marketplace apps are excluded by `metadata.app_id`, stamped by the backend on app checkout.
-- MRR includes `active` and `past_due`; report `trialing` separately.
-- Normalize amounts with each price's `interval` and `interval_count`; never assume monthly or annual pricing.
-
-## Grafana
+Fetcher, SWR, partial-failure, and subscription-scope detail: [`docs/data-contracts.md`](docs/data-contracts.md).
 
 `/dashboard` embeds uid `omi-tv` from `grafana/`; see `grafana/README.md`.

--- a/web/admin/docs/data-contracts.md
+++ b/web/admin/docs/data-contracts.md
@@ -1,0 +1,23 @@
+# Web Admin Data Contracts
+
+Detail for the two rules in `web/admin/AGENTS.md`.
+
+## Networking
+
+All fetches use `hooks/useAuthToken.ts`; never call `getIdToken()`, create auth headers, or read Firestore in the client.
+
+- Reads: `useAuthToken()` + `authenticatedFetcher`; mutations: `useAuthFetch()` → `fetchWithAuth(url, init)`.
+- Server routes call `verifyAdmin(request)` from `lib/auth.ts`.
+- Parallel fetches use `Promise.allSettled`, returning `partial: true` on partial failure and 502 on total failure.
+- SWR configuration belongs in `components/swr-provider.tsx`; keys are `token ? [url, token] : null`.
+- Partial data shows an amber warning. On error, clear stale data and show N/A; never show stale data with an error flag.
+- Do not add custom fetchers, `useEffect` token handling, manual-auth `fetch()`, `Promise.all` upstream calls, or zero metrics for upstream failures.
+
+## Revenue metrics
+
+Subscription metrics use `lib/stripe-subscriptions.ts`; never list subscriptions by price ID.
+
+- `OMI_PLAN_PRODUCTS` defines the subscription scope; it excludes marketplace apps and internal test products. Add a line when launching a plan.
+- Marketplace apps are excluded by `metadata.app_id`, stamped by the backend on app checkout.
+- MRR includes `active` and `past_due`; report `trialing` separately.
+- Normalize amounts with each price's `interval` and `interval_count`; never assume monthly or annual pricing.

--- a/web/admin/package-lock.json
+++ b/web/admin/package-lock.json
@@ -53,9 +53,9 @@
         "input-otp": "^1.2.4",
         "ioredis": "^5.10.1",
         "lucide-react": "^0.446.0",
-        "next": "16.2.11",
+        "next": "~16.2.11",
         "next-themes": "^0.3.0",
-        "postcss": "^8.5.18",
+        "postcss": "~8.5.18",
         "react": "18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "18.2.0",
@@ -78,6 +78,8 @@
         "@testing-library/react": "^16.3.2",
         "dotenv": "^17.3.1",
         "jsdom": "^29.0.2",
+        "prettier": "^2.8.8",
+        "prettier-plugin-tailwindcss": "^0.3.0",
         "vitest": "^4.1.3"
       }
     },
@@ -10045,6 +10047,97 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.3.0.tgz",
+      "integrity": "sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@shufo/prettier-plugin-blade": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "prettier": ">=2.2.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*",
+        "prettier-plugin-twig-melody": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@shufo/prettier-plugin-blade": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "prettier-plugin-twig-melody": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -83,6 +83,8 @@
     "@testing-library/react": "^16.3.2",
     "dotenv": "^17.3.1",
     "jsdom": "^29.0.2",
+    "prettier": "^2.8.8",
+    "prettier-plugin-tailwindcss": "^0.3.0",
     "vitest": "^4.1.3"
   },
   "overrides": {
@@ -91,7 +93,7 @@
     "glob@>=10.0.0 <10.5.0": "^10.5.0",
     "protobufjs": "^7.6.3",
     "cross-spawn": "^7.0.5",
-    "postcss": "^8.5.10",
+    "postcss": "$postcss",
     "zod": "^3.23.8",
     "jws@>=3.0.0 <3.2.3": "^3.2.3",
     "@grpc/grpc-js": ">=1.9.16",
@@ -105,7 +107,6 @@
     "websocket-driver": ">=0.5.8",
     "undici": "7.28.0",
     "js-yaml": "~5.2.2",
-    "sharp": "~0.35.0",
-    "postcss": "$postcss"
+    "sharp": "~0.35.0"
   }
 }

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -74,6 +74,8 @@
     "eslint": "^9",
     "jsdom": "^29.1.1",
     "postcss": "~8.5.18",
+    "prettier": "^2.8.8",
+    "prettier-plugin-tailwindcss": "^0.3.0",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.7",


### PR DESCRIPTION
## Why

Four independent hygiene fixes to local/CI gates.

1. **The pre-commit hook could reformat files into a shape CI rejects.** When a web directory had no `node_modules`, `scripts/pre-commit` fell back to a floating `npx prettier` — prettier 3 against the `^2.8.8` `web/frontend` pins and CI installs with `npm ci`. That rewrote `getPlatformLink` in `web/frontend/src/app/apps/[id]/page.tsx` into a CI-failing shape (#11304) and polluted four PRs in one day, plus unrelated `app/` Dart files reformatted by a locally-installed Dart SDK that differs from the repo's pinned Flutter.
2. **`web/frontend`'s test suite ran in no lane.** `package.json` has `"test": "node --test src/__tests__/*.test.mjs"` with real guards (`app-detail-not-found`, `case-status`, `shared-conversation-chat-contract`), but `.github/checks-manifest.yaml` never selected them — which is why a deleted frontend test's guards had to be re-homed into a backend pytest to keep running.
3. **`web/admin/AGENTS.md` was 137 bytes from red.** `agents-md-lean` going over budget takes `main` red and blocks every PR touching any `AGENTS.md` (#11409, fixed by #11410).
4. **The pre-push backend test cap had an unbounded escape hatch.** The root `AGENTS.md` push-gate budget says pre-push must "cap broad backend selection at 40 files", and `scripts/pre-push` does cap it — but when the selector overflows, the cap branch swaps in the diff's *own* changed backend test files and never re-applies the cap to that replacement. A diff changing more than 40 backend test files ran unbounded, while the message still printed `cap is 40`. #11018's 92-file diff stalled its push on this gate repeatedly; it had 15 changed backend test files so it stayed under the cap, but slow enough that several agents resorted to documented skip hatches — one size larger and there would have been no bound at all.

## What changed

1. `scripts/pre-commit` resolves the pinned toolchain and **refuses to format** rather than formatting with the wrong one: each web dir's `package.json` prettier major must match `node_modules/.bin/prettier`, and Dart requires the `flutter-version` pinned in `.github/workflows/repo-checks.yml`. Both fallbacks (`npx`, global `prettier`) are gone. Hatches: `OMI_SKIP_WEB_FORMAT=1`, `OMI_SKIP_DART_FORMAT=1`, both documented in the root `AGENTS.md` Formatting section. Web directories are now derived from the staged paths, so `web/admin` (previously skipped entirely) is covered. New regression test `scripts/test-pre-commit-pinned-toolchains.sh`, registered as manifest check `pre-commit-pinned-toolchains`.
2. New manifest check `web-frontend-tests` (`local` + `ci`, triggers `web/frontend/**`) running `node --test 'web/frontend/src/__tests__/**/*.test.mjs'` — the glob picks up test files added later.
3. `web/admin/AGENTS.md` networking and revenue-metrics detail moved verbatim into `web/admin/docs/data-contracts.md`, with the two top-level rules and a pointer left behind. **Budgets untouched.**
4. The `scripts/pre-push` fallback now **truncates deterministically to the cap**. The changed-test list is already `sort -u`ed, so `head -n cap` picks the same files on every push of the same diff rather than sampling a different subset. Truncation beats skipping here because the diff's own changed test files are the highest-signal local coverage available; the message now names the full changed-test count, what actually ran, and points at `cd backend && bash test.sh` for the remainder — it never prints a cap the run then exceeds. `PRE_PUSH_MAX_BACKEND_UNIT_TEST_FILES` stays the single knob. New regression test `scripts/test-pre-push-backend-test-cap.sh`, registered as manifest check `pre-push-backend-test-cap` (`local` + `ci`). Distinct lane from #11361, which narrows `flutter-codegen` selection in `scripts/pre_push_ci_prediction.py` — same class of problem, no overlapping files.

## Verification

**Mutation test of the new guard** — with `scripts/pre-commit` reverted to `origin/main`, `scripts/test-pre-commit-pinned-toolchains.sh` fails and the output shows the exact hazard:

```
FAIL: missing pinned prettier — hook exited 0 instead of refusing
Formatting staged web files with Prettier...
npm warn exec The following package was not found and will be installed: prettier@3.9.6
web/frontend/src/a.ts 34ms
```

With the fix applied: `pre-commit pinned-toolchain refusal tests passed` (refusal cases for missing prettier, prettier major mismatch, no flutter, flutter version mismatch; positive cases for the pinned versions; and both hatches).

**Manifest selection** (`run_checks.py --list`):

| Diff | `web-frontend-tests` |
|---|---|
| `web/frontend/src/app/apps/x.tsx` | SELECTED |
| `web/frontend/src/__tests__/new-thing.test.mjs` | SELECTED |
| `backend/main.py` | not selected |

`run_checks.py --lane ci --check-id web-frontend-tests` → **47 tests pass, 0 fail**.

**AGENTS.md headroom** after this PR (`python3 .github/scripts/check_agents_md_lean.py` → `ok: 7 AGENTS.md files within budget`):

| File | Bytes | Headroom |
|---|---|---|
| `web/admin/AGENTS.md` | 457 / 1500 | **1043** |
| `AGENTS.md` | 17082 / 18000 | 918 |
| `.github/AGENTS.md` | 3825 / 4500 | 675 |
| `app/AGENTS.md` | 10606 / 11500 | 894 |
| `backend/AGENTS.md` | 38936 / 39000 | 64 |
| `desktop/macos/AGENTS.md` | 45531 / 47000 | 1469 |
| `omi/firmware/AGENTS.md` | 853 / 1500 | 647 |

`backend/AGENTS.md` remains 64 bytes from the same failure and still needs its own PR.

**Mutation test of the pre-push cap bound** — the regression test extracts the real `check_backend_unit_tests_if_needed` from the hook and runs it against a stubbed selector and backend, so it exercises production control flow rather than scraping source. With the bound reverted:

```
FAIL: fallback ran 25 backend test file(s), over the cap of 10
Selector requested broad selector fallout (500 files; running 25 changed backend test file(s) instead; cap is 10).
Selected 25 backend unit test file(s): broad selector fallout
```

With the bound restored: `pre-push backend unit test cap tests passed` (over-cap truncation, stable + sorted truncation across repeated runs, the unchanged under-cap fallback message, and the unchanged empty-fallback skip).

`make preflight` passes.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

The pre-push cap fix is likewise `none`: no registered class covers "a bound's own fallback path must re-apply that bound", and one instance does not justify opening one.

The nearest existing class, `FC-dev-fallback-masks-install-defect` (a development-only fallback must never be the reason a check passes), is scoped to packaged-app resource resolution on desktop; this is the same shape in a different subsystem but the registry transition belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to git hooks, check manifest entries, and devDependency/docs wiring; no production runtime or auth paths are modified.
> 
> **Overview**
> Tightens local git hooks and CI manifest guards so formatting and pre-push selection cannot silently diverge from what CI enforces.
> 
> **`scripts/pre-commit`** now **refuses** to auto-format when toolchains do not match repo pins: web Prettier (and `prettier-plugin-tailwindcss`) must match `package-lock.json` via local `node_modules`; Dart uses the Flutter version from `.github/workflows/repo-checks.yml` and that SDK’s `dart` binary. Floating `npx`/global Prettier fallbacks are removed. Web dirs are inferred from staged paths (so `web/admin` is included), `*.generated.ts` is skipped, and format-and-add is blocked when a file has unstaged edits. Escape hatches `OMI_SKIP_WEB_FORMAT=1` / `OMI_SKIP_DART_FORMAT=1` are documented in root **`AGENTS.md`**.
> 
> **`scripts/pre-push`** re-applies **`PRE_PUSH_MAX_BACKEND_UNIT_TEST_FILES`** when the broad-selector fallback runs changed backend test files from the diff—deterministic sorted truncation and clearer logging instead of an unbounded run that still claimed a cap.
> 
> **`.github/checks-manifest.yaml`** adds **`pre-commit-pinned-toolchains`**, **`pre-push-backend-test-cap`**, and **`web-frontend-tests`** (`scripts/run-web-frontend-tests.sh` → `node --test` on `web/frontend`).
> 
> **`web/admin/AGENTS.md`** is trimmed for the lean budget; networking/revenue detail moves to **`web/admin/docs/data-contracts.md`**. **`web/admin`** and **`web/app`** pin Prettier ^2.8.8 (+ tailwind plugin) so the hook can format them safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44dcc984e4a44ba9a6656cd6b1d4d30c888f9834. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

