### PR TITLE
fix(desktop): keep the main window in the app switcher

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -1,9 +1,9 @@
 //
 //  ShellSummon.swift — where the shell lands when you call it, and where it goes when you don't.
 //
-//  `ShellWindowChrome` says *what* the shell is: transparent, buttonless, floating, hiding itself the
-//  moment it loses focus. This says *where*, and it is a separate file because "where" is the half
-//  that is per-display state rather than per-window properties.
+//  `ShellWindowChrome` says *what* the shell is: transparent, buttonless, and an ordinary application
+//  window that stays where you left it. This says *where*, and it is a separate file because "where"
+//  is the half that is per-display state rather than per-window properties.
 //
 //  ## Why per-display, and not one remembered frame
 //
@@ -28,8 +28,9 @@
 //
 //  ## Dismissal
 //
-//  The signed-in shell dismisses when AppKit deactivates it, so clicking the desktop or another app
-//  returns the user to their work. `⌘O` toggles it directly; `⌘W` and Escape are explicit alternatives.
+//  Putting the shell away is always something the user asks for — it does not happen because focus
+//  moved, which is what made the window unreachable from any switcher (see `ShellWindowChrome`).
+//  `⌘O` toggles it; `⌘W` and Escape are explicit alternatives.
 //  Escape is `WindowEscapeKeyMonitor` at `.shell` — the lowest priority there is, so it fires only
 //  after every modal, editor, page and navigation handler has declined it. Escape on a page still goes
 //  Home; Escape on Home, where nothing else wants it, puts the shell away.
@@ -88,24 +89,12 @@ enum ShellSummonPlacement {
   /// Whether this summon should place the window at all.
   ///
   /// `false` is the interesting answer: a shell already up on the display you are on is a shell you
-  /// are already using, and moving it would be the app fighting the user. A hidden window normally
-  /// needs placement; the click-away return seam below preserves its frame on the same display.
+  /// are already using, and moving it would be the app fighting the user. Since the shell stays up
+  /// when focus moves elsewhere, that is also the answer for the common case of switching back to it.
   static func shouldReposition(isVisible: Bool, windowDisplayKey: String?, cursorDisplayKey: String?) -> Bool {
     guard isVisible else { return true }
     guard let cursorDisplayKey, let windowDisplayKey else { return false }
     return windowDisplayKey != cursorDisplayKey
-  }
-
-  /// A passive click-away is not a request to move the shell. Preserve its exact frame when it is
-  /// summoned back onto the same display; a summon from another display still lands under the user.
-  static func frameAfterClickAway(
-    previousFrame: NSRect,
-    previousDisplayKey: String?,
-    landingDisplayKey: String?,
-    landingVisibleFrame: NSRect
-  ) -> NSRect? {
-    guard let previousDisplayKey, previousDisplayKey == landingDisplayKey else { return nil }
-    return frame(remembered: previousFrame, visibleFrame: landingVisibleFrame)
   }
 
   /// The stable per-display identity frames are filed under.
@@ -161,30 +150,6 @@ enum ShellFrameMemory {
   }
 }
 
-/// The one-shot placement state created by passive AppKit deactivation. Keeping record, clear, and
-/// consume together prevents an explicit dismissal from being mistaken for a click-away return.
-struct ShellClickAwayReturn {
-  private var snapshot: (frame: NSRect, displayKey: String?)?
-
-  mutating func record(frame: NSRect, displayKey: String?) {
-    snapshot = (frame, displayKey)
-  }
-
-  mutating func clear() {
-    snapshot = nil
-  }
-
-  mutating func consume(landingDisplayKey: String?, landingVisibleFrame: NSRect) -> NSRect? {
-    guard let snapshot else { return nil }
-    self.snapshot = nil
-    return ShellSummonPlacement.frameAfterClickAway(
-      previousFrame: snapshot.frame,
-      previousDisplayKey: snapshot.displayKey,
-      landingDisplayKey: landingDisplayKey,
-      landingVisibleFrame: landingVisibleFrame)
-  }
-}
-
 /// Summoning, dismissing, and remembering — the live half, which owns the one shell window.
 @MainActor
 enum ShellSummon {
@@ -205,9 +170,6 @@ enum ShellSummon {
   /// attention. This is deliberately separate from ordinary dismissal: returning from a permission
   /// flow must restore the exact panel the user was looking at, not re-land it under the cursor.
   private static var permissionSuspendedFrame: NSRect?
-  /// The frame AppKit is about to hide because the user clicked away. Unlike Escape or Command-O,
-  /// this passive dismissal must not re-center a window the user deliberately placed.
-  private static var clickAwayReturn = ShellClickAwayReturn()
   /// Which window the Escape route and the frame observers are currently bound to.
   ///
   /// Both are per-window — `WindowEscapeKeyMonitor` matches on window identity and the notification
@@ -240,11 +202,21 @@ enum ShellSummon {
   /// The global launch shortcut is the one summon route that doubles as a dismissal gesture.
   /// Miniaturised windows are not visible to the user, so the shortcut must restore them rather
   /// than treat them as an already-open shell and order them out.
+  ///
+  /// `isAppActive` is what stops the chord from turning into a hide button. The shell no longer hides
+  /// itself when you switch apps, so "still on screen" stopped meaning "you are looking at it" — it is
+  /// usually sitting behind whatever you are working in. Pressing Open Omi from another app is a
+  /// request to be shown Omi; only pressing it while Omi is the app you are already in means "put it
+  /// away". It defaults to AppKit's answer so the shortcut path reads it without ceremony, and is a
+  /// parameter at all so a test can state the case it is asserting.
   static func toggleAction(
-    for window: NSWindow?, presentation: ShellWindowChrome.Presentation = .summoned
+    for window: NSWindow?,
+    presentation: ShellWindowChrome.Presentation = .summoned,
+    isAppActive: Bool = NSApp.isActive
   ) -> ToggleAction {
     guard presentation == .summoned else { return .summon }
     guard let window, window.isVisible, !window.isMiniaturized else { return .summon }
+    guard isAppActive else { return .summon }
     return .dismiss
   }
 
@@ -268,7 +240,6 @@ enum ShellSummon {
     if presentation == .summoned {
       registerEscapeRoute(on: window)
     } else {
-      clickAwayReturn.clear()
       unregisterEscapeRoute()
     }
   }
@@ -286,7 +257,6 @@ enum ShellSummon {
   @discardableResult
   static func summon(alwaysPlace: Bool = false) -> Bool {
     guard let window = shellWindow() else { return false }
-    let wasVisible = window.isVisible
     applyPresentation(to: window)
     if window.isMiniaturized { window.deminiaturize(nil) }
 
@@ -301,20 +271,13 @@ enum ShellSummon {
         cursorDisplayKey: landingScreen.flatMap(ShellSummonPlacement.displayKey(for:)))
 
     if appliedPresentation == .summoned, repositions, let screen = landingScreen ?? window.screen {
-      let preservedClickAwayFrame =
-        wasVisible
-        ? nil
-        : clickAwayReturn.consume(
-          landingDisplayKey: ShellSummonPlacement.displayKey(for: screen),
-          landingVisibleFrame: screen.visibleFrame)
-      window.setFrame(preservedClickAwayFrame ?? landingFrame(on: screen), display: true)
+      window.setFrame(landingFrame(on: screen), display: true)
     } else if let screen = NSScreen.main, !screen.visibleFrame.intersects(window.frame) {
       // Anchored, or nothing to land on: the window may still be stranded on a display that went away.
       window.center()
     }
 
     window.makeKeyAndOrderFront(nil)
-    clickAwayReturn.clear()
     hasBeenShown = true
     return true
   }
@@ -346,7 +309,6 @@ enum ShellSummon {
       permissionSuspendedFrame = window.frame
       rememberFrame(of: window)
     }
-    clickAwayReturn.clear()
     window.orderOut(nil)
     return true
   }
@@ -376,7 +338,6 @@ enum ShellSummon {
   /// one of them because the shell closed would be a bug of its own.
   static func dismiss() {
     guard let window = shellWindow(), window.isVisible else { return }
-    clickAwayReturn.clear()
     rememberFrame(of: window)
     window.orderOut(nil)
     let othersVisible = NSApp.windows.contains { other in
@@ -459,21 +420,6 @@ enum ShellSummon {
           }
         })
     }
-    observers.append(
-      center.addObserver(forName: NSApplication.willResignActiveNotification, object: nil, queue: .main) { _ in
-        MainActor.assumeIsolated {
-          guard
-            presentation() == .summoned,
-            let shell = shellWindow(),
-            shell.isVisible,
-            shell.hidesOnDeactivate
-          else { return }
-          clickAwayReturn.record(
-            frame: shell.frame,
-            displayKey: shell.screen.flatMap(ShellSummonPlacement.displayKey(for:)))
-          rememberFrame(of: shell)
-        }
-      })
     // Onboarding completion and sign-out are both `UserDefaults` writes, so this is the one signal
     // that covers the switch in either direction. Re-dressing only on a real change keeps it off the
     // hot path of every other `@AppStorage` write in the app.

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -36,26 +36,31 @@
 //    and steals its click. A root SwiftUI gesture also competes with every Button, Menu, search field,
 //    and filter in the shell. The top-bar-only simultaneous gesture preserves those child controls.
 //
-//  ## The two presentations, and why there are two
+//  ## It is still an ordinary application window
 //
-//  A surface with no visible chrome is not a conventional managed application window any more; it is a
-//  thing you summon. `.summoned` says so to AppKit — floating level, so it comes up over whatever you
-//  were reading until focus moves elsewhere. `ShellSummon` owns where it lands.
+//  Chrome-less is a *drawing* decision. It is not permission to leave AppKit's application-window
+//  contract, and the shell did leave it: `.floating` level plus `hidesOnDeactivate` made it a panel
+//  that vanished the moment another app took focus. That is unreachable, not transient. A window
+//  AppKit has ordered out is in no switcher's list — not ⌘-Tab's window cycling, not AltTab, not
+//  Mission Control — so the only ways back to a shell holding the user's chat history were the chord
+//  and the menu bar icon, while every other window on the machine was an ⌥-Tab away. A `.floating`
+//  shell that stayed up would have been the opposite failure: permanently on top of the app you
+//  switched to.
 //
-//  ## Click-away dismissal
+//  So both presentations are `.normal` and neither auto-hides. The shell stays where you left it,
+//  every switcher can offer it, and putting it away is something the user asks for: ⌘O toggles,
+//  Escape and ⌘W dismiss.
 //
-//  A signed-in shell is a transient summoned surface: press the Open Omi chord, work in it, then click
-//  the desktop or another app to put it away. AppKit already owns that contract through
-//  `hidesOnDeactivate`; using the native property avoids a global mouse monitor or an Accessibility
-//  permission dependency.
+//  ## The two presentations, and why there are still two
 //
-//  `.anchored` is the same window before the user has an account and a completed setup, and what
-//  separates it is still behavioural rather than cosmetic. A first run sends people to System Settings
-//  for microphone, screen recording and accessibility; a `.floating` window sits on top of the Settings
-//  pane and covers the control the user was just told to click. So onboarding stays at `.normal` and
-//  takes a Space of its own (`.fullScreenPrimary`), and the shell only becomes summonable once
-//  `ShellSummon` can see a signed-in, onboarded user — with `dress` idempotent so the switch is a
-//  re-dress, not a rebuild.
+//  What separates them is how they join Spaces, and that is behavioural rather than cosmetic.
+//  `.summoned` is `.fullScreenAuxiliary` — the chord must be able to bring the shell up *over* a
+//  full-screen app, which is the whole point of a global summon. `.anchored` is the same window before
+//  the user has an account and a completed setup: a first run sends people to System Settings for
+//  microphone, screen recording and accessibility, so onboarding takes a Space of its own
+//  (`.fullScreenPrimary`) rather than riding along on someone else's. `ShellSummon` decides which one
+//  applies and owns where the window lands — with `dress` idempotent so the switch is a re-dress, not
+//  a rebuild.
 //
 //  Brand: nothing here picks a colour at all (INV-UI-1).
 //
@@ -67,14 +72,15 @@ import SwiftUI
 /// The main window's chrome: transparent, light-pinned, and without the system's window buttons.
 @MainActor
 enum ShellWindowChrome {
-  /// Whether the shell is a thing you summon, or a window that stays where you left it.
+  /// Whether the shell is a thing you summon onto whatever Space you are on, or a window that owns a
+  /// Space of its own.
   ///
-  /// Behavioural, not cosmetic — the two differ only in the AppKit properties that decide whether the
-  /// window survives losing focus. See this file's header for why a first run needs the second.
+  /// Behavioural, not cosmetic — the two differ only in how the window joins Spaces. Both stay put
+  /// when focus moves elsewhere. See this file's header for why a first run needs the second.
   enum Presentation: Equatable, CaseIterable, Sendable {
-    /// Steady state: floats over other apps and hides when another app or the desktop takes focus.
+    /// Steady state: the chord can bring it up over a full-screen app.
     case summoned
-    /// Onboarding, sign-in and permission-granting: an ordinary window that stays put.
+    /// Onboarding, sign-in and permission-granting: takes a Space of its own.
     case anchored
   }
 
@@ -146,10 +152,12 @@ enum ShellWindowChrome {
     // mouse-down may move the window even when the point is a Button, so this native switch turns
     // ordinary clicks into window drags. `ShellWindowDragHandle` keeps the explicit top-bar handle in SwiftUI.
     window.isMovableByWindowBackground = false
-    window.level = presentation == .summoned ? .floating : .normal
-    // Onboarding and sign-in must survive trips to a browser or System Settings. Once the shell is a
-    // summoned surface, AppKit owns click-away dismissal without an event monitor.
-    window.hidesOnDeactivate = presentation == .summoned
+    // The two properties that decide whether this window exists for the rest of the system. A window
+    // switcher can only offer a window that is on screen, and `.normal` is the level an application
+    // window is expected to cycle at — assert both in every presentation, so no path can leave the
+    // shell as an overlay only its own chord can reach. See this file's header.
+    window.level = .normal
+    window.hidesOnDeactivate = false
     window.collectionBehavior = collectionBehavior(for: presentation, current: window.collectionBehavior)
   }
 
@@ -192,8 +200,8 @@ enum ShellWindowChrome {
       && window.titlebarSeparatorStyle == .none
       && buttonsAreHidden
       && !window.isMovableByWindowBackground
-      && window.level == (presentation == .summoned ? .floating : .normal)
-      && window.hidesOnDeactivate == (presentation == .summoned)
+      && window.level == .normal
+      && !window.hidesOnDeactivate
       && window.collectionBehavior.contains(.moveToActiveSpace)
       && hasExpectedSpaceBehavior
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBPostOnboardingGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBPostOnboardingGuidance.swift
@@ -173,14 +173,14 @@ enum SBPostOnboardingGuidance {
     talkShortcutTokens: [String],
     setup: SBSetupSnapshot
   ) -> [SBOrientationCue] {
-    // Describe the signed-in shell's native click-away dismissal, then name the persistent way back.
-    // The menu bar icon is named rather than left to the chord cue below because the chord is
-    // conditional and the icon is always there.
+    // Describe how this window actually behaves — it stays where you leave it — then name the
+    // persistent way back. The menu bar icon is named rather than left to the chord cue below because
+    // the chord is conditional and the icon is always there.
     var cues: [SBOrientationCue] = [
       SBOrientationCue(
         id: "menubar",
         symbol: "menubar.arrow.up.rectangle",
-        title: "Click the desktop or another app to put me away. My menu bar icon brings me back.",
+        title: "I stay open while you work — switch back any time. My menu bar icon brings me back too.",
         keys: [])
     ]
 

--- a/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
@@ -210,9 +210,10 @@ final class SBPostOnboardingGuidanceWiringTests: XCTestCase {
 
   // MARK: - The orientation cue describes the window the user actually has
 
-  /// The orientation cue must describe the signed-in shell's actual click-away behavior and name the
-  /// persistent way back after AppKit hides it.
-  func testTheMenuBarCueDescribesClickAwayDismissalAndTheWayBack() throws {
+  /// The orientation cue must describe the window the user actually has. It described click-away
+  /// dismissal for as long as the shell hid itself on deactivation; the shell now stays open when you
+  /// switch apps, and a cue promising it disappears is worse than no cue.
+  func testTheMenuBarCueDescribesAWindowThatStaysOpenAndNamesTheWayBack() throws {
     let cues = SBPostOnboardingGuidance.orientationCues(
       openShortcutTokens: ["⌃", "⌘", "O"], talkShortcutTokens: [], setup: SBSetupSnapshot())
     let menubar = try XCTUnwrap(cues.first { $0.id == "menubar" })
@@ -221,9 +222,12 @@ final class SBPostOnboardingGuidanceWiringTests: XCTestCase {
     XCTAssertFalse(
       title.contains("clos"),
       "there is no close button on this window, and describing one is how the first cue went stale")
+    XCTAssertFalse(
+      title.contains("put me away") || title.contains("click the desktop"),
+      "the shell no longer dismisses itself when another app takes focus")
     XCTAssertTrue(
-      title.contains("click the desktop") && title.contains("another app"),
-      "the cue must explain that app deactivation dismisses the summoned shell")
+      title.contains("stay open"),
+      "the cue must say the window survives switching apps — that is the behaviour change users see")
     XCTAssertTrue(
       title.contains("menu bar"),
       "the always-available way back must be named — the chord cue is conditional, this one is not")

--- a/desktop/macos/Desktop/Tests/ShellSummonTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellSummonTests.swift
@@ -23,17 +23,33 @@ final class ShellSummonTests: XCTestCase {
     let window = makeShellWindow()
 
     XCTAssertFalse(window.isVisible)
-    XCTAssertEqual(ShellSummon.toggleAction(for: window), .summon)
+    XCTAssertEqual(ShellSummon.toggleAction(for: window, isAppActive: false), .summon)
   }
 
   @MainActor
-  func testGlobalLaunchToggleDismissesAVisibleShell() {
+  func testGlobalLaunchToggleDismissesTheShellYouAreAlreadyIn() {
     let window = makeShellWindow()
     NonintrusiveTestWindow.orderIn(window)
     defer { window.orderOut(nil) }
 
     XCTAssertTrue(window.isVisible)
-    XCTAssertEqual(ShellSummon.toggleAction(for: window), .dismiss)
+    XCTAssertEqual(ShellSummon.toggleAction(for: window, isAppActive: true), .dismiss)
+  }
+
+  /// **The chord is not a hide button.** The shell stays on screen behind whatever you are working in,
+  /// so "visible" alone would turn every Open Omi press from another app into a dismissal — the chord
+  /// would appear to do nothing, or worse, put Omi away just as you asked for it.
+  @MainActor
+  func testGlobalLaunchToggleSummonsAVisibleShellWhenYouAreInAnotherApp() {
+    let window = makeShellWindow()
+    NonintrusiveTestWindow.orderIn(window)
+    defer { window.orderOut(nil) }
+
+    XCTAssertTrue(window.isVisible)
+    XCTAssertEqual(
+      ShellSummon.toggleAction(for: window, isAppActive: false),
+      .summon,
+      "Open Omi pressed from another app must bring Omi forward, never hide it")
   }
 
   @MainActor
@@ -43,7 +59,7 @@ final class ShellSummonTests: XCTestCase {
     defer { window.orderOut(nil) }
 
     XCTAssertEqual(
-      ShellSummon.toggleAction(for: window, presentation: .anchored),
+      ShellSummon.toggleAction(for: window, presentation: .anchored, isAppActive: true),
       .summon,
       "Command-O must focus the only setup surface rather than hide it")
   }
@@ -184,54 +200,18 @@ final class ShellSummonTests: XCTestCase {
       ShellSummonPlacement.shouldReposition(isVisible: true, windowDisplayKey: "1", cursorDisplayKey: nil))
   }
 
-  /// The click-away round trip composes the AppKit presentation with the shortcut toggle policy.
-  /// AppKit orders a `hidesOnDeactivate` window out, and a hidden shell must be summoned—not dismissed—
-  /// by the next Command-O.
+  /// A dismissal composes the AppKit presentation with the shortcut toggle policy: Escape or ⌘W orders
+  /// the shell out, and the next Command-O must summon it rather than read it as still open.
   @MainActor
-  func testClickAwayLeavesTheShellReadyForTheNextCommandOToSummon() {
+  func testAnOrderedOutShellIsSummonedNotDismissedByTheNextCommandO() {
     let window = makeShellWindow()
 
     ShellWindowChrome.dress(window, as: .summoned)
-
-    XCTAssertTrue(window.hidesOnDeactivate)
     window.orderOut(nil)
-    XCTAssertEqual(ShellSummon.toggleAction(for: window), .summon)
+
+    XCTAssertEqual(ShellSummon.toggleAction(for: window, isAppActive: true), .summon)
   }
 
-  func testClickAwayReturnRecordsAndConsumesTheExactFrameOnceOnTheSameDisplay() {
-    let placed = NSRect(x: 180, y: 95, width: 980, height: 720)
-    var clickAwayReturn = ShellClickAwayReturn()
-    clickAwayReturn.record(frame: placed, displayKey: "1")
-
-    let restored = clickAwayReturn.consume(
-      landingDisplayKey: "1",
-      landingVisibleFrame: laptop)
-
-    XCTAssertEqual(restored, placed)
-    XCTAssertNil(clickAwayReturn.consume(landingDisplayKey: "1", landingVisibleFrame: laptop))
-  }
-
-  func testClickAwayReturnConsumesWithoutDraggingTheShellAcrossDisplays() {
-    let placed = NSRect(x: 180, y: 95, width: 980, height: 720)
-    var clickAwayReturn = ShellClickAwayReturn()
-    clickAwayReturn.record(frame: placed, displayKey: "1")
-
-    let restored = clickAwayReturn.consume(
-      landingDisplayKey: "2",
-      landingVisibleFrame: studio)
-
-    XCTAssertNil(restored, "a Command-O from another display must land the shell under the user")
-  }
-
-  func testExplicitDismissalClearsThePendingClickAwayReturn() {
-    let placed = NSRect(x: 180, y: 95, width: 980, height: 720)
-    var clickAwayReturn = ShellClickAwayReturn()
-    clickAwayReturn.record(frame: placed, displayKey: "1")
-
-    clickAwayReturn.clear()
-
-    XCTAssertNil(clickAwayReturn.consume(landingDisplayKey: "1", landingVisibleFrame: laptop))
-  }
   // MARK: - Memory
 
   /// Two displays, two placements, neither overwriting the other. A single remembered frame is the

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -136,34 +136,33 @@ final class ShellWindowChromeTests: XCTestCase {
 
   // MARK: - Summoned vs anchored
 
-  /// A summoned shell behaves like the thing it is: it comes up over whatever you were reading, and
-  /// clicking outside puts it away. `hidesOnDeactivate` is the native AppKit ownership boundary for
-  /// that behavior, so no global mouse monitor or Accessibility permission is involved.
-  func testASummonedShellFloatsOverOtherAppsAndPutsItselfAwayWhenYouClickOutside() {
+  /// **The app-switcher guard.** The shell used to be a `.floating` panel with `hidesOnDeactivate`, so
+  /// switching to any other app ordered it out — and a window that is not on screen is in no switcher's
+  /// list, which left ⌥-Tab and ⌘-Tab window cycling with no Omi window to offer at all. These two
+  /// properties are the whole difference between an application window and an overlay, so they are
+  /// asserted directly rather than through the presentation that happens to be applied.
+  func testASummonedShellStaysOnScreenAtNormalLevelSoWindowSwitchersCanOfferIt() {
     let window = makeWindow()
 
     ShellWindowChrome.dress(window, as: .summoned)
 
-    XCTAssertEqual(window.level, .floating, "a summoned surface that sinks behind the app you called it over")
-    XCTAssertTrue(window.hidesOnDeactivate, "clicking outside must dismiss the summoned shell")
+    XCTAssertEqual(window.level, .normal, "an overlay level is not a window any switcher will cycle to")
+    XCTAssertFalse(window.hidesOnDeactivate, "AppKit orders a hidden window out of every switcher's list")
     XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
     XCTAssertTrue(window.collectionBehavior.contains(.moveToActiveSpace))
   }
 
-  /// `dress` runs repeatedly as auth/onboarding changes presentation. It must write both directions:
-  /// a signed-in shell dismisses on click-away, while sign-in and onboarding survive browser and
-  /// System Settings trips.
-  func testDressingReconcilesClickAwayBehaviorForEachPresentation() {
+  /// `dress` runs repeatedly as auth and onboarding change presentation, and no presentation may
+  /// reintroduce the auto-hide: a signed-in shell has to survive a trip to another app for the same
+  /// reason onboarding has to survive a trip to System Settings.
+  func testNoPresentationEverMakesTheShellHideItselfOnDeactivate() {
     let window = makeWindow()
 
-    ShellWindowChrome.dress(window, as: .summoned)
-    XCTAssertTrue(window.hidesOnDeactivate)
-
-    ShellWindowChrome.dress(window, as: .anchored)
-    XCTAssertFalse(window.hidesOnDeactivate)
-
-    ShellWindowChrome.dress(window, as: .summoned)
-    XCTAssertTrue(window.hidesOnDeactivate)
+    for presentation in ShellWindowChrome.Presentation.allCases {
+      ShellWindowChrome.dress(window, as: presentation)
+      XCTAssertFalse(window.hidesOnDeactivate, "\(presentation) hides the shell from every window switcher")
+      XCTAssertEqual(window.level, .normal, "\(presentation) puts the shell at a level switchers skip")
+    }
   }
   /// **The first-run guard.** Onboarding sends people to System Settings for microphone, screen
   /// recording and accessibility, and every trip deactivates this app. A shell that auto-hid would

--- a/desktop/macos/changelog/unreleased/20260811-shell-window-in-app-switcher.json
+++ b/desktop/macos/changelog/unreleased/20260811-shell-window-in-app-switcher.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the main Omi window disappearing when you switch apps — it now stays open and shows up in the app switcher"
+}


### PR DESCRIPTION
## The bug

Cmd-Tab / AltTab showed no Omi window. The only Omi entries in the switcher were the "Microphone Isn't Capturing Audio" alert and the installer's Finder window — never the app itself.

The signed-in shell was a `.floating` panel with `hidesOnDeactivate`, so switching to another app ordered it out. A window AppKit has ordered out is in no switcher's list at all, so ⌥-Tab / ⌘-Tab window cycling had nothing to offer, and the only ways back to a window holding the user's chat history were the chord and the menu bar icon.

Measured on the shipping build with another app frontmost:

```
'Omi Beta v0.12.159'  layer=3 (floating)  onscreen=False   ← in no switcher's list
```

## The fix

Both presentations are now `.normal` level and neither auto-hides, so the shell behaves like the application window it is: it stays where you left it, and every switcher can offer it. `Presentation` still separates the two — `.summoned` is `.fullScreenAuxiliary` so the chord can bring Omi up over a full-screen app; `.anchored` keeps `.fullScreenPrimary` so onboarding owns a Space.

Dismissal stays explicit: ⌘O toggles, ⌘W and Escape put it away.

Two consequences carried in the same change:

- **The ⌘O toggle is no longer a hide button.** "Still on screen" stopped meaning "you are looking at it" — the shell now sits behind whatever you are working in. `toggleAction` therefore dismisses only when Omi is the active app; pressed from another app it summons. Without this, the chord would have hidden the shell exactly when the user asked to see it.
- **The click-away seam is deleted, not left dormant.** `ShellClickAwayReturn` / `frameAfterClickAway` and the `willResignActive` observer existed only to preserve a frame across the auto-hide. The onboarding cue that promised "Click the desktop or another app to put me away" now describes the window users actually have.

## Verification (real path, not compile-only)

Named dev bundle `omi-alttab`, signed in and onboarded so the shell is in the `.summoned` presentation (the presentation carrying the bug).

| Check | Result |
|---|---|
| Shell window while Chrome/Messages frontmost | `layer=0 onscreen=True 960x712` — what a switcher enumerates |
| Accessibility API (what AltTab reads), Omi inactive | lists `AXWindow "omi-alttab v1.0"` 960×712 |
| Open Omi chord from another app (`trigger_open_omi_shortcut` → the same `openOmiFromShortcut()` the hotkey calls) | frontmost Chrome → `omi-alttab`, shell stays up |
| Open Omi chord while Omi is frontmost | `main_window_visible=false`, window ordered out, focus returns to the previous app |
| `xcrun swift test --package-path Desktop --filter "ShellWindowChromeTests\|ShellSummonTests\|SBPostOnboardingGuidanceWiringTests"` | 57 tests, 0 failures |

Reporter confirmed on his own machine that Omi now appears in the switcher.

Not exercised: I did not screenshot the AltTab grid itself, because triggering it means injecting a global hotkey into the reporter's live session. The window-list and Accessibility readings above are the exact data AltTab enumerates.

## Tests

- `testASummonedShellStaysOnScreenAtNormalLevelSoWindowSwitchersCanOfferIt` — the regression guard: asserts `.normal` + `!hidesOnDeactivate` directly, since those two properties are the whole difference between an application window and an overlay.
- `testNoPresentationEverMakesTheShellHideItselfOnDeactivate` — no presentation may reintroduce the auto-hide.
- `testGlobalLaunchToggleSummonsAVisibleShellWhenYouAreInAnotherApp` — the chord is not a hide button.
- Onboarding cue test now asserts the window stays open instead of asserting the retired click-away copy.

## Product invariants

- `INV-AUTH-1` — matched by path (`ShellSummon`/`OmiApp` are on the desktop session surface glob). No auth or session behaviour changes here: this diff touches window level, deactivation behaviour, and the summon toggle only.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

