### PR TITLE
fix(desktop): stop the silent-mic alert loop, and unify the microphone setting

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1620
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1623
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "silentMicHealedDeviceID: the healed input route must survive a CoreAudio rebuild, otherwise the rebuild re-resolves the system default back onto the silent device and the fallback loops into a user-facing alert every 60-90s."
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "silentMicHealedDeviceID plus the SilentMicRoutePolicy call at the rebuild site: the healed input route must survive a CoreAudio rebuild, otherwise the rebuild re-resolves the system default back onto the silent device and the fallback loops into a user-facing alert."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1607
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1620
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds local transcript duplicate suppression and persistence flushes before stop or rotation so source-aware deduplication cannot leave stale rows."
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "silentMicHealedDeviceID: the healed input route must survive a CoreAudio rebuild, otherwise the rebuild re-resolves the system default back onto the silent device and the fallback loops into a user-facing alert every 60-90s."
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -449,6 +449,15 @@ class AppState: ObservableObject {
   /// transcription session. This lives above `AudioCaptureService` because each
   /// rebuild creates a fresh service (and therefore a fresh service-local watchdog).
   var silentMicRecoveryAttempts = 0
+
+  /// The input device a silent-mic fallback healed onto, held for the rest of the session.
+  ///
+  /// Without this the heal is undone by its own recovery: `handleSilentMicFallback` pins
+  /// capture to the built-in mic, then the next watchdog trip rebuilds the CoreAudio stack
+  /// with a plain `AudioCaptureService()`, which re-resolves the *system default* input —
+  /// still the silent Bluetooth device. The two fight until the attempt cap is hit and the
+  /// user gets an alert, then it starts over.
+  var silentMicHealedDeviceID: AudioDeviceID?
   var meetingEndFinalizationInProgress = false
   @Published var isAwaitingMeeting = false
 

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -606,6 +606,11 @@ class AppState: ObservableObject {
   }
 
   init() {
+    // Fold any legacy PTT-only microphone choice into the shared preference before
+    // anything reads it. Running this only from PTT routing meant a user who had picked a
+    // PTT microphone saw "System Default" in Transcription — and was recorded by it —
+    // until they happened to take a push-to-talk turn.
+    ShortcutSettings.migratePTTMicrophoneChoiceIfNeeded()
     // Register as the current instance so background services can check recording state
     AppState.current = self
     ownerChangeObserver = NotificationCenter.default.addObserver(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -19,6 +19,9 @@ extension AppState {
     guard !isTranscribing else { return }
     sttSession.prepareForStart()
     silentMicRecoveryAttempts = 0
+    // A new session re-evaluates the route from scratch: the user may have unplugged the
+    // dead device, and pinning last session's heal would ignore a working default.
+    silentMicHealedDeviceID = nil
     meetingEndFinalizationInProgress = false
 
     // Paywall hard-stop: every code path that enables the mic + WS streaming
@@ -693,6 +696,9 @@ extension AppState {
     // Silent healing — no user-facing UI, the recording just keeps working.
     audioCaptureService?.stopCapture()
     audioCaptureService = AudioCaptureService(overrideDeviceID: builtInID)
+    // Hold the healed route for the rest of the session so the next rebuild does not
+    // re-resolve back to the silent default and undo this.
+    silentMicHealedDeviceID = builtInID
     recordingInputDeviceName =
       AudioCaptureService.getCurrentMicrophoneName() ?? "Built-in Microphone"
 
@@ -724,7 +730,12 @@ extension AppState {
     }
 
     audioCaptureService?.stopCapture()
-    audioCaptureService = AudioCaptureService()
+    // Rebuilding must not silently move the user back onto a route already proven dead.
+    if let healed = silentMicHealedDeviceID {
+      audioCaptureService = AudioCaptureService(overrideDeviceID: healed)
+    } else {
+      audioCaptureService = AudioCaptureService()
+    }
     AudioLevelMonitor.shared.updateMicrophoneLevel(0)
 
     if !sttSession.useLocalSTT {
@@ -1265,6 +1276,7 @@ extension AppState {
     captureReconcilePending = false
     pendingCoreAudioCaptureRecoveryReason = nil
     silentMicRecoveryAttempts = 0
+    silentMicHealedDeviceID = nil
     isAwaitingMeeting = false
     meetingEndFinalizationInProgress = false
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -731,8 +731,12 @@ extension AppState {
 
     audioCaptureService?.stopCapture()
     // Rebuilding must not silently move the user back onto a route already proven dead.
-    if let healed = silentMicHealedDeviceID {
-      audioCaptureService = AudioCaptureService(overrideDeviceID: healed)
+    // The choice is `SilentMicRoutePolicy`'s so the contract has one tested home; a nil
+    // result means "follow the system default", which is what the plain initialiser does.
+    if let deviceID = SilentMicRoutePolicy.captureDeviceID(
+      healed: silentMicHealedDeviceID, systemDefault: nil)
+    {
+      audioCaptureService = AudioCaptureService(overrideDeviceID: deviceID)
     } else {
       audioCaptureService = AudioCaptureService()
     }

--- a/desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
@@ -1,3 +1,5 @@
+import CoreAudio
+
 /// Terminal policy for the shared microphone capture path used by listening,
 /// manual recording, and Quick Note. `AudioCaptureService` is deliberately
 /// recreated during recovery, so the cross-rebuild cap belongs here.
@@ -18,5 +20,21 @@ enum SharedCaptureSilentMicRecoveryPolicy {
 
   static func action(for recoveryAttempt: Int) -> Action {
     recoveryAttempt >= maximumRecoveryAttempts ? .stopAndSurfaceError : .rebuild
+  }
+}
+
+/// Which input device a rebuilt capture stack must use.
+///
+/// The alert loop this exists to prevent: a silent Bluetooth mic triggers a fallback onto
+/// the built-in device, then the next watchdog trip rebuilds the CoreAudio stack from the
+/// *system default* — still the silent device — and the two fight until the recovery cap is
+/// hit and the user gets a modal. A heal that a rebuild can undo is not a heal.
+enum SilentMicRoutePolicy {
+  /// `healed` wins for the rest of the session; `nil` means follow the system default.
+  static func captureDeviceID(
+    healed: AudioDeviceID?,
+    systemDefault: AudioDeviceID?
+  ) -> AudioDeviceID? {
+    healed ?? systemDefault
   }
 }

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -60,6 +60,9 @@ enum DefaultsKey: String {
   /// Test hook: forces TTS playback start to report failure (non-prod gauntlets).
   case forceTTSPlaybackStartFalse = "forceTTSPlaybackStartFalse"
   case shortcutPTTInputDeviceUID = "shortcut_pttInputDeviceUID"
+  /// One-shot marker: the PTT-only microphone choice has been folded into the shared
+  /// `preferredMicrophoneDeviceUID`, so it is never carried over twice.
+  case shortcutPTTMicrophoneMergedIntoPreferred = "shortcut_pttMicrophoneMergedIntoPreferred"
   case floatingBarNotificationPreviewsEnabled = "shortcut_floatingBarNotificationPreviewsEnabled"
   case floatingBarCachedPlan = "floatingBar_cachedPlan"
   case floatingBarCachedDesktopGrandfatherUntil = "floatingBar_cachedDesktopGrandfatherUntil"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+InputDeviceRouting.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager+InputDeviceRouting.swift
@@ -158,7 +158,7 @@ private final class SnapshotStore: @unchecked Sendable {
 extension PushToTalkManager {
   /// Non-blocking. Kicks the next HAL read and answers from the last one that landed.
   func preferredPTTInputOverrideDeviceID() -> AudioDeviceID? {
-    let selectedUID = ShortcutSettings.shared.pttInputDeviceUID
+    let selectedUID = ShortcutSettings.unifiedMicrophoneUID
     let snapshot = PTTInputDeviceRouting.currentSnapshot(selectedUID: selectedUID)
     if let snapshot, !selectedUID.isEmpty, snapshot.selectedDeviceID == nil {
       log("PushToTalkManager: selected PTT microphone is unavailable — using Automatic")
@@ -240,6 +240,6 @@ extension PushToTalkManager {
   /// Warms the routing snapshot at the start of a turn, before the turn's own setup
   /// work, so the HAL read overlaps that work instead of gating capture on it.
   func warmPTTInputRouting() {
-    PTTInputDeviceRouting.refresh(selectedUID: ShortcutSettings.shared.pttInputDeviceUID)
+    PTTInputDeviceRouting.refresh(selectedUID: ShortcutSettings.unifiedMicrophoneUID)
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -379,7 +379,7 @@ class ShortcutSettings: ObservableObject {
 
   /// Carry a PTT-only choice into the shared setting once, so unifying does not silently
   /// discard a microphone the user deliberately picked.
-  private static func migratePTTMicrophoneChoiceIfNeeded() {
+  static func migratePTTMicrophoneChoiceIfNeeded() {
     let defaults = UserDefaults.standard
     guard !defaults.bool(forKey: .shortcutPTTMicrophoneMergedIntoPreferred) else { return }
     defaults.set(true, forKey: .shortcutPTTMicrophoneMergedIntoPreferred)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -381,8 +381,8 @@ class ShortcutSettings: ObservableObject {
   /// discard a microphone the user deliberately picked.
   private static func migratePTTMicrophoneChoiceIfNeeded() {
     let defaults = UserDefaults.standard
-    guard !defaults.bool(forKey: "shortcut_pttMicrophoneMergedIntoPreferred") else { return }
-    defaults.set(true, forKey: "shortcut_pttMicrophoneMergedIntoPreferred")
+    guard !defaults.bool(forKey: .shortcutPTTMicrophoneMergedIntoPreferred) else { return }
+    defaults.set(true, forKey: .shortcutPTTMicrophoneMergedIntoPreferred)
     let legacy = defaults.string(forKey: DefaultsKey.shortcutPTTInputDeviceUID.rawValue) ?? ""
     let current = defaults.string(forKey: AudioCaptureService.preferredInputUIDDefaultsKey) ?? ""
     guard !legacy.isEmpty, current.isEmpty else { return }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -367,6 +367,28 @@ class ShortcutSettings: ObservableObject {
 
   /// Empty means Automatic. A non-empty value is a stable CoreAudio device UID
   /// selected specifically for push-to-talk, independent of the macOS default input.
+  /// The one microphone choice, shared by transcription and push-to-talk.
+  ///
+  /// Push-to-talk used to carry its own picker in Shortcuts settings, so a user could
+  /// select a microphone in one place and still be recorded by another. There is one
+  /// physical microphone; there is now one setting, the transcription one.
+  static var unifiedMicrophoneUID: String {
+    migratePTTMicrophoneChoiceIfNeeded()
+    return UserDefaults.standard.string(forKey: AudioCaptureService.preferredInputUIDDefaultsKey) ?? ""
+  }
+
+  /// Carry a PTT-only choice into the shared setting once, so unifying does not silently
+  /// discard a microphone the user deliberately picked.
+  private static func migratePTTMicrophoneChoiceIfNeeded() {
+    let defaults = UserDefaults.standard
+    guard !defaults.bool(forKey: "shortcut_pttMicrophoneMergedIntoPreferred") else { return }
+    defaults.set(true, forKey: "shortcut_pttMicrophoneMergedIntoPreferred")
+    let legacy = defaults.string(forKey: DefaultsKey.shortcutPTTInputDeviceUID.rawValue) ?? ""
+    let current = defaults.string(forKey: AudioCaptureService.preferredInputUIDDefaultsKey) ?? ""
+    guard !legacy.isEmpty, current.isEmpty else { return }
+    defaults.set(legacy, forKey: AudioCaptureService.preferredInputUIDDefaultsKey)
+  }
+
   @Published var pttInputDeviceUID: String {
     didSet { UserDefaults.standard.set(pttInputDeviceUID, forKey: .shortcutPTTInputDeviceUID) }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -8,7 +8,6 @@ struct ShortcutsSettingsSection: View {
   @State private var captureError: String?
   @State private var pendingModifierOnlyShortcut: ShortcutSettings.KeyboardShortcut?
   @State private var localShortcutCaptureMonitor: Any?
-  @State private var pttInputDevices: [AudioCaptureService.InputDevice] = []
 
   init(highlightedSettingId: Binding<String?> = .constant(nil)) {
     self._highlightedSettingId = highlightedSettingId
@@ -23,13 +22,11 @@ struct ShortcutsSettingsSection: View {
     VStack(spacing: OmiSpacing.xl) {
       askOmiKeyCard
       pttKeyCard
-      pttMicrophoneCard
       doubleTapCard
       pttSoundsCard
       muteAudioCard
     }
     .onAppear {
-      refreshPTTInputDevices()
     }
     .onDisappear {
       stopShortcutCapture()
@@ -156,45 +153,6 @@ struct ShortcutsSettingsSection: View {
       shortcutSelectionLabel(tokens: shortcut.displayTokens, isSelected: isSelected)
     }
     .buttonStyle(.plain)
-  }
-
-  private var pttMicrophoneCard: some View {
-    HStack(spacing: OmiSpacing.lg) {
-      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        Text("Push-to-Talk Microphone")
-          .scaledFont(size: OmiType.subheading, weight: .semibold)
-          .foregroundColor(Ink.primary)
-        Text(
-          "Automatic follows your system input and uses the built-in mic with Bluetooth output to keep replies clear. Choose a microphone to override it."
-        )
-        .scaledFont(size: OmiType.body)
-        .foregroundColor(Ink.secondary)
-      }
-      Spacer()
-      SettingsMenuPicker(selection: $settings.pttInputDeviceUID) {
-        Text("Automatic").tag("")
-        ForEach(pttInputDevices, id: \.uid) { device in
-          Text(device.name).tag(device.uid)
-        }
-        if !settings.pttInputDeviceUID.isEmpty,
-          !pttInputDevices.contains(where: { $0.uid == settings.pttInputDeviceUID })
-        {
-          Text("Unavailable selected microphone").tag(settings.pttInputDeviceUID)
-        }
-      }
-    }
-    .padding(OmiSpacing.xl)
-    .background(
-      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-        .fill(Ink.rowFill)
-    )
-    .modifier(
-      SettingHighlightModifier(
-        settingId: "floatingbar.pttmicrophone", highlightedSettingId: $highlightedSettingId))
-  }
-
-  private func refreshPTTInputDevices() {
-    pttInputDevices = AudioCaptureService.availableInputDevices()
   }
 
   private var doubleTapCard: some View {

--- a/desktop/macos/Desktop/Tests/SharedCaptureSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/SharedCaptureSilentMicRecoveryPolicyTests.swift
@@ -41,3 +41,62 @@ final class SilentMicRoutePolicyTests: XCTestCase {
     XCTAssertNil(SilentMicRoutePolicy.captureDeviceID(healed: nil, systemDefault: nil))
   }
 }
+
+/// Behavioural, not a source tripwire: the migration is pure UserDefaults, so it can be
+/// exercised directly. A legacy PTT-only microphone must reach the shared preference the
+/// first time anything asks for it — previously it only moved during a push-to-talk turn,
+/// so Transcription showed "System Default" and recorded with it until the user happened
+/// to hold the PTT key.
+@MainActor
+final class PTTMicrophoneMigrationTests: XCTestCase {
+  private let legacyKey = DefaultsKey.shortcutPTTInputDeviceUID.rawValue
+  private let sharedKey = AudioCaptureService.preferredInputUIDDefaultsKey
+  private let markerKey = DefaultsKey.shortcutPTTMicrophoneMergedIntoPreferred.rawValue
+
+  private func withCleanDefaults(_ body: () -> Void) {
+    let d = UserDefaults.standard
+    let saved = (d.string(forKey: legacyKey), d.string(forKey: sharedKey), d.bool(forKey: markerKey))
+    defer {
+      saved.0.map { d.set($0, forKey: legacyKey) } ?? d.removeObject(forKey: legacyKey)
+      saved.1.map { d.set($0, forKey: sharedKey) } ?? d.removeObject(forKey: sharedKey)
+      d.set(saved.2, forKey: markerKey)
+    }
+    d.removeObject(forKey: legacyKey)
+    d.removeObject(forKey: sharedKey)
+    d.set(false, forKey: markerKey)
+    body()
+  }
+
+  func testLegacyPTTChoiceIsCarriedIntoTheSharedPreference() {
+    withCleanDefaults {
+      UserDefaults.standard.set("BuiltInMicrophoneDevice", forKey: legacyKey)
+      ShortcutSettings.migratePTTMicrophoneChoiceIfNeeded()
+      XCTAssertEqual(
+        UserDefaults.standard.string(forKey: sharedKey), "BuiltInMicrophoneDevice",
+        "unifying the setting must not silently discard a microphone the user picked")
+    }
+  }
+
+  /// An explicit transcription choice is the newer, more visible decision; the legacy
+  /// PTT-only value must not overwrite it.
+  func testAnExistingSharedChoiceIsNotOverwritten() {
+    withCleanDefaults {
+      UserDefaults.standard.set("legacy-ptt-uid", forKey: legacyKey)
+      UserDefaults.standard.set("chosen-in-transcription", forKey: sharedKey)
+      ShortcutSettings.migratePTTMicrophoneChoiceIfNeeded()
+      XCTAssertEqual(UserDefaults.standard.string(forKey: sharedKey), "chosen-in-transcription")
+    }
+  }
+
+  func testMigrationRunsOnlyOnce() {
+    withCleanDefaults {
+      UserDefaults.standard.set("legacy-ptt-uid", forKey: legacyKey)
+      ShortcutSettings.migratePTTMicrophoneChoiceIfNeeded()
+      UserDefaults.standard.set("", forKey: sharedKey)
+      ShortcutSettings.migratePTTMicrophoneChoiceIfNeeded()
+      XCTAssertEqual(
+        UserDefaults.standard.string(forKey: sharedKey), "",
+        "a second run must not resurrect a choice the user has since cleared")
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/SharedCaptureSilentMicRecoveryPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/SharedCaptureSilentMicRecoveryPolicyTests.swift
@@ -22,3 +22,22 @@ final class SharedCaptureSilentMicRecoveryPolicyTests: XCTestCase {
       .stopAndSurfaceError)
   }
 }
+
+/// Nik's prod log showed 31 silent-mic detections and 14 alerts in one sitting: the
+/// fallback pinned the built-in mic, the rebuild re-resolved the system default back to a
+/// silent AirPods Max, repeat. These pin that a healed route outranks the system default.
+final class SilentMicRoutePolicyTests: XCTestCase {
+  func testHealedDeviceSurvivesARebuild() {
+    XCTAssertEqual(
+      SilentMicRoutePolicy.captureDeviceID(healed: 86, systemDefault: 97), 86,
+      "a rebuild must not move capture back onto the route that was already proven silent")
+  }
+
+  func testSystemDefaultIsUsedWhenNothingHasBeenHealed() {
+    XCTAssertEqual(SilentMicRoutePolicy.captureDeviceID(healed: nil, systemDefault: 97), 97)
+  }
+
+  func testNoDeviceAtAllStaysNil() {
+    XCTAssertNil(SilentMicRoutePolicy.captureDeviceID(healed: nil, systemDefault: nil))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260811-unified-mic-and-silent-heal.json
+++ b/desktop/macos/changelog/unreleased/20260811-unified-mic-and-silent-heal.json
@@ -1,0 +1,3 @@
+{
+  "change": "One microphone setting for everything, and Omi no longer nags you when a Bluetooth mic goes silent — it switches to the built-in mic and stays there"
+}


### PR DESCRIPTION
## Silent-mic alert loop

Nik's prod log shows **31 silent-mic detections and 14 alerts** in one sitting, roughly one modal every 60–90s:

```
13:53:52  Started session (device: AirPods Max)
13:54:00  Bluetooth mic returning silence for 2s — falling back to built-in mic
13:54:00  Using override device ID 86            <- built-in
13:54:12  Input device returning silence for 2s — rebuilding CoreAudio capture
13:54:15  Bluetooth mic returning silence for 2s — falling back to built-in mic
```

`handleSilentMicFallback` pins capture to the built-in mic; `rebuildCoreAudioCaptureStack` then builds a plain `AudioCaptureService()` with no override, re-resolving the **system default** — still the silent AirPods Max. The heal and its own recovery fight until the 3-attempt cap trips the modal, then it repeats.

AirPods Max returning zero samples is normal macOS behaviour (output-only mode). The bug is that the recovery undoes the fix.

**Fix:** `silentMicHealedDeviceID` holds the healed route for the session and the rebuild honours it; cleared at session start/stop. `SilentMicRoutePolicy` states the contract as a pure, tested function.

## One microphone setting

Push-to-talk carried its own picker in Shortcuts (#10393) storing `shortcut_pttInputDeviceUID`, separate from the transcription picker's `preferredMicrophoneDeviceUID` — a user could pick a mic in one place and be recorded by another. The duplicate card is removed; PTT reads the transcription setting, with a one-time migration so an existing PTT-only choice carries over.

## Verification

Exercised on the running `omi-mic` bundle:
- **Shortcuts** — no microphone card (screenshot)
- **Transcription** — single Microphone picker
- 25 focused tests pass; swift-format clean

**UNVERIFIED:** the alert loop end-to-end. Reproducing it needs a Bluetooth mic returning zero samples during a live session; the mechanism above is read from the prod log rather than re-triggered.

Failure-Class: none

## Product invariants affected

- **INV-CHAT-1** — unchanged. This diff touches microphone *input routing* and the settings surface for it; it does not alter transcript ownership, session identity, or how a transcript is shared across surfaces. The silent-mic heal only changes which CoreAudio device a rebuilt capture reads from, and the PTT change consolidates two settings keys into the existing one.