### PR TITLE
fix(ci): align gateway guard with file chat

### DIFF
--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -115,14 +115,14 @@ surfaces:
     current_provider_model: openai/gpt-5.6-luna
     request_shape: streaming vision chat completion
     gateway_lane_capability_needed: gateway-owned vision chat lane or file-chat replacement retrieval path
-    migration_status: inventoried_direct_file_lifecycle_surface; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and checked-in serving configuration does not permit the exception
+    migration_status: acknowledged_direct_file_lifecycle_surface; intentionally remains direct during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and records direct-exception telemetry without raising (PR #11419)
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: file_chat_assistants
     code_path: backend/utils/other/chat_file.py:FileChatTool
     current_provider_model: openai/gpt-5.6-luna with Assistants, Threads, Files, File Search
     request_shape: file upload, assistants, file_search, streaming run deltas
     gateway_lane_capability_needed: gateway-owned file/assistant lifecycle or replacement retrieval path
-    migration_status: inventoried_direct_file_lifecycle_surface; blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and checked-in serving configuration does not permit the exception
+    migration_status: acknowledged_direct_file_lifecycle_surface; intentionally remains direct during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and records direct-exception telemetry without raising (PR #11419)
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: omni_realtime_relay
     code_path: backend/routers/omni_relay.py

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -173,14 +173,44 @@ def test_direct_provider_usage_stays_inside_approved_boundaries():
     assert stale_allowlist == []
 
 
-def test_direct_exception_files_are_inventoried_and_fail_closed_for_gateway_flip():
+def test_direct_exception_files_follow_their_declared_gateway_policy():
     inventory = _load_inventory()
     inventory_paths = {_code_path_file(surface['code_path']) for surface in inventory['surfaces']}
 
     assert INVENTORIED_DIRECT_EXCEPTION_FILES <= inventory_paths
-    for rel_path in INVENTORIED_DIRECT_EXCEPTION_FILES:
+    policies_by_file: dict[str, set[str]] = {path: set() for path in INVENTORIED_DIRECT_EXCEPTION_FILES}
+    for surface in inventory['surfaces']:
+        rel_path = _code_path_file(surface['code_path'])
+        if rel_path in policies_by_file:
+            policies_by_file[rel_path].add(_direct_exception_policy(surface['migration_status']))
+
+    assert all(len(policies) == 1 for policies in policies_by_file.values())
+    policy_by_file = {rel_path: next(iter(policies)) for rel_path, policies in policies_by_file.items()}
+    assert policy_by_file['utils/other/chat_file.py'] == 'acknowledged'
+    assert policy_by_file['routers/omni_relay.py'] == 'blocked'
+
+    for rel_path, policy in policy_by_file.items():
         source = (BACKEND_DIR / rel_path).read_text(encoding='utf-8')
-        assert 'raise_if_gateway_feature_mode_blocks_direct_model_surface' in source
+        if policy == 'acknowledged':
+            assert 'record_direct_exception_surface' in source
+            assert 'raise_if_gateway_feature_mode_blocks_direct_model_surface' not in source
+        elif policy == 'blocked':
+            assert 'raise_if_gateway_feature_mode_blocks_direct_model_surface' in source
+            assert 'record_direct_exception_surface' not in source
+        else:
+            raise AssertionError(f'unknown direct gateway policy {policy!r} for {rel_path}')
+
+
+def test_acknowledged_file_chat_surface_is_observed_without_a_gateway_block():
+    """Static regression guard for PR #11419's acknowledged file-chat direct surface.
+
+    Behavioral upload coverage lives in test_chat_file_gateway_surface.py; this tripwire
+    keeps the acknowledged implementation from regressing to the fail-closed gate.
+    """
+    source = (BACKEND_DIR / 'utils/other/chat_file.py').read_text(encoding='utf-8')
+
+    assert 'record_direct_exception_surface(surface=\'file_chat.openai_files_assistants_vision\')' in source
+    assert 'raise_if_gateway_feature_mode_blocks_direct_model_surface' not in source
 
 
 def _load_inventory() -> dict:
@@ -284,3 +314,11 @@ def _inventory_file_exists(code_path: str) -> bool:
 def _code_path_file(code_path: str) -> str:
     normalized = code_path.removeprefix('backend/')
     return normalized.split(':', 1)[0]
+
+
+def _direct_exception_policy(migration_status: str) -> str:
+    if migration_status.startswith('acknowledged_direct_'):
+        return 'acknowledged'
+    if 'blocked during OMI_LLM_GATEWAY_FEATURE_MODE=gateway' in migration_status:
+        return 'blocked'
+    raise AssertionError(f'direct exception surface has no declared gateway policy: {migration_status!r}')


### PR DESCRIPTION
## Summary

- align the LLM surface inventory and guardrail with the acknowledged file-chat exception from #11419

## Verification

- focused backend gateway guard and file-chat tests
- diff hygiene

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

