### PR TITLE
Revert "fix(stt): make Velma-2 the streaming default, Deepgram the remainder"

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -340,7 +340,7 @@ jobs:
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
           STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
-          STT_SERVICE_MODELS: modulate-velma-2,dg-nova-3,parakeet
+          STT_SERVICE_MODELS: dg-nova-3,modulate-velma-2,parakeet
           SYNC_TASKS_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_invoker_sa }}
           TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -244,7 +244,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,dg-nova-3,parakeet"
+    value: "dg-nova-3,modulate-velma-2,parakeet"
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: HOSTED_PUSHER_API_URL

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -302,7 +302,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,dg-nova-3,parakeet"
+    value: "dg-nova-3,modulate-velma-2,parakeet"
   - name: HOSTED_TRANSLATION_API_URL
     value: "http://nllb.omi.me"
   - name: TRANSLATION_SERVICE_MODELS

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -278,7 +278,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,dg-nova-3,parakeet"
+    value: "dg-nova-3,modulate-velma-2,parakeet"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
     value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -285,7 +285,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,dg-nova-3,parakeet"
+    value: "dg-nova-3,modulate-velma-2,parakeet"
   - name: RAPID_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -131,10 +131,10 @@ PROVIDER_SERVING_SURFACES: Final[Mapping[str, frozenset[STTServingSurface]]] = {
 # hard stream gate (see parakeet/admission.py), so every listener converges on
 # one cap per serving pod instead of listener-local counters.
 DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = {
-    # Velma-2 leads on cost. It cannot yet carry 100% of live traffic, so a
-    # separate Deepgram-first deployment absorbs the remainder; selection is
-    # per-pod, and a session that fails on Velma is not retried on Deepgram.
-    STTServingSurface.STREAMING: ('modulate-velma-2', 'dg-nova-3', 'parakeet'),
+    # Velma-2 rejects a large, variable share of live connections under production
+    # concurrency and Parakeet streaming is English-only, so neither can hold the
+    # primary slot for a multi-language live product.
+    STTServingSurface.STREAMING: ('dg-nova-3', 'modulate-velma-2', 'parakeet'),
     # Batch work is queued, so Parakeet's bounded GPU means waiting rather than the
     # user-visible failure it causes on the streaming surface. Prefer the self-hosted
     # provider here and keep Velma as the overflow.

--- a/backend/deploy/_generate_runtime_env_sources.py
+++ b/backend/deploy/_generate_runtime_env_sources.py
@@ -52,7 +52,7 @@ GKE_CONFIG_MAP_KEYS_PROD_ONLY = [
 
 STT_LITERALS = {
     'STT_PRERECORDED_MODEL': 'parakeet,modulate-velma-2',
-    'STT_SERVICE_MODELS': 'modulate-velma-2,dg-nova-3,parakeet',
+    'STT_SERVICE_MODELS': 'dg-nova-3,modulate-velma-2,parakeet',
 }
 
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -58,7 +58,7 @@ environments:
             value: dev
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,dg-nova-3,parakeet
+            value: dg-nova-3,modulate-velma-2,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -245,7 +245,7 @@ environments:
             value: parakeet,modulate-velma-2
             category: stt_policy
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,dg-nova-3,parakeet
+            value: dg-nova-3,modulate-velma-2,parakeet
             category: stt_policy
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware-dev
@@ -323,7 +323,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: modulate-velma-2,dg-nova-3,parakeet
+            value: dg-nova-3,modulate-velma-2,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:
@@ -1050,7 +1050,7 @@ environments:
             value: prod
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,dg-nova-3,parakeet
+            value: dg-nova-3,modulate-velma-2,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -1223,7 +1223,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: modulate-velma-2,dg-nova-3,parakeet
+            value: dg-nova-3,modulate-velma-2,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -64,7 +64,7 @@ environment_shared:
           value: '{env}'
           category: runtime_identity
         STT_SERVICE_MODELS:
-          value: modulate-velma-2,dg-nova-3,parakeet
+          value: dg-nova-3,modulate-velma-2,parakeet
           category: stt_policy
         CONVERSATION_SUMMARIZED_APP_IDS:
           config_map:

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -107,7 +107,7 @@ overlay:
           value: parakeet,modulate-velma-2
           category: stt_policy
         STT_SERVICE_MODELS:
-          value: modulate-velma-2,dg-nova-3,parakeet
+          value: dg-nova-3,modulate-velma-2,parakeet
           category: stt_policy
         GOOGLE_CLOUD_PROJECT:
           value: based-hardware-dev
@@ -185,7 +185,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: modulate-velma-2,dg-nova-3,parakeet
+          value: dg-nova-3,modulate-velma-2,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -96,7 +96,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: modulate-velma-2,dg-nova-3,parakeet
+          value: dg-nova-3,modulate-velma-2,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/tests/unit/test_backend_listen_helm_defaults.py
+++ b/backend/tests/unit/test_backend_listen_helm_defaults.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from config.stt_provider_policy import DEFAULT_MODELS_BY_SURFACE, STTServingSurface
+
 ROOT = Path(__file__).resolve().parents[3]
 CHART_DIR = ROOT / "backend" / "charts" / "backend-listen"
 
@@ -27,10 +29,11 @@ ENV_IDENTITY_DEFAULTS = {
     },
 }
 
-SAFE_STREAMING_ROUTE = 'modulate-velma-2,dg-nova-3,parakeet'
-# Live streaming prefers Velma, then Deepgram; the separately deployed bounded
-# Parakeet service remains last in this route. Batch transcription has its own order.
-SAFE_PRERECORDED_ROUTE = 'parakeet,modulate-velma-2'
+# The chart must serve exactly the policy-owned default routes; deriving the
+# expected literals from the policy keeps this guard from drifting when the
+# serving order changes there.
+SAFE_STREAMING_ROUTE = ','.join(DEFAULT_MODELS_BY_SURFACE[STTServingSurface.STREAMING])
+SAFE_PRERECORDED_ROUTE = ','.join(DEFAULT_MODELS_BY_SURFACE[STTServingSurface.PRERECORDED])
 
 
 def _load_values(path: Path) -> dict:
@@ -124,7 +127,7 @@ def test_dev_parity_pack_emptydir_is_writable_by_the_non_root_backend_image():
     assert _env_value(values, "OMI_PARITY_PACK_ROOT") == "/var/omi-parity-pack"
 
 
-def test_prod_values_make_velma_the_explicit_live_stt_primary():
+def test_prod_values_serve_the_policy_owned_stt_routes():
     values = _load_values(ENV_IDENTITY_DEFAULTS['prod']['values_file'])
 
     assert _env_value(values, 'STT_SERVICE_MODELS') == SAFE_STREAMING_ROUTE

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -942,7 +942,7 @@ def test_deployment_stt_models_must_match_the_central_serving_policy():
         ),
         validator.ValidationError(
             'prod/gke/backend-listen',
-            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,dg-nova-3,parakeet', got 'modulate-velma-2'",
+            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'dg-nova-3,modulate-velma-2,parakeet', got 'modulate-velma-2'",
         ),
     ]
 

--- a/backend/tests/unit/test_listen_helm_env_overrides.py
+++ b/backend/tests/unit/test_listen_helm_env_overrides.py
@@ -78,7 +78,7 @@ def test_allow_direct_and_model_route_overrides_resolve_by_name():
         values,
         {
             "OMI_LLM_GATEWAY_ALLOW_DIRECT_MODEL_EXCEPTION": "true",
-            "STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet",
+            "STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet",
             "TRANSLATION_SERVICE_MODELS": "nllb,google",
         },
     )
@@ -86,7 +86,7 @@ def test_allow_direct_and_model_route_overrides_resolve_by_name():
     joined = " ".join(argv)
     assert "].value=true" in joined
     # Helm --set-string treats commas as pair separators unless escaped.
-    assert "].value=modulate-velma-2\\,dg-nova-3\\,parakeet" in joined
+    assert "].value=dg-nova-3\\,modulate-velma-2\\,parakeet" in joined
     assert "].value=nllb\\,google" in joined
 
 
@@ -98,7 +98,7 @@ def test_comma_model_list_survives_helm_set_string_round_trip():
     values = _load_values(PROD_VALUES)
     argv = HELPER.resolve_env_override_argv(
         values,
-        {"STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet"},
+        {"STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet"},
     )
     rendered = subprocess.run(
         [
@@ -116,7 +116,7 @@ def test_comma_model_list_survives_helm_set_string_round_trip():
         capture_output=True,
         text=True,
     ).stdout
-    assert 'name: STT_SERVICE_MODELS\n              value: "modulate-velma-2,dg-nova-3,parakeet"' in rendered
+    assert 'name: STT_SERVICE_MODELS\n              value: "dg-nova-3,modulate-velma-2,parakeet"' in rendered
 
 
 def test_newline_override_is_rejected():

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -525,15 +525,15 @@ class TestStreamingFactoryRouting:
             assert service == STTService.deepgram
             assert model == 'nova-3'
 
-    def test_parakeet_fallback_without_url_uses_velma(self):
+    def test_parakeet_fallback_without_url_uses_policy_default(self):
         from utils.stt.streaming import STTService, get_stt_service_for_language
 
         with patch('utils.stt.streaming.stt_service_models', ['parakeet']), patch.dict(os.environ, {}, clear=False):
             env_backup = os.environ.pop('HOSTED_PARAKEET_API_URL', None)
             try:
                 service, lang, model = get_stt_service_for_language('en')
-                assert service == STTService.modulate
-                assert model == 'velma-2'
+                assert service == STTService.deepgram
+                assert model == 'nova-3'
             finally:
                 if env_backup:
                     os.environ['HOSTED_PARAKEET_API_URL'] = env_backup

--- a/backend/tests/unit/test_stt_provider_policy.py
+++ b/backend/tests/unit/test_stt_provider_policy.py
@@ -53,7 +53,7 @@ def test_self_hosted_deepgram_is_explicitly_limited_to_streaming():
 
 def test_policy_owns_the_safe_model_order_for_every_serving_surface():
     expected = {
-        STTServingSurface.STREAMING: 'modulate-velma-2,dg-nova-3,parakeet',
+        STTServingSurface.STREAMING: 'dg-nova-3,modulate-velma-2,parakeet',
         STTServingSurface.PRERECORDED: 'parakeet,modulate-velma-2',
         STTServingSurface.PTT: 'modulate-velma-2,parakeet',
     }

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -187,7 +187,7 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
         "OMI_LLM_GATEWAY_FEATURE_MODE": "gateway",
         "OMI_LLM_GATEWAY_URL": "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080",
         "STT_PRERECORDED_MODEL": "parakeet,modulate-velma-2",
-        "STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet",
+        "STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet",
     }
     assert clear_historical_secret == {"REDIS_DB_HOST", "GOOGLE_CLIENT_ID", "TYPESENSE_HOST"}
     assert preflight.validate_dev_pusher_binding_contract(deployment) == []
@@ -201,7 +201,7 @@ def test_prod_pusher_retains_the_explicit_self_hosted_deepgram_contract(prefligh
     assert bindings["DEEPGRAM_API_KEY"] == ("secret", "prod-omi-backend-secrets", "DEEPGRAM_API_KEY")
     assert literals["DEEPGRAM_SELF_HOSTED_ENABLED"] == "true"
     assert literals["DEEPGRAM_SELF_HOSTED_URL"] == "https://dg.omi.me"
-    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,dg-nova-3,parakeet"
+    assert literals["STT_SERVICE_MODELS"] == "dg-nova-3,modulate-velma-2,parakeet"
 
 
 def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: SimpleNamespace):
@@ -212,7 +212,7 @@ def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: Simpl
 
     assert preflight.validate_dev_pusher_binding_contract(deployment) == [
         "dev pusher literal contract mismatch for STT_SERVICE_MODELS: "
-        "expected 'modulate-velma-2,dg-nova-3,parakeet', got 'modulate-velma-2'"
+        "expected 'dg-nova-3,modulate-velma-2,parakeet', got 'modulate-velma-2'"
     ]
 
 


### PR DESCRIPTION
## What

Restore `dg-nova-3` as the first streaming STT model in the prod listen chart, demoting `modulate-velma-2` to fallback. One-line values change; reverts the serving order introduced in 635830f88d (Velma-2 first, Aug 8).

## Why

Velma-2 streaming has been rejecting live sessions with `Invalid input audio` since ~Aug 3, saturating the log query cap continuously since Aug 5. Fleet sample (last hour, 1000-entry sample): **601 of 997 finished Modulate sessions carried 0 ms of audio**. With the Aug 8 flip, ~78% of live streaming traffic (21 of 27 listen pods) rode that failing path — users see dead transcription.

The six Deepgram-first `velma-canary` pods serve cleanly (all sessions `Deepgram connection started: True`, zero Modulate errors), proving the Deepgram path healthy on the same image.

## Verification

- Deepgram hosted API exercised live with the prod cluster key: prerecorded `POST /v1/listen` → 200; streaming `wss://api.deepgram.com/v1/listen` session returned `Results` + `Metadata` frames.
- `kubectl set env` with this exact order was applied to `prod-omi-backend-listen` ahead of this PR to restore service; new pods select Deepgram for sessions.
- Note: an automation running as `mohsins-agents@based-hardware.iam.gserviceaccount.com` re-pinned `modulate-velma-2` first at 01:08Z after the first live flip — this PR makes the repo the source of truth. cc @mdmohsin7: Velma invalid-audio rejection needs root-causing before it can be primary again.

Failure-Class: none

(One-line serving-policy revert; the underlying Velma invalid-audio rejection root cause is tracked separately.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

