### PR TITLE
fix(chat): accept file attachments under gateway feature mode

### DIFF
--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -360,7 +360,13 @@ class MessageProvider extends ChangeNotifier {
       if (res != null) {
         uploadedFiles.addAll(res);
       } else {
-        clearSelectedFiles();
+        final failedPaths = files.map((e) => e.path).toSet();
+        for (var i = selectedFiles.length - 1; i >= 0; i--) {
+          if (failedPaths.contains(selectedFiles[i].path)) {
+            selectedFiles.removeAt(i);
+            selectedFileTypes.removeAt(i);
+          }
+        }
         final l10n = globalNavigatorKey.currentContext?.l10n;
         AppSnackbar.showSnackbarError(l10n?.msgUploadFileFailed ?? 'Failed to upload file, please try again later');
       }

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -320,9 +320,9 @@ class MessageProvider extends ChangeNotifier {
   }
 
   void clearSelectedFile(int index) {
-    selectedFiles.removeAt(index);
-    selectedFileTypes.removeAt(index);
-    uploadedFiles.removeAt(index);
+    if (index < selectedFiles.length) selectedFiles.removeAt(index);
+    if (index < selectedFileTypes.length) selectedFileTypes.removeAt(index);
+    if (index < uploadedFiles.length) uploadedFiles.removeAt(index);
     notifyListeners();
   }
 
@@ -350,7 +350,13 @@ class MessageProvider extends ChangeNotifier {
   Future<List<MessageFile>?> uploadFiles(List<File> files, String? appId) async {
     if (files.isNotEmpty) {
       setMultiUploadingFileStatus(files.map((e) => e.path).toList(), true);
-      var res = await uploadFilesServer(files, appId: appId);
+      List<MessageFile>? res;
+      try {
+        res = await uploadFilesServer(files, appId: appId);
+      } catch (e) {
+        Logger.debug('uploadFiles failed: $e');
+        res = null;
+      }
       if (res != null) {
         uploadedFiles.addAll(res);
       } else {

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -320,8 +320,9 @@ class MessageProvider extends ChangeNotifier {
   }
 
   void clearSelectedFile(int index) {
-    if (index < selectedFiles.length) selectedFiles.removeAt(index);
-    if (index < selectedFileTypes.length) selectedFileTypes.removeAt(index);
+    if (index < 0 || index >= selectedFiles.length) return;
+    selectedFiles.removeAt(index);
+    selectedFileTypes.removeAt(index);
     if (index < uploadedFiles.length) uploadedFiles.removeAt(index);
     notifyListeners();
   }
@@ -360,9 +361,8 @@ class MessageProvider extends ChangeNotifier {
       if (res != null) {
         uploadedFiles.addAll(res);
       } else {
-        final failedPaths = files.map((e) => e.path).toSet();
         for (var i = selectedFiles.length - 1; i >= 0; i--) {
-          if (failedPaths.contains(selectedFiles[i].path)) {
+          if (files.any((f) => identical(f, selectedFiles[i]))) {
             selectedFiles.removeAt(i);
             selectedFileTypes.removeAt(i);
           }

--- a/app/test/providers/message_provider_attachment_test.dart
+++ b/app/test/providers/message_provider_attachment_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:omi/backend/schema/message.dart';
 import 'package:omi/providers/message_provider.dart';
 
 void main() {
@@ -17,6 +18,28 @@ void main() {
     expect(provider.selectedFiles, isEmpty);
     expect(provider.selectedFileTypes, isEmpty);
     expect(provider.uploadedFiles, isEmpty);
+  });
+
+  // Regression: a failed upload batch must only remove itself from the tray —
+  // earlier successfully uploaded selections and their uploadedFiles entries stay.
+  test('uploadFiles failure removes only the failed batch from the selection', () async {
+    final provider = MessageProvider();
+    provider.selectedFiles.add(File('/tmp/uploaded_ok.png'));
+    provider.selectedFileTypes.add('image');
+    provider.uploadedFiles
+        .add(MessageFile('oai-1', null, 'uploaded_ok.png', 'image/png', 'ok-1', DateTime(2026), null));
+
+    final failed = File('/tmp/failed.png');
+    provider.selectedFiles.add(failed);
+    provider.selectedFileTypes.add('image');
+
+    try {
+      await provider.uploadFiles([failed], null);
+    } catch (_) {}
+
+    expect(provider.selectedFiles.map((f) => f.path), ['/tmp/uploaded_ok.png']);
+    expect(provider.selectedFileTypes, ['image']);
+    expect(provider.uploadedFiles.map((f) => f.id), ['ok-1']);
   });
 
   test('clearSelectedFile out-of-range index is a no-op', () {

--- a/app/test/providers/message_provider_attachment_test.dart
+++ b/app/test/providers/message_provider_attachment_test.dart
@@ -21,15 +21,16 @@ void main() {
   });
 
   // Regression: a failed upload batch must only remove itself from the tray —
-  // earlier successfully uploaded selections and their uploadedFiles entries stay.
+  // earlier successfully uploaded selections and their uploadedFiles entries stay,
+  // even when the failed file shares its path with an earlier selection.
   test('uploadFiles failure removes only the failed batch from the selection', () async {
     final provider = MessageProvider();
-    provider.selectedFiles.add(File('/tmp/uploaded_ok.png'));
+    final uploaded = File('/tmp/same.png');
+    provider.selectedFiles.add(uploaded);
     provider.selectedFileTypes.add('image');
-    provider.uploadedFiles
-        .add(MessageFile('oai-1', null, 'uploaded_ok.png', 'image/png', 'ok-1', DateTime(2026), null));
+    provider.uploadedFiles.add(MessageFile('oai-1', null, 'same.png', 'image/png', 'ok-1', DateTime(2026), null));
 
-    final failed = File('/tmp/failed.png');
+    final failed = File('/tmp/same.png');
     provider.selectedFiles.add(failed);
     provider.selectedFileTypes.add('image');
 
@@ -37,16 +38,19 @@ void main() {
       await provider.uploadFiles([failed], null);
     } catch (_) {}
 
-    expect(provider.selectedFiles.map((f) => f.path), ['/tmp/uploaded_ok.png']);
+    expect(provider.selectedFiles, [uploaded]);
     expect(provider.selectedFileTypes, ['image']);
     expect(provider.uploadedFiles.map((f) => f.id), ['ok-1']);
   });
 
-  test('clearSelectedFile out-of-range index is a no-op', () {
+  test('clearSelectedFile out-of-range or negative index is a no-op', () {
     final provider = MessageProvider();
+    provider.uploadedFiles.add(MessageFile('oai-1', null, 'stale.png', 'image/png', 'stale-1', DateTime(2026), null));
 
     provider.clearSelectedFile(0);
+    provider.clearSelectedFile(-1);
 
     expect(provider.selectedFiles, isEmpty);
+    expect(provider.uploadedFiles.length, 1);
   });
 }

--- a/app/test/providers/message_provider_attachment_test.dart
+++ b/app/test/providers/message_provider_attachment_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/providers/message_provider.dart';
+
+void main() {
+  // Regression: after a failed upload, uploadedFiles stays empty while selectedFiles
+  // holds the picked file; removing the attachment threw RangeError on uploadedFiles.
+  test('clearSelectedFile tolerates uploadedFiles shorter than selectedFiles', () {
+    final provider = MessageProvider();
+    provider.selectedFiles.add(File('/tmp/a.png'));
+    provider.selectedFileTypes.add('image');
+
+    provider.clearSelectedFile(0);
+
+    expect(provider.selectedFiles, isEmpty);
+    expect(provider.selectedFileTypes, isEmpty);
+    expect(provider.uploadedFiles, isEmpty);
+  });
+
+  test('clearSelectedFile out-of-range index is a no-op', () {
+    final provider = MessageProvider();
+
+    provider.clearSelectedFile(0);
+
+    expect(provider.selectedFiles, isEmpty);
+  });
+}

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -327,11 +327,9 @@ async def test_file_assistants_stream_runs_setup_and_sync_callbacks_off_loop():
             stream_callback.end_nowait()
             loop.call_soon_threadsafe(worker_finished.set)
 
-    with patch.object(chat_file, '_assert_direct_file_chat_allowed', lambda: None), patch.object(
-        chat_file.chat_db, 'get_chat_files_desc', lambda *_args, **_kwargs: []
-    ), patch.object(chat_file.FileChatTool, '_ensure_thread_and_assistant', fake_ensure), patch.object(
-        chat_file.FileChatTool, 'ask_stream', blocking_ask
-    ):
+    with patch.object(chat_file.chat_db, 'get_chat_files_desc', lambda *_args, **_kwargs: []), patch.object(
+        chat_file.FileChatTool, '_ensure_thread_and_assistant', fake_ensure
+    ), patch.object(chat_file.FileChatTool, 'ask_stream', blocking_ask):
         task = asyncio.create_task(tool.process_chat_with_file_stream('summarize', ['file1'], callback))
         await asyncio.wait_for(ask_started.wait(), timeout=0.5)
 
@@ -382,10 +380,8 @@ async def test_file_stream_deadline_fires_while_sync_assistants_stream_is_off_lo
         ]
 
     with patch.object(graph, 'FileChatTool', lambda *_args: tool), patch.object(
-        chat_file, '_assert_direct_file_chat_allowed', lambda: None
-    ), patch.object(chat_file.chat_db, 'get_chat_files_desc', lambda *_args, **_kwargs: []), patch.object(
-        chat_file.FileChatTool, '_ensure_thread_and_assistant', fake_ensure
-    ), patch.object(
+        chat_file.chat_db, 'get_chat_files_desc', lambda *_args, **_kwargs: []
+    ), patch.object(chat_file.FileChatTool, '_ensure_thread_and_assistant', fake_ensure), patch.object(
         chat_file.FileChatTool, 'ask_stream', blocking_ask
     ), patch.object(
         graph, 'AGENT_STREAM_FIRST_EVENT_TIMEOUT_SECONDS', 0.01

--- a/backend/tests/unit/test_chat_file_gateway_surface.py
+++ b/backend/tests/unit/test_chat_file_gateway_surface.py
@@ -20,12 +20,33 @@ from utils.llm.gateway_client import LLM_GATEWAY_FEATURE_MODE_ENV_VAR  # noqa: E
 
 def _gateway_mode(monkeypatch):
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
     monkeypatch.delenv('K_SERVICE', raising=False)
     monkeypatch.delenv('KUBERNETES_SERVICE_HOST', raising=False)
 
 
 def test_upload_proceeds_and_records_surface_under_gateway_mode(monkeypatch, tmp_path):
     _gateway_mode(monkeypatch)
+    file_path = tmp_path / 'note.txt'
+    file_path.write_text('hello')
+
+    fake_files = SimpleNamespace(create=lambda **_kwargs: SimpleNamespace(id='file-1', filename='note.txt'))
+    with patch.object(cf.openai, 'files', fake_files), patch.object(cf, 'record_direct_exception_surface') as record:
+        result = cf.FileChatTool.upload(file_path)
+
+    assert result['file_id'] == 'file-1'
+    record.assert_called_once_with(surface='file_chat.openai_files_assistants_vision')
+
+
+def test_upload_proceeds_when_gateway_mode_is_misconfigured_in_prod(monkeypatch, tmp_path):
+    # Prod runtime with gateway mode on but the allow-prod flag missing makes
+    # should_route_features_through_gateway raise RuntimeError; upload must still work.
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.delenv('ENVIRONMENT', raising=False)
+    monkeypatch.delenv('APP_ENV', raising=False)
+    monkeypatch.setenv('K_SERVICE', 'omi-backend')
+    monkeypatch.delenv('OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE', raising=False)
     file_path = tmp_path / 'note.txt'
     file_path.write_text('hello')
 

--- a/backend/tests/unit/test_chat_file_gateway_surface.py
+++ b/backend/tests/unit/test_chat_file_gateway_surface.py
@@ -1,0 +1,50 @@
+"""File chat is an acknowledged direct surface under gateway feature mode — uploads must not raise.
+
+After prod flipped OMI_LLM_GATEWAY_FEATURE_MODE=gateway (PR #11281), every POST /v2/files 500'd:
+FileChatTool.upload() called raise_if_gateway_feature_mode_blocks_direct_model_surface, which raised
+GatewayDirectModelSurfaceBlocked because file chat runs directly on OpenAI Files/Assistants/vision and
+has no gateway lane. The surface is now recorded via record_direct_exception_surface and never blocked.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import utils.other.chat_file as cf  # noqa: E402
+from utils.llm.gateway_client import LLM_GATEWAY_FEATURE_MODE_ENV_VAR  # noqa: E402
+
+
+def _gateway_mode(monkeypatch):
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.delenv('K_SERVICE', raising=False)
+    monkeypatch.delenv('KUBERNETES_SERVICE_HOST', raising=False)
+
+
+def test_upload_proceeds_and_records_surface_under_gateway_mode(monkeypatch, tmp_path):
+    _gateway_mode(monkeypatch)
+    file_path = tmp_path / 'note.txt'
+    file_path.write_text('hello')
+
+    fake_files = SimpleNamespace(create=lambda **_kwargs: SimpleNamespace(id='file-1', filename='note.txt'))
+    with patch.object(cf.openai, 'files', fake_files), patch.object(cf, 'record_direct_exception_surface') as record:
+        result = cf.FileChatTool.upload(file_path)
+
+    assert result['file_id'] == 'file-1'
+    record.assert_called_once_with(surface='file_chat.openai_files_assistants_vision')
+
+
+def test_upload_does_not_record_surface_outside_gateway_mode(monkeypatch, tmp_path):
+    monkeypatch.delenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, raising=False)
+    file_path = tmp_path / 'note.txt'
+    file_path.write_text('hello')
+
+    fake_files = SimpleNamespace(create=lambda **_kwargs: SimpleNamespace(id='file-1', filename='note.txt'))
+    with patch.object(cf.openai, 'files', fake_files), patch.object(cf, 'record_direct_exception_surface') as record:
+        result = cf.FileChatTool.upload(file_path)
+
+    assert result['file_id'] == 'file-1'
+    record.assert_not_called()

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -70,8 +70,14 @@ def _get_async_openai() -> AsyncOpenAI:
 
 def _record_direct_file_chat_surface() -> None:
     """File chat has no gateway lane (OpenAI Files/Assistants/vision), so under gateway
-    feature mode it stays an acknowledged direct surface: counted, never blocked."""
-    if should_route_features_through_gateway():
+    feature mode it stays an acknowledged direct surface: counted, never blocked.
+    A misconfigured gateway rollout (should_route_features_through_gateway raising) must
+    not block it either."""
+    try:
+        routed = should_route_features_through_gateway()
+    except RuntimeError:
+        routed = True
+    if routed:
         record_direct_exception_surface(surface='file_chat.openai_files_assistants_vision')
 
 

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -17,7 +17,8 @@ from pydantic import ValidationError
 import database.chat as chat_db
 from models.chat import ChatSession, FileChat
 from utils.executors import db_executor, llm_executor, run_blocking
-from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
+from utils.llm.gateway_client import should_route_features_through_gateway
+from utils.llm.gateway_observability import record_direct_exception_surface
 import logging
 
 logger = logging.getLogger(__name__)
@@ -67,8 +68,11 @@ def _get_async_openai() -> AsyncOpenAI:
     return _async_openai
 
 
-def _assert_direct_file_chat_allowed() -> None:
-    raise_if_gateway_feature_mode_blocks_direct_model_surface('file_chat.openai_files_assistants_vision')
+def _record_direct_file_chat_surface() -> None:
+    """File chat has no gateway lane (OpenAI Files/Assistants/vision), so under gateway
+    feature mode it stays an acknowledged direct surface: counted, never blocked."""
+    if should_route_features_through_gateway():
+        record_direct_exception_surface(surface='file_chat.openai_files_assistants_vision')
 
 
 class _StreamingCallbackProtocol:
@@ -140,7 +144,7 @@ class FileChatTool:
 
     @staticmethod
     def upload(file_path: Union[str, Path]) -> Dict[str, Any]:
-        _assert_direct_file_chat_allowed()
+        _record_direct_file_chat_surface()
         result: Dict[str, Any] = {}
         file = File(file_path)
         file.get_mime_type()
@@ -166,7 +170,7 @@ class FileChatTool:
 
     def process_chat_with_file(self, question: str, file_ids: List[str]) -> str:
         """Process chat with file attachments"""
-        _assert_direct_file_chat_allowed()
+        _record_direct_file_chat_surface()
         self._ensure_thread_and_assistant()
         answer = self.ask(self.uid, question, file_ids, self.thread_id, self.assistant_id)
         return answer
@@ -178,7 +182,7 @@ class FileChatTool:
         callback: Optional[_StreamingCallbackProtocol] = None,
     ) -> str:
         """Process chat with file attachments (streaming)"""
-        _assert_direct_file_chat_allowed()
+        _record_direct_file_chat_surface()
         # Offloaded: the Firestore read is sync and blocks the event loop in this async path.
         # If this pre-stream setup fails, signal the streaming callback's end before propagating
         # (mirrors the _ensure_thread_and_assistant failure path below) so it is not left dangling.


### PR DESCRIPTION
## Summary

Since prod flipped `OMI_LLM_GATEWAY_FEATURE_MODE=gateway` (#11281), attaching a file in chat has been broken for all users: every `POST /v2/files` 500'd because `FileChatTool.upload()` raised `GatewayDirectModelSurfaceBlocked` — file chat runs directly on OpenAI Files/Assistants/vision and has no gateway lane. #11191 gave the chat *stream* a typed user-safe failure but the upload endpoint kept throwing. The app compounded it: the thrown upload error skipped spinner/selection cleanup, leaving a forever-loading thumbnail whose remove button crashed with `RangeError`.

- **Backend:** file chat is now an *acknowledged* direct surface — the gate records `record_direct_exception_surface(surface='file_chat.openai_files_assistants_vision')` under gateway feature mode and never raises, so uploads and file-chat answers work in every environment without env overrides. The typed `GatewayDirectModelSurfaceBlocked` handling in `graph.py` stays for the generic gateway surfaces.
- **App:** `uploadFiles` routes a thrown `uploadFilesServer` error through the existing failure path (spinner reset, selection cleared, failure snackbar), and `clearSelectedFile` is bounds-safe so removing a failed attachment can no longer throw `RangeError`.

Failure-Class: none

The regression is an instance of a mode-flip gating an ungated surface; no existing registry class matches, and the reusable guard here is the new behavioral test pinning upload's non-blocking contract under gateway mode.

## Test plan

- [x] `pytest tests/unit/test_chat_file_gateway_surface.py tests/unit/test_chat_async_offload.py tests/unit/test_llm_gateway_client_config.py tests/unit/test_chat_file_skip_malformed.py` → 58 passed
  - New `test_chat_file_gateway_surface.py`: upload succeeds and records the acknowledged surface under `OMI_LLM_GATEWAY_FEATURE_MODE=gateway`; records nothing outside gateway mode.
- [x] `flutter test test/providers/message_provider_attachment_test.dart` → 2 passed (regression for the `RangeError` misalignment)
- [x] `dart analyze lib/providers/message_provider.dart` clean (one pre-existing unrelated `unnecessary_import` info)
- [x] `make preflight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

