### PR TITLE
feat(app): add debug-only local_prod profile for a local backend with production identity

### DIFF
--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:omi/flavors.dart';
 
 import 'environment_profile.dart';
@@ -105,6 +107,7 @@ abstract class Env {
     required bool productionFamily,
     String? configuredApiBaseUrl,
     AppEnvironmentProfile? configuredProfile,
+    bool releaseBuild = kReleaseMode,
   }) {
     final effectiveProfile = configuredProfile ?? (productionFamily ? AppEnvironmentProfile.production : profile);
     final normalized = (configuredApiBaseUrl ?? apiBaseUrl ?? '').trim().replaceFirst(RegExp(r'/+$'), '');
@@ -119,6 +122,17 @@ abstract class Env {
           'Profile local_dev requires a loopback or private-network API endpoint; '
           'use mobile_beta for https://api.omiapi.com/.',
         );
+      }
+      return;
+    }
+
+    if (effectiveProfile == AppEnvironmentProfile.localProd) {
+      if (releaseBuild) {
+        throw StateError('Profile local_prod is only available in debug builds.');
+      }
+      final uri = Uri.tryParse(normalized);
+      if (uri == null || uri.host.isEmpty || (uri.scheme != 'http' && uri.scheme != 'https')) {
+        throw StateError('Profile local_prod requires a valid http(s) API endpoint.');
       }
       return;
     }

--- a/app/lib/env/environment_profile.dart
+++ b/app/lib/env/environment_profile.dart
@@ -12,6 +12,14 @@ enum AppEnvironmentProfile {
     usesFirebaseAuthEmulator: true,
     allowsProductionData: false,
   ),
+  localProd(
+    name: 'local_prod',
+    defaultApiBaseUrl: 'http://127.0.0.1:8000/',
+    firebaseProjectId: 'based-hardware',
+    authCallbackScheme: 'omi',
+    usesFirebaseAuthEmulator: false,
+    allowsProductionData: true,
+  ),
   mobileBeta(
     name: 'mobile_beta',
     defaultApiBaseUrl: 'https://api.omiapi.com/',

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -232,7 +232,12 @@ void main() {
     }
     await _init();
     runApp(const MyApp());
-  }, (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack, fatal: true));
+  }, (error, stack) {
+    print('Uncaught error: $error\n$stack');
+    if (Firebase.apps.isNotEmpty) {
+      FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    }
+  });
 }
 
 class MyApp extends StatefulWidget {

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -77,6 +77,13 @@ void main() {
       );
     });
 
+    test('local prod pairs production Firebase with a developer-chosen backend', () {
+      expect(AppEnvironmentProfile.localProd.firebaseProjectId, 'based-hardware');
+      expect(AppEnvironmentProfile.localProd.usesFirebaseAuthEmulator, isFalse);
+      expect(AppEnvironmentProfile.localProd.allowsProductionData, isTrue);
+      expect(AppEnvironmentProfile.localProd.authCallbackScheme, 'omi');
+    });
+
     test('local profile rejects a production Firebase project', () {
       expect(
         () => Env.validateFirebaseProject(
@@ -141,6 +148,45 @@ void main() {
           reason: endpoint,
         );
       }
+    });
+
+    test('local prod accepts loopback, private-network, and tunnel endpoints in debug builds', () {
+      for (final endpoint in [
+        'http://127.0.0.1:8000/',
+        'http://192.168.1.20:8000/',
+        'https://example.ngrok-free.app/',
+      ]) {
+        Env.validateStartupRouting(
+          productionFamily: true,
+          configuredProfile: AppEnvironmentProfile.localProd,
+          configuredApiBaseUrl: endpoint,
+          releaseBuild: false,
+        );
+      }
+    });
+
+    test('local prod is rejected in release builds', () {
+      expect(
+        () => Env.validateStartupRouting(
+          productionFamily: true,
+          configuredProfile: AppEnvironmentProfile.localProd,
+          configuredApiBaseUrl: 'http://127.0.0.1:8000/',
+          releaseBuild: true,
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('local prod rejects a malformed endpoint', () {
+      expect(
+        () => Env.validateStartupRouting(
+          productionFamily: true,
+          configuredProfile: AppEnvironmentProfile.localProd,
+          configuredApiBaseUrl: 'not a url',
+          releaseBuild: false,
+        ),
+        throwsStateError,
+      );
     });
 
     test('local development startup accepts the emulator API', () {

--- a/docs/product/invariants/data-plane-continuity.md
+++ b/docs/product/invariants/data-plane-continuity.md
@@ -19,6 +19,12 @@ serving endpoints, while its OAuth authority remains production (`api.omi.me`).
 This is the sole allowed serving-plane split: it must not select another Firebase
 project, account universe, or arbitrary endpoint.
 
+The debug-only `local_prod` mobile profile is a developer-workflow exception,
+not a serving-plane split: an explicit `OMI_APP_PROFILE=local_prod` dart-define
+pairs production Firebase identity with a developer-chosen backend endpoint for
+local development. Release builds reject the profile at startup, so no shipped
+artifact can select it.
+
 A release channel controls *eligibility, rollout exposure, diagnostics, and
 feature availability*. It MUST NOT select a different account or customer-data
 universe. TestFlight detection, an Android dart define, an update-channel
@@ -42,7 +48,8 @@ The routing authority matrix is:
 - Route Stable, mobile, or any other production-family artifact to development,
   staging, a beta API, or any arbitrary endpoint through a build define, CI
   variable, runtime preference, update channel, process environment, or bundled
-  `.env` value. Beta's two fixed development serving authorities are the sole exception.
+  `.env` value. Beta's two fixed development serving authorities and the
+  debug-only `local_prod` developer profile are the sole exceptions.
 - Route Beta OAuth, Firebase Auth, Firebase API-key binding, or Firestore to a
   development project or endpoint. Beta must ignore `OMI_AUTH_API_URL`.
 - Treat `OMI_BETA_RELEASE_RING`, `STAGING_API_URL`, `api-beta.omi.me`, or an
@@ -67,7 +74,7 @@ reuse a production-family identity.
 ## Guard tests
 
 - `app/test/unit/env_test.dart` — production startup rejects non-canonical API
-  and agent routing.
+  and agent routing; `local_prod` is rejected in release builds.
 - `desktop/macos/Desktop/Tests/APIClientRoutingTests.swift` — Stable remains
   production-routed; Beta resolves only its fixed development serving endpoints
   and production auth despite contaminated values.


### PR DESCRIPTION
## What

- Adds a `local_prod` mobile profile: production Firebase identity (`based-hardware`) paired with a developer-chosen backend endpoint, selected only by an explicit `--dart-define=OMI_APP_PROFILE=local_prod`. Release builds reject the profile at startup (`kReleaseMode`), so no shipped artifact can select it. `local_dev` keeps its stricter loopback/private-network rule.
- Fixes the `runZonedGuarded` crash handler in `main.dart`: it called `FirebaseCrashlytics.instance` unconditionally, so any error thrown before `Firebase.initializeApp()` completed was replaced by a secondary `[core/no-app]` exception and the root cause was lost. It now prints the original error and only forwards to Crashlytics once Firebase is initialized.

## Why

Since #11273 the dev flavor is emulator-first (`demo-omi-local`) and there is no sanctioned way to run the prod-flavor app against a locally served backend for development. `local_prod` fills that gap the same way `mobile_beta` did for the dev serving plane: an explicit, enumerated, build-time profile instead of an env-file or debug-flag bypass.

## INV-DATA-1

This PR changes `app/lib/env/env.dart` and `app/lib/main.dart` (INV-DATA-1 path globs). It preserves every production-family routing authority — production and mobile_beta pins are untouched and their rejection tests still pass. It amends the proposed invariant text to enumerate `local_prod` as a debug-only developer-workflow exception; because release builds reject the profile, no production-family *artifact* can leave its data plane. This is not the deliberate-migration exception.

Failure-Class: none

## Verification

- `cd app && flutter test test/unit/env_test.dart` — 20 passed (4 new: profile pairing, debug endpoint acceptance incl. tunnel hosts, release-build rejection, malformed-endpoint rejection).
- On device: prod-flavor debug build launched with `OMI_APP_PROFILE=local_prod` and `OMI_API_BASE_URL` pointing at an ngrok tunnel to a locally served backend; app authenticated with production identity and traffic was observed arriving at the local backend.
- Crash-guard: reproduced a startup `StateError` that previously surfaced only as `[core/no-app]`; with the guard the real error and stack print to the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

